### PR TITLE
feat(app): movable tabs between terminal and file groups, with a real drop indicator

### DIFF
--- a/BUILD-LOG.md
+++ b/BUILD-LOG.md
@@ -3796,3 +3796,137 @@ diff_render_tests` flake (a real, unrelated timing race, already documented in t
 reproduced once in an earlier full run and confirmed flaky - not a regression - by re-running that
 module alone three times (2 clean, 1 failure on a different test within the same module each
 time).
+
+## Movable tabs between terminal and file groups, with a real drop indicator (GitHub issue #16, scoped)
+
+Issue #16's full body describes a large unified-tab-model feature (drag ghost, insertion
+carets, cross-group highlight, settle/cancel spring animations, a reduced-motion setting, and
+full arbitrary-layout persistence across restart). Per explicit direction, this pass is
+deliberately narrowed to the two concrete things actually requested: every tab draggable between
+the terminal-tab group and the file-tab group (today they're two rigid, non-interleaving
+blocks), and clearer visual feedback during a drag.
+
+**The real architectural blocker.** `work_surface::sessions::Sessions` (a flat `Vec<Session>`,
+filtered per-worktree by `iter_for_cwd`) and `AdeApp::open_files` (a separate, independently
+ordered `Vec<PathBuf>`) are two entirely independent ordered lists with no shared notion of
+position - `render_tab_strip` rendered them as "every session, then every file," full stop.
+Drag-and-drop already existed, but `DraggedSessionTab`/`DraggedFileTab` were two deliberately
+separate types precisely so a session tab could never land in a file tab's `on_drop::<T>`
+handler or vice versa - GPUI dispatches `on_drop::<T>` purely on the dragged value's concrete
+type (verified against `vendor/zed/crates/gpui/src/elements/div.rs`), so two distinct types can
+never cross-target each other's handlers by construction.
+
+**Data structure: a combined per-worktree order, reconciled fresh on every render rather than
+eagerly maintained.** Added `work_surface::state::TabRef` (`Session(SessionId)` / `File(PathBuf)`)
+and `AdeApp::tab_order: HashMap<PathBuf, Vec<TabRef>>`, keyed by worktree cwd. Deliberately *not*
+the source of truth for which tabs exist - `Sessions`/`AdeApp::open_files` keep that job entirely
+unchanged, so spawning, closing, PTY lifecycle, and edit-buffer state needed zero modification, as
+directed. `tab_order` only ever records a user's real drag-chosen *position*. The two are
+reconnected by a small, deliberately `gpui`-free pure function,
+`work_surface::state::reconcile_tab_order(stored, sessions_for_cwd, open_files)`: it drops any
+stored entry that no longer exists (a closed session, a closed file tab) and appends anything open
+that isn't in `stored` yet, in creation/open order - the same position a brand-new tab has always
+landed at. `AdeApp::combined_tab_order()` calls this fresh on every read (never caches a mutated
+copy), which is what let `render_tab_strip`, `current_worktree_sessions` (and therefore the
+`secondary-1`..`8` jump keycaps and Session-menu "Next/Previous session" cycling, which both read
+`current_worktree_sessions`) become order-agnostic to tab *kind* for free, satisfying "keyboard
+cycling and tab actions must work regardless of a tab's position in the combined order" without
+touching their own logic at all. The one place that does mutate `tab_order` is
+`AdeApp::reorder_tab` (the real drag-drop entry point), which reconciles, calls the equally pure
+`work_surface::state::move_tab_order(order, dragged, target, insert_after)`, and persists the
+result back into the map for that worktree's cwd - `insert_after` lets one function place the
+dragged tab on either side of the target, so cross-kind and same-kind reorders share one code
+path instead of two.
+
+This design choice deliberately *removed* `Sessions::move_before` and
+`AdeApp::reorder_open_file_before`, the two old same-kind reorder functions the tab strip used to
+call directly: once `tab_order` is the real visual source of truth, letting `Sessions`'/
+`open_files`' own internal `Vec` order *also* silently drift via a second, independent mutation
+path was judged a worse footgun (two orderings that can disagree) than one clean cut - their own
+two tests (`drag_reordering_two_session_tabs_changes_their_order`,
+`drag_reorder_is_a_no_op_for_an_unknown_or_identical_id`) were rewritten in place to exercise
+`AdeApp::reorder_tab`/`current_worktree_sessions` instead of the removed methods directly, keeping
+the same real assertions.
+
+Because `open_files` is already fully cleared on every worktree switch
+(`reset_per_worktree_ui_state`) and never holds more than one worktree's file tabs at once, a
+worktree's own `tab_order` entry naturally reconciles down to just its session tabs the moment its
+file tabs close - no extra reset code was needed in `select_worktree` at all. A pleasant, *un*designed
+side effect of this same reconciliation: if a file is closed and later reopened at the same
+worktree-relative path (including across a worktree switch away and back), it silently reclaims
+its old position in the stored order rather than always landing at the end - real, but explicitly
+not a guarantee this pass makes or tests for (see "left out of scope" below).
+
+**Unified drag type.** `DraggedSessionTab`/`DraggedFileTab` were merged into one
+`DraggedTab { Session { id, label }, File { path, label } }` enum, with a `.tab_ref()` method
+converting either variant to the `TabRef` `AdeApp::reorder_tab` actually moves. Both
+`render_session_tab` and `render_file_tab` now register exactly one `on_drag`/`on_drag_move`/
+`on_drop` set, all typed `DraggedTab` - so a file tab dropped on a session tab (or vice versa)
+reaches the same real handler a same-kind drop does. `Render for DraggedTab` keeps the existing
+floating-chip ghost essentially unchanged (still a small legible label chip), per direction not to
+over-invest there.
+
+**The drop indicator: a precise per-tab insertion caret, not a whole-tab highlight.** The old
+feedback was `tab.border_l(px(2.0))` on `drag_over::<T>` - the entire hovered tab got a left
+border regardless of where the cursor actually was over it, so "will this land before or after
+the hovered tab" was ambiguous. The new mechanism registers `on_drag_move::<DraggedTab>` on
+*every* tab (not a single container-level listener) - verified real GPUI behavior, confirmed both
+against `vendor/zed/crates/gpui/src/elements/div.rs`'s own dispatch and this repo's own
+`root::scrollbar` module docs, which document the identical caveat for `ScrollbarDrag`: GPUI
+dispatches a matching `on_drag_move::<T>` to *every* mounted element of that type on every
+drag-move tick, each receiving its own element's `bounds` - so each tab's own handler
+(`AdeApp::update_tab_drag_insertion`) checks `event.bounds.contains(&event.event.position)`
+itself before claiming the caret, and splits its own width in half via `Bounds::center()` to
+decide "before" (left half) vs. "after" (right half). The winning tab renders a 2px absolute
+`div` at the exact boundary (`render_tab_insertion_caret`) - unambiguous, not a whole-tab tint.
+State lives in one new field, `AdeApp::tab_drag_insertion: Option<(TabRef, bool)>`, read by
+`AdeApp::drop_dragged_tab` (the shared `on_drop` handler both tab kinds call) to decide the real
+`insert_after` value, and cleared there once handled. Because a drag can be cancelled by
+releasing outside any tab's own hitbox (no `on_drop` fires in that case), a defensive
+`on_mouse_up` was also added to `render_workspace_body` (which spans virtually the whole window
+below the title bar) clearing `tab_drag_insertion` so a cancelled drag can't leave a caret
+stuck on a tab nothing is being dragged over anymore.
+
+**Left out of scope, explicitly, per the user's own narrowing (not partially attempted, not
+half-shipped):**
+- No reduced-motion setting - there is no new animation for it to gate.
+- No settle/cancel spring animations for the dragged chip or the tabs it passes over - the
+  existing instant-reflow drag ghost is unchanged.
+- No designed guarantee that an arbitrary mixed session/file layout survives an app restart -
+  `AdeApp::tab_order` is in-memory only, never written to `settings.toml`/disk. It does survive a
+  worktree switch away and back within the same running window (sessions persist regardless;
+  files reconcile back into their old slot if reopened at the same path, per the "un-designed side
+  effect" noted above) but that's a byproduct of the reconciliation design, not a tested contract,
+  and explicitly does not extend across a process restart.
+- `AdeApp::close_file_tab`'s own "which tab becomes active next" fallback was deliberately left
+  reading only `open_files`' own neighbor, not the combined order - closing a file tab still
+  activates the next/previous *file* tab (falling back to the active session only once no file
+  tabs remain), rather than whichever tab is visually adjacent in the combined strip. Changing
+  this would touch a currently-working, separately-tested code path for a corner case outside the
+  two things actually asked for.
+
+**Testing discipline.** New coverage spans both layers: seven new `work_surface::state` plain
+`#[test]`s for `reconcile_tab_order`/`move_tab_order` (no GPUI needed - deliberately kept
+`gpui`-free like the rest of that module), and two new `#[gpui::test]`s in
+`work_surface::render`'s `tab_scoping_tests`: `dragging_a_file_tab_between_two_session_tabs_interleaves_them`
+(spawns two real sessions, opens one real temp file via the real `open_file_view` path, drags the
+file tab to land between the two sessions, asserts `combined_tab_order()` actually interleaves
+them - the core new capability), and `drop_dragged_tab_honors_the_recorded_insertion_side_then_clears_it`
+(asserts `insert_after` is honored and the caret state is cleared post-drop). The two existing
+drag-reorder tests were adapted in place rather than deleted, per the note above. Every new test
+was verified to actually fail without its corresponding fix by temporarily reverting the
+production code (breaking `move_tab_order`'s `insert_after` branch, no-opping
+`reconcile_tab_order`'s filter, no-opping `AdeApp::reorder_tab`'s call into `move_tab_order`, and
+hardcoding `drop_dragged_tab`'s `insert_after` to `false`), confirming the exact expected failure,
+then restoring the real fix.
+
+**Gates**, from this project's usual Linux sandbox (`export
+LIBRARY_PATH=/tmp/x11-deps/prefix/usr/lib/x86_64-linux-gnu`): `cargo fmt --all -- --check`,
+`cargo build --workspace`, and `cargo clippy --workspace --all-targets -- -D warnings` all clean.
+`cargo test --workspace --lib -- --test-threads=1`: **1230 passed, 0 failed** across all four
+crates on the final, clean run (`app` 1065, `lsp-core` 44, `pty-core` 14, `wt-core` 107). One
+earlier run of the full suite hit the known pre-existing `code_surface::diff_view::
+diff_render_tests` flake - a different test in that module than the two previously documented in
+this repo's own notes (`repeated_refreshes_of_the_same_open_diff_reuse_the_cached_highlighting`
+this time), same timing-sensitive family, `diff_view.rs` untouched anywhere by this change -
+confirmed it passes cleanly in isolation, and the subsequent full-suite re-run above was clean.

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -1176,6 +1176,22 @@ pub struct AdeApp {
     /// convention. Cleared by [`Self::start_new_file`]/[`Self::create_new_file`]'s own success
     /// path.
     pub(crate) new_file_error: Option<String>,
+    /// Each worktree's own real, drag-chosen tab order (GitHub issue #16) - session and file
+    /// tabs interleaved, keyed by that worktree's cwd. Never itself the source of truth for
+    /// which tabs exist (`Sessions`/[`Self::open_files`] still are - see
+    /// [`Self::combined_tab_order`]'s own docs); only [`Self::reorder_tab`] writes to it, and a
+    /// worktree with no entry here simply renders its sessions then its files, exactly the old
+    /// two-block layout.
+    pub(crate) tab_order: HashMap<PathBuf, Vec<work_surface::TabRef>>,
+    /// The unified tab strip's real, precise drop-target indicator (GitHub issue #16's "better
+    /// visual feedback" ask): `Some((target, insert_after))` while a tab is being dragged over
+    /// `target`'s own tab, where `insert_after` says whether the cursor is over the right half
+    /// of `target` (dragged tab would land immediately after it) or the left half (immediately
+    /// before) - see [`Self::render_tab_strip`]'s per-tab `on_drag_move` wiring. Cleared on drop
+    /// and, defensively, on any mouse-up over the workspace body, so a cancelled drag (released
+    /// outside any drop target) can't leave a stale caret painted on a tab no drag is over
+    /// anymore.
+    pub(crate) tab_drag_insertion: Option<(work_surface::TabRef, bool)>,
 }
 
 impl AdeApp {
@@ -1505,6 +1521,21 @@ impl AdeApp {
                     this.apply_pane_resize(target, event.event.position.x, cx);
                 },
             ))
+            // Defensive cleanup for `Self::tab_drag_insertion`: unlike `PaneResizeDrag` above,
+            // this one *does* need an explicit mouse-up handler, because it isn't derived fresh
+            // from the cursor position on every tick - it's the last tab strip
+            // `on_drag_move::<DraggedTab>` claimed, which stays stale if the drag ends by
+            // releasing outside any tab's own hitbox (a cancelled drag) rather than through a
+            // real `on_drop`. The body spans virtually the whole window below the title bar, so
+            // this reaches almost every real release point.
+            .on_mouse_up(
+                MouseButton::Left,
+                cx.listener(|this, _event: &gpui::MouseUpEvent, _window, cx| {
+                    if this.tab_drag_insertion.take().is_some() {
+                        cx.notify();
+                    }
+                }),
+            )
             // Captures the body's paint bounds into `Self::body_bounds` every render, the same
             // `gpui::canvas` pattern `vendor/zed/crates/workspace/src/workspace.rs` uses for its
             // own dock-resize `bounds` field.

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -267,6 +267,8 @@ impl AdeApp {
             new_file_input: None,
             new_file_focus_handle: cx.focus_handle(),
             new_file_error: None,
+            tab_order: HashMap::new(),
+            tab_drag_insertion: None,
         };
         // See the `expanded_dirs`/`fold_state_root_key` note in the literal above: resolving the
         // worktree key here, through the one function that ever resolves it, is what keeps the

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -3,6 +3,7 @@ use crate::root::widgets::{
     render_action_keycap_row, render_env_chip, render_hint_pair, render_keycap_row, text_tooltip,
     KeycapSize,
 };
+use gpui::DragMoveEvent;
 
 /// Defines one `JumpToSessionN` action handler forwarding a literal position to
 /// [`AdeApp::jump_to_session_at`]. Each `actions!`-generated struct is a distinct action type
@@ -330,22 +331,124 @@ impl AdeApp {
         }
     }
 
-    /// Every session open in the *currently selected* worktree (`Self::active_session_cwd`), in
-    /// creation order - the real per-worktree tab-strip filter (`crate::work_surface::sessions::Sessions::
-    /// iter_for_cwd`) both [`Self::render_tab_strip`] and [`Self::session_jump_keys`]/
-    /// [`Self::jump_to_session_at`] share, so the tabs shown and the tabs a jump keycap can
-    /// reach can never disagree.
-    pub(crate) fn current_worktree_sessions(&self) -> impl Iterator<Item = &Session> {
-        self.sessions.iter_for_cwd(self.active_session_cwd())
+    /// The active worktree's real combined tab order (GitHub issue #16) - every session and file
+    /// tab currently open in it, interleaved exactly as [`Self::render_tab_strip`] draws them,
+    /// instead of always "every session, then every file". Reconciled fresh from
+    /// [`Self::tab_order`]'s stored order plus whatever's *actually* open right now
+    /// (`work_surface::state::reconcile_tab_order`'s own docs on why this is safe to call on
+    /// every render rather than caching a mutated copy) - [`Self::tab_order`] itself only records
+    /// a user's real drag-chosen order, never which tabs exist; that's still `Sessions`/
+    /// [`Self::open_files`]'s job.
+    pub(crate) fn combined_tab_order(&self) -> Vec<work_surface::TabRef> {
+        let cwd = self.active_session_cwd();
+        let stored = self.tab_order.get(&cwd).map(Vec::as_slice).unwrap_or(&[]);
+        let session_ids: Vec<SessionId> = self
+            .sessions
+            .iter_for_cwd(cwd.clone())
+            .map(|session| session.id)
+            .collect();
+        work_surface::reconcile_tab_order(stored, &session_ids, &self.open_files)
     }
 
-    /// The tab strip: one [`render_session_tab`] per session open in the *currently selected*
-    /// worktree (`Self::current_worktree_sessions`) - never every session across every
-    /// worktree, per this revision's whole point (see `crate::root::mod`'s "One rail row per
-    /// worktree" docs) - followed by one [`Self::render_file_tab`] per entry of
-    /// [`Self::open_files`] in that `Vec`'s order (already worktree-scoped: `Self::
-    /// select_worktree` clears it on every switch), then the `+` menu button
-    /// ([`Self::render_tab_strip_plus`]) and right-aligned session-jump keycaps.
+    /// The unified tab strip's real drag-to-reorder entry point (GitHub issue #16) - moves
+    /// `dragged` to sit immediately before (or, if `insert_after`, immediately after) `target` in
+    /// the active worktree's own combined tab order, regardless of whether either is a session or
+    /// a file tab (`work_surface::state::move_tab_order`'s own docs on why this is one function,
+    /// not a per-kind pair). Persists the result into [`Self::tab_order`], keyed by the active
+    /// worktree's cwd, so it survives the next render's [`Self::combined_tab_order`]
+    /// reconciliation and, for session tabs, a later worktree switch away and back. Never
+    /// restarts a pty or reloads a file buffer - `Sessions`/[`Self::open_files`] themselves are
+    /// untouched; only this ordering layer changes.
+    pub(in crate::work_surface) fn reorder_tab(
+        &mut self,
+        dragged: work_surface::TabRef,
+        target: work_surface::TabRef,
+        insert_after: bool,
+        cx: &mut Context<Self>,
+    ) {
+        let cwd = self.active_session_cwd();
+        let mut order = self.combined_tab_order();
+        work_surface::move_tab_order(&mut order, &dragged, &target, insert_after);
+        self.tab_order.insert(cwd, order);
+        cx.notify();
+    }
+
+    /// One tab's own `on_drag_move::<DraggedTab>` handler (both [`Self::render_session_tab`] and
+    /// [`Self::render_file_tab`] register this, each closing over its own `hovered` [`work_surface::
+    /// TabRef`]) - real per-tab mouse tracking during a drag, not a container-level listener:
+    /// `on_drag_move`'s own doc comment and `crate::root::scrollbar`'s module docs both confirm
+    /// GPUI dispatches a matching `on_drag_move::<T>` to *every* mounted element of that type on
+    /// every drag-move tick, each receiving its own `event.bounds` - so every tab checks whether
+    /// the live cursor (`event.event.position`) actually falls inside its own bounds before
+    /// claiming the insertion caret; whichever tab's bounds the cursor is really over is the one
+    /// that wins, on the very next tick after the cursor crosses into it. Splits `hovered`'s own
+    /// width in half (`Bounds::center`) to decide "before" (`insert_after = false`, left half) vs.
+    /// "after" (`insert_after = true`, right half) - the exact cursor-position precision GitHub
+    /// issue #16 asks for, replacing the old whole-tab `border_l` highlight that couldn't tell
+    /// the two apart. A no-op while the dragged tab is hovering over *itself* - dropping a tab on
+    /// its own slot is always a no-op ([`work_surface::state::move_tab_order`]'s own docs), so no
+    /// caret should invite it either.
+    pub(in crate::work_surface) fn update_tab_drag_insertion(
+        &mut self,
+        hovered: &work_surface::TabRef,
+        event: &DragMoveEvent<DraggedTab>,
+        cx: &mut Context<Self>,
+    ) {
+        if event.drag(cx).tab_ref() == *hovered {
+            return;
+        }
+        if !event.bounds.contains(&event.event.position) {
+            return;
+        }
+        let insert_after = event.event.position.x >= event.bounds.center().x;
+        if self.tab_drag_insertion.as_ref() != Some(&(hovered.clone(), insert_after)) {
+            self.tab_drag_insertion = Some((hovered.clone(), insert_after));
+            cx.notify();
+        }
+    }
+
+    /// One tab's own `on_drop::<DraggedTab>` handler (both [`Self::render_session_tab`] and
+    /// [`Self::render_file_tab`] register this) - reads which half of `target`'s own tab the
+    /// cursor last landed on from [`Self::tab_drag_insertion`] (defaulting to "before" if the
+    /// drop lands on a tab [`Self::update_tab_drag_insertion`] never actually recorded for - a
+    /// drop can still fire on a tab the cursor technically never entered, e.g. a very fast
+    /// release), then delegates to [`Self::reorder_tab`], and clears the now-stale caret state.
+    pub(in crate::work_surface) fn drop_dragged_tab(
+        &mut self,
+        dragged: work_surface::TabRef,
+        target: work_surface::TabRef,
+        cx: &mut Context<Self>,
+    ) {
+        let insert_after = self
+            .tab_drag_insertion
+            .as_ref()
+            .is_some_and(|(hovered, after)| *hovered == target && *after);
+        self.reorder_tab(dragged, target, insert_after, cx);
+        self.tab_drag_insertion = None;
+    }
+
+    /// Every session open in the *currently selected* worktree (`Self::active_session_cwd`), in
+    /// the same order [`Self::combined_tab_order`] renders them - never Sessions' own raw
+    /// creation order once a real drag has interleaved them differently, and never every session
+    /// across every worktree, per this revision's whole point (see `crate::root::mod`'s "One
+    /// rail row per worktree" docs). The real per-worktree tab-strip order both
+    /// [`Self::render_tab_strip`] and [`Self::session_jump_keys`]/[`Self::jump_to_session_at`]
+    /// share, so the tabs shown and the tabs a jump keycap can reach can never disagree.
+    pub(crate) fn current_worktree_sessions(&self) -> impl Iterator<Item = &Session> {
+        let order = self.combined_tab_order();
+        order.into_iter().filter_map(move |tab_ref| match tab_ref {
+            work_surface::TabRef::Session(id) => {
+                self.sessions.iter().find(|session| session.id == id)
+            }
+            work_surface::TabRef::File(_) => None,
+        })
+    }
+
+    /// The tab strip: one tab per entry of [`Self::combined_tab_order`], in that exact order -
+    /// [`Self::render_session_tab`] for a `TabRef::Session`, [`Self::render_file_tab`] for a
+    /// `TabRef::File` - so a session tab and a file tab can sit side by side in either order
+    /// (GitHub issue #16), rather than always "every session, then every file" - followed by the
+    /// `+` menu button ([`Self::render_tab_strip_plus`]) and right-aligned session-jump keycaps.
     pub(in crate::work_surface) fn render_tab_strip(
         &self,
         cx: &mut Context<Self>,
@@ -360,18 +463,17 @@ impl AdeApp {
             .border_b_1()
             .border_color(theme::border::ZONE);
 
-        let session_ids: Vec<SessionId> = self
-            .current_worktree_sessions()
-            .map(|session| session.id)
-            .collect();
-        for id in &session_ids {
-            if let Some(session) = self.sessions.iter().find(|session| session.id == *id) {
-                bar = bar.child(self.render_session_tab(session, cx));
+        for tab_ref in self.combined_tab_order() {
+            match tab_ref {
+                work_surface::TabRef::Session(id) => {
+                    if let Some(session) = self.sessions.iter().find(|session| session.id == id) {
+                        bar = bar.child(self.render_session_tab(session, cx));
+                    }
+                }
+                work_surface::TabRef::File(path) => {
+                    bar = bar.child(self.render_file_tab(&path, cx));
+                }
             }
-        }
-
-        for path in &self.open_files {
-            bar = bar.child(self.render_file_tab(path, cx));
         }
 
         bar = bar.child(self.render_tab_strip_plus(cx));
@@ -454,13 +556,19 @@ impl AdeApp {
             .edit_buffers
             .get(path)
             .is_some_and(|buffer| buffer.is_dirty());
-        let drag_value = DraggedFileTab {
+        let tab_ref = work_surface::TabRef::File(path.to_path_buf());
+        let drag_value = DraggedTab::File {
             path: path.to_path_buf(),
             label: file_name.clone(),
+        };
+        let insertion_caret = match &self.tab_drag_insertion {
+            Some((target, insert_after)) if *target == tab_ref => Some(*insert_after),
+            _ => None,
         };
 
         div()
             .id(format!("file-tab-{key}"))
+            .relative()
             .flex()
             .flex_none()
             .flex_col()
@@ -477,21 +585,26 @@ impl AdeApp {
                     this.request_close_file_tab(middle_click_path.clone(), window, cx);
                 }),
             )
-            // Real drag-to-reorder among file tabs - see `DraggedSessionTab`'s own docs for the
-            // identical mechanism, mirrored here for `Self::open_files` instead of `Sessions`.
+            // Real drag-to-reorder, unified across session and file tabs (GitHub issue #16) -
+            // see `DraggedTab`'s own docs for the shared mechanism.
             .on_drag(drag_value, |dragged, _position, _window, cx| {
                 cx.new(|_| dragged.clone())
             })
-            .drag_over::<DraggedFileTab>(|tab, _dragged, _window, _cx| {
-                tab.border_l(px(2.0)).border_color(theme::status::ASK)
-            })
-            .on_drop(cx.listener({
-                let target = path.to_path_buf();
-                move |this, dragged: &DraggedFileTab, _window, cx| {
-                    this.reorder_open_file_before(&dragged.path, &target);
-                    cx.notify();
+            .on_drag_move(cx.listener({
+                let tab_ref = tab_ref.clone();
+                move |this, event: &DragMoveEvent<DraggedTab>, _window, cx| {
+                    this.update_tab_drag_insertion(&tab_ref, event, cx);
                 }
             }))
+            .on_drop(cx.listener({
+                let target = tab_ref.clone();
+                move |this, dragged: &DraggedTab, _window, cx| {
+                    this.drop_dragged_tab(dragged.tab_ref(), target.clone(), cx);
+                }
+            }))
+            .when_some(insertion_caret, |el, insert_after| {
+                el.child(render_tab_insertion_caret(insert_after))
+            })
             .child(
                 div()
                     .id(format!("file-tab-hit-{key}"))
@@ -569,33 +682,6 @@ impl AdeApp {
                     ),
             )
             .child(div().flex_none().w_full().h(px(1.0)).bg(colors.underline))
-    }
-
-    /// Moves `dragged` to sit immediately before `target` in [`Self::open_files`] - the file-tab
-    /// strip's own drag-to-reorder backing, mirroring `crate::work_surface::sessions::Sessions::move_before`'s
-    /// identical shape for session tabs. A no-op if either path isn't currently open, or if
-    /// they're the same path.
-    pub(in crate::work_surface) fn reorder_open_file_before(
-        &mut self,
-        dragged: &Path,
-        target: &Path,
-    ) {
-        if dragged == target {
-            return;
-        }
-        let Some(from) = self.open_files.iter().position(|path| path == dragged) else {
-            return;
-        };
-        if !self.open_files.iter().any(|path| path == target) {
-            return;
-        }
-        let path = self.open_files.remove(from);
-        let to = self
-            .open_files
-            .iter()
-            .position(|path| path == target)
-            .unwrap_or(self.open_files.len());
-        self.open_files.insert(to, path);
     }
 
     /// The tab strip's `+` menu button - toggles [`Self::plus_menu_open`] (unconditionally
@@ -1025,13 +1111,19 @@ impl AdeApp {
         };
         let is_mono = matches!(chip_kind, work_surface::TabChipKind::Cli);
         let colors = work_surface::tab_colors(is_active);
-        let drag_value = DraggedSessionTab {
+        let tab_ref = work_surface::TabRef::Session(id);
+        let drag_value = DraggedTab::Session {
             id,
             label: label.clone(),
+        };
+        let insertion_caret = match &self.tab_drag_insertion {
+            Some((target, insert_after)) if *target == tab_ref => Some(*insert_after),
+            _ => None,
         };
 
         div()
             .id(("session-tab", id))
+            .relative()
             .flex()
             .flex_none()
             .flex_col()
@@ -1049,24 +1141,28 @@ impl AdeApp {
                     cx.notify();
                 }),
             )
-            // Real drag-to-reorder (see `DraggedSessionTab`'s own docs): dragging this tab and
-            // dropping it on another session tab in the same (per-worktree) strip moves it to
-            // sit immediately before whichever tab it was dropped on
-            // (`crate::work_surface::sessions::Sessions::move_before`). No `can_drop` predicate needed - the
-            // `on_drop::<DraggedSessionTab>` type parameter alone already rejects a drop of any
-            // other dragged-value type (e.g. `DraggedFileTab`).
+            // Real drag-to-reorder, unified across session and file tabs (GitHub issue #16) -
+            // see `DraggedTab`'s own docs for the shared mechanism. No `can_drop` predicate
+            // needed - the `on_drop::<DraggedTab>` type parameter alone already rejects a drop of
+            // any other dragged-value type.
             .on_drag(drag_value, |dragged, _position, _window, cx| {
                 cx.new(|_| dragged.clone())
             })
-            .drag_over::<DraggedSessionTab>(|tab, _dragged, _window, _cx| {
-                tab.border_l(px(2.0)).border_color(theme::status::ASK)
+            .on_drag_move(cx.listener({
+                let tab_ref = tab_ref.clone();
+                move |this, event: &DragMoveEvent<DraggedTab>, _window, cx| {
+                    this.update_tab_drag_insertion(&tab_ref, event, cx);
+                }
+            }))
+            .on_drop(cx.listener({
+                let target = tab_ref.clone();
+                move |this, dragged: &DraggedTab, _window, cx| {
+                    this.drop_dragged_tab(dragged.tab_ref(), target.clone(), cx);
+                }
+            }))
+            .when_some(insertion_caret, |el, insert_after| {
+                el.child(render_tab_insertion_caret(insert_after))
             })
-            .on_drop(
-                cx.listener(move |this, dragged: &DraggedSessionTab, _window, cx| {
-                    this.sessions.move_before(dragged.id, id);
-                    cx.notify();
-                }),
-            )
             .child(
                 div()
                     .id(("session-tab-hit", id))
@@ -1882,21 +1978,44 @@ pub(in crate::work_surface) fn render_tab_chip(
     }
 }
 
-/// The tab strip's drag-to-reorder value for a session tab (`Self::render_session_tab`'s
-/// `on_drag`/`on_drop`) - real GPUI drag-and-drop (`on_drag`/`drag_over`/`can_drop`/`on_drop`,
-/// verified against `vendor/zed/crates/gpui/src/elements/div.rs` and mirroring
-/// `vendor/zed/crates/workspace/src/pane.rs`'s own `DraggedTab` for exactly this "reorder tabs
-/// by dragging" pattern), not this project's earlier `on_drag`/`on_drag_move` use in
-/// `crate::root::resize` (a resize-handle hack with no real drag *payload* at all). `Render`ing
-/// the dragged value itself as its own small floating chip - the same choice Zed's own
-/// `DraggedTab` makes - rather than a generic ghost, so what's being dragged stays legible.
+/// The unified tab strip's drag-to-reorder value (GitHub issue #16) - both
+/// [`AdeApp::render_session_tab`] and [`AdeApp::render_file_tab`]'s `on_drag`/`on_drag_move`/
+/// `on_drop` share this one type (rather than the two separate, kind-locked types this revision
+/// replaces) precisely so a session tab can be dropped onto a file tab and vice versa: GPUI's
+/// `on_drop::<T>`/`on_drag_move::<T>` dispatch purely on the dragged value's concrete type
+/// (verified against `vendor/zed/crates/gpui/src/elements/div.rs`, and
+/// `crate::root::scrollbar`'s own module docs on that exact dispatch rule), so two distinct types
+/// could never cross-target each other's drop handlers - real GPUI drag-and-drop
+/// (`on_drag`/`on_drag_move`/`on_drop`), not this project's earlier `on_drag`/`on_drag_move` use
+/// in `crate::root::resize` (a resize-handle hack with no real drag *payload* at all), and
+/// mirroring `vendor/zed/crates/workspace/src/pane.rs`'s own `DraggedTab` for the "reorder tabs
+/// by dragging" pattern itself. `Render`ing the dragged value as its own small floating chip -
+/// the same choice Zed's own `DraggedTab` makes - keeps what's being dragged legible.
 #[derive(Clone)]
-pub(in crate::work_surface) struct DraggedSessionTab {
-    pub(in crate::work_surface) id: SessionId,
-    pub(in crate::work_surface) label: String,
+pub(in crate::work_surface) enum DraggedTab {
+    Session { id: SessionId, label: String },
+    File { path: PathBuf, label: String },
 }
 
-impl Render for DraggedSessionTab {
+impl DraggedTab {
+    fn label(&self) -> &str {
+        match self {
+            DraggedTab::Session { label, .. } => label,
+            DraggedTab::File { label, .. } => label,
+        }
+    }
+
+    /// This dragged value's own identity as a [`work_surface::TabRef`] - what
+    /// [`AdeApp::reorder_tab`] actually moves, regardless of which concrete kind was dragged.
+    pub(in crate::work_surface) fn tab_ref(&self) -> work_surface::TabRef {
+        match self {
+            DraggedTab::Session { id, .. } => work_surface::TabRef::Session(*id),
+            DraggedTab::File { path, .. } => work_surface::TabRef::File(path.clone()),
+        }
+    }
+}
+
+impl Render for DraggedTab {
     fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
         div()
             .px(px(10.0))
@@ -1908,34 +2027,25 @@ impl Render for DraggedSessionTab {
             .font(font(theme::font::SANS))
             .text_size(px(11.0))
             .text_color(theme::text::BODY)
-            .child(self.label.clone())
+            .child(self.label().to_string())
     }
 }
 
-/// The file-tab strip's own drag-to-reorder value - see [`DraggedSessionTab`]'s own docs for the
-/// shared mechanism; kept as a distinct type (not a shared enum) so a session tab can never be
-/// accidentally dropped into a file-tab reorder or vice versa - GPUI's `on_drop::<T>` dispatches
-/// purely on the dragged value's concrete type.
-#[derive(Clone)]
-pub(in crate::work_surface) struct DraggedFileTab {
-    pub(in crate::work_surface) path: PathBuf,
-    pub(in crate::work_surface) label: String,
-}
-
-impl Render for DraggedFileTab {
-    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
-        div()
-            .px(px(10.0))
-            .py(px(4.0))
-            .rounded(theme::radius::CHIP)
-            .bg(theme::surface::PALETTE)
-            .border_1()
-            .border_color(theme::border::POPOVER)
-            .font(font(theme::font::SANS))
-            .text_size(px(11.0))
-            .text_color(theme::text::BODY)
-            .child(self.label.clone())
-    }
+/// A precise insertion-point marker (GitHub issue #16's "better visual feedback" ask) - a thin
+/// vertical bar at the exact boundary a dropped tab would land on: a hovered tab's own left edge
+/// if `insert_after` is `false` (the dragged tab would land immediately before it), its right
+/// edge if `insert_after` is `true` (immediately after) - replacing the old whole-tab `border_l`
+/// highlight, which never distinguished "before" from "after" the hovered tab, with an
+/// unambiguous "it lands exactly here" caret instead.
+fn render_tab_insertion_caret(insert_after: bool) -> impl IntoElement {
+    div()
+        .absolute()
+        .top(px(0.0))
+        .bottom(px(0.0))
+        .w(px(2.0))
+        .bg(theme::status::ASK)
+        .when(insert_after, |el| el.right(px(0.0)))
+        .when(!insert_after, |el| el.left(px(0.0)))
 }
 
 /// The session context bar's status pill: a coloured dot plus label in the status colour.
@@ -2262,8 +2372,10 @@ mod tab_scoping_tests {
         );
     }
 
-    /// Real drag-to-reorder: dropping one session tab onto another must actually change their
-    /// order in `Sessions`' own underlying storage (what `Self::render_tab_strip` iterates).
+    /// Real drag-to-reorder, unified across session and file tabs (GitHub issue #16): dropping
+    /// one session tab onto another must actually change the *combined* tab order
+    /// (`Self::current_worktree_sessions`, which now reads `Self::combined_tab_order` rather than
+    /// `Sessions`' own raw creation order - see that method's own docs on why).
     #[gpui::test]
     fn drag_reordering_two_session_tabs_changes_their_order(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
@@ -2288,17 +2400,24 @@ mod tab_scoping_tests {
             (initial_id, id2, id3)
         });
 
-        let before: Vec<SessionId> =
-            app.read_with(cx, |app, _| app.sessions.iter().map(|s| s.id).collect());
+        let before: Vec<SessionId> = app.read_with(cx, |app, _| {
+            app.current_worktree_sessions().map(|s| s.id).collect()
+        });
         assert_eq!(before, vec![initial_id, id2, id3]);
 
-        // The real drop handler's own logic: drag id3, drop it on `initial_id`'s tab.
-        app.update(cx, |app, _cx| {
-            app.sessions.move_before(id3, initial_id);
+        // The real drop handler's own logic: drag id3, drop it before `initial_id`'s tab.
+        app.update(cx, |app, cx| {
+            app.reorder_tab(
+                work_surface::TabRef::Session(id3),
+                work_surface::TabRef::Session(initial_id),
+                false,
+                cx,
+            );
         });
 
-        let after: Vec<SessionId> =
-            app.read_with(cx, |app, _| app.sessions.iter().map(|s| s.id).collect());
+        let after: Vec<SessionId> = app.read_with(cx, |app, _| {
+            app.current_worktree_sessions().map(|s| s.id).collect()
+        });
         assert_eq!(
             after,
             vec![id3, initial_id, id2],
@@ -2307,8 +2426,9 @@ mod tab_scoping_tests {
         );
     }
 
-    /// `move_before` must never corrupt the tab order on a bad target - an unknown dragged id, an
-    /// unknown drop target, or dropping a tab onto itself must all be real no-ops.
+    /// `Self::reorder_tab`/`work_surface::state::move_tab_order` must never corrupt the tab order
+    /// on a bad target - an unknown dragged id, an unknown drop target, or dropping a tab onto
+    /// itself must all be real no-ops.
     #[gpui::test]
     fn drag_reorder_is_a_no_op_for_an_unknown_or_identical_id(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
@@ -2317,14 +2437,30 @@ mod tab_scoping_tests {
             app.sessions.active_id().expect("initial shell session")
         });
 
-        app.update(cx, |app, _cx| {
-            app.sessions.move_before(initial_id, initial_id);
-            app.sessions.move_before(9999, initial_id);
-            app.sessions.move_before(initial_id, 9999);
+        app.update(cx, |app, cx| {
+            app.reorder_tab(
+                work_surface::TabRef::Session(initial_id),
+                work_surface::TabRef::Session(initial_id),
+                false,
+                cx,
+            );
+            app.reorder_tab(
+                work_surface::TabRef::Session(9999),
+                work_surface::TabRef::Session(initial_id),
+                false,
+                cx,
+            );
+            app.reorder_tab(
+                work_surface::TabRef::Session(initial_id),
+                work_surface::TabRef::Session(9999),
+                false,
+                cx,
+            );
         });
 
-        let after: Vec<SessionId> =
-            app.read_with(cx, |app, _| app.sessions.iter().map(|s| s.id).collect());
+        let after: Vec<SessionId> = app.read_with(cx, |app, _| {
+            app.current_worktree_sessions().map(|s| s.id).collect()
+        });
         assert_eq!(
             after,
             vec![initial_id],
@@ -2408,6 +2544,120 @@ mod tab_scoping_tests {
             foreground_ids(&app, cx),
             Vec::<SessionId>::new(),
             "with no active session, no pane may keep the foreground cadence"
+        );
+    }
+
+    /// The real cross-kind capability GitHub issue #16 exists to unlock: a file tab dragged so it
+    /// lands between two session tabs must actually interleave them in the combined tab order,
+    /// not just reorder within its own kind - the exact case the old, kind-locked
+    /// `DraggedSessionTab`/`DraggedFileTab` types could never produce (GPUI's `on_drop::<T>`
+    /// dispatches purely on the dragged value's concrete type, so a `DraggedFileTab` could never
+    /// be dropped onto a session tab's `on_drop::<DraggedSessionTab>` handler or vice versa).
+    #[gpui::test]
+    fn dragging_a_file_tab_between_two_session_tabs_interleaves_them(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let file_path = repo.path().join("a.txt");
+        std::fs::write(&file_path, "hello\n").expect("write a.txt");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+
+        let (initial_id, second_id) = app.update_in(cx, |app, window, cx| {
+            let initial_id = app.sessions.active_id().expect("initial shell session");
+            let second_id = app.sessions.spawn(
+                SessionKind::Shell,
+                repo.path().to_path_buf(),
+                12.0,
+                window,
+                cx,
+            );
+            app.open_file_view(file_path.clone(), window, cx);
+            (initial_id, second_id)
+        });
+
+        let before = app.read_with(cx, |app, _| app.combined_tab_order());
+        assert_eq!(
+            before,
+            vec![
+                work_surface::TabRef::Session(initial_id),
+                work_surface::TabRef::Session(second_id),
+                work_surface::TabRef::File(PathBuf::from("a.txt")),
+            ],
+            "with no drag yet, sessions come first (creation order), then files - the old \
+             two-block layout"
+        );
+
+        // The real cross-kind drop: drag the file tab so it lands between the two session tabs.
+        app.update(cx, |app, cx| {
+            app.reorder_tab(
+                work_surface::TabRef::File(PathBuf::from("a.txt")),
+                work_surface::TabRef::Session(second_id),
+                false,
+                cx,
+            );
+        });
+
+        let after = app.read_with(cx, |app, _| app.combined_tab_order());
+        assert_eq!(
+            after,
+            vec![
+                work_surface::TabRef::Session(initial_id),
+                work_surface::TabRef::File(PathBuf::from("a.txt")),
+                work_surface::TabRef::Session(second_id),
+            ],
+            "the file tab must now sit between the two session tabs - the real cross-group \
+             interleaving this revision exists to unlock"
+        );
+    }
+
+    /// `Self::drop_dragged_tab` must actually honor whichever half of the target tab the cursor
+    /// was last recorded over (`Self::tab_drag_insertion`, set by
+    /// `Self::update_tab_drag_insertion`'s own real per-tab `on_drag_move` tracking) - "after"
+    /// must land the dragged tab on the far side of the target from a plain "before" drop - and
+    /// must clear that state once handled, so a later drop on a different tab can't inherit it.
+    #[gpui::test]
+    fn drop_dragged_tab_honors_the_recorded_insertion_side_then_clears_it(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+
+        let (initial_id, second_id) = app.update_in(cx, |app, window, cx| {
+            let initial_id = app.sessions.active_id().expect("initial shell session");
+            let second_id = app.sessions.spawn(
+                SessionKind::Shell,
+                repo.path().to_path_buf(),
+                12.0,
+                window,
+                cx,
+            );
+            (initial_id, second_id)
+        });
+
+        // Simulates what a real `on_drag_move` tick over the right half of `second_id`'s tab
+        // would already have recorded, just before the drop.
+        app.update(cx, |app, _cx| {
+            app.tab_drag_insertion = Some((work_surface::TabRef::Session(second_id), true));
+        });
+
+        app.update(cx, |app, cx| {
+            app.drop_dragged_tab(
+                work_surface::TabRef::Session(initial_id),
+                work_surface::TabRef::Session(second_id),
+                cx,
+            );
+        });
+
+        let order = app.read_with(cx, |app, _| app.combined_tab_order());
+        assert_eq!(
+            order,
+            vec![
+                work_surface::TabRef::Session(second_id),
+                work_surface::TabRef::Session(initial_id),
+            ],
+            "insert_after == true must land the dragged tab immediately after the target, not \
+             before"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.tab_drag_insertion.clone()),
+            None,
+            "a handled drop must clear the now-stale insertion-caret state"
         );
     }
 }

--- a/crates/app/src/work_surface/sessions.rs
+++ b/crates/app/src/work_surface/sessions.rs
@@ -341,40 +341,6 @@ impl Sessions {
         }
         self.sync_pane_cadence(cx);
     }
-
-    /// Moves session `dragged_id` to sit immediately before session `target_id` in this app's
-    /// underlying tab order - the real backing for the tab strip's drag-to-reorder gesture
-    /// (`crate::root::AdeApp::render_session_tab`'s `on_drop`). A no-op if either id is
-    /// missing, or if they're the same id.
-    ///
-    /// Reorders within the single flat `Vec` shared by every worktree's sessions, not a
-    /// per-worktree sub-list - safe because the tab strip only ever drags tabs that are
-    /// already both visible in the same (per-worktree-filtered) strip, and inserting
-    /// `dragged_id` immediately before `target_id`'s own position preserves their relative
-    /// order in *any* filtered view that contains both, regardless of which other worktrees'
-    /// sessions happen to be interleaved between them in the real storage order.
-    pub fn move_before(&mut self, dragged_id: SessionId, target_id: SessionId) {
-        if dragged_id == target_id {
-            return;
-        }
-        let Some(from) = self
-            .sessions
-            .iter()
-            .position(|session| session.id == dragged_id)
-        else {
-            return;
-        };
-        if !self.sessions.iter().any(|session| session.id == target_id) {
-            return;
-        }
-        let session = self.sessions.remove(from);
-        let to = self
-            .sessions
-            .iter()
-            .position(|session| session.id == target_id)
-            .unwrap_or(self.sessions.len());
-        self.sessions.insert(to, session);
-    }
 }
 
 impl Default for Sessions {
@@ -387,12 +353,14 @@ impl Default for Sessions {
 mod tests {
     use super::*;
 
-    /// `move_before`/`close`/`activate_for_worktree` all need a real `Session` (a real
-    /// `Entity<TerminalPane>`, only buildable via `Sessions::spawn` inside a real GPUI window) to
-    /// exercise meaningfully, so that coverage lives in `work_surface::render`'s GPUI-test
-    /// module (`tab_scoping_tests`) instead, alongside the rest of this revision's worktree/tab
-    /// scoping coverage. This module only holds the plain, GPUI-free checks that don't need a
-    /// real pane at all.
+    /// `close`/`activate_for_worktree` both need a real `Session` (a real `Entity<TerminalPane>`,
+    /// only buildable via `Sessions::spawn` inside a real GPUI window) to exercise meaningfully,
+    /// so that coverage lives in `work_surface::render`'s GPUI-test module (`tab_scoping_tests`)
+    /// instead, alongside the rest of this revision's worktree/tab scoping coverage (and the
+    /// combined tab-order drag-to-reorder coverage - see `work_surface::state`'s own
+    /// `reconcile_tab_order`/`move_tab_order` for the tab strip's real ordering layer, which
+    /// tracks position on top of `Sessions` rather than inside it). This module only holds the
+    /// plain, GPUI-free checks that don't need a real pane at all.
     #[test]
     fn a_fresh_sessions_collection_has_no_active_session() {
         let sessions = Sessions::new();

--- a/crates/app/src/work_surface/state.rs
+++ b/crates/app/src/work_surface/state.rs
@@ -8,12 +8,100 @@
 //! wiring click handlers) happens one layer up, in `crate::root`, which has the
 //! `Context<AdeApp>` these decisions need to act on.
 
+use std::path::PathBuf;
+
 use gpui::Rgba;
 
 use crate::rail::status::Status;
 use crate::sidebar::file_tree::LangChip;
 use crate::theme;
-use crate::work_surface::sessions::SessionKind;
+use crate::work_surface::sessions::{SessionId, SessionKind};
+
+/// One entry in a worktree's combined tab-strip order (GitHub issue #16) - either a session tab
+/// or a file tab. `Sessions`/`crate::root::AdeApp::open_files` remain the real storage for
+/// *existence* and all process/buffer behaviour (spawning, closing, PTY lifecycle, edit-buffer
+/// state) - this only records where a tab sits *visually*, so the two groups can interleave in
+/// one strip instead of always rendering as two rigid blocks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TabRef {
+    Session(SessionId),
+    File(PathBuf),
+}
+
+/// Reconciles a worktree's stored tab order (`crate::root::AdeApp::tab_order`) against what's
+/// *actually* open right now: drops any entry that no longer exists (a closed session, a closed
+/// file tab), then appends anything open that isn't in `stored` yet (a freshly spawned session,
+/// a freshly opened file) in `sessions_for_cwd`/`open_files`'s own order - the same "just append
+/// at the end" position a brand new tab has always landed at.
+///
+/// Pure and idempotent: calling it again on its own output, with the same
+/// `sessions_for_cwd`/`open_files`, changes nothing. That's what lets
+/// `crate::root::AdeApp::combined_tab_order` call this fresh on every render instead of caching
+/// a mutated copy - only a real drag-drop (`crate::root::AdeApp::reorder_tab`) needs to persist a
+/// changed `Vec<TabRef>` back into `tab_order`.
+pub fn reconcile_tab_order(
+    stored: &[TabRef],
+    sessions_for_cwd: &[SessionId],
+    open_files: &[PathBuf],
+) -> Vec<TabRef> {
+    let mut order: Vec<TabRef> = stored
+        .iter()
+        .filter(|tab_ref| match tab_ref {
+            TabRef::Session(id) => sessions_for_cwd.contains(id),
+            TabRef::File(path) => open_files.contains(path),
+        })
+        .cloned()
+        .collect();
+    for id in sessions_for_cwd {
+        if !order
+            .iter()
+            .any(|tab_ref| matches!(tab_ref, TabRef::Session(existing) if existing == id))
+        {
+            order.push(TabRef::Session(*id));
+        }
+    }
+    for path in open_files {
+        if !order
+            .iter()
+            .any(|tab_ref| matches!(tab_ref, TabRef::File(existing) if existing == path))
+        {
+            order.push(TabRef::File(path.clone()));
+        }
+    }
+    order
+}
+
+/// Moves `dragged` to sit immediately before `target` (or immediately after it, if
+/// `insert_after`) in `order` - the real backing for the unified tab strip's drag-to-reorder
+/// gesture (`crate::root::AdeApp::reorder_tab`), used regardless of whether `dragged`/`target`
+/// are the same kind (`TabRef::Session`/`TabRef::File`) or not, which is GitHub issue #16's real
+/// "any tab can cross into either group" ask - there is no separate per-kind reorder function to
+/// keep in sync. A no-op if either entry is missing from `order`, or if they're the same entry.
+pub fn move_tab_order(
+    order: &mut Vec<TabRef>,
+    dragged: &TabRef,
+    target: &TabRef,
+    insert_after: bool,
+) {
+    if dragged == target {
+        return;
+    }
+    let Some(from) = order.iter().position(|tab_ref| tab_ref == dragged) else {
+        return;
+    };
+    if !order.iter().any(|tab_ref| tab_ref == target) {
+        return;
+    }
+    let item = order.remove(from);
+    let mut to = order
+        .iter()
+        .position(|tab_ref| tab_ref == target)
+        .unwrap_or(order.len());
+    if insert_after {
+        to += 1;
+    }
+    order.insert(to, item);
+}
 
 /// Fully transparent - used for the "outline"/"ghost" button variants and an inactive tab's
 /// background, so every button/tab can always call `.bg()`/`.border_color()` uniformly rather
@@ -556,5 +644,122 @@ mod tests {
                 }
             }
         }
+    }
+
+    /// A fresh worktree (nothing dragged yet) must render its sessions first, in creation order,
+    /// then its file tabs, in `open_files`' own order - exactly the old two-block layout, so this
+    /// revision's interleaving layer is a strict superset of the old behaviour, not a visible
+    /// change until a real drag happens.
+    #[test]
+    fn reconcile_with_no_stored_order_appends_sessions_then_files_in_their_own_order() {
+        let order = reconcile_tab_order(
+            &[],
+            &[1, 2],
+            &[PathBuf::from("a.rs"), PathBuf::from("b.rs")],
+        );
+        assert_eq!(
+            order,
+            vec![
+                TabRef::Session(1),
+                TabRef::Session(2),
+                TabRef::File(PathBuf::from("a.rs")),
+                TabRef::File(PathBuf::from("b.rs")),
+            ]
+        );
+    }
+
+    /// The real interleaving case (GitHub issue #16): a stored order with a file tab sitting
+    /// between two session tabs must survive reconciliation unchanged, as long as every entry in
+    /// it still exists.
+    #[test]
+    fn reconcile_preserves_a_stored_interleaved_order() {
+        let stored = vec![
+            TabRef::Session(1),
+            TabRef::File(PathBuf::from("a.rs")),
+            TabRef::Session(2),
+        ];
+        let order = reconcile_tab_order(&stored, &[1, 2], &[PathBuf::from("a.rs")]);
+        assert_eq!(order, stored);
+    }
+
+    /// A session closed (or a file tab closed) since the order was last stored must be dropped,
+    /// not left as a dangling reference to something `crate::root::AdeApp::render_tab_strip`
+    /// would otherwise try to render.
+    #[test]
+    fn reconcile_drops_entries_that_no_longer_exist() {
+        let stored = vec![
+            TabRef::Session(1),
+            TabRef::File(PathBuf::from("a.rs")),
+            TabRef::Session(2),
+        ];
+        let order = reconcile_tab_order(&stored, &[2], &[]);
+        assert_eq!(order, vec![TabRef::Session(2)]);
+    }
+
+    /// A brand new session/file not yet in the stored order must be appended at the end, never
+    /// silently dropped or inserted somewhere the user never asked for.
+    #[test]
+    fn reconcile_appends_newly_opened_tabs_not_yet_in_the_stored_order() {
+        let stored = vec![TabRef::Session(1)];
+        let order = reconcile_tab_order(&stored, &[1, 2], &[PathBuf::from("a.rs")]);
+        assert_eq!(
+            order,
+            vec![
+                TabRef::Session(1),
+                TabRef::Session(2),
+                TabRef::File(PathBuf::from("a.rs")),
+            ]
+        );
+    }
+
+    /// The real cross-kind drag this revision exists to unlock: dropping a file tab so it lands
+    /// immediately before a session tab must actually interleave them, not just reorder within
+    /// each tab's own kind.
+    #[test]
+    fn move_tab_order_drops_a_file_tab_before_a_session_tab() {
+        let mut order = vec![
+            TabRef::Session(1),
+            TabRef::Session(2),
+            TabRef::File(PathBuf::from("a.rs")),
+        ];
+        move_tab_order(
+            &mut order,
+            &TabRef::File(PathBuf::from("a.rs")),
+            &TabRef::Session(2),
+            false,
+        );
+        assert_eq!(
+            order,
+            vec![
+                TabRef::Session(1),
+                TabRef::File(PathBuf::from("a.rs")),
+                TabRef::Session(2),
+            ]
+        );
+    }
+
+    /// `insert_after` must land the dragged tab on the far side of the target from a plain
+    /// "insert before" - the real distinction the insertion-caret precision (left half vs. right
+    /// half of the hovered tab) is for.
+    #[test]
+    fn move_tab_order_respects_insert_after() {
+        let mut order = vec![TabRef::Session(1), TabRef::Session(2), TabRef::Session(3)];
+        move_tab_order(&mut order, &TabRef::Session(1), &TabRef::Session(2), true);
+        assert_eq!(
+            order,
+            vec![TabRef::Session(2), TabRef::Session(1), TabRef::Session(3)]
+        );
+    }
+
+    /// `move_tab_order` must never corrupt the order on a bad move - dropping a tab onto itself,
+    /// an unknown dragged entry, or an unknown target must all be real no-ops.
+    #[test]
+    fn move_tab_order_is_a_no_op_for_an_unknown_or_identical_entry() {
+        let original = vec![TabRef::Session(1), TabRef::File(PathBuf::from("a.rs"))];
+        let mut order = original.clone();
+        move_tab_order(&mut order, &TabRef::Session(1), &TabRef::Session(1), false);
+        move_tab_order(&mut order, &TabRef::Session(99), &TabRef::Session(1), false);
+        move_tab_order(&mut order, &TabRef::Session(1), &TabRef::Session(99), false);
+        assert_eq!(order, original);
     }
 }


### PR DESCRIPTION
## Summary

Closes the two concrete asks from #16 that were explicitly scoped in for this pass (the full issue body describes a larger feature - see "Explicitly out of scope" below):

- **All tabs draggable between the terminal-tab group and the file-tab group.** Session tabs and file tabs used to render as two rigid, non-interleaving blocks because their order came from two separate lists (`Sessions`'s own `Vec<Session>` and `AdeApp::open_files`) with no shared notion of position, and drag-and-drop was split into two kind-locked types (`DraggedSessionTab`/`DraggedFileTab`) that could never cross-target each other's `on_drop` handlers. This adds a real combined per-worktree order (`work_surface::state::TabRef`, an enum of `Session(SessionId)`/`File(PathBuf)`, stored in `AdeApp::tab_order: HashMap<PathBuf, Vec<TabRef>>` and reconciled fresh against `Sessions`/`open_files` on every render) and merges the two dragged types into one `DraggedTab` enum, so any tab can now be dropped anywhere in the strip regardless of kind. `Sessions`/`open_files` themselves are unchanged - moving a tab's position never restarts a PTY or reloads a file buffer.
- **Better visual feedback during drag.** Replaces the old whole-tab `border_l` highlight (which never distinguished "before" from "after" the hovered tab) with a precise 2px insertion caret rendered at the exact boundary a dropped tab would land on - computed per-tab via `on_drag_move`, checking which half of the hovered tab's own bounds the cursor is over.

Keyboard tab-cycling (`secondary-1`..`8` jump keycaps, Session-menu "Next/Previous session") and existing tab actions (close, activate, middle-click close per #26) all read the same combined order now, so they stay correct regardless of a tab's position after a drag.

## Explicitly out of scope (per the user's own narrowing of #16, not a partial attempt)

- No reduced-motion setting - no new animation exists for it to gate.
- No settle/cancel spring animations for the dragged chip or tabs it passes over - the existing instant-reflow ghost is unchanged.
- No designed guarantee that an arbitrary mixed layout survives an app **restart** - `tab_order` is in-memory only, never persisted to `settings.toml`/disk. It does naturally survive a worktree switch away and back within the same running window (a side effect of how the order reconciles against what's still open, not a tested contract).

See this PR's `BUILD-LOG.md` entry for the full technical writeup (data-structure rationale, why `Sessions::move_before`/`AdeApp::reorder_open_file_before` were removed rather than kept in parallel, and the drop-indicator mechanism verified against `vendor/zed/crates/gpui/src/elements/div.rs`'s real `on_drag_move` dispatch).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib -- --test-threads=1` - 1230 passed, 0 failed (app 1065, lsp-core 44, pty-core 14, wt-core 107)
- [x] New regression tests added and each verified to actually fail without its corresponding fix (temporarily reverted, confirmed failure, restored) before being trusted: `reconcile_tab_order`/`move_tab_order` pure-logic tests, plus two `#[gpui::test]`s exercising the real cross-kind drag (`dragging_a_file_tab_between_two_session_tabs_interleaves_them`) and the insertion-side/clear-on-drop wiring (`drop_dragged_tab_honors_the_recorded_insertion_side_then_clears_it`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)