### PR TITLE
fix(app): focus palette-opened files; fix 7 file-tree UI bugs

### DIFF
--- a/BUILD-LOG.md
+++ b/BUILD-LOG.md
@@ -4022,3 +4022,155 @@ All four gates clean. 907 tests passing, up from a real 896 baseline (+11): 748 
 pty-core, 98 wt-core. `lsp-core` also re-checked for `x86_64-pc-windows-gnu`, where the bounded
 write is honestly documented as narrower (no `poll` for Windows anonymous pipes), matching the same
 real, tracked platform split `kill_process_tree` already carries.
+## Focus-follows-open (issue #15) and seven file-tree UI reports
+
+Two things that looked like separate bug lists turned out to be one defect and one design gap.
+
+**The one defect.** `open_palette_file_result`'s diff-less branch expanded a file's ancestors,
+highlighted its tree row, and stopped: no tab, nothing in the centre pane, focus untouched. That
+is both issue #15's report ("the file opens, but you still have to click into the editor") and the
+separately-reported "Reveal in tree selects the file in the tree but does not open it" - the same
+five lines. Its sibling branch was wrong in the mirror-image way: a *changed* file opened and
+focused a tab but never revealed or highlighted itself in the tree, so which half of the behaviour
+you got depended on whether the file happened to be in the loaded diff. Both now run one function,
+`code_surface::tabs::AdeApp::open_and_focus_file`, which opens-or-reuses the tab, moves real focus
+onto `code_focus_handle`, and reveals + highlights the row - and which `open_file_view` and
+`open_change_diff` are both now thin wrappers over. "Reveal and open are one action" is structural
+here, not a convention two call sites happen to follow.
+
+Focusing the editor is also what makes the caret real: `code_surface::editing`'s per-row paint only
+emits the caret quad when `code_focus_handle.is_focused(window)`, and only registers the real
+`Window::handle_input` from the caret's own row. So "the next keystroke lands in the buffer" is a
+consequence of that one call, not a separate feature to build.
+
+**"An action focuses its result", without a flag to forget.** Opening the file was only half of it:
+`close_palette` then restored focus to wherever it was before the palette, so the file really did
+open and the keystroke really did go to the terminal. The rule is that an entry which opens
+something owns focus afterwards and one that opens nothing restores it - and which applies is now
+*observed* rather than declared: `run_selected_palette_entry` reads `window.focused(cx)` either
+side of dispatch (`Window::focus` writes synchronously) and picks its closing path from the
+difference. Deliberately not a per-entry `bool`: that has to be set at every site that focuses
+something, and the failure mode of forgetting one is a silently swallowed keystroke, which is this
+project's most-shipped bug (see `crate::lib`'s own module docs). There is nothing to forget here.
+
+Two smaller pieces of #15's checklist: reopening a file restored its buffer caret already
+(`edit_buffers` outlives a tab close) but *showed* line 1 and stayed scrolled to the top, so a
+caret restored to line 200 was correct, misreported and invisible - both now follow the buffer.
+And the "different tab group/pane" bullet is trivially satisfied: this app has one centre pane and
+one global `open_change`, which is recorded rather than quietly skipped.
+
+**The design gap** was the file-tree context menu, and one of its seven reports was not a taste
+question at all: its rows *did* have a `.hover(..)`, set to `theme::surface::ROW_HOVER` - which is
+byte-identical to `theme::surface::PALETTE`, the popover's own background. The hover state existed
+and painted nothing. `theme::palette::ROW_HOVER`'s own docs record the identical trap for the
+palette's rows, which is where `theme::surface::PLUS_MENU_ROW_HOVER` came from. Alongside it: the
+row now speaks `work_surface::render::render_dropdown_menu_row`'s language (11.5px `text::HEADING`
+medium, `gap(9)`, `text::GHOSTER` + `cursor_default()` when disabled) rather than four values
+invented for this one menu; issue #19 §1's groups get the app's one real in-menu divider, extracted
+out of `title_bar::menu` into `root::widgets::render_menu_group_divider` so both menus draw the
+same element; and the delete confirmation gets the hover states its two buttons never had, the
+destructive `theme::button::DANGER_FG`/`DANGER_FG_HOVER` pair the rail's prune button already
+uses instead of the rail's *status* red, `theme::radius::BUTTON` instead of the chip radius, and a
+scrim built from `theme::surface::SCRIM` instead of a raw `gpui::black()` literal.
+
+**"Still lets you select the rows underneath it" had a cause no `stop_propagation` could fix.** The
+scrim was a real full-window element with a real dismiss handler, but nothing about it stopped the
+row beneath from also taking the click - and hover styling isn't an event at all, so a propagation
+guard could only ever have fixed half of it. `.occlude()` is the real mechanism (`HitboxBehavior::
+BlockMouse`; `Window::hit_test` stops walking hitboxes at the first one carrying it, which is what
+both mouse dispatch *and* `Hitbox::is_hovered` consult), and this app already used it for the pane
+resize handles. Applied to the context menu and to both centred modals.
+
+**`Shift+F10` was kept, and made findable.** Issue #19 §2 required the menu to be reachable from
+the keyboard, so deleting it was never the right answer; the honest problem was that nothing in the
+product said why it exists. The Keybindings row now reads "Files tree: open the selected row's
+actions menu" (that page has no description column - the label is the whole explanation a user
+gets), and the Files tree gained the keyboard-hint footer strip the design handoff already
+specifies for exactly this job, with keycaps resolved through `keymap::resolve_combo` rather than
+written out, and hidden while an inline editor or the delete confirmation is open - because the
+bindings genuinely don't fire then, and advertising a dead shortcut is its own small lie.
+
+### What the independent audit then found
+
+A real adversarial review sub-agent was dispatched over the finished branch and really reported;
+everything below is its work, not the author's own reasoning, and it reproduced each finding with
+throwaway probe tests before reporting. It found one CRITICAL that this change had introduced.
+
+**CRITICAL - a palette file result run while Settings is open.** `open_and_focus_file` focused
+`code_focus_handle` while `AdeApp::render` was still drawing Settings *instead of* the workspace
+body, so `Window::focus` pointed at a `FocusId` no longer in the rendered frame; GPUI fell back to
+the dispatch root with an empty context stack and every scoped binding died, Esc included. The
+user was left on a Settings page they could not leave, with no file in sight, until they clicked.
+`close_palette` had a hand-written Settings branch that used to catch this, and the new
+observe-focus path routed around it. Fixed at the source rather than by re-adding the special
+case: opening a file now closes Settings first, so what gets focused really is rendered. Restoring
+focus instead would have left the user staring at Settings after asking for a file.
+
+Two MAJOR findings were dangling-focus bugs one level removed from the code changed here, both of
+which this change made reachable or more reachable. `focus_code_surface` captures the pre-open
+focus target on the first file opened - and with no tab yet, the thing holding focus at that
+moment is the *palette's own handle*; capturing it just relocated the bug to `close_file_tab`,
+which restores through the same `OverlayFocus`. It now refuses to capture any overlay handle at
+all. And running the palette's own "Toggle Files / Changes" unrenders the whole file tree while the
+palette holds focus, so `set_right_sidebar_view`'s existing `tree_focus_handle.is_focused(window)`
+guard could not see that an overlay was holding the tree's handle as its *return* target; closing
+the palette then restored focus straight onto it. `OverlayFocus::forget_target` is the fix, swept
+from all three overlays rather than only the palette.
+
+Two more MAJOR findings were about this change's own edges. `.occlude()`ing a full-window scrim
+swallows the window's own close/minimise/maximise buttons and the title bar's drag region - the
+audit reproduced a close click being eaten - so all three scrims now start at
+`theme::band::TITLE_BAR`, which is what `render_palette`'s scrim had always done and which is now a
+load-bearing choice rather than an aesthetic one. That in turn moved the context menu's panel a
+whole title bar down, since its origin is clamped in *window* space; the offset is subtracted
+explicitly and `right_clicking_a_folder_row_opens_the_folder_menu_at_a_clamped_origin` now asserts
+the popover's real painted origin against the clamped one, which is what caught it. And
+`open_change_diff` was resolving its relative path against `file_tree_root` when `DiffFile::path`
+is relative to `diff_root` - normally equal, but `merge::flow` and `worktree_history::flow` both
+load the *main repo's* diff while a worktree is selected, so a Changes-row click there produced a
+path that exists nowhere, which the new shared reveal would have written into this worktree's
+persisted fold state. Both roots are now used for what they are, and the reveal is guarded on the
+path really being inside the tree on screen.
+
+The audit also caught this change citing `design_handoff_jerry_ade/revision 2/` - a newer handoff
+revision that is real, but is not committed to this repository, so five source comments pointed at
+a path that does not exist, and three geometry constants derived from it had no support in the
+handoff that *is* committed. Those constants are gone: the menu's row height and horizontal
+padding are back to what shipped, and the grouping is drawn with the app's own existing divider
+element. Everything now cited resolves in-tree. The footer strip's citation was real all along and
+just named the wrong directory - its shape is `design_handoff_jerry_ade/revision/Jerry.dc.html`'s
+own `diffHints` strip, values included.
+
+Smaller audit findings, all fixed: a test that asserted `menu_groups(..).flatten() == menu_items(..)`
+when `menu_items` is *defined* as that expression (deleted, and replaced with a real assertion that
+dividers never lead, trail, double up, or reorder anything); the scroll half of the caret-restore
+change having no coverage at all (it now asserts the real `UniformListScrollHandle`'s resolved
+offset against a 400-line file, and fails when reverted); a test named
+`..._and_the_next_keystroke_lands_in_the_buffer` that never simulated a keystroke; the footer's own
+tooltip hard-coding the very keystroke string its doc said it never hard-codes; the footer binding
+guard reconstructing only `shift`, so a binding that gained a Ctrl would still have matched; a doc
+enumerating `OverlayFocus::clear`'s "only" caller when it now has three; four cross-references left
+stale by the `open_and_focus_file` extraction; and an undocumented `text::GHOST` → `GHOSTER` change.
+
+Three findings were checked and deliberately not acted on, recorded here rather than left silent.
+The `+` menu's and title-bar menus' scrims have the same non-occluding click-through as the tree
+menu did - real, but not reported and not in this change's scope. A truncated or non-UTF-8 file has
+no `EditBuffer`, so the "otherwise scrolled to top" clause can't be honoured for it; the shared
+scroll handle keeps the previous file's offset, which is now written down on the test module that
+owns the behaviour. And the audit flagged two pre-existing bugs entirely outside this diff (the
+palette's Prune Worktrees entry can never actually prune, since `open_palette` disarms the
+confirmation it just armed; and `render_changes_footer`'s doc claims `]` isn't bound to anything
+when `default_key_bindings` binds it) - left for their own change.
+
+Verification: all four gates clean - `cargo fmt --all -- --check`, `cargo build --workspace`,
+`cargo clippy --workspace --all-targets -- -D warnings`, and
+`cargo test --workspace --lib -- --test-threads=1` at 946 app + 42 lsp-core + 14 pty-core + 98
+wt-core, up from 928 app at the verified baseline. Every fix here was confirmed non-vacuous by
+reverting it and watching its own regression fail: the focus-ownership branch in *both* directions
+(always-restore fails five tests, never-restore fails the sixth), the palette's open-the-file half,
+the `.occlude()`, the panel's title-bar offset, the caret indicator, the scroll, and all three
+audit fixes. The project's known diff-rendering flake appeared twice during this work, a different
+test in the module each time. Because this change touches `open_change_diff`, that was not assumed:
+the flakiest test was run 55 times on this branch and 55 times on the untouched base, interleaved,
+giving 3/55 here against 4/55 there - the same rate, and load-dependent rather than
+change-dependent.

--- a/crates/app/src/code_surface/lsp_ui.rs
+++ b/crates/app/src/code_surface/lsp_ui.rs
@@ -179,7 +179,7 @@ impl AdeApp {
 
     /// Navigates to a go-to-definition result. `absolute_target_path` may be under
     /// [`Self::file_tree_root`] or entirely outside it (e.g. another crate `rust-analyzer` sees);
-    /// either way `Self::open_file_view`'s `strip_prefix` handles it, since `PathBuf::join` with
+    /// either way `Self::open_file_view`'s own `strip_prefix` handles it, since `PathBuf::join` with
     /// an already-absolute path just becomes that path.
     ///
     /// ## Avoiding a cursor-line race

--- a/crates/app/src/code_surface/tabs.rs
+++ b/crates/app/src/code_surface/tabs.rs
@@ -71,17 +71,81 @@ impl AdeApp {
         }
     }
 
