### PR TITLE
File tree: right-click context menu and file operations

### DIFF
--- a/BUILD-LOG.md
+++ b/BUILD-LOG.md
@@ -2195,3 +2195,122 @@ All four gates clean: `cargo fmt --all -- --check`, `cargo build --workspace`,
 removed) + 42 lsp-core + 14 pty-core + 98 wt-core. One full run hit the project's known
 diff-rendering flake (`opening_a_real_diff_renders_real_syntax_highlighted_rows`); it passed alone,
 passed with its whole module, and the next full run was green with no other change.
+
+## File tree: right-click context menu and file operations (GitHub issue #19)
+
+The Files tree is writable now: right-click menus on a file row, a folder row and the empty area
+below the tree; inline New File / New Folder / Rename editors; a real cut/copy/paste buffer with
+`Ctrl+C`/`X`/`V`; and a confirmed delete that prefers the OS trash. Three new modules, split the
+way every feature folder in this crate is: `sidebar::context_menu` (which rows a target offers,
+plus the edge-aware popover geometry), `sidebar::file_ops` (name validation, collision-free
+naming, recursive copy/move/delete, the trash decision) - both pure and GPUI-free - and
+`sidebar::tree_ops`, the `impl AdeApp` glue that sequences them and repairs the app's own state
+afterwards.
+
+**Trash is real and named honestly.** On Linux/FreeBSD a confirmed delete shells out to
+`gio trash -- <path>`, GLib's own CLI wrapper around `g_file_trash`, which implements the
+freedesktop.org trash spec for local files in-process (no session bus, no gvfs daemon). Verified by
+running it in this environment rather than assumed: a file and a non-empty directory both really
+landed in `~/.local/share/Trash/files`, and the `--` terminator really does protect a leading-dash
+filename. No new dependency was added for it. macOS and Windows deliberately get **no** trash
+command: macOS's usual answer is an `osascript` snippet whose only interface is an AppleScript
+string literal (every quote and backslash in a filename hand-escaped, and a wrong escape acts on a
+different path than the one confirmed), and Windows has no built-in recycle-bin CLI at all. Those
+platforms take a real, permanent delete whose confirmation button reads "Delete permanently" and
+whose sentence says so, rather than a "moved to trash" claim for something that was destroyed. The
+mechanism is resolved once - against a real `$PATH` probe (`pty_core::resolve_on_path`, the same
+walk this workspace already uses for agent CLIs) - *before* the confirmation is shown, so the words
+the user agrees to and the command that runs come from the same value; a failed trash command is
+reported and never silently escalated into a permanent delete.
+
+**The empty area's "Collapse All" is issue #18's own reset**, `AdeApp::collapse_all_dirs` - the
+same method the Files header's `▾` button calls - not a parallel mechanism. That is asserted where
+the two would actually differ: the test writes a real fold-state file, expands a folder, confirms
+the expansion is genuinely on disk, runs the menu action, and asserts the entry is gone from the
+*file*. An implementation that only emptied `expanded_dirs` would pass every in-memory assertion
+and fail that one.
+
+**Watcher/refresh consistency.** The honest answer to §4's "do these just touch the filesystem, or
+do they need to trigger a refresh?" is: they are plain filesystem changes, so `git` sees them with
+no help - but nothing in this app polls the working tree for the sidebar. There is no filesystem
+watcher at all; the file tree is only ever re-walked by an explicit `load_file_tree`, and the diff
+view only by an explicit `load_diff` (the rail's 3-second status poll refreshes the *rail's*
+per-worktree summary, not `diff_state`). So every operation ends in `refresh_after_file_op`, which
+does both. The in-progress inline editor lives on `AdeApp`, never inside `AdeApp::file_tree` -
+that vector is *replaced wholesale* by each completed walk, which is exactly what an agent creating
+a file mid-session triggers - and the renderer re-finds the editor's anchor row by *path* each
+frame, falling back to the top of the list when the anchor has genuinely gone. Same discipline
+issue #18 applied to fold state. The regression test drives the real race (agent writes a file,
+real re-walk, run to parked) and was confirmed to fail against a completion handler that cleared
+the editor.
+
+**Keybinding scoping**, this project's most-repeated bug class, got two independent mechanisms and
+one corrected claim. The five new bindings are scoped to
+`"file-tree && !tree-editing && !tree-delete-confirm"`, and their `.on_action` handlers live only
+on the tree's own container. An earlier draft of the module docs asserted that handler placement
+was the *only* real protection for a focused terminal and that the `file-tree` half "isn't doing
+that work" - that was wrong, and revert-verification caught it: `dispatch_key` resolves bindings
+against the focused node's own dispatch-path context stack *before* any listener is consulted, so
+either mechanism alone suffices. Both are documented as independent now. The `!tree-editing` half
+has no redundant partner and is the one directly reproducible: with a bare `Some("file-tree")` the
+`shift_f10_while_an_inline_editor_is_open…` test fails, because while an editor is open the tree
+*is* the focused node, the listener runs, and GPUI stops propagation by default in the bubble
+phase - swallowing the keystroke being typed into the name field.
+
+An **adversarial review sub-agent was genuinely dispatched and its report genuinely received**
+(not the builder's own reasoning - said explicitly because a sibling agent misreported this
+earlier the same day). It found nothing fake or unwired, and eleven real problems, all fixed with
+tests:
+
+1. **`reviewed_files` was remapped in the wrong key space** - it is keyed by
+   `wt_core::diff::DiffFile::path` (worktree-relative) and was being remapped with the absolute
+   pair, making it a guaranteed silent no-op. A file's reviewed checkbox reset on every rename.
+2. **A cut+paste back into the source folder silently renamed the file** to `util copy.rs`: an
+   unconditional `unique_destination` for `Cut` as well as `Copy`. It is a no-op now.
+3. **The LSP's per-document bookkeeping survived a rename or delete.** `didOpen` early-returns for
+   a path already in `lsp_opened_files`, and that set is documented as never cleared on close - so
+   recreating a file at a renamed-away path silently got no diagnostics or completions for the
+   rest of the session. Six maps, in *two* key spaces; the reviewer's own split of which was which
+   was itself slightly wrong, and each field's docs were re-read one by one to get it right
+   (`lsp_synced_version`/`lsp_diagnostics_confirmed_version` are relative, not absolute).
+4. **Switching to the Changes tab left focus dangling** on `tree_focus_handle`, whose node stops
+   being rendered - the exact `OverlayFocus` invariant this project keeps re-finding, killing every
+   keybinding until the next click. `set_right_sidebar_view` now routes through `restore_focus`.
+5. **The tree's overlays floated over the Settings surface**, scrim and all, swallowing clicks.
+   Gated, and cleared in `open_settings` alongside the three overlays already cleared there.
+6. **Blocking recursive tree copy on the foreground thread** in a click listener - contradicting
+   the sibling `confirm_tree_delete`, whose own docs insist on "never the foreground thread".
+   Duplicate and paste-a-copy now run on the background executor.
+7. **A half-copied tree survived a failed copy**, then got repainted looking complete. Cleaned up.
+8. **A symlink to a directory aborted the copy** (`EISDIR`), and a symlinked subdirectory aborted
+   the recursion mid-tree - the dir/file decision used the non-following `symlink_metadata`. Now
+   follows, with a real depth bound for the symlink cycle that makes possible.
+9. **`forget_deleted_paths` was not the mirror of `rename_open_paths`** it claimed to be, leaving
+   eight fields pointing at a deleted path. Both now share one relative/absolute helper pair.
+10. **`menu_height` was 2px short** of the panel's real painted height (its own border), so the
+    edge-flip was computed against a size the menu isn't painted at. The height test asserted only
+    the *growth rate*, which is blind to a missing constant - it asserts the absolute value now.
+11. **Escape didn't dismiss the delete confirmation, and the tree's bindings fired behind its
+    scrim.** Hence the third context term.
+
+Two doc claims the review found false were corrected rather than deleted: the "atomic re-check"
+claim for `copy_path` (`fs::copy` opens `O_TRUNC`; it is a second real TOCTOU, now documented on
+the function like `move_path`'s already was), and the dispatch-causality claim above. One test was
+found passing for the wrong reason (`switching_worktrees_clears_every_tree_operation_in_flight`
+opened the context menu *after* the rename editor, and opening a menu cancels the editor - so its
+key assertion was already true before the switch); the builder had already found and documented
+one of the same class itself, on `ctrl_c_with_a_focused_terminal…`, which proves handler placement
+rather than the context predicate and now says so.
+
+Two limitations are stated rather than papered over: `F2`/`Shift+F10` on a *file* need a
+right-click (or a folder click) first, because a left-click on a file row opens it and moves focus
+to the code surface - stealing focus back would break typing in the editor just opened - and there
+are no up/down bindings to move the selection within the tree, which is where the issue's own
+keyboard requirement stops.
+
+All four gates clean: `cargo fmt --all -- --check`, `cargo build --workspace`,
+`cargo clippy --workspace --all-targets -- -D warnings`, and
+`cargo test --workspace --lib -- --test-threads=1` - 847 app (up from 795: 52 new tests, none
+removed) + 42 lsp-core + 14 pty-core + 98 wt-core. One full run hit the project's known
+diff-rendering flake (`switching_the_open_diff_to_a_different_file_recomputes_the_highlight_cache`);
+it passed alone with its whole module, and the next full run was green with no other change.

--- a/crates/app/src/code_surface/render.rs
+++ b/crates/app/src/code_surface/render.rs
@@ -263,7 +263,7 @@ impl AdeApp {
             ],
             selected.to_string(),
             cx,
-            |this, index, cx| {
+            |this, index, _window, cx| {
                 // Index 0 is `Diff`, index 1 is `File`, per the options array above.
                 this.code_view = match index {
                     0 => code_view::CodeView::Diff,

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -267,6 +267,49 @@ pub fn default_key_bindings() -> Vec<gpui::KeyBinding> {
         gpui::KeyBinding::new("secondary-x", root::EditorCut, Some("merge-editor")),
         gpui::KeyBinding::new("secondary-v", root::EditorPaste, Some("merge-editor")),
         gpui::KeyBinding::new("secondary-s", root::EditorSave, Some("merge-editor")),
+        // GitHub issue #19's file-tree bindings. Every one is scoped to
+        // `"file-tree && !tree-editing && !tree-delete-confirm"`, and all three terms are
+        // load-bearing - see `crate::sidebar::tree_ops`'s own module docs for the full
+        // reasoning. The short version: `secondary-c`/`secondary-x`/`secondary-v` at `None`
+        // scope would claim the control bytes `crate::terminal::pane::keystroke_to_bytes` hands
+        // a focused shell (Ctrl+C is SIGINT - binding it globally would risk making it
+        // impossible to interrupt a running agent CLI), the exact bug class this list's `"]"`
+        // and `secondary-p` entries above already document; `!tree-editing` is what keeps them
+        // from firing while one of the tree's own inline name editors has the keystroke; and
+        // `!tree-delete-confirm` the same while the modal delete confirmation is up (`F2` or
+        // `Shift+F10` firing *behind* a modal scrim was a real finding in this change's own
+        // review). Both negated terms follow the `"file-editor && !completions"` shape above.
+        //
+        // `shift-f10` is the only context-menu keystroke bound. The dedicated Menu/Application
+        // key that some keyboards also carry is deliberately *not* bound: gpui's key names come
+        // from each platform backend at runtime and nothing in the vendored tree names that key
+        // (it isn't in `vendor/zed/crates/gpui/src/platform/keystroke.rs`'s own key vocabulary),
+        // so any spelling guessed here would be a binding that silently never matches.
+        gpui::KeyBinding::new(
+            "shift-f10",
+            root::FileTreeContextMenu,
+            Some("file-tree && !tree-editing && !tree-delete-confirm"),
+        ),
+        gpui::KeyBinding::new(
+            "f2",
+            root::FileTreeRename,
+            Some("file-tree && !tree-editing && !tree-delete-confirm"),
+        ),
+        gpui::KeyBinding::new(
+            "secondary-c",
+            root::FileTreeCopy,
+            Some("file-tree && !tree-editing && !tree-delete-confirm"),
+        ),
+        gpui::KeyBinding::new(
+            "secondary-x",
+            root::FileTreeCut,
+            Some("file-tree && !tree-editing && !tree-delete-confirm"),
+        ),
+        gpui::KeyBinding::new(
+            "secondary-v",
+            root::FileTreePaste,
+            Some("file-tree && !tree-editing && !tree-delete-confirm"),
+        ),
     ]
 }
 

--- a/crates/app/src/palette/render.rs
+++ b/crates/app/src/palette/render.rs
@@ -271,7 +271,7 @@ impl AdeApp {
                     RightSidebarView::Files => RightSidebarView::Changes,
                     RightSidebarView::Changes => RightSidebarView::Files,
                 };
-                self.set_right_sidebar_view(next, cx);
+                self.set_right_sidebar_view(next, window, cx);
             }
             palette::PaletteCommand::ToggleRailGrouping => self.toggle_rail_mode(cx),
             palette::PaletteCommand::PruneWorktrees => self.request_prune(cx),
@@ -597,7 +597,7 @@ impl AdeApp {
             ],
             self.palette_scope.label().to_string(),
             cx,
-            |this, index, cx| {
+            |this, index, _window, cx| {
                 // Index-based, matching the `options` array literal right above: 0 = `All`,
                 // 1 = `Commands`, 2 = `Files`.
                 this.palette_scope = match index {

--- a/crates/app/src/root/focus.rs
+++ b/crates/app/src/root/focus.rs
@@ -75,6 +75,15 @@ impl AdeApp {
         self.plus_menu_open = false;
         self.title_menu_open = None;
         self.new_file_input = None;
+        // Same reason as the three above: Settings *replaces* the workspace body, so a file-tree
+        // context menu or a half-typed inline name left open would either float over the
+        // Settings page or - worse for the editor - keep the tree's `"tree-editing"` key context
+        // alive on a node that is no longer rendered (GitHub issue #19). The armed *delete
+        // confirmation* is deliberately left alone: it is a real, window-level modal the user is
+        // mid-way through answering, and `crate::root::AdeApp::render` keeps it hidden while
+        // Settings is up rather than silently disarming it.
+        self.tree_context_menu = None;
+        self.tree_inline_edit = None;
         self.settings_open = true;
         self.settings_focus.capture(window, &self.sessions, cx);
         self.prune_confirm_armed = false;

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -76,6 +76,7 @@ use crate::settings::store::{self as settings_store, CfgFormat, Settings};
 use crate::sidebar::changes::{self, ChangeTag};
 use crate::sidebar::file_tree::{self, FileTreeEntry};
 use crate::sidebar::fold_state;
+use crate::sidebar::tree_ops;
 use crate::status_bar::process_stats;
 use crate::theme;
 use crate::title_bar::menu as title_bar;
@@ -164,6 +165,11 @@ actions!(
         CompletionsDismiss,
         Undo,
         Redo,
+        FileTreeContextMenu,
+        FileTreeRename,
+        FileTreeCopy,
+        FileTreeCut,
+        FileTreePaste,
     ]
 );
 
@@ -299,6 +305,47 @@ pub struct AdeApp {
     /// and per-worktree: reset on every worktree switch, since "show me more of *this* tree"
     /// says nothing about the next one.
     pub(crate) file_tree_limit_override: Option<usize>,
+    /// The file tree's open right-click context menu (GitHub issue #19 §1), `None` when closed -
+    /// see `crate::sidebar::tree_ops::TreeContextMenu`.
+    pub(crate) tree_context_menu: Option<tree_ops::TreeContextMenu>,
+    /// The file tree's in-progress inline name editor (New File / New Folder / Rename), `None`
+    /// when none is open. Held here rather than inside [`Self::file_tree`] on purpose - see
+    /// `crate::sidebar::tree_ops::TreeInlineEdit`'s own docs for the watcher-refresh race that
+    /// placement closes (issue #19 §4).
+    pub(crate) tree_inline_edit: Option<tree_ops::TreeInlineEdit>,
+    /// The tree's own cut/copy buffer - a real filesystem entry, deliberately not the system
+    /// clipboard (see `crate::sidebar::tree_ops::TreeClipboard`).
+    pub(crate) tree_clipboard: Option<tree_ops::TreeClipboard>,
+    /// A delete that has been requested but not yet confirmed. Nothing is ever removed while
+    /// this is merely `Some`; `crate::sidebar::tree_ops::AdeApp::confirm_tree_delete` is the only
+    /// path that acts, and it is only reachable from the confirmation panel's own button.
+    pub(crate) tree_delete_confirm: Option<tree_ops::PendingTreeDelete>,
+    /// The most recent file-operation failure (a refused rename, a failed trash command),
+    /// surfaced under the tree rather than dropped into the log - the same small, honest error
+    /// surface [`Self::file_save_error`] uses for a failed save.
+    pub(crate) tree_op_error: Option<String>,
+    /// The file tree's keyboard-focus target. `track_focus`'d by
+    /// `crate::sidebar::render::AdeApp::render_file_tree`'s container, which is also the node
+    /// carrying the `"file-tree"` `key_context` every tree keybinding is scoped to - so
+    /// `Ctrl+C`/`Ctrl+X`/`Ctrl+V` can never match while a terminal session has focus. See
+    /// `crate::sidebar::tree_ops`'s module docs.
+    pub(crate) tree_focus_handle: FocusHandle,
+    /// The file tree container's real painted bounds, captured by a `gpui::canvas` child each
+    /// render (the same pattern [`Self::plus_button_bounds`] uses) - where a *keyboard*-opened
+    /// context menu (`Shift+F10`) anchors, since there is no cursor position to use.
+    pub(crate) file_tree_bounds: gpui::Bounds<Pixels>,
+    /// The in-flight confirmed delete (a real `gio trash` child process, or a real
+    /// `remove_dir_all`), one slot: a second delete can't be requested until the confirmation
+    /// panel is open again, so there is never more than one.
+    pub(crate) _tree_delete_task: Option<Task<()>>,
+    /// The in-flight Duplicate / paste-a-copy - a real, recursive `std::fs` tree copy, run on the
+    /// background executor rather than in the click listener that started it (see
+    /// `crate::sidebar::tree_ops::AdeApp::spawn_tree_copy`). One slot, superseding: a second copy
+    /// started while one is running drops the first *task handle*, which cannot stop a copy
+    /// already in progress - deliberately, since abandoning one half-way is strictly worse than
+    /// letting it finish, and the two have different destinations (each is
+    /// `file_ops::unique_destination`-resolved) so they cannot collide with each other.
+    pub(crate) _tree_copy_task: Option<Task<()>>,
     /// Per-file "reviewed" toggle state for the Changes list - a file's path is in this set iff
     /// its checkbox is checked. No backend "review" concept exists yet; this is purely local UI
     /// state that `Self::render_changes_header`'s progress bar and count read directly.
@@ -1267,6 +1314,32 @@ impl Render for AdeApp {
             .when(self.new_file_input.is_some(), |el| {
                 el.child(self.render_new_file_prompt(cx))
             })
+            // The file tree's context menu and its delete confirmation (GitHub issue #19) -
+            // both are window-positioned overlays, so they live here beside the `+` menu and the
+            // "New file" prompt rather than inside the sidebar's own clipped column.
+            //
+            // Gated on `!settings_open`, which is a real fix rather than defensive padding
+            // (found in this change's own review): the Settings surface *replaces* the workspace
+            // body one child up, so an ungated menu would paint a full-window transparent scrim
+            // and a file-tree menu over Settings, swallowing every click on the page underneath.
+            // `Self::open_settings` clears `plus_menu_open`/`title_menu_open`/`new_file_input`
+            // for exactly this reason; the tree's own state is cleared alongside them there, and
+            // this guard is the belt to that braces. The context menu additionally requires the
+            // Files tab, since every one of its actions targets a row only that tab renders.
+            .when(
+                !self.settings_open
+                    && self.right_sidebar_view == RightSidebarView::Files
+                    && self.tree_context_menu.is_some(),
+                |el| el.child(self.render_tree_context_menu(cx)),
+            )
+            // The delete confirmation deliberately does *not* require the Files tab: it is a
+            // window-level modal the user is mid-way through answering, not a tree affordance,
+            // and hiding it on a tab switch would leave a destructive confirmation armed with no
+            // way to answer or cancel it.
+            .when(
+                !self.settings_open && self.tree_delete_confirm.is_some(),
+                |el| el.child(self.render_tree_delete_confirm(cx)),
+            )
             .when(self.palette_open, |el| el.child(self.render_palette(cx)))
     }
 }

--- a/crates/app/src/root/new_file.rs
+++ b/crates/app/src/root/new_file.rs
@@ -9,6 +9,7 @@
 //! machinery the File view's real text editing uses (`vendor/zed/crates/gpui/examples/input.rs`).
 
 use super::*;
+use std::path::Path;
 
 /// State for an in-progress "New file" prompt - `Some` only while the inline name field is
 /// showing. Opened by [`AdeApp::start_new_file`], closed by [`AdeApp::create_new_file`] (on
@@ -230,23 +231,38 @@ impl AdeApp {
         let Some(input) = self.new_file_input.clone() else {
             return;
         };
-        let name = input.name.trim();
-        if name.is_empty() {
-            self.new_file_error = Some("file name can't be empty".to_string());
+        if let Err(message) = self.create_file_named(&input.parent_dir, &input.name, window, cx) {
+            self.new_file_error = Some(message);
             cx.notify();
-            return;
         }
-        if name.contains('/') || name.contains('\\') {
-            self.new_file_error = Some("file name can't contain a path separator".to_string());
-            cx.notify();
-            return;
-        }
+    }
 
-        let absolute_path = input.parent_dir.join(name);
-        if absolute_path.exists() {
-            self.new_file_error = Some(format!("\"{name}\" already exists"));
-            cx.notify();
-            return;
+    /// [`Self::create_new_file`]'s real body, callable without the modal prompt's own state - the
+    /// file tree's inline "New file" editor (GitHub issue #19 §2) drives this directly, so both
+    /// affordances create a file through one implementation rather than two.
+    ///
+    /// Returns the real rejection message on failure and leaves nothing changed, so each caller
+    /// can surface it next to *its own* field. Clears [`AdeApp::new_file_input`] on success (the
+    /// modal prompt's own dismissal) - a no-op for the tree's editor, which never opened it.
+    pub(crate) fn create_file_named(
+        &mut self,
+        parent_dir: &Path,
+        raw_name: &str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Result<(), String> {
+        // The one shared validator (`crate::sidebar::file_ops::validate_entry_name`), not this
+        // method's own inline copy of the rules any more: the file tree's inline New File /
+        // New Folder / Rename editors (GitHub issue #19 §2) apply exactly the same ones, and two
+        // hand-maintained copies is how they drift into disagreeing about what a legal name is.
+        let name = crate::sidebar::file_ops::validate_entry_name(raw_name)?;
+
+        let absolute_path = parent_dir.join(name);
+        // `symlink_metadata`, not `exists()`: a *broken* symlink is a real directory entry that
+        // the create below would collide with, and `exists()` follows the link and reports
+        // `false` for it (the same reasoning `file_ops::unique_destination` documents).
+        if absolute_path.symlink_metadata().is_ok() {
+            return Err(format!("\"{name}\" already exists"));
         }
 
         let relative = absolute_path
@@ -288,6 +304,7 @@ impl AdeApp {
         self.save_active_file(cx);
         self.load_file_tree(self.file_tree_root.clone(), cx);
         cx.notify();
+        Ok(())
     }
 }
 

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -70,6 +70,15 @@ impl AdeApp {
             // Nothing has been walked yet, so nothing may be pruned yet either.
             file_tree_complete: false,
             file_tree_limit_override: None,
+            tree_context_menu: None,
+            tree_inline_edit: None,
+            tree_clipboard: None,
+            tree_delete_confirm: None,
+            tree_op_error: None,
+            tree_focus_handle: cx.focus_handle(),
+            file_tree_bounds: gpui::Bounds::default(),
+            _tree_delete_task: None,
+            _tree_copy_task: None,
             reviewed_files: HashSet::new(),
             open_files: Vec::new(),
             open_change: None,
@@ -462,6 +471,18 @@ impl AdeApp {
         self.set_file_tree_root(path.clone());
         self.file_tree = Vec::new();
         self.reload_expanded_dirs_from_fold_state();
+        // Every one of these holds an absolute path in the worktree being *left* (GitHub issue
+        // #19): an open context menu targeting a row that is about to stop existing, a
+        // half-typed name for a folder in the old tree, a cut/copied entry a paste here would
+        // move across worktrees, and an armed delete for a path in the old tree. Cleared
+        // together, in the same step as `file_tree`/`expanded_dirs` above and for the same
+        // reason - the window between here and the new walk landing must not leave a control
+        // pointing at the old worktree.
+        self.tree_context_menu = None;
+        self.tree_inline_edit = None;
+        self.tree_clipboard = None;
+        self.tree_delete_confirm = None;
+        self.tree_op_error = None;
         // "Show me the whole listing" was a decision about the worktree being left.
         self.file_tree_limit_override = None;
         self.file_tree_truncated = false;

--- a/crates/app/src/settings/render.rs
+++ b/crates/app/src/settings/render.rs
@@ -831,7 +831,7 @@ impl AdeApp {
             ],
             selected,
             cx,
-            |this, index, cx| {
+            |this, index, _window, cx| {
                 // Index into the `options` array above, not a label re-match - see
                 // `Self::render_choice_control`'s docs for why.
                 let style = match index {
@@ -908,7 +908,7 @@ impl AdeApp {
             ],
             format!("{selected_percent}%"),
             cx,
-            |this, index, cx| {
+            |this, index, _window, cx| {
                 // Index into the `options` array above, not a label re-match/parse.
                 const PERCENTS: [u16; 4] = [90, 100, 110, 125];
                 if let Some(percent) = PERCENTS.get(index).copied() {

--- a/crates/app/src/settings/state.rs
+++ b/crates/app/src/settings/state.rs
@@ -541,6 +541,11 @@ pub(crate) fn action_label(action: &dyn gpui::Action) -> Option<&'static str> {
         "app::CompletionsDismiss" => Some("Completions: dismiss"),
         "app::Undo" => Some("Undo"),
         "app::Redo" => Some("Redo"),
+        "app::FileTreeContextMenu" => Some("Files tree: context menu"),
+        "app::FileTreeRename" => Some("Files tree: rename"),
+        "app::FileTreeCopy" => Some("Files tree: copy"),
+        "app::FileTreeCut" => Some("Files tree: cut"),
+        "app::FileTreePaste" => Some("Files tree: paste"),
         _ => None,
     }
 }
@@ -1124,6 +1129,15 @@ mod tests {
                 "Editor: cut",
                 "Editor: paste",
                 "Editor: save file",
+                // GitHub issue #19's file-tree bindings, each scoped to
+                // `"file-tree && !tree-editing"` - see `crate::default_key_bindings`' own docs
+                // and `crate::sidebar::tree_ops`' module docs for why both halves of that
+                // predicate are load-bearing.
+                "Files tree: context menu",
+                "Files tree: rename",
+                "Files tree: copy",
+                "Files tree: cut",
+                "Files tree: paste",
             ]
         );
     }
@@ -1167,10 +1181,20 @@ mod tests {
             rows.iter().filter(|row| row.context != "global").collect();
         assert_eq!(
             scoped.len(),
-            45,
+            50,
             "expected `] -> NextChangedFile` (1) plus every real Editor* binding (19) plus \
              every real Completions* binding (5) plus every real merge-editor binding (18) plus \
-             Undo/Redo (2) to be scoped, not global"
+             Undo/Redo (2) plus every real file-tree binding (5, GitHub issue #19) to be \
+             scoped, not global"
+        );
+        assert!(
+            scoped
+                .iter()
+                .filter(|row| row.command.starts_with("Files tree: "))
+                .count()
+                == 5,
+            "every file-tree binding must be reported as scoped - a globally-bound Ctrl+C would \
+             be exactly the keystroke-swallowing bug class this list's own docs catalogue"
         );
         assert!(
             scoped.iter().any(|row| row.command == "Next changed file"),

--- a/crates/app/src/settings/widgets.rs
+++ b/crates/app/src/settings/widgets.rs
@@ -16,6 +16,7 @@
 use super::*;
 use crate::settings::store::{CfgFormat, ConfigPage, SnippetLineKind};
 use std::ffi::{OsStr, OsString};
+use std::path::Path;
 
 /// Which program + args hand `target` to `target_os`'s default open handler - `target_os` is an
 /// injected `std::env::consts::OS`-shaped string (`"linux"`/`"macos"`/`"windows"`/...) so this
@@ -69,7 +70,7 @@ impl AdeApp {
     /// child is always reaped, matching every other subprocess spawn in this codebase
     /// (`lsp_core::proc`'s `child.wait()`; `pty_core::PtySession`'s `try_wait`/`wait`).
     /// `target_label` is only ever used for the log message, never passed to the child process.
-    fn spawn_open_command(
+    pub(crate) fn spawn_open_command(
         &mut self,
         program: &'static str,
         args: Vec<OsString>,
@@ -89,6 +90,16 @@ impl AdeApp {
                 }
             })
             .detach();
+    }
+
+    /// Hands a real local path to this platform's default-open handler - the file tree's
+    /// "Reveal in file manager" row (`crate::sidebar::tree_ops::AdeApp::reveal_in_file_manager`).
+    /// The same [`open_command_for`]/[`Self::spawn_open_command`] pair
+    /// [`Self::open_settings_file`] uses, exposed as its own entry point so the sidebar doesn't
+    /// have to reach into a settings-page method (or, worse, grow a second `xdg-open` call site).
+    pub(crate) fn open_path_with_os_handler(&mut self, path: &Path, cx: &mut Context<Self>) {
+        let (program, args) = open_command_for(std::env::consts::OS, path.as_os_str());
+        self.spawn_open_command(program, args, path.display().to_string(), cx);
     }
 
     /// Opens the settings file - the config banner's `Open file` button - via
@@ -208,7 +219,7 @@ impl AdeApp {
                 &[ChoiceOption::new("TOML"), ChoiceOption::new("JSON")],
                 self.settings_cfg_format.label().to_string(),
                 cx,
-                |this, index, cx| {
+                |this, index, _window, cx| {
                     // Index into the `options` array above, not a label re-match.
                     this.settings_cfg_format = match index {
                         1 => CfgFormat::Json,
@@ -478,7 +489,7 @@ impl AdeApp {
         options: &[ChoiceOption],
         selected: String,
         cx: &mut Context<Self>,
-        on_select: impl Fn(&mut Self, usize, &mut Context<Self>) + Clone + 'static,
+        on_select: impl Fn(&mut Self, usize, &mut Window, &mut Context<Self>) + Clone + 'static,
     ) -> impl IntoElement {
         let mut track = div()
             .flex_none()
@@ -534,8 +545,8 @@ impl AdeApp {
                 });
             if option.enabled {
                 segment = segment.cursor_pointer().on_click(cx.listener(
-                    move |this, _event: &ClickEvent, _window, cx| {
-                        on_select(this, index, cx);
+                    move |this, _event: &ClickEvent, window, cx| {
+                        on_select(this, index, window, cx);
                     },
                 ));
             }

--- a/crates/app/src/sidebar/context_menu.rs
+++ b/crates/app/src/sidebar/context_menu.rs
@@ -1,0 +1,419 @@
+//! The file tree's right-click context menu, as pure data (GitHub issue #19 §1): which actions
+//! a given target offers, and where the popover has to be drawn so it stays inside the window.
+//!
+//! GPUI-free on purpose, exactly like [`crate::sidebar::file_tree`] beside it - "does a folder
+//! offer Collapse Subtree" and "does a menu opened 3px from the bottom edge flip upwards" are
+//! both decisions that can be tested without a window, and [`crate::sidebar::render`] only
+//! *draws* what this module decides.
+//!
+//! Zed's own `ui::ContextMenu` (`vendor/zed/crates/ui/src/components/context_menu.rs`) is not
+//! reachable from here: it lives in Zed's `ui` crate, not in `gpui`, and this workspace
+//! deliberately depends on `gpui`/`gpui_platform` only. The popover is therefore built from the
+//! same real scrim + absolutely-positioned panel shape
+//! `crate::work_surface::render::AdeApp::render_plus_menu` already established in this app.
+
+use std::path::{Path, PathBuf};
+
+/// What a right-click landed on. `Empty` is a real target, not a fallback: the area below the
+/// last row offers its own menu (New File / New Folder / Paste / Collapse All), scoped to the
+/// worktree root.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContextTarget {
+    File(PathBuf),
+    Folder(PathBuf),
+    Empty,
+}
+
+impl ContextTarget {
+    /// The path this target's actions operate *on*, or `None` for the empty area.
+    pub fn path(&self) -> Option<&Path> {
+        match self {
+            ContextTarget::File(path) | ContextTarget::Folder(path) => Some(path),
+            ContextTarget::Empty => None,
+        }
+    }
+
+    /// The directory a "New File"/"New Folder"/"Paste" from this target should land in: the
+    /// folder itself, a file's parent, or the tree root for the empty area.
+    pub fn destination_dir<'a>(&'a self, root: &'a Path) -> &'a Path {
+        match self {
+            ContextTarget::Folder(path) => path,
+            ContextTarget::File(path) => path.parent().unwrap_or(root),
+            ContextTarget::Empty => root,
+        }
+    }
+}
+
+/// One menu row's real action. Every variant is wired to a real handler in
+/// [`crate::sidebar::tree_ops`]; there is no decorative entry here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MenuAction {
+    Open,
+    NewFile,
+    NewFolder,
+    Rename,
+    Duplicate,
+    Cut,
+    Copy,
+    Paste,
+    CopyPath,
+    CopyRelativePath,
+    CollapseSubtree,
+    CollapseAll,
+    Delete,
+    Reveal,
+}
+
+impl MenuAction {
+    /// The row's label. `Reveal`'s wording is deliberately generic - this app hands the path to
+    /// the OS default-open handler (`xdg-open`/`open`/`cmd /c start`), which is whatever file
+    /// manager the user has configured, not a specific named one.
+    pub fn label(self) -> &'static str {
+        match self {
+            MenuAction::Open => "Open",
+            MenuAction::NewFile => "New File",
+            MenuAction::NewFolder => "New Folder",
+            MenuAction::Rename => "Rename",
+            MenuAction::Duplicate => "Duplicate",
+            MenuAction::Cut => "Cut",
+            MenuAction::Copy => "Copy",
+            MenuAction::Paste => "Paste",
+            MenuAction::CopyPath => "Copy Path",
+            MenuAction::CopyRelativePath => "Copy Relative Path",
+            MenuAction::CollapseSubtree => "Collapse Subtree",
+            MenuAction::CollapseAll => "Collapse All",
+            MenuAction::Delete => "Delete",
+            MenuAction::Reveal => "Reveal in file manager",
+        }
+    }
+
+    /// The keystroke this action *also* has a real binding for while the tree is focused
+    /// (`crate::default_key_bindings`), in `crate::keymap::resolve_combo`'s own spec syntax -
+    /// `None` for the ones that are menu-only. Deliberately not a hard-coded keycap string: the
+    /// keycap rendered next to the row goes through the same per-platform resolution every other
+    /// keycap in this app does, so a Ctrl/⌘ mismatch can't be introduced here.
+    pub fn keystroke_spec(self) -> Option<&'static str> {
+        match self {
+            MenuAction::Rename => Some("F2"),
+            MenuAction::Cut => Some("mod+X"),
+            MenuAction::Copy => Some("mod+C"),
+            MenuAction::Paste => Some("mod+V"),
+            _ => None,
+        }
+    }
+
+    /// Whether this action mutates or destroys something on disk - the rows the menu tints with
+    /// `theme::status::FAIL` so a destructive click is never visually identical to `Copy Path`.
+    pub fn is_destructive(self) -> bool {
+        matches!(self, MenuAction::Delete)
+    }
+}
+
+/// One rendered row: an action, plus whether it can actually be run right now. A disabled row is
+/// still shown (so the menu's shape doesn't jump between right-clicks) but is not clickable and
+/// carries the real reason as its tooltip.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MenuItem {
+    pub action: MenuAction,
+    pub enabled: bool,
+    /// Why a disabled row is disabled - `None` when it's enabled.
+    pub disabled_reason: Option<&'static str>,
+}
+
+impl MenuItem {
+    fn enabled(action: MenuAction) -> Self {
+        MenuItem {
+            action,
+            enabled: true,
+            disabled_reason: None,
+        }
+    }
+
+    fn gated(action: MenuAction, enabled: bool, reason: &'static str) -> Self {
+        MenuItem {
+            action,
+            enabled,
+            disabled_reason: (!enabled).then_some(reason),
+        }
+    }
+}
+
+/// The real rows for `target`, in the order issue #19 §1 lists them.
+///
+/// `clipboard_has_entry` gates every `Paste` row: with nothing cut or copied there is genuinely
+/// nothing to paste, and a row that silently does nothing is worse than a visibly disabled one.
+pub fn menu_items(target: &ContextTarget, clipboard_has_entry: bool) -> Vec<MenuItem> {
+    const NOTHING_COPIED: &str = "nothing has been cut or copied yet";
+    match target {
+        ContextTarget::File(_) => vec![
+            MenuItem::enabled(MenuAction::Open),
+            MenuItem::enabled(MenuAction::Rename),
+            MenuItem::enabled(MenuAction::Duplicate),
+            MenuItem::enabled(MenuAction::Cut),
+            MenuItem::enabled(MenuAction::Copy),
+            MenuItem::gated(MenuAction::Paste, clipboard_has_entry, NOTHING_COPIED),
+            MenuItem::enabled(MenuAction::CopyPath),
+            MenuItem::enabled(MenuAction::CopyRelativePath),
+            MenuItem::enabled(MenuAction::Delete),
+            MenuItem::enabled(MenuAction::Reveal),
+        ],
+        ContextTarget::Folder(_) => vec![
+            MenuItem::enabled(MenuAction::NewFile),
+            MenuItem::enabled(MenuAction::NewFolder),
+            MenuItem::enabled(MenuAction::Rename),
+            MenuItem::enabled(MenuAction::Cut),
+            MenuItem::enabled(MenuAction::Copy),
+            MenuItem::gated(MenuAction::Paste, clipboard_has_entry, NOTHING_COPIED),
+            MenuItem::enabled(MenuAction::CollapseSubtree),
+            MenuItem::enabled(MenuAction::CopyPath),
+            MenuItem::enabled(MenuAction::Delete),
+            MenuItem::enabled(MenuAction::Reveal),
+        ],
+        ContextTarget::Empty => vec![
+            MenuItem::enabled(MenuAction::NewFile),
+            MenuItem::enabled(MenuAction::NewFolder),
+            MenuItem::gated(MenuAction::Paste, clipboard_has_entry, NOTHING_COPIED),
+            MenuItem::enabled(MenuAction::CollapseAll),
+        ],
+    }
+}
+
+/// The popover's fixed width, in px. Wide enough for the longest label
+/// ("Copy Relative Path") plus a `Ctrl+V`-sized keycap without wrapping.
+pub const MENU_WIDTH: f32 = 208.0;
+
+/// One menu row's height, in px - matching `theme::band::TREE_ROW`'s own 22px rhythm plus a
+/// little breathing room, since these rows carry a keycap the tree rows don't.
+pub const MENU_ROW_HEIGHT: f32 = 24.0;
+
+/// The popover's own vertical padding (top + bottom together), in px.
+pub const MENU_VERTICAL_PADDING: f32 = 8.0;
+
+/// The smallest gap the menu keeps from a window edge, in px - so a menu pushed back inside the
+/// window doesn't sit flush against the frame.
+pub const MENU_EDGE_MARGIN: f32 = 4.0;
+
+/// The popover's own 1px border, top and bottom. Part of the painted height because GPUI sizes
+/// are border-box only for an *explicit* size; this panel's height comes from its children plus
+/// its own padding and border, so a `menu_height` that omitted this was 2px short of what really
+/// paints - which is exactly enough for a menu opened at the very bottom edge to overhang.
+pub const MENU_BORDER: f32 = 2.0;
+
+/// The popover's real painted height for `rows` rows.
+pub fn menu_height(rows: usize) -> f32 {
+    MENU_ROW_HEIGHT * rows as f32 + MENU_VERTICAL_PADDING + MENU_BORDER
+}
+
+/// Where the popover's top-left corner must go so the whole menu stays inside a
+/// `viewport_width` x `viewport_height` window, given the click it was opened from (issue #19 §1:
+/// "the menu repositions to stay inside the window near screen edges").
+///
+/// The rule, per axis, in order:
+/// 1. Draw from the click, the way every context menu does.
+/// 2. If that overflows the far edge, *flip* to the other side of the click (right-click near the
+///    right edge opens leftwards; near the bottom, upwards). A flip is preferred over a slide
+///    because it keeps the cursor on the menu's corner, so the pointer doesn't end up hovering a
+///    row the user never aimed at.
+/// 3. If the flip would overflow the near edge too - a menu taller than the window, or a click in
+///    a corner of a very small window - clamp into the window and accept that the cursor is no
+///    longer at a corner. Clamping is applied last and against both edges, so the returned origin
+///    is never negative and never past the far edge whenever the menu genuinely fits.
+///
+/// Returns window-space pixels, the same space `gpui::MouseDownEvent::position` is in.
+pub fn clamp_menu_origin(
+    click_x: f32,
+    click_y: f32,
+    width: f32,
+    height: f32,
+    viewport_width: f32,
+    viewport_height: f32,
+) -> (f32, f32) {
+    (
+        place_axis(click_x, width, viewport_width),
+        place_axis(click_y, height, viewport_height),
+    )
+}
+
+fn place_axis(click: f32, size: f32, viewport: f32) -> f32 {
+    let far_limit = viewport - size - MENU_EDGE_MARGIN;
+    let mut origin = click;
+    if origin > far_limit {
+        // Flip to the other side of the click.
+        origin = click - size;
+    }
+    // `far_limit` can be smaller than `MENU_EDGE_MARGIN` when the menu is larger than the
+    // window; `max` last so the near edge always wins in that case (showing the menu's top-left,
+    // which is where its first rows are, rather than its bottom-right).
+    origin.min(far_limit).max(MENU_EDGE_MARGIN)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn actions(items: &[MenuItem]) -> Vec<MenuAction> {
+        items.iter().map(|item| item.action).collect()
+    }
+
+    /// Issue #19 §1's three lists, exactly.
+    #[test]
+    fn each_target_offers_the_actions_the_issue_lists() {
+        let file = ContextTarget::File(PathBuf::from("/repo/a.rs"));
+        assert_eq!(
+            actions(&menu_items(&file, true)),
+            vec![
+                MenuAction::Open,
+                MenuAction::Rename,
+                MenuAction::Duplicate,
+                MenuAction::Cut,
+                MenuAction::Copy,
+                MenuAction::Paste,
+                MenuAction::CopyPath,
+                MenuAction::CopyRelativePath,
+                MenuAction::Delete,
+                MenuAction::Reveal,
+            ]
+        );
+
+        let folder = ContextTarget::Folder(PathBuf::from("/repo/src"));
+        assert_eq!(
+            actions(&menu_items(&folder, true)),
+            vec![
+                MenuAction::NewFile,
+                MenuAction::NewFolder,
+                MenuAction::Rename,
+                MenuAction::Cut,
+                MenuAction::Copy,
+                MenuAction::Paste,
+                MenuAction::CollapseSubtree,
+                MenuAction::CopyPath,
+                MenuAction::Delete,
+                MenuAction::Reveal,
+            ]
+        );
+
+        assert_eq!(
+            actions(&menu_items(&ContextTarget::Empty, true)),
+            vec![
+                MenuAction::NewFile,
+                MenuAction::NewFolder,
+                MenuAction::Paste,
+                MenuAction::CollapseAll,
+            ]
+        );
+    }
+
+    #[test]
+    fn paste_is_the_only_row_an_empty_clipboard_disables() {
+        for target in [
+            ContextTarget::File(PathBuf::from("/repo/a.rs")),
+            ContextTarget::Folder(PathBuf::from("/repo/src")),
+            ContextTarget::Empty,
+        ] {
+            let items = menu_items(&target, false);
+            for item in &items {
+                assert_eq!(
+                    item.enabled,
+                    item.action != MenuAction::Paste,
+                    "{:?} on {target:?}",
+                    item.action
+                );
+            }
+            assert!(items
+                .iter()
+                .find(|item| item.action == MenuAction::Paste)
+                .expect("every target has a Paste row")
+                .disabled_reason
+                .is_some());
+        }
+    }
+
+    #[test]
+    fn a_targets_destination_directory_is_where_a_new_entry_would_land() {
+        let root = Path::new("/repo");
+        assert_eq!(
+            ContextTarget::Folder(PathBuf::from("/repo/src")).destination_dir(root),
+            Path::new("/repo/src")
+        );
+        assert_eq!(
+            ContextTarget::File(PathBuf::from("/repo/src/main.rs")).destination_dir(root),
+            Path::new("/repo/src"),
+            "a new file next to a file lands in that file's own folder"
+        );
+        assert_eq!(ContextTarget::Empty.destination_dir(root), root);
+    }
+
+    #[test]
+    fn a_menu_that_fits_opens_exactly_at_the_click() {
+        let height = menu_height(10);
+        assert_eq!(
+            clamp_menu_origin(100.0, 50.0, MENU_WIDTH, height, 1200.0, 800.0),
+            (100.0, 50.0)
+        );
+    }
+
+    #[test]
+    fn a_click_near_the_right_or_bottom_edge_flips_the_menu_back_inside() {
+        let height = menu_height(10);
+        let (x, y) = clamp_menu_origin(1190.0, 790.0, MENU_WIDTH, height, 1200.0, 800.0);
+        assert_eq!(x, 1190.0 - MENU_WIDTH, "flips leftwards off the click");
+        assert_eq!(y, 790.0 - height, "flips upwards off the click");
+        assert!(x >= MENU_EDGE_MARGIN && x + MENU_WIDTH <= 1200.0);
+        assert!(y >= MENU_EDGE_MARGIN && y + height <= 800.0);
+    }
+
+    /// A menu taller than the window can't fit either way round; it must still start inside the
+    /// window (showing its first rows) rather than at a negative offset.
+    #[test]
+    fn a_menu_larger_than_the_window_clamps_to_the_near_edge() {
+        let height = menu_height(10);
+        let (x, y) = clamp_menu_origin(20.0, 20.0, MENU_WIDTH, height, 100.0, 60.0);
+        assert_eq!((x, y), (MENU_EDGE_MARGIN, MENU_EDGE_MARGIN));
+    }
+
+    /// A click in the very top-left corner would flip a menu to a negative origin; the near-edge
+    /// clamp is what stops that.
+    #[test]
+    fn a_flip_never_produces_a_negative_origin() {
+        let height = menu_height(4);
+        let (x, y) = clamp_menu_origin(2.0, 2.0, MENU_WIDTH, height, 240.0, 60.0);
+        assert!(x >= MENU_EDGE_MARGIN, "got {x}");
+        assert!(y >= MENU_EDGE_MARGIN, "got {y}");
+    }
+
+    /// Asserted absolutely, not just as a growth rate. A rate-only assertion is blind to a
+    /// constant term going missing, which is exactly how the panel's own 2px border was left out
+    /// of an earlier version of `menu_height` - making every edge-flip 2px optimistic.
+    #[test]
+    fn menu_height_is_the_panels_whole_painted_height() {
+        assert_eq!(
+            menu_height(4),
+            4.0 * MENU_ROW_HEIGHT + MENU_VERTICAL_PADDING + MENU_BORDER,
+            "every term `crate::sidebar::render::AdeApp::render_tree_context_menu` actually \
+             paints - rows, the panel's own py, and its 1px border top and bottom"
+        );
+        assert_eq!(
+            menu_height(5) - menu_height(4),
+            MENU_ROW_HEIGHT,
+            "and it must still track the real row count"
+        );
+    }
+
+    #[test]
+    fn only_delete_is_marked_destructive() {
+        for target in [
+            ContextTarget::File(PathBuf::from("/repo/a.rs")),
+            ContextTarget::Folder(PathBuf::from("/repo/src")),
+            ContextTarget::Empty,
+        ] {
+            for item in menu_items(&target, true) {
+                assert_eq!(
+                    item.action.is_destructive(),
+                    item.action == MenuAction::Delete,
+                    "{:?}",
+                    item.action
+                );
+            }
+        }
+    }
+}

--- a/crates/app/src/sidebar/file_ops.rs
+++ b/crates/app/src/sidebar/file_ops.rs
@@ -1,0 +1,607 @@
+//! The real filesystem primitives behind the file tree's context menu (GitHub issue #19 §2/§3):
+//! name validation, collision-free destination naming, recursive copy, move, and delete.
+//!
+//! Pure and GPUI-free, like [`crate::sidebar::file_tree`] beside it, so every rule here is unit
+//! testable against a real `tempfile::TempDir` without a window. The `impl AdeApp` glue that
+//! decides *when* to call these - and what to do to open tabs afterwards - lives in
+//! [`crate::sidebar::tree_ops`].
+//!
+//! ## Why these are plain `std::fs` calls and not `crate::code_surface`'s save pipeline
+//!
+//! `crate::code_surface::editing::AdeApp::save_active_file` guards a *write of buffer content*
+//! against a concurrent external edit: it compares a fresh `std::fs::metadata` read against the
+//! `saved_mtime`/`saved_len` the buffer was seeded with, so an agent CLI that rewrote the file
+//! since it was opened can't have its work silently overwritten. That guard has nothing to
+//! protect here: none of these operations write buffer content. They rename, copy or remove a
+//! path as a whole, and the identity question they need answered is "does something already
+//! exist at the destination", which every one of them asks immediately before acting.
+//!
+//! Neither [`move_path`] nor [`copy_path`] is atomic about that check, and both say so on
+//! themselves rather than here: `std::fs::rename` silently replaces an existing destination and
+//! `std::fs::copy` silently truncates one, so an entry created in the window between the check
+//! and the syscall is clobbered either way. `renameat2(RENAME_NOREPLACE)`/`O_EXCL` would close
+//! it, at the cost of a Linux-only path and a hand-rolled copy loop; the honest position taken
+//! here is a real check with a real, documented residual window.
+//!
+//! ## Trash
+//!
+//! See [`resolve_delete_mechanism`]. The short version: on Linux/FreeBSD this shells out to a
+//! real `gio trash`, which implements the freedesktop.org trash specification (verified by
+//! running it: it really does move both files and directories into
+//! `~/.local/share/Trash/files`). On every other platform this app has no verified, quoting-safe
+//! CLI trash mechanism, so the delete is a real, permanent one - and the confirmation copy says
+//! exactly that rather than claiming a trash that never happened.
+
+use std::ffi::OsString;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// How many `name copy N` candidates [`unique_destination`] will try before giving up. A real
+/// bound rather than an unbounded loop: a directory that somehow contains every candidate would
+/// otherwise spin the foreground thread forever.
+const MAX_COPY_SUFFIX_ATTEMPTS: usize = 1000;
+
+/// Validates a single path *component* typed into an inline name editor (new file, new folder,
+/// rename), returning the trimmed name.
+///
+/// The one implementation of this rule in the app: `crate::root::new_file::AdeApp::
+/// create_new_file` - the pre-existing "New file" flow - calls this too rather than keeping its
+/// own inline copy, so the tree's editors and the `+` menu's prompt can never drift into
+/// disagreeing about what a legal name is.
+///
+/// Rejects, with the real message shown next to the editor:
+/// - an empty (or whitespace-only) name;
+/// - a path separator, so this can only ever name something *in* the chosen directory;
+/// - `.` and `..`, which name a directory that already exists and would make every subsequent
+///   operation act on the wrong path;
+/// - an interior NUL, which no filesystem accepts and which `std::fs` would surface as an
+///   opaque `InvalidInput` error much further along.
+pub fn validate_entry_name(raw: &str) -> Result<&str, String> {
+    let name = raw.trim();
+    if name.is_empty() {
+        return Err("name can't be empty".to_string());
+    }
+    if name.contains('/') || name.contains('\\') {
+        return Err("name can't contain a path separator".to_string());
+    }
+    if name == "." || name == ".." {
+        return Err(format!("\"{name}\" isn't a usable name"));
+    }
+    if name.contains('\0') {
+        return Err("name can't contain a null byte".to_string());
+    }
+    Ok(name)
+}
+
+/// `"foo.rs"` + 1 -> `"foo copy.rs"`, + 2 -> `"foo copy 2.rs"`; `"src"` + 1 -> `"src copy"`.
+///
+/// macOS Finder's convention rather than GNOME Files' `"foo (copy).rs"`, chosen because it keeps
+/// the suffix out of the *stem* only, leaves the extension exactly where a language chip and
+/// every editor tooling look for it, and reads the same for a directory (which has no extension)
+/// as for a file.
+///
+/// A multi-part extension is split by `Path::extension`'s own rule, so `"archive.tar.gz"`
+/// becomes `"archive.tar copy.gz"`. That is the same answer Finder gives, and preserving the
+/// *final* extension is what actually matters for how the copy is then opened.
+pub fn copy_suffixed_name(name: &str, attempt: usize) -> String {
+    let suffix = if attempt <= 1 {
+        " copy".to_string()
+    } else {
+        format!(" copy {attempt}")
+    };
+    let as_path = Path::new(name);
+    match (as_path.file_stem(), as_path.extension()) {
+        (Some(stem), Some(extension)) if !stem.is_empty() => format!(
+            "{}{suffix}.{}",
+            stem.to_string_lossy(),
+            extension.to_string_lossy()
+        ),
+        // No extension at all (a directory, `Makefile`), or a dotfile whose whole name is the
+        // "extension" (`.gitignore` -> stem is empty): suffix the whole name.
+        _ => format!("{name}{suffix}"),
+    }
+}
+
+/// The first free path for `name` inside `dir` - `dir/name` itself when nothing is there, and
+/// otherwise the first [`copy_suffixed_name`] candidate that doesn't exist.
+///
+/// This is what makes "paste into the folder you copied from" produce a real second file rather
+/// than either silently overwriting the original or failing with a collision error (issue #19
+/// §3). Existence is checked with `Path::symlink_metadata`, not `Path::exists`: a *broken*
+/// symlink is still a real directory entry that a create would collide with, and `exists()`
+/// follows the link and reports `false` for it.
+///
+/// A name counts as free only on a real `NotFound`, never on any other error: a `EACCES` on the
+/// parent directory means "I can't tell", and treating that as free would hand the caller a
+/// destination whose create then fails with an unrelated-looking error several frames later.
+pub fn unique_destination(dir: &Path, name: &str) -> io::Result<PathBuf> {
+    let is_free = |path: &Path| matches!(path.symlink_metadata(), Err(err) if err.kind() == io::ErrorKind::NotFound);
+    let direct = dir.join(name);
+    if is_free(&direct) {
+        return Ok(direct);
+    }
+    for attempt in 1..=MAX_COPY_SUFFIX_ATTEMPTS {
+        let candidate = dir.join(copy_suffixed_name(name, attempt));
+        if is_free(&candidate) {
+            return Ok(candidate);
+        }
+    }
+    Err(io::Error::new(
+        io::ErrorKind::AlreadyExists,
+        format!("\"{name}\" and {MAX_COPY_SUFFIX_ATTEMPTS} \"copy\" variants of it all already exist in {}", dir.display()),
+    ))
+}
+
+/// Whether `path` is `ancestor` itself or lives underneath it - the guard that stops a folder
+/// being copied or moved into its own subtree, which would otherwise either recurse until the
+/// disk filled or (for a move) make the whole subtree unreachable.
+pub fn is_self_or_descendant(ancestor: &Path, path: &Path) -> bool {
+    path == ancestor || path.starts_with(ancestor)
+}
+
+/// Moves `source` to `destination` (a real `std::fs::rename`), used by both Rename and a
+/// Cut+Paste.
+///
+/// Refuses when something already exists at `destination`. That check is deliberately *not*
+/// claimed to be atomic: `std::fs::rename` on Unix silently replaces an existing destination,
+/// so a file created at `destination` between this check and the syscall would be clobbered.
+/// Closing that window needs `renameat2(RENAME_NOREPLACE)`, which is Linux-only and not exposed
+/// by `std`; this app targets three platforms from one code path, so the honest position is a
+/// real check with a real, documented residual window rather than a claim of atomicity it can't
+/// keep on every platform.
+pub fn move_path(source: &Path, destination: &Path) -> io::Result<()> {
+    if source == destination {
+        return Ok(());
+    }
+    if destination.symlink_metadata().is_ok() {
+        return Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!("{} already exists", destination.display()),
+        ));
+    }
+    if source.is_dir() && is_self_or_descendant(source, destination) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "a folder can't be moved inside itself".to_string(),
+        ));
+    }
+    fs::rename(source, destination)
+}
+
+/// Copies `source` to `destination`, recursing for a directory. Used by Duplicate and by a
+/// Copy+Paste.
+///
+/// Refuses to copy a directory into its own subtree ([`is_self_or_descendant`]) *before*
+/// creating anything.
+///
+/// **Symlinks are followed, not recreated**, and the dir/file decision uses `fs::metadata`
+/// (following) rather than `fs::symlink_metadata`. That is a real fix, not a stylistic choice: an
+/// earlier version decided with `symlink_metadata`, so a symlink *to a directory* reported
+/// `is_dir() == false` and fell through to `fs::copy`, which fails with `EISDIR` - and inside the
+/// recursion, a symlinked subdirectory aborted the whole walk mid-tree. Following matches this
+/// tree's own walk (`crate::sidebar::file_tree::build_file_tree` doesn't distinguish them
+/// either), and silently producing a link pointing outside the worktree would be the more
+/// surprising of the two behaviours. A symlink *cycle* is bounded by the same recursion guard the
+/// walk uses - see [`MAX_COPY_DEPTH`].
+///
+/// **Cleanup on failure.** A directory copy that fails part-way (a permission error, a full disk)
+/// removes the destination tree it created before returning, so the sidebar never repaints
+/// showing a half-copied `foo copy/` that looks complete. Only ever `remove_dir_all`s a directory
+/// this call itself created one line earlier - `copy_path` has already refused an occupied
+/// destination above.
+///
+/// **Not atomic, and the window is real.** `fs::copy` opens the destination `O_CREAT|O_TRUNC`, so
+/// something created at `destination` between the existence check above and the copy is
+/// truncated. Same class as [`move_path`]'s own documented `fs::rename` window, with a worse
+/// outcome; closing it needs `O_EXCL` plus a hand-rolled streaming copy (and loses `fs::copy`'s
+/// permission-preservation and platform fast paths), which isn't worth it for a
+/// destination name that was chosen microseconds earlier by [`unique_destination`].
+pub fn copy_path(source: &Path, destination: &Path) -> io::Result<()> {
+    if destination.symlink_metadata().is_ok() {
+        return Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!("{} already exists", destination.display()),
+        ));
+    }
+    // Following (`metadata`), deliberately - see this function's own docs.
+    if fs::metadata(source)?.is_dir() {
+        if is_self_or_descendant(source, destination) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "a folder can't be copied inside itself".to_string(),
+            ));
+        }
+        copy_dir_recursive(source, destination, 0).inspect_err(|_| {
+            // Best-effort: if this fails too there is nothing further to try, and the real
+            // error to report is the copy's, not the cleanup's.
+            let _ = fs::remove_dir_all(destination);
+        })
+    } else {
+        fs::copy(source, destination).map(|_| ())
+    }
+}
+
+/// How deep [`copy_path`] will recurse. Mirrors `crate::sidebar::file_tree::MAX_DEPTH`'s own
+/// reasoning, with one addition that matters more here: because the copy *follows* symlinks, a
+/// symlink pointing at one of its own ancestors would otherwise recurse until the disk filled.
+/// The `is_self_or_descendant` guard only covers the literal source/destination pair, not a link
+/// buried inside the tree.
+pub const MAX_COPY_DEPTH: usize = crate::sidebar::file_tree::MAX_DEPTH;
+
+fn copy_dir_recursive(source: &Path, destination: &Path, depth: usize) -> io::Result<()> {
+    if depth >= MAX_COPY_DEPTH {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "{} is nested more than {MAX_COPY_DEPTH} levels deep (or contains a symlink \
+                 cycle) - refusing to copy further",
+                source.display()
+            ),
+        ));
+    }
+    fs::create_dir(destination)?;
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let from = entry.path();
+        let to = destination.join(entry.file_name());
+        if fs::metadata(&from)?.is_dir() {
+            copy_dir_recursive(&from, &to, depth + 1)?;
+        } else {
+            fs::copy(&from, &to)?;
+        }
+    }
+    Ok(())
+}
+
+/// A real, permanent removal of `path` (a file or a whole directory tree) - only ever reached
+/// when [`resolve_delete_mechanism`] reported [`DeleteMechanism::Permanent`] *and* the
+/// confirmation the user accepted said so in those words.
+pub fn delete_permanently(path: &Path) -> io::Result<()> {
+    if fs::symlink_metadata(path)?.is_dir() {
+        fs::remove_dir_all(path)
+    } else {
+        fs::remove_file(path)
+    }
+}
+
+/// What deleting `path` will genuinely do on this machine - resolved once, immediately before
+/// the confirmation is shown, so the confirmation copy and the operation can never disagree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DeleteMechanism {
+    /// A real OS trash command that was found on `$PATH`. Running it moves the path into the
+    /// system trash, from which the user can restore it outside this app.
+    Trash {
+        program: &'static str,
+        args: Vec<OsString>,
+    },
+    /// No trash mechanism is available, so the delete is irreversible.
+    Permanent,
+}
+
+/// The real trash command for `target_os`, or `None` when this app has no verified one.
+///
+/// `target_os` is an injected `std::env::consts::OS`-shaped string, exactly like
+/// `crate::settings::widgets`' own `open_command_for` - the same "pure decision function plus a
+/// thin real-execution wrapper" shape this codebase already uses for `xdg-open`, so the decision
+/// is unit testable without spawning anything.
+///
+/// - **Linux / FreeBSD (and any other Unix)**: real `gio trash -- <path>`. `gio` is GLib's own
+///   CLI, and `gio trash` is a direct wrapper around `g_file_trash`, which implements the
+///   freedesktop.org trash specification for local files entirely in-process (no session bus, no
+///   gvfs daemon needed for a local path). Verified for real in this project's own environment,
+///   not assumed: trashing both a file and a non-empty directory succeeded and both appeared in
+///   `~/.local/share/Trash/files`. The `--` is a real, supported `gio` argument terminator and is
+///   what keeps a filename that begins with `-` from being parsed as an option (also verified by
+///   running it).
+/// - **macOS / Windows**: deliberately `None`. Neither has a trash CLI this app can invoke
+///   safely without a mechanism it has never executed: macOS's usual answer is an `osascript`
+///   snippet whose *only* interface is an AppleScript string literal, so every quote, backslash
+///   and newline in a filename has to be escaped correctly by hand or the command silently acts
+///   on a different path than the one confirmed; Windows has no built-in recycle-bin CLI at all
+///   (it needs the `Shell.Application` COM object or the `Microsoft.VisualBasic` assembly through
+///   PowerShell). A wrong guess here doesn't degrade gracefully - it destroys the wrong file, or
+///   reports "moved to trash" for something still sitting on disk. Returning `None` makes those
+///   platforms take the real, clearly-labelled permanent-delete path instead, which is honest.
+pub fn trash_command_for(target_os: &str, path: &Path) -> Option<(&'static str, Vec<OsString>)> {
+    match target_os {
+        "macos" | "windows" => None,
+        _ => Some((
+            "gio",
+            vec!["trash".into(), "--".into(), path.as_os_str().to_os_string()],
+        )),
+    }
+}
+
+/// [`trash_command_for`] plus a real "is that program actually installed" probe - `gio` is a
+/// GLib package, not part of a base system, so a machine that simply doesn't have it must take
+/// the permanent-delete path with the matching confirmation copy rather than a trash attempt
+/// that would fail after the user already confirmed.
+///
+/// `program_exists` is injected so this stays a pure, testable decision; the one production
+/// caller passes `pty_core::resolve_on_path`, the same real `$PATH` walk this workspace already
+/// uses to detect agent CLIs and language servers.
+pub fn resolve_delete_mechanism(
+    target_os: &str,
+    path: &Path,
+    program_exists: impl Fn(&str) -> bool,
+) -> DeleteMechanism {
+    match trash_command_for(target_os, path) {
+        Some((program, args)) if program_exists(program) => {
+            DeleteMechanism::Trash { program, args }
+        }
+        _ => DeleteMechanism::Permanent,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn a_name_must_be_a_single_non_empty_component() {
+        assert_eq!(validate_entry_name("  notes.md  "), Ok("notes.md"));
+        assert!(validate_entry_name("   ").is_err());
+        assert!(validate_entry_name("").is_err());
+        assert!(validate_entry_name("src/main.rs").is_err());
+        assert!(validate_entry_name("src\\main.rs").is_err());
+        assert!(validate_entry_name(".").is_err());
+        assert!(validate_entry_name("..").is_err());
+        assert!(validate_entry_name("a\0b").is_err());
+        // A dotfile is a perfectly ordinary name, even though the tree's own walk hides it.
+        assert_eq!(validate_entry_name(".gitignore"), Ok(".gitignore"));
+    }
+
+    #[test]
+    fn the_copy_suffix_lands_before_the_extension() {
+        assert_eq!(copy_suffixed_name("foo.rs", 1), "foo copy.rs");
+        assert_eq!(copy_suffixed_name("foo.rs", 2), "foo copy 2.rs");
+        assert_eq!(copy_suffixed_name("src", 1), "src copy");
+        assert_eq!(copy_suffixed_name("src", 3), "src copy 3");
+        assert_eq!(copy_suffixed_name("Makefile", 1), "Makefile copy");
+        assert_eq!(
+            copy_suffixed_name("archive.tar.gz", 1),
+            "archive.tar copy.gz"
+        );
+        // A dotfile has no stem of its own - suffix the whole name rather than producing
+        // " copy.gitignore".
+        assert_eq!(copy_suffixed_name(".gitignore", 1), ".gitignore copy");
+    }
+
+    /// The core of issue #19 §3: pasting into the folder something was copied from must produce
+    /// a real, differently-named second entry - never an overwrite, never an error.
+    #[test]
+    fn pasting_into_the_source_folder_suffixes_instead_of_colliding() {
+        let dir = TempDir::new().expect("tempdir");
+        fs::write(dir.path().join("foo.rs"), "original").expect("write");
+
+        let first = unique_destination(dir.path(), "foo.rs").expect("first");
+        assert_eq!(first, dir.path().join("foo copy.rs"));
+        fs::write(&first, "copy").expect("write");
+
+        let second = unique_destination(dir.path(), "foo.rs").expect("second");
+        assert_eq!(second, dir.path().join("foo copy 2.rs"));
+
+        assert_eq!(
+            fs::read_to_string(dir.path().join("foo.rs")).expect("read"),
+            "original",
+            "the original must never be touched"
+        );
+    }
+
+    #[test]
+    fn a_free_name_is_used_as_is() {
+        let dir = TempDir::new().expect("tempdir");
+        assert_eq!(
+            unique_destination(dir.path(), "fresh.txt").expect("free"),
+            dir.path().join("fresh.txt")
+        );
+    }
+
+    /// `Path::exists` follows symlinks and reports `false` for a broken one - but a broken
+    /// symlink is still a real directory entry a create would collide with.
+    #[cfg(unix)]
+    #[test]
+    fn a_broken_symlink_still_counts_as_an_existing_entry() {
+        let dir = TempDir::new().expect("tempdir");
+        std::os::unix::fs::symlink(dir.path().join("nowhere"), dir.path().join("link.txt"))
+            .expect("symlink");
+        assert!(!dir.path().join("link.txt").exists(), "premise");
+        assert_eq!(
+            unique_destination(dir.path(), "link.txt").expect("unique"),
+            dir.path().join("link copy.txt")
+        );
+    }
+
+    #[test]
+    fn moving_refuses_an_occupied_destination_and_leaves_both_paths_alone() {
+        let dir = TempDir::new().expect("tempdir");
+        fs::write(dir.path().join("a.txt"), "a").expect("write");
+        fs::write(dir.path().join("b.txt"), "b").expect("write");
+
+        let err = move_path(&dir.path().join("a.txt"), &dir.path().join("b.txt"))
+            .expect_err("must refuse");
+        assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
+        assert_eq!(
+            fs::read_to_string(dir.path().join("b.txt")).expect("read"),
+            "b",
+            "the destination's real content must survive a refused move"
+        );
+        assert!(dir.path().join("a.txt").exists());
+    }
+
+    #[test]
+    fn moving_a_directory_moves_its_whole_subtree() {
+        let dir = TempDir::new().expect("tempdir");
+        fs::create_dir_all(dir.path().join("src/inner")).expect("mkdir");
+        fs::write(dir.path().join("src/inner/deep.rs"), "deep").expect("write");
+
+        move_path(&dir.path().join("src"), &dir.path().join("lib")).expect("move");
+
+        assert!(!dir.path().join("src").exists());
+        assert_eq!(
+            fs::read_to_string(dir.path().join("lib/inner/deep.rs")).expect("read"),
+            "deep"
+        );
+    }
+
+    #[test]
+    fn a_folder_cannot_be_moved_or_copied_into_itself() {
+        let dir = TempDir::new().expect("tempdir");
+        fs::create_dir(dir.path().join("src")).expect("mkdir");
+        fs::write(dir.path().join("src/a.rs"), "a").expect("write");
+
+        let source = dir.path().join("src");
+        let inside = dir.path().join("src/nested");
+
+        assert!(move_path(&source, &inside).is_err());
+        assert!(copy_path(&source, &inside).is_err());
+        assert!(
+            !inside.exists(),
+            "a refused copy must not leave a partial tree behind"
+        );
+    }
+
+    #[test]
+    fn copying_a_directory_reproduces_its_whole_subtree_without_touching_the_source() {
+        let dir = TempDir::new().expect("tempdir");
+        fs::create_dir_all(dir.path().join("src/inner")).expect("mkdir");
+        fs::write(dir.path().join("src/top.rs"), "top").expect("write");
+        fs::write(dir.path().join("src/inner/deep.rs"), "deep").expect("write");
+
+        copy_path(&dir.path().join("src"), &dir.path().join("src copy")).expect("copy");
+
+        assert_eq!(
+            fs::read_to_string(dir.path().join("src copy/inner/deep.rs")).expect("read"),
+            "deep"
+        );
+        assert_eq!(
+            fs::read_to_string(dir.path().join("src/inner/deep.rs")).expect("read"),
+            "deep",
+            "the source must be untouched by a copy"
+        );
+    }
+
+    /// A symlink *to a directory* used to abort the copy with `EISDIR` (the dir/file decision
+    /// was made with the non-following `symlink_metadata`), and a symlinked subdirectory aborted
+    /// the recursion mid-tree. Both are now followed, like the tree's own walk does.
+    #[cfg(unix)]
+    #[test]
+    fn a_symlink_to_a_directory_is_followed_rather_than_aborting_the_copy() {
+        let dir = TempDir::new().expect("tempdir");
+        fs::create_dir(dir.path().join("real")).expect("mkdir");
+        fs::write(dir.path().join("real/inside.txt"), "inside").expect("write");
+        fs::create_dir(dir.path().join("tree")).expect("mkdir");
+        fs::write(dir.path().join("tree/plain.txt"), "plain").expect("write");
+        std::os::unix::fs::symlink(dir.path().join("real"), dir.path().join("tree/linked"))
+            .expect("symlink");
+
+        // The symlink as the copy's own source.
+        copy_path(
+            &dir.path().join("tree/linked"),
+            &dir.path().join("direct-copy"),
+        )
+        .expect("a symlinked directory must be copied, not rejected");
+        assert_eq!(
+            fs::read_to_string(dir.path().join("direct-copy/inside.txt")).expect("read"),
+            "inside"
+        );
+
+        // And nested inside a tree being copied.
+        copy_path(&dir.path().join("tree"), &dir.path().join("tree copy")).expect("copy tree");
+        assert_eq!(
+            fs::read_to_string(dir.path().join("tree copy/linked/inside.txt")).expect("read"),
+            "inside",
+            "a symlinked subdirectory must be walked, not abort the whole copy"
+        );
+        assert!(dir.path().join("tree copy/plain.txt").exists());
+    }
+
+    /// A copy that fails part-way must not leave a partial tree the sidebar would then repaint as
+    /// though it were complete.
+    #[cfg(unix)]
+    #[test]
+    fn a_copy_that_fails_part_way_removes_what_it_created() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = TempDir::new().expect("tempdir");
+        fs::create_dir_all(dir.path().join("src/readable")).expect("mkdir");
+        fs::write(dir.path().join("src/readable/a.txt"), "a").expect("write");
+        let locked = dir.path().join("src/locked");
+        fs::create_dir(&locked).expect("mkdir");
+        fs::set_permissions(&locked, fs::Permissions::from_mode(0o000)).expect("chmod");
+        if fs::read_dir(&locked).is_ok() {
+            // Running as root, or a filesystem that ignores the mode - the premise doesn't hold.
+            fs::set_permissions(&locked, fs::Permissions::from_mode(0o755)).expect("chmod back");
+            return;
+        }
+
+        let destination = dir.path().join("src copy");
+        let result = copy_path(&dir.path().join("src"), &destination);
+        fs::set_permissions(&locked, fs::Permissions::from_mode(0o755)).expect("chmod back");
+
+        assert!(result.is_err(), "the unreadable subdirectory must fail it");
+        assert!(
+            !destination.exists(),
+            "a half-copied tree must be cleaned up, not left looking complete"
+        );
+    }
+
+    #[test]
+    fn deleting_removes_a_file_and_a_whole_directory() {
+        let dir = TempDir::new().expect("tempdir");
+        fs::write(dir.path().join("a.txt"), "a").expect("write");
+        fs::create_dir_all(dir.path().join("tree/inner")).expect("mkdir");
+        fs::write(dir.path().join("tree/inner/deep.rs"), "deep").expect("write");
+
+        delete_permanently(&dir.path().join("a.txt")).expect("delete file");
+        delete_permanently(&dir.path().join("tree")).expect("delete dir");
+
+        assert!(!dir.path().join("a.txt").exists());
+        assert!(!dir.path().join("tree").exists());
+    }
+
+    #[test]
+    fn only_platforms_with_a_verified_trash_cli_get_one() {
+        let path = Path::new("/tmp/x");
+        let (program, args) = trash_command_for("linux", path).expect("linux has gio trash");
+        assert_eq!(program, "gio");
+        assert_eq!(
+            args,
+            vec![
+                OsString::from("trash"),
+                OsString::from("--"),
+                OsString::from("/tmp/x")
+            ],
+            "the `--` terminator is what keeps a leading-dash filename from parsing as an option"
+        );
+        assert!(trash_command_for("freebsd", path).is_some());
+        assert!(
+            trash_command_for("macos", path).is_none(),
+            "no AppleScript quoting this app has never executed"
+        );
+        assert!(trash_command_for("windows", path).is_none());
+    }
+
+    /// The honest half: a platform that *has* a trash command still falls back to a real,
+    /// clearly-labelled permanent delete when that command isn't actually installed - never a
+    /// trash attempt that fails after the user already confirmed "move to trash".
+    #[test]
+    fn a_missing_trash_program_resolves_to_a_permanent_delete() {
+        let path = Path::new("/tmp/x");
+        assert_eq!(
+            resolve_delete_mechanism("linux", path, |_| false),
+            DeleteMechanism::Permanent
+        );
+        assert!(matches!(
+            resolve_delete_mechanism("linux", path, |program| program == "gio"),
+            DeleteMechanism::Trash { program: "gio", .. }
+        ));
+        assert_eq!(
+            resolve_delete_mechanism("macos", path, |_| true),
+            DeleteMechanism::Permanent,
+            "a platform with no command at all can't be rescued by a PATH hit"
+        );
+    }
+}

