### PR TITLE
fix(lsp-core,app): bound LSP writes, detect hung servers, add a real restart

### DIFF
--- a/BUILD-LOG.md
+++ b/BUILD-LOG.md
@@ -3930,3 +3930,95 @@ diff_render_tests` flake - a different test in that module than the two previous
 this repo's own notes (`repeated_refreshes_of_the_same_open_diff_reuse_the_cached_highlighting`
 this time), same timing-sensitive family, `diff_view.rs` untouched anywhere by this change -
 confirmed it passes cleanly in isolation, and the subsequent full-suite re-run above was clean.
+
+## Fix: language servers silently dying, with no health check and no way back
+
+A real, user-reported reliability complaint - "even when they're installed they disconnect or
+don't work" - traced to two genuinely distinct bugs, one of them live-reproduced, the other
+structural. Both are the same class this project's discipline exists to catch: silently degrading
+instead of failing honestly, and failing to recover when it legitimately could.
+
+**Live-reproduced root cause: a server that is alive but has stopped reading its stdin wedged the
+client permanently.** Driven against a real child process that completed a real handshake and then
+stopped draining its stdin, a single 256 KiB `textDocument/didChange` never returned - the pipe's
+own ~64 KiB kernel buffer filled and `write_all` parked with no time bound whatsoever. Worse, it
+parked *holding* `LspClient`'s `stdin` mutex, which meant the per-request timeout this crate
+documents was not a real timeout at all: a subsequent `textDocument/hover` carrying an explicit
+**3-second** budget was measured still unfinished **8 seconds** later, because it never got as far
+as its own `recv_timeout`. And since the process was genuinely still alive, the reader thread never
+saw EOF, so `is_connection_alive()` kept answering `true` throughout. Nothing anywhere could say
+what had happened. Revision R8.5b's own crash detection was re-verified and is intact and fast (a
+real `SIGKILL` flips the flag in ~330ns; writes then fail `BrokenPipe` in ~40µs) - it simply never
+covered the hung-but-alive case, which has no EOF to observe.
+
+Fixed by giving writes a real bound: the child's stdin is set `O_NONBLOCK` once at spawn, and every
+outbound message now goes through a new `transport::write_message_bounded` that owns its waiting via
+a deadline-bounded `poll`. POSIX is explicit that a blocking `write()` past `PIPE_BUF` returns only
+once *all* bytes are written, so "poll, then write the rest" on a blocking fd would still have
+parked mid-frame - hence the non-blocking fd rather than the cheaper-looking alternative. The budget
+is a *no-progress* one, refreshed on every byte the peer accepts, so a large frame against a merely
+slow server costs nothing; only a peer that has accepted nothing at all for 30 seconds trips it. A
+write that cannot finish ends the connection honestly, and a connection already known dead now fails
+writes immediately - that early-out is its own measured fix, since without it the first write
+correctly gave up after 30s and a 3-second-timeout hover still sat there 12 seconds later, refilling
+and re-timing-out the same wedged pipe.
+
+**Structural root cause: there was no recovery path at all, and no health check on any cadence.**
+`is_connection_alive` has been an honest signal since R8.5b, but nothing ever *checked* it
+periodically - only `lsp_file_status` read it, i.e. only while the dead server's own language
+happened to be the file on screen. Meanwhile `spawn_lsp_client` deliberately no-ops for a key that
+already has an entry *in any state*, and nothing ever removed one whose process had died. So a dead
+`rust-analyzer` stayed `Ready` in `lsp_clients` for the window's life, with every sync tick, hover
+and completion still routed at a process that would never answer; the only real way back was to
+switch worktrees and back, or restart the app - neither discoverable as a fix for "diagnostics
+stopped appearing". Now a real liveness sweep runs on the existing 250ms poll loop and demotes a
+dead client to a named `Failed` state (which also stops further doomed requests, since the
+connection then stops resolving), and a real `restart_lsp_clients` frees the key so the ordinary
+render path spawns fresh - reachable both from a new `Restart Language Servers` palette command and
+by clicking the failed status chip in the File view footer, which is where a user who has noticed
+the problem is actually looking. Automatic respawning was deliberately not chosen: a server that
+died analyzing a particular file will likely die again on it, turning one honest failure into an
+invisible crash loop. Real Zed was checked in the vendored tree rather than assumed and makes the
+same call - a user-invoked `"Restart Server"` entry, no automatic post-crash respawn.
+
+The verification here is honestly bounded and worth stating: the real GUI could not be driven in
+this sandbox (screenshots come back black under WSLg's rootless X, and there is no `xdotool`/`wtype`
+or sudo to install one), so the app binary was launched for real but not clicked. Everything else
+was driven against real processes - including a real, installed `rust-analyzer` frozen with
+`SIGSTOP`, which is what a deadlocked or thrashing server genuinely looks like.
+
+An adversarial review was dispatched to a checker sub-agent and its report genuinely received (this
+is a real sub-agent finding, not self-review). It found eight real issues, several serious, and one
+of them was a **new data-corruption bug introduced by the first fix itself**: writers queue on the
+`stdin` mutex, so every concurrent hover/completion/pull has already passed the liveness check and
+is parked on the lock while one writer is mid-frame - and the wedged writer released the guard
+*before* publishing the death, letting the next writer emit a perfectly-formed frame into a peer
+whose framer was mid-body, to be swallowed as the previous message's payload. Fixed by publishing
+the death while still holding the guard and re-checking liveness after acquiring it, with a
+regression test using two real threads against a real frozen rust-analyzer - verified to genuinely
+fail without the fix, not merely to pass with it. The same review found: the reader thread's own
+reply writer had no early-out and could re-create the original symptom from a different direction;
+`restart_lsp_clients` did not cancel in-flight sync/completion tasks, which could re-pollute the
+bookkeeping it had just cleared for a real ~8 seconds and leave the old process alive alongside the
+new one - the exact "worse silent failure" that method's own doc claimed to prevent; restarting a
+`Spawning` entry could double-spawn; the reap ran `LspClient::drop` (a `/proc` walk plus real
+`kill(2)`s) on the GPUI foreground thread; a `flush` failure after a fully-written frame was
+reported as a mid-frame desync; and four doc comments overstated things, one citing a function that
+does not exist. All fixed. One review finding was deliberately answered with documentation rather
+than code: killing the connection when a write times out having accepted *zero* bytes is a policy
+call, not a correctness requirement, and is now named as one - it is defensible because the budget
+measures stalled time, and because the counterweight is a real one-click restart rather than a dead
+end.
+
+Two tests were written honestly rather than optimistically. The attempt to reproduce the
+stale-task interleaving as a *symptom* was abandoned after verifying it passed identically with and
+without the fix - GPUI's deterministic test executor collapses exactly that window - so it pins the
+mechanism instead and says so. And a test originally named as if it proved a server "comes back" was
+renamed to what it actually proves (the spawn guard is genuinely freed and a real attempt reaches
+the OS); the real end-to-end recovery is proven separately, by the chip-click test, which genuinely
+observed a fresh `rust-analyzer` spawn and reach `Ready` after a real painted-bounds click.
+
+All four gates clean. 907 tests passing, up from a real 896 baseline (+11): 748 app, 47 lsp-core, 14
+pty-core, 98 wt-core. `lsp-core` also re-checked for `x86_64-pc-windows-gnu`, where the bounded
+write is honestly documented as narrower (no `poll` for Windows anonymous pipes), matching the same
+real, tracked platform split `kill_process_tree` already carries.

--- a/crates/app/src/code_surface/file_view.rs
+++ b/crates/app/src/code_surface/file_view.rs
@@ -291,7 +291,8 @@ impl AdeApp {
         };
 
         let cursor = self.code_cursor;
-        let status_bar = render_file_status_bar(parsed, cursor, lsp_status.as_ref(), lsp_binary);
+        let status_bar =
+            render_file_status_bar(parsed, cursor, lsp_status.as_ref(), lsp_binary, cx);
         let truncated = parsed.truncated;
         // Real, editable file-view state (Revision R8.5a): whichever `EditBuffer`
         // `spawn_file_load`'s completion already lazily seeded for `relative_path` (`None` only
@@ -1108,6 +1109,7 @@ pub(in crate::code_surface) fn render_file_status_bar(
     cursor: Option<usize>,
     lsp_status: Option<&LspFileStatus>,
     lsp_binary: Option<&str>,
+    cx: &mut Context<AdeApp>,
 ) -> impl IntoElement {
     let position = cursor
         .map(|line| format!("ln {line}"))
@@ -1130,7 +1132,20 @@ pub(in crate::code_surface) fn render_file_status_bar(
 
     if let Some(status) = lsp_status {
         let (dot_color, label) = lsp_status_label(status, lsp_binary);
-        bar = bar
+        // A `Failed` status is the one status a user can actually *do* something about, so it is
+        // the one status that is clickable: it restarts this worktree's language servers, the
+        // same real `AdeApp::restart_lsp_clients` the `Restart Language Servers` palette command
+        // runs. Without it the recovery path exists but is only reachable by already knowing to
+        // look for it in the palette - and the failing chip is precisely where a user who has
+        // noticed their diagnostics stop is looking. Every other status is left inert rather than
+        // given a handler that would silently no-op (the same rule `render_diff_row` follows).
+        let failed = matches!(status, LspFileStatus::Failed(_));
+        let mut chip = div()
+            .id("file-view-lsp-status")
+            .debug_selector(|| "file-view-lsp-status".to_string())
+            .flex()
+            .items_center()
+            .gap(px(10.0))
             .child(
                 div()
                     .flex_none()
@@ -1140,6 +1155,18 @@ pub(in crate::code_surface) fn render_file_status_bar(
                     .bg(dot_color),
             )
             .child(label);
+        if failed {
+            chip = chip
+                .cursor_pointer()
+                .hover(|el| el.bg(theme::surface::ROW_HOVER_ALT))
+                .tooltip(crate::root::widgets::text_tooltip(
+                    "Click to restart this worktree's language servers",
+                ))
+                .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
+                    this.restart_lsp_clients(cx);
+                }));
+        }
+        bar = bar.child(chip);
     }
 
     bar.child(parsed.language)
@@ -1463,5 +1490,76 @@ mod lsp_status_label_tests {
             lsp_status_label(&LspFileStatus::Indexing, None).1,
             "language server: indexing..."
         );
+    }
+}
+
+/// The File view footer's failed-status chip is the one place a user who has *noticed* their
+/// language server stop is actually looking, so it is a real, clickable recovery - driven here
+/// through a genuine painted-bounds click, the same idiom the status bar's own zoom-value test
+/// uses, rather than by calling the handler directly.
+///
+/// Without this, the recovery existed but was reachable only by already knowing to search the
+/// command palette for it - which is not a recovery path a user can find.
+#[cfg(test)]
+mod lsp_failed_status_chip_tests {
+    use super::*;
+    use crate::lsp::client::LspClientState;
+    use gpui::TestAppContext;
+
+    const CHIP_SELECTOR: &str = "file-view-lsp-status";
+
+    #[gpui::test]
+    async fn clicking_the_failed_status_chip_really_restarts_the_language_servers(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let root = repo.path().to_path_buf();
+        std::fs::create_dir_all(root.join("src")).expect("mkdir src");
+        let main_rs = root.join("src").join("main.rs");
+        std::fs::write(&main_rs, "fn main() {}\n").expect("write main.rs");
+
+        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+        let key = (root.clone(), "rust-analyzer");
+        app.update_in(cx, |app, window, cx| {
+            // A real, already-recorded failure - exactly the state `reap_dead_lsp_clients` puts a
+            // dead server into on the poll cadence.
+            app.lsp_clients.insert(
+                key.clone(),
+                LspClientState::Failed(
+                    "rust-analyzer's connection was lost (the process exited or stopped \
+                     responding)"
+                        .to_string(),
+                ),
+            );
+            app.open_file_view(main_rs.clone(), window, cx);
+        });
+        cx.run_until_parked();
+        app.update(cx, |app, cx| {
+            app.render_center_pane(cx);
+        });
+        cx.run_until_parked();
+
+        let bounds = cx
+            .debug_bounds(CHIP_SELECTOR)
+            .expect("a file with a failed language server must paint its real status chip");
+        cx.simulate_click(bounds.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        // The real, complete recovery, observed rather than assumed: the click freed the key, the
+        // very next render's own `ensure_lsp_client` spawned a genuinely new `rust-analyzer`, and
+        // it completed a real handshake into `Ready`. Before this fix `spawn_lsp_client` would
+        // have found the `Failed` entry still sitting there and done nothing at all.
+        app.read_with(cx, |app, _| {
+            let state = app
+                .lsp_clients
+                .get(&key)
+                .expect("the ordinary render path should have re-populated this key");
+            assert!(
+                matches!(state, LspClientState::Spawning | LspClientState::Ready(_)),
+                "a real click on the failed chip must run the same real \
+                 AdeApp::restart_lsp_clients the palette command does - the stale Failed entry \
+                 must be gone, replaced by a genuinely fresh spawn"
+            );
+        });
     }
 }

--- a/crates/app/src/lsp/client.rs
+++ b/crates/app/src/lsp/client.rs
@@ -136,6 +136,21 @@ fn lsp_result_is_empty<T: serde::Serialize>(value: &T) -> bool {
     }
 }
 
+/// The one real "this server is gone" message, shared by [`LspConnection::liveness_failure_reason`]
+/// (which reports it for the file being rendered) and [`AdeApp::reap_dead_lsp_clients`] (which
+/// records it into [`LspClientState::Failed`] on the poll cadence) so the two can't drift into
+/// telling the user two different things about the same dead process.
+///
+/// Says "exited or stopped responding", not just "exited", because both are now real, distinct
+/// ways `lsp_core::LspClient::is_connection_alive` genuinely goes `false`: the reader thread
+/// seeing EOF (a crash/kill), and an outbound write that the server never accepted within
+/// `lsp-core`'s own write budget (a hung-but-alive server - see that crate's
+/// `transport::write_message_bounded`). Naming only the first would be actively wrong for the
+/// second.
+fn connection_lost_message(server: &str) -> String {
+    format!("{server}'s connection was lost (the process exited or stopped responding)")
+}
+
 impl LspConnection {
     fn primary(&self) -> &std::sync::Arc<lsp_core::LspClient> {
         match self {
@@ -299,10 +314,7 @@ impl LspConnection {
             .flatten()
         {
             if !client.is_connection_alive() {
-                return Some(format!(
-                    "{}'s connection was lost (the process exited unexpectedly)",
-                    client.name()
-                ));
+                return Some(connection_lost_message(client.name()));
             }
         }
         None
@@ -537,30 +549,186 @@ impl AdeApp {
             let Some(state) = self.lsp_clients.remove(&key) else {
                 continue;
             };
-            if let LspClientState::Ready(client) = state {
-                let server_name = client.name();
-                let task = cx.background_executor().spawn(async move {
-                    match std::sync::Arc::try_unwrap(client) {
-                        Ok(mut client) => {
-                            if let Err(err) = client.shutdown() {
-                                log::warn!("failed to shut down {server_name}: {err}");
-                            }
-                        }
-                        Err(client) => {
-                            // Some other clone is still alive - see this method's own docs.
-                            // Dropping it here is still real cleanup via `Drop`, just not the
-                            // graceful path.
-                            drop(client);
-                        }
-                    }
-                });
-                self._lsp_tasks.push(task);
-            }
+            self.shutdown_lsp_client_off_thread(state, cx);
             // `Spawning`/`Failed` states hold no process to tear down. A `Spawning` one whose
             // background task is still in-flight will, once it resolves, re-insert an entry
             // under `key` even though it's no longer active - harmless: the next eviction pass
             // catches it same as any other stale entry.
         }
+    }
+
+    /// Tears one real server down without blocking the GPUI thread - the shared body behind both
+    /// [`Self::evict_stale_lsp_clients`] and [`Self::restart_lsp_clients`], so the
+    /// `try_unwrap`-then-`shutdown`-else-`drop` rule lives in exactly one place. See
+    /// [`Self::evict_stale_lsp_clients`]'s own docs for why each half of that rule is what it is.
+    fn shutdown_lsp_client_off_thread(&mut self, state: LspClientState, cx: &mut Context<Self>) {
+        let LspClientState::Ready(client) = state else {
+            // `Spawning`/`Failed` hold no process to tear down.
+            return;
+        };
+        let server_name = client.name();
+        let task = cx.background_executor().spawn(async move {
+            match std::sync::Arc::try_unwrap(client) {
+                Ok(mut client) => {
+                    if let Err(err) = client.shutdown() {
+                        log::warn!("failed to shut down {server_name}: {err}");
+                    }
+                }
+                Err(client) => drop(client),
+            }
+        });
+        self._lsp_tasks.push(task);
+    }
+
+    /// Demotes every [`LspClientState::Ready`] entry whose real process has actually died to a
+    /// [`LspClientState::Failed`] one naming it. Returns `true` if anything changed, so
+    /// [`Self::ensure_lsp_poll_task`]'s loop - the one real cadence this runs on - can `cx.notify()`
+    /// only when there's something new to draw.
+    ///
+    /// ## The real bug this closes
+    ///
+    /// `lsp_core::LspClient::is_connection_alive` has been a real, honest signal since Revision
+    /// R8.5b, but nothing in this crate ever *checked* it on a cadence: it was read only by
+    /// `lsp_file_status`, i.e. only while the dead server's own language happened to be the file
+    /// being rendered. A dead `rust-analyzer` therefore stayed `Ready` in [`Self::lsp_clients`]
+    /// indefinitely while a TypeScript file was open, with every sync tick, hover and completion
+    /// still being routed at a process that will never answer, and nothing anywhere saying so.
+    ///
+    /// Demoting to `Failed` fixes both halves of that at once, because the rest of this module
+    /// already treats `Failed` correctly: [`Self::lsp_connection_for_path`] stops resolving a
+    /// connection at all (so no further doomed requests are dispatched), and [`lsp_file_status`]
+    /// reports the real message. It deliberately does **not** respawn - see
+    /// [`Self::restart_lsp_clients`] for why that stays the user's call.
+    pub(in crate::lsp) fn reap_dead_lsp_clients(&mut self, cx: &mut Context<Self>) -> bool {
+        let dead: Vec<(LspClientKey, String)> = self
+            .lsp_clients
+            .iter()
+            .filter_map(|(key, state)| {
+                let LspClientState::Ready(client) = state else {
+                    return None;
+                };
+                (!client.is_connection_alive())
+                    .then(|| (key.clone(), connection_lost_message(client.name())))
+            })
+            .collect();
+        if dead.is_empty() {
+            return false;
+        }
+        for (key, reason) in dead {
+            log::warn!("{reason} - it will not be used again until it is restarted");
+            let replaced = self.lsp_clients.insert(key, LspClientState::Failed(reason));
+            // The replaced `Ready` state is handed to the same off-thread teardown eviction and
+            // restart use, never just dropped here. Dropping the last `Arc` inline would run
+            // `lsp_core::LspClient`'s own `Drop` on the GPUI foreground thread - a `/proc`
+            // descendant walk, real `kill(2)` calls and a blocking reap - from inside this
+            // method's 250ms poll tick, breaking this file's own "never block the UI thread on
+            // process teardown" rule. Short in practice for an already-dead process, but the rule
+            // does not have a "probably fast" exemption.
+            if let Some(replaced) = replaced {
+                self.shutdown_lsp_client_off_thread(replaced, cx);
+            }
+        }
+        true
+    }
+
+    /// Throws away every language server for the active worktree root and lets the ordinary
+    /// render path start fresh ones - the real recovery action behind
+    /// [`crate::palette::state::PaletteCommand::RestartLanguageServers`] and the File view footer's own
+    /// clickable failed-status chip.
+    ///
+    /// ## Why this is a user action and not an automatic respawn
+    ///
+    /// Before this existed there was no recovery path at all: [`Self::spawn_lsp_client`]
+    /// deliberately no-ops for a key that already has an entry *in any state* (so a failure isn't
+    /// retried on every render), and nothing ever removed an entry whose process had died. The
+    /// only thing that did was [`Self::evict_stale_lsp_clients`], on a worktree switch - so the
+    /// sole real way a user could revive a dead server was to switch worktrees and back, or
+    /// restart the app, neither of which is discoverable as a fix for "diagnostics stopped
+    /// appearing".
+    ///
+    /// Automatic respawning was considered and deliberately not chosen. A server that died *while
+    /// analyzing a particular file* will very likely die again the moment it's handed that same
+    /// file, and an automatic loop turns one honest failure into a permanent, invisible
+    /// spawn/crash cycle - the opposite of this app's "honest status over magic" rule. Real Zed
+    /// makes the same call, and it was checked in the vendored tree rather than assumed: its own
+    /// recovery is a user-invoked `"Restart Server"` menu entry
+    /// (`vendor/zed/crates/language_tools/src/lsp_button.rs:476`) calling
+    /// `LspStore::restart_language_servers_for_buffers`; no automatic post-crash respawn path was
+    /// found in `vendor/zed/crates/project/src/lsp_store.rs` to point at (an absence, so cited as
+    /// one rather than as a verified line).
+    ///
+    /// ## Why the document bookkeeping has to be cleared too
+    ///
+    /// [`Self::lsp_opened_files`] is what makes `didOpen` fire exactly once per path, and the
+    /// version/sync maps describe a conversation with a process that no longer exists. Leaving
+    /// any of them behind would give the fresh server a file it was never told to open, or a
+    /// `didChange` at a version it never saw - a *worse* silent failure than the dead connection
+    /// this is recovering from, since everything would look alive while answering about nothing.
+    /// [`Self::lsp_uri_cache`] is deliberately kept: it is a pure path-to-`file://` mapping with
+    /// no server state in it at all, and dropping it would needlessly stall the next tick's
+    /// completions (see [`Self::prepare_lsp_sync`]'s own cache-miss branch).
+    pub(crate) fn restart_lsp_clients(&mut self, cx: &mut Context<Self>) {
+        let root = self.file_tree_root.clone();
+        // Dropped *first*, before a single map is cleared. Each of these is a real in-flight
+        // background task that ends by writing back into exactly the bookkeeping cleared below:
+        // `schedule_lsp_sync`'s continuation re-inserts `lsp_last_synced_content`/
+        // `lsp_synced_version` when its `did_change_full` returns `Ok`, and its diagnostics-pull
+        // retry loop re-inserts `lsp_diagnostics_confirmed_version` on every attempt - a window
+        // of `PULL_DIAGNOSTICS_EMPTY_RETRIES` x `PULL_DIAGNOSTICS_EMPTY_RETRY_DELAY`, about 8
+        // real seconds *after* the restart. A resurrected `lsp_last_synced_content` entry is the
+        // damaging one: `prepare_lsp_sync` reads it as "the server already has this content", so
+        // the freshly spawned server would never be sent a `didChange` for a dirty buffer and
+        // would answer forever about the file's on-disk text instead - a user who clicked restart
+        // because diagnostics stopped, and now silently gets diagnostics for the wrong content.
+        // Dropping a `Task` cancels it, which is also what stops a surviving task's captured
+        // `Arc<LspConnection>` clone from defeating `Arc::try_unwrap` in the teardown below and
+        // leaving the old server process alive alongside the new one. Same discipline, and the
+        // same ordering, as `AdeApp::select_worktree`'s own worktree-switch reset.
+        self._lsp_sync_tasks = std::collections::HashMap::new();
+        self._completions_request_task = None;
+
+        let keys: Vec<LspClientKey> = self
+            .lsp_clients
+            .keys()
+            .filter(|(key_root, _)| *key_root == root)
+            // A `Spawning` entry is deliberately left in place. Its own background task is still
+            // in flight and will re-insert under this key when it resolves, so removing it here
+            // would free the key for the next render to spawn a *second* real process for the
+            // same server - two rust-analyzers indexing one workspace, at real GB apiece.
+            // (`evict_stale_lsp_clients` tolerates that same re-insert only because its keys are
+            // no longer the active root's; that reasoning does not carry over here.) Nothing is
+            // lost by waiting: a spawn in flight is already the fresh start a restart is asking
+            // for, and if it resolves into a client that is itself dead, the poll loop's own
+            // `reap_dead_lsp_clients` catches it on the next tick.
+            .filter(|key| !matches!(self.lsp_clients.get(key), Some(LspClientState::Spawning)))
+            .cloned()
+            .collect();
+        for key in keys {
+            if let Some(state) = self.lsp_clients.remove(&key) {
+                log::info!("restarting {} for {}", key.1, root.display());
+                self.shutdown_lsp_client_off_thread(state, cx);
+            }
+        }
+
+        self.lsp_opened_files
+            .retain(|path| !path.starts_with(&root));
+        self.lsp_document_versions
+            .retain(|path, _| !path.starts_with(&root));
+        // Worktree-relative-keyed, and only ever holding the *active* worktree's paths (see
+        // `AdeApp::select_worktree`, which clears all three on a switch) - so
+        // clearing them outright is exactly "forget this root's conversation", not an
+        // over-broad reset.
+        self.lsp_last_synced_content.clear();
+        self.lsp_synced_version.clear();
+        self.lsp_diagnostics_confirmed_version.clear();
+        // Anything still on screen was computed from the connection just torn down - the same
+        // set `AdeApp::select_worktree` clears for the same reason.
+        self.dismiss_completions();
+        self.hover = None;
+        self.file_view_diagnostics = std::collections::HashMap::new();
+        // The next render's own `ensure_lsp_client`/`dispatch_did_open` calls do the real
+        // respawn and re-open, through exactly the same code path a cold start uses.
+        cx.notify();
     }
 
     /// Lazily spawns (or reuses) an `lsp_core::LspClient` for `repo_root` running the server for