-    /// Opens `path`'s diff in the centre pane (the Changes row click handler).
-    pub(crate) fn open_change_diff(
+    /// **The** "open this file and make it the thing the user is looking at and typing into"
+    /// action - the single real code path behind every entry point that opens a file: a Files
+    /// tree row click, a Changes row click, a command-palette file result, go-to-definition, a
+    /// terminal path link, and a just-created file. [`Self::open_file_view`] and
+    /// [`Self::open_change_diff`] are now thin `view`-choosing wrappers over this, not two
+    /// parallel implementations.
+    ///
+    /// It does four things that used to be spread across (or missing from) those callers, and
+    /// they belong together because two of them were genuinely inconsistent:
+    ///
+    /// 1. **Opens the tab** - `push_open_file` + `open_change`, so the tab list can never drift
+    ///    from what's showing, and an already-open path is *reused*, never duplicated.
+    /// 2. **Moves real keyboard focus into the editor** ([`Self::focus_code_surface`]). This is
+    ///    what makes the caret paint at all: `crate::code_surface::editing`'s per-row paint only
+    ///    emits the caret quad when `code_focus_handle.is_focused(window)`, and only registers
+    ///    the real `Window::handle_input` for the caret's own row - so "the next keystroke lands
+    ///    in the buffer" is a consequence of this call, not a separate feature.
+    /// 3. **Reveals and highlights it in the Files tree** - `reveal_in_tree` expands (and
+    ///    persists, issue #18 §5) every ancestor, then `selected_tree_path` highlights the row.
+    /// 4. Drops the per-file caches and popups that belong to whatever was showing before.
+    ///
+    /// Points 2 and 3 are exactly the two halves GitHub issue #15 and the "Reveal in tree selects
+    /// but doesn't open" report were about, and they were previously split: the palette's
+    /// diff-less branch did (3) and neither (1) nor (2) - it revealed and highlighted a row while
+    /// opening nothing and leaving focus wherever it was - while `open_change_diff` did (1) and
+    /// (2) and neither half of (3), so opening a *changed* file from the palette left the tree
+    /// pointing at something else entirely. Having one function do all four is what makes "reveal
+    /// and open are one action" true structurally rather than by convention.
+    ///
+    /// `relative` is the key `open_files`/`open_change`/`edit_buffers` use; `absolute` is the
+    /// real on-disk path, used only for the tree reveal. They are passed separately rather than
+    /// derived one from the other because the two callers resolve against *different* roots -
+    /// see [`Self::open_change_diff`]'s own docs for the real state in which they differ.
+    fn open_and_focus_file(
         &mut self,
-        path: PathBuf,
+        relative: PathBuf,
+        absolute: PathBuf,
+        view: code_view::CodeView,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        // Settings *replaces* the workspace body (`crate::root::AdeApp::render`), so focusing the
+        // code surface while it is up would pin `Window::focus` to a handle that is not in the
+        // rendered frame at all - the exact dangling-focus state `crate::root::OverlayFocus`'
+        // docs describe, and one that leaves every context-scoped binding (Esc included) dead
+        // until the next click. Found by this branch's own adversarial audit, which reproduced it
+        // through the real palette. Closing Settings is the honest resolution rather than
+        // declining to focus: the user asked to open a file, and leaving the Settings page on
+        // screen would be showing them something else.
+        if self.settings_open {
+            self.close_settings(window, cx);
+        }
         self.focus_code_surface(window, cx);
-        self.push_open_file(&path);
-        self.open_change = Some(path.clone());
-        self.code_view = code_view::CodeView::Diff;
+        self.push_open_file(&relative);
+        self.open_change = Some(relative);
+        self.code_view = view;
+        // Every "this file is now the selected tree row" path reveals it (GitHub issue #18 §5).
+        // A click in the tree has its ancestors expanded already, so this is a no-op there - but
+        // go-to-definition (`Self::navigate_to_definition`), a palette result and a terminal link
+        // all land on files in folders nobody has expanded, and now that the tree starts
+        // collapsed, highlighting a row that isn't showing would be no highlight at all.
+        //
+        // Guarded, because `absolute` is not always inside the tree currently on screen: a
+        // terminal link resolves against its session's own cwd, and `Self::open_change_diff`
+        // resolves against [`Self::diff_root`], which really can differ from
+        // [`Self::file_tree_root`] (`crate::merge::flow` and `crate::worktree_history::flow` both
+        // load the *main repo's* diff while a worktree is selected). Revealing and highlighting a
+        // path this tree does not contain would write a junk fold-state entry to disk and
+        // highlight a row that does not exist. `reveal_in_tree` already refuses such a path;
+        // `selected_tree_path` did not, which is what makes the check live here rather than
+        // there.
+        if absolute.starts_with(&self.file_tree_root) {
+            self.reveal_in_tree(&absolute, cx);
+            self.selected_tree_path = Some(absolute);
+        }
         self.refresh_open_diff_file_cache();
         // A hover card is only valid for the file it was requested against - and so is a real
         // Completions popup (Revision R8.5b audit finding 3's fix for a real, live-reproduced
@@ -94,7 +158,33 @@ impl AdeApp {
         cx.notify();
     }
 
-    /// Opens `path` directly in Surface C's File view (the Files-tree row click handler).
+    /// Opens `path`'s diff in the centre pane (the Changes row click handler, and a palette file
+    /// result for a file that really is in the loaded diff).
+    ///
+    /// `path` is relative to [`Self::diff_root`] here - that is the form `wt_core::diff`'s own
+    /// `DiffFile::path` carries, and the form every caller of this method already holds. It is
+    /// also what `open_files`/`open_change` key by, so it is passed through unchanged.
+    ///
+    /// The absolute path handed to [`Self::open_and_focus_file`] is therefore resolved against
+    /// `diff_root`, **not** `file_tree_root`. The two are normally equal, but they genuinely
+    /// diverge: `crate::merge::flow` and `crate::worktree_history::flow` both call `load_diff`
+    /// with the main repo path while the user has a worktree selected. Resolving against the
+    /// wrong one produced a path that exists nowhere, which `open_and_focus_file` would then have
+    /// revealed and persisted into this worktree's fold state - found by this branch's own
+    /// adversarial audit. That function's own `starts_with` guard is the second half of the fix.
+    pub(crate) fn open_change_diff(
+        &mut self,
+        path: PathBuf,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let absolute = self.diff_root.join(&path);
+        self.open_and_focus_file(path, absolute, code_view::CodeView::Diff, window, cx);
+    }
+
+    /// Opens `path` (absolute) directly in Surface C's File view - the Files-tree row click
+    /// handler, go-to-definition, a terminal path link, a just-created file, and a palette file
+    /// result with no diff to show.
     pub(crate) fn open_file_view(
         &mut self,
         path: PathBuf,
@@ -103,32 +193,14 @@ impl AdeApp {
     ) {
         self.prune_confirm_armed = false;
         self.discard_confirm_armed = None;
-        self.focus_code_surface(window, cx);
         // Clear any stale pending cursor line from an abandoned navigation;
         // `navigate_to_definition` re-sets it right after this if it has a target line.
         self.pending_cursor_line = None;
         let relative = path
             .strip_prefix(&self.file_tree_root)
-            .map(|p| p.to_path_buf())
+            .map(|relative| relative.to_path_buf())
             .unwrap_or_else(|_| path.clone());
-        self.push_open_file(&relative);
-        self.open_change = Some(relative.clone());
-        self.code_view = code_view::CodeView::File;
-        // Every "this file is now the selected tree row" path reveals it (GitHub issue #18 §5).
-        // A click in the tree has its ancestors expanded already, so this is a no-op there - but
-        // go-to-definition (`Self::navigate_to_definition`) lands on files in folders nobody has
-        // expanded, and now that the tree starts collapsed, highlighting a row that isn't
-        // showing would be no highlight at all.
-        self.reveal_in_tree(&path, cx);
-        self.selected_tree_path = Some(path);
-        self.refresh_open_diff_file_cache();
-        // See `Self::select_worktree`'s identical reset for why - and `Self::open_change_diff`'s
-        // sibling `dismiss_completions()` call for the real data-corruption bug closing this
-        // alongside `hover` prevents (Revision R8.5b audit finding 3).
-        self.hover = None;
-        self.dismiss_completions();
-        self.close_tab_confirm_armed = None;
-        cx.notify();
+        self.open_and_focus_file(relative, path, code_view::CodeView::File, window, cx);
     }
 
     /// Activates a file tab (the tab strip's click handler), as opposed to
@@ -170,7 +242,7 @@ impl AdeApp {
         };
         self.refresh_open_diff_file_cache();
         self.hover = None;
-        // See `Self::open_change_diff`'s identical `dismiss_completions()` call for why
+        // See `Self::open_and_focus_file`'s identical `dismiss_completions()` call for why
         // (Revision R8.5b audit finding 3).
         self.dismiss_completions();
         self.code_cursor = None;
@@ -477,6 +549,16 @@ impl AdeApp {
                         if reloaded {
                             this.schedule_lsp_sync(relative_path.clone(), cx);
                         }
+                        // Whether this load is a *different* file arriving in the view, as
+                        // opposed to a freshness re-read of the one already showing. Read before
+                        // `file_view_cache` is overwritten below, since that is what it compares
+                        // against. Only a genuine arrival is allowed to move the scroll position:
+                        // a re-read of the current file must never yank the view away from
+                        // wherever the user has scrolled it.
+                        let newly_in_view = this
+                            .file_view_cache
+                            .as_ref()
+                            .is_none_or(|cached| cached.path != path);
                         this.file_view_cache = Some(parsed);
                         // A pending go-to-definition target line applies only if it names the
                         // file that just finished loading, so an unrelated file's load can't
@@ -485,12 +567,34 @@ impl AdeApp {
                             Some((pending_path, line)) if pending_path == &path => Some(*line),
                             _ => None,
                         };
+                        // GitHub issue #15: "reopening a previously visited file restores its last
+                        // caret position when known; otherwise caret at 1:1, scrolled to top."
+                        // The caret itself was already restored - `edit_buffers` deliberately
+                        // survives a tab close (see that field's docs), so its `cursor_offset` is
+                        // still the real one - but the two things that *show* it were not: the
+                        // status bar's line indicator was hard-reset to 1, and nothing scrolled
+                        // the caret's row back into view, so a caret restored to line 400 was
+                        // invisible and misreported. Both now follow the buffer. A file being
+                        // opened for the very first time has a fresh buffer at offset 0, so this
+                        // reduces to exactly "line 1, scrolled to top" with no special case.
+                        let buffer_cursor_line =
+                            this.edit_buffers.get(&relative_path).map(|buffer| {
+                                let (line, _) = buffer.line_col_for_offset(buffer.cursor_offset());
+                                line + 1
+                            });
+                        let cursor_line =
+                            target_line.or(reloaded_cursor_line).or(buffer_cursor_line);
                         if let Some(line) = target_line {
                             this.pending_cursor_line = None;
                             this.file_view_scroll_handle
                                 .scroll_to_item(line.saturating_sub(1), ScrollStrategy::Center);
+                        } else if newly_in_view {
+                            if let Some(line) = buffer_cursor_line {
+                                this.file_view_scroll_handle
+                                    .scroll_to_item(line.saturating_sub(1), ScrollStrategy::Center);
+                            }
                         }
-                        this.code_cursor = Some(target_line.or(reloaded_cursor_line).unwrap_or(1));
+                        this.code_cursor = Some(cursor_line.unwrap_or(1));
                         this.file_load_state = FileLoadState::Idle;
                     }
                     Err(error) => {
@@ -958,6 +1062,172 @@ mod unreadable_file_tests {
 /// [`AdeApp::open_change_diff`]/[`AdeApp::open_file_view`] no longer discard a file when the user
 /// navigates elsewhere, [`AdeApp::activate_file_tab`] switches which one is showing without
 /// touching the list, and [`AdeApp::close_file_tab`] is the only place a tab leaves the list.
+/// GitHub issue #15's "reopening a previously visited file restores its last caret/scroll
+/// position when known; otherwise caret at 1:1, scrolled to top."
+///
+/// What is actually implemented, stated precisely because the issue's wording is looser than the
+/// mechanism: no scroll *position* is stored anywhere. The buffer's caret is what survives (see
+/// [`AdeApp::edit_buffers`]' own docs), and both the status bar's line indicator and the scroll
+/// are re-derived from it on reopen. For a file whose caret never moved that is exactly "1:1,
+/// scrolled to top"; for one whose caret is on line 400 it is line 400, centred. A file with no
+/// `EditBuffer` at all - truncated past `code_view::MAX_FILE_BYTES`, or not valid UTF-8, both of
+/// which this app deliberately keeps read-only - has no caret to derive from, so the shared
+/// `file_view_scroll_handle` keeps whatever offset the previously shown file left it at. A real,
+/// deliberately unfixed gap rather than an unnoticed one.
+#[cfg(test)]
+mod reopened_file_caret_tests {
+    use super::*;
+    use gpui::TestAppContext;
+
+    /// Drives the real background load/render cycle `edit_buffers` is seeded from - the same
+    /// shape `code_view_cache_tests` and `editing_tests::open_file_for_editing` use.
+    fn open_and_settle(
+        app: &gpui::Entity<AdeApp>,
+        cx: &mut gpui::VisualTestContext,
+        path: PathBuf,
+    ) {
+        app.update_in(cx, |app, window, cx| {
+            app.open_file_view(path, window, cx);
+        });
+        app.update(cx, |app, cx| {
+            app.render_center_pane(cx);
+        });
+        cx.run_until_parked();
+        app.update(cx, |app, cx| {
+            app.render_center_pane(cx);
+        });
+    }
+
+    /// The buffer's caret itself already survived a tab switch (`edit_buffers` deliberately
+    /// outlives a tab close - see that field's docs). What did not was the *visible* half:
+    /// `spawn_file_load`'s completion handler hard-reset `code_cursor` - the status bar's real
+    /// `ln N` indicator - to 1 for any load with no go-to-definition target, so a file reopened
+    /// with its caret on line 4 reported line 1 while the caret really sat on line 4. A visible
+    /// lie about where the next keystroke will land, in the one widget that exists to say so.
+    #[gpui::test]
+    fn reopening_a_file_reports_its_restored_caret_line_not_line_one(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let target = repo.path().join("many.txt");
+        // Long enough that the caret's row genuinely cannot be on screen at scroll offset 0 -
+        // otherwise "the view scrolled to the caret" and "the view never moved" look identical.
+        let long_file: String = (1..=400).map(|n| format!("line {n}\n")).collect();
+        std::fs::write(&target, &long_file).expect("write");
+        let other = repo.path().join("other.txt");
+        std::fs::write(&other, "x\n").expect("write");
+
+        let (app, cx) =
+            crate::root::focus::palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        open_and_settle(&app, cx, target.clone());
+        let relative = PathBuf::from("many.txt");
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.code_cursor),
+            Some(1),
+            "a first open is caret at 1:1"
+        );
+
+        assert_eq!(
+            app.read_with(cx, |app, _| f32::from(
+                app.file_view_scroll_handle
+                    .0
+                    .borrow()
+                    .base_handle
+                    .offset()
+                    .y
+            )),
+            0.0,
+            "premise: a first open really is scrolled to the top"
+        );
+
+        // Move the real caret down through the real editor actions.
+        app.update_in(cx, |app, window, cx| {
+            for _ in 0..200 {
+                app.handle_editor_down_action(&crate::root::EditorDown, window, cx);
+            }
+        });
+        cx.run_until_parked();
+        let moved = app.read_with(cx, |app, _| {
+            let buffer = app.edit_buffers.get(&relative).expect("buffer");
+            buffer.line_col_for_offset(buffer.cursor_offset()).0
+        });
+        assert_eq!(
+            moved, 200,
+            "premise: the caret really moved to buffer line 200"
+        );
+        assert_eq!(app.read_with(cx, |app, _| app.code_cursor), Some(201));
+
+        // Switch away and back, which is what makes `spawn_file_load` run again.
+        open_and_settle(&app, cx, other);
+        app.update_in(cx, |app, window, cx| {
+            app.open_file_view(target, window, cx);
+        });
+        app.update(cx, |app, cx| {
+            app.render_center_pane(cx);
+        });
+        cx.run_until_parked();
+        app.update(cx, |app, cx| {
+            app.render_center_pane(cx);
+        });
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            let buffer = app.edit_buffers.get(&relative).expect("buffer");
+            assert_eq!(
+                buffer.line_col_for_offset(buffer.cursor_offset()).0,
+                200,
+                "premise: the buffer's own caret survived the round trip"
+            );
+            assert_eq!(
+                app.code_cursor,
+                Some(201),
+                "and the indicator must follow it rather than snapping back to line 1"
+            );
+            // The other half of the same fix, read off the real list's own resolved scroll
+            // offset (`vendor/zed/crates/gpui/src/elements/uniform_list.rs`'s `base_handle`,
+            // which is what `scroll_to_item`'s deferred target resolves into on the next
+            // layout): the caret's row must have been scrolled back into view, or a caret
+            // restored to line 200 of a 400-line file would be correct and invisible.
+            assert!(
+                f32::from(
+                    app.file_view_scroll_handle
+                        .0
+                        .borrow()
+                        .base_handle
+                        .offset()
+                        .y
+                ) < 0.0,
+                "reopening must scroll the restored caret's row into view, not sit at the top"
+            );
+        });
+    }
+
+    /// The "otherwise" half of the same clause. This one deliberately still passes with the fix
+    /// reverted - it is an over-correction guard, not coverage: it fails only if some future edit
+    /// makes a *first* open report anything but 1:1, which is the direction "always restore the
+    /// buffer's caret" would break if the buffer were ever seeded at a non-zero offset.
+    #[gpui::test]
+    fn a_first_open_is_caret_at_line_one(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let target = repo.path().join("fresh.txt");
+        std::fs::write(&target, "a\nb\nc\n").expect("write");
+
+        let (app, cx) =
+            crate::root::focus::palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        open_and_settle(&app, cx, target);
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.code_cursor, Some(1));
+            assert_eq!(
+                app.edit_buffers
+                    .get(Path::new("fresh.txt"))
+                    .expect("buffer")
+                    .cursor_offset(),
+                0
+            );
+        });
+    }
+}
+
 #[cfg(test)]
 mod multi_file_tab_tests {
     use super::*;
@@ -965,7 +1235,7 @@ mod multi_file_tab_tests {
 
     /// Writes three files under `dir` and returns both their absolute paths (what
     /// `open_file_view` takes) and their repo-relative paths (what `open_change`/`open_files`/
-    /// `activate_file_tab`/`close_file_tab` key by, via `open_file_view`'s `strip_prefix`).
+    /// `activate_file_tab`/`close_file_tab` key by, via `open_file_view`'s own `strip_prefix`).
     fn write_three_files(
         dir: &std::path::Path,
     ) -> ((PathBuf, PathBuf, PathBuf), (PathBuf, PathBuf, PathBuf)) {

--- a/crates/app/src/palette/render.rs
+++ b/crates/app/src/palette/render.rs
@@ -291,11 +291,24 @@ impl AdeApp {
         }
     }
 
-    /// Runs a palette file result: a file that is changed in the currently loaded diff opens
-    /// its diff in the centre (reusing [`Self::open_change_diff`], same as a Changes-row click);
-    /// a file with no diff to open instead reveals it in the Files tree - switches Zone 3 to
-    /// `Files`, expands every ancestor directory, and highlights it via
-    /// [`Self::selected_tree_path`].
+    /// Runs a palette file result (GitHub issue #15): opens the file - its diff if it is changed
+    /// in the currently loaded diff, otherwise the editable File view - moves real keyboard focus
+    /// into it, and reveals and highlights it in the Files tree.
+    ///
+    /// All of that is [`Self::open_and_focus_file`]'s, reached through the same
+    /// [`Self::open_change_diff`]/[`Self::open_file_view`] pair a Changes row click and a tree row
+    /// click use. This function decides exactly one thing - which of the two views to open - and
+    /// switches Zone 3 to `Files` so the row it just revealed is actually on screen.
+    ///
+    /// ## What this used to do
+    ///
+    /// The diff-less branch revealed the file in the tree, highlighted its row, and *stopped*: no
+    /// tab was opened, nothing was shown in the centre, and focus stayed wherever it was, so the
+    /// palette closed onto an unchanged screen with a highlighted tree row. That is issue #15's
+    /// report and the separately-reported "reveal in tree selects the file but does not open it"
+    /// in one defect. The diff branch did open a tab and focus it, but never revealed or
+    /// highlighted the file in the tree - so which of the two halves you got depended on whether
+    /// the file happened to be in the diff. Both now run the one path that does all of it.
     // `pub(crate)`, not `pub(in crate::palette)`: `crate::sidebar::render`'s own
     // "reveal in tree" regression test drives this real flow rather than calling
     // `AdeApp::reveal_in_tree` directly, so that the wiring between the two is what's covered.
@@ -317,21 +330,45 @@ impl AdeApp {
             .current_diff()
             .is_some_and(|diff| diff.files.iter().any(|file| file.path == relative));
 
+        // The revealed row has to be on a tab that is actually showing, or the reveal is
+        // invisible. Set before opening, so the one `cx.notify()` at the end of
+        // `open_and_focus_file` covers this too.
+        self.right_sidebar_view = RightSidebarView::Files;
         if has_diff {
             self.open_change_diff(relative, window, cx);
         } else {
-            self.right_sidebar_view = RightSidebarView::Files;
-            // Expands every ancestor *and records those expansions on disk*, exactly like a
-            // manual click (issue #18 §5) - not a transient, this-session-only reveal.
-            self.reveal_in_tree(&path, cx);
-            self.selected_tree_path = Some(path);
-            cx.notify();
+            self.open_file_view(path, window, cx);
         }
     }
 
     /// Runs the currently highlighted palette result (`⏎`) - looks it up fresh via
     /// [`Self::build_palette_groups`], dispatches by its [`palette::EntryTarget`], then closes
     /// the palette.
+    ///
+    /// ## "An action focuses its result" (GitHub issue #15)
+    ///
+    /// An entry that opens something owns keyboard focus afterwards; an entry that opens nothing
+    /// leaves focus where it was before the palette. Both are the same closing step here, and
+    /// which one applies is *observed* rather than declared: focus is read before dispatch (it is
+    /// the palette's own handle, since the palette is open and focused) and again after, and the
+    /// entry is taken to have claimed focus exactly when it moved it. `Window::focus` writes
+    /// `Window::focus` synchronously (`vendor/zed/crates/gpui/src/window.rs`), so by the time
+    /// dispatch returns this comparison is already the real answer.
+    ///
+    /// Deliberately not a per-entry `bool` the way this app's first sketch of it was, for the
+    /// reason `crate::default_key_bindings`' own docs give about this codebase's most-shipped bug
+    /// class: a flag has to be set at every site that focuses something, and the failure mode of
+    /// forgetting one is a silently swallowed keystroke. There is nothing to forget here - a new
+    /// palette entry that focuses its result keeps focus automatically, and one that doesn't
+    /// restores automatically, with no third state to get wrong.
+    ///
+    /// What this fixes concretely: [`Self::open_palette_file_result`] moves focus into the
+    /// editor, and [`Self::close_palette`]'s unconditional `restore_focus` then moved it straight
+    /// back to whatever was focused before the palette opened - so the file really did open and
+    /// the very next keystroke still went to the terminal. `OpenSettings` had the same shape and
+    /// survived only because [`Self::close_palette`] carries a hand-written special case for
+    /// Settings specifically; that case is now subsumed by this general rule (it is kept, since
+    /// `close_palette` is also reached from Esc and the scrim, where no entry ran at all).
     pub(in crate::palette) fn run_selected_palette_entry(
         &mut self,
         window: &mut Window,
@@ -341,6 +378,7 @@ impl AdeApp {
         let target = palette::flatten(&groups)
             .get(self.palette_selected)
             .map(|entry| entry.target.clone());
+        let focus_before = window.focused(cx);
         if let Some(target) = target {
             match target {
                 palette::EntryTarget::Command(command) => {
@@ -356,7 +394,11 @@ impl AdeApp {
                 }
             }
         }
-        self.close_palette(window, cx);
+        if window.focused(cx) == focus_before {
+            self.close_palette(window, cx);
+        } else {
+            self.close_palette_keeping_result_focus(cx);
+        }
     }
 
     /// `TextUndo` for the palette query (GitHub issue #17). Resets the highlighted row alongside

--- a/crates/app/src/root/focus.rs
+++ b/crates/app/src/root/focus.rs
@@ -14,11 +14,33 @@ impl AdeApp {
     /// (`Self::open_change` was `None`) - a second file opened while one is already showing must
     /// not overwrite the real original target with `Self::code_focus_handle` itself (already
     /// focused by then). Always moves focus onto [`Self::code_focus_handle`] regardless.
+    ///
+    /// A handle belonging to one of this app's *other* overlays is never captured, even on that
+    /// transition. An overlay's handle is by definition about to stop being rendered - the
+    /// overlay is closing, which is why something is being opened underneath it - so storing one
+    /// as this surface's return target just relocates the dangling-focus bug to whenever the last
+    /// file tab is closed ([`Self::close_file_tab`] restores through the same
+    /// [`OverlayFocus`]). Reproduced by this branch's own adversarial audit: opening a file from
+    /// the palette with no tab yet captured `palette_focus_handle`, and closing that tab then
+    /// focused it. Each overlay already holds the real pre-overlay target in its own
+    /// `OverlayFocus`; declining to capture here leaves `restore_focus`'s active-session-pane
+    /// fallback as the honest answer instead of a handle that is certain to be wrong.
     pub(crate) fn focus_code_surface(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        if self.open_change.is_none() {
+        if self.open_change.is_none() && !self.focus_is_on_an_overlay(window, cx) {
             self.code_focus.capture(window, &self.sessions, cx);
         }
         window.focus(&self.code_focus_handle, cx);
+    }
+
+    /// Whether keyboard focus is currently on one of this app's overlay handles - the palette,
+    /// Settings, or the "New file" prompt. See [`Self::focus_code_surface`] for why capturing one
+    /// as a return target is always wrong.
+    fn focus_is_on_an_overlay(&self, window: &Window, cx: &App) -> bool {
+        window.focused(cx).is_some_and(|focused| {
+            focused == self.palette_focus_handle
+                || focused == self.settings_focus_handle
+                || focused == self.new_file_focus_handle
+        })
     }
 
     /// Opens the command palette (⌘P): resets query/scope/selection to a fresh "browse
@@ -47,8 +69,10 @@ impl AdeApp {
         cx.notify();
     }
 
-    /// Closes the palette overlay (scrim click, Esc, or running a result) and restores focus via
-    /// [`restore_focus`].
+    /// Closes the palette overlay (scrim click, Esc, or running a result that moved no focus)
+    /// and restores focus via [`restore_focus`]. A result that *did* move focus closes through
+    /// [`Self::close_palette_keeping_result_focus`] instead - see
+    /// [`crate::palette::render::AdeApp::run_selected_palette_entry`].
     pub(crate) fn close_palette(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.palette_open = false;
         if self.settings_open {
@@ -63,6 +87,35 @@ impl AdeApp {
             return;
         }
         restore_focus(&self.sessions, &mut self.palette_focus, window, cx);
+        cx.notify();
+    }
+
+    /// Closes the palette *without* touching focus - for the one case
+    /// [`crate::palette::render::AdeApp::run_selected_palette_entry`] detects: the entry that
+    /// just ran moved keyboard focus onto its own result, and that is where focus belongs
+    /// (GitHub issue #15's "an action focuses its result"). See that method's docs for how the
+    /// two closing paths are chosen between.
+    ///
+    /// Deliberately *not* `restore_focus` with a pre-cleared [`OverlayFocus`]: that function
+    /// falls back to the active session's terminal pane when it has no captured target, so
+    /// clearing first would have moved focus off the file that was just opened and into the
+    /// terminal - the same class of wrong-place focus this whole mechanism exists to stop. The
+    /// captured target is discarded via [`OverlayFocus::clear`] instead, which is exactly what
+    /// that method is for and what `Self::close_palette`'s own Settings branch already does.
+    ///
+    /// This does not violate [`OverlayFocus`]' dangling-focus invariant, but only because the
+    /// entries that move focus each move it onto something they have also made *rendered*. That
+    /// is a property of those entries, not something this function can check, and this branch's
+    /// own adversarial audit found the one case where it did not hold: a file result run while
+    /// Settings was open focused `code_focus_handle` while `render` was still drawing Settings
+    /// instead of the workspace. The fix is at the source -
+    /// [`crate::code_surface::tabs::AdeApp::open_and_focus_file`] now closes Settings before
+    /// focusing the code surface, so what it focuses really is rendered - rather than a special
+    /// case here, which would only have restored focus while leaving the user staring at
+    /// Settings after asking for a file.
+    pub(crate) fn close_palette_keeping_result_focus(&mut self, cx: &mut Context<Self>) {
+        self.palette_open = false;
+        self.palette_focus.clear();
         cx.notify();
     }
 
@@ -1740,6 +1793,460 @@ mod text_undo_scoping_tests {
             Some("nothing to undo".to_string()),
             "with the filter no longer rendered, secondary-z must reach a real handler and \
              produce real feedback - not fall into an empty dispatch context and vanish"
+        );
+    }
+}
+
+/// GitHub issue #15: "an action focuses its result". Every one of these drives the *real*
+/// palette - open it, type a real query, press a real `enter` - and then asserts with a real
+/// keystroke, because the whole risk is which widget the keystroke reaches, which no state
+/// assertion can see. `cx.simulate_input` goes through GPUI's real platform input path, so
+/// "the character landed in the buffer" is only true if a real `EntityInputHandler` was really
+/// registered against the really-focused editor.
+#[cfg(test)]
+mod palette_result_focus_tests {
+    use super::*;
+    use crate::palette::state as palette;
+    use gpui::{Entity, TestAppContext};
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// `src/main.rs` (the file every test opens) plus a sibling, so the palette's own filtering
+    /// has something to actually discriminate between.
+    fn seed(repo: &TempDir) {
+        fs::create_dir_all(repo.path().join("src")).expect("mkdir");
+        fs::write(repo.path().join("src/main.rs"), "fn main() {}\n").expect("write");
+        fs::write(repo.path().join("src/other.rs"), "pub fn o() {}\n").expect("write");
+    }
+
+    fn open_seeded(
+        cx: &mut TestAppContext,
+    ) -> (TempDir, Entity<AdeApp>, &mut gpui::VisualTestContext) {
+        let repo = TempDir::new().expect("tempdir");
+        seed(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
+        cx.run_until_parked();
+        (repo, app, cx)
+    }
+
+    /// Opens the palette and drives it to the file result for `name` the way a user does - typing
+    /// the query and pressing `enter` - after asserting that the highlighted row really is that
+    /// file, so a test can never pass by running some unrelated entry that happened to be first.
+    fn open_file_through_the_palette(
+        app: &Entity<AdeApp>,
+        cx: &mut gpui::VisualTestContext,
+        query: &str,
+        expected: &std::path::Path,
+    ) {
+        app.update_in(cx, |app, window, cx| app.open_palette(window, cx));
+        cx.run_until_parked();
+        cx.simulate_input(query);
+        cx.run_until_parked();
+
+        app.update(cx, |app, cx| {
+            let groups = app.build_palette_groups(cx);
+            let flat = palette::flatten(&groups);
+            let entry = flat
+                .get(app.palette_selected)
+                .expect("the palette must have a highlighted row");
+            assert_eq!(
+                entry.target,
+                palette::EntryTarget::File(expected.to_path_buf()),
+                "premise: typing {query:?} must highlight {expected:?}, not some other entry"
+            );
+        });
+
+        cx.simulate_keystrokes("enter");
+        // The file's content arrives on a background read; `edit_buffers` is seeded from its
+        // completion handler, and the caret's row has to paint once for the real input handler to
+        // be registered. Same render/park cycle `text_undo_scoping_tests::open_file_for_editing`
+        // drives for the same reason.
+        app.update(cx, |app, cx| {
+            app.render_center_pane(cx);
+        });
+        cx.run_until_parked();
+        app.update(cx, |app, cx| {
+            app.render_center_pane(cx);
+        });
+    }
+
+    /// The *open and reveal* half of the issue: a palette file result really opens the file's
+    /// tab, with a real edit buffer behind it, and really highlights it in the tree. The keystroke
+    /// half is the two tests below - deliberately separate, so a failure names one thing.
+    ///
+    /// Before the fix the diff-less branch of `open_palette_file_result` opened no tab at all: it
+    /// expanded the file's ancestors, highlighted its row, and stopped. That is both this issue's
+    /// report and the separately-reported "reveal in tree selects the file but does not open it".
+    #[gpui::test]
+    fn selecting_a_file_in_the_palette_opens_and_reveals_it(cx: &mut TestAppContext) {
+        let (repo, app, cx) = open_seeded(cx);
+        let target = repo.path().join("src/main.rs");
+        open_file_through_the_palette(&app, cx, "main.rs", &target);
+
+        let relative = PathBuf::from("src/main.rs");
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.open_change.as_deref(),
+                Some(relative.as_path()),
+                "the palette must have opened the file's tab"
+            );
+            assert_eq!(app.open_files, vec![relative.clone()]);
+            assert!(
+                app.edit_buffers.contains_key(&relative),
+                "and a real edit buffer must be backing it"
+            );
+        });
+        assert!(
+            !app.read_with(cx, |app, _| app.palette_open),
+            "and the palette must have closed behind it"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.selected_tree_path.clone()),
+            Some(target),
+            "the same action must also highlight the file in the tree - reveal and open are one \
+             action, not two that might disagree"
+        );
+    }
+
+    /// The issue's own acceptance criterion, verbatim: "Palette -> type a name -> Enter -> type:
+    /// the characters land in the file. No mouse involved at any point."
+    ///
+    /// This is the assertion `close_palette`'s unconditional `restore_focus` used to fail: the
+    /// file opened, and the keystroke went to whatever had focus before the palette.
+    #[gpui::test]
+    fn the_keystroke_after_a_palette_file_result_lands_in_the_buffer(cx: &mut TestAppContext) {
+        let (repo, app, cx) = open_seeded(cx);
+        let target = repo.path().join("src/main.rs");
+        open_file_through_the_palette(&app, cx, "main.rs", &target);
+        let relative = PathBuf::from("src/main.rs");
+
+        cx.simulate_input("X");
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app
+                .edit_buffers
+                .get(&relative)
+                .expect("buffer")
+                .content
+                .clone()),
+            "Xfn main() {}\n",
+            "the very next keystroke after the palette closes must land in the file that was \
+             just opened - not in the palette, and not in the terminal that had focus before"
+        );
+    }
+
+    /// The arrow-key half of the same criterion: `EditorRight` is a real, `\"file-editor\"`-scoped
+    /// action, so it only fires if the code surface really is the focused dispatch node.
+    #[gpui::test]
+    fn arrow_keys_after_a_palette_file_result_move_the_caret(cx: &mut TestAppContext) {
+        let (repo, app, cx) = open_seeded(cx);
+        let target = repo.path().join("src/main.rs");
+        open_file_through_the_palette(&app, cx, "main.rs", &target);
+        let relative = PathBuf::from("src/main.rs");
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app
+                .edit_buffers
+                .get(&relative)
+                .expect("buffer")
+                .cursor_offset()),
+            0,
+            "a freshly opened file starts at 1:1"
+        );
+
+        cx.simulate_keystrokes("right");
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app
+                .edit_buffers
+                .get(&relative)
+                .expect("buffer")
+                .cursor_offset()),
+            1,
+            "arrow keys must move the caret in the opened file"
+        );
+    }
+
+    /// "Works identically when the file is already open: switch to its tab and focus it, never
+    /// open a duplicate." Focus is deliberately parked somewhere else first, so this genuinely
+    /// tests the re-open path rather than passing because focus never moved.
+    #[gpui::test]
+    fn reopening_an_already_open_file_focuses_it_without_duplicating_its_tab(
+        cx: &mut TestAppContext,
+    ) {
+        let (repo, app, cx) = open_seeded(cx);
+        let target = repo.path().join("src/main.rs");
+        let relative = PathBuf::from("src/main.rs");
+
+        open_file_through_the_palette(&app, cx, "main.rs", &target);
+        cx.simulate_input("A");
+        cx.run_until_parked();
+
+        // Park focus off the editor, the way clicking into the file tree would - so this test
+        // genuinely exercises the re-open path rather than passing because focus never left.
+        app.update_in(cx, |app, window, cx| {
+            window.focus(&app.tree_focus_handle, cx);
+        });
+        cx.run_until_parked();
+        cx.simulate_input("!");
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.edit_buffers.get(&relative).expect("buffer").content,
+                "Afn main() {}\n",
+                "premise: with the tree focused, a keystroke must not reach the buffer"
+            );
+        });
+
+        open_file_through_the_palette(&app, cx, "main.rs", &target);
+        cx.simulate_input("B");
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.open_files,
+                vec![relative.clone()],
+                "reopening the same file must reuse its tab, never append a second one"
+            );
+            assert_eq!(
+                app.edit_buffers.get(&relative).expect("buffer").content,
+                "ABfn main() {}\n",
+                "both keystrokes must have landed in the same real buffer - and `B` lands \
+                 *after* `A` because the buffer kept its own caret (offset 1) across the \
+                 reopen. That half is pre-existing `edit_buffers` behaviour, not this change; \
+                 the visible half of the same clause is covered by \
+                 `code_surface::tabs::reopened_file_caret_tests`"
+            );
+        });
+    }
+
+    /// "Dismissing the palette with Esc (no selection) restores focus to exactly where it was
+    /// before the palette opened." Asserted through a real keystroke against a real editor rather
+    /// than by reading `window.focused`, so it covers the dispatch path and not just the handle.
+    #[gpui::test]
+    fn escaping_the_palette_restores_focus_to_the_editor_it_was_opened_over(
+        cx: &mut TestAppContext,
+    ) {
+        let (repo, app, cx) = open_seeded(cx);
+        let target = repo.path().join("src/main.rs");
+        open_file_through_the_palette(&app, cx, "main.rs", &target);
+        let relative = PathBuf::from("src/main.rs");
+
+        app.update_in(cx, |app, window, cx| app.open_palette(window, cx));
+        cx.run_until_parked();
+        cx.simulate_input("some query");
+        cx.simulate_keystrokes("escape");
+        cx.run_until_parked();
+        assert!(!app.read_with(cx, |app, _| app.palette_open));
+
+        cx.simulate_input("Z");
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app
+                .edit_buffers
+                .get(&relative)
+                .expect("buffer")
+                .content
+                .clone()),
+            "Zfn main() {}\n",
+            "an Esc-dismissed palette must hand focus straight back to the editor it opened \
+             over - the query it swallowed must not have taken the editor's focus with it"
+        );
+    }
+
+    /// Adversarial-audit regression, CRITICAL. Running a palette file result while the Settings
+    /// surface is open used to focus `code_focus_handle` while `AdeApp::render` was still drawing
+    /// Settings *instead of* the workspace body - so `Window::focus` pointed at a `FocusId` that
+    /// `focus_node_id_in_rendered_frame` could not find, GPUI fell back to the dispatch root with
+    /// an empty context stack, and every context-scoped binding died. Esc included: the user was
+    /// left on a Settings page they could not leave, with no file in sight, until they clicked.
+    ///
+    /// The fix is that opening a file closes Settings, so what gets focused really is rendered.
+    /// Asserted end to end: the file is showing, a keystroke reaches its buffer, and Esc still
+    /// does something real.
+    #[gpui::test]
+    fn a_palette_file_result_run_over_settings_leaves_a_usable_keyboard(cx: &mut TestAppContext) {
+        let (repo, app, cx) = open_seeded(cx);
+        let target = repo.path().join("src/main.rs");
+        let relative = PathBuf::from("src/main.rs");
+
+        app.update_in(cx, |app, window, cx| app.open_settings(window, cx));
+        cx.run_until_parked();
+        assert!(
+            app.read_with(cx, |app, _| app.settings_open),
+            "premise: Settings must really be up"
+        );
+
+        open_file_through_the_palette(&app, cx, "main.rs", &target);
+
+        app.read_with(cx, |app, _| {
+            assert!(
+                !app.settings_open,
+                "opening a file must not leave Settings covering it - focusing a surface that \
+                 isn't rendered is the dangling-focus bug this app has shipped repeatedly"
+            );
+            assert_eq!(app.open_change.as_deref(), Some(relative.as_path()));
+        });
+
+        cx.simulate_input("K");
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app
+                .edit_buffers
+                .get(&relative)
+                .expect("buffer")
+                .content
+                .clone()),
+            "Kfn main() {}\n",
+            "and the next keystroke must land in the file that was asked for"
+        );
+    }
+
+    /// Adversarial-audit regression, MAJOR. `focus_code_surface` captures the pre-open focus
+    /// target on the first file opened - and with no tab open yet, the thing holding focus at
+    /// that moment is the palette's own handle. Capturing it moved the dangling-focus bug to
+    /// `close_file_tab`, which restores through the very same `OverlayFocus`.
+    #[gpui::test]
+    fn opening_the_first_file_from_the_palette_never_captures_the_palettes_own_handle(
+        cx: &mut TestAppContext,
+    ) {
+        let (repo, app, cx) = open_seeded(cx);
+        let target = repo.path().join("src/main.rs");
+        let relative = PathBuf::from("src/main.rs");
+
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.open_change.is_none(),
+                "premise: no tab yet, so this really is the capturing transition"
+            );
+        });
+        open_file_through_the_palette(&app, cx, "main.rs", &target);
+
+        app.update_in(cx, |app, window, cx| {
+            app.close_file_tab(relative.clone(), window, cx);
+        });
+        cx.run_until_parked();
+
+        let (focused, palette_handle) = app.update_in(cx, |app, window, cx| {
+            (window.focused(cx), app.palette_focus_handle.clone())
+        });
+        assert_ne!(
+            focused.as_ref(),
+            Some(&palette_handle),
+            "closing the last tab must not restore focus onto the palette's own handle - the \
+             palette has not been rendered since it closed"
+        );
+    }
+
+    /// Adversarial-audit regression, MAJOR. With the tree focused, opening the palette captures
+    /// `tree_focus_handle`; running the palette's own "Toggle Files / Changes" then unrenders the
+    /// whole tree. `set_right_sidebar_view`'s own `is_focused` guard cannot see this, because the
+    /// *palette* holds focus at that moment - so closing the palette restored focus straight onto
+    /// a handle that is no longer in the frame.
+    #[gpui::test]
+    fn toggling_to_changes_from_the_palette_does_not_restore_focus_onto_the_unrendered_tree(
+        cx: &mut TestAppContext,
+    ) {
+        let (_repo, app, cx) = open_seeded(cx);
+
+        app.update_in(cx, |app, window, cx| {
+            window.focus(&app.tree_focus_handle, cx);
+        });
+        cx.run_until_parked();
+        app.update_in(cx, |app, window, cx| app.open_palette(window, cx));
+        cx.run_until_parked();
+
+        let ran = app.update(cx, |app, cx| {
+            let groups = app.build_palette_groups(cx);
+            let index = palette::flatten(&groups).iter().position(|entry| {
+                entry.target
+                    == palette::EntryTarget::Command(palette::PaletteCommand::ToggleFilesChanges)
+            });
+            match index {
+                Some(index) => {
+                    app.palette_selected = index;
+                    true
+                }
+                None => false,
+            }
+        });
+        assert!(ran, "the palette must offer the real Files/Changes toggle");
+        cx.simulate_keystrokes("enter");
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.right_sidebar_view,
+                RightSidebarView::Changes,
+                "premise: the toggle really ran and the tree really is unrendered"
+            );
+        });
+        let (focused, tree_handle) = app.update_in(cx, |app, window, cx| {
+            (window.focused(cx), app.tree_focus_handle.clone())
+        });
+        assert_ne!(
+            focused.as_ref(),
+            Some(&tree_handle),
+            "focus must not be restored onto the file tree's handle once the tree is gone - \
+             GPUI would fall back to the dispatch root and silently kill every scoped binding"
+        );
+    }
+
+    /// The other direction of the same rule, and the reason it is *observed* rather than
+    /// declared: an entry that opens nothing must leave focus exactly where it was.
+    /// `ToggleRailGrouping` is the smallest real such entry - it flips one rail field and
+    /// touches no focus handle at all.
+    #[gpui::test]
+    fn a_palette_entry_that_opens_nothing_still_restores_the_previous_focus(
+        cx: &mut TestAppContext,
+    ) {
+        let (repo, app, cx) = open_seeded(cx);
+        let target = repo.path().join("src/main.rs");
+        open_file_through_the_palette(&app, cx, "main.rs", &target);
+        let relative = PathBuf::from("src/main.rs");
+
+        app.update_in(cx, |app, window, cx| app.open_palette(window, cx));
+        cx.run_until_parked();
+        let ran = app.update(cx, |app, cx| {
+            let groups = app.build_palette_groups(cx);
+            let index = palette::flatten(&groups).iter().position(|entry| {
+                entry.target
+                    == palette::EntryTarget::Command(palette::PaletteCommand::ToggleRailGrouping)
+            });
+            match index {
+                Some(index) => {
+                    app.palette_selected = index;
+                    true
+                }
+                None => false,
+            }
+        });
+        assert!(
+            ran,
+            "the palette must offer the real rail-grouping command to run"
+        );
+        cx.simulate_keystrokes("enter");
+        cx.run_until_parked();
+        assert!(
+            !app.read_with(cx, |app, _| app.palette_open),
+            "premise: the entry really ran and closed the palette"
+        );
+
+        cx.simulate_input("Q");
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app
+                .edit_buffers
+                .get(&relative)
+                .expect("buffer")
+                .content
+                .clone()),
+            "Qfn main() {}\n",
+            "an entry that focuses nothing must restore the pre-palette focus, or every \
+             non-opening palette command would silently strand the next keystroke"
         );
     }
 }

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -1623,12 +1623,31 @@ impl OverlayFocus {
         self.opened_session = sessions.active_id();
     }
 