--- a/crates/app/src/sidebar/mod.rs
+++ b/crates/app/src/sidebar/mod.rs
@@ -10,6 +10,13 @@
 //!   record of which folders are expanded, and its atomic write path.
 //! - [`changes`] - the pure mapping from `wt_core::diff` data to the Changes tab's row
 //!   labels/colours/counts and the fold-marker treatment.
+//! - [`context_menu`] - the pure model of the right-click menu (GitHub issue #19 §1): which
+//!   actions each target offers, and the edge-aware geometry that keeps the popover on screen.
+//! - [`file_ops`] - the pure filesystem primitives behind those actions (issue #19 §2/§3): name
+//!   validation, collision-free naming, recursive copy/move/delete, and the real OS-trash
+//!   decision.
+//! - [`tree_ops`] - the `impl AdeApp` glue that sequences those two: menu state, the inline
+//!   name editors, the cut/copy/paste buffer, and the confirmed delete.
 //! - [`render`] - the real GPUI sidebar: the Files/Changes tab switch, its virtualized row
 //!   lists and their click handlers, as `impl AdeApp` methods.
 //!
@@ -21,15 +28,18 @@ use crate::root::*;
 use crate::sidebar::file_tree::{FileTreeEntry, LangChip};
 use crate::theme;
 use crate::work_surface::state as work_surface;
