### PR TITLE
File tree: collapsed by default, persistent fold state, indent guides, complete listings

### DIFF
--- a/BUILD-LOG.md
+++ b/BUILD-LOG.md
@@ -2041,3 +2041,105 @@ same baseline both times - 742 app + 42 lsp-core + 14 pty-core + 98 wt-core test
 confirming this added no new functionality and lost none. `git`'s own rename detection on the
 final commit independently corroborates the move: the large majority of touched files show as
 high-percentage renames, not delete+create pairs.
+
+## File tree: collapsed by default, persisted fold state, indent guides, complete listings (GitHub issue #18)
+
+The Files tree now opens fully collapsed and remembers exactly what was left open, per worktree,
+across restarts. `AdeApp::collapsed_dirs` became `expanded_dirs` - the inversion is the whole of
+the "collapsed by default" requirement: absence from the set means collapsed, so a worktree this
+app has never seen (a freshly created one included) opens showing only its root-level entries,
+with no separate "first open" special case anywhere in the code.
+
+**Persistence.** A new `crate::sidebar::fold_state` writes
+`~/.config/jerry/file-tree-state.toml`, resolved as a sibling of the real `settings.toml` path,
+and driven by the same serial-writer-loop mechanism `AdeApp::persist_settings` already
+established (one write in flight at a time; a change landing mid-write is picked up by the
+running loop, never raced). It is a separate file from `settings.toml` for two real reasons:
+`Settings`' own module docs are explicit that every field there is something a settings *page*
+reads and writes and the config banner renders back as hand-editable config, which machine-
+managed fold state for every worktree ever opened is not; and `Settings::save_at` is a
+deliberately non-atomic truncate-then-write, while "recorded immediately (crash-safe)" is a
+requirement here. `FoldState::save_at` writes a process-unique temp file, `sync_all`s it,
+renames it over the target, and syncs the parent directory, so neither a killed process nor a
+power loss can leave a half-written file. The map is keyed by canonicalized worktree path with
+worktree-relative paths inside, and non-UTF-8 paths are refused outright rather than
+`to_string_lossy`'d - a lossy key would map every undecodable byte to the same U+FFFD and could
+collapse two different worktrees onto one entry, which is exactly the cross-worktree leak the
+keying exists to prevent.
+
+**Indent guides** are drawn as each row's own absolutely-positioned children, not as an overlay
+across the list. That is what makes them correct under the recently-landed `uniform_list`
+virtualization for free: a guide is a pure function of the row it belongs to (`entry.depth`, plus
+the selected path for the ancestor-chain highlight), so a recycled row can only ever draw the
+guides that belong to whatever row it now shows. An overlay would have to track the visible range
+and scroll offset itself and stay in step with them - the real source of the "gaps or misaligned
+segments as rows recycle" failure the issue names. Verified against real painted geometry rather
+than assumed: tests assert each guide's `debug_bounds` x-offset equals `indent_guide_x(level)`
+from its row's left edge, that consecutive rows' segments meet with no gap, and that all of that
+still holds for a row materialized only after a real 100,000px scroll event recycled the list.
+Two new `ColorToken`s (`theme::tree::INDENT_GUIDE`/`INDENT_GUIDE_ACTIVE`) go through the same
+derived-per-theme mechanism as the ~200 tokens around them; the active/resting branch is testable
+because each guide's `debug_selector` records which one it took.
+
+**Complete listings.** The 500-row `MAX_RENDERED_FILE_ENTRIES` render cap and its
+"... and N more entries not shown" row are gone; every visible row is rendered. One cap survives
+and it is a *load* bound, not a render one: the walk is eager and synchronous (the palette's file
+search needs the whole tree, so it can't be made lazy), so it is bounded by a real, configurable
+`settings.toml` value (`file_tree.max_entries`, 20,000 by default). When it is hit the sidebar
+shows a real "Stopped at N entries - load more" action that re-walks with a tenfold larger
+budget. Deliberately still a budget rather than an unbounded re-walk: one click on a directory
+containing a vendored tree or a bind-mounted `$HOME` would otherwise allocate millions of
+`PathBuf`s and hand them all to the palette candidate list. Each click raises the bound and the
+row keeps reporting where the walk stopped, so nothing is ever *silently* cut off.
+
+Also landed while in here: "collapse all" (clears the tree and the saved state in one step);
+"reveal in tree" (the palette's open-file flow, a just-created file, and go-to-definition landing
+in an unexpanded folder) now expands ancestors and records those expansions like manual ones; and
+`render_file_tree` resolves its visible-row set once per frame into an `Rc<Vec<usize>>` shared
+with the row-builder closure, instead of re-walking the whole loaded tree on each of
+`uniform_list`'s three per-frame closure calls.
+
+An adversarial audit of the first draft found seven real problems, all fixed: `save_at` claimed
+crash-safety it didn't have (no `fsync`, so only *process* crash was covered); a fixed `.tmp`
+name meant two `jerry` processes could interleave into one torn file, and whole-file writes made
+the last saver silently erase every other repository's state (writes now merge against a set of
+owned worktree keys); a startup prune that dropped any worktree whose root `Path::exists()`
+reported gone would have permanently deleted state for a worktree on a briefly-unmounted volume
+(removed entirely - a few hundred stale bytes is cheaper than destroying real state on a false
+negative); a subdirectory the walk couldn't read looked identical to a deleted one, so pruning
+would have discarded every fold-state entry beneath it (the listing now reports `partial`, and
+pruning only ever runs against a genuinely complete walk); `select_worktree` moved `expanded_dirs`
+to the new worktree ~90 lines before `file_tree_root` followed, leaving a window in which a click
+on a still-rendered stale row recorded state against the wrong root; the live tree and the file
+could diverge silently when a path wasn't recordable (now a three-state outcome and a real log
+line, with the expansion still happening - refusing to open a folder because of how its name is
+encoded would be worse than not remembering it); and one test asserted on state it had
+hand-written itself rather than on a walk that genuinely truncated. The audit also confirmed the
+absolute-positioning assumption directly against vendored taffy: absolute insets resolve against
+the container's border box, not its padding box, so a guide's `left` really is measured from the
+row's own left edge despite the row's left padding.
+
+A second audit of those fixes then caught the worst bug of the whole change: the merged write was
+*written but never wired* - one edit had silently failed to apply, so `persist_fold_state` still
+called the whole-file `save_at`, `save_merged_at` was reachable only from its own unit test, and
+`fold_state_owned` was write-only dead state, while three doc comments and this log claimed
+otherwise. The unit test couldn't catch it (it called the unused function directly) and the
+existing app-level leak test couldn't either (its second instance started before the first ever
+wrote, so a whole-file write preserved both). The regression test added for it drives the exact
+ordering that distinguishes the two - instance B starts, *then* A writes, *then* B writes - and
+was confirmed to fail against the un-wired version before being kept. The same round also found
+two more walk paths that could report an incomplete listing as complete (a `DirEntry` that errors
+mid-iteration, and a `file_type()` failure recording a real directory as a file - either one
+would have let pruning delete good fold state), a silent `Refused` in `reveal_in_tree` that
+bypassed the log line its sibling write path already had, an orphaned-temp-file leak that
+making the temp name process-unique had turned from one reusable file into unbounded
+accumulation (now swept on save, with an hour's age threshold so it can never race another
+instance's live write), and several docs still describing the earlier unbounded "Show all
+entries" behaviour. The remaining honest gap is stated in `fold_state`'s own module docs rather
+than papered over: the merge is an unlocked read-modify-write, so two saves that genuinely
+interleave can still lose one update - it narrows the window rather than closing it.
+
+All four gates clean: `cargo fmt --all -- --check`, `cargo build --workspace`,
+`cargo clippy --workspace --all-targets -- -D warnings`, and
+`cargo test --workspace --lib -- --test-threads=1` - 790 app (up from 742: 48 new tests, none
+removed) + 42 lsp-core + 14 pty-core + 98 wt-core.

--- a/BUILD-LOG.md
+++ b/BUILD-LOG.md
@@ -2099,7 +2099,9 @@ in an unexpanded folder) now expands ancestors and records those expansions like
 with the row-builder closure, instead of re-walking the whole loaded tree on each of
 `uniform_list`'s three per-frame closure calls.
 
-An adversarial audit of the first draft found seven real problems, all fixed: `save_at` claimed
+An adversarial **self-review** of the first draft - a checker sub-agent the builder dispatched
+against its own work, not an independent or external audit - found seven real problems, all
+fixed: `save_at` claimed
 crash-safety it didn't have (no `fsync`, so only *process* crash was covered); a fixed `.tmp`
 name meant two `jerry` processes could interleave into one torn file, and whole-file writes made
 the last saver silently erase every other repository's state (writes now merge against a set of
@@ -2114,12 +2116,13 @@ on a still-rendered stale row recorded state against the wrong root; the live tr
 could diverge silently when a path wasn't recordable (now a three-state outcome and a real log
 line, with the expansion still happening - refusing to open a folder because of how its name is
 encoded would be worse than not remembering it); and one test asserted on state it had
-hand-written itself rather than on a walk that genuinely truncated. The audit also confirmed the
-absolute-positioning assumption directly against vendored taffy: absolute insets resolve against
+hand-written itself rather than on a walk that genuinely truncated. That same self-review also
+confirmed the absolute-positioning assumption directly against vendored taffy: absolute insets resolve against
 the container's border box, not its padding box, so a guide's `left` really is measured from the
 row's own left edge despite the row's left padding.
 
-A second audit of those fixes then caught the worst bug of the whole change: the merged write was
+A second self-review pass over those fixes (same mechanism, same caveat - the builder reviewing
+its own work) then caught the worst bug of the whole change: the merged write was
 *written but never wired* - one edit had silently failed to apply, so `persist_fold_state` still
 called the whole-file `save_at`, `save_merged_at` was reachable only from its own unit test, and
 `fold_state_owned` was write-only dead state, while three doc comments and this log claimed
@@ -2127,7 +2130,8 @@ otherwise. The unit test couldn't catch it (it called the unused function direct
 existing app-level leak test couldn't either (its second instance started before the first ever
 wrote, so a whole-file write preserved both). The regression test added for it drives the exact
 ordering that distinguishes the two - instance B starts, *then* A writes, *then* B writes - and
-was confirmed to fail against the un-wired version before being kept. The same round also found
+was confirmed to fail against the un-wired version before being kept. The same self-review round
+also found
 two more walk paths that could report an incomplete listing as complete (a `DirEntry` that errors
 mid-iteration, and a `file_type()` failure recording a real directory as a file - either one
 would have let pruning delete good fold state), a silent `Refused` in `reveal_in_tree` that
@@ -2139,7 +2143,55 @@ entries" behaviour. The remaining honest gap is stated in `fold_state`'s own mod
 than papered over: the merge is an unlocked read-modify-write, so two saves that genuinely
 interleave can still lose one update - it narrows the window rather than closing it.
 
+A third review round - this one genuinely independent, dispatched by the coordinator rather than
+by the builder - found four more real bugs, all fixed with revert-verified regression tests
+(each test was confirmed to fail against the pre-fix code before being kept):
+
+1. **"Load more" could shrink the tree.** `FileTreeSettings::sanitize` clamped `max_entries` up
+   but never down, so a hand-edited `max_entries` above the escalation ceiling made
+   `saturating_mul(10).min(ceiling)` compute a *smaller* budget than the one already in force -
+   one click on "load more" would visibly remove rows. The escalation is now monotonic
+   (`.max(current)`) and `max_entries` has a real upper clamp. Separately, once the ceiling was
+   reached the row remained a button that re-walked a full budget's worth of entries to produce
+   byte-identical results; at the ceiling it is now a plain, non-interactive disclosure, enforced
+   both in the render and in the handler.
+2. **Blocking `canonicalize` on the foreground thread, per gesture.** `fold_state::worktree_key`
+   calls `std::fs::canonicalize`, and it was being called once per expand/collapse and once *per
+   ancestor* in "reveal in tree" - up to a dozen blocking syscalls per gesture, which on a stale
+   NFS/FUSE mount is a frozen window rather than a slow one. The key is now resolved once per real
+   root change into `AdeApp::fold_state_root_key`, with `*_with_key` variants on `FoldState` for
+   every hot path. Resolving it lives in exactly one function (`set_file_tree_root`): the first
+   draft of this fix had the constructor computing it a second time, which the revert-verification
+   caught by passing when it should have failed - a real drift risk, closed by making startup go
+   through the same chokepoint as every later switch.
+3. **Unbounded main-thread work at the load ceiling.** Two foreground costs scale linearly with
+   loaded entries (`rebuild_palette_file_candidates` on load, the visible-row scan per frame), so
+   the ceiling was lowered to a number they can genuinely absorb, and `max_entries` clamps to the
+   same value. The sidebar still discloses the stop point, so this is a bounded honest cap rather
+   than a silent one.
+4. **A failed fold-state write was dropped.** The writer loop cleared its pending flag *before*
+   the write, so a real failure (full disk, read-only `~/.config`) lost the user's expand/collapse
+   with only a `log::warn!` - while the feature's whole claim is "recorded immediately". Failures
+   now re-queue with linear backoff and a bounded attempt budget, after which the next real
+   expand/collapse starts a fresh one.
+
+The same round also fixed: `reveal_in_tree` being a hand-copied second implementation of
+`set_dir_expanded`'s body (both now share one `record_dir_expanded`, and the reveal's missing
+`cx.notify()` - which worked only because every caller happened to notify afterwards - is gone);
+`theme::tree`'s two tokens being hand-copied hex duplicates instead of real aliases of
+`border::DIVIDER`/`border::SELECTED_EDGE`; a row-range clamp that guarded only the upper bound and
+would still have panicked on `start > end`; a doc comment claiming a fold change was written to
+disk "before this returns" when it is queued; the settings module's "every field is page-backed"
+invariant, which `file_tree.max_entries` genuinely breaks (now a documented exception rather than
+a quiet violation); and the missing test for the non-UTF-8 path refusal. The
+same-worktree-open-twice limitation of the merge (each instance replaces that key's whole entry,
+so two instances of one worktree revert each other for as long as both run) is now written down in
+`fold_state`'s module docs instead of being papered over by the "narrow window" claim, which was
+only true for the different-worktree case.
+
 All four gates clean: `cargo fmt --all -- --check`, `cargo build --workspace`,
 `cargo clippy --workspace --all-targets -- -D warnings`, and
-`cargo test --workspace --lib -- --test-threads=1` - 790 app (up from 742: 48 new tests, none
-removed) + 42 lsp-core + 14 pty-core + 98 wt-core.
+`cargo test --workspace --lib -- --test-threads=1` - 795 app (up from 742: 53 new tests, none
+removed) + 42 lsp-core + 14 pty-core + 98 wt-core. One full run hit the project's known
+diff-rendering flake (`opening_a_real_diff_renders_real_syntax_highlighted_rows`); it passed alone,
+passed with its whole module, and the next full run was green with no other change.