-    /// Discards captured state without restoring it - used only by
-    /// [`AdeApp::close_palette`]'s Settings-showing-underneath branch, which moves focus onto
-    /// `settings_focus_handle` directly instead of through [`restore_focus`].
+    /// Discards captured state without restoring it. Three real callers: [`AdeApp::close_palette`]'s
+    /// Settings-showing-underneath branch and [`AdeApp::close_palette_keeping_result_focus`],
+    /// both of which put focus somewhere real themselves instead of going through
+    /// [`restore_focus`], and `crate::work_surface::render`'s session teardown.
     pub(crate) fn clear(&mut self) {
         self.return_focus = None;
         self.opened_session = None;
+    }
+
+    /// Forgets a captured target that is about to stop being rendered, leaving [`restore_focus`]
+    /// to fall back to the active session's pane instead of focusing a node GPUI can no longer
+    /// find in the frame.
+    ///
+    /// This exists for a real, reproduced case (found by the `tree-focus-bugfixes` branch's own
+    /// adversarial audit): with the file tree focused, opening the palette captures
+    /// `tree_focus_handle`; running the palette's own "Toggle Files / Changes" then unrenders the
+    /// whole tree, and closing the palette restored focus straight onto it.
+    /// `crate::sidebar::render::AdeApp::set_right_sidebar_view` already had a
+    /// `tree_focus_handle.is_focused(window)` guard for the *direct* version of this, but the
+    /// palette is what holds focus at that moment, so the guard could not see it. Every overlay
+    /// that could be holding the tree's handle is swept there instead.
+    pub(crate) fn forget_target(&mut self, handle: &FocusHandle) {
+        if self.return_focus.as_ref() == Some(handle) {
+            self.return_focus = None;
+        }
     }
 }
 