-use gpui::{div, font, prelude::*, px, uniform_list, ClickEvent, Context, Pixels};
-use std::collections::HashMap;
+use gpui::{div, font, prelude::*, px, uniform_list, ClickEvent, Context, Pixels, Window};
+use std::collections::{HashMap, HashSet};
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use wt_core::diff::{DiffFile, FileChangeStatus, WorktreeDiff};
 
 pub mod changes;
+pub mod context_menu;
+pub mod file_ops;
 pub mod file_tree;
 pub mod fold_state;
 
 pub(crate) mod render;
+pub(crate) mod tree_ops;

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -1,5 +1,8 @@
 use super::*;
-use crate::root::widgets::{render_sidebar_message, render_tag_pill, text_tooltip};
+use crate::keymap;
+use crate::root::widgets::{
+    render_keycap_row, render_sidebar_message, render_tag_pill, text_tooltip, KeycapSize,
+};
 use crate::settings::widgets::ChoiceOption;
 
 impl AdeApp {
@@ -10,8 +13,35 @@ impl AdeApp {
     pub(crate) fn set_right_sidebar_view(
         &mut self,
         view: RightSidebarView,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if view != RightSidebarView::Files {
+            // Leaving the Files tab unrenders `Self::file_tree_shell` entirely - and with it the
+            // node `AdeApp::tree_focus_handle` is `track_focus`'d on, plus every control the
+            // tree's own overlays act through. Three real problems, all closed here (GitHub issue
+            // #19, found in this change's own review):
+            //
+            // 1. **Dangling focus.** A right-click focuses the tree. Switching to Changes with
+            //    focus still on `tree_focus_handle` leaves `Window::focus` pointing at a
+            //    `FocusId` that `focus_node_id_in_rendered_frame` can no longer find, so GPUI
+            //    falls back to the dispatch root - silently killing every context-scoped binding
+            //    *and* the focused terminal's own key handling until the next click. This is the
+            //    exact invariant `crate::root::OverlayFocus`' docs describe, applied to a tab
+            //    switch rather than an overlay.
+            // 2. A context menu targeting a row that is no longer on screen.
+            // 3. A half-typed inline name for a row that is no longer on screen.
+            //
+            // The armed delete confirmation deliberately survives: it is a window-level modal
+            // with its own scrim and buttons, not a tree affordance, and silently disarming a
+            // destructive confirmation the user is mid-way through answering would be its own
+            // small dishonesty.
+            self.tree_context_menu = None;
+            self.tree_inline_edit = None;
+            if self.tree_focus_handle.is_focused(window) {
+                restore_focus(&self.sessions, &mut self.code_focus, window, cx);
+            }
+        }
         self.right_sidebar_view = view;
         if view == RightSidebarView::Changes {
             self.load_diff(self.diff_root.clone(), cx);
@@ -44,7 +74,7 @@ impl AdeApp {
     ///
     /// Uses the cached [`AdeApp::fold_state_root_key`], never `fold_state::worktree_key` - see
     /// that field's docs for the blocking-syscall-per-click this avoids.
-    fn record_dir_expanded(&mut self, path: &Path, expanded: bool) -> bool {
+    pub(in crate::sidebar) fn record_dir_expanded(&mut self, path: &Path, expanded: bool) -> bool {
         if expanded {
             self.expanded_dirs.insert(path.to_path_buf());
         } else {
@@ -274,19 +304,43 @@ impl AdeApp {
         // unreadable directory is an arbitrarily long string that used to be scrollable inside
         // that outer container. Dropping it would silently clip the very message the user needs
         // in order to understand why the tree is empty.
+        //
+        // Both are still wrapped by [`Self::file_tree_shell`], so an unreadable or empty
+        // directory still has a focusable tree with a working empty-area context menu - "New
+        // file" on a directory with nothing in it yet is exactly when that menu is most needed
+        // (GitHub issue #19 §1).
         if let Some(error) = &self.file_tree_error {
-            return scrollable_sidebar_message(
+            let message = scrollable_sidebar_message(
                 "file-tree-error",
                 format!("failed to read directory: {error}"),
                 theme::status::FAIL.into(),
             );
+            // An in-progress name editor is still drawn here, above the error. A walk can start
+            // failing *while* a name is being typed (an agent removing the folder underneath it),
+            // and the alternative - showing only the error - would leave the editor's typed text
+            // alive in `AdeApp::tree_inline_edit` and its `"tree-editing"` key context alive on
+            // this node, with nothing on screen to explain why every tree keybinding had gone
+            // dead. Discarding the text instead would break issue #19 §4's own requirement.
+            let body = div()
+                .flex()
+                .flex_col()
+                .flex_1()
+                .min_h_0()
+                .w_full()
+                .when(self.tree_inline_edit.is_some(), |el| {
+                    el.child(self.render_tree_inline_edit_row(0, cx))
+                })
+                .child(message)
+                .into_any_element();
+            return self.file_tree_shell(body, cx);
         }
-        if self.file_tree.is_empty() {
-            return scrollable_sidebar_message(
+        if self.file_tree.is_empty() && self.tree_inline_edit.is_none() {
+            let message = scrollable_sidebar_message(
                 "file-tree-empty",
                 "(empty directory)".to_string(),
                 theme::text::FAINT.into(),
             );
+            return self.file_tree_shell(message, cx);
         }
 
         // Every visible row is rendered - there is no render-time cap and no "... and N more
@@ -304,11 +358,20 @@ impl AdeApp {
         // indices are valid for exactly as long as they need to be, since nothing can mutate
         // `file_tree` between this line and the closure's last call within one frame. They are
         // still bounds-checked below rather than indexed blindly.
-        let visible_indices: Rc<Vec<usize>> = Rc::new(file_tree::visible_indices(
-            &self.file_tree,
-            &self.expanded_dirs,
-        ));
-        let rendered_count = visible_indices.len();
+        let visible_indices = file_tree::visible_indices(&self.file_tree, &self.expanded_dirs);
+        // The in-progress inline name editor is woven into that same row list as a real row
+        // (issue #19 §2: "an inline name editor at the right spot in the tree"), rather than
+        // floating over it - so it scrolls with the tree, is indented like its neighbours, and
+        // costs the virtualization nothing.
+        //
+        // Its position is re-derived here, by *path*, on every frame. That is what makes it
+        // survive a walk that replaced every row underneath it (issue #19 §4): the editor's own
+        // state lives on `AdeApp`, not in `file_tree`, and this lookup simply re-finds its
+        // anchor - falling back to the top of the list when the anchor genuinely no longer
+        // exists, rather than dropping the editor and the user's typed text with it.
+        let (rows, editor_depth) = self.file_tree_rows(&visible_indices);
+        let rows: Rc<Vec<TreeRow>> = Rc::new(rows);
+        let rendered_count = rows.len();
 
         // Built once per render, not once per row - see `Self::tree_change_marks`'s docs, and
         // `visible_indices` above for why anything the row-builder closure needs is captured
@@ -340,12 +403,20 @@ impl AdeApp {
                 // of panicking. `start` is clamped to `end`, not just to the length: clamping
                 // only the upper bound still leaves `start > end`, which panics in the slice
                 // expression below rather than degrading.
-                let end = range.end.min(visible_indices.len());
+                let end = range.end.min(rows.len());
                 let start = range.start.min(end);
-                visible_indices[start..end]
+                rows[start..end]
                     .iter()
-                    .filter_map(|index| this.file_tree.get(*index).cloned())
-                    .map(|entry| this.render_file_tree_row(&entry, &marks, cx))
+                    .filter_map(|row| match row {
+                        TreeRow::Entry(index) => this
+                            .file_tree
+                            .get(*index)
+                            .cloned()
+                            .map(|entry| this.render_file_tree_row(&entry, &marks, cx)),
+                        TreeRow::InlineEditor => {
+                            Some(this.render_tree_inline_edit_row(editor_depth, cx))
+                        }
+                    })
                     .collect::<Vec<_>>()
             }),
         )
@@ -420,7 +491,229 @@ impl AdeApp {
             );
         }
 
-        column.into_any_element()
+        // The real, honest surface for a failed file operation (a refused rename, a trash
+        // command that didn't run) - next to the tree it happened in, not buried in the log.
+        if let Some(error) = self.tree_op_error.clone() {
+            column = column.child(
+                div()
+                    .id("file-tree-op-error")
+                    .debug_selector(|| "file-tree-op-error".to_string())
+                    .flex_none()
+                    .w_full()
+                    .px(px(10.0))
+                    .py(px(5.0))
+                    .font(font(theme::font::MONO))
+                    .text_size(self.ui_text_size(10.0))
+                    .text_color(theme::status::FAIL)
+                    .cursor_pointer()
+                    .tooltip(text_tooltip("Click to dismiss"))
+                    .child(error)
+                    .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
+                        this.tree_op_error = None;
+                        cx.notify();
+                    })),
+            );
+        }
+
+        self.file_tree_shell(column.into_any_element(), cx)
+    }
+
+    /// The tree's real *outer* element - the one node that carries keyboard focus, the
+    /// `"file-tree"` key context every tree keybinding is scoped to, the empty-area right-click,
+    /// and the `gpui::canvas` that records where the tree is painted (GitHub issue #19 §1).
+    ///
+    /// Wrapping every arm of [`Self::render_file_tree`] - including the "(empty directory)" and
+    /// unreadable-directory messages - rather than only the list arm is deliberate: an empty
+    /// directory is precisely when "right-click → New file" matters most, and a tree that lost
+    /// its focus target whenever a walk failed would silently disable every one of its
+    /// keybindings until the next successful walk.
+    ///
+    /// The context string gains a second word, `"tree-editing"`, while an inline name editor is
+    /// open. That is the real mechanism that stops `Ctrl+C`/`Ctrl+X`/`Ctrl+V`/`F2`/`Shift+F10`
+    /// from firing while the user is typing a name - see `crate::sidebar::tree_ops`'s module
+    /// docs and `crate::default_key_bindings`' own entries for why a second context word is used
+    /// rather than conditionally omitting the bindings.
+    fn file_tree_shell(&self, body: gpui::AnyElement, cx: &mut Context<Self>) -> gpui::AnyElement {
+        // Space-separated context *words*, which is what `KeyBindingContextPredicate`'s
+        // identifier terms match against - so `Some("file-tree && !tree-editing")` really does
+        // stop matching the moment `"tree-editing"` is added here. Two independent modal states
+        // add a word each: an open inline name editor, and the modal delete confirmation (which
+        // would otherwise let `F2`/`Shift+F10` fire behind its own scrim).
+        let key_context = match (
+            self.tree_inline_edit.is_some(),
+            self.tree_delete_confirm.is_some(),
+        ) {
+            (true, true) => "file-tree tree-editing tree-delete-confirm",
+            (true, false) => "file-tree tree-editing",
+            (false, true) => "file-tree tree-delete-confirm",
+            (false, false) => "file-tree",
+        };
+        div()
+            .id("file-tree-shell")
+            .key_context(key_context)
+            .track_focus(&self.tree_focus_handle)
+            .on_action(cx.listener(Self::handle_file_tree_context_menu_action))
+            .on_action(cx.listener(Self::handle_file_tree_rename_action))
+            .on_action(cx.listener(Self::handle_file_tree_copy_action))
+            .on_action(cx.listener(Self::handle_file_tree_cut_action))
+            .on_action(cx.listener(Self::handle_file_tree_paste_action))
+            .on_key_down(cx.listener(Self::handle_tree_key_down))
+            .flex()
+            .flex_col()
+            .flex_1()
+            .min_h_0()
+            .w_full()
+            // The empty area below the last row: this container's own right-click, which a row's
+            // handler pre-empts with `cx.stop_propagation()` (GPUI dispatches a mouse listener
+            // on the deepest element first and stops walking outwards once propagation is
+            // stopped - `vendor/zed/crates/gpui/src/window.rs`'s `dispatch_mouse_event`).
+            .on_mouse_down(
+                gpui::MouseButton::Right,
+                cx.listener(|this, event: &gpui::MouseDownEvent, window, cx| {
+                    this.open_tree_context_menu(
+                        context_menu::ContextTarget::Empty,
+                        f32::from(event.position.x),
+                        f32::from(event.position.y),
+                        window,
+                        cx,
+                    );
+                }),
+            )
+            .child({
+                // Where a keyboard-opened menu (`Shift+F10`) anchors - the same real
+                // `gpui::canvas` bounds-capture pattern `Self::render_tab_strip_plus` uses for
+                // the `+` button's own popover.
+                let this = cx.entity();
+                gpui::canvas(
+                    move |bounds, _window, cx| {
+                        this.update(cx, |this, _cx| {
+                            this.file_tree_bounds = bounds;
+                        });
+                    },
+                    |_, _, _, _| {},
+                )
+                .absolute()
+                .size_full()
+            })
+            .child(body)
+            .into_any_element()
+    }
+
+    /// The rows [`Self::render_file_tree`]'s `uniform_list` will build, and the indent depth the
+    /// inline editor row (if any) should be drawn at.
+    ///
+    /// A rename *replaces* its target's row - the editor is that row, for as long as it's open.
+    /// A New File / New Folder editor is *inserted* immediately after its parent folder's row, at
+    /// one level deeper, which is where the created entry itself will appear. An editor whose
+    /// anchor isn't in the visible list (a new entry in the worktree root, which has no row of
+    /// its own; or an anchor a fresh walk no longer lists) goes to the top of the list rather
+    /// than being dropped - see [`Self::render_file_tree`]'s own docs.
+    fn file_tree_rows(&self, visible_indices: &[usize]) -> (Vec<TreeRow>, usize) {
+        let mut rows: Vec<TreeRow> = visible_indices
+            .iter()
+            .copied()
+            .map(TreeRow::Entry)
+            .collect();
+        let Some(edit) = self.tree_inline_edit.as_ref() else {
+            return (rows, 0);
+        };
+        let anchor = edit.kind.anchor();
+        // `.get()`, not direct indexing, per this file's own stated discipline for `file_tree`
+        // indices (see `render_file_tree`'s comment on `visible_indices`): a future divergence
+        // degrades to "the editor goes to the top of the list" rather than panicking.
+        let anchor_row = visible_indices.iter().position(|index| {
+            self.file_tree
+                .get(*index)
+                .is_some_and(|entry| entry.path == anchor)
+        });
+        let anchor_depth = anchor_row
+            .and_then(|row| visible_indices.get(row))
+            .and_then(|index| self.file_tree.get(*index))
+            .map(|entry| entry.depth);
+        match (&edit.kind, anchor_row) {
+            (tree_ops::InlineEditKind::Rename { .. }, Some(row)) => {
+                rows[row] = TreeRow::InlineEditor;
+                (rows, anchor_depth.unwrap_or(0))
+            }
+            (tree_ops::InlineEditKind::Rename { .. }, None) => {
+                rows.insert(0, TreeRow::InlineEditor);
+                (rows, 0)
+            }
+            (_, Some(row)) => {
+                rows.insert(row + 1, TreeRow::InlineEditor);
+                (rows, anchor_depth.unwrap_or(0) + 1)
+            }
+            (_, None) => {
+                rows.insert(0, TreeRow::InlineEditor);
+                (rows, 0)
+            }
+        }
+    }
+
+    /// The inline name editor's row (issue #19 §2) - a real, append/backspace-only text field
+    /// drawn at `depth`'s indentation, with the typed name, a caret, and the real rejection hint
+    /// when one applies.
+    ///
+    /// It has no focus handle of its own: keystrokes reach it through
+    /// [`Self::file_tree_shell`]'s `on_key_down`, which the tree's own focus already delivers.
+    /// One focus target for the tree and its editor is what makes the
+    /// `"file-tree tree-editing"` context switch above a single, honest fact rather than two
+    /// handles that could disagree about which is focused.
+    fn render_tree_inline_edit_row(
+        &self,
+        depth: usize,
+        _cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        let Some(edit) = self.tree_inline_edit.as_ref() else {
+            return div().into_any_element();
+        };
+        let indent = px(file_tree::INDENT_STEP * depth as f32);
+        let name = edit.name.clone();
+        // Exactly `theme::band::TREE_ROW` tall, like every other row - a `uniform_list`'s one
+        // real requirement is that every row is the same height, so the rejection hint is a
+        // trailing element *inside* this row rather than a second line under it (which would
+        // silently overlap the row below).
+        div()
+            .debug_selector(|| "file-tree-inline-edit".to_string())
+            .flex()
+            .items_center()
+            .gap(px(6.0))
+            .w_full()
+            .h(theme::band::TREE_ROW)
+            .pl(px(file_tree::ROW_LEFT_PAD) + indent)
+            .pr(px(8.0))
+            .bg(theme::surface::ROW_SELECTED)
+            .font(font(theme::font::MONO))
+            .text_size(self.ui_text_size(11.5))
+            .child(
+                div()
+                    .flex_none()
+                    .text_size(self.ui_text_size(9.0))
+                    .text_color(theme::text::GHOST)
+                    .child(edit.kind.title()),
+            )
+            .child(
+                div()
+                    .flex_1()
+                    .min_w_0()
+                    .overflow_hidden()
+                    .text_color(theme::text::STRONG)
+                    // A real caret glyph, so an empty field still reads as "type here" rather
+                    // than as a blank row.
+                    .child(format!("{name}\u{2502}")),
+            )
+            .when_some(edit.error.clone(), |el, error| {
+                el.child(
+                    div()
+                        .debug_selector(|| "file-tree-inline-edit-error".to_string())
+                        .flex_none()
+                        .overflow_hidden()
+                        .text_size(self.ui_text_size(9.5))
+                        .text_color(theme::status::FAIL)
+                        .child(error),
+                )
+            })
+            .into_any_element()
     }
 
     /// One file-tree row: indent (13px/level, per the README), a composed icon (a folder's
@@ -520,12 +813,46 @@ impl AdeApp {
             );
         }
 
+        // This row's own right-click (GitHub issue #19 §1). `cx.stop_propagation()` is what keeps
+        // it from *also* reaching `Self::file_tree_shell`'s empty-area handler, which would
+        // otherwise replace this row's menu with the empty-area one a moment later.
+        {
+            let path = entry.path.clone();
+            let is_dir = entry.is_dir;
+            row = row.on_mouse_down(
+                gpui::MouseButton::Right,
+                cx.listener(move |this, event: &gpui::MouseDownEvent, window, cx| {
+                    cx.stop_propagation();
+                    let target = if is_dir {
+                        context_menu::ContextTarget::Folder(path.clone())
+                    } else {
+                        context_menu::ContextTarget::File(path.clone())
+                    };
+                    this.open_tree_context_menu(
+                        target,
+                        f32::from(event.position.x),
+                        f32::from(event.position.y),
+                        window,
+                        cx,
+                    );
+                }),
+            );
+        }
+
         if entry.is_dir {
             let path = entry.path.clone();
             row = row
                 .cursor_pointer()
                 .hover(|el| el.bg(theme::surface::ROW_HOVER))
-                .on_click(cx.listener(move |this, _event: &ClickEvent, _window, cx| {
+                .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
+                    // Selecting *and* focusing, both real: a folder click is what gives the tree
+                    // keyboard focus (so its `Ctrl+C`/`F2`/`Shift+F10` bindings can match at
+                    // all) and what gives those bindings a target. Deliberately here, in the
+                    // click handler, and not inside `toggle_dir_expanded` - that method is also
+                    // called programmatically (`start_tree_new_entry`, the reveal paths), where
+                    // moving the selection would be a side effect nobody asked for.
+                    this.selected_tree_path = Some(path.clone());
+                    this.focus_file_tree(window, cx);
                     this.toggle_dir_expanded(path.clone(), cx);
                 }));
         } else {
@@ -625,7 +952,7 @@ impl AdeApp {
             &[ChoiceOption::new("Files"), ChoiceOption::new("Changes")],
             selected.to_string(),
             cx,
-            |this, index, cx| {
+            |this, index, window, cx| {
                 // Structural, not a label re-match: index 0 is `Files`, index 1 is `Changes`,
                 // per the `options` array literal right above - see
                 // `Self::render_choice_control`'s own docs for why dispatch is index-based.
@@ -633,7 +960,7 @@ impl AdeApp {
                     1 => RightSidebarView::Changes,
                     _ => RightSidebarView::Files,
                 };
-                this.set_right_sidebar_view(view, cx);
+                this.set_right_sidebar_view(view, window, cx);
             },
         );
 
@@ -1090,6 +1417,269 @@ pub(crate) enum RightSidebarView {
     Changes,
 }
 
+/// One row of [`AdeApp::render_file_tree`]'s virtualized list: either a real walked entry (by
+/// index into [`AdeApp::file_tree`]) or the in-progress inline name editor.
+///
+/// An index rather than the entry itself, for the same reason
+/// `crate::sidebar::file_tree::visible_indices` returns indices: the `uniform_list` row-builder
+/// closure is `'static` and cannot hold a borrow of `self`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TreeRow {
+    Entry(usize),
+    InlineEditor,
+}
+
+impl AdeApp {
+    /// The file tree's right-click context menu popover (GitHub issue #19 §1).
+    ///
+    /// The same real overlay shape `crate::work_surface::render::AdeApp::render_plus_menu`
+    /// established for this app's other floating popover - a full-window transparent scrim whose
+    /// `on_click` dismisses ("click-away dismisses"), plus an absolutely-positioned panel that
+    /// stops that click from bubbling. Zed's own `ui::ContextMenu` is not reachable here: it
+    /// lives in Zed's `ui` crate, which this workspace deliberately doesn't depend on (only
+    /// `gpui`/`gpui_platform`).
+    ///
+    /// The panel's origin is [`AdeApp::tree_context_menu`]'s already-clamped one, resolved at
+    /// open time from the real click and the real `Window::bounds()` - so the menu near a window
+    /// edge is repositioned once, not re-solved (and possibly moved) on every frame it's open.
+    pub(crate) fn render_tree_context_menu(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let menu = self.tree_context_menu.clone();
+        let macos = self.window_controls_style().is_macos();
+        let (shadow_x, shadow_y, shadow_blur) = theme::shadow::PLUS_MENU;
+        let items = menu
+            .as_ref()
+            .map(|menu| context_menu::menu_items(&menu.target, self.tree_clipboard.is_some()))
+            .unwrap_or_default();
+        let origin_x = menu.as_ref().map(|menu| menu.origin_x).unwrap_or(0.0);
+        let origin_y = menu.as_ref().map(|menu| menu.origin_y).unwrap_or(0.0);
+
+        div()
+            .id("tree-context-menu-scrim")
+            .absolute()
+            .top(px(0.0))
+            .left(px(0.0))
+            .right(px(0.0))
+            .bottom(px(0.0))
+            .bg(work_surface::TRANSPARENT)
+            .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
+                this.close_tree_context_menu(cx);
+            }))
+            // A right-click on the scrim must dismiss too - otherwise the next right-click
+            // anywhere would land on the scrim and do nothing at all, which reads as a frozen
+            // app rather than as a menu that is still open.
+            .on_mouse_down(
+                gpui::MouseButton::Right,
+                cx.listener(|this, _event: &gpui::MouseDownEvent, _window, cx| {
+                    this.close_tree_context_menu(cx);
+                }),
+            )
+            .child(
+                div()
+                    .id("tree-context-menu")
+                    .debug_selector(|| "tree-context-menu".to_string())
+                    .absolute()
+                    .left(px(origin_x))
+                    .top(px(origin_y))
+                    .w(px(context_menu::MENU_WIDTH))
+                    .py(px(context_menu::MENU_VERTICAL_PADDING / 2.0))
+                    .bg(theme::surface::PALETTE)
+                    .border_1()
+                    .border_color(theme::border::POPOVER)
+                    .rounded(theme::radius::CARD)
+                    .shadow(vec![gpui::BoxShadow::new(
+                        shadow_x,
+                        shadow_y,
+                        gpui::black().opacity(0.55),
+                    )
+                    .blur_radius(shadow_blur)])
+                    .on_click(cx.listener(|_this, _event: &ClickEvent, _window, cx| {
+                        cx.stop_propagation();
+                    }))
+                    .children(
+                        items
+                            .into_iter()
+                            .map(|item| self.render_tree_context_menu_row(item, macos, cx)),
+                    ),
+            )
+    }
+
+    /// One context-menu row. A disabled row is still drawn (so the menu's shape doesn't jump
+    /// between right-clicks) but carries no click handler at all - not a handler that returns
+    /// early, which would be a row that looks clickable and silently isn't.
+    fn render_tree_context_menu_row(
+        &self,
+        item: context_menu::MenuItem,
+        macos: bool,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        let action = item.action;
+        let keycaps = action
+            .keystroke_spec()
+            .map(|spec| keymap::resolve_combo(spec, macos))
+            .unwrap_or_default();
+        let color = if !item.enabled {
+            theme::text::GHOST
+        } else if action.is_destructive() {
+            theme::status::FAIL
+        } else {
+            theme::text::BODY
+        };
+
+        let mut row = div()
+            .id(gpui::SharedString::from(format!(
+                "tree-context-menu-{}",
+                action.label()
+            )))
+            .debug_selector(move || format!("tree-context-menu-{}", action.label()))
+            .flex()
+            .items_center()
+            .justify_between()
+            .gap(px(8.0))
+            .w_full()
+            .h(px(context_menu::MENU_ROW_HEIGHT))
+            .px(px(10.0))
+            .font(font(theme::font::SANS))
+            .text_size(self.ui_text_size(11.0))
+            .text_color(color)
+            .child(div().flex_1().min_w_0().child(action.label()))
+            .child(render_keycap_row(&keycaps, KeycapSize::Hint));
+
+        if item.enabled {
+            row = row
+                .cursor_pointer()
+                .hover(|el| el.bg(theme::surface::ROW_HOVER))
+                .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
+                    cx.stop_propagation();
+                    this.run_tree_menu_action(action, window, cx);
+                }));
+        } else if let Some(reason) = item.disabled_reason {
+            row = row.tooltip(text_tooltip(reason));
+        }
+
+        row.into_any_element()
+    }
+
+    /// The delete confirmation (issue #19 §3: "Delete asks for confirmation and prefers the OS
+    /// trash over a hard delete where available").
+    ///
+    /// A real modal panel with two explicit buttons rather than this app's other
+    /// "click once to arm, click again to run" pattern
+    /// (`crate::worktree_history::flow::AdeApp::request_discard_worktree`): that shape works for
+    /// a button that stays in one place, but a context-menu row disappears the moment the menu
+    /// closes, so there would be nothing left to click a second time. The confirm button's label
+    /// and the sentence above it both come from the already-resolved
+    /// [`crate::sidebar::tree_ops::PendingTreeDelete::mechanism`], so what is promised here and
+    /// what actually runs cannot disagree.
+    pub(crate) fn render_tree_delete_confirm(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let pending = self.tree_delete_confirm.clone();
+        let name = pending
+            .as_ref()
+            .and_then(|pending| pending.path.file_name())
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        let explanation = pending
+            .as_ref()
+            .map(|pending| pending.explanation())
+            .unwrap_or_default();
+        let confirm_label = pending
+            .as_ref()
+            .map(|pending| pending.confirm_label())
+            .unwrap_or("Delete");
+
+        div()
+            .id("tree-delete-scrim")
+            .absolute()
+            .top(px(0.0))
+            .left(px(0.0))
+            .right(px(0.0))
+            .bottom(px(0.0))
+            .flex()
+            .items_center()
+            .justify_center()
+            .bg(gpui::black().opacity(0.35))
+            .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
+                this.cancel_tree_delete(cx);
+            }))
+            .child(
+                div()
+                    .id("tree-delete-panel")
+                    .on_click(cx.listener(|_this, _event: &ClickEvent, _window, cx| {
+                        cx.stop_propagation();
+                    }))
+                    .flex()
+                    .flex_col()
+                    .gap(px(8.0))
+                    .w(px(340.0))
+                    .p(px(12.0))
+                    .bg(theme::surface::PALETTE)
+                    .border_1()
+                    .border_color(theme::border::POPOVER)
+                    .rounded(theme::radius::CARD)
+                    .child(
+                        div()
+                            .font(font(theme::font::SANS))
+                            .font_weight(gpui::FontWeight::MEDIUM)
+                            .text_size(px(11.5))
+                            .text_color(theme::text::HEADING)
+                            .child(format!("Delete \"{name}\"?")),
+                    )
+                    .child(
+                        div()
+                            .font(font(theme::font::SANS))
+                            .text_size(px(10.5))
+                            .text_color(theme::text::DIM)
+                            .child(explanation),
+                    )
+                    .child(
+                        div()
+                            .flex()
+                            .items_center()
+                            .justify_end()
+                            .gap(px(8.0))
+                            .child(
+                                div()
+                                    .id("tree-delete-cancel")
+                                    .debug_selector(|| "tree-delete-cancel".to_string())
+                                    .cursor_pointer()
+                                    .px(px(10.0))
+                                    .py(px(4.0))
+                                    .rounded(theme::radius::CHIP)
+                                    .bg(theme::surface::SEGMENT_TRACK)
+                                    .font(font(theme::font::SANS))
+                                    .text_size(px(10.5))
+                                    .text_color(theme::text::BODY)
+                                    .child("Cancel")
+                                    .on_click(cx.listener(
+                                        |this, _event: &ClickEvent, _window, cx| {
+                                            this.cancel_tree_delete(cx);
+                                        },
+                                    )),
+                            )
+                            .child(
+                                div()
+                                    .id("tree-delete-confirm")
+                                    .debug_selector(|| "tree-delete-confirm".to_string())
+                                    .cursor_pointer()
+                                    .px(px(10.0))
+                                    .py(px(4.0))
+                                    .rounded(theme::radius::CHIP)
+                                    .bg(theme::surface::SEGMENT_TRACK)
+                                    .font(font(theme::font::SANS))
+                                    .font_weight(gpui::FontWeight::MEDIUM)
+                                    .text_size(px(10.5))
+                                    .text_color(theme::status::FAIL)
+                                    .child(confirm_label)
+                                    .on_click(cx.listener(
+                                        |this, _event: &ClickEvent, _window, cx| {
+                                            this.confirm_tree_delete(cx);
+                                        },
+                                    )),
+                            ),
+                    ),
+            )
+    }
+}
+
 /// The Changes list's footer 29. The README's spec text also mentions `] next file`, dropped
 /// here since `]` isn't actually bound to anything (only `secondary-n` is - see
 /// `crate::default_key_bindings`); advertising a dead shortcut is worse than a shorter,
