### PR TITLE
feat(settings): custom theme support (GitHub issue #5)

### DIFF
--- a/BUILD-LOG.md
+++ b/BUILD-LOG.md
@@ -4352,3 +4352,109 @@ work. All four gates clean after the deadlock fix: `cargo fmt --all -- --check`,
 failed. A separate full run earlier hit the same known
 `code_surface::diff_view::diff_render_tests` flake documented above (that file has zero diff on
 this branch); re-run in isolation, all 7 of that module's tests passed.
+
+## Re-implementing three lost custom-theme safety fixes after a real concurrency data-loss incident
+
+The paragraphs immediately above this one - describing `custom_theme_shift_preserves_readability`,
+a `JERRY_DARK_BASE_SWATCHES` const, and a
+`jerry_dark_base_swatches_matches_the_real_initialized_theme_defs_entry` regression test - do not
+correspond to anything in the code as committed. Grepping the current tree for all three names
+returns zero matches. Earlier in this branch's history, two agent sessions were accidentally run
+concurrently against this same shared (non-isolated) worktree directory - a coordinator mistake,
+not a code one. One of those sessions built three real, correct safety fixes for
+`crates/app/src/settings/custom_theme.rs` and left them uncommitted; the other concurrent session's
+own file writes silently clobbered them before they were ever committed, and the commit message
+recorded above was itself written against a version of the file that no longer matches what
+actually landed. This entry is the honest re-implementation, done from a clean read of the real
+current file (not from trusting the description above), and independently verified against the
+real committed diff by a fresh adversarial checker sub-agent rather than taken on this session's own
+word.
+
+The three real gaps, and what actually landed for each, by name:
+
+1. **Symlink-based unrelated-file-clobber in `non_colliding_dest_path`.** The collision-check loop
+   used `while candidate.exists() { ... }`. `Path::exists()` follows symlinks and reports `false`
+   for a *dangling* `{slug}.toml -> /some/other/path` symlink sitting in the destination directory,
+   so the loop treated that path as free, and `import_theme_file`'s own `std::fs::write` (which also
+   follows symlinks) would then write straight through it into whatever it pointed at - a real
+   clobber of an unrelated file, staged via a symlink instead of a same-named regular file. Fixed by
+   changing the loop condition to `candidate.symlink_metadata().is_ok()`, which detects the
+   symlink's own presence without following it, while a symlink that genuinely points at a file
+   already holding *this same* theme is still correctly reused rather than rejected. New tests:
+   `import_theme_file_does_not_follow_a_dangling_symlink_planted_at_the_slug_path`,
+   `import_theme_file_does_not_follow_a_symlink_to_an_unrelated_theme_file` (a real symlink via
+   `std::os::unix::fs::symlink`, `#[cfg(unix)]`), and
+   `non_colliding_dest_path_reuses_a_symlink_that_points_at_a_file_holding_the_same_theme`.
+
+2. **No file-size cap at import time.** `load_custom_themes_from_dir` already enforced
+   `MAX_THEME_FILE_BYTES` against files already sitting in a custom-themes directory, but
+   `import_theme_file` (the user-facing "import this file" action) had no matching check against
+   the *source* file being imported. Fixed by checking `std::fs::metadata(source_path).len()`
+   against the same `MAX_THEME_FILE_BYTES` constant before ever calling `read_to_string`, returning
+   a new `ThemeFileError::TooLarge { bytes, max_bytes }` variant. New test:
+   `import_theme_file_rejects_an_oversized_source_before_reading_or_writing_it`.
+
+3. **No readability-floor validation for custom theme swatches.** There was no check that a custom
+   theme's `panel` swatch is meaningfully different in brightness from `background` - a theme with
+   `panel == background` (or nearly so) validated and loaded cleanly. Fixed inside
+   `CustomThemeFile::validate_with_builtin_check` (so both `validate()` and the built-in-parsing
+   path run it) with three new functions - `relative_luma_per_mille` (standard ITU-R BT.709 luma,
+   scaled to an integer per-mille so the new error variant can stay `#[derive(Eq)]`),
+   `panel_background_luma_delta_per_mille`, and `readability_floor_per_mille` (half of Jerry Dark's
+   own real panel/background delta) - and a new `ThemeFileError::LowReadability { delta_per_mille,
+   floor_per_mille }` variant. The critical ordering constraint: this check must never read
+   `crate::settings::state::THEME_DEFS`, because `validate_with_builtin_check(false)` is called from
+   *inside* `THEME_DEFS`'s own `std::sync::LazyLock` initializer while parsing the six built-in
+   embedded theme files - reading `THEME_DEFS` from there would re-enter the still-initializing
+   `LazyLock` and hang forever on `std::sync::Once` (a real, previously-reproduced deadlock in this
+   branch's history, not a hypothetical). Solved by pinning a new `JERRY_DARK_BASELINE_SWATCHES`
+   const (`[0x0e0f11, 0x1a1e21, 0x5cb87f, 0xe2a336, 0x74ade8]`, transcribed by hand from
+   `assets/themes/jerry-dark.toml`, confirmed byte-for-byte against that file) as the readability
+   baseline instead of reading `THEME_DEFS` at runtime. A new regression test,
+   `jerry_dark_baseline_swatches_const_matches_the_real_initialized_theme_defs_0_swatches`, asserts
+   this pinned copy stays equal to `THEME_DEFS[0].swatches` - called from an ordinary `#[test]`,
+   never from inside another `LazyLock`'s own initializer, which is the one context that assertion
+   must never run in. Also added: `every_built_in_theme_clears_the_readability_floor` (asserts the
+   real per-theme delta against the floor by name, not just that validation didn't panic),
+   `readability_floor_per_mille_is_pinned_to_a_real_computed_value` (locks the floor at its actual
+   computed value, `28`, so a future edit can't silently weaken the check while every other test
+   stays green), `a_panel_swatch_with_no_real_contrast_against_background_is_rejected`, and
+   `a_panel_swatch_only_a_few_hex_digits_off_from_background_is_still_rejected` (a real near-miss,
+   not just the zero-contrast extreme).
+
+One existing test needed a fixture change, not a behavior change: `render.rs`'s
+`reimporting_the_currently_active_theme_immediately_reskins_the_app` re-imported Midnight Coral with
+its background swatch changed to `#301010`, which - now that the readability floor is enforced - is
+too close in brightness to that theme's own `#181a1e` panel (delta 12, floor 28) and was correctly
+rejected, breaking the test's own premise of exercising a live re-skin. Changed the fixture's new
+background to `#050505` (delta 81 against the same panel) instead; the test still proves the same
+live-re-skin behavior with a swatch that legitimately clears the floor.
+
+An independent, adversarial checker sub-agent was dispatched against the finished diff before
+committing, instructed explicitly to verify by direct `grep`/reading the real committed diff rather
+than trusting this session's own summary, and to run the actual test suite itself rather than take
+"tests pass" on faith. It confirmed all three fixes present with exact line numbers and ran the
+relevant tests itself, then flagged three real, legitimate weaknesses this session then fixed before
+committing: `every_built_in_theme_clears_the_readability_floor` originally only relied on a generic
+`expect`-panic inside `parse_builtin_theme_file_str` (duplicate coverage of an existing test, no
+real per-theme assertion) - now asserts the real delta against the floor by theme name;
+`import_theme_file_does_not_follow_a_symlink_to_an_unrelated_theme_file`'s doc comment incorrectly
+framed it as testing the same regression as the dangling-symlink fix, when a symlink to a real,
+existing file was already handled correctly by the old `candidate.exists()` check too - doc comment
+corrected to describe it as independent coverage, not a regression test for the fix itself; and
+`readability_floor_per_mille`'s magnitude was previously unpinned by any test (only proven `> 0`),
+so a future edit weakening the floor divisor would have passed the whole suite - added
+`readability_floor_per_mille_is_pinned_to_a_real_computed_value` and the near-miss test above to
+close that gap. The checker also correctly noted this is a real, disclosed compatibility change: an
+existing on-disk custom theme file with `panel`/`background` delta below the floor will now fail to
+load - not silently, though, since `load_custom_themes_from_dir` already surfaces a per-file
+validation error through the existing `custom_theme_load_errors` list the Themes page renders, the
+same path any other malformed theme file already goes through.
+
+All four gates clean: `cargo fmt --all -- --check`, `cargo build --workspace`, `cargo clippy
+--workspace --all-targets -- -D warnings`, and a full `cargo test --workspace --lib --
+--test-threads=1` at 981 app + 42 lsp-core + 14 pty-core + 98 wt-core, 0 failed (9 new tests in
+`settings::custom_theme::tests` specifically, plus the one fixture change in
+`settings::render::custom_theme_settings_tests`). One full run hit the known
+`code_surface::diff_view::diff_render_tests::switching_the_open_diff_to_a_different_file_recomputes_the_highlight_cache`
+flake noted above; re-run alone immediately afterward, it passed.

--- a/BUILD-LOG.md
+++ b/BUILD-LOG.md
@@ -4493,3 +4493,33 @@ rather than writing a separate, longer guide.
 All four gates clean: `cargo fmt --all -- --check`, `cargo build --workspace`, `cargo clippy
 --workspace --all-targets -- -D warnings`, and `cargo test --workspace --lib -- --test-threads=1`
 at 989 app + 42 lsp-core + 14 pty-core + 98 wt-core, 0 failed.
+
+## "Open theme folder" action, and a real per-character-wrap rendering bug
+
+Two more real fixes, reported directly against the built app: the theme card's `subtitle` text
+had `.overflow_hidden()` alone, the same missing-`.truncate()` gap the git graph tab's row text
+had (`.truncate()` is really `overflow_hidden() + whitespace_nowrap() + text_ellipsis()` -
+without the middle one, wrapped text is still legal layout). Here it manifested far more visibly
+than in the graph tab, because the subtitle is a `flex_1().min_w_0()` item competing against three
+`flex_none()` siblings (name, an "in use" badge, Remove) inside one narrow 212px card - with
+almost no space left over, `min_w_0()` let it shrink toward zero width, and with no
+`whitespace_nowrap()` the text wrapped at every available character boundary: the template
+theme's own subtitle rendered as one character per line, dozens of lines tall. Fixed the same way
+as the graph tab: `.truncate()` in place of the bare `.overflow_hidden()`.
+
+Added a fourth real action to the Themes page's "Custom themes" toolbar, `Open theme folder`
+(`AdeApp::start_open_custom_themes_folder`), reusing `Self::open_path_with_os_handler` - the same
+real per-platform default-open handler (`xdg-open`/`open`/`cmd /c start`) the file tree's "Reveal
+in file manager" already uses - rather than growing a second one. Creates the real directory
+first if it doesn't exist yet (a user who has never imported or created a custom theme has
+nothing there otherwise), via `std::fs::create_dir_all` on the background executor, never the
+GPUI foreground thread, matching every other real I/O in this module.
+
+All four gates clean: `cargo fmt --all -- --check`, `cargo build --workspace`, `cargo clippy
+--workspace --all-targets -- -D warnings`, and `cargo test --workspace --lib -- --test-threads=1`
+at 989 app + 42 lsp-core + 14 pty-core + 98 wt-core, 0 failed (unchanged counts - both fixes reuse
+already-tested primitives: `open_command_for`/`spawn_open_command` already have real coverage, and
+`.truncate()` is GPUI's own tested method, not new logic here - no new subprocess-spawning test
+was added for the folder-open action itself, since actually invoking `xdg-open` from a test would
+risk real flakiness in this sandbox with no established precedent elsewhere in the codebase for
+doing so).

--- a/BUILD-LOG.md
+++ b/BUILD-LOG.md
@@ -4174,3 +4174,98 @@ test in the module each time. Because this change touches `open_change_diff`, th
 the flakiest test was run 55 times on this branch and 55 times on the untouched base, interleaved,
 giving 3/55 here against 4/55 there - the same rate, and load-dependent rather than
 change-dependent.
+## Custom theme support (GitHub issue #5)
+
+User-authored themes, loaded from `~/.config/jerry/themes/*.toml`, layered on top of the six
+built-in `settings::THEME_DEFS` rather than replacing them. A hand-written file supplies exactly
+the same five swatches (`background`, `panel`, `accent_green`, `accent_amber`, `accent_blue`) a
+built-in `ThemeDef` does, and is run through the exact same `derive_shift`/`apply_shift` machinery
+every built-in non-Jerry-Dark theme already goes through - a new thread-local,
+`CURRENT_CUSTOM_SHIFT`, overrides the existing `CURRENT_THEME_INDEX` mechanism in `ColorToken::
+resolve` whenever a custom theme is the live selection, and `AdeApp::apply_theme_selection` is the
+one place that ever writes both together. Icon colours ride along for free: this app's "icons"
+(`sidebar::render::render_folder_icon`/`render_lang_chip`) are `div`-composed rectangles and
+letter chips coloured entirely by ordinary `ColorToken`s, not a separate image/glyph-pack system,
+so no second mechanism was needed for them.
+
+The Themes settings page gained a "Custom themes" section - built-in and custom themes render as
+the same card (`render_theme_card`, now taking raw name/subtitle/swatches instead of a
+`&ThemeDef`), with real `Import theme…`/`Export current theme…` actions via genuine native file
+dialogs (`gpui::App::prompt_for_paths`/`prompt_for_new_path`, verified against
+`vendor/zed/crates/agent_ui/src/threads_archive_view.rs` and `miniprofiler_ui` before writing this)
+and a `Remove` action per custom card.
+
+### What the independent adversarial audit found, and what was fixed
+
+One audit round ran over the finished feature, reading the code directly rather than trusting a
+summary, and ran clippy/tests itself. It found two CRITICAL issues, both real:
+
+**Import could silently destroy an unrelated file.** `import_theme_file` joined the destination
+directory with the incoming theme's own slug unconditionally, so importing a theme whose slug
+happened to collide with an existing, differently-named file on disk (a real, reachable case - a
+hand-authored `themes/my-theme.toml` holding `"Ocean"`, then importing something that also
+slugifies to `my-theme`) silently overwrote it, with the in-memory list left holding two entries
+pointing at the same now-wrong file. Fixed with `non_colliding_dest_path`: the plain slug path is
+used when free or when it already holds *this same* theme (the intentional "re-import to update"
+case), otherwise `{slug}-2.toml`, `{slug}-3.toml`, … until a free or matching path is found -
+proven by a regression test that imports over a pre-existing, differently-named file and asserts
+it survives untouched.
+
+**"Remove" deleted the user's file on a single click**, unlike every other destructive action in
+this app (`prune_confirm_armed`, `discard_confirm_armed`, `tree_delete_confirm`). Fixed with a real
+two-click confirmation (`custom_theme_remove_armed`/`request_remove_custom_theme`), mirroring
+`request_discard_worktree`'s identical shape, disarmed on leaving the Themes page or reopening
+Settings. The same audit had flagged the *first* version of this as hiding the Remove affordance
+whenever the theme was currently selected, making the active theme's own file permanently
+undeletable from the UI - dropped that gate too, since the two-click confirm is itself the guard
+against an accidental click.
+
+Four MAJOR findings, also fixed: re-importing the theme currently in use didn't re-skin the app
+until restart (`apply_custom_theme_import_result` now calls `apply_theme_selection` when the
+imported name matches the active one); removing a theme could leave `Settings.theme.
+last_dark_theme` dangling, which a later real OS-dark `follow_system` signal would have written
+straight back into `theme.name`, resolving to nothing (now reset alongside `theme.name` in the
+same fallback); exporting a built-in theme under its own bare name produced a file
+`CustomThemeFile::validate` unconditionally rejects on import - `crate::settings::render::
+export_theme_name_for` (a pure, directly-tested function) now renames it to `"<name> (copy)"` so
+the exported file is actually importable; and `custom_theme_load_errors`/`custom_themes` were
+manually spliced after import/remove instead of re-read from disk, so a stale load error (e.g. a
+since-fixed duplicate-name warning) stayed pinned on screen forever - both actions now reload the
+registry wholesale from what's actually on disk.
+
+Six MINOR findings, also fixed: import/remove ran blocking filesystem I/O on the foreground thread
+(moved to the background executor, matching `start_export_custom_theme`'s own existing
+convention); `CustomTheme::to_toml_string`'s `unwrap_or_default()` would have silently written a
+zero-byte file on a hypothetical serialization failure (now `expect`s, since a plain struct of
+`String` fields cannot genuinely fail to serialize - a real failure should panic loudly, not ship
+an empty theme file); `load_custom_themes_from_dir` had no size cap on a theme file (added a 64
+KiB defensive limit, since this read runs on the foreground thread at `AdeApp` construction);
+the `.toml` extension match was case-sensitive (now `eq_ignore_ascii_case`); the export dialog's
+suggested filename re-implemented slugify by hand and could disagree with the real one (now reuses
+`custom_theme::slugify`, made `pub(crate)`); and the empty-state hint hardcoded
+`~/.config/jerry/themes/` instead of the real, `settings_path`-derived directory.
+
+The audit also verified several suspected issues were *not* bugs by reading real source rather than
+guessing: no path traversal via a crafted theme name (`slugify` maps every non-alphanumeric
+character to `-`); no arbitrary-file delete via a symlinked theme file (`remove_file` unlinks the
+symlink, not its target); no stale `CURRENT_CUSTOM_SHIFT` leak between selections or across test
+instances (`apply_theme_selection` always writes both thread-locals together, in all three
+branches); and - read directly from `vendor/zed/crates/gpui/src/{elements/div.rs,window.rs}` -
+that a nested "Remove" button's `cx.stop_propagation()` genuinely does suppress the card's own
+`on_click` during GPUI's bubble-phase dispatch, not just in theory. That last one was re-verified
+with a real, click-driven test (`cx.simulate_click` against the button's own painted bounds, not
+just calling the method directly) rather than left as a source-reading conclusion, alongside
+similar real-click tests for the Import/Export buttons - the audit had separately noted that
+nothing exercised those three buttons as rendered, clickable elements, only as directly-invoked
+methods.
+
+38 new tests, all in the touched modules (`settings::custom_theme`, `settings::render::
+custom_theme_settings_tests`, `settings::render::export_theme_name_tests`, `theme::
+theme_runtime_tests`). All four gates clean: `cargo fmt --all -- --check`, `cargo build
+--workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace
+--lib -- --test-threads=1` run twice end-to-end (969 app + 42 lsp-core + 14 pty-core + 98 wt-core,
+0 failed, both times). One single-threaded run separately hit
+`code_surface::diff_view::diff_render_tests::opening_a_real_diff_renders_real_syntax_highlighted_rows`
+- confirmed pre-existing and unrelated: that file has zero diff on this branch, and the same test
+run three times in complete isolation with nothing else running failed once on its own, an
+already-known timing flake in that module, not a regression from this work.

--- a/BUILD-LOG.md
+++ b/BUILD-LOG.md
@@ -4269,3 +4269,86 @@ theme_runtime_tests`). All four gates clean: `cargo fmt --all -- --check`, `carg
 - confirmed pre-existing and unrelated: that file has zero diff on this branch, and the same test
 run three times in complete isolation with nothing else running failed once on its own, an
 already-known timing flake in that module, not a regression from this work.
+
+## Built-in themes as real files, not a hardcoded array (GitHub issue #5 follow-up)
+
+A distinct follow-up to the "Custom theme support" entry above, not a duplicate of it: the app's
+six *built-in* themes moved from a hardcoded `const THEME_DEFS: [ThemeDef; 6]` array of Rust
+struct literals in `crates/app/src/settings/state.rs` to six real, checked-in files at
+`assets/themes/{jerry-dark,jerry-dim,slate,ember,moss,paper}.toml` - the exact same five-swatch
+format a user's own custom theme file already used - embedded via `include_str!` and parsed
+through the exact same `CustomThemeFile` deserialization and validation core
+(`crate::settings::custom_theme::parse_builtin_theme_file_str`, a thin wrapper that skips only the
+self-referential built-in-name-collision half of the check) that GitHub issue #5's user-authored
+themes already go through, not a second, parallel parser. `THEME_DEFS` itself became a
+`std::sync::LazyLock<[ThemeDef; 6]>` in place of the old `const`, computed once on first access;
+every existing call site across the crate only ever indexed or iterated it, so none needed to
+change. The five swatch values themselves are untouched, transcribed verbatim from the old array -
+this was a "where do these six live" change, not a "what do they look like" change - and the
+existing `derive_shift`/`apply_shift` HSL-shift machinery that turns Jerry Dark's tokens into the
+other five themes' tokens was not touched at all.
+
+### Self-review and what it found
+
+Before this file's own work started, an existing user's `settings.toml` persists a theme choice by
+*name* (`ThemeSettings::name`, a plain `String`), never by array index - `theme_swatches_for` and
+`apply_theme_selection` in `crate::settings::render` both resolve it with
+`THEME_DEFS.iter().find(|def| def.name == name)`, which a `LazyLock`'s `Deref` serves identically
+to the old `const`. Traced end to end (and pinned by
+`every_documented_built_in_theme_name_still_resolves_by_name_lookup` in `state.rs` and the
+existing click-driven `selecting_a_real_theme_card_...`/`follow_system_selects_paper_on_light_...`
+tests in `render.rs`), this still resolves correctly for all six built-in names - an existing
+user's settings file keeps loading and re-skinning the app exactly as before. Built-ins also stay
+correctly protected from the Remove/import paths issue #5 added: built-in cards render with
+`is_custom: false` (no Remove affordance at all), `execute_remove_custom_theme` only ever touches
+`Self::custom_themes`, and `import_theme_file`'s validation path rejects any file whose name
+collides with a built-in (`NameCollidesWithBuiltin`) before anything is written to disk.
+
+An independent, adversarial checker sub-agent was then dispatched against the finished diff with
+instructions to verify those same three things itself (not trust this description of them) plus a
+general pass over the rest of the change. It confirmed all three by reading the real code and
+running its own tests, and separately caught two real, distinct problems this session then fixed:
+
+**A real formatting/lint break left over from a prior, interrupted session.** `cargo fmt --all --
+--check` and `cargo clippy --workspace --all-targets -- -D warnings` both failed outright before
+being touched here: two unformatted blocks (an inline `enum` variant and a wrapped `symlink()`
+call) plus eight `clippy::doc_lazy_continuation` errors from a doc comment on
+`custom_theme_shift_preserves_readability` whose second line started with `- ` in a way rustdoc's
+markdown parser reads as an unindented list continuation. Both fixed - `cargo fmt --all` for the
+former, a reflow that removes the leading dash for the latter.
+
+**A real reentrant-deadlock bug, not just a lint issue.** `custom_theme_shift_preserves_readability`
+(added earlier in this same uncommitted diff, gating every candidate theme's swatches against a
+readability floor before `validate()` accepts them) read
+`crate::settings::state::THEME_DEFS[0].swatches` as its comparison base. But that function's one
+real caller into `CustomThemeFile::validate_with_builtin_check` runs *inside* `THEME_DEFS`'s own
+`LazyLock` initializer while parsing `jerry-dark.toml` itself - so reading `THEME_DEFS[0]` from
+there re-enters the still-initializing `LazyLock` and hangs forever on `std::sync::Once`, not a
+panic. This meant the app could never start, and every test that touched a theme (`cargo test
+--workspace --lib -- --test-threads=1` in full) hung indefinitely - confirmed with a real repro
+(the checker's own isolated invocations timed out at exit code 124, and this session independently
+found and had to `kill -9` several minutes-stuck `cargo test`/`app-*` processes still running from
+the same underlying cause). Fixed by introducing `JERRY_DARK_BASE_SWATCHES`, a real, pinned `const`
+copy of Jerry Dark's five swatches used as the comparison base instead of reading through the
+`LazyLock` - with a new regression test,
+`jerry_dark_base_swatches_matches_the_real_initialized_theme_defs_entry`, asserting it stays equal
+to the real, safely-initialized `THEME_DEFS[0].swatches` from an ordinary test context where
+reading it is no longer reentrant.
+
+The checker also flagged, as a non-blocking observation rather than a bug to fix here: the
+readability-floor validation (bundled into this same diff ahead of this session, alongside a
+theme-file size cap and a dangling-symlink import fix) now also runs on every custom theme file
+`load_custom_themes_from_dir` reads from disk at startup, so a pre-existing hand-authored file with
+`panel` no lighter than `background` would newly fail to load. This isn't silent, though - that
+loader already reports a validation failure per file, prefixed with the file name, through the
+existing `custom_theme_load_errors` list the Themes page renders, the same path any other malformed
+custom theme file already goes through.
+
+14 new tests in this follow-up specifically (`settings::custom_theme::tests`,
+`settings::state::tests`, `theme::theme_runtime_tests`), on top of the 38 from the base custom-theme
+work. All four gates clean after the deadlock fix: `cargo fmt --all -- --check`, `cargo build
+--workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, and a full `cargo test
+--workspace --lib -- --test-threads=1` at 983 app + 42 lsp-core + 14 pty-core + 98 wt-core, 0
+failed. A separate full run earlier hit the same known
+`code_surface::diff_view::diff_render_tests` flake documented above (that file has zero diff on
+this branch); re-run in isolation, all 7 of that module's tests passed.

--- a/BUILD-LOG.md
+++ b/BUILD-LOG.md
@@ -4458,3 +4458,38 @@ All four gates clean: `cargo fmt --all -- --check`, `cargo build --workspace`, `
 `settings::render::custom_theme_settings_tests`). One full run hit the known
 `code_surface::diff_view::diff_render_tests::switching_the_open_diff_to_a_different_file_recomputes_the_highlight_cache`
 flake noted above; re-run alone immediately afterward, it passed.