--- a/crates/app/src/root/new_file.rs
+++ b/crates/app/src/root/new_file.rs
@@ -176,14 +176,27 @@ impl AdeApp {
         div()
             .id("new-file-scrim")
             .absolute()
-            .top(px(0.0))
+            // Starts *below* the title bar, exactly like `crate::palette::render`'s own scrim
+            // does and for the same reason - now a real one, since this layer `.occlude()`s.
+            // A full-window occluding scrim swallows the window's own close/minimise/maximise
+            // caption buttons and the title bar's drag region, so the window could not be closed
+            // or moved while it was up. Reproduced against the real caption button by this
+            // change's own adversarial audit.
+            .top(theme::band::TITLE_BAR)
             .left(px(0.0))
             .right(px(0.0))
             .bottom(px(0.0))
             .flex()
             .items_center()
             .justify_center()
-            .bg(gpui::black().opacity(0.35))
+            // The same real modal layer the file tree's delete confirmation is - a transparent-
+            // to-the-mouse scrim would let the workspace behind it keep taking clicks and
+            // painting hover states while a modal is up. See
+            // `crate::sidebar::render::AdeApp::render_tree_context_menu`'s own docs for what
+            // `.occlude()` actually does, and `crate::root::widgets::modal_scrim_bg` for why the
+            // fill is a token rather than the raw `gpui::black()` that used to be here.
+            .occlude()
+            .bg(widgets::modal_scrim_bg())
             .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
                 this.cancel_new_file(window, cx);
             }))

--- a/crates/app/src/root/widgets.rs
+++ b/crates/app/src/root/widgets.rs
@@ -270,3 +270,87 @@ impl AdeApp {
             .when(self.caret_blink_visible, |el| el.bg(theme::term::CURSOR))
     }
 }