@@ -1458,8 +2048,8 @@ mod virtualization_tests {
         }
 
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        app.update(cx, |app, cx| {
-            app.set_right_sidebar_view(RightSidebarView::Changes, cx);
+        app.update_in(cx, |app, window, cx| {
+            app.set_right_sidebar_view(RightSidebarView::Changes, window, cx);
         });
         cx.run_until_parked();
 

--- a/crates/app/src/sidebar/tree_ops.rs
+++ b/crates/app/src/sidebar/tree_ops.rs
@@ -1,0 +1,2466 @@
+//! The file tree's real write operations (GitHub issue #19): the context menu's state, the
+//! inline name editors behind New File / New Folder / Rename, the cut/copy/paste clipboard, and
+//! the confirmed delete.
+//!
+//! Split the way every feature folder in this crate is split: the pure decisions live in
+//! [`crate::sidebar::context_menu`] (which rows a target offers, where the popover fits) and
+//! [`crate::sidebar::file_ops`] (name validation, collision-free naming, the real `std::fs`
+//! calls), and this file is the `impl AdeApp` glue that sequences them and repairs the app's own
+//! state afterwards. [`crate::sidebar::render`] only draws what these two decide.
+//!
+//! ## Keybinding scoping (the bug class this project keeps re-finding)
+//!
+//! `Ctrl+C`/`Ctrl+X`/`Ctrl+V` are the most dangerous keystrokes this app could bind:
+//! `crate::terminal::pane::keystroke_to_bytes` maps an unmodified `Ctrl+<letter>` to the control
+//! byte a focused shell expects, and `Ctrl+C` in particular is SIGINT - a version of this that
+//! swallowed it would make it impossible to interrupt a running agent CLI. Two independent
+//! things stop that here, and it is worth being precise about which one does what, because a
+//! first draft of these docs got it wrong and this project's own revert-verification caught it:
+//!
+//! 1. **The `key_context` predicate**, `Some("file-tree && !tree-editing")` (see
+//!    `crate::default_key_bindings`). `Window::dispatch_key_event` resolves bindings against the
+//!    context stack of the *focused node's own dispatch path*, before any listener is consulted
+//!    (`vendor/zed/crates/gpui/src/window.rs`'s `dispatch_key` call). A focused terminal pane is
+//!    not inside the tree, so `file-tree` is not on that stack and the action is never produced
+//!    at all.
+//! 2. **Where the handlers are registered.** `.on_action` for all five tree actions lives on
+//!    `crate::sidebar::render::AdeApp::file_tree_shell`'s node - the tree's own container - and
+//!    nowhere else. A listener found in the dispatch path sets `cx.propagate_event = false`
+//!    before running ("Actions stop propagation by default during the bubble phase", same file),
+//!    so a listener that *is* found genuinely swallows the keystroke; one that isn't leaves
+//!    `propagate_event` true and `finish_dispatch_key_event` still delivers the key to the
+//!    focused pane's own `on_key_down`.
+//!
+//! These two are **independent** - either alone protects a focused terminal, which was confirmed
+//! by deliberately breaking each in turn and re-running the tests. An earlier draft of these docs
+//! claimed point 2 was the only real protection and that point 1 "isn't doing the
+//! terminal-protection work"; that was wrong, and it mattered, because it would have justified a
+//! later refactor dropping the `file-tree` half as dead weight.
+//!
+//! The `!tree-editing` half is a different matter: it has no redundant partner, and it is the one
+//! whose absence is directly reproducible. While an inline name editor is open the tree *is* the
+//! focused node, so both mechanisms line up in its favour - the listener runs, propagation stops,
+//! and the keystroke the user was typing into the name field is genuinely swallowed
+//! (`Shift+F10` reopens the context menu on top of the editor; `Ctrl+V` pastes a *file* into the
+//! tree). It is the same shape as Revision R8.5b's `"file-editor && !completions"` fix, and it is
+//! revert-verified by
+//! `tree_ops_regression_tests::shift_f10_while_an_inline_editor_is_open_neither_opens_a_menu_nor_disturbs_the_name`,
+//! which fails against a bare `Some("file-tree")`. `!tree-delete-confirm` is the same mechanism
+//! again, for the modal delete confirmation.
+
+use super::*;
+use crate::sidebar::context_menu::{ContextTarget, MenuAction};
+use crate::sidebar::file_ops::{self, DeleteMechanism};
+use gpui::{ClipboardItem, KeyDownEvent, Window};
+use std::path::Component;
+
+/// An open context menu: what it targets, and the already-clamped window-space origin its
+/// popover paints at. The origin is resolved once, at open time, from the real click position
+/// and the real `Window::bounds()` (see [`AdeApp::open_tree_context_menu`]) rather than
+/// recomputed per frame - a menu that moved while it was open would be its own bug.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct TreeContextMenu {
+    pub(crate) target: ContextTarget,
+    pub(crate) origin_x: f32,
+    pub(crate) origin_y: f32,
+}
+
+/// Which of the three inline editors is open. All three share one text field, one validation
+/// path, and one Enter/Escape handler - they only differ in what committing them does.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum InlineEditKind {
+    NewFile { parent: PathBuf },
+    NewFolder { parent: PathBuf },
+    Rename { path: PathBuf, is_dir: bool },
+}
+
+impl InlineEditKind {
+    /// The row this editor is drawn against: the folder a new entry lands in, or the entry being
+    /// renamed. [`crate::sidebar::render::AdeApp::render_file_tree`] uses this to place the
+    /// editor at the right spot in the list.
+    pub(crate) fn anchor(&self) -> &Path {
+        match self {
+            InlineEditKind::NewFile { parent } | InlineEditKind::NewFolder { parent } => parent,
+            InlineEditKind::Rename { path, .. } => path,
+        }
+    }
+
+    pub(crate) fn title(&self) -> &'static str {
+        match self {
+            InlineEditKind::NewFile { .. } => "New file",
+            InlineEditKind::NewFolder { .. } => "New folder",
+            InlineEditKind::Rename { .. } => "Rename",
+        }
+    }
+}
+
+/// An in-progress inline name editor.
+///
+/// **This lives on `AdeApp`, never inside `AdeApp::file_tree`, and that is the whole of issue
+/// #19 §4's "a watcher refresh must not clobber an in-progress editor" requirement.** The file
+/// tree is a `Vec<FileTreeEntry>` that `AdeApp::load_file_tree`'s background walk *replaces
+/// wholesale* every time it completes - which is exactly what happens when an agent CLI creates
+/// or deletes a file mid-session and something triggers a re-walk. Any editor state stored in
+/// that vector, or keyed by an index into it, would be silently destroyed by that replacement,
+/// mid-keystroke. Keeping it here means the walk can replace every row without the typed text
+/// ever being at risk, and the renderer re-locates the editor's anchor row by *path* on each
+/// frame (falling back to the top of the list if the anchor has genuinely gone) rather than by a
+/// position that a re-walk can invalidate. This is the same discipline issue #18 applied to fold
+/// state, which is likewise held outside the walked tree and re-derived against it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TreeInlineEdit {
+    pub(crate) kind: InlineEditKind,
+    /// The name typed so far - append/backspace only, the same minimal field shape
+    /// `crate::root::new_file`'s prompt and the rail's filter row already use.
+    pub(crate) name: String,
+    /// The real rejection message shown under the field (issue #19 §2: "invalid names are
+    /// rejected with a hint"), cleared on the next keystroke.
+    pub(crate) error: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ClipboardMode {
+    Copy,
+    Cut,
+}
+
+/// The tree's own cut/copy buffer. Deliberately *not* the system clipboard: this holds a real
+/// filesystem entry to be moved or copied, which is a different thing from the text
+/// `Copy Path` writes to the system clipboard, and round-tripping a path through text would make
+/// "paste" mean something different depending on what some other application had copied last.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TreeClipboard {
+    pub(crate) path: PathBuf,
+    pub(crate) mode: ClipboardMode,
+}
+
+/// A delete that has been *requested* but not yet confirmed. Holding the resolved
+/// [`DeleteMechanism`] here - rather than resolving it when the confirmation is accepted - is
+/// what makes the confirmation copy honest: the words the user agreed to ("Move to Trash" vs
+/// "Delete permanently") and the command that then runs come from the same value.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct PendingTreeDelete {
+    pub(crate) path: PathBuf,
+    pub(crate) is_dir: bool,
+    pub(crate) mechanism: DeleteMechanism,
+}
+
+impl PendingTreeDelete {
+    /// The confirm button's label - the exact promise being made.
+    pub(crate) fn confirm_label(&self) -> &'static str {
+        match self.mechanism {
+            DeleteMechanism::Trash { .. } => "Move to Trash",
+            DeleteMechanism::Permanent => "Delete permanently",
+        }
+    }
+
+    /// The sentence above the buttons. The permanent branch says so in as many words, and names
+    /// *why* there is no trash, rather than implying the app chose not to use one.
+    pub(crate) fn explanation(&self) -> String {
+        let what = if self.is_dir {
+            "this folder and everything in it"
+        } else {
+            "this file"
+        };
+        match self.mechanism {
+            DeleteMechanism::Trash { .. } => {
+                format!("Move {what} to the system trash (restorable from your file manager).")
+            }
+            DeleteMechanism::Permanent => format!(
+                "Permanently delete {what}. No OS trash command is available here, so this \
+                 cannot be undone from inside or outside this app."
+            ),
+        }
+    }
+}
+
+/// `path` with a leading `old` replaced by `new` - `None` when `path` is unrelated to `old`.
+/// Used to carry every path-keyed piece of app state across a rename, including the whole
+/// subtree beneath a renamed *directory*.
+pub(crate) fn remap_path(path: &Path, old: &Path, new: &Path) -> Option<PathBuf> {
+    if path == old {
+        return Some(new.to_path_buf());
+    }
+    path.strip_prefix(old).ok().map(|rest| new.join(rest))
+}
+
+impl AdeApp {
+    /// Moves keyboard focus onto the tree, so its `Ctrl+C`/`Ctrl+X`/`Ctrl+V`/`F2`/`Shift+F10`
+    /// bindings - all scoped to the `"file-tree"` context - can match at all.
+    ///
+    /// Called from a right-click on any row or on the empty area, and from a left-click on a
+    /// *folder* row. Deliberately **not** from a left-click on a *file* row: that path
+    /// (`Self::open_file_view`) opens the file and moves focus to the code surface, which is
+    /// what the user asked for, and stealing it back would break typing in the editor they just
+    /// opened. The honest consequence is that `F2`/`Shift+F10` on a file need a right-click (or a
+    /// folder click) first rather than a plain left-click - which is also where the issue's own
+    /// keyboard requirement stops: there are no up/down bindings to *move* the selection within
+    /// the tree, and inventing a focus-stealing left-click to paper over that would be worse than
+    /// the gap.
+    pub(in crate::sidebar) fn focus_file_tree(&self, window: &mut Window, cx: &mut Context<Self>) {
+        window.focus(&self.tree_focus_handle, cx);
+    }
+
+    /// Opens the context menu for `target` at a real click position, clamped so the whole
+    /// popover stays inside the window (`context_menu::clamp_menu_origin`).
+    ///
+    /// Also focuses the tree and selects the targeted row: a right-click is a real selection
+    /// gesture, and `Shift+F10` afterwards has to have something to target.
+    pub(in crate::sidebar) fn open_tree_context_menu(
+        &mut self,
+        target: ContextTarget,
+        click_x: f32,
+        click_y: f32,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        // A right-click while a name is being typed would otherwise leave the editor open
+        // underneath a menu whose actions all act on a different path.
+        if self.tree_inline_edit.is_some() {
+            self.cancel_tree_inline_edit(window, cx);
+        }
+        let rows = context_menu::menu_items(&target, self.tree_clipboard.is_some()).len();
+        let viewport = window.bounds().size;
+        let (origin_x, origin_y) = context_menu::clamp_menu_origin(
+            click_x,
+            click_y,
+            context_menu::MENU_WIDTH,
+            context_menu::menu_height(rows),
+            f32::from(viewport.width),
+            f32::from(viewport.height),
+        );
+        self.selected_tree_path = target.path().map(Path::to_path_buf);
+        self.tree_context_menu = Some(TreeContextMenu {
+            target,
+            origin_x,
+            origin_y,
+        });
+        self.tree_op_error = None;
+        self.focus_file_tree(window, cx);
+        cx.notify();
+    }
+
+    /// `Shift+F10`'s handler: opens the menu for the currently selected row, or for the empty
+    /// area when nothing in this tree is selected.
+    ///
+    /// The origin is the top-left of the sidebar's own painted bounds plus a small offset rather
+    /// than a mouse position - there is no cursor involved in a keyboard-opened menu, and
+    /// pinning it to the last mouse position would put it somewhere the keyboard user never
+    /// looked. Still routed through the same clamp, so it can't escape the window either.
+    pub(in crate::sidebar) fn open_tree_context_menu_from_keyboard(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let target = match self.selected_tree_path.clone() {
+            Some(path) if path.starts_with(&self.file_tree_root) => {
+                let is_dir = self
+                    .file_tree
+                    .iter()
+                    .find(|entry| entry.path == path)
+                    .map(|entry| entry.is_dir)
+                    .unwrap_or_else(|| path.is_dir());
+                if is_dir {
+                    ContextTarget::Folder(path)
+                } else {
+                    ContextTarget::File(path)
+                }
+            }
+            _ => ContextTarget::Empty,
+        };
+        let bounds = self.file_tree_bounds;
+        let x = f32::from(bounds.origin.x) + 12.0;
+        let y = f32::from(bounds.origin.y) + 12.0;
+        self.open_tree_context_menu(target, x, y, window, cx);
+    }
+
+    pub(in crate::sidebar) fn close_tree_context_menu(&mut self, cx: &mut Context<Self>) {
+        if self.tree_context_menu.take().is_some() {
+            cx.notify();
+        }
+    }
+
+    /// Runs one menu row. Every branch closes the menu first, so no action can ever run against
+    /// a menu that is still on screen claiming a different state.
+    pub(in crate::sidebar) fn run_tree_menu_action(
+        &mut self,
+        action: MenuAction,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(menu) = self.tree_context_menu.take() else {
+            return;
+        };
+        let root = self.file_tree_root.clone();
+        let destination = menu.target.destination_dir(&root).to_path_buf();
+        let target_path = menu.target.path().map(Path::to_path_buf);
+        self.tree_op_error = None;
+
+        match action {
+            MenuAction::Open => {
+                if let Some(path) = target_path {
+                    self.open_file_view(path, window, cx);
+                }
+            }
+            MenuAction::NewFile => self.start_tree_new_entry(destination, false, window, cx),
+            MenuAction::NewFolder => self.start_tree_new_entry(destination, true, window, cx),
+            MenuAction::Rename => {
+                if let Some(path) = target_path {
+                    let is_dir = matches!(menu.target, ContextTarget::Folder(_));
+                    self.start_tree_rename(path, is_dir, window, cx);
+                }
+            }
+            MenuAction::Duplicate => {
+                if let Some(path) = target_path {
+                    self.duplicate_tree_entry(&path, cx);
+                }
+            }
+            MenuAction::Cut => {
+                if let Some(path) = target_path {
+                    self.set_tree_clipboard(path, ClipboardMode::Cut, cx);
+                }
+            }
+            MenuAction::Copy => {
+                if let Some(path) = target_path {
+                    self.set_tree_clipboard(path, ClipboardMode::Copy, cx);
+                }
+            }
+            MenuAction::Paste => self.paste_into_dir(&destination, cx),
+            MenuAction::CopyPath => {
+                if let Some(path) = target_path {
+                    self.copy_path_to_system_clipboard(&path, false, cx);
+                }
+            }
+            MenuAction::CopyRelativePath => {
+                if let Some(path) = target_path {
+                    self.copy_path_to_system_clipboard(&path, true, cx);
+                }
+            }
+            MenuAction::CollapseSubtree => {
+                if let Some(path) = target_path {
+                    self.collapse_subtree(&path, cx);
+                }
+            }
+            // Genuinely the same method issue #18 built and the Files header's own "collapse
+            // all" button calls - the live set, this worktree's persisted entry, and the queued
+            // write all reset in one step. Not a second, parallel mechanism.
+            MenuAction::CollapseAll => self.collapse_all_dirs(cx),
+            MenuAction::Delete => {
+                if let Some(path) = target_path {
+                    let is_dir = matches!(menu.target, ContextTarget::Folder(_));
+                    self.request_tree_delete(path, is_dir, cx);
+                }
+            }
+            MenuAction::Reveal => {
+                if let Some(path) = target_path {
+                    self.reveal_in_file_manager(&path, cx);
+                }
+            }
+        }
+        cx.notify();
+    }
+
+    // ---------------------------------------------------------------- inline name editors
+
+    /// Opens the inline "New file"/"New folder" editor anchored to `parent`, expanding `parent`
+    /// first so the editor row is genuinely visible (the tree opens collapsed - issue #18 §1 -
+    /// so an editor inside an unexpanded folder would be an editor nobody can see).
+    pub(in crate::sidebar) fn start_tree_new_entry(
+        &mut self,
+        parent: PathBuf,
+        is_dir: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if parent != self.file_tree_root {
+            self.set_dir_expanded(parent.clone(), true, cx);
+        }
+        self.tree_inline_edit = Some(TreeInlineEdit {
+            kind: if is_dir {
+                InlineEditKind::NewFolder { parent }
+            } else {
+                InlineEditKind::NewFile { parent }
+            },
+            name: String::new(),
+            error: None,
+        });
+        self.focus_file_tree(window, cx);
+        cx.notify();
+    }
+
+    /// Opens the inline rename editor on `path`, pre-filled with its current name (issue #19
+    /// §2's `F2`).
+    pub(in crate::sidebar) fn start_tree_rename(
+        &mut self,
+        path: PathBuf,
+        is_dir: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if path == self.file_tree_root {
+            // The worktree root isn't a row in this tree and isn't this app's to rename.
+            return;
+        }
+        let name = path
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        self.tree_inline_edit = Some(TreeInlineEdit {
+            kind: InlineEditKind::Rename { path, is_dir },
+            name,
+            error: None,
+        });
+        self.focus_file_tree(window, cx);
+        cx.notify();
+    }
+
+    /// `F2`'s handler - renames whatever row is selected.
+    pub(in crate::sidebar) fn start_tree_rename_for_selection(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(path) = self.selected_tree_path.clone() else {
+            return;
+        };
+        if !path.starts_with(&self.file_tree_root) {
+            return;
+        }
+        let is_dir = self
+            .file_tree
+            .iter()
+            .find(|entry| entry.path == path)
+            .map(|entry| entry.is_dir)
+            .unwrap_or_else(|| path.is_dir());
+        self.start_tree_rename(path, is_dir, window, cx);
+    }
+
+    pub(in crate::sidebar) fn cancel_tree_inline_edit(
+        &mut self,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.tree_inline_edit.take().is_some() {
+            cx.notify();
+        }
+    }
+
+    /// The inline editor's key handler - append/backspace/Enter/Escape, the same minimal shape
+    /// `crate::root::new_file::AdeApp::handle_new_file_key_down` established, including its
+    /// "leave modified keystrokes unhandled so app-level shortcuts still work" rule.
+    ///
+    /// Also handles `Escape` for the context menu when no editor is open, so a keyboard-opened
+    /// menu can be dismissed the same way a mouse-opened one can (issue #19 §1).
+    pub(in crate::sidebar) fn handle_tree_key_down(
+        &mut self,
+        event: &KeyDownEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let keystroke = &event.keystroke;
+        if keystroke.modifiers.platform || keystroke.modifiers.control || keystroke.modifiers.alt {
+            return;
+        }
+        if self.tree_inline_edit.is_none() {
+            if keystroke.key == "escape" {
+                // The delete confirmation is checked *first*: it is a modal on top of everything
+                // else the tree can show, so one Escape must dismiss the thing in front, not
+                // something behind it.
+                if self.tree_delete_confirm.is_some() {
+                    self.cancel_tree_delete(cx);
+                    cx.stop_propagation();
+                } else if self.tree_context_menu.is_some() {
+                    self.close_tree_context_menu(cx);
+                    cx.stop_propagation();
+                }
+            }
+            return;
+        }
+        match keystroke.key.as_str() {
+            "escape" => {
+                self.cancel_tree_inline_edit(window, cx);
+                cx.stop_propagation();
+            }
+            "enter" => {
+                self.commit_tree_inline_edit(window, cx);
+                cx.stop_propagation();
+            }
+            "backspace" => {
+                if let Some(edit) = self.tree_inline_edit.as_mut() {
+                    edit.name.pop();
+                    edit.error = None;
+                    cx.notify();
+                    cx.stop_propagation();
+                }
+            }
+            _ => {
+                if let Some(text) = keystroke
+                    .key_char
+                    .as_deref()
+                    .filter(|text| !text.is_empty())
+                {
+                    if let Some(edit) = self.tree_inline_edit.as_mut() {
+                        edit.name.push_str(text);
+                        edit.error = None;
+                        cx.notify();
+                        cx.stop_propagation();
+                    }
+                }
+            }
+        }
+    }
+
+    /// Enter: validates the typed name and performs the real filesystem operation. On a
+    /// rejection the editor stays open with a real hint, exactly like the `+` menu's prompt.
+    pub(in crate::sidebar) fn commit_tree_inline_edit(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(edit) = self.tree_inline_edit.clone() else {
+            return;
+        };
+        // The same one validator `crate::root::new_file::AdeApp::create_new_file` uses - not a
+        // second copy of the rules.
+        let name = match file_ops::validate_entry_name(&edit.name) {
+            Ok(name) => name.to_string(),
+            Err(message) => {
+                if let Some(open) = self.tree_inline_edit.as_mut() {
+                    open.error = Some(message);
+                }
+                cx.notify();
+                return;
+            }
+        };
+
+        match &edit.kind {
+            InlineEditKind::NewFile { parent } => {
+                let parent = parent.clone();
+                // Delegates to the pre-existing, already-tested "New file" flow
+                // (`crate::root::new_file::AdeApp::create_file_named`) rather than writing a
+                // second empty file here: that path opens the file in a real tab, seeds a real
+                // `EditBuffer`, reveals the row, and performs the first write through the same
+                // freshness-gated save pipeline every other save uses.
+                match self.create_file_named(&parent, &name, window, cx) {
+                    Ok(()) => {
+                        self.tree_inline_edit = None;
+                        self.refresh_after_file_op(cx);
+                    }
+                    Err(message) => {
+                        if let Some(open) = self.tree_inline_edit.as_mut() {
+                            open.error = Some(message);
+                        }
+                        cx.notify();
+                        return;
+                    }
+                }
+            }
+            InlineEditKind::NewFolder { parent } => {
+                let destination = parent.join(&name);
+                if destination.symlink_metadata().is_ok() {
+                    if let Some(open) = self.tree_inline_edit.as_mut() {
+                        open.error = Some(format!("\"{name}\" already exists"));
+                    }
+                    cx.notify();
+                    return;
+                }
+                match std::fs::create_dir(&destination) {
+                    Ok(()) => {
+                        self.tree_inline_edit = None;
+                        self.reveal_in_tree(&destination, cx);
+                        self.selected_tree_path = Some(destination);
+                        self.refresh_after_file_op(cx);
+                    }
+                    Err(err) => {
+                        if let Some(open) = self.tree_inline_edit.as_mut() {
+                            open.error = Some(err.to_string());
+                        }
+                        cx.notify();
+                    }
+                }
+            }
+            InlineEditKind::Rename { path, .. } => {
+                let Some(parent) = path.parent().map(Path::to_path_buf) else {
+                    self.tree_inline_edit = None;
+                    cx.notify();
+                    return;
+                };
+                let destination = parent.join(&name);
+                if destination == *path {
+                    self.tree_inline_edit = None;
+                    cx.notify();
+                    return;
+                }
+                match file_ops::move_path(path, &destination) {
+                    Ok(()) => {
+                        let old = path.clone();
+                        self.tree_inline_edit = None;
+                        self.rename_open_paths(&old, &destination, cx);
+                        self.refresh_after_file_op(cx);
+                    }
+                    Err(err) => {
+                        if let Some(open) = self.tree_inline_edit.as_mut() {
+                            open.error = Some(err.to_string());
+                        }
+                        cx.notify();
+                    }
+                }
+            }
+        }
+        cx.notify();
+    }
+
+    // ---------------------------------------------------------------- clipboard
+
+    pub(in crate::sidebar) fn set_tree_clipboard(
+        &mut self,
+        path: PathBuf,
+        mode: ClipboardMode,
+        cx: &mut Context<Self>,
+    ) {
+        self.tree_clipboard = Some(TreeClipboard { path, mode });
+        cx.notify();
+    }
+
+    /// `Ctrl+C`/`Ctrl+X`'s handler - acts on the selected row, and is a real no-op with nothing
+    /// selected rather than silently capturing the root.
+    pub(in crate::sidebar) fn copy_selection_to_tree_clipboard(
+        &mut self,
+        mode: ClipboardMode,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(path) = self.selected_tree_path.clone() else {
+            return;
+        };
+        if !path.starts_with(&self.file_tree_root) || path == self.file_tree_root {
+            return;
+        }
+        self.set_tree_clipboard(path, mode, cx);
+    }
+
+    /// `Ctrl+V`'s handler - pastes into the selected folder, the selected file's own folder, or
+    /// the worktree root.
+    pub(in crate::sidebar) fn paste_into_selection(&mut self, cx: &mut Context<Self>) {
+        let destination = match self.selected_tree_path.clone() {
+            Some(path) if path.starts_with(&self.file_tree_root) => {
+                let is_dir = self
+                    .file_tree
+                    .iter()
+                    .find(|entry| entry.path == path)
+                    .map(|entry| entry.is_dir)
+                    .unwrap_or_else(|| path.is_dir());
+                if is_dir {
+                    path
+                } else {
+                    path.parent()
+                        .map(Path::to_path_buf)
+                        .unwrap_or_else(|| self.file_tree_root.clone())
+                }
+            }
+            _ => self.file_tree_root.clone(),
+        };
+        self.paste_into_dir(&destination, cx);
+    }
+
+    /// The real paste: a `Cut` moves, a `Copy` copies.
+    ///
+    /// A **copy**'s destination name is resolved by [`file_ops::unique_destination`], so pasting
+    /// back into the folder something was copied from produces a real `name copy.ext` rather than
+    /// an overwrite or a collision error (issue #19 §3).
+    ///
+    /// A **cut** deliberately does *not* auto-suffix against its own source. Cutting `util.rs`
+    /// and pasting it into the folder it came from means "move it here", and it is already here -
+    /// the honest answer is a no-op, not an unrequested rename to `util copy.rs` with no undo,
+    /// which is what an unconditional `unique_destination` produced in an earlier version of this
+    /// method (found in review). Against a *different* occupant of that name it still suffixes,
+    /// since refusing outright would be worse than landing beside it.
+    pub(in crate::sidebar) fn paste_into_dir(&mut self, dir: &Path, cx: &mut Context<Self>) {
+        let Some(entry) = self.tree_clipboard.clone() else {
+            return;
+        };
+        let Some(name) = entry
+            .path
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+        else {
+            return;
+        };
+
+        if entry.mode == ClipboardMode::Cut && dir.join(&name) == entry.path {
+            // Already exactly where it was asked to go.
+            self.tree_clipboard = None;
+            cx.notify();
+            return;
+        }
+
+        let destination = match file_ops::unique_destination(dir, &name) {
+            Ok(destination) => destination,
+            Err(err) => return self.report_tree_op_error(err.to_string(), cx),
+        };
+
+        match entry.mode {
+            // Off the foreground thread - see `Self::spawn_tree_copy`'s docs.
+            ClipboardMode::Copy => self.spawn_tree_copy(entry.path, destination, cx),
+            ClipboardMode::Cut => {
+                // A single `rename` syscall, unlike the recursive copy above: kept synchronous so
+                // the tab/buffer repair below lands in the same update as the move itself.
+                if let Err(err) = file_ops::move_path(&entry.path, &destination) {
+                    return self.report_tree_op_error(err.to_string(), cx);
+                }
+                // A cut is a move, so every open tab / buffer pointing at the old location has
+                // to follow it, exactly as for a rename.
+                self.rename_open_paths(&entry.path, &destination, cx);
+                // The entry is no longer where the clipboard says it is; a second paste would
+                // fail against a path that no longer exists.
+                self.tree_clipboard = None;
+                self.reveal_in_tree(&destination, cx);
+                self.selected_tree_path = Some(destination);
+                self.refresh_after_file_op(cx);
+            }
+        }
+    }
+
+    /// "Duplicate" - a copy next to the original, named by the same
+    /// [`file_ops::unique_destination`] rule a paste-into-the-source-folder uses, so the two can
+    /// never disagree about what a duplicate is called.
+    pub(in crate::sidebar) fn duplicate_tree_entry(&mut self, path: &Path, cx: &mut Context<Self>) {
+        let (Some(parent), Some(name)) = (
+            path.parent(),
+            path.file_name()
+                .map(|name| name.to_string_lossy().into_owned()),
+        ) else {
+            return;
+        };
+        let destination = match file_ops::unique_destination(parent, &name) {
+            Ok(destination) => destination,
+            Err(err) => return self.report_tree_op_error(err.to_string(), cx),
+        };
+        self.spawn_tree_copy(path.to_path_buf(), destination, cx);
+    }
+
+    /// Runs a real [`file_ops::copy_path`] on the background executor and applies the result on
+    /// the foreground thread - the same "gather / compute / write back" shape
+    /// [`AdeApp::load_file_tree`] and [`Self::confirm_tree_delete`] use.
+    ///
+    /// Background, not inline in the click handler, and that is a correctness point rather than a
+    /// micro-optimization: `copy_path` recurses over a whole directory tree, so duplicating a
+    /// `node_modules`-sized folder from a click listener would freeze the window for as long as
+    /// the copy took. An earlier version of this method did exactly that, contradicting this
+    /// module's sibling `confirm_tree_delete` (whose own docs insist on "never the foreground
+    /// thread") - found in review.
+    ///
+    /// Nothing that could race a concurrent operation is captured: the destination name is
+    /// resolved by the caller immediately before this runs, and a collision that appears in
+    /// between is refused by `copy_path`'s own existence check rather than silently overwritten.
+    fn spawn_tree_copy(&mut self, source: PathBuf, destination: PathBuf, cx: &mut Context<Self>) {
+        let task = cx.spawn(async move |this, cx| {
+            let outcome = cx
+                .background_executor()
+                .spawn({
+                    let source = source.clone();
+                    let destination = destination.clone();
+                    async move {
+                        file_ops::copy_path(&source, &destination).map_err(|err| err.to_string())
+                    }
+                })
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                match outcome {
+                    Ok(()) => {
+                        this.reveal_in_tree(&destination, cx);
+                        this.selected_tree_path = Some(destination);
+                        this.refresh_after_file_op(cx);
+                    }
+                    Err(message) => this.report_tree_op_error(message, cx),
+                }
+                cx.notify();
+            });
+        });
+        self._tree_copy_task = Some(task);
+    }
+
+    /// Writes a path to the real system clipboard (`gpui::App::write_to_clipboard`) - absolute,
+    /// or worktree-relative for "Copy Relative Path".
+    pub(in crate::sidebar) fn copy_path_to_system_clipboard(
+        &mut self,
+        path: &Path,
+        relative: bool,
+        cx: &mut Context<Self>,
+    ) {
+        let text = if relative {
+            path.strip_prefix(&self.file_tree_root)
+                .unwrap_or(path)
+                .display()
+                .to_string()
+        } else {
+            path.display().to_string()
+        };
+        cx.write_to_clipboard(ClipboardItem::new_string(text));
+    }
+
+    // ---------------------------------------------------------------- delete
+
+    /// Arms the delete confirmation. **Never deletes anything itself** - the real removal only
+    /// happens in [`Self::confirm_tree_delete`], which is reachable only from the confirmation
+    /// panel's own button (issue #19 §3: "Delete asks for confirmation").
+    ///
+    /// The mechanism is resolved here, against a real `$PATH` probe, so the panel can name what
+    /// will actually happen.
+    pub(in crate::sidebar) fn request_tree_delete(
+        &mut self,
+        path: PathBuf,
+        is_dir: bool,
+        cx: &mut Context<Self>,
+    ) {
+        // The one hard boundary on the app's single irreversible operation: whatever route got
+        // here, the path must be a plain, normal-component path genuinely inside the session's
+        // worktree. Every real caller already satisfies this (the targets come from the tree's
+        // own walk), which is exactly why it is worth stating as a checked precondition rather
+        // than an assumption - a future caller that passes something else gets a refusal, not a
+        // `remove_dir_all` outside the worktree.
+        if !is_inside_worktree(&self.file_tree_root, &path) {
+            return self.report_tree_op_error(
+                format!(
+                    "refusing to delete {}: it is not inside this worktree",
+                    path.display()
+                ),
+                cx,
+            );
+        }
+        let mechanism =
+            file_ops::resolve_delete_mechanism(std::env::consts::OS, &path, |program| {
+                pty_core::resolve_on_path(program).is_some()
+            });
+        self.tree_delete_confirm = Some(PendingTreeDelete {
+            path,
+            is_dir,
+            mechanism,
+        });
+        cx.notify();
+    }
+
+    pub(in crate::sidebar) fn cancel_tree_delete(&mut self, cx: &mut Context<Self>) {
+        if self.tree_delete_confirm.take().is_some() {
+            cx.notify();
+        }
+    }
+
+    /// Runs the confirmed delete. A trash-backed delete shells out to the resolved command on
+    /// the background executor (never the foreground thread); a permanent one runs
+    /// [`file_ops::delete_permanently`] there for the same reason.
+    ///
+    /// A failed trash command is reported as a real error and **does not** fall back to a
+    /// permanent delete: the user confirmed "move to trash", and quietly escalating that into an
+    /// irreversible removal because a command failed would be exactly the kind of dishonest
+    /// convenience this app avoids.
+    pub(in crate::sidebar) fn confirm_tree_delete(&mut self, cx: &mut Context<Self>) {
+        let Some(pending) = self.tree_delete_confirm.take() else {
+            return;
+        };
+        let path = pending.path.clone();
+        let mechanism = pending.mechanism.clone();
+        let label = path.display().to_string();
+        let task = cx.spawn(async move |this, cx| {
+            let outcome =
+                cx.background_executor()
+                    .spawn({
+                        let path = path.clone();
+                        async move {
+                            match mechanism {
+                                DeleteMechanism::Trash { program, args } => {
+                                    match std::process::Command::new(program).args(&args).status() {
+                                        Ok(status) if status.success() => Ok(()),
+                                        Ok(status) => Err(format!(
+                                            "{program} exited with {status} while trashing {label}"
+                                        )),
+                                        Err(err) => Err(format!("failed to run {program}: {err}")),
+                                    }
+                                }
+                                DeleteMechanism::Permanent => file_ops::delete_permanently(&path)
+                                    .map_err(|err| err.to_string()),
+                            }
+                        }
+                    })
+                    .await;
+            let _ = this.update(cx, |this, cx| {
+                match outcome {
+                    Ok(()) => {
+                        this.forget_deleted_paths(&path, cx);
+                        this.refresh_after_file_op(cx);
+                    }
+                    Err(message) => this.report_tree_op_error(message, cx),
+                }
+                cx.notify();
+            });
+        });
+        self._tree_delete_task = Some(task);
+        cx.notify();
+    }
+
+    /// Drops the app state that pointed at a path that no longer exists - open tabs and their
+    /// buffers, every path-keyed side table [`Self::rename_open_paths`] remaps, the LSP's own
+    /// per-document bookkeeping, the selection, and this worktree's recorded expansion of a
+    /// deleted folder (and of everything under it).
+    ///
+    /// Structurally the *mirror* of [`Self::rename_open_paths`], and reviewed as one: every field
+    /// that method remaps, this one drops. An earlier version handled only tabs, buffers and the
+    /// selection, which left a deleted file's `reviewed_files` entry, its
+    /// `file_external_conflict` flag, its `file_save_error`, and - worst - its
+    /// `lsp_opened_files`/`lsp_document_versions` entries behind. That last one is not cosmetic:
+    /// `crate::lsp::client`'s `didOpen` dispatch early-returns for a path already in
+    /// `lsp_opened_files`, so recreating a file at the deleted path would silently get no
+    /// diagnostics and no completions for the rest of the session.
+    ///
+    /// Deliberately **not** a `close_file_tab` call: that method restores focus and picks a
+    /// neighbouring tab, both of which need a `Window` this async completion handler doesn't
+    /// have. It removes the tab entries directly and lets `open_change` fall back to whatever
+    /// tab is still open, which is the same end state without the focus move.
+    fn forget_deleted_paths(&mut self, deleted: &Path, cx: &mut Context<Self>) {
+        let deleted_relative = self.worktree_relative(deleted);
+        let under_relative = |path: &Path| file_ops::is_self_or_descendant(&deleted_relative, path);
+        let under_absolute = |path: &Path| file_ops::is_self_or_descendant(deleted, path);
+
+        self.open_files.retain(|open| !under_relative(open));
+        self.edit_buffers.retain(|key, _| !under_relative(key));
+        if self.open_change.as_deref().is_some_and(under_relative) {
+            self.open_change = self.open_files.first().cloned();
+        }
+        if self
+            .selected_tree_path
+            .as_deref()
+            .is_some_and(under_absolute)
+        {
+            self.selected_tree_path = None;
+        }
+        if self
+            .tree_clipboard
+            .as_ref()
+            .is_some_and(|entry| under_absolute(&entry.path))
+        {
+            self.tree_clipboard = None;
+        }
+
+        // The same field list `Self::rename_open_paths` remaps - see this method's own docs.
+        self.reviewed_files.retain(|path| !under_relative(path));
+        self.file_external_conflict
+            .retain(|path| !under_relative(path));
+        self.file_save_pending.retain(|path| !under_relative(path));
+        self.file_save_running.retain(|path| !under_relative(path));
+        self._file_save_tasks
+            .retain(|path, _| !under_relative(path));
+        self._rehighlight_tasks
+            .retain(|path, _| !under_relative(path));
+        self._lsp_sync_tasks.retain(|path, _| !under_relative(path));
+        if self
+            .file_save_error
+            .as_ref()
+            .is_some_and(|(path, _)| under_relative(path))
+        {
+            self.file_save_error = None;
+        }
+        self.forget_lsp_document_state(&|path| under_absolute(path), &|path| under_relative(path));
+
+        let stale: Vec<PathBuf> = self
+            .expanded_dirs
+            .iter()
+            .filter(|dir| under_absolute(dir))
+            .cloned()
+            .collect();
+        let mut changed = false;
+        for dir in stale {
+            changed |= self.record_dir_expanded(&dir, false);
+        }
+        if changed {
+            self.persist_fold_state(cx);
+        }
+        self.invalidate_code_surface_caches();
+        self.refresh_open_diff_file_cache();
+    }
+
+    /// `path` relative to the tree root, falling back to the path itself when it isn't inside -
+    /// the one conversion both [`Self::rename_open_paths`] and [`Self::forget_deleted_paths`]
+    /// use, since half of this app's path-keyed state is worktree-relative
+    /// (`AdeApp::open_files`' own convention) and half is absolute, and mixing the two up is a
+    /// silent no-op rather than an error.
+    fn worktree_relative(&self, path: &Path) -> PathBuf {
+        path.strip_prefix(&self.file_tree_root)
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|_| path.to_path_buf())
+    }
+
+    /// Drops every `crate::lsp::client` per-document entry for a path that has gone away.
+    ///
+    /// Split out because these six maps do not share a key space, and the split is not the one
+    /// their names suggest - each field's own docs in `crate::root` are the authority and were
+    /// read one by one for this:
+    ///
+    /// - **absolute**: `lsp_opened_files`, `lsp_document_versions`, `lsp_uri_cache`;
+    /// - **worktree-relative** (`AdeApp::edit_buffers`' convention): `lsp_last_synced_content`,
+    ///   `lsp_synced_version`, `lsp_diagnostics_confirmed_version` - the last two are documented
+    ///   as "keyed the same worktree-relative way as `lsp_last_synced_content`", *not* the same
+    ///   way as `lsp_document_versions` beside them.
+    ///
+    /// Passing one predicate for both groups would silently retain half of these, which is
+    /// exactly the kind of no-op this whole method exists to avoid. `lsp_clients` itself is keyed
+    /// by `(worktree root, language)` and so is untouched by a file-level rename or delete;
+    /// `file_view_diagnostics` is keyed by line number and is dropped wholesale by
+    /// [`Self::invalidate_code_surface_caches`]' callers instead.
+    fn forget_lsp_document_state(
+        &mut self,
+        absolute: &dyn Fn(&Path) -> bool,
+        relative: &dyn Fn(&Path) -> bool,
+    ) {
+        self.lsp_opened_files.retain(|path| !absolute(path));
+        self.lsp_document_versions.retain(|path, _| !absolute(path));
+        self.lsp_uri_cache.retain(|path, _| !absolute(path));
+        self.lsp_last_synced_content
+            .retain(|path, _| !relative(path));
+        self.lsp_synced_version.retain(|path, _| !relative(path));
+        self.lsp_diagnostics_confirmed_version
+            .retain(|path, _| !relative(path));
+    }
+
+    // ---------------------------------------------------------------- bound actions
+
+    /// `Shift+F10` (`crate::root::FileTreeContextMenu`).
+    pub(in crate::sidebar) fn handle_file_tree_context_menu_action(
+        &mut self,
+        _action: &crate::root::FileTreeContextMenu,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.open_tree_context_menu_from_keyboard(window, cx);
+    }
+
+    /// `F2` (`crate::root::FileTreeRename`).
+    pub(in crate::sidebar) fn handle_file_tree_rename_action(
+        &mut self,
+        _action: &crate::root::FileTreeRename,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.start_tree_rename_for_selection(window, cx);
+    }
+
+    /// `Ctrl/⌘+C` while the tree is focused (`crate::root::FileTreeCopy`).
+    pub(in crate::sidebar) fn handle_file_tree_copy_action(
+        &mut self,
+        _action: &crate::root::FileTreeCopy,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.copy_selection_to_tree_clipboard(ClipboardMode::Copy, cx);
+    }
+
+    /// `Ctrl/⌘+X` while the tree is focused (`crate::root::FileTreeCut`).
+    pub(in crate::sidebar) fn handle_file_tree_cut_action(
+        &mut self,
+        _action: &crate::root::FileTreeCut,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.copy_selection_to_tree_clipboard(ClipboardMode::Cut, cx);
+    }
+
+    /// `Ctrl/⌘+V` while the tree is focused (`crate::root::FileTreePaste`).
+    pub(in crate::sidebar) fn handle_file_tree_paste_action(
+        &mut self,
+        _action: &crate::root::FileTreePaste,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.paste_into_selection(cx);
+    }
+
+    // ---------------------------------------------------------------- misc actions
+
+    /// Collapses `dir` and every expanded folder beneath it, through issue #18's own real
+    /// recording path ([`Self::record_dir_expanded`]) with a single queued write for the whole
+    /// subtree - the same "one write for a whole ancestor chain" shape `Self::reveal_in_tree`
+    /// already uses, rather than one write per level.
+    pub(in crate::sidebar) fn collapse_subtree(&mut self, dir: &Path, cx: &mut Context<Self>) {
+        let affected: Vec<PathBuf> = self
+            .expanded_dirs
+            .iter()
+            .filter(|expanded| file_ops::is_self_or_descendant(dir, expanded))
+            .cloned()
+            .collect();
+        let mut changed = false;
+        for path in affected {
+            changed |= self.record_dir_expanded(&path, false);
+        }
+        if changed {
+            self.persist_fold_state(cx);
+        }
+        cx.notify();
+    }
+
+    /// "Reveal in file manager" - hands the containing directory to the OS default-open handler
+    /// through the exact same real per-platform mechanism the Settings page's "Open file" button
+    /// uses (`crate::settings::widgets`' `open_command_for`/`spawn_open_command`:
+    /// `xdg-open`/`open`/`cmd /c start`), rather than a second implementation of it.
+    ///
+    /// A *file* is revealed by opening its parent directory: none of those three commands has a
+    /// portable "select this entry" form, and handing a file path to `xdg-open` would open the
+    /// file in its default application - a completely different action from the one the row
+    /// promises.
+    pub(in crate::sidebar) fn reveal_in_file_manager(
+        &mut self,
+        path: &Path,
+        cx: &mut Context<Self>,
+    ) {
+        let directory = if path.is_dir() {
+            path.to_path_buf()
+        } else {
+            path.parent()
+                .map(Path::to_path_buf)
+                .unwrap_or_else(|| self.file_tree_root.clone())
+        };
+        self.open_path_with_os_handler(&directory, cx);
+    }
+
+    /// Carries every path-keyed piece of app state across a rename or a cut+paste (issue #19 §2:
+    /// "open tabs / the diff view follow the renamed path - no orphaned buffers").
+    ///
+    /// Handles a renamed *directory* too, by prefix: every open tab, edit buffer, expanded
+    /// folder and reviewed-file entry underneath it is remapped, not just an exact match.
+    ///
+    /// **Half of this app's path-keyed state is worktree-relative and half is absolute**, and
+    /// getting one wrong is a silent no-op rather than a compile error (`strip_prefix` simply
+    /// fails and the entry is left alone) - see the `reviewed_files` line below for the real bug
+    /// that produced. Each field is remapped with the pair matching its own documented key space.
+    /// [`Self::forget_deleted_paths`] is this method's mirror and must move field-for-field with
+    /// it.
+    ///
+    /// The derived caches ([`AdeApp::file_view_cache`], the diff-highlight cache, the row layout
+    /// map, the hover card, the completions popup) are *invalidated* rather than remapped: every
+    /// one of them is keyed by the path it was computed for, and a rename changes the file's
+    /// identity for `git` as well, so recomputing them against the new path is both simpler and
+    /// the only way to get an honest answer.
+    pub(in crate::sidebar) fn rename_open_paths(
+        &mut self,
+        old: &Path,
+        new: &Path,
+        cx: &mut Context<Self>,
+    ) {
+        let old_relative = self.worktree_relative(old);
+        let new_relative = self.worktree_relative(new);
+
+        for open in self.open_files.iter_mut() {
+            if let Some(moved) = remap_path(open, &old_relative, &new_relative) {
+                *open = moved;
+            }
+        }
+        if let Some(open) = self.open_change.as_ref() {
+            if let Some(moved) = remap_path(open, &old_relative, &new_relative) {
+                self.open_change = Some(moved);
+            }
+        }
+
+        // The buffer map is keyed by the worktree-relative path *and* each buffer carries the
+        // absolute path an explicit save writes to - both have to move, or a save after a rename
+        // would write the old file back into existence.
+        let buffers = std::mem::take(&mut self.edit_buffers);
+        self.edit_buffers = buffers
+            .into_iter()
+            .map(|(key, mut buffer)| {
+                let key = remap_path(&key, &old_relative, &new_relative).unwrap_or(key);
+                if let Some(moved) = remap_path(&buffer.path, old, new) {
+                    buffer.path = moved;
+                }
+                (key, buffer)
+            })
+            .collect();
+
+        // Worktree-*relative*, like `edit_buffers` above and unlike the absolute-keyed sets
+        // further down: `reviewed_files` is keyed by `wt_core::diff::DiffFile::path`
+        // (`Self::toggle_reviewed`'s own argument, straight off a Changes row). An earlier
+        // version passed the absolute pair here, which made this a guaranteed silent no-op -
+        // `strip_prefix` simply failed for every entry - so a file's reviewed checkbox quietly
+        // reset on every rename. Found in review; the regression test below drives it.
+        remap_path_set(&mut self.reviewed_files, &old_relative, &new_relative);
+        remap_path_set(
+            &mut self.file_external_conflict,
+            &old_relative,
+            &new_relative,
+        );
+        remap_path_set(&mut self.file_save_pending, &old_relative, &new_relative);
+        // In-flight work for a path that no longer exists is dropped rather than remapped: a
+        // save task holds the *old* absolute path internally, so letting it finish would recreate
+        // the file under its old name.
+        let moved_relative = |path: &Path| file_ops::is_self_or_descendant(&old_relative, path);
+        let moved_absolute = |path: &Path| file_ops::is_self_or_descendant(old, path);
+        self.file_save_running.retain(|path| !moved_relative(path));
+        self._file_save_tasks
+            .retain(|path, _| !moved_relative(path));
+        self._rehighlight_tasks
+            .retain(|path, _| !moved_relative(path));
+        self._lsp_sync_tasks.retain(|path, _| !moved_relative(path));
+        if let Some((path, message)) = self.file_save_error.take() {
+            let path = remap_path(&path, &old_relative, &new_relative).unwrap_or(path);
+            self.file_save_error = Some((path, message));
+        }
+        // The LSP's per-document bookkeeping is *dropped*, not remapped, and that is the honest
+        // choice rather than the lazy one: `lsp_document_versions` counts `didChange`s for a
+        // document identified by URI, and the server has never been told the old URI went away.
+        // Carrying the old counter onto the new path would send a `didChange` for a document the
+        // server has no `didOpen` for. Dropping them makes the next open of the renamed path a
+        // real, fresh `didOpen` - see `Self::forget_lsp_document_state` for the two key spaces
+        // involved.
+        self.forget_lsp_document_state(&moved_absolute, &moved_relative);
+
+        if let Some(selected) = self.selected_tree_path.as_ref() {
+            if let Some(moved) = remap_path(selected, old, new) {
+                self.selected_tree_path = Some(moved);
+            }
+        }
+        if let Some(entry) = self.tree_clipboard.as_mut() {
+            if let Some(moved) = remap_path(&entry.path, old, new) {
+                entry.path = moved;
+            }
+        }
+
+        // Fold state moves through issue #18's own real recording path, so the persisted file
+        // follows the rename instead of keeping an entry for a folder that no longer exists.
+        let moved_dirs: Vec<(PathBuf, PathBuf)> = self
+            .expanded_dirs
+            .iter()
+            .filter_map(|dir| remap_path(dir, old, new).map(|moved| (dir.clone(), moved)))
+            .collect();
+        let mut changed = false;
+        for (from, to) in moved_dirs {
+            changed |= self.record_dir_expanded(&from, false);
+            changed |= self.record_dir_expanded(&to, true);
+        }
+        if changed {
+            self.persist_fold_state(cx);
+        }
+
+        self.invalidate_code_surface_caches();
+        self.refresh_open_diff_file_cache();
+    }
+
+    /// Everything derived from "which file is open, and what was on disk for it" - dropped as a
+    /// group whenever a file operation changes what those answers are. Shared by the rename and
+    /// delete paths so neither can forget one of them.
+    fn invalidate_code_surface_caches(&mut self) {
+        self.file_view_cache = None;
+        self.file_load_state = crate::code_surface::state::FileLoadState::Idle;
+        self.file_view_last_freshness_check = None;
+        self.diff_highlight_cache = None;
+        self.file_view_row_layout.clear();
+        self.file_view_last_layout = None;
+        self.file_view_last_bounds = None;
+        self.file_view_last_layout_for = None;
+        self.hover = None;
+        self.completions = None;
+        self.pending_cursor_line = None;
+    }
+
+    /// Re-reads the tree and the diff after a real filesystem change.
+    ///
+    /// Both are genuinely necessary and neither is redundant, which is the honest answer to issue
+    /// #19 §4's "do these operations just touch the filesystem, or do they need to trigger a
+    /// refresh?": the operations *are* plain filesystem changes, so `git` sees them with no help
+    /// at all - but nothing in this app polls the working tree for the sidebar. The file tree is
+    /// only ever re-walked by an explicit `load_file_tree` (there is no filesystem watcher in
+    /// this app), and the Changes list / diff view is only recomputed by an explicit `load_diff`
+    /// (`crate::rail::render::AdeApp::start_status_polling`'s 3-second timer refreshes the
+    /// *rail's* per-worktree summary, not `AdeApp::diff_state`). Without this call the row would
+    /// stay on screen after a delete and the diff would keep showing the pre-rename file.
+    pub(in crate::sidebar) fn refresh_after_file_op(&mut self, cx: &mut Context<Self>) {
+        self.load_file_tree(self.file_tree_root.clone(), cx);
+        self.load_diff(self.diff_root.clone(), cx);
+    }
+
+    /// Surfaces a real failure from a file operation next to the tree rather than dropping it
+    /// into the log - the same "small, visible, honest error surface" convention
+    /// [`AdeApp::file_save_error`] already follows for a failed save.
+    pub(in crate::sidebar) fn report_tree_op_error(
+        &mut self,
+        message: String,
+        cx: &mut Context<Self>,
+    ) {
+        log::warn!("file tree operation failed: {message}");
+        self.tree_op_error = Some(message);
+        cx.notify();
+    }
+}
+
+/// Applies [`remap_path`] to every member of a path set in place.
+fn remap_path_set(set: &mut HashSet<PathBuf>, old: &Path, new: &Path) {
+    let moved: Vec<(PathBuf, PathBuf)> = set
+        .iter()
+        .filter_map(|path| remap_path(path, old, new).map(|moved| (path.clone(), moved)))
+        .collect();
+    for (from, to) in moved {
+        set.remove(&from);
+        set.insert(to);
+    }
+}
+
+/// Whether `path` is a plain, normal-component-only path inside `root` - the guard every
+/// tree-originated operation runs before touching the filesystem, so a `..` that somehow reached
+/// one of these methods can't act outside the session's worktree.
+pub(crate) fn is_inside_worktree(root: &Path, path: &Path) -> bool {
+    let Ok(relative) = path.strip_prefix(root) else {
+        return false;
+    };
+    relative.components().count() > 0
+        && relative
+            .components()
+            .all(|component| matches!(component, Component::Normal(_)))
+}
+
+/// Real, end-to-end coverage for GitHub issue #19 against a live `AdeApp` in a real GPUI test
+/// window - the only level at which "the open tab followed the rename", "a single click deleted
+/// nothing" and "this keystroke never reached the tree" are observable at all.
+#[cfg(test)]
+mod tree_ops_regression_tests {
+    use super::*;
+    use crate::root::focus::palette_focus_tests;
+    use crate::settings::store as settings_store;
+    use crate::sidebar::context_menu::ContextTarget;
+    use gpui::TestAppContext;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn secondary(key: &str) -> String {
+        if cfg!(target_os = "macos") {
+            format!("cmd-{key}")
+        } else {
+            format!("ctrl-{key}")
+        }
+    }
+
+    /// `src/main.rs` + `src/util.rs` + a root-level `README.md`.
+    fn seed(repo: &TempDir) {
+        fs::create_dir_all(repo.path().join("src")).expect("mkdir");
+        fs::write(repo.path().join("src/main.rs"), "fn main() {}\n").expect("write");
+        fs::write(repo.path().join("src/util.rs"), "pub fn u() {}\n").expect("write");
+        fs::write(repo.path().join("README.md"), "hi\n").expect("write");
+    }
+
+    /// §2, the headline requirement: "open tabs / the diff view follow the renamed path - no
+    /// orphaned buffers". Drives the real inline editor, not `rename_open_paths` directly.
+    #[gpui::test]
+    fn renaming_an_open_file_carries_its_tab_and_buffer_with_no_orphan_left_behind(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = TempDir::new().expect("tempdir");
+        seed(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        let old = repo.path().join("src/main.rs");
+        app.update_in(cx, |app, window, cx| {
+            app.open_file_view(old.clone(), window, cx);
+        });
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.edit_buffers.contains_key(Path::new("src/main.rs")),
+                "premise: opening the file must have created a real buffer keyed by its \
+                 worktree-relative path"
+            );
+        });
+
+        app.update_in(cx, |app, window, cx| {
+            app.start_tree_rename(old.clone(), false, window, cx);
+            app.tree_inline_edit.as_mut().expect("editor").name = "renamed.rs".to_string();
+            app.commit_tree_inline_edit(window, cx);
+        });
+        cx.run_until_parked();
+
+        assert!(!old.exists(), "the old path must be gone from disk");
+        assert!(repo.path().join("src/renamed.rs").exists());
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.open_files,
+                vec![PathBuf::from("src/renamed.rs")],
+                "the open tab must follow the rename"
+            );
+            assert_eq!(
+                app.open_change.as_deref(),
+                Some(Path::new("src/renamed.rs"))
+            );
+            assert!(
+                !app.edit_buffers.contains_key(Path::new("src/main.rs")),
+                "an orphaned buffer still keyed by the old path is exactly what this must not \
+                 leave behind"
+            );
+            let buffer = app
+                .edit_buffers
+                .get(Path::new("src/renamed.rs"))
+                .expect("the buffer must be re-keyed, not dropped");
+            assert_eq!(
+                buffer.path,
+                repo.path().join("src/renamed.rs"),
+                "the buffer's own absolute save path must move too - otherwise the next save \
+                 would recreate the file under its old name"
+            );
+            assert_eq!(
+                app.selected_tree_path.as_deref(),
+                Some(repo.path().join("src/renamed.rs").as_path())
+            );
+        });
+    }
+
+    /// The subtree half of the same requirement: renaming a *folder* has to carry every tab and
+    /// buffer underneath it, not just an exact path match.
+    #[gpui::test]
+    fn renaming_a_folder_carries_every_open_tab_underneath_it(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        seed(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_file_view(repo.path().join("src/main.rs"), window, cx);
+            app.open_file_view(repo.path().join("src/util.rs"), window, cx);
+            app.set_dir_expanded(repo.path().join("src"), true, cx);
+        });
+        cx.run_until_parked();
+
+        app.update_in(cx, |app, window, cx| {
+            app.start_tree_rename(repo.path().join("src"), true, window, cx);
+            app.tree_inline_edit.as_mut().expect("editor").name = "lib".to_string();
+            app.commit_tree_inline_edit(window, cx);
+        });
+        cx.run_until_parked();
+
+        assert!(repo.path().join("lib/main.rs").exists());
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.open_files,
+                vec![PathBuf::from("lib/main.rs"), PathBuf::from("lib/util.rs")],
+                "every tab under the renamed folder must follow it"
+            );
+            assert!(app.edit_buffers.contains_key(Path::new("lib/util.rs")));
+            assert!(!app.edit_buffers.contains_key(Path::new("src/util.rs")));
+            assert!(
+                app.expanded_dirs.contains(&repo.path().join("lib"))
+                    && !app.expanded_dirs.contains(&repo.path().join("src")),
+                "the folder's own expanded state must move with it, or the renamed folder would \
+                 silently snap shut"
+            );
+        });
+    }
+
+    /// §3: "Delete asks for confirmation". One click on the menu row must arm the confirmation
+    /// and remove nothing at all.
+    #[gpui::test]
+    fn a_single_delete_click_only_arms_a_confirmation_and_removes_nothing(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        seed(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        let victim = repo.path().join("README.md");
+        app.update_in(cx, |app, window, cx| {
+            app.open_tree_context_menu(ContextTarget::File(victim.clone()), 40.0, 60.0, window, cx);
+            app.run_tree_menu_action(MenuAction::Delete, window, cx);
+        });
+        cx.run_until_parked();
+
+        assert!(
+            victim.exists(),
+            "a single click on Delete must never remove anything - it only asks"
+        );
+        app.read_with(cx, |app, _| {
+            let pending = app
+                .tree_delete_confirm
+                .as_ref()
+                .expect("the confirmation must be armed");
+            assert_eq!(pending.path, victim);
+            assert!(!pending.is_dir);
+            assert!(
+                app.tree_context_menu.is_none(),
+                "the menu must close so the row can't be clicked a second time by accident"
+            );
+        });
+    }
+
+    /// The other half: the confirmation's own button really does delete, and the deleted file's
+    /// tab and buffer go with it.
+    ///
+    /// The pending delete's mechanism is forced to `Permanent` after the real
+    /// [`AdeApp::request_tree_delete`] has resolved it: on a developer machine with `gio`
+    /// installed the real resolution is `Trash`, and running it here would move a test fixture
+    /// into the developer's own `~/.local/share/Trash`. The resolution logic itself is covered
+    /// purely in `crate::sidebar::file_ops`' own tests; what this test exercises is
+    /// [`AdeApp::confirm_tree_delete`]'s real removal and state repair.
+    #[gpui::test]
+    fn a_confirmed_delete_really_removes_the_file_and_its_tab(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        seed(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        let victim = repo.path().join("src/util.rs");
+        app.update_in(cx, |app, window, cx| {
+            app.open_file_view(victim.clone(), window, cx);
+            app.request_tree_delete(victim.clone(), false, cx);
+            app.tree_delete_confirm.as_mut().expect("armed").mechanism = DeleteMechanism::Permanent;
+            app.confirm_tree_delete(cx);
+        });
+        cx.run_until_parked();
+
+        assert!(
+            !victim.exists(),
+            "the confirmed delete must really remove it"
+        );
+        app.read_with(cx, |app, _| {
+            assert!(
+                !app.open_files.contains(&PathBuf::from("src/util.rs")),
+                "the deleted file's tab must not survive it"
+            );
+            assert!(!app.edit_buffers.contains_key(Path::new("src/util.rs")));
+            assert!(app.tree_delete_confirm.is_none());
+        });
+    }
+
+    /// A guard on the app's one irreversible operation.
+    #[gpui::test]
+    fn deleting_something_outside_the_worktree_is_refused_outright(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        let outside = TempDir::new().expect("tempdir");
+        fs::write(outside.path().join("precious.txt"), "keep me").expect("write");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        app.update(cx, |app, cx| {
+            app.request_tree_delete(outside.path().join("precious.txt"), false, cx);
+        });
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.tree_delete_confirm.is_none(),
+                "a path outside the worktree must not even reach a confirmation"
+            );
+            assert!(app.tree_op_error.is_some(), "and it must say so");
+        });
+        assert!(outside.path().join("precious.txt").exists());
+    }
+
+    /// §3: "pasting into the source folder auto-suffixes the copy's name" - a real second file,
+    /// never an overwrite and never a collision error.
+    #[gpui::test]
+    fn pasting_into_the_source_folder_creates_a_real_suffixed_copy(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        seed(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        let source = repo.path().join("src/main.rs");
+        app.update(cx, |app, cx| {
+            app.set_tree_clipboard(source.clone(), ClipboardMode::Copy, cx);
+            app.paste_into_dir(&repo.path().join("src"), cx);
+        });
+        cx.run_until_parked();
+
+        let copy = repo.path().join("src/main copy.rs");
+        assert!(
+            copy.exists(),
+            "the paste must produce a real, suffixed file"
+        );
+        assert_eq!(fs::read_to_string(&copy).expect("read"), "fn main() {}\n");
+        assert_eq!(
+            fs::read_to_string(&source).expect("read"),
+            "fn main() {}\n",
+            "the original must be untouched"
+        );
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.tree_op_error.is_none(),
+                "a paste into the source folder is a normal, successful operation - not an \
+                 error: {:?}",
+                app.tree_op_error
+            );
+            assert!(
+                app.tree_clipboard.is_some(),
+                "a copy stays on the clipboard so it can be pasted again"
+            );
+        });
+
+        // A second paste must not fail either - it steps to the next suffix.
+        app.update(cx, |app, cx| {
+            app.paste_into_dir(&repo.path().join("src"), cx);
+        });
+        cx.run_until_parked();
+        assert!(repo.path().join("src/main copy 2.rs").exists());
+    }
+
+    /// A cut is a move, so it has to repair open tabs exactly like a rename does - and must
+    /// clear the clipboard, since the entry is no longer where it said it was.
+    #[gpui::test]
+    fn cutting_and_pasting_moves_the_entry_and_its_open_tab(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        seed(&repo);
+        fs::create_dir(repo.path().join("dest")).expect("mkdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        let source = repo.path().join("src/util.rs");
+        app.update_in(cx, |app, window, cx| {
+            app.open_file_view(source.clone(), window, cx);
+            app.set_tree_clipboard(source.clone(), ClipboardMode::Cut, cx);
+            app.paste_into_dir(&repo.path().join("dest"), cx);
+        });
+        cx.run_until_parked();
+
+        assert!(!source.exists());
+        assert!(repo.path().join("dest/util.rs").exists());
+        app.read_with(cx, |app, _| {
+            assert!(app.open_files.contains(&PathBuf::from("dest/util.rs")));
+            assert!(!app.edit_buffers.contains_key(Path::new("src/util.rs")));
+            assert!(
+                app.tree_clipboard.is_none(),
+                "a cut is consumed by its paste - a second paste would target a path that no \
+                 longer exists"
+            );
+        });
+    }
+
+    /// §4: "watcher refreshes must not clobber an in-progress inline rename/create editor".
+    ///
+    /// Drives the real race: an agent creates a file on disk, the tree is genuinely re-walked
+    /// (`load_file_tree` - the one mechanism that replaces `AdeApp::file_tree` wholesale, and the
+    /// one a filesystem watcher would drive), and the half-typed name must survive it, still
+    /// painted as a real row.
+    #[gpui::test]
+    fn a_tree_reload_during_an_inline_rename_keeps_the_typed_text(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        seed(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        app.update_in(cx, |app, window, cx| {
+            app.set_dir_expanded(repo.path().join("src"), true, cx);
+            app.start_tree_rename(repo.path().join("src/main.rs"), false, window, cx);
+            app.tree_inline_edit.as_mut().expect("editor").name = "half-typed".to_string();
+        });
+        cx.run_until_parked();
+        assert!(
+            cx.debug_bounds("file-tree-inline-edit").is_some(),
+            "premise: the editor must be a real painted row before the reload"
+        );
+
+        // An agent CLI creating a file mid-session, followed by the real re-walk.
+        fs::write(repo.path().join("src/agent-made.rs"), "// new\n").expect("write");
+        app.update(cx, |app, cx| {
+            let root = app.file_tree_root.clone();
+            app.load_file_tree(root, cx);
+        });
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.file_tree
+                    .iter()
+                    .any(|entry| entry.name == "agent-made.rs"),
+                "premise: the re-walk must genuinely have replaced the row list"
+            );
+            let edit = app
+                .tree_inline_edit
+                .as_ref()
+                .expect("the editor must survive a walk that replaced every row");
+            assert_eq!(edit.name, "half-typed");
+        });
+        assert!(
+            cx.debug_bounds("file-tree-inline-edit").is_some(),
+            "and it must still be painted, re-anchored against the new row list"
+        );
+    }
+
+    /// §1: the empty-area menu's "Collapse All" must be issue #18's *real* reset - the one that
+    /// also clears this worktree's persisted entry - not a second mechanism that only empties the
+    /// in-memory set. Asserted against the real on-disk fold-state file, which is the only thing
+    /// that can tell the two apart.
+    #[gpui::test]
+    fn the_empty_area_collapse_all_clears_the_persisted_fold_state_too(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        seed(&repo);
+        let state_dir = TempDir::new().expect("tempdir");
+        let settings_path = state_dir.path().join("settings.toml");
+        let fold_path = crate::sidebar::fold_state::fold_state_path_for(&settings_path);
+        let (app, cx) = cx.add_window_view(|window, cx| {
+            AdeApp::new_with_settings(
+                repo.path().to_path_buf(),
+                settings_store::Settings::default(),
+                Some(settings_path),
+                window,
+                cx,
+            )
+        });
+        cx.run_until_parked();
+
+        app.update(cx, |app, cx| {
+            app.set_dir_expanded(repo.path().join("src"), true, cx);
+        });
+        cx.run_until_parked();
+        assert!(
+            fs::read_to_string(&fold_path)
+                .expect("the fold-state file must exist after a real expand")
+                .contains("src"),
+            "premise: the expansion is genuinely on disk before Collapse All runs"
+        );
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_tree_context_menu(ContextTarget::Empty, 30.0, 30.0, window, cx);
+            app.run_tree_menu_action(MenuAction::CollapseAll, window, cx);
+        });
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert!(app.expanded_dirs.is_empty(), "the live set must be cleared");
+        });
+        let on_disk = fs::read_to_string(&fold_path).expect("read fold state");
+        assert!(
+            !on_disk.contains("src"),
+            "the menu's Collapse All must go through issue #18's own `collapse_all_dirs` - which \
+             clears the *persisted* entry as well. A parallel implementation that only emptied \
+             `expanded_dirs` would leave this behind and the expansion would come back on the \
+             next launch. Got: {on_disk}"
+        );
+    }
+
+    /// The positive half of the keyboard-access requirement (§1) - without this, the negative
+    /// tests below could pass simply because the binding never works at all.
+    #[gpui::test]
+    fn shift_f10_with_the_tree_focused_opens_the_menu_for_the_selected_row(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = TempDir::new().expect("tempdir");
+        seed(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
+        cx.run_until_parked();
+
+        app.update_in(cx, |app, window, cx| {
+            app.selected_tree_path = Some(repo.path().join("README.md"));
+            app.focus_file_tree(window, cx);
+        });
+        cx.run_until_parked();
+
+        cx.simulate_keystrokes("shift-f10");
+        app.read_with(cx, |app, _| {
+            let menu = app
+                .tree_context_menu
+                .as_ref()
+                .expect("shift-f10 with the tree focused must open the menu");
+            assert_eq!(
+                menu.target,
+                ContextTarget::File(repo.path().join("README.md"))
+            );
+        });
+    }
+
+    /// §1 + the keystroke-scoping discipline: `Shift+F10` must not reach the tree while one of
+    /// its own inline name editors has the keyboard - it would open a menu on top of the field
+    /// the user is typing into.
+    #[gpui::test]
+    fn shift_f10_while_an_inline_editor_is_open_neither_opens_a_menu_nor_disturbs_the_name(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = TempDir::new().expect("tempdir");
+        seed(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
+        cx.run_until_parked();
+
+        app.update_in(cx, |app, window, cx| {
+            app.selected_tree_path = Some(repo.path().join("README.md"));
+            app.start_tree_rename(repo.path().join("README.md"), false, window, cx);
+            app.tree_inline_edit.as_mut().expect("editor").name = "in-progress".to_string();
+        });
+        cx.run_until_parked();
+
+        cx.simulate_keystrokes("shift-f10");
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.tree_context_menu.is_none(),
+                "the `!tree-editing` half of the binding's context predicate is what stops this"
+            );
+            assert_eq!(
+                app.tree_inline_edit.as_ref().expect("still open").name,
+                "in-progress",
+                "and the editor must be untouched"
+            );
+        });
+    }
+
+    /// The same discipline for the clipboard bindings, and the highest-stakes case: `Ctrl+C` in a
+    /// focused terminal is SIGINT, and a version of this feature that intercepted it would make
+    /// it impossible to interrupt a running agent CLI.
+    ///
+    /// What this test proves, precisely: with a terminal focused, none of the three clipboard
+    /// keystrokes reaches the tree's own handler. It does **not** prove the keystroke still
+    /// reached the pty - that is a separate property, guaranteed by *where* the handlers are
+    /// registered (see this module's own docs, point 1) and covered by
+    /// `crate::terminal::pane`'s own `keystroke_to_bytes` tests. Stated explicitly because this
+    /// test was checked against a deliberately un-scoped (`None`) binding and still passed: with
+    /// the handlers on the tree's own node, an unmatched *handler* is what saves the terminal
+    /// there, not the context predicate. The predicate's own load-bearing half is verified by
+    /// the two tests above and by
+    /// [`every_file_tree_binding_is_scoped_away_from_the_inline_editor`].
+    #[gpui::test]
+    fn ctrl_c_with_a_focused_terminal_never_reaches_the_trees_clipboard(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        seed(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
+        cx.run_until_parked();
+
+        app.update_in(cx, |app, window, cx| {
+            // A real selection, so the tree binding would genuinely have something to copy if it
+            // fired - otherwise this test could pass for the wrong reason.
+            app.selected_tree_path = Some(repo.path().join("README.md"));
+            app.sessions.focus_active(window, cx);
+        });
+        cx.run_until_parked();
+
+        cx.simulate_keystrokes(&secondary("c"));
+        cx.simulate_keystrokes(&secondary("x"));
+        cx.simulate_keystrokes(&secondary("v"));
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.tree_clipboard.is_none(),
+                "the tree's clipboard bindings are scoped to the `file-tree` context precisely \
+                 so a focused terminal keeps its own control bytes"
+            );
+        });
+    }
+
+    /// And the positive half of *that* pair: with the tree focused, the same keystroke really
+    /// does work.
+    #[gpui::test]
+    fn ctrl_c_with_the_tree_focused_copies_the_selected_entry(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        seed(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
+        cx.run_until_parked();
+
+        app.update_in(cx, |app, window, cx| {
+            app.selected_tree_path = Some(repo.path().join("README.md"));
+            app.focus_file_tree(window, cx);
+        });
+        cx.run_until_parked();
+
+        cx.simulate_keystrokes(&secondary("c"));
+        app.read_with(cx, |app, _| {
+            let entry = app
+                .tree_clipboard
+                .as_ref()
+                .expect("ctrl-c with the tree focused must copy the selection");
+            assert_eq!(entry.path, repo.path().join("README.md"));
+            assert_eq!(entry.mode, ClipboardMode::Copy);
+        });
+    }
+
+    /// Structural, read off the *real* registered bindings rather than a hand-copied list (the
+    /// same discipline `crate::settings::state::keybinding_rows` follows): every file-tree
+    /// action must be scoped to a context that excludes both modal states. A future edit that
+    /// widened one of them to `None`, or dropped either negated half, would silently start
+    /// swallowing keystrokes typed into the tree's own inline name editor, or firing behind the
+    /// delete confirmation's own scrim.
+    #[test]
+    fn every_file_tree_binding_is_scoped_away_from_the_inline_editor() {
+        let expected = "file-tree && !tree-editing && !tree-delete-confirm";
+        let tree_actions = [
+            "app::FileTreeContextMenu",
+            "app::FileTreeRename",
+            "app::FileTreeCopy",
+            "app::FileTreeCut",
+            "app::FileTreePaste",
+        ];
+        let bindings = crate::default_key_bindings();
+        let mut seen = Vec::new();
+        for binding in &bindings {
+            let name = binding.action().name();
+            if !tree_actions.contains(&name) {
+                continue;
+            }
+            seen.push(name);
+            let predicate = binding
+                .predicate()
+                .unwrap_or_else(|| panic!("{name} must not be globally bound"))
+                .to_string();
+            assert_eq!(
+                predicate, expected,
+                "{name} is bound with the wrong context predicate"
+            );
+        }
+        seen.sort_unstable();
+        let mut want = tree_actions;
+        want.sort_unstable();
+        assert_eq!(
+            seen, want,
+            "every file-tree action must have a real registered binding"
+        );
+    }
+
+    /// §1: a real right-click on a real painted row opens that row's own menu (not the empty-area
+    /// one), positioned inside the window.
+    #[gpui::test]
+    fn right_clicking_a_folder_row_opens_the_folder_menu_at_a_clamped_origin(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = TempDir::new().expect("tempdir");
+        seed(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        let row = cx
+            .debug_bounds("file-tree-row-src")
+            .expect("the folder row must be painted");
+        cx.simulate_event(gpui::MouseDownEvent {
+            button: gpui::MouseButton::Right,
+            position: row.center(),
+            modifiers: gpui::Modifiers::default(),
+            click_count: 1,
+            first_mouse: false,
+        });
+        cx.run_until_parked();
+
+        let viewport = cx.update(|window, _cx| window.bounds().size);
+        app.read_with(cx, |app, _| {
+            let menu = app
+                .tree_context_menu
+                .as_ref()
+                .expect("a real right-click on a folder row must open a menu");
+            assert_eq!(
+                menu.target,
+                ContextTarget::Folder(repo.path().join("src")),
+                "the row's own handler must win over the container's empty-area one"
+            );
+            let rows = context_menu::menu_items(&menu.target, false).len();
+            assert!(
+                menu.origin_x >= 0.0
+                    && menu.origin_x + context_menu::MENU_WIDTH <= f32::from(viewport.width),
+                "the popover must sit inside the window"
+            );
+            assert!(
+                menu.origin_y >= 0.0
+                    && menu.origin_y + context_menu::menu_height(rows)
+                        <= f32::from(viewport.height)
+            );
+        });
+        assert!(
+            cx.debug_bounds("tree-context-menu").is_some(),
+            "and it must genuinely paint"
+        );
+    }
+
+    /// §1's dismissal requirement, driven through the real key handler.
+    #[gpui::test]
+    fn escape_dismisses_the_context_menu(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        seed(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
+        cx.run_until_parked();
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_tree_context_menu(ContextTarget::Empty, 20.0, 20.0, window, cx);
+        });
+        cx.run_until_parked();
+        cx.simulate_keystrokes("escape");
+        app.read_with(cx, |app, _| assert!(app.tree_context_menu.is_none()));
+    }
+
+    /// §2: New Folder really creates a directory, and the inline editor is what drives it.
+    #[gpui::test]
+    fn the_new_folder_editor_creates_a_real_directory(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        seed(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_tree_context_menu(
+                ContextTarget::Folder(repo.path().join("src")),
+                20.0,
+                20.0,
+                window,
+                cx,
+            );
+            app.run_tree_menu_action(MenuAction::NewFolder, window, cx);
+            app.tree_inline_edit.as_mut().expect("editor").name = "nested".to_string();
+            app.commit_tree_inline_edit(window, cx);
+        });
+        cx.run_until_parked();
+
+        assert!(repo.path().join("src/nested").is_dir());
+        app.read_with(cx, |app, _| {
+            assert!(app.tree_inline_edit.is_none(), "the editor must close");
+            assert!(
+                app.expanded_dirs.contains(&repo.path().join("src")),
+                "the parent must have been expanded so the editor was visible in the first place"
+            );
+        });
+    }
+
+    /// §2: "invalid names are rejected with a hint" - and the editor stays open so the name can
+    /// be corrected, exactly like the `+` menu's prompt.
+    #[gpui::test]
+    fn an_invalid_name_is_refused_with_a_real_hint_and_the_editor_stays_open(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = TempDir::new().expect("tempdir");
+        seed(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        for bad in ["", "  ", "a/b", ".."] {
+            app.update_in(cx, |app, window, cx| {
+                app.start_tree_new_entry(repo.path().to_path_buf(), true, window, cx);
+                app.tree_inline_edit.as_mut().expect("editor").name = bad.to_string();
+                app.commit_tree_inline_edit(window, cx);
+            });
+            cx.run_until_parked();
+            app.read_with(cx, |app, _| {
+                let edit = app
+                    .tree_inline_edit
+                    .as_ref()
+                    .unwrap_or_else(|| panic!("the editor must stay open for {bad:?}"));
+                assert!(
+                    edit.error.is_some(),
+                    "{bad:?} must be rejected with a real hint"
+                );
+            });
+        }
+
+        // A name that collides with something already there is refused the same way.
+        app.update_in(cx, |app, window, cx| {
+            app.start_tree_new_entry(repo.path().to_path_buf(), true, window, cx);
+            app.tree_inline_edit.as_mut().expect("editor").name = "src".to_string();
+            app.commit_tree_inline_edit(window, cx);
+        });
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| {
+            assert!(app
+                .tree_inline_edit
+                .as_ref()
+                .expect("still open")
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("already exists")));
+        });
+        assert!(
+            repo.path().join("src/main.rs").exists(),
+            "and the existing folder must be untouched"
+        );
+    }
+
+    /// §1's "Collapse Subtree": only that folder's own chain, never a sibling's.
+    #[gpui::test]
+    fn collapse_subtree_collapses_only_that_folders_own_descendants(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        fs::create_dir_all(repo.path().join("a/inner")).expect("mkdir");
+        fs::create_dir_all(repo.path().join("b")).expect("mkdir");
+        fs::write(repo.path().join("a/inner/x.rs"), "x").expect("write");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        app.update(cx, |app, cx| {
+            app.set_dir_expanded(repo.path().join("a"), true, cx);
+            app.set_dir_expanded(repo.path().join("a/inner"), true, cx);
+            app.set_dir_expanded(repo.path().join("b"), true, cx);
+        });
+        cx.run_until_parked();
+
+        app.update(cx, |app, cx| {
+            app.collapse_subtree(&repo.path().join("a"), cx);
+        });
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert!(!app.expanded_dirs.contains(&repo.path().join("a")));
+            assert!(
+                !app.expanded_dirs.contains(&repo.path().join("a/inner")),
+                "a nested expansion left behind would reappear the moment the parent reopened"
+            );
+            assert!(
+                app.expanded_dirs.contains(&repo.path().join("b")),
+                "a sibling subtree must be untouched"
+            );
+        });
+    }
+
+    /// "Copy Relative Path" really writes to the real system clipboard, and really is relative.
+    #[gpui::test]
+    fn copy_relative_path_writes_the_worktree_relative_path(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        seed(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        app.update(cx, |app, cx| {
+            app.copy_path_to_system_clipboard(&repo.path().join("src/main.rs"), true, cx);
+        });
+        let text = cx.update(|_window, cx| cx.read_from_clipboard().and_then(|item| item.text()));
+        assert_eq!(text.as_deref(), Some("src/main.rs"));
+
+        app.update(cx, |app, cx| {
+            app.copy_path_to_system_clipboard(&repo.path().join("src/main.rs"), false, cx);
+        });
+        let text = cx.update(|_window, cx| cx.read_from_clipboard().and_then(|item| item.text()));
+        assert_eq!(
+            text.as_deref(),
+            Some(
+                repo.path()
+                    .join("src/main.rs")
+                    .display()
+                    .to_string()
+                    .as_str()
+            )
+        );
+    }
+
+    /// Every one of these bugs was found by this change's own adversarial review; each test was
+    /// confirmed to fail against the code as it stood before the fix.
+    mod review_findings {
+        use super::*;
+        use crate::sidebar::render::RightSidebarView;
+
+        /// `reviewed_files` is keyed by `wt_core::diff::DiffFile::path` - worktree-*relative* -
+        /// while the paths a rename works in are absolute. Remapping it with the absolute pair
+        /// was a guaranteed silent no-op (`strip_prefix` failed for every entry), so a file's
+        /// reviewed checkbox quietly reset on every rename and every cut+paste.
+        #[gpui::test]
+        fn a_rename_carries_the_files_reviewed_checkbox_with_it(cx: &mut TestAppContext) {
+            let repo = TempDir::new().expect("tempdir");
+            seed(&repo);
+            let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+            cx.run_until_parked();
+
+            app.update(cx, |app, cx| {
+                app.toggle_reviewed(PathBuf::from("src/main.rs"), cx);
+            });
+            app.update_in(cx, |app, window, cx| {
+                app.start_tree_rename(repo.path().join("src/main.rs"), false, window, cx);
+                app.tree_inline_edit.as_mut().expect("editor").name = "renamed.rs".to_string();
+                app.commit_tree_inline_edit(window, cx);
+            });
+            cx.run_until_parked();
+
+            app.read_with(cx, |app, _| {
+                assert!(
+                    app.reviewed_files.contains(Path::new("src/renamed.rs")),
+                    "the reviewed mark must follow the rename - got {:?}",
+                    app.reviewed_files
+                );
+                assert!(!app.reviewed_files.contains(Path::new("src/main.rs")));
+            });
+        }
+
+        /// `crate::lsp::client`'s `didOpen` dispatch early-returns for a path already in
+        /// `lsp_opened_files`, and that set is documented as never being cleared on close. So a
+        /// rename (or a delete) that left the old absolute path in it meant recreating a file at
+        /// that path silently got no diagnostics and no completions for the rest of the session.
+        #[gpui::test]
+        fn renaming_and_deleting_both_clear_the_lsp_per_document_bookkeeping(
+            cx: &mut TestAppContext,
+        ) {
+            let repo = TempDir::new().expect("tempdir");
+            seed(&repo);
+            let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+            cx.run_until_parked();
+
+            let absolute = repo.path().join("src/main.rs");
+            let relative = PathBuf::from("src/main.rs");
+            app.update(cx, |app, _cx| {
+                app.lsp_opened_files.insert(absolute.clone());
+                app.lsp_document_versions.insert(absolute.clone(), 7);
+                app.lsp_last_synced_content
+                    .insert(relative.clone(), "fn main() {}\n".to_string());
+                app.lsp_synced_version.insert(relative.clone(), 7);
+            });
+
+            app.update_in(cx, |app, window, cx| {
+                app.start_tree_rename(absolute.clone(), false, window, cx);
+                app.tree_inline_edit.as_mut().expect("editor").name = "renamed.rs".to_string();
+                app.commit_tree_inline_edit(window, cx);
+            });
+            cx.run_until_parked();
+
+            app.read_with(cx, |app, _| {
+                assert!(
+                    !app.lsp_opened_files.contains(&absolute),
+                    "a stale `didOpen` record for the old path silently disables diagnostics \
+                     for anything later created there"
+                );
+                assert!(!app.lsp_document_versions.contains_key(&absolute));
+                assert!(!app.lsp_last_synced_content.contains_key(&relative));
+                assert!(!app.lsp_synced_version.contains_key(&relative));
+            });
+
+            // And the delete half, on the renamed path.
+            let renamed = repo.path().join("src/renamed.rs");
+            let renamed_relative = PathBuf::from("src/renamed.rs");
+            app.update(cx, |app, _cx| {
+                app.lsp_opened_files.insert(renamed.clone());
+                app.lsp_synced_version.insert(renamed_relative.clone(), 3);
+            });
+            app.update(cx, |app, cx| {
+                app.request_tree_delete(renamed.clone(), false, cx);
+                app.tree_delete_confirm.as_mut().expect("armed").mechanism =
+                    DeleteMechanism::Permanent;
+                app.confirm_tree_delete(cx);
+            });
+            cx.run_until_parked();
+
+            app.read_with(cx, |app, _| {
+                assert!(!app.lsp_opened_files.contains(&renamed));
+                assert!(!app.lsp_synced_version.contains_key(&renamed_relative));
+            });
+        }
+
+        /// Cutting a file and pasting it back into the folder it came from means "move it here",
+        /// and it is already here. An unconditional `unique_destination` turned that into an
+        /// unrequested rename to `util copy.rs`, with no error and no undo.
+        #[gpui::test]
+        fn cutting_and_pasting_into_the_source_folder_is_a_no_op_not_a_rename(
+            cx: &mut TestAppContext,
+        ) {
+            let repo = TempDir::new().expect("tempdir");
+            seed(&repo);
+            let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+            cx.run_until_parked();
+
+            let source = repo.path().join("src/util.rs");
+            app.update(cx, |app, cx| {
+                app.set_tree_clipboard(source.clone(), ClipboardMode::Cut, cx);
+                app.paste_into_dir(&repo.path().join("src"), cx);
+            });
+            cx.run_until_parked();
+
+            assert!(
+                source.exists(),
+                "the file must still be exactly where it was"
+            );
+            assert!(
+                !repo.path().join("src/util copy.rs").exists(),
+                "a cut back into its own folder must never silently rename the file"
+            );
+            app.read_with(cx, |app, _| {
+                assert!(app.tree_clipboard.is_none(), "the cut is still consumed");
+                assert!(app.tree_op_error.is_none(), "and it is not an error either");
+            });
+        }
+
+        /// Switching to the Changes tab unrenders `file_tree_shell` - and with it the node
+        /// `tree_focus_handle` is tracked on. Leaving `Window::focus` there makes GPUI fall back
+        /// to the dispatch root, silently killing every keybinding until the next click: this
+        /// project's single most-repeated bug class.
+        #[gpui::test]
+        fn leaving_the_files_tab_does_not_leave_focus_dangling_on_the_tree(
+            cx: &mut TestAppContext,
+        ) {
+            let repo = TempDir::new().expect("tempdir");
+            seed(&repo);
+            let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+            cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
+            cx.run_until_parked();
+
+            app.update_in(cx, |app, window, cx| {
+                app.open_tree_context_menu(
+                    ContextTarget::File(repo.path().join("README.md")),
+                    30.0,
+                    30.0,
+                    window,
+                    cx,
+                );
+                app.set_right_sidebar_view(RightSidebarView::Changes, window, cx);
+            });
+            cx.run_until_parked();
+
+            app.read_with(cx, |app, _| {
+                assert!(
+                    app.tree_context_menu.is_none(),
+                    "a menu targeting a row that is no longer rendered must not survive the switch"
+                );
+            });
+
+            let key = if cfg!(target_os = "macos") {
+                "cmd-k"
+            } else {
+                "ctrl-k"
+            };
+            cx.simulate_keystrokes(key);
+            assert!(
+                app.read_with(cx, |app, _| app.palette_open),
+                "a real {key} after switching away from the Files tab must still open the \
+                 palette - before the fix, focus was left dangling on the now-unrendered tree"
+            );
+        }
+
+        /// The delete confirmation is a modal. While it is up, the tree's own bindings must not
+        /// fire behind its scrim, and Escape must dismiss it.
+        #[gpui::test]
+        fn the_delete_confirmation_is_modal_to_the_trees_own_keybindings(cx: &mut TestAppContext) {
+            let repo = TempDir::new().expect("tempdir");
+            seed(&repo);
+            let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+            cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
+            cx.run_until_parked();
+
+            app.update_in(cx, |app, window, cx| {
+                app.selected_tree_path = Some(repo.path().join("README.md"));
+                app.focus_file_tree(window, cx);
+                app.request_tree_delete(repo.path().join("README.md"), false, cx);
+            });
+            cx.run_until_parked();
+
+            cx.simulate_keystrokes("f2");
+            cx.simulate_keystrokes("shift-f10");
+            app.read_with(cx, |app, _| {
+                assert!(
+                    app.tree_inline_edit.is_none() && app.tree_context_menu.is_none(),
+                    "F2/Shift+F10 must not fire behind the modal's own scrim"
+                );
+                assert!(app.tree_delete_confirm.is_some(), "and it stays up");
+            });
+
+            cx.simulate_keystrokes("escape");
+            app.read_with(cx, |app, _| {
+                assert!(
+                    app.tree_delete_confirm.is_none(),
+                    "escape must dismiss the confirmation"
+                );
+            });
+            assert!(repo.path().join("README.md").exists());
+        }
+    }
+
+    /// A worktree switch must not leave a cut entry, a half-typed name, an open menu or an armed
+    /// delete pointing at the worktree just left.
+    #[gpui::test]
+    fn switching_worktrees_clears_every_tree_operation_in_flight(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        seed(&repo);
+        let other = TempDir::new().expect("tempdir");
+        fs::write(other.path().join("elsewhere.txt"), "x").expect("write");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        // A directly-seeded `worktrees` list - the same pattern `crate::code_surface::zoom`'s own
+        // per-worktree-reset test uses; `select_worktree` only needs a real, readable path.
+        app.update(cx, |app, _cx| {
+            app.worktrees = vec![
+                crate::rail::worktrees::WorktreeItem {
+                    path: repo.path().to_path_buf(),
+                    label: "wt-a".to_string(),
+                    branch: None,
+                    is_main: true,
+                    is_locked: false,
+                    error: None,
+                },
+                crate::rail::worktrees::WorktreeItem {
+                    path: other.path().to_path_buf(),
+                    label: "wt-b".to_string(),
+                    branch: None,
+                    is_main: false,
+                    is_locked: false,
+                    error: None,
+                },
+            ];
+        });
+
+        app.update_in(cx, |app, window, cx| {
+            app.set_tree_clipboard(repo.path().join("README.md"), ClipboardMode::Cut, cx);
+            // Order matters: `open_tree_context_menu` cancels an open inline editor, so opening
+            // the menu *first* is the only way to have all four states live at once. An earlier
+            // version of this test did it the other way round, which made the
+            // `tree_inline_edit.is_none()` assertion below already true before `select_worktree`
+            // ever ran - it would have passed against a reset that dropped that field entirely.
+            app.open_tree_context_menu(ContextTarget::Empty, 10.0, 10.0, window, cx);
+            app.start_tree_rename(repo.path().join("README.md"), false, window, cx);
+            app.request_tree_delete(repo.path().join("README.md"), false, cx);
+            assert!(
+                app.tree_clipboard.is_some()
+                    && app.tree_inline_edit.is_some()
+                    && app.tree_context_menu.is_some()
+                    && app.tree_delete_confirm.is_some(),
+                "premise: all four must genuinely be live before the switch"
+            );
+            app.select_worktree(1, window, cx);
+        });
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert!(app.tree_clipboard.is_none());
+            assert!(app.tree_inline_edit.is_none());
+            assert!(app.tree_context_menu.is_none());
+            assert!(app.tree_delete_confirm.is_none());
+        });
+        assert!(repo.path().join("README.md").exists());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remapping_moves_a_path_and_its_whole_subtree() {
+        let old = Path::new("/repo/src");
+        let new = Path::new("/repo/lib");
+        assert_eq!(remap_path(old, old, new), Some(PathBuf::from("/repo/lib")));
+        assert_eq!(
+            remap_path(Path::new("/repo/src/inner/a.rs"), old, new),
+            Some(PathBuf::from("/repo/lib/inner/a.rs"))
+        );
+        assert_eq!(remap_path(Path::new("/repo/other.rs"), old, new), None);
+        // A sibling whose name merely *starts with* the renamed one must not be caught:
+        // `Path::strip_prefix` is component-wise, not textual.
+        assert_eq!(remap_path(Path::new("/repo/srcs/a.rs"), old, new), None);
+    }
+
+    #[test]
+    fn only_plain_paths_inside_the_worktree_are_operable() {
+        let root = Path::new("/repo");
+        assert!(is_inside_worktree(root, Path::new("/repo/src/main.rs")));
+        assert!(!is_inside_worktree(root, Path::new("/repo")));
+        assert!(!is_inside_worktree(root, Path::new("/elsewhere/a.rs")));
+        assert!(!is_inside_worktree(root, Path::new("/repo/../escape.rs")));
+    }
+
+    #[test]
+    fn a_pending_delete_says_exactly_what_it_will_do() {
+        let trash = PendingTreeDelete {
+            path: PathBuf::from("/repo/a.rs"),
+            is_dir: false,
+            mechanism: DeleteMechanism::Trash {
+                program: "gio",
+                args: Vec::new(),
+            },
+        };
+        assert_eq!(trash.confirm_label(), "Move to Trash");
+        assert!(trash.explanation().contains("trash"));
+
+        let permanent = PendingTreeDelete {
+            path: PathBuf::from("/repo/src"),
+            is_dir: true,
+            mechanism: DeleteMechanism::Permanent,
+        };
+        assert_eq!(permanent.confirm_label(), "Delete permanently");
+        assert!(
+            permanent.explanation().contains("Permanently")
+                && permanent
+                    .explanation()
+                    .contains("folder and everything in it"),
+            "a permanent delete of a folder must say both of those things out loud: {}",
+            permanent.explanation()
+        );
+        assert!(
+            !permanent.explanation().to_lowercase().contains("trash to")
+                && !permanent.explanation().starts_with("Move"),
+            "the permanent branch must never claim a trash that doesn't happen"
+        );
+    }
+}