@@ -842,6 +1010,12 @@ impl AdeApp {
                     crate::language::CompanionServer,
                     serde_json::Value,
                 )> = Vec::new();
+                // A real, cadence-driven health check, before anything else this tick reads
+                // `lsp_clients` - see `AdeApp::reap_dead_lsp_clients`'s own docs for the real
+                // silent-failure bug it closes.
+                if this.reap_dead_lsp_clients(cx) {
+                    any_update = true;
+                }
                 for (key, state) in this.lsp_clients.iter() {
                     if let LspClientState::Ready(client) = state {
                         if client.drain_updates() {
@@ -2749,6 +2923,351 @@ process.stdin.on('data', (d) => {
             "a companion mid-spawn says nothing yet - the primary's own honest 'no result for \
              this file yet' is the right answer"
         );
+    }
+
+    /// Waits for a genuinely spawned server's real process death to be observed by its client.
+    fn wait_until_dead(client: &lsp_core::LspClient) {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while client.is_connection_alive() {
+            assert!(
+                Instant::now() < deadline,
+                "the real process death should have been observed within 10s"
+            );
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    }
+
+    /// The real bug: nothing in this crate ever checked `is_connection_alive` on a *cadence*. It
+    /// was read only by [`lsp_file_status`], i.e. only while the dead server's own language
+    /// happened to be the file on screen - so a `rust-analyzer` that died while a TypeScript file
+    /// was open stayed `Ready` in `lsp_clients` indefinitely, with every sync tick, hover and
+    /// completion still routed at a process that would never answer, and nothing anywhere saying
+    /// so.
+    ///
+    /// Driven through a genuinely spawned process killed on cue, and through the real
+    /// [`AdeApp::reap_dead_lsp_clients`] the production poll loop calls - not a simulated state
+    /// flip.
+    #[gpui::test]
+    fn a_dead_ready_client_is_reaped_into_a_real_named_failed_state(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let client = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
+        let key: LspClientKey = (repo.path().to_path_buf(), "rust-analyzer");
+
+        app.update(cx, |app, cx| {
+            app.lsp_clients
+                .insert(key.clone(), LspClientState::Ready(client.clone()));
+            assert!(
+                !app.reap_dead_lsp_clients(cx),
+                "a genuinely alive client must never be reaped - that would be a self-inflicted \
+                 outage, not a fix"
+            );
+        });
+
+        // A real, unprompted process death, with no `shutdown()` - standing in for a crash.
+        client
+            .notify_raw("test/die", serde_json::Value::Null)
+            .expect("the fake server should accept the notification that kills it");
+        wait_until_dead(&client);
+
+        app.update(cx, |app, cx| {
+            assert!(
+                app.reap_dead_lsp_clients(cx),
+                "a real, dead process must be noticed on the poll cadence"
+            );
+            let Some(LspClientState::Failed(message)) = app.lsp_clients.get(&key) else {
+                panic!(
+                    "a dead client must be demoted to a real Failed state, got: {:?}",
+                    app.lsp_clients.get(&key).map(std::mem::discriminant)
+                );
+            };
+            assert!(
+                message.contains("rust-analyzer"),
+                "the recorded reason must name which real server died, got: {message}"
+            );
+            assert!(
+                !app.reap_dead_lsp_clients(cx),
+                "a second pass must report no change - the poll loop calls this every 250ms and \
+                 must not notify the window forever over one death"
+            );
+        });
+
+        // The real consequence that makes the demotion worth doing: no further request is routed
+        // at the dead process, because the connection no longer resolves at all.
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.lsp_connection_for_path(&repo.path().join("main.rs"))
+                    .is_none(),
+                "a reaped client must stop resolving into a usable connection"
+            );
+        });
+    }
+
+    /// The other half of the same bug, and the one a user actually feels: before this, there was
+    /// no recovery path at all. [`AdeApp::spawn_lsp_client`] deliberately no-ops for a key that
+    /// already has an entry *in any state*, and nothing ever removed one whose process had died -
+    /// so the only real way to revive a dead server was to switch worktrees and back, or restart
+    /// the app.
+    ///
+    /// Also pins the part that would be a *worse* silent failure if it were forgotten: the
+    /// per-server document bookkeeping has to go too. `lsp_opened_files` is what makes `didOpen`
+    /// fire exactly once per path, so a restart that left it behind would give the fresh server a
+    /// file it was never told to open - everything would look alive while answering about nothing.
+    #[gpui::test]
+    fn restarting_clears_the_dead_client_and_all_of_its_document_bookkeeping(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let root = repo.path().to_path_buf();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+        let opened = root.join("src").join("main.rs");
+        let relative = PathBuf::from("src/main.rs");
+
+        app.update(cx, |app, _cx| {
+            app.lsp_clients.insert(
+                (root.clone(), "rust-analyzer"),
+                LspClientState::Failed("rust-analyzer's connection was lost".to_string()),
+            );
+            app.lsp_opened_files.insert(opened.clone());
+            app.lsp_document_versions.insert(opened.clone(), 42);
+            app.lsp_last_synced_content
+                .insert(relative.clone(), "fn main() {}".to_string());
+            app.lsp_synced_version.insert(relative.clone(), 42);
+            app.lsp_diagnostics_confirmed_version
+                .insert(relative.clone(), 42);
+        });
+
+        app.update(cx, |app, cx| app.restart_lsp_clients(cx));
+
+        app.read_with(cx, |app, _| {
+            assert!(
+                !app.lsp_clients
+                    .contains_key(&(root.clone(), "rust-analyzer")),
+                "the entry has to be genuinely removed, not merely marked - `spawn_lsp_client` \
+                 no-ops for any key that still exists, so leaving it behind would mean the \
+                 restart silently did nothing at all"
+            );
+            assert!(
+                !app.lsp_opened_files.contains(&opened),
+                "a fresh server has been told about no files; leaving this behind would suppress \
+                 the real didOpen the next render owes it"
+            );
+            assert!(
+                !app.lsp_document_versions.contains_key(&opened),
+                "document versions describe a conversation with a process that no longer exists"
+            );
+            assert!(app.lsp_last_synced_content.is_empty());
+            assert!(app.lsp_synced_version.is_empty());
+            assert!(
+                app.lsp_diagnostics_confirmed_version.is_empty(),
+                "a stale confirmed-version would let the sync-pending banner claim a fresh \
+                 server's diagnostics were up to date before it had answered anything"
+            );
+        });
+    }
+
+    /// The race an adversarial review of this fix caught, and the nastier half of it: clearing
+    /// the bookkeeping is not enough on its own, because the tasks that *write* that bookkeeping
+    /// are still in flight when the restart happens.
+    ///
+    /// [`AdeApp::schedule_lsp_sync`]'s continuation captures its own `Arc<LspConnection>` at plan
+    /// time and never re-checks [`AdeApp::lsp_clients`] afterwards, so once past that point it
+    /// completes against the *old* client and writes back unconditionally: `lsp_last_synced_content`
+    /// and `lsp_synced_version` when its `did_change_full` returns `Ok`, and
+    /// `lsp_diagnostics_confirmed_version` on every attempt of a retry loop that runs for a real
+    /// ~8 seconds. A resurrected `lsp_last_synced_content` entry is the damaging one:
+    /// [`AdeApp::prepare_lsp_sync`] reads it as "the server already has this content", so the
+    /// freshly spawned server would never be sent a `didChange` for a dirty buffer and would
+    /// answer forever about the file's on-disk text - a user who restarted *because* diagnostics
+    /// went wrong then silently gets diagnostics for the wrong content.
+    ///
+    /// ## What this test does and does not prove
+    ///
+    /// It pins the **mechanism**, not the symptom: that a restart genuinely drops the in-flight
+    /// sync/completion tasks, which is what makes the write-back impossible. Reproducing the
+    /// interleaving itself was attempted and abandoned honestly - GPUI's deterministic test
+    /// executor collapses exactly the window in question (driving the clock runs the awaiting
+    /// continuation straight through to completion), so a test written against the symptom passes
+    /// identically with and without the fix, which was verified rather than assumed. The
+    /// assertions below do fail without it.
+    #[gpui::test]
+    async fn a_restart_drops_the_in_flight_tasks_that_would_repopulate_cleared_bookkeeping(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let root = repo.path().to_path_buf();
+        std::fs::create_dir_all(root.join("src")).expect("mkdir src");
+        let absolute = root.join("src").join("main.rs");
+        std::fs::write(&absolute, "fn main() {}\n").expect("write main.rs");
+        let relative = PathBuf::from("src/main.rs");
+
+        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+        let server = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
+        app.update_in(cx, |app, window, cx| {
+            app.lsp_clients.insert(
+                (root.clone(), "rust-analyzer"),
+                LspClientState::Ready(server.clone()),
+            );
+            app.open_file_view(absolute.clone(), window, cx);
+        });
+        cx.run_until_parked();
+
+        // A real, armed sync task through the real production entry point - and a real check that
+        // it is genuinely armed, so this can't quietly become a test of nothing.
+        app.update(cx, |app, cx| {
+            app.schedule_lsp_sync(relative.clone(), cx);
+        });
+        app.read_with(cx, |app, _| {
+            assert!(
+                app._lsp_sync_tasks.contains_key(&relative),
+                "sanity check: the real production call must genuinely arm a sync task, or the \
+                 assertion below proves nothing"
+            );
+        });
+
+        app.update(cx, |app, cx| app.restart_lsp_clients(cx));
+
+        app.read_with(cx, |app, _| {
+            assert!(
+                app._lsp_sync_tasks.is_empty(),
+                "an in-flight sync task outliving the restart re-records 'the server already has \
+                 this content' for a server that never saw it - the fresh server would then never \
+                 be sent a didChange at all"
+            );
+            assert!(
+                app._completions_request_task.is_none(),
+                "an in-flight completion request belongs to the connection just torn down"
+            );
+        });
+
+        // And the bookkeeping those tasks write is genuinely clear once everything drains.
+        cx.background_executor.advance_clock(LSP_SYNC_DEBOUNCE * 4);
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| {
+            assert!(app.lsp_last_synced_content.is_empty());
+            assert!(app.lsp_synced_version.is_empty());
+            assert!(app.lsp_diagnostics_confirmed_version.is_empty());
+        });
+    }
+
+    /// The recovery has to be reachable without already knowing where to look, so the palette
+    /// command is wired to the same real method the failed-status chip calls - proven by running
+    /// the real [`AdeApp::execute_palette_command`], not by asserting the enum variant exists.
+    #[gpui::test]
+    fn the_restart_palette_command_runs_the_real_restart(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let root = repo.path().to_path_buf();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+
+        app.update(cx, |app, _cx| {
+            app.lsp_clients.insert(
+                (root.clone(), "rust-analyzer"),
+                LspClientState::Failed("dead".to_string()),
+            );
+        });
+        assert!(
+            crate::palette::state::PaletteCommand::ALL
+                .contains(&crate::palette::state::PaletteCommand::RestartLanguageServers),
+            "a command absent from ALL never appears in the palette, so it is not a real \
+             recovery path a user can find"
+        );
+
+        app.update_in(cx, |app, window, cx| {
+            app.execute_palette_command(
+                crate::palette::state::PaletteCommand::RestartLanguageServers,
+                window,
+                cx,
+            );
+        });
+
+        app.read_with(cx, |app, _| {
+            assert!(
+                !app.lsp_clients
+                    .contains_key(&(root.clone(), "rust-analyzer")),
+                "the palette command must run the real restart, not a stub"
+            );
+        });
+    }
+
+    /// A live client dies, the real poll-cadence reap notices, the real restart clears it, and a
+    /// subsequent real spawn attempt genuinely *reaches the OS* under the same key.
+    ///
+    /// That last step is the whole point, and it is deliberately checked with a binary that
+    /// cannot exist rather than a real server: what has to be proven is that
+    /// [`AdeApp::spawn_lsp_client`]'s "already have an entry, do nothing" guard - the exact thing
+    /// that made a dead connection permanent - is genuinely cleared, and a real `Failed` outcome
+    /// proves an attempt was made where previously none would have been. This test does not
+    /// claim a working server comes back; that is `ensure_lsp_client`'s ordinary cold-start path,
+    /// already covered end to end against a real rust-analyzer by
+    /// `lsp_diagnostics_wiring_tests`.
+    #[gpui::test]
+    async fn a_restart_frees_the_key_so_a_fresh_spawn_is_really_attempted(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let root = repo.path().to_path_buf();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+        let key: LspClientKey = (root.clone(), "rust-analyzer");
+
+        let first = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
+        app.update(cx, |app, _cx| {
+            app.lsp_clients
+                .insert(key.clone(), LspClientState::Ready(first.clone()));
+        });
+        first
+            .notify_raw("test/die", serde_json::Value::Null)
+            .expect("notification accepted");
+        wait_until_dead(&first);
+        app.update(cx, |app, cx| {
+            assert!(app.reap_dead_lsp_clients(cx));
+        });
+
+        app.update(cx, |app, cx| app.restart_lsp_clients(cx));
+        // The real production spawn path, exactly as `render_file_view` drives it - with a
+        // deliberately non-existent binary swapped in via the same real `build_config` seam
+        // `ensure_lsp_client` uses, so this proves the *guard* is genuinely cleared without
+        // making the test depend on a real toolchain being installed. A `Failed` outcome here is
+        // a real spawn attempt that reached the OS; before the restart cleared the entry, no
+        // attempt would have been made at all.
+        app.update(cx, |app, cx| {
+            app.spawn_lsp_client(
+                key.clone(),
+                root.clone(),
+                || {
+                    Ok(lsp_core::ServerSpawnConfig {
+                        // Both fields carry the same deliberately-impossible marker: `name` is
+                        // what `LspError::Spawn` actually prints, and `binary` is what is really
+                        // handed to the OS - so the assertion below can only pass if a genuine
+                        // spawn was attempted and genuinely failed.
+                        name: "ade-no-such-language-server-binary",
+                        binary: "ade-no-such-language-server-binary",
+                        args: Vec::new(),
+                        initialization_options: None,
+                        workspace_configuration: lsp_core::default_workspace_configuration,
+                        custom_notification_methods: Vec::new(),
+                    })
+                },
+                cx,
+            );
+        });
+        app.read_with(cx, |app, _| {
+            assert!(
+                matches!(app.lsp_clients.get(&key), Some(LspClientState::Spawning)),
+                "the restart must leave the key genuinely free for a fresh spawn - a still-present \
+                 entry would make this call a silent no-op, which is the original bug"
+            );
+        });
+
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| {
+            let Some(LspClientState::Failed(message)) = app.lsp_clients.get(&key) else {
+                panic!("the real spawn attempt should have resolved to a real outcome");
+            };
+            assert!(
+                message.contains("ade-no-such-language-server-binary"),
+                "the real spawn error must be surfaced as-is, naming the binary that was actually \
+                 attempted - anything vaguer would let this pass without a real attempt having \
+                 been made: {message}"
+            );
+        });
     }
 
     /// The real, full relay round trip through the real production dispatch, with both halves