+
+/// The fill behind a centered modal panel - the file tree's delete confirmation
+/// (`crate::sidebar::render::AdeApp::render_tree_delete_confirm`) and the New file prompt
+/// (`crate::root::new_file::AdeApp::render_new_file_prompt`), this app's only two.
+///
+/// Derived from `theme::surface::SCRIM`, the design handoff's own scrim colour
+/// (`design_handoff_jerry_ade/revision/README.md`: "Scrim rgba(6,7,8,.62)"), rather than the raw
+/// `gpui::black()` both modals used to hard-code - a literal colour rather than a token, which is
+/// exactly what this app's theming discipline exists to keep out. The alpha stays at the 0.35
+/// both modals already used: a small centered dialog does not dim as hard as the palette, which
+/// replaces the entire workspace and uses the designed 0.62.
+pub(crate) fn modal_scrim_bg() -> gpui::Rgba {
+    theme::surface::SCRIM.resolve().opacity(0.35)
+}
+
+/// One button in a centered modal's action row - `label`, tinted `theme::button::DANGER_FG` when
+/// `destructive` (with `DANGER_FG_HOVER` on hover, this app's established destructive-control
+/// pair) and `theme::text::BODY` otherwise.
+///
+/// Shape is `crate::work_surface::render::render_footer_action_button`'s: `h(23)`, `px(10)`,
+/// `theme::radius::BUTTON` - the 4px "buttons" radius the design handoff calls for, not the 3px
+/// `radius::CHIP` meant for chips and keycaps. Carries a real hover fill; the delete
+/// confirmation's two buttons shipped with none at all, so the only clickable controls in that
+/// dialog were also the only ones in the app that gave no feedback under the pointer. The caller
+/// attaches its own `.on_click`.
+pub(crate) fn render_modal_button(
+    id: &'static str,
+    label: impl Into<gpui::SharedString>,
+    destructive: bool,
+) -> gpui::Stateful<gpui::Div> {
+    let (color, hover_color) = if destructive {
+        (theme::button::DANGER_FG, theme::button::DANGER_FG_HOVER)
+    } else {
+        (theme::text::BODY, theme::text::PRIMARY)
+    };
+    div()
+        .id(id)
+        .debug_selector(move || id.to_string())
+        .cursor_pointer()
+        .flex()
+        .items_center()
+        .h(px(23.0))
+        .px(px(10.0))
+        .rounded(theme::radius::BUTTON)
+        .bg(theme::surface::SEGMENT_TRACK)
+        .hover(move |el| el.bg(theme::surface::ROW_HOVER_ALT).text_color(hover_color))
+        .font(font(theme::font::SANS))
+        .font_weight(gpui::FontWeight::MEDIUM)
+        .text_size(px(10.5))
+        .text_color(color)
+        .child(label.into())
+}
+
+/// One group divider's whole vertical footprint, in px: the 1px rule of
+/// [`render_menu_group_divider`] plus its 4px margins top and bottom. Exported because the two
+/// menus that have to *measure* themselves - `crate::title_bar::menu`'s row-index math and
+/// `crate::sidebar::context_menu::menu_height`'s window-edge clamp - both read the real number
+/// rather than each restating `1 + 4 + 4`.
+pub(crate) const MENU_GROUP_DIVIDER_HEIGHT: Pixels = px(9.0);
+
+/// A thin 1px rule between two groups of rows inside a dropdown or context popover -
+/// [`theme::border::DIVIDER`], the same token the title bar's own left-cluster rule uses, inset
+/// `mx(10.0)` so it lines up flush with a menu row's own `px(10.0)` label column.
+///
+/// The app's one in-menu divider, shared by the title bar's File/Edit/View/Session/Help menus
+/// (where it was first built, as `title_bar::menu`'s `render_title_menu_divider`) and the file
+/// tree's right-click context menu, whose groups (GitHub issue #19 §1) shipped with no visual
+/// separation at all. See [`MENU_GROUP_DIVIDER_HEIGHT`] for the height both of those menus
+/// measure against.
+pub(crate) fn render_menu_group_divider() -> gpui::AnyElement {
+    // The margins are *derived* from the total rather than written alongside it, so the constant
+    // the two menus measure themselves against and the element they are measuring cannot
+    // disagree - which is the whole reason the constant is public in the first place.
+    let margin = (MENU_GROUP_DIVIDER_HEIGHT - MENU_GROUP_DIVIDER_RULE) / 2.0;
+    div()
+        .h(MENU_GROUP_DIVIDER_RULE)
+        .mx(px(10.0))
+        .my(margin)
+        .bg(theme::border::DIVIDER)
+        .into_any_element()
+}
+
+/// The divider's own rule thickness - the rest of [`MENU_GROUP_DIVIDER_HEIGHT`] is its margins.
+const MENU_GROUP_DIVIDER_RULE: Pixels = px(1.0);

--- a/crates/app/src/settings/state.rs
+++ b/crates/app/src/settings/state.rs
@@ -570,7 +570,14 @@ pub(crate) fn action_label(action: &dyn gpui::Action) -> Option<&'static str> {
         "app::TextUndo" => Some("Text: undo"),
         "app::TextRedo" => Some("Text: redo"),
         "app::CloseFocusedTab" => Some("Close focused tab"),
-        "app::FileTreeContextMenu" => Some("Files tree: context menu"),
+        // Deliberately says what it is *for*, not just what it opens. This page has no
+        // description column - a row's label is the whole explanation a user ever gets - and
+        // "Files tree: context menu" left a real reader with no idea why the app binds Shift+F10
+        // at all. It is the keyboard equivalent of right-clicking the selected row, which is what
+        // GitHub issue #19 §2 required and what this wording now states outright. The Files
+        // tree's own footer hint strip
+        // (`crate::sidebar::render::render_file_tree_footer`) is the other half of that answer.
+        "app::FileTreeContextMenu" => Some("Files tree: open the selected row's actions menu"),
         "app::FileTreeRename" => Some("Files tree: rename"),
         "app::FileTreeCopy" => Some("Files tree: copy"),
         "app::FileTreeCut" => Some("Files tree: cut"),
@@ -1199,7 +1206,7 @@ mod tests {
                 // `"file-tree && !tree-editing"` - see `crate::default_key_bindings`' own docs
                 // and `crate::sidebar::tree_ops`' module docs for why both halves of that
                 // predicate are load-bearing.
-                "Files tree: context menu",
+                "Files tree: open the selected row's actions menu",
                 "Files tree: rename",
                 "Files tree: copy",
                 "Files tree: cut",

--- a/crates/app/src/sidebar/context_menu.rs
+++ b/crates/app/src/sidebar/context_menu.rs
@@ -10,7 +10,12 @@
 //! reachable from here: it lives in Zed's `ui` crate, not in `gpui`, and this workspace
 //! deliberately depends on `gpui`/`gpui_platform` only. The popover is therefore built from the
 //! same real scrim + absolutely-positioned panel shape
-//! `crate::work_surface::render::AdeApp::render_plus_menu` already established in this app.
+//! `crate::work_surface::render::AdeApp::render_plus_menu` already established in this app - with
+//! two deliberate differences that scrim does not (yet) have, both forced by a real reported bug:
+//! this one `.occlude()`s, so the rows behind it stop taking clicks and painting hover states,
+//! and it starts below the title bar rather than at the window top, so occluding it doesn't
+//! swallow the window's own caption buttons. See
+//! `crate::sidebar::render::AdeApp::render_tree_context_menu`'s own docs.
 
 use std::path::{Path, PathBuf};
 
@@ -138,53 +143,123 @@ impl MenuItem {
     }
 }
 
-/// The real rows for `target`, in the order issue #19 §1 lists them.
+/// The real rows for `target`, **grouped** the way issue #19 §1 lists them - one inner `Vec` per
+/// logical group, in order. This is the single source of truth for both the flat order
+/// ([`menu_items`], which is literally this flattened) and the rendered separators
+/// ([`menu_rows`]), so the two can never disagree about where a group ends: there is no second,
+/// hand-maintained list of "and the divider goes after row 3".
 ///
 /// `clipboard_has_entry` gates every `Paste` row: with nothing cut or copied there is genuinely
 /// nothing to paste, and a row that silently does nothing is worse than a visibly disabled one.
-pub fn menu_items(target: &ContextTarget, clipboard_has_entry: bool) -> Vec<MenuItem> {
+pub fn menu_groups(target: &ContextTarget, clipboard_has_entry: bool) -> Vec<Vec<MenuItem>> {
     const NOTHING_COPIED: &str = "nothing has been cut or copied yet";
+    let paste = || MenuItem::gated(MenuAction::Paste, clipboard_has_entry, NOTHING_COPIED);
     match target {
         ContextTarget::File(_) => vec![
-            MenuItem::enabled(MenuAction::Open),
-            MenuItem::enabled(MenuAction::Rename),
-            MenuItem::enabled(MenuAction::Duplicate),
-            MenuItem::enabled(MenuAction::Cut),
-            MenuItem::enabled(MenuAction::Copy),
-            MenuItem::gated(MenuAction::Paste, clipboard_has_entry, NOTHING_COPIED),
-            MenuItem::enabled(MenuAction::CopyPath),
-            MenuItem::enabled(MenuAction::CopyRelativePath),
-            MenuItem::enabled(MenuAction::Delete),
-            MenuItem::enabled(MenuAction::Reveal),
+            vec![
+                MenuItem::enabled(MenuAction::Open),
+                MenuItem::enabled(MenuAction::Rename),
+                MenuItem::enabled(MenuAction::Duplicate),
+            ],
+            vec![
+                MenuItem::enabled(MenuAction::Cut),
+                MenuItem::enabled(MenuAction::Copy),
+                paste(),
+            ],
+            vec![
+                MenuItem::enabled(MenuAction::CopyPath),
+                MenuItem::enabled(MenuAction::CopyRelativePath),
+            ],
+            vec![
+                MenuItem::enabled(MenuAction::Delete),
+                MenuItem::enabled(MenuAction::Reveal),
+            ],
         ],
         ContextTarget::Folder(_) => vec![
-            MenuItem::enabled(MenuAction::NewFile),
-            MenuItem::enabled(MenuAction::NewFolder),
-            MenuItem::enabled(MenuAction::Rename),
-            MenuItem::enabled(MenuAction::Cut),
-            MenuItem::enabled(MenuAction::Copy),
-            MenuItem::gated(MenuAction::Paste, clipboard_has_entry, NOTHING_COPIED),
-            MenuItem::enabled(MenuAction::CollapseSubtree),
-            MenuItem::enabled(MenuAction::CopyPath),
-            MenuItem::enabled(MenuAction::Delete),
-            MenuItem::enabled(MenuAction::Reveal),
+            vec![
+                MenuItem::enabled(MenuAction::NewFile),
+                MenuItem::enabled(MenuAction::NewFolder),
+                MenuItem::enabled(MenuAction::Rename),
+            ],
+            vec![
+                MenuItem::enabled(MenuAction::Cut),
+                MenuItem::enabled(MenuAction::Copy),
+                paste(),
+            ],
+            vec![
+                MenuItem::enabled(MenuAction::CollapseSubtree),
+                MenuItem::enabled(MenuAction::CopyPath),
+            ],
+            vec![
+                MenuItem::enabled(MenuAction::Delete),
+                MenuItem::enabled(MenuAction::Reveal),
+            ],
         ],
         ContextTarget::Empty => vec![
-            MenuItem::enabled(MenuAction::NewFile),
-            MenuItem::enabled(MenuAction::NewFolder),
-            MenuItem::gated(MenuAction::Paste, clipboard_has_entry, NOTHING_COPIED),
-            MenuItem::enabled(MenuAction::CollapseAll),
+            vec![
+                MenuItem::enabled(MenuAction::NewFile),
+                MenuItem::enabled(MenuAction::NewFolder),
+            ],
+            vec![paste()],
+            vec![MenuItem::enabled(MenuAction::CollapseAll)],
         ],
     }
+}
+
+/// The real rows for `target`, flattened - issue #19 §1's order exactly. Derived from
+/// [`menu_groups`] rather than written out a second time.
+pub fn menu_items(target: &ContextTarget, clipboard_has_entry: bool) -> Vec<MenuItem> {
+    menu_groups(target, clipboard_has_entry)
+        .into_iter()
+        .flatten()
+        .collect()
+}
+
+/// One thing the popover paints, top to bottom: a real action row, or the divider between two of
+/// [`menu_groups`]' groups. Issue #19 §1 always described those groups; the shipped menu listed
+/// them in the right order and drew them as one undifferentiated run of ten rows.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MenuRow {
+    Item(MenuItem),
+    Separator,
+}
+
+/// [`menu_groups`] with a [`MenuRow::Separator`] between each pair of adjacent groups - never a
+/// leading or trailing one, and never one around a group that came out empty.
+pub fn menu_rows(target: &ContextTarget, clipboard_has_entry: bool) -> Vec<MenuRow> {
+    let mut rows = Vec::new();
+    for group in menu_groups(target, clipboard_has_entry) {
+        if group.is_empty() {
+            continue;
+        }
+        if !rows.is_empty() {
+            rows.push(MenuRow::Separator);
+        }
+        rows.extend(group.into_iter().map(MenuRow::Item));
+    }
+    rows
 }
 
 /// The popover's fixed width, in px. Wide enough for the longest label
 /// ("Copy Relative Path") plus a `Ctrl+V`-sized keycap without wrapping.
 pub const MENU_WIDTH: f32 = 208.0;
 
-/// One menu row's height, in px - matching `theme::band::TREE_ROW`'s own 22px rhythm plus a
-/// little breathing room, since these rows carry a keycap the tree rows don't.
+/// One menu row's height, in px - unchanged from what this menu shipped with. Matching
+/// `theme::band::TREE_ROW`'s own 22px rhythm plus a little breathing room, since these rows carry
+/// a keycap the tree rows don't.
 pub const MENU_ROW_HEIGHT: f32 = 24.0;
+
+/// One group separator's whole vertical footprint, in px - a restatement of
+/// `crate::root::widgets::MENU_GROUP_DIVIDER_HEIGHT` (its 1px rule plus its 4px margins top and
+/// bottom), as a plain `f32` because this module is deliberately GPUI-free and that constant is
+/// typed in `gpui::Pixels`. `crate::sidebar::render`'s
+/// `the_context_menu_paints_exactly_the_height_it_measures` is the real guard on the restatement:
+/// it compares [`menu_height`] against the popover's *actually painted* bounds, so neither this
+/// nor any other term here can drift from the element without failing.
+///
+/// Part of [`menu_height`] because a menu that measured its rows but not its dividers would flip
+/// short of a window edge by 9px per group boundary.
+pub const MENU_SEPARATOR_HEIGHT: f32 = 9.0;
 
 /// The popover's own vertical padding (top + bottom together), in px.
 pub const MENU_VERTICAL_PADDING: f32 = 8.0;
@@ -199,9 +274,19 @@ pub const MENU_EDGE_MARGIN: f32 = 4.0;
 /// paints - which is exactly enough for a menu opened at the very bottom edge to overhang.
 pub const MENU_BORDER: f32 = 2.0;
 
-/// The popover's real painted height for `rows` rows.
-pub fn menu_height(rows: usize) -> f32 {
-    MENU_ROW_HEIGHT * rows as f32 + MENU_VERTICAL_PADDING + MENU_BORDER
+/// The popover's real painted height for exactly the `rows` it is about to paint - action rows
+/// and group dividers both, since [`crate::sidebar::render::AdeApp::render_tree_context_menu`]
+/// paints both and an edge flip computed from the row count alone would be short by
+/// [`MENU_SEPARATOR_HEIGHT`] per group boundary.
+pub fn menu_height(rows: &[MenuRow]) -> f32 {
+    let painted: f32 = rows
+        .iter()
+        .map(|row| match row {
+            MenuRow::Item(_) => MENU_ROW_HEIGHT,
+            MenuRow::Separator => MENU_SEPARATOR_HEIGHT,
+        })
+        .sum();
+    painted + MENU_VERTICAL_PADDING + MENU_BORDER
 }
 
 /// Where the popover's top-left corner must go so the whole menu stays inside a
@@ -303,6 +388,60 @@ mod tests {
         );
     }
 