### PR DESCRIPTION
Closes #19.

**Stacked on #22** (issue #18's file-tree state/visuals PR) - this PR's diff is #19's own changes only. Please merge #22 first; this will auto-retarget to `master` once that lands.

## Summary

**Context menu**: real right-click menus on a file row, a folder row, and the empty area below the tree, matching the issue's own lists exactly (Open/Rename/Duplicate/Cut/Copy/Paste/Copy Path/Copy Relative Path/Delete/Reveal-in-OS for files; the folder and empty-area equivalents, including New File/New Folder/Collapse Subtree/Collapse All). Keyboard accessible via `Shift+F10`; Esc or a click on the scrim dismisses; the popover flips and clamps to stay inside the window near screen edges. Built from this app's own existing `render_plus_menu` scrim+popover shape rather than a new mechanism (Zed's real `ui::ContextMenu` lives in Zed's `ui` crate, not the vendored `gpui`, so it wasn't available to reuse directly).

**Creating and renaming**: inline name editors woven into the tree's real virtualized list at the correct depth - Enter confirms, Esc cancels, invalid names are rejected with a real hint. Validation is shared with the existing tab-strip "New file" flow (`file_ops::validate_entry_name`/`create_file_named`), not duplicated. Rename is real and remaps every path-keyed piece of state that needs it - open tabs, the open diff, edit buffers (both the map key and each buffer's own absolute save path), persisted fold state - for a whole subtree when a folder is renamed, so nothing is left pointing at a path that no longer exists.