+
+## Custom theme template and docs (GitHub issue #5 follow-up)
+
+A user asked, after the custom-theme work above landed, for "something like a theme template and
+docs so we can know how they work" - both in the app and in the repository, not just an external
+file someone would have to go find.
+
+Added `assets/themes/template.toml`: a real, well-commented starting-point theme file, embedded
+into the binary as `custom_theme::CUSTOM_THEME_TEMPLATE_TOML` and parsed through the exact same
+`parse_theme_file_str` validation path a user-supplied file goes through - not a second, informally
+-maintained example that could quietly drift out of sync with what the app actually accepts. Every
+claim its own comments make (the five-swatch format, the `#rrggbb` requirement, the readability
+floor's real `28`-per-mille threshold) is read from the real code, not guessed.
+
+The Themes settings page gets a third real action, `New from template…`
+(`AdeApp::start_create_theme_from_template`), alongside the existing `Import theme…`/`Export
+current theme…`. It writes `CUSTOM_THEME_TEMPLATE_TOML` straight into the real custom-themes
+directory via a new `custom_theme::write_template_theme`, then reloads the registry from disk -
+the same real background-executor write-then-reload shape `start_import_custom_theme` already
+uses, sharing its result-applying code (`apply_custom_theme_load_result`, factored out of what was
+previously import-specific handling) rather than duplicating the success/failure bookkeeping.
+`write_template_theme` is idempotent and non-destructive: clicking the action again refreshes the
+same file only if its contents still match the template verbatim; if a user has since edited it,
+the file is left alone and the existing (now user-owned) theme is handed back instead of being
+silently overwritten - covered by `write_template_theme_a_second_time_refreshes_the_same_file_not_a_new_one`
+and `write_template_theme_never_clobbers_a_file_the_user_has_since_edited`.
+
+`README.md` gets a new "Custom themes" section: the file format with a real example, where files
+live, that the six built-ins are themselves just files now (cross-referencing the follow-up
+above), and the three real in-app actions - matching this project's existing documentation depth
+rather than writing a separate, longer guide.
+
+All four gates clean: `cargo fmt --all -- --check`, `cargo build --workspace`, `cargo clippy
+--workspace --all-targets -- -D warnings`, and `cargo test --workspace --lib -- --test-threads=1`
+at 989 app + 42 lsp-core + 14 pty-core + 98 wt-core, 0 failed.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,51 @@ design_handoff_jerry_ade/
               something to port markup from, and not itself part of the app.
 ```
 
+## Custom themes
+
+Besides the six built-in themes (Jerry Dark, Jerry Dim, Slate, Ember, Moss, Paper), the Themes
+settings page (Settings → Themes) supports user-authored ones too (GitHub issue #5) — built-in
+and custom themes are shown as the same kind of card, not a first-class set and a second-tier
+list. In fact, the six built-ins are themselves just files: `assets/themes/*.toml` in this
+repository, embedded into the binary and parsed through the exact same code path a custom
+theme's own file goes through, not a separate hardcoded palette.
+
+**File format.** One `.toml` file per theme, five hex colours plus a name/subtitle:
+
+```toml
+name = "Midnight Coral"
+subtitle = "warm accent, dark base"
+background   = "#0c0d10"
+panel        = "#181a1e"
+accent_green = "#5cb87f"
+accent_amber = "#e2a336"
+accent_blue  = "#e07a5f"
+```
+
+Colours are `#rrggbb` — a `#` plus exactly six hex digits; no `#rgb` shorthand, alpha channel, or
+named CSS colours. `name` must be unique (it can't reuse a built-in theme's own name); `subtitle`
+is optional. Those five swatches are the same five every built-in theme is defined by — the rest
+of the app's roughly 200 colour tokens are derived from how they differ from Jerry Dark's own
+five (see `derive_shift` in `crates/app/src/theme.rs` for the actual HSL transform — it's a
+private function, so this means reading the source, not generated rustdoc), so authoring five
+colours re-skins the whole app, not just a preview card. `panel` also has to actually read as a
+different shade from `background`: a real perceptual-brightness check rejects a `panel` that's
+the same colour as (or only a couple of hex digits off from) `background`.
+
+**Where files live.** `~/.config/jerry/themes/*.toml` — a `themes` directory sitting next to
+`~/.config/jerry/settings.toml`. Every `.toml` file directly inside it is loaded as a theme at
+startup; a file that fails to parse or validate is skipped with a real, specific error shown on
+the Themes page (the rest of the directory still loads normally).
+
+**Getting started without leaving the app.** The Themes page's "Custom themes" section has three
+real actions: **New from template…** writes a real, well-commented starting-point file straight
+into that directory (the same file checked into this repository at
+[`assets/themes/template.toml`](assets/themes/template.toml) — copying it by hand works exactly
+as well as clicking the button); **Import theme…** validates and copies in any `.toml` file you
+already have, via a native file picker; **Export current theme…** saves whichever theme is
+currently active to a file you can hand to someone else. Every custom theme card also has a
+two-click **Remove** action that deletes its backing file.
+
 ## Building and running it
 
 ### GPUI version pin

--- a/assets/themes/ember.toml
+++ b/assets/themes/ember.toml
@@ -1,0 +1,7 @@
+name = "Ember"
+subtitle = "warm"
+background   = "#12100e"
+panel        = "#1e1a16"
+accent_green = "#8fae6b"
+accent_amber = "#d98b3a"
+accent_blue  = "#c4713f"

--- a/assets/themes/jerry-dark.toml
+++ b/assets/themes/jerry-dark.toml
@@ -1,0 +1,7 @@
+name = "Jerry Dark"
+subtitle = "default"
+background   = "#0e0f11"
+panel        = "#1a1e21"
+accent_green = "#5cb87f"
+accent_amber = "#e2a336"
+accent_blue  = "#74ade8"

--- a/assets/themes/jerry-dim.toml
+++ b/assets/themes/jerry-dim.toml
@@ -1,0 +1,7 @@
+name = "Jerry Dim"
+subtitle = "lower contrast"
+background   = "#15181b"
+panel        = "#20252a"
+accent_green = "#6ab97f"
+accent_amber = "#d8a94a"
+accent_blue  = "#7f9ad4"

--- a/assets/themes/moss.toml
+++ b/assets/themes/moss.toml
@@ -1,0 +1,7 @@
+name = "Moss"
+subtitle = "green-tinted"
+background   = "#0f1310"
+panel        = "#1a201b"
+accent_green = "#7fc79a"
+accent_amber = "#c8b45a"
+accent_blue  = "#6f9bb5"

--- a/assets/themes/paper.toml
+++ b/assets/themes/paper.toml
@@ -1,0 +1,7 @@
+name = "Paper"
+subtitle = "light · beta"
+background   = "#f4f1ea"
+panel        = "#e4e0d6"
+accent_green = "#3f7a52"
+accent_amber = "#a8752a"
+accent_blue  = "#3d6c9c"

--- a/assets/themes/slate.toml
+++ b/assets/themes/slate.toml
@@ -1,0 +1,7 @@
+name = "Slate"
+subtitle = "cool greys"
+background   = "#0d1117"
+panel        = "#161b22"
+accent_green = "#57a773"
+accent_amber = "#c9a227"
+accent_blue  = "#6b9bd1"

--- a/assets/themes/template.toml
+++ b/assets/themes/template.toml
@@ -1,0 +1,55 @@
+# Jerry custom theme template
+#
+# Copy this file (or click "New from template..." on Settings -> Themes, which writes this
+# exact file for you) into your own custom themes directory and edit the values below to
+# author your own Jerry theme. Lines starting with "#" are comments - the TOML parser ignores
+# them, so keep or delete as many as you like.
+#
+# WHERE THIS FILE GOES
+#   ~/.config/jerry/themes/<any-file-name>.toml - a "themes" directory sitting right next to
+#   ~/.config/jerry/settings.toml. Jerry loads every *.toml file directly inside it at startup,
+#   one theme per file. The file's own name doesn't matter to Jerry - only the `name` field
+#   below does, since that's what's shown on the Themes page and what a theme is selected by.
+#
+# FIELDS
+#   name          Required, non-empty, and must not match a built-in theme's name (Jerry Dark,
+#                 Jerry Dim, Slate, Ember, Moss, Paper) - shown as the card title on the Themes
+#                 page.
+#   subtitle      Optional (defaults to empty if omitted) - a short one-line description shown
+#                 under the name on the card.
+#   background    The app's main window background.
+#   panel         Sidebar/panel backgrounds, sitting on top of `background`.
+#   accent_green  The app's "success"-ish accent.
+#   accent_amber  The app's "in-progress / needs attention"-ish accent.
+#   accent_blue   The app's "info / selection"-ish accent.
+#
+# These are the same five swatches every built-in theme is defined by. You are not expected to
+# hand-author all of the app's ~200 individual colour tokens (borders, hover states, syntax
+# highlighting, diff colours, ...) - they're derived automatically from how these five swatches
+# differ from Jerry Dark's own five, the same real derivation every non-Jerry-Dark built-in
+# theme already goes through. Picking these five well re-skins the whole app, not just the
+# preview card.
+#
+# COLOUR FORMAT
+#   Exactly "#rrggbb" - a "#" followed by six hex digits. No "#rgb" shorthand, no alpha
+#   channel, and no named CSS colours (e.g. "black") - any of those are rejected with a real
+#   error naming the offending field.
+#
+# READABILITY FLOOR
+#   `panel` must be clearly different in *perceived brightness* from `background` - specifically
+#   at least 28 per-mille (out of 1000) of standard-weighted (ITU-R BT.709) luma difference,
+#   which is about half of Jerry Dark's own built-in panel/background contrast. (See
+#   `readability_floor_per_mille` in crates/app/src/settings/custom_theme.rs for exactly how
+#   this is computed, in case Jerry Dark's own swatches - and so this number - ever change.) A
+#   `panel` that's the same colour as `background`, or only a couple of hex digits off from it,
+#   is rejected. In practice: make panel a clearly different shade (lighter or darker) than
+#   background, not just a different hue at the same brightness.
+
+name = "My Custom Theme"
+subtitle = "replace this with a short description"
+
+background   = "#0c0d10"
+panel        = "#181a1e"
+accent_green = "#5cb87f"
+accent_amber = "#e2a336"
+accent_blue  = "#e07a5f"

--- a/crates/app/src/root/focus.rs
+++ b/crates/app/src/root/focus.rs
@@ -144,6 +144,7 @@ impl AdeApp {
         self.settings_focus.capture(window, &self.sessions, cx);
         self.prune_confirm_armed = false;
         self.discard_confirm_armed = None;
+        self.custom_theme_remove_armed = None;
         window.focus(&self.settings_focus_handle, cx);
         self.load_agent_rows(cx);
         self.load_lsp_rows(cx);

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -69,6 +69,7 @@ use crate::merge::state as merge;
 use crate::palette::state as palette;
 use crate::rail::state::{self as rail, RailMode};
 use crate::rail::worktrees::{self, WorktreeItem};
+use crate::settings::custom_theme;
 use crate::settings::state as settings;
 #[cfg(test)]
 use crate::settings::state::SettingsPage;
@@ -1192,6 +1193,42 @@ pub struct AdeApp {
     /// outside any drop target) can't leave a stale caret painted on a tab no drag is over
     /// anymore.
     pub(crate) tab_drag_insertion: Option<(work_surface::TabRef, bool)>,
+    /// User-authored themes loaded from `~/.config/jerry/themes/*.toml` at construction time
+    /// (GitHub issue #5) - real, additional `crate::settings::custom_theme::CustomTheme` entries
+    /// layered on top of the six built-in `settings::THEME_DEFS`, not a replacement for them. See
+    /// `crate::settings::custom_theme`'s own module docs for the file format, and
+    /// `Self::apply_theme_selection`/`Self::render_settings_theme_page` for the two real
+    /// consumers.
+    pub(crate) custom_themes: Vec<custom_theme::CustomTheme>,
+    /// Real, honestly-reported parse/validation failures from the last time `custom_themes` was
+    /// (re)loaded - one entry per file that didn't make it in, shown on the Themes settings page
+    /// rather than a bad hand-edit silently vanishing.
+    pub(crate) custom_theme_load_errors: Vec<String>,
+    /// The Themes page's most recent import/export/remove action result (`Ok` message or a real,
+    /// honest `Err` one) - shown as an inline status line until the next action replaces it.
+    pub(crate) custom_theme_status: Option<Result<String, String>>,
+    /// The in-flight "Import theme..." real native file-picker task
+    /// (`Self::start_import_custom_theme`) - a single slot, since only one file-open dialog can
+    /// meaningfully be in flight at a time.
+    pub(crate) _custom_theme_import_task: Option<Task<()>>,
+    /// The in-flight "Export theme..." real native save-file-picker task
+    /// (`Self::start_export_custom_theme`) - same one-slot reasoning as
+    /// [`Self::_custom_theme_import_task`].
+    pub(crate) _custom_theme_export_task: Option<Task<()>>,
+    /// The in-flight, already-confirmed "Remove" background delete-and-reload task
+    /// (`Self::execute_remove_custom_theme`) - same one-slot reasoning as
+    /// [`Self::_custom_theme_import_task`].
+    pub(crate) _custom_theme_remove_task: Option<Task<()>>,
+    /// A real, just-armed "Remove" click on a custom theme card, by name - an adversarial audit
+    /// caught the first version of this action deleting the user's file on a single click, unlike
+    /// every other destructive action in this app (`Self::prune_confirm_armed`,
+    /// `Self::discard_confirm_armed`, `Self::tree_delete_confirm`). `Self::request_remove_custom_theme`
+    /// is the one real place this is armed/consumed - a first click on a given name arms it, a
+    /// second click on the *same* name actually deletes. Disarmed by leaving the Themes settings
+    /// page or reopening Settings (`Self::select_settings_page`/`Self::open_settings`), the same
+    /// "most other gestures clear it" discipline `Self::discard_confirm_armed`'s own docs
+    /// describe, scoped to this control's own page since nothing else in the app can arm it.
+    pub(crate) custom_theme_remove_armed: Option<String>,
 }
 
 impl AdeApp {

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -1219,6 +1219,13 @@ pub struct AdeApp {
     /// (`Self::execute_remove_custom_theme`) - same one-slot reasoning as
     /// [`Self::_custom_theme_import_task`].
     pub(crate) _custom_theme_remove_task: Option<Task<()>>,
+    /// The in-flight "New from template" background write-and-reload task
+    /// (`Self::start_create_theme_from_template`) - same one-slot reasoning as
+    /// [`Self::_custom_theme_import_task`]; unlike Import there's no file-picker dialog to await
+    /// first (the "file" is a fixed, embedded constant), but the actual disk write still runs on
+    /// the background executor like every other real write in this module, so this still needs a
+    /// slot to keep that task alive.
+    pub(crate) _custom_theme_create_task: Option<Task<()>>,
     /// A real, just-armed "Remove" click on a custom theme card, by name - an adversarial audit
     /// caught the first version of this action deleting the user's file on a single click, unlike
     /// every other destructive action in this app (`Self::prune_confirm_armed`,

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -65,6 +65,21 @@ impl AdeApp {
             cx,
         );
 
+        // GitHub issue #5: real, additional themes loaded from disk, before `apply_theme_selection`
+        // (below) needs to resolve `settings.theme.name` against them. Derived from
+        // `settings_path` (`custom_theme::custom_themes_dir_for`), not `$HOME` directly - the same
+        // seam `fold_state_path`/`fold_state` just above use, so a test constructed with a `None`/
+        // temp-dir settings path never touches the real developer machine's own
+        // `~/.config/jerry/themes`. Same "block the foreground thread once, at startup" exception
+        // `Settings::load_or_init` itself already takes - a small, one-time directory read, not a
+        // per-render or per-poll cost.
+        let (custom_themes, custom_theme_load_errors) = match settings_path.as_deref() {
+            Some(path) => custom_theme::load_custom_themes_from_dir(
+                &custom_theme::custom_themes_dir_for(path),
+            ),
+            None => (Vec::new(), Vec::new()),
+        };
+
         let mut this = Self {
             file_tree_root: repo_path.clone(),
             diff_root: repo_path.clone(),
@@ -269,6 +284,13 @@ impl AdeApp {
             new_file_error: None,
             tab_order: HashMap::new(),
             tab_drag_insertion: None,
+            custom_themes,
+            custom_theme_load_errors,
+            custom_theme_status: None,
+            _custom_theme_import_task: None,
+            _custom_theme_export_task: None,
+            _custom_theme_remove_task: None,
+            custom_theme_remove_armed: None,
         };
         // See the `expanded_dirs`/`fold_state_root_key` note in the literal above: resolving the
         // worktree key here, through the one function that ever resolves it, is what keeps the

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -290,6 +290,7 @@ impl AdeApp {
             _custom_theme_import_task: None,
             _custom_theme_export_task: None,
             _custom_theme_remove_task: None,
+            _custom_theme_create_task: None,
             custom_theme_remove_armed: None,
         };
         // See the `expanded_dirs`/`fold_state_root_key` note in the literal above: resolving the

--- a/crates/app/src/settings/custom_theme.rs
+++ b/crates/app/src/settings/custom_theme.rs
@@ -174,13 +174,33 @@ impl CustomThemeFile {
     /// [`crate::settings::state::THEME_DEFS`], not a second hand-copied name list) must not
     /// collide with a built-in theme's own name - a custom theme silently shadowing e.g. "Jerry
     /// Dark" would be confusing at best, and would also make `crate::root::AdeApp::
-    /// apply_theme_selection`'s "which one did the user mean" lookup ambiguous.
+    /// apply_theme_selection`'s "which one did the user mean" lookup ambiguous. A thin wrapper
+    /// over [`Self::validate_with_builtin_check`] with the collision check always on - see that
+    /// function's own docs for the one real caller that needs it off.
     pub fn validate(&self) -> Result<CustomTheme, ThemeFileError> {
+        self.validate_with_builtin_check(true)
+    }
+
+    /// The real, shared validation core [`Self::validate`] and [`parse_builtin_theme_file_str`]
+    /// both go through - not two independently-maintained checks. `check_builtin_collision` is
+    /// `false` for exactly one real caller: [`parse_builtin_theme_file_str`], parsing the six
+    /// built-in themes' own embedded files while `crate::settings::state::THEME_DEFS` (a
+    /// `std::sync::LazyLock`) is itself still being computed *from* those same files - checking a
+    /// built-in theme's name against `THEME_DEFS` at that point would read a value still in the
+    /// middle of being initialized. Every other check (non-empty name, real `#rrggbb` colours)
+    /// still runs regardless - see `custom_theme::tests::
+    /// validate_with_builtin_check_false_skips_only_the_collision_check_not_the_others`. Built-in
+    /// name uniqueness is instead guarded the ordinary way, by
+    /// `crate::settings::state::tests::every_theme_def_name_is_unique_and_jerry_dark_is_the_default_named_theme`.
+    pub(crate) fn validate_with_builtin_check(
+        &self,
+        check_builtin_collision: bool,
+    ) -> Result<CustomTheme, ThemeFileError> {
         let name = self.name.trim();
         if name.is_empty() {
             return Err(ThemeFileError::EmptyName);
         }
-        if THEME_DEFS.iter().any(|def| def.name == name) {
+        if check_builtin_collision && THEME_DEFS.iter().any(|def| def.name == name) {
             return Err(ThemeFileError::NameCollidesWithBuiltin(name.to_string()));
         }
         let parse = |field: &'static str, value: &str| -> Result<u32, ThemeFileError> {
@@ -203,6 +223,28 @@ impl CustomThemeFile {
             source_path: None,
         })
     }
+}
+
+/// Parses and validates one built-in theme's embedded TOML text (one of the six real
+/// `assets/themes/*.toml` files `crate::settings::state::THEME_DEFS` embeds via `include_str!`)
+/// through the exact same [`CustomThemeFile`] deserialization and
+/// [`CustomThemeFile::validate_with_builtin_check`] validation core [`parse_theme_file_str`] uses
+/// for a user's own disk-loaded file - not a second, parallel parser. Only the built-in-collision
+/// half of that check is skipped (see [`CustomThemeFile::validate_with_builtin_check`]'s own
+/// docs for why that one specific check is self-referential here).
+///
+/// Panics on a malformed file. That's a real, deliberate choice, not a shortcut: these six files
+/// are compiled into the binary from this repository at build time (not user input reachable at
+/// runtime), and `custom_theme::tests::
+/// parse_builtin_theme_file_str_parses_every_embedded_built_in_theme_file_into_the_exact_documented_swatches`
+/// already proves every one of them parses and validates cleanly - a failure here could only mean
+/// a real, committed asset went bad, which should fail loudly (a panic surfaces immediately in
+/// `cargo test`/at first real use) rather than silently reducing the Themes page below six cards.
+pub(crate) fn parse_builtin_theme_file_str(contents: &str) -> CustomTheme {
+    let file: CustomThemeFile = toml::from_str(contents)
+        .expect("a built-in theme file under assets/themes/ failed to parse as TOML");
+    file.validate_with_builtin_check(false)
+        .expect("a built-in theme file under assets/themes/ failed validation")
 }
 
 impl CustomTheme {
@@ -825,6 +867,126 @@ mod tests {
         assert_eq!(
             custom_themes_dir_for(Path::new("settings.toml")),
             Path::new("themes")
+        );
+    }
+
+    /// GitHub issue #5 follow-up: the six built-in themes moved from a hardcoded Rust
+    /// `THEME_DEFS` const array to real `assets/themes/*.toml` files, embedded via `include_str!`
+    /// and parsed through [`parse_builtin_theme_file_str`] - this pins the exact hex swatches and
+    /// names/subtitles those files must produce, transcribed verbatim from the old array, so a
+    /// single-digit typo made while writing one of those files would fail a test rather than
+    /// silently changing the app's real default appearance.
+    #[test]
+    fn parse_builtin_theme_file_str_parses_every_embedded_built_in_theme_file_into_the_exact_documented_swatches(
+    ) {
+        let cases: [(&str, &str, &str, [u32; 5]); 6] = [
+            (
+                include_str!("../../../../assets/themes/jerry-dark.toml"),
+                "Jerry Dark",
+                "default",
+                [0x0e0f11, 0x1a1e21, 0x5cb87f, 0xe2a336, 0x74ade8],
+            ),
+            (
+                include_str!("../../../../assets/themes/jerry-dim.toml"),
+                "Jerry Dim",
+                "lower contrast",
+                [0x15181b, 0x20252a, 0x6ab97f, 0xd8a94a, 0x7f9ad4],
+            ),
+            (
+                include_str!("../../../../assets/themes/slate.toml"),
+                "Slate",
+                "cool greys",
+                [0x0d1117, 0x161b22, 0x57a773, 0xc9a227, 0x6b9bd1],
+            ),
+            (
+                include_str!("../../../../assets/themes/ember.toml"),
+                "Ember",
+                "warm",
+                [0x12100e, 0x1e1a16, 0x8fae6b, 0xd98b3a, 0xc4713f],
+            ),
+            (
+                include_str!("../../../../assets/themes/moss.toml"),
+                "Moss",
+                "green-tinted",
+                [0x0f1310, 0x1a201b, 0x7fc79a, 0xc8b45a, 0x6f9bb5],
+            ),
+            (
+                include_str!("../../../../assets/themes/paper.toml"),
+                "Paper",
+                "light \u{b7} beta",
+                [0xf4f1ea, 0xe4e0d6, 0x3f7a52, 0xa8752a, 0x3d6c9c],
+            ),
+        ];
+        for (contents, name, subtitle, swatches) in cases {
+            let theme = parse_builtin_theme_file_str(contents);
+            assert_eq!(theme.name, name, "name mismatch for {contents:?}");
+            assert_eq!(theme.subtitle, subtitle, "subtitle mismatch for {name}");
+            assert_eq!(theme.swatches, swatches, "swatch mismatch for {name}");
+            assert_eq!(
+                theme.source_path, None,
+                "a built-in theme parsed straight from an embedded string was never read from a \
+                 real path on disk"
+            );
+        }
+    }
+
+    /// Proves the built-in files really do go through the *same* deserialization/validation core
+    /// a user-supplied file does, not a second parser: feeding one's raw embedded contents to the
+    /// ordinary user-facing [`parse_theme_file_str`] (which - unlike
+    /// [`parse_builtin_theme_file_str`] - does check for a built-in-name collision) is correctly
+    /// rejected, since by definition its name already is a real `THEME_DEFS` entry.
+    #[test]
+    fn a_built_in_theme_files_raw_contents_are_rejected_by_the_ordinary_user_facing_parser_as_a_builtin_collision(
+    ) {
+        let contents = include_str!("../../../../assets/themes/slate.toml");
+        let err = parse_theme_file_str(contents).unwrap_err();
+        assert_eq!(
+            err,
+            ThemeFileError::NameCollidesWithBuiltin("Slate".to_string())
+        );
+    }
+
+    /// [`CustomThemeFile::validate_with_builtin_check`]'s `false` branch (the one
+    /// [`parse_builtin_theme_file_str`] uses to avoid the self-referential "is this built-in name
+    /// already in `THEME_DEFS`" check while `THEME_DEFS` is itself still being built from these
+    /// same files) must still run every *other* real check - a bad hex colour or an empty name in
+    /// a built-in file would be a real bug in that file, not something to silently wave through.
+    #[test]
+    fn validate_with_builtin_check_false_skips_only_the_collision_check_not_the_others() {
+        let mut colliding_but_valid = valid_file();
+        colliding_but_valid.name = "Jerry Dark".to_string();
+        assert!(
+            colliding_but_valid
+                .validate_with_builtin_check(false)
+                .is_ok(),
+            "the collision check must be skippable"
+        );
+        assert_eq!(
+            colliding_but_valid.validate_with_builtin_check(true),
+            Err(ThemeFileError::NameCollidesWithBuiltin(
+                "Jerry Dark".to_string()
+            )),
+            "sanity check: the same file must still collide when the check runs"
+        );
+
+        let mut bad_color = valid_file();
+        bad_color.name = "Jerry Dark".to_string();
+        bad_color.background = "not-a-color".to_string();
+        assert_eq!(
+            bad_color.validate_with_builtin_check(false),
+            Err(ThemeFileError::InvalidColor {
+                field: "background",
+                value: "not-a-color".to_string()
+            }),
+            "an invalid colour must still be rejected even with the collision check off"
+        );
+
+        let mut empty_name = valid_file();
+        empty_name.name = "   ".to_string();
+        assert_eq!(
+            empty_name.validate_with_builtin_check(false),
+            Err(ThemeFileError::EmptyName),
+            "an empty name must still be rejected even with the collision check off"
         );
     }
 }

--- a/crates/app/src/settings/custom_theme.rs
+++ b/crates/app/src/settings/custom_theme.rs
@@ -1,0 +1,830 @@
+//! User-authored custom themes (GitHub issue #5) - real, additional theme definitions loaded
+//! from disk, layered on top of [`crate::settings::state::THEME_DEFS`]' six built-in themes
+//! rather than replacing them.
+//!
+//! ## Real file format
+//!
+//! Same `~/.config/jerry` config directory `crate::settings::store::settings_toml_path` already
+//! uses, and the same TOML format `settings.toml` itself is written in (see that module's own
+//! "TOML is the real file" docs for why TOML, not a second format, is the right choice here too)
+//! - one file per theme, at `~/.config/jerry/themes/<slug>.toml`:
+//!
+//! ```toml
+//! name = "Midnight Coral"
+//! subtitle = "warm accent, dark base"
+//! background   = "#0c0d10"
+//! panel        = "#181a1e"
+//! accent_green = "#5cb87f"
+//! accent_amber = "#e2a336"
+//! accent_blue  = "#e07a5f"
+//! ```
+//!
+//! The five colour fields are exactly [`crate::settings::state::ThemeDef::swatches`]' own
+//! `[background, panel, green-ish, amber-ish, blue-ish]` shape (see `crate::theme::derive_shift`'s
+//! docs for what each position means and how the *rest* of the app's ~200 colour tokens are
+//! derived from them) - a user hand-authoring one of these files supplies exactly the same five
+//! swatches a built-in [`crate::settings::state::ThemeDef`] does, not a from-scratch 200-token
+//! palette. This is a deliberate, honestly-scoped choice: [`CustomTheme`] plugs into the exact
+//! same derivation machinery every built-in theme already goes through
+//! (`crate::theme::set_current_custom_theme`), so a hand-written file re-skins the *whole* app,
+//! not just a couple of preview swatches.
+//!
+//! Hex colours are `#rrggbb` (a leading `#`, exactly six hex digits) - `#rgb` shorthand, alpha
+//! channels, and named CSS colours are all rejected with a real, specific
+//! [`ThemeFileError::InvalidColor`] rather than guessed at.
+//!
+//! ## Icon colours ride along for free; there is no separate icon-pack loader
+//!
+//! This app's own "icons" (`crate::sidebar::render::render_folder_icon`/`render_lang_chip`) are
+//! not a glyph/image-asset pack system - they're `div`-composed rectangles and 1-3 letter text
+//! labels coloured entirely by ordinary [`crate::theme::ColorToken`]s
+//! (`theme::surface::CHIP_NEUTRAL`, `theme::text::FAINT`/`GHOST`, `theme::lang::*`). Since every
+//! one of those tokens already resolves through the same live theme selection every other token
+//! does, a custom theme automatically re-colours the folder icon and every language chip too -
+//! no second mechanism needed. This is the honest scope for "custom icon packs" in this pass -
+//! see `BUILD-LOG.md`'s GitHub issue #5 entry for why: there is no image/glyph-asset loading
+//! surface anywhere in this app for a real swappable-*pack* system to attach to, so building one
+//! would mean inventing a mechanism nothing else in the app has a use for yet.
+//!
+//! ## Storage: one file per theme, not one combined file
+//!
+//! Deliberately one file per theme (not a single `themes.toml` list) so [`export_theme_to_path`]
+//! can hand a user exactly one shareable file and [`import_theme_file`] can validate and adopt
+//! exactly one at a time - matching how someone would actually receive a theme from another user
+//! (a single attached/downloaded `.toml` file), and letting [`load_custom_themes_from_dir`] skip
+//! one malformed file without losing every other already-working custom theme in the directory.
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::settings::state::THEME_DEFS;
+
+/// A defensive upper bound on a single theme file's size - see
+/// [`load_custom_themes_from_dir`]'s own docs for why.
+const MAX_THEME_FILE_BYTES: u64 = 64 * 1024;
+
+/// The real on-disk shape of one `~/.config/jerry/themes/<slug>.toml` file - see the module docs.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CustomThemeFile {
+    pub name: String,
+    #[serde(default)]
+    pub subtitle: String,
+    pub background: String,
+    pub panel: String,
+    pub accent_green: String,
+    pub accent_amber: String,
+    pub accent_blue: String,
+}
+
+/// A [`CustomThemeFile`] that has already been validated - real hex colours, a non-empty name
+/// that doesn't collide with a built-in theme - and is safe to hand straight to
+/// `crate::theme::set_current_custom_theme` or render as a Themes-page card.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CustomTheme {
+    pub name: String,
+    pub subtitle: String,
+    /// `[background, panel, green-ish, amber-ish, blue-ish]` - see the module docs.
+    pub swatches: [u32; 5],
+    /// The real file this theme was loaded from/written to. `None` only for a value built
+    /// in-memory without ever touching disk (no real production path constructs one that way,
+    /// but keeps this struct honestly total rather than assuming every caller has a path).
+    pub source_path: Option<PathBuf>,
+}
+
+/// Every real, specific way a theme file can fail to load - shown verbatim to the user rather
+/// than collapsed into one generic "invalid theme" message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ThemeFileError {
+    Io(String),
+    Parse(String),
+    EmptyName,
+    InvalidColor { field: &'static str, value: String },
+    NameCollidesWithBuiltin(String),
+}
+
+impl std::fmt::Display for ThemeFileError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ThemeFileError::Io(msg) => write!(f, "couldn't read the theme file: {msg}"),
+            ThemeFileError::Parse(msg) => write!(f, "not a valid theme file: {msg}"),
+            ThemeFileError::EmptyName => write!(f, "a theme file needs a non-empty `name`"),
+            ThemeFileError::InvalidColor { field, value } => write!(
+                f,
+                "`{field}` is not a real colour (\"{value}\") - expected `#rrggbb`"
+            ),
+            ThemeFileError::NameCollidesWithBuiltin(name) => write!(
+                f,
+                "\"{name}\" is already a built-in theme name - choose a different name"
+            ),
+        }
+    }
+}
+
+/// Parses `#rrggbb` (exactly a `#` plus six hex digits) into a `0xrrggbb` value - the same shape
+/// [`crate::settings::state::ThemeDef::swatches`] literals already use, just written as a string
+/// a hand-authored file can hold. Deliberately narrower than CSS: no `#rgb` shorthand, no alpha,
+/// no named colours - see the module docs for why.
+fn parse_hex_color(value: &str) -> Option<u32> {
+    let hex = value.strip_prefix('#')?;
+    if hex.len() != 6 || !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return None;
+    }
+    u32::from_str_radix(hex, 16).ok()
+}
+
+fn format_hex_color(value: u32) -> String {
+    format!("#{:06x}", value & 0x00ff_ffff)
+}
+
+/// Filesystem-safe, lowercase, hyphenated identifier for `name` - used for the `<slug>.toml`
+/// filename [`import_theme_file`] derives from a theme's own display name. Never empty: an
+/// all-punctuation name falls back to `"theme"`. `pub(crate)`, not private: an adversarial audit
+/// caught `crate::settings::render::AdeApp::start_export_custom_theme`'s own suggested-filename
+/// computation re-implementing this by hand (missing the empty-segment collapse and the
+/// `"theme"` fallback, so the two could suggest different names for the same theme) - reusing
+/// this one real implementation is what fixed it.
+pub(crate) fn slugify(name: &str) -> String {
+    let collapsed: String = name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    let slug = collapsed
+        .split('-')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("-");
+    if slug.is_empty() {
+        "theme".to_string()
+    } else {
+        slug
+    }
+}
+
+impl CustomThemeFile {
+    /// Validates `self` into a real [`CustomTheme`] - every hex colour must actually parse, the
+    /// name must be non-empty (after trimming), and (checked against
+    /// [`crate::settings::state::THEME_DEFS`], not a second hand-copied name list) must not
+    /// collide with a built-in theme's own name - a custom theme silently shadowing e.g. "Jerry
+    /// Dark" would be confusing at best, and would also make `crate::root::AdeApp::
+    /// apply_theme_selection`'s "which one did the user mean" lookup ambiguous.
+    pub fn validate(&self) -> Result<CustomTheme, ThemeFileError> {
+        let name = self.name.trim();
+        if name.is_empty() {
+            return Err(ThemeFileError::EmptyName);
+        }
+        if THEME_DEFS.iter().any(|def| def.name == name) {
+            return Err(ThemeFileError::NameCollidesWithBuiltin(name.to_string()));
+        }
+        let parse = |field: &'static str, value: &str| -> Result<u32, ThemeFileError> {
+            parse_hex_color(value).ok_or_else(|| ThemeFileError::InvalidColor {
+                field,
+                value: value.to_string(),
+            })
+        };
+        let swatches = [
+            parse("background", &self.background)?,
+            parse("panel", &self.panel)?,
+            parse("accent_green", &self.accent_green)?,
+            parse("accent_amber", &self.accent_amber)?,
+            parse("accent_blue", &self.accent_blue)?,
+        ];
+        Ok(CustomTheme {
+            name: name.to_string(),
+            subtitle: self.subtitle.trim().to_string(),
+            swatches,
+            source_path: None,
+        })
+    }
+}
+
+impl CustomTheme {
+    /// The inverse of [`CustomThemeFile::validate`] - a real, re-parseable form.
+    pub fn to_file(&self) -> CustomThemeFile {
+        CustomThemeFile {
+            name: self.name.clone(),
+            subtitle: self.subtitle.clone(),
+            background: format_hex_color(self.swatches[0]),
+            panel: format_hex_color(self.swatches[1]),
+            accent_green: format_hex_color(self.swatches[2]),
+            accent_amber: format_hex_color(self.swatches[3]),
+            accent_blue: format_hex_color(self.swatches[4]),
+        }
+    }
+
+    /// The same `toml::to_string_pretty` serializer
+    /// [`crate::settings::store::Settings::to_toml_string`] uses - the shareable form
+    /// [`export_theme_to_path`]/[`import_theme_file`] write to disk.
+    ///
+    /// `expect`, not `unwrap_or_default()` (an adversarial audit flagged the original
+    /// `unwrap_or_default()` as a real "hollow success" shape: a serialization failure would have
+    /// silently produced an empty string, which `export_theme_to_path` would then have happily
+    /// written as a zero-byte file while still reporting success to the user). `CustomThemeFile`
+    /// is a plain struct of five `String` fields wrapped in another plain struct - there is no
+    /// `NaN`, no non-string map key, nothing `toml::to_string_pretty` can genuinely fail to
+    /// encode here - so a real failure would mean this type grew a field that breaks that
+    /// invariant, which is exactly the kind of regression that should panic loudly in tests
+    /// rather than quietly ship an empty theme file.
+    pub fn to_toml_string(&self) -> String {
+        toml::to_string_pretty(&self.to_file())
+            .expect("CustomThemeFile is a plain struct of Strings - TOML serialization cannot fail")
+    }
+}
+
+/// The real `themes/` directory sibling of a given `settings_path` (e.g.
+/// `~/.config/jerry/settings.toml` -> `~/.config/jerry/themes`) - mirrors
+/// `crate::sidebar::fold_state::fold_state_path_for`'s own "derive from the settings path this
+/// `AdeApp` instance was actually given, never `$HOME` directly" convention, for the exact same
+/// reason: `crate::root::AdeApp::new_with_settings` (every `#[gpui::test]`'s shared entry point,
+/// not just production) calls this unconditionally at construction time, so resolving straight
+/// from `$HOME` here would mean every test in this crate reads (and a real "Import theme" action
+/// would write into) whatever `~/.config/jerry/themes` happens to exist on the machine actually
+/// running the tests - a real, previously-caught-in-review test-isolation bug for exactly this
+/// reason. Production's own real settings path (`crate::settings::store::settings_toml_path`)
+/// still resolves to `~/.config/jerry/settings.toml` off `$HOME` same as ever; this function only
+/// asks "what's this *specific* settings path's own sibling themes directory", the same question
+/// `fold_state_path_for` answers for its own file.
+pub fn custom_themes_dir_for(settings_path: &Path) -> PathBuf {
+    match settings_path.parent() {
+        Some(parent) => parent.join("themes"),
+        None => PathBuf::from("themes"),
+    }
+}
+
+/// Parses and validates one theme file's raw text - the real shared step both
+/// [`load_custom_themes_from_dir`] (an existing file on disk) and [`import_theme_file`] (a
+/// freshly picked one, not yet copied anywhere) go through, so the two can never validate
+/// differently.
+pub fn parse_theme_file_str(contents: &str) -> Result<CustomTheme, ThemeFileError> {
+    let file: CustomThemeFile =
+        toml::from_str(contents).map_err(|err| ThemeFileError::Parse(err.to_string()))?;
+    file.validate()
+}
+
+/// Loads every real, validatable `*.toml` file directly inside `dir` (non-recursive) as a
+/// [`CustomTheme`]. A file that fails to read, parse, or validate is skipped - not silently: its
+/// real error, prefixed with the file name, is appended to the returned tuple's second element
+/// so a caller can surface it (`crate::root::AdeApp::custom_theme_load_errors`) rather than a bad
+/// hand-edit quietly vanishing.
+///
+/// Two *different* files that both validate to the same theme `name` (a real, reachable case: a
+/// hand-authored file sitting next to one [`import_theme_file`] wrote for a re-import of "the
+/// same" theme under a different original filename) are also a real, reported skip, not two
+/// identically-named cards - `crate::settings::render::AdeApp::apply_theme_selection`'s own
+/// name-keyed lookup can only ever resolve to one of them anyway, and two GPUI elements sharing
+/// one `.id()` (`crate::settings::render::AdeApp::render_theme_card`'s
+/// `settings-theme-card-{name}`) is a real rendering bug, not a cosmetic one. Files are processed
+/// in a sorted-by-path order first, so which one "wins" a name collision is deterministic rather
+/// than dependent on `std::fs::read_dir`'s own unspecified iteration order.
+pub fn load_custom_themes_from_dir(dir: &Path) -> (Vec<CustomTheme>, Vec<String>) {
+    let mut errors = Vec::new();
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return (Vec::new(), errors);
+    };
+    let mut candidate_paths: Vec<PathBuf> = entries
+        .flatten()
+        .map(|entry| entry.path())
+        // Case-insensitive (`Foo.TOML` is a real, common Windows/macOS-authored spelling) - an
+        // adversarial audit caught the original exact-lowercase `== Some("toml")` silently
+        // ignoring such a file with no reported error at all.
+        .filter(|path| {
+            path.extension()
+                .and_then(|ext| ext.to_str())
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("toml"))
+        })
+        .collect();
+    candidate_paths.sort();
+
+    let mut themes: Vec<CustomTheme> = Vec::new();
+    for path in candidate_paths {
+        let file_name = path
+            .file_name()
+            .map(|name| name.to_string_lossy().to_string())
+            .unwrap_or_default();
+        // A real, cheap defensive cap (this is real foreground-thread I/O at `AdeApp`
+        // construction time, per `crate::root::AdeApp::new_with_settings`'s own docs) - an
+        // adversarial audit noted a pathologically large file in this directory would otherwise
+        // stall every window's startup with no bound at all. A hand-authored five-swatch theme
+        // file is a few hundred bytes; 64 KiB is generous headroom, not a tight fit.
+        match std::fs::metadata(&path) {
+            Ok(metadata) if metadata.len() > MAX_THEME_FILE_BYTES => {
+                errors.push(format!(
+                    "{file_name}: {} bytes exceeds the {MAX_THEME_FILE_BYTES}-byte limit for a theme file - skipping",
+                    metadata.len()
+                ));
+                continue;
+            }
+            _ => {}
+        }
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => match parse_theme_file_str(&contents) {
+                Ok(mut theme) => {
+                    if let Some(existing) = themes.iter().find(|other| other.name == theme.name) {
+                        let existing_file = existing
+                            .source_path
+                            .as_ref()
+                            .and_then(|p| p.file_name())
+                            .map(|n| n.to_string_lossy().to_string())
+                            .unwrap_or_default();
+                        errors.push(format!(
+                            "{file_name}: a theme named \"{}\" was already loaded from {existing_file} - \
+                             skipping this duplicate",
+                            theme.name
+                        ));
+                        continue;
+                    }
+                    theme.source_path = Some(path.clone());
+                    themes.push(theme);
+                }
+                Err(err) => errors.push(format!("{file_name}: {err}")),
+            },
+            Err(err) => errors.push(format!("{file_name}: {err}")),
+        }
+    }
+    themes.sort_by(|a, b| a.name.cmp(&b.name));
+    (themes, errors)
+}
+
+/// Real import: reads and validates the file at `source_path` (any real path on disk, e.g. one a
+/// user just picked in a real file-open dialog - `crate::settings::render::AdeApp::
+/// import_custom_theme_from_path` is the one real caller), then writes its *validated,
+/// re-serialized* form (not a byte-for-byte copy - see [`CustomTheme::to_toml_string`], so a
+/// source file with extra whitespace or key ordering still lands as a canonical file) into
+/// `dest_dir`. A malformed source file is rejected with a real [`ThemeFileError`] and nothing is
+/// written - the whole point of validating before copying.
+///
+/// The destination filename ([`non_colliding_dest_path`]) is the theme's own slug when that's
+/// either free or already holds *this same* theme (an intentional "re-import to update" - the
+/// second import of a theme with the same `name` really does overwrite its own previous file) -
+/// but never a *different*, unrelated theme's file: an adversarial audit caught the first version
+/// of this function joining `dest_dir` with the bare slug unconditionally, so importing a theme
+/// whose slug happened to collide with an existing, differently-named file silently destroyed it.
+pub fn import_theme_file(
+    source_path: &Path,
+    dest_dir: &Path,
+) -> Result<CustomTheme, ThemeFileError> {
+    let contents =
+        std::fs::read_to_string(source_path).map_err(|err| ThemeFileError::Io(err.to_string()))?;
+    let mut theme = parse_theme_file_str(&contents)?;
+    std::fs::create_dir_all(dest_dir).map_err(|err| ThemeFileError::Io(err.to_string()))?;
+    let dest_path = non_colliding_dest_path(dest_dir, &theme.name);
+    std::fs::write(&dest_path, theme.to_toml_string())
+        .map_err(|err| ThemeFileError::Io(err.to_string()))?;
+    theme.source_path = Some(dest_path);
+    Ok(theme)
+}
+
+/// Picks a real, collision-safe destination path for a theme named `name` inside `dest_dir` - see
+/// [`import_theme_file`]'s own docs for the bug this exists to fix. Starts from the plain
+/// `{slugify(name)}.toml` path; if something is already there, reads and validates it - an exact
+/// `name` match means it's genuinely the same theme being re-imported (real "update" behaviour,
+/// intentionally overwritten), anything else (a different theme, or a file that doesn't even
+/// parse as one) means the slug is taken by something unrelated, so this tries
+/// `{slug}-2.toml`, `{slug}-3.toml`, ... until it finds either a free path or one already holding
+/// this same theme.
+fn non_colliding_dest_path(dest_dir: &Path, name: &str) -> PathBuf {
+    let base_slug = slugify(name);
+    let mut candidate = dest_dir.join(format!("{base_slug}.toml"));
+    let mut suffix = 2;
+    while candidate.exists() {
+        let same_theme = std::fs::read_to_string(&candidate)
+            .ok()
+            .and_then(|contents| parse_theme_file_str(&contents).ok())
+            .is_some_and(|existing| existing.name == name);
+        if same_theme {
+            break;
+        }
+        candidate = dest_dir.join(format!("{base_slug}-{suffix}.toml"));
+        suffix += 1;
+    }
+    candidate
+}
+
+/// Real export: serializes `theme` (see [`CustomTheme::to_toml_string`]) to `dest_path` - a
+/// user-chosen destination (e.g. a real "Save file" dialog's result), not necessarily inside a
+/// [`custom_themes_dir_for`] directory at all, since exporting means "give me a shareable file",
+/// not "install this theme".
+pub fn export_theme_to_path(theme: &CustomTheme, dest_path: &Path) -> io::Result<()> {
+    if let Some(parent) = dest_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(dest_path, theme.to_toml_string())
+}
+
+/// Removes a loaded custom theme's real backing file - the Themes page's "Remove" action. A
+/// no-op `Ok(())` if `theme` has no `source_path` (shouldn't happen for anything the Themes page
+/// actually lists, but keeps this honestly total rather than panicking on an `unwrap`).
+pub fn remove_custom_theme_file(theme: &CustomTheme) -> io::Result<()> {
+    match &theme.source_path {
+        Some(path) => std::fs::remove_file(path),
+        None => Ok(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_file() -> CustomThemeFile {
+        CustomThemeFile {
+            name: "Midnight Coral".to_string(),
+            subtitle: "warm accent".to_string(),
+            background: "#0c0d10".to_string(),
+            panel: "#181a1e".to_string(),
+            accent_green: "#5cb87f".to_string(),
+            accent_amber: "#e2a336".to_string(),
+            accent_blue: "#e07a5f".to_string(),
+        }
+    }
+
+    #[test]
+    fn a_well_formed_file_validates_into_the_real_swatches_in_order() {
+        let theme = valid_file().validate().expect("should validate");
+        assert_eq!(theme.name, "Midnight Coral");
+        assert_eq!(theme.subtitle, "warm accent");
+        assert_eq!(
+            theme.swatches,
+            [0x0c0d10, 0x181a1e, 0x5cb87f, 0xe2a336, 0xe07a5f]
+        );
+        assert_eq!(theme.source_path, None);
+    }
+
+    #[test]
+    fn an_empty_name_is_a_real_rejection_not_a_silent_fallback() {
+        let mut file = valid_file();
+        file.name = "   ".to_string();
+        assert_eq!(file.validate(), Err(ThemeFileError::EmptyName));
+    }
+
+    #[test]
+    fn a_name_colliding_with_a_builtin_theme_is_rejected() {
+        let mut file = valid_file();
+        file.name = "Jerry Dark".to_string();
+        assert_eq!(
+            file.validate(),
+            Err(ThemeFileError::NameCollidesWithBuiltin(
+                "Jerry Dark".to_string()
+            ))
+        );
+    }
+
+    type FieldSetter = fn(&mut CustomThemeFile, String);
+
+    #[test]
+    fn every_real_invalid_color_shape_is_rejected_with_the_offending_field_named() {
+        let cases: [(&str, FieldSetter); 5] = [
+            ("background", |f, v| f.background = v),
+            ("panel", |f, v| f.panel = v),
+            ("accent_green", |f, v| f.accent_green = v),
+            ("accent_amber", |f, v| f.accent_amber = v),
+            ("accent_blue", |f, v| f.accent_blue = v),
+        ];
+        for (field, set) in cases {
+            for bad in ["0c0d10", "#0c0", "#gggggg", "#0c0d1012", "not-a-color", ""] {
+                let mut file = valid_file();
+                set(&mut file, bad.to_string());
+                let err = file.validate().expect_err(&format!(
+                    "field {field} with value {bad:?} should have been rejected"
+                ));
+                assert_eq!(
+                    err,
+                    ThemeFileError::InvalidColor {
+                        field,
+                        value: bad.to_string()
+                    }
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn round_trips_through_to_file_and_back() {
+        let theme = valid_file().validate().expect("should validate");
+        let file = theme.to_file();
+        let reparsed = file.validate().expect("re-validated file should parse");
+        assert_eq!(theme.name, reparsed.name);
+        assert_eq!(theme.subtitle, reparsed.subtitle);
+        assert_eq!(theme.swatches, reparsed.swatches);
+    }
+
+    #[test]
+    fn parse_theme_file_str_rejects_garbage_toml_with_a_real_parse_error() {
+        let err = parse_theme_file_str("this is not valid toml {{{").unwrap_err();
+        assert!(matches!(err, ThemeFileError::Parse(_)));
+    }
+
+    #[test]
+    fn parse_theme_file_str_accepts_a_real_well_formed_document() {
+        let toml = valid_file().to_toml_string_for_test();
+        let theme = parse_theme_file_str(&toml).expect("should parse");
+        assert_eq!(theme.name, "Midnight Coral");
+    }
+
+    // Test-only helper: `CustomThemeFile` itself has no `to_toml_string` (only the already
+    // validated `CustomTheme` does) - this stands in for "a real file on disk", independent of
+    // the struct-under-test's own serializer.
+    impl CustomThemeFile {
+        fn to_toml_string_for_test(&self) -> String {
+            toml::to_string_pretty(self).unwrap_or_default()
+        }
+    }
+
+    #[test]
+    fn load_custom_themes_from_dir_skips_one_bad_file_and_keeps_the_rest() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("good.toml"),
+            valid_file().to_toml_string_for_test(),
+        )
+        .expect("write good file");
+        std::fs::write(dir.path().join("bad.toml"), "not valid toml {{{").expect("write bad file");
+        // Non-`.toml` files are ignored entirely, not treated as errors.
+        std::fs::write(dir.path().join("notes.txt"), "hello").expect("write unrelated file");
+
+        let (themes, errors) = load_custom_themes_from_dir(dir.path());
+
+        assert_eq!(themes.len(), 1);
+        assert_eq!(themes[0].name, "Midnight Coral");
+        assert_eq!(
+            themes[0].source_path.as_deref(),
+            Some(dir.path().join("good.toml").as_path())
+        );
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].starts_with("bad.toml:"));
+    }
+
+    #[test]
+    fn load_custom_themes_from_dir_on_a_missing_directory_is_empty_not_an_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let missing = dir.path().join("does-not-exist");
+        let (themes, errors) = load_custom_themes_from_dir(&missing);
+        assert!(themes.is_empty());
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn load_custom_themes_from_dir_sorts_by_name() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut zebra = valid_file();
+        zebra.name = "Zebra".to_string();
+        let mut apple = valid_file();
+        apple.name = "Apple".to_string();
+        std::fs::write(dir.path().join("z.toml"), zebra.to_toml_string_for_test()).expect("write");
+        std::fs::write(dir.path().join("a.toml"), apple.to_toml_string_for_test()).expect("write");
+
+        let (themes, _) = load_custom_themes_from_dir(dir.path());
+
+        assert_eq!(
+            themes.iter().map(|t| t.name.as_str()).collect::<Vec<_>>(),
+            ["Apple", "Zebra"]
+        );
+    }
+
+    #[test]
+    fn load_custom_themes_from_dir_accepts_an_uppercase_toml_extension() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("Windows-Authored.TOML"),
+            valid_file().to_toml_string_for_test(),
+        )
+        .expect("write");
+
+        let (themes, errors) = load_custom_themes_from_dir(dir.path());
+
+        assert!(
+            errors.is_empty(),
+            "a real .TOML file should not be reported as an error"
+        );
+        assert_eq!(
+            themes.len(),
+            1,
+            "a real .TOML (uppercase) file must still be loaded"
+        );
+    }
+
+    #[test]
+    fn load_custom_themes_from_dir_skips_a_file_over_the_size_cap_with_a_real_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let oversized = "x".repeat((MAX_THEME_FILE_BYTES + 1) as usize);
+        std::fs::write(dir.path().join("huge.toml"), oversized).expect("write huge file");
+
+        let (themes, errors) = load_custom_themes_from_dir(dir.path());
+
+        assert!(themes.is_empty());
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].starts_with("huge.toml:"));
+        assert!(errors[0].contains("exceeds"));
+    }
+
+    #[test]
+    fn import_theme_file_validates_before_writing_and_rejects_a_malformed_source() {
+        let source_dir = tempfile::tempdir().expect("tempdir");
+        let dest_dir = tempfile::tempdir().expect("tempdir");
+        let source_path = source_dir.path().join("picked.toml");
+        // Missing every required colour field - `toml::from_str::<CustomThemeFile>` fails before
+        // `validate()` even runs (`background`/`panel`/... aren't `#[serde(default)]`), so this
+        // is a real `Parse` error, not `EmptyName`.
+        std::fs::write(&source_path, "name = \"Something\"\n").expect("write malformed source");
+
+        let err = import_theme_file(&source_path, dest_dir.path()).unwrap_err();
+        assert!(
+            matches!(err, ThemeFileError::Parse(_)),
+            "expected a Parse error, got {err:?}"
+        );
+        assert!(
+            std::fs::read_dir(dest_dir.path())
+                .map(|mut entries| entries.next().is_none())
+                .unwrap_or(true),
+            "a rejected import must not write any file"
+        );
+    }
+
+    #[test]
+    fn import_theme_file_writes_a_real_canonical_file_into_dest_dir() {
+        let source_dir = tempfile::tempdir().expect("tempdir");
+        let dest_dir = tempfile::tempdir().expect("tempdir");
+        let source_path = source_dir.path().join("picked.toml");
+        std::fs::write(&source_path, valid_file().to_toml_string_for_test()).expect("write");
+
+        let theme = import_theme_file(&source_path, dest_dir.path()).expect("should import");
+
+        assert_eq!(theme.name, "Midnight Coral");
+        let expected_path = dest_dir.path().join("midnight-coral.toml");
+        assert_eq!(theme.source_path.as_deref(), Some(expected_path.as_path()));
+        assert!(expected_path.exists());
+        let (loaded, errors) = load_custom_themes_from_dir(dest_dir.path());
+        assert!(errors.is_empty());
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].name, "Midnight Coral");
+    }
+
+    /// Regression for a real bug an adversarial audit found: importing a theme whose slug
+    /// happens to collide with an *unrelated*, differently-named theme already on disk must
+    /// never silently overwrite that file.
+    #[test]
+    fn import_theme_file_never_clobbers_an_unrelated_theme_with_a_colliding_slug() {
+        let source_dir = tempfile::tempdir().expect("tempdir");
+        let dest_dir = tempfile::tempdir().expect("tempdir");
+
+        // A pre-existing, differently-named theme that happens to slugify to the exact same
+        // filename "Midnight Coral" would use.
+        let mut ocean = valid_file();
+        ocean.name = "Ocean".to_string();
+        std::fs::write(
+            dest_dir.path().join("midnight-coral.toml"),
+            ocean.to_toml_string_for_test(),
+        )
+        .expect("write pre-existing file");
+
+        let source_path = source_dir.path().join("picked.toml");
+        std::fs::write(&source_path, valid_file().to_toml_string_for_test()).expect("write");
+
+        let imported = import_theme_file(&source_path, dest_dir.path()).expect("should import");
+
+        assert_eq!(imported.name, "Midnight Coral");
+        assert_ne!(
+            imported.source_path,
+            Some(dest_dir.path().join("midnight-coral.toml")),
+            "must not have written into Ocean's own file"
+        );
+
+        let (loaded, errors) = load_custom_themes_from_dir(dest_dir.path());
+        assert!(
+            errors.is_empty(),
+            "both real files should still load cleanly: {errors:?}"
+        );
+        let names: Vec<&str> = loaded.iter().map(|t| t.name.as_str()).collect();
+        assert!(
+            names.contains(&"Ocean"),
+            "Ocean's file must survive completely untouched, got: {names:?}"
+        );
+        assert!(names.contains(&"Midnight Coral"));
+    }
+
+    /// A second import of the *same* theme (by name) is a real, intentional update - it must
+    /// land back at the exact same path, not spawn a `-2` sibling.
+    #[test]
+    fn import_theme_file_reimporting_the_same_theme_overwrites_its_own_file_not_a_new_one() {
+        let source_dir = tempfile::tempdir().expect("tempdir");
+        let dest_dir = tempfile::tempdir().expect("tempdir");
+        let source_path = source_dir.path().join("picked.toml");
+        std::fs::write(&source_path, valid_file().to_toml_string_for_test()).expect("write");
+
+        let first = import_theme_file(&source_path, dest_dir.path()).expect("first import");
+
+        let mut updated = valid_file();
+        updated.background = "#111111".to_string();
+        std::fs::write(&source_path, updated.to_toml_string_for_test()).expect("write update");
+        let second = import_theme_file(&source_path, dest_dir.path()).expect("second import");
+
+        assert_eq!(first.source_path, second.source_path);
+        assert_eq!(second.swatches[0], 0x111111);
+        let (loaded, _) = load_custom_themes_from_dir(dest_dir.path());
+        assert_eq!(
+            loaded.len(),
+            1,
+            "must not have left a stale duplicate file behind"
+        );
+    }
+
+    #[test]
+    fn import_theme_file_rejects_a_name_colliding_with_a_builtin_and_writes_nothing() {
+        let source_dir = tempfile::tempdir().expect("tempdir");
+        let dest_dir = tempfile::tempdir().expect("tempdir");
+        let source_path = source_dir.path().join("picked.toml");
+        let mut file = valid_file();
+        file.name = "Slate".to_string();
+        std::fs::write(&source_path, file.to_toml_string_for_test()).expect("write");
+
+        let err = import_theme_file(&source_path, dest_dir.path()).unwrap_err();
+        assert_eq!(
+            err,
+            ThemeFileError::NameCollidesWithBuiltin("Slate".to_string())
+        );
+        assert!(
+            std::fs::read_dir(dest_dir.path())
+                .map(|mut entries| entries.next().is_none())
+                .unwrap_or(true),
+            "a rejected import must not write any file"
+        );
+    }
+
+    #[test]
+    fn import_theme_file_reports_a_real_io_error_for_a_missing_source() {
+        let dest_dir = tempfile::tempdir().expect("tempdir");
+        let missing_source = dest_dir.path().join("does-not-exist.toml");
+        let err = import_theme_file(&missing_source, dest_dir.path()).unwrap_err();
+        assert!(matches!(err, ThemeFileError::Io(_)));
+    }
+
+    #[test]
+    fn export_then_import_round_trips_a_real_theme_through_disk() {
+        let theme = valid_file().validate().expect("should validate");
+        let export_dir = tempfile::tempdir().expect("tempdir");
+        let export_path = export_dir.path().join("shared-theme.toml");
+        export_theme_to_path(&theme, &export_path).expect("export should succeed");
+
+        let import_dest = tempfile::tempdir().expect("tempdir");
+        let imported =
+            import_theme_file(&export_path, import_dest.path()).expect("import should succeed");
+
+        assert_eq!(imported.name, theme.name);
+        assert_eq!(imported.subtitle, theme.subtitle);
+        assert_eq!(imported.swatches, theme.swatches);
+    }
+
+    #[test]
+    fn remove_custom_theme_file_deletes_the_real_backing_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("midnight-coral.toml");
+        std::fs::write(&path, valid_file().to_toml_string_for_test()).expect("write");
+        let mut theme = valid_file().validate().expect("should validate");
+        theme.source_path = Some(path.clone());
+
+        remove_custom_theme_file(&theme).expect("remove should succeed");
+
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn remove_custom_theme_file_with_no_source_path_is_a_harmless_no_op() {
+        let theme = valid_file().validate().expect("should validate");
+        assert_eq!(theme.source_path, None);
+        assert!(remove_custom_theme_file(&theme).is_ok());
+    }
+
+    #[test]
+    fn slugify_produces_filesystem_safe_lowercase_hyphenated_names() {
+        assert_eq!(slugify("Midnight Coral"), "midnight-coral");
+        assert_eq!(slugify("  Spaces   Everywhere  "), "spaces-everywhere");
+        // Only the non-ASCII letters (`Ü`/`ï`/`ö`/`é`) become separators - the plain ASCII
+        // letters already inside "Ünïcödé" (`n`, `c`, `d`) survive as their own segments.
+        assert_eq!(slugify("Ünïcödé Theme!!"), "n-c-d-theme");
+        assert_eq!(slugify("...."), "theme");
+        assert_eq!(slugify("UPPER_CASE-name"), "upper-case-name");
+    }
+
+    #[test]
+    fn custom_themes_dir_for_is_a_real_sibling_of_the_given_settings_path() {
+        let settings_path = Path::new("/home/user/.config/jerry/settings.toml");
+        assert_eq!(
+            custom_themes_dir_for(settings_path),
+            Path::new("/home/user/.config/jerry/themes")
+        );
+    }
+
+    #[test]
+    fn custom_themes_dir_for_falls_back_to_a_bare_name_for_a_settings_path_with_no_parent() {
+        assert_eq!(
+            custom_themes_dir_for(Path::new("settings.toml")),
+            Path::new("themes")
+        );
+    }
+}

--- a/crates/app/src/settings/custom_theme.rs
+++ b/crates/app/src/settings/custom_theme.rs
@@ -62,8 +62,68 @@ use serde::{Deserialize, Serialize};
 use crate::settings::state::THEME_DEFS;
 
 /// A defensive upper bound on a single theme file's size - see
-/// [`load_custom_themes_from_dir`]'s own docs for why.
+/// [`load_custom_themes_from_dir`]'s own docs for why. [`import_theme_file`] enforces this same
+/// cap against the *source* file it's about to import, not just files already sitting in a
+/// custom-themes directory - a concurrency incident on this branch (two agent sessions
+/// accidentally run against the same shared worktree) lost the original fix for this gap before
+/// it was ever committed; this is that fix, re-implemented and verified against the real
+/// committed diff rather than taken on trust.
 const MAX_THEME_FILE_BYTES: u64 = 64 * 1024;
+
+/// Jerry Dark's own five swatches, transcribed verbatim from `assets/themes/jerry-dark.toml` -
+/// pinned as this module's own real `u32` values rather than re-derived from
+/// `crate::settings::state::THEME_DEFS` at runtime. That distinction matters: `THEME_DEFS` is a
+/// `std::sync::LazyLock` whose own initializer parses (and therefore validates - see
+/// [`CustomThemeFile::validate_with_builtin_check`]) all six built-in theme files, so a
+/// readability check reachable from that validation path that itself read `THEME_DEFS` would
+/// deadlock on `std::sync::Once` the first time any code touched `THEME_DEFS` at all (a real,
+/// reproduced hang during this branch's own history, not a hypothetical) - `THEME_DEFS`'s
+/// initializer would be blocked waiting on a readability check that is itself blocked waiting for
+/// `THEME_DEFS` to finish initializing. Using this pinned copy instead sidesteps that entirely.
+///
+/// `custom_theme::tests::
+/// jerry_dark_baseline_swatches_const_matches_the_real_initialized_theme_defs_0_swatches` is the
+/// real regression test keeping this copy honest against `THEME_DEFS[0]`'s actual initialized
+/// value - safe to call from an ordinary `#[test]` (never from inside another `LazyLock`'s own
+/// initializer), so a future edit to Jerry Dark's own swatches can't silently desync the two
+/// without a test catching it.
+const JERRY_DARK_BASELINE_SWATCHES: [u32; 5] = [0x0e0f11, 0x1a1e21, 0x5cb87f, 0xe2a336, 0x74ade8];
+
+/// Standard ITU-R BT.709 luma weighting - the same "how bright does this actually look" mix most
+/// contrast-ratio formulas use, not a naive `(r+g+b)/3` average that would treat blue as visually
+/// as bright as green. Scaled to a per-mille (0-1000) `u32` rather than left as a bare `f64` so
+/// [`ThemeFileError::LowReadability`] can stay `#[derive(Eq)]` like every other variant (bare
+/// `f64` cannot implement `Eq`), and so tests compare exact integers instead of float epsilons.
+fn relative_luma_per_mille(hex: u32) -> u32 {
+    let r = ((hex >> 16) & 0xff) as f64 / 255.0;
+    let g = ((hex >> 8) & 0xff) as f64 / 255.0;
+    let b = (hex & 0xff) as f64 / 255.0;
+    let luma = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+    (luma * 1000.0).round() as u32
+}
+
+/// The real, concrete readability signal this module checks: how far apart `background` and
+/// `panel` actually look, in perceptual brightness - a `panel` that's barely distinguishable from
+/// `background` (or identical to it) is unreadable regardless of what the three accent colours
+/// are. `u32::abs_diff` rather than signed subtraction since a lighter-panel-on-dark-background
+/// theme and a darker-panel-on-light-background theme (e.g. "Paper") are equally valid - only the
+/// magnitude of the difference matters, not its sign.
+fn panel_background_luma_delta_per_mille(swatches: &[u32; 5]) -> u32 {
+    relative_luma_per_mille(swatches[0]).abs_diff(relative_luma_per_mille(swatches[1]))
+}
+
+/// The minimum real `panel`-vs-`background` luma difference (see
+/// [`panel_background_luma_delta_per_mille`]) [`CustomThemeFile::validate_with_builtin_check`]
+/// requires before accepting any theme, built-in or custom - half of
+/// [`JERRY_DARK_BASELINE_SWATCHES`]' own real shipped contrast. Half, not the full baseline
+/// value, so this is a real but generous floor: every one of the six built-in theme files clears
+/// it with room to spare (`custom_theme::tests::every_built_in_theme_clears_the_readability_floor`;
+/// the tightest of the six, Slate, clears it by roughly 1.4x) while still catching the concrete
+/// unreadable-theme case this exists for: a hand-authored `panel` that's the same colour as
+/// `background`, or only a couple of hex digits off from it.
+fn readability_floor_per_mille() -> u32 {
+    panel_background_luma_delta_per_mille(&JERRY_DARK_BASELINE_SWATCHES) / 2
+}
 
 /// The real on-disk shape of one `~/.config/jerry/themes/<slug>.toml` file - see the module docs.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -100,8 +160,24 @@ pub enum ThemeFileError {
     Io(String),
     Parse(String),
     EmptyName,
-    InvalidColor { field: &'static str, value: String },
+    InvalidColor {
+        field: &'static str,
+        value: String,
+    },
     NameCollidesWithBuiltin(String),
+    /// `panel` is too close in perceptual brightness to `background` to read comfortably - see
+    /// [`readability_floor_per_mille`]'s own docs for how the floor is derived.
+    LowReadability {
+        delta_per_mille: u32,
+        floor_per_mille: u32,
+    },
+    /// The *source* file [`import_theme_file`] was asked to import is over
+    /// [`MAX_THEME_FILE_BYTES`] - checked before that file is ever read or written, the same real
+    /// cap [`load_custom_themes_from_dir`] already enforces against files already on disk.
+    TooLarge {
+        bytes: u64,
+        max_bytes: u64,
+    },
 }
 
 impl std::fmt::Display for ThemeFileError {
@@ -117,6 +193,18 @@ impl std::fmt::Display for ThemeFileError {
             ThemeFileError::NameCollidesWithBuiltin(name) => write!(
                 f,
                 "\"{name}\" is already a built-in theme name - choose a different name"
+            ),
+            ThemeFileError::LowReadability {
+                delta_per_mille,
+                floor_per_mille,
+            } => write!(
+                f,
+                "`panel` is too close in brightness to `background` to read comfortably \
+                 ({delta_per_mille} per-mille luma difference, need at least {floor_per_mille})"
+            ),
+            ThemeFileError::TooLarge { bytes, max_bytes } => write!(
+                f,
+                "theme file is {bytes} bytes, over the {max_bytes}-byte limit for a theme file"
             ),
         }
     }
@@ -216,6 +304,19 @@ impl CustomThemeFile {
             parse("accent_amber", &self.accent_amber)?,
             parse("accent_blue", &self.accent_blue)?,
         ];
+        // Readability floor - deliberately checked against a pinned `JERRY_DARK_BASELINE_SWATCHES`
+        // const, never `crate::settings::state::THEME_DEFS`: this function runs for every built-in
+        // theme file too (via `parse_builtin_theme_file_str`, called from *inside* `THEME_DEFS`'s
+        // own `LazyLock` initializer), so reading `THEME_DEFS` here would deadlock - see
+        // `JERRY_DARK_BASELINE_SWATCHES`'s own docs.
+        let delta = panel_background_luma_delta_per_mille(&swatches);
+        let floor = readability_floor_per_mille();
+        if delta < floor {
+            return Err(ThemeFileError::LowReadability {
+                delta_per_mille: delta,
+                floor_per_mille: floor,
+            });
+        }
         Ok(CustomTheme {
             name: name.to_string(),
             subtitle: self.subtitle.trim().to_string(),
@@ -412,6 +513,19 @@ pub fn import_theme_file(
     source_path: &Path,
     dest_dir: &Path,
 ) -> Result<CustomTheme, ThemeFileError> {
+    // The same real cap `load_custom_themes_from_dir` already enforces against files already
+    // sitting in a custom-themes directory, applied here against the *source* file before it's
+    // ever read into memory or written anywhere - a pathologically large "theme" file picked in a
+    // real file-open dialog should be rejected with a real, specific error, not silently read in
+    // full (or truncated) first.
+    let metadata =
+        std::fs::metadata(source_path).map_err(|err| ThemeFileError::Io(err.to_string()))?;
+    if metadata.len() > MAX_THEME_FILE_BYTES {
+        return Err(ThemeFileError::TooLarge {
+            bytes: metadata.len(),
+            max_bytes: MAX_THEME_FILE_BYTES,
+        });
+    }
     let contents =
         std::fs::read_to_string(source_path).map_err(|err| ThemeFileError::Io(err.to_string()))?;
     let mut theme = parse_theme_file_str(&contents)?;
@@ -427,15 +541,27 @@ pub fn import_theme_file(
 /// [`import_theme_file`]'s own docs for the bug this exists to fix. Starts from the plain
 /// `{slugify(name)}.toml` path; if something is already there, reads and validates it - an exact
 /// `name` match means it's genuinely the same theme being re-imported (real "update" behaviour,
-/// intentionally overwritten), anything else (a different theme, or a file that doesn't even
-/// parse as one) means the slug is taken by something unrelated, so this tries
-/// `{slug}-2.toml`, `{slug}-3.toml`, ... until it finds either a free path or one already holding
-/// this same theme.
+/// intentionally overwritten - including when that path is a real symlink to a legitimate theme
+/// file elsewhere, a genuine way to share one across machines), anything else (a different theme,
+/// a file that doesn't even parse as one, or a *dangling* symlink) means the slug is taken by
+/// something unrelated, so this tries `{slug}-2.toml`, `{slug}-3.toml`, ... until it finds either
+/// a free path or one already holding this same theme.
+///
+/// `symlink_metadata`, not `Path::exists` - an adversarial audit caught the original
+/// `candidate.exists()` here as a real vulnerability, not just a style nit: `exists()` follows
+/// symlinks and reports `false` for a *dangling* `{slug}.toml -> /some/other/path` symlink sitting
+/// in `dest_dir`, so this loop would treat that path as free, and [`import_theme_file`]'s own
+/// `std::fs::write` (which also follows symlinks) would then write straight through it into
+/// whatever it points at - a real clobber of an unrelated file, just staged via a symlink instead
+/// of a same-named regular file. `symlink_metadata` reports the symlink's own presence without
+/// following it, so a dangling (or unrelated-target) symlink here is treated as a real collision
+/// like any other occupied path, while a symlink that genuinely points at a file already holding
+/// *this same* theme is still correctly reused below.
 fn non_colliding_dest_path(dest_dir: &Path, name: &str) -> PathBuf {
     let base_slug = slugify(name);
     let mut candidate = dest_dir.join(format!("{base_slug}.toml"));
     let mut suffix = 2;
-    while candidate.exists() {
+    while candidate.symlink_metadata().is_ok() {
         let same_theme = std::fs::read_to_string(&candidate)
             .ok()
             .and_then(|contents| parse_theme_file_str(&contents).ok())
@@ -750,6 +876,106 @@ mod tests {
         assert!(names.contains(&"Midnight Coral"));
     }
 
+    /// Regression for a real, concurrency-incident-lost fix: a *dangling* symlink planted at the
+    /// exact path `import_theme_file` would otherwise write to must not be followed. Before this
+    /// fix, `non_colliding_dest_path`'s `candidate.exists()` reported `false` for a dangling
+    /// symlink (it follows symlinks and the *target* doesn't exist), so the loop treated the path
+    /// as free and `std::fs::write` then wrote straight through the symlink into whatever it
+    /// pointed at.
+    #[cfg(unix)]
+    #[test]
+    fn import_theme_file_does_not_follow_a_dangling_symlink_planted_at_the_slug_path() {
+        let source_dir = tempfile::tempdir().expect("tempdir");
+        let dest_dir = tempfile::tempdir().expect("tempdir");
+        let outside = tempfile::tempdir().expect("tempdir");
+        // The symlink's target deliberately does not exist - a dangling symlink.
+        let attacker_target = outside.path().join("does-not-exist-yet.toml");
+        std::os::unix::fs::symlink(
+            &attacker_target,
+            dest_dir.path().join("midnight-coral.toml"),
+        )
+        .expect("create dangling symlink");
+
+        let source_path = source_dir.path().join("picked.toml");
+        std::fs::write(&source_path, valid_file().to_toml_string_for_test()).expect("write");
+
+        let imported = import_theme_file(&source_path, dest_dir.path()).expect("should import");
+
+        assert_ne!(
+            imported.source_path,
+            Some(dest_dir.path().join("midnight-coral.toml")),
+            "must not have written through the dangling symlink"
+        );
+        assert!(
+            !attacker_target.exists(),
+            "must never have created the symlink's target by following it"
+        );
+    }
+
+    /// A companion guard, not itself a regression test for the dangling-symlink fix (a symlink to
+    /// a real, *existing* file was already correctly treated as a collision by the old
+    /// `candidate.exists()` check too - `exists()` only misreports a *dangling* symlink as absent,
+    /// which is what
+    /// [`import_theme_file_does_not_follow_a_dangling_symlink_planted_at_the_slug_path`] actually
+    /// regression-tests). Kept anyway as real, independent coverage that a symlink pointing at a
+    /// real, *unrelated* (differently-named) theme file is treated as a collision (redirected to a
+    /// new candidate name), exactly like an ordinary same-named regular file already is, and that
+    /// the unrelated file it points at survives untouched.
+    #[cfg(unix)]
+    #[test]
+    fn import_theme_file_does_not_follow_a_symlink_to_an_unrelated_theme_file() {
+        let source_dir = tempfile::tempdir().expect("tempdir");
+        let dest_dir = tempfile::tempdir().expect("tempdir");
+        let outside = tempfile::tempdir().expect("tempdir");
+
+        let mut ocean = valid_file();
+        ocean.name = "Ocean".to_string();
+        let real_file = outside.path().join("ocean.toml");
+        std::fs::write(&real_file, ocean.to_toml_string_for_test()).expect("write real file");
+        std::os::unix::fs::symlink(&real_file, dest_dir.path().join("midnight-coral.toml"))
+            .expect("create symlink to unrelated theme");
+
+        let source_path = source_dir.path().join("picked.toml");
+        std::fs::write(&source_path, valid_file().to_toml_string_for_test()).expect("write");
+
+        let imported = import_theme_file(&source_path, dest_dir.path()).expect("should import");
+
+        assert_eq!(imported.name, "Midnight Coral");
+        assert_ne!(
+            imported.source_path,
+            Some(dest_dir.path().join("midnight-coral.toml")),
+            "must not have written through the symlink into Ocean's real file"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&real_file).expect("Ocean's file should still be readable"),
+            ocean.to_toml_string_for_test(),
+            "Ocean's real file must survive completely untouched"
+        );
+    }
+
+    /// The flip side: a symlink that genuinely points at a file already holding *this same*
+    /// theme (a real, legitimate way to share one across machines) is a real re-import-to-update,
+    /// not a collision - it must be reused, not redirected to a `-2` sibling.
+    #[cfg(unix)]
+    #[test]
+    fn non_colliding_dest_path_reuses_a_symlink_that_points_at_a_file_holding_the_same_theme() {
+        let dest_dir = tempfile::tempdir().expect("tempdir");
+        let real_file_dir = tempfile::tempdir().expect("tempdir");
+        let real_file = real_file_dir.path().join("shared-theme.toml");
+        std::fs::write(&real_file, valid_file().to_toml_string_for_test())
+            .expect("write real file");
+        let symlink_path = dest_dir.path().join("midnight-coral.toml");
+        std::os::unix::fs::symlink(&real_file, &symlink_path).expect("create symlink");
+
+        let candidate = non_colliding_dest_path(dest_dir.path(), "Midnight Coral");
+
+        assert_eq!(
+            candidate, symlink_path,
+            "a symlink to a file already holding this exact theme is a legitimate re-import \
+             target, not a collision"
+        );
+    }
+
     /// A second import of the *same* theme (by name) is a real, intentional update - it must
     /// land back at the exact same path, not spawn a `-2` sibling.
     #[test]
@@ -804,6 +1030,38 @@ mod tests {
         let missing_source = dest_dir.path().join("does-not-exist.toml");
         let err = import_theme_file(&missing_source, dest_dir.path()).unwrap_err();
         assert!(matches!(err, ThemeFileError::Io(_)));
+    }
+
+    /// Regression for a real, concurrency-incident-lost fix: [`load_custom_themes_from_dir`]
+    /// already capped a directory's own files at [`MAX_THEME_FILE_BYTES`], but
+    /// [`import_theme_file`] (the user-facing "import this file" action) had no matching check
+    /// against the *source* file it's about to import - an oversized source would previously have
+    /// been read into memory in full before validation ever rejected it as malformed TOML. This
+    /// must reject it before reading or writing anything at all.
+    #[test]
+    fn import_theme_file_rejects_an_oversized_source_before_reading_or_writing_it() {
+        let source_dir = tempfile::tempdir().expect("tempdir");
+        let dest_dir = tempfile::tempdir().expect("tempdir");
+        let source_path = source_dir.path().join("huge.toml");
+        let oversized_len = MAX_THEME_FILE_BYTES + 1;
+        std::fs::write(&source_path, "x".repeat(oversized_len as usize))
+            .expect("write huge source");
+
+        let err = import_theme_file(&source_path, dest_dir.path()).unwrap_err();
+
+        assert_eq!(
+            err,
+            ThemeFileError::TooLarge {
+                bytes: oversized_len,
+                max_bytes: MAX_THEME_FILE_BYTES,
+            }
+        );
+        assert!(
+            std::fs::read_dir(dest_dir.path())
+                .map(|mut entries| entries.next().is_none())
+                .unwrap_or(true),
+            "a rejected oversized import must not write any file"
+        );
     }
 
     #[test]
@@ -987,6 +1245,97 @@ mod tests {
             empty_name.validate_with_builtin_check(false),
             Err(ThemeFileError::EmptyName),
             "an empty name must still be rejected even with the collision check off"
+        );
+    }
+
+    /// Regression for a real, concurrency-incident-lost fix: a `panel` swatch with zero real
+    /// contrast against `background` (here, literally the same colour) must be rejected - the
+    /// concrete unreadable-theme case the readability floor exists to catch.
+    #[test]
+    fn a_panel_swatch_with_no_real_contrast_against_background_is_rejected() {
+        let mut file = valid_file();
+        file.panel = file.background.clone();
+        let err = file.validate().unwrap_err();
+        assert_eq!(
+            err,
+            ThemeFileError::LowReadability {
+                delta_per_mille: 0,
+                floor_per_mille: readability_floor_per_mille(),
+            }
+        );
+    }
+
+    /// [`JERRY_DARK_BASELINE_SWATCHES`] is a pinned copy of Jerry Dark's own swatches, kept
+    /// deliberately independent of `crate::settings::state::THEME_DEFS` at runtime (see that
+    /// const's own docs for the reentrant `LazyLock` deadlock this avoids). This is the real
+    /// regression test that keeps the pinned copy honest: a future edit to Jerry Dark's own
+    /// swatches (`assets/themes/jerry-dark.toml`) that forgets to update this copy fails here,
+    /// loudly, in an ordinary `#[test]` - never from inside another `LazyLock`'s own initializer,
+    /// which is the one context this exact comparison must never run in.
+    #[test]
+    fn jerry_dark_baseline_swatches_const_matches_the_real_initialized_theme_defs_0_swatches() {
+        assert_eq!(
+            JERRY_DARK_BASELINE_SWATCHES,
+            crate::settings::state::THEME_DEFS[0].swatches
+        );
+    }
+
+    /// Real regression: the readability floor (derived from [`JERRY_DARK_BASELINE_SWATCHES`])
+    /// must not accidentally reject any of the six real, shipped built-in theme files -
+    /// `parse_builtin_theme_file_str` already panics on any validation failure, including a
+    /// `LowReadability` rejection, so reaching the end of this loop at all is the real assertion.
+    #[test]
+    fn every_built_in_theme_clears_the_readability_floor() {
+        let files = [
+            include_str!("../../../../assets/themes/jerry-dark.toml"),
+            include_str!("../../../../assets/themes/jerry-dim.toml"),
+            include_str!("../../../../assets/themes/slate.toml"),
+            include_str!("../../../../assets/themes/ember.toml"),
+            include_str!("../../../../assets/themes/moss.toml"),
+            include_str!("../../../../assets/themes/paper.toml"),
+        ];
+        let floor = readability_floor_per_mille();
+        for contents in files {
+            // `parse_builtin_theme_file_str` already panics on any validation failure - including
+            // a `LowReadability` rejection - so it alone would prove this passes, but a bare panic
+            // there names neither the theme nor the actual margin. Recomputing the real delta here
+            // too and asserting it directly gives a real, specific failure message instead.
+            let theme = parse_builtin_theme_file_str(contents);
+            let delta = panel_background_luma_delta_per_mille(&theme.swatches);
+            assert!(
+                delta >= floor,
+                "{}: panel/background luma delta {delta} is below the readability floor {floor}",
+                theme.name
+            );
+        }
+    }
+
+    /// Pins the readability floor's actual real, computed magnitude - not just its existence.
+    /// Every other test in this suite only proves the floor rejects a *zero*-contrast panel and
+    /// accepts the six real built-in themes; none of them would catch a future edit that quietly
+    /// weakens [`readability_floor_per_mille`] (e.g. dividing by `50` instead of `2`) while still
+    /// passing every other assertion. This is the one test that would.
+    #[test]
+    fn readability_floor_per_mille_is_pinned_to_a_real_computed_value() {
+        assert_eq!(readability_floor_per_mille(), 28);
+    }
+
+    /// A real near-miss, not just the zero-contrast extreme
+    /// [`a_panel_swatch_with_no_real_contrast_against_background_is_rejected`] already covers:
+    /// `panel` here is a visibly different hex string from `background` (a hand-author could
+    /// easily mistake this for "different enough"), but still well under the floor - real
+    /// per-mille values transcribed from a real luma computation, not hand-waved.
+    #[test]
+    fn a_panel_swatch_only_a_few_hex_digits_off_from_background_is_still_rejected() {
+        let mut file = valid_file();
+        file.panel = "#0e0f12".to_string();
+        let err = file.validate().unwrap_err();
+        assert_eq!(
+            err,
+            ThemeFileError::LowReadability {
+                delta_per_mille: 8,
+                floor_per_mille: 28,
+            }
         );
     }
 }

--- a/crates/app/src/settings/custom_theme.rs
+++ b/crates/app/src/settings/custom_theme.rs
@@ -575,6 +575,61 @@ fn non_colliding_dest_path(dest_dir: &Path, name: &str) -> PathBuf {
     candidate
 }
 
+/// The real, well-commented starting-point template a user can copy to author their own theme -
+/// checked in at `assets/themes/template.toml` and embedded here via `include_str!` so the file a
+/// user finds in the repository and the one [`write_template_theme`]'s "New from template"
+/// Themes-page action writes are the literal same bytes, never two independently-maintained
+/// copies that could drift apart. Deliberately *not* one of [`crate::settings::state::THEME_DEFS`]'
+/// own six `include_str!`s: that list names all six built-in theme files explicitly, and this
+/// isn't a seventh built-in theme - it lives in the same `assets/themes/` directory purely because
+/// that's this repository's one real home for theme-shaped `.toml` files, not because it's wired
+/// into `THEME_DEFS`.
+pub const CUSTOM_THEME_TEMPLATE_TOML: &str =
+    include_str!("../../../../assets/themes/template.toml");
+
+/// Writes the real template ([`CUSTOM_THEME_TEMPLATE_TOML`]) into `dest_dir` - the Themes page's
+/// "New from template" action's one real caller
+/// (`crate::settings::render::AdeApp::start_create_theme_from_template`). Validates through the
+/// same [`parse_theme_file_str`] core [`import_theme_file`] uses (never written unvalidated - if
+/// this template itself ever regressed into something that fails its own validation, this would
+/// fail loudly rather than silently hand a user a broken file), then writes the template's own
+/// literal bytes - comments and all - not a re-serialized [`CustomTheme::to_toml_string`] copy,
+/// unlike [`import_theme_file`]: the whole point of a "well-commented template" is that a user who
+/// clicks the button gets the same explanatory comments as one who copies the file straight out of
+/// the repository, not a canonicalized file stripped down to five bare key-value lines.
+///
+/// Uses the same [`non_colliding_dest_path`] collision handling [`import_theme_file`] does: a
+/// second click reuses (refreshes) the one file this already wrote, since the template's own
+/// `name` never changes between clicks, rather than spawning a `-2` sibling every time - *as long
+/// as that file's contents are still the pristine, unedited template*. An adversarial audit
+/// caught the original version of this function always overwriting that path unconditionally: a
+/// user who clicked "New from template", edited the resulting file's colours in place (keeping
+/// its default `name`), then clicked "New from template" again - e.g. wanting a *second* fresh
+/// theme to start a new one from - would have silently lost those edits with no confirmation,
+/// unlike every other destructive action in this module (`execute_remove_custom_theme` requires
+/// an arm-then-confirm double click). Fixed by checking the existing file's real bytes first: if
+/// they've diverged from [`CUSTOM_THEME_TEMPLATE_TOML`], this leaves the file untouched and hands
+/// back the user's own edited theme instead of clobbering it; only a byte-identical (never
+/// touched since the last write) file is refreshed.
+pub fn write_template_theme(dest_dir: &Path) -> Result<CustomTheme, ThemeFileError> {
+    let mut theme = parse_theme_file_str(CUSTOM_THEME_TEMPLATE_TOML)?;
+    std::fs::create_dir_all(dest_dir).map_err(|err| ThemeFileError::Io(err.to_string()))?;
+    let dest_path = non_colliding_dest_path(dest_dir, &theme.name);
+    if let Ok(existing_contents) = std::fs::read_to_string(&dest_path) {
+        if existing_contents != CUSTOM_THEME_TEMPLATE_TOML {
+            // The user has edited this file since it was created from the template - do not
+            // overwrite their real edits. Hand back their existing theme as-is.
+            let mut existing = parse_theme_file_str(&existing_contents)?;
+            existing.source_path = Some(dest_path);
+            return Ok(existing);
+        }
+    }
+    std::fs::write(&dest_path, CUSTOM_THEME_TEMPLATE_TOML)
+        .map_err(|err| ThemeFileError::Io(err.to_string()))?;
+    theme.source_path = Some(dest_path);
+    Ok(theme)
+}
+
 /// Real export: serializes `theme` (see [`CustomTheme::to_toml_string`]) to `dest_path` - a
 /// user-chosen destination (e.g. a real "Save file" dialog's result), not necessarily inside a
 /// [`custom_themes_dir_for`] directory at all, since exporting means "give me a shareable file",
@@ -1078,6 +1133,106 @@ mod tests {
         assert_eq!(imported.name, theme.name);
         assert_eq!(imported.subtitle, theme.subtitle);
         assert_eq!(imported.swatches, theme.swatches);
+    }
+
+    /// Real proof (not an assumption) that `toml`/`serde`'s parsing genuinely ignores
+    /// `#`-prefixed comments: [`CUSTOM_THEME_TEMPLATE_TOML`] is mostly comment lines, and this
+    /// feeds its *real, checked-in* contents (not a hand-copied excerpt) through the exact same
+    /// [`parse_theme_file_str`] a user's own disk file goes through.
+    #[test]
+    fn the_real_template_file_parses_and_validates_as_a_well_formed_theme() {
+        let theme = parse_theme_file_str(CUSTOM_THEME_TEMPLATE_TOML)
+            .expect("the real, checked-in template file must parse and validate cleanly");
+        assert_eq!(theme.name, "My Custom Theme");
+        assert_eq!(theme.subtitle, "replace this with a short description");
+        assert_eq!(
+            theme.swatches,
+            [0x0c0d10, 0x181a1e, 0x5cb87f, 0xe2a336, 0xe07a5f]
+        );
+    }
+
+    #[test]
+    fn write_template_theme_writes_the_real_template_bytes_verbatim_comments_included() {
+        let dest_dir = tempfile::tempdir().expect("tempdir");
+
+        let written = write_template_theme(dest_dir.path()).expect("should write");
+
+        assert_eq!(written.name, "My Custom Theme");
+        let dest_path = written.source_path.expect("should record its own path");
+        let on_disk = std::fs::read_to_string(&dest_path).expect("should read back");
+        assert_eq!(
+            on_disk, CUSTOM_THEME_TEMPLATE_TOML,
+            "the written file must be the template's own literal bytes - comments included - \
+             not a re-serialized, comment-stripped copy"
+        );
+        assert!(
+            on_disk.contains("READABILITY FLOOR"),
+            "a real explanatory comment must have survived the write"
+        );
+
+        // The written file is itself a real, loadable custom theme, not just bytes on disk.
+        let (loaded, errors) = load_custom_themes_from_dir(dest_dir.path());
+        assert!(
+            errors.is_empty(),
+            "the written template must load cleanly: {errors:?}"
+        );
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].name, "My Custom Theme");
+    }
+
+    #[test]
+    fn write_template_theme_a_second_time_refreshes_the_same_file_not_a_new_one() {
+        let dest_dir = tempfile::tempdir().expect("tempdir");
+
+        let first = write_template_theme(dest_dir.path()).expect("first write");
+        let second = write_template_theme(dest_dir.path()).expect("second write");
+
+        assert_eq!(
+            first.source_path, second.source_path,
+            "writing the template twice must refresh the same file, not spawn a -2 sibling"
+        );
+        let (loaded, _) = load_custom_themes_from_dir(dest_dir.path());
+        assert_eq!(
+            loaded.len(),
+            1,
+            "must not have left a stale duplicate file behind"
+        );
+    }
+
+    /// Adversarial-audit regression: a user who edits the template-created file in place (keeping
+    /// its default `name`) must not have those edits silently destroyed by a second "New from
+    /// template" click.
+    #[test]
+    fn write_template_theme_never_clobbers_a_file_the_user_has_since_edited() {
+        let dest_dir = tempfile::tempdir().expect("tempdir");
+
+        let first = write_template_theme(dest_dir.path()).expect("first write");
+        let dest_path = first.source_path.clone().expect("should record its path");
+
+        // The user edits the file in place, keeping the same `name`.
+        let edited_toml = CUSTOM_THEME_TEMPLATE_TOML.replace("#0c0d10", "#123456");
+        assert_ne!(
+            edited_toml, CUSTOM_THEME_TEMPLATE_TOML,
+            "sanity check: the edit must actually change the file's bytes"
+        );
+        std::fs::write(&dest_path, &edited_toml).expect("simulate a user edit");
+
+        let second = write_template_theme(dest_dir.path()).expect("second write");
+
+        assert_eq!(
+            second.source_path, first.source_path,
+            "must still resolve to the same file, not a -2 sibling"
+        );
+        assert_eq!(
+            second.swatches[0], 0x123456,
+            "the user's edited colour must be preserved, not overwritten with the pristine \
+             template's own #0c0d10"
+        );
+        let on_disk = std::fs::read_to_string(&dest_path).expect("read back");
+        assert_eq!(
+            on_disk, edited_toml,
+            "the file on disk must be untouched by the second click"
+        );
     }
 
     #[test]

--- a/crates/app/src/settings/mod.rs
+++ b/crates/app/src/settings/mod.rs
@@ -8,6 +8,8 @@
 //!   `$PATH` agent/language-server detection). No `gpui::Window`.
 //! - [`store`] - the persisted `~/.config/jerry/settings.toml` file: load, save, and the
 //!   read-only JSON alternate view.
+//! - [`custom_theme`] - user-authored themes loaded from `~/.config/jerry/themes/*.toml`
+//!   (GitHub issue #5): the real file format, validation, and import/export. No `gpui::Window`.
 //! - [`render`] - the real GPUI rendering and interaction for every settings page, as
 //!   `impl AdeApp` methods.
 //! - [`widgets`] - the row-control widget shapes (`toggle`/`stepper`/`choice`) shared by the
@@ -37,6 +39,7 @@ use crate::theme;
 use crate::work_surface::sessions::SessionKind;
 use crate::work_surface::state as work_surface;
 
+pub mod custom_theme;
 pub mod state;
 pub mod store;
 

--- a/crates/app/src/settings/render.rs
+++ b/crates/app/src/settings/render.rs
@@ -1322,6 +1322,12 @@ impl AdeApp {
                         "Export current theme\u{2026}",
                         cx,
                         |this, cx| this.start_export_custom_theme(cx),
+                    ))
+                    .child(self.render_theme_action_button(
+                        "settings-theme-open-folder",
+                        "Open theme folder",
+                        cx,
+                        |this, cx| this.start_open_custom_themes_folder(cx),
                     )),
             );
 
@@ -1504,7 +1510,7 @@ impl AdeApp {
                         div()
                             .flex_1()
                             .min_w_0()
-                            .overflow_hidden()
+                            .truncate()
                             .font(font(theme::font::MONO))
                             .text_size(px(10.0))
                             .text_color(theme::text::FAINTER)
@@ -2542,6 +2548,41 @@ impl AdeApp {
     /// [`Self::apply_custom_theme_import_result`] applies the outcome once it resolves. A
     /// cancelled dialog (`Ok(Ok(None))`) or a platform error (`Err`/`Ok(Err(_))`) is a real,
     /// silent no-op - there is nothing wrong to report, the user simply didn't pick a file.
+    /// "Open theme folder" - hands the real custom-themes directory
+    /// ([`custom_theme::custom_themes_dir_for`]) to [`Self::open_path_with_os_handler`], the same
+    /// real per-platform default-open handler the file tree's "Reveal in file manager" already
+    /// uses. Creates the directory first if it doesn't exist yet, on the background executor
+    /// (never the GPUI foreground thread, matching every other real I/O in this module) - a user
+    /// who has never imported or created a custom theme has no real directory there otherwise,
+    /// and handing a nonexistent path to `xdg-open`/`open`/`cmd /c start` would just fail.
+    pub(in crate::settings) fn start_open_custom_themes_folder(&mut self, cx: &mut Context<Self>) {
+        let Some(settings_path) = self.settings_path.clone() else {
+            self.custom_theme_status = Some(Err(
+                "can't open the themes folder: no settings file location is known".to_string(),
+            ));
+            cx.notify();
+            return;
+        };
+        let dest_dir = custom_theme::custom_themes_dir_for(&settings_path);
+        cx.spawn(async move |this, cx| {
+            let mkdir_dir = dest_dir.clone();
+            let mkdir_result = cx
+                .background_executor()
+                .spawn(async move { std::fs::create_dir_all(&mkdir_dir) })
+                .await;
+            if let Err(err) = mkdir_result {
+                log::warn!(
+                    "failed to create the custom themes directory {}: {err}",
+                    dest_dir.display()
+                );
+            }
+            let _ = this.update(cx, |this, cx| {
+                this.open_path_with_os_handler(&dest_dir, cx);
+            });
+        })
+        .detach();
+    }
+
     pub(in crate::settings) fn start_import_custom_theme(&mut self, cx: &mut Context<Self>) {
         let paths_receiver = cx.prompt_for_paths(gpui::PathPromptOptions {
             files: true,

--- a/crates/app/src/settings/render.rs
+++ b/crates/app/src/settings/render.rs
@@ -1280,10 +1280,10 @@ impl AdeApp {
     /// GitHub issue #5: the "Custom themes" block - every real, disk-loaded
     /// [`custom_theme::CustomTheme`] as a card (same [`Self::render_theme_card`] used for the six
     /// built-ins, so a custom theme is visually a first-class citizen, not a second-tier list),
-    /// the real `Import theme…`/`Export current theme…` actions
-    /// ([`Self::start_import_custom_theme`]/[`Self::start_export_custom_theme`]), any real
-    /// load errors from the last time `Self::custom_themes` was populated, and the most recent
-    /// action's own real result.
+    /// the real `New from template…`/`Import theme…`/`Export current theme…` actions
+    /// ([`Self::start_create_theme_from_template`]/[`Self::start_import_custom_theme`]/
+    /// [`Self::start_export_custom_theme`]), any real load errors from the last time
+    /// `Self::custom_themes` was populated, and the most recent action's own real result.
     fn render_custom_themes_section(&self, cx: &mut Context<Self>) -> impl IntoElement {
         let has_custom = !self.custom_themes.is_empty();
 
@@ -1305,6 +1305,12 @@ impl AdeApp {
                 div()
                     .flex()
                     .gap(px(6.0))
+                    .child(self.render_theme_action_button(
+                        "settings-theme-new-from-template",
+                        "New from template\u{2026}",
+                        cx,
+                        |this, cx| this.start_create_theme_from_template(cx),
+                    ))
                     .child(self.render_theme_action_button(
                         "settings-theme-import",
                         "Import theme\u{2026}",
@@ -1348,8 +1354,9 @@ impl AdeApp {
                 .text_size(px(10.5))
                 .text_color(theme::text::DISABLED)
                 .child(format!(
-                    "No custom themes yet - Import a `.toml` theme file, or drop one into \
-                     {themes_dir}/."
+                    "No custom themes yet - click \u{201c}New from template\u{2026}\u{201d} for a \
+                     real, well-commented starting point, Import a `.toml` theme file, or drop \
+                     one into {themes_dir}/."
                 ))
         });
 
@@ -2606,12 +2613,38 @@ impl AdeApp {
         >,
         cx: &mut Context<Self>,
     ) {
+        self.apply_custom_theme_load_result(result, |name| format!("Imported \"{name}\"."), cx);
+    }
+
+    /// The real, shared "a background load-or-write-then-reload-from-disk action finished"
+    /// applier both [`Self::apply_custom_theme_import_result`] and
+    /// [`Self::apply_custom_theme_create_from_template_result`] go through - not two
+    /// independently-maintained copies of the same success/failure bookkeeping (registry
+    /// replacement, load-error replacement, status line, and - if the affected theme is the one
+    /// currently selected - an immediate re-skin via [`Self::apply_theme_selection`], matching
+    /// [`Self::apply_custom_theme_import_result`]'s own original "re-import the active theme"
+    /// fix). `success_message` is the one real difference between the two real callers: what the
+    /// status line should say for *this* action having succeeded.
+    #[allow(clippy::type_complexity)]
+    fn apply_custom_theme_load_result(
+        &mut self,
+        result: Result<
+            (
+                custom_theme::CustomTheme,
+                Vec<custom_theme::CustomTheme>,
+                Vec<String>,
+            ),
+            custom_theme::ThemeFileError,
+        >,
+        success_message: impl FnOnce(&str) -> String,
+        cx: &mut Context<Self>,
+    ) {
         match result {
-            Ok((imported, themes, errors)) => {
-                let name = imported.name;
+            Ok((theme, themes, errors)) => {
+                let name = theme.name;
                 self.custom_themes = themes;
                 self.custom_theme_load_errors = errors;
-                self.custom_theme_status = Some(Ok(format!("Imported \"{name}\".")));
+                self.custom_theme_status = Some(Ok(success_message(&name)));
                 if self.settings.theme.name == name {
                     self.apply_theme_selection(cx);
                 }
@@ -2621,6 +2654,65 @@ impl AdeApp {
             }
         }
         cx.notify();
+    }
+
+    /// GitHub issue #5 follow-up's real "New from template" action - writes the same real,
+    /// well-commented starting-point file the repository itself ships at
+    /// `assets/themes/template.toml` (`custom_theme::write_template_theme`, which embeds and
+    /// writes `custom_theme::CUSTOM_THEME_TEMPLATE_TOML` verbatim) straight into this instance's
+    /// own real custom-themes directory, then reloads the registry from disk - the same real
+    /// background-executor write-then-reload-from-disk shape
+    /// [`Self::start_import_custom_theme`] already uses, reusing the exact same
+    /// [`custom_theme::load_custom_themes_from_dir`] reload and
+    /// [`Self::apply_custom_theme_load_result`] applier, not a second, parallel path. Unlike
+    /// Import, there's no file-picker dialog to await first - the "file" being written is a
+    /// fixed, embedded constant, not something the user picks - so this goes straight to the
+    /// background executor.
+    pub(in crate::settings) fn start_create_theme_from_template(&mut self, cx: &mut Context<Self>) {
+        let Some(settings_path) = self.settings_path.clone() else {
+            self.custom_theme_status = Some(Err(
+                "can't create a theme: no settings file location is known".to_string(),
+            ));
+            cx.notify();
+            return;
+        };
+        let task = cx.spawn(async move |this, cx| {
+            let dest_dir = custom_theme::custom_themes_dir_for(&settings_path);
+            let result = cx
+                .background_executor()
+                .spawn(async move {
+                    let created = custom_theme::write_template_theme(&dest_dir)?;
+                    let (themes, errors) = custom_theme::load_custom_themes_from_dir(&dest_dir);
+                    Ok((created, themes, errors))
+                })
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                this.apply_custom_theme_create_from_template_result(result, cx);
+            });
+        });
+        self._custom_theme_create_task = Some(task);
+    }
+
+    /// Applies [`Self::start_create_theme_from_template`]'s real result - shared with nothing
+    /// else but [`Self::apply_custom_theme_load_result`]'s own common bookkeeping.
+    #[allow(clippy::type_complexity)]
+    fn apply_custom_theme_create_from_template_result(
+        &mut self,
+        result: Result<
+            (
+                custom_theme::CustomTheme,
+                Vec<custom_theme::CustomTheme>,
+                Vec<String>,
+            ),
+            custom_theme::ThemeFileError,
+        >,
+        cx: &mut Context<Self>,
+    ) {
+        self.apply_custom_theme_load_result(
+            result,
+            |name| format!("Created \"{name}\" from the template."),
+            cx,
+        );
     }
 
     /// GitHub issue #5's real "Export current theme…" action - serializes whichever theme
@@ -4141,6 +4233,158 @@ mod custom_theme_settings_tests {
             app.read_with(cx, |app, _| app._custom_theme_export_task.is_some()),
             "a real click on the button must actually invoke Self::start_export_custom_theme, \
              not silently do nothing"
+        );
+    }
+
+    /// The full real, click-driven "New from template" round trip - not just "the handler was
+    /// reached" (unlike the Import/Export click tests above, this action has no file-picker
+    /// dialog to get stuck awaiting, so a real click here really can run to completion under
+    /// `cx.run_until_parked()`): a genuine click on the button writes the real template file to
+    /// disk, the resulting theme actually renders as a selectable Themes-page card (not just data
+    /// sitting unrendered in `Self::custom_themes`), selecting that card really re-skins the app,
+    /// and the two-click Remove affordance on it really deletes the file again - proving this
+    /// isn't a decorative button bound to nothing.
+    #[gpui::test]
+    fn clicking_new_from_template_creates_a_real_selectable_removable_theme_end_to_end(
+        cx: &mut TestAppContext,
+    ) {
+        let _guard = ResetThemeStateOnDrop;
+        let repo = tempfile::tempdir().expect("tempdir");
+        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+        let themes_dir = settings_dir.path().join("themes");
+        let (app, cx) = open_test_app_with_real_settings_path(
+            cx,
+            repo.path().to_path_buf(),
+            settings_store::Settings::default(),
+            settings_path.clone(),
+        );
+        cx.dispatch_action(ToggleSettings);
+        app.update_in(cx, |app, window, cx| {
+            app.select_settings_page(SettingsPage::Theme, window, cx);
+        });
+        cx.run_until_parked();
+
+        assert!(
+            app.read_with(cx, |app, _| app.custom_themes.is_empty()),
+            "sanity check: no custom theme should exist before the click"
+        );
+
+        // The real click.
+        let create_bounds = cx
+            .debug_bounds("settings-theme-new-from-template")
+            .expect("the New from template… button must have painted");
+        cx.simulate_click(create_bounds.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        // The real file landed on disk, at the real settings-sibling themes directory.
+        let written_path = themes_dir.join("my-custom-theme.toml");
+        assert!(
+            written_path.exists(),
+            "a real click must actually write the template file to the real custom-themes \
+             directory, not just update in-memory state"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&written_path).expect("read written template"),
+            custom_theme::CUSTOM_THEME_TEMPLATE_TOML,
+            "the written file must be the real template's own bytes, comments included"
+        );
+        assert_eq!(app.read_with(cx, |app, _| app.custom_themes.len()), 1);
+        let status = app.read_with(cx, |app, _| app.custom_theme_status.clone());
+        assert!(
+            matches!(status, Some(Ok(_))),
+            "a real successful create-from-template should report a real success status, got \
+             {status:?}"
+        );
+
+        // It really renders as a selectable card, not just data.
+        assert!(
+            cx.debug_bounds("settings-theme-card-My Custom Theme")
+                .is_some(),
+            "the created theme must actually render as a card on the Themes page"
+        );
+
+        // Selecting it really re-skins the app and persists.
+        let jerry_dark_window_bg = theme::surface::WINDOW.resolve();
+        let card_bounds = cx
+            .debug_bounds("settings-theme-card-My Custom Theme")
+            .expect("card must still be painted");
+        cx.simulate_click(card_bounds.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.settings.theme.name.clone()),
+            "My Custom Theme"
+        );
+        assert!(
+            theme::surface::WINDOW.resolve() != jerry_dark_window_bg,
+            "selecting the template-created theme must really change what a representative \
+             colour token resolves to"
+        );
+
+        // And it's really removable: first click arms, second click deletes.
+        let remove_bounds = cx
+            .debug_bounds("settings-theme-card-remove-My Custom Theme")
+            .expect("the Remove affordance must have painted");
+        cx.simulate_click(remove_bounds.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.custom_theme_remove_armed.clone()),
+            Some("My Custom Theme".to_string())
+        );
+        let confirm_bounds = cx
+            .debug_bounds("settings-theme-card-remove-My Custom Theme")
+            .expect("the button must still be painted, now reading Confirm?");
+        cx.simulate_click(confirm_bounds.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        assert!(
+            !written_path.exists(),
+            "confirming Remove must really delete the real backing file"
+        );
+        assert!(app.read_with(cx, |app, _| app.custom_themes.is_empty()));
+        assert_eq!(
+            app.read_with(cx, |app, _| app.settings.theme.name.clone()),
+            "Jerry Dark",
+            "removing the currently-selected theme must fall back to Jerry Dark"
+        );
+    }
+
+    /// A second real click on "New from template" refreshes the same on-disk file rather than
+    /// creating a second, differently-suffixed one - matching
+    /// `custom_theme::write_template_theme_a_second_time_refreshes_the_same_file_not_a_new_one`'s
+    /// pure-function proof, exercised here through the real button instead.
+    #[gpui::test]
+    fn clicking_new_from_template_twice_refreshes_the_same_file_not_a_duplicate(
+        cx: &mut TestAppContext,
+    ) {
+        let _guard = ResetThemeStateOnDrop;
+        let repo = tempfile::tempdir().expect("tempdir");
+        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+        let (app, cx) = open_test_app_with_real_settings_path(
+            cx,
+            repo.path().to_path_buf(),
+            settings_store::Settings::default(),
+            settings_path,
+        );
+        cx.dispatch_action(ToggleSettings);
+        app.update_in(cx, |app, window, cx| {
+            app.select_settings_page(SettingsPage::Theme, window, cx);
+        });
+        cx.run_until_parked();
+
+        for _ in 0..2 {
+            let create_bounds = cx
+                .debug_bounds("settings-theme-new-from-template")
+                .expect("the New from template… button must have painted");
+            cx.simulate_click(create_bounds.center(), gpui::Modifiers::none());
+            cx.run_until_parked();
+        }
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.custom_themes.len()),
+            1,
+            "clicking New from template twice must not leave two entries behind"
         );
     }
 

--- a/crates/app/src/settings/render.rs
+++ b/crates/app/src/settings/render.rs
@@ -3867,12 +3867,16 @@ mod custom_theme_settings_tests {
         });
         let original = theme::surface::WINDOW.resolve();
 
-        // Re-import the same theme under a different background swatch.
+        // Re-import the same theme under a different background swatch - deliberately near-black
+        // (`#050505`), not an arbitrary colour: it must still clear the real panel/background
+        // readability floor `CustomThemeFile::validate_with_builtin_check` enforces (see
+        // `custom_theme::readability_floor_per_mille`'s own docs), or this re-import would be a
+        // real, correct rejection rather than the re-skin this test means to exercise.
         let source_dir = tempfile::tempdir().expect("tempdir");
         let source_path = source_dir.path().join("picked.toml");
         std::fs::write(
             &source_path,
-            MIDNIGHT_CORAL_TOML.replace("#0c0d10", "#301010"),
+            MIDNIGHT_CORAL_TOML.replace("#0c0d10", "#050505"),
         )
         .expect("write updated source");
         let result = custom_theme::import_theme_file(&source_path, &dest_dir).map(|imported| {

--- a/crates/app/src/settings/render.rs
+++ b/crates/app/src/settings/render.rs
@@ -62,6 +62,12 @@ impl AdeApp {
         if self.settings_page == SettingsPage::Keymap && page != SettingsPage::Keymap {
             window.focus(&self.settings_focus_handle, cx);
         }
+        if page != SettingsPage::Theme {
+            // See `Self::custom_theme_remove_armed`'s own docs - the confirm-arm is scoped to
+            // this one page, so leaving it (even to come straight back) must not leave a stale
+            // arm ready to fire on whatever card happens to render in the same position.
+            self.custom_theme_remove_armed = None;
+        }
         self.settings_page = page;
         cx.notify();
     }
@@ -268,7 +274,11 @@ impl AdeApp {
                 // Live counts, not Jerry.dc.html's fabricated sample badges (Keybindings' mockup
                 // `48` doesn't match this app's real, smaller count - see
                 // `crate::settings::state::keybinding_rows`'s own docs).
-                SettingsPage::Theme => Some(settings::THEME_DEFS.len().to_string()),
+                // Built-in + real, disk-loaded custom themes (GitHub issue #5) - one combined
+                // count, matching `Self::render_settings_theme_page`'s own combined card list.
+                SettingsPage::Theme => {
+                    Some((settings::THEME_DEFS.len() + self.custom_themes.len()).to_string())
+                }
                 SettingsPage::Keymap => Some(
                     settings::keybinding_rows(
                         &crate::default_key_bindings(),
@@ -1206,11 +1216,14 @@ impl AdeApp {
         &self,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        let cards = div().flex().flex_wrap().gap(px(8.0)).children(
-            settings::THEME_DEFS
-                .iter()
-                .map(|def| self.render_theme_card(def, cx)),
-        );
+        let builtin_cards =
+            div()
+                .flex()
+                .flex_wrap()
+                .gap(px(8.0))
+                .children(settings::THEME_DEFS.iter().map(|def| {
+                    self.render_theme_card(def.name, def.subtitle, def.swatches, false, cx)
+                }));
 
         let follow_system_row = self.render_settings_row(
             "Follow system appearance",
@@ -1247,7 +1260,8 @@ impl AdeApp {
                     .text_color(theme::palette::GROUP_HEADER)
                     .child("Installed themes"),
             )
-            .child(cards)
+            .child(builtin_cards)
+            .child(self.render_custom_themes_section(cx))
             .child(
                 div()
                     .pt(px(20.0))
@@ -1263,16 +1277,176 @@ impl AdeApp {
             .child(self.render_snippet_block(settings_store::ConfigPage::Theme))
     }
 
+    /// GitHub issue #5: the "Custom themes" block - every real, disk-loaded
+    /// [`custom_theme::CustomTheme`] as a card (same [`Self::render_theme_card`] used for the six
+    /// built-ins, so a custom theme is visually a first-class citizen, not a second-tier list),
+    /// the real `Import theme…`/`Export current theme…` actions
+    /// ([`Self::start_import_custom_theme`]/[`Self::start_export_custom_theme`]), any real
+    /// load errors from the last time `Self::custom_themes` was populated, and the most recent
+    /// action's own real result.
+    fn render_custom_themes_section(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let has_custom = !self.custom_themes.is_empty();
+
+        let header_row = div()
+            .flex()
+            .items_center()
+            .justify_between()
+            .pt(px(20.0))
+            .pb(px(6.0))
+            .child(
+                div()
+                    .font(font(theme::font::SANS))
+                    .font_weight(gpui::FontWeight::SEMIBOLD)
+                    .text_size(px(9.5))
+                    .text_color(theme::palette::GROUP_HEADER)
+                    .child("Custom themes"),
+            )
+            .child(
+                div()
+                    .flex()
+                    .gap(px(6.0))
+                    .child(self.render_theme_action_button(
+                        "settings-theme-import",
+                        "Import theme\u{2026}",
+                        cx,
+                        |this, cx| this.start_import_custom_theme(cx),
+                    ))
+                    .child(self.render_theme_action_button(
+                        "settings-theme-export",
+                        "Export current theme\u{2026}",
+                        cx,
+                        |this, cx| this.start_export_custom_theme(cx),
+                    )),
+            );
+
+        let cards = div()
+            .flex()
+            .flex_wrap()
+            .gap(px(8.0))
+            .children(self.custom_themes.iter().map(|theme| {
+                self.render_theme_card(&theme.name, &theme.subtitle, theme.swatches, true, cx)
+            }));
+
+        let empty_state = (!has_custom).then(|| {
+            // The real directory this instance actually loads from
+            // (`crate::settings::custom_theme::custom_themes_dir_for`, derived from
+            // `Self::settings_path`) - not a hardcoded `~/.config/jerry/themes/` string, which
+            // would have been wrong for anything other than the one real production settings
+            // path.
+            let themes_dir = self
+                .settings_path
+                .as_deref()
+                .map(|path| {
+                    custom_theme::custom_themes_dir_for(path)
+                        .display()
+                        .to_string()
+                })
+                .unwrap_or_else(|| "~/.config/jerry/themes".to_string());
+            div()
+                .py(px(10.0))
+                .font(font(theme::font::MONO))
+                .text_size(px(10.5))
+                .text_color(theme::text::DISABLED)
+                .child(format!(
+                    "No custom themes yet - Import a `.toml` theme file, or drop one into \
+                     {themes_dir}/."
+                ))
+        });
+
+        let load_errors = (!self.custom_theme_load_errors.is_empty()).then(|| {
+            div().flex().flex_col().gap(px(2.0)).pt(px(6.0)).children(
+                self.custom_theme_load_errors.iter().map(|message| {
+                    div()
+                        .font(font(theme::font::MONO))
+                        .text_size(px(10.0))
+                        .text_color(theme::status::ASK)
+                        .child(format!("skipped: {message}"))
+                }),
+            )
+        });
+
+        let status = self.custom_theme_status.as_ref().map(|result| {
+            let (text, color) = match result {
+                Ok(message) => (message.clone(), theme::status::REVIEW),
+                Err(message) => (message.clone(), theme::status::FAIL),
+            };
+            div()
+                .pt(px(6.0))
+                .font(font(theme::font::MONO))
+                .text_size(px(10.0))
+                .text_color(color)
+                .child(text)
+        });
+
+        div()
+            .flex()
+            .flex_col()
+            .child(header_row)
+            .children(empty_state)
+            .child(cards)
+            .children(load_errors)
+            .children(status)
+    }
+
+    /// A small bordered text button, matching [`Self::render_config_banner`]'s own `Open file`
+    /// button shape - the real trigger for [`Self::start_import_custom_theme`]/
+    /// [`Self::start_export_custom_theme`].
+    fn render_theme_action_button(
+        &self,
+        id: &'static str,
+        label: &'static str,
+        cx: &mut Context<Self>,
+        on_click: impl Fn(&mut Self, &mut Context<Self>) + 'static,
+    ) -> impl IntoElement {
+        div()
+            .id(id)
+            .debug_selector(move || id.to_string())
+            .cursor_pointer()
+            .h(px(20.0))
+            .px(px(8.0))
+            .rounded(theme::radius::BUTTON)
+            .border_1()
+            .border_color(theme::border::BUTTON)
+            .flex()
+            .items_center()
+            .font(font(theme::font::SANS))
+            .font_weight(gpui::FontWeight::MEDIUM)
+            .text_size(px(10.5))
+            .text_color(theme::text::MUTED)
+            .hover(|el| el.bg(theme::surface::ROW_HOVER_ALT))
+            .child(label)
+            .on_click(cx.listener(move |this, _event: &ClickEvent, _window, cx| {
+                on_click(this, cx);
+            }))
+    }
+
+    /// Renders one Themes-page card - shared by built-in (`settings::THEME_DEFS`) and real,
+    /// disk-loaded custom (`Self::custom_themes`) themes alike, so the two read as one combined
+    /// list rather than a first-class set and a second-tier one (GitHub issue #5). `is_custom`
+    /// only controls whether a `Remove` affordance is shown - `crate::settings::custom_theme`'s
+    /// own validation already guarantees a custom theme's `name` can never collide with a
+    /// built-in's, so no other branch needs it.
     fn render_theme_card(
         &self,
-        def: &settings::ThemeDef,
+        name: &str,
+        subtitle: &str,
+        swatches: [u32; 5],
+        is_custom: bool,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        let is_selected = def.name == self.settings.theme.name;
-        let name = def.name;
+        let is_selected = name == self.settings.theme.name;
+        let is_remove_armed = self.custom_theme_remove_armed.as_deref() == Some(name);
+        let name = name.to_string();
+        let name_for_click = name.clone();
+        let name_for_remove = name.clone();
+        let name_for_selector = name.clone();
 
         div()
             .id(format!("settings-theme-card-{name}"))
+            // Test-only, no-op in release builds - lets `VisualTestContext::debug_bounds` (keyed
+            // by this, not `.id`) confirm a real theme (built-in or custom) actually renders as
+            // its own card, matching `Self::render_settings_lsp_row`'s identical convention.
+            .debug_selector(move || format!("settings-theme-card-{name_for_selector}"))
             .cursor_pointer()
             .w(px(212.0))
             .rounded(theme::radius::CARD)
@@ -1293,7 +1467,7 @@ impl AdeApp {
             })
             .child(
                 div().h(px(34.0)).flex().children(
-                    def.swatches
+                    swatches
                         .iter()
                         .map(|hex| div().flex_1().bg(gpui::rgb(*hex))),
                 ),
@@ -1317,7 +1491,7 @@ impl AdeApp {
                             } else {
                                 theme::text::BODY
                             })
-                            .child(name),
+                            .child(name.clone()),
                     )
                     .child(
                         div()
@@ -1327,7 +1501,7 @@ impl AdeApp {
                             .font(font(theme::font::MONO))
                             .text_size(px(10.0))
                             .text_color(theme::text::FAINTER)
-                            .child(def.subtitle),
+                            .child(subtitle.to_string()),
                     )
                     .when(is_selected, |el| {
                         el.child(
@@ -1339,10 +1513,64 @@ impl AdeApp {
                                 .text_color(theme::status::REVIEW)
                                 .child("in use"),
                         )
+                    })
+                    .when(is_custom, |el| {
+                        // Not `move` - see `crate::settings::render::AdeApp::
+                        // render_settings_lsp_row`'s identical `let install_url = row.install_url;`
+                        // pattern this mirrors: a fresh owned clone taken *inside* the closure
+                        // body, so only the innermost `cx.listener` closure (which really is
+                        // `move`, since a `gpui::Context::listener` callback must own what it
+                        // captures) takes `name_for_remove` by value - the outer `.when` closure
+                        // stays a plain borrow, leaving `cx` itself free for the row's own
+                        // `on_click` below.
+                        //
+                        // Shown even for the currently-*selected* custom theme (an audit caught
+                        // an earlier version that hid this whenever `is_selected`, making the
+                        // active theme's own file permanently undeletable from the UI) - a real
+                        // two-click confirm (`Self::request_remove_custom_theme`) is the guard
+                        // against an accidental single click, not "only show it somewhere less
+                        // reachable".
+                        let name_for_remove = name_for_remove.clone();
+                        let name_for_remove_selector = name_for_remove.clone();
+                        let label = if is_remove_armed {
+                            "Confirm?"
+                        } else {
+                            "Remove"
+                        };
+                        el.child(
+                            div()
+                                .id(format!("settings-theme-card-remove-{name_for_remove}"))
+                                // Test-only, no-op in release builds - lets a real, click-driven
+                                // interaction test (`VisualTestContext::debug_bounds` +
+                                // `simulate_click`) find and click this exact button, proving
+                                // `cx.stop_propagation()` above genuinely beats the card's own
+                                // `on_click` rather than that only being verified by reading
+                                // GPUI's dispatch source.
+                                .debug_selector(move || {
+                                    format!("settings-theme-card-remove-{name_for_remove_selector}")
+                                })
+                                .cursor_pointer()
+                                .flex_none()
+                                .font(font(theme::font::SANS))
+                                .font_weight(gpui::FontWeight::MEDIUM)
+                                .text_size(px(9.0))
+                                .text_color(theme::button::DANGER_FG)
+                                .hover(|el| el.text_color(theme::button::DANGER_FG_HOVER))
+                                .child(label)
+                                .on_click(cx.listener(
+                                    move |this, _event: &ClickEvent, _window, cx| {
+                                        cx.stop_propagation();
+                                        this.request_remove_custom_theme(
+                                            name_for_remove.clone(),
+                                            cx,
+                                        );
+                                    },
+                                )),
+                        )
                     }),
             )
             .on_click(cx.listener(move |this, _event: &ClickEvent, _window, cx| {
-                this.set_theme_name(name.to_string(), cx);
+                this.set_theme_name(name_for_click.clone(), cx);
             }))
     }
 
@@ -2202,19 +2430,43 @@ impl AdeApp {
         cx.notify();
     }
 
-    /// A real theme card click - persists the name *and* actually re-skins the running app (see
-    /// [`Self::render_settings_theme_page`]'s own docs). Also updates
-    /// `Settings.theme.last_dark_theme` whenever `name` isn't `"Paper"` (the one real light
-    /// theme) - see that field's own docs for the real data-loss bug this fixes for
+    /// A real theme card click (built-in or custom - see
+    /// [`Self::render_settings_theme_page`]'s own docs) - persists the name *and* actually
+    /// re-skins the running app. Also updates `Settings.theme.last_dark_theme` whenever the
+    /// newly selected theme isn't a light one (`crate::theme::theme_is_light`, generalized from
+    /// the old hardcoded `name == "Paper"` check so a custom light theme is remembered correctly
+    /// too) - see that field's own docs for the real data-loss bug this fixes for
     /// `follow_system`.
     fn set_theme_name(&mut self, name: String, cx: &mut Context<Self>) {
-        if name != "Paper" {
+        let is_light = self
+            .theme_swatches_for(&name)
+            .map(theme::theme_is_light)
+            .unwrap_or(false);
+        if !is_light {
             self.settings.theme.last_dark_theme = name.clone();
         }
         self.settings.theme.name = name;
         self.apply_theme_selection(cx);
         self.persist_settings(cx);
         cx.notify();
+    }
+
+    /// Real, single lookup used by both [`Self::apply_theme_selection`] (which colour palette is
+    /// live) and [`Self::set_theme_name`] (is the newly selected theme light, for
+    /// `last_dark_theme` bookkeeping) - looks up `name` first against the six built-in
+    /// `settings::THEME_DEFS`, then against [`Self::custom_themes`], so the two callers can never
+    /// resolve a name differently.
+    fn theme_swatches_for(&self, name: &str) -> Option<[u32; 5]> {
+        settings::THEME_DEFS
+            .iter()
+            .find(|def| def.name == name)
+            .map(|def| def.swatches)
+            .or_else(|| {
+                self.custom_themes
+                    .iter()
+                    .find(|theme| theme.name == name)
+                    .map(|theme| theme.swatches)
+            })
     }
 
     /// Turning this on immediately syncs to the real, current OS appearance
@@ -2238,20 +2490,307 @@ impl AdeApp {
         cx.notify();
     }
 
-    /// Applies `self.settings.theme.name` as the real, live-selected theme
-    /// (`crate::theme::set_current_theme_index`) and forces a real full repaint
-    /// (`App::refresh_windows`, `vendor/zed/crates/gpui/src/app.rs:1025`) so every
+    /// Applies `self.settings.theme.name` as the real, live-selected theme and forces a real full
+    /// repaint (`App::refresh_windows`, `vendor/zed/crates/gpui/src/app.rs:1025`) so every
     /// already-rendered surface - not just ones that happen to re-render for some other reason -
-    /// picks up the new colours on the very next frame. An unrecognized `theme.name` (only
-    /// reachable via a hand-edited `settings.toml`) falls back to index `0` (Jerry Dark) rather
-    /// than leaving the previous theme's index in place unnoticed.
+    /// picks up the new colours on the very next frame.
+    ///
+    /// Checks the six built-in `settings::THEME_DEFS` first, then [`Self::custom_themes`]
+    /// (GitHub issue #5) - a built-in name always wins if both somehow matched, though
+    /// `crate::settings::custom_theme::CustomThemeFile::validate` already rejects a custom theme
+    /// whose name collides with a built-in one, so that's not actually reachable outside a
+    /// theoretical race with a hand-edited file. A name matching neither (only reachable via a
+    /// hand-edited `settings.toml`, or a custom theme file that's since been deleted) falls back
+    /// to index `0` (Jerry Dark) rather than leaving the previous theme's index in place
+    /// unnoticed. [`crate::theme::set_current_theme_index`]/[`crate::theme::
+    /// set_current_custom_theme`] are always written together here - see the latter's own docs
+    /// for why `crate::theme::ColorToken::resolve` depends on that.
     pub(crate) fn apply_theme_selection(&self, cx: &mut Context<Self>) {
-        let index = settings::THEME_DEFS
+        let name = self.settings.theme.name.as_str();
+        if let Some(index) = settings::THEME_DEFS.iter().position(|def| def.name == name) {
+            theme::set_current_theme_index(index);
+            theme::set_current_custom_theme(None);
+        } else if let Some(swatches) = self
+            .custom_themes
             .iter()
-            .position(|def| def.name == self.settings.theme.name)
-            .unwrap_or(0);
-        theme::set_current_theme_index(index);
+            .find(|theme| theme.name == name)
+            .map(|theme| theme.swatches)
+        {
+            theme::set_current_theme_index(0);
+            theme::set_current_custom_theme(Some(swatches));
+        } else {
+            theme::set_current_theme_index(0);
+            theme::set_current_custom_theme(None);
+        }
         cx.refresh_windows();
+    }
+
+    /// GitHub issue #5's real "Import theme…" action - a genuine native file-open dialog
+    /// (`gpui::App::prompt_for_paths`, `vendor/zed/crates/gpui/src/app.rs:1490` - the same real
+    /// API `vendor/zed/crates/agent_ui/src/threads_archive_view.rs`'s own `open_local_folder`
+    /// uses, verified there before writing this), not a synthetic path. The user picks any real
+    /// `.toml` file on disk; the actual import+reload runs on the background executor (matching
+    /// [`Self::start_export_custom_theme`]'s own convention - an adversarial audit caught the
+    /// first version of this doing synchronous foreground-thread I/O instead), and
+    /// [`Self::apply_custom_theme_import_result`] applies the outcome once it resolves. A
+    /// cancelled dialog (`Ok(Ok(None))`) or a platform error (`Err`/`Ok(Err(_))`) is a real,
+    /// silent no-op - there is nothing wrong to report, the user simply didn't pick a file.
+    pub(in crate::settings) fn start_import_custom_theme(&mut self, cx: &mut Context<Self>) {
+        let paths_receiver = cx.prompt_for_paths(gpui::PathPromptOptions {
+            files: true,
+            directories: false,
+            multiple: false,
+            prompt: Some("Import".into()),
+        });
+        // Same seam `Self::custom_themes` was populated through at construction time
+        // (`crate::root::AdeApp::new_with_settings`) - a test instance (`settings_path == None`)
+        // has nowhere real to import into, matching its own real "no persistence" contract.
+        let settings_path = self.settings_path.clone();
+        let task = cx.spawn(async move |this, cx| {
+            let Ok(Ok(Some(mut paths))) = paths_receiver.await else {
+                return;
+            };
+            let Some(source_path) = paths.pop() else {
+                return;
+            };
+            let Some(settings_path) = settings_path else {
+                let _ = this.update(cx, |this, cx| {
+                    this.custom_theme_status = Some(Err(
+                        "can't import a theme: no settings file location is known".to_string(),
+                    ));
+                    cx.notify();
+                });
+                return;
+            };
+            let dest_dir = custom_theme::custom_themes_dir_for(&settings_path);
+            let result = cx
+                .background_executor()
+                .spawn(async move {
+                    let imported = custom_theme::import_theme_file(&source_path, &dest_dir)?;
+                    // Reload from disk rather than manually splicing the in-memory list - an
+                    // adversarial audit caught the previous `retain` + `push` version drifting
+                    // from what's actually on disk whenever `import_theme_file` itself resolved
+                    // a slug collision to a *different* path than the naive one (see that
+                    // function's own docs), and it also left stale `custom_theme_load_errors`
+                    // (e.g. a since-fixed duplicate-name warning) on screen forever.
+                    let (themes, errors) = custom_theme::load_custom_themes_from_dir(&dest_dir);
+                    Ok((imported, themes, errors))
+                })
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                this.apply_custom_theme_import_result(result, cx);
+            });
+        });
+        self._custom_theme_import_task = Some(task);
+    }
+
+    /// Applies [`Self::start_import_custom_theme`]'s real background-executor result - shared
+    /// with nothing else (there is exactly one real caller). On success, re-loads
+    /// [`Self::custom_themes`]/[`Self::custom_theme_load_errors`] wholesale from what's actually
+    /// on disk (see [`Self::start_import_custom_theme`]'s own docs for why), and - if the
+    /// imported theme is the one currently selected (a real "re-import to update my colours"
+    /// flow) - immediately re-applies it via [`Self::apply_theme_selection`] rather than leaving
+    /// the app rendering the *old* palette until the next restart (a real bug an adversarial
+    /// audit caught: the card would redraw with the new swatches and an "in use" badge while
+    /// every other surface stayed on the stale colours).
+    #[allow(clippy::type_complexity)]
+    fn apply_custom_theme_import_result(
+        &mut self,
+        result: Result<
+            (
+                custom_theme::CustomTheme,
+                Vec<custom_theme::CustomTheme>,
+                Vec<String>,
+            ),
+            custom_theme::ThemeFileError,
+        >,
+        cx: &mut Context<Self>,
+    ) {
+        match result {
+            Ok((imported, themes, errors)) => {
+                let name = imported.name;
+                self.custom_themes = themes;
+                self.custom_theme_load_errors = errors;
+                self.custom_theme_status = Some(Ok(format!("Imported \"{name}\".")));
+                if self.settings.theme.name == name {
+                    self.apply_theme_selection(cx);
+                }
+            }
+            Err(err) => {
+                self.custom_theme_status = Some(Err(err.to_string()));
+            }
+        }
+        cx.notify();
+    }
+
+    /// GitHub issue #5's real "Export current theme…" action - serializes whichever theme
+    /// (built-in or custom) is currently active to a real file at a location the user picks via a
+    /// genuine native save dialog (`gpui::App::prompt_for_new_path`,
+    /// `vendor/zed/crates/gpui/src/app.rs:1503` - verified against
+    /// `vendor/zed/crates/miniprofiler_ui/src/miniprofiler_ui.rs`'s own real caller before writing
+    /// this). The real file write itself runs on the background executor, matching every other
+    /// disk write in this codebase (`crate::settings::store::Settings::save_at`'s own callers).
+    ///
+    /// A built-in theme is exported under `"<name> (copy)"`, never its own bare built-in name -
+    /// `crate::settings::custom_theme::CustomThemeFile::validate` unconditionally rejects any
+    /// file whose `name` collides with a `settings::THEME_DEFS` entry, so exporting e.g. "Slate"
+    /// verbatim would produce a file this app (the exporter's own, or anyone it's shared with)
+    /// can never actually import back - a real "looks like it worked, quietly can't be used"
+    /// bug an adversarial audit caught. A custom theme keeps its own name, so re-importing an
+    /// unmodified export is a real no-op "update" rather than spawning a `(copy)` duplicate.
+    pub(in crate::settings) fn start_export_custom_theme(&mut self, cx: &mut Context<Self>) {
+        let active_name = self.settings.theme.name.clone();
+        let Some(swatches) = self.theme_swatches_for(&active_name) else {
+            self.custom_theme_status = Some(Err(format!(
+                "can't export: no theme named \"{active_name}\" is currently loaded"
+            )));
+            cx.notify();
+            return;
+        };
+        let export_name = export_theme_name_for(active_name.as_str());
+        let subtitle = self
+            .custom_themes
+            .iter()
+            .find(|theme| theme.name == active_name)
+            .map(|theme| theme.subtitle.clone())
+            .or_else(|| {
+                settings::THEME_DEFS
+                    .iter()
+                    .find(|def| def.name == active_name)
+                    .map(|def| def.subtitle.to_string())
+            })
+            .unwrap_or_default();
+        let export_theme = custom_theme::CustomTheme {
+            name: export_name.clone(),
+            subtitle,
+            swatches,
+            source_path: None,
+        };
+        let default_dir = std::env::var_os("HOME")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_default();
+        // Reuses `crate::settings::custom_theme::slugify` rather than a second, hand-rolled
+        // implementation - an adversarial audit caught the original inline `.replace(...)` here
+        // disagreeing with the real one on e.g. runs of punctuation, so the suggested filename
+        // and the filename `import_theme_file` would actually pick on re-import could differ.
+        let suggested_name = format!("{}.toml", custom_theme::slugify(&export_name));
+        let path_receiver = cx.prompt_for_new_path(&default_dir, Some(suggested_name.as_str()));
+        let task = cx.spawn(async move |this, cx| {
+            let Ok(Ok(Some(dest_path))) = path_receiver.await else {
+                return;
+            };
+            let write_result = cx
+                .background_executor()
+                .spawn(async move {
+                    custom_theme::export_theme_to_path(&export_theme, &dest_path).map(|_| dest_path)
+                })
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                match write_result {
+                    Ok(path) => {
+                        this.custom_theme_status =
+                            Some(Ok(format!("Exported to {}.", path.display())));
+                    }
+                    Err(err) => {
+                        this.custom_theme_status =
+                            Some(Err(format!("couldn't export the theme: {err}")));
+                    }
+                }
+                cx.notify();
+            });
+        });
+        self._custom_theme_export_task = Some(task);
+    }
+
+    /// The Themes page's "Remove" action on a custom theme card - real two-click confirmation via
+    /// [`Self::custom_theme_remove_armed`] (see that field's own docs for why: an adversarial
+    /// audit caught the first version of this deleting the user's file on a single click, unlike
+    /// every other destructive action in this app). The first click on a given `name` only arms
+    /// it; a second click on the *same* name actually deletes
+    /// ([`Self::execute_remove_custom_theme`]) - mirroring
+    /// `crate::worktree_history::flow::AdeApp::request_discard_worktree`'s identical shape.
+    fn request_remove_custom_theme(&mut self, name: String, cx: &mut Context<Self>) {
+        if self.custom_theme_remove_armed.as_deref() != Some(name.as_str()) {
+            self.custom_theme_remove_armed = Some(name);
+            cx.notify();
+            return;
+        }
+        self.custom_theme_remove_armed = None;
+        self.execute_remove_custom_theme(name, cx);
+    }
+
+    /// Runs the real, already-confirmed removal - only ever reached through
+    /// [`Self::request_remove_custom_theme`]'s second click. Deletes the theme's real backing
+    /// file (`crate::settings::custom_theme::remove_custom_theme_file`) on the background
+    /// executor, then reloads [`Self::custom_themes`]/[`Self::custom_theme_load_errors`] fresh
+    /// from disk (same "never manually splice, always re-read" discipline as
+    /// [`Self::apply_custom_theme_import_result`]). If the removed theme was the active
+    /// selection, falls back to `"Jerry Dark"`; if it was also the remembered
+    /// `Settings.theme.last_dark_theme`, that is reset too - an adversarial audit caught the
+    /// first version leaving a dangling `last_dark_theme` that a later real OS-dark
+    /// `follow_system` signal (`Self::apply_follow_system_appearance`) would have written straight
+    /// back into `Settings.theme.name`, resolving to nothing and silently landing back on Jerry
+    /// Dark with no visible error - exactly the "dangling selection" this method's remaining
+    /// fallback logic is meant to prevent.
+    fn execute_remove_custom_theme(&mut self, name: String, cx: &mut Context<Self>) {
+        let Some(theme) = self
+            .custom_themes
+            .iter()
+            .find(|theme| theme.name == name)
+            .cloned()
+        else {
+            return;
+        };
+        let Some(settings_path) = self.settings_path.clone() else {
+            self.custom_theme_status = Some(Err(
+                "can't remove a theme: no settings file location is known".to_string(),
+            ));
+            cx.notify();
+            return;
+        };
+        let task = cx.spawn(async move |this, cx| {
+            let dest_dir = custom_theme::custom_themes_dir_for(&settings_path);
+            let result = cx
+                .background_executor()
+                .spawn(async move {
+                    custom_theme::remove_custom_theme_file(&theme)?;
+                    Ok(custom_theme::load_custom_themes_from_dir(&dest_dir))
+                })
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                this.apply_custom_theme_remove_result(name, result, cx);
+            });
+        });
+        self._custom_theme_remove_task = Some(task);
+    }
+
+    /// Applies [`Self::execute_remove_custom_theme`]'s real result - shared with nothing else.
+    #[allow(clippy::type_complexity)]
+    fn apply_custom_theme_remove_result(
+        &mut self,
+        name: String,
+        result: std::io::Result<(Vec<custom_theme::CustomTheme>, Vec<String>)>,
+        cx: &mut Context<Self>,
+    ) {
+        match result {
+            Ok((themes, errors)) => {
+                self.custom_themes = themes;
+                self.custom_theme_load_errors = errors;
+                if self.settings.theme.name == name {
+                    self.settings.theme.name = "Jerry Dark".to_string();
+                    self.apply_theme_selection(cx);
+                }
+                if self.settings.theme.last_dark_theme == name {
+                    self.settings.theme.last_dark_theme = "Jerry Dark".to_string();
+                }
+                self.custom_theme_status = Some(Ok(format!("Removed \"{name}\".")));
+                self.persist_settings(cx);
+            }
+            Err(err) => {
+                self.custom_theme_status = Some(Err(format!("couldn't remove \"{name}\": {err}")));
+            }
+        }
+        cx.notify();
     }
 
     /// The real, shared "follow system" logic both [`Self::toggle_theme_follow_system`] (a
@@ -2305,6 +2844,71 @@ impl AdeApp {
         let appearance = window.appearance();
         self.apply_follow_system_appearance(appearance, cx);
         cx.notify();
+    }
+}
+
+/// The real name [`AdeApp::start_export_custom_theme`] exports `active_name` under - a pure,
+/// directly-`#[test]`-able decision (not a `gpui`-window-touching method) so this can be checked
+/// without a real save dialog. A built-in theme (`settings::THEME_DEFS`) is renamed to `"<name>
+/// (copy)"`; a custom one keeps its own name unchanged. See `AdeApp::start_export_custom_theme`'s
+/// own docs for why this matters: `crate::settings::custom_theme::CustomThemeFile::validate`
+/// unconditionally rejects any file whose `name` collides with a built-in, so exporting a
+/// built-in theme under its own bare name would produce a file nobody - not even this same app -
+/// could ever import back in.
+fn export_theme_name_for(active_name: &str) -> String {
+    if settings::THEME_DEFS
+        .iter()
+        .any(|def| def.name == active_name)
+    {
+        format!("{active_name} (copy)")
+    } else {
+        active_name.to_string()
+    }
+}
+
+#[cfg(test)]
+mod export_theme_name_tests {
+    use super::*;
+
+    #[test]
+    fn a_builtin_theme_is_renamed_to_a_real_importable_copy() {
+        assert_eq!(export_theme_name_for("Slate"), "Slate (copy)");
+        assert_eq!(export_theme_name_for("Jerry Dark"), "Jerry Dark (copy)");
+        assert_eq!(export_theme_name_for("Paper"), "Paper (copy)");
+    }
+
+    #[test]
+    fn a_custom_theme_keeps_its_own_name() {
+        assert_eq!(export_theme_name_for("Midnight Coral"), "Midnight Coral");
+    }
+
+    /// The real, end-to-end proof this fixes the bug it exists for: exporting a built-in under
+    /// its bare name would produce a file `CustomThemeFile::validate` rejects (a real, previously
+    /// shipped "looks like it worked, quietly can't be imported back" bug an adversarial audit
+    /// caught) - the renamed form must actually validate successfully.
+    #[test]
+    fn the_renamed_export_of_a_builtin_actually_validates_as_importable() {
+        let bare = custom_theme::CustomThemeFile {
+            name: "Slate".to_string(),
+            subtitle: String::new(),
+            background: "#0d1117".to_string(),
+            panel: "#161b22".to_string(),
+            accent_green: "#57a773".to_string(),
+            accent_amber: "#c9a227".to_string(),
+            accent_blue: "#6b9bd1".to_string(),
+        };
+        assert!(
+            bare.validate().is_err(),
+            "exporting a builtin under its own bare name must be rejected on import - this is \
+             the real bug being guarded against"
+        );
+
+        let mut renamed = bare;
+        renamed.name = export_theme_name_for("Slate");
+        assert!(
+            renamed.validate().is_ok(),
+            "the renamed export must actually be importable"
+        );
     }
 }
 
@@ -3018,6 +3622,553 @@ mod theme_swap_tests {
             app.read_with(cx, |app, _| app.settings.theme.name.clone()),
             expected_name,
             "turning follow_system on must immediately apply the real current OS appearance"
+        );
+    }
+}
+
+/// GitHub issue #5's real end-to-end wiring coverage: a theme file really written to disk really
+/// gets loaded into a fresh `AdeApp`, really renders as a selectable card, really re-skins the
+/// app when picked, and a real removal really deletes its backing file - each proven the same
+/// way `theme_swap_tests` proves the built-in mechanism, by driving the actual `AdeApp` methods a
+/// real user action invokes, not `crate::settings::custom_theme`'s own already-covered pure
+/// functions directly.
+#[cfg(test)]
+mod custom_theme_settings_tests {
+    use super::*;
+    use gpui::TestAppContext;
+
+    /// Same real-global-leak discipline `theme_swap_tests::ResetThemeIndexOnDrop` documents, for
+    /// both `CURRENT_THEME_INDEX` and `CURRENT_CUSTOM_SHIFT` together - a custom-theme test can
+    /// leave either non-default.
+    struct ResetThemeStateOnDrop;
+    impl Drop for ResetThemeStateOnDrop {
+        fn drop(&mut self) {
+            theme::set_current_theme_index(0);
+            theme::set_current_custom_theme(None);
+        }
+    }
+
+    fn open_test_app_with_real_settings_path(
+        cx: &mut TestAppContext,
+        repo_path: PathBuf,
+        settings: settings_store::Settings,
+        settings_path: PathBuf,
+    ) -> (gpui::Entity<AdeApp>, &mut gpui::VisualTestContext) {
+        cx.add_window_view(|window, cx| {
+            AdeApp::new_with_settings(repo_path, settings, Some(settings_path), window, cx)
+        })
+    }
+
+    fn write_custom_theme_file(themes_dir: &std::path::Path, file_name: &str, contents: &str) {
+        std::fs::create_dir_all(themes_dir).expect("create themes dir");
+        std::fs::write(themes_dir.join(file_name), contents).expect("write theme file");
+    }
+
+    const MIDNIGHT_CORAL_TOML: &str = "name = \"Midnight Coral\"\n\
+         subtitle = \"warm accent\"\n\
+         background = \"#0c0d10\"\n\
+         panel = \"#181a1e\"\n\
+         accent_green = \"#5cb87f\"\n\
+         accent_amber = \"#e2a336\"\n\
+         accent_blue = \"#e07a5f\"\n";
+
+    /// A real theme file, sitting in the settings-sibling `themes/` directory before the app is
+    /// ever constructed, is loaded at startup (`crate::root::AdeApp::new_with_settings`) and
+    /// really renders as a selectable card on the Themes page - not just present in
+    /// `Self::custom_themes` as data nothing draws.
+    #[gpui::test]
+    fn a_custom_theme_file_on_disk_loads_at_startup_and_renders_as_a_real_card(
+        cx: &mut TestAppContext,
+    ) {
+        let _guard = ResetThemeStateOnDrop;
+        let repo = tempfile::tempdir().expect("tempdir");
+        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+        write_custom_theme_file(
+            &settings_dir.path().join("themes"),
+            "midnight-coral.toml",
+            MIDNIGHT_CORAL_TOML,
+        );
+
+        let (app, cx) = open_test_app_with_real_settings_path(
+            cx,
+            repo.path().to_path_buf(),
+            settings_store::Settings::default(),
+            settings_path,
+        );
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.custom_themes.len()),
+            1,
+            "the real on-disk theme file must be loaded into the registry at construction"
+        );
+        assert!(app.read_with(cx, |app, _| app.custom_theme_load_errors.is_empty()));
+
+        cx.dispatch_action(ToggleSettings);
+        app.update_in(cx, |app, window, cx| {
+            app.select_settings_page(SettingsPage::Theme, window, cx);
+        });
+        cx.run_until_parked();
+
+        assert!(
+            cx.debug_bounds("settings-theme-card-Midnight Coral")
+                .is_some(),
+            "the custom theme must actually render as a card on the Themes page, not just exist \
+             as unrendered data"
+        );
+    }
+
+    /// Selecting a real custom theme (`Self::set_theme_name`, the same method a card click
+    /// invokes) must really re-skin the app - a representative colour token resolves to
+    /// something other than Jerry Dark's own value - and persist the selection, exactly like
+    /// `theme_swap_tests::selecting_a_real_theme_card_changes_the_live_selected_index_and_a_representative_color`
+    /// proves for a built-in theme.
+    #[gpui::test]
+    fn selecting_a_custom_theme_really_reskins_the_app_and_persists(cx: &mut TestAppContext) {
+        let _guard = ResetThemeStateOnDrop;
+        let repo = tempfile::tempdir().expect("tempdir");
+        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+        write_custom_theme_file(
+            &settings_dir.path().join("themes"),
+            "midnight-coral.toml",
+            MIDNIGHT_CORAL_TOML,
+        );
+        let (app, cx) = open_test_app_with_real_settings_path(
+            cx,
+            repo.path().to_path_buf(),
+            settings_store::Settings::default(),
+            settings_path.clone(),
+        );
+
+        let jerry_dark_window_bg = theme::surface::WINDOW.resolve();
+
+        app.update(cx, |app, cx| {
+            app.set_theme_name("Midnight Coral".to_string(), cx);
+        });
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.settings.theme.name.clone()),
+            "Midnight Coral"
+        );
+        assert!(
+            theme::surface::WINDOW.resolve() != jerry_dark_window_bg,
+            "selecting a real custom theme must actually change what a representative colour \
+             token resolves to"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.settings.theme.last_dark_theme.clone()),
+            "Midnight Coral",
+            "Midnight Coral's background swatch is dark, so it should be remembered as the last \
+             dark theme"
+        );
+
+        // Persisted for real - reloading the same settings file picks the same theme back up.
+        cx.run_until_parked();
+        let reloaded = settings_store::Settings::load_or_init_at(&settings_path);
+        assert_eq!(reloaded.theme.name, "Midnight Coral");
+    }
+
+    /// The real, synchronous validate-then-apply step (`Self::apply_custom_theme_import_result`)
+    /// behind `Self::start_import_custom_theme`'s async file-picker plumbing - driven directly
+    /// with a real `custom_theme::import_theme_file`/`load_custom_themes_from_dir` result here
+    /// since there is no real headless file dialog to simulate, matching how
+    /// `Self::open_install_url`/`Self::open_settings_file`'s own OS-handoff calls are only ever
+    /// unit-tested at the pure-decision-function layer (`crate::settings::widgets::
+    /// open_command_for`), never through an actual OS dialog. The picker plumbing itself
+    /// (`cx.prompt_for_paths`, `cx.background_executor()`) is real, verified GPUI API usage, not
+    /// re-tested here.
+    #[gpui::test]
+    fn importing_a_real_theme_file_adds_it_to_the_registry_and_writes_a_canonical_copy(
+        cx: &mut TestAppContext,
+    ) {
+        let _guard = ResetThemeStateOnDrop;
+        let repo = tempfile::tempdir().expect("tempdir");
+        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+        let (app, cx) = open_test_app_with_real_settings_path(
+            cx,
+            repo.path().to_path_buf(),
+            settings_store::Settings::default(),
+            settings_path.clone(),
+        );
+
+        let source_dir = tempfile::tempdir().expect("tempdir");
+        let source_path = source_dir.path().join("picked.toml");
+        std::fs::write(&source_path, MIDNIGHT_CORAL_TOML).expect("write source file");
+        let dest_dir = settings_dir.path().join("themes");
+
+        let result = custom_theme::import_theme_file(&source_path, &dest_dir).map(|imported| {
+            let (themes, errors) = custom_theme::load_custom_themes_from_dir(&dest_dir);
+            (imported, themes, errors)
+        });
+        app.update(cx, |app, cx| {
+            app.apply_custom_theme_import_result(result, cx);
+        });
+
+        assert_eq!(app.read_with(cx, |app, _| app.custom_themes.len()), 1);
+        assert_eq!(
+            app.read_with(cx, |app, _| app.custom_themes[0].name.clone()),
+            "Midnight Coral"
+        );
+        let status = app.read_with(cx, |app, _| app.custom_theme_status.clone());
+        assert!(
+            matches!(status, Some(Ok(_))),
+            "a real successful import should report a real success status, got {status:?}"
+        );
+        let expected_file = dest_dir.join("midnight-coral.toml");
+        assert!(
+            expected_file.exists(),
+            "import must write a real, canonical copy into the settings-sibling themes directory"
+        );
+
+        // A malformed source is rejected with a real error and does not touch the registry.
+        let bad_source = source_dir.path().join("bad.toml");
+        std::fs::write(&bad_source, "name = \"\"\n").expect("write bad source");
+        let bad_result = custom_theme::import_theme_file(&bad_source, &dest_dir).map(|imported| {
+            let (themes, errors) = custom_theme::load_custom_themes_from_dir(&dest_dir);
+            (imported, themes, errors)
+        });
+        app.update(cx, |app, cx| {
+            app.apply_custom_theme_import_result(bad_result, cx);
+        });
+        assert_eq!(
+            app.read_with(cx, |app, _| app.custom_themes.len()),
+            1,
+            "a malformed import must not add a bogus entry"
+        );
+        let status = app.read_with(cx, |app, _| app.custom_theme_status.clone());
+        assert!(
+            matches!(status, Some(Err(_))),
+            "a malformed import should report a real, honest error, got {status:?}"
+        );
+    }
+
+    /// Re-importing the theme currently in use must immediately re-skin the app with its updated
+    /// swatches, not leave it rendering the stale palette until a restart - a real bug an
+    /// adversarial audit caught in the first version of `Self::apply_custom_theme_import_result`.
+    #[gpui::test]
+    fn reimporting_the_currently_active_theme_immediately_reskins_the_app(cx: &mut TestAppContext) {
+        let _guard = ResetThemeStateOnDrop;
+        let repo = tempfile::tempdir().expect("tempdir");
+        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+        let dest_dir = settings_dir.path().join("themes");
+        write_custom_theme_file(&dest_dir, "midnight-coral.toml", MIDNIGHT_CORAL_TOML);
+        let (app, cx) = open_test_app_with_real_settings_path(
+            cx,
+            repo.path().to_path_buf(),
+            settings_store::Settings::default(),
+            settings_path,
+        );
+        app.update(cx, |app, cx| {
+            app.set_theme_name("Midnight Coral".to_string(), cx);
+        });
+        let original = theme::surface::WINDOW.resolve();
+
+        // Re-import the same theme under a different background swatch.
+        let source_dir = tempfile::tempdir().expect("tempdir");
+        let source_path = source_dir.path().join("picked.toml");
+        std::fs::write(
+            &source_path,
+            MIDNIGHT_CORAL_TOML.replace("#0c0d10", "#301010"),
+        )
+        .expect("write updated source");
+        let result = custom_theme::import_theme_file(&source_path, &dest_dir).map(|imported| {
+            let (themes, errors) = custom_theme::load_custom_themes_from_dir(&dest_dir);
+            (imported, themes, errors)
+        });
+        app.update(cx, |app, cx| {
+            app.apply_custom_theme_import_result(result, cx);
+        });
+
+        assert!(
+            theme::surface::WINDOW.resolve() != original,
+            "re-importing the active custom theme with new swatches must re-skin the app \
+             immediately, not require a restart"
+        );
+    }
+
+    /// The Themes page's "Remove" action - real two-click confirmation
+    /// (`Self::request_remove_custom_theme`/`Self::custom_theme_remove_armed`): the first click
+    /// only arms it and touches nothing on disk; the second click actually deletes the real
+    /// backing file and, when the removed theme was the active selection or the remembered
+    /// `last_dark_theme`, falls back to Jerry Dark rather than leaving a dangling name neither
+    /// can resolve.
+    #[gpui::test]
+    fn removing_the_active_custom_theme_requires_two_clicks_then_falls_back_to_jerry_dark(
+        cx: &mut TestAppContext,
+    ) {
+        let _guard = ResetThemeStateOnDrop;
+        let repo = tempfile::tempdir().expect("tempdir");
+        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+        let themes_dir = settings_dir.path().join("themes");
+        write_custom_theme_file(&themes_dir, "midnight-coral.toml", MIDNIGHT_CORAL_TOML);
+        let (app, cx) = open_test_app_with_real_settings_path(
+            cx,
+            repo.path().to_path_buf(),
+            settings_store::Settings::default(),
+            settings_path,
+        );
+
+        app.update(cx, |app, cx| {
+            app.set_theme_name("Midnight Coral".to_string(), cx);
+        });
+        assert_eq!(
+            app.read_with(cx, |app, _| app.settings.theme.name.clone()),
+            "Midnight Coral"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.settings.theme.last_dark_theme.clone()),
+            "Midnight Coral"
+        );
+
+        // First click only arms the confirmation - nothing is deleted yet.
+        app.update(cx, |app, cx| {
+            app.request_remove_custom_theme("Midnight Coral".to_string(), cx);
+        });
+        cx.run_until_parked();
+        assert!(
+            themes_dir.join("midnight-coral.toml").exists(),
+            "a single click must not delete anything"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.custom_theme_remove_armed.clone()),
+            Some("Midnight Coral".to_string())
+        );
+        assert_eq!(app.read_with(cx, |app, _| app.custom_themes.len()), 1);
+
+        // Second click on the same name actually removes it.
+        app.update(cx, |app, cx| {
+            app.request_remove_custom_theme("Midnight Coral".to_string(), cx);
+        });
+        cx.run_until_parked();
+
+        assert!(app.read_with(cx, |app, _| app.custom_themes.is_empty()));
+        assert!(!themes_dir.join("midnight-coral.toml").exists());
+        assert_eq!(
+            app.read_with(cx, |app, _| app.custom_theme_remove_armed.clone()),
+            None
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.settings.theme.name.clone()),
+            "Jerry Dark",
+            "removing the active theme must fall back to Jerry Dark, not leave a dangling \
+             selection"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.settings.theme.last_dark_theme.clone()),
+            "Jerry Dark",
+            "the dangling last_dark_theme must be reset too, or a later real OS-dark \
+             follow_system signal would resolve to nothing"
+        );
+    }
+
+    /// Leaving the Themes page must disarm a pending "Remove" confirmation - otherwise a stray
+    /// click landing back on the same card position later could delete a theme the user never
+    /// actually confirmed removing this time.
+    #[gpui::test]
+    fn leaving_the_themes_page_disarms_a_pending_remove_confirmation(cx: &mut TestAppContext) {
+        let _guard = ResetThemeStateOnDrop;
+        let repo = tempfile::tempdir().expect("tempdir");
+        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+        write_custom_theme_file(
+            &settings_dir.path().join("themes"),
+            "midnight-coral.toml",
+            MIDNIGHT_CORAL_TOML,
+        );
+        let (app, cx) = open_test_app_with_real_settings_path(
+            cx,
+            repo.path().to_path_buf(),
+            settings_store::Settings::default(),
+            settings_path,
+        );
+        cx.dispatch_action(ToggleSettings);
+        app.update_in(cx, |app, window, cx| {
+            app.select_settings_page(SettingsPage::Theme, window, cx);
+            app.request_remove_custom_theme("Midnight Coral".to_string(), cx);
+        });
+        assert_eq!(
+            app.read_with(cx, |app, _| app.custom_theme_remove_armed.clone()),
+            Some("Midnight Coral".to_string())
+        );
+
+        app.update_in(cx, |app, window, cx| {
+            app.select_settings_page(SettingsPage::General, window, cx);
+        });
+        assert_eq!(
+            app.read_with(cx, |app, _| app.custom_theme_remove_armed.clone()),
+            None
+        );
+    }
+
+    /// The real, click-driven proof behind [`Self::request_remove_custom_theme`]'s
+    /// `cx.stop_propagation()` (an adversarial audit verified this by reading GPUI's own event
+    /// dispatch source rather than a live test - this closes that gap for real): two genuine
+    /// simulated clicks on the Remove button's own real painted bounds delete the theme, and
+    /// neither click also fires the card's own `on_click` underneath it - if it did, the first
+    /// click would have switched the active theme to "Midnight Coral" instead of just arming the
+    /// confirmation.
+    #[gpui::test]
+    fn clicking_the_real_remove_button_deletes_the_theme_without_selecting_its_card(
+        cx: &mut TestAppContext,
+    ) {
+        let _guard = ResetThemeStateOnDrop;
+        let repo = tempfile::tempdir().expect("tempdir");
+        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+        let themes_dir = settings_dir.path().join("themes");
+        write_custom_theme_file(&themes_dir, "midnight-coral.toml", MIDNIGHT_CORAL_TOML);
+        let mut settings = settings_store::Settings::default();
+        settings.theme.name = "Slate".to_string();
+        let (app, cx) = open_test_app_with_real_settings_path(
+            cx,
+            repo.path().to_path_buf(),
+            settings,
+            settings_path,
+        );
+        cx.dispatch_action(ToggleSettings);
+        app.update_in(cx, |app, window, cx| {
+            app.select_settings_page(SettingsPage::Theme, window, cx);
+        });
+        cx.run_until_parked();
+
+        let remove_bounds = cx
+            .debug_bounds("settings-theme-card-remove-Midnight Coral")
+            .expect("the Remove affordance must have painted on the custom theme's card");
+
+        // First real click: arms the confirmation.
+        cx.simulate_click(remove_bounds.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.settings.theme.name.clone()),
+            "Slate",
+            "clicking Remove must not also select the card underneath it via the same click"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.custom_theme_remove_armed.clone()),
+            Some("Midnight Coral".to_string())
+        );
+        assert!(themes_dir.join("midnight-coral.toml").exists());
+
+        // Second real click on the same button (now re-rendered reading "Confirm?", same real
+        // id/`debug_selector`) actually deletes it.
+        let confirm_bounds = cx
+            .debug_bounds("settings-theme-card-remove-Midnight Coral")
+            .expect("the button must still be painted, now reading Confirm?");
+        cx.simulate_click(confirm_bounds.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        assert!(!themes_dir.join("midnight-coral.toml").exists());
+        assert!(app.read_with(cx, |app, _| app.custom_themes.is_empty()));
+        assert_eq!(
+            app.read_with(cx, |app, _| app.settings.theme.name.clone()),
+            "Slate",
+            "Slate wasn't the removed theme, so it must stay selected throughout"
+        );
+    }
+
+    /// The real, click-driven proof the Import/Export action buttons themselves are wired to a
+    /// real handler, not just present in the tree - clicking "Import theme…" with no real file
+    /// dialog available in this headless test environment still reaches
+    /// `Self::start_import_custom_theme` (proven by the in-flight picker task actually being
+    /// set), rather than silently doing nothing because the button's `on_click` was never wired.
+    #[gpui::test]
+    fn clicking_the_real_import_button_reaches_the_real_handler(cx: &mut TestAppContext) {
+        let _guard = ResetThemeStateOnDrop;
+        let repo = tempfile::tempdir().expect("tempdir");
+        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+        let (app, cx) = open_test_app_with_real_settings_path(
+            cx,
+            repo.path().to_path_buf(),
+            settings_store::Settings::default(),
+            settings_path,
+        );
+        cx.dispatch_action(ToggleSettings);
+        app.update_in(cx, |app, window, cx| {
+            app.select_settings_page(SettingsPage::Theme, window, cx);
+        });
+        cx.run_until_parked();
+
+        let import_bounds = cx
+            .debug_bounds("settings-theme-import")
+            .expect("the Import theme… button must have painted");
+        cx.simulate_click(import_bounds.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        assert!(
+            app.read_with(cx, |app, _| app._custom_theme_import_task.is_some()),
+            "a real click on the button must actually invoke Self::start_import_custom_theme, \
+             not silently do nothing"
+        );
+    }
+
+    /// Same real-click proof as
+    /// [`clicking_the_real_import_button_reaches_the_real_handler`], for "Export current theme…".
+    #[gpui::test]
+    fn clicking_the_real_export_button_reaches_the_real_handler(cx: &mut TestAppContext) {
+        let _guard = ResetThemeStateOnDrop;
+        let repo = tempfile::tempdir().expect("tempdir");
+        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+        let (app, cx) = open_test_app_with_real_settings_path(
+            cx,
+            repo.path().to_path_buf(),
+            settings_store::Settings::default(),
+            settings_path,
+        );
+        cx.dispatch_action(ToggleSettings);
+        app.update_in(cx, |app, window, cx| {
+            app.select_settings_page(SettingsPage::Theme, window, cx);
+        });
+        cx.run_until_parked();
+
+        let export_bounds = cx
+            .debug_bounds("settings-theme-export")
+            .expect("the Export current theme… button must have painted");
+        cx.simulate_click(export_bounds.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        assert!(
+            app.read_with(cx, |app, _| app._custom_theme_export_task.is_some()),
+            "a real click on the button must actually invoke Self::start_export_custom_theme, \
+             not silently do nothing"
+        );
+    }
+
+    /// A malformed theme file on disk at startup is skipped with a real, honest error - not
+    /// silently dropped, and not a startup crash.
+    #[gpui::test]
+    fn a_malformed_theme_file_on_disk_is_skipped_with_a_real_recorded_error(
+        cx: &mut TestAppContext,
+    ) {
+        let _guard = ResetThemeStateOnDrop;
+        let repo = tempfile::tempdir().expect("tempdir");
+        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+        write_custom_theme_file(
+            &settings_dir.path().join("themes"),
+            "broken.toml",
+            "this is not { valid toml",
+        );
+
+        let (app, cx) = open_test_app_with_real_settings_path(
+            cx,
+            repo.path().to_path_buf(),
+            settings_store::Settings::default(),
+            settings_path,
+        );
+
+        assert!(app.read_with(cx, |app, _| app.custom_themes.is_empty()));
+        let errors = app.read_with(cx, |app, _| app.custom_theme_load_errors.clone());
+        assert_eq!(errors.len(), 1);
+        assert!(
+            errors[0].starts_with("broken.toml:"),
+            "the real error should name the offending file, got: {errors:?}"
         );
     }
 }

--- a/crates/app/src/settings/state.rs
+++ b/crates/app/src/settings/state.rs
@@ -310,41 +310,49 @@ pub struct ThemeDef {
     pub swatches: [u32; 5],
 }
 
-/// The Themes page's six cards, transcribed verbatim from `Jerry.dc.html`'s `themeDefs`.
+/// The Themes page's six cards - real `assets/themes/*.toml` files (repo root, alongside
+/// `assets/fonts/` - see `crate::fonts`' own module docs for the established "embed a real,
+/// checked-in asset at compile time via `include_str!`/`include_bytes!`" convention this
+/// mirrors), embedded into the binary and parsed through the exact same
+/// `CustomThemeFile`/`validate` deserialization and validation path GitHub issue #5's
+/// user-authored custom themes already use (`crate::settings::custom_theme::
+/// parse_builtin_theme_file_str`) - not a second, parallel parser. Follow-up to GitHub issue #5:
+/// before this, these six were a hardcoded `const` array of Rust struct literals; the *values*
+/// are unchanged (transcribed verbatim - see `custom_theme::tests::
+/// parse_builtin_theme_file_str_parses_every_embedded_built_in_theme_file_into_the_exact_documented_swatches`
+/// and this module's own `theme_defs_match_the_documented_exact_names_subtitles_and_hex_swatches`
+/// for the regression pins), only *where they live* changed.
+///
+/// A `std::sync::LazyLock`, not a `const`, since parsing TOML is real runtime work - computed
+/// exactly once, on first access, and cached for the rest of the process; every existing call
+/// site across this crate (`crate::theme`, `crate::root`, `crate::settings::render`,
+/// `crate::settings::store`) already only ever indexes (`THEME_DEFS[i]`) or iterates
+/// (`THEME_DEFS.iter()`) this array, both of which `LazyLock`'s `Deref` impl serves exactly like
+/// the old `const` did, so none of them needed to change for this. `name`/`subtitle` are each
+/// leaked once (`Box::leak`) into real `&'static str`s, so [`ThemeDef`] keeps its existing
+/// `Copy`-friendly shape rather than growing owned `String` fields just for six values that live
+/// for the process's entire lifetime anyway.
+///
 /// `crate::settings::store::ThemeSettings::name` - not this fixture's own `on` field, which this
 /// app never reads - is the persisted source of truth for which one is selected.
-pub const THEME_DEFS: [ThemeDef; 6] = [
-    ThemeDef {
-        name: "Jerry Dark",
-        subtitle: "default",
-        swatches: [0x0e0f11, 0x1a1e21, 0x5cb87f, 0xe2a336, 0x74ade8],
-    },
-    ThemeDef {
-        name: "Jerry Dim",
-        subtitle: "lower contrast",
-        swatches: [0x15181b, 0x20252a, 0x6ab97f, 0xd8a94a, 0x7f9ad4],
-    },
-    ThemeDef {
-        name: "Slate",
-        subtitle: "cool greys",
-        swatches: [0x0d1117, 0x161b22, 0x57a773, 0xc9a227, 0x6b9bd1],
-    },
-    ThemeDef {
-        name: "Ember",
-        subtitle: "warm",
-        swatches: [0x12100e, 0x1e1a16, 0x8fae6b, 0xd98b3a, 0xc4713f],
-    },
-    ThemeDef {
-        name: "Moss",
-        subtitle: "green-tinted",
-        swatches: [0x0f1310, 0x1a201b, 0x7fc79a, 0xc8b45a, 0x6f9bb5],
-    },
-    ThemeDef {
-        name: "Paper",
-        subtitle: "light \u{b7} beta",
-        swatches: [0xf4f1ea, 0xe4e0d6, 0x3f7a52, 0xa8752a, 0x3d6c9c],
-    },
-];
+pub static THEME_DEFS: std::sync::LazyLock<[ThemeDef; 6]> = std::sync::LazyLock::new(|| {
+    const FILES: [&str; 6] = [
+        include_str!("../../../../assets/themes/jerry-dark.toml"),
+        include_str!("../../../../assets/themes/jerry-dim.toml"),
+        include_str!("../../../../assets/themes/slate.toml"),
+        include_str!("../../../../assets/themes/ember.toml"),
+        include_str!("../../../../assets/themes/moss.toml"),
+        include_str!("../../../../assets/themes/paper.toml"),
+    ];
+    FILES.map(|contents| {
+        let theme = crate::settings::custom_theme::parse_builtin_theme_file_str(contents);
+        ThemeDef {
+            name: Box::leak(theme.name.into_boxed_str()),
+            subtitle: Box::leak(theme.subtitle.into_boxed_str()),
+            swatches: theme.swatches,
+        }
+    })
+});
 
 /// One Language servers page row's static, per-language identity - the binary name
 /// [`detect_lsp_rows`] searches `$PATH` for. Sourced from `crate::language`'s canonical registry
@@ -922,6 +930,73 @@ mod tests {
         names.dedup();
         assert_eq!(names.len(), original_len, "duplicate theme name");
         assert_eq!(THEME_DEFS[0].name, "Jerry Dark");
+    }
+
+    /// The real regression guard for the built-in-themes-as-files refactor (GitHub issue #5
+    /// follow-up): `THEME_DEFS` is now built at runtime from `assets/themes/*.toml` rather than a
+    /// hardcoded `const` array, so this pins the exact same names/subtitles/hex swatches the old
+    /// array held, transcribed verbatim - a single-digit typo made while writing one of those
+    /// `.toml` files would silently change the app's real default appearance, and this is what
+    /// would catch it. `custom_theme::tests::
+    /// parse_builtin_theme_file_str_parses_every_embedded_built_in_theme_file_into_the_exact_documented_swatches`
+    /// pins the same values one layer lower, straight off each file's own `include_str!`; this
+    /// test instead goes through the real, public `THEME_DEFS` every other call site in this
+    /// crate actually reads.
+    #[test]
+    fn theme_defs_match_the_documented_exact_names_subtitles_and_hex_swatches() {
+        let expected: [(&str, &str, [u32; 5]); 6] = [
+            (
+                "Jerry Dark",
+                "default",
+                [0x0e0f11, 0x1a1e21, 0x5cb87f, 0xe2a336, 0x74ade8],
+            ),
+            (
+                "Jerry Dim",
+                "lower contrast",
+                [0x15181b, 0x20252a, 0x6ab97f, 0xd8a94a, 0x7f9ad4],
+            ),
+            (
+                "Slate",
+                "cool greys",
+                [0x0d1117, 0x161b22, 0x57a773, 0xc9a227, 0x6b9bd1],
+            ),
+            (
+                "Ember",
+                "warm",
+                [0x12100e, 0x1e1a16, 0x8fae6b, 0xd98b3a, 0xc4713f],
+            ),
+            (
+                "Moss",
+                "green-tinted",
+                [0x0f1310, 0x1a201b, 0x7fc79a, 0xc8b45a, 0x6f9bb5],
+            ),
+            (
+                "Paper",
+                "light \u{b7} beta",
+                [0xf4f1ea, 0xe4e0d6, 0x3f7a52, 0xa8752a, 0x3d6c9c],
+            ),
+        ];
+        assert_eq!(THEME_DEFS.len(), expected.len());
+        for (def, (name, subtitle, swatches)) in THEME_DEFS.iter().zip(expected.iter()) {
+            assert_eq!(def.name, *name, "name mismatch");
+            assert_eq!(def.subtitle, *subtitle, "subtitle mismatch for {name}");
+            assert_eq!(def.swatches, *swatches, "swatch mismatch for {name}");
+        }
+    }
+
+    /// A hand-edited `settings.toml` from before this refactor persists a built-in theme
+    /// selection purely by its `name` (`crate::settings::store::ThemeSettings::name`'s own docs) -
+    /// this proves that lookup still resolves for every one of the six real names after built-ins
+    /// moved from a `const` array to `assets/themes/*.toml` files, so an existing user's settings
+    /// file keeps loading and resolving exactly as it did before.
+    #[test]
+    fn every_documented_built_in_theme_name_still_resolves_by_name_lookup() {
+        for name in ["Jerry Dark", "Jerry Dim", "Slate", "Ember", "Moss", "Paper"] {
+            assert!(
+                THEME_DEFS.iter().any(|def| def.name == name),
+                "{name:?} must still resolve by name lookup"
+            );
+        }
     }
 
     /// [`lsp_languages`] now derives its length directly from

--- a/crates/app/src/theme.rs
+++ b/crates/app/src/theme.rs
@@ -58,11 +58,17 @@ const fn hex(v: u32) -> ColorToken {
 pub struct ColorToken(pub Rgba);
 
 impl ColorToken {
-    /// Resolves this token against [`current_theme_index`]'s real, live-selected theme. Jerry
-    /// Dark (`index == 0`) returns [`Self`]'s own original value completely unchanged, not even
-    /// a lossy `Rgba -> Hsla -> Rgba` round trip - see the module docs for why this matters for
-    /// existing exact-hex tests.
+    /// Resolves this token against whichever theme is really live-selected right now. A live
+    /// custom (disk-loaded) theme - [`CURRENT_CUSTOM_SHIFT`], set by
+    /// [`set_current_custom_theme`] - always wins over [`current_theme_index`]'s built-in
+    /// selection when one is set (see that function's own docs for why the two are never left to
+    /// drift independently). Otherwise, Jerry Dark (`index == 0`) returns [`Self`]'s own original
+    /// value completely unchanged, not even a lossy `Rgba -> Hsla -> Rgba` round trip - see the
+    /// module docs for why this matters for existing exact-hex tests.
     pub fn resolve(self) -> Rgba {
+        if let Some(shift) = CURRENT_CUSTOM_SHIFT.with(|cell| cell.get()) {
+            return apply_shift(self.0, shift);
+        }
         let index = current_theme_index();
         if index == 0 {
             return self.0;
@@ -150,6 +156,55 @@ pub fn current_theme_index() -> usize {
 /// index; nothing here can reach into GPUI's own render loop to schedule one.
 pub fn set_current_theme_index(index: usize) {
     CURRENT_THEME_INDEX.with(|cell| cell.set(index));
+}
+
+thread_local! {
+    /// A live-selected *custom* (disk-loaded) theme's already-derived shift, if any - see
+    /// `crate::settings::custom_theme`'s own module docs for the real on-disk file format this is
+    /// computed from (GitHub issue #5). `Some` overrides [`CURRENT_THEME_INDEX`] entirely in
+    /// [`ColorToken::resolve`] - `crate::settings::render::AdeApp::apply_theme_selection` is the
+    /// one real place both are ever written, always together (never one without the other), so
+    /// this can never point at a shift for a theme that isn't `Settings.theme.name` any more.
+    /// Same `thread_local!`-not-global reasoning as [`CURRENT_THEME_INDEX`] itself: `cargo test`'s
+    /// default parallel mode runs each `#[gpui::test]` on its own OS thread, and a shared global
+    /// here would let one test's custom-theme selection corrupt another's colour assertions.
+    static CURRENT_CUSTOM_SHIFT: std::cell::Cell<Option<HslShift>> =
+        const { std::cell::Cell::new(None) };
+}
+
+/// Selects (`Some`) or clears (`None`) the live custom-theme override - see
+/// [`CURRENT_CUSTOM_SHIFT`]'s own docs. `swatches` is a custom theme's own
+/// `crate::settings::custom_theme::CustomTheme::swatches` (the same `[background, panel,
+/// green-ish, amber-ish, blue-ish]` shape `crate::settings::state::THEME_DEFS`' own swatches use),
+/// derived against Jerry Dark's own swatches through the exact same [`derive_shift`] every
+/// built-in non-Jerry-Dark theme already goes through - a custom theme is not a second-class
+/// palette that only gets a few re-tinted preview swatches.
+pub fn set_current_custom_theme(swatches: Option<[u32; 5]>) {
+    CURRENT_CUSTOM_SHIFT.with(|cell| {
+        cell.set(swatches.map(|target| {
+            let base = crate::settings::state::THEME_DEFS[0].swatches;
+            derive_shift(base, target)
+        }));
+    });
+}
+
+/// Real, general "is this swatch set a light theme" check - the background swatch (index 0)'s
+/// HSL lightness alone, `> 0.5`. Generalizes the old hardcoded `name == "Paper"` special case
+/// (`crate::settings::render::AdeApp::set_theme_name`'s `last_dark_theme` bookkeeping used to
+/// compare literal theme names) so a disk-loaded custom theme's own light/dark status can be
+/// determined the same real way a built-in one's already is - `crate::settings::state::
+/// THEME_DEFS[5]`, "Paper", is the one built-in example: its background swatch `0xf4f1ea` is
+/// genuinely light (`l` well above `0.5`), every other built-in's background swatch is near-black
+/// (`l` well below it).
+pub fn theme_is_light(swatches: [u32; 5]) -> bool {
+    let hsla: Hsla = Rgba {
+        r: ((swatches[0] >> 16) & 0xff) as f32 / 255.0,
+        g: ((swatches[0] >> 8) & 0xff) as f32 / 255.0,
+        b: (swatches[0] & 0xff) as f32 / 255.0,
+        a: 1.0,
+    }
+    .into();
+    hsla.l > 0.5
 }
 
 /// A real, systematic HSL transform - see [`derive_shift`]'s own docs for how one is computed,
@@ -1180,6 +1235,21 @@ mod theme_runtime_tests {
         ResetThemeIndexOnDrop
     }
 
+    /// Same real-global-leak concern as [`ResetThemeIndexOnDrop`], for
+    /// [`CURRENT_CUSTOM_SHIFT`]/[`set_current_custom_theme`].
+    struct ResetCustomThemeOnDrop;
+
+    impl Drop for ResetCustomThemeOnDrop {
+        fn drop(&mut self) {
+            set_current_custom_theme(None);
+        }
+    }
+
+    fn with_custom_theme(swatches: [u32; 5]) -> ResetCustomThemeOnDrop {
+        set_current_custom_theme(Some(swatches));
+        ResetCustomThemeOnDrop
+    }
+
     fn same(a: Rgba, b: Rgba) -> bool {
         a.r == b.r && a.g == b.g && a.b == b.b && a.a == b.a
     }
@@ -1358,6 +1428,101 @@ mod theme_runtime_tests {
         assert!(shift.lightness_offset.is_finite());
         assert!(shift.hue.is_finite());
         assert!(shift.saturation_scale.is_finite());
+    }
+
+    /// A live custom theme actually changes what a representative token resolves to - the same
+    /// real "not a two-token cosmetic re-tint" proof
+    /// [`every_non_jerry_dark_theme_changes_tokens_across_multiple_unrelated_modules`] gives the
+    /// built-in themes, now for a disk-loaded one.
+    #[test]
+    fn a_custom_theme_changes_tokens_across_multiple_unrelated_modules() {
+        let jerry_dark = (
+            surface::WINDOW.0,
+            text::BODY.0,
+            syntax::KEYWORD.0,
+            status::ASK.0,
+            diff::ADD_BG.0,
+        );
+        // A genuinely different, light custom palette - deliberately unlike any built-in theme's
+        // own swatches, so this can't coincidentally pass by reusing one of their shifts.
+        let _guard = with_custom_theme([0xf0e6da, 0xe0d2c0, 0x3a8f5c, 0xa8622a, 0x2c5f8f]);
+        let resolved = (
+            surface::WINDOW.resolve(),
+            text::BODY.resolve(),
+            syntax::KEYWORD.resolve(),
+            status::ASK.resolve(),
+            diff::ADD_BG.resolve(),
+        );
+        let mut changed = 0;
+        if !same(resolved.0, jerry_dark.0) {
+            changed += 1;
+        }
+        if !same(resolved.1, jerry_dark.1) {
+            changed += 1;
+        }
+        if !same(resolved.2, jerry_dark.2) {
+            changed += 1;
+        }
+        if !same(resolved.3, jerry_dark.3) {
+            changed += 1;
+        }
+        if !same(resolved.4, jerry_dark.4) {
+            changed += 1;
+        }
+        assert!(
+            changed >= 4,
+            "a real custom theme should move nearly every token, not leave most still reading \
+             Jerry Dark's own values (only {changed}/5 changed)"
+        );
+    }
+
+    /// A live custom theme overrides whatever built-in [`CURRENT_THEME_INDEX`] happens to still
+    /// be set to - `crate::settings::render::AdeApp::apply_theme_selection` always writes both
+    /// together, but this proves [`ColorToken::resolve`] itself gives the custom shift priority
+    /// rather than relying on the caller to have zeroed the index first.
+    #[test]
+    fn a_custom_theme_overrides_a_stale_built_in_index() {
+        let _index_guard = with_theme_index(2); // "Slate" - deliberately left non-zero.
+        let _custom_guard = with_custom_theme([0xf0e6da, 0xe0d2c0, 0x3a8f5c, 0xa8622a, 0x2c5f8f]);
+        let custom = surface::WINDOW.resolve();
+        let slate_only = {
+            set_current_custom_theme(None);
+            let value = surface::WINDOW.resolve();
+            set_current_custom_theme(Some([0xf0e6da, 0xe0d2c0, 0x3a8f5c, 0xa8622a, 0x2c5f8f]));
+            value
+        };
+        assert!(
+            !same(custom, slate_only),
+            "the live custom theme must win over the stale built-in index, not the reverse"
+        );
+    }
+
+    /// Clearing the custom override (`set_current_custom_theme(None)`) falls back to the
+    /// built-in index mechanism exactly as if no custom theme had ever been selected.
+    #[test]
+    fn clearing_the_custom_theme_restores_the_built_in_index_mechanism() {
+        let jerry_dark = surface::WINDOW.resolve();
+        {
+            let _guard = with_custom_theme([0xf0e6da, 0xe0d2c0, 0x3a8f5c, 0xa8622a, 0x2c5f8f]);
+            assert!(!same(surface::WINDOW.resolve(), jerry_dark));
+        }
+        // The guard above already cleared it on drop.
+        assert!(same(surface::WINDOW.resolve(), jerry_dark));
+    }
+
+    #[test]
+    fn theme_is_light_matches_paper_and_rejects_every_dark_built_in() {
+        assert!(
+            theme_is_light(crate::settings::state::THEME_DEFS[5].swatches),
+            "\"Paper\" (index 5) is the one real light built-in theme"
+        );
+        for index in 0..5 {
+            assert!(
+                !theme_is_light(crate::settings::state::THEME_DEFS[index].swatches),
+                "built-in theme index {index} ({}) should read as dark",
+                crate::settings::state::THEME_DEFS[index].name
+            );
+        }
     }
 }
 

--- a/crates/app/src/theme.rs
+++ b/crates/app/src/theme.rs
@@ -348,7 +348,7 @@ fn derive_shift(base_swatches: [u32; 5], target_swatches: [u32; 5]) -> HslShift 
 fn theme_shift(index: usize) -> HslShift {
     static SHIFTS: std::sync::OnceLock<[HslShift; 6]> = std::sync::OnceLock::new();
     let shifts = SHIFTS.get_or_init(|| {
-        let defs = crate::settings::state::THEME_DEFS;
+        let defs = *crate::settings::state::THEME_DEFS;
         let base = defs[0].swatches;
         std::array::from_fn(|i| {
             if i == 0 {


### PR DESCRIPTION
## Summary

Implements GitHub issue #5: full customization of the app's appearance via custom color palettes and theme import/export. Three commits:

1. **`42dd859`** — the core feature. An extensible theme registry: user-authored themes loaded from `~/.config/jerry/themes/*.toml` (same TOML convention `settings.toml` already uses), layered on top of the six built-in themes via the existing HSL-shift derivation machinery — a custom theme supplies 5 swatches, same as a built-in, and the other ~200 color tokens in the app derive from them the same way. Real Import/Export (native file dialogs) and Remove actions on the Themes settings page, with both built-in and custom themes shown together.
2. **`be17d24`** — a requested follow-up: unifies storage. The 6 built-in themes moved from a compiled-in Rust const array to real embedded `assets/themes/*.toml` files, parsed through the exact same validation path user themes use. `THEME_DEFS` is now a `LazyLock` computed from those files; swatch values are transcribed verbatim (unchanged) and the HSL-shift math is untouched.
3. **`f9b18f0`** — re-implements three real safety checks (symlink-based file-clobber protection, an import-time file-size cap, and a readability-floor validation for a theme's swatches) that were genuinely lost to a concurrency data-loss incident during development — two agent sessions were briefly run against the same shared worktree without isolation, and one's uncommitted work was silently overwritten by the other's writes before either committed. This is disclosed in full in `BUILD-LOG.md` rather than hidden; the readability-floor fix in particular required care to avoid a real reentrant deadlock (it must not read the same `LazyLock`-initialized `THEME_DEFS` it can be called from inside of during startup — fixed with a separately pinned baseline const plus a regression test tying it back to the real value).

## Adversarial review

Each commit was independently checked by a genuinely dispatched adversarial checker sub-agent (not the builder's own reasoning relabeled). Real findings across the three passes: 2 CRITICAL in the original import/remove flow (a slug collision could silently clobber an unrelated file; Remove deleted a file on a single click with no confirmation), 4 MAJOR (stale palette state, a dangling theme reference, unimportable built-in exports, stale in-memory state after import/remove), plus the reentrant-deadlock bug caught in the follow-up pass. All fixed with regression tests.

## Testing

Independently re-verified by me at each step, not taken on the builders' reports alone — including directly grepping the final diff for the specific fixes claimed in the commit messages, after catching a real discrepancy earlier in this branch's history (a since-superseded commit's message described a fix that wasn't actually in the code; addressed head-on in `f9b18f0` rather than quietly patched over).

- `cargo fmt --all -- --check`, `cargo build --workspace`, `cargo clippy --workspace --all-targets -- -D warnings` — all clean.
- `cargo test --workspace --lib -- --test-threads=1`: 983 app + 42 lsp-core + 14 pty-core + 98 wt-core = 1137 tests, 0 failures.
- Spot-checked directly in source: `non_colliding_dest_path` uses `symlink_metadata().is_ok()`, not `exists()`; `import_theme_file` checks `MAX_THEME_FILE_BYTES` against the source file before reading; `JERRY_DARK_BASELINE_SWATCHES` is a real pinned const whose 5 values match `assets/themes/jerry-dark.toml` exactly, and the readability-floor check path never touches `THEME_DEFS`.

## Known, honestly-scoped gap

Custom "icon packs" (also requested in issue #5) are scoped down to icon *color* overrides riding along for free through the same theme tokens — this app's icons are `div`-composed rectangles/text labels colored by ordinary `ColorToken`s, not a glyph/image-asset pack system, so there's no existing swappable-pack surface to attach a real pack loader to. Documented in `BUILD-LOG.md`.