### PR TITLE
feat(app): repo data model - Revision R12 Phase 0

### DIFF
--- a/crates/app/src/code_surface/tabs.rs
+++ b/crates/app/src/code_surface/tabs.rs
@@ -15,6 +15,11 @@ impl AdeApp {
         self.diff_root = root.clone();
         self.diff_state = DiffLoadState::Loading;
         self.diff_totals = None;
+        // A reloaded diff is a new worktree's (or the same worktree's freshly re-read) file
+        // list - any authorship recorded against the *previous* one belongs to files that may
+        // not even be in this diff anymore. See `changes::Authorship`'s own docs for why this is
+        // always empty today regardless (no real tracking wired up yet).
+        self.file_authorship = changes::Authorship::default();
         cx.notify();
         let task = cx.spawn(async move |this, cx| {
             let result = cx

--- a/crates/app/src/merge/flow.rs
+++ b/crates/app/src/merge/flow.rs
@@ -80,7 +80,7 @@ impl AdeApp {
         let Some(session) = self.sessions.iter().find(|session| session.id == id) else {
             return;
         };
-        let repo_path = self.repo_path.clone();
+        let repo_path = self.focused_repo_path();
         let worktree_path = session.cwd.clone();
         // A fresh attempt, even one reusing `id` (e.g. Abort then immediately Merge again on the
         // same session tab) - see `merge::MergeFlow::generation`'s own docs. Any hand-edit from a
@@ -284,7 +284,7 @@ impl AdeApp {
                             this.merge_flow = None;
                             this.clear_merge_edit_state();
                         }
-                        let repo_path = this.repo_path.clone();
+                        let repo_path = this.focused_repo_path();
                         this.load_worktrees(cx);
                         this.load_diff(repo_path, cx);
                     }
@@ -294,7 +294,7 @@ impl AdeApp {
                             // MERGE_HEAD is still present when `complete_merge`'s defense in
                             // depth is what failed, so `Abort merge` stays offered.
                             let abortable_worktree =
-                                wt_core::merge::find_in_progress_merge(&this.repo_path)
+                                wt_core::merge::find_in_progress_merge(&this.focused_repo_path())
                                     .ok()
                                     .flatten();
                             if let Some(flow) = this.merge_flow.as_mut() {
@@ -367,8 +367,11 @@ impl AdeApp {
                             this.clear_merge_edit_state();
                         }
                         Err(err) => {
-                            let abortable_worktree =
-                                wt_core::merge::find_in_progress_merge(&this.repo_path).ok().flatten();
+                            let abortable_worktree = wt_core::merge::find_in_progress_merge(
+                                &this.focused_repo_path(),
+                            )
+                            .ok()
+                            .flatten();
                             if let Some(flow) = this.merge_flow.as_mut() {
                                 flow.state = merge::MergeFlowState::Error {
                                     message: format!(

--- a/crates/app/src/rail/mod.rs
+++ b/crates/app/src/rail/mod.rs
@@ -3,6 +3,9 @@
 //! Split the way every feature folder in this crate is split - pure, GPUI-window-free
 //! logic separate from the `gpui::Div`-building code that draws it:
 //!
+//! - [`repo`] - one added git repository (`Repo`/`RepoId`), the rail's group level
+//!   (Revision R12 Phase 0), plus its own crash-safe `~/.config/jerry/repos.toml`
+//!   persistence, mirroring [`crate::sidebar::fold_state`]'s pattern.
 //! - [`state`] - the pure row model: one row per worktree, aggregating every session open
 //!   in it, plus the filter/grouping rules. No `gpui::Window`.
 //! - [`worktrees`] - maps `wt-core`'s raw worktree list into that row model's input shape, plus
@@ -40,6 +43,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::time::Instant;
 
+pub mod repo;
 pub mod state;
 pub mod status;
 pub mod worktree_watch;

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -117,6 +117,9 @@ impl AdeApp {
                     del: diff.map(|summary| summary.del).unwrap_or(0),
                     question_preview,
                     exit_code: pane.exit_status().map(|status| status.exit_code()),
+                    // See `SessionRow::activity`'s own docs: no real PTY-activity heuristic is
+                    // wired up yet, so every row threads `None` through for now.
+                    activity: None,
                 }
             })
             .collect()
@@ -268,7 +271,7 @@ impl AdeApp {
     ///   backstop for changes with no filesystem-watchable signature at all (a worktree
     ///   directory deleted by hand - see [`crate::rail::worktree_watch`]'s module docs).
     pub(crate) fn start_worktree_watch(&mut self, cx: &mut Context<Self>) {
-        let repo_path = self.repo_path.clone();
+        let repo_path = self.focused_repo_path();
         let dirty: worktree_watch::DirtyFlag = Arc::new(AtomicBool::new(false));
         self._worktree_watcher = worktree_watch::spawn_worktree_watcher(&repo_path, dirty.clone());
 
@@ -375,7 +378,7 @@ impl AdeApp {
             cx.notify();
             return;
         }
-        let repo_path = self.repo_path.clone();
+        let repo_path = self.focused_repo_path();
         self.prune_in_flight = true;
         self.prune_status = Some(format!("pruning {} worktree(s)...", candidates.len()));
         cx.notify();
@@ -797,10 +800,9 @@ impl AdeApp {
         }
 
         let project_name = self
-            .repo_path
-            .file_name()
-            .map(|name| name.to_string_lossy().into_owned())
-            .unwrap_or_else(|| self.repo_path.display().to_string());
+            .focused_repo()
+            .map(|repo| repo.name.clone())
+            .unwrap_or_else(|| self.focused_repo_path().display().to_string());
         let project_branch = self
             .worktrees
             .iter()

--- a/crates/app/src/rail/repo.rs
+++ b/crates/app/src/rail/repo.rs
@@ -1,0 +1,426 @@
+//! A **repo**: one git repository the user has added to Jerry - the top level of the rail's
+//! two-level grouping, `design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §2.0 ("What
+//! a repo is here, and why the rail groups by one"). A real checkout on disk (`~/code/
+//! jerry-core`); every worktree belongs to exactly one repo and carries it (`repo:` on the
+//! worktree record, a later phase's concern - see [`Repo::worktrees`]'s own docs for why that
+//! field can't just be derived by walking up a worktree's path).
+//!
+//! Kept separate from [`super::worktrees`] (which maps *one* repo's `wt_core::WorktreeResult`
+//! list into display rows) the same way [`super::status`] is separate from [`super::state`]:
+//! [`Repo`] is the identity/persistence layer multiple worktrees hang off of, not another
+//! worktree-shaped thing itself.
+//!
+//! ## Persistence
+//!
+//! Which repos are currently added must survive an app restart (this revision's Phase 0 scope -
+//! see the revision doc's introduction). [`RepoState`] is `crate::sidebar::fold_state::FoldState`'s
+//! own shape and safety properties, copied rather than reinvented: a sibling
+//! `~/.config/jerry/repos.toml`, written via the identical crash-safe temp-file-then-rename
+//! sequence ([`RepoState::save_at`]), and merged rather than clobbered when more than one `jerry`
+//! process is running ([`RepoState::save_merged_at`]) - see that module's docs for the full
+//! reasoning, which applies here unchanged. The one difference: a repo has no per-worktree
+//! sub-structure to merge *within* one key the way fold state's `expanded` set does, so there is
+//! no `*_with_key` fast path here - [`repo_key`] is only ever called from real add/remove/save
+//! points (a user action, or startup), never a render or per-keystroke path, so its blocking
+//! `std::fs::canonicalize` call is cheap enough to call directly rather than caching it the way
+//! `crate::root::AdeApp::fold_state_root_key` caches [`super::worktrees`]'s equivalent.
+
+use std::collections::BTreeMap;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::rail::worktrees::WorktreeItem;
+
+/// Stable identity for one added repo. A plain, process-local monotonic counter
+/// (`crate::root::AdeApp::next_repo_id`) - **not** derived from the path, since a repo can be
+/// removed and re-added (or its directory renamed) without the identity a worktree's `repo:`
+/// reference points at needing to change mid-session. Never persisted itself: [`RepoState`]
+/// re-derives a fresh id per entry on every load (see that type's docs), since nothing durable
+/// outside one running process needs to reference a specific numeric id across a restart yet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct RepoId(pub u64);
+
+/// One git repository the user has added - the rail's group header, and eventually the owner of
+/// every worktree under it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Repo {
+    pub id: RepoId,
+    /// The real checkout's path on disk. Jerry's own worktrees for this repo live *outside* this
+    /// path entirely (`~/.jerry/wt/<name>`, per the revision doc) - this is only ever the main
+    /// checkout's own location.
+    pub path: PathBuf,
+    /// What the rail's group header shows - the directory's own basename by default (see
+    /// [`display_name`]), persisted alongside the path so a repo whose directory has since been
+    /// renamed or gone missing still has something honest to call itself.
+    pub name: String,
+    /// Every worktree belonging to this repo, main checkout included (`design_handoff_jerry_ade/
+    /// revision 3/REVISION-2026-07-31.md` §2.0: "The repo's main checkout is itself a worktree
+    /// row in its group"). Always empty today - **not** wired to `wt_core::list_worktrees` by
+    /// this phase, which is data-model-and-persistence only (see `crate::root::AdeApp::worktrees`
+    /// for where the single-focused-repo worktree list still lives while that wiring is pending).
+    /// Real per-repo population is a later rail-rendering phase's job; this field exists now so
+    /// that phase has a real place to write into rather than bolting one on afterwards.
+    pub worktrees: Vec<WorktreeItem>,
+}
+
+impl Repo {
+    /// Builds a fresh, worktree-less `Repo` for `path`, deriving its display name the same way
+    /// [`super::worktrees::build_worktree_items`] derives a worktree's own label when it has no
+    /// branch: the path's basename, falling back to the whole path for a root-only path (`/`) or
+    /// one that ends in `..`/`.`.
+    pub fn new(id: RepoId, path: PathBuf) -> Self {
+        let name = display_name(&path);
+        Repo {
+            id,
+            path,
+            name,
+            worktrees: Vec::new(),
+        }
+    }
+}
+
+fn display_name(path: &Path) -> String {
+    match path.file_name() {
+        Some(name) => name.to_string_lossy().into_owned(),
+        None => path.to_string_lossy().into_owned(),
+    }
+}
+
+/// The repo-list file's name, resolved next to the real `settings.toml` - mirrors
+/// `crate::sidebar::fold_state::FOLD_STATE_FILE_NAME`.
+pub const REPO_STATE_FILE_NAME: &str = "repos.toml";
+
+/// The repo-list file for a given real settings-file path - identical reasoning to
+/// `crate::sidebar::fold_state::fold_state_path_for`: a test that supplies a temp-dir settings
+/// path gets real, isolated repo-list persistence in that same directory, and a test that passes
+/// `None` gets none at all.
+pub fn repo_state_path_for(settings_path: &Path) -> PathBuf {
+    match settings_path.parent() {
+        Some(parent) => parent.join(REPO_STATE_FILE_NAME),
+        None => PathBuf::from(REPO_STATE_FILE_NAME),
+    }
+}
+
+/// The map key for one repo - its real path, canonicalized so the same repo reached through a
+/// symlink (or a `.`-relative invocation) resolves to one entry rather than two. Falls back to
+/// the path as given when it can't be canonicalized (doesn't exist yet, or is a pure in-memory
+/// path in a unit test) - still a stable key for that path. `None` for a path that isn't valid
+/// UTF-8, refused outright for the identical reason `crate::sidebar::fold_state::worktree_key`
+/// refuses one: a lossy `to_string_lossy` key could collide two genuinely different repos onto
+/// one TOML key.
+pub fn repo_key(path: &Path) -> Option<String> {
+    let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    canonical.to_str().map(str::to_owned)
+}
+
+/// The whole on-disk repo-list file: every repo this user has ever added, keyed by [`repo_key`].
+/// A `BTreeMap` (not a `HashMap`) so the serialized file has a stable, diffable order rather than
+/// reshuffling itself on every write - the identical reasoning
+/// `crate::sidebar::fold_state::FoldState` gives for its own map.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct RepoState {
+    pub repos: BTreeMap<String, RepoRecord>,
+}
+
+/// One repo's persisted record - just its display name today. The map key (a [`repo_key`]) is
+/// the path; nothing about `Repo::worktrees` is persisted here (see that field's own docs for
+/// why - it isn't populated yet at all).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct RepoRecord {
+    pub name: String,
+}
+
+/// How stale a `*.tmp` sibling must be before [`sweep_orphaned_temp_files`] deletes it - the
+/// identical constant/reasoning `crate::sidebar::fold_state` uses for its own file.
+const ORPHANED_TEMP_MAX_AGE: std::time::Duration = std::time::Duration::from_secs(60 * 60);
+
+/// Deletes leftover `<file-name>.<pid>.<n>.tmp` siblings from a save that was killed between
+/// creating its temp file and renaming it - see `crate::sidebar::fold_state::
+/// sweep_orphaned_temp_files`'s own docs, which this mirrors exactly for `repos.toml`'s own
+/// sibling temp files rather than sharing one function across two otherwise-unrelated file
+/// formats.
+fn sweep_orphaned_temp_files(path: &Path, file_name: &str) {
+    let Some(parent) = path.parent() else {
+        return;
+    };
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return;
+    };
+    let prefix = format!("{file_name}.");
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        if !name.starts_with(&prefix) || !name.ends_with(".tmp") {
+            continue;
+        }
+        let stale = entry
+            .metadata()
+            .and_then(|metadata| metadata.modified())
+            .and_then(|modified| {
+                std::time::SystemTime::now()
+                    .duration_since(modified)
+                    .map_err(|err| io::Error::other(err.to_string()))
+            })
+            .is_ok_and(|age| age > ORPHANED_TEMP_MAX_AGE);
+        if stale {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
+}
+
+impl RepoState {
+    /// Loads `path`, falling back to an empty state for *any* failure - missing file (the
+    /// overwhelmingly common first-run case), unreadable file, or unparseable contents. Exactly
+    /// `crate::sidebar::fold_state::FoldState::load_at`'s own contract: the repo list is never
+    /// important enough to fail startup over.
+    pub fn load_at(path: &Path) -> RepoState {
+        let Ok(contents) = std::fs::read_to_string(path) else {
+            return RepoState::default();
+        };
+        match toml::from_str::<RepoState>(&contents) {
+            Ok(state) => state,
+            Err(err) => {
+                log::warn!(
+                    "{} failed to parse ({err}) - starting from an empty repo list",
+                    path.display()
+                );
+                RepoState::default()
+            }
+        }
+    }
+
+    /// Writes `self` to `path` **atomically**: a sibling `*.tmp` file first, `File::sync_all`,
+    /// then a same-directory `std::fs::rename` over the target, then a best-effort parent-
+    /// directory sync - identical mechanics and identical reasoning to
+    /// `crate::sidebar::fold_state::FoldState::save_at` (see that method's own docs for exactly
+    /// why each step exists); repeated here rather than shared because the two persisted files
+    /// have unrelated shapes and this crash-safety sequence is the only part they have in common.
+    pub fn save_at(&self, path: &Path) -> io::Result<()> {
+        use std::io::Write;
+
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let contents = toml::to_string_pretty(self)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+        let file_name = path
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| REPO_STATE_FILE_NAME.to_string());
+        static WRITE_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let unique = WRITE_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let temp = path.with_file_name(format!("{file_name}.{}.{unique}.tmp", std::process::id()));
+
+        let write_result = (|| -> io::Result<()> {
+            let mut file = std::fs::File::create(&temp)?;
+            file.write_all(contents.as_bytes())?;
+            file.sync_all()
+        })();
+        if let Err(err) = write_result {
+            let _ = std::fs::remove_file(&temp);
+            return Err(err);
+        }
+        if let Err(err) = std::fs::rename(&temp, path) {
+            let _ = std::fs::remove_file(&temp);
+            return Err(err);
+        }
+        if let Some(parent) = path.parent() {
+            if let Ok(dir) = std::fs::File::open(parent) {
+                let _ = dir.sync_all();
+            }
+        }
+        sweep_orphaned_temp_files(path, &file_name);
+        Ok(())
+    }
+
+    /// The app's real write path: merges `self`'s entries for the repos this instance actually
+    /// touched (`owned`) into whatever is currently on disk, then writes the result via
+    /// [`Self::save_at`] - `crate::sidebar::fold_state::FoldState::save_merged_at`'s own contract,
+    /// copied because two `jerry` processes each open against a different repo are exactly the
+    /// same "two writers, one file" situation fold state already solved: a plain whole-file write
+    /// here would let the second process's save silently erase the first process's repo from the
+    /// list the moment it saves anything of its own.
+    ///
+    /// `owned` is the set of [`repo_key`]s this instance has recorded anything for (added or
+    /// removed) - taken from `self`, *including absence* (that's how removing a repo deletes its
+    /// entry); every other key already on disk is passed through untouched.
+    pub fn save_merged_at(
+        &self,
+        path: &Path,
+        owned: &std::collections::BTreeSet<String>,
+    ) -> io::Result<()> {
+        let mut merged = RepoState::load_at(path);
+        for key in owned {
+            match self.repos.get(key) {
+                Some(entry) => merged.repos.insert(key.clone(), entry.clone()),
+                None => merged.repos.remove(key),
+            };
+        }
+        merged.save_at(path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repo_state_lives_next_to_the_real_settings_file() {
+        let path = repo_state_path_for(Path::new("/home/someone/.config/jerry/settings.toml"));
+        assert_eq!(
+            path,
+            PathBuf::from("/home/someone/.config/jerry/repos.toml")
+        );
+    }
+
+    #[test]
+    fn repo_new_derives_a_display_name_from_the_path_basename() {
+        let repo = Repo::new(RepoId(0), PathBuf::from("/home/user/code/jerry-core"));
+        assert_eq!(repo.name, "jerry-core");
+        assert!(repo.worktrees.is_empty());
+    }
+
+    #[test]
+    fn repo_new_falls_back_to_the_whole_path_when_there_is_no_basename() {
+        let repo = Repo::new(RepoId(0), PathBuf::from("/"));
+        assert_eq!(repo.name, "/");
+    }
+
+    #[test]
+    fn a_missing_file_loads_as_empty_state_rather_than_failing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state = RepoState::load_at(&dir.path().join("does-not-exist.toml"));
+        assert_eq!(state, RepoState::default());
+    }
+
+    #[test]
+    fn a_corrupted_file_loads_as_empty_state_rather_than_failing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("repos.toml");
+        std::fs::write(&path, "this is not valid toml {{{").expect("write");
+        assert_eq!(RepoState::load_at(&path), RepoState::default());
+    }
+
+    #[test]
+    fn saving_and_loading_round_trips_a_real_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("repos.toml");
+        let mut state = RepoState::default();
+        state.repos.insert(
+            "/repo/a".to_string(),
+            RepoRecord {
+                name: "a".to_string(),
+            },
+        );
+        state.repos.insert(
+            "/repo/b".to_string(),
+            RepoRecord {
+                name: "b".to_string(),
+            },
+        );
+        state.save_at(&path).expect("save");
+
+        let reloaded = RepoState::load_at(&path);
+        assert_eq!(reloaded, state);
+    }
+
+    #[test]
+    fn saving_leaves_no_temp_file_behind() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("nested").join("repos.toml");
+        let mut state = RepoState::default();
+        state.repos.insert(
+            "/repo/a".to_string(),
+            RepoRecord {
+                name: "a".to_string(),
+            },
+        );
+        state.save_at(&path).expect("save");
+
+        assert!(path.exists());
+        let siblings: Vec<String> = std::fs::read_dir(path.parent().expect("parent"))
+            .expect("read_dir")
+            .map(|entry| {
+                entry
+                    .expect("entry")
+                    .file_name()
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .collect();
+        assert_eq!(siblings, vec!["repos.toml".to_string()]);
+    }
+
+    /// The multi-instance guarantee, mirroring `crate::sidebar::fold_state`'s own identical test:
+    /// a second `jerry` instance saving its own repo must not erase the first's.
+    #[test]
+    fn saving_merges_with_another_instances_repo_instead_of_erasing_it() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("repos.toml");
+
+        let mut instance_a = RepoState::default();
+        instance_a.repos.insert(
+            "/repo/a".to_string(),
+            RepoRecord {
+                name: "a".to_string(),
+            },
+        );
+        let owned_a: std::collections::BTreeSet<String> =
+            ["/repo/a".to_string()].into_iter().collect();
+        instance_a.save_merged_at(&path, &owned_a).expect("save a");
+
+        // Instance B started before A wrote anything, so its in-memory copy knows nothing of A.
+        let mut instance_b = RepoState::default();
+        instance_b.repos.insert(
+            "/repo/b".to_string(),
+            RepoRecord {
+                name: "b".to_string(),
+            },
+        );
+        let owned_b: std::collections::BTreeSet<String> =
+            ["/repo/b".to_string()].into_iter().collect();
+        instance_b.save_merged_at(&path, &owned_b).expect("save b");
+
+        let on_disk = RepoState::load_at(&path);
+        assert!(
+            on_disk.repos.contains_key("/repo/a"),
+            "instance B's save must not have erased instance A's repo"
+        );
+        assert!(on_disk.repos.contains_key("/repo/b"));
+    }
+
+    /// The other half of the merge contract: for a repo this instance *does* own, absence is a
+    /// real deletion (how removing a repo removes its entry), not something merged back in from
+    /// disk.
+    #[test]
+    fn a_merged_save_really_deletes_an_owned_repos_entry() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("repos.toml");
+        let owned: std::collections::BTreeSet<String> =
+            ["/repo/a".to_string()].into_iter().collect();
+
+        let mut state = RepoState::default();
+        state.repos.insert(
+            "/repo/a".to_string(),
+            RepoRecord {
+                name: "a".to_string(),
+            },
+        );
+        state.save_merged_at(&path, &owned).expect("save");
+        assert!(RepoState::load_at(&path).repos.contains_key("/repo/a"));
+
+        state.repos.remove("/repo/a");
+        state.save_merged_at(&path, &owned).expect("save");
+
+        assert!(
+            !RepoState::load_at(&path).repos.contains_key("/repo/a"),
+            "removing a repo must survive the merge as a real deletion"
+        );
+    }
+}

--- a/crates/app/src/rail/state.rs
+++ b/crates/app/src/rail/state.rs
@@ -59,6 +59,23 @@ pub struct SessionRow {
     /// The process exit code, only for [`Status::Fail`]/[`Status::Review`]/exited-`Idle`
     /// rows. `None` while still running or never started.
     pub exit_code: Option<u32>,
+    /// The agent row's "what it is doing" trailing text for a [`Status::Run`] row -
+    /// `design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §2.3: "the live tool call -
+    /// `writing auth.rs`, `editing reports.rs`, `bench 3 of 5`, `148 of 312`".
+    ///
+    /// A sibling field here rather than a payload on [`Status::Run`] itself, mirroring
+    /// [`Self::question_preview`]'s own shape immediately above (also status-conditional, also a
+    /// row-level fact rather than part of the status enum) - keeping [`Status`] itself a plain
+    /// `Copy` value users of `Status::ORDER`/`urgency_rank`/`color` etc. can keep relying on,
+    /// rather than every one of those call sites suddenly needing to supply or ignore an
+    /// `activity` payload for a `Run` variant they don't care about.
+    ///
+    /// **Always `None` today.** The real PTY-output-to-activity-text heuristic is a separate,
+    /// parallel piece of work (this revision's Phase 0 is data-model-and-persistence only); this
+    /// field exists so that work has a real, already-plumbed-through place to write into -
+    /// [`crate::rail::render::AdeApp::build_session_rows`] is where a live value would be filled
+    /// in, the same real construction site [`Self::question_preview`] is already filled in from.
+    pub activity: Option<String>,
 }
 
 impl SessionRow {
@@ -586,7 +603,25 @@ mod tests {
             del: 0,
             question_preview: None,
             exit_code: None,
+            activity: None,
         }
+    }
+
+    /// [`SessionRow::activity`] is a plain, independent field - carrying a value must not change
+    /// filtering (it isn't title/branch/kind text) or anything else about the row's identity.
+    #[test]
+    fn activity_is_independent_of_filtering_and_defaults_to_none() {
+        let idle_row = row(1, Status::Run, "agent-a", "/a");
+        assert_eq!(idle_row.activity, None);
+
+        let mut running_row = row(2, Status::Run, "agent-b", "/b");
+        running_row.activity = Some("writing auth.rs".to_string());
+        assert_eq!(running_row.activity.as_deref(), Some("writing auth.rs"));
+        // Matching is still driven by title/kind/branch alone - an unrelated `activity` value
+        // must never make an otherwise-non-matching row start matching a filter query, or vice
+        // versa.
+        assert!(running_row.matches_filter("agent-b"));
+        assert!(!running_row.matches_filter("writing auth.rs"));
     }
 
     #[test]

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -67,6 +67,7 @@ use crate::keymap_overrides;
 use crate::lsp::diagnostics as diagnostics_view;
 use crate::merge::state as merge;
 use crate::palette::state as palette;
+use crate::rail::repo::{self as repo, Repo, RepoId};
 use crate::rail::state::{self as rail, RailMode};
 use crate::rail::worktrees::{self, WorktreeItem};
 use crate::settings::custom_theme;
@@ -259,7 +260,50 @@ pub(crate) const LSP_DIAGNOSTICS_POLL_INTERVAL: Duration = Duration::from_millis
 pub(crate) const LSP_QUERY_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub struct AdeApp {
-    pub(crate) repo_path: PathBuf,
+    /// Every git repository the user has added (Revision R12 Phase 0 - see [`repo`]'s
+    /// module docs). Zero-to-many: the app's *current* single-repo-per-window behaviour is just
+    /// the common case of this list holding exactly one entry, not a separate code path - see
+    /// [`Self::add_repo`]. Order is insertion order and carries no meaning of its own (a later
+    /// rail-rendering phase orders *groups* by urgency, not by this `Vec`'s order -
+    /// `design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §2.0).
+    pub(crate) repos: Vec<Repo>,
+    /// Which of [`Self::repos`] is "the" repo for every currently-single-repo-scoped piece of
+    /// state this app still has (the file tree, the diff, a fresh session's cwd, `worktrees`
+    /// below) - see [`Self::focused_repo`]/[`Self::focused_repo_path`]. `None` only when
+    /// [`Self::repos`] is empty, which nothing in this phase's startup path (`Self::
+    /// new_with_settings`) ever produces - it always adds and focuses exactly one repo, mirroring
+    /// today's single-CLI-argument launch.
+    pub(crate) focused_repo: Option<RepoId>,
+    /// The next [`RepoId`] [`Self::add_repo`] will assign - a plain, process-local monotonic
+    /// counter (see [`RepoId`]'s own docs for why it's never derived from a path or persisted).
+    /// Seeded past every id already assigned while restoring [`Self::repos`] from
+    /// [`repo::RepoState`] at startup, so a freshly-added repo can never collide with one
+    /// just loaded from disk.
+    pub(crate) next_repo_id: u64,
+    /// The resolved path [`Self::persist_repo_state`] writes to - a sibling of
+    /// [`Self::settings_path`]/[`Self::fold_state_path`], `None` for the same tests that get a
+    /// `None` settings path (see [`repo::repo_state_path_for`]).
+    pub(crate) repo_state_path: Option<PathBuf>,
+    /// The [`repo::repo_key`]s this instance has added a repo under (and, once a later phase
+    /// adds a way to remove one, would mark removed too - [`repo::RepoState::save_merged_at`]'s
+    /// own contract already covers both) - what [`Self::persist_repo_state`] hands
+    /// `RepoState::save_merged_at` as "mine to overwrite". See [`Self::fold_state_owned`]'s
+    /// identical role for the equivalent whole-file-clobber this prevents when a second `jerry`
+    /// process (open against a different repo) is writing the same `repos.toml` at the same
+    /// time.
+    pub(crate) repo_state_owned: std::collections::BTreeSet<String>,
+    /// The repo-list file's own serial writer loop task - see [`Self::_fold_state_save_task`]'s
+    /// identical role/reasoning, just for `repos.toml` instead of `file-tree-state.toml`.
+    pub(crate) _repo_state_save_task: Option<Task<()>>,
+    /// See [`Self::fold_state_save_pending`] - same contract, for the repo-list file.
+    pub(crate) repo_state_save_pending: bool,
+    /// See [`Self::fold_state_save_running`] - same contract, for the repo-list file.
+    pub(crate) repo_state_save_running: bool,
+    /// Every worktree of [`Self::focused_repo`], as read by `wt_core::list_worktrees` -
+    /// deliberately still a flat, single-repo list rather than living on the [`Repo`] itself
+    /// (see [`Repo::worktrees`]'s own docs): this phase is data-model-and-persistence only, and
+    /// rewiring every consumer of "the worktree list" onto a per-repo one is the rail-rendering
+    /// phase's job, not this one's.
     pub(crate) worktrees: Vec<WorktreeItem>,
     pub(crate) worktrees_error: Option<String>,
     /// GitHub issue #12's "the user is notified" half of selection recovery - set by
@@ -305,6 +349,13 @@ pub struct AdeApp {
     /// [`Self::current_diff`]'s docs for exactly which [`DiffLoadState`]/[`DiffBase`]
     /// combinations count).
     pub(crate) diff_totals: Option<(u32, u32)>,
+    /// Which agent session(s) wrote each file in [`Self::diff_state`]'s currently loaded diff
+    /// (`design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §4's `by: 's1'`/`by:
+    /// ['s1','s9']` record) - see [`changes::Authorship`]'s own docs for why this is always empty
+    /// today (no real authorship tracking exists yet; this phase only defines the shape a later
+    /// one populates). Reset alongside [`Self::diff_state`] on every reload
+    /// (`crate::code_surface::tabs::AdeApp::load_diff`), never carried across one.
+    pub(crate) file_authorship: changes::Authorship,
     /// Real expand/collapse state for the file tree - a directory's absolute path is in this set
     /// iff it is expanded (see `crate::sidebar::file_tree::visible_entries`, which this set feeds
     /// directly). **Absence means collapsed**, so a worktree opened for the first time shows only
@@ -1468,6 +1519,143 @@ impl AdeApp {
         });
         self._fold_state_save_task = Some(task);
     }
+
+    /// The repo currently focused for every single-repo-scoped piece of state ([`Self::
+    /// focused_repo_path`], and - for now - [`Self::worktrees`]/[`Self::file_tree_root`]/
+    /// [`Self::diff_root`] alike) - `None` only when [`Self::repos`] is empty.
+    pub(crate) fn focused_repo(&self) -> Option<&Repo> {
+        self.focused_repo
+            .and_then(|id| self.repos.iter().find(|repo| repo.id == id))
+    }
+
+    /// [`Self::focused_repo`]'s path, falling back to [`Self::repos`]' first entry (defensive,
+    /// should [`Self::focused_repo`] ever point at an id no longer in the list) and finally to an
+    /// empty path when [`Self::repos`] itself is empty - not reachable today (every real startup
+    /// path, [`Self::new_with_settings`], always adds and focuses one repo first, and this phase
+    /// has no way to remove one afterward), but an honest fallback rather than a panic if that
+    /// ever changes.
+    pub(crate) fn focused_repo_path(&self) -> PathBuf {
+        self.focused_repo()
+            .map(|repo| repo.path.clone())
+            .or_else(|| self.repos.first().map(|repo| repo.path.clone()))
+            .unwrap_or_default()
+    }
+
+    /// Adds `path` as a repo the user has open, or returns the id of an already-added repo at the
+    /// same real (canonicalized) path - adding the same repo twice (e.g. two `app <path>`
+    /// launches sharing one `~/.config/jerry`, or a redundant call from a future "add repo" UI)
+    /// is idempotent, never a duplicate rail group. Does **not** change [`Self::focused_repo`] -
+    /// see [`Self::focus_repo`] for that half, kept as a separate call so a caller that only
+    /// wants "make sure this repo is known" (startup, before deciding what's focused) doesn't get
+    /// an unwanted focus side effect.
+    ///
+    /// Calls [`repo::repo_key`] synchronously (a single `std::fs::canonicalize`, not offloaded to
+    /// the background executor) - safe here the same way [`Settings::load_or_init`]'s own
+    /// single-file-read constructor exception is safe (see [`Self::new`]'s docs): this only ever
+    /// runs from a real, infrequent user action or once at startup, never a render or per-
+    /// keystroke path, unlike [`repo::repo_key`]'s hot-path sibling
+    /// `crate::sidebar::fold_state::worktree_key`.
+    pub(crate) fn add_repo(&mut self, path: PathBuf, cx: &mut Context<Self>) -> RepoId {
+        let key = repo::repo_key(&path);
+        if let Some(key) = key.as_deref() {
+            if let Some(existing) = self
+                .repos
+                .iter()
+                .find(|repo| repo::repo_key(&repo.path).as_deref() == Some(key))
+            {
+                return existing.id;
+            }
+        }
+        let id = RepoId(self.next_repo_id);
+        self.next_repo_id += 1;
+        self.repos.push(Repo::new(id, path));
+        if let Some(key) = key {
+            self.repo_state_owned.insert(key);
+        }
+        self.persist_repo_state(cx);
+        cx.notify();
+        id
+    }
+
+    /// Makes `id` [`Self::focused_repo`] - a no-op if `id` isn't (or is no longer) in
+    /// [`Self::repos`], so a stale id from a closed-over click handler can never point focus at
+    /// nothing. Deliberately synchronous and cheap: unlike [`Self::select_worktree`], changing
+    /// which *repo* is focused doesn't yet reload anything (the file tree/diff/sessions are still
+    /// single-repo-scoped fields this phase doesn't rewire - see [`Self::worktrees`]'s own docs),
+    /// so there is nothing to kick off here beyond the assignment itself.
+    pub(crate) fn focus_repo(&mut self, id: RepoId) {
+        if self.repos.iter().any(|repo| repo.id == id) {
+            self.focused_repo = Some(id);
+        }
+    }
+
+    /// [`Self::repos`], reduced to the on-disk shape [`repo::RepoState::save_merged_at`] expects -
+    /// every repo whose path resolves to a real [`repo::repo_key`] (a non-UTF-8 path is silently
+    /// omitted here, the identical refusal `crate::sidebar::fold_state::FoldState`'s own key
+    /// functions apply, rather than stored under a lossily-mangled key that could collide).
+    fn repo_state_snapshot(&self) -> repo::RepoState {
+        let mut state = repo::RepoState::default();
+        for r in &self.repos {
+            if let Some(key) = repo::repo_key(&r.path) {
+                state.repos.insert(
+                    key,
+                    repo::RepoRecord {
+                        name: r.name.clone(),
+                    },
+                );
+            }
+        }
+        state
+    }
+
+    /// Queues a background-executor save of the current repo list to [`Self::repo_state_path`],
+    /// called from [`Self::add_repo`] (and, once a later phase adds a way to remove one, would be
+    /// called from there too - [`Self::repo_state_owned`]/[`repo::RepoState::save_merged_at`]
+    /// already carry a real deletion-on-absence contract, unused only for lack of a caller).
+    /// `None` path (every GPUI test that hasn't asked for a real one) makes this a no-op; a save
+    /// failure is logged, not surfaced - the same simpler shape [`Self::persist_settings`] uses (a
+    /// single retry-free attempt per pending write), not [`Self::persist_fold_state`]'s elaborate
+    /// bounded-retry loop: losing one `repos.toml` write is a rare, low-stakes miss a user would
+    /// notice and just re-add the repo for, unlike a silently-dropped file-tree expand/collapse
+    /// edit that issue #18 specifically called out as needing to survive a transient failure.
+    pub(crate) fn persist_repo_state(&mut self, cx: &mut Context<Self>) {
+        let Some(path) = self.repo_state_path.clone() else {
+            return;
+        };
+        self.repo_state_save_pending = true;
+        if self.repo_state_save_running {
+            // The loop below already re-checks `repo_state_save_pending` before writing or
+            // stopping - see `Self::persist_settings`'s identical comment for why spawning a
+            // second loop here would let two real `save_merged_at` calls overlap.
+            return;
+        }
+        self.repo_state_save_running = true;
+        let task = cx.spawn(async move |this, cx| loop {
+            let step = this.update(cx, |this, _cx| {
+                if this.repo_state_save_pending {
+                    this.repo_state_save_pending = false;
+                    Some((this.repo_state_snapshot(), this.repo_state_owned.clone()))
+                } else {
+                    this.repo_state_save_running = false;
+                    None
+                }
+            });
+            let Ok(Some((state, owned))) = step else {
+                break;
+            };
+            let result = cx
+                .background_executor()
+                .spawn({
+                    let path = path.clone();
+                    async move { state.save_merged_at(&path, &owned) }
+                })
+                .await;
+            if let Err(err) = result {
+                log::warn!("failed to save {}: {err}", path.display());
+            }
+        });
+        self._repo_state_save_task = Some(task);
+    }
 }
 
 impl Render for AdeApp {
@@ -1920,6 +2108,215 @@ mod settings_persist_tests {
             on_disk.appearance.editor_font_size, 20.0,
             "the file must hold the LAST edit's value, never an earlier, longer-delayed edit's \
              stale one landing on top of it afterward"
+        );
+    }
+}
+
+/// Real, `Context<AdeApp>`-driven coverage for [`AdeApp::add_repo`]/[`AdeApp::focus_repo`]/
+/// [`AdeApp::persist_repo_state`] (Revision R12 Phase 0) - the restructured multi-repo-capable
+/// state this revision's rail-rendering/authorship-heuristic/worktree-watcher sibling work
+/// depends on. `crate::rail::repo`'s own module carries the pure `RepoState` persistence-format
+/// tests (including the deletion-on-absence half `save_merged_at` already supports); these
+/// exercise the same behaviour through a real `AdeApp` entity, the way [`settings_persist_tests`]
+/// does for settings. No `AdeApp::remove_repo` exists yet - there is no real (non-test) caller
+/// for one until a later phase adds a "remove repo" affordance, so it isn't defined here rather
+/// than kept as unreachable scaffolding; `Self::repo_state_owned`/`RepoState::save_merged_at`'s
+/// contract is already shaped to support it when that phase adds the method and its own tests.
+#[cfg(test)]
+mod repo_list_tests {
+    use super::*;
+    use crate::rail::repo::RepoState;
+    use gpui::TestAppContext;
+
+    fn open_test_app_with_real_settings_path(
+        cx: &mut TestAppContext,
+        repo_path: PathBuf,
+        settings_path: PathBuf,
+    ) -> (gpui::Entity<AdeApp>, &mut gpui::VisualTestContext) {
+        cx.add_window_view(|window, cx| {
+            AdeApp::new_with_settings(
+                repo_path,
+                settings_store::Settings::default(),
+                Some(settings_path),
+                window,
+                cx,
+            )
+        })
+    }
+
+    /// A fresh window's own startup path already exercises the common single-repo case: exactly
+    /// one repo, focused, matching the CLI-given path - "a user launching `app <path>` today must
+    /// keep working exactly as before" is this test.
+    #[gpui::test]
+    fn a_fresh_window_starts_with_exactly_one_focused_repo(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.repos.len(), 1);
+            assert_eq!(app.repos[0].path, repo.path());
+            assert_eq!(app.focused_repo().map(|r| r.id), Some(app.repos[0].id));
+            assert_eq!(app.focused_repo_path(), repo.path());
+        });
+    }
+
+    #[gpui::test]
+    fn add_repo_appends_a_new_entry_without_changing_focus(cx: &mut TestAppContext) {
+        let repo_a = tempfile::tempdir().expect("tempdir");
+        let repo_b = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let focused_before = app.read_with(cx, |app, _| app.focused_repo_path());
+
+        app.update(cx, |app, cx| {
+            app.add_repo(repo_b.path().to_path_buf(), cx);
+        });
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.repos.len(), 2);
+            assert!(app.repos.iter().any(|r| r.path == repo_b.path()));
+            assert_eq!(
+                app.focused_repo_path(),
+                focused_before,
+                "add_repo must not change which repo is focused"
+            );
+        });
+    }
+
+    /// Adding the same real path twice (e.g. a repeat `app <path>` launch sharing one
+    /// `~/.config/jerry`) must not produce a second rail group for the same repo.
+    #[gpui::test]
+    fn add_repo_is_idempotent_for_the_same_path(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+
+        let (first_id, second_id) = app.update(cx, |app, cx| {
+            let first = app.repos[0].id;
+            let second = app.add_repo(repo.path().to_path_buf(), cx);
+            (first, second)
+        });
+
+        assert_eq!(
+            first_id, second_id,
+            "re-adding the same path must return the same id"
+        );
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.repos.len(),
+                1,
+                "re-adding the same path must not duplicate it"
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn focus_repo_moves_focus_to_a_known_repo(cx: &mut TestAppContext) {
+        let repo_a = tempfile::tempdir().expect("tempdir");
+        let repo_b = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+
+        let repo_b_id = app.update(cx, |app, cx| app.add_repo(repo_b.path().to_path_buf(), cx));
+        app.update(cx, |app, _cx| app.focus_repo(repo_b_id));
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.focused_repo_path(), repo_b.path());
+        });
+    }
+
+    /// A stale/unknown id must not blank out focus - the same "refuse rather than corrupt state"
+    /// shape `crate::sidebar::fold_state::FoldState::set_expanded` uses for an out-of-worktree
+    /// path.
+    #[gpui::test]
+    fn focus_repo_with_an_unknown_id_is_a_no_op(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let focused_before = app.read_with(cx, |app, _| app.focused_repo_path());
+
+        app.update(cx, |app, _cx| app.focus_repo(RepoId(u64::MAX)));
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.focused_repo_path(), focused_before);
+        });
+    }
+
+    /// The persistence half: adding a repo with a real settings path must, once the background
+    /// writer loop settles, leave a real `repos.toml` on disk that a fresh load recovers - "which
+    /// repos are currently added should survive an app restart".
+    #[gpui::test]
+    fn adding_a_repo_persists_to_a_real_repos_toml(cx: &mut TestAppContext) {
+        let repo_a = tempfile::tempdir().expect("tempdir");
+        let repo_b = tempfile::tempdir().expect("tempdir");
+        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+
+        let (app, cx) = open_test_app_with_real_settings_path(
+            cx,
+            repo_a.path().to_path_buf(),
+            settings_path.clone(),
+        );
+        app.update(cx, |app, cx| {
+            app.add_repo(repo_b.path().to_path_buf(), cx);
+        });
+        cx.run_until_parked();
+
+        let repo_state_path = repo::repo_state_path_for(&settings_path);
+        let on_disk = RepoState::load_at(&repo_state_path);
+        let canonical_a = repo::repo_key(repo_a.path()).expect("repo a key");
+        let canonical_b = repo::repo_key(repo_b.path()).expect("repo b key");
+        assert!(
+            on_disk.repos.contains_key(&canonical_a),
+            "the startup repo must be persisted too, not just later additions"
+        );
+        assert!(on_disk.repos.contains_key(&canonical_b));
+    }
+
+    /// A window opened against `repo_a`, sharing a real `~/.config/jerry` that *another* running
+    /// `jerry` instance already recorded `repo_b` into, must not erase `repo_b` the moment it
+    /// saves anything of its own - the identical multi-instance guarantee
+    /// `crate::sidebar::fold_state` already provides for the file-tree fold state, proven here
+    /// through one real `AdeApp` entity's startup-and-save cycle against a `repos.toml` seeded as
+    /// if a second instance had already written to it (`crate::rail::repo`'s own tests already
+    /// cover the pure `RepoState::save_merged_at` half; this proves the real `AdeApp` wiring
+    /// reaches it correctly end to end).
+    #[gpui::test]
+    fn opening_against_one_repo_does_not_erase_another_instances_already_persisted_repo(
+        cx: &mut TestAppContext,
+    ) {
+        let repo_a = tempfile::tempdir().expect("tempdir");
+        let repo_b = tempfile::tempdir().expect("tempdir");
+        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+
+        // Simulate a second `jerry` instance that already added `repo_b` and saved it.
+        let repo_state_path = repo::repo_state_path_for(&settings_path);
+        let mut seed = RepoState::default();
+        let canonical_b = repo::repo_key(repo_b.path()).expect("repo b key");
+        seed.repos.insert(
+            canonical_b.clone(),
+            crate::rail::repo::RepoRecord {
+                name: "repo-b".to_string(),
+            },
+        );
+        seed.save_at(&repo_state_path).expect("seed save");
+
+        // This instance opens against a different repo, sharing the same `repos.toml`.
+        let (app, cx) = open_test_app_with_real_settings_path(
+            cx,
+            repo_a.path().to_path_buf(),
+            settings_path.clone(),
+        );
+        cx.run_until_parked();
+        let _ = app;
+
+        let on_disk = RepoState::load_at(&repo_state_path);
+        let canonical_a = repo::repo_key(repo_a.path()).expect("repo a key");
+        assert!(
+            on_disk.repos.contains_key(&canonical_a),
+            "this instance's own repo must be persisted"
+        );
+        assert!(
+            on_disk.repos.contains_key(&canonical_b),
+            "this instance's own save must not have erased the other instance's already-\
+             persisted repo"
         );
     }
 }

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -41,6 +41,33 @@ impl AdeApp {
         // time, which for a worktree this file has never seen (including a freshly created one)
         // is nothing at all.
 
+        // The repo-list file mirrors the fold-state file's own resolution one line up (see
+        // `rail::repo`'s module docs for why it's the identical pattern): a sibling of whatever
+        // settings path this instance was given, `None` (and so no persistence at all) for a test
+        // that doesn't opt into a real one. Every repo this user has previously added is restored
+        // here - not just the one `repo_path` names below - so "which repos are added" genuinely
+        // survives a restart; nothing yet *renders* more than the focused one (see
+        // `Self::worktrees`'s own docs), so a returning user with several repos added in a
+        // previous session sees exactly the same single-repo view they always have, just with the
+        // rest of their repos already known to `Self::repos` for the rail-rendering phase that
+        // will actually show them.
+        let repo_state_path = settings_path.as_deref().map(repo::repo_state_path_for);
+        let loaded_repo_state = repo_state_path
+            .as_deref()
+            .map(repo::RepoState::load_at)
+            .unwrap_or_default();
+        let mut repos: Vec<Repo> = Vec::with_capacity(loaded_repo_state.repos.len());
+        let mut next_repo_id: u64 = 0;
+        for (key, record) in &loaded_repo_state.repos {
+            repos.push(Repo {
+                id: RepoId(next_repo_id),
+                path: PathBuf::from(key),
+                name: record.name.clone(),
+                worktrees: Vec::new(),
+            });
+            next_repo_id += 1;
+        }
+
         // Built before the `Self` literal below (rather than inline as `cx.focus_handle()` at
         // their own field positions, as every other focus handle in this literal is) because
         // `AdeApp::wire_caret_blink` needs real, already-constructed handles to subscribe to -
@@ -83,7 +110,16 @@ impl AdeApp {
         let mut this = Self {
             file_tree_root: repo_path.clone(),
             diff_root: repo_path.clone(),
-            repo_path: repo_path.clone(),
+            repos,
+            // Resolved just below the literal, via `Self::add_repo`/`Self::focus_repo` - there is
+            // no `self` yet at this point in construction to call them against.
+            focused_repo: None,
+            next_repo_id,
+            repo_state_path,
+            repo_state_owned: std::collections::BTreeSet::new(),
+            _repo_state_save_task: None,
+            repo_state_save_pending: false,
+            repo_state_save_running: false,
             worktrees: Vec::new(),
             worktrees_error: None,
             worktree_selection_notice: None,
@@ -97,6 +133,7 @@ impl AdeApp {
             changes_rows_scroll_handle: UniformListScrollHandle::new(),
             diff_state: DiffLoadState::Loading,
             diff_totals: None,
+            file_authorship: changes::Authorship::default(),
             // Both are filled in immediately after this literal, through the same single
             // chokepoints every later change uses (`set_file_tree_root` +
             // `reload_expanded_dirs_from_fold_state`) - a second, constructor-only copy of that
@@ -295,6 +332,17 @@ impl AdeApp {
             _custom_theme_create_task: None,
             custom_theme_remove_armed: None,
         };
+        // Real "add this one repo on startup" (Revision R12 Phase 0): the CLI argument (or a
+        // test's own `repo_path`) becomes the first, focused entry of `Self::repos` rather than a
+        // separate field - `Self::add_repo` is idempotent against whatever `loaded_repo_state`
+        // above already restored, so a repeat launch of the same path never duplicates it. Every
+        // other single-repo-scoped field below (`file_tree_root`/`diff_root`/the initial shell's
+        // cwd/`load_worktrees`) still reads `repo_path` directly rather than
+        // `Self::focused_repo_path()` - they're the same value here by construction, and `Self::
+        // focused_repo_path()` becomes the real accessor once a repo switch is more than "one repo
+        // was ever set".
+        let focused_repo_id = this.add_repo(repo_path.clone(), cx);
+        this.focus_repo(focused_repo_id);
         // See the `expanded_dirs`/`fold_state_root_key` note in the literal above: resolving the
         // worktree key here, through the one function that ever resolves it, is what keeps the
         // startup path and every later worktree switch structurally identical.
@@ -351,7 +399,7 @@ impl AdeApp {
     /// effect; gone or newly broken → falls back to the main worktree and sets
     /// [`Self::worktree_selection_notice`]. See that function's docs for the full state machine.
     pub(crate) fn load_worktrees(&mut self, cx: &mut Context<Self>) {
-        let repo_path = self.repo_path.clone();
+        let repo_path = self.focused_repo_path();
         let task = cx.spawn(async move |this, cx| {
             let result = cx
                 .background_executor()
@@ -396,7 +444,7 @@ impl AdeApp {
                         let new_root = new_index
                             .and_then(|index| this.worktrees.get(index))
                             .map(|item| item.path.clone())
-                            .unwrap_or_else(|| this.repo_path.clone());
+                            .unwrap_or_else(|| this.focused_repo_path());
                         this.set_file_tree_root(new_root.clone());
                         this.file_tree = Vec::new();
                         this.reload_expanded_dirs_from_fold_state();
@@ -534,7 +582,7 @@ impl AdeApp {
     pub(crate) fn active_session_cwd(&self) -> PathBuf {
         match self.selected.and_then(|index| self.worktrees.get(index)) {
             Some(item) if item.error.is_none() => item.path.clone(),
-            _ => self.repo_path.clone(),
+            _ => self.focused_repo_path(),
         }
     }
 
@@ -1166,7 +1214,7 @@ mod load_worktrees_integration_tests {
                 app.worktrees.iter().position(|item| item.path == feature)
             })
             .expect("the added worktree must be in the list");
-        let main_path = app.read_with(cx, |app, _| app.repo_path.clone());
+        let main_path = app.read_with(cx, |app, _| app.focused_repo_path());
         app.update_in(cx, |app, window, cx| {
             app.select_worktree(feature_index, window, cx);
         });

--- a/crates/app/src/sidebar/changes.rs
+++ b/crates/app/src/sidebar/changes.rs
@@ -6,12 +6,72 @@
 //! shows lives here; `gpui::Div` construction happens in `crate::root`, which owns the
 //! `Context<AdeApp>` the click handlers (review-toggle, open-in-centre) need.
 
-use std::path::Path;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 
 use gpui::Rgba;
 
 use crate::theme;
+use crate::work_surface::sessions::SessionId;
 use wt_core::diff::{DiffFile, DiffHunk, DiffLineKind, FileChangeStatus};
+
+/// Which agent session(s) wrote each changed file in one worktree's diff -
+/// `design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §4 ("Where numbers live")'s
+/// `by: 's1'`, or `by: ['s1', 's9']` when more than one agent touched the same file. Keyed by a
+/// [`DiffFile::path`] (or `old_path`, before a rename - callers decide which path they're asking
+/// about; this type doesn't special-case renames itself).
+///
+/// **Not wired to any real tracking yet.** A separate, parallel piece of work watches an agent's
+/// edit tool calls and is meant to call [`Self::record`] as it observes them; this phase only
+/// defines the shape so that work has somewhere real to write into, and so every current consumer
+/// (`crate::code_surface::tabs::AdeApp::load_diff`, which resets this to
+/// [`Authorship::default`] on every worktree/diff reload - see that method's own docs) has a real,
+/// empty value to thread through rather than a stub. An empty `Authorship` means exactly what an
+/// empty [`Self::authors_for`] result says: "nobody's authorship has been recorded for this file
+/// yet", never fabricated as "no agent touched it".
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Authorship {
+    by_path: HashMap<PathBuf, Vec<SessionId>>,
+}
+
+impl Authorship {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Every session id recorded as having written `path`, in the order [`Self::record`] saw
+    /// them - empty (never fabricated) when nothing has recorded authorship for it yet, which
+    /// today is every path (see this type's own docs).
+    pub fn authors_for(&self, path: &Path) -> &[SessionId] {
+        self.by_path.get(path).map(Vec::as_slice).unwrap_or(&[])
+    }
+
+    /// Records `session` as (one of) `path`'s authors. Idempotent: recording the same session
+    /// against the same path twice does not duplicate the entry, so [`Self::authors_for`]'s
+    /// length is always the real distinct-author count, not an edit-tool-call count.
+    pub fn record(&mut self, path: PathBuf, session: SessionId) {
+        let authors = self.by_path.entry(path).or_default();
+        if !authors.contains(&session) {
+            authors.push(session);
+        }
+    }
+
+    /// `true` when more than one distinct session has written `path` - the design's amber
+    /// shared-file warning: the rail's worktree-row `⚠ N` and the Changes panel's amber
+    /// author-chip ring both key off this per-file check.
+    pub fn has_multiple_authors(&self, path: &Path) -> bool {
+        self.authors_for(path).len() > 1
+    }
+
+    /// How many of `paths` have more than one recorded author - the worktree row's `⚠ N` count
+    /// itself (§4: "files two agents both wrote").
+    pub fn shared_file_count<'a>(&self, paths: impl IntoIterator<Item = &'a Path>) -> usize {
+        paths
+            .into_iter()
+            .filter(|path| self.has_multiple_authors(path))
+            .count()
+    }
+}
 
 /// Added/removed line counts for one file, counted directly from its hunks.
 /// `wt_core::diff::DiffFile` has no separate stored counter for this, so it's recomputed here
@@ -594,5 +654,65 @@ mod tests {
             empty_hunks_message(FileChangeStatus::Deleted),
             "no line changes"
         );
+    }
+
+    #[test]
+    fn a_fresh_authorship_has_no_authors_for_any_path() {
+        let authorship = Authorship::new();
+        assert_eq!(
+            authorship.authors_for(Path::new("src/main.rs")),
+            &[] as &[SessionId]
+        );
+        assert!(!authorship.has_multiple_authors(Path::new("src/main.rs")));
+    }
+
+    #[test]
+    fn recording_one_session_makes_it_the_sole_author() {
+        let mut authorship = Authorship::new();
+        authorship.record(PathBuf::from("src/main.rs"), 1);
+        assert_eq!(authorship.authors_for(Path::new("src/main.rs")), &[1]);
+        assert!(!authorship.has_multiple_authors(Path::new("src/main.rs")));
+    }
+
+    #[test]
+    fn recording_the_same_session_twice_does_not_duplicate_it() {
+        let mut authorship = Authorship::new();
+        authorship.record(PathBuf::from("src/main.rs"), 1);
+        authorship.record(PathBuf::from("src/main.rs"), 1);
+        assert_eq!(authorship.authors_for(Path::new("src/main.rs")), &[1]);
+    }
+
+    #[test]
+    fn two_distinct_sessions_writing_the_same_file_is_a_shared_file() {
+        let mut authorship = Authorship::new();
+        authorship.record(PathBuf::from("src/main.rs"), 1);
+        authorship.record(PathBuf::from("src/main.rs"), 9);
+        assert_eq!(authorship.authors_for(Path::new("src/main.rs")), &[1, 9]);
+        assert!(authorship.has_multiple_authors(Path::new("src/main.rs")));
+    }
+
+    #[test]
+    fn shared_file_count_only_counts_paths_with_more_than_one_author() {
+        let mut authorship = Authorship::new();
+        authorship.record(PathBuf::from("src/main.rs"), 1);
+        authorship.record(PathBuf::from("src/main.rs"), 9);
+        authorship.record(PathBuf::from("src/lib.rs"), 1);
+
+        let paths = [
+            PathBuf::from("src/main.rs"),
+            PathBuf::from("src/lib.rs"),
+            PathBuf::from("src/untouched.rs"),
+        ];
+        assert_eq!(
+            authorship.shared_file_count(paths.iter().map(PathBuf::as_path)),
+            1
+        );
+    }
+
+    #[test]
+    fn different_paths_never_share_recorded_authors() {
+        let mut authorship = Authorship::new();
+        authorship.record(PathBuf::from("src/main.rs"), 1);
+        assert!(authorship.authors_for(Path::new("src/other.rs")).is_empty());
     }
 }

--- a/crates/app/src/title_bar/render.rs
+++ b/crates/app/src/title_bar/render.rs
@@ -202,10 +202,9 @@ impl AdeApp {
     /// any of those controls can never also arm this drag.
     pub(crate) fn render_title_bar(&self, cx: &mut Context<Self>) -> impl IntoElement {
         let project_name = self
-            .repo_path
-            .file_name()
-            .map(|name| name.to_string_lossy().into_owned())
-            .unwrap_or_else(|| self.repo_path.display().to_string());
+            .focused_repo()
+            .map(|repo| repo.name.clone())
+            .unwrap_or_else(|| self.focused_repo_path().display().to_string());
         let branch = self
             .worktrees
             .iter()

--- a/crates/app/src/worktree_history/flow.rs
+++ b/crates/app/src/worktree_history/flow.rs
@@ -37,7 +37,7 @@ impl AdeApp {
     /// on disk) - the same `load_worktrees` + `load_diff` pair `Self::complete_merge_flow`'s own
     /// success arm already uses for the identical reason.
     fn refresh_after_worktree_history_op(&mut self, cx: &mut Context<Self>) {
-        let repo_path = self.repo_path.clone();
+        let repo_path = self.focused_repo_path();
         self.load_worktrees(cx);
         self.load_diff(repo_path, cx);
     }
@@ -129,7 +129,7 @@ impl AdeApp {
             return;
         };
         let worktree_path = session.cwd.clone();
-        let repo_path = self.repo_path.clone();
+        let repo_path = self.focused_repo_path();
         let branch_display = self.branch_display_for(&worktree_path);
         self.worktree_history_op_in_flight = Some(WorktreeHistoryOpKind::Discard);
         self.worktree_history_status = Some(format!("discarding {branch_display}\u{2026}"));


### PR DESCRIPTION
## Summary

Foundation for the "multiple repos, each with worktrees" redesign (`design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §1, §2.0). `AdeApp` moves from a single `repo_path: PathBuf` to a real repo list. Data-model and persistence only — no rail rendering changes; those build on top of this in separate, stacked follow-up branches (rail rewrite, authorship heuristic, Changes-panel commit composer).

- `crate::rail::repo` (new module): `Repo { id: RepoId, path, name, worktrees }` and `RepoId(u64)`, a process-local id — never derived from path, since Jerry's own worktrees live outside their repo's checkout under `~/.jerry/wt/<name>` and need an explicit `repo:` reference rather than a path-derived one.
- `RepoState`/`RepoRecord` persist the added-repo list to a new `~/.config/jerry/repos.toml`, mirroring `crate::sidebar::fold_state`'s atomic temp-file-then-rename write and multi-instance `save_merged_at` exactly.
- `AdeApp`: `repo_path` replaced by `repos: Vec<Repo>` + `focused_repo: Option<RepoId>` + `next_repo_id`/`repo_state_*`. New methods: `focused_repo()`/`focused_repo_path()` (the read side every call site now uses), `add_repo()` (idempotent by canonicalized path), `focus_repo()`, `persist_repo_state()`. `new_with_settings` restores any previously-persisted repos at startup and adds+focuses the CLI-given path into that list — a user launching `app <path>` today keeps working exactly as before, just now expressed as one repo in the list.
- `repo` removal (`AdeApp::remove_repo`) deliberately not defined yet — no caller exists until a later phase adds a "remove repo" affordance; the persistence format's deletion-on-absence contract is already there for it to use when it does.
- `sidebar::changes::Authorship` (`by_path: HashMap<PathBuf, Vec<SessionId>>`, with `authors_for`/`record`/`has_multiple_authors`/`shared_file_count`) — the `by: 's1'`/`by: ['s1','s9']` record from the design spec's §4. New `AdeApp::file_authorship` field, reset on every diff reload. Real shape, not yet populated by any tracking — that's a separate, parallel piece of work stacked on top.

## Testing

Independently verified by me: rebased cleanly onto current master (no conflicts), all four gates clean — `cargo fmt --all -- --check`, `cargo build --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace --lib -- --test-threads=1` at 1088 app + 44 lsp-core + 14 pty-core + 107 wt-core, 0 failures (no flake this run).