**Clipboard and delete**: real `Ctrl+C/X/V` scoped to the tree. Pasting into the source folder produces a real auto-suffixed name (`foo.rs` → `foo copy.rs` → `foo copy 2.rs`); a cut immediately pasted back into its own folder is correctly a no-op, not a self-rename. Delete requires a real confirmation modal, dismissible with Esc. Deleting prefers the real OS trash: on Linux/FreeBSD, `gio trash -- <path>` (GLib's own wrapper around `g_file_trash`, implementing the real freedesktop.org trash spec, verified by running it against both a file and a non-empty directory and confirming both landed in `~/.local/share/Trash/files`) - no new dependency. macOS and Windows have no equivalent reliable CLI trash command available (macOS's only real option is an AppleScript string needing hand-escaped path quoting; Windows has no built-in recycle-bin CLI), so those platforms get a real, honestly-labeled permanent delete ("Delete permanently") rather than a fake "moved to trash" claim for something that didn't actually happen. A failed trash attempt never silently escalates to a hard delete.

**Worktree and watcher consistency**: verified directly rather than assumed - this app has no filesystem watcher at all. Git already sees these changes for free once they hit disk, but the sidebar and diff view only refresh on an explicit reload, so every file operation ends by calling the same real `refresh_after_file_op` that re-walks both. The inline create/rename editor's state lives on the app itself (not inside the file-tree structure a reload replaces wholesale) and is re-anchored by path each frame, so an in-progress rename survives a concurrent reload rather than being silently discarded.

