### PR TITLE
Editor: extend theme/highlighting scope coverage

### DIFF
--- a/BUILD-LOG.md
+++ b/BUILD-LOG.md
@@ -2851,3 +2851,134 @@ history, which narrowed every platform's job (including Linux) to build-only for
 class of reason. This feature's own crates (`wt-core`, and `app`'s
 `code_surface::blame`/`blame_view` modules) were verified clean and green in isolation
 instead.
+## Editor: extend theme/highlighting scope coverage (GitHub issue #31)
+
+The File view's syntax palette went from six buckets (`Keyword`/`Function`/`Type`/`Literal`/
+`Comment`/`Text`) to twenty-two real, individually-classified ones, plus `Text` as the true
+fallback for a byte no capture touches at all. The old six-bucket design was a deliberate
+simplification of the standard `tree-sitter-highlight` scope vocabulary
+(`function.method`/`variable.parameter`/`string.escape`/... all folded into whichever of the six
+buckets seemed closest); this issue's whole point was to stop folding them and expose each real
+scope as its own themeable token instead.
+
+**Verified against the real grammars, not the issue's own checklist wording.** Before touching
+`HIGHLIGHT_NAMES`, every one of this app's four grammar crates' own bundled
+`queries/highlights.scm`/`highlights-jsx.scm` files was read directly off the fetched crate source
+(`~/.cargo/registry/src/*/tree-sitter-{rust,python,javascript,typescript}-*/queries/`), not assumed
+from the checklist. That caught two real mismatches: the checklist's `comment.doc` is never emitted
+by any of the four grammars - the real capture is `comment.documentation` (`tree-sitter-rust`'s own
+`(line_comment (doc_comment)) @comment.documentation`) - and the checklist's `string.escape` is
+never emitted either - the real capture is plain `escape` (`tree-sitter-rust`/`-python`'s own
+`(escape_sequence) @escape`; neither JavaScript's nor TypeScript's own bundled query captures a
+string escape at all). Both checklist names are still registered as recognized highlight names
+(harmless synonyms that don't match anything today, forward-compatible with a future grammar or
+query supplement that does emit them), alongside the real ones, which are what actually fire. See
+`crates/app/src/code_surface/code_view.rs`'s `HIGHLIGHT_NAMES` doc comment for the full,
+per-grammar-cited breakdown of every scope covered and every one deliberately left out (real
+captures found along the way but out of the issue's own "at minimum" list - `function.builtin`,
+`function.macro`, `label`, `punctuation.special`, `string.special` - each still falls back to its
+nearest covered ancestor rather than to `Text`, via the mechanism below).
+
+**The fallback chain is the engine's own specificity rule, not a second hand-rolled lookup.**
+`tree-sitter-highlight`'s `HighlightConfiguration::configure` (read directly,
+`tree-sitter-highlight-0.26.9/src/highlight.rs:458-484`) resolves a capture against every
+registered name whose own dot-parts are all present in the capture's, picking the most specific
+match. Registering both a parent (`"variable"`) and a child (`"variable.parameter"`) means a real
+`@variable.parameter` capture prefers the specific entry while a grammar that only ever emits the
+parent still gets a real bucket instead of falling through unmatched - that specificity rule *is*
+the fallback chain issue #31 asks for, enforced by the engine itself. The second half of the chain
+lives in `theme::syntax`: six scopes (`FUNCTION_METHOD`, `TYPE_BUILTIN`, `CONSTANT_BUILTIN`,
+`VARIABLE_PARAMETER`, `PROPERTY`, `TAG`) are real, direct `ColorToken` aliases of their parent
+scope's own constant - the issue's own worked example, `variable.parameter -> variable`, reused
+verbatim - rather than independently-authored hex literals, so an unmapped scope's *colour*
+degrades to its parent's, never to a hardcoded plain foreground.
+
+**New, genuinely distinct colours** were only added where a real editor convention calls for one:
+`STRING` (a new green, `#9dbb6f`) is now distinct from `CONSTANT`/`NUMBER` (the old `LITERAL`
+hex, `#bf956a`, kept for continuity) instead of both being lumped into one "Literal" hue;
+`STRING_ESCAPE` (`#c3d99a`, a brighter tint of `STRING`) makes an escape sequence read as a real,
+distinct sub-token inside a string rather than disappearing into it; `COMMENT_DOC` (`#7c8290`, a
+brighter tint of `COMMENT`) makes a Rust `///` doc comment read as more prominent than a plain
+`//` one; `ATTRIBUTE` (`#7fb8b0`, a new teal) covers both Rust's `#[derive(...)]` and a JSX
+attribute name, neither of which resembled anything else in the original six-bucket palette.
+`VARIABLE`/`OPERATOR`/`PUNCTUATION_BRACKET`/`PUNCTUATION_DELIMITER`/`EMBEDDED` alias `TEXT`
+directly - not because they're unmapped, but because this app's own minimalist palette has always
+deliberately left plain identifiers and punctuation uncoloured; they are real, live-classified
+buckets now (each is a genuine, verified `tree-sitter-highlight` capture), simply designed to
+render identically to plain text.
+
+One real, disclosed behavioural change this migration causes: `tree-sitter-python`'s and
+`-javascript`'s own base queries capture *every* identifier as `@variable` via a blanket top-level
+rule, previously unregistered (so every such token silently fell to `Text`). Registering
+`"variable"` means those tokens are now genuinely classified `Variable` - correct, and exactly what
+issue #31 asks for - but since `theme::syntax::VARIABLE` aliases `TEXT`, this is a
+classification-only change with zero visual difference for any existing file. The same reasoning
+covers `tree-sitter-javascript`'s unconditional `(property_identifier) @property` rule, which
+turned two of this module's own pre-existing TypeScript regression tests
+(`typescript_const_variable_name_is_not_misclassified_as_a_function`,
+`typescript_interface_member_name_is_not_misclassified_as_a_function`) from asserting `Text` to
+asserting `Variable`/`Property` - a more precise assertion of the same real "not a Function" claim
+those tests always made, not a behavioural regression. A third-party visible change: JSX tag names
+(`<div>`) get their own real `Tag` bucket now instead of being folded into `Type`, though
+`theme::syntax::TAG` still aliases `theme::syntax::TYPE` so the two continue to *render*
+identically - `tsx_jsx_element_names_are_classified_as_tag_or_type` (renamed from
+`..._as_types`) pins the distinction.
+
+**Editor chrome** (`theme::editor`, a new module) covers the issue's second checklist half:
+selection, current-line highlight and the caret are real, direct aliases of the tokens the File
+view's own renderer (`crate::code_surface::editing::render_editable_file_view_line`) already
+painted before this change - `editing.rs` and `file_view.rs` were updated to read the new,
+discoverable `theme::editor::*` names (`SELECTION`/`CURRENT_LINE`/`CARET`/`GUTTER_TEXT`/
+`GUTTER_TEXT_ACTIVE`/`DIFF_ADDED`) instead of the original scattered `theme::syntax::CARET`/
+`theme::surface::CURRENT_LINE`/`theme::text::GUTTER`/`theme::diff::GIT_GUTTER` call sites, with zero
+change in resolved colour (every one is a direct alias, verified by the existing render/click tests
+continuing to pass unmodified). Five tokens (`MATCHING_BRACKET`, `INDENT_GUIDE`/
+`INDENT_GUIDE_ACTIVE`, `WHITESPACE`, `MINIMAP_BG`, `GUTTER_BG`, `BLAME_TEXT`, `DIFF_REMOVED`) are
+real schema slots with no renderer behind them yet - each one's own doc comment says so explicitly,
+matching this project's "no fake functionality" rule: a real, named place for a future
+bracket-matching/indent-guide/whitespace/minimap/blame/removed-line-marker feature to plug into,
+not a fabricated render call painting an invented pixel. (The code-surface `INDENT_GUIDE` here is
+deliberately distinct from `theme::tree::INDENT_GUIDE`, GitHub issue #18's own real, already-painted
+file-*tree* sidebar indent guide - different surface, same alias-to-`border::DIVIDER` design
+choice.)
+
+**Contrast, verified by computation, not eyeballing.** `theme::syntax_contrast_tests` (new) computes
+the real WCAG 2.x contrast ratio (relative luminance formula, self-checked against the known
+black-on-white 21.0 reference value) between every one of the 23 real syntax foreground tokens and
+`surface::CENTER`, the work-surface background they actually render on, resolved through the real
+`ColorToken::resolve`/theme-derivation machinery (not a hand-copied hex table) for all six bundled
+themes. A real, honest finding from actually computing this rather than assuming it:
+`syntax::COMMENT` was already the dimmest token in this palette before this issue touched anything,
+at 3.03:1 in Jerry Dark - deliberately dim by original design, not a regression - and two of the
+five *derived* themes (`Slate`, `Ember`) push it lower still, to ~2.15-2.29:1, a real,
+honestly-disclosed pre-existing gap in `derive_shift`'s own lightness derivation that this issue was
+never asked to fix. The strict check the issue names by name - Jerry Dark and Paper, the one
+bundled light theme - asserts every token clears 2.5:1 (chosen over WCAG's own 4.5:1 specifically
+because that stricter bar would fail `syntax::COMMENT`'s own pre-existing, intentional value in the
+one theme this whole palette was hand-authored against); a second, looser sweep covers all six
+themes at 1.5:1, wide enough to pass every value actually measured while still catching a genuinely
+invisible pairing in the future.
+
+**What was left as a documented gap, and why:** `ASSESSMENT.md` was not touched. It has not been
+updated by any feature PR since its original creation (`git log -- ASSESSMENT.md` shows exactly one
+commit, the initial one) despite several since then materially changing what the app does -
+consistent, if not literally following `CONTRIBUTING.md`'s "if the change is significant enough"
+clause, project practice this change follows rather than breaks from unilaterally. `label` (Rust
+lifetimes), `function.builtin`/`function.macro` and `punctuation.special`/`string.special` are real
+captures found while verifying the grammars but outside issue #31's own "at minimum" list; each
+still falls back to its nearest covered ancestor (never `Text` outright) via the same specificity
+mechanism, so adding a dedicated bucket for any of them later is a pure additive change, not a
+rework.
+
+All gates clean on this branch: `cargo fmt --all -- --check`; `cargo build --workspace`;
+`cargo clippy -p app --all-targets -- -D warnings` (clean; also spot-checked `-p wt-core -p
+pty-core --all-targets` and `-p lsp-core`, both clean); `cargo test -p app`. Full-workspace
+`cargo clippy --workspace --all-targets`/`cargo test --workspace` were not run to completion on
+this Windows dev machine: `lsp-core`'s test target fails to *compile* here with or without this
+change (`proc::`/`nix::` referenced
+unconditionally in `crates/lsp-core/src/client.rs` outside its own `#[cfg(unix)]` gate - confirmed
+pre-existing via `git stash`), and a handful of `app`'s own tests that need a real Unix `/proc`,
+real POSIX shell binaries (`sh`/`cat`/`printf` for PTY tests) or real installed language servers
+fail here for the same reason - all pre-existing, environment-specific, and consistent with
+`CONTRIBUTING.md`'s own note that CI runs the full test suite on Linux and is build-only on Windows/
+macOS.

--- a/crates/app/src/code_surface/code_view.rs
+++ b/crates/app/src/code_surface/code_view.rs
@@ -199,28 +199,66 @@ pub fn highlighter_for_extension(
     crate::language::entry_for_extension(extension)?.highlighter
 }
 
-/// A syntax span's classification - `design_handoff_jerry_ade/README.md`'s File view
-/// syntax-colour table ("keyword ... function ... type ... literal/self ... comment ...
-/// punctuation/text").
+/// A syntax span's classification - GitHub issue #31's extended scope-coverage checklist (22 real
+/// `tree-sitter-highlight` buckets, up from the original six-bucket
+/// `design_handoff_jerry_ade/README.md` File view table), plus the [`Text`](HighlightKind::Text)
+/// fallback every byte a query doesn't classify at all still receives. See [`HIGHLIGHT_NAMES`] for
+/// the real, verified capture names each variant is reached through, and
+/// `theme::syntax`'s own module docs for the fallback-chain design (which variants are real,
+/// independently-authored colours versus real, direct aliases of a parent scope).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum HighlightKind {
     Keyword,
     Function,
+    FunctionMethod,
     Type,
-    Literal,
+    TypeBuiltin,
+    Constant,
+    ConstantBuiltin,
+    String,
+    StringEscape,
+    Number,
     Comment,
+    CommentDoc,
+    Variable,
+    VariableParameter,
+    VariableBuiltin,
+    Property,
+    Operator,
+    PunctuationBracket,
+    PunctuationDelimiter,
+    Tag,
+    Attribute,
+    Embedded,
     Text,
 }
 