--- a/crates/app/src/code_surface/tabs.rs
+++ b/crates/app/src/code_surface/tabs.rs
@@ -113,6 +113,12 @@ impl AdeApp {
         self.push_open_file(&relative);
         self.open_change = Some(relative.clone());
         self.code_view = code_view::CodeView::File;
+        // Every "this file is now the selected tree row" path reveals it (GitHub issue #18 §5).
+        // A click in the tree has its ancestors expanded already, so this is a no-op there - but
+        // go-to-definition (`Self::navigate_to_definition`) lands on files in folders nobody has
+        // expanded, and now that the tree starts collapsed, highlighting a row that isn't
+        // showing would be no highlight at all.
+        self.reveal_in_tree(&path, cx);
         self.selected_tree_path = Some(path);
         self.refresh_open_diff_file_cache();
         // See `Self::select_worktree`'s identical reset for why - and `Self::open_change_diff`'s

--- a/crates/app/src/palette/render.rs
+++ b/crates/app/src/palette/render.rs
@@ -45,8 +45,8 @@ impl AdeApp {
     /// built fresh every call so what's drawn and what `⏎`/`↑`/`↓` act on can never disagree.
     ///
     /// `sessions`/`commands` are cheap (bounded by open-tab count plus 10 fixed commands) and
-    /// built fresh here. `files` is the expensive part (up to `file_tree::MAX_ENTRIES` = 5000
-    /// entries) and is *not* rebuilt here - this reads [`Self::palette_file_candidates`], which
+    /// built fresh here. `files` is the expensive part (as many entries as the whole loaded
+    /// tree has, bounded by `Settings.file_tree.max_entries`) and is *not* rebuilt here - this reads [`Self::palette_file_candidates`], which
     /// [`Self::rebuild_palette_file_candidates`] keeps current at its own two mutation points.
     pub(crate) fn build_palette_groups(&self, cx: &App) -> Vec<palette::PaletteGroup> {
         let sessions: Vec<palette::SessionCandidate> = self
@@ -295,7 +295,10 @@ impl AdeApp {
     /// a file with no diff to open instead reveals it in the Files tree - switches Zone 3 to
     /// `Files`, expands every ancestor directory, and highlights it via
     /// [`Self::selected_tree_path`].
-    pub(in crate::palette) fn open_palette_file_result(
+    // `pub(crate)`, not `pub(in crate::palette)`: `crate::sidebar::render`'s own
+    // "reveal in tree" regression test drives this real flow rather than calling
+    // `AdeApp::reveal_in_tree` directly, so that the wiring between the two is what's covered.
+    pub(crate) fn open_palette_file_result(
         &mut self,
         path: PathBuf,
         window: &mut Window,
@@ -317,9 +320,9 @@ impl AdeApp {
             self.open_change_diff(relative, window, cx);
         } else {
             self.right_sidebar_view = RightSidebarView::Files;
-            for ancestor in path.ancestors() {
-                self.collapsed_dirs.remove(ancestor);
-            }
+            // Expands every ancestor *and records those expansions on disk*, exactly like a
+            // manual click (issue #18 §5) - not a transient, this-session-only reveal.
+            self.reveal_in_tree(&path, cx);
             self.selected_tree_path = Some(path);
             cx.notify();
         }

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -197,6 +197,15 @@ pub(crate) type DiffHighlightCache = (
     Vec<Vec<(Option<usize>, Option<usize>)>>,
 );
 
+/// How many times [`AdeApp::persist_fold_state`]'s writer loop retries a failing write before
+/// giving up on it. Bounded so a permanently broken path (a read-only `~/.config`, say) can't
+/// spin the loop forever; the next real expand/collapse starts a fresh budget, since a new user
+/// action is the honest trigger for trying again.
+pub(crate) const FOLD_STATE_SAVE_MAX_ATTEMPTS: u32 = 5;
+
+/// Multiplied by the attempt number for [`AdeApp::persist_fold_state`]'s linear retry backoff.
+pub(crate) const FOLD_STATE_SAVE_RETRY_BACKOFF: Duration = Duration::from_millis(250);
+
 /// How often [`AdeApp::ensure_lsp_poll_task`]'s background loop checks for a newly-arrived
 /// `publishDiagnostics` notification. Coarser than `crate::terminal::pane::POLL_INTERVAL` (8ms):
 /// pty output is latency-sensitive, rust-analyzer's diagnostics are not.
@@ -246,6 +255,15 @@ pub struct AdeApp {
     /// [`Self::settings_path`], and `None` for exactly the same tests that get a `None` settings
     /// path, which makes a fold-state save a real no-op rather than a special-cased test skip.
     pub(crate) fold_state_path: Option<PathBuf>,
+    /// [`Self::file_tree_root`]'s resolved `fold_state::worktree_key`, recomputed exactly once
+    /// per real root change (`Self::set_file_tree_root`) rather than per lookup. That caching is
+    /// not a micro-optimization: `worktree_key` calls `std::fs::canonicalize`, and the callers
+    /// are an expand/collapse click and - once per ancestor - a "reveal in tree", so resolving it
+    /// on demand meant up to a dozen blocking syscalls on the foreground thread per gesture,
+    /// which on a stale NFS/FUSE mount is a frozen window rather than a slow one. `None` when the
+    /// root isn't valid UTF-8 (see `worktree_key`), which makes every record attempt a logged
+    /// refusal instead of a silent mis-key.
+    pub(crate) fold_state_root_key: Option<String>,
     /// The `fold_state::worktree_key`s this instance has recorded anything for - what
     /// [`Self::persist_fold_state`] hands `FoldState::save_merged_at` as "mine to overwrite".
     /// Every other key in the file belongs to some other running instance (one `jerry` process
@@ -1114,30 +1132,71 @@ impl AdeApp {
             return;
         }
         self.fold_state_save_running = true;
-        let task = cx.spawn(async move |this, cx| loop {
-            // The state and the owned-key set are read in the *same* synchronous step, so the
-            // pair handed to `save_merged_at` can never be a mix of two different moments.
-            let step = this.update(cx, |this, _cx| {
-                if this.fold_state_save_pending {
-                    this.fold_state_save_pending = false;
-                    Some((this.fold_state.clone(), this.fold_state_owned.clone()))
-                } else {
-                    this.fold_state_save_running = false;
-                    None
+        let task = cx.spawn(async move |this, cx| {
+            let mut attempt: u32 = 0;
+            loop {
+                // The state and the owned-key set are read in the *same* synchronous step, so the
+                // pair handed to `save_merged_at` can never be a mix of two different moments.
+                let step = this.update(cx, |this, _cx| {
+                    if this.fold_state_save_pending {
+                        this.fold_state_save_pending = false;
+                        Some((this.fold_state.clone(), this.fold_state_owned.clone()))
+                    } else {
+                        this.fold_state_save_running = false;
+                        None
+                    }
+                });
+                let Ok(Some((state, owned))) = step else {
+                    break;
+                };
+                let result = cx
+                    .background_executor()
+                    .spawn({
+                        let path = path.clone();
+                        async move { state.save_merged_at(&path, &owned) }
+                    })
+                    .await;
+                match result {
+                    Ok(()) => attempt = 0,
+                    Err(err) => {
+                        // Do **not** drop the change. `fold_state_save_pending` was cleared above,
+                        // before the write, so without this a real failure (disk full, a read-only
+                        // `~/.config`, a permissions change) would lose the user's expand/collapse
+                        // with nothing but a log line - while this feature's whole claim is that a
+                        // fold change is recorded immediately. Re-marking it pending means the very
+                        // next iteration rewrites the *current* state, which is also why this needs
+                        // no queue: only the latest value ever matters.
+                        attempt += 1;
+                        if attempt > FOLD_STATE_SAVE_MAX_ATTEMPTS {
+                            log::error!(
+                            "giving up saving {} after {FOLD_STATE_SAVE_MAX_ATTEMPTS} attempts \
+                             ({err}) - file-tree fold state will not persist until something \
+                             changes again",
+                            path.display()
+                        );
+                            // Deliberately *not* re-marked pending: a permanently broken path would
+                            // otherwise spin this loop forever. A later real expand/collapse calls
+                            // `persist_fold_state` again and starts a fresh attempt budget, which is
+                            // the right retry trigger - the user did something new.
+                            continue;
+                        }
+                        log::warn!(
+                        "failed to save {} (attempt {attempt}/{FOLD_STATE_SAVE_MAX_ATTEMPTS}): \
+                         {err} - retrying",
+                        path.display()
+                    );
+                        let requeued =
+                            this.update(cx, |this, _cx| this.fold_state_save_pending = true);
+                        if requeued.is_err() {
+                            break;
+                        }
+                        // Linear backoff, so a transient failure (a full disk being cleared, a mount
+                        // coming back) is retried promptly without hammering a broken path.
+                        cx.background_executor()
+                            .timer(FOLD_STATE_SAVE_RETRY_BACKOFF * attempt)
+                            .await;
+                    }
                 }
-            });
-            let Ok(Some((state, owned))) = step else {
-                break;
-            };
-            let result = cx
-                .background_executor()
-                .spawn({
-                    let path = path.clone();
-                    async move { state.save_merged_at(&path, &owned) }
-                })
-                .await;
-            if let Err(err) = result {
-                log::warn!("failed to save {}: {err}", path.display());
             }
         });
         self._fold_state_save_task = Some(task);

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -75,6 +75,7 @@ use crate::settings::state::SettingsPage;
 use crate::settings::store::{self as settings_store, CfgFormat, Settings};
 use crate::sidebar::changes::{self, ChangeTag};
 use crate::sidebar::file_tree::{self, FileTreeEntry};
+use crate::sidebar::fold_state;
 use crate::status_bar::process_stats;
 use crate::theme;
 use crate::title_bar::menu as title_bar;
@@ -177,7 +178,8 @@ pub(crate) const STATUS_POLL_INTERVAL: Duration = Duration::from_secs(3);
 pub(crate) const FILE_FRESHNESS_CHECK_INTERVAL: Duration = Duration::from_millis(500);
 
 /// Cap on how many changed files the diff view renders, independent of `wt_core::diff`'s own
-/// `MAX_FILES` cap (300) on the loaded diff. Mirrors `file_tree::MAX_RENDERED_FILE_ENTRIES`.
+/// `MAX_FILES` cap (300) on the loaded diff. The Files tree used to have a matching
+/// render cap; it no longer does (GitHub issue #18 §4), so this one now stands alone.
 pub(crate) const MAX_RENDERED_DIFF_FILES: usize = 40;
 
 /// Cap on how many hunk lines a single file's diff renders, independent of `wt_core::diff`'s
@@ -225,11 +227,60 @@ pub struct AdeApp {
     /// [`Self::current_diff`]'s docs for exactly which [`DiffLoadState`]/[`DiffBase`]
     /// combinations count).
     pub(crate) diff_totals: Option<(u32, u32)>,
-    /// Real collapse/expand state for the file tree - a directory's path is in this set iff
-    /// the user has collapsed it (see `crate::sidebar::file_tree::visible_entries`, which this set
-    /// feeds directly). Absence means expanded, so a freshly loaded tree starts fully open,
-    /// matching the design's own default screenshots.
-    pub(crate) collapsed_dirs: HashSet<PathBuf>,
+    /// Real expand/collapse state for the file tree - a directory's absolute path is in this set
+    /// iff it is expanded (see `crate::sidebar::file_tree::visible_entries`, which this set feeds
+    /// directly). **Absence means collapsed**, so a worktree opened for the first time shows only
+    /// its root-level entries (GitHub issue #18 §1).
+    ///
+    /// This is the live, in-memory mirror of one worktree's entry in [`Self::fold_state`]; every
+    /// mutation goes through `AdeApp::set_dir_expanded`/`collapse_all_dirs`/`reveal_in_tree`,
+    /// which keep the two in step and write the change to disk immediately. Re-derived from
+    /// `fold_state` on every worktree switch (`Self::select_worktree`), never carried across one.
+    pub(crate) expanded_dirs: HashSet<PathBuf>,
+    /// Every worktree's persisted fold state, loaded once at startup from
+    /// `~/.config/jerry/file-tree-state.toml` - see `crate::sidebar::fold_state`'s module docs
+    /// for the file's shape, its per-worktree-path keying, and why it is a separate file from
+    /// `settings.toml` with a genuinely atomic write path.
+    pub(crate) fold_state: fold_state::FoldState,
+    /// The resolved path [`Self::persist_fold_state`] writes to - a sibling of
+    /// [`Self::settings_path`], and `None` for exactly the same tests that get a `None` settings
+    /// path, which makes a fold-state save a real no-op rather than a special-cased test skip.
+    pub(crate) fold_state_path: Option<PathBuf>,
+    /// The `fold_state::worktree_key`s this instance has recorded anything for - what
+    /// [`Self::persist_fold_state`] hands `FoldState::save_merged_at` as "mine to overwrite".
+    /// Every other key in the file belongs to some other running instance (one `jerry` process
+    /// per repository) and is passed through untouched; see `crate::sidebar::fold_state`'s
+    /// module docs for the whole-file-clobber this exists to prevent.
+    pub(crate) fold_state_owned: std::collections::BTreeSet<String>,
+    /// The fold-state file's serial writer loop - the exact same mechanism (and the same
+    /// reasoning) as [`Self::_settings_save_task`], just for the other file. Two writes to one
+    /// path are never allowed to overlap; a change that lands while a write is in flight is
+    /// picked up by the still-running loop.
+    pub(crate) _fold_state_save_task: Option<Task<()>>,
+    /// See [`Self::settings_save_pending`] - same contract, for the fold-state file.
+    pub(crate) fold_state_save_pending: bool,
+    /// See [`Self::settings_save_running`] - same contract, for the fold-state file.
+    pub(crate) fold_state_save_running: bool,
+    /// Whether the last completed file-tree walk stopped early at its configured entry cap
+    /// (`Settings.file_tree.max_entries`, or [`Self::file_tree_limit_override`]). Drives the
+    /// sidebar's real "load more" action - the explicit replacement for the removed
+    /// "... and N more entries not shown" row.
+    pub(crate) file_tree_truncated: bool,
+    /// Whether that walk was a *complete* inventory of the worktree's directories
+    /// (`file_tree::FileTreeListing::is_complete`) - false when it was truncated, and also when
+    /// it silently skipped an unreadable or too-deep subdirectory. The only condition under
+    /// which `AdeApp::prune_stale_fold_state` may read "not in this listing" as "deleted".
+    pub(crate) file_tree_complete: bool,
+    /// Set by the sidebar's "load more" action (`Self::load_more_file_tree_entries`): the cap
+    /// this worktree's walks use instead of `Settings.file_tree.max_entries`, raised tenfold per
+    /// click. Deliberately still a cap and never `None`: a single click that re-walked a
+    /// bind-mounted `$HOME` with an unbounded budget would allocate millions of `PathBuf`s on a
+    /// background thread and then hand them all to `rebuild_palette_file_candidates`. Each click
+    /// raises the bound and the row keeps reporting where the walk stopped, so the listing is
+    /// never *silently* cut off - which is what issue #18 §4 actually asks for. Session-scoped
+    /// and per-worktree: reset on every worktree switch, since "show me more of *this* tree"
+    /// says nothing about the next one.
+    pub(crate) file_tree_limit_override: Option<usize>,
     /// Per-file "reviewed" toggle state for the Changes list - a file's path is in this set iff
     /// its checkbox is checked. No backend "review" concept exists yet; this is purely local UI
     /// state that `Self::render_changes_header`'s progress bar and count read directly.
@@ -418,7 +469,7 @@ pub struct AdeApp {
     /// [`OverlayFocus`]/[`restore_focus`].
     pub(crate) palette_focus: OverlayFocus,
     /// The palette's file-candidate list (`crate::palette::state::FileCandidate`, one per non-directory
-    /// [`Self::file_tree`] entry, up to `file_tree::MAX_ENTRIES` = 5000) - built once by
+    /// [`Self::file_tree`] entry, up to `Settings.file_tree.max_entries`) - built once by
     /// [`Self::rebuild_palette_file_candidates`] when `file_tree`/the diff reload, not rebuilt on
     /// every `Self::build_palette_groups` call (which runs on every render while the palette is
     /// open, up to ~30x/sec during a streaming session). Session/command candidates aren't
@@ -1037,6 +1088,59 @@ impl AdeApp {
     #[cfg(test)]
     pub(crate) fn set_settings_save_test_delay(&mut self, delay: Option<Duration>) {
         self.settings_save_test_delay = delay;
+    }
+
+    /// Queues a background-executor save of [`Self::fold_state`] to [`Self::fold_state_path`].
+    /// Called from every single expand/collapse - that immediacy is the point (GitHub issue #18
+    /// §2 asks for fold changes to be "recorded immediately (crash-safe), not only on clean
+    /// exit"), and `FoldState::save_at`'s write-temp-then-rename is what makes an interrupted
+    /// write a no-op rather than a corrupted file.
+    ///
+    /// Structurally identical to [`Self::persist_settings`], including the "clear the running
+    /// flag in the same synchronous step that decides to stop" trick that keeps a change landing
+    /// at exactly the wrong moment from being silently dropped - see that method's own docs for
+    /// the full reasoning. It is a genuine no-op with a `None` path (every GPUI test that hasn't
+    /// asked for a real one).
+    ///
+    /// Unlike settings, the write is a *merge* (`FoldState::save_merged_at` against
+    /// [`Self::fold_state_owned`]): a second `jerry` process browsing a different repository is
+    /// writing the same file, and a whole-file write would erase its state.
+    pub(crate) fn persist_fold_state(&mut self, cx: &mut Context<Self>) {
+        let Some(path) = self.fold_state_path.clone() else {
+            return;
+        };
+        self.fold_state_save_pending = true;
+        if self.fold_state_save_running {
+            return;
+        }
+        self.fold_state_save_running = true;
+        let task = cx.spawn(async move |this, cx| loop {
+            // The state and the owned-key set are read in the *same* synchronous step, so the
+            // pair handed to `save_merged_at` can never be a mix of two different moments.
+            let step = this.update(cx, |this, _cx| {
+                if this.fold_state_save_pending {
+                    this.fold_state_save_pending = false;
+                    Some((this.fold_state.clone(), this.fold_state_owned.clone()))
+                } else {
+                    this.fold_state_save_running = false;
+                    None
+                }
+            });
+            let Ok(Some((state, owned))) = step else {
+                break;
+            };
+            let result = cx
+                .background_executor()
+                .spawn({
+                    let path = path.clone();
+                    async move { state.save_merged_at(&path, &owned) }
+                })
+                .await;
+            if let Err(err) = result {
+                log::warn!("failed to save {}: {err}", path.display());
+            }
+        });
+        self._fold_state_save_task = Some(task);
     }
 }
 

--- a/crates/app/src/root/new_file.rs
+++ b/crates/app/src/root/new_file.rs
@@ -273,6 +273,11 @@ impl AdeApp {
         self.open_change = Some(relative.clone());
         self.code_view = code_view::CodeView::File;
         self.selected_tree_path = Some(absolute_path.clone());
+        // Now that the tree starts collapsed (GitHub issue #18 §1), a file created inside a
+        // folder nobody has expanded yet would otherwise be highlighted on a row that isn't
+        // showing at all. Same real reveal - and same recorded expansions - as the palette's own
+        // "reveal in tree".
+        self.reveal_in_tree(&absolute_path, cx);
         self.edit_buffers.insert(
             relative,
             edit_buffer::EditBuffer::new(absolute_path, String::new(), extension, None, 0),

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -26,6 +26,22 @@ impl AdeApp {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
+        // The fold-state file is resolved as a sibling of whatever settings path this instance
+        // was given (`crate::sidebar::fold_state::fold_state_path_for`), so a test with a
+        // temp-dir settings path gets real, isolated fold-state persistence and a test with
+        // `None` gets none at all - the same seam, one decision.
+        let fold_state_path = settings_path
+            .as_deref()
+            .map(fold_state::fold_state_path_for);
+        let fold_state = fold_state_path
+            .as_deref()
+            .map(fold_state::FoldState::load_at)
+            .unwrap_or_default();
+        // Issue #18 §1/§2: the tree opens with exactly what this worktree had expanded last
+        // time, which for a worktree this file has never seen (including a freshly created one)
+        // is nothing at all.
+        let expanded_dirs = fold_state.expanded_dirs(&repo_path);
+
         let mut this = Self {
             file_tree_root: repo_path.clone(),
             diff_root: repo_path.clone(),
@@ -39,7 +55,17 @@ impl AdeApp {
             right_sidebar_view: RightSidebarView::Files,
             diff_state: DiffLoadState::Loading,
             diff_totals: None,
-            collapsed_dirs: HashSet::new(),
+            expanded_dirs,
+            fold_state,
+            fold_state_path,
+            fold_state_owned: std::collections::BTreeSet::new(),
+            _fold_state_save_task: None,
+            fold_state_save_pending: false,
+            fold_state_save_running: false,
+            file_tree_truncated: false,
+            // Nothing has been walked yet, so nothing may be pruned yet either.
+            file_tree_complete: false,
+            file_tree_limit_override: None,
             reviewed_files: HashSet::new(),
             open_files: Vec::new(),
             open_change: None,
@@ -280,24 +306,44 @@ impl AdeApp {
         self._disk_usage_task = Some(task);
     }
 
-    pub(super) fn load_file_tree(&mut self, root: PathBuf, cx: &mut Context<Self>) {
+    pub(crate) fn load_file_tree(&mut self, root: PathBuf, cx: &mut Context<Self>) {
         self.file_tree_root = root.clone();
+        // Always a real bound - see [`Self::file_tree_limit_override`] for why even the "load
+        // more" escape hatch raises the cap rather than removing it.
+        let limit = Some(
+            self.file_tree_limit_override
+                .unwrap_or(self.settings.file_tree.max_entries),
+        );
         let task = cx.spawn(async move |this, cx| {
             let result = cx
                 .background_executor()
                 .spawn({
                     let root = root.clone();
-                    async move { file_tree::build_file_tree(&root) }
+                    async move { file_tree::build_file_tree(&root, limit) }
                 })
                 .await;
             let _ = this.update(cx, |this, cx| {
+                // Identity guard: a worktree switch that lands while this walk is still running
+                // replaces `_load_file_tree_task` (cancelling it) *and* moves
+                // `file_tree_root` - but a task already past its `await` point can still reach
+                // here. Applying a stale walk would show one worktree's tree under another's
+                // root, and - far worse now - prune the *new* worktree's fold state against the
+                // *old* worktree's directory list.
+                if this.file_tree_root != root {
+                    return;
+                }
                 match result {
-                    Ok(entries) => {
-                        this.file_tree = entries;
+                    Ok(listing) => {
+                        this.file_tree_truncated = listing.truncated;
+                        this.file_tree_complete = listing.is_complete();
+                        this.file_tree = listing.entries;
                         this.file_tree_error = None;
+                        this.prune_stale_fold_state(cx);
                     }
                     Err(err) => {
                         this.file_tree = Vec::new();
+                        this.file_tree_truncated = false;
+                        this.file_tree_complete = false;
                         this.file_tree_error = Some(err.to_string());
                     }
                 }
@@ -363,10 +409,29 @@ impl AdeApp {
             &mut self.reviewed_files,
             &mut self.open_files,
             &mut self.open_change,
-            &mut self.collapsed_dirs,
+            &mut self.expanded_dirs,
             &mut self.selected_tree_path,
             &mut self.edit_buffers,
         );
+        // The tree's fold state is per-worktree *persisted* state, not merely per-worktree
+        // transient state: the reset above clears the live set, and this re-derives it from the
+        // worktree genuinely being switched *to*. A worktree with no recorded state (a freshly
+        // created one, say) gets an empty set and so opens fully collapsed - the issue's own
+        // suggested answer to "does a fresh worktree inherit anything".
+        //
+        // `file_tree_root`/`file_tree` move in the *same* step, deliberately: `load_file_tree`
+        // below sets the root too, but its walk is asynchronous, so without this the frames
+        // between here and the walk landing would render the worktree just left's rows against
+        // the new worktree's expanded set - and a click on one of those stale rows would reach
+        // `set_dir_expanded` with a path from a different worktree entirely. Clearing
+        // `file_tree` makes that window render an honestly empty tree instead.
+        self.file_tree_root = path.clone();
+        self.file_tree = Vec::new();
+        self.expanded_dirs = self.fold_state.expanded_dirs(&path);
+        // "Show me the whole listing" was a decision about the worktree being left.
+        self.file_tree_limit_override = None;
+        self.file_tree_truncated = false;
+        self.file_tree_complete = false;
         // `focus_newly_spawned_session` (despite its name - its body has no "newly spawned" logic
         // in it, just the shared "move focus unless a file tab/Settings is showing" guard) closes
         // the dangling-focus risk this switch creates: the previously-active session's pane may
@@ -483,22 +548,25 @@ impl AdeApp {
 /// called from [`AdeApp::select_worktree`] on every switch. `reviewed_files`/`open_files`/
 /// `open_change` are keyed by repo-relative paths with no per-worktree scoping of their own, so
 /// without this reset a file reviewed or opened in worktree A would read as already-reviewed (or
-/// reopen) in worktree B if it shares the same relative path. `collapsed_dirs` is keyed by
-/// absolute path, so it doesn't bleed the same way, but nothing else ever pruned its entries
-/// either. A free, `gpui`-free function so this is unit-testable without constructing an
+/// reopen) in worktree B if it shares the same relative path. `expanded_dirs` is keyed by
+/// absolute path, so it doesn't bleed the same way - but it must still be emptied here, because
+/// [`AdeApp::select_worktree`] re-derives it from the *new* worktree's own persisted fold state
+/// immediately afterwards, and a leftover entry from the worktree just left would otherwise
+/// survive that (its absolute path simply never matches anything in the new tree, so nothing
+/// would ever remove it). A free, `gpui`-free function so this is unit-testable without constructing an
 /// `AdeApp`.
 pub(super) fn reset_per_worktree_ui_state(
     reviewed_files: &mut HashSet<PathBuf>,
     open_files: &mut Vec<PathBuf>,
     open_change: &mut Option<PathBuf>,
-    collapsed_dirs: &mut HashSet<PathBuf>,
+    expanded_dirs: &mut HashSet<PathBuf>,
     selected_tree_path: &mut Option<PathBuf>,
     edit_buffers: &mut HashMap<PathBuf, edit_buffer::EditBuffer>,
 ) {
     reviewed_files.clear();
     open_files.clear();
     *open_change = None;
-    collapsed_dirs.clear();
+    expanded_dirs.clear();
     *selected_tree_path = None;
     // Real, live unsaved-edit state (Revision R8.5a) is just as worktree-relative-path-keyed as
     // `open_files` above - without this, a same-named file in a different worktree could
@@ -517,7 +585,7 @@ mod tests {
         reviewed_files.insert(PathBuf::from("Cargo.toml"));
         let mut open_files = Vec::new();
         let mut open_change = Some(PathBuf::from("src/main.rs"));
-        let mut collapsed_dirs = HashSet::new();
+        let mut expanded_dirs = HashSet::new();
         let mut selected_tree_path = None;
         let mut edit_buffers = HashMap::new();
 
@@ -525,7 +593,7 @@ mod tests {
             &mut reviewed_files,
             &mut open_files,
             &mut open_change,
-            &mut collapsed_dirs,
+            &mut expanded_dirs,
             &mut selected_tree_path,
             &mut edit_buffers,
         );
@@ -544,7 +612,7 @@ mod tests {
             PathBuf::from("README.md"),
         ];
         let mut open_change = Some(PathBuf::from("Cargo.toml"));
-        let mut collapsed_dirs = HashSet::new();
+        let mut expanded_dirs = HashSet::new();
         let mut selected_tree_path = None;
         let mut edit_buffers = HashMap::new();
 
@@ -552,7 +620,7 @@ mod tests {
             &mut reviewed_files,
             &mut open_files,
             &mut open_change,
-            &mut collapsed_dirs,
+            &mut expanded_dirs,
             &mut selected_tree_path,
             &mut edit_buffers,
         );
@@ -569,7 +637,7 @@ mod tests {
         let mut reviewed_files = HashSet::new();
         let mut open_files = Vec::new();
         let mut open_change = None;
-        let mut collapsed_dirs = HashSet::new();
+        let mut expanded_dirs = HashSet::new();
         let mut selected_tree_path = None;
         let mut edit_buffers = HashMap::new();
 
@@ -577,37 +645,37 @@ mod tests {
             &mut reviewed_files,
             &mut open_files,
             &mut open_change,
-            &mut collapsed_dirs,
+            &mut expanded_dirs,
             &mut selected_tree_path,
             &mut edit_buffers,
         );
 
         assert!(reviewed_files.is_empty());
         assert_eq!(open_change, None);
-        assert!(collapsed_dirs.is_empty());
+        assert!(expanded_dirs.is_empty());
     }
 
     #[test]
-    fn reset_per_worktree_ui_state_clears_collapsed_dirs_too() {
+    fn reset_per_worktree_ui_state_clears_expanded_dirs_too() {
         let mut reviewed_files = HashSet::new();
         let mut open_files = Vec::new();
         let mut open_change = None;
-        let mut collapsed_dirs = HashSet::new();
+        let mut expanded_dirs = HashSet::new();
         let mut selected_tree_path = None;
         let mut edit_buffers = HashMap::new();
-        collapsed_dirs.insert(PathBuf::from("/repo/worktree-a/src"));
-        collapsed_dirs.insert(PathBuf::from("/repo/worktree-a/tests"));
+        expanded_dirs.insert(PathBuf::from("/repo/worktree-a/src"));
+        expanded_dirs.insert(PathBuf::from("/repo/worktree-a/tests"));
 
         reset_per_worktree_ui_state(
             &mut reviewed_files,
             &mut open_files,
             &mut open_change,
-            &mut collapsed_dirs,
+            &mut expanded_dirs,
             &mut selected_tree_path,
             &mut edit_buffers,
         );
 
-        assert!(collapsed_dirs.is_empty());
+        assert!(expanded_dirs.is_empty());
     }
 
     #[test]
@@ -615,7 +683,7 @@ mod tests {
         let mut reviewed_files = HashSet::new();
         let mut open_files = Vec::new();
         let mut open_change = None;
-        let mut collapsed_dirs = HashSet::new();
+        let mut expanded_dirs = HashSet::new();
         let mut selected_tree_path = Some(PathBuf::from("/repo/worktree-a/src/main.rs"));
         let mut edit_buffers = HashMap::new();
 
@@ -623,7 +691,7 @@ mod tests {
             &mut reviewed_files,
             &mut open_files,
             &mut open_change,
-            &mut collapsed_dirs,
+            &mut expanded_dirs,
             &mut selected_tree_path,
             &mut edit_buffers,
         );
@@ -639,7 +707,7 @@ mod tests {
         let mut reviewed_files = HashSet::new();
         let mut open_files = Vec::new();
         let mut open_change = None;
-        let mut collapsed_dirs = HashSet::new();
+        let mut expanded_dirs = HashSet::new();
         let mut selected_tree_path = None;
         let mut edit_buffers = HashMap::new();
         edit_buffers.insert(
@@ -657,7 +725,7 @@ mod tests {
             &mut reviewed_files,
             &mut open_files,
             &mut open_change,
-            &mut collapsed_dirs,
+            &mut expanded_dirs,
             &mut selected_tree_path,
             &mut edit_buffers,
         );

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -40,7 +40,6 @@ impl AdeApp {
         // Issue #18 §1/§2: the tree opens with exactly what this worktree had expanded last
         // time, which for a worktree this file has never seen (including a freshly created one)
         // is nothing at all.
-        let expanded_dirs = fold_state.expanded_dirs(&repo_path);
 
         let mut this = Self {
             file_tree_root: repo_path.clone(),
@@ -55,9 +54,14 @@ impl AdeApp {
             right_sidebar_view: RightSidebarView::Files,
             diff_state: DiffLoadState::Loading,
             diff_totals: None,
-            expanded_dirs,
+            // Both are filled in immediately after this literal, through the same single
+            // chokepoints every later change uses (`set_file_tree_root` +
+            // `reload_expanded_dirs_from_fold_state`) - a second, constructor-only copy of that
+            // resolution is exactly how the cached key and the root it describes drift apart.
+            expanded_dirs: HashSet::new(),
             fold_state,
             fold_state_path,
+            fold_state_root_key: None,
             fold_state_owned: std::collections::BTreeSet::new(),
             _fold_state_save_task: None,
             fold_state_save_pending: false,
@@ -207,6 +211,11 @@ impl AdeApp {
             new_file_focus_handle: cx.focus_handle(),
             new_file_error: None,
         };
+        // See the `expanded_dirs`/`fold_state_root_key` note in the literal above: resolving the
+        // worktree key here, through the one function that ever resolves it, is what keeps the
+        // startup path and every later worktree switch structurally identical.
+        this.set_file_tree_root(repo_path.clone());
+        this.reload_expanded_dirs_from_fold_state();
         // Applies `this.settings.keymap.overrides` on top of `crate::default_key_bindings()` -
         // see `Self::apply_effective_key_bindings`'s own docs. Must run before this constructor
         // returns and the entity's first render, so a persisted rebind is live from the very
@@ -306,8 +315,33 @@ impl AdeApp {
         self._disk_usage_task = Some(task);
     }
 
+    /// The **one** place [`Self::file_tree_root`] is ever assigned, so its cached
+    /// `fold_state_root_key` can never drift out of step with it - the identity-guard discipline
+    /// this codebase has been bitten by repeatedly, applied to a derived value rather than a
+    /// borrowed one. `worktree_key`'s blocking `canonicalize` therefore runs once per real
+    /// worktree change and never on a click or a render.
+    /// Re-derives [`Self::expanded_dirs`] from the persisted fold state for whatever
+    /// [`Self::file_tree_root`] currently is - the one place that mapping is made, shared by
+    /// startup and by every worktree switch.
+    pub(crate) fn reload_expanded_dirs_from_fold_state(&mut self) {
+        self.expanded_dirs = match &self.fold_state_root_key {
+            Some(key) => self
+                .fold_state
+                .expanded_dirs_with_key(key, &self.file_tree_root),
+            None => HashSet::new(),
+        };
+    }
+
+    pub(crate) fn set_file_tree_root(&mut self, root: PathBuf) {
+        if self.file_tree_root == root && self.fold_state_root_key.is_some() {
+            return;
+        }
+        self.fold_state_root_key = fold_state::worktree_key(&root);
+        self.file_tree_root = root;
+    }
+
     pub(crate) fn load_file_tree(&mut self, root: PathBuf, cx: &mut Context<Self>) {
-        self.file_tree_root = root.clone();
+        self.set_file_tree_root(root.clone());
         // Always a real bound - see [`Self::file_tree_limit_override`] for why even the "load
         // more" escape hatch raises the cap rather than removing it.
         let limit = Some(
@@ -425,9 +459,9 @@ impl AdeApp {
         // the new worktree's expanded set - and a click on one of those stale rows would reach
         // `set_dir_expanded` with a path from a different worktree entirely. Clearing
         // `file_tree` makes that window render an honestly empty tree instead.
-        self.file_tree_root = path.clone();
+        self.set_file_tree_root(path.clone());
         self.file_tree = Vec::new();
-        self.expanded_dirs = self.fold_state.expanded_dirs(&path);
+        self.reload_expanded_dirs_from_fold_state();
         // "Show me the whole listing" was a decision about the worktree being left.
         self.file_tree_limit_override = None;
         self.file_tree_truncated = false;

--- a/crates/app/src/settings/store.rs
+++ b/crates/app/src/settings/store.rs
@@ -77,6 +77,7 @@ pub struct Settings {
     pub appearance: AppearanceSettings,
     pub theme: ThemeSettings,
     pub keymap: KeymapSettings,
+    pub file_tree: FileTreeSettings,
 }
 
 /// `crate::root::AdeApp::window_controls_style`'s persisted backing - see
@@ -222,6 +223,41 @@ pub struct KeybindingOverride {
     pub keystrokes: String,
 }
 
+/// The Files tree's one real tunable (GitHub issue #18 §4): how many entries a single
+/// `crate::sidebar::file_tree::build_file_tree` walk will collect before stopping. Not backed by a
+/// settings *page* (unlike every other section here) - it's the "large, configurable" cap the
+/// issue asks any surviving safety cap to be, edited from `settings.toml` directly, and when it
+/// is hit the sidebar shows a real "load more" action naming the count it stopped at, rather
+/// than a silent cut-off.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct FileTreeSettings {
+    pub max_entries: usize,
+}
+
+impl Default for FileTreeSettings {
+    fn default() -> Self {
+        Self {
+            max_entries: FILE_TREE_MAX_ENTRIES_DEFAULT,
+        }
+    }
+}
+
+/// 20,000 entries - four times the old hard-coded 5,000 bound, and comfortably more than any
+/// real source tree this app is meant for once dot-directories (`.git`, and with them the vast
+/// majority of a repository's loose files) are already skipped by the walk itself.
+pub const FILE_TREE_MAX_ENTRIES_DEFAULT: usize = 20_000;
+
+/// A hand-edited `max_entries` below this can't render a useful tree at all, so it's clamped up
+/// rather than honoured - the same [`AppearanceSettings::sanitize`] discipline applied here.
+pub const FILE_TREE_MAX_ENTRIES_MIN: usize = 100;
+
+impl FileTreeSettings {
+    pub fn sanitize(&mut self) {
+        self.max_entries = self.max_entries.max(FILE_TREE_MAX_ENTRIES_MIN);
+    }
+}
+
 /// The config banner's `TOML | JSON` segment state (`CHANGELOG.md`'s change 3) - a display-only
 /// choice, not a [`Settings`] field (switching it never touches the file) - see the module docs'
 /// "TOML is the real file; JSON is a read-only alternate view" section.
@@ -281,6 +317,7 @@ impl Settings {
             Ok(contents) => match toml::from_str::<Settings>(&contents) {
                 Ok(mut settings) => {
                     settings.appearance.sanitize();
+                    settings.file_tree.sanitize();
                     settings
                 }
                 Err(err) => {
@@ -470,6 +507,28 @@ mod tests {
         assert!(
             settings.keymap.overrides.is_empty(),
             "a fresh install has no real rebinds yet"
+        );
+        assert_eq!(
+            settings.file_tree.max_entries,
+            FILE_TREE_MAX_ENTRIES_DEFAULT
+        );
+    }
+
+    #[test]
+    fn a_hand_edited_file_tree_cap_round_trips_and_an_absurd_one_is_clamped() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("settings.toml");
+        std::fs::write(&path, "[file_tree]\nmax_entries = 120000\n").expect("write");
+        assert_eq!(
+            Settings::load_or_init_at(&path).file_tree.max_entries,
+            120_000
+        );
+
+        std::fs::write(&path, "[file_tree]\nmax_entries = 1\n").expect("write");
+        assert_eq!(
+            Settings::load_or_init_at(&path).file_tree.max_entries,
+            FILE_TREE_MAX_ENTRIES_MIN,
+            "a cap too small to render a usable tree is clamped up, not honoured"
         );
     }
 

--- a/crates/app/src/settings/store.rs
+++ b/crates/app/src/settings/store.rs
@@ -12,6 +12,13 @@
 //! `crate::settings::render`'s per-page docs for which) - no field exists here "for
 //! completeness" just because the mockup shows a row for it.
 //!
+//! One documented exception, added with GitHub issue #18: [`FileTreeSettings`] is read and
+//! applied for real (`crate::root::AdeApp::load_file_tree` bounds every walk with it) but has no
+//! settings *page* and appears in no config banner - it is a file-only tunable. It is called out
+//! here rather than quietly breaking the rule above: the invariant that still holds for every
+//! field, this one included, is "loaded, saved, and genuinely consumed by real behaviour"; what
+//! this one lacks is a UI surface, not a consumer.
+//!
 //! ## TOML is the real file; JSON is a read-only alternate view
 //!
 //! The config banner's `TOML | JSON` segment (`crate::settings::widgets::render_config_banner`)
@@ -252,9 +259,23 @@ pub const FILE_TREE_MAX_ENTRIES_DEFAULT: usize = 20_000;
 /// rather than honoured - the same [`AppearanceSettings::sanitize`] discipline applied here.
 pub const FILE_TREE_MAX_ENTRIES_MIN: usize = 100;
 
+/// And a real upper clamp, which the first version of this setting was missing. It is not an
+/// arbitrary round number: two pieces of *foreground-thread* work scale linearly with the number
+/// of loaded entries - `crate::root::AdeApp::rebuild_palette_file_candidates` allocates one
+/// candidate per file in the walk-completion handler, and `render_file_tree` scans every loaded
+/// entry once per frame to resolve which rows are visible. At 100,000 both are real but
+/// absorbable; at the millions a hand-edited file could otherwise ask for, the first is a
+/// multi-second freeze on load and the second is a per-frame one. This is the honest hard
+/// ceiling on how much tree this sidebar holds, and the tree says so (see
+/// `crate::sidebar::render::AdeApp::render_file_tree`'s truncation row) rather than cutting off
+/// silently.
+pub const FILE_TREE_MAX_ENTRIES_MAX: usize = 100_000;
+
 impl FileTreeSettings {
     pub fn sanitize(&mut self) {
-        self.max_entries = self.max_entries.max(FILE_TREE_MAX_ENTRIES_MIN);
+        self.max_entries = self
+            .max_entries
+            .clamp(FILE_TREE_MAX_ENTRIES_MIN, FILE_TREE_MAX_ENTRIES_MAX);
     }
 }
 
@@ -518,10 +539,17 @@ mod tests {
     fn a_hand_edited_file_tree_cap_round_trips_and_an_absurd_one_is_clamped() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("settings.toml");
-        std::fs::write(&path, "[file_tree]\nmax_entries = 120000\n").expect("write");
+        std::fs::write(&path, "[file_tree]\nmax_entries = 50000\n").expect("write");
         assert_eq!(
             Settings::load_or_init_at(&path).file_tree.max_entries,
-            120_000
+            50_000
+        );
+
+        std::fs::write(&path, "[file_tree]\nmax_entries = 5000000\n").expect("write");
+        assert_eq!(
+            Settings::load_or_init_at(&path).file_tree.max_entries,
+            FILE_TREE_MAX_ENTRIES_MAX,
+            "a cap larger than the foreground thread can absorb is clamped down, not honoured"
         );
 
         std::fs::write(&path, "[file_tree]\nmax_entries = 1\n").expect("write");

--- a/crates/app/src/sidebar/file_tree.rs
+++ b/crates/app/src/sidebar/file_tree.rs
@@ -3,8 +3,26 @@
 //!
 //! Dotfiles/dot-directories are skipped, matching most file explorers' defaults and, more
 //! importantly, keeping this fast: `.git` can contain many thousands of loose objects, and
-//! walking it would make browsing unusably slow. The walk is capped at [`MAX_ENTRIES`] total
-//! entries as a defensive bound; once hit, remaining entries are simply omitted.
+//! walking it would make browsing unusably slow.
+//!
+//! ## No entry is ever hidden without saying so (GitHub issue #18 §4)
+//!
+//! There is no longer a render-time cap: `crate::sidebar::render::AdeApp::render_file_tree` is a
+//! real virtualized `gpui::uniform_list`, so every visible row is rendered and only the rows
+//! genuinely on screen become elements. The old `MAX_RENDERED_FILE_ENTRIES` (500) cap and its
+//! "... and N more entries not shown" row are gone.
+//!
+//! One cap survives, and it is a *load* bound rather than a render one: the recursive walk is
+//! bounded by [`FileTreeSettings::max_entries`](crate::settings::store::FileTreeSettings), a
+//! real, configurable `settings.toml` value (20,000 by default). It exists because the walk is
+//! eager and synchronous - `crate::root::AdeApp::rebuild_palette_file_candidates` needs the whole
+//! tree for file search, so it cannot be made lazy - and pointing this app at a directory with a
+//! million files should not allocate a million `PathBuf`s before the first frame. When it is hit
+//! the listing reports [`FileTreeListing::truncated`] and the sidebar shows a real
+//! "Stopped at N entries - load more" action
+//! (`crate::sidebar::render::AdeApp::load_more_file_tree_entries`), which re-walks with a
+//! tenfold larger budget. Still a budget, deliberately - see that method's own docs - but the
+//! row always names the count the walk stopped at, so nothing is ever *silently* cut off.
 
 use std::collections::HashSet;
 use std::fs;
@@ -16,24 +34,6 @@ use gpui::Rgba;
 #[cfg(test)]
 use crate::theme;
 
-/// Defensive cap on how many entries [`build_file_tree`] will collect, regardless of how
-/// large the real tree is.
-const MAX_ENTRIES: usize = 5000;
-
-/// Cap on how many *visible* file-tree rows `crate::root::AdeApp::render_file_tree` will show,
-/// independent of [`MAX_ENTRIES`]'s much larger loaded-tree size. Also bounds
-/// [`visible_entries`]'s allocation.
-///
-/// This is no longer a layout-cost guard. It used to be: every one of these rows really was
-/// turned into a GPUI element on every render, and laying out that many `div`s per frame was a
-/// measured foreground stall while a terminal pane streams output - the dominant one, in fact
-/// (~145ms of a ~200ms `Window::draw` on a real tree, measured with `gpui::FrameTiming`).
-/// `render_file_tree` is a real virtualized `gpui::uniform_list` now, so only the rows genuinely
-/// on screen ever become elements and the per-frame cost no longer scales with this number at
-/// all. What survives is the honest product decision it also encodes: this list does not pretend
-/// to represent an unbounded tree, and says so with a "... and N more entries not shown" row.
-pub const MAX_RENDERED_FILE_ENTRIES: usize = 500;
-
 /// One row in the flattened file tree: a real filesystem entry, its path, and its depth
 /// (0 = direct child of the tree root) for indentation.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -44,23 +44,74 @@ pub struct FileTreeEntry {
     pub is_dir: bool,
 }
 
+/// A completed walk: the flattened entries, plus the two ways it can be less than the whole
+/// truth. `truncated` is the honest half of the load cap (see the module docs) and is what the
+/// sidebar's "load more" action keys off. `partial` covers the quieter case - a subdirectory the
+/// walk couldn't read, or one that was deeper than [`MAX_DEPTH`] - which is deliberately *not*
+/// surfaced as a user-facing action but must still stop
+/// `crate::sidebar::render::AdeApp::prune_stale_fold_state` from treating this listing as a
+/// complete inventory of the worktree's directories.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FileTreeListing {
+    pub entries: Vec<FileTreeEntry>,
+    pub truncated: bool,
+    pub partial: bool,
+}
+
+impl FileTreeListing {
+    /// Whether this listing is a complete inventory of the tree - the only condition under which
+    /// "a directory isn't in here" may be taken as "that directory no longer exists".
+    pub fn is_complete(&self) -> bool {
+        !self.truncated && !self.partial
+    }
+}
+
+/// The ceiling `crate::sidebar::render::AdeApp::load_more_file_tree_entries` escalates towards -
+/// see that method for why the escape hatch stays bounded.
+pub const MAX_LOAD_MORE_ENTRIES: usize = 1_000_000;
+
+/// How deep the walk will recurse. A defensive bound on stack depth, not a product decision: the
+/// walk is recursive, and while `std::fs::DirEntry::file_type` doesn't follow symlinks (so a
+/// symlink loop can't be descended into), a genuinely pathological directory tree could still
+/// overflow the background thread's stack, which aborts the process rather than failing
+/// gracefully. Anything cut off here marks the listing [`FileTreeListing::partial`].
+pub const MAX_DEPTH: usize = 64;
+
 /// Recursively lists `root`'s contents (directories first, then alphabetically within each
 /// group) as a flattened, depth-annotated list suitable for indented rendering.
-pub fn build_file_tree(root: &Path) -> io::Result<Vec<FileTreeEntry>> {
-    let mut entries = Vec::new();
-    let mut budget = MAX_ENTRIES;
-    visit(root, 0, &mut entries, &mut budget)?;
-    Ok(entries)
+///
+/// `limit` is the maximum number of entries to collect. `None` is genuinely unbounded and is a
+/// test-only convenience: every production caller passes a real cap (see
+/// `crate::root::AdeApp::load_file_tree`), including the sidebar's own "load more" action.
+pub fn build_file_tree(root: &Path, limit: Option<usize>) -> io::Result<FileTreeListing> {
+    let mut listing = FileTreeListing::default();
+    let mut budget = limit.unwrap_or(usize::MAX);
+    visit(root, 0, &mut budget, &mut listing)?;
+    Ok(listing)
 }
 
 fn visit(
     dir: &Path,
     depth: usize,
-    out: &mut Vec<FileTreeEntry>,
     budget: &mut usize,
+    listing: &mut FileTreeListing,
 ) -> io::Result<()> {
+    if depth >= MAX_DEPTH {
+        listing.partial = true;
+        return Ok(());
+    }
     let mut children: Vec<fs::DirEntry> = fs::read_dir(dir)?
-        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| match entry {
+            Ok(entry) => Some(entry),
+            // An entry that fails mid-iteration (an I/O error, a race with a `rmdir`) is
+            // skipped - but silently skipping it would make this listing claim to be a complete
+            // inventory when it isn't, which is what `prune_stale_fold_state` would then delete
+            // real fold state on the strength of.
+            Err(_) => {
+                listing.partial = true;
+                None
+            }
+        })
         .filter(|entry| !entry.file_name().to_string_lossy().starts_with('.'))
         .collect();
 
@@ -75,14 +126,23 @@ fn visit(
 
     for child in children {
         if *budget == 0 {
+            listing.truncated = true;
             return Ok(());
         }
         *budget -= 1;
 
         let path = child.path();
-        let is_dir = child.file_type().map(|t| t.is_dir()).unwrap_or(false);
+        // A `file_type()` that fails leaves a real directory recorded as a file, so its whole
+        // subtree is never walked - the same "incomplete but doesn't look it" hazard as above.
+        let is_dir = match child.file_type() {
+            Ok(file_type) => file_type.is_dir(),
+            Err(_) => {
+                listing.partial = true;
+                false
+            }
+        };
         let name = child.file_name().to_string_lossy().into_owned();
-        out.push(FileTreeEntry {
+        listing.entries.push(FileTreeEntry {
             path: path.clone(),
             name,
             depth,
@@ -92,8 +152,13 @@ fn visit(
         if is_dir {
             // A directory that fails to read (permissions, race with deletion, etc.) is
             // skipped rather than aborting the whole tree: the sidebar should show as much
-            // real structure as it can.
-            let _ = visit(&path, depth + 1, out, budget);
+            // real structure as it can. It does make this listing an incomplete inventory
+            // though, which `partial` records - without it, an unreadable folder would look
+            // exactly like a deleted one to `prune_stale_fold_state`, which would then throw
+            // away every fold-state entry beneath it.
+            if visit(&path, depth + 1, budget, listing).is_err() {
+                listing.partial = true;
+            }
         }
     }
 
@@ -121,28 +186,42 @@ pub fn lang_chip_for_name(name: &str) -> LangChip {
     LangChip { label, fg, bg }
 }
 
-/// Filters a flattened, depth-annotated [`build_file_tree`] listing down to the rows that
-/// should be rendered given which directories are collapsed (a collapsed directory's own row
-/// still shows, but everything nested underneath it is hidden until re-expanded).
+/// Filters a flattened, depth-annotated [`build_file_tree`] listing down to the rows that should
+/// be rendered given which directories are **expanded** (an unexpanded directory's own row still
+/// shows, but everything nested underneath it is hidden until it is expanded).
 ///
-/// Relies on `entries` being in `build_file_tree`'s pre-order depth-first shape: once a
-/// collapsed directory at depth `d` is seen, every following entry with `depth > d` is skipped
-/// until one with `depth <= d` is reached. Nested collapsed directories inside an already-hidden
-/// subtree need no special case - they're skipped along with the rest of their parent.
+/// Keyed on expanded-ness, not collapsed-ness, and that inversion is the whole of GitHub issue
+/// #18 §1: absence from this set means *collapsed*, so a worktree nobody has ever expanded
+/// anything in - including a freshly created one - opens showing only its root-level entries,
+/// with no separate "first open" special case anywhere.
 ///
-/// The full result length still matters to the caller (`crate::root::AdeApp::render_file_tree`'s
-/// "... and N more entries not shown" count), so every visible entry is collected rather than
-/// stopping early at [`MAX_RENDERED_FILE_ENTRIES`] - only the initial allocation is capped at
-/// that bound instead of `entries.len()` (up to [`MAX_ENTRIES`], 5000), since most trees have far
-/// fewer than 500 visible entries.
+/// Relies on `entries` being in [`build_file_tree`]'s pre-order depth-first shape: once an
+/// unexpanded directory at depth `d` is seen, every following entry with `depth > d` is skipped
+/// until one with `depth <= d` is reached. Expanded directories nested inside an already-hidden
+/// subtree need no special case - they're skipped along with the rest of their parent, so a stale
+/// deep expansion can never make a row appear underneath a collapsed ancestor.
+/// Defined in terms of [`visible_indices`] rather than duplicating the walk, so the two can
+/// never disagree about which rows are showing.
 pub fn visible_entries<'a>(
     entries: &'a [FileTreeEntry],
-    collapsed: &HashSet<PathBuf>,
+    expanded: &HashSet<PathBuf>,
 ) -> Vec<&'a FileTreeEntry> {
-    let mut visible = Vec::with_capacity(entries.len().min(MAX_RENDERED_FILE_ENTRIES));
+    visible_indices(entries, expanded)
+        .into_iter()
+        .map(|index| &entries[index])
+        .collect()
+}
+
+/// [`visible_entries`]'s index-returning twin - the same walk, reporting positions in `entries`
+/// rather than borrowing from it. `crate::sidebar::render::AdeApp::render_file_tree` needs the
+/// result inside a `'static` closure that cannot hold a borrow of the app, and re-running the
+/// walk inside that closure would mean walking the whole loaded tree once per `uniform_list`
+/// pass (three per frame) instead of once per frame.
+pub fn visible_indices(entries: &[FileTreeEntry], expanded: &HashSet<PathBuf>) -> Vec<usize> {
+    let mut visible = Vec::new();
     let mut hidden_below_depth: Option<usize> = None;
 
-    for entry in entries {
+    for (index, entry) in entries.iter().enumerate() {
         if let Some(hidden_depth) = hidden_below_depth {
             if entry.depth > hidden_depth {
                 continue;
@@ -150,9 +229,9 @@ pub fn visible_entries<'a>(
             hidden_below_depth = None;
         }
 
-        visible.push(entry);
+        visible.push(index);
 
-        if entry.is_dir && collapsed.contains(&entry.path) {
+        if entry.is_dir && !expanded.contains(&entry.path) {
             hidden_below_depth = Some(entry.depth);
         }
     }
@@ -160,10 +239,71 @@ pub fn visible_entries<'a>(
     visible
 }
 
+/// Every directory in a loaded listing, as the absolute-path set
+/// `crate::sidebar::fold_state::FoldState::prune_missing_dirs` prunes stale entries against.
+pub fn directory_paths(entries: &[FileTreeEntry]) -> HashSet<PathBuf> {
+    entries
+        .iter()
+        .filter(|entry| entry.is_dir)
+        .map(|entry| entry.path.clone())
+        .collect()
+}
+
+/// A row's left padding before any indentation (`crate::sidebar::render`'s `pl(px(8.0) + indent)`).
+pub const ROW_LEFT_PAD: f32 = 8.0;
+
+/// Horizontal indent per nesting level, per `design_handoff_jerry_ade/README.md`'s Zone 3 spec.
+pub const INDENT_STEP: f32 = 13.0;
+
+/// Where level `level`'s vertical indent guide sits, in pixels from the row's left edge.
+///
+/// Deliberately derived from the same two constants the row's own `pl` indent is, plus half of
+/// `render_tree_caret`'s real 8px width, so the guide lands exactly under the expand chevron of
+/// the ancestor directory it belongs to (issue #18 §3: "aligned with the expand chevrons")
+/// instead of at some independently-chosen offset that would drift the first time the indent
+/// step changes.
+pub fn indent_guide_x(level: usize) -> f32 {
+    ROW_LEFT_PAD + INDENT_STEP * level as f32 + CARET_WIDTH / 2.0
+}
+
+/// `render_tree_caret`'s real width - see [`indent_guide_x`].
+const CARET_WIDTH: f32 = 8.0;
+
+/// How many of a row's indent guides belong to the selected file's own ancestor chain, and so
+/// should be drawn in the highlighted colour (issue #18 §3's optional "highlight the active
+/// guide"). Always a prefix of the row's levels: two paths share a *prefix* of ancestors, never a
+/// gap in the middle, so this is one count rather than a per-level set.
+///
+/// Returns `0` (nothing highlighted) when nothing is selected, when the selection isn't inside
+/// this tree's root, or when the two paths diverge immediately - the common case for most rows.
+pub fn active_guide_levels(root: &Path, entry: &Path, selected: Option<&Path>) -> usize {
+    let Some(selected) = selected else {
+        return 0;
+    };
+    let (Ok(entry_relative), Ok(selected_relative)) =
+        (entry.strip_prefix(root), selected.strip_prefix(root))
+    else {
+        return 0;
+    };
+    let depth = entry_relative.components().count().saturating_sub(1);
+    let shared = entry_relative
+        .components()
+        .zip(selected_relative.components())
+        .take_while(|(a, b)| a == b)
+        .count();
+    shared.min(depth)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    fn tree_of(root: &Path) -> Vec<FileTreeEntry> {
+        build_file_tree(root, None)
+            .expect("build_file_tree")
+            .entries
+    }
 
     #[test]
     fn lists_files_and_directories_with_depth() {
@@ -173,7 +313,7 @@ mod tests {
         fs::create_dir(dir.path().join("sub")).expect("mkdir");
         fs::write(dir.path().join("sub/nested.txt"), "n").expect("write");
 
-        let entries = build_file_tree(dir.path()).expect("build_file_tree");
+        let entries = tree_of(dir.path());
 
         // Directories sort before files at the same depth; "sub" (dir) before "a.txt"/"b.txt".
         assert_eq!(entries[0].name, "sub");
@@ -196,7 +336,7 @@ mod tests {
         fs::write(dir.path().join(".git/HEAD"), "ref: refs/heads/main").expect("write");
         fs::write(dir.path().join("visible.txt"), "v").expect("write");
 
-        let entries = build_file_tree(dir.path()).expect("build_file_tree");
+        let entries = tree_of(dir.path());
 
         assert_eq!(entries.len(), 1, "only the non-dot entry should be listed");
         assert_eq!(entries[0].name, "visible.txt");
@@ -205,15 +345,123 @@ mod tests {
     #[test]
     fn empty_directory_yields_no_entries() {
         let dir = TempDir::new().expect("tempdir");
-        let entries = build_file_tree(dir.path()).expect("build_file_tree");
-        assert!(entries.is_empty());
+        let listing = build_file_tree(dir.path(), None).expect("build_file_tree");
+        assert!(listing.entries.is_empty());
+        assert!(!listing.truncated);
     }
 
     #[test]
     fn nonexistent_root_returns_io_error() {
         let missing = PathBuf::from("/definitely/not/a/real/path/for/ade/file-tree-test");
-        let result = build_file_tree(&missing);
+        let result = build_file_tree(&missing, None);
         assert!(result.is_err());
+    }
+
+    /// The load cap must be honest in both directions: a walk that hits it says so, and one that
+    /// doesn't must never claim it did (which would put a "Show all entries" action in the
+    /// sidebar for a tree that is already complete).
+    #[test]
+    fn a_walk_that_hits_its_limit_reports_truncation_and_one_that_does_not_says_so() {
+        let dir = TempDir::new().expect("tempdir");
+        for index in 0..10 {
+            fs::write(dir.path().join(format!("f-{index}.txt")), "x").expect("write");
+        }
+
+        let capped = build_file_tree(dir.path(), Some(4)).expect("build_file_tree");
+        assert_eq!(capped.entries.len(), 4);
+        assert!(capped.truncated);
+
+        let complete = build_file_tree(dir.path(), Some(10)).expect("build_file_tree");
+        assert_eq!(complete.entries.len(), 10);
+        assert!(
+            !complete.truncated,
+            "a walk that collected everything must not report truncation, even when the entry \
+             count exactly equals the budget"
+        );
+
+        let uncapped = build_file_tree(dir.path(), None).expect("build_file_tree");
+        assert_eq!(uncapped.entries.len(), 10);
+        assert!(!uncapped.truncated);
+    }
+
+    /// A directory the walk can't read is skipped (so one bad folder never blanks the sidebar),
+    /// but the listing must *say* it is incomplete - otherwise
+    /// `crate::sidebar::render::AdeApp::prune_stale_fold_state` would read the missing subtree
+    /// as deleted and permanently drop its fold state.
+    #[cfg(unix)]
+    #[test]
+    fn an_unreadable_subdirectory_makes_the_listing_partial_but_not_an_error() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = TempDir::new().expect("tempdir");
+        fs::create_dir(dir.path().join("open")).expect("mkdir");
+        fs::write(dir.path().join("open/file.txt"), "x").expect("write");
+        let locked = dir.path().join("locked");
+        fs::create_dir(&locked).expect("mkdir");
+        fs::write(locked.join("hidden-from-us.txt"), "x").expect("write");
+        fs::set_permissions(&locked, fs::Permissions::from_mode(0o000)).expect("chmod");
+
+        if fs::read_dir(&locked).is_ok() {
+            // Running as root (or on a filesystem that ignores the mode) - the premise doesn't
+            // hold, so this would pass for the wrong reason.
+            fs::set_permissions(&locked, fs::Permissions::from_mode(0o755)).expect("chmod back");
+            return;
+        }
+
+        let listing = build_file_tree(dir.path(), None).expect("build_file_tree");
+        // Restore before any assertion can fail, or `TempDir`'s own cleanup fails too.
+        fs::set_permissions(&locked, fs::Permissions::from_mode(0o755)).expect("chmod back");
+
+        assert!(
+            listing.entries.iter().any(|entry| entry.name == "file.txt"),
+            "the readable part of the tree must still be listed"
+        );
+        assert!(listing.partial, "the skipped directory must be reported");
+        assert!(
+            !listing.is_complete(),
+            "and so this listing must never be used as a complete inventory"
+        );
+        assert!(!listing.truncated, "no entry budget was involved");
+    }
+
+    /// The recursion bound - a defensive stack guard, reported the same honest way.
+    #[test]
+    fn a_tree_deeper_than_the_depth_cap_is_reported_as_partial() {
+        let dir = TempDir::new().expect("tempdir");
+        let mut deep = dir.path().to_path_buf();
+        for level in 0..(MAX_DEPTH + 2) {
+            deep = deep.join(format!("d{level}"));
+        }
+        fs::create_dir_all(&deep).expect("mkdir -p");
+
+        let listing = build_file_tree(dir.path(), None).expect("build_file_tree");
+
+        assert_eq!(listing.entries.len(), MAX_DEPTH);
+        assert!(listing.partial);
+        assert!(!listing.truncated);
+    }
+
+    /// The listing has to hold hundreds of entries in a single directory without any cap of its
+    /// own - the sidebar's virtualized list is what keeps that cheap to render, not a cut-off
+    /// here (issue #18 §4).
+    #[test]
+    fn a_large_directory_is_listed_completely() {
+        let dir = TempDir::new().expect("tempdir");
+        for index in 0..800 {
+            fs::write(dir.path().join(format!("f-{index:03}.txt")), "x").expect("write");
+        }
+
+        let listing = build_file_tree(dir.path(), Some(20_000)).expect("build_file_tree");
+
+        assert_eq!(listing.entries.len(), 800);
+        assert!(!listing.truncated);
+        let expanded = HashSet::new();
+        assert_eq!(
+            visible_entries(&listing.entries, &expanded).len(),
+            800,
+            "every entry in a flat directory is visible with nothing expanded, and none of them \
+             may be dropped by a render cap"
+        );
     }
 
     fn same(a: Rgba, b: Rgba) -> bool {
@@ -269,19 +517,22 @@ mod tests {
         }
     }
 
+    /// Issue #18 §1's default state, at the level it's actually decided: nothing expanded means
+    /// root-level entries only.
     #[test]
-    fn nothing_collapsed_shows_every_entry() {
+    fn nothing_expanded_shows_only_root_level_entries() {
         let entries = vec![
             entry("sub", 0, true),
             entry("nested.txt", 1, false),
             entry("a.txt", 0, false),
         ];
         let visible = visible_entries(&entries, &HashSet::new());
-        assert_eq!(visible.len(), 3);
+        let names: Vec<&str> = visible.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, vec!["sub", "a.txt"]);
     }
 
     #[test]
-    fn collapsing_a_directory_hides_only_its_own_descendants() {
+    fn expanding_a_directory_reveals_only_its_own_immediate_subtree() {
         let entries = vec![
             entry("sub", 0, true),
             entry("nested.txt", 1, false),
@@ -289,44 +540,57 @@ mod tests {
             entry("deepest.txt", 2, false),
             entry("a.txt", 0, false),
         ];
-        let mut collapsed = HashSet::new();
-        collapsed.insert(PathBuf::from("sub"));
+        let mut expanded = HashSet::new();
+        expanded.insert(PathBuf::from("sub"));
 
-        let visible = visible_entries(&entries, &collapsed);
+        let visible = visible_entries(&entries, &expanded);
         let names: Vec<&str> = visible.iter().map(|e| e.name.as_str()).collect();
-        // "sub" itself still shows (its own row is what you click to re-expand it); every
-        // entry nested underneath it (at a strictly greater depth) is hidden; "a.txt", a
-        // sibling back at "sub"'s own depth, is unaffected.
+        // "deeper" shows because its parent is expanded, but its own children stay hidden until
+        // it is expanded too.
+        assert_eq!(names, vec!["sub", "nested.txt", "deeper", "a.txt"]);
+    }
+
+    #[test]
+    fn expanding_a_whole_chain_reveals_the_deepest_entry() {
+        let entries = vec![
+            entry("sub", 0, true),
+            entry("deeper", 1, true),
+            entry("deepest.txt", 2, false),
+        ];
+        let mut expanded = HashSet::new();
+        expanded.insert(PathBuf::from("sub"));
+        expanded.insert(PathBuf::from("deeper"));
+
+        let visible = visible_entries(&entries, &expanded);
+        let names: Vec<&str> = visible.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, vec!["sub", "deeper", "deepest.txt"]);
+    }
+
+    /// A stale deep expansion (e.g. one restored from disk whose parent the user has since
+    /// collapsed) must never punch a hole through a collapsed ancestor.
+    #[test]
+    fn an_expanded_directory_under_a_collapsed_ancestor_stays_hidden() {
+        let entries = vec![
+            entry("sub", 0, true),
+            entry("deeper", 1, true),
+            entry("deepest.txt", 2, false),
+            entry("a.txt", 0, false),
+        ];
+        let mut expanded = HashSet::new();
+        expanded.insert(PathBuf::from("deeper"));
+
+        let visible = visible_entries(&entries, &expanded);
+        let names: Vec<&str> = visible.iter().map(|e| e.name.as_str()).collect();
         assert_eq!(names, vec!["sub", "a.txt"]);
     }
 
     #[test]
-    fn collapsing_a_nested_directory_only_hides_its_own_subtree() {
-        let entries = vec![
-            entry("sub", 0, true),
-            entry("nested.txt", 1, false),
-            entry("deeper", 1, true),
-            entry("deepest.txt", 2, false),
-            entry("after-deeper.txt", 1, false),
-        ];
-        let mut collapsed = HashSet::new();
-        collapsed.insert(PathBuf::from("deeper"));
-
-        let visible = visible_entries(&entries, &collapsed);
-        let names: Vec<&str> = visible.iter().map(|e| e.name.as_str()).collect();
-        assert_eq!(
-            names,
-            vec!["sub", "nested.txt", "deeper", "after-deeper.txt"]
-        );
-    }
-
-    #[test]
-    fn collapsing_a_directory_with_no_children_hides_nothing_extra() {
+    fn expanding_a_directory_with_no_children_reveals_nothing_extra() {
         let entries = vec![entry("empty-dir", 0, true), entry("a.txt", 0, false)];
-        let mut collapsed = HashSet::new();
-        collapsed.insert(PathBuf::from("empty-dir"));
+        let mut expanded = HashSet::new();
+        expanded.insert(PathBuf::from("empty-dir"));
 
-        let visible = visible_entries(&entries, &collapsed);
+        let visible = visible_entries(&entries, &expanded);
         assert_eq!(visible.len(), 2);
     }
 
@@ -337,12 +601,100 @@ mod tests {
         fs::write(dir.path().join("sub/nested.txt"), "n").expect("write");
         fs::write(dir.path().join("a.txt"), "a").expect("write");
 
-        let entries = build_file_tree(dir.path()).expect("build_file_tree");
-        let mut collapsed = HashSet::new();
-        collapsed.insert(dir.path().join("sub"));
+        let entries = tree_of(dir.path());
+        let mut expanded = HashSet::new();
+        expanded.insert(dir.path().join("sub"));
 
-        let visible = visible_entries(&entries, &collapsed);
+        let visible = visible_entries(&entries, &expanded);
         let names: Vec<&str> = visible.iter().map(|e| e.name.as_str()).collect();
-        assert_eq!(names, vec!["sub", "a.txt"]);
+        assert_eq!(names, vec!["sub", "nested.txt", "a.txt"]);
+    }
+
+    #[test]
+    fn directory_paths_collects_every_directory_and_no_files() {
+        let dir = TempDir::new().expect("tempdir");
+        fs::create_dir(dir.path().join("sub")).expect("mkdir");
+        fs::create_dir(dir.path().join("sub/deeper")).expect("mkdir");
+        fs::write(dir.path().join("sub/nested.txt"), "n").expect("write");
+
+        let dirs = directory_paths(&tree_of(dir.path()));
+
+        assert_eq!(dirs.len(), 2);
+        assert!(dirs.contains(&dir.path().join("sub")));
+        assert!(dirs.contains(&dir.path().join("sub/deeper")));
+    }
+
+    #[test]
+    fn indent_guides_line_up_with_each_levels_expand_chevron() {
+        // The chevron for depth `d` starts at `8 + 13*d` and is 8 wide, so its centre - and the
+        // guide - is at `12 + 13*d`.
+        assert_eq!(indent_guide_x(0), 12.0);
+        assert_eq!(indent_guide_x(1), 25.0);
+        assert_eq!(indent_guide_x(2), 38.0);
+    }
+
+    #[test]
+    fn no_selection_means_no_active_guides() {
+        let root = Path::new("/repo");
+        assert_eq!(
+            active_guide_levels(root, &root.join("src/app/main.rs"), None),
+            0
+        );
+    }
+
+    #[test]
+    fn the_selected_files_whole_ancestor_chain_is_active() {
+        let root = Path::new("/repo");
+        let selected = root.join("src/app/main.rs");
+        // The selected row itself: both of its guides (for `src` and `src/app`) are active.
+        assert_eq!(
+            active_guide_levels(root, &selected, Some(&selected)),
+            2,
+            "the selected file's own ancestor guides are the active chain"
+        );
+        // A sibling of the selected file shares the same two ancestors.
+        assert_eq!(
+            active_guide_levels(root, &root.join("src/app/other.rs"), Some(&selected)),
+            2
+        );
+        // A row in a different subtree shares only `src`.
+        assert_eq!(
+            active_guide_levels(root, &root.join("src/other/thing.rs"), Some(&selected)),
+            1
+        );
+        // A row that diverges immediately shares nothing.
+        assert_eq!(
+            active_guide_levels(root, &root.join("docs/readme.md"), Some(&selected)),
+            0
+        );
+    }
+
+    /// A row can never highlight more guides than it draws - `min(shared, depth)` is what stops
+    /// a deeper selected path from claiming a guide level this row doesn't have.
+    #[test]
+    fn active_guides_never_exceed_a_rows_own_depth() {
+        let root = Path::new("/repo");
+        let selected = root.join("src/app/deep/main.rs");
+        assert_eq!(
+            active_guide_levels(root, &root.join("src"), Some(&selected)),
+            0
+        );
+        assert_eq!(
+            active_guide_levels(root, &root.join("src/app"), Some(&selected)),
+            1
+        );
+    }
+
+    #[test]
+    fn a_selection_outside_the_tree_root_highlights_nothing() {
+        let root = Path::new("/repo");
+        assert_eq!(
+            active_guide_levels(
+                root,
+                &root.join("src/main.rs"),
+                Some(Path::new("/elsewhere/src/main.rs"))
+            ),
+            0
+        );
     }
 }

--- a/crates/app/src/sidebar/file_tree.rs
+++ b/crates/app/src/sidebar/file_tree.rs
@@ -66,9 +66,12 @@ impl FileTreeListing {
     }
 }
 
-/// The ceiling `crate::sidebar::render::AdeApp::load_more_file_tree_entries` escalates towards -
-/// see that method for why the escape hatch stays bounded.
-pub const MAX_LOAD_MORE_ENTRIES: usize = 1_000_000;
+/// The ceiling `crate::sidebar::render::AdeApp::load_more_file_tree_entries` escalates towards.
+/// Deliberately the same number as `crate::settings::store::FILE_TREE_MAX_ENTRIES_MAX` - see that
+/// constant for the real reasoning (two foreground-thread costs that scale with the loaded entry
+/// count). An escape hatch that could exceed the configured maximum would just be the unbounded
+/// walk again, wearing a click.
+pub const MAX_LOAD_MORE_ENTRIES: usize = crate::settings::store::FILE_TREE_MAX_ENTRIES_MAX;
 
 /// How deep the walk will recurse. A defensive bound on stack depth, not a product decision: the
 /// walk is recursive, and while `std::fs::DirEntry::file_type` doesn't follow symlinks (so a

--- a/crates/app/src/sidebar/fold_state.rs
+++ b/crates/app/src/sidebar/fold_state.rs
@@ -38,11 +38,19 @@
 //! owns. Without that merge, the last process to save would silently erase every other
 //! repository's fold state, since each holds a whole-file copy read at its own startup.
 //!
-//! Honest about what that does *not* buy: the merge is an unlocked read-modify-write, so two
-//! processes whose saves genuinely interleave can still lose one update. It narrows the window
-//! from "every save clobbers everything" to "a few microseconds around each save", which is the
-//! right trade for state of this consequence - a lock file guarding a fold-state write would be
-//! more machinery, and more failure modes, than the data is worth.
+//! Honest about the two things that does *not* buy, both real:
+//!
+//! 1. The merge is an unlocked read-modify-write, so two instances owning *different* worktrees
+//!    whose saves genuinely interleave can still lose one update. That narrows the exposure from
+//!    "every save clobbers every other repository" to "a few microseconds around each save".
+//! 2. Two instances that own the **same** worktree key - the same worktree open twice - are not
+//!    merged at all, and this is not a narrow window: each save replaces that key's whole entry
+//!    with its own copy, so the two instances permanently revert each other's expansions for
+//!    that worktree, last-writer-wins, for as long as both are running. Fixing it properly means
+//!    a delta-based merge (record what changed, not what the whole entry now is), which is a
+//!    materially bigger design than this feature justifies; the sibling-worktree case above is
+//!    the one that actually happens (one `jerry` per repository), and it *is* fixed. This is
+//!    written down rather than left to be discovered.
 //!
 //! ## Nothing is ever pruned because a path merely looks absent
 //!
@@ -88,6 +96,13 @@ pub fn fold_state_path_for(settings_path: &Path) -> PathBuf {
 /// through a symlink (or a `.`-relative invocation) resolves to one entry rather than two.
 /// Falls back to the path as given when it can't be canonicalized (it may not exist yet, or be
 /// a pure in-memory path in a unit test), which is still a stable key for that path.
+///
+/// **Calls `std::fs::canonicalize`, so it must never be called from a render or per-event
+/// path.** On a stale or slow mount (NFS, FUSE, a briefly-disconnected network drive) that syscall can
+/// block for the mount's full timeout, which on the foreground thread is a frozen window. Every
+/// hot caller instead uses the `*_with_key` variants below against
+/// `crate::root::AdeApp::fold_state_root_key`, which is resolved exactly once per worktree
+/// change; this function is called only from those few real change points (and from tests).
 ///
 /// `None` for a path that isn't valid UTF-8. TOML keys are strings, and the obvious shortcut -
 /// `to_string_lossy` - would map every undecodable byte to the same U+FFFD, so two genuinely
@@ -309,7 +324,16 @@ impl FoldState {
     /// compared against `crate::sidebar::file_tree::FileTreeEntry::path`. Entries that don't
     /// decode to a plain relative path are silently skipped ([`absolute_from_key`]).
     pub fn expanded_dirs(&self, root: &Path) -> HashSet<PathBuf> {
-        let Some(entry) = worktree_key(root).and_then(|key| self.worktrees.get(&key)) else {
+        match worktree_key(root) {
+            Some(key) => self.expanded_dirs_with_key(&key, root),
+            None => HashSet::new(),
+        }
+    }
+
+    /// [`Self::expanded_dirs`] against an already-resolved [`worktree_key`] - see that function's
+    /// own docs for why every hot path takes this variant.
+    pub fn expanded_dirs_with_key(&self, root_key: &str, root: &Path) -> HashSet<PathBuf> {
+        let Some(entry) = self.worktrees.get(root_key) else {
             return HashSet::new();
         };
         entry
@@ -324,9 +348,26 @@ impl FoldState {
     /// being non-UTF-8: those would have to be stored under a key they don't belong to, or under
     /// a lossily-mangled one that could collide with a different worktree's.
     pub fn set_expanded(&mut self, root: &Path, dir: &Path, expanded: bool) -> SetExpanded {
-        let (Some(root_key), Some(key)) = (worktree_key(root), relative_key(root, dir)) else {
+        match worktree_key(root) {
+            Some(root_key) => self.set_expanded_with_key(&root_key, root, dir, expanded),
+            None => SetExpanded::Refused,
+        }
+    }
+
+    /// [`Self::set_expanded`] against an already-resolved [`worktree_key`] - the variant every
+    /// real expand/collapse goes through, since [`worktree_key`] itself does blocking filesystem
+    /// work. `root` is still needed to make `dir` relative, which is pure string work.
+    pub fn set_expanded_with_key(
+        &mut self,
+        root_key: &str,
+        root: &Path,
+        dir: &Path,
+        expanded: bool,
+    ) -> SetExpanded {
+        let Some(key) = relative_key(root, dir) else {
             return SetExpanded::Refused;
         };
+        let root_key = root_key.to_string();
         let changed = if expanded {
             self.worktrees
                 .entry(root_key)
@@ -357,9 +398,12 @@ impl FoldState {
     /// which the issue asks to reset "both the tree and the saved state in one step". Returns
     /// whether anything was actually removed.
     pub fn clear_worktree(&mut self, root: &Path) -> bool {
-        worktree_key(root)
-            .and_then(|key| self.worktrees.remove(&key))
-            .is_some()
+        worktree_key(root).is_some_and(|key| self.clear_worktree_with_key(&key))
+    }
+
+    /// [`Self::clear_worktree`] against an already-resolved [`worktree_key`].
+    pub fn clear_worktree_with_key(&mut self, root_key: &str) -> bool {
+        self.worktrees.remove(root_key).is_some()
     }
 
     /// Drops any recorded directory for `root` that isn't in `existing_dirs` - the "stale entries
@@ -371,9 +415,20 @@ impl FoldState {
     /// importantly - it cannot prune an entry merely because a *slow or racing* filesystem check
     /// happened to miss it.
     pub fn prune_missing_dirs(&mut self, root: &Path, existing_dirs: &HashSet<PathBuf>) -> bool {
-        let Some(worktree_key) = worktree_key(root) else {
-            return false;
-        };
+        match worktree_key(root) {
+            Some(key) => self.prune_missing_dirs_with_key(&key, root, existing_dirs),
+            None => false,
+        }
+    }
+
+    /// [`Self::prune_missing_dirs`] against an already-resolved [`worktree_key`].
+    pub fn prune_missing_dirs_with_key(
+        &mut self,
+        root_key: &str,
+        root: &Path,
+        existing_dirs: &HashSet<PathBuf>,
+    ) -> bool {
+        let worktree_key = root_key.to_string();
         let Some(entry) = self.worktrees.get_mut(&worktree_key) else {
             return false;
         };
@@ -615,6 +670,45 @@ mod tests {
         let path = dir.path().join("file-tree-state.toml");
         std::fs::write(&path, "this is not valid toml {{{").expect("write");
         assert_eq!(FoldState::load_at(&path), FoldState::default());
+    }
+
+    /// The non-UTF-8 refusal, exercised against a genuinely non-UTF-8 path rather than only
+    /// described in the docs. Both halves matter: a directory name that isn't UTF-8 is refused
+    /// (it has no honest TOML key), and - crucially - refusing it does not disturb the entries
+    /// that *are* recordable for the same worktree.
+    #[cfg(unix)]
+    #[test]
+    fn a_non_utf8_path_is_refused_and_leaves_the_rest_of_the_worktree_intact() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let root = Path::new("/repo/worktree-a");
+        let mut state = FoldState::default();
+        set(&mut state, root, &root.join("src"), true);
+
+        // 0xff is not valid UTF-8 in any position.
+        let invalid = root.join(OsStr::from_bytes(&[b'b', b'a', 0xff, b'd']));
+        assert_eq!(
+            state.set_expanded(root, &invalid, true),
+            SetExpanded::Refused,
+            "a directory whose name isn't UTF-8 has no honest TOML key, so it must be refused \
+             outright rather than stored lossily under a key that could collide"
+        );
+        assert_eq!(
+            expanded_set(&state, root),
+            vec!["/repo/worktree-a/src"],
+            "and the refusal must leave every recordable entry for the same worktree untouched"
+        );
+
+        // The same refusal for a non-UTF-8 *root*, which would otherwise mangle the map key
+        // itself - the collision this guard actually exists to prevent.
+        let invalid_root = PathBuf::from(OsStr::from_bytes(&[b'/', b'r', 0xff, b'p']));
+        assert_eq!(worktree_key(&invalid_root), None);
+        assert_eq!(
+            state.set_expanded(&invalid_root, &invalid_root.join("src"), true),
+            SetExpanded::Refused
+        );
+        assert!(state.expanded_dirs(&invalid_root).is_empty());
     }
 
     /// A hand-corrupted (or maliciously written) file must not be able to make the app treat a

--- a/crates/app/src/sidebar/fold_state.rs
+++ b/crates/app/src/sidebar/fold_state.rs
@@ -1,0 +1,717 @@
+//! Real, on-disk persistence for the Files tree's expand/collapse state (GitHub issue #18).
+//!
+//! ## What is stored, and why it's *expanded* rather than *collapsed*
+//!
+//! The tree opens **fully collapsed** on the first visit to a worktree, so "expanded" is the
+//! exceptional state and the one worth recording: an empty (or missing) entry for a worktree
+//! means "nothing is expanded", which is exactly the right default for a worktree this file has
+//! never seen - a freshly created worktree therefore inherits nothing and starts collapsed, with
+//! no special case needed anywhere. `crate::root::AdeApp::expanded_dirs` is the live mirror of
+//! one worktree's entry here.
+//!
+//! ## Why a separate file rather than a `[file_tree]` section in `settings.toml`
+//!
+//! `crate::settings::store`'s own module docs are explicit that every field of `Settings` is a
+//! value some settings *page* reads and writes, and the config banner/snippet widgets render
+//! those sections back to the user as hand-editable config. This is not that: it's machine-
+//! managed UI state, potentially hundreds of paths across every worktree ever opened, that no
+//! settings page shows and nobody would hand-edit. It lives in its own
+//! `~/.config/jerry/file-tree-state.toml`, resolved as a sibling of the real settings path
+//! ([`fold_state_path_for`]) so the two always share a directory and a test that supplies a
+//! temp-dir settings path automatically gets a temp-dir fold-state path too.
+//!
+//! The second, load-bearing reason is crash-safety, which the issue asks for by name.
+//! `Settings::save_at` is documented as a deliberately non-atomic truncate-then-write; a crash
+//! mid-write there loses at worst a settings edit. [`FoldState::save_at`] instead writes a
+//! process-unique sibling temp file, `File::sync_all`s it, `std::fs::rename`s it over the
+//! target, and syncs the parent directory - so neither a killed process nor a power loss can
+//! leave a half-written (and therefore unparseable) file behind. What survives a crash is
+//! always either the previous complete state or the new complete state.
+//!
+//! ## Two running instances share this file, so writes merge rather than clobber
+//!
+//! One `jerry` process opens one window against one repository (`crate::run`), so running it
+//! against two repositories at once means two processes writing this one file. The temp file's
+//! name therefore includes the process id and a per-process counter (two writers can't scribble
+//! over each other's temp file), and the app writes through [`FoldState::save_merged_at`], which
+//! re-reads whatever is on disk and replaces only the worktree keys *this* instance actually
+//! owns. Without that merge, the last process to save would silently erase every other
+//! repository's fold state, since each holds a whole-file copy read at its own startup.
+//!
+//! Honest about what that does *not* buy: the merge is an unlocked read-modify-write, so two
+//! processes whose saves genuinely interleave can still lose one update. It narrows the window
+//! from "every save clobbers everything" to "a few microseconds around each save", which is the
+//! right trade for state of this consequence - a lock file guarding a fold-state write would be
+//! more machinery, and more failure modes, than the data is worth.
+//!
+//! ## Nothing is ever pruned because a path merely looks absent
+//!
+//! Stale entries are pruned against a real, completed directory walk
+//! ([`FoldState::prune_missing_dirs`]) and nothing else. An earlier draft also dropped whole
+//! worktrees at startup whose root `Path::exists()` reported gone; that was removed as
+//! destructive-on-a-false-negative - an unmounted volume, or a parent directory that is briefly
+//! unreadable, would have permanently deleted that worktree's state. The cost of not doing it is
+//! a few hundred bytes per worktree that no longer exists.
+//!
+//! ## Identity: keyed by real worktree path, never by relative path alone
+//!
+//! Two worktrees of the same repository share every relative path in the tree, so a fold-state
+//! entry keyed only by `src/app` would apply to both. The map is therefore keyed by the
+//! worktree's real, canonicalized absolute path ([`worktree_key`]) with worktree-relative paths
+//! stored *inside* that entry - the same "identity guard" discipline the rest of this codebase
+//! documents. A path that doesn't sit under the worktree root at all is refused outright rather
+//! than stored with a surprising key ([`relative_key`]).
+
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::io;
+use std::path::{Component, Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// The fold-state file's name, resolved next to the real `settings.toml` - see the module docs.
+pub const FOLD_STATE_FILE_NAME: &str = "file-tree-state.toml";
+
+/// The fold-state file for a given real settings-file path (`~/.config/jerry/settings.toml` in
+/// production, a temp dir in tests). Deriving it from the settings path rather than resolving
+/// `$HOME` a second time means a test that opts into a real settings path
+/// (`crate::root::AdeApp::new_with_settings`) gets real fold-state persistence in the same temp
+/// directory for free, and a test that passes `None` gets no persistence at all - never a write
+/// to whatever machine happens to run `cargo test`.
+pub fn fold_state_path_for(settings_path: &Path) -> PathBuf {
+    match settings_path.parent() {
+        Some(parent) => parent.join(FOLD_STATE_FILE_NAME),
+        None => PathBuf::from(FOLD_STATE_FILE_NAME),
+    }
+}
+
+/// The map key for one worktree - its real path, canonicalized so the same worktree reached
+/// through a symlink (or a `.`-relative invocation) resolves to one entry rather than two.
+/// Falls back to the path as given when it can't be canonicalized (it may not exist yet, or be
+/// a pure in-memory path in a unit test), which is still a stable key for that path.
+///
+/// `None` for a path that isn't valid UTF-8. TOML keys are strings, and the obvious shortcut -
+/// `to_string_lossy` - would map every undecodable byte to the same U+FFFD, so two genuinely
+/// different worktrees could collapse onto one key: the exact cross-worktree leak this module
+/// exists to prevent. Refusing outright means such a worktree simply doesn't persist fold state
+/// (and says so in the log, see `crate::root::AdeApp::set_dir_expanded`), which is a far smaller
+/// failure than silently sharing another worktree's.
+pub fn worktree_key(root: &Path) -> Option<String> {
+    let canonical = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+    canonical.to_str().map(str::to_owned)
+}
+
+/// One worktree's stored relative directory path, or `None` if `dir` isn't a real descendant of
+/// `root`. `/`-joined `Component::Normal` segments only: a `..`, a drive prefix, or a root
+/// component would let a stored entry escape the worktree it's filed under, which is exactly the
+/// cross-worktree leak this whole module is keyed to prevent.
+fn relative_key(root: &Path, dir: &Path) -> Option<String> {
+    let relative = dir.strip_prefix(root).ok()?;
+    let mut parts = Vec::new();
+    for component in relative.components() {
+        match component {
+            // `to_str`, not `to_string_lossy` - see [`worktree_key`]'s own docs for why a
+            // lossy conversion here would be an identity bug rather than a cosmetic one.
+            Component::Normal(part) => parts.push(part.to_str()?.to_owned()),
+            _ => return None,
+        }
+    }
+    if parts.is_empty() {
+        // The root itself is never a fold-state entry: it has no row to expand or collapse.
+        return None;
+    }
+    Some(parts.join("/"))
+}
+
+/// Rebuilds an absolute path from a stored relative key, refusing anything that isn't a plain
+/// sequence of normal path segments - the read-side half of [`relative_key`]'s guard, since the
+/// file on disk is a real file a user (or a corrupted write) can put anything into.
+fn absolute_from_key(root: &Path, key: &str) -> Option<PathBuf> {
+    let mut path = root.to_path_buf();
+    let mut segments = 0;
+    for segment in key.split('/') {
+        if segment.is_empty() || segment == "." || segment == ".." {
+            return None;
+        }
+        if segment.contains('\\') || Path::new(segment).components().count() != 1 {
+            return None;
+        }
+        path.push(segment);
+        segments += 1;
+    }
+    (segments > 0).then_some(path)
+}
+
+/// How stale a `*.tmp` sibling must be before [`sweep_orphaned_temp_files`] deletes it. A real
+/// in-flight temp file lives for microseconds; an hour is far beyond any plausible write, so
+/// this can never race a live writer in another process.
+const ORPHANED_TEMP_MAX_AGE: std::time::Duration = std::time::Duration::from_secs(60 * 60);
+
+/// Deletes leftover `<file-name>.<pid>.<n>.tmp` siblings from a save that was killed between
+/// creating its temp file and renaming it. Without this, making the temp name process-unique
+/// (which is what stops two instances from tearing each other's writes) would turn one
+/// reusable orphan into an unbounded pile of them, since a save runs on every single
+/// expand/collapse. Entirely best-effort: every error is ignored, and a failure here has no
+/// bearing on whether the save itself succeeded.
+fn sweep_orphaned_temp_files(path: &Path, file_name: &str) {
+    let Some(parent) = path.parent() else {
+        return;
+    };
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return;
+    };
+    let prefix = format!("{file_name}.");
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        if !name.starts_with(&prefix) || !name.ends_with(".tmp") {
+            continue;
+        }
+        let stale = entry
+            .metadata()
+            .and_then(|metadata| metadata.modified())
+            .and_then(|modified| {
+                std::time::SystemTime::now()
+                    .duration_since(modified)
+                    .map_err(|err| io::Error::other(err.to_string()))
+            })
+            .is_ok_and(|age| age > ORPHANED_TEMP_MAX_AGE);
+        if stale {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
+}
+
+/// The whole on-disk file: every worktree this app has ever recorded fold state for, keyed by
+/// [`worktree_key`]. A `BTreeMap`/`BTreeSet` (not a `HashMap`/`HashSet`) so the serialized file
+/// has a stable, diffable order rather than reshuffling itself on every write.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct FoldState {
+    pub worktrees: BTreeMap<String, WorktreeFoldState>,
+}
+
+/// One worktree's entry - the worktree-relative paths of every directory the user has expanded.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct WorktreeFoldState {
+    pub expanded: BTreeSet<String>,
+}
+
+/// What [`FoldState::set_expanded`] did - three distinct outcomes, not a `bool`, because the
+/// caller has to tell "already in that state, no write needed" apart from "refused, so the live
+/// UI state and this file have genuinely diverged and somebody should hear about it".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SetExpanded {
+    /// Recorded; the file needs writing.
+    Changed,
+    /// Already recorded that way; nothing to write.
+    Unchanged,
+    /// Not recordable at all - see [`FoldState::set_expanded`].
+    Refused,
+}
+
+impl FoldState {
+    /// Loads `path`, falling back to an empty state for *any* failure - missing file (the
+    /// overwhelmingly common first-run case), unreadable file, or unparseable contents. Fold
+    /// state is never important enough to fail startup or surface an error over; the issue asks
+    /// for stale/bad entries to be "silently ignored, never an error", and this is the outermost
+    /// case of that rule.
+    pub fn load_at(path: &Path) -> FoldState {
+        let Ok(contents) = std::fs::read_to_string(path) else {
+            return FoldState::default();
+        };
+        match toml::from_str::<FoldState>(&contents) {
+            Ok(state) => state,
+            Err(err) => {
+                log::warn!(
+                    "{} failed to parse ({err}) - starting from an empty file-tree fold state",
+                    path.display()
+                );
+                FoldState::default()
+            }
+        }
+    }
+
+    /// Writes `self` to `path` **atomically**: a sibling `*.tmp` file first, then a
+    /// `std::fs::rename` over the target. See the module docs for why this one is atomic where
+    /// `Settings::save_at` deliberately isn't - "recorded immediately (crash-safe)" is a
+    /// requirement here, and a truncate-then-write leaves a real window in which a crash
+    /// produces a half-written, unparseable file. The temp file is created in the *same*
+    /// directory so the rename never crosses a filesystem boundary (where it would fail).
+    pub fn save_at(&self, path: &Path) -> io::Result<()> {
+        use std::io::Write;
+
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let contents = toml::to_string_pretty(self)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+        let file_name = path
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| FOLD_STATE_FILE_NAME.to_string());
+        // Process- *and* call-unique: two `jerry` instances saving at the same moment must not
+        // write to the same temp path (they would interleave into one torn file that both then
+        // rename into place), and neither must two saves from the same process.
+        static WRITE_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let unique = WRITE_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let temp = path.with_file_name(format!("{file_name}.{}.{unique}.tmp", std::process::id()));
+
+        // `sync_all` before the rename, and a directory sync after it: a plain `write` + `rename`
+        // is only atomic with respect to *metadata*, so a power loss can otherwise leave the
+        // renamed inode pointing at unflushed (zero-length or truncated) data.
+        let write_result = (|| -> io::Result<()> {
+            let mut file = std::fs::File::create(&temp)?;
+            file.write_all(contents.as_bytes())?;
+            file.sync_all()
+        })();
+        if let Err(err) = write_result {
+            let _ = std::fs::remove_file(&temp);
+            return Err(err);
+        }
+        if let Err(err) = std::fs::rename(&temp, path) {
+            let _ = std::fs::remove_file(&temp);
+            return Err(err);
+        }
+        if let Some(parent) = path.parent() {
+            // Best-effort: a failure to sync the directory entry costs at most this one save on
+            // a power loss, and is not worth reporting the whole write as failed over.
+            if let Ok(dir) = std::fs::File::open(parent) {
+                let _ = dir.sync_all();
+            }
+        }
+        sweep_orphaned_temp_files(path, &file_name);
+        Ok(())
+    }
+
+    /// The app's real write path: merges `self`'s entries for the worktrees this instance
+    /// actually owns into whatever is currently on disk, then writes the result via
+    /// [`Self::save_at`]. See the module docs for why a plain whole-file write would silently
+    /// erase a second running instance's state.
+    ///
+    /// `owned` is the set of [`worktree_key`]s this instance has recorded anything for. Keys in
+    /// `owned` are taken from `self` (including *absence* - that's how "collapse all" deletes an
+    /// entry); every other key on disk is passed through untouched.
+    pub fn save_merged_at(&self, path: &Path, owned: &BTreeSet<String>) -> io::Result<()> {
+        let mut merged = FoldState::load_at(path);
+        for key in owned {
+            match self.worktrees.get(key) {
+                Some(entry) => merged.worktrees.insert(key.clone(), entry.clone()),
+                None => merged.worktrees.remove(key),
+            };
+        }
+        merged.save_at(path)
+    }
+
+    /// Every directory currently recorded as expanded for `root`, as absolute paths ready to be
+    /// compared against `crate::sidebar::file_tree::FileTreeEntry::path`. Entries that don't
+    /// decode to a plain relative path are silently skipped ([`absolute_from_key`]).
+    pub fn expanded_dirs(&self, root: &Path) -> HashSet<PathBuf> {
+        let Some(entry) = worktree_key(root).and_then(|key| self.worktrees.get(&key)) else {
+            return HashSet::new();
+        };
+        entry
+            .expanded
+            .iter()
+            .filter_map(|key| absolute_from_key(root, key))
+            .collect()
+    }
+
+    /// Records `dir` as expanded (or not) under `root`. [`SetExpanded::Refused`] - rather than a
+    /// silent no-op - for a `dir` that isn't a plain descendant of `root`, or for either path
+    /// being non-UTF-8: those would have to be stored under a key they don't belong to, or under
+    /// a lossily-mangled one that could collide with a different worktree's.
+    pub fn set_expanded(&mut self, root: &Path, dir: &Path, expanded: bool) -> SetExpanded {
+        let (Some(root_key), Some(key)) = (worktree_key(root), relative_key(root, dir)) else {
+            return SetExpanded::Refused;
+        };
+        let changed = if expanded {
+            self.worktrees
+                .entry(root_key)
+                .or_default()
+                .expanded
+                .insert(key)
+        } else {
+            let Some(entry) = self.worktrees.get_mut(&root_key) else {
+                return SetExpanded::Unchanged;
+            };
+            let removed = entry.expanded.remove(&key);
+            if entry.expanded.is_empty() {
+                // Don't leave an empty table behind - an entry with nothing expanded is
+                // indistinguishable from no entry at all, and dropping it keeps the file from
+                // accumulating one section per worktree ever browsed.
+                self.worktrees.remove(&root_key);
+            }
+            removed
+        };
+        if changed {
+            SetExpanded::Changed
+        } else {
+            SetExpanded::Unchanged
+        }
+    }
+
+    /// Forgets everything recorded for `root` - the persisted half of the "collapse all" action,
+    /// which the issue asks to reset "both the tree and the saved state in one step". Returns
+    /// whether anything was actually removed.
+    pub fn clear_worktree(&mut self, root: &Path) -> bool {
+        worktree_key(root)
+            .and_then(|key| self.worktrees.remove(&key))
+            .is_some()
+    }
+
+    /// Drops any recorded directory for `root` that isn't in `existing_dirs` - the "stale entries
+    /// (folders since deleted or renamed) are silently ignored and pruned, never an error" half
+    /// of the issue. Returns whether anything was pruned.
+    ///
+    /// Takes the real, currently-loaded directory set rather than doing its own `Path::exists`
+    /// calls: the caller has just walked the tree, so this needs no syscalls at all, and - more
+    /// importantly - it cannot prune an entry merely because a *slow or racing* filesystem check
+    /// happened to miss it.
+    pub fn prune_missing_dirs(&mut self, root: &Path, existing_dirs: &HashSet<PathBuf>) -> bool {
+        let Some(worktree_key) = worktree_key(root) else {
+            return false;
+        };
+        let Some(entry) = self.worktrees.get_mut(&worktree_key) else {
+            return false;
+        };
+        let before = entry.expanded.len();
+        entry.expanded.retain(|key| {
+            absolute_from_key(root, key).is_some_and(|path| existing_dirs.contains(&path))
+        });
+        let pruned = entry.expanded.len() != before;
+        if entry.expanded.is_empty() {
+            self.worktrees.remove(&worktree_key);
+        }
+        pruned
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn expanded_set(state: &FoldState, root: &Path) -> Vec<String> {
+        let mut names: Vec<String> = state
+            .expanded_dirs(root)
+            .into_iter()
+            .map(|path| path.display().to_string())
+            .collect();
+        names.sort();
+        names
+    }
+
+    #[test]
+    fn fold_state_lives_next_to_the_real_settings_file() {
+        let path = fold_state_path_for(Path::new("/home/someone/.config/jerry/settings.toml"));
+        assert_eq!(
+            path,
+            PathBuf::from("/home/someone/.config/jerry/file-tree-state.toml")
+        );
+    }
+
+    #[test]
+    fn an_unseen_worktree_starts_with_nothing_expanded() {
+        let state = FoldState::default();
+        assert!(state
+            .expanded_dirs(Path::new("/repo/fresh-worktree"))
+            .is_empty());
+    }
+
+    fn set(state: &mut FoldState, root: &Path, dir: &Path, expanded: bool) -> bool {
+        match state.set_expanded(root, dir, expanded) {
+            SetExpanded::Changed => true,
+            SetExpanded::Unchanged => false,
+            SetExpanded::Refused => panic!("unexpectedly refused {}", dir.display()),
+        }
+    }
+
+    #[test]
+    fn expanding_and_collapsing_round_trips_through_a_real_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("file-tree-state.toml");
+        let root = Path::new("/repo/worktree-a");
+
+        let mut state = FoldState::default();
+        assert!(set(&mut state, root, &root.join("src"), true));
+        assert!(set(&mut state, root, &root.join("src/app"), true));
+        state.save_at(&path).expect("save");
+
+        let reloaded = FoldState::load_at(&path);
+        assert_eq!(reloaded, state);
+        assert_eq!(
+            expanded_set(&reloaded, root),
+            vec![
+                "/repo/worktree-a/src".to_string(),
+                "/repo/worktree-a/src/app".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn set_expanded_reports_whether_it_actually_changed_anything() {
+        let root = Path::new("/repo/worktree-a");
+        let mut state = FoldState::default();
+        assert!(set(&mut state, root, &root.join("src"), true));
+        assert!(
+            !set(&mut state, root, &root.join("src"), true),
+            "re-expanding an already-expanded directory changes nothing, so it must not \
+             trigger a disk write"
+        );
+        assert!(set(&mut state, root, &root.join("src"), false));
+        assert!(!set(&mut state, root, &root.join("src"), false));
+    }
+
+    /// The identity guard this module exists for: two worktrees of the same repository share
+    /// every relative path, so state recorded for one must never appear in the other.
+    #[test]
+    fn fold_state_for_one_worktree_never_leaks_into_another() {
+        let a = Path::new("/repo/worktree-a");
+        let b = Path::new("/repo/worktree-b");
+        let mut state = FoldState::default();
+        set(&mut state, a, &a.join("src"), true);
+
+        assert_eq!(expanded_set(&state, a), vec!["/repo/worktree-a/src"]);
+        assert!(
+            state.expanded_dirs(b).is_empty(),
+            "worktree B shares the relative path `src` with A, and must still start collapsed"
+        );
+    }
+
+    #[test]
+    fn a_path_outside_the_worktree_is_refused_rather_than_stored() {
+        let root = Path::new("/repo/worktree-a");
+        let mut state = FoldState::default();
+        assert_eq!(
+            state.set_expanded(root, Path::new("/etc/passwd"), true),
+            SetExpanded::Refused
+        );
+        assert_eq!(
+            state.set_expanded(root, Path::new("/repo/worktree-b/src"), true),
+            SetExpanded::Refused
+        );
+        assert!(state.worktrees.is_empty());
+    }
+
+    #[test]
+    fn the_worktree_root_itself_is_never_stored() {
+        let root = Path::new("/repo/worktree-a");
+        let mut state = FoldState::default();
+        assert_eq!(state.set_expanded(root, root, true), SetExpanded::Refused);
+        assert!(state.worktrees.is_empty());
+    }
+
+    #[test]
+    fn a_stale_entry_for_a_deleted_folder_is_silently_pruned() {
+        let root = Path::new("/repo/worktree-a");
+        let mut state = FoldState::default();
+        set(&mut state, root, &root.join("src"), true);
+        set(&mut state, root, &root.join("deleted-since"), true);
+
+        let mut existing = HashSet::new();
+        existing.insert(root.join("src"));
+        assert!(state.prune_missing_dirs(root, &existing));
+
+        assert_eq!(expanded_set(&state, root), vec!["/repo/worktree-a/src"]);
+    }
+
+    #[test]
+    fn pruning_reports_no_change_when_every_entry_still_exists() {
+        let root = Path::new("/repo/worktree-a");
+        let mut state = FoldState::default();
+        set(&mut state, root, &root.join("src"), true);
+        let mut existing = HashSet::new();
+        existing.insert(root.join("src"));
+        assert!(!state.prune_missing_dirs(root, &existing));
+        assert_eq!(expanded_set(&state, root), vec!["/repo/worktree-a/src"]);
+    }
+
+    #[test]
+    fn pruning_a_worktree_with_no_entry_at_all_is_not_an_error() {
+        let mut state = FoldState::default();
+        assert!(!state.prune_missing_dirs(Path::new("/repo/never-seen"), &HashSet::new()));
+    }
+
+    #[test]
+    fn clear_worktree_forgets_only_that_worktree() {
+        let a = Path::new("/repo/worktree-a");
+        let b = Path::new("/repo/worktree-b");
+        let mut state = FoldState::default();
+        set(&mut state, a, &a.join("src"), true);
+        set(&mut state, b, &b.join("src"), true);
+
+        assert!(state.clear_worktree(a));
+        assert!(state.expanded_dirs(a).is_empty());
+        assert_eq!(expanded_set(&state, b), vec!["/repo/worktree-b/src"]);
+    }
+
+    /// The multi-instance guarantee: a second `jerry` saving its own worktree's state must not
+    /// erase the first's. Both instances hold a whole-file copy read at their own startup, so a
+    /// plain whole-file write would do exactly that.
+    #[test]
+    fn saving_merges_with_another_instances_entries_instead_of_erasing_them() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("file-tree-state.toml");
+        let a = Path::new("/repo/worktree-a");
+        let b = Path::new("/repo/worktree-b");
+
+        // Instance A saves first.
+        let mut instance_a = FoldState::default();
+        set(&mut instance_a, a, &a.join("src"), true);
+        let owned_a: BTreeSet<String> = [worktree_key(a).expect("key")].into_iter().collect();
+        instance_a.save_merged_at(&path, &owned_a).expect("save a");
+
+        // Instance B started before A wrote anything, so its in-memory copy knows nothing of A.
+        let mut instance_b = FoldState::default();
+        set(&mut instance_b, b, &b.join("src"), true);
+        let owned_b: BTreeSet<String> = [worktree_key(b).expect("key")].into_iter().collect();
+        instance_b.save_merged_at(&path, &owned_b).expect("save b");
+
+        let on_disk = FoldState::load_at(&path);
+        assert_eq!(
+            expanded_set(&on_disk, a),
+            vec!["/repo/worktree-a/src"],
+            "instance B's save must not have erased instance A's worktree"
+        );
+        assert_eq!(expanded_set(&on_disk, b), vec!["/repo/worktree-b/src"]);
+    }
+
+    /// The other half of the merge contract: for a worktree this instance *does* own, absence is
+    /// a real deletion (that's how "collapse all" removes an entry), not something to merge back
+    /// in from disk.
+    #[test]
+    fn a_merged_save_really_deletes_an_owned_worktrees_entry() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("file-tree-state.toml");
+        let root = Path::new("/repo/worktree-a");
+        let owned: BTreeSet<String> = [worktree_key(root).expect("key")].into_iter().collect();
+
+        let mut state = FoldState::default();
+        set(&mut state, root, &root.join("src"), true);
+        state.save_merged_at(&path, &owned).expect("save");
+        assert_eq!(FoldState::load_at(&path).expanded_dirs(root).len(), 1);
+
+        state.clear_worktree(root);
+        state.save_merged_at(&path, &owned).expect("save");
+
+        assert!(
+            FoldState::load_at(&path).expanded_dirs(root).is_empty(),
+            "collapse-all must survive the merge as a real deletion"
+        );
+    }
+
+    #[test]
+    fn a_missing_file_loads_as_empty_state_rather_than_failing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state = FoldState::load_at(&dir.path().join("does-not-exist.toml"));
+        assert_eq!(state, FoldState::default());
+    }
+
+    #[test]
+    fn a_corrupted_file_loads_as_empty_state_rather_than_failing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("file-tree-state.toml");
+        std::fs::write(&path, "this is not valid toml {{{").expect("write");
+        assert_eq!(FoldState::load_at(&path), FoldState::default());
+    }
+
+    /// A hand-corrupted (or maliciously written) file must not be able to make the app treat a
+    /// path outside the worktree as an expanded directory.
+    #[test]
+    fn a_traversal_entry_in_a_hand_edited_file_is_ignored() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("file-tree-state.toml");
+        std::fs::write(
+            &path,
+            "[worktrees.\"/repo/worktree-a\"]\nexpanded = [\"../worktree-b/src\", \"src\"]\n",
+        )
+        .expect("write");
+
+        let state = FoldState::load_at(&path);
+        assert_eq!(
+            expanded_set(&state, Path::new("/repo/worktree-a")),
+            vec!["/repo/worktree-a/src"],
+            "the `..` entry must be silently dropped, and the good one kept"
+        );
+    }
+
+    /// The atomic-write contract: after a save there is exactly one real file at `path` and no
+    /// leftover temp file, and its contents parse.
+    #[test]
+    fn saving_leaves_no_temp_file_behind_and_the_result_parses() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("nested").join("file-tree-state.toml");
+        let root = Path::new("/repo/worktree-a");
+        let mut state = FoldState::default();
+        set(&mut state, root, &root.join("src"), true);
+
+        state.save_at(&path).expect("save");
+
+        assert!(path.exists());
+        let siblings: Vec<String> = std::fs::read_dir(path.parent().expect("parent"))
+            .expect("read_dir")
+            .map(|entry| {
+                entry
+                    .expect("entry")
+                    .file_name()
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .collect();
+        assert_eq!(siblings, vec!["file-tree-state.toml".to_string()]);
+        assert_eq!(FoldState::load_at(&path), state);
+    }
+
+    /// A save killed between creating its temp file and renaming it leaves an orphan behind.
+    /// Because the temp name is process-unique (so two instances can't tear each other's
+    /// writes), those would otherwise accumulate forever.
+    #[test]
+    fn a_stale_orphaned_temp_file_is_swept_and_a_fresh_one_is_left_alone() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("file-tree-state.toml");
+        let stale = dir.path().join("file-tree-state.toml.999999.0.tmp");
+        let fresh = dir.path().join("file-tree-state.toml.999998.0.tmp");
+        let unrelated = dir.path().join("settings.toml");
+        std::fs::write(&stale, "orphan").expect("write");
+        std::fs::write(&fresh, "in flight").expect("write");
+        std::fs::write(&unrelated, "keep me").expect("write");
+        // Backdate the orphan well past `ORPHANED_TEMP_MAX_AGE` (`File::set_modified`, stable
+        // since Rust 1.75 - no extra dev-dependency needed to age a file).
+        let old = std::time::SystemTime::now() - std::time::Duration::from_secs(60 * 60 * 24);
+        std::fs::File::options()
+            .write(true)
+            .open(&stale)
+            .expect("open orphan")
+            .set_modified(old)
+            .expect("backdate");
+
+        FoldState::default().save_at(&path).expect("save");
+
+        assert!(!stale.exists(), "the aged orphan must be swept");
+        assert!(
+            fresh.exists(),
+            "a temp file young enough to be another instance's live write must be left alone"
+        );
+        assert!(unrelated.exists(), "unrelated siblings are never touched");
+        assert!(path.exists());
+    }
+
+    /// Overwriting an existing file must replace it wholesale, not merge into it.
+    #[test]
+    fn saving_over_an_existing_file_replaces_its_contents() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("file-tree-state.toml");
+        let root = Path::new("/repo/worktree-a");
+
+        let mut first = FoldState::default();
+        set(&mut first, root, &root.join("src"), true);
+        first.save_at(&path).expect("save");
+
+        let second = FoldState::default();
+        second.save_at(&path).expect("save");
+
+        assert_eq!(FoldState::load_at(&path), FoldState::default());
+    }
+}

--- a/crates/app/src/sidebar/mod.rs
+++ b/crates/app/src/sidebar/mod.rs
@@ -4,7 +4,10 @@
 //! logic separate from the `gpui::Div`-building code that draws it:
 //!
 //! - [`file_tree`] - the pure `std::fs::read_dir` walk that flattens a directory into the
-//!   indented row list the Files tab shows.
+//!   indented row list the Files tab shows, plus the pure indent-guide geometry that list
+//!   draws.
+//! - [`fold_state`] - the real, on-disk (`~/.config/jerry/file-tree-state.toml`) per-worktree
+//!   record of which folders are expanded, and its atomic write path.
 //! - [`changes`] - the pure mapping from `wt_core::diff` data to the Changes tab's row
 //!   labels/colours/counts and the fold-marker treatment.
 //! - [`render`] - the real GPUI sidebar: the Files/Changes tab switch, its virtualized row
@@ -21,10 +24,12 @@ use crate::work_surface::state as work_surface;
 use gpui::{div, font, prelude::*, px, uniform_list, ClickEvent, Context, Pixels};
 use std::collections::HashMap;
 use std::ops::Range;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
 use wt_core::diff::{DiffFile, FileChangeStatus, WorktreeDiff};
 
 pub mod changes;
 pub mod file_tree;
+pub mod fold_state;
 
 pub(crate) mod render;

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -21,72 +21,90 @@ impl AdeApp {
     }
 
     /// Toggles a directory's expanded state - `crate::sidebar::file_tree::visible_entries` does
-    /// the actual hiding at render time, and [`Self::set_dir_expanded`] records the change on
-    /// disk before this returns.
+    /// the actual hiding at render time, and [`Self::set_dir_expanded`] records the change in
+    /// memory and queues an immediate background write of it (never a write awaited here on the
+    /// foreground thread).
     pub(crate) fn toggle_dir_expanded(&mut self, path: PathBuf, cx: &mut Context<Self>) {
         let expanded = !self.expanded_dirs.contains(&path);
         self.set_dir_expanded(path, expanded, cx);
     }
 
-    /// The single write path for one directory's expanded state: live set, persisted
-    /// [`AdeApp::fold_state`], and a real disk write, always together (GitHub issue #18 §2 -
-    /// "expanding or collapsing a folder is recorded immediately, not only on clean exit").
-    ///
-    /// The disk write is skipped only when `fold_state` reports that nothing actually changed -
-    /// a genuine no-op, not a debounce.
+    /// Records one directory's expanded state in the live set and in the persisted
+    /// [`AdeApp::fold_state`] - **the** single place either is mutated for a single directory, so
+    /// [`Self::set_dir_expanded`] and [`Self::reveal_in_tree`] can't drift apart (they used to be
+    /// two hand-copied bodies, log string and all). Returns whether the persisted state changed,
+    /// leaving the caller to decide when to write and when to notify: a reveal touches a whole
+    /// ancestor chain and wants one write for all of it, not one per level.
     ///
     /// The tree still expands when the state is *refusable* (a non-UTF-8 path, which has no
     /// honest TOML key - see `fold_state::worktree_key`): silently declining to open a folder
     /// because of how its name is encoded would be a far worse outcome than not remembering that
     /// it was opened. But it says so in the log rather than leaving the live tree and the file
     /// quietly disagreeing.
+    ///
+    /// Uses the cached [`AdeApp::fold_state_root_key`], never `fold_state::worktree_key` - see
+    /// that field's docs for the blocking-syscall-per-click this avoids.
+    fn record_dir_expanded(&mut self, path: &Path, expanded: bool) -> bool {
+        if expanded {
+            self.expanded_dirs.insert(path.to_path_buf());
+        } else {
+            self.expanded_dirs.remove(path);
+        }
+        let root = self.file_tree_root.clone();
+        let outcome = match self.fold_state_root_key.clone() {
+            Some(root_key) => {
+                let outcome = self
+                    .fold_state
+                    .set_expanded_with_key(&root_key, &root, path, expanded);
+                if outcome == fold_state::SetExpanded::Changed {
+                    // Claimed here rather than at each call site: "I changed this worktree's
+                    // entry" and "this worktree's entry is mine to overwrite on the next merged
+                    // write" are the same fact, and splitting them is how one of them gets
+                    // forgotten.
+                    self.fold_state_owned.insert(root_key);
+                }
+                outcome
+            }
+            None => fold_state::SetExpanded::Refused,
+        };
+        if outcome == fold_state::SetExpanded::Refused {
+            log::warn!(
+                "not recording the fold state of {} under {}: it is not a plain UTF-8 path \
+                 inside that worktree, so this expansion won't survive a restart",
+                path.display(),
+                root.display()
+            );
+        }
+        outcome == fold_state::SetExpanded::Changed
+    }
+
+    /// One directory's expand/collapse, recorded and queued for an immediate background write
+    /// (GitHub issue #18 §2 - "expanding or collapsing a folder is recorded immediately, not only
+    /// on clean exit"). The write is queued, not awaited: see [`AdeApp::persist_fold_state`] for
+    /// the serial writer loop it hands off to, and what happens when that write fails.
     pub(crate) fn set_dir_expanded(
         &mut self,
         path: PathBuf,
         expanded: bool,
         cx: &mut Context<Self>,
     ) {
-        if expanded {
-            self.expanded_dirs.insert(path.clone());
-        } else {
-            self.expanded_dirs.remove(&path);
-        }
-        let root = self.file_tree_root.clone();
-        match self.fold_state.set_expanded(&root, &path, expanded) {
-            fold_state::SetExpanded::Changed => {
-                self.claim_fold_state_for(&root);
-                self.persist_fold_state(cx);
-            }
-            fold_state::SetExpanded::Unchanged => {}
-            fold_state::SetExpanded::Refused => log::warn!(
-                "not recording the fold state of {} under {}: it is not a plain UTF-8 path \
-                 inside that worktree, so this expansion won't survive a restart",
-                path.display(),
-                root.display()
-            ),
+        if self.record_dir_expanded(&path, expanded) {
+            self.persist_fold_state(cx);
         }
         cx.notify();
-    }
-
-    /// Marks this worktree as one whose fold-state entry this instance owns and may overwrite -
-    /// see [`AdeApp::fold_state_owned`] and `crate::sidebar::fold_state`'s module docs for the
-    /// second-running-instance clobber this prevents.
-    fn claim_fold_state_for(&mut self, root: &Path) {
-        if let Some(key) = fold_state::worktree_key(root) {
-            self.fold_state_owned.insert(key);
-        }
     }
 
     /// "Collapse all" - resets the tree *and* the saved state for this worktree in one step
     /// (issue #18 §1), so relaunching doesn't bring the old expansions back.
     pub(crate) fn collapse_all_dirs(&mut self, cx: &mut Context<Self>) {
-        let root = self.file_tree_root.clone();
         self.expanded_dirs.clear();
-        if self.fold_state.clear_worktree(&root) {
-            // Claimed *because* the entry is now gone: the merge on write treats an owned key's
-            // absence as a real deletion, which is exactly what this action means.
-            self.claim_fold_state_for(&root);
-            self.persist_fold_state(cx);
+        if let Some(root_key) = self.fold_state_root_key.clone() {
+            if self.fold_state.clear_worktree_with_key(&root_key) {
+                // Claimed *because* the entry is now gone: the merge on write treats an owned
+                // key's absence as a real deletion, which is exactly what this action means.
+                self.fold_state_owned.insert(root_key);
+                self.persist_fold_state(cx);
+            }
         }
         cx.notify();
     }
@@ -112,25 +130,16 @@ impl AdeApp {
                 // record under this worktree's key.
                 break;
             }
-            self.expanded_dirs.insert(ancestor.to_path_buf());
-            // A refusal here is the same non-UTF-8 case [`Self::set_dir_expanded`] documents -
-            // the reveal still happens, it just isn't recorded - and it gets the same log line
-            // rather than leaving the live tree and the file silently disagreeing.
-            match self.fold_state.set_expanded(&root, ancestor, true) {
-                fold_state::SetExpanded::Changed => changed = true,
-                fold_state::SetExpanded::Unchanged => {}
-                fold_state::SetExpanded::Refused => log::warn!(
-                    "not recording the fold state of {} under {}: it is not a plain UTF-8 path \
-                     inside that worktree, so this expansion won't survive a restart",
-                    ancestor.display(),
-                    root.display()
-                ),
-            }
+            // The same real recording path a manual click takes, refusal logging included -
+            // one shared helper, not a second copy of it.
+            changed |= self.record_dir_expanded(ancestor, true);
         }
         if changed {
-            self.claim_fold_state_for(&root);
             self.persist_fold_state(cx);
         }
+        // A reveal genuinely changes what the tree shows, so it must repaint on its own rather
+        // than relying on every caller happening to notify afterwards.
+        cx.notify();
     }
 
     /// Drops fold-state entries for directories that no longer exist, against the tree that has
@@ -150,14 +159,29 @@ impl AdeApp {
         }
         let dirs = file_tree::directory_paths(&self.file_tree);
         let root = self.file_tree_root.clone();
-        let mut changed = self.fold_state.prune_missing_dirs(&root, &dirs);
+        let Some(root_key) = self.fold_state_root_key.clone() else {
+            return;
+        };
+        let mut changed = self
+            .fold_state
+            .prune_missing_dirs_with_key(&root_key, &root, &dirs);
         let before = self.expanded_dirs.len();
         self.expanded_dirs.retain(|path| dirs.contains(path));
         changed |= self.expanded_dirs.len() != before;
         if changed {
-            self.claim_fold_state_for(&root);
+            self.fold_state_owned.insert(root_key);
             self.persist_fold_state(cx);
         }
+    }
+
+    /// Whether the current walk budget is already at [`file_tree::MAX_LOAD_MORE_ENTRIES`], so
+    /// [`Self::load_more_file_tree_entries`] has nothing left to raise - the condition that turns
+    /// the sidebar's action row into a plain disclosure rather than a button that re-walks a
+    /// ceiling's worth of entries to no effect.
+    pub(crate) fn file_tree_limit_is_at_ceiling(&self) -> bool {
+        self.file_tree_limit_override
+            .unwrap_or(self.settings.file_tree.max_entries)
+            >= file_tree::MAX_LOAD_MORE_ENTRIES
     }
 
     /// The "load more" action's real handler - re-walks the current tree with a tenfold larger
@@ -168,15 +192,23 @@ impl AdeApp {
         let current = self
             .file_tree_limit_override
             .unwrap_or(self.settings.file_tree.max_entries);
-        // Ceilinged, not just `saturating_mul`: seven clicks from the 20,000 default would
-        // otherwise reach `usize::MAX`, at which point "still a real cap" would be true only
-        // literally. A million entries is already far past any tree this sidebar can usefully
-        // show, and the row keeps naming where the walk stopped either way.
-        self.file_tree_limit_override = Some(
-            current
-                .saturating_mul(10)
-                .min(file_tree::MAX_LOAD_MORE_ENTRIES),
-        );
+        // Ceilinged *and* monotonic. The ceiling is why this can't escalate into the unbounded
+        // walk again (see `file_tree::MAX_LOAD_MORE_ENTRIES`); the `.max(current)` is a real bug
+        // fix rather than defensive padding - a `max_entries` above the ceiling would otherwise
+        // make one click *shrink* the budget, so "load more" would visibly remove rows from the
+        // tree. A limit this action produces can never be smaller than the one it replaced.
+        let next = current
+            .saturating_mul(10)
+            .min(file_tree::MAX_LOAD_MORE_ENTRIES)
+            .max(current);
+        if next == current {
+            // Already at the ceiling: re-walking would burn a whole budget's worth of work to
+            // produce byte-identical rows. `render_file_tree` doesn't offer the action at all in
+            // this state (it renders a plain disclosure instead); this is the same fact enforced
+            // at the handler, so no other caller can reintroduce the dead-but-expensive click.
+            return;
+        }
+        self.file_tree_limit_override = Some(next);
         self.load_file_tree(self.file_tree_root.clone(), cx);
     }
 
@@ -305,9 +337,11 @@ impl AdeApp {
             cx.processor(move |this: &mut Self, range: Range<usize>, _window, cx| {
                 // Both the row range and each index into `file_tree` are clamped/checked rather
                 // than trusted, so a future divergence degrades to "renders fewer rows" instead
-                // of panicking.
-                let start = range.start.min(visible_indices.len());
+                // of panicking. `start` is clamped to `end`, not just to the length: clamping
+                // only the upper bound still leaves `start > end`, which panics in the slice
+                // expression below rather than degrading.
                 let end = range.end.min(visible_indices.len());
+                let start = range.start.min(end);
                 visible_indices[start..end]
                     .iter()
                     .filter_map(|index| this.file_tree.get(*index).cloned())
@@ -344,7 +378,20 @@ impl AdeApp {
         // (`Self::load_more_file_tree_entries`). Only ever shown when the walk genuinely stopped
         // early, and it names the exact count it stopped at rather than implying a total it
         // cannot know without walking the rest.
-        if self.file_tree_truncated {
+        if self.file_tree_truncated && self.file_tree_limit_is_at_ceiling() {
+            // The honest end of the escalation: still truncated, but no larger budget is
+            // available, so an action here would be a button that re-walks a whole ceiling's
+            // worth of entries to produce exactly the same rows. A plain, non-interactive
+            // disclosure instead - it still names the count, so the listing is never *silently*
+            // cut off, which is the actual requirement.
+            column = column.child(render_sidebar_message(
+                format!(
+                    "Showing the first {} entries (the most this tree can load)",
+                    self.file_tree.len()
+                ),
+                theme::text::FAINT.into(),
+            ));
+        } else if self.file_tree_truncated {
             let loaded = self.file_tree.len();
             column = column.child(
                 div()
@@ -1982,6 +2029,176 @@ mod fold_state_tests {
             Some(100),
             "the escape hatch raises the bound tenfold - it never removes it, or one click on a \
              pathological tree would pull the whole thing into memory"
+        );
+    }
+
+    /// CRITICAL 1: "load more" must never *shrink* the budget. With a `max_entries` above the
+    /// escalation ceiling, the old `saturating_mul(10).min(ceiling)` computed a smaller limit
+    /// than the one already in force, so clicking "load more" would visibly remove rows from the
+    /// tree.
+    #[gpui::test]
+    fn load_more_can_never_shrink_the_walk_budget(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        let state_dir = TempDir::new().expect("tempdir");
+        seed_tree(&repo);
+        // Deliberately above `MAX_LOAD_MORE_ENTRIES`. `sanitize` clamps this on load from a real
+        // file, so this is constructed directly - the handler must still be correct for it.
+        let mut settings = settings_store::Settings::default();
+        settings.file_tree.max_entries = file_tree::MAX_LOAD_MORE_ENTRIES * 5;
+
+        let (app, cx) = open_app_with_state_dir_and_settings(
+            cx,
+            repo.path().to_path_buf(),
+            state_dir.path().join("settings.toml"),
+            settings,
+        );
+        cx.run_until_parked();
+
+        app.update(cx, |app, cx| app.load_more_file_tree_entries(cx));
+        cx.run_until_parked();
+
+        let effective = app.read_with(cx, |app, _| {
+            app.file_tree_limit_override
+                .unwrap_or(app.settings.file_tree.max_entries)
+        });
+        assert!(
+            effective >= file_tree::MAX_LOAD_MORE_ENTRIES * 5,
+            "the effective walk budget went *down* from {} to {effective} - one click on \
+             `load more` would remove rows from the tree",
+            file_tree::MAX_LOAD_MORE_ENTRIES * 5
+        );
+    }
+
+    /// CRITICAL 1, other half: once the budget is at the ceiling and the walk is *still*
+    /// truncated, the row must stop being an action. Clicking it would re-walk a whole ceiling's
+    /// worth of entries to produce byte-identical rows.
+    ///
+    /// The at-the-ceiling state is set directly rather than reached by walking: producing it
+    /// honestly needs `MAX_LOAD_MORE_ENTRIES` real files on disk. Everything asserted *from* that
+    /// precondition is real behaviour - what renders, and what the handler does.
+    #[gpui::test]
+    fn at_the_ceiling_the_row_stops_being_a_button(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        let state_dir = TempDir::new().expect("tempdir");
+        seed_tree(&repo);
+
+        let (app, cx) = open_app_with_state_dir(
+            cx,
+            repo.path().to_path_buf(),
+            state_dir.path().join("settings.toml"),
+        );
+        cx.run_until_parked();
+
+        app.update(cx, |app, cx| {
+            app.file_tree_truncated = true;
+            app.file_tree_limit_override = Some(file_tree::MAX_LOAD_MORE_ENTRIES);
+            cx.notify();
+        });
+        cx.run_until_parked();
+
+        assert!(
+            cx.debug_bounds("file-tree-show-all").is_none(),
+            "at the ceiling there is nothing left to load, so the clickable row must be gone - \
+             a button that re-walks a ceiling's worth of entries for identical results is worse \
+             than no button"
+        );
+
+        let before = app.read_with(cx, |app, _| app.file_tree_limit_override);
+        app.update(cx, |app, cx| app.load_more_file_tree_entries(cx));
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.file_tree_limit_override),
+            before,
+            "and the handler itself must be a no-op at the ceiling, not just unreachable"
+        );
+    }
+
+    /// CRITICAL 2: the canonicalized worktree key is resolved once per real root change and
+    /// cached, because `worktree_key` calls the blocking `std::fs::canonicalize` and the callers
+    /// are clicks and per-ancestor reveals. What's asserted here is the part that would actually
+    /// break if the cache were wrong: reaching a worktree through a symlink must record against
+    /// the *canonical* path, and a reveal through that symlink must still persist.
+    #[cfg(unix)]
+    #[gpui::test]
+    fn the_cached_worktree_key_is_canonical_and_records_through_a_symlink(cx: &mut TestAppContext) {
+        let real = TempDir::new().expect("tempdir");
+        let link_parent = TempDir::new().expect("tempdir");
+        seed_tree(&real);
+        let link = link_parent.path().join("linked-worktree");
+        std::os::unix::fs::symlink(real.path(), &link).expect("symlink");
+        let state_dir = TempDir::new().expect("tempdir");
+
+        let (app, cx) =
+            open_app_with_state_dir(cx, link.clone(), state_dir.path().join("settings.toml"));
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.fold_state_root_key.clone()),
+            crate::sidebar::fold_state::worktree_key(&link),
+            "the cached key must be the canonicalized one, so the same worktree reached through \
+             a symlink and through its real path is one entry rather than two"
+        );
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_palette_file_result(link.join("src/app/main.rs"), window, cx);
+        });
+        cx.run_until_parked();
+
+        // Reopening against the *real* path must see what was recorded through the symlink.
+        let (reloaded, cx) = open_app_with_state_dir(
+            cx,
+            real.path().to_path_buf(),
+            state_dir.path().join("settings.toml"),
+        );
+        cx.run_until_parked();
+        assert_eq!(
+            reloaded.read_with(cx, |app, _| expanded_names(app)),
+            vec!["src".to_string(), "src/app".to_string()],
+            "a symlinked and a direct open of one worktree must share one fold-state entry"
+        );
+    }
+
+    /// CRITICAL 4: a write that fails must not silently drop the change. The pending flag is
+    /// cleared *before* the write, so without an explicit re-queue on error the user's
+    /// expand/collapse is lost with only a log line - directly contradicting this feature's
+    /// "recorded immediately" claim.
+    ///
+    /// The failure is real, not injected: the settings path's parent is a regular *file*, so the
+    /// `create_dir_all` inside `FoldState::save_at` fails on every attempt.
+    #[gpui::test]
+    fn a_failed_fold_state_write_is_requeued_rather_than_dropped(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        let state_dir = TempDir::new().expect("tempdir");
+        seed_tree(&repo);
+        let blocker = state_dir.path().join("not-a-directory");
+        fs::write(
+            &blocker,
+            "this is a file, so nothing can be created inside it",
+        )
+        .expect("write");
+
+        let (app, cx) =
+            open_app_with_state_dir(cx, repo.path().to_path_buf(), blocker.join("settings.toml"));
+        cx.run_until_parked();
+
+        app.update(cx, |app, cx| {
+            app.toggle_dir_expanded(repo.path().join("src"), cx);
+        });
+        cx.run_until_parked();
+
+        assert!(
+            app.read_with(cx, |app, _| app.fold_state_save_pending),
+            "after a failing write the change must still be pending a retry - clearing the flag \
+             before the write and not restoring it on error loses the change outright"
+        );
+        assert!(
+            app.read_with(cx, |app, _| app.fold_state_save_running),
+            "and the writer loop must still be alive to perform that retry"
+        );
+        assert!(
+            app.read_with(cx, |app, _| app.expanded_dirs.len()) == 1,
+            "the live tree keeps the expansion regardless - a failing disk is not a reason to \
+             refuse to open a folder"
         );
     }
 

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -20,17 +20,164 @@ impl AdeApp {
         }
     }
 
-    /// Toggles a directory's collapsed/expanded state - `crate::sidebar::file_tree::visible_entries`
-    /// does the actual hiding at render time.
-    pub(in crate::sidebar) fn toggle_dir_collapsed(
+    /// Toggles a directory's expanded state - `crate::sidebar::file_tree::visible_entries` does
+    /// the actual hiding at render time, and [`Self::set_dir_expanded`] records the change on
+    /// disk before this returns.
+    pub(crate) fn toggle_dir_expanded(&mut self, path: PathBuf, cx: &mut Context<Self>) {
+        let expanded = !self.expanded_dirs.contains(&path);
+        self.set_dir_expanded(path, expanded, cx);
+    }
+
+    /// The single write path for one directory's expanded state: live set, persisted
+    /// [`AdeApp::fold_state`], and a real disk write, always together (GitHub issue #18 §2 -
+    /// "expanding or collapsing a folder is recorded immediately, not only on clean exit").
+    ///
+    /// The disk write is skipped only when `fold_state` reports that nothing actually changed -
+    /// a genuine no-op, not a debounce.
+    ///
+    /// The tree still expands when the state is *refusable* (a non-UTF-8 path, which has no
+    /// honest TOML key - see `fold_state::worktree_key`): silently declining to open a folder
+    /// because of how its name is encoded would be a far worse outcome than not remembering that
+    /// it was opened. But it says so in the log rather than leaving the live tree and the file
+    /// quietly disagreeing.
+    pub(crate) fn set_dir_expanded(
         &mut self,
         path: PathBuf,
+        expanded: bool,
         cx: &mut Context<Self>,
     ) {
-        if !self.collapsed_dirs.remove(&path) {
-            self.collapsed_dirs.insert(path);
+        if expanded {
+            self.expanded_dirs.insert(path.clone());
+        } else {
+            self.expanded_dirs.remove(&path);
+        }
+        let root = self.file_tree_root.clone();
+        match self.fold_state.set_expanded(&root, &path, expanded) {
+            fold_state::SetExpanded::Changed => {
+                self.claim_fold_state_for(&root);
+                self.persist_fold_state(cx);
+            }
+            fold_state::SetExpanded::Unchanged => {}
+            fold_state::SetExpanded::Refused => log::warn!(
+                "not recording the fold state of {} under {}: it is not a plain UTF-8 path \
+                 inside that worktree, so this expansion won't survive a restart",
+                path.display(),
+                root.display()
+            ),
         }
         cx.notify();
+    }
+
+    /// Marks this worktree as one whose fold-state entry this instance owns and may overwrite -
+    /// see [`AdeApp::fold_state_owned`] and `crate::sidebar::fold_state`'s module docs for the
+    /// second-running-instance clobber this prevents.
+    fn claim_fold_state_for(&mut self, root: &Path) {
+        if let Some(key) = fold_state::worktree_key(root) {
+            self.fold_state_owned.insert(key);
+        }
+    }
+
+    /// "Collapse all" - resets the tree *and* the saved state for this worktree in one step
+    /// (issue #18 §1), so relaunching doesn't bring the old expansions back.
+    pub(crate) fn collapse_all_dirs(&mut self, cx: &mut Context<Self>) {
+        let root = self.file_tree_root.clone();
+        self.expanded_dirs.clear();
+        if self.fold_state.clear_worktree(&root) {
+            // Claimed *because* the entry is now gone: the merge on write treats an owned key's
+            // absence as a real deletion, which is exactly what this action means.
+            self.claim_fold_state_for(&root);
+            self.persist_fold_state(cx);
+        }
+        cx.notify();
+    }
+
+    /// Reveals `path` in the tree by expanding every ancestor directory between it and the tree
+    /// root - and records each of those expansions exactly like a manual click would (issue #18
+    /// §5). The one entry point for every "reveal in tree" flow: a palette file result
+    /// (`Self::open_palette_file_result`) and a just-created file (`Self::create_new_file`),
+    /// both of which would otherwise point at a row hidden inside a collapsed parent now that
+    /// the tree starts collapsed.
+    ///
+    /// `path` itself is deliberately not expanded when it happens to be a directory: revealing
+    /// something means making it visible, not opening it.
+    pub(crate) fn reveal_in_tree(&mut self, path: &Path, cx: &mut Context<Self>) {
+        let root = self.file_tree_root.clone();
+        let mut changed = false;
+        for ancestor in path.ancestors().skip(1) {
+            if ancestor == root {
+                break;
+            }
+            if !ancestor.starts_with(&root) {
+                // Not part of this tree at all - nothing to reveal, and certainly nothing to
+                // record under this worktree's key.
+                break;
+            }
+            self.expanded_dirs.insert(ancestor.to_path_buf());
+            // A refusal here is the same non-UTF-8 case [`Self::set_dir_expanded`] documents -
+            // the reveal still happens, it just isn't recorded - and it gets the same log line
+            // rather than leaving the live tree and the file silently disagreeing.
+            match self.fold_state.set_expanded(&root, ancestor, true) {
+                fold_state::SetExpanded::Changed => changed = true,
+                fold_state::SetExpanded::Unchanged => {}
+                fold_state::SetExpanded::Refused => log::warn!(
+                    "not recording the fold state of {} under {}: it is not a plain UTF-8 path \
+                     inside that worktree, so this expansion won't survive a restart",
+                    ancestor.display(),
+                    root.display()
+                ),
+            }
+        }
+        if changed {
+            self.claim_fold_state_for(&root);
+            self.persist_fold_state(cx);
+        }
+    }
+
+    /// Drops fold-state entries for directories that no longer exist, against the tree that has
+    /// just finished loading (issue #18 §2 - "stale entries are silently ignored and pruned,
+    /// never an error"). Called from `Self::load_file_tree`'s completion handler, which has
+    /// already checked that the walk it is applying belongs to the current root.
+    ///
+    /// Only ever prunes against a walk that is genuinely *complete*
+    /// ([`file_tree::FileTreeListing::is_complete`]). A walk that stopped at its entry cap - or
+    /// that silently skipped a directory it couldn't read, which the walk does deliberately so
+    /// one unreadable folder can't blank the whole sidebar - is not evidence that the
+    /// directories it never reached are gone. Pruning against either would permanently delete
+    /// perfectly good state, since the prune is written straight back to disk.
+    pub(crate) fn prune_stale_fold_state(&mut self, cx: &mut Context<Self>) {
+        if !self.file_tree_complete {
+            return;
+        }
+        let dirs = file_tree::directory_paths(&self.file_tree);
+        let root = self.file_tree_root.clone();
+        let mut changed = self.fold_state.prune_missing_dirs(&root, &dirs);
+        let before = self.expanded_dirs.len();
+        self.expanded_dirs.retain(|path| dirs.contains(path));
+        changed |= self.expanded_dirs.len() != before;
+        if changed {
+            self.claim_fold_state_for(&root);
+            self.persist_fold_state(cx);
+        }
+    }
+
+    /// The "load more" action's real handler - re-walks the current tree with a tenfold larger
+    /// entry budget. Genuinely reloads rather than revealing something already loaded: the
+    /// capped walk never collected those entries. Still bounded, deliberately - see
+    /// [`AdeApp::file_tree_limit_override`] for why this raises the cap instead of removing it.
+    pub(crate) fn load_more_file_tree_entries(&mut self, cx: &mut Context<Self>) {
+        let current = self
+            .file_tree_limit_override
+            .unwrap_or(self.settings.file_tree.max_entries);
+        // Ceilinged, not just `saturating_mul`: seven clicks from the 20,000 default would
+        // otherwise reach `usize::MAX`, at which point "still a real cap" would be true only
+        // literally. A million entries is already far past any tree this sidebar can usefully
+        // show, and the row keeps naming where the walk stopped either way.
+        self.file_tree_limit_override = Some(
+            current
+                .saturating_mul(10)
+                .min(file_tree::MAX_LOAD_MORE_ENTRIES),
+        );
+        self.load_file_tree(self.file_tree_root.clone(), cx);
     }
 
     /// Toggles a file's reviewed state - the Changes row checkbox's click handler.
@@ -77,7 +224,7 @@ impl AdeApp {
     /// The file tree - `design_handoff_jerry_ade/README.md`'s Zone 3 "Files (tree)" spec:
     /// rect-composed folder/language-chip icons (see [`render_folder_icon`]/
     /// [`render_lang_chip`], never emoji or an SVG pipeline), collapse/expand (see
-    /// [`Self::toggle_dir_collapsed`]/`crate::sidebar::file_tree::visible_entries`).
+    /// [`Self::toggle_dir_expanded`]/`crate::sidebar::file_tree::visible_entries`).
     ///
     /// **Scrolling lives here, not in the caller.** This list is a `gpui::uniform_list`, which
     /// sets its own `overflow.y = Scroll` and owns the scroll offset
@@ -110,25 +257,34 @@ impl AdeApp {
             );
         }
 
-        let visible_count = file_tree::visible_entries(&self.file_tree, &self.collapsed_dirs).len();
-        let rendered_count = visible_count.min(file_tree::MAX_RENDERED_FILE_ENTRIES);
+        // Every visible row is rendered - there is no render-time cap and no "... and N more
+        // entries not shown" row any more (GitHub issue #18 §4). The list below is virtualized,
+        // so this count drives `uniform_list`'s scroll extent, not how many elements get built.
+        //
+        // Resolved *once* per frame, into indices into `self.file_tree`, and shared with the
+        // row-builder closure through an `Rc`. That indirection is load-bearing: `uniform_list`
+        // invokes its closure **three** times per frame (`measure_item` from `request_layout`,
+        // again from `prepaint`, then `render_items` for the real visible range -
+        // `vendor/zed/crates/gpui/src/elements/uniform_list.rs:283`, `:359`, `:489`), so a
+        // `visible_entries` call inside it would walk the whole loaded tree four times per frame
+        // including this one. Indices rather than the borrowed `&FileTreeEntry`s the walk
+        // returns, because the closure is `'static` and cannot hold a borrow of `self` - and
+        // indices are valid for exactly as long as they need to be, since nothing can mutate
+        // `file_tree` between this line and the closure's last call within one frame. They are
+        // still bounds-checked below rather than indexed blindly.
+        let visible_indices: Rc<Vec<usize>> = Rc::new(file_tree::visible_indices(
+            &self.file_tree,
+            &self.expanded_dirs,
+        ));
+        let rendered_count = visible_indices.len();
 
-        // Built once per render, not once per row - see `Self::tree_change_marks`'s docs. Moved
-        // *into* the row-builder closure below (rather than recomputed inside it) because
-        // `uniform_list` calls that closure **three** times per frame, not once: `measure_item`
-        // from `request_layout`, `measure_item` again from `prepaint`, then `render_items` for
-        // the real visible range (`vendor/zed/crates/gpui/src/elements/uniform_list.rs:283`,
-        // `:359`, `:489`). Capturing the map keeps it at one build per frame, exactly as the
-        // previous eager loop had it. `file_tree::visible_entries` below does *not* get that
-        // treatment and genuinely does run three times per frame now where it used to run once -
-        // a real, accepted regression on that one call: it is a borrowing walk with a single
-        // `Vec` allocation, measured at well under a millisecond against the ~145ms of per-frame
-        // element layout this whole change removes, and capturing it instead would mean cloning
-        // every entry (the walk borrows from `self`, so the `'static` closure cannot hold it).
+        // Built once per render, not once per row - see `Self::tree_change_marks`'s docs, and
+        // `visible_indices` above for why anything the row-builder closure needs is captured
+        // rather than recomputed inside it.
         let marks = self.tree_change_marks();
 
         // Virtualized: only the rows genuinely on screen become real elements. Previously every
-        // one of up to `file_tree::MAX_RENDERED_FILE_ENTRIES` (500) *visible* rows was built,
+        // one of up to 500 (the since-removed `MAX_RENDERED_FILE_ENTRIES` cap) *visible* rows was built,
         // laid out and painted on every single frame - including the ~460 of them scrolled off
         // screen - which measured (real `gpui::FrameTiming` data, debug build, this repository's
         // own tree, terminal streaming) as ~145ms of a ~200ms `Window::draw`, i.e. ~72% of the
@@ -138,24 +294,24 @@ impl AdeApp {
         // `vendor/zed/crates/gpui/examples/uniform_list.rs`); every row here is exactly
         // `theme::band::TREE_ROW` tall, which is `uniform_list`'s one real requirement.
         //
-        // `MAX_RENDERED_FILE_ENTRIES` deliberately stays: it is no longer a layout-cost guard
-        // (virtualization removed that cost), but it is still the real bound on how much of a
-        // huge tree this list claims to represent, and on the scroll extent `uniform_list`
-        // derives from `item_count`. The "... and N more" trailer below keeps that honest.
+        // The former `MAX_RENDERED_FILE_ENTRIES` (500) cap is gone: virtualization already
+        // removed the per-frame cost it was originally guarding, and hiding real entries behind
+        // a "... and N more" row was the dishonesty issue #18 §4 set out to remove. The one
+        // surviving cap is a *load*-time one (`Settings.file_tree.max_entries`), and it announces
+        // itself with the real "load more" action below rather than a silent cut-off.
         let list = uniform_list(
             "file-tree-list",
             rendered_count,
             cx.processor(move |this: &mut Self, range: Range<usize>, _window, cx| {
-                // Recomputed from the same two fields `rendered_count` above was derived from,
-                // which cannot change between that read and this call within one frame. The
-                // range is still clamped rather than indexed blindly, so a future divergence
-                // degrades to "renders fewer rows" instead of panicking.
-                let visible = file_tree::visible_entries(&this.file_tree, &this.collapsed_dirs);
-                let start = range.start.min(visible.len());
-                let end = range.end.min(visible.len());
-                visible[start..end]
+                // Both the row range and each index into `file_tree` are clamped/checked rather
+                // than trusted, so a future divergence degrades to "renders fewer rows" instead
+                // of panicking.
+                let start = range.start.min(visible_indices.len());
+                let end = range.end.min(visible_indices.len());
+                visible_indices[start..end]
                     .iter()
-                    .map(|entry| this.render_file_tree_row(entry, &marks, cx))
+                    .filter_map(|index| this.file_tree.get(*index).cloned())
+                    .map(|entry| this.render_file_tree_row(&entry, &marks, cx))
                     .collect::<Vec<_>>()
             }),
         )
@@ -183,14 +339,38 @@ impl AdeApp {
             .min_h_0()
             .py(px(4.0))
             .child(list);
-        if visible_count > rendered_count {
-            column = column.child(render_sidebar_message(
-                format!(
-                    "... and {} more entries not shown",
-                    visible_count - rendered_count
-                ),
-                theme::text::FAINT.into(),
-            ));
+        // The explicit replacement for the old truncation row: not a message saying entries were
+        // silently dropped, but a real action that goes and loads more of them
+        // (`Self::load_more_file_tree_entries`). Only ever shown when the walk genuinely stopped
+        // early, and it names the exact count it stopped at rather than implying a total it
+        // cannot know without walking the rest.
+        if self.file_tree_truncated {
+            let loaded = self.file_tree.len();
+            column = column.child(
+                div()
+                    .id("file-tree-show-all")
+                    .debug_selector(|| "file-tree-show-all".to_string())
+                    .flex_none()
+                    .w_full()
+                    .cursor_pointer()
+                    .px(px(10.0))
+                    .py(px(5.0))
+                    .font(font(theme::font::MONO))
+                    .text_size(self.ui_text_size(10.5))
+                    .text_color(theme::text::DIM)
+                    .hover(|el| {
+                        el.bg(theme::surface::ROW_HOVER)
+                            .text_color(theme::text::PRIMARY)
+                    })
+                    .tooltip(text_tooltip(
+                        "Re-read this worktree with a 10x larger entry limit. Set \
+                         `file_tree.max_entries` in settings.toml to raise it permanently.",
+                    ))
+                    .child(format!("Stopped at {loaded} entries \u{2013} load more"))
+                    .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
+                        this.load_more_file_tree_entries(cx);
+                    })),
+            );
         }
 
         column.into_any_element()
@@ -198,15 +378,15 @@ impl AdeApp {
 
     /// One file-tree row: indent (13px/level, per the README), a composed icon (a folder's
     /// two-rect glyph or a file's language chip), the name, and, for a directory, a click
-    /// handler that toggles [`Self::collapsed_dirs`].
+    /// handler that toggles its membership of [`AdeApp::expanded_dirs`].
     pub(in crate::sidebar) fn render_file_tree_row(
         &self,
         entry: &FileTreeEntry,
         marks: &HashMap<PathBuf, (&'static str, gpui::Rgba)>,
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
-        let indent = px(13.0 * entry.depth as f32);
-        let is_open = entry.is_dir && !self.collapsed_dirs.contains(&entry.path);
+        let indent = px(file_tree::INDENT_STEP * entry.depth as f32);
+        let is_open = entry.is_dir && self.expanded_dirs.contains(&entry.path);
         let mark = marks.get(&entry.path).copied();
         // The Files tree's row-selection highlight (README's Zone 3 "Selected row bg
         // `#1a1e21`") - set by `Self::open_file_view` (this row's own click handler, below)
@@ -229,15 +409,69 @@ impl AdeApp {
             .id(format!("file-tree-row-{}", entry.path.display()))
             .debug_selector(|| format!("file-tree-row-{}", entry.name))
             .flex()
+            // Positioning context for this row's own indent guides, below - `.absolute()` needs
+            // a `.relative()` ancestor (`vendor/zed/crates/gpui/examples/list_example.rs:118`'s
+            // own scrollbar track/thumb pair uses exactly this pairing).
+            .relative()
             .w_full()
             .items_center()
             .gap(px(6.0))
             .h(theme::band::TREE_ROW)
-            .pl(px(8.0) + indent)
+            .pl(px(file_tree::ROW_LEFT_PAD) + indent)
             .pr(px(8.0))
             .font(font(theme::font::MONO))
             .text_size(self.ui_text_size(11.5))
             .when(is_selected, |el| el.bg(theme::surface::ROW_SELECTED));
+
+        // Indent guides (issue #18 §3), one per level of nesting between this row and the root.
+        //
+        // Drawn as this row's *own* absolutely-positioned children rather than as one overlay
+        // across the list, which is what makes them correct under `uniform_list`'s
+        // virtualization for free: a guide is a pure function of the row it belongs to
+        // (`entry.depth`, plus the selected path for the active-chain highlight), so a recycled
+        // row can only ever draw the guides that genuinely belong to whatever row it now shows.
+        // An overlay would instead have to track the visible range and scroll offset itself and
+        // stay in step with them - the real source of the "gaps or misaligned segments as rows
+        // recycle" failure the issue calls out. Each guide spans the row's full 22px height with
+        // no gap or inset, so consecutive rows' segments meet exactly and read as one continuous
+        // line down the subtree.
+        let active_levels = file_tree::active_guide_levels(
+            &self.file_tree_root,
+            &entry.path,
+            self.selected_tree_path.as_deref(),
+        );
+        for level in 0..entry.depth {
+            let active = level < active_levels;
+            row = row.child(
+                div()
+                    // Test-only (a no-op outside test builds, like the row's own selector
+                    // above): the only way a real render test can prove a guide painted at the
+                    // right x, at the right height, on the right row - including after
+                    // `uniform_list` has recycled that row's element. The `active`/`idle` half
+                    // is what makes the ancestor-chain highlight testable at all: the colour
+                    // itself isn't observable from a test, but which of the two branches a given
+                    // row took is. Keyed on `entry.name` like the row selector above, so two
+                    // same-named files in different folders would collide - every test using
+                    // these gives its fixtures unique names.
+                    .debug_selector(|| {
+                        format!(
+                            "file-tree-guide-{}-{}-{level}",
+                            if active { "active" } else { "idle" },
+                            entry.name
+                        )
+                    })
+                    .absolute()
+                    .top_0()
+                    .h_full()
+                    .w(px(1.0))
+                    .left(px(file_tree::indent_guide_x(level)))
+                    .bg(if active {
+                        theme::tree::INDENT_GUIDE_ACTIVE
+                    } else {
+                        theme::tree::INDENT_GUIDE
+                    }),
+            );
+        }
 
         if entry.is_dir {
             let path = entry.path.clone();
@@ -245,7 +479,7 @@ impl AdeApp {
                 .cursor_pointer()
                 .hover(|el| el.bg(theme::surface::ROW_HOVER))
                 .on_click(cx.listener(move |this, _event: &ClickEvent, _window, cx| {
-                    this.toggle_dir_collapsed(path.clone(), cx);
+                    this.toggle_dir_expanded(path.clone(), cx);
                 }));
         } else {
             // Opens the file in Surface C's File view - see `Self::open_file_view`'s docs.
@@ -386,6 +620,36 @@ impl AdeApp {
                                 .text_color(theme::diff::STAT_DEL)
                                 .child(format!("\u{2212}{del}")),
                         ),
+                )
+            })
+            // "Collapse all" (issue #18 §1) - resets the tree *and* this worktree's saved fold
+            // state in one step, so it genuinely undoes the expansions rather than hiding them
+            // until the next launch. Files view only, like the "+" beside it.
+            .when(self.right_sidebar_view == RightSidebarView::Files, |el| {
+                el.child(
+                    div()
+                        .id("file-tree-collapse-all")
+                        .debug_selector(|| "file-tree-collapse-all".to_string())
+                        .flex_none()
+                        .cursor_pointer()
+                        .px(px(5.0))
+                        .rounded(theme::radius::CHIP)
+                        .font(font(theme::font::MONO))
+                        .text_size(self.ui_text_size(12.0))
+                        .text_color(theme::text::GHOST)
+                        .hover(|el| {
+                            el.bg(theme::surface::ROW_HOVER_ALT)
+                                .text_color(theme::text::PRIMARY)
+                        })
+                        .tooltip(text_tooltip(
+                            "Collapse all folders (also clears the saved fold state)",
+                        ))
+                        // The same "\u{25be} pointing down" glyph `render_tree_caret` uses for an
+                        // open folder, since this is the action that closes every one of them.
+                        .child("\u{25be}")
+                        .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
+                            this.collapse_all_dirs(cx);
+                        })),
                 )
             })
             // Root-level "New file" - creates directly in the worktree root, the one location
@@ -989,7 +1253,7 @@ mod virtualization_tests {
     }
 
     /// Before this revision's fix, every one of the first
-    /// `file_tree::MAX_RENDERED_FILE_ENTRIES` (500) visible rows was built, laid out and painted
+    /// 500 (the since-removed `MAX_RENDERED_FILE_ENTRIES` cap) visible rows was built, laid out and painted
     /// on *every* frame - including all the ones below the fold - which measured, against real
     /// `gpui::FrameTiming` data on this repository's own tree, as ~145ms of a ~200ms
     /// `Window::draw`.
@@ -998,8 +1262,8 @@ mod virtualization_tests {
         let repo = TempDir::new().expect("tempdir");
         // Deliberately more rows than any plausible test viewport can show at
         // `theme::band::TREE_ROW` (22px) each, but fewer than
-        // `file_tree::MAX_RENDERED_FILE_ENTRIES`, so this measures virtualization alone and not
-        // the "... and N more entries not shown" cap.
+        // the since-removed `MAX_RENDERED_FILE_ENTRIES` cap, so this measured virtualization
+        // alone even back when that cap still existed.
         for index in 0..300 {
             fs::write(repo.path().join(format!("file-{index:03}.txt")), "x\n").expect("write");
         }
@@ -1063,18 +1327,19 @@ mod virtualization_tests {
     }
 
     /// The correctness half of the same change: virtualizing must not break the tree's real
-    /// content. A collapsed directory's children must still be genuinely absent, and expanding
-    /// it must genuinely bring them back - the state `crate::sidebar::file_tree::visible_entries` owns,
-    /// now consulted from inside `uniform_list`'s row-builder rather than from an eager loop.
+    /// content. A collapsed directory's children must be genuinely absent, and expanding it must
+    /// genuinely bring them in - the state `crate::sidebar::file_tree::visible_entries` owns, now
+    /// consulted from inside `uniform_list`'s row-builder rather than from an eager loop.
+    ///
+    /// Also the render-level proof of issue #18 §1's default: the very first assertion is that a
+    /// directory's child does *not* paint before anything has been expanded.
     ///
     /// Honest about its own reach: with only two entries this exercises no virtualization at
     /// all, and it passes identically against the pre-fix eager loop. It is a guard on the
     /// tree's *content* surviving the rewrite, not evidence that the rewrite virtualizes -
     /// that is what the two "far below the viewport" tests and the scroll test are for.
     #[gpui::test]
-    fn collapsing_a_directory_still_removes_its_children_from_the_virtualized_tree(
-        cx: &mut TestAppContext,
-    ) {
+    fn expanding_and_collapsing_a_directory_adds_and_removes_its_children(cx: &mut TestAppContext) {
         let repo = TempDir::new().expect("tempdir");
         fs::create_dir(repo.path().join("src")).expect("mkdir");
         fs::write(repo.path().join("src/only.rs"), "fn main() {}\n").expect("write");
@@ -1082,28 +1347,32 @@ mod virtualization_tests {
         cx.run_until_parked();
 
         assert!(
-            cx.debug_bounds("file-tree-row-only.rs").is_some(),
-            "an expanded directory's child must really paint"
+            cx.debug_bounds("file-tree-row-src").is_some(),
+            "the root-level directory row itself must paint"
+        );
+        assert!(
+            cx.debug_bounds("file-tree-row-only.rs").is_none(),
+            "nothing is expanded on first open, so a nested child must not paint"
         );
 
         let src_dir = repo.path().join("src");
         app.update(cx, |app, cx| {
-            app.toggle_dir_collapsed(src_dir.clone(), cx);
-        });
-        cx.run_until_parked();
-        assert!(
-            cx.debug_bounds("file-tree-row-only.rs").is_none(),
-            "a collapsed directory's child must not paint"
-        );
-
-        app.update(cx, |app, cx| {
-            app.toggle_dir_collapsed(src_dir, cx);
+            app.toggle_dir_expanded(src_dir.clone(), cx);
         });
         cx.run_until_parked();
         assert!(
             cx.debug_bounds("file-tree-row-only.rs").is_some(),
-            "re-expanding must bring the child back - a virtualized list that caches its row \
-             set without invalidating on `collapsed_dirs` would fail exactly here"
+            "expanding must bring the child in - a virtualized list that caches its row set \
+             without invalidating on `expanded_dirs` would fail exactly here"
+        );
+
+        app.update(cx, |app, cx| {
+            app.toggle_dir_expanded(src_dir, cx);
+        });
+        cx.run_until_parked();
+        assert!(
+            cx.debug_bounds("file-tree-row-only.rs").is_none(),
+            "collapsing again must remove it"
         );
     }
 
@@ -1162,6 +1431,914 @@ mod virtualization_tests {
             cx.debug_bounds("change-row-f-39.txt").is_none(),
             "the 40th changed file's row is past any plausible viewport, so a virtualized \
              list must never build it as an element at all"
+        );
+    }
+}
+
+/// Real, end-to-end coverage for GitHub issue #18's persisted fold state: a live `AdeApp`, a
+/// real fold-state file on disk, and a second `AdeApp` constructed against that same file
+/// standing in for an app restart (the same "simulated reload" discipline
+/// `crate::settings::render`'s keybinding-rebind test already established - nothing in this
+/// codebase can restart the actual process mid-test).
+#[cfg(test)]
+mod fold_state_tests {
+    use super::*;
+    use crate::settings::store as settings_store;
+    use crate::sidebar::fold_state::FoldState;
+    use gpui::TestAppContext;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Opens an `AdeApp` with a *real*, temp-dir-scoped settings path - which is what gives it a
+    /// real fold-state file (`fold_state::fold_state_path_for`), unlike
+    /// `palette_focus_tests::open_test_app`'s deliberately unpersisted `None`.
+    fn open_app_with_state_dir(
+        cx: &mut TestAppContext,
+        repo_path: PathBuf,
+        settings_path: PathBuf,
+    ) -> (gpui::Entity<AdeApp>, &mut gpui::VisualTestContext) {
+        open_app_with_state_dir_and_settings(
+            cx,
+            repo_path,
+            settings_path,
+            settings_store::Settings::default(),
+        )
+    }
+
+    fn open_app_with_state_dir_and_settings(
+        cx: &mut TestAppContext,
+        repo_path: PathBuf,
+        settings_path: PathBuf,
+        settings: settings_store::Settings,
+    ) -> (gpui::Entity<AdeApp>, &mut gpui::VisualTestContext) {
+        cx.add_window_view(|window, cx| {
+            AdeApp::new_with_settings(repo_path, settings, Some(settings_path), window, cx)
+        })
+    }
+
+    /// `src/app/` + `src/lib/` + a root-level file, the shape every test below expands into.
+    fn seed_tree(repo: &TempDir) {
+        fs::create_dir_all(repo.path().join("src/app")).expect("mkdir");
+        fs::create_dir_all(repo.path().join("src/lib")).expect("mkdir");
+        fs::write(repo.path().join("src/app/main.rs"), "fn main() {}\n").expect("write");
+        fs::write(repo.path().join("src/lib/util.rs"), "pub fn u() {}\n").expect("write");
+        fs::write(repo.path().join("README.md"), "hi\n").expect("write");
+    }
+
+    fn expanded_names(app: &AdeApp) -> Vec<String> {
+        let mut names: Vec<String> = app
+            .expanded_dirs
+            .iter()
+            .filter_map(|path| path.strip_prefix(&app.file_tree_root).ok())
+            .map(|path| path.display().to_string())
+            .collect();
+        names.sort();
+        names
+    }
+
+    /// §1: nothing is expanded on the first visit to a worktree, and the tree really only shows
+    /// its root-level entries.
+    #[gpui::test]
+    fn a_worktree_opened_for_the_first_time_starts_fully_collapsed(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        let state_dir = TempDir::new().expect("tempdir");
+        seed_tree(&repo);
+
+        let (app, cx) = open_app_with_state_dir(
+            cx,
+            repo.path().to_path_buf(),
+            state_dir.path().join("settings.toml"),
+        );
+        cx.run_until_parked();
+
+        assert!(app.read_with(cx, |app, _| app.expanded_dirs.is_empty()));
+        let visible = app.read_with(cx, |app, _| {
+            file_tree::visible_entries(&app.file_tree, &app.expanded_dirs)
+                .iter()
+                .map(|entry| entry.name.clone())
+                .collect::<Vec<_>>()
+        });
+        assert_eq!(visible, vec!["src".to_string(), "README.md".to_string()]);
+        assert!(cx.debug_bounds("file-tree-row-src").is_some());
+        assert!(
+            cx.debug_bounds("file-tree-row-main.rs").is_none(),
+            "a file two levels down must not be showing before anything is expanded"
+        );
+    }
+
+    /// §2's headline requirement: expand three folders, "quit", "relaunch" - the same three are
+    /// open and nothing else. The reload reads the real file this app wrote, not an in-memory
+    /// cache handed between the two instances.
+    #[gpui::test]
+    fn expanded_folders_are_restored_exactly_after_a_simulated_reload(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        let state_dir = TempDir::new().expect("tempdir");
+        seed_tree(&repo);
+        let settings_path = state_dir.path().join("settings.toml");
+        let fold_path = state_dir.path().join("file-tree-state.toml");
+
+        let (app, cx) =
+            open_app_with_state_dir(cx, repo.path().to_path_buf(), settings_path.clone());
+        cx.run_until_parked();
+        app.update(cx, |app, cx| {
+            app.toggle_dir_expanded(repo.path().join("src"), cx);
+            app.toggle_dir_expanded(repo.path().join("src/app"), cx);
+        });
+        cx.run_until_parked();
+
+        assert!(
+            fold_path.exists(),
+            "expanding a folder must be recorded on disk immediately - not on a clean exit, \
+             which is exactly what this test never performs"
+        );
+        assert_eq!(
+            FoldState::load_at(&fold_path)
+                .expanded_dirs(repo.path())
+                .len(),
+            2
+        );
+
+        // The "relaunch": a brand-new `AdeApp` reading that same real file.
+        let (reloaded, cx) = open_app_with_state_dir(cx, repo.path().to_path_buf(), settings_path);
+        cx.run_until_parked();
+
+        assert_eq!(
+            reloaded.read_with(cx, |app, _| expanded_names(app)),
+            vec!["src".to_string(), "src/app".to_string()],
+            "the reloaded tree must restore exactly what was left open - `src/lib` was never \
+             expanded and must stay closed"
+        );
+        assert!(
+            cx.debug_bounds("file-tree-row-main.rs").is_some(),
+            "the restored expansion must be visible in the real rendered tree, not just in state"
+        );
+        assert!(
+            cx.debug_bounds("file-tree-row-util.rs").is_none(),
+            "`src/lib` was never expanded, so its child must still be hidden after the reload"
+        );
+    }
+
+    /// §2's identity requirement, at the app level: two worktrees with an identically-named
+    /// `src/` share one fold-state file, and one's expansion must never open the other's.
+    #[gpui::test]
+    fn fold_state_from_one_worktree_never_leaks_into_another(cx: &mut TestAppContext) {
+        let worktree_a = TempDir::new().expect("tempdir");
+        let worktree_b = TempDir::new().expect("tempdir");
+        let state_dir = TempDir::new().expect("tempdir");
+        seed_tree(&worktree_a);
+        seed_tree(&worktree_b);
+        let settings_path = state_dir.path().join("settings.toml");
+
+        let (app_a, cx) =
+            open_app_with_state_dir(cx, worktree_a.path().to_path_buf(), settings_path.clone());
+        cx.run_until_parked();
+        app_a.update(cx, |app, cx| {
+            app.toggle_dir_expanded(worktree_a.path().join("src"), cx);
+        });
+        cx.run_until_parked();
+
+        let (app_b, cx) =
+            open_app_with_state_dir(cx, worktree_b.path().to_path_buf(), settings_path);
+        cx.run_until_parked();
+
+        assert!(
+            app_b.read_with(cx, |app, _| app.expanded_dirs.is_empty()),
+            "worktree B shares the relative path `src` with worktree A, and a fold-state entry \
+             keyed by anything less than the real worktree path would open it here"
+        );
+        // And A's own state is genuinely still there - this must fail as a leak test, never as a
+        // "nothing was ever persisted" test.
+        let fold_path = state_dir.path().join("file-tree-state.toml");
+        assert_eq!(
+            FoldState::load_at(&fold_path)
+                .expanded_dirs(worktree_a.path())
+                .len(),
+            1
+        );
+    }
+
+    /// Two `jerry` processes (one per repository) share one fold-state file, and each holds a
+    /// whole-file copy read at its own startup. A plain whole-file write would therefore make
+    /// whichever instance saved last erase the other's worktree entirely.
+    ///
+    /// The ordering here is the whole point, and is what distinguishes this from
+    /// `fold_state_from_one_worktree_never_leaks_into_another`: B starts *before* A's second
+    /// write, so B's in-memory copy can never contain A's newer entry. Only a write that
+    /// genuinely re-reads the file and merges can preserve it.
+    #[gpui::test]
+    fn a_second_instances_saves_never_erase_the_first_instances_worktree(cx: &mut TestAppContext) {
+        let repo_a = TempDir::new().expect("tempdir");
+        let repo_b = TempDir::new().expect("tempdir");
+        let state_dir = TempDir::new().expect("tempdir");
+        seed_tree(&repo_a);
+        seed_tree(&repo_b);
+        let settings_path = state_dir.path().join("settings.toml");
+        let fold_path = state_dir.path().join("file-tree-state.toml");
+
+        let (app_a, cx) =
+            open_app_with_state_dir(cx, repo_a.path().to_path_buf(), settings_path.clone());
+        cx.run_until_parked();
+
+        // Instance B starts here, snapshotting a file that knows nothing about A yet.
+        let (app_b, cx) =
+            open_app_with_state_dir(cx, repo_b.path().to_path_buf(), settings_path.clone());
+        cx.run_until_parked();
+
+        app_a.update(cx, |app, cx| {
+            app.toggle_dir_expanded(repo_a.path().join("src"), cx);
+        });
+        cx.run_until_parked();
+        // ...and now B writes, from its stale whole-file snapshot.
+        app_b.update(cx, |app, cx| {
+            app.toggle_dir_expanded(repo_b.path().join("src"), cx);
+        });
+        cx.run_until_parked();
+
+        let on_disk = FoldState::load_at(&fold_path);
+        assert_eq!(
+            on_disk.expanded_dirs(repo_a.path()).len(),
+            1,
+            "the second instance's save must merge, not clobber - repository A's fold state is \
+             gone here if the write is a plain whole-file one"
+        );
+        assert_eq!(on_disk.expanded_dirs(repo_b.path()).len(), 1);
+
+        // And a real relaunch of A sees its own state, which is what the user actually notices.
+        let (reloaded_a, cx) =
+            open_app_with_state_dir(cx, repo_a.path().to_path_buf(), settings_path);
+        cx.run_until_parked();
+        assert_eq!(
+            reloaded_a.read_with(cx, |app, _| expanded_names(app)),
+            vec!["src".to_string()]
+        );
+    }
+
+    /// §2: a folder that has since been deleted is dropped silently on the next load - no error
+    /// surfaces, and the surviving entries are untouched.
+    #[gpui::test]
+    fn a_stale_entry_for_a_deleted_folder_is_pruned_silently(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        let state_dir = TempDir::new().expect("tempdir");
+        seed_tree(&repo);
+        let settings_path = state_dir.path().join("settings.toml");
+        let fold_path = state_dir.path().join("file-tree-state.toml");
+
+        let (app, cx) =
+            open_app_with_state_dir(cx, repo.path().to_path_buf(), settings_path.clone());
+        cx.run_until_parked();
+        app.update(cx, |app, cx| {
+            app.toggle_dir_expanded(repo.path().join("src"), cx);
+            app.toggle_dir_expanded(repo.path().join("src/app"), cx);
+            app.toggle_dir_expanded(repo.path().join("src/lib"), cx);
+        });
+        cx.run_until_parked();
+
+        // An agent deletes one of them from underneath the running app.
+        fs::remove_dir_all(repo.path().join("src/lib")).expect("remove");
+
+        // The "relaunch" - which is also where the prune happens, against the freshly walked
+        // tree.
+        let (reloaded, cx) = open_app_with_state_dir(cx, repo.path().to_path_buf(), settings_path);
+        cx.run_until_parked();
+
+        assert_eq!(
+            reloaded.read_with(cx, |app, _| app.file_tree_error.clone()),
+            None,
+            "a stale fold-state entry must never surface as an error"
+        );
+        assert_eq!(
+            reloaded.read_with(cx, |app, _| expanded_names(app)),
+            vec!["src".to_string(), "src/app".to_string()]
+        );
+        let on_disk = FoldState::load_at(&fold_path);
+        assert_eq!(
+            on_disk.expanded_dirs(repo.path()).len(),
+            2,
+            "the prune must be written back to the file, not just applied in memory"
+        );
+    }
+
+    /// §2: a mid-session refresh of the same worktree (what an agent creating or deleting files
+    /// causes, via `create_new_file`'s own reload) must not reset fold state.
+    #[gpui::test]
+    fn reloading_the_same_worktrees_tree_keeps_the_fold_state(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        let state_dir = TempDir::new().expect("tempdir");
+        seed_tree(&repo);
+
+        let (app, cx) = open_app_with_state_dir(
+            cx,
+            repo.path().to_path_buf(),
+            state_dir.path().join("settings.toml"),
+        );
+        cx.run_until_parked();
+        app.update(cx, |app, cx| {
+            app.toggle_dir_expanded(repo.path().join("src"), cx);
+            app.toggle_dir_expanded(repo.path().join("src/app"), cx);
+        });
+        cx.run_until_parked();
+
+        // A file appears and another disappears underneath the running app, then the tree is
+        // re-walked - neither touches any directory that was expanded.
+        fs::write(repo.path().join("src/app/new.rs"), "//\n").expect("write");
+        fs::remove_file(repo.path().join("README.md")).expect("remove");
+        app.update(cx, |app, cx| {
+            let root = app.file_tree_root.clone();
+            app.load_file_tree(root, cx);
+        });
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| expanded_names(app)),
+            vec!["src".to_string(), "src/app".to_string()],
+            "a refresh must re-render, not reset - the folders stay exactly as they were"
+        );
+        assert!(
+            cx.debug_bounds("file-tree-row-new.rs").is_some(),
+            "and the newly created file must really appear inside the still-expanded folder"
+        );
+    }
+
+    /// §1: "collapse all" resets the tree *and* the saved state, in one step - so it survives a
+    /// reload rather than springing back open.
+    #[gpui::test]
+    fn collapse_all_clears_both_the_tree_and_the_saved_state(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        let state_dir = TempDir::new().expect("tempdir");
+        seed_tree(&repo);
+        let settings_path = state_dir.path().join("settings.toml");
+
+        let (app, cx) =
+            open_app_with_state_dir(cx, repo.path().to_path_buf(), settings_path.clone());
+        cx.run_until_parked();
+        app.update(cx, |app, cx| {
+            app.toggle_dir_expanded(repo.path().join("src"), cx);
+            app.toggle_dir_expanded(repo.path().join("src/app"), cx);
+        });
+        cx.run_until_parked();
+        assert!(cx.debug_bounds("file-tree-row-main.rs").is_some());
+        assert!(
+            cx.debug_bounds("file-tree-collapse-all").is_some(),
+            "the collapse-all control must really be in the rendered header"
+        );
+
+        app.update(cx, |app, cx| app.collapse_all_dirs(cx));
+        cx.run_until_parked();
+
+        assert!(app.read_with(cx, |app, _| app.expanded_dirs.is_empty()));
+        assert!(cx.debug_bounds("file-tree-row-main.rs").is_none());
+
+        let (reloaded, cx) = open_app_with_state_dir(cx, repo.path().to_path_buf(), settings_path);
+        cx.run_until_parked();
+        assert!(
+            reloaded.read_with(cx, |app, _| app.expanded_dirs.is_empty()),
+            "collapse-all must have cleared the *saved* state too, or the folders would spring \
+             back open on the next launch"
+        );
+    }
+
+    /// §5: "reveal in tree", driven through the real command-palette open-file flow, expands
+    /// every ancestor of the revealed file - and records those expansions exactly like manual
+    /// ones, so they survive a reload.
+    #[gpui::test]
+    fn revealing_a_file_expands_its_ancestors_and_records_them(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        let state_dir = TempDir::new().expect("tempdir");
+        seed_tree(&repo);
+        let settings_path = state_dir.path().join("settings.toml");
+        let target = repo.path().join("src/app/main.rs");
+
+        let (app, cx) =
+            open_app_with_state_dir(cx, repo.path().to_path_buf(), settings_path.clone());
+        cx.run_until_parked();
+        assert!(
+            cx.debug_bounds("file-tree-row-main.rs").is_none(),
+            "precondition: the file to reveal starts hidden inside two collapsed folders"
+        );
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_palette_file_result(target.clone(), window, cx);
+        });
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| expanded_names(app)),
+            vec!["src".to_string(), "src/app".to_string()],
+            "both ancestors - and only the ancestors - must be expanded"
+        );
+        assert!(
+            cx.debug_bounds("file-tree-row-main.rs").is_some(),
+            "the revealed file's row must really be showing"
+        );
+
+        let (reloaded, cx) = open_app_with_state_dir(cx, repo.path().to_path_buf(), settings_path);
+        cx.run_until_parked();
+        assert_eq!(
+            reloaded.read_with(cx, |app, _| expanded_names(app)),
+            vec!["src".to_string(), "src/app".to_string()],
+            "a reveal is recorded like a manual expansion, so it must survive a reload"
+        );
+    }
+
+    /// §5 again, through the other real entry point: opening a file directly (what
+    /// go-to-definition does when it lands in a folder nobody has expanded) reveals it too.
+    #[gpui::test]
+    fn opening_a_file_directly_reveals_it_in_the_tree(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        let state_dir = TempDir::new().expect("tempdir");
+        seed_tree(&repo);
+        let target = repo.path().join("src/app/main.rs");
+
+        let (app, cx) = open_app_with_state_dir(
+            cx,
+            repo.path().to_path_buf(),
+            state_dir.path().join("settings.toml"),
+        );
+        cx.run_until_parked();
+        app.update_in(cx, |app, window, cx| {
+            app.open_file_view(target.clone(), window, cx);
+        });
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| expanded_names(app)),
+            vec!["src".to_string(), "src/app".to_string()]
+        );
+        assert!(
+            cx.debug_bounds("file-tree-row-main.rs").is_some(),
+            "the selected row must actually be showing, or its selection highlight is invisible"
+        );
+    }
+
+    /// §4: a directory with hundreds of entries renders *every* one of them - no truncation row,
+    /// no cap - while staying virtualized (the row far below the viewport is never built).
+    #[gpui::test]
+    fn a_large_directory_renders_completely_with_no_truncation_row(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        let state_dir = TempDir::new().expect("tempdir");
+        fs::create_dir(repo.path().join("big")).expect("mkdir");
+        for index in 0..800 {
+            fs::write(repo.path().join(format!("big/f-{index:03}.txt")), "x\n").expect("write");
+        }
+
+        let (app, cx) = open_app_with_state_dir(
+            cx,
+            repo.path().to_path_buf(),
+            state_dir.path().join("settings.toml"),
+        );
+        cx.run_until_parked();
+        app.update(cx, |app, cx| {
+            app.toggle_dir_expanded(repo.path().join("big"), cx);
+        });
+        cx.run_until_parked();
+
+        let visible = app.read_with(cx, |app, _| {
+            file_tree::visible_entries(&app.file_tree, &app.expanded_dirs).len()
+        });
+        assert_eq!(
+            visible, 801,
+            "all 800 files plus the folder row itself are visible rows - the old 500-row cap \
+             would have silently hidden 301 of them"
+        );
+        assert!(
+            !app.read_with(cx, |app, _| app.file_tree_truncated),
+            "800 entries is far below the configured load cap, so nothing was truncated"
+        );
+        assert!(
+            cx.debug_bounds("file-tree-show-all").is_none(),
+            "and no 'Show all entries' action may appear for a complete listing"
+        );
+
+        assert!(cx.debug_bounds("file-tree-row-f-000.txt").is_some());
+        assert!(
+            cx.debug_bounds("file-tree-row-f-799.txt").is_none(),
+            "still virtualized: the last of 800 rows is far below the viewport and must never \
+             become an element"
+        );
+
+        // The entry the old cap would have dropped entirely (#501 of 800) must be genuinely
+        // reachable, not merely counted.
+        let first_row = cx
+            .debug_bounds("file-tree-row-f-000.txt")
+            .expect("first row");
+        cx.simulate_event(gpui::ScrollWheelEvent {
+            position: first_row.center(),
+            delta: gpui::ScrollDelta::Pixels(gpui::point(px(0.0), px(-100_000.0))),
+            modifiers: gpui::Modifiers::default(),
+            touch_phase: gpui::TouchPhase::Moved,
+        });
+        cx.run_until_parked();
+        assert!(
+            cx.debug_bounds("file-tree-row-f-799.txt").is_some(),
+            "scrolling to the bottom must reach the very last entry - proof the listing really \
+             is complete rather than capped"
+        );
+    }
+
+    /// §4's surviving load cap, and its honest replacement for the old silent cut-off: when the
+    /// walk really does stop early, a real action appears that goes and loads more - and the cap
+    /// it re-walks with is still a real cap, so a pathological tree can't be pulled into memory
+    /// wholesale by one click.
+    #[gpui::test]
+    fn hitting_the_load_cap_offers_a_load_more_action_that_really_loads_more(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = TempDir::new().expect("tempdir");
+        let state_dir = TempDir::new().expect("tempdir");
+        for index in 0..40 {
+            fs::write(repo.path().join(format!("f-{index:02}.txt")), "x\n").expect("write");
+        }
+        let mut settings = settings_store::Settings::default();
+        settings.file_tree.max_entries = 10;
+
+        let (app, cx) = open_app_with_state_dir_and_settings(
+            cx,
+            repo.path().to_path_buf(),
+            state_dir.path().join("settings.toml"),
+            settings,
+        );
+        cx.run_until_parked();
+
+        assert_eq!(app.read_with(cx, |app, _| app.file_tree.len()), 10);
+        assert!(app.read_with(cx, |app, _| app.file_tree_truncated));
+        assert!(
+            cx.debug_bounds("file-tree-show-all").is_some(),
+            "a walk that stopped early must say so with a real action, never silently"
+        );
+
+        app.update(cx, |app, cx| app.load_more_file_tree_entries(cx));
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.file_tree.len()),
+            40,
+            "the action must genuinely re-walk with a bigger budget - the capped walk never \
+             collected these entries, so nothing else could have produced them"
+        );
+        assert!(!app.read_with(cx, |app, _| app.file_tree_truncated));
+        assert!(cx.debug_bounds("file-tree-show-all").is_none());
+        assert_eq!(
+            app.read_with(cx, |app, _| app.file_tree_limit_override),
+            Some(100),
+            "the escape hatch raises the bound tenfold - it never removes it, or one click on a \
+             pathological tree would pull the whole thing into memory"
+        );
+    }
+
+    /// A truncated walk must never be used as evidence that the directories it never reached are
+    /// gone - pruning against it would silently, and permanently, destroy good state. Driven
+    /// through a walk that genuinely truncates, not by hand-setting the flag.
+    #[gpui::test]
+    fn a_truncated_walk_never_prunes_fold_state(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        let state_dir = TempDir::new().expect("tempdir");
+        // Directories sort first and then alphabetically, so a 1-entry budget reaches `aaa` and
+        // stops - `zzz`, the one whose expansion is recorded, is never seen by the capped walk.
+        fs::create_dir(repo.path().join("aaa")).expect("mkdir");
+        fs::create_dir(repo.path().join("zzz")).expect("mkdir");
+        fs::write(repo.path().join("zzz/inside.txt"), "x\n").expect("write");
+        let settings_path = state_dir.path().join("settings.toml");
+        let fold_path = state_dir.path().join("file-tree-state.toml");
+
+        let (app, cx) =
+            open_app_with_state_dir(cx, repo.path().to_path_buf(), settings_path.clone());
+        cx.run_until_parked();
+        app.update(cx, |app, cx| {
+            app.toggle_dir_expanded(repo.path().join("zzz"), cx);
+        });
+        cx.run_until_parked();
+        assert_eq!(
+            FoldState::load_at(&fold_path)
+                .expanded_dirs(repo.path())
+                .len(),
+            1
+        );
+
+        let mut capped = settings_store::Settings::default();
+        capped.file_tree.max_entries = 1;
+        let (reloaded, cx) = open_app_with_state_dir_and_settings(
+            cx,
+            repo.path().to_path_buf(),
+            settings_path,
+            capped,
+        );
+        cx.run_until_parked();
+
+        assert!(
+            reloaded.read_with(cx, |app, _| app.file_tree_truncated),
+            "precondition: the walk really must have stopped early, from the real cap - not \
+             from a flag this test set itself"
+        );
+        assert!(
+            reloaded.read_with(cx, |app, _| !app
+                .file_tree
+                .iter()
+                .any(|entry| entry.name == "zzz")),
+            "precondition: the expanded directory really must be absent from the capped listing"
+        );
+
+        assert_eq!(
+            FoldState::load_at(&fold_path)
+                .expanded_dirs(repo.path())
+                .len(),
+            1,
+            "an incomplete listing is not evidence that a folder is gone"
+        );
+    }
+}
+
+/// GitHub issue #18 §3, verified where it actually matters: against real painted geometry in a
+/// real virtualized list, not against the pure `indent_guide_x` arithmetic alone (which
+/// `crate::sidebar::file_tree`'s own unit tests already cover).
+///
+/// The failure mode the issue names - "gaps or misaligned segments as rows recycle while
+/// scrolling" - is only observable this way: every assertion below reads
+/// `VisualTestContext::debug_bounds`, i.e. the bounds GPUI genuinely laid the guide out at, and
+/// the recycling test re-asserts them *after* a real scroll event has forced `uniform_list` to
+/// rebuild its rows from a different starting index.
+#[cfg(test)]
+mod indent_guide_tests {
+    use super::*;
+    use crate::root::focus::palette_focus_tests;
+    use gpui::TestAppContext;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn close_enough(a: f32, b: f32) -> bool {
+        (a - b).abs() < 1.0
+    }
+
+    /// `a/b/c/deep.txt`, with the whole chain expanded, plus a sibling file at each level.
+    fn open_deep_tree<'a>(
+        cx: &'a mut TestAppContext,
+        repo: &TempDir,
+    ) -> (gpui::Entity<AdeApp>, &'a mut gpui::VisualTestContext) {
+        fs::create_dir_all(repo.path().join("a/b/c")).expect("mkdir");
+        fs::write(repo.path().join("a/b/c/deep.txt"), "x\n").expect("write");
+        fs::write(repo.path().join("a/b/mid.txt"), "x\n").expect("write");
+        fs::write(repo.path().join("a/top.txt"), "x\n").expect("write");
+
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        app.update(cx, |app, cx| {
+            app.toggle_dir_expanded(repo.path().join("a"), cx);
+            app.toggle_dir_expanded(repo.path().join("a/b"), cx);
+            app.toggle_dir_expanded(repo.path().join("a/b/c"), cx);
+        });
+        cx.run_until_parked();
+        (app, cx)
+    }
+
+    /// One guide per nesting level, each at exactly its level's chevron offset from the row's
+    /// own left edge, and none at all for a root-level row.
+    #[gpui::test]
+    fn each_row_draws_one_guide_per_level_aligned_with_that_levels_chevron(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = TempDir::new().expect("tempdir");
+        let (_app, cx) = open_deep_tree(cx, &repo);
+
+        assert!(
+            cx.debug_bounds("file-tree-guide-idle-a-0").is_none(),
+            "a root-level row has no ancestors, so it must draw no guide at all"
+        );
+
+        let row = cx
+            .debug_bounds("file-tree-row-deep.txt")
+            .expect("the deepest row must paint");
+        // Literal selectors, not `format!`: `debug_bounds` takes a `&'static str`.
+        for (level, selector) in [
+            (0usize, "file-tree-guide-idle-deep.txt-0"),
+            (1, "file-tree-guide-idle-deep.txt-1"),
+            (2, "file-tree-guide-idle-deep.txt-2"),
+        ] {
+            let guide = cx
+                .debug_bounds(selector)
+                .unwrap_or_else(|| panic!("a depth-3 row must draw a guide for level {level}"));
+            assert!(
+                close_enough(
+                    f32::from(guide.origin.x - row.origin.x),
+                    file_tree::indent_guide_x(level)
+                ),
+                "level {level}'s guide must sit under that level's expand chevron: expected \
+                 {:?} from the row's left edge, got {:?}",
+                file_tree::indent_guide_x(level),
+                f32::from(guide.origin.x - row.origin.x)
+            );
+        }
+        assert!(
+            cx.debug_bounds("file-tree-guide-idle-deep.txt-3").is_none(),
+            "a depth-3 row must not draw a fourth guide"
+        );
+    }
+
+    /// The "no gaps" half: a guide spans its row's full height, and consecutive rows' segments
+    /// for the same level meet exactly - which is what makes them read as one continuous line
+    /// rather than a dashed one.
+    #[gpui::test]
+    fn guides_on_consecutive_rows_join_with_no_gap(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        let (_app, cx) = open_deep_tree(cx, &repo);
+
+        // The three consecutive rows `c`, `deep.txt`, `mid.txt` (in that render order - `c`'s
+        // own child comes between it and its sibling), all of which draw a level-1 guide.
+        let segments: Vec<gpui::Bounds<Pixels>> = [
+            "file-tree-guide-idle-c-1",
+            "file-tree-guide-idle-deep.txt-1",
+            "file-tree-guide-idle-mid.txt-1",
+        ]
+        .into_iter()
+        .map(|selector| {
+            cx.debug_bounds(selector)
+                .unwrap_or_else(|| panic!("{selector} must paint"))
+        })
+        .collect();
+        let row = cx.debug_bounds("file-tree-row-c").expect("the `c` row");
+
+        assert!(
+            close_enough(
+                f32::from(segments[0].size.height),
+                f32::from(row.size.height)
+            ),
+            "a guide must span its row's whole height, or consecutive rows leave a visible gap"
+        );
+        for pair in segments.windows(2) {
+            let (upper, lower) = (pair[0], pair[1]);
+            assert!(
+                close_enough(f32::from(upper.origin.x), f32::from(lower.origin.x)),
+                "the same level's guide must be at the same x on every row"
+            );
+            assert!(
+                close_enough(
+                    f32::from(upper.origin.y + upper.size.height),
+                    f32::from(lower.origin.y)
+                ),
+                "one row's guide must end exactly where the next row's begins: {:?} vs {:?}",
+                f32::from(upper.origin.y + upper.size.height),
+                f32::from(lower.origin.y)
+            );
+        }
+    }
+
+    /// The real risk this whole approach was chosen to eliminate: after a scroll, `uniform_list`
+    /// rebuilds its rows from a different start index, reusing element slots. A guide drawn from
+    /// anything other than the row's own depth would land on the wrong row here.
+    #[gpui::test]
+    fn guides_stay_aligned_with_their_own_rows_after_the_list_recycles(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        fs::create_dir_all(repo.path().join("nested/inner")).expect("mkdir");
+        // Enough rows inside the nested folder to fill several viewports, so scrolling genuinely
+        // recycles row elements rather than merely translating them.
+        for index in 0..300 {
+            fs::write(
+                repo.path().join(format!("nested/inner/f-{index:03}.txt")),
+                "x\n",
+            )
+            .expect("write");
+        }
+        let (_app, cx) = {
+            let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+            cx.run_until_parked();
+            app.update(cx, |app, cx| {
+                app.toggle_dir_expanded(repo.path().join("nested"), cx);
+                app.toggle_dir_expanded(repo.path().join("nested/inner"), cx);
+            });
+            cx.run_until_parked();
+            (app, cx)
+        };
+
+        let first_row = cx
+            .debug_bounds("file-tree-row-f-000.txt")
+            .expect("the first nested row must paint");
+        assert!(
+            cx.debug_bounds("file-tree-row-f-299.txt").is_none(),
+            "precondition: the last row is below the viewport, so reaching it must recycle rows"
+        );
+
+        cx.simulate_event(gpui::ScrollWheelEvent {
+            position: first_row.center(),
+            delta: gpui::ScrollDelta::Pixels(gpui::point(px(0.0), px(-100_000.0))),
+            modifiers: gpui::Modifiers::default(),
+            touch_phase: gpui::TouchPhase::Moved,
+        });
+        cx.run_until_parked();
+
+        let recycled_row = cx
+            .debug_bounds("file-tree-row-f-299.txt")
+            .expect("the last row must materialize after scrolling");
+        assert!(
+            cx.debug_bounds("file-tree-guide-idle-f-000.txt-0")
+                .is_none(),
+            "the row that scrolled out of view must take its guides with it - a leftover guide \
+             here would be a segment painted over an unrelated row"
+        );
+
+        for (level, selector) in [
+            (0usize, "file-tree-guide-idle-f-299.txt-0"),
+            (1, "file-tree-guide-idle-f-299.txt-1"),
+        ] {
+            let guide = cx
+                .debug_bounds(selector)
+                .unwrap_or_else(|| panic!("recycled row must still draw its level-{level} guide"));
+            assert!(
+                close_enough(
+                    f32::from(guide.origin.x - recycled_row.origin.x),
+                    file_tree::indent_guide_x(level)
+                ),
+                "after recycling, level {level}'s guide must still be at that level's offset"
+            );
+            assert!(
+                close_enough(f32::from(guide.origin.y), f32::from(recycled_row.origin.y)),
+                "after recycling, the guide must still sit on its own row, not a neighbour's"
+            );
+            assert!(
+                close_enough(
+                    f32::from(guide.size.height),
+                    f32::from(recycled_row.size.height)
+                ),
+                "after recycling, the guide must still span its row's full height"
+            );
+        }
+    }
+
+    /// The optional half of §3: the guides along the selected file's ancestor chain are drawn in
+    /// the highlighted colour, and only those. The colour itself isn't observable from a test,
+    /// so this asserts on which of the two real branches each guide took (see the guide's own
+    /// `debug_selector`) - which is what would actually break if the condition were inverted.
+    #[gpui::test]
+    fn only_the_selected_files_ancestor_chain_is_highlighted(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        // A second branch at the same depth as `a/b`, so there is a row whose guides must stay
+        // idle while the selection's chain is active.
+        fs::create_dir_all(repo.path().join("a/other")).expect("mkdir");
+        fs::write(repo.path().join("a/other/elsewhere.txt"), "x\n").expect("write");
+        let (app, cx) = open_deep_tree(cx, &repo);
+        app.update(cx, |app, cx| {
+            app.toggle_dir_expanded(repo.path().join("a/other"), cx);
+        });
+        cx.run_until_parked();
+
+        assert!(
+            cx.debug_bounds("file-tree-guide-idle-deep.txt-0").is_some(),
+            "precondition: with nothing selected every guide is idle"
+        );
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_file_view(repo.path().join("a/b/c/deep.txt"), window, cx);
+        });
+        cx.run_until_parked();
+
+        for selector in [
+            "file-tree-guide-active-deep.txt-0",
+            "file-tree-guide-active-deep.txt-1",
+            "file-tree-guide-active-deep.txt-2",
+        ] {
+            assert!(
+                cx.debug_bounds(selector).is_some(),
+                "{selector}: every guide on the selected file's own row is part of its \
+                 ancestor chain"
+            );
+        }
+        // `a/other/elsewhere.txt` shares only `a` with the selection.
+        assert!(
+            cx.debug_bounds("file-tree-guide-active-elsewhere.txt-0")
+                .is_some(),
+            "the shared `a` ancestor is on the chain"
+        );
+        assert!(
+            cx.debug_bounds("file-tree-guide-idle-elsewhere.txt-1")
+                .is_some(),
+            "`a/other` is not on the selected file's chain, so its guide stays idle"
+        );
+        assert!(
+            cx.debug_bounds("file-tree-guide-active-elsewhere.txt-1")
+                .is_none(),
+            "and it must not also be drawn as active"
+        );
+    }
+
+    /// Collapsing a folder removes its children's guides along with their rows - the guides are
+    /// pure functions of the rows that are actually showing, with no independently-tracked state
+    /// that could survive them.
+    #[gpui::test]
+    fn collapsing_removes_the_hidden_rows_guides_too(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        let (app, cx) = open_deep_tree(cx, &repo);
+        assert!(cx.debug_bounds("file-tree-guide-idle-deep.txt-2").is_some());
+
+        app.update(cx, |app, cx| {
+            app.toggle_dir_expanded(repo.path().join("a/b"), cx);
+        });
+        cx.run_until_parked();
+
+        assert!(cx.debug_bounds("file-tree-row-deep.txt").is_none());
+        assert!(
+            cx.debug_bounds("file-tree-guide-idle-deep.txt-2").is_none(),
+            "a hidden row's guides must be gone with it"
+        );
+        assert!(
+            cx.debug_bounds("file-tree-guide-idle-b-0").is_some(),
+            "the still-visible `b` row keeps its own level-0 guide"
         );
     }
 }

--- a/crates/app/src/theme.rs
+++ b/crates/app/src/theme.rs
@@ -370,16 +370,18 @@ pub mod border {
 /// highlighted - obvious. Both are ordinary [`ColorToken`]s, so they re-derive under every theme
 /// exactly like the ~200 tokens around them.
 pub mod tree {
-    use super::{hex, ColorToken};
+    use super::ColorToken;
 
-    /// The resting indent guide: deliberately the same value as `border::DIVIDER`, this
-    /// palette's existing "1px vertical rule" colour, so the guides read as structure rather
-    /// than content. Subtle by design - a guide that competes with a filename is worse than none.
-    pub const INDENT_GUIDE: ColorToken = hex(0x22262a);
-    /// The guide for a level in the selected file's ancestor chain - `border::SELECTED_EDGE`'s
-    /// value, the same blue the selected-row edge already uses, so "this line leads to what's
-    /// selected" is the same visual language in both places.
-    pub const INDENT_GUIDE_ACTIVE: ColorToken = hex(0x3f5b74);
+    /// The resting indent guide **is** [`super::border::DIVIDER`], this palette's existing "1px
+    /// vertical rule" colour, so the guides read as structure rather than content - a real alias
+    /// rather than a hand-copied hex literal, so the two can never drift apart if that token is
+    /// ever retuned. Subtle by design: a guide that competes with a filename is worse than none.
+    pub const INDENT_GUIDE: ColorToken = super::border::DIVIDER;
+    /// The guide for a level in the selected file's ancestor chain **is**
+    /// [`super::border::SELECTED_EDGE`], the same blue the selected-row edge already uses, so
+    /// "this line leads to what's selected" is the same visual language in both places. Aliased
+    /// for the same reason as above.
+    pub const INDENT_GUIDE_ACTIVE: ColorToken = super::border::SELECTED_EDGE;
 }
 
 pub mod text {

--- a/crates/app/src/theme.rs
+++ b/crates/app/src/theme.rs
@@ -364,6 +364,24 @@ pub mod border {
     pub const SELECTED_EDGE: ColorToken = hex(0x3f5b74); // 2px left edge on a selected row
 }
 
+/// The Files tree's own structural marks (GitHub issue #18 §3). A scope of its own rather than
+/// two more entries in [`border`]: these are painted *inside* rows as 1px quads, not the border
+/// of anything, and keeping them together makes the pair's relationship - one resting, one
+/// highlighted - obvious. Both are ordinary [`ColorToken`]s, so they re-derive under every theme
+/// exactly like the ~200 tokens around them.
+pub mod tree {
+    use super::{hex, ColorToken};
+
+    /// The resting indent guide: deliberately the same value as `border::DIVIDER`, this
+    /// palette's existing "1px vertical rule" colour, so the guides read as structure rather
+    /// than content. Subtle by design - a guide that competes with a filename is worse than none.
+    pub const INDENT_GUIDE: ColorToken = hex(0x22262a);
+    /// The guide for a level in the selected file's ancestor chain - `border::SELECTED_EDGE`'s
+    /// value, the same blue the selected-row edge already uses, so "this line leads to what's
+    /// selected" is the same visual language in both places.
+    pub const INDENT_GUIDE_ACTIVE: ColorToken = hex(0x3f5b74);
+}
+
 pub mod text {
     use super::{hex, ColorToken};
 


### PR DESCRIPTION
Closes #18.

## Summary

**Default state**: a worktree the app has never seen (a freshly created one included) now opens with only root-level entries visible - the model inverted from tracking "which folders are collapsed" to "which folders are expanded," so absence genuinely means collapsed, with no special-casing needed for first-open. A "collapse all" action in the Files header resets both the live tree and its saved state in one step.

**Persisted fold state**: a new, dedicated `~/.config/jerry/file-tree-state.toml` (not `settings.toml` - fold state is machine-managed per-worktree data, not a hand-editable setting), written on every expand/collapse via a real crash-safe sequence (process-unique temp file, `fsync`, rename, parent-directory `fsync`). Keyed by canonicalized worktree path so two worktrees of the same repo never clobber each other; a merge-on-save (read-modify-write against the file, not last-writer-wins) means two concurrently running app instances working in *different* worktrees don't erase each other's state either. Stale entries for since-deleted or renamed folders are pruned, but only when a directory walk is proven complete - never on a partial or failed walk. Watcher refreshes (an agent creating or deleting files mid-session) never reset fold state or scroll.

**Indent guide lines**: real vertical guides per nesting level, aligned with the expand chevrons, each row computing its own guide segments from its own real depth and position - verified against the sidebar's existing `uniform_list` virtualization by a test that forces genuine row recycling (a 300-row tree, a real 100,000px scroll) and asserts the guide geometry on a row that only materializes afterward.

**Complete listings**: the "...and more entries not shown" truncation is gone, along with the old 500-row render cap. Large folders stay smooth via the sidebar's existing virtualization; a much larger, configurable load-time cap remains only for pathological cases, and hitting it now offers a real "load more" action instead of a silent cut-off.

**Reveal in tree**: the command-palette open-file flow, newly-created files, and go-to-definition all expand the revealed file's ancestors and persist those expansions through the same write path a manual click uses - not a separate, driftable mechanism.

## Review process

Built, then independently and adversarially reviewed twice before this PR - the same discipline as the companion #17 PR, and for the same reason: two rounds each found real, additional critical bugs.

1. The builder's own self-review (explicitly labeled as such in the BUILD-LOG entry, including which parts really did involve a dispatched checker sub-agent versus the builder's own reasoning) found and fixed seven problems across two passes, including a serious one: an early edit had silently failed to apply, leaving the real merge-safe write path built but never actually wired into the save call.
2. An independent adversarial audit (dispatched separately, no access to the builder's own findings) confirmed most of the self-review's claims were genuinely real - but found four further **critical** bugs:
   - "Load more" could silently *shrink* the visible tree on a click (a missing monotonic floor on the escalating budget), and could become a dead, expensive button that still re-walked the whole cap on every further click once it was reached.
   - `worktree_key` canonicalized the filesystem path on every single call - including once per ancestor when revealing a deep file - a real, blocking syscall on the render thread that could freeze the window on a slow or disconnected mount.
   - The new, much larger load-time ceiling was reachable in two clicks and did unbounded, synchronous main-thread work at that size (the file-tree walk itself was already backgrounded; a downstream palette-candidate rebuild and a per-frame visibility scan were not).
   - A failed fold-state write (disk full, read-only config directory) was silently dropped with no retry, contradicting the feature's own "recorded immediately" claim.
3. All four were fixed - a real cached worktree-key resolved once per worktree change instead of per-call, a monotonic `.max(current)` floor plus a real ceiling that turns the button into an honest disclosure once reached, a lowered and justified load ceiling, and a bounded retry-with-backoff on write failure - each covered by a regression test independently confirmed to fail when the fix is reverted. One of those revert-checks caught the builder's *own* first attempt at the caching fix leaving a real gap (the constructor still computed the key on a separate path); the test correctly failed, and the fix was corrected before being reported done.

Same transparency note as the companion PR: the builder's own BUILD-LOG entry initially described its two self-review passes with unqualified "adversarial audit" language. I flagged this and asked for it to be corrected to "self-review" with honest provenance (including exactly which findings came from a dispatched sub-agent versus the builder's own reasoning) before doing anything else - it now is, in both the BUILD-LOG and the commit message.

One deliberate, disclosed scope limit: the merge-on-save logic fully protects two instances working in *different* worktrees, but two instances both actively open on the *same* worktree can still overwrite each other's fold state for that one worktree (not the whole file). A delta-based merge would close this but is a materially bigger design than this feature warrants; it's documented as a known limitation in `fold_state`'s own module docs rather than silently left unhandled.

## Verification

- `cargo fmt --all -- --check`, `cargo build --workspace`, `cargo clippy --workspace --all-targets -- -D warnings` all clean.
- `cargo test --workspace --lib -- --test-threads=1`: **795 app tests** (up from 742 on `master`), 42 lsp-core + 14 pty-core + 98 wt-core unchanged, 0 failures.
- Independently re-verified directly: all four gates re-run myself, the two most critical fixes (the cached worktree key, the monotonic load-more floor) spot-checked directly in source and confirmed to match what was reported.
- Not verified by either pass: no live run of the app (headless sandbox) and no release-build timing measurement - the guide/virtualization correctness rests on real GPUI render tests, not a human eye on a running window.

## Test plan

- [x] A never-before-seen worktree opens fully collapsed
- [x] Expand three folders, simulate a reload, the same three folders are open and nothing else
- [x] Fold state for one worktree never leaks into a different worktree
- [x] Two app instances in different worktrees never erase each other's saved state
- [x] A stale entry for a deleted folder is silently pruned, never surfaced as an error
- [x] A folder-tree walk that fails or is only partial never triggers pruning
- [x] Indent guides stay correctly aligned on a row that only exists after the virtualized list has recycled through a real scroll
- [x] A large directory (hundreds of entries) renders complete, with no truncation row, and stays smooth
- [x] "Load more" genuinely re-walks with a larger budget and can never shrink the visible tree
- [x] "Reveal in tree" expands and persists ancestor folders through the same path a manual click uses
- [x] A failed fold-state write is retried, not silently dropped