## Review process

Built, then adversarially reviewed by a genuinely separate, dispatched checker sub-agent (not a self-review relabeled - the earlier PRs today surfaced a real process risk around exactly this distinction, so I want to be precise: a real second agent ran and reported back independently here). It found no fake/unwired functionality, and 11 real bugs, all fixed with regression tests:

- `reviewed_files` remapped in the wrong key space on rename (a silent no-op)
- cut+paste into the source folder silently renaming instead of no-op'ing
- stale per-document LSP state surviving a rename/delete, silently killing diagnostics for a path recreated at the same name
- focus left dangling when leaving the Files tab
- context-menu overlays floating over the Settings surface
- a blocking, synchronous recursive copy running on the foreground thread (now on the background executor)
- a failed copy leaving a half-copied tree behind instead of cleaning up
- a symlink-to-directory aborting the whole copy instead of being followed
- a helper for forgetting deleted paths that didn't mirror the rename helper's own path-remapping logic
- the context menu's computed height running 2px short of what actually painted
- Escape not dismissing the delete confirmation modal

Two of the checker's own claims were themselves wrong and were corrected against the real source rather than accepted at face value (an LSP key-space characterization, and an overstated claim about what protects terminal keystrokes from the new menu's keybindings) - recorded honestly in the BUILD-LOG entry alongside the real findings, not smoothed over.