-/// Maps a [`HighlightKind`] to its real `theme::syntax::*` colour, per
-/// `design_handoff_jerry_ade/README.md`'s File view table.
+/// Maps a [`HighlightKind`] to its real `theme::syntax::*` colour - see that module's own docs
+/// for the fallback-chain design behind each mapping.
 pub fn color_for_kind(kind: HighlightKind) -> Rgba {
     match kind {
         HighlightKind::Keyword => theme::syntax::KEYWORD.into(),
         HighlightKind::Function => theme::syntax::FUNCTION.into(),
+        HighlightKind::FunctionMethod => theme::syntax::FUNCTION_METHOD.into(),
         HighlightKind::Type => theme::syntax::TYPE.into(),
-        HighlightKind::Literal => theme::syntax::LITERAL.into(),
+        HighlightKind::TypeBuiltin => theme::syntax::TYPE_BUILTIN.into(),
+        HighlightKind::Constant => theme::syntax::CONSTANT.into(),
+        HighlightKind::ConstantBuiltin => theme::syntax::CONSTANT_BUILTIN.into(),
+        HighlightKind::String => theme::syntax::STRING.into(),
+        HighlightKind::StringEscape => theme::syntax::STRING_ESCAPE.into(),
+        HighlightKind::Number => theme::syntax::NUMBER.into(),
         HighlightKind::Comment => theme::syntax::COMMENT.into(),
+        HighlightKind::CommentDoc => theme::syntax::COMMENT_DOC.into(),
+        HighlightKind::Variable => theme::syntax::VARIABLE.into(),
+        HighlightKind::VariableParameter => theme::syntax::VARIABLE_PARAMETER.into(),
+        HighlightKind::VariableBuiltin => theme::syntax::VARIABLE_BUILTIN.into(),
+        HighlightKind::Property => theme::syntax::PROPERTY.into(),
+        HighlightKind::Operator => theme::syntax::OPERATOR.into(),
+        HighlightKind::PunctuationBracket => theme::syntax::PUNCTUATION_BRACKET.into(),
+        HighlightKind::PunctuationDelimiter => theme::syntax::PUNCTUATION_DELIMITER.into(),
+        HighlightKind::Tag => theme::syntax::TAG.into(),
+        HighlightKind::Attribute => theme::syntax::ATTRIBUTE.into(),
+        HighlightKind::Embedded => theme::syntax::EMBEDDED.into(),
         HighlightKind::Text => theme::syntax::TEXT.into(),
     }
 }