+    /// The real group boundaries, asserted by action rather than by index, so renaming or
+    /// reordering *within* a group doesn't churn this test but moving a row *across* one does.
+    #[test]
+    fn each_target_groups_its_actions_the_way_the_issue_describes() {
+        let grouped = |target: &ContextTarget| -> Vec<Vec<MenuAction>> {
+            menu_groups(target, true)
+                .iter()
+                .map(|group| actions(group))
+                .collect()
+        };
+
+        assert_eq!(
+            grouped(&ContextTarget::File(PathBuf::from("/repo/a.rs"))),
+            vec![
+                vec![MenuAction::Open, MenuAction::Rename, MenuAction::Duplicate],
+                vec![MenuAction::Cut, MenuAction::Copy, MenuAction::Paste],
+                vec![MenuAction::CopyPath, MenuAction::CopyRelativePath],
+                vec![MenuAction::Delete, MenuAction::Reveal],
+            ]
+        );
+        assert_eq!(
+            grouped(&ContextTarget::Folder(PathBuf::from("/repo/src"))),
+            vec![
+                vec![
+                    MenuAction::NewFile,
+                    MenuAction::NewFolder,
+                    MenuAction::Rename
+                ],
+                vec![MenuAction::Cut, MenuAction::Copy, MenuAction::Paste],
+                vec![MenuAction::CollapseSubtree, MenuAction::CopyPath],
+                vec![MenuAction::Delete, MenuAction::Reveal],
+            ]
+        );
+        assert_eq!(
+            grouped(&ContextTarget::Empty),
+            vec![
+                vec![MenuAction::NewFile, MenuAction::NewFolder],
+                vec![MenuAction::Paste],
+                vec![MenuAction::CollapseAll],
+            ]
+        );
+
+        for target in [
+            ContextTarget::File(PathBuf::from("/repo/a.rs")),
+            ContextTarget::Folder(PathBuf::from("/repo/src")),
+            ContextTarget::Empty,
+        ] {
+            assert!(
+                menu_groups(&target, true).iter().all(|g| !g.is_empty()),
+                "an empty group would paint a rule with nothing under it: {target:?}"
+            );
+        }
+    }
+
     #[test]
     fn paste_is_the_only_row_an_empty_clipboard_disables() {
         for target in [
@@ -343,9 +482,17 @@ mod tests {
         assert_eq!(ContextTarget::Empty.destination_dir(root), root);
     }
 
+    /// A menu of `count` plain rows and no dividers - the sizing fixture the geometry tests
+    /// below use, so they stay about placement rather than about grouping.
+    fn plain_rows(count: usize) -> Vec<MenuRow> {
+        (0..count)
+            .map(|_| MenuRow::Item(MenuItem::enabled(MenuAction::Open)))
+            .collect()
+    }
+
     #[test]
     fn a_menu_that_fits_opens_exactly_at_the_click() {
-        let height = menu_height(10);
+        let height = menu_height(&plain_rows(10));
         assert_eq!(
             clamp_menu_origin(100.0, 50.0, MENU_WIDTH, height, 1200.0, 800.0),
             (100.0, 50.0)
@@ -354,7 +501,7 @@ mod tests {
 
     #[test]
     fn a_click_near_the_right_or_bottom_edge_flips_the_menu_back_inside() {
-        let height = menu_height(10);
+        let height = menu_height(&plain_rows(10));
         let (x, y) = clamp_menu_origin(1190.0, 790.0, MENU_WIDTH, height, 1200.0, 800.0);
         assert_eq!(x, 1190.0 - MENU_WIDTH, "flips leftwards off the click");
         assert_eq!(y, 790.0 - height, "flips upwards off the click");
@@ -366,7 +513,7 @@ mod tests {
     /// window (showing its first rows) rather than at a negative offset.
     #[test]
     fn a_menu_larger_than_the_window_clamps_to_the_near_edge() {
-        let height = menu_height(10);
+        let height = menu_height(&plain_rows(10));
         let (x, y) = clamp_menu_origin(20.0, 20.0, MENU_WIDTH, height, 100.0, 60.0);
         assert_eq!((x, y), (MENU_EDGE_MARGIN, MENU_EDGE_MARGIN));
     }
@@ -375,7 +522,7 @@ mod tests {
     /// clamp is what stops that.
     #[test]
     fn a_flip_never_produces_a_negative_origin() {
-        let height = menu_height(4);
+        let height = menu_height(&plain_rows(4));
         let (x, y) = clamp_menu_origin(2.0, 2.0, MENU_WIDTH, height, 240.0, 60.0);
         assert!(x >= MENU_EDGE_MARGIN, "got {x}");
         assert!(y >= MENU_EDGE_MARGIN, "got {y}");
@@ -387,16 +534,65 @@ mod tests {
     #[test]
     fn menu_height_is_the_panels_whole_painted_height() {
         assert_eq!(
-            menu_height(4),
+            menu_height(&plain_rows(4)),
             4.0 * MENU_ROW_HEIGHT + MENU_VERTICAL_PADDING + MENU_BORDER,
             "every term `crate::sidebar::render::AdeApp::render_tree_context_menu` actually \
              paints - rows, the panel's own py, and its 1px border top and bottom"
         );
         assert_eq!(
-            menu_height(5) - menu_height(4),
+            menu_height(&plain_rows(5)) - menu_height(&plain_rows(4)),
             MENU_ROW_HEIGHT,
             "and it must still track the real row count"
         );
+        let mut with_one_divider = plain_rows(4);
+        with_one_divider.insert(2, MenuRow::Separator);
+        assert_eq!(
+            menu_height(&with_one_divider) - menu_height(&plain_rows(4)),
+            MENU_SEPARATOR_HEIGHT,
+            "a divider is painted height too - a menu measured by row count alone would overhang \
+             a window edge by 9px per group boundary"
+        );
+    }
+
+    /// Dividers go *between* groups and nowhere else - never leading, never trailing, never two
+    /// in a row - and the rows they separate stay in issue #19 §1's order.
+    #[test]
+    fn dividers_only_ever_sit_between_two_real_groups() {
+        for target in [
+            ContextTarget::File(PathBuf::from("/repo/a.rs")),
+            ContextTarget::Folder(PathBuf::from("/repo/src")),
+            ContextTarget::Empty,
+        ] {
+            for clipboard in [true, false] {
+                let rows = menu_rows(&target, clipboard);
+                assert!(!matches!(rows.first(), Some(MenuRow::Separator)));
+                assert!(!matches!(rows.last(), Some(MenuRow::Separator)));
+                assert!(
+                    !rows
+                        .windows(2)
+                        .any(|pair| pair == [MenuRow::Separator, MenuRow::Separator]),
+                    "two dividers in a row means an empty group got a rule of its own"
+                );
+                let items: Vec<MenuAction> = rows
+                    .iter()
+                    .filter_map(|row| match row {
+                        MenuRow::Item(item) => Some(item.action),
+                        MenuRow::Separator => None,
+                    })
+                    .collect();
+                assert_eq!(
+                    items,
+                    actions(&menu_items(&target, clipboard)),
+                    "adding dividers must not reorder or drop a single action: {target:?}"
+                );
+                assert_eq!(
+                    rows.iter()
+                        .filter(|row| matches!(row, MenuRow::Separator))
+                        .count(),
+                    menu_groups(&target, clipboard).len() - 1
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/app/src/sidebar/mod.rs
+++ b/crates/app/src/sidebar/mod.rs
@@ -11,7 +11,8 @@
 //! - [`changes`] - the pure mapping from `wt_core::diff` data to the Changes tab's row
 //!   labels/colours/counts and the fold-marker treatment.
 //! - [`context_menu`] - the pure model of the right-click menu (GitHub issue #19 §1): which
-//!   actions each target offers, and the edge-aware geometry that keeps the popover on screen.
+//!   actions each target offers, how they group, and the edge-aware geometry that keeps the
+//!   popover - dividers and all - on screen.
 //! - [`file_ops`] - the pure filesystem primitives behind those actions (issue #19 §2/§3): name
 //!   validation, collision-free naming, recursive copy/move/delete, and the real OS-trash
 //!   decision.

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -1,7 +1,8 @@
 use super::*;
 use crate::keymap;
 use crate::root::widgets::{
-    render_keycap_row, render_sidebar_message, render_tag_pill, text_tooltip, KeycapSize,
+    modal_scrim_bg, render_keycap_row, render_menu_group_divider, render_modal_button,
+    render_sidebar_message, render_tag_pill, text_tooltip, KeycapSize,
 };
 use crate::settings::widgets::ChoiceOption;
 
@@ -41,6 +42,17 @@ impl AdeApp {
             if self.tree_focus_handle.is_focused(window) {
                 restore_focus(&self.sessions, &mut self.code_focus, window, cx);
             }
+            // 1 again, one level removed, and invisible to the check above: an *overlay* can be
+            // holding the tree's handle as its own return target while the overlay itself has
+            // focus - which is exactly the state the palette's own "Toggle Files / Changes"
+            // command runs in, since the palette is focused and the tree is not. Closing the
+            // palette afterwards would then restore focus onto a handle this very branch has
+            // just unrendered. Swept from every overlay rather than only the palette, so a
+            // future overlay reaching this path doesn't reintroduce it. Reproduced by this
+            // change's own adversarial audit; see `OverlayFocus::forget_target`.
+            self.palette_focus.forget_target(&self.tree_focus_handle);
+            self.settings_focus.forget_target(&self.tree_focus_handle);
+            self.code_focus.forget_target(&self.tree_focus_handle);
         }
         self.right_sidebar_view = view;
         if view == RightSidebarView::Changes {
@@ -1126,15 +1138,21 @@ impl AdeApp {
             // (`vendor/zed/crates/gpui/src/elements/uniform_list.rs`'s `uniform_list()`), so an
             // outer scroll box here would let the list grow to its full virtual height inside a
             // second scroller and defeat the virtualization entirely.
-            RightSidebarView::Files => container.child(
-                div()
-                    .id("right-sidebar-body")
-                    .flex()
-                    .flex_col()
-                    .flex_1()
-                    .min_h_0()
-                    .child(self.render_file_tree(cx)),
-            ),
+            RightSidebarView::Files => container
+                .child(
+                    div()
+                        .id("right-sidebar-body")
+                        .flex()
+                        .flex_col()
+                        .flex_1()
+                        .min_h_0()
+                        .child(self.render_file_tree(cx)),
+                )
+                .child(render_file_tree_footer(
+                    self.ui_text_size(10.0),
+                    self.window_controls_style().is_macos(),
+                    self.tree_inline_edit.is_none() && self.tree_delete_confirm.is_none(),
+                )),
             RightSidebarView::Changes => match self.current_diff() {
                 Some(diff) => {
                     let header = self.render_changes_header(diff);
@@ -1343,7 +1361,8 @@ impl AdeApp {
     /// One Changes row: a review checkbox, `dir`/`name`, an optional tag pill, `+n`/`−n`, and
     /// the five-segment stat bar. Clicking anywhere on the row other than the checkbox itself
     /// (see [`Self::render_review_checkbox`]'s `stop_propagation`) opens the file's diff via
-    /// [`Self::open_change_diff`].
+    /// [`Self::open_change_diff`] - which, since GitHub issue #15, also reveals and highlights
+    /// that file in the Files tree, the same as every other way of opening a file in this app.
     pub(in crate::sidebar) fn render_change_row(
         &self,
         file: &DiffFile,
@@ -1507,13 +1526,27 @@ impl AdeApp {
     /// The panel's origin is [`AdeApp::tree_context_menu`]'s already-clamped one, resolved at
     /// open time from the real click and the real `Window::bounds()` - so the menu near a window
     /// edge is repositioned once, not re-solved (and possibly moved) on every frame it's open.
+    ///
+    /// ## The scrim genuinely blocks what is behind it
+    ///
+    /// `.occlude()` (`gpui::InteractiveElement::occlude`, which sets
+    /// `HitboxBehavior::BlockMouse` - `vendor/zed/crates/gpui/src/window.rs`'s `hit_test` stops
+    /// walking hitboxes at the first one carrying it) is what makes this a real modal layer
+    /// rather than a decorative one. Without it the scrim's `on_click` fired *and* the file-tree
+    /// row underneath it took the same click - so dismissing the menu also opened whatever file
+    /// happened to be under the cursor - and every row under the pointer still painted its
+    /// `:hover` fill and its tooltip, because those read `Hitbox::is_hovered` directly and never
+    /// consulted the click handlers at all. A `cx.stop_propagation()` in the scrim's own handler
+    /// could only ever have fixed the click half; hover styling is not an event. The same
+    /// `.occlude()` is on `Self::render_tree_delete_confirm`'s scrim, and this app already used
+    /// the identical mechanism for the pane resize handles (`crate::root::resize`).
     pub(crate) fn render_tree_context_menu(&self, cx: &mut Context<Self>) -> impl IntoElement {
         let menu = self.tree_context_menu.clone();
         let macos = self.window_controls_style().is_macos();
         let (shadow_x, shadow_y, shadow_blur) = theme::shadow::PLUS_MENU;
-        let items = menu
+        let rows = menu
             .as_ref()
-            .map(|menu| context_menu::menu_items(&menu.target, self.tree_clipboard.is_some()))
+            .map(|menu| context_menu::menu_rows(&menu.target, self.tree_clipboard.is_some()))
             .unwrap_or_default();
         let origin_x = menu.as_ref().map(|menu| menu.origin_x).unwrap_or(0.0);
         let origin_y = menu.as_ref().map(|menu| menu.origin_y).unwrap_or(0.0);
@@ -1521,10 +1554,17 @@ impl AdeApp {
         div()
             .id("tree-context-menu-scrim")
             .absolute()
-            .top(px(0.0))
+            // Starts *below* the title bar, exactly like `crate::palette::render`'s own scrim
+            // does and for the same reason - now a real one, since this layer `.occlude()`s.
+            // A full-window occluding scrim swallows the window's own close/minimise/maximise
+            // caption buttons and the title bar's drag region, so the window could not be closed
+            // or moved while it was up. Reproduced against the real caption button by this
+            // change's own adversarial audit.
+            .top(theme::band::TITLE_BAR)
             .left(px(0.0))
             .right(px(0.0))
             .bottom(px(0.0))
+            .occlude()
             .bg(work_surface::TRANSPARENT)
             .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
                 this.close_tree_context_menu(cx);
@@ -1544,7 +1584,13 @@ impl AdeApp {
                     .debug_selector(|| "tree-context-menu".to_string())
                     .absolute()
                     .left(px(origin_x))
-                    .top(px(origin_y))
+                    // `origin_y` is window-space (it is clamped against `Window::bounds()`, from
+                    // a window-space `MouseDownEvent::position`), but this panel is positioned
+                    // relative to the scrim - which starts at `theme::band::TITLE_BAR`, not at
+                    // the window top. Without this subtraction the menu paints a whole title bar
+                    // too low. `context_menu_paints_at_its_clamped_window_space_origin` is the
+                    // assertion that keeps the two in step.
+                    .top(px(origin_y) - theme::band::TITLE_BAR)
                     .w(px(context_menu::MENU_WIDTH))
                     .py(px(context_menu::MENU_VERTICAL_PADDING / 2.0))
                     .bg(theme::surface::PALETTE)
@@ -1560,17 +1606,46 @@ impl AdeApp {
                     .on_click(cx.listener(|_this, _event: &ClickEvent, _window, cx| {
                         cx.stop_propagation();
                     }))
-                    .children(
-                        items
-                            .into_iter()
-                            .map(|item| self.render_tree_context_menu_row(item, macos, cx)),
-                    ),
+                    .children(rows.into_iter().map(|row| match row {
+                        context_menu::MenuRow::Item(item) => {
+                            self.render_tree_context_menu_row(item, macos, cx)
+                        }
+                        context_menu::MenuRow::Separator => render_menu_group_divider(),
+                    })),
             )
     }
 
     /// One context-menu row. A disabled row is still drawn (so the menu's shape doesn't jump
     /// between right-clicks) but carries no click handler at all - not a handler that returns
     /// early, which would be a row that looks clickable and silently isn't.
+    ///
+    /// Speaks this app's own established dropdown-row language rather than one invented here.
+    /// Every value below is `crate::work_surface::render::render_dropdown_menu_row`'s - the row
+    /// shared by the tab strip's `+` menu and the title bar's File/Edit/View/Session/Help menus,
+    /// and the closest thing this app has to a specified menu row (the design handoff's
+    /// `revision/CHANGELOG.md` specifies that popover; it has no context-menu spec of its own).
+    /// That function is deliberately *not* reused: its row is a fixed chip + label + sub-label +
+    /// keycap quad, and a file-tree context menu has no honest chip glyph or secondary text for
+    /// two of those four slots.
+    ///
+    /// Four values were off that language, and the first of them was the reported "the context
+    /// menu has no hover state" bug outright:
+    ///
+    /// - **hover fill** was `theme::surface::ROW_HOVER` (`#15181b`) - the *exact* hex of
+    ///   `theme::surface::PALETTE`, this panel's own background - so hovering a row painted
+    ///   nothing at all. `theme::surface::PLUS_MENU_ROW_HOVER` (`#1d2226`) is the token that
+    ///   exists for this; `theme::palette::ROW_HOVER`'s own docs record the identical trap for
+    ///   the palette's rows.
+    /// - **label colour and size** were `theme::text::BODY` at 11.0px, against the dropdown row's
+    ///   `theme::text::HEADING` at 11.5px medium.
+    /// - **gap** was 8px, against 9.
+    /// - **disabled rows** were `theme::text::GHOST` and kept `cursor_pointer`'s absence but not
+    ///   the explicit `cursor_default()`; the dropdown row uses `theme::text::GHOSTER` and sets
+    ///   the cursor, so a row that cannot be run does not advertise itself as clickable.
+    ///
+    /// The destructive tint stays `theme::status::FAIL`, unchanged - `theme::button::DANGER_FG`
+    /// is this app's destructive *button* pair (the rail's prune control, and now the delete
+    /// confirmation's own confirm button), not its menu-row accent.
     fn render_tree_context_menu_row(
         &self,
         item: context_menu::MenuItem,
@@ -1583,11 +1658,11 @@ impl AdeApp {
             .map(|spec| keymap::resolve_combo(spec, macos))
             .unwrap_or_default();
         let color = if !item.enabled {
-            theme::text::GHOST
+            theme::text::GHOSTER
         } else if action.is_destructive() {
             theme::status::FAIL
         } else {
-            theme::text::BODY
+            theme::text::HEADING
         };
 
         let mut row = div()
@@ -1599,26 +1674,30 @@ impl AdeApp {
             .flex()
             .items_center()
             .justify_between()
-            .gap(px(8.0))
+            .gap(px(9.0))
             .w_full()
             .h(px(context_menu::MENU_ROW_HEIGHT))
             .px(px(10.0))
             .font(font(theme::font::SANS))
-            .text_size(self.ui_text_size(11.0))
+            .font_weight(gpui::FontWeight::MEDIUM)
+            .text_size(self.ui_text_size(11.5))
             .text_color(color)
-            .child(div().flex_1().min_w_0().child(action.label()))
+            .child(div().flex_1().min_w_0().truncate().child(action.label()))
             .child(render_keycap_row(&keycaps, KeycapSize::Hint));
 
         if item.enabled {
             row = row
                 .cursor_pointer()
-                .hover(|el| el.bg(theme::surface::ROW_HOVER))
+                .hover(|el| el.bg(theme::surface::PLUS_MENU_ROW_HOVER))
                 .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
                     cx.stop_propagation();
                     this.run_tree_menu_action(action, window, cx);
                 }));
-        } else if let Some(reason) = item.disabled_reason {
-            row = row.tooltip(text_tooltip(reason));
+        } else {
+            row = row.cursor_default();
+            if let Some(reason) = item.disabled_reason {
+                row = row.tooltip(text_tooltip(reason));
+            }
         }
 
         row.into_any_element()
@@ -1635,6 +1714,23 @@ impl AdeApp {
     /// and the sentence above it both come from the already-resolved
     /// [`crate::sidebar::tree_ops::PendingTreeDelete::mechanism`], so what is promised here and
     /// what actually runs cannot disagree.
+    ///
+    /// ## Design language
+    ///
+    /// The panel geometry is `crate::root::new_file::AdeApp::render_new_file_prompt`'s - this
+    /// app's first centered modal and therefore the pattern to match, not to re-derive: scrim +
+    /// `flex/items_center/justify_center`, panel `p(12)` `gap(8)` on
+    /// `theme::surface::PALETTE`/`theme::border::POPOVER`/`theme::radius::CARD`, title SANS 11.5
+    /// MEDIUM `theme::text::HEADING`, body SANS 10.5 `theme::text::DIM`. Three things that were
+    /// genuinely off it are fixed here: the scrim was a raw `gpui::black()` literal rather than a
+    /// theme token (now `crate::root::widgets::modal_scrim_bg`, shared with the New file prompt),
+    /// the two buttons had no hover state at all, and the destructive one was tinted
+    /// `theme::status::FAIL` - the rail's *status* red - rather than `theme::button::DANGER_FG`,
+    /// the pair this app already uses for a destructive control. Both buttons now come from the
+    /// one shared `crate::root::widgets::render_modal_button`.
+    ///
+    /// The scrim `.occlude()`s for the same real reason
+    /// [`Self::render_tree_context_menu`]'s does - see that method's docs.
     pub(crate) fn render_tree_delete_confirm(&self, cx: &mut Context<Self>) -> impl IntoElement {
         let pending = self.tree_delete_confirm.clone();
         let name = pending
@@ -1654,14 +1750,21 @@ impl AdeApp {
         div()
             .id("tree-delete-scrim")
             .absolute()
-            .top(px(0.0))
+            // Starts *below* the title bar, exactly like `crate::palette::render`'s own scrim
+            // does and for the same reason - now a real one, since this layer `.occlude()`s.
+            // A full-window occluding scrim swallows the window's own close/minimise/maximise
+            // caption buttons and the title bar's drag region, so the window could not be closed
+            // or moved while it was up. Reproduced against the real caption button by this
+            // change's own adversarial audit.
+            .top(theme::band::TITLE_BAR)
             .left(px(0.0))
             .right(px(0.0))
             .bottom(px(0.0))
             .flex()
             .items_center()
             .justify_center()
-            .bg(gpui::black().opacity(0.35))
+            .occlude()
+            .bg(modal_scrim_bg())
             .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
                 this.cancel_tree_delete(cx);
             }))
@@ -1702,18 +1805,7 @@ impl AdeApp {
                             .justify_end()
                             .gap(px(8.0))
                             .child(
-                                div()
-                                    .id("tree-delete-cancel")
-                                    .debug_selector(|| "tree-delete-cancel".to_string())
-                                    .cursor_pointer()
-                                    .px(px(10.0))
-                                    .py(px(4.0))
-                                    .rounded(theme::radius::CHIP)
-                                    .bg(theme::surface::SEGMENT_TRACK)
-                                    .font(font(theme::font::SANS))
-                                    .text_size(px(10.5))
-                                    .text_color(theme::text::BODY)
-                                    .child("Cancel")
+                                render_modal_button("tree-delete-cancel", "Cancel", false)
                                     .on_click(cx.listener(
                                         |this, _event: &ClickEvent, _window, cx| {
                                             this.cancel_tree_delete(cx);
@@ -1721,19 +1813,7 @@ impl AdeApp {
                                     )),
                             )
                             .child(
-                                div()
-                                    .id("tree-delete-confirm")
-                                    .debug_selector(|| "tree-delete-confirm".to_string())
-                                    .cursor_pointer()
-                                    .px(px(10.0))
-                                    .py(px(4.0))
-                                    .rounded(theme::radius::CHIP)
-                                    .bg(theme::surface::SEGMENT_TRACK)
-                                    .font(font(theme::font::SANS))
-                                    .font_weight(gpui::FontWeight::MEDIUM)
-                                    .text_size(px(10.5))
-                                    .text_color(theme::status::FAIL)
-                                    .child(confirm_label)
+                                render_modal_button("tree-delete-confirm", confirm_label, true)
                                     .on_click(cx.listener(
                                         |this, _event: &ClickEvent, _window, cx| {
                                             this.confirm_tree_delete(cx);
@@ -1768,6 +1848,93 @@ pub(in crate::sidebar) fn render_changes_footer(text_size: Pixels) -> impl IntoE
         .text_color(theme::text::HINT)
         .child("click a file to open its diff in the centre")
 }
+
+/// The Files tree's keyboard-hint footer - the counterpart to [`render_changes_footer`] beside
+/// it, so switching between the two sidebar views with a diff loaded doesn't move the list under
+/// the cursor. (The Changes view's *no-diff* arm still has no footer; that arm renders a single
+/// message rather than a list, so there is nothing for a footer to sit under.)
+///
+/// This exists to answer a real, reported complaint: `Shift+F10` opens the tree's context menu
+/// (issue #19 §2 required the menu to be reachable from the keyboard, so right-click alone was
+/// never enough) but nothing in the product said so. A user's only encounter with it was a row in
+/// Settings → Keybindings reading "Files tree: context menu", which explains what it does and not
+/// why it exists or that it is the right-click equivalent. Two surfaces now do: that row's own
+/// label (`crate::settings::state::action_label`), and this strip.
+///
+/// The shape is the hint strip the design handoff already specifies for
+/// exactly this job - `design_handoff_jerry_ade/revision/Jerry.dc.html`'s own `diffHints` strip:
+/// `height:28px ... padding:0 12px;background:#111316;border-top:1px solid #1c2023`, hints at
+/// `gap:11`, each hint `gap:5`, hint-size keycaps, label `400 10px 'IBM Plex Sans'` in `#4a5057`.
+/// Which is this app's
+/// `theme::band::SURFACE_FOOTER`/`surface::FOOTER`/`border::INNER`/`text::PATH` and the
+/// `KeycapSize::Hint` keycap it already had.
+///
+/// The keystrokes are resolved through [`keymap::resolve_combo`], the same per-platform
+/// resolution the context menu's own row keycaps use - never a hard-coded keystroke string that
+/// could drift from the real binding, which is also why the tooltip below names no key at all and
+/// points at the keycaps instead. Both hints are for real, registered bindings in
+/// `crate::default_key_bindings`, asserted by
+/// `crate::sidebar::tree_ops`'s own
+/// `the_file_tree_footer_only_advertises_real_registered_bindings`.
+///
+/// `live` is the other half of that honesty: both bindings are scoped
+/// `"file-tree && !tree-editing && !tree-delete-confirm"`, so while an inline name editor or the
+/// delete confirmation is open they genuinely do not fire, and the strip drops its hints rather
+/// than advertising a dead shortcut. The band itself stays, so the tree doesn't jump 28px.
+///
+/// `text_size` - see [`render_changes_footer`]'s docs for why this takes an already-scaled value.
+pub(in crate::sidebar) fn render_file_tree_footer(
+    text_size: Pixels,
+    macos: bool,
+    live: bool,
+) -> impl IntoElement {
+    let hint = move |spec: &'static str, label: &'static str| {
+        div()
+            .flex()
+            .items_center()
+            .gap(px(5.0))
+            .child(render_keycap_row(
+                &keymap::resolve_combo(spec, macos),
+                KeycapSize::Hint,
+            ))
+            .child(
+                div()
+                    .font(font(theme::font::SANS))
+                    .text_size(text_size)
+                    .text_color(theme::text::PATH)
+                    .child(label),
+            )
+    };
+
+    div()
+        .id("file-tree-footer")
+        .debug_selector(|| "file-tree-footer".to_string())
+        .flex_none()
+        .h(theme::band::SURFACE_FOOTER)
+        .px(px(12.0))
+        .flex()
+        .items_center()
+        .gap(px(11.0))
+        .border_t_1()
+        .border_color(theme::border::INNER)
+        .bg(theme::surface::FOOTER)
+        .tooltip(text_tooltip(
+            "Right-click a row for file actions. The keycaps here are the keyboard equivalents, \
+             for the row currently selected in the tree.",
+        ))
+        .when(live, |el| {
+            el.child(hint(FILE_TREE_CONTEXT_MENU_SPEC, "actions"))
+                .child(hint(FILE_TREE_RENAME_SPEC, "rename"))
+        })
+}
+
+/// The two `crate::keymap::resolve_combo` specs [`render_file_tree_footer`] advertises, named so
+/// its own test can assert each one really is a registered binding rather than a plausible
+/// string. `shift+F10` has no `mod` in it and so resolves identically on every platform; it still
+/// goes through `resolve_combo` rather than being written out, so the glyphs match every other
+/// keycap in the app.
+pub(in crate::sidebar) const FILE_TREE_CONTEXT_MENU_SPEC: &str = "shift+F10";
+pub(in crate::sidebar) const FILE_TREE_RENAME_SPEC: &str = "F2";
 
 /// The file tree row's `▾`/`▸` caret, signaling a directory row is clickable/expandable,
 /// distinct from the folder icon itself. Blank but still 8px wide for a file row, to keep
@@ -2532,6 +2699,22 @@ mod fold_state_tests {
             cx.debug_bounds("file-tree-row-main.rs").is_some(),
             "the revealed file's row must really be showing"
         );
+        // Reveal and open are one action, not two (the "Reveal in tree selects the file but does
+        // not open it" report, and GitHub issue #15's "reveal + highlight the opened file in the
+        // file tree"). Before that fix this branch expanded the ancestors and highlighted the row
+        // while opening nothing at all.
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.open_change.as_deref(),
+                Some(Path::new("src/app/main.rs")),
+                "revealing a file must also open its tab"
+            );
+            assert_eq!(app.selected_tree_path.as_deref(), Some(target.as_path()));
+            assert_eq!(
+                app.code_view,
+                crate::code_surface::code_view::CodeView::File
+            );
+        });
 
         let (reloaded, cx) = open_app_with_state_dir(cx, repo.path().to_path_buf(), settings_path);
         cx.run_until_parked();

--- a/crates/app/src/sidebar/tree_ops.rs
+++ b/crates/app/src/sidebar/tree_ops.rs
@@ -232,13 +232,17 @@ impl AdeApp {
         if self.tree_inline_edit.is_some() {
             self.cancel_tree_inline_edit(window, cx);
         }
-        let rows = context_menu::menu_items(&target, self.tree_clipboard.is_some()).len();
+        // The exact rows `crate::sidebar::render::AdeApp::render_tree_context_menu` will paint,
+        // group dividers included - measuring the action rows alone would leave the popover 9px
+        // per group boundary taller than the clamp believed, so a menu opened near the bottom
+        // edge would overhang it.
+        let rows = context_menu::menu_rows(&target, self.tree_clipboard.is_some());
         let viewport = window.bounds().size;
         let (origin_x, origin_y) = context_menu::clamp_menu_origin(
             click_x,
             click_y,
             context_menu::MENU_WIDTH,
-            context_menu::menu_height(rows),
+            context_menu::menu_height(&rows),
             f32::from(viewport.width),
             f32::from(viewport.height),
         );
@@ -2288,7 +2292,7 @@ mod tree_ops_regression_tests {
                 ContextTarget::Folder(repo.path().join("src")),
                 "the row's own handler must win over the container's empty-area one"
             );
-            let rows = context_menu::menu_items(&menu.target, false).len();
+            let rows = context_menu::menu_rows(&menu.target, false);
             assert!(
                 menu.origin_x >= 0.0
                     && menu.origin_x + context_menu::MENU_WIDTH <= f32::from(viewport.width),
@@ -2296,14 +2300,27 @@ mod tree_ops_regression_tests {
             );
             assert!(
                 menu.origin_y >= 0.0
-                    && menu.origin_y + context_menu::menu_height(rows)
+                    && menu.origin_y + context_menu::menu_height(&rows)
                         <= f32::from(viewport.height)
             );
         });
-        assert!(
-            cx.debug_bounds("tree-context-menu").is_some(),
-            "and it must genuinely paint"
-        );
+        let painted = cx
+            .debug_bounds("tree-context-menu")
+            .expect("and it must genuinely paint");
+        // The clamp works in window space; the panel is positioned inside a scrim that starts
+        // below the title bar. A menu that paints anywhere other than where the clamp put it is
+        // a menu whose edge-flip math is about a different rectangle than the one on screen.
+        app.read_with(cx, |app, _| {
+            let menu = app.tree_context_menu.as_ref().expect("menu");
+            assert_eq!(
+                (
+                    f32::from(painted.origin.x).round(),
+                    f32::from(painted.origin.y).round()
+                ),
+                (menu.origin_x.round(), menu.origin_y.round()),
+                "the popover must paint at exactly its clamped window-space origin"
+            );
+        });
     }
 
     /// §1's dismissal requirement, driven through the real key handler.
@@ -2755,6 +2772,224 @@ mod tree_ops_regression_tests {
             assert!(app.tree_delete_confirm.is_none());
         });
         assert!(repo.path().join("README.md").exists());
+    }
+
+    /// The reported "the context menu still lets you hover and select the rows underneath it"
+    /// bug, driven as a real click at a real row's real painted bounds.
+    ///
+    /// The reported symptom had two halves with two different causes, and only one of them is
+    /// observable from a test: the click must not reach the row's own `on_click` (asserted here,
+    /// via `open_change`), and the row must not paint its hover fill or its tooltip (not
+    /// observable - GPUI resolves both inside `Interactivity::paint` from
+    /// `Hitbox::is_hovered`, with no app state to read back). Both come from the same one-line
+    /// cause and the same one-line fix, which is why this test is honest coverage of the pair
+    /// rather than of only the half it names: `Window::hit_test` stops walking hitboxes at the
+    /// first `HitboxBehavior::BlockMouse` one, so with `.occlude()` on the scrim the row's
+    /// hitbox is not in the hit test's ids at all - which is exactly what both the click
+    /// dispatch and `is_hovered` consult. Note a `cx.stop_propagation()` in the scrim's own
+    /// handler would have fixed only the click half; hover styling is not an event.
+    #[gpui::test]
+    fn a_click_on_a_tree_row_under_an_open_context_menu_does_not_reach_that_row(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = TempDir::new().expect("tempdir");
+        seed(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        // Open the menu from the empty area, so the menu's own panel is nowhere near the row
+        // this test clicks and cannot be what absorbs the click.
+        app.update_in(cx, |app, window, cx| {
+            app.open_tree_context_menu(ContextTarget::Empty, 4.0, 4.0, window, cx);
+        });
+        cx.run_until_parked();
+        assert!(
+            app.read_with(cx, |app, _| app.tree_context_menu.is_some()),
+            "premise: the menu must be open"
+        );
+        assert!(
+            app.read_with(cx, |app, _| app.open_change.is_none()),
+            "premise: no file is open yet"
+        );
+
+        let row = cx
+            .debug_bounds("file-tree-row-README.md")
+            .expect("the file row must be painted underneath the menu");
+        cx.simulate_click(row.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.open_change.is_none(),
+                "the click must have been absorbed by the menu's scrim - a click that dismisses \
+                 a context menu must not also run whatever was underneath it"
+            );
+            assert!(
+                app.tree_context_menu.is_none(),
+                "and it must still have dismissed the menu"
+            );
+        });
+    }
+
+    /// The positive half of the same pair, so the `.occlude()` above can't pass by making the
+    /// tree permanently unclickable: with no menu open, the identical click really does open the
+    /// file.
+    #[gpui::test]
+    fn the_same_click_with_no_menu_open_really_does_open_the_file(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        seed(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        let row = cx
+            .debug_bounds("file-tree-row-README.md")
+            .expect("the file row must be painted");
+        cx.simulate_click(row.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.open_change.clone()),
+            Some(PathBuf::from("README.md")),
+            "with no menu in the way, a row click must open its file"
+        );
+    }
+
+    /// `Shift+F10` must reach the tree only when the tree is really the focused surface. With the
+    /// command palette open - a real, focused text-input surface - it must do nothing at all, and
+    /// the palette must keep taking the keystrokes that follow.
+    ///
+    /// Honest framing: this covers *pre-existing* scoping (`"file-tree && ..."`), not anything
+    /// this branch changed - it passes against the untouched base too. It is here because the
+    /// same branch makes `Shift+F10` more discoverable (the Files-tree footer hint strip and the
+    /// Keybindings-page relabel), and "more people will now press it" is exactly the moment to
+    /// pin down that pressing it in the wrong place costs nothing.
+    #[gpui::test]
+    fn shift_f10_with_the_palette_focused_neither_opens_the_menu_nor_eats_the_next_keystroke(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = TempDir::new().expect("tempdir");
+        seed(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
+        cx.run_until_parked();
+
+        app.update_in(cx, |app, window, cx| app.open_palette(window, cx));
+        cx.run_until_parked();
+
+        cx.simulate_keystrokes("shift-f10");
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.tree_context_menu.is_none(),
+                "the binding is scoped to the `file-tree` context precisely so a focused text \
+                 input keeps its own keystrokes"
+            );
+            assert!(app.palette_open, "and the palette must still be open");
+        });
+
+        cx.simulate_input("ab");
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.palette_query.as_str().to_string()),
+            "ab",
+            "and the keystrokes after it must still land in the palette's own query"
+        );
+    }
+
+    /// `menu_height` is what the window-edge flip is computed from, so it has to equal what the
+    /// popover *actually paints* - not just what its own formula restates. Asserted against real
+    /// painted bounds for all three targets, which is the only form of this assertion that can
+    /// catch a term going missing (an earlier version of `menu_height` omitted the panel's own
+    /// 2px border, making every edge flip 2px optimistic, and a formula-only test could not see
+    /// it).
+    #[gpui::test]
+    fn the_context_menu_paints_exactly_the_height_it_measures(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        seed(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        for target in [
+            ContextTarget::File(repo.path().join("README.md")),
+            ContextTarget::Folder(repo.path().join("src")),
+            ContextTarget::Empty,
+        ] {
+            let expected = context_menu::menu_height(&context_menu::menu_rows(&target, false));
+            app.update_in(cx, |app, window, cx| {
+                app.tree_clipboard = None;
+                app.open_tree_context_menu(target.clone(), 40.0, 80.0, window, cx);
+            });
+            cx.run_until_parked();
+            let painted = cx
+                .debug_bounds("tree-context-menu")
+                .expect("the popover must paint");
+            assert_eq!(
+                f32::from(painted.size.height).round(),
+                expected.round(),
+                "measured and painted height disagree for {target:?} - the edge clamp is \
+                 solving for a rectangle that isn't on screen"
+            );
+            app.update(cx, |app, cx| app.close_tree_context_menu(cx));
+            cx.run_until_parked();
+        }
+    }
+
+    /// The Files tree's footer hint strip advertises real keystrokes or none at all: each spec it
+    /// prints must resolve to a keystroke some real, registered binding actually carries. A hint
+    /// that named a keystroke nothing dispatches would be worse than no hint.
+    #[test]
+    fn the_file_tree_footer_only_advertises_real_registered_bindings() {
+        use crate::sidebar::render::{FILE_TREE_CONTEXT_MENU_SPEC, FILE_TREE_RENAME_SPEC};
+
+        let bindings = crate::default_key_bindings();
+        for (spec, action) in [
+            (FILE_TREE_CONTEXT_MENU_SPEC, "app::FileTreeContextMenu"),
+            (FILE_TREE_RENAME_SPEC, "app::FileTreeRename"),
+        ] {
+            let binding = bindings
+                .iter()
+                .find(|binding| binding.action().name() == action)
+                .unwrap_or_else(|| panic!("{action} must have a real registered binding"));
+            let printed = crate::keymap::resolve_combo(spec, false);
+            let real: Vec<String> = binding
+                .keystrokes()
+                .iter()
+                .flat_map(|keystroke| {
+                    // Every modifier, not just `shift` - a binding that silently gained a Ctrl or
+                    // Alt would otherwise still match, and the footer would keep printing a
+                    // keycap nobody can trigger.
+                    let modifiers = keystroke.modifiers();
+                    let mut parts: Vec<String> = Vec::new();
+                    if modifiers.control {
+                        parts.push("ctrl".to_string());
+                    }
+                    if modifiers.alt {
+                        parts.push("alt".to_string());
+                    }
+                    if modifiers.platform {
+                        parts.push("cmd".to_string());
+                    }
+                    if modifiers.shift {
+                        parts.push("shift".to_string());
+                    }
+                    parts.push(keystroke.key().to_string());
+                    parts
+                })
+                .map(|part| crate::keymap::resolve_combo(&part, false).join(""))
+                .collect();
+            // Case-insensitively: `gpui::Keystroke` normalises `key` to lowercase (`"f10"`),
+            // while the spec - and so the keycap the user reads - carries the conventional
+            // uppercase `"F10"`. The glyph, not its case, is what has to match.
+            let lower = |parts: &[String]| -> Vec<String> {
+                parts.iter().map(|part| part.to_lowercase()).collect()
+            };
+            assert_eq!(
+                lower(&printed),
+                lower(&real),
+                "the footer prints {spec:?} for {action}, which is not what that action is \
+                 actually bound to"
+            );
+        }
     }
 }
 

--- a/crates/app/src/title_bar/menu.rs
+++ b/crates/app/src/title_bar/menu.rs
@@ -7,6 +7,7 @@
 use super::*;
 #[cfg(test)]
 use crate::root::focus::palette_focus_tests;
+use crate::root::widgets::render_menu_group_divider;
 use crate::work_surface::render::render_dropdown_menu_row;
 
 /// The Windows/Linux title bar's five real menu dropdowns (`File Edit View Session Help`) - see
@@ -154,15 +155,14 @@ impl AdeApp {
             .into_any_element()
     }
 
-    /// A thin 1px divider between two groups of rows within a [`render_title_menu`] popover -
-    /// the same [`theme::border::DIVIDER`] token the title bar's own left-cluster divider uses.
+    /// A thin 1px divider between two groups of rows within a [`render_title_menu`] popover.
+    ///
+    /// Kept as a named method purely for this module's own call sites; the element itself is
+    /// `crate::root::widgets::render_menu_group_divider`, shared with the file tree's right-click
+    /// context menu (GitHub issue #19) so the app has exactly one in-menu divider rather than two
+    /// that happen to agree today.
     fn render_title_menu_divider() -> gpui::AnyElement {
-        div()
-            .h(px(1.0))
-            .mx(px(10.0))
-            .my(px(4.0))
-            .bg(theme::border::DIVIDER)
-            .into_any_element()
+        render_menu_group_divider()
     }
 
     /// The File menu: open a file (the same real, files-scoped command palette the `+` menu's
@@ -748,22 +748,22 @@ mod title_menu_tests {
     /// Generalizes [`first_row_click_point`] to any row deeper in the popover: the real click
     /// point of the row that sits after `rows_before` real rows and `dividers_before` dividers,
     /// using the same real per-row/per-divider heights every menu shares
-    /// (`theme::band::PLUS_MENU_ROW`, and [`render_title_menu_divider`]'s own `h(1.0)` plus
-    /// `my(4.0)` top/bottom margins - `1.0 + 4.0 + 4.0 = 9.0`px total) rather than a hand-tuned
+    /// (`theme::band::PLUS_MENU_ROW`, and `crate::root::widgets::MENU_GROUP_DIVIDER_HEIGHT` -
+    /// the divider element's own `h(1.0)` plus `my(4.0)` top/bottom margins, read from the
+    /// constant that element is measured by rather than restated here) rather than a hand-tuned
     /// pixel offset that could silently drift from the real rendered layout.
     fn nth_row_click_point(
         button_bounds: gpui::Bounds<Pixels>,
         rows_before: u32,
         dividers_before: u32,
     ) -> gpui::Point<Pixels> {
-        const DIVIDER_HEIGHT: Pixels = px(9.0);
         let popover_top = button_bounds.origin.y + button_bounds.size.height;
         gpui::point(
             button_bounds.origin.x + px(20.0),
             popover_top
                 + px(4.0)
                 + theme::band::PLUS_MENU_ROW * rows_before as f32
-                + DIVIDER_HEIGHT * dividers_before as f32
+                + crate::root::widgets::MENU_GROUP_DIVIDER_HEIGHT * dividers_before as f32
                 + theme::band::PLUS_MENU_ROW / 2.0,
         )
     }

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -131,7 +131,7 @@ impl AdeApp {
             self.open_change = None;
             self.refresh_open_diff_file_cache();
             self.hover = None;
-            // See `crate::code_surface::tabs::AdeApp::open_change_diff`'s identical
+            // See `crate::code_surface::tabs::AdeApp::open_and_focus_file`'s identical
             // `dismiss_completions()` call for why (Revision R8.5b audit finding 3).
             self.dismiss_completions();
             if self.settings_open {


### PR DESCRIPTION
## Summary

Fixes GitHub issue #15 (focus the opened file when using the command palette) and the 7-item bug list reported against PR #22/#23 (file tree). Bug #1 ("Reveal in tree selects the file but does not open it") turned out to be the exact same 5 lines as issue #15, so both land as one fix.

## Root cause and fix

`open_and_focus_file` is now the single path behind both `open_file_view` and `open_change_diff`: it opens-or-reuses the tab, moves real keyboard focus onto the code surface, and reveals + highlights the tree row. Previously the palette's diff-less branch only revealed (no tab, no focus) and its diff branch only opened (no reveal) — which half you got depended on whether the file happened to be in the diff.

`run_selected_palette_entry` now decides how to close by observing focus state either side of dispatch, rather than a per-entry flag that has to be remembered at every focusing call site.

Also fixed: reopening a file now restores its real caret/scroll position instead of reporting line 1; context menu hover state (was painting the panel's own background color — invisible); context menu now follows the design system (11.5px heading type, proper spacing); a `.occlude()` scrim now actually blocks clicks/hover on rows underneath it; the delete confirmation modal now has hover states and the app's destructive-button tokens; context menu groups now have the app's real divider (extracted into a shared `root::widgets` helper, also used by the title-bar menus); Shift+F10 is kept (opens the context menu via keyboard) but is now discoverable through a Files-tree hint strip and a self-explanatory Keybindings label.

## Adversarial review

An independently dispatched checker sub-agent found:
- **CRITICAL** (introduced by this change's own first draft): a palette file result run while Settings was open focused an unrendered node, silently killing every scoped keybinding including Esc. Fixed at the source — opening a file now explicitly closes Settings first.
- **MAJOR ×4**: `focus_code_surface` capturing the palette's own focus handle; the Files/Changes sidebar toggle restoring focus onto an unrendered tree; `.occlude()` on a full-window scrim swallowing the window's own caption buttons (reproduced against a real close-button click); `open_change_diff` resolving paths against the wrong root when `diff_root != file_tree_root`.
- 5 source comments citing an uncommitted design-handoff revision folder, with 3 constants derived from them — removed; everything now cites what's actually in this repo.

All fixed and regression-tested (three of the focus fixes were individually revert-verified by the checker to confirm they were the actual cause, not correlation).

## Testing

Independently re-verified by me, not taken on the builder's report alone:
- `cargo fmt --all -- --check`, `cargo build --workspace`, `cargo clippy --workspace --all-targets -- -D warnings` — all clean.
- `cargo test --workspace --lib -- --test-threads=1`: 945/946, one `diff_render_tests` failure — re-ran in isolation and it passed; this is the project's known, pre-existing cache-timing flake, not a regression (confirmed via an interleaved A/B against untouched master: 3/55 vs. 4/55, same rate).
- Spot-checked the CRITICAL fix directly in `crates/app/src/code_surface/tabs.rs`: `open_and_focus_file` explicitly calls `close_settings` when `self.settings_open`, before focusing the code surface.
- Confirmed no remaining references to the uncommitted `design_handoff_jerry_ade/revision 2/` folder anywhere in `crates/app/src`.

Branch was already based on current `master` (no rebase needed).