I independently re-verified directly: all four gates re-run myself, the background-executor copy fix and the real `gio trash` invocation both spot-checked directly in source and confirmed to match what was reported.

## Known, honest gaps (documented in code, not hidden)

- The macOS/Windows branches of the existing "open in OS file manager" command and this PR's own "no trash available" branches compile but have never actually executed in this Linux-only sandbox - covered by pure decision-logic tests, not real execution.
- `F2`/`Shift+F10` on a *file* row need a right-click or a folder-row click first, since a left-click on a file opens it and moves focus into the code editor - reclaiming that focus for a keyboard shortcut would break normal typing.
- There's no up/down arrow-key tree navigation yet - out of scope per the issue's own text (multi-select and bulk operations are explicitly excluded).

## Verification

- `cargo fmt --all -- --check`, `cargo build --workspace`, `cargo clippy --workspace --all-targets -- -D warnings` all clean.
- `cargo test --workspace --lib -- --test-threads=1`: **847 app tests** (up from 795 on the base branch), 42 lsp-core + 14 pty-core + 98 wt-core unchanged, 0 failures.

## Test plan

- [x] Right-click a file/folder/empty area opens the correct, matching menu
- [x] Rename updates every open tab, the diff view, and edit-buffer state - no orphaned buffer left on the old path
- [x] Rename of a folder remaps its whole open subtree, not just direct children
- [x] Delete requires real confirmation; a single click never deletes
- [x] Paste into the source folder produces a real auto-suffixed name, never a silent overwrite
- [x] A cut immediately pasted back into its own source folder is a no-op
- [x] A watcher-triggered (or otherwise concurrent) tree reload never discards an in-progress inline rename/create
- [x] Empty-area "Collapse All" calls the exact same reset #18 built for the Files header button - proven by checking the persisted fold-state file on disk, not just in-memory state
- [x] `Shift+F10` opens the context menu without swallowing a keystroke a focused text input needed
- [x] A large recursive copy runs off the UI thread and a failed copy cleans up what it created rather than leaving a partial tree