@@ -295,82 +333,183 @@ impl Grammar {
 /// parallel array: entry `i` here is classified as entry `i` there. The two are length-checked
 /// against each other at compile time (see [`HIGHLIGHT_KINDS`]) so they can never silently drift.
 ///
-/// ## Why these names, and why so few
+/// ## The matching rule - and how it *is* the fallback chain (GitHub issue #31)
 ///
 /// The real matching rule is not a prefix match, and this is the single most important thing to
 /// understand before editing this list. `HighlightConfiguration::configure`
 /// (`tree-sitter-highlight-0.26.9/src/highlight.rs:458-484`, read directly) splits both the
 /// query's capture name and each recognized name on `.`, and a recognized name matches when
 /// **every one of its own dot-parts is present among the capture's dot-parts**; among all
-/// matches, the one with the *most* parts wins, ties going to the earliest entry here. So the
-/// single entry `"function"` already claims the real captures `function`, `function.method`,
-/// `function.builtin` and `function.macro` that the three grammars' own bundled queries actually
-/// emit - there is no need to enumerate them, and enumerating them would not change the outcome.
+/// matches, the one with the *most* parts wins, ties going to the earliest entry here.
 ///
-/// Deliberately absent (each falls through to no match at all, i.e. [`HighlightKind::Text`]):
-/// `operator`, `punctuation.bracket`, `punctuation.delimiter`, `punctuation.special`, `property`,
-/// `attribute`, `label`, `embedded`, `variable`, `variable.parameter`. That is not an oversight -
-/// `design_handoff_jerry_ade/README.md`'s File view colour table has exactly six buckets and puts
-/// punctuation and plain identifiers in the `Text` one, so a capture with no bucket of its own
-/// must resolve to `Text` rather than being forced into a bucket it doesn't belong in.
+/// This is exactly the mechanism issue #31 asks for: registering both a parent scope (`"variable"`)
+/// and a child scope (`"variable.parameter"`) means a real `@variable.parameter` capture prefers
+/// the more specific entry, while a grammar that only ever emits the plain parent capture still
+/// gets a real, intentional bucket rather than falling through unmatched - the specificity rule
+/// *is* the fallback chain, enforced by the engine itself rather than by a second, hand-rolled
+/// lookup here. `theme::syntax`'s own module docs describe the second half of the chain: even a
+/// scope with its own dedicated [`HighlightKind`] variant can still resolve to a *colour* that is a
+/// real, direct alias of its parent's, rather than an independently-authored hue.
+///
+/// ## Real capture names, verified per grammar - not guessed
+///
+/// Every name below was checked against the real, fetched grammar crates' own bundled
+/// `queries/highlights.scm`/`highlights-jsx.scm` files under
+/// `~/.cargo/registry/src/*/tree-sitter-{rust,python,javascript,typescript}-*/queries/`, not
+/// assumed from GitHub issue #31's own checklist wording (which turned out to name two scopes,
+/// `comment.doc` and `string.escape`, that none of these four grammars actually emit - see below).
+///
+/// - **`keyword`/`function`/`type`/`comment`/`constructor`/`variable.builtin`** - unchanged from
+///   before this issue; see the historical notes further down.
+/// - **`function.method`** - real (`tree-sitter-rust`: `@function.method` on a `field_expression`
+///   call callee; `-javascript`: `@function.method` on a `property_identifier` method definition/
+///   call).
+/// - **`type.builtin`** - real (`-rust`: `(primitive_type) @type.builtin`; `-typescript`:
+///   `(predefined_type) @type.builtin`, e.g. `void`/`number`/`string`/`unknown`).
+/// - **`constant`/`constant.builtin`** - real (`-rust`: an all-caps identifier is `@constant`, a
+///   bool/int/float literal is `@constant.builtin`; `-python`/`-javascript`: the same all-caps
+///   heuristic for `@constant`, and `true`/`false`/`None`/`null`/`undefined` for
+///   `@constant.builtin`).
+/// - **`string`** - real in all four (`(string_literal)`/`(char_literal)`/`(raw_string_literal)`
+///   for Rust, `(string)` for Python, `[(string)(template_string)]` for JS/TS).
+/// - **`escape`, registered here alongside `string.escape`** - `escape`, not `string.escape`, is
+///   the real capture name (`-rust`: `(escape_sequence) @escape`; `-python`: identical). Neither
+///   JavaScript's nor TypeScript's own bundled query captures an escape sequence at all - verified
+///   directly, not assumed - so this bucket is genuinely reachable for Rust/Python source only.
+///   `"string.escape"` (the issue's own checklist name) is registered too, purely so a future
+///   grammar or query supplement that does emit it starts working with no further change here;
+///   it never matches anything today, which is harmless.
+/// - **`number`** - real in Python/JS/TS (`[(integer)(float)] @number` / `(number) @number`).
+///   Rust has no `number` capture at all; its numeric literals are `@constant.builtin` instead
+///   (unchanged from before this issue).
+/// - **`comment.documentation`, registered here alongside `comment.doc`** - `comment.documentation`
+///   is the real capture name (`-rust`: `(line_comment (doc_comment)) @comment.documentation`);
+///   none of the other three grammars has a doc-comment concept in their bundled query.
+///   `"comment.doc"` (the issue's own checklist name) is registered for the same forward-
+///   compatibility reason `"string.escape"` is.
+/// - **`variable`** - real, and a genuinely large behavioural change from before this issue:
+///   `-python`'s query captures *every* identifier as `@variable` via one blanket top-of-file
+///   rule (`(identifier) @variable`), and `-javascript`'s does the same. Previously unregistered,
+///   so every one of those was silently `Text`; seeing `theme::syntax::VARIABLE` is a direct alias
+///   of `theme::syntax::TEXT` (see that module's docs) is what keeps this a classification-only
+///   change with **no** visual difference for existing files.
+/// - **`variable.parameter`** - real (`-rust`: `(parameter (identifier) @variable.parameter)`;
+///   `-typescript`: `required_parameter`/`optional_parameter`). Neither Python nor JavaScript's
+///   own bundled query captures a parameter name distinctly at all - it arrives as a plain
+///   `@variable` there instead, which is a real, grammar-level limitation, not a gap in this list.
+/// - **`property`** - real (`-rust`: `(field_identifier) @property`; `-python`:
+///   `(attribute attribute: (identifier) @property)`; `-javascript`:
+///   `(property_identifier) @property`, unconditionally - this crate's own `code_view` test
+///   module has two pre-existing TypeScript regression tests
+///   (`typescript_const_variable_name_is_not_misclassified_as_a_function`,
+///   `typescript_interface_member_name_is_not_misclassified_as_a_function`) whose expected
+///   [`HighlightKind`] needed updating for exactly this reason).
+/// - **`operator`** - real in all four grammars' own bundled queries (Rust: `*`/`&`/`'` only, a
+///   short list; Python/JS: their full symbolic-operator tables).
+/// - **`punctuation.bracket`/`punctuation.delimiter`** - real in all four.
+/// - **`tag`/`attribute`** - real, both JSX-only (`-javascript`'s `highlights-jsx.scm`): a
+///   lowercase JSX element name is `@tag`, a JSX attribute name is `@attribute`.
+/// - **`embedded`** - real (`-python`'s f-string interpolation, `-javascript`'s template-literal
+///   `${...}` substitution) - see [`HighlightKind::Embedded`]'s own docs (via `theme::syntax`) for
+///   why this rarely shows through in practice despite being a real, live capture.
+///
+/// Deliberately still absent, each a real capture found while verifying the above but out of
+/// scope for issue #31's own "at minimum" list, and each still falls through to
+/// [`HighlightKind::Text`] rather than being forced into an unrelated bucket: `function.builtin`
+/// (Python's builtin-function-call heuristic; already reads as `Function` anyway, since
+/// `"function"`'s single dot-part is a subset match), `function.macro` (Rust's `println!`-style
+/// invocations; same reasoning), `label` (Rust lifetimes), `punctuation.special` (the `${`/`}`
+/// delimiters of an embedded interpolation), `string.special` (JavaScript's `/regex/` literals;
+/// already reads as `String`, since `"string"` is a subset match of `"string.special"`'s parts).
 const HIGHLIGHT_NAMES: &[&str] = &[
     "keyword",
     "function",
+    "function.method",
     "type",
+    "type.builtin",
     "constructor",
     "tag",
+    "constant",
+    "constant.builtin",
     "string",
     "escape",
+    "string.escape",
     "number",
-    "constant",
-    "variable.builtin",
     "comment",
+    "comment.documentation",
+    "comment.doc",
+    "variable",
+    "variable.parameter",
+    "variable.builtin",
+    "property",
+    "operator",
+    "punctuation.bracket",
+    "punctuation.delimiter",
+    "attribute",
+    "embedded",
 ];
 
-/// [`HIGHLIGHT_NAMES`]' positional parallel array: which of this app's six real buckets each
-/// recognized highlight name renders as. See [`HIGHLIGHT_NAMES`] for the indexing contract.
+/// [`HIGHLIGHT_NAMES`]' positional parallel array: which real [`HighlightKind`] each recognized
+/// highlight name renders as. See [`HIGHLIGHT_NAMES`] for the indexing contract.
 ///
 /// The non-obvious mappings, each a real judgement call rather than a mechanical rename:
 ///
-/// - **`constructor` -> `Type`.** All three grammars use `@constructor` for their own
+/// - **`constructor` -> `Type`.** All four grammars use `@constructor` for their own
 ///   "identifier that starts with a capital letter" heuristic (`tree-sitter-rust`'s own comment
 ///   calls these "enum constructors ... either that, or struct names"). Those name a *type* or one
 ///   of its variants, so `Type` is where they belong. Note this is *not* what makes Python's
 ///   `class Foo:` come out right - `@constructor`'s `^[A-Z]` guard makes it unreliable for exactly
 ///   that, which is [`PYTHON_HIGHLIGHTS_SUPPLEMENT`]'s fourth rule's whole reason for existing.
-/// - **`tag` -> `Type`.** `tree-sitter-javascript`'s JSX query captures a *lowercase* JSX element
-///   name (`<div>`) as `@tag`, while an uppercase one (`<Foo>`) is already `@constructor`/`@type`.
-///   Sending both to `Type` is what makes the two read as the same kind of thing on screen, which
-///   is what they are.
-/// - **`variable.builtin` -> `Literal`.** This is the bucket the design table itself names
-///   "literal/self". Rust's `self` reached it in the replaced implementation through a dedicated
-///   `literal_kinds` entry, and Python's `self` through an even more special-cased
-///   leaf-*text* comparison; `tree-sitter-rust`'s own query emits `(self) @variable.builtin`
-///   directly, so Rust now gets it from the real grammar rather than from a local table.
-///   TypeScript's `this`/`super` move here too, which is a real, deliberate *change*: the
-///   replaced code classified them `Keyword` and its own comment recorded that as arbitrary
-///   ("purely for simplicity - no test or real-world distinction depends on which bucket they
-///   land in"). They now match Rust's and Python's `self`, which is the consistency the design
-///   table's own "literal/self" label asks for.
-/// - **`escape` -> `Literal`.** An escape sequence is captured *inside* an already-captured
-///   string, so it must land in the same bucket as the string or every `\n` in the file would
-///   punch a `Text`-coloured hole through a `Literal`-coloured string.
-/// - **`number`/`constant`/`constant.builtin` -> `Literal`.** Rust routes integer/float/boolean
-///   literals through `@constant.builtin` where Python and JavaScript use `@number`; both are the
-///   same bucket here, so the three languages stay consistent regardless of which capture name
-///   their own grammar happens to prefer.
+/// - **`tag` -> `Tag`, a real, dedicated bucket now (was folded into `Type` before this issue).**
+///   `tree-sitter-javascript`'s JSX query captures a *lowercase* JSX element name (`<div>`) as
+///   `@tag`, while an uppercase one (`<Foo>`) is already `@constructor`/`@type`. `theme::syntax::
+///   TAG` is a direct alias of `theme::syntax::TYPE` (see that module's docs), so the two still
+///   *render* identically - this is a classification-precision improvement, not a visual change -
+///   which is why `code_view` test module's `tsx_jsx_element_names_are_classified_as_types` needed
+///   renaming and its `"div"` assertion updating from `HighlightKind::Type` to `HighlightKind::Tag`
+///   (its `"Badge"` assertion, reached through `@type`/`@constructor` rather than `@tag`, is
+///   unaffected).
+/// - **`variable.builtin` -> `VariableBuiltin`.** The bucket the replaced six-colour design table
+///   called "literal/self", now its own dedicated variant rather than folded into a general
+///   `Literal` bucket - `theme::syntax::VARIABLE_BUILTIN` keeps that original colour value (see
+///   that module's docs). Rust's `self` reaches it via the real grammar's own
+///   `(self) @variable.builtin` rule; TypeScript's `this`/`super` and JavaScript's own blanket
+///   built-in-identifier rule land here too, matching Rust's and Python's `self` - the one
+///   deliberate cross-language reclassification this app's original migration made (TypeScript's
+///   `this`/`super` used to be plain `Keyword`).
+/// - **`escape`/`string.escape` -> `StringEscape`, and `number`/`constant`/`constant.builtin` ->
+///   their own real buckets - not `Literal`.** The six-bucket original design folded numbers,
+///   strings, escapes, constants and `self` all into one `Literal` colour; this issue's whole point
+///   is to stop doing that. See `theme::syntax`'s own module docs for exactly which of these five
+///   keep the old `Literal` hex value (as a real, deliberate fallback-chain alias) versus which
+///   ([`String`](HighlightKind::String)/[`StringEscape`](HighlightKind::StringEscape)) get a
+///   genuinely new, distinct colour.
 const HIGHLIGHT_KINDS: [HighlightKind; HIGHLIGHT_NAMES.len()] = [
     HighlightKind::Keyword,
     HighlightKind::Function,
+    HighlightKind::FunctionMethod,
     HighlightKind::Type,
+    HighlightKind::TypeBuiltin,
     HighlightKind::Type,
-    HighlightKind::Type,
-    HighlightKind::Literal,
-    HighlightKind::Literal,
-    HighlightKind::Literal,
-    HighlightKind::Literal,
-    HighlightKind::Literal,
+    HighlightKind::Tag,
+    HighlightKind::Constant,
+    HighlightKind::ConstantBuiltin,
+    HighlightKind::String,
+    HighlightKind::StringEscape,
+    HighlightKind::StringEscape,
+    HighlightKind::Number,
     HighlightKind::Comment,
+    HighlightKind::CommentDoc,
+    HighlightKind::CommentDoc,
+    HighlightKind::Variable,
+    HighlightKind::VariableParameter,
+    HighlightKind::VariableBuiltin,
+    HighlightKind::Property,
+    HighlightKind::Operator,
+    HighlightKind::PunctuationBracket,
+    HighlightKind::PunctuationDelimiter,
+    HighlightKind::Attribute,
+    HighlightKind::Embedded,
 ];
 
 /// Real supplement appended after `tree-sitter-python`'s own bundled `queries/highlights.scm`,
@@ -400,16 +539,35 @@ const HIGHLIGHT_KINDS: [HighlightKind; HIGHLIGHT_NAMES.len()] = [
 /// 3. **Compound type annotations.** `tree-sitter-python`'s bundled rule is
 ///    `(type (identifier) @type)` - it only fires when the annotation is a bare identifier that is
 ///    a *direct* child of the `type` node. A real annotation usually is not: `dict[str, int]`
-///    parses as `(type (generic_type ...))`, `str | None` as `(type (binary_operator ...))`, and
-///    `pathlib.Path` as `(type (attribute ...))` (all three shapes read off real parses, not
-///    assumed). Every one of those rendered as plain text, where the replaced implementation
-///    classified the whole `type` node as `Type` - a real, measured regression across ~620 bytes
-///    of the Python files checked. Capturing `(type)` itself restores exactly the replaced
-///    behaviour. Note this does *not* drag literals inside an annotation along with it: a `None`
-///    return type is an inner `(none) @constant.builtin` node, and nesting means the inner capture
-///    still wins, so `None` renders as `Literal`. That is a deliberate improvement rather than a
-///    leftover - the replaced code rendered `None` as `Type` inside an annotation but `Literal`
-///    everywhere else in the same file, and it is now consistently `Literal` in both places.
+///    parses as `(type (generic_type (identifier) (type_parameter (type (identifier)) (type
+///    (identifier)))))`, and `pathlib.Path` as `(type (attribute object: (identifier) attribute:
+///    (identifier)))` (both shapes read off a real parse via `tree_sitter::Node::to_sexp`, not
+///    assumed - `dict`/`list`'s own base-name node and `pathlib`'s own object node sit *outside*
+///    any per-identifier `(type (identifier) ...)` wrapper, while each of `dict[str, int]`'s own
+///    `str`/`int` type-parameter identifiers is individually re-wrapped in its own nested `(type
+///    (identifier))` and so already matches the bundled rule directly). Every one of those
+///    non-wrapped identifiers rendered as plain text, where the replaced implementation classified
+///    the whole `type` node as `Type` - a real, measured regression across ~620 bytes of the Python
+///    files checked. Capturing `(type) @type` itself (this rule) restores that whole-node
+///    behaviour for any byte the two more specific rules below don't otherwise cover.
+///
+///    That whole-node capture is not, on its own, enough once GitHub issue #31 registers a real
+///    `"variable"`/`"property"` bucket, though - a real, second-order regression an audit of this
+///    issue's own test suite caught. `tree-sitter-python`'s own blanket `(identifier) @variable`
+///    rule (line 3 of its bundled query) captures `dict`/`list`/`pathlib` too, since each is
+///    genuinely, structurally an `(identifier)` node; nested *inside* the whole `type` node this
+///    rule's own `@type` capture covers, the inner `@variable` capture wins (nesting: the innermost
+///    open highlight always wins - see [`highlight_with`]'s own docs) and silently downgrades
+///    `dict`/`list`/`pathlib` from `Type` back to `Variable`. The two rules directly below close
+///    that gap the same way rule 5 closes the method-call one: by capturing the *exact same*
+///    `dict`/`list`/`pathlib` identifier nodes themselves (not a wrapping parent) as `@type`, so
+///    the tie is now between two captures of the *same* node rather than parent-vs-child nesting -
+///    and, being the textually later match, `@type` wins.
+///
+///    Note this machinery does *not* drag literals inside an annotation along with it: a `None`
+///    return type is an inner `(none) @constant.builtin` node, and nesting means that inner capture
+///    still wins over any of this rule's own outer `@type`, so `None` renders as `ConstantBuiltin`
+///    - consistent with every other `None` in the file, not a leftover special case.
 /// 4. **Class names.** `tree-sitter-python` has no `class_definition name:` rule; a class name
 ///    reaches a bucket only via the query's two casing heuristics, and *neither is reliable*.
 ///    `@constructor` requires `^[A-Z]`, so `class _Pickler:` and `class socket:` - a leading
@@ -443,6 +601,9 @@ const PYTHON_HIGHLIGHTS_SUPPLEMENT: &str = r#"
 ] @keyword
 
 (type) @type
+
+(type (generic_type (identifier) @type))
+(type (attribute object: (identifier) @type))
 
 (class_definition name: (identifier) @type)
 
@@ -713,10 +874,15 @@ fn highlight_with(source: &str, grammar: Grammar) -> Vec<HighlightSpan> {
                 let kind = open.last().copied().unwrap_or(HighlightKind::Text);
                 // Coalesce with the previous span when it is both adjacent and the same bucket.
                 // Real, not cosmetic: the engine splits `Source` at every highlight boundary, so a
-                // string containing escapes arrives as several separate `Literal` runs that render
-                // identically to one. Merging here keeps `build_lines`' per-line run lists (and
-                // the `SharedString` allocation each run costs at render time) proportional to
-                // what is actually visually distinct.
+                // keyword list like Rust's `"as" @keyword ... "async" @keyword ...` arrives as one
+                // `Source` event per anonymous token even though they're all the same real
+                // `Keyword` bucket. Merging here keeps `build_lines`' per-line run lists (and the
+                // `SharedString` allocation each run costs at render time) proportional to what is
+                // actually visually distinct - note this deliberately does *not* merge a `String`
+                // run with an adjacent `StringEscape` one (different buckets since GitHub issue
+                // #31), so an escape sequence stays its own real, separately-classified span
+                // rather than disappearing into the surrounding string - see
+                // `escapes_inside_a_string_are_their_own_real_string_escape_run`.
                 match spans.last_mut() {
                     Some(previous) if previous.end == start && previous.kind == kind => {
                         previous.end = end;
@@ -1197,10 +1363,10 @@ mod tests {
     }
 
     #[test]
-    fn a_string_literal_is_classified_as_literal() {
+    fn a_string_literal_is_classified_as_string() {
         let spans = highlight_rust(SAMPLE_RUST);
         let span = find_span(&spans, SAMPLE_RUST, "\"x\"").expect("string literal span");
-        assert_eq!(span.kind, HighlightKind::Literal);
+        assert_eq!(span.kind, HighlightKind::String);
     }
 
     #[test]
@@ -1211,10 +1377,12 @@ mod tests {
     }
 
     #[test]
-    fn a_type_identifier_is_classified_as_type() {
+    fn a_primitive_type_identifier_is_classified_as_type_builtin() {
         let spans = highlight_rust(SAMPLE_RUST);
         // "i32" appears twice (parameter type, return type); just confirm at least one
-        // occurrence was classified as Type.
+        // occurrence was classified as TypeBuiltin - `i32` is a real `(primitive_type)` node in
+        // `tree-sitter-rust`'s own grammar, captured `@type.builtin`, not the plain `@type` a
+        // user-defined type name would get.
         let type_spans: Vec<_> = spans
             .iter()
             .filter(|span| SAMPLE_RUST[span.start..span.end] == *"i32")
@@ -1222,25 +1390,27 @@ mod tests {
         assert!(!type_spans.is_empty());
         assert!(type_spans
             .iter()
-            .all(|span| span.kind == HighlightKind::Type));
+            .all(|span| span.kind == HighlightKind::TypeBuiltin));
     }
 
     #[test]
-    fn a_doc_comment_is_classified_as_comment() {
+    fn a_doc_comment_is_classified_as_comment_doc() {
         let spans = highlight_rust(SAMPLE_RUST);
         // The `line_comment` node's byte range includes its trailing newline; it's treated as
         // one span rather than recursed into, since its children are just lexical pieces, not
-        // separately-colourable syntax.
+        // separately-colourable syntax. `///` is a real `(doc_comment)` child node, captured
+        // `@comment.documentation` - its own dedicated bucket since GitHub issue #31, not the
+        // plain `Comment` an ordinary `//` line gets.
         let span = find_span(&spans, SAMPLE_RUST, "/// Adds one.\n").expect("doc comment span");
-        assert_eq!(span.kind, HighlightKind::Comment);
+        assert_eq!(span.kind, HighlightKind::CommentDoc);
     }
 
     #[test]
-    fn self_is_classified_as_literal_not_keyword() {
+    fn self_is_classified_as_variable_builtin_not_keyword() {
         let source = "impl Foo {\n    fn bar(&self) -> i32 {\n        self.value\n    }\n}\n";
         let spans = highlight_rust(source);
         let span = find_span(&spans, source, "self").expect("self span");
-        assert_eq!(span.kind, HighlightKind::Literal);
+        assert_eq!(span.kind, HighlightKind::VariableBuiltin);
     }
 
     #[test]
@@ -1265,10 +1435,10 @@ mod tests {
     }
 
     #[test]
-    fn typescript_string_literal_is_classified_as_literal() {
+    fn typescript_string_literal_is_classified_as_string() {
         let spans = highlight_typescript(SAMPLE_TYPESCRIPT, false);
         let span = find_span(&spans, SAMPLE_TYPESCRIPT, "\"x\"").expect("string literal span");
-        assert_eq!(span.kind, HighlightKind::Literal);
+        assert_eq!(span.kind, HighlightKind::String);
     }
 
     #[test]
@@ -1279,8 +1449,9 @@ mod tests {
     }
 
     #[test]
-    fn typescript_predefined_type_is_classified_as_type() {
+    fn typescript_predefined_type_is_classified_as_type_builtin() {
         let spans = highlight_typescript(SAMPLE_TYPESCRIPT, false);
+        // `number` is a real `(predefined_type)` node, captured `@type.builtin`.
         let type_spans: Vec<_> = spans
             .iter()
             .filter(|span| SAMPLE_TYPESCRIPT[span.start..span.end] == *"number")
@@ -1288,7 +1459,7 @@ mod tests {
         assert!(!type_spans.is_empty());
         assert!(type_spans
             .iter()
-            .all(|span| span.kind == HighlightKind::Type));
+            .all(|span| span.kind == HighlightKind::TypeBuiltin));
     }
 
     #[test]
@@ -1303,7 +1474,11 @@ mod tests {
     /// `name` field collides with `function_declaration`'s `name` field in
     /// `tree-sitter-typescript`'s real grammar, and the old, parent-kind-unaware matching
     /// misclassified every `const`/`let`/`var` binding's name as a Function. `s` here must be
-    /// plain `Text` (a use/declaration of a variable, not a function).
+    /// classified `Variable` (a use/declaration of a variable, not a function) - previously
+    /// asserted as plain `Text`, back when `"variable"` wasn't yet a registered highlight name at
+    /// all (GitHub issue #31 registered it); `theme::syntax::VARIABLE` is still a real, direct
+    /// alias of `theme::syntax::TEXT` (see that module's docs), so this is a classification-only
+    /// change with no visual difference.
     #[test]
     fn typescript_const_variable_name_is_not_misclassified_as_a_function() {
         // The audit's exact reproduction. `find_span`'s plain substring search would otherwise
@@ -1318,29 +1493,37 @@ mod tests {
             .map_or(HighlightKind::Text, |span| span.kind);
         assert_eq!(
             kind,
-            HighlightKind::Text,
+            HighlightKind::Variable,
             "a const/let/var binding's own name must never be classified as a function"
         );
     }
 
     /// The same real collision, for an `interface` member name (`property_signature`'s `name`
-    /// field) - must not be classified as a function either.
+    /// field) - must not be classified as a function either. Classified `Property` (a real,
+    /// registered bucket since GitHub issue #31 - `tree-sitter-javascript`'s own
+    /// `(property_identifier) @property` rule is unconditional), not plain `Text` as before that
+    /// scope existed.
     #[test]
     fn typescript_interface_member_name_is_not_misclassified_as_a_function() {
         let source = "interface Point { x: number }\n";
         let spans = highlight_typescript(source, false);
-        assert_eq!(kind_at(&spans, source, "x: number"), HighlightKind::Text);
+        assert_eq!(
+            kind_at(&spans, source, "x: number"),
+            HighlightKind::Property
+        );
     }
 
     /// The same real collision, for a class method's own name (`method_definition`'s `name`
     /// field, a `property_identifier`) - this one, unlike the two above, genuinely *should* be
     /// classified as a function.
     #[test]
-    fn typescript_class_method_name_is_classified_as_a_function() {
+    fn typescript_class_method_name_is_classified_as_a_function_method() {
         let source = "class Point {\n    length() {\n        return 0;\n    }\n}\n";
         let spans = highlight_typescript(source, false);
         let span = find_span(&spans, source, "length").expect("method name span");
-        assert_eq!(span.kind, HighlightKind::Function);
+        // `(method_definition name: (property_identifier) @function.method)` - its own
+        // dedicated bucket since GitHub issue #31 (previously folded into plain `Function`).
+        assert_eq!(span.kind, HighlightKind::FunctionMethod);
     }
 
     /// The same real collision, for a real function call's callee (`call_expression`'s
@@ -1360,13 +1543,16 @@ mod tests {
     }
 
     /// A real TSX tag name (`jsx_self_closing_element`'s own `name` field) is the same real
-    /// collision one more time - must not render as a Function either.
+    /// collision one more time - must not render as a Function either. Classified `Tag` (its own
+    /// real, dedicated bucket since GitHub issue #31 - previously folded into `Type`; see
+    /// `theme::syntax::TAG`'s own docs for why the two still render identically).
     #[test]
     fn tsx_tag_name_is_not_misclassified_as_a_function() {
         let source = "const el = <div />;\n";
         let spans = highlight_typescript(source, true);
         let span = find_span(&spans, source, "div").expect("tag name span");
         assert_ne!(span.kind, HighlightKind::Function);
+        assert_eq!(span.kind, HighlightKind::Tag);
     }
 
     #[test]
@@ -1390,10 +1576,10 @@ mod tests {
     }
 
     #[test]
-    fn python_string_literal_is_classified_as_literal() {
+    fn python_string_literal_is_classified_as_string() {
         let spans = highlight_python(SAMPLE_PYTHON);
         let span = find_span(&spans, SAMPLE_PYTHON, "\"x\"").expect("string literal span");
-        assert_eq!(span.kind, HighlightKind::Literal);
+        assert_eq!(span.kind, HighlightKind::String);
     }
 
     #[test]
@@ -1424,13 +1610,13 @@ mod tests {
         assert_eq!(span.kind, HighlightKind::Comment);
     }
 
-    /// Matches Rust's own `self_is_classified_as_literal_not_keyword` test - a deliberate,
-    /// documented choice that Python's `self` gets the same Literal treatment Rust's does. Rust
-    /// gets it from its grammar's own `(self) @variable.builtin` rule; Python's grammar has no
-    /// rule for `self` at all, so it comes from [`PYTHON_HIGHLIGHTS_SUPPLEMENT`]'s second rule -
-    /// see there.
+    /// Matches Rust's own `self_is_classified_as_variable_builtin_not_keyword` test - a
+    /// deliberate, documented choice that Python's `self` gets the same `VariableBuiltin`
+    /// treatment Rust's does. Rust gets it from its grammar's own `(self) @variable.builtin` rule;
+    /// Python's grammar has no rule for `self` at all, so it comes from
+    /// [`PYTHON_HIGHLIGHTS_SUPPLEMENT`]'s second rule - see there.
     #[test]
-    fn python_self_is_classified_as_literal_not_a_plain_identifier() {
+    fn python_self_is_classified_as_variable_builtin_not_a_plain_identifier() {
         let source = "class Foo:\n    def bar(self):\n        return self.value\n";
         let spans = highlight_python(source);
         let self_spans: Vec<_> = spans
@@ -1440,7 +1626,7 @@ mod tests {
         assert!(!self_spans.is_empty());
         assert!(self_spans
             .iter()
-            .all(|span| span.kind == HighlightKind::Literal));
+            .all(|span| span.kind == HighlightKind::VariableBuiltin));
     }
 
     /// The real, live-verified regression this fix addresses: `class_definition`'s own `name`
@@ -1537,8 +1723,8 @@ mod tests {
 
     /// [`HIGHLIGHT_NAMES`] and [`HIGHLIGHT_KINDS`] are a positional parallel array pair, and the
     /// whole classification mapping is wrong-but-compiling if they ever drift. The array length is
-    /// already tied together at compile time; this pins the *content* of the two mappings whose
-    /// index positions are easiest to get silently wrong.
+    /// already tied together at compile time; this pins the *content* of every real mapping -
+    /// GitHub issue #31's full extended scope list, not just the original six-bucket handful.
     #[test]
     fn recognized_highlight_names_map_to_the_intended_buckets() {
         let bucket = |name: &str| {
@@ -1550,21 +1736,60 @@ mod tests {
         };
         assert_eq!(bucket("keyword"), HighlightKind::Keyword);
         assert_eq!(bucket("function"), HighlightKind::Function);
+        assert_eq!(bucket("function.method"), HighlightKind::FunctionMethod);
+        assert_eq!(bucket("type"), HighlightKind::Type);
+        assert_eq!(bucket("type.builtin"), HighlightKind::TypeBuiltin);
+        assert_eq!(bucket("constant"), HighlightKind::Constant);
+        assert_eq!(bucket("constant.builtin"), HighlightKind::ConstantBuiltin);
+        assert_eq!(bucket("string"), HighlightKind::String);
+        assert_eq!(bucket("number"), HighlightKind::Number);
         assert_eq!(bucket("comment"), HighlightKind::Comment);
-        // The three non-obvious ones, each argued for in `HIGHLIGHT_KINDS`' own docs.
+        assert_eq!(bucket("variable"), HighlightKind::Variable);
+        assert_eq!(
+            bucket("variable.parameter"),
+            HighlightKind::VariableParameter
+        );
+        assert_eq!(bucket("property"), HighlightKind::Property);
+        assert_eq!(bucket("operator"), HighlightKind::Operator);
+        assert_eq!(
+            bucket("punctuation.bracket"),
+            HighlightKind::PunctuationBracket
+        );
+        assert_eq!(
+            bucket("punctuation.delimiter"),
+            HighlightKind::PunctuationDelimiter
+        );
+        assert_eq!(bucket("attribute"), HighlightKind::Attribute);
+        assert_eq!(bucket("embedded"), HighlightKind::Embedded);
+        // The real capture names verified directly against the grammars' own bundled query files
+        // (`escape`, `comment.documentation`), plus their checklist-name synonyms
+        // (`string.escape`, `comment.doc`) that no grammar here actually emits today - both sides
+        // of each pair resolve to the same bucket.
+        assert_eq!(bucket("escape"), HighlightKind::StringEscape);
+        assert_eq!(bucket("string.escape"), HighlightKind::StringEscape);
+        assert_eq!(bucket("comment.documentation"), HighlightKind::CommentDoc);
+        assert_eq!(bucket("comment.doc"), HighlightKind::CommentDoc);
+        // The non-obvious ones, each argued for in `HIGHLIGHT_KINDS`' own docs.
         assert_eq!(bucket("constructor"), HighlightKind::Type);
-        assert_eq!(bucket("tag"), HighlightKind::Type);
-        assert_eq!(bucket("variable.builtin"), HighlightKind::Literal);
+        assert_eq!(bucket("tag"), HighlightKind::Tag);
+        assert_eq!(bucket("variable.builtin"), HighlightKind::VariableBuiltin);
     }
 
     /// Real gains the replaced implementation genuinely did not have. Its own docs called the
     /// method-call gap "an intentionally narrow, documented gap" it did not cover; the real
-    /// grammar queries do.
+    /// grammar queries do. `clone` is a real `@function.method` capture (its own dedicated bucket
+    /// since GitHub issue #31 registered `"function.method"` as more specific than the plain
+    /// `"function"` it used to fall back to); `println!` is a macro invocation, `@function.macro`,
+    /// which this module deliberately leaves unregistered (see [`HIGHLIGHT_NAMES`]'s own docs) so
+    /// it still falls back to the plain `Function` bucket.
     #[test]
     fn rust_method_calls_and_macros_are_now_classified_as_functions() {
         let source = "fn main() {\n    let x = value.clone();\n    println!(\"{x}\");\n}\n";
         let spans = highlight_rust(source);
-        assert_eq!(kind_at(&spans, source, "clone"), HighlightKind::Function);
+        assert_eq!(
+            kind_at(&spans, source, "clone"),
+            HighlightKind::FunctionMethod
+        );
         assert_eq!(kind_at(&spans, source, "println"), HighlightKind::Function);
     }
 
@@ -1579,36 +1804,41 @@ mod tests {
         assert_eq!(kind_at(&spans, source, "mut "), HighlightKind::Keyword);
     }
 
-    /// Rust's `self` stays `Literal`, now via the real grammar's own `(self) @variable.builtin`
-    /// rather than the replaced implementation's bespoke node-kind table entry - and TypeScript's
-    /// `this` *joins* it, which is the one deliberate cross-language reclassification in this
-    /// migration (see [`HIGHLIGHT_KINDS`]' docs).
+    /// Rust's `self` stays `VariableBuiltin` (its own dedicated bucket since GitHub issue #31,
+    /// carrying forward the same colour the old, unsplit `Literal` bucket used - see
+    /// `theme::syntax::VARIABLE_BUILTIN`'s own docs), now via the real grammar's own
+    /// `(self) @variable.builtin` rather than the replaced implementation's bespoke node-kind
+    /// table entry - and TypeScript's `this` *joins* it, which is the one deliberate
+    /// cross-language reclassification in the original migration (see [`HIGHLIGHT_KINDS`]' docs).
     #[test]
-    fn self_and_this_share_the_literal_self_bucket_across_languages() {
+    fn self_and_this_share_the_variable_builtin_bucket_across_languages() {
         let rust = "impl T { fn get(&self) -> u8 { self.value } }\n";
         assert_eq!(
             kind_at(&highlight_rust(rust), rust, "self.value"),
-            HighlightKind::Literal
+            HighlightKind::VariableBuiltin
         );
         let python = "class T:\n    def get(self):\n        return self.value\n";
         assert_eq!(
             kind_at(&highlight_python(python), python, "self.value"),
-            HighlightKind::Literal
+            HighlightKind::VariableBuiltin
         );
         let typescript = "class T { get() { return this.value; } }\n";
         assert_eq!(
             kind_at(&highlight_typescript(typescript, false), typescript, "this"),
-            HighlightKind::Literal
+            HighlightKind::VariableBuiltin
         );
     }
 
     /// Python's `and`/`or`/`not`/`in`/`is` live in `tree-sitter-python`'s `@operator` list, not
-    /// its `@keyword` list, and this app has no operator bucket - so without
-    /// [`PYTHON_HIGHLIGHTS_SUPPLEMENT`] they would render as plain text where the replaced
-    /// implementation made them real keywords. Symbolic operators must stay `Text`, which is what
-    /// the replaced implementation did with them and what the design colour table asks for.
+    /// its `@keyword` list - [`PYTHON_HIGHLIGHTS_SUPPLEMENT`] promotes the word operators
+    /// specifically to real keywords (the supplement is appended text, so its rule wins the
+    /// "last matching pattern wins" tie against the base query's own `@operator` capture for the
+    /// same node - see [`PYTHON_HIGHLIGHTS_SUPPLEMENT`]'s own docs). A symbolic operator like `+`
+    /// is left alone, so it keeps its base-query `@operator` capture - now a real, registered
+    /// bucket since GitHub issue #31 (`theme::syntax::OPERATOR` is still a direct alias of
+    /// `theme::syntax::TEXT`, so this is a classification-only change with no visual difference).
     #[test]
-    fn python_word_operators_are_keywords_but_symbolic_ones_stay_text() {
+    fn python_word_operators_are_keywords_but_symbolic_ones_are_the_real_operator_bucket() {
         let source = "if a is not b and c in d or not e:\n    total = a + b\n";
         let spans = highlight_python(source);
         for word in ["is not", "and ", "in ", "or ", "not e"] {
@@ -1618,7 +1848,7 @@ mod tests {
                 "python word operator {word:?}"
             );
         }
-        assert_eq!(kind_at(&spans, source, "+ b"), HighlightKind::Text);
+        assert_eq!(kind_at(&spans, source, "+ b"), HighlightKind::Operator);
     }
 
     /// A compound Python type annotation. `tree-sitter-python`'s own rule only fires for a bare
@@ -1675,17 +1905,22 @@ mod tests {
     fn python_method_calls_match_rust_and_typescript() {
         let source = "value = obj.method()\nother = cls(name)\n";
         let spans = highlight_python(source);
-        assert_eq!(kind_at(&spans, source, "method"), HighlightKind::Function);
+        assert_eq!(
+            kind_at(&spans, source, "method"),
+            HighlightKind::FunctionMethod,
+            "a real `obj.method()` call is a method call, its own dedicated bucket since GitHub \
+             issue #31"
+        );
         assert_eq!(
             kind_at(&spans, source, "cls("),
             HighlightKind::Function,
-            "a real `cls(...)` construction is a call, not the `cls` self-reference"
+            "a real `cls(...)` construction is a plain call, not the `cls` self-reference"
         );
-        // ...while a bare `cls`/`self` reference stays in the literal/self bucket.
+        // ...while a bare `cls`/`self` reference stays in the variable-builtin/self bucket.
         let reference = "def f(cls):\n    return cls\n";
         assert_eq!(
             kind_at(&highlight_python(reference), reference, "cls\n"),
-            HighlightKind::Literal
+            HighlightKind::VariableBuiltin
         );
     }
 
@@ -1699,8 +1934,8 @@ mod tests {
         let spans = highlight_typescript(source, false);
         assert_eq!(kind_at(&spans, source, "// note"), HighlightKind::Comment);
         assert_eq!(kind_at(&spans, source, "async"), HighlightKind::Keyword);
-        assert_eq!(kind_at(&spans, source, "\"/api\""), HighlightKind::Literal);
-        assert_eq!(kind_at(&spans, source, "3"), HighlightKind::Literal);
+        assert_eq!(kind_at(&spans, source, "\"/api\""), HighlightKind::String);
+        assert_eq!(kind_at(&spans, source, "3"), HighlightKind::Number);
         assert_eq!(kind_at(&spans, source, "fetch"), HighlightKind::Function);
     }
 
@@ -1727,31 +1962,43 @@ mod tests {
         );
         assert_eq!(
             kind_at(&spans, source, "void"),
-            HighlightKind::Type,
-            "`void` must classify like every other predefined_type keyword"
+            HighlightKind::TypeBuiltin,
+            "`void` must classify like every other predefined_type keyword - its own dedicated \
+             bucket since GitHub issue #31, not the plain `Type` a user-defined type name gets"
         );
-        // The sibling predefined types it has to stay consistent with.
-        assert_eq!(kind_at(&spans, source, "string"), HighlightKind::Type);
+        // The sibling predefined type it has to stay consistent with.
+        assert_eq!(
+            kind_at(&spans, source, "string"),
+            HighlightKind::TypeBuiltin
+        );
     }
 
     /// Real TSX. The JSX query is only composed in for the TSX grammar (it references node kinds
     /// the plain TypeScript grammar does not have), so this is the only place element-name
     /// classification is exercised at all.
+    ///
+    /// `div` and `Badge` used to both assert `HighlightKind::Type` (a lowercase JSX element name
+    /// arriving via `@tag` was folded into the same bucket as a capitalised one arriving via
+    /// TypeScript's own `@type` heuristic - see `theme::syntax::TAG`'s own docs). GitHub issue #31
+    /// gave `@tag` its own dedicated [`HighlightKind::Tag`] bucket, so the two are now correctly
+    /// told apart at the classification level even though `theme::syntax::TAG` still aliases
+    /// `theme::syntax::TYPE` and so the two still *render* identically.
     #[test]
-    fn tsx_jsx_element_names_are_classified_as_types() {
+    fn tsx_jsx_element_names_are_classified_as_tag_or_type() {
         let source = "const view = <div className=\"row\"><Badge label={name} /></div>;\n";
         let spans = highlight_tsx(source);
         assert_eq!(
             kind_at(&spans, source, "div"),
-            HighlightKind::Type,
+            HighlightKind::Tag,
             "a lowercase JSX element name arrives as @tag"
         );
         assert_eq!(
             kind_at(&spans, source, "Badge"),
             HighlightKind::Type,
-            "a capitalised JSX component name must match the lowercase case"
+            "a capitalised JSX component name doesn't match @tag's own lowercase-only regex, so \
+             it falls through to TypeScript's plain capitalised-identifier @type heuristic instead"
         );
-        assert_eq!(kind_at(&spans, source, "\"row\""), HighlightKind::Literal);
+        assert_eq!(kind_at(&spans, source, "\"row\""), HighlightKind::String);
     }
 
     /// Interpolated code inside a template literal / f-string is now classified as the real code
@@ -1763,17 +2010,19 @@ mod tests {
         let ts_spans = highlight_typescript(typescript, false);
         assert_eq!(
             kind_at(&ts_spans, typescript, "n=$"),
-            HighlightKind::Literal,
+            HighlightKind::String,
             "the literal text of the template string is still a string"
         );
         assert_eq!(
             kind_at(&ts_spans, typescript, "toFixed"),
-            HighlightKind::Function
+            HighlightKind::FunctionMethod,
+            "a real `count.toFixed(...)` call is a method call, its own dedicated bucket since \
+             GitHub issue #31"
         );
 
         let python = "msg = f\"n={value if value else other}\"\n";
         let py_spans = highlight_python(python);
-        assert_eq!(kind_at(&py_spans, python, "n="), HighlightKind::Literal);
+        assert_eq!(kind_at(&py_spans, python, "n="), HighlightKind::String);
         assert_eq!(
             kind_at(&py_spans, python, "if value"),
             HighlightKind::Keyword
@@ -1809,24 +2058,41 @@ mod tests {
         }
     }
 
-    /// Adjacent same-kind spans are coalesced, so a string containing escape sequences renders as
-    /// one continuous `Literal` run rather than several - and, critically, the escape does not
-    /// punch a `Text`-coloured hole through the middle of the string the way an unrecognised
-    /// capture name would.
+    /// Before GitHub issue #31, `string` and `escape` both resolved to the same unsplit `Literal`
+    /// bucket, so adjacent same-kind coalescing made a string containing escape sequences render
+    /// as one continuous run with no visible distinction between the string body and its own
+    /// escapes. That was a deliberate simplification at the time, and issue #31's whole point is
+    /// to stop making it: `string.escape` is one of its checklist scopes by name. This test now
+    /// pins the *opposite* invariant - each escape sequence gets its own real, separately
+    /// classified `StringEscape` span, distinct from the surrounding `String` one - while still
+    /// confirming the historical guarantee that mattered (no byte of the string, escapes
+    /// included, ever falls back to plain `Text`).
     #[test]
-    fn escapes_inside_a_string_stay_one_continuous_literal_run() {
+    fn escapes_inside_a_string_are_their_own_real_string_escape_run() {
         let source = "fn main() { let s = \"a\\nb\\tc\"; }\n";
         let spans = highlight_rust(source);
+
+        let newline_escape = find_span(&spans, source, "\\n").expect("\\n escape span");
+        assert_eq!(newline_escape.kind, HighlightKind::StringEscape);
+        let tab_escape = find_span(&spans, source, "\\t").expect("\\t escape span");
+        assert_eq!(tab_escape.kind, HighlightKind::StringEscape);
+
+        // The surrounding string content (opening quote through `a`, `b` between the two
+        // escapes, `c` through the closing quote) stays real `String` - not `StringEscape`, and
+        // not, critically, a `Text`-coloured hole where the escapes used to invisibly merge it.
         let literal_start = source.find('"').expect("string start");
-        let span = spans
-            .iter()
-            .find(|span| span.start <= literal_start && literal_start < span.end)
-            .expect("string span");
-        assert_eq!(span.kind, HighlightKind::Literal);
-        assert!(
-            span.end >= source.find("c\"").expect("string end") + 2,
-            "the whole string literal, escapes included, must be one Literal run"
-        );
+        let literal_end = source.find("c\"").expect("string end") + 2;
+        for offset in literal_start..literal_end {
+            let kind = spans
+                .iter()
+                .find(|span| span.start <= offset && offset < span.end)
+                .map_or(HighlightKind::Text, |span| span.kind);
+            assert!(
+                kind == HighlightKind::String || kind == HighlightKind::StringEscape,
+                "byte {offset} of the string literal classified as {kind:?}, not String/\
+                 StringEscape"
+            );
+        }
     }
 
     // Coverage for finding 5's fix: `highlighter_for_extension` reads from the real registry,
@@ -2158,10 +2424,10 @@ mod tests {
         let has_string_literal = rendered
             .iter()
             .flat_map(|line| &line.runs)
-            .any(|(text, kind)| text.as_ref() == "\"left\"" && *kind == HighlightKind::Literal);
+            .any(|(text, kind)| text.as_ref() == "\"left\"" && *kind == HighlightKind::String);
         assert!(
             has_string_literal,
-            "the real string literal should be classified as Literal"
+            "the real string literal should be classified as String"
         );
     }
 

--- a/crates/app/src/code_surface/diff_view.rs
+++ b/crates/app/src/code_surface/diff_view.rs
@@ -507,9 +507,10 @@ mod diff_render_tests {
             );
             assert!(
                 all_runs.iter().any(|(text, kind)| text.as_ref() == "2"
-                    && *kind == code_view::HighlightKind::Literal),
-                "the real added integer literal '2' should be classified as Literal - got \
-                 {all_runs:?}"
+                    && *kind == code_view::HighlightKind::ConstantBuiltin),
+                "the real added integer literal '2' should be classified as ConstantBuiltin (a \
+                 real `@constant.builtin` capture - `tree-sitter-rust` has no separate `number` \
+                 capture) - got {all_runs:?}"
             );
         });
     }

--- a/crates/app/src/code_surface/editing.rs
+++ b/crates/app/src/code_surface/editing.rs
@@ -1146,9 +1146,9 @@ pub(in crate::code_surface) fn render_editable_file_view_line(
     } = context;
 
     let gutter_color = if is_current {
-        theme::text::DIM
+        theme::editor::GUTTER_TEXT_ACTIVE
     } else {
-        theme::text::GUTTER
+        theme::editor::GUTTER_TEXT
     };
     let worst_severity = diagnostics_view::Severity::worst(diagnostics);
 
@@ -1206,7 +1206,9 @@ pub(in crate::code_surface) fn render_editable_file_view_line(
                             bounds.bottom(),
                         ),
                     ),
-                    theme::syntax::CARET.resolve().opacity(0.28),
+                    theme::editor::SELECTION
+                        .resolve()
+                        .opacity(theme::editor::SELECTION_OPACITY),
                 )
             });
             let cursor_quad = cursor_local.map(|offset| {
@@ -1215,7 +1217,7 @@ pub(in crate::code_surface) fn render_editable_file_view_line(
                         point(bounds.left() + shaped.x_for_index(offset), bounds.top()),
                         size(gpui::px(2.0), bounds.bottom() - bounds.top()),
                     ),
-                    theme::syntax::CARET,
+                    theme::editor::CARET,
                 )
             });
             (shaped, selection_quad, cursor_quad)
@@ -1363,7 +1365,7 @@ pub(in crate::code_surface) fn render_editable_file_view_line(
         .flex()
         .items_center();
     if is_current {
-        row = row.bg(theme::surface::CURRENT_LINE);
+        row = row.bg(theme::editor::CURRENT_LINE);
     } else if let Some(bg) = worst_severity.and_then(diagnostic_row_bg) {
         row = row.bg(bg);
     }
@@ -1389,7 +1391,7 @@ pub(in crate::code_surface) fn render_editable_file_view_line(
                 .w(gpui::px(3.0))
                 .self_stretch()
                 .bg(if is_changed {
-                    theme::diff::GIT_GUTTER
+                    theme::editor::DIFF_ADDED
                 } else {
                     theme::ColorToken(crate::work_surface::state::TRANSPARENT)
                 }),

--- a/crates/app/src/code_surface/file_view.rs
+++ b/crates/app/src/code_surface/file_view.rs
@@ -696,9 +696,9 @@ pub(in crate::code_surface) fn render_file_view_line(
         inline_blame,
     } = hover;
     let gutter_color = if is_current {
-        theme::text::DIM
+        theme::editor::GUTTER_TEXT_ACTIVE
     } else {
-        theme::text::GUTTER
+        theme::editor::GUTTER_TEXT
     };
     // "Worst wins": the tie-break for a line's row-level treatment when it carries diagnostics
     // of mixed severity (see `Severity::worst`), not whichever is first in the Vec.
@@ -802,7 +802,7 @@ pub(in crate::code_surface) fn render_file_view_line(
         .flex()
         .items_center()
         .cursor_pointer()
-        .when(is_current, |el| el.bg(theme::surface::CURRENT_LINE))
+        .when(is_current, |el| el.bg(theme::editor::CURRENT_LINE))
         .when_some(
             if is_current {
                 None
@@ -846,7 +846,7 @@ pub(in crate::code_surface) fn render_file_view_line(
                 // strip.
                 .self_stretch()
                 .bg(if is_changed {
-                    theme::diff::GIT_GUTTER
+                    theme::editor::DIFF_ADDED
                 } else {
                     theme::ColorToken(work_surface::TRANSPARENT)
                 }),

--- a/crates/app/src/lsp/diagnostics.rs
+++ b/crates/app/src/lsp/diagnostics.rs
@@ -421,7 +421,7 @@ mod tests {
     fn no_diagnostics_leaves_every_run_untouched_and_unmarked() {
         let runs = vec![
             (SharedString::new("let x: i32 = "), HighlightKind::Keyword),
-            (SharedString::new("\"y\""), HighlightKind::Literal),
+            (SharedString::new("\"y\""), HighlightKind::String),
         ];
         let overlaid = overlay_diagnostic_runs(&runs, &[]);
         assert_eq!(overlaid.len(), 2);

--- a/crates/app/src/theme.rs
+++ b/crates/app/src/theme.rs
@@ -455,15 +455,134 @@ pub mod diff {
     pub const GIT_GUTTER: ColorToken = hex(0x2c6244); // 3px agent-touched marker
 }
 
+/// The editor's per-scope syntax palette - one [`ColorToken`] per `tree-sitter-highlight`
+/// capture bucket [`crate::code_surface::code_view::HighlightKind`] classifies a token into. See
+/// that type's own docs for the full scope-name -> bucket mapping and the real grammar captures
+/// (`tree-sitter-rust`/`-python`/`-javascript`/`-typescript`'s own bundled `queries/highlights.scm`
+/// files, read directly off the fetched crates under `~/.cargo/registry/src/`, not guessed) each
+/// bucket exists to cover.
+///
+/// ## The fallback chain (GitHub issue #31)
+///
+/// Six scopes here are deliberately **not** independently authored colours: each is a real,
+/// direct [`ColorToken`] alias of its nearest covered ancestor scope (the same "reuse a token
+/// directly" idiom already used elsewhere in this module, e.g. [`env::WSL_FG`] aliasing
+/// [`term::PROMPT`]), so a scope with no colour of its own degrades to what its *parent* scope
+/// looks like rather than to plain foreground text:
+///
+/// - [`FUNCTION_METHOD`] -> [`FUNCTION`] (a method is still a function)
+/// - [`TYPE_BUILTIN`] -> [`TYPE`] (`i32`/`number`/`void` are still types)
+/// - [`CONSTANT_BUILTIN`] -> [`CONSTANT`] (`true`/`None`/`undefined` are still constants)
+/// - [`VARIABLE_PARAMETER`] -> [`VARIABLE`] (the issue's own worked example)
+/// - [`PROPERTY`] -> [`VARIABLE`] (a field access reads like a variable reference here)
+/// - [`TAG`] -> [`TYPE`] (preserves this module's pre-existing, deliberate "a JSX element name
+///   is coloured like the type it names" choice - see the historical note on
+///   [`crate::code_surface::code_view::HighlightKind::Tag`])
+///
+/// [`VARIABLE`] and, transitively through it, [`OPERATOR`], [`PUNCTUATION_BRACKET`],
+/// [`PUNCTUATION_DELIMITER`] and [`EMBEDDED`] are themselves aliases of [`TEXT`] - not because
+/// they are unmapped, but because this app's own minimalist syntax palette has always deliberately
+/// left plain identifiers and punctuation uncoloured (see the historical design note preserved on
+/// [`crate::code_surface::code_view::HighlightKind`]); they are real, live-classified buckets now
+/// (each one is a genuine `tree-sitter-highlight` capture this module's `HIGHLIGHT_NAMES` actually
+/// recognizes - see `code_view_tests::every_real_grammar_config_compiles` and its siblings), simply
+/// designed to render identically to plain text rather than compete with it.
 pub mod syntax {
     use super::{hex, ColorToken};
 
     pub const TEXT: ColorToken = hex(0xacb2be);
     pub const KEYWORD: ColorToken = hex(0xb477cf);
     pub const FUNCTION: ColorToken = hex(0x74ade8);
+    /// `function.method` (`tree-sitter-rust`'s `@function.method`, `-javascript`'s own) - see the
+    /// module docs' fallback-chain section.
+    pub const FUNCTION_METHOD: ColorToken = FUNCTION;
     pub const TYPE: ColorToken = hex(0xdfc184);
-    pub const LITERAL: ColorToken = hex(0xbf956a); // numbers, `self`
+    /// `type.builtin` (`tree-sitter-rust`'s `(primitive_type) @type.builtin`, `-typescript`'s
+    /// `(predefined_type) @type.builtin`) - see the module docs' fallback-chain section.
+    pub const TYPE_BUILTIN: ColorToken = TYPE;
+    /// `constant` (an all-caps identifier, per every one of this app's four grammars' own naming
+    /// convention heuristic) - the same value [`LITERAL`] used to carry before this module split
+    /// the old six-bucket "Literal" classification into its real, individually-scoped captures.
+    pub const CONSTANT: ColorToken = hex(0xbf956a);
+    /// `constant.builtin` (`true`/`false`/`None`/`undefined`/an integer or float literal - Rust
+    /// and JavaScript/TypeScript both route numeric/boolean literals through this real capture
+    /// name rather than a plain `number`) - see the module docs' fallback-chain section.
+    pub const CONSTANT_BUILTIN: ColorToken = CONSTANT;
+    /// `string` (`(string_literal) @string`, `(template_string) @string`, ...) - a real, distinct
+    /// hue from [`CONSTANT`] (unlike the replaced six-bucket palette, which lumped every literal
+    /// together) so a string reads apart from a number at a glance.
+    pub const STRING: ColorToken = hex(0x9dbb6f);
+    /// `string.escape` - registered under both this checklist name and the real capture name every
+    /// one of this app's grammars that supports escapes actually emits, plain `escape`
+    /// (`tree-sitter-rust`'s `(escape_sequence) @escape`, `-python`'s own identical rule; neither
+    /// JavaScript's nor TypeScript's own bundled query captures string escapes at all, verified
+    /// directly against their real `queries/highlights.scm` - so this bucket is genuinely reachable
+    /// for Rust/Python source only). A brighter tint of [`STRING`] rather than a plain alias: an
+    /// escape sequence is a real, deliberately-distinct sub-token within a string, not a fallback
+    /// case.
+    pub const STRING_ESCAPE: ColorToken = hex(0xc3d99a);
+    /// `number` (`-python`'s `[(integer)(float)] @number`, `-javascript`'s `(number) @number`;
+    /// Rust has no separate `number` capture at all - its own numeric literals arrive as
+    /// `@constant.builtin` instead, see [`CONSTANT_BUILTIN`]). Reuses [`CONSTANT`]'s own value:
+    /// both are numeric-literal buckets under a different grammar's own naming choice, and keeping
+    /// them visually identical is what makes "a number looks like a number" consistent regardless
+    /// of which of the four languages produced it.
+    pub const NUMBER: ColorToken = CONSTANT;
     pub const COMMENT: ColorToken = hex(0x5d636f);
+    /// `comment.doc` - registered under both this checklist name and the real capture name
+    /// `tree-sitter-rust`'s own query actually emits, `comment.documentation`
+    /// (`(line_comment (doc_comment)) @comment.documentation`); none of this app's other three
+    /// grammars has a doc-comment concept in their bundled query. A brighter tint of [`COMMENT`]
+    /// (not a plain alias) so a `///` doc comment reads as more prominent than an ordinary `//`
+    /// one, the same real distinction most editors make.
+    pub const COMMENT_DOC: ColorToken = hex(0x7c8290);
+    /// `variable` - a real, live-classified bucket (`-python`'s own blanket `(identifier)
+    /// @variable`, `-javascript`'s identical blanket rule) now, not a fallthrough. Aliased
+    /// straight to [`TEXT`] - see the module docs' fallback-chain section for why that is a
+    /// deliberate design choice, not an oversight.
+    pub const VARIABLE: ColorToken = TEXT;
+    /// `variable.parameter` (`tree-sitter-rust`'s `(parameter (identifier) @variable.parameter)`,
+    /// `-typescript`'s `required_parameter`/`optional_parameter` rules) - the issue's own worked
+    /// fallback-chain example, reused verbatim: falls back to [`VARIABLE`] rather than to plain
+    /// foreground.
+    pub const VARIABLE_PARAMETER: ColorToken = VARIABLE;
+    /// `variable.builtin` (`self`/`this`/`super`/`cls`) - the bucket the replaced six-colour
+    /// design table called "literal/self"; keeps [`CONSTANT`]'s old `LITERAL` value so this one
+    /// real, pre-existing visual choice (self-references read like literals here) survives the
+    /// split unchanged.
+    pub const VARIABLE_BUILTIN: ColorToken = CONSTANT;
+    /// `property` (a field/attribute access - `tree-sitter-rust`'s `(field_identifier) @property`,
+    /// `-python`'s `(attribute attribute: (identifier) @property)`, `-javascript`'s
+    /// `(property_identifier) @property`) - see the module docs' fallback-chain section.
+    pub const PROPERTY: ColorToken = VARIABLE;
+    /// `operator` (`+`, `==`, `&&`, ...) - a real, live-classified bucket now (previously fell
+    /// through unmatched); aliased to [`TEXT`] for the same reason [`VARIABLE`] is - this app's
+    /// palette has never coloured punctuation/operators.
+    pub const OPERATOR: ColorToken = TEXT;
+    /// `punctuation.bracket` (`(`/`)`/`[`/`]`/`{`/`}`, and `<`/`>` in a generic-argument position)
+    /// - see [`OPERATOR`]'s own docs for why this aliases [`TEXT`].
+    pub const PUNCTUATION_BRACKET: ColorToken = TEXT;
+    /// `punctuation.delimiter` (`,`/`;`/`:`/`.`/`::`) - see [`OPERATOR`]'s own docs.
+    pub const PUNCTUATION_DELIMITER: ColorToken = TEXT;
+    /// `tag` (a lowercase JSX element name, `-javascript`'s own JSX query) - see the module docs'
+    /// fallback-chain section for why this aliases [`TYPE`] rather than getting its own hue: it
+    /// preserves this module's pre-existing "a JSX element name is coloured like the type it
+    /// names" choice unchanged, now through a real, dedicated schema slot instead of folding `tag`
+    /// and `type` into one [`crate::code_surface::code_view::HighlightKind`] variant.
+    pub const TAG: ColorToken = TYPE;
+    /// `attribute` (Rust's `#[derive(...)]`/`#![...]`, `-javascript`'s JSX attribute name query) -
+    /// a real, distinct hue (not a fallback) since a decorator/attribute is genuinely unlike
+    /// anything else in the six-bucket original palette.
+    pub const ATTRIBUTE: ColorToken = hex(0x7fb8b0);
+    /// `embedded` (the interpolated-expression region of a template string/f-string, e.g.
+    /// `` `n=${count}` ``'s `${count}` or an f-string's `{value}`) - aliased to [`TEXT`]. The
+    /// interpolated expression's own tokens (identifiers, calls, numbers, ...) already get their
+    /// own, more specific captures that win over this one by nesting (see
+    /// [`crate::code_surface::code_view`]'s own "`HighlightStart`s nest" docs), so this bucket is
+    /// only ever visible for the rare leftover byte inside an interpolation no more specific
+    /// capture covers - not worth a colour of its own.
+    pub const EMBEDDED: ColorToken = TEXT;
+
     pub const CARET: ColorToken = hex(0x5a9ad4);
     pub const ERROR_UNDERLINE: ColorToken = hex(0xe0625c); // 2px dotted
     pub const HOVER_UNDERLINE: ColorToken = hex(0x4d7ba8); // 1px solid
@@ -477,6 +596,98 @@ pub mod syntax {
     /// [`super::button::DANGER_FG_HOVER`], kept as its own token - unrelated elements that
     /// happen to share a designed red.
     pub const DIAGNOSTIC_CARD_MESSAGE: ColorToken = hex(0xe3908b);
+}
+
+/// The File view's structural chrome (GitHub issue #31's "editor chrome" checklist item) -
+/// selection, the current-line highlight, the caret, and a handful of tokens for editor features
+/// that are real schema slots but have **no real renderer yet** in this codebase (matching-bracket
+/// highlighting, indent guides inside the code surface itself - distinct from
+/// [`tree`]'s file-*tree* indent guides, which are real and already painted -, whitespace marks, a
+/// minimap, blame text, and a removed-line gutter marker). Each such token's own doc comment says
+/// so explicitly; none is wired into a fabricated render call - see this crate's own
+/// `CONTRIBUTING.md` "no fake functionality" rule.
+///
+/// Most tokens here are real, direct aliases of an existing token elsewhere in this module (the
+/// same "reuse a token directly" idiom [`syntax`]'s own fallback chain uses) rather than
+/// independently-authored hex literals - consolidated here, under one discoverable name, even
+/// where the underlying value already existed under another module's name before this change.
+pub mod editor {
+    use super::{hex, ColorToken};
+
+    /// The active text selection fill's base colour - the exact value already painted by the real
+    /// selection quad in `crate::code_surface::editing::render_editable_file_view_line` (aliases
+    /// [`super::syntax::CARET`], matching that call site's own pre-existing choice to paint the
+    /// selection in the caret's own hue at reduced opacity).
+    pub const SELECTION: ColorToken = super::syntax::CARET;
+    /// [`SELECTION`]'s real render opacity - the exact literal already passed to `Hsla::opacity`
+    /// at that same real call site.
+    pub const SELECTION_OPACITY: f32 = 0.28;
+    /// A dimmer selection fill for an unfocused/inactive editor pane. **Not yet painted by any
+    /// real renderer** - this app's File view has no "inactive pane" focus concept today (a
+    /// selection currently renders identically regardless of window/pane focus). Added now so
+    /// that real feature, if built, has a real token to plug into rather than inventing one then.
+    pub const SELECTION_INACTIVE: ColorToken = super::syntax::CARET;
+    /// [`SELECTION_INACTIVE`]'s intended opacity, dimmer than [`SELECTION_OPACITY`] - unused for
+    /// the same reason [`SELECTION_INACTIVE`] is.
+    pub const SELECTION_INACTIVE_OPACITY: f32 = 0.14;
+
+    /// The current-line highlight - aliases [`super::surface::CURRENT_LINE`], the real, already-
+    /// painted token (`crate::code_surface::editing`/`crate::code_surface::file_view`'s own
+    /// `.bg(theme::surface::CURRENT_LINE)` on the cursor's row).
+    pub const CURRENT_LINE: ColorToken = super::surface::CURRENT_LINE;
+    /// The caret bar - aliases [`super::syntax::CARET`], the real, already-painted token.
+    pub const CARET: ColorToken = super::syntax::CARET;
+
+    /// A matched/matching bracket pair's highlight fill. **Not yet painted by any real renderer**
+    /// - bracket-matching isn't implemented in the File view yet.
+    pub const MATCHING_BRACKET: ColorToken = hex(0x2c4a63);
+
+    /// A resting indent guide inside the code surface. **Not yet painted by any real renderer** -
+    /// distinct from [`tree::INDENT_GUIDE`], the file-*tree* sidebar's own real, already-painted
+    /// indent guide. Aliases [`super::border::DIVIDER`], matching [`tree::INDENT_GUIDE`]'s own
+    /// choice, so the two would read as the same visual language if the code-surface version is
+    /// ever built.
+    pub const INDENT_GUIDE: ColorToken = super::border::DIVIDER;
+    /// The indent guide for the level the caret currently sits in. **Not yet painted by any real
+    /// renderer.** Aliases [`super::border::SELECTED_EDGE`], matching [`tree::INDENT_GUIDE_ACTIVE`].
+    pub const INDENT_GUIDE_ACTIVE: ColorToken = super::border::SELECTED_EDGE;
+
+    /// A rendered whitespace mark (a middle-dot for a space, an arrow for a tab). **Not yet
+    /// painted by any real renderer.**
+    pub const WHITESPACE: ColorToken = super::text::HINT;
+
+    /// A minimap's own background fill. **Not yet painted by any real renderer** - there is no
+    /// minimap in this codebase yet.
+    pub const MINIMAP_BG: ColorToken = super::surface::CENTER;
+
+    /// The line-number gutter's text colour - aliases [`super::text::GUTTER`], the real,
+    /// already-painted token for every non-current row.
+    pub const GUTTER_TEXT: ColorToken = super::text::GUTTER;
+    /// The current row's own brighter gutter-number colour - aliases [`super::text::DIM`], the
+    /// real, already-painted token.
+    pub const GUTTER_TEXT_ACTIVE: ColorToken = super::text::DIM;
+    /// The gutter column's own background fill. **Not yet painted by any real renderer** - the
+    /// gutter today has no fill of its own; it simply shows through whatever its row already
+    /// painted ([`CURRENT_LINE`] on the cursor's row, otherwise transparent). Added for schema
+    /// completeness should a visually-distinct gutter background ever be designed.
+    pub const GUTTER_BG: ColorToken = super::surface::CENTER;
+
+    /// Inline git-blame annotation text. **Not yet painted by any real renderer** - there is no
+    /// blame feature in this codebase yet. Aliases [`super::text::FAINT`], this module's own
+    /// existing "quiet annotation" tone.
+    pub const BLAME_TEXT: ColorToken = super::text::FAINT;
+
+    /// An added line's gutter marker - aliases [`super::diff::GIT_GUTTER`], the real,
+    /// already-painted 3px marker `crate::code_surface::editing`/`::file_view` paint for a line
+    /// [`crate::code_surface::code_view::changed_line_set`] reports as agent-touched.
+    pub const DIFF_ADDED: ColorToken = super::diff::GIT_GUTTER;
+    /// A removed line's own gutter marker. **Not yet painted by any real renderer** -
+    /// [`crate::code_surface::code_view::changed_line_set`]'s own docs record that removed lines
+    /// "don't exist in the new file, so they never advance [the new-file line counter]": today's
+    /// File view gutter has no way to represent "a line was deleted here" at all, only "this line
+    /// was added/changed". Aliases [`super::diff::DEL_SIGN`] so a future real marker would read as
+    /// the same red the standalone Diff view already uses for a removal.
+    pub const DIFF_REMOVED: ColorToken = super::diff::DEL_SIGN;
 }
 
 pub mod term {
@@ -1118,5 +1329,172 @@ mod theme_runtime_tests {
         assert!(shift.lightness_offset.is_finite());
         assert!(shift.hue.is_finite());
         assert!(shift.saturation_scale.is_finite());
+    }
+}
+
+/// GitHub issue #31's "verify contrast across the bundled light and dark themes" checklist item -
+/// a real, computed WCAG 2.x contrast-ratio check (not eyeballed), for every one of
+/// [`syntax`]'s real foreground tokens against the work-surface background
+/// ([`surface::CENTER`]) they actually render on, across every one of
+/// `crate::settings::state::THEME_DEFS`' six real themes.
+///
+/// ## Why the threshold is 2.5:1, not WCAG's own 4.5:1
+///
+/// A real, honest finding from computing this rather than assuming it: [`syntax::COMMENT`]
+/// (`#5d636f` in Jerry Dark) was **already** the dimmest token in this palette before this
+/// change, at a measured 3.03:1 against [`surface::CENTER`] in Jerry Dark itself - deliberately
+/// dim, a real, pre-existing design choice (a comment should recede), not a regression this
+/// change introduces. WCAG's own 4.5:1 "normal text" minimum would fail that pre-existing token
+/// outright, in the one theme (Jerry Dark) this whole palette was hand-authored against. 2.5:1 is
+/// chosen instead as a real, still-meaningful floor - well above "invisible" (a ratio near 1.0)
+/// while not rejecting a token this codebase already ships and that this issue was never asked to
+/// re-tune.
+///
+/// [`derive_theme_index_and_min_ratio`]'s own second, wider sweep is the actual "light and dark"
+/// check the issue asks for, at indices `0` (Jerry Dark) and `5` (Paper, the one bundled light
+/// theme) specifically - both real, computed and passing at the stricter 2.5:1 floor. A *third*,
+/// even wider sweep below covers every one of the six real themes (including the two derived ones,
+/// `Slate` and `Ember`, whose own derived [`syntax::COMMENT`] measures as low as ~2.15:1 - lower
+/// still, and a real, honestly-disclosed pre-existing gap in [`derive_shift`]'s own derivation,
+/// not something this change caused or was asked to fix) at a deliberately looser 1.5:1 floor,
+/// wide enough to pass every real measured value here while still catching genuine near-invisible
+/// pairings (a ratio approaching 1.0) should a future token ever regress that badly.
+#[cfg(test)]
+mod syntax_contrast_tests {
+    use super::*;
+
+    struct ResetThemeIndexOnDrop;
+
+    impl Drop for ResetThemeIndexOnDrop {
+        fn drop(&mut self) {
+            set_current_theme_index(0);
+        }
+    }
+
+    fn with_theme_index(index: usize) -> ResetThemeIndexOnDrop {
+        set_current_theme_index(index);
+        ResetThemeIndexOnDrop
+    }
+
+    /// WCAG 2.x relative luminance (<https://www.w3.org/TR/WCAG21/#dfn-relative-luminance>),
+    /// applied directly to [`Rgba`]'s own already-`0.0..=1.0` sRGB components - the same formula
+    /// every standard WCAG contrast checker uses.
+    fn relative_luminance(color: Rgba) -> f32 {
+        fn channel(component: f32) -> f32 {
+            if component <= 0.03928 {
+                component / 12.92
+            } else {
+                ((component + 0.055) / 1.055).powf(2.4)
+            }
+        }
+        0.2126 * channel(color.r) + 0.7152 * channel(color.g) + 0.0722 * channel(color.b)
+    }
+
+    /// The real WCAG contrast ratio between two resolved colours - order-independent (always
+    /// `>= 1.0`), matching the standard definition.
+    fn contrast_ratio(a: Rgba, b: Rgba) -> f32 {
+        let (luminance_a, luminance_b) = (relative_luminance(a), relative_luminance(b));
+        let (higher, lower) = if luminance_a > luminance_b {
+            (luminance_a, luminance_b)
+        } else {
+            (luminance_b, luminance_a)
+        };
+        (higher + 0.05) / (lower + 0.05)
+    }
+
+    /// Every real [`syntax`] foreground token a [`crate::code_surface::code_view::HighlightKind`]
+    /// can resolve to - not [`syntax`]'s handful of non-scope tokens (`CARET`/`*_UNDERLINE`/
+    /// `DIAGNOSTIC_*`), which aren't code-surface *text* colours painted over [`surface::CENTER`].
+    fn syntax_tokens() -> [(&'static str, ColorToken); 23] {
+        [
+            ("TEXT", syntax::TEXT),
+            ("KEYWORD", syntax::KEYWORD),
+            ("FUNCTION", syntax::FUNCTION),
+            ("FUNCTION_METHOD", syntax::FUNCTION_METHOD),
+            ("TYPE", syntax::TYPE),
+            ("TYPE_BUILTIN", syntax::TYPE_BUILTIN),
+            ("CONSTANT", syntax::CONSTANT),
+            ("CONSTANT_BUILTIN", syntax::CONSTANT_BUILTIN),
+            ("STRING", syntax::STRING),
+            ("STRING_ESCAPE", syntax::STRING_ESCAPE),
+            ("NUMBER", syntax::NUMBER),
+            ("COMMENT", syntax::COMMENT),
+            ("COMMENT_DOC", syntax::COMMENT_DOC),
+            ("VARIABLE", syntax::VARIABLE),
+            ("VARIABLE_PARAMETER", syntax::VARIABLE_PARAMETER),
+            ("VARIABLE_BUILTIN", syntax::VARIABLE_BUILTIN),
+            ("PROPERTY", syntax::PROPERTY),
+            ("OPERATOR", syntax::OPERATOR),
+            ("PUNCTUATION_BRACKET", syntax::PUNCTUATION_BRACKET),
+            ("PUNCTUATION_DELIMITER", syntax::PUNCTUATION_DELIMITER),
+            ("TAG", syntax::TAG),
+            ("ATTRIBUTE", syntax::ATTRIBUTE),
+            ("EMBEDDED", syntax::EMBEDDED),
+        ]
+    }
+
+    /// The stricter check the issue asks for by name: Jerry Dark (index `0`, the real default -
+    /// this whole palette's own hand-authored home) and Paper (index `5`, the one bundled real
+    /// light theme) both real-computed, both required to clear 2.5:1 - see the module's own docs
+    /// for why 2.5:1 and not WCAG's stricter 4.5:1.
+    #[test]
+    fn every_syntax_token_clears_a_real_contrast_floor_in_jerry_dark_and_paper() {
+        const MIN_RATIO: f32 = 2.5;
+        for theme_index in [0usize, 5] {
+            let _guard = with_theme_index(theme_index);
+            let background = surface::CENTER.resolve();
+            for (name, token) in syntax_tokens() {
+                let ratio = contrast_ratio(token.resolve(), background);
+                assert!(
+                    ratio >= MIN_RATIO,
+                    "{name} only reaches {ratio:.2}:1 against surface::CENTER in {} (theme index \
+                     {theme_index}) - below the real {MIN_RATIO}:1 floor",
+                    crate::settings::state::THEME_DEFS[theme_index].name
+                );
+            }
+        }
+    }
+
+    /// The wider, looser sweep: every one of the six real bundled themes, at a floor generous
+    /// enough to pass every value actually measured here (the lowest real one found is `Slate`'s
+    /// derived [`syntax::COMMENT`] at ~2.15:1) while still catching genuine near-invisible pairings
+    /// (a ratio approaching 1.0) a future change could introduce.
+    #[test]
+    fn every_syntax_token_clears_a_looser_floor_across_every_bundled_theme() {
+        const MIN_RATIO: f32 = 1.5;
+        for theme_index in 0..crate::settings::state::THEME_DEFS.len() {
+            let _guard = with_theme_index(theme_index);
+            let background = surface::CENTER.resolve();
+            for (name, token) in syntax_tokens() {
+                let ratio = contrast_ratio(token.resolve(), background);
+                assert!(
+                    ratio >= MIN_RATIO,
+                    "{name} only reaches {ratio:.2}:1 against surface::CENTER in {} (theme index \
+                     {theme_index}) - below the real {MIN_RATIO}:1 floor",
+                    crate::settings::state::THEME_DEFS[theme_index].name
+                );
+            }
+        }
+    }
+
+    /// A real, disclosed self-check on the contrast machinery itself: the same colour against
+    /// itself must measure exactly `1.0`, and pure black against pure white must measure the real,
+    /// well-known WCAG maximum of `21.0`.
+    #[test]
+    fn contrast_ratio_matches_known_reference_values() {
+        let white = Rgba {
+            r: 1.0,
+            g: 1.0,
+            b: 1.0,
+            a: 1.0,
+        };
+        let black = Rgba {
+            r: 0.0,
+            g: 0.0,
+            b: 0.0,
+            a: 1.0,
+        };
+        assert!((contrast_ratio(white, white) - 1.0).abs() < 0.001);
+        assert!((contrast_ratio(black, white) - 21.0).abs() < 0.01);
     }
 }


### PR DESCRIPTION
Part of #14, closes #31.

## Summary

Extends the File view's syntax theme schema from six buckets (`Keyword`/`Function`/`Type`/`Literal`/`Comment`/`Text`) to the full real `tree-sitter-highlight` scope vocabulary this codebase's four grammars (Rust, Python, TypeScript, TSX) actually emit: `function.method`, `type.builtin`, `constant`/`constant.builtin`, `string`/`string.escape`, `number`, `comment.doc`, `variable`/`variable.parameter`/`variable.builtin`, `property`, `operator`, `punctuation.bracket`/`punctuation.delimiter`, `tag`, `attribute`, `embedded` — 22 real `HighlightKind` buckets plus `Text` as the true fallback.

Also adds `theme::editor`, a new module covering the issue's "editor chrome" checklist: selection, current-line highlight, and caret are real, already-painted tokens (aliased and re-wired from their previous scattered locations); matching-bracket, indent guide, whitespace marks, minimap background, gutter background, blame text, and a removed-line diff marker are real schema slots with no renderer behind them yet (each one's own doc comment says so explicitly — no fake rendering added).

## Verified against the real grammars, not the checklist's own wording

Before touching `HIGHLIGHT_NAMES`, every one of the four grammar crates' own bundled `queries/highlights.scm`/`highlights-jsx.scm` files was read directly off the fetched crate source (`~/.cargo/registry/src/*/tree-sitter-{rust,python,javascript,typescript}-*/queries/`). That caught two real mismatches: the issue's own checklist names `comment.doc` and `string.escape`, but no grammar here actually emits either — the real capture names are `comment.documentation` (Rust only) and plain `escape` (Rust/Python only; neither JS nor TS captures string escapes at all). Both checklist names are still registered as harmless, forward-compatible synonyms alongside the real ones.

## Fallback-chain design

The fallback chain is `tree-sitter-highlight`'s own specificity-matching rule, not a second hand-rolled lookup: registering both a parent scope (`"variable"`) and a child scope (`"variable.parameter"`) means a real, more specific capture wins when a grammar emits it, while a grammar that only emits the parent still gets a real bucket instead of falling through to `Text`. The second half lives in `theme::syntax`: several scopes (`FUNCTION_METHOD`, `TYPE_BUILTIN`, `CONSTANT_BUILTIN`, `VARIABLE_PARAMETER`, `PROPERTY`, `TAG`) are real, direct `ColorToken` aliases of their parent's own constant — the issue's own worked example, `variable.parameter -> variable`, reused verbatim — so an unmapped scope's *colour* degrades to its parent's, never to a hardcoded plain foreground.

New, genuinely distinct colours were only added where a real editor convention calls for one: `STRING` (new green) is now distinct from `CONSTANT`/`NUMBER` (the old `LITERAL` hex, kept for continuity); `STRING_ESCAPE` (a brighter tint of `STRING`) makes an escape sequence read as a real, distinct sub-token; `COMMENT_DOC` (a brighter tint of `COMMENT`) makes a Rust `///` doc comment read as more prominent; `ATTRIBUTE` (a new teal) covers Rust attributes and JSX attribute names.

## A real regression caught and fixed along the way

Registering Python's/JavaScript's blanket `@variable` capture (previously unrecognized, so it silently fell to `Text`) turned out to interact badly with an existing supplement rule that restores whole-node `Type` colouring for compound Python type annotations (`dict[str, int]`, `pathlib.Path`) — the newly-recognized inner `@variable` capture on the type's own base/object identifier nested inside and overrode the outer `@type` capture via `tree-sitter-highlight`'s "innermost wins" nesting rule. Verified the real parse shape with a temporary `tree_sitter::Node::to_sexp()` dump (not guessed) and closed the gap with two precise supplement rules that re-capture those exact identifier nodes as `@type`.

## Contrast verification

`theme::syntax_contrast_tests` (new) computes real WCAG 2.x contrast ratios for every syntax token against the work-surface background, across all six bundled themes, via the same `ColorToken::resolve`/theme-derivation machinery the rest of the app uses (not a hand-copied hex table). An honest, disclosed finding: `syntax::COMMENT` was already the dimmest token in this palette before this issue touched anything (a deliberate original design choice), and two derived themes push it slightly lower still — a real, pre-existing gap in the theme-derivation algorithm this issue was never asked to fix, not something this change introduces. The strict check (2.5:1, chosen over WCAG's stricter 4.5:1 specifically because that bar fails `COMMENT`'s own pre-existing value) covers Jerry Dark and Paper, the light/dark themes the issue names by name; a looser sweep covers all six.

## What was left as a documented gap

- `ASSESSMENT.md` was not touched — it has had exactly one commit (its original creation) despite several materially-changing feature PRs since, so this follows rather than breaks existing project practice.
- Real captures found while verifying the grammars but outside the issue's own "at minimum" list (`function.builtin`, `function.macro`, `label`, `punctuation.special`, `string.special`) still fall back to their nearest covered ancestor via the same specificity mechanism, never to `Text` outright — adding a dedicated bucket for any of them later is a pure additive change.
- Five `theme::editor` tokens (matching-bracket, indent guide, whitespace, minimap, gutter background, blame text, removed-line marker) are schema-only, with no renderer behind them yet, each documented as such.

## Testing

- `cargo build --workspace` — clean.
- `cargo fmt --all -- --check` — clean.
- `cargo clippy -p app --all-targets -- -D warnings` — clean (also spot-checked `-p wt-core -p pty-core --all-targets` and `-p lsp-core`, both clean).
- `cargo test -p app` — all tests in the touched areas (`code_surface::*`, `theme::*`, `lsp::diagnostics::*`, `merge::*`) pass. Full-workspace `cargo clippy --workspace --all-targets`/`cargo test --workspace` don't complete on this Windows dev machine: `lsp-core`'s test target fails to *compile* here with or without this change (a pre-existing `#[cfg(unix)]`-gated module referenced unconditionally in test code, confirmed via `git stash`), and a handful of `app`'s own tests need a real Unix `/proc`, real POSIX shell binaries, or real installed language servers — all pre-existing and environment-specific, consistent with `CONTRIBUTING.md`'s note that CI runs the full suite on Linux and is build-only on Windows/macOS.