--- a/crates/app/src/palette/render.rs
+++ b/crates/app/src/palette/render.rs
@@ -276,6 +276,7 @@ impl AdeApp {
             palette::PaletteCommand::ToggleRailGrouping => self.toggle_rail_mode(cx),
             palette::PaletteCommand::PruneWorktrees => self.request_prune(cx),
             palette::PaletteCommand::OpenSettings => self.open_settings(window, cx),
+            palette::PaletteCommand::RestartLanguageServers => self.restart_lsp_clients(cx),
             // Also reachable from the Settings "General" page - both entry points call
             // `Self::set_window_controls_style`, never two independent copies.
             palette::PaletteCommand::WindowControlsSystem => {

--- a/crates/app/src/palette/state.rs
+++ b/crates/app/src/palette/state.rs
@@ -136,6 +136,13 @@ pub enum PaletteCommand {
     PruneWorktrees,
     /// `crate::root::AdeApp::open_settings`.
     OpenSettings,
+    /// `crate::root::AdeApp::restart_lsp_clients` - the real, discoverable recovery for a
+    /// language server that has died (see that method's own docs for why recovery is a user
+    /// action here rather than an automatic respawn). Deliberately always listed, not hidden
+    /// until something is broken: a user whose diagnostics have gone quiet is looking for this
+    /// *before* they know which server died, and a command that appears only once the app has
+    /// already diagnosed the problem is not a recovery path they can find.
+    RestartLanguageServers,
     /// Pins `crate::keymap::WindowControlsStyle::System`. These three variants and the
     /// Settings "General" page's `Window controls` row both call
     /// `crate::root::AdeApp::set_window_controls_style`, which mutates and persists the same
@@ -149,7 +156,7 @@ pub enum PaletteCommand {
 }
 
 impl PaletteCommand {
-    pub const ALL: [PaletteCommand; 10] = [
+    pub const ALL: [PaletteCommand; 11] = [
         PaletteCommand::NewShell,
         PaletteCommand::NewClaudeSession,
         PaletteCommand::NewCodexSession,
@@ -157,6 +164,7 @@ impl PaletteCommand {
         PaletteCommand::ToggleRailGrouping,
         PaletteCommand::PruneWorktrees,
         PaletteCommand::OpenSettings,
+        PaletteCommand::RestartLanguageServers,
         PaletteCommand::WindowControlsSystem,
         PaletteCommand::WindowControlsMacos,
         PaletteCommand::WindowControlsWindowsLinux,
@@ -171,6 +179,7 @@ impl PaletteCommand {
             PaletteCommand::ToggleRailGrouping => "Toggle Rail Grouping",
             PaletteCommand::PruneWorktrees => "Prune Worktrees",
             PaletteCommand::OpenSettings => "Open Settings",
+            PaletteCommand::RestartLanguageServers => "Restart Language Servers",
             PaletteCommand::WindowControlsSystem => "Window Controls: System Default",
             PaletteCommand::WindowControlsMacos => "Window Controls: macOS Style",
             PaletteCommand::WindowControlsWindowsLinux => "Window Controls: Windows/Linux Style",
@@ -188,6 +197,10 @@ impl PaletteCommand {
             PaletteCommand::ToggleRailGrouping => "rail grouping urgency project sessions",
             PaletteCommand::PruneWorktrees => "prune worktree remove delete cleanup merged",
             PaletteCommand::OpenSettings => "settings preferences agents worktrees config",
+            PaletteCommand::RestartLanguageServers => {
+                "lsp language server restart reconnect reload crashed died dead disconnected \
+                 hung stuck diagnostics hover completions rust-analyzer typescript pyright vue"
+            }
             PaletteCommand::WindowControlsSystem => {
                 "window controls title bar caption buttons dots platform override reset"
             }

--- a/crates/lsp-core/Cargo.toml
+++ b/crates/lsp-core/Cargo.toml
@@ -51,7 +51,7 @@ pty-core = { path = "../pty-core" }
 # since rust-analyzer is spawned as a plain `std::process::Command` child, not a pty session
 # leader). Pinned to the exact version `pty-core/Cargo.toml` already pins.
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.28", default-features = false, features = ["signal"] }
+nix = { version = "0.28", default-features = false, features = ["fs", "poll", "signal"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/lsp-core/src/client.rs
+++ b/crates/lsp-core/src/client.rs
@@ -30,9 +30,17 @@
 //! callers can be the GPUI foreground thread (a key-handler), where blocking on a full pty
 //! write buffer would freeze the UI. Every write this crate performs ([`LspClient::request`],
 //! [`LspClient::notify`]) is only ever called from inside `cx.background_executor().spawn(..)`
-//! by this workspace's convention, so blocking the *calling* background thread for the
-//! duration of a `write_all` to a child's stdin pipe (a small, fast syscall in the common
-//! case) is an acceptable, simpler alternative to a second thread and channel here.
+//! by this workspace's convention, so occupying the *calling* background thread for the
+//! duration of one write is an acceptable, simpler alternative to a second thread and channel
+//! here.
+//!
+//! What made that acceptable is no longer "the write is a small, fast syscall in the common
+//! case" - that was true in the common case and catastrophic outside it. The child's stdin is
+//! non-blocking (set in [`LspClient::spawn`]) and every write goes through
+//! [`transport::write_message_bounded`], which owns its own bounded waiting: a server that stops
+//! reading its stdin now costs one background thread a bounded [`WRITE_TIMEOUT`] and ends the
+//! connection honestly, instead of parking that thread forever while holding the writer mutex
+//! every other caller queues on.
 //!
 //! ## Why no self-pipe for reader-thread shutdown, unlike `pty-core`
 //!
@@ -154,6 +162,23 @@ const SHUTDOWN_GRACE_PERIOD: Duration = Duration::from_millis(800);
 /// re-checks real current state via [`LspClient::diagnostics_for`], so a dropped/coalesced wake
 /// never loses a real diagnostic, only a redundant "something changed" nudge).
 const WAKE_CHANNEL_CAPACITY: usize = 64;
+
+/// How long any one outbound message may spend waiting for a language server to accept it into
+/// its own stdin pipe before that write is treated as a real failure - see
+/// [`transport::write_message_bounded`]'s own docs for the live-reproduced unbounded hang this
+/// bound closes, and for why unix and Windows differ here.
+///
+/// Deliberately generous, and it bounds *stalled* time rather than total time: it is a
+/// no-progress budget (see [`transport::write_message_bounded`], which refreshes it on every byte
+/// the peer accepts), so a large frame against a server that is draining slowly costs nothing
+/// here no matter how long the whole write takes. It is only ever consumed while the kernel pipe
+/// buffer is completely full and the server has not read a single further byte of its stdin. A
+/// healthy server drains even a whole-file `didOpen` in milliseconds; one that has not touched
+/// its stdin for a full 30 seconds is not slow, it is not running. Matched to
+/// [`INITIALIZE_TIMEOUT`], the crate's other "something is deeply wrong" bound, rather than to
+/// the app's much tighter per-query timeouts, so an ordinary busy-server stall can never be
+/// misreported as a dead connection.
+const WRITE_TIMEOUT: Duration = Duration::from_secs(30);
 /// Hard bound on how many un-drained entries [`LspClient::drain_custom_notifications`]' own queue
 /// holds - see [`LspClient::custom_notifications`]'s docs. A server that sends an unrecognized
 /// notification faster than its caller drains one (or a caller that never drains at all, which is
@@ -478,6 +503,32 @@ impl LspClient {
             .take()
             .ok_or(LspError::MissingStdio { server: name })?;
 
+        // Every outbound byte this client ever writes goes through
+        // `transport::write_message_bounded`, which owns its own waiting via a real,
+        // deadline-bounded `poll` and therefore requires a genuinely non-blocking fd - see that
+        // function's own docs for the live-reproduced unbounded hang this is half of the fix for,
+        // and for why POSIX makes "poll, then write the rest" insufficient on a blocking fd. A
+        // failure here is fatal to the whole point (the client would silently fall back to
+        // unbounded blocking writes), so it is a real spawn error, not a warning.
+        #[cfg(unix)]
+        {
+            use std::os::fd::AsRawFd;
+            let fd = stdin.as_raw_fd();
+            let flags = nix::fcntl::fcntl(fd, nix::fcntl::FcntlArg::F_GETFL).map_err(|errno| {
+                LspError::Io {
+                    server: name,
+                    source: std::io::Error::from(errno),
+                }
+            })?;
+            let flags =
+                nix::fcntl::OFlag::from_bits_truncate(flags) | nix::fcntl::OFlag::O_NONBLOCK;
+            nix::fcntl::fcntl(fd, nix::fcntl::FcntlArg::F_SETFL(flags)).map_err(|errno| {
+                LspError::Io {
+                    server: name,
+                    source: std::io::Error::from(errno),
+                }
+            })?;
+        }
         let stdin = Arc::new(Mutex::new(stdin));
         let pending: Arc<Mutex<HashMap<i64, SyncSender<PendingResponse>>>> =
             Arc::new(Mutex::new(HashMap::new()));
@@ -511,8 +562,8 @@ impl LspClient {
                         wake_tx,
                         stdin: stdin_for_replies,
                         workspace_configuration,
+                        connection_alive,
                     },
-                    connection_alive,
                 )
             }
         });
@@ -995,15 +1046,9 @@ impl LspClient {
             "method": method,
             "params": params,
         });
-        {
-            let mut stdin = lock(&self.stdin);
-            if let Err(source) = transport::write_message(&mut *stdin, &message) {
-                lock(&self.pending).remove(&id);
-                return Err(LspError::Io {
-                    server: self.name,
-                    source,
-                });
-            }
+        if let Err(err) = self.write_framed(&message, method) {
+            lock(&self.pending).remove(&id);
+            return Err(err);
         }
 
         match rx.recv_timeout(timeout) {
@@ -1037,10 +1082,99 @@ impl LspClient {
             "method": method,
             "params": params,
         });
+        self.write_framed(&message, method)
+    }
+
+    /// The single real outbound path for every message this client sends - requests and
+    /// notifications alike - so the time bound and the "did that failure corrupt the stream"
+    /// rule below exist in exactly one place rather than per call site.
+    ///
+    /// A write that cannot complete within [`WRITE_TIMEOUT`] flips
+    /// [`Self::connection_alive`] to `false`, for both of the real reasons it can happen, which
+    /// are worth telling apart in the log but not in the outcome:
+    ///
+    /// * **A partial frame reached the server** ([`transport::BoundedWriteError::stream_desynced`]).
+    ///   Its framer is now mid-body waiting on bytes that will never arrive and will mis-frame
+    ///   everything after them. Unrecoverable by construction.
+    /// * **Not one byte was accepted in the whole budget.** Here the stream is provably still
+    ///   intact ([`transport::BoundedWriteError::stream_desynced`] is `false`), so killing the
+    ///   connection is a deliberate policy call rather than a correctness requirement, and worth
+    ///   naming as one: `connection_alive` is never set back to `true`, so this permanently ends
+    ///   a connection that a slower judgement might have let recover. It is the right call
+    ///   anyway. [`WRITE_TIMEOUT`] is a *no-progress* budget, so reaching it means a full pipe
+    ///   and zero bytes accepted for 30 consecutive seconds - not a busy server, a stopped one.
+    ///   And reporting that as merely "this one call failed" is exactly what produced the real,
+    ///   live-reproduced symptom this fixes: the client kept answering
+    ///   `is_connection_alive() == true` while every request piled up behind the stuck write's
+    ///   mutex, so the app had nothing honest to show and no reason to offer a restart. The
+    ///   counterweight to being wrong is real and cheap: the `app` crate surfaces this as a named
+    ///   `Failed` status with a one-click restart, rather than leaving it as a dead end.
+    ///
+    /// An ordinary I/O error that wrote nothing (the common `EPIPE` after a real crash) is left
+    /// alone: the reader thread's own EOF is already the real, direct signal there, and it
+    /// arrives first.
+    fn write_framed(
+        &self,
+        message: &serde_json::Value,
+        method: &'static str,
+    ) -> Result<(), LspError> {
+        // Once this connection is known dead, every further write fails immediately rather than
+        // spending its own full [`WRITE_TIMEOUT`] rediscovering the same fact. Live-measured, and
+        // the reason this early-out exists rather than being left to the loop below: against a
+        // real hung server, the *first* write correctly gave up after 30s - and then a
+        // `textDocument/hover` request carrying an explicit 3-second timeout still sat there
+        // 12 seconds later, because it had to fill and time out the same wedged pipe all over
+        // again. Fanned across hover, completions and each diagnostics-pull retry, that is the
+        // difference between an app that reports a dead server promptly and one that appears to
+        // hang for minutes.
+        if !self.is_connection_alive() {
+            return Err(LspError::ConnectionClosed { server: self.name });
+        }
         let mut stdin = lock(&self.stdin);
-        transport::write_message(&mut *stdin, &message).map_err(|source| LspError::Io {
-            server: self.name,
-            source,
+        // Re-checked **after** acquiring the lock, and this is load-bearing rather than
+        // defensive. Every concurrent caller (hover, completions, and each diagnostics-pull
+        // retry all run at once - see the `app` crate's `schedule_lsp_sync`) has already passed
+        // the check above and is queued right here while one writer is mid-frame. If that writer
+        // gives up part-way through, the peer's framer is left mid-body, and a queued writer that
+        // proceeded would have its own perfectly-formed frame swallowed as the *previous*
+        // message's body - silent, confident wire corruption, the exact class this whole fix
+        // exists to remove. The wedged writer publishes the death before releasing the guard
+        // (below), so by the time anyone else holds it, this check is guaranteed to see it.
+        if !self.is_connection_alive() {
+            return Err(LspError::ConnectionClosed { server: self.name });
+        }
+        let Err(err) = transport::write_message_bounded(&mut *stdin, message, WRITE_TIMEOUT) else {
+            return Ok(());
+        };
+
+        let desynced = err.stream_desynced();
+        let timed_out = matches!(err, transport::BoundedWriteError::Timeout { .. });
+        if timed_out || desynced {
+            // Published while the `stdin` guard is still held, deliberately: dropping the guard
+            // first would let a writer already queued on it wake up and write into the stream
+            // this call just desynced, before it had been told the connection was over.
+            self.connection_alive.store(false, Ordering::SeqCst);
+            log::warn!(
+                "marking {}'s connection dead: a `{method}` write {} within {WRITE_TIMEOUT:?}",
+                self.name,
+                if desynced {
+                    "was cut off part-way through, desyncing the server's own framer"
+                } else {
+                    "was not accepted at all - the server has stopped reading its stdin"
+                }
+            );
+        }
+        drop(stdin);
+        Err(if timed_out {
+            LspError::Timeout {
+                server: self.name,
+                method,
+            }
+        } else {
+            LspError::Io {
+                server: self.name,
+                source: err.into_io_error(),
+            }
         })
     }
 
@@ -1290,13 +1424,13 @@ struct IncomingSinks {
     wake_tx: SyncSender<()>,
     stdin: Arc<Mutex<ChildStdin>>,
     workspace_configuration: WorkspaceConfigFn,
+    /// The same flag [`run_reader_loop`] clears on EOF - shared in here too so the detached
+    /// server-request-reply writer in [`handle_incoming`] can report a write it could not finish,
+    /// which is just as fatal to the connection as EOF is (see that write's own comment).
+    connection_alive: Arc<AtomicBool>,
 }
 
-fn run_reader_loop(
-    stdout: std::process::ChildStdout,
-    sinks: IncomingSinks,
-    connection_alive: Arc<AtomicBool>,
-) {
+fn run_reader_loop(stdout: std::process::ChildStdout, sinks: IncomingSinks) {
     let mut reader = BufReader::new(stdout);
     loop {
         match transport::read_message(&mut reader) {
@@ -1317,7 +1451,7 @@ fn run_reader_loop(
     // `recv_timeout` gets a real, immediate `Disconnected` rather than waiting out its own
     // timeout for a response that will now never arrive.
     lock(&sinks.pending).clear();
-    connection_alive.store(false, Ordering::SeqCst);
+    sinks.connection_alive.store(false, Ordering::SeqCst);
 }
 
 fn handle_incoming(value: serde_json::Value, sinks: &IncomingSinks) {
@@ -1342,20 +1476,50 @@ fn handle_incoming(value: serde_json::Value, sinks: &IncomingSinks) {
             );
 
             // Written from a short-lived, detached thread rather than inline from this reader
-            // thread: `transport::write_message` is a blocking `write_all` to the child's
-            // stdin pipe, and if that pipe's OS write buffer is full at this moment (e.g.
-            // another thread is mid-write of a large un-chunked `textDocument/didOpen`),
-            // writing here would block this reader thread from draining the child's stdout -
-            // if the child is itself blocked writing to its own undrained stdout waiting for
-            // more stdin, neither side can make progress. Server-initiated requests needing a
-            // reply are rare (a handful per session, not a hot path), so the per-call
-            // thread-spawn cost is negligible; the spawned thread reuses the same
-            // lock-then-`write_message` path every other outbound message goes through
-            // (`LspClient::send_request_raw`/`send_notification_raw`).
+            // thread: the write is to the child's own stdin pipe, and if that pipe's OS write
+            // buffer is full at this moment (e.g. another thread is mid-write of a large
+            // `textDocument/didOpen`), writing here would stop this reader thread from draining
+            // the child's stdout - if the child is itself blocked writing to its own undrained
+            // stdout waiting for more stdin, neither side can make progress. Server-initiated
+            // requests needing a reply are rare (a handful per session, not a hot path), so the
+            // per-call thread-spawn cost is negligible.
             let stdin = Arc::clone(&sinks.stdin);
+            // This thread must follow **both** halves of `LspClient::write_framed`'s rule, not
+            // just the bounded-write half, and for a sharper reason than consistency: it takes
+            // the very mutex the whole client serializes on, and `write_framed`'s own early-out
+            // sits *before* that mutex. So a reply thread that sat here for a full
+            // `WRITE_TIMEOUT` against a wedged server would park every caller on the mutex behind
+            // it - reproducing, from a different direction, the exact "a request with a 3-second
+            // timeout takes 30" symptom this fix exists to remove. Hence: skip entirely if the
+            // connection is already known dead, re-check once the guard is held (same
+            // wire-corruption reason as `write_framed`'s own post-lock re-check), and publish a
+            // death before releasing the guard.
+            let connection_alive = Arc::clone(&sinks.connection_alive);
+            let method = method.to_string();
             std::thread::spawn(move || {
+                if !connection_alive.load(Ordering::SeqCst) {
+                    return;
+                }
                 let mut guard = lock(&stdin);
-                let _ = transport::write_message(&mut *guard, &reply);
+                if !connection_alive.load(Ordering::SeqCst) {
+                    return;
+                }
+                let Err(err) = transport::write_message_bounded(&mut *guard, &reply, WRITE_TIMEOUT)
+                else {
+                    return;
+                };
+                let desynced = err.stream_desynced();
+                // Matches `write_framed`'s own condition exactly rather than killing the
+                // connection for any error at all: a plain `EPIPE` that wrote nothing means the
+                // process is already gone, and the reader thread's own EOF is the real, direct
+                // signal for that - it arrives first and says it better.
+                if desynced || matches!(err, transport::BoundedWriteError::Timeout { .. }) {
+                    connection_alive.store(false, Ordering::SeqCst);
+                    log::warn!(
+                        "marking a connection dead: replying to a server-initiated `{method}` \
+                         failed ({err:?}); desynced={desynced}"
+                    );
+                }
             });
             return;
         }
@@ -1761,6 +1925,7 @@ mod tests {
                     wake_tx,
                     stdin: Arc::new(Mutex::new(stdin)),
                     workspace_configuration: default_workspace_configuration,
+                    connection_alive: Arc::new(AtomicBool::new(true)),
                 },
                 wake_rx,
             }
@@ -2431,6 +2596,205 @@ mod tests {
             );
             std::thread::sleep(Duration::from_millis(20));
         }
+    }
+
+    /// The other real way a language server stops working - and, unlike a crash, the one nothing
+    /// used to detect at all: the process stays **alive** but stops reading its own stdin.
+    ///
+    /// Live-reproduced before this fix, against a real child that had completed a real handshake:
+    /// a single 256 KiB `textDocument/didChange` never returned (the pipe's ~64 KiB kernel buffer
+    /// filled and `write_all` parked with no time bound), it parked *holding* the `stdin` mutex so
+    /// a subsequent `textDocument/hover` carrying an explicit 3-second timeout was still unfinished
+    /// 8 seconds later, and [`LspClient::is_connection_alive`] reported `true` throughout - the
+    /// reader thread never sees EOF for a process that hasn't exited. The whole connection silently
+    /// stopped working with nothing anywhere able to say why.
+    ///
+    /// `SIGSTOP` against a **real, installed rust-analyzer** is used rather than a scripted stand-in
+    /// precisely because this is the failure mode a stand-in would be easiest to fake: a stopped
+    /// process is genuinely still alive, genuinely still holds its end of the pipe open, and
+    /// genuinely never drains it - exactly what a deadlocked or thrashing real server does.
+    #[test]
+    fn a_real_but_frozen_server_fails_the_write_within_the_budget_instead_of_hanging_forever() {
+        let project = write_scratch_project("fn main() {\n    let x: i32 = 1;\n}\n");
+        let main_rs = project.path().join("src").join("main.rs");
+        let client = LspClient::spawn(project.path(), rust_analyzer_config())
+            .expect("a real rust-analyzer should spawn and handshake");
+        let pid = client.pid;
+        assert!(
+            client.is_connection_alive(),
+            "sanity check: a freshly handshaked client is alive"
+        );
+
+        // Freeze the real process. It keeps its end of the pipe open and never reads another byte.
+        nix::sys::signal::kill(
+            nix::unistd::Pid::from_raw(pid as i32),
+            nix::sys::signal::Signal::SIGSTOP,
+        )
+        .expect("a real SIGSTOP against the real rust-analyzer pid");
+
+        // Comfortably more than a pipe's ~64 KiB kernel buffer, so the write genuinely cannot
+        // complete into it - the same shape as a real whole-file sync for a large source file.
+        let oversized = "x".repeat(256 * 1024);
+        let started = Instant::now();
+        let result = client.did_change_full(&main_rs, oversized.clone(), 2);
+        let elapsed = started.elapsed();
+
+        // Cleaned up before any assertion can unwind past it: a still-`SIGSTOP`ped process would
+        // otherwise ignore the `SIGTERM` half of teardown and linger until the `SIGKILL`.
+        let _ = nix::sys::signal::kill(
+            nix::unistd::Pid::from_raw(pid as i32),
+            nix::sys::signal::Signal::SIGCONT,
+        );
+
+        assert!(
+            matches!(result, Err(LspError::Timeout { .. })),
+            "a write a frozen server never accepts must surface as a real timeout, got: {result:?}"
+        );
+        assert!(
+            elapsed < WRITE_TIMEOUT * 2,
+            "the write must give up on its own budget rather than blocking indefinitely - took \
+             {elapsed:?} against a {WRITE_TIMEOUT:?} budget"
+        );
+        assert!(
+            !client.is_connection_alive(),
+            "a write that could not be completed leaves the server's own framer mid-message; the \
+             connection must be reported dead rather than left looking healthy - this reporting \
+             `true` is exactly what made the original bug invisible"
+        );
+    }
+
+    /// The follow-up half of the same fix, and its own real, measured bug: once a connection is
+    /// known dead, further writes must fail *immediately* rather than each re-paying the full
+    /// [`WRITE_TIMEOUT`] rediscovering it.
+    ///
+    /// Measured live while building this: with the bounded write in place but no early-out, the
+    /// first write correctly gave up after its 30s budget, and a `textDocument/hover` carrying an
+    /// explicit 3-second timeout was *still* unfinished 12 seconds later - it had to fill and time
+    /// out the same wedged pipe all over again. Fanned across hover, completions and every
+    /// diagnostics-pull retry, that is the difference between reporting a dead server promptly and
+    /// appearing to hang for minutes.
+    #[test]
+    fn a_connection_already_known_dead_fails_further_writes_immediately() {
+        let project = write_scratch_project("fn main() {}\n");
+        let main_rs = project.path().join("src").join("main.rs");
+        let client = LspClient::spawn(project.path(), rust_analyzer_config())
+            .expect("a real rust-analyzer should spawn and handshake");
+        let pid = client.pid;
+
+        // A real, unprompted death - the reader thread observes EOF and flips the flag.
+        nix::sys::signal::kill(
+            nix::unistd::Pid::from_raw(pid as i32),
+            nix::sys::signal::Signal::SIGKILL,
+        )
+        .expect("a real SIGKILL against the real rust-analyzer pid");
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while client.is_connection_alive() {
+            assert!(
+                Instant::now() < deadline,
+                "the real process death should have been observed within 10s"
+            );
+            std::thread::sleep(Duration::from_millis(20));
+        }
+
+        let started = Instant::now();
+        let result = client.request::<lsp_types::request::HoverRequest>(
+            lsp_types::HoverParams {
+                text_document_position_params: lsp_types::TextDocumentPositionParams {
+                    text_document: lsp_types::TextDocumentIdentifier {
+                        uri: path_to_uri(&main_rs).expect("a real uri"),
+                    },
+                    position: lsp_types::Position {
+                        line: 0,
+                        character: 3,
+                    },
+                },
+                work_done_progress_params: Default::default(),
+            },
+            Duration::from_secs(30),
+        );
+        let elapsed = started.elapsed();
+        assert!(
+            matches!(result, Err(LspError::ConnectionClosed { .. })),
+            "a request on a known-dead connection must say so directly, got: {result:?}"
+        );
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "it must not re-pay any real timeout budget to rediscover a death already recorded - \
+             took {elapsed:?}"
+        );
+    }
+
+    /// A real, concurrent-writer regression, and one an adversarial review of this very fix
+    /// caught *in* the fix: the bounded write closed the unbounded hang but left a window in
+    /// which the corruption it exists to prevent could still happen.
+    ///
+    /// The shape: writers queue on the `stdin` mutex, so every concurrent hover/completion/pull
+    /// (all genuinely in flight at once - see the `app` crate's `schedule_lsp_sync`) has already
+    /// passed the "is this connection alive" check and is parked on the lock while one writer is
+    /// mid-frame. If that writer gives up part-way through and releases the guard *before*
+    /// publishing the death, the next writer emits a perfectly-formed frame into a peer whose
+    /// framer is mid-body - and those bytes get eaten as the previous message's payload. Silent,
+    /// confident wire corruption.
+    ///
+    /// Driven against a real, `SIGSTOP`ped rust-analyzer, with a real second thread genuinely
+    /// contending for the real mutex.
+    #[test]
+    fn a_writer_queued_behind_one_that_gives_up_is_refused_rather_than_corrupting_the_stream() {
+        let project = write_scratch_project("fn main() {}\n");
+        let main_rs = project.path().join("src").join("main.rs");
+        let client = Arc::new(
+            LspClient::spawn(project.path(), rust_analyzer_config())
+                .expect("a real rust-analyzer should spawn and handshake"),
+        );
+        let pid = client.pid;
+        nix::sys::signal::kill(
+            nix::unistd::Pid::from_raw(pid as i32),
+            nix::sys::signal::Signal::SIGSTOP,
+        )
+        .expect("a real SIGSTOP against the real rust-analyzer pid");
+
+        // Writer A: wedges on the frozen server for the full budget, holding the real mutex.
+        let wedged = {
+            let client = Arc::clone(&client);
+            let main_rs = main_rs.clone();
+            std::thread::spawn(move || client.did_change_full(&main_rs, "x".repeat(256 * 1024), 2))
+        };
+
+        // Writer B: a real second caller, started while A is definitely still inside its write,
+        // so it genuinely queues on the mutex rather than racing the liveness check.
+        std::thread::sleep(Duration::from_secs(2));
+        let queued = {
+            let client = Arc::clone(&client);
+            let main_rs = main_rs.clone();
+            std::thread::spawn(move || {
+                let started = Instant::now();
+                let result = client.did_change_full(&main_rs, "fn main() {}".to_string(), 3);
+                (result, started.elapsed())
+            })
+        };
+
+        let wedged_result = wedged.join().expect("writer A should not panic");
+        let (queued_result, queued_elapsed) = queued.join().expect("writer B should not panic");
+        let _ = nix::sys::signal::kill(
+            nix::unistd::Pid::from_raw(pid as i32),
+            nix::sys::signal::Signal::SIGCONT,
+        );
+
+        assert!(
+            matches!(wedged_result, Err(LspError::Timeout { .. })),
+            "sanity check: writer A should have given up on its own budget, got {wedged_result:?}"
+        );
+        assert!(
+            matches!(queued_result, Err(LspError::ConnectionClosed { .. })),
+            "the queued writer must be refused outright once the writer ahead of it desynced the \
+             stream - anything else means it wrote a frame the peer will swallow as the previous \
+             message's body: {queued_result:?}"
+        );
+        assert!(
+            queued_elapsed < WRITE_TIMEOUT * 2,
+            "the queued writer must be refused as soon as the lock is released, not left to time \
+             out on its own account - took {queued_elapsed:?}"
+        );
     }
 
     /// The real `ServerSpawnConfig` for typescript-language-server this test module spawns

--- a/crates/lsp-core/src/transport.rs
+++ b/crates/lsp-core/src/transport.rs
@@ -24,15 +24,213 @@ use std::io::{self, BufRead, Read, Write};
 /// outright-malicious peer.
 const MAX_MESSAGE_BYTES: usize = 64 * 1024 * 1024;
 
-/// Writes one real, framed JSON-RPC message: `Content-Length: <n>\r\n\r\n<json bytes>`, then
-/// flushes so the bytes actually leave this process rather than sitting in a `Write` adapter's
-/// internal buffer (load-bearing for a child process reading from a pipe with no buffering of
-/// its own to force a flush on).
-pub fn write_message<W: Write>(writer: &mut W, value: &serde_json::Value) -> io::Result<()> {
+/// Why a real [`write_message_bounded`] call gave up, and - load-bearing - **how far into the
+/// frame it got before it did**.
+///
+/// `bytes_written > 0` is not a detail: it means part of a `Content-Length`-framed message is
+/// already sitting in the peer's pipe with no way to finish it, so the peer's own framer is now
+/// permanently desynced (it is mid-body, waiting on bytes that will never arrive, and will
+/// mis-frame everything after them). A caller that sees that must treat the whole connection as
+/// dead rather than retrying on it - see [`crate::client::LspClient::is_connection_alive`]'s own
+/// docs for what actually acts on this.
+#[derive(Debug)]
+pub enum BoundedWriteError {
+    /// The caller's deadline elapsed with the peer still not accepting bytes.
+    ///
+    /// Never constructed on Windows: that platform's [`write_message_bounded`] is honestly
+    /// unbounded (no `poll` for anonymous pipes - see its own docs), so it can only ever produce
+    /// [`Self::Io`]. The `allow` documents that as the real, tracked platform gap it is, rather
+    /// than letting a dead-code warning fail the build for a variant unix genuinely uses - the
+    /// same pattern `crate::client` already uses for its own unix-only items.
+    #[cfg_attr(not(unix), allow(dead_code))]
+    Timeout { bytes_written: usize },
+    /// A real I/O error (the peer closed its read end, etc.).
+    Io {
+        source: io::Error,
+        bytes_written: usize,
+    },
+}
+
+impl BoundedWriteError {
+    /// `true` when a partial frame genuinely reached the peer - see this type's own docs for why
+    /// that is unrecoverable rather than merely a failed call.
+    pub fn stream_desynced(&self) -> bool {
+        match self {
+            Self::Timeout { bytes_written } | Self::Io { bytes_written, .. } => *bytes_written > 0,
+        }
+    }
+
+    /// The real underlying `io::Error`, synthesizing a [`io::ErrorKind::TimedOut`] one for the
+    /// timeout case so a caller that only wants to report *something* honest doesn't have to
+    /// match on the variant.
+    pub fn into_io_error(self) -> io::Error {
+        match self {
+            Self::Timeout { .. } => io::Error::new(
+                io::ErrorKind::TimedOut,
+                "the language server stopped reading its stdin",
+            ),
+            Self::Io { source, .. } => source,
+        }
+    }
+}
+
+/// Serializes `value` into one real, framed message: `Content-Length: <n>\r\n\r\n<json bytes>`.
+/// The single place this crate encodes the wire format, shared by both
+/// [`write_message_bounded`] platform paths (and exercised directly by this module's own
+/// round-trip tests) so no two writers can ever drift apart on it.
+fn frame(value: &serde_json::Value) -> io::Result<Vec<u8>> {
     let body = serde_json::to_vec(value).map_err(io::Error::from)?;
-    write!(writer, "Content-Length: {}\r\n\r\n", body.len())?;
-    writer.write_all(&body)?;
-    writer.flush()
+    let mut frame = Vec::with_capacity(body.len() + 32);
+    write!(&mut frame, "Content-Length: {}\r\n\r\n", body.len())?;
+    frame.extend_from_slice(&body);
+    Ok(frame)
+}
+
+/// Writes one real, framed JSON-RPC message to a **non-blocking** fd, giving up with a real
+/// [`BoundedWriteError::Timeout`] if `timeout` elapses before the peer accepts the whole frame.
+///
+/// ## The real bug this exists for
+///
+/// An ordinary blocking `write_all` of a framed message has no time bound at all, and that is
+/// not theoretical:
+/// live-reproduced against a real child process that completed a real LSP handshake and then
+/// stopped reading its stdin (`process.stdin.pause()`, standing in for a hung/SIGSTOPped/
+/// deadlocked server), a single 256 KiB `textDocument/didChange` never returned - the pipe's own
+/// ~64 KiB kernel buffer filled and `write_all` parked forever. Worse, it parks *holding*
+/// `LspClient`'s `stdin` mutex, so every later call on that client blocks on the mutex before it
+/// can even reach its own `recv_timeout`: a subsequent `textDocument/hover` request with an
+/// explicit **3-second** timeout was measured still unfinished 8 seconds later. And because the
+/// process is genuinely still alive, the reader thread never sees EOF, so
+/// `LspClient::is_connection_alive` keeps honestly-but-uselessly reporting `true` - the whole
+/// connection silently stops working with nothing anywhere saying why.
+///
+/// ## Why `O_NONBLOCK` rather than "poll, then write the rest"
+///
+/// POSIX is explicit that a blocking `write()` of more than `PIPE_BUF` bytes returns only once
+/// *all* `nbyte` have been written, so a "poll for `POLLOUT`, then write everything remaining"
+/// loop on a blocking fd would still park inside `write()` the moment the peer stalls mid-frame.
+/// Making the fd non-blocking once, at spawn (see [`crate::client::LspClient::spawn`]), removes
+/// that class of reasoning entirely: `write` then answers `EWOULDBLOCK` instead of parking, and
+/// this loop owns the waiting via a real, deadline-bounded `poll`.
+///
+/// `writer` must therefore genuinely be `O_NONBLOCK`; passing a blocking fd is not unsafe, it
+/// just silently gives back the unbounded behavior this function exists to remove.
+#[cfg(unix)]
+pub fn write_message_bounded<W: Write + std::os::fd::AsFd>(
+    writer: &mut W,
+    value: &serde_json::Value,
+    timeout: std::time::Duration,
+) -> Result<(), BoundedWriteError> {
+    use nix::poll::{PollFd, PollFlags, PollTimeout};
+
+    let frame = frame(value).map_err(|source| BoundedWriteError::Io {
+        source,
+        bytes_written: 0,
+    })?;
+    // A *no-progress* deadline, refreshed on every byte the peer actually accepts - not one
+    // budget for the whole frame. The difference is real: a single absolute deadline would kill a
+    // peer that is genuinely draining, just slowly (a large frame against a busy server), and
+    // report it as a desynced connection. What this bound is actually for is a peer that has
+    // stopped reading altogether, and "no progress at all for `timeout`" says exactly that.
+    let mut deadline = std::time::Instant::now() + timeout;
+    let mut written = 0usize;
+
+    while written < frame.len() {
+        match writer.write(&frame[written..]) {
+            Ok(0) => {
+                return Err(BoundedWriteError::Io {
+                    source: io::Error::new(io::ErrorKind::WriteZero, "wrote zero bytes"),
+                    bytes_written: written,
+                });
+            }
+            Ok(count) => {
+                written += count;
+                deadline = std::time::Instant::now() + timeout;
+                continue;
+            }
+            Err(err) if err.kind() == io::ErrorKind::Interrupted => continue,
+            Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+            Err(source) => {
+                return Err(BoundedWriteError::Io {
+                    source,
+                    bytes_written: written,
+                });
+            }
+        }
+
+        // The pipe is full right now. Wait - bounded by whatever is left of the caller's own
+        // deadline - for the peer to drain enough of it to accept more.
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            return Err(BoundedWriteError::Timeout {
+                bytes_written: written,
+            });
+        }
+        // `PollTimeout::try_from` only fails for a duration whose millisecond count overflows
+        // `i32`; `remaining` is bounded by the caller's own timeout, and clamping to
+        // `PollTimeout::MAX` for an absurdly large one keeps the deadline check above the single
+        // real authority on when to give up rather than introducing a second failure mode.
+        let poll_timeout = PollTimeout::try_from(remaining).unwrap_or(PollTimeout::MAX);
+        let mut fds = [PollFd::new(writer.as_fd(), PollFlags::POLLOUT)];
+        match nix::poll::poll(&mut fds, poll_timeout) {
+            // A real poll timeout: the peer has not freed a single byte of pipe space within the
+            // caller's whole budget.
+            Ok(0) => {
+                return Err(BoundedWriteError::Timeout {
+                    bytes_written: written,
+                });
+            }
+            Ok(_) => {}
+            Err(nix::errno::Errno::EINTR) => {}
+            Err(errno) => {
+                return Err(BoundedWriteError::Io {
+                    source: io::Error::from(errno),
+                    bytes_written: written,
+                });
+            }
+        }
+    }
+
+    // A pipe fd has no userspace buffer of its own to flush, but `flush` is still called for the
+    // same reason any framed writer would: `W` is only promised to be a `Write`.
+    //
+    // Reported with `bytes_written: 0` even though the whole frame demonstrably went out, because
+    // that field means one specific thing to callers - "a *partial* frame reached the peer, so its
+    // framer is desynced" (see [`BoundedWriteError`]). Nothing was cut off here; passing `written`
+    // through would make [`BoundedWriteError::stream_desynced`] claim a corruption that did not
+    // happen, and the caller would log "was cut off part-way through" about a frame that wasn't.
+    writer.flush().map_err(|source| BoundedWriteError::Io {
+        source,
+        bytes_written: 0,
+    })
+}
+
+/// Windows twin of [`write_message_bounded`], honestly narrower: it performs the same real,
+/// framed write but has **no** time bound, because `poll` does not exist for Windows anonymous
+/// pipes and the non-blocking-write machinery above has no direct equivalent. Documented as a
+/// real, tracked gap rather than papered over with a fake timeout - the same shape as
+/// `LspClient::kill_process_tree`'s own `#[cfg(windows)]` twin, which is likewise real but
+/// narrower than its unix counterpart (direct child only, no descendant-process-tree walk).
+#[cfg(not(unix))]
+pub fn write_message_bounded<W: Write>(
+    writer: &mut W,
+    value: &serde_json::Value,
+    _timeout: std::time::Duration,
+) -> Result<(), BoundedWriteError> {
+    let frame = frame(value).map_err(|source| BoundedWriteError::Io {
+        source,
+        bytes_written: 0,
+    })?;
+    writer
+        .write_all(&frame)
+        .and_then(|()| writer.flush())
+        .map_err(|source| BoundedWriteError::Io {
+            source,
+            // A failed `write_all` genuinely may have written part of the frame, and there is no
+            // way to find out how much - reported as a desync, the conservative answer, since
+            // treating a possibly-half-written frame as recoverable is the unsafe direction.
+            bytes_written: 1,
+        })
 }
 
 /// Reads one real, framed JSON-RPC message from `reader`. Returns `Ok(None)` on a clean EOF
@@ -122,6 +320,15 @@ mod tests {
     use super::*;
     use std::io::BufReader;
     use std::io::Cursor;
+
+    /// Appends one real, production-framed message to `buffer`. Deliberately goes through
+    /// [`frame`] - the exact encoder both real [`write_message_bounded`] paths use - so these
+    /// round-trip tests pin the framing production actually emits, not a second copy of it
+    /// written for the tests' convenience.
+    fn write_message(buffer: &mut Vec<u8>, value: &serde_json::Value) -> io::Result<()> {
+        buffer.extend_from_slice(&frame(value)?);
+        Ok(())
+    }
 
     #[test]
     fn round_trips_a_real_message_through_encode_then_decode() {
@@ -285,5 +492,95 @@ mod tests {
             .expect("read_message should succeed")
             .expect("message present");
         assert_eq!(decoded, value);
+    }
+
+    /// Real, fast, process-backed coverage for [`write_message_bounded`]'s own deadline, against
+    /// a genuine OS pipe nobody is draining - no language server involved, so this pins the write
+    /// bound itself in under a second rather than paying `client.rs`'s real 30-second production
+    /// budget.
+    ///
+    /// `sleep` is spawned purely for its stdin: it holds the read end of a real pipe open and
+    /// never reads a byte of it, which is exactly the frozen-server condition the bound exists
+    /// for (see [`write_message_bounded`]'s own docs for the live reproduction).
+    #[cfg(unix)]
+    mod bounded_write_tests {
+        use super::*;
+        use std::process::{Command, Stdio};
+        use std::time::{Duration, Instant};
+
+        struct UndrainedPipe {
+            child: std::process::Child,
+            stdin: std::process::ChildStdin,
+        }
+
+        impl UndrainedPipe {
+            fn new() -> Self {
+                let mut child = Command::new("sleep")
+                    .arg("60")
+                    .stdin(Stdio::piped())
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .spawn()
+                    .expect("spawning a real `sleep` for its stdin pipe");
+                let stdin = child.stdin.take().expect("piped stdin");
+                // The same real `O_NONBLOCK` production sets at spawn - `write_message_bounded`
+                // owns its own waiting and requires it (see that function's own docs).
+                use std::os::fd::AsRawFd;
+                let fd = stdin.as_raw_fd();
+                let flags = nix::fcntl::fcntl(fd, nix::fcntl::FcntlArg::F_GETFL).expect("F_GETFL");
+                let flags =
+                    nix::fcntl::OFlag::from_bits_truncate(flags) | nix::fcntl::OFlag::O_NONBLOCK;
+                nix::fcntl::fcntl(fd, nix::fcntl::FcntlArg::F_SETFL(flags)).expect("F_SETFL");
+                Self { child, stdin }
+            }
+        }
+
+        impl Drop for UndrainedPipe {
+            fn drop(&mut self) {
+                let _ = self.child.kill();
+                let _ = self.child.wait();
+            }
+        }
+
+        /// A message that fits in the kernel pipe buffer still goes through untouched - the
+        /// common case must not have been turned into a timeout by the bound.
+        #[test]
+        fn a_small_message_still_writes_straight_through() {
+            let mut pipe = UndrainedPipe::new();
+            let value = serde_json::json!({"jsonrpc": "2.0", "method": "initialized"});
+            write_message_bounded(&mut pipe.stdin, &value, Duration::from_secs(5))
+                .expect("a message that fits in the pipe buffer must not time out");
+        }
+
+        /// The real regression: a frame far larger than the pipe buffer, to a peer that never
+        /// reads, gives up on the caller's own deadline instead of blocking forever - and reports
+        /// the partial write, which is what tells the caller the peer's framer is now desynced.
+        #[test]
+        fn an_oversized_message_to_a_peer_that_never_reads_times_out_and_reports_the_desync() {
+            let mut pipe = UndrainedPipe::new();
+            let value = serde_json::json!({ "payload": "x".repeat(1024 * 1024) });
+
+            let started = Instant::now();
+            let error = write_message_bounded(&mut pipe.stdin, &value, Duration::from_millis(250))
+                .expect_err("a 1 MiB frame cannot fit in a pipe nobody is draining");
+            let elapsed = started.elapsed();
+
+            assert!(
+                matches!(error, BoundedWriteError::Timeout { .. }),
+                "the peer is alive and the fd is fine - this is a real timeout, not an I/O \
+                 error: {error:?}"
+            );
+            assert!(
+                error.stream_desynced(),
+                "part of the frame genuinely reached the pipe, so the peer's framer is mid-body \
+                 and can never recover - the caller has to be told that, not just that one write \
+                 failed"
+            );
+            assert!(
+                elapsed < Duration::from_secs(5),
+                "the write must give up on the 250ms deadline it was given, not block - took \
+                 {elapsed:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes the reported bug: "even when [language servers] are installed they disconnect or don't work." Root-caused live (not guessed) by SIGSTOP-freezing a real installed `rust-analyzer` process to simulate a server that is alive but has stopped reading its own stdin.

## Root cause

A language server process that is alive but has stopped reading its stdin makes a large `write_all` call block indefinitely — **while holding the transport's stdin mutex**. Every other request queues on that same mutex to write its own frame, so their own explicit per-call timeouts never even get a chance to fire: they're stuck waiting for the mutex, not waiting on their own I/O. `is_connection_alive()`'s existing crash-detection (fast, from an earlier revision) never covered this case, since a live-but-wedged process produces no EOF for the reader thread to observe. The client kept reporting `is_connection_alive() == true` while requests silently piled up.

## Fix

- `crates/lsp-core/src/transport.rs`: `O_NONBLOCK` + deadline-bounded `poll()`-based bounded writes, with a **no-progress deadline that resets on every byte the peer actually accepts** (not a flat one-shot timeout, so a slow-but-live peer isn't killed early).
- `crates/lsp-core/src/client.rs`: death-on-unfinishable-write detection (`connection_alive` flips to `false`), fast-fail on an already-known-dead connection (so a second request doesn't re-pay the full write timeout discovering the same thing), and a real data-corruption fix an adversarially-dispatched checker caught in this fix's own first draft: writers queue on the stdin mutex, and a wedged/dying writer must publish the connection's death **before** releasing that guard — otherwise the next queued writer would emit a perfectly well-formed frame into what is actually a desynced, dead connection's mid-body (silent wire corruption). Fixed by storing `connection_alive = false` while the guard is still held, both on the main write path and the server-initiated-request reply path.
- `crates/app/src/lsp/client.rs`: a liveness sweep added to the existing 250ms LSP poll loop, and a real (explicitly non-automatic) restart action — reachable from a new palette command and the failed-status UI chip. Checked against real Zed's own actual behavior (`vendor/zed`) to confirm this matches: no silent auto-respawn, an honest failed status the user acts on.
- Windows note: the bounded-write mechanism is honestly narrower there (no real `poll()` equivalent for Windows anonymous pipes), documented inline — matching this project's existing platform-split precedent (`kill_process_tree`).

## Testing

- `cargo fmt --all -- --check`, `cargo build --workspace`, `cargo clippy --workspace --all-targets -- -D warnings` all clean.
- `cargo test --workspace --lib -- --test-threads=1`: full suite green (one `diff_render_tests` failure on the full run is the project's known, pre-existing, documented cache flake — re-ran in isolation and it passed).
- Root cause was live-reproduced with a real SIGSTOP-frozen `rust-analyzer`, not simulated.
- Independently re-verified by re-reading the landed diff directly: the mutex-release-ordering fix (`connection_alive.store(false, ...)` happens before `drop(stdin)`, both on the main write path and the server-initiated-reply thread) and the app-side liveness sweep / `restart_lsp_clients` wiring were spot-checked in source, not taken on faith from the build report.

## Known gaps (disclosed, not hidden)

- Could not drive the GUI for a full end-to-end repro in this sandbox — verification stops at the `lsp-core`/`app`-state layer, not a literal on-screen click-through.
- The "stale task" symptom is pinned at the mechanism level (the bounded-write + liveness-sweep code paths), not the literal end-to-end symptom, since GPUI's test executor collapses the real timing window that made the bug visible in practice.

Branch was rebased onto current `master` (this now includes PR #21's merge and the Linux CI simplification) before this PR was opened; `palette/render.rs` merged with zero real conflict (a 5-line additive footprint), only `BUILD-LOG.md` needed manual splicing.