### PR TITLE
refactor(app): rename Session to Agent throughout crates/app

### DIFF
--- a/BUILD-LOG.md
+++ b/BUILD-LOG.md
@@ -4901,3 +4901,75 @@ infrastructure for one narrow change. Flagged here rather than silently skipped.
 `cargo clippy --workspace --all-targets -- -D warnings` - all clean.
 `cargo test --workspace --lib --test-threads=1`: **1098 + 44 + 14 + 107 = 1263 passed, 0 failed**
 across all four crates.
+
+## Renaming `Session` to `Agent` throughout `crates/app` (Revision R12)
+
+A pure rename, zero behavior change: `design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md`
+§1 states the new model plainly - "Previously a 'session' fused agent and worktree into one
+object, so two agents on one branch showed as two unrelated rows with the same branch name...
+**Agents are processes inside a worktree** - several can run in one." The code's actual semantics
+already matched this (a `Session`'s `cwd` is the worktree it runs in; several already shared one
+`cwd` without incident - see the R12 rail rewrite's own `build_session_rows`, which already
+grouped multiple sessions per worktree row). Only the name was stale, left over from the
+pre-redesign model this same revision's rail rewrite (`crates/app/src/rail/`) already replaced.
+Carrying "Session" forward would keep every doc comment, test name, and the rail's own literal
+`"SESSIONS"` header lying about a model this app no longer has.
+
+**Scope**: `Session` → `Agent`, `SessionId` → `AgentId`, `SessionKind` → `AgentKind`, `SessionRow`
+→ `AgentRow`, `SessionCandidate` → `AgentCandidate`, the `Sessions` collection → `Agents`; the
+module `work_surface::sessions` → `work_surface::agents` (`git mv`, `mod` declaration and every
+`use`/path reference updated); every function/method with "session" in its name that operates on
+this concept (`new_session` → `new_agent`, `session_status` → `agent_status`,
+`build_session_rows` → `build_agent_rows`, `render_session_tab` → `render_agent_tab`,
+`current_worktree_sessions` → `current_worktree_agents`, `active_session_cwd` →
+`active_agent_cwd`, `focus_newly_spawned_session` → `focus_newly_spawned_agent`,
+`render_new_session_button` → `render_new_agent_button`, `session_jump_keys`/`jump_to_session_at`
+→ `agent_jump_keys`/`jump_to_agent_at`, and dozens more in the same vein); every field
+(`self.sessions` → `self.agents`); every doc comment describing this concept, in every file that
+touches it, not just the obviously-named ones; every test name, including collapsing the several
+places a test already said "agent" *and* redundantly said "session" for the same thing (e.g.
+`secondary_shift_n_spawns_a_real_agent_session_through_the_real_key_bindings` →
+`..._spawns_a_real_agent_through_...`) down to saying it once. The rail header's own literal
+`"SESSIONS"` label (`crates/app/src/rail/render.rs`) was also updated to `"AGENTS"` - not called
+out by name in the rename's own scope note, but the same stale terminology the whole rename exists
+to remove, on the exact rail whose rows this revision's own design doc calls agent rows throughout
+§2.3.
+
+**What deliberately did not change**: `SessionKind::Shell`/`Claude`/`Codex` variant names (only
+the enum's own name changed); anything outside `crates/app`; and, inside
+`crates/app/src/terminal/pane.rs` and `terminal/grid.rs`, every reference to the literal
+`pty_core::PtySession` type and to `TerminalPane`'s own `session: Option<PtySession>` field (plus
+`ResizeLatch`'s parallel `session: Option<GridDims>` field tracking the same live-pty concept at
+one remove) - these name a different, lower-level thing: the raw OS process handle one pane's
+`Agent` currently owns, not the `Agent` itself. A `TerminalPane` can exist with `session: None`
+(mid-spawn) while still belonging to a real, already-tabbed `Agent`, so collapsing the two names
+would have made that distinction unreadable. Doc comments in the same file that referred to the
+*outer* `Agent`/tab concept in passing (`"a pane whose session isn't the globally active tab"`,
+`"a wall of background sessions"`, the rail's `"new session"` shortcut mentioned in a keystroke
+comment, a cross-reference to a test renamed elsewhere) were still renamed - only the pty-handle
+field and its direct usages were left alone. Three literal strings were protected from the
+mechanical pass and left as-is because they're not this concept: `pty_core::PtySession` (a real
+type name from a different crate), `window.restore_sessions` (a quoted external settings key
+mentioned only in a comment about what this app does *not* implement), and `groupSessions` (a
+direct quote of the design doc's own §7 naming an old, already-removed prop).
+
+**The rail's `+` button's tooltip - flagged, not guessed.** The task briefing for this rename
+assumed `render_new_agent_button`'s existing tooltip/label text needed updating to say "New agent"
+to match the tab strip's own `+` menu. Checked both before touching it: the button has no text
+label at all today (just a `+` glyph and a `mod+N` keycap pair - no `.tooltip()` call anywhere in
+its body), and its real click handler spawns `AgentKind::Shell` specifically
+(`this.new_agent(AgentKind::Shell, window, cx)`), which is the tab strip's own `+` menu's *"New
+terminal"* row, not its separate *"New agent pane"* row (which spawns the resolved Claude/Codex
+kind instead, per `render_tab_strip_plus`'s docs). Design doc §3 lists a single `New agent` menu
+item, but the code's own `+` menu already distinguishes "terminal" from "agent" as two different
+offers - so labeling this Shell-spawning rail button "New agent" would contradict the app's own
+existing vocabulary, not just rename it. Left the button's render body untouched beyond the
+already-completed identifier rename, per this task's own instruction to flag rather than guess at
+user-facing copy that isn't clearly in scope.
+
+**Gates**, from this project's usual Linux sandbox: `cargo fmt --all -- --check`,
+`cargo build --workspace`, and `cargo clippy --workspace --all-targets -- -D warnings` all clean.
+`cargo test --workspace --lib -- --test-threads=1`: **1098 + 44 + 14 + 107 = 1263 passed, 0
+failed** across all four crates, both before and after the final text-only `"SESSIONS"` →
+`"AGENTS"` edit. 54 files touched in `crates/app` (53 modified, one renamed:
+`work_surface/sessions.rs` → `work_surface/agents.rs`); nothing outside `crates/app` changed.

--- a/crates/app/src/code_surface/code_view.rs
+++ b/crates/app/src/code_surface/code_view.rs
@@ -734,7 +734,7 @@ fn build_highlight_config(
 /// as - but it makes the first request for *any* grammar compile *all four*. That cost is not
 /// hypothetical and it does not always land on a background thread: `CodeView::Diff` is the
 /// default view, and `crate::code_surface`'s `ensure_diff_highlight_cache` calls into here
-/// synchronously on the main thread, so opening the first `.rs` diff of a session paid the
+/// synchronously on the main thread, so opening the first `.rs` diff of an agent paid the
 /// TypeScript, TSX *and* Python query-compile cost for grammars that diff would never use. Per-
 /// grammar slots mean a `.rs` file pays for Rust only.
 ///

--- a/crates/app/src/code_surface/edit_buffer.rs
+++ b/crates/app/src/code_surface/edit_buffer.rs
@@ -1319,7 +1319,7 @@ impl EditBuffer {
     /// buffer's history away and starting over.
     ///
     /// That distinction is the whole point per GitHub issue #17: an external rewrite landing
-    /// mid-session must never be a silent history wipe. It is recorded as a sealed, programmatic
+    /// mid-agent must never be a silent history wipe. It is recorded as a sealed, programmatic
     /// group, so the step before it and the step after it are both still reachable, and Ctrl+Z
     /// immediately after the reload really does put the pre-reload content back.
     ///
@@ -1398,7 +1398,7 @@ impl EditBuffer {
     /// [`Self::marked_range`] over [`Self::selected_range`] whenever both exist, so passing `None`
     /// while a real IME composition happens to be active deleted the *entire* composing text
     /// instead of one real grapheme - wrong every time Backspace was pressed mid-composition, a
-    /// real, live-reachable case for any real CJK/composed input session.
+    /// real, live-reachable case for any real CJK/composed input agent.
     pub fn backspace(&mut self) {
         if !self.secondary_cursors.is_empty() {
             self.apply_at_every_cursor(EditKind::Delete, |buffer, cursor_range| {

--- a/crates/app/src/code_surface/editing.rs
+++ b/crates/app/src/code_surface/editing.rs
@@ -7,7 +7,7 @@
 //!    `Window::handle_input`). Every method resolves its target buffer through
 //!    [`AdeApp::active_editable_path`]/`AdeApp::edit_buffers` and returns an honest empty/`None`
 //!    result when there's no active File-view tab or buffer for it - an input-handler call
-//!    arriving while, say, a terminal session or the read-only Diff view has focus is a safe
+//!    arriving while, say, a terminal agent or the read-only Diff view has focus is a safe
 //!    no-op, never a panic or a wrong-buffer edit (the Diff view's own dispatch path never even
 //!    gets the `"file-editor"` key context these actions are scoped to - see
 //!    `crate::code_surface::render::AdeApp::render_code_surface`'s own docs for exactly where that
@@ -89,7 +89,7 @@ const REHIGHLIGHT_DEBOUNCE: Duration = Duration::from_millis(150);
 /// `crate::code_surface::tabs::AdeApp::activate_file_tab`'s own doc comment): `open_change` can
 /// be `Some` while Surface C is *not* shown at all - a tab can be "active" (its path still in
 /// `open_change`) without a diff to show it (`open_diff_file_cache` is `None`) and `code_view`
-/// left on `Diff`, in which case `render_center_pane` falls through to the session/merge surface
+/// left on `Diff`, in which case `render_center_pane` falls through to the agent/merge surface
 /// with `open_change` still `Some` the whole time. [`AdeApp::active_edit_target`] mirrors this
 /// exact predicate (not the weaker "`open_change.is_some()`" a first version of this method used,
 /// which incorrectly treated that real, reachable state as "Surface C is showing" and silently
@@ -119,8 +119,8 @@ impl AdeApp {
 
     /// The generalized real edit target (Revision R8.5c) - see [`EditTarget`]'s own docs for the
     /// mutual-exclusivity guarantee this relies on. `Merge` only while the merge hand-edit slot
-    /// exists *and* actually belongs to the currently active session tab (a merge for a
-    /// background session tab the user has since switched away from is real, live state, but
+    /// exists *and* actually belongs to the currently active agent tab (a merge for a
+    /// background agent tab the user has since switched away from is real, live state, but
     /// genuinely not on screen right now, so it must not receive keystrokes meant for whatever
     /// *is* focused).
     fn active_edit_target(&self) -> Option<EditTarget> {
@@ -137,8 +137,8 @@ impl AdeApp {
             return None;
         }
         let edit = self.merge_edit.as_ref()?;
-        let active_session_id = self.sessions.active().map(|session| session.id)?;
-        if edit.session_id != active_session_id {
+        let active_agent_id = self.agents.active().map(|agent| agent.id)?;
+        if edit.agent_id != active_agent_id {
             return None;
         }
         Some(EditTarget::Merge)
@@ -682,7 +682,7 @@ impl AdeApp {
 
     /// Moves keyboard focus off the editor entirely, onto [`AdeApp::filter_focus_handle`] (the
     /// rail's own filter field) - the same real fallback target [`crate::work_surface::render::
-    /// AdeApp::close_session`] already uses for "nothing session/file-related is left to focus".
+    /// AdeApp::close_agent`] already uses for "nothing agent/file-related is left to focus".
     /// Since `Tab`/`Shift+Tab` are now real indent/dedent actions while the editor has focus
     /// (rather than falling through to GPUI's ordinary focus-cycling), a keyboard-only user needs
     /// some other way to leave the editor and keep tabbing through the rest of the UI - this is
@@ -963,7 +963,7 @@ impl AdeApp {
     /// and [`Self::save_active_file`]'s own freshness gate can never pass again after any real
     /// external touch to the file (even reverting it back to byte-identical content still
     /// changes its real mtime) - so without a real, deliberate way to override it, the file
-    /// would stay unsavable for the rest of the session. This skips the *freshness* gate
+    /// would stay unsavable for the rest of the agent. This skips the *freshness* gate
     /// entirely and unconditionally overwrites the file with the buffer's current content - a
     /// real, user-initiated action, never automatic (matches this phase's own "no auto-merge"
     /// scope: this is a real, explicit "keep mine" choice, not a silent one) - reusing the exact
@@ -1610,7 +1610,7 @@ pub(in crate::code_surface) fn render_editable_file_view_line(
             // the primary's own above - `theme.rs` has no separate "secondary cursor" color, and
             // inventing one with no `design_handoff_jerry_ade` spec to back it would be an
             // unjustified guess (`CONTRIBUTING.md`'s own "exact values" discipline) - so a real
-            // multi-cursor session simply shows several real, identically-styled carets/
+            // multi-cursor agent simply shows several real, identically-styled carets/
             // selections rather than a fabricated visual distinction between them. Empty in
             // ordinary single-cursor use, so this is real, additional work only when it's real,
             // additional cursors.
@@ -3376,7 +3376,7 @@ mod editing_tests {
     /// cleared it, and `AdeApp::save_active_file`'s own freshness gate could never pass again
     /// after any real external touch (even reverting the file back to byte-identical content
     /// still changes its real mtime) - so the file became permanently unsavable for the rest of
-    /// the session, with no real way out. `EditorSaveAnyway`/`AdeApp::force_save_active_file` is
+    /// the agent, with no real way out. `EditorSaveAnyway`/`AdeApp::force_save_active_file` is
     /// the real, explicit, opt-in escape hatch this fixes it with.
     #[gpui::test]
     fn editor_save_anyway_resolves_a_real_permanently_stuck_conflict(cx: &mut TestAppContext) {

--- a/crates/app/src/code_surface/file_view.rs
+++ b/crates/app/src/code_surface/file_view.rs
@@ -366,7 +366,7 @@ impl AdeApp {
                     // but was never pruned per-frame, only cleared wholesale on a worktree
                     // switch - a real, measured unbounded-growth risk (one `(Bounds, ShapedLine)`
                     // retained per line ever scrolled past, for the life of the worktree
-                    // session). Pruned here to just this frame's own visible range (1-based, to
+                    // agent). Pruned here to just this frame's own visible range (1-based, to
                     // match the map's own key convention): any entry this drops for a row that's
                     // about to be rebuilt below is harmless - that row's own real paint, moments
                     // later this same pass, reinserts it fresh anyway.

--- a/crates/app/src/code_surface/lsp_ui.rs
+++ b/crates/app/src/code_surface/lsp_ui.rs
@@ -768,7 +768,7 @@ mod lsp_hover_wiring_tests {
     ///
     /// Mounting a File view via `render_center_pane` was found, while writing this test, to leave
     /// `TestAppContext::dispatch_action` unable to reach any `on_action` handler at all:
-    /// `render_center_pane` stops rendering the active session's terminal pane the instant a File
+    /// `render_center_pane` stops rendering the active agent's terminal pane the instant a File
     /// view mounts, leaving `Window::focus` dangling on a `FocusId` the last frame no longer
     /// contains - the same bug class [`palette_focus_tests`]/[`settings_focus_tests`] describe,
     /// fixed for Surface C by [`AdeApp::code_focus_handle`] (see [`code_focus_tests`] for

--- a/crates/app/src/code_surface/tabs.rs
+++ b/crates/app/src/code_surface/tabs.rs
@@ -139,7 +139,7 @@ impl AdeApp {
         // collapsed, highlighting a row that isn't showing would be no highlight at all.
         //
         // Guarded, because `absolute` is not always inside the tree currently on screen: a
-        // terminal link resolves against its session's own cwd, and `Self::open_change_diff`
+        // terminal link resolves against its agent's own cwd, and `Self::open_change_diff`
         // resolves against [`Self::diff_root`], which really can differ from
         // [`Self::file_tree_root`] (`crate::merge::flow` and `crate::worktree_history::flow` both
         // load the *main repo's* diff while a worktree is selected). Revealing and highlighting a
@@ -219,7 +219,7 @@ impl AdeApp {
     ///
     /// Re-clicking the already-"active" tab is not always a no-op: the tab can be active without
     /// being shown (e.g. its diff disappeared after a revert, so [`Self::render_center_pane`]
-    /// falls back to the active session while the tab strip still marks it active). That case
+    /// falls back to the active agent while the tab strip still marks it active). That case
     /// falls back to `code_view = File`, which always has content to show.
     pub(crate) fn activate_file_tab(
         &mut self,
@@ -259,7 +259,7 @@ impl AdeApp {
 
     /// Closes file tab `path`, removing it from [`Self::open_files`] (the tab's `×` hit box). If
     /// `path` was the active tab, activates the neighbor to its right, else the one to its left,
-    /// else falls back to the active session's terminal (restoring focus like
+    /// else falls back to the active agent's terminal (restoring focus like
     /// [`Self::close_settings`] does). No-op if `path` isn't an open tab.
     ///
     /// Cancels any real, in-flight debounced LSP sync/completion-request task for `path` (via
@@ -351,7 +351,7 @@ impl AdeApp {
                     self.refresh_open_diff_file_cache();
                     self.hover = None;
                     self.dismiss_completions();
-                    restore_focus(&self.sessions, &mut self.code_focus, window, cx);
+                    restore_focus(&self.agents, &mut self.code_focus, window, cx);
                 }
             }
         }
@@ -617,7 +617,7 @@ impl AdeApp {
     }
 
     /// Handles `TerminalPaneEvent::OpenPath` - a mod-held click on a detected path/`path:line`
-    /// link in a session's terminal output. `path` is already resolved against the session's cwd
+    /// link in an agent's terminal output. `path` is already resolved against the agent's cwd
     /// (see `crate::terminal::links::resolve`). Reuses [`Self::navigate_to_definition`] when the
     /// link carried a line number, else [`Self::open_file_view`].
     ///
@@ -1289,7 +1289,7 @@ mod multi_file_tab_tests {
 
     /// Closing the active tab activates a sensible neighbor: the tab that was to its right first
     /// - `Self::close_file_tab`'s own documented "prefer right, then left, then fall back to the
-    /// active session" order.
+    /// active agent" order.
     #[gpui::test]
     fn closing_the_active_tab_activates_the_tab_that_was_to_its_right(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
@@ -1341,7 +1341,7 @@ mod multi_file_tab_tests {
         );
 
         // Closing the last remaining tab falls all the way back to no active file at all (the
-        // active session shows through instead).
+        // active agent shows through instead).
         app.update_in(cx, |app, window, cx| {
             let active = app.open_change.clone().expect("a should be active");
             app.close_file_tab(active, window, cx);
@@ -1387,21 +1387,19 @@ mod multi_file_tab_tests {
         assert_eq!(app.read_with(cx, |app, _| app.open_files.len()), 1);
     }
 
-    /// Clicking a session tab while a file tab is active deactivates the file (it stops being
+    /// Clicking an agent tab while a file tab is active deactivates the file (it stops being
     /// shown) without closing it - it stays in `open_files`, exactly like switching away from a
     /// browser tab doesn't close it.
     #[gpui::test]
-    fn selecting_a_session_deactivates_the_open_file_tab_without_closing_it(
-        cx: &mut TestAppContext,
-    ) {
+    fn selecting_a_agent_deactivates_the_open_file_tab_without_closing_it(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
         let ((a, _b, _c), (a_rel, _, _)) = write_three_files(repo.path());
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
 
-        let session_id = app.read_with(cx, |app, _| {
-            app.sessions
+        let agent_id = app.read_with(cx, |app, _| {
+            app.agents
                 .active_id()
-                .expect("a fresh window has one real session")
+                .expect("a fresh window has one real agent")
         });
 
         app.update_in(cx, |app, window, cx| {
@@ -1414,13 +1412,13 @@ mod multi_file_tab_tests {
         );
 
         app.update_in(cx, |app, window, cx| {
-            app.select_session(session_id, window, cx);
+            app.select_agent(agent_id, window, cx);
         });
 
         assert_eq!(
             app.read_with(cx, |app, _| app.open_change.clone()),
             None,
-            "selecting a session tab should deactivate the file tab"
+            "selecting an agent tab should deactivate the file tab"
         );
         assert_eq!(
             app.read_with(cx, |app, _| app.open_files.clone()),
@@ -1428,7 +1426,7 @@ mod multi_file_tab_tests {
             "the file tab must still be in open_files, just not active"
         );
 
-        // The centre pane must actually render the session again, not silently panic/show
+        // The centre pane must actually render the agent again, not silently panic/show
         // nothing - a real smoke check on top of the state assertions above.
         app.update(cx, |app, cx| {
             app.render_center_pane(cx);
@@ -1607,7 +1605,7 @@ mod multi_file_tab_tests {
     /// Regression test for the "active but not actually showing" gap: a file tab can stay
     /// `open_change`-active even after its diff disappears (e.g. the underlying change was
     /// reverted), so `render_center_pane`'s `has_diff_or_file_view` check falls back to the
-    /// active session while the tab strip still paints the file tab as active. Before the fix,
+    /// active agent while the tab strip still paints the file tab as active. Before the fix,
     /// `activate_file_tab` early-returned as a dead no-op whenever `path` already equalled
     /// `open_change`, so re-clicking such a tab did nothing.
     #[gpui::test]
@@ -1812,7 +1810,7 @@ mod stale_completions_popup_tests {
 
 /// End-to-end proof of the "terminal is interactive" link-click-opens-a-file path:
 /// `simulate_click` against the pane's own painted bounds drives `TerminalPane`'s `on_click`/
-/// `cx.emit`, `Sessions::spawn`'s `cx.subscribe_in`, and `AdeApp::open_terminal_link` - the same
+/// `cx.emit`, `Agents::spawn`'s `cx.subscribe_in`, and `AdeApp::open_terminal_link` - the same
 /// chain a real mouse click goes through.
 #[cfg(test)]
 mod terminal_link_click_tests {
@@ -1823,7 +1821,7 @@ mod terminal_link_click_tests {
     };
 
     /// Injects a row of terminal text containing a `path:line` link on the third visible row
-    /// (`"see src/main.rs:1 for it"`, 0-indexed row 2) into the active session's pane, and
+    /// (`"see src/main.rs:1 for it"`, 0-indexed row 2) into the active agent's pane, and
     /// returns the painted geometry (`content_bounds`, cell size) needed to compute a click
     /// position.
     fn inject_link_row_and_measure(
@@ -1831,8 +1829,8 @@ mod terminal_link_click_tests {
         cx: &mut VisualTestContext,
     ) -> (Bounds<Pixels>, Size<Pixels>) {
         let pane = app
-            .read_with(cx, |app, _| app.sessions.active().map(|s| s.pane.clone()))
-            .expect("a fresh test window has one real, active shell session");
+            .read_with(cx, |app, _| app.agents.active().map(|s| s.pane.clone()))
+            .expect("a fresh test window has one real, active shell agent");
 
         pane.update(cx, |pane, cx| {
             pane.inject_bytes_for_test(
@@ -1841,7 +1839,7 @@ mod terminal_link_click_tests {
             );
         });
         // Lets the injected `cx.notify()` drive a real paint (populating `content_bounds`). The
-        // session's `$SHELL` spawn may also make background progress here, but only ever appends
+        // agent's `$SHELL` spawn may also make background progress here, but only ever appends
         // after the injected bytes, so it can't touch the link characters this test's
         // click-position math depends on.
         cx.run_until_parked();

--- a/crates/app/src/keymap.rs
+++ b/crates/app/src/keymap.rs
@@ -31,7 +31,7 @@
 //! itself start working as a live shortcut on Linux (not possible - GPUI resolves `"secondary"`
 //! once, at compile time, per `cfg!`). The mismatch only exists behind a deliberate, explicit,
 //! opt-in command-palette action whose own label says "preview", not a promise that this
-//! session's keys changed - a materially different risk profile than the original bug below,
+//! agent's keys changed - a materially different risk profile than the original bug below,
 //! which silently mismatched every user's default, un-opted-into experience.
 //!
 //! ## Real platform detection

--- a/crates/app/src/keymap_overrides.rs
+++ b/crates/app/src/keymap_overrides.rs
@@ -539,22 +539,19 @@ mod tests {
                     && context_label(b.predicate().as_deref()) == "file-editor"
             })
             .expect("a file-editor-scoped EditorLeft binding should exist");
-        let new_session = bindings
+        let new_agent = bindings
             .iter()
-            .find(|b| b.action().name() == "app::NewSession")
-            .expect("NewSession should be a real global default binding");
-        assert_eq!(context_label(new_session.predicate().as_deref()), "global");
+            .find(|b| b.action().name() == "app::NewAgent")
+            .expect("NewAgent should be a real global default binding");
+        assert_eq!(context_label(new_agent.predicate().as_deref()), "global");
 
         let collision = find_colliding_binding(
             &bindings,
             &bindings,
             editor_left,
-            &new_session.keystrokes()[0].inner().unparse(),
+            &new_agent.keystrokes()[0].inner().unparse(),
         );
-        assert_eq!(
-            collision.map(|b| b.action().name()),
-            Some("app::NewSession")
-        );
+        assert_eq!(collision.map(|b| b.action().name()), Some("app::NewAgent"));
     }
 
     #[test]

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -1,10 +1,10 @@
 //! `app`: the ADE desktop application shell.
 //!
 //! A three-pane GPUI window: a left sidebar listing the target repository's real git
-//! worktrees (via `wt-core`) with session/tab controls for spawning agent CLIs or shells
-//! into them, a tabbed center pane of real terminal sessions (via `pty-core` +
+//! worktrees (via `wt-core`) with agent/tab controls for spawning agent CLIs or shells
+//! into them, a tabbed center pane of real terminal agents (via `pty-core` +
 //! `alacritty_terminal`), and a right sidebar showing the active worktree's real file tree
-//! (via `std::fs::read_dir`). See `crate::root`, `crate::work_surface::sessions`, `crate::terminal::pane`,
+//! (via `std::fs::read_dir`). See `crate::root`, `crate::work_surface::agents`, `crate::terminal::pane`,
 //! and `crate::terminal::grid` for the interesting design decisions (entity/state model,
 //! blocking-call offloading, terminal grid rendering).
 
@@ -51,7 +51,7 @@ use gpui::{
 /// Ctrl. Binding `"cmd-k"` left the shortcut on Super+K while `crate::keymap`'s rendering
 /// (correctly) showed a `Ctrl` keycap on those platforms: `Ctrl+K` did nothing, and `Ctrl+,`
 /// fell through to whatever had keyboard focus and typed a literal `,` into it (e.g. a live
-/// terminal session).
+/// terminal agent).
 ///
 /// `"secondary"` (same file, lines 143-150) is GPUI's own answer to exactly this: it resolves to
 /// the `platform` modifier on macOS and `control` everywhere else, at compile time - the same OS
@@ -74,9 +74,9 @@ use gpui::{
 ///   that decision accepts. The `+` menu row itself is still a working, click-only way to open
 ///   the palette scoped to files.
 /// - `"]"` (Next changed file) has no modifier, and is scoped to `Some("diff && !file-editor")`
-///   rather than global - the only one of this app's bindings with a non-`'rail'`/`'session'`
+///   rather than global - the only one of this app's bindings with a non-`'rail'`/`'agent'`
 ///   context. A global `"]"` would swallow a literal `]` typed into any focused terminal/agent
-///   session (closing a bracket, an array literal, a regex class) - the same bug class as above.
+///   agent (closing a bracket, an array literal, a regex class) - the same bug class as above.
 ///   Scoping to `"diff"` (`crate::code_surface`'s `.key_context("diff")` on the Surface C
 ///   container) means it only fires while a file tab already has focus, matching the design's
 ///   intent: `]` cycles *through an already-open review*, not a global "jump into reviewing"
@@ -88,8 +88,8 @@ use gpui::{
 ///   actively being edited, reproduced live by typing `]` into real content. `!`/`&&` are real,
 ///   supported `KeyBindingContextPredicate` syntax (`vendor/zed/crates/gpui/src/keymap/
 ///   context.rs:172-420`'s own `Not`/`And` variants and parser), not invented here.
-/// - `"secondary-1"` through `"secondary-8"` back the tab strip's session-jump keycaps
-///   (`root::AdeApp::jump_to_session_at`), expanding the design's `mod+1…8` spec into eight
+/// - `"secondary-1"` through `"secondary-8"` back the tab strip's agent-jump keycaps
+///   (`root::AdeApp::jump_to_agent_at`), expanding the design's `mod+1…8` spec into eight
 ///   individually bound keystrokes since GPUI has no "N" wildcard keystroke component.
 /// - The `Editor*` entries (Revision R8.5a's real File view text editing) are scoped to
 ///   `Some("file-editor")`, a real *additional* context alongside `"diff"` above - both live on
@@ -104,7 +104,7 @@ use gpui::{
 ///   real, live-verified bug this was. The read-only Diff view genuinely never receives a single
 ///   one of these bindings: its context string never gains `"file-editor"`. Plain letters/arrows
 ///   are deliberately *not* globally bound (unlike, say, `f12`) - binding them at `None` scope
-///   would swallow ordinary typing in every focused terminal session the same way an unscoped
+///   would swallow ordinary typing in every focused terminal agent the same way an unscoped
 ///   `"]"` would have (see that entry's own docs above) - `"file-editor"` is the only context
 ///   they're ever active in. `EditorSave` is `"secondary-s"`, following this list's own
 ///   `"secondary-"` convention (verified against this same list: no other entry already claims
@@ -181,7 +181,7 @@ use gpui::{
 ///   would need claiming there.
 pub fn default_key_bindings() -> Vec<gpui::KeyBinding> {
     vec![
-        gpui::KeyBinding::new("secondary-n", root::NewSession, None),
+        gpui::KeyBinding::new("secondary-n", root::NewAgent, None),
         // The palette's real shortcut, matching the VS Code/Sublime "command palette" convention
         // directly rather than reusing "secondary-k". "secondary-k" was the original binding, but
         // the file-editor's real `"ctrl-k ctrl-d"` chord (multi-cursor "skip occurrence",
@@ -203,14 +203,14 @@ pub fn default_key_bindings() -> Vec<gpui::KeyBinding> {
         gpui::KeyBinding::new("ctrl-shift-t", root::NewTerminal, None),
         gpui::KeyBinding::new("secondary-shift-n", root::NewAgentPane, None),
         gpui::KeyBinding::new("]", root::NextChangedFile, Some("diff && !file-editor")),
-        gpui::KeyBinding::new("secondary-1", root::JumpToSession1, None),
-        gpui::KeyBinding::new("secondary-2", root::JumpToSession2, None),
-        gpui::KeyBinding::new("secondary-3", root::JumpToSession3, None),
-        gpui::KeyBinding::new("secondary-4", root::JumpToSession4, None),
-        gpui::KeyBinding::new("secondary-5", root::JumpToSession5, None),
-        gpui::KeyBinding::new("secondary-6", root::JumpToSession6, None),
-        gpui::KeyBinding::new("secondary-7", root::JumpToSession7, None),
-        gpui::KeyBinding::new("secondary-8", root::JumpToSession8, None),
+        gpui::KeyBinding::new("secondary-1", root::JumpToAgent1, None),
+        gpui::KeyBinding::new("secondary-2", root::JumpToAgent2, None),
+        gpui::KeyBinding::new("secondary-3", root::JumpToAgent3, None),
+        gpui::KeyBinding::new("secondary-4", root::JumpToAgent4, None),
+        gpui::KeyBinding::new("secondary-5", root::JumpToAgent5, None),
+        gpui::KeyBinding::new("secondary-6", root::JumpToAgent6, None),
+        gpui::KeyBinding::new("secondary-7", root::JumpToAgent7, None),
+        gpui::KeyBinding::new("secondary-8", root::JumpToAgent8, None),
         gpui::KeyBinding::new("backspace", root::EditorBackspace, Some("file-editor")),
         gpui::KeyBinding::new("delete", root::EditorDelete, Some("file-editor")),
         // Narrowed to `!completions` (Revision R8.5b) - see the `Completions*` entries below and
@@ -481,7 +481,7 @@ pub fn default_key_bindings() -> Vec<gpui::KeyBinding> {
             root::FileTreePaste,
             Some("file-tree && !tree-editing && !tree-delete-confirm"),
         ),
-        // `Ctrl+W` (GitHub issue #26) - closes the focused tab (file or session), via
+        // `Ctrl+W` (GitHub issue #26) - closes the focused tab (file or agent), via
         // `crate::work_surface::render::AdeApp::handle_close_focused_tab_action`'s own docs for
         // exactly what "focused" resolves to and why this can never close the window (this app
         // registers no window-close keybinding anywhere in this list, on any platform, so there
@@ -490,7 +490,7 @@ pub fn default_key_bindings() -> Vec<gpui::KeyBinding> {
         // conflict class: plain `Ctrl+W` is `crate::terminal::pane::keystroke_to_bytes`'s own real
         // `unix-word-rerase` control byte (`0x17`), a standard readline word-backspace a focused
         // shell needs unclaimed - a global binding here would swallow it in every focused
-        // terminal/agent session on Linux/Windows, the same bug class this list's own
+        // terminal/agent on Linux/Windows, the same bug class this list's own
         // `"]"`/`secondary-z` entries already document (`secondary-p` deliberately accepts this
         // exact class of collision instead - see that binding's own docs for why). A
         // terminal/agent tab is still always closeable via the tab strip's own `×` or
@@ -600,7 +600,7 @@ mod undo_scoping_matrix_tests {
             "a dangling focus handle - GPUI's empty-context dispatch-root fallback",
             "any surface with no key context of its own (the Settings overlay, the tab strip) - \
              only the root div's baseline tag",
-            "a focused terminal session",
+            "a focused terminal agent",
             "the read-only Diff view",
             "the editable File view",
             "the editable File view with the completions popup open",

--- a/crates/app/src/lsp/client.rs
+++ b/crates/app/src/lsp/client.rs
@@ -926,7 +926,7 @@ impl AdeApp {
     /// intentionally treats that as "already open," not "reopen." Sending `didClose` on every
     /// tab switch would mean re-sending `didOpen` (and re-waiting through indexing) every time
     /// the user switches back to a file - real latency for no benefit, since this app keeps at
-    /// most a handful of files' worth of server-side state alive per session. The `LspClient`
+    /// most a handful of files' worth of server-side state alive per agent. The `LspClient`
     /// (and every document it opened) is torn down when its owning root's client is dropped -
     /// this app's actual document lifetime boundary.
     ///

--- a/crates/app/src/merge/editing.rs
+++ b/crates/app/src/merge/editing.rs
@@ -53,8 +53,8 @@ impl AdeApp {
     /// quick-pick view whenever [`AdeApp::merge_edit`] matches the currently active conflicted
     /// file (see `crate::merge::render`'s own docs for exactly where this is called
     /// from) - `&self`, matching `crate::merge::render::AdeApp::
-    /// render_merge_flow_surface`'s own receiver (the caller already holds an immutable `session`
-    /// borrow from `self.sessions`, so `&mut self` isn't available there; every real mutation
+    /// render_merge_flow_surface`'s own receiver (the caller already holds an immutable `agent`
+    /// borrow from `self.agents`, so `&mut self` isn't available there; every real mutation
     /// here happens later, inside an event handler's own `&mut Self` lease, not during this
     /// render call).
     pub(in crate::merge) fn render_merge_edit_view(

--- a/crates/app/src/merge/flow.rs
+++ b/crates/app/src/merge/flow.rs
@@ -3,7 +3,7 @@ use super::*;
 use crate::root::focus::palette_focus_tests;
 
 impl AdeApp {
-    /// Cleanup for [`Self::close_session`] closing the session whose `Merge` click started
+    /// Cleanup for [`Self::close_agent`] closing the agent whose `Merge` click started
     /// [`Self::merge_flow`]. If a merge is still in progress in the base worktree at that
     /// moment (`Clean`/`Conflicted`, or an `Error` with `abortable_worktree`), this aborts it
     /// (`wt_core::merge::abort_merge`) rather than leaving the repository mid-merge with no UI
@@ -11,7 +11,7 @@ impl AdeApp {
     ///
     /// A `Running` attempt (the `git merge` child process itself) can't be cancelled from here -
     /// there is no cancellation token threaded through it. Clearing `merge_flow` regardless is
-    /// still correct: [`Self::start_merge`]'s completion handler guards on `session_id` still
+    /// still correct: [`Self::start_merge`]'s completion handler guards on `agent_id` still
     /// matching, so a `Running` attempt that finishes after this point is a no-op there. If it
     /// left a `MERGE_HEAD` behind, the next `Merge` click hits a git failure and
     /// [`run_merge_attempt`]'s `find_in_progress_merge` fallback surfaces `Abort merge` for it
@@ -23,7 +23,7 @@ impl AdeApp {
     /// their shared [`Self::_merge_task`] slot here would drop (cancel) their in-flight
     /// operation. See [`Self::_merge_cleanup_task`]'s docs for why this method's own
     /// best-effort abort uses a separate field instead.
-    pub(crate) fn clear_merge_flow_for_closed_session(&mut self, cx: &mut Context<Self>) {
+    pub(crate) fn clear_merge_flow_for_closed_agent(&mut self, cx: &mut Context<Self>) {
         let Some(flow) = self.merge_flow.take() else {
             return;
         };
@@ -31,7 +31,7 @@ impl AdeApp {
         // unconditionally taken above, regardless of `merge_op_in_flight` below - only the
         // best-effort abort *spawn* further down is skipped while an in-flight
         // complete/abort owns the outcome instead) - see `Self::clear_merge_edit_state`'s own
-        // docs. The session tab (and thus any UI that could show this hand-edit) is genuinely
+        // docs. The agent tab (and thus any UI that could show this hand-edit) is genuinely
         // gone either way, so this always runs.
         self.clear_merge_edit_state();
         if self.merge_op_in_flight {
@@ -53,7 +53,7 @@ impl AdeApp {
             return;
         };
         let task = cx.spawn(async move |_this, cx| {
-            // Fire-and-forget: the session tab is already gone, so there's no UI left to
+            // Fire-and-forget: the agent tab is already gone, so there's no UI left to
             // report a failure to. Best-effort is the honest ceiling here - on failure the
             // repository is left in whatever state `git merge --abort` left it in,
             // inspectable/recoverable via a terminal.
@@ -71,26 +71,26 @@ impl AdeApp {
     /// spawned `git merge` child process - see that function's own docs).
     ///
     /// Only one merge flow is tracked at a time; a click while one is already in progress for
-    /// any session is a no-op, since two concurrent `git merge` invocations would race over the
+    /// any agent is a no-op, since two concurrent `git merge` invocations would race over the
     /// same base worktree.
-    pub(crate) fn start_merge(&mut self, id: SessionId, cx: &mut Context<Self>) {
+    pub(crate) fn start_merge(&mut self, id: AgentId, cx: &mut Context<Self>) {
         if self.merge_flow.is_some() {
             return;
         }
-        let Some(session) = self.sessions.iter().find(|session| session.id == id) else {
+        let Some(agent) = self.agents.iter().find(|agent| agent.id == id) else {
             return;
         };
         let repo_path = self.focused_repo_path();
-        let worktree_path = session.cwd.clone();
+        let worktree_path = agent.cwd.clone();
         // A fresh attempt, even one reusing `id` (e.g. Abort then immediately Merge again on the
-        // same session tab) - see `merge::MergeFlow::generation`'s own docs. Any hand-edit from a
+        // same agent tab) - see `merge::MergeFlow::generation`'s own docs. Any hand-edit from a
         // *previous* attempt is unconditionally gone the moment a new one starts, since its
         // `files[]`/hunk indices belong to an attempt that no longer exists.
         self.merge_generation = self.merge_generation.wrapping_add(1);
         let generation = self.merge_generation;
         self.clear_merge_edit_state();
         self.merge_flow = Some(merge::MergeFlow {
-            session_id: id,
+            agent_id: id,
             generation,
             state: merge::MergeFlowState::Running,
         });
@@ -104,9 +104,9 @@ impl AdeApp {
                 .spawn(async move { run_merge_attempt(&repo_path, &worktree_path) })
                 .await;
             let _ = this.update(cx, |this, cx| {
-                if this.merge_flow.as_ref().map(|flow| flow.session_id) == Some(id) {
+                if this.merge_flow.as_ref().map(|flow| flow.agent_id) == Some(id) {
                     this.merge_flow = Some(merge::MergeFlow {
-                        session_id: id,
+                        agent_id: id,
                         generation,
                         state,
                     });
@@ -169,10 +169,10 @@ impl AdeApp {
             *active_file = next_file;
             *active_hunk = next_hunk;
         }
-        // `session_id`/`generation` (plain `Copy` values) read out now, while `flow` (borrowed
+        // `agent_id`/`generation` (plain `Copy` values) read out now, while `flow` (borrowed
         // from `self.merge_flow`) is still alive - `flow`/`files`/`active_file`/`active_hunk` are
         // not used again past this point, so this is the last real use of that borrow.
-        let session_id = flow.session_id;
+        let agent_id = flow.agent_id;
         let generation = flow.generation;
         cx.notify();
         // The real state-transition point the newly-active hunk (if the advance above landed on
@@ -200,12 +200,12 @@ impl AdeApp {
             let _ = this.update(cx, |this, cx| {
                 if let Err(err) = result {
                     // Real defense in depth (see `merge::MergeFlow::generation`'s own docs): a
-                    // bare `session_id` match alone can't tell "this write's own attempt is still
-                    // the live one" apart from "the same session started a *fresh* attempt while
-                    // this write was still in flight" - both share `session_id`, only the newer
+                    // bare `agent_id` match alone can't tell "this write's own attempt is still
+                    // the live one" apart from "the same agent started a *fresh* attempt while
+                    // this write was still in flight" - both share `agent_id`, only the newer
                     // one shares `generation` too.
                     let still_current = this.merge_flow.as_ref().is_some_and(|flow| {
-                        flow.session_id == session_id && flow.generation == generation
+                        flow.agent_id == agent_id && flow.generation == generation
                     });
                     if still_current {
                         // Re-check MERGE_HEAD so `Abort merge` stays offered rather than
@@ -240,12 +240,12 @@ impl AdeApp {
     /// second click while the first is still in flight (e.g. a fast Abort-right-after-Complete)
     /// would otherwise spawn a second git operation, overwriting [`Self::_merge_task`] and
     /// dropping the first one's completion handler mid-commit.
-    /// [`Self::clear_merge_flow_for_closed_session`] respects the same flag so closing the
-    /// session mid-commit can't cancel this operation either.
+    /// [`Self::clear_merge_flow_for_closed_agent`] respects the same flag so closing the
+    /// agent mid-commit can't cancel this operation either.
     ///
     /// The success arm only clears [`Self::merge_flow`] when it still belongs to this
-    /// `session_id`, matching the error arm below it: a session close no longer blocks this
-    /// commit from running to completion, so a merge for a *different* session could
+    /// `agent_id`, matching the error arm below it: an agent close no longer blocks this
+    /// commit from running to completion, so a merge for a *different* agent could
     /// legitimately be in `merge_flow` by the time this closure runs.
     pub(in crate::merge) fn complete_merge_flow(&mut self, cx: &mut Context<Self>) {
         self.prune_confirm_armed = false;
@@ -269,7 +269,7 @@ impl AdeApp {
         };
         self.merge_op_in_flight = true;
         cx.notify();
-        let session_id = flow.session_id;
+        let agent_id = flow.agent_id;
         let task = cx.spawn(async move |this, cx| {
             let result = cx
                 .background_executor()
@@ -279,8 +279,7 @@ impl AdeApp {
                 this.merge_op_in_flight = false;
                 match result {
                     Ok(()) => {
-                        if this.merge_flow.as_ref().map(|flow| flow.session_id) == Some(session_id)
-                        {
+                        if this.merge_flow.as_ref().map(|flow| flow.agent_id) == Some(agent_id) {
                             this.merge_flow = None;
                             this.clear_merge_edit_state();
                         }
@@ -289,8 +288,7 @@ impl AdeApp {
                         this.load_diff(repo_path, cx);
                     }
                     Err(err) => {
-                        if this.merge_flow.as_ref().map(|flow| flow.session_id) == Some(session_id)
-                        {
+                        if this.merge_flow.as_ref().map(|flow| flow.agent_id) == Some(agent_id) {
                             // MERGE_HEAD is still present when `complete_merge`'s defense in
                             // depth is what failed, so `Abort merge` stays offered.
                             let abortable_worktree =
@@ -352,7 +350,7 @@ impl AdeApp {
         };
         self.merge_op_in_flight = true;
         cx.notify();
-        let session_id = flow.session_id;
+        let agent_id = flow.agent_id;
         let task = cx.spawn(async move |this, cx| {
             let result = cx
                 .background_executor()
@@ -360,7 +358,7 @@ impl AdeApp {
                 .await;
             let _ = this.update(cx, |this, cx| {
                 this.merge_op_in_flight = false;
-                if this.merge_flow.as_ref().map(|flow| flow.session_id) == Some(session_id) {
+                if this.merge_flow.as_ref().map(|flow| flow.agent_id) == Some(agent_id) {
                     match result {
                         Ok(()) => {
                             this.merge_flow = None;
@@ -404,11 +402,11 @@ impl AdeApp {
     /// Real teardown for [`Self::merge_edit`] - clears the hand-edit slot itself. Does not, and
     /// need not, cancel [`Self::_merge_edit_save_task`] if a save happens to be in flight at the
     /// moment this runs: that background task's own completion handler
-    /// ([`Self::apply_merge_edit_save_result`]) independently re-checks `(session_id,
+    /// ([`Self::apply_merge_edit_save_result`]) independently re-checks `(agent_id,
     /// generation, relative_path)` before applying anything, so a stale completion after this
     /// call is already a safe no-op - the same "identify, don't cancel" discipline
     /// [`Self::_merge_write_tasks`] already establishes for the quick-pick resolution path (see
-    /// [`Self::clear_merge_flow_for_closed_session`]'s own docs for why that path doesn't reach
+    /// [`Self::clear_merge_flow_for_closed_agent`]'s own docs for why that path doesn't reach
     /// into its own task pool either).
     pub(in crate::merge) fn clear_merge_edit_state(&mut self) {
         self.merge_edit = None;
@@ -428,7 +426,7 @@ impl AdeApp {
             return;
         };
         let still_active = self.merge_flow.as_ref().is_some_and(|flow| {
-            flow.session_id == edit.session_id
+            flow.agent_id == edit.agent_id
                 && flow.generation == edit.generation
                 && matches!(
                     &flow.state,
@@ -501,7 +499,7 @@ impl AdeApp {
         // `merge::MergeEditState::buffer_id`'s own docs for the real race this closes.
         self.merge_edit_buffer_id = self.merge_edit_buffer_id.wrapping_add(1);
         self.merge_edit = Some(merge::MergeEditState {
-            session_id: flow.session_id,
+            agent_id: flow.agent_id,
             generation: flow.generation,
             buffer_id: self.merge_edit_buffer_id,
             base_worktree_path,
@@ -573,7 +571,7 @@ impl AdeApp {
                     this.merge_edit_save_pending = false;
                     match this.merge_edit.as_ref() {
                         Some(edit) => Some((
-                            edit.session_id,
+                            edit.agent_id,
                             edit.generation,
                             edit.buffer_id,
                             edit.base_worktree_path.clone(),
@@ -592,7 +590,7 @@ impl AdeApp {
                     }
                 });
                 let Ok(Some((
-                    session_id,
+                    agent_id,
                     generation,
                     buffer_id,
                     base_worktree_path,
@@ -697,11 +695,11 @@ impl AdeApp {
                             // superseded, while this write was in flight must not resurrect
                             // `Self::merge_edit` or silently apply to the wrong attempt's/
                             // buffer's state. `buffer_id` is load-bearing on top of
-                            // `session_id`/`generation`/`relative_path`: a discard followed by an
+                            // `agent_id`/`generation`/`relative_path`: a discard followed by an
                             // immediate re-open of hand-edit mode for the *same* file keeps all
                             // three of those identical but seeds a genuinely new `EditBuffer`.
                             let still_current = this.merge_edit.as_ref().is_some_and(|edit| {
-                                edit.session_id == session_id
+                                edit.agent_id == agent_id
                                     && edit.generation == generation
                                     && edit.buffer_id == buffer_id
                                     && edit.relative_path == relative_path
@@ -722,7 +720,7 @@ impl AdeApp {
                                             )
                                         });
                                         this.apply_merge_edit_save_result(
-                                            session_id,
+                                            agent_id,
                                             generation,
                                             relative_path,
                                             fresh,
@@ -742,7 +740,7 @@ impl AdeApp {
                         }
                         Err(err) => {
                             if this.merge_edit.as_ref().is_some_and(|edit| {
-                                edit.session_id == session_id
+                                edit.agent_id == agent_id
                                     && edit.generation == generation
                                     && edit.buffer_id == buffer_id
                             }) {
@@ -762,14 +760,14 @@ impl AdeApp {
     /// matched by path), recomputes `active_file`/`active_hunk`
     /// ([`crate::merge::state::first_unresolved`]), and refreshes the highlight cache - the real
     /// state-transition point mirroring [`Self::resolve_active_hunk`]'s own identical sequence
-    /// for the quick-pick path. Only applies anything if `session_id`/`generation` still match
+    /// for the quick-pick path. Only applies anything if `agent_id`/`generation` still match
     /// the live flow - see [`Self::spawn_merge_edit_save_loop`]'s own docs for why the caller
     /// already re-checked this once (for [`Self::merge_edit`] itself) before calling here; this
     /// method independently re-checks against [`Self::merge_flow`] too, since those are two
     /// different pieces of state that could in principle have diverged.
     fn apply_merge_edit_save_result(
         &mut self,
-        session_id: SessionId,
+        agent_id: AgentId,
         generation: u64,
         relative_path: PathBuf,
         fresh: wt_core::merge::ConflictedFile,
@@ -777,7 +775,7 @@ impl AdeApp {
         let Some(flow) = self.merge_flow.as_mut() else {
             return;
         };
-        if flow.session_id != session_id || flow.generation != generation {
+        if flow.agent_id != agent_id || flow.generation != generation {
             return;
         }
         let merge::MergeFlowState::Conflicted {
@@ -995,13 +993,11 @@ mod merge_regression_tests {
         cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
     }
 
-    /// Regression test: closing/archiving the session mid-`Complete merge` must not cancel the
+    /// Regression test: closing/archiving the agent mid-`Complete merge` must not cancel the
     /// in-flight `git commit` or strand `merge_op_in_flight` at `true` - see
-    /// `AdeApp::clear_merge_flow_for_closed_session`'s docs for the mechanism this guards.
+    /// `AdeApp::clear_merge_flow_for_closed_agent`'s docs for the mechanism this guards.
     #[gpui::test]
-    fn close_session_during_in_flight_complete_merge_lets_the_commit_finish(
-        cx: &mut TestAppContext,
-    ) {
+    fn close_agent_during_in_flight_complete_merge_lets_the_commit_finish(cx: &mut TestAppContext) {
         let repo = init_repo();
         let feature = add_worktree(repo.path(), "feature", "feature-wt");
         fs::write(feature.join("new.txt"), "from feature\n").expect("write");
@@ -1009,9 +1005,9 @@ mod merge_regression_tests {
         git(&feature, &["commit", "-m", "feature commit"]);
 
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        let feature_session_id = app.update_in(cx, |app, window, cx| {
-            app.sessions.spawn(
-                SessionKind::Shell,
+        let feature_agent_id = app.update_in(cx, |app, window, cx| {
+            app.agents.spawn(
+                AgentKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 window,
@@ -1019,7 +1015,7 @@ mod merge_regression_tests {
             )
         });
 
-        app.update(cx, |app, cx| app.start_merge(feature_session_id, cx));
+        app.update(cx, |app, cx| app.start_merge(feature_agent_id, cx));
         cx.run_until_parked();
 
         app.read_with(cx, |app, _| {
@@ -1027,7 +1023,7 @@ mod merge_regression_tests {
                 .merge_flow
                 .as_ref()
                 .expect("merge_flow after start_merge");
-            assert_eq!(flow.session_id, feature_session_id);
+            assert_eq!(flow.agent_id, feature_agent_id);
             assert!(
                 matches!(flow.state, merge::MergeFlowState::Clean { .. }),
                 "seed setup should produce a clean (no-conflict) merge, ready for Complete"
@@ -1042,10 +1038,10 @@ mod merge_regression_tests {
             "merge_op_in_flight should be set synchronously by complete_merge_flow"
         );
 
-        // Close (archive) the session before that commit has run - the "click Complete, then
+        // Close (archive) the agent before that commit has run - the "click Complete, then
         // immediately click Archive" race.
         app.update_in(cx, |app, window, cx| {
-            app.close_session(feature_session_id, window, cx)
+            app.close_agent(feature_agent_id, window, cx)
         });
 
         // Let the pending commit and its completion handler run.
@@ -1054,7 +1050,7 @@ mod merge_regression_tests {
         assert!(
             !app.read_with(cx, |app, _| app.merge_op_in_flight),
             "merge_op_in_flight must not be permanently stranded at true - the real commit's \
-             own completion handler must still run to reset it, since closing the session must \
+             own completion handler must still run to reset it, since closing the agent must \
              not cancel that in-flight task"
         );
 
@@ -1077,7 +1073,7 @@ mod merge_regression_tests {
     /// Same setup, asserting the repository is left clean and usable: a brand-new merge started
     /// right after the close-during-complete race must succeed, not hit a wedged repo.
     #[gpui::test]
-    fn close_session_during_in_flight_complete_merge_leaves_repo_usable_for_a_new_merge(
+    fn close_agent_during_in_flight_complete_merge_leaves_repo_usable_for_a_new_merge(
         cx: &mut TestAppContext,
     ) {
         let repo = init_repo();
@@ -1087,9 +1083,9 @@ mod merge_regression_tests {
         git(&feature, &["commit", "-m", "feature commit"]);
 
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        let feature_session_id = app.update_in(cx, |app, window, cx| {
-            app.sessions.spawn(
-                SessionKind::Shell,
+        let feature_agent_id = app.update_in(cx, |app, window, cx| {
+            app.agents.spawn(
+                AgentKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 window,
@@ -1097,11 +1093,11 @@ mod merge_regression_tests {
             )
         });
 
-        app.update(cx, |app, cx| app.start_merge(feature_session_id, cx));
+        app.update(cx, |app, cx| app.start_merge(feature_agent_id, cx));
         cx.run_until_parked();
         app.update(cx, |app, cx| app.complete_merge_flow(cx));
         app.update_in(cx, |app, window, cx| {
-            app.close_session(feature_session_id, window, cx)
+            app.close_agent(feature_agent_id, window, cx)
         });
         cx.run_until_parked();
 
@@ -1111,23 +1107,23 @@ mod merge_regression_tests {
         git(&second_feature, &["add", "more.txt"]);
         git(&second_feature, &["commit", "-m", "second feature commit"]);
 
-        let second_session_id = app.update_in(cx, |app, window, cx| {
-            app.sessions.spawn(
-                SessionKind::Shell,
+        let second_agent_id = app.update_in(cx, |app, window, cx| {
+            app.agents.spawn(
+                AgentKind::Shell,
                 second_feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 window,
                 cx,
             )
         });
-        app.update(cx, |app, cx| app.start_merge(second_session_id, cx));
+        app.update(cx, |app, cx| app.start_merge(second_agent_id, cx));
         cx.run_until_parked();
         app.read_with(cx, |app, _| {
             let flow = app
                 .merge_flow
                 .as_ref()
                 .expect("merge_flow after second start_merge");
-            assert_eq!(flow.session_id, second_session_id);
+            assert_eq!(flow.agent_id, second_agent_id);
             assert!(
                 matches!(flow.state, merge::MergeFlowState::Clean { .. }),
                 "a real, independent merge must succeed cleanly on the now-clean repo, not hit \
@@ -1170,9 +1166,9 @@ mod merge_regression_tests {
         );
 
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        let feature_session_id = app.update_in(cx, |app, window, cx| {
-            app.sessions.spawn(
-                SessionKind::Shell,
+        let feature_agent_id = app.update_in(cx, |app, window, cx| {
+            app.agents.spawn(
+                AgentKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 window,
@@ -1180,7 +1176,7 @@ mod merge_regression_tests {
             )
         });
 
-        app.update(cx, |app, cx| app.start_merge(feature_session_id, cx));
+        app.update(cx, |app, cx| app.start_merge(feature_agent_id, cx));
         cx.run_until_parked();
 
         app.read_with(cx, |app, _| {
@@ -1281,9 +1277,9 @@ mod merge_regression_tests {
         git(&feature, &["commit", "-am", "feature changes value.rs"]);
 
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        let feature_session_id = app.update_in(cx, |app, window, cx| {
-            app.sessions.spawn(
-                SessionKind::Shell,
+        let feature_agent_id = app.update_in(cx, |app, window, cx| {
+            app.agents.spawn(
+                AgentKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 window,
@@ -1291,7 +1287,7 @@ mod merge_regression_tests {
             )
         });
 
-        app.update(cx, |app, cx| app.start_merge(feature_session_id, cx));
+        app.update(cx, |app, cx| app.start_merge(feature_agent_id, cx));
         cx.run_until_parked();
 
         // Hand-verified real line numbers for the conflict git produces from this fixture:
@@ -1384,16 +1380,16 @@ mod merge_regression_tests {
         git(&feature, &["commit", "-am", "feature changes value.rs"]);
 
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        let feature_session_id = app.update_in(cx, |app, window, cx| {
-            app.sessions.spawn(
-                SessionKind::Shell,
+        let feature_agent_id = app.update_in(cx, |app, window, cx| {
+            app.agents.spawn(
+                AgentKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 window,
                 cx,
             )
         });
-        app.update(cx, |app, cx| app.start_merge(feature_session_id, cx));
+        app.update(cx, |app, cx| app.start_merge(feature_agent_id, cx));
         cx.run_until_parked();
 
         let first_ptr = app.read_with(cx, |app, _| {
@@ -1451,16 +1447,16 @@ mod merge_regression_tests {
         );
 
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        let feature_session_id = app.update_in(cx, |app, window, cx| {
-            app.sessions.spawn(
-                SessionKind::Shell,
+        let feature_agent_id = app.update_in(cx, |app, window, cx| {
+            app.agents.spawn(
+                AgentKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 window,
                 cx,
             )
         });
-        app.update(cx, |app, cx| app.start_merge(feature_session_id, cx));
+        app.update(cx, |app, cx| app.start_merge(feature_agent_id, cx));
         cx.run_until_parked();
 
         let first_path = app.read_with(cx, |app, _| {
@@ -1536,9 +1532,9 @@ mod merge_regression_tests {
 
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
-        let feature_session_id = app.update_in(cx, |app, window, cx| {
-            app.sessions.spawn(
-                SessionKind::Shell,
+        let feature_agent_id = app.update_in(cx, |app, window, cx| {
+            app.agents.spawn(
+                AgentKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 window,
@@ -1546,7 +1542,7 @@ mod merge_regression_tests {
             )
         });
 
-        app.update(cx, |app, cx| app.start_merge(feature_session_id, cx));
+        app.update(cx, |app, cx| app.start_merge(feature_agent_id, cx));
         cx.run_until_parked();
         app.read_with(cx, |app, _| {
             let flow = app
@@ -1654,16 +1650,16 @@ mod merge_regression_tests {
 
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
-        let feature_session_id = app.update_in(cx, |app, window, cx| {
-            app.sessions.spawn(
-                SessionKind::Shell,
+        let feature_agent_id = app.update_in(cx, |app, window, cx| {
+            app.agents.spawn(
+                AgentKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 window,
                 cx,
             )
         });
-        app.update(cx, |app, cx| app.start_merge(feature_session_id, cx));
+        app.update(cx, |app, cx| app.start_merge(feature_agent_id, cx));
         cx.run_until_parked();
 
         let hunk_count = app.read_with(cx, |app, _| {
@@ -1786,16 +1782,16 @@ mod merge_regression_tests {
 
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
-        let feature_session_id = app.update_in(cx, |app, window, cx| {
-            app.sessions.spawn(
-                SessionKind::Shell,
+        let feature_agent_id = app.update_in(cx, |app, window, cx| {
+            app.agents.spawn(
+                AgentKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 window,
                 cx,
             )
         });
-        app.update(cx, |app, cx| app.start_merge(feature_session_id, cx));
+        app.update(cx, |app, cx| app.start_merge(feature_agent_id, cx));
         cx.run_until_parked();
         app.read_with(cx, |app, _| {
             let flow = app.merge_flow.as_ref().expect("merge_flow");
@@ -1890,16 +1886,16 @@ mod merge_regression_tests {
 
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
-        let feature_session_id = app.update_in(cx, |app, window, cx| {
-            app.sessions.spawn(
-                SessionKind::Shell,
+        let feature_agent_id = app.update_in(cx, |app, window, cx| {
+            app.agents.spawn(
+                AgentKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 window,
                 cx,
             )
         });
-        app.update(cx, |app, cx| app.start_merge(feature_session_id, cx));
+        app.update(cx, |app, cx| app.start_merge(feature_agent_id, cx));
         cx.run_until_parked();
         app.update_in(cx, |app, window, cx| {
             app.start_merge_hand_edit(window, cx);
@@ -1957,7 +1953,7 @@ mod merge_regression_tests {
     /// R2, R4a, R4b, R8.5a, R8.5b) - proves the new `"merge-editor"` key context does not swallow
     /// a keystroke while a *different* surface (here, the File view) is what's actually focused,
     /// even while a merge hand-edit is genuinely still alive in the background for a different
-    /// session.
+    /// agent.
     #[gpui::test]
     fn merge_editor_context_does_not_swallow_keystrokes_meant_for_a_different_focused_surface(
         cx: &mut TestAppContext,
@@ -1989,16 +1985,16 @@ mod merge_regression_tests {
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
         let notes_path = repo.path().join("notes.txt");
-        let feature_session_id = app.update_in(cx, |app, window, cx| {
-            app.sessions.spawn(
-                SessionKind::Shell,
+        let feature_agent_id = app.update_in(cx, |app, window, cx| {
+            app.agents.spawn(
+                AgentKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 window,
                 cx,
             )
         });
-        app.update(cx, |app, cx| app.start_merge(feature_session_id, cx));
+        app.update(cx, |app, cx| app.start_merge(feature_agent_id, cx));
         cx.run_until_parked();
         app.update_in(cx, |app, window, cx| {
             app.start_merge_hand_edit(window, cx);
@@ -2129,7 +2125,7 @@ mod merge_regression_tests {
     /// flow (here, abort), must genuinely tear down [`AdeApp::merge_edit`] (not merely hide it),
     /// and a fresh, unrelated merge started afterward must neither resurrect it nor be corruptible
     /// by a stale result for the old attempt - even one carrying the old attempt's own real
-    /// `session_id`/`generation` identity, directly proving `Self::apply_merge_edit_save_result`'s
+    /// `agent_id`/`generation` identity, directly proving `Self::apply_merge_edit_save_result`'s
     /// own guard rather than relying on timing to reproduce the race.
     #[gpui::test]
     fn ending_a_merge_flow_tears_down_hand_edit_state_and_a_fresh_merge_cannot_be_polluted_by_it(
@@ -2155,25 +2151,25 @@ mod merge_regression_tests {
 
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
-        let feature_session_id = app.update_in(cx, |app, window, cx| {
-            app.sessions.spawn(
-                SessionKind::Shell,
+        let feature_agent_id = app.update_in(cx, |app, window, cx| {
+            app.agents.spawn(
+                AgentKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 window,
                 cx,
             )
         });
-        app.update(cx, |app, cx| app.start_merge(feature_session_id, cx));
+        app.update(cx, |app, cx| app.start_merge(feature_agent_id, cx));
         cx.run_until_parked();
         app.update_in(cx, |app, window, cx| {
             app.start_merge_hand_edit(window, cx);
         });
         cx.run_until_parked();
-        let (stale_session_id, stale_generation, stale_relative_path) =
+        let (stale_agent_id, stale_generation, stale_relative_path) =
             app.read_with(cx, |app, _| {
                 let edit = app.merge_edit.as_ref().expect("merge_edit");
-                (edit.session_id, edit.generation, edit.relative_path.clone())
+                (edit.agent_id, edit.generation, edit.relative_path.clone())
             });
 
         // Abort the merge - a real exit point.
@@ -2208,23 +2204,23 @@ mod merge_regression_tests {
             &second_feature,
             &["commit", "-am", "second feature changes second.txt"],
         );
-        let second_session_id = app.update_in(cx, |app, window, cx| {
-            app.sessions.spawn(
-                SessionKind::Shell,
+        let second_agent_id = app.update_in(cx, |app, window, cx| {
+            app.agents.spawn(
+                AgentKind::Shell,
                 second_feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 window,
                 cx,
             )
         });
-        app.update(cx, |app, cx| app.start_merge(second_session_id, cx));
+        app.update(cx, |app, cx| app.start_merge(second_agent_id, cx));
         cx.run_until_parked();
         app.read_with(cx, |app, _| {
             let flow = app
                 .merge_flow
                 .as_ref()
                 .expect("merge_flow after second start_merge");
-            assert_eq!(flow.session_id, second_session_id);
+            assert_eq!(flow.agent_id, second_agent_id);
             assert!(
                 matches!(flow.state, merge::MergeFlowState::Conflicted { .. }),
                 "the fresh, independent merge must succeed (conflicted, as this fixture \
@@ -2241,13 +2237,13 @@ mod merge_regression_tests {
         );
 
         // Direct identity-guard proof: a stale hand-edit save result carrying the *old*
-        // attempt's own real `session_id`/`generation` must be a real, verified no-op against
+        // attempt's own real `agent_id`/`generation` must be a real, verified no-op against
         // the live, fresh flow - never silently applied to it.
         let injected = wt_core::merge::load_conflicted_file(repo.path(), Path::new("shared.txt"))
             .expect("load_conflicted_file");
         app.update(cx, |app, _cx| {
             app.apply_merge_edit_save_result(
-                stale_session_id,
+                stale_agent_id,
                 stale_generation,
                 stale_relative_path,
                 injected,
@@ -2256,7 +2252,7 @@ mod merge_regression_tests {
         app.read_with(cx, |app, _| {
             let flow = app.merge_flow.as_ref().expect("merge_flow still present");
             assert_eq!(
-                flow.session_id, second_session_id,
+                flow.agent_id, second_agent_id,
                 "the stale call must not have touched the live, fresh flow's own identity"
             );
             let merge::MergeFlowState::Conflicted { files, .. } = &flow.state else {
@@ -2284,7 +2280,7 @@ mod merge_regression_tests {
     /// `open_diff_file_cache` goes back to `None` with `open_change` untouched - exactly the state
     /// `crate::code_surface::tabs::AdeApp::activate_file_tab`'s own doc comment describes ("the
     /// tab can be active without being shown"). `render_center_pane` then genuinely falls through
-    /// to the session/merge surface with `open_change` still `Some` the whole time. Set directly
+    /// to the agent/merge surface with `open_change` still `Some` the whole time. Set directly
     /// here (the same established precedent `status_bar::render`'s own tests already use for this
     /// exact field pair) rather than chasing the full multi-step live path, for a deterministic
     /// reproduction of the *state* the routing bug actually depends on - what matters for this
@@ -2316,16 +2312,16 @@ mod merge_regression_tests {
 
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
-        let feature_session_id = app.update_in(cx, |app, window, cx| {
-            app.sessions.spawn(
-                SessionKind::Shell,
+        let feature_agent_id = app.update_in(cx, |app, window, cx| {
+            app.agents.spawn(
+                AgentKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 window,
                 cx,
             )
         });
-        app.update(cx, |app, cx| app.start_merge(feature_session_id, cx));
+        app.update(cx, |app, cx| app.start_merge(feature_agent_id, cx));
         cx.run_until_parked();
         app.update_in(cx, |app, window, cx| {
             app.start_merge_hand_edit(window, cx);
@@ -2412,16 +2408,16 @@ mod merge_regression_tests {
 
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
-        let feature_session_id = app.update_in(cx, |app, window, cx| {
-            app.sessions.spawn(
-                SessionKind::Shell,
+        let feature_agent_id = app.update_in(cx, |app, window, cx| {
+            app.agents.spawn(
+                AgentKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 window,
                 cx,
             )
         });
-        app.update(cx, |app, cx| app.start_merge(feature_session_id, cx));
+        app.update(cx, |app, cx| app.start_merge(feature_agent_id, cx));
         cx.run_until_parked();
         app.update_in(cx, |app, window, cx| {
             app.start_merge_hand_edit(window, cx);
@@ -2496,7 +2492,7 @@ mod merge_regression_tests {
     /// test-only-delay seam `AdeApp::persist_settings`'s own tests already use for the analogous
     /// settings-save race - `AdeApp::set_merge_edit_save_test_delay`): a save dispatched against
     /// one hand-edit buffer, discarded and immediately replaced by a genuinely fresh buffer for
-    /// the *same* file (same session/generation/relative_path) *before* the first save's real
+    /// the *same* file (same agent/generation/relative_path) *before* the first save's real
     /// background write lands, must not let that stale completion apply itself to the new
     /// buffer/state at all - not `EditBuffer::mark_saved` (which would wrongly stamp the new,
     /// untouched buffer as having saved the old buffer's content, corrupting its own dirty-state
@@ -2527,16 +2523,16 @@ mod merge_regression_tests {
 
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
-        let feature_session_id = app.update_in(cx, |app, window, cx| {
-            app.sessions.spawn(
-                SessionKind::Shell,
+        let feature_agent_id = app.update_in(cx, |app, window, cx| {
+            app.agents.spawn(
+                AgentKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 window,
                 cx,
             )
         });
-        app.update(cx, |app, cx| app.start_merge(feature_session_id, cx));
+        app.update(cx, |app, cx| app.start_merge(feature_agent_id, cx));
         cx.run_until_parked();
 
         // Buffer A: hand-edit, resolve it fully, and dispatch a save with a long artificial

--- a/crates/app/src/merge/mod.rs
+++ b/crates/app/src/merge/mod.rs
@@ -23,8 +23,8 @@ use crate::merge::state as merge;
 use crate::root::*;
 use crate::theme;
 #[cfg(test)]
-use crate::work_surface::sessions::SessionKind;
-use crate::work_surface::sessions::{Session, SessionId};
+use crate::work_surface::agents::AgentKind;
+use crate::work_surface::agents::{Agent, AgentId};
 use crate::work_surface::state as work_surface;
 use gpui::{
     div, font, prelude::*, px, rems, uniform_list, ClickEvent, Context, Empty, FocusHandle, Pixels,

--- a/crates/app/src/merge/render.rs
+++ b/crates/app/src/merge/render.rs
@@ -3,9 +3,9 @@ use crate::code_surface::zoom::zoom_scoped;
 
 impl AdeApp {
     /// Surface D - the merge-conflict resolution surface, replacing the pty/diff body below the
-    /// tab strip and session context bar (which keep rendering normally) exactly like Surface
+    /// tab strip and agent context bar (which keep rendering normally) exactly like Surface
     /// B/C already do. Renders whichever [`merge::MergeFlowState`] `self.merge_flow` is
-    /// currently in for `session`; every value shown (branch names, file paths, conflict line
+    /// currently in for `agent`; every value shown (branch names, file paths, conflict line
     /// content) comes from the `wt_core::merge` call [`Self::start_merge`] made.
     ///
     /// Real per-token syntax coloring ([`code_view::highlight_block`], cached in
@@ -29,10 +29,10 @@ impl AdeApp {
     ///
     /// The left ("ours"/base) column is labelled with the base branch name rather than an agent
     /// identity, since `attempt_merge` always runs `git merge` from the base worktree - real git
-    /// state, not a running session, so there's no agent to attribute a tint to.
+    /// state, not a running agent, so there's no agent to attribute a tint to.
     pub(crate) fn render_merge_flow_surface(
         &self,
-        session: &Session,
+        agent: &Agent,
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
         let Some(flow) = self.merge_flow.as_ref() else {
@@ -226,7 +226,7 @@ impl AdeApp {
                             body = body
                                 .child(self.render_conflict_columns(
                                     base_branch,
-                                    session,
+                                    agent,
                                     &file.relative_path,
                                     hunk,
                                     cx,
@@ -387,7 +387,7 @@ impl AdeApp {
     pub(in crate::merge) fn render_conflict_columns(
         &self,
         base_branch: &str,
-        session: &Session,
+        agent: &Agent,
         relative_path: &Path,
         hunk: &ConflictHunk,
         cx: &mut Context<Self>,
@@ -403,11 +403,11 @@ impl AdeApp {
         // keeps `theme::syntax::COMMENT` a single real, unconditional token wherever it's used
         // (the File/Diff views included) instead of a merge-view-specific override, and gets
         // both columns to the same real legibility - neither has text sitting on a color wash.
-        let (agent_fg, _) = work_surface::agent_tint(session.kind);
-        let session_branch = self
+        let (agent_fg, _) = work_surface::agent_tint(agent.kind);
+        let agent_branch = self
             .worktrees
             .iter()
-            .find(|item| item.path == session.cwd)
+            .find(|item| item.path == agent.cwd)
             .and_then(|item| item.branch.clone())
             .unwrap_or_else(|| hunk.theirs_label.clone());
 
@@ -600,8 +600,8 @@ impl AdeApp {
                     )
                     .child(column(
                         "theirs",
-                        session.kind.label().to_string(),
-                        session_branch,
+                        agent.kind.label().to_string(),
+                        agent_branch,
                         &hunk.theirs,
                         theirs_rendered,
                         hunk.theirs_start_line,

--- a/crates/app/src/merge/state.rs
+++ b/crates/app/src/merge/state.rs
@@ -9,19 +9,19 @@ use std::path::{Path, PathBuf};
 use wt_core::merge::{ConflictSegment, ConflictedFile, ConflictedPath, UnmergeableReason};
 
 use crate::code_surface::edit_buffer::EditBuffer;
-use crate::work_surface::sessions::SessionId;
+use crate::work_surface::agents::AgentId;
 
-/// The live state of one merge attempt/resolution, scoped to the session whose `Merge` button
+/// The live state of one merge attempt/resolution, scoped to the agent whose `Merge` button
 /// started it.
 pub struct MergeFlow {
-    pub session_id: SessionId,
+    pub agent_id: AgentId,
     /// Bumped by [`crate::root::AdeApp::start_merge`] every time a fresh attempt is started -
-    /// including a fresh attempt for the *same* `session_id` (aborting a merge and immediately
-    /// re-clicking `Merge` on the same session tab reuses the same `session_id`). Real callers
-    /// that stamp a background operation with `(session_id, generation)` at dispatch time (see
+    /// including a fresh attempt for the *same* `agent_id` (aborting a merge and immediately
+    /// re-clicking `Merge` on the same agent tab reuses the same `agent_id`). Real callers
+    /// that stamp a background operation with `(agent_id, generation)` at dispatch time (see
     /// [`MergeEditState::generation`]'s own docs) use this to tell "a result for the attempt
     /// still in progress" apart from "a stale result for an attempt that has since been
-    /// superseded" - a bare `session_id` match alone cannot distinguish those two cases from each
+    /// superseded" - a bare `agent_id` match alone cannot distinguish those two cases from each
     /// other.
     pub generation: u64,
     pub state: MergeFlowState,
@@ -33,14 +33,14 @@ pub struct MergeFlow {
 /// sidebar-worktree-selection-scoped map with its own wholesale-reset discipline this state must
 /// never share - a hand-edit here must survive a sidebar worktree switch untouched, since
 /// browsing a different worktree in the sidebar is a completely independent axis from which
-/// session/merge flow is on screen).
+/// agent/merge flow is on screen).
 pub struct MergeEditState {
-    /// Which [`MergeFlow`] (by session) this hand-edit belongs to.
-    pub session_id: SessionId,
+    /// Which [`MergeFlow`] (by agent) this hand-edit belongs to.
+    pub agent_id: AgentId,
     /// [`MergeFlow::generation`] at the moment this hand-edit was started - see that field's own
     /// docs for the real, narrow race this closes: a stale in-flight background save from an
     /// aborted merge attempt landing *after* a fresh `start_merge` reused the very same
-    /// `session_id` must never be silently applied to the new attempt's unrelated conflict
+    /// `agent_id` must never be silently applied to the new attempt's unrelated conflict
     /// state.
     pub generation: u64,
     /// A real, monotonic per-buffer identity stamp - bumped by
@@ -48,16 +48,16 @@ pub struct MergeEditState {
     /// `EditBuffer` is actually seeded (not on a re-click that reuses an already-open one - see
     /// that method's own docs). Closes a real, narrow race an audit found by reading (not
     /// live-reproduced under the test executor, since it requires a real yield point mid-save
-    /// that this app's synchronous UI-event dispatch doesn't offer without one): `session_id`/
+    /// that this app's synchronous UI-event dispatch doesn't offer without one): `agent_id`/
     /// `generation`/`relative_path` alone are *not* enough to identify a specific *buffer*, only
     /// a specific merge attempt's specific file - if a hand-edit save is dispatched, the user
     /// then discards it and immediately re-opens hand-edit mode for the *same* file (same
-    /// session/generation/relative_path, but a brand-new `EditBuffer`) before that earlier save's
+    /// agent/generation/relative_path, but a brand-new `EditBuffer`) before that earlier save's
     /// background write actually lands, the earlier save's completion would otherwise call
     /// `EditBuffer::mark_saved` on the *new* buffer, stamping the old buffer's own written
     /// content as the new buffer's `saved_content` - silently corrupting the new buffer's dirty-
     /// state bookkeeping against content it never actually held. Every place a background save
-    /// result gets applied checks this alongside `session_id`/`generation`/`relative_path`.
+    /// result gets applied checks this alongside `agent_id`/`generation`/`relative_path`.
     pub buffer_id: u64,
     pub base_worktree_path: PathBuf,
     /// The conflicted file this hand-edit is for - matched by path (never a captured index) at
@@ -76,7 +76,7 @@ pub struct MergeEditState {
 pub enum MergeFlowState {
     /// The `git merge` child process is still running on a background thread.
     Running,
-    /// The session branch already contributes nothing new to the base branch - `git merge`
+    /// The agent branch already contributes nothing new to the base branch - `git merge`
     /// exited successfully but there was nothing to merge.
     AlreadyUpToDate { base_branch: String },
     /// The merge completed with no conflicts and is staged, uncommitted - waiting for an

--- a/crates/app/src/palette/mod.rs
+++ b/crates/app/src/palette/mod.rs
@@ -26,7 +26,7 @@ use crate::root::*;
 use crate::sidebar::changes;
 use crate::sidebar::file_tree::{self, LangChip};
 use crate::theme;
-use crate::work_surface::sessions::SessionKind;
+use crate::work_surface::agents::AgentKind;
 use crate::work_surface::state as work_surface;
 
 pub mod state;

--- a/crates/app/src/palette/render.rs
+++ b/crates/app/src/palette/render.rs
@@ -8,7 +8,7 @@ use crate::sidebar::render::RightSidebarView;
 /// `Self::build_palette_groups`'s other live-state secondaries.
 ///
 /// [`WindowControlsStyle`] is a rendering-only preview of another platform's title bar and
-/// keycap glyphs, never a rebinding of this session's globally-bound shortcuts (fixed at compile
+/// keycap glyphs, never a rebinding of this agent's globally-bound shortcuts (fixed at compile
 /// time by the real OS - see `crate::keymap`'s "cosmetic preview, not a rebinding" docs).
 /// Picking "macOS" on Linux/Windows makes every keycap render `⌘`-style while the key that
 /// actually works is still Ctrl - a deliberate tradeoff, not an oversight.
@@ -44,28 +44,28 @@ impl AdeApp {
     /// by keyboard handling ([`Self::move_palette_selection`]/[`Self::run_selected_palette_entry`]),
     /// built fresh every call so what's drawn and what `⏎`/`↑`/`↓` act on can never disagree.
     ///
-    /// `sessions`/`commands` are cheap (bounded by open-tab count plus 10 fixed commands) and
+    /// `agents`/`commands` are cheap (bounded by open-tab count plus 10 fixed commands) and
     /// built fresh here. `files` is the expensive part (as many entries as the whole loaded
     /// tree has, bounded by `Settings.file_tree.max_entries`) and is *not* rebuilt here - this reads [`Self::palette_file_candidates`], which
     /// [`Self::rebuild_palette_file_candidates`] keeps current at its own two mutation points.
     pub(crate) fn build_palette_groups(&self, cx: &App) -> Vec<palette::PaletteGroup> {
-        let sessions: Vec<palette::SessionCandidate> = self
-            .sessions
+        let agents: Vec<palette::AgentCandidate> = self
+            .agents
             .iter()
-            .map(|session| {
-                let status = self.session_status(session, cx);
+            .map(|agent| {
+                let status = self.agent_status(agent, cx);
                 let branch = self
                     .worktrees
                     .iter()
-                    .find(|item| item.path == session.cwd)
+                    .find(|item| item.path == agent.cwd)
                     .and_then(|item| item.branch.clone());
-                let title = match session.cwd.file_name() {
+                let title = match agent.cwd.file_name() {
                     Some(name) => name.to_string_lossy().into_owned(),
-                    None => session.cwd.display().to_string(),
+                    None => agent.cwd.display().to_string(),
                 };
-                palette::SessionCandidate {
-                    id: session.id,
-                    kind: session.kind,
+                palette::AgentCandidate {
+                    id: agent.id,
+                    kind: agent.kind,
                     title,
                     branch,
                     status,
@@ -73,7 +73,7 @@ impl AdeApp {
             })
             .collect();
 
-        let active_cwd = self.active_session_cwd();
+        let active_cwd = self.active_agent_cwd();
         let next_sidebar_view = match self.right_sidebar_view {
             RightSidebarView::Files => "Changes",
             RightSidebarView::Changes => "Files",
@@ -84,11 +84,11 @@ impl AdeApp {
                 secondary: format!("spawn a shell in {}", active_cwd.display()),
             },
             palette::CommandCandidate {
-                command: palette::PaletteCommand::NewClaudeSession,
+                command: palette::PaletteCommand::NewClaudeAgent,
                 secondary: format!("spawn claude in {}", active_cwd.display()),
             },
             palette::CommandCandidate {
-                command: palette::PaletteCommand::NewCodexSession,
+                command: palette::PaletteCommand::NewCodexAgent,
                 secondary: format!("spawn codex in {}", active_cwd.display()),
             },
             palette::CommandCandidate {
@@ -132,7 +132,7 @@ impl AdeApp {
         palette::build_groups(
             self.palette_scope,
             self.palette_query.as_str(),
-            &sessions,
+            &agents,
             &commands,
             &self.palette_file_candidates,
         )
@@ -222,13 +222,11 @@ impl AdeApp {
         cx: &mut Context<Self>,
     ) {
         match command {
-            palette::PaletteCommand::NewShell => self.new_session(SessionKind::Shell, window, cx),
-            palette::PaletteCommand::NewClaudeSession => {
-                self.new_session(SessionKind::Claude, window, cx)
+            palette::PaletteCommand::NewShell => self.new_agent(AgentKind::Shell, window, cx),
+            palette::PaletteCommand::NewClaudeAgent => {
+                self.new_agent(AgentKind::Claude, window, cx)
             }
-            palette::PaletteCommand::NewCodexSession => {
-                self.new_session(SessionKind::Codex, window, cx)
-            }
+            palette::PaletteCommand::NewCodexAgent => self.new_agent(AgentKind::Codex, window, cx),
             palette::PaletteCommand::ToggleFilesChanges => {
                 // Any palette gesture must disarm a pending prune confirmation (see
                 // `Self::open_palette`'s docs); the other branches already do this via the
@@ -351,7 +349,7 @@ impl AdeApp {
                 palette::EntryTarget::Command(command) => {
                     self.execute_palette_command(command, window, cx)
                 }
-                palette::EntryTarget::Session(id) => self.select_session(id, window, cx),
+                palette::EntryTarget::Agent(id) => self.select_agent(id, window, cx),
                 palette::EntryTarget::File(path) => self.open_palette_file_result(path, window, cx),
             }
         }
@@ -618,7 +616,7 @@ impl AdeApp {
                             .child(if has_query {
                                 self.palette_query.as_str().to_string()
                             } else {
-                                "Type a command, file or session\u{2026}".to_string()
+                                "Type a command, file or agent\u{2026}".to_string()
                             })
                             .debug_selector(|| "palette-query-text".to_string()),
                     )
@@ -787,9 +785,9 @@ impl AdeApp {
 
         let chip = match &entry.target {
             palette::EntryTarget::Command(_) => render_palette_command_chip().into_any_element(),
-            palette::EntryTarget::Session(_) => {
-                let kind = entry.session_kind.unwrap_or(SessionKind::Shell);
-                render_palette_session_chip(kind).into_any_element()
+            palette::EntryTarget::Agent(_) => {
+                let kind = entry.agent_kind.unwrap_or(AgentKind::Shell);
+                render_palette_agent_chip(kind).into_any_element()
             }
             palette::EntryTarget::File(path) => {
                 let name = path
@@ -915,7 +913,7 @@ impl AdeApp {
 }
 
 /// The palette row's 15×15 command chip - every command result gets the same generic `›` chip,
-/// since (unlike sessions/files) a command has no per-instance colour to inherit.
+/// since (unlike agents/files) a command has no per-instance colour to inherit.
 pub(in crate::palette) fn render_palette_command_chip() -> impl IntoElement {
     let (fg, bg) = theme::palette::COMMAND_CHIP;
     div()
@@ -934,10 +932,10 @@ pub(in crate::palette) fn render_palette_command_chip() -> impl IntoElement {
         .child("\u{203A}")
 }
 
-/// The palette row's 15×15 session chip - the same agent badge/tint
-/// (`crate::work_surface::state::agent_tint`/`agent_initial`) the rail's session rows use, reused
+/// The palette row's 15×15 agent chip - the same agent badge/tint
+/// (`crate::work_surface::state::agent_tint`/`agent_initial`) the rail's agent rows use, reused
 /// verbatim rather than a second, independently-drifting colour mapping.
-pub(in crate::palette) fn render_palette_session_chip(kind: SessionKind) -> impl IntoElement {
+pub(in crate::palette) fn render_palette_agent_chip(kind: AgentKind) -> impl IntoElement {
     let (fg, bg) = work_surface::agent_tint(kind);
     div()
         .flex_none()
@@ -978,7 +976,7 @@ pub(in crate::palette) fn render_palette_file_chip(chip: LangChip) -> impl IntoE
 /// A result row's matched-substring label: three adjacent spans (`pre`/`mid`/`post`), the
 /// middle one tinted with `theme::term::PROMPT` (reused rather than a separate token, since the
 /// hex value is identical - same precedent as `theme::button::GREEN_KEYCAP_FG`'s docs). `mono`
-/// selects mono for a file result, sans for a command/session result.
+/// selects mono for a file result, sans for a command/agent result.
 pub(in crate::palette) fn render_palette_label(
     matched: &palette::MatchedText,
     mono: bool,

--- a/crates/app/src/palette/state.rs
+++ b/crates/app/src/palette/state.rs
@@ -1,5 +1,5 @@
 //! Pure, GPUI-free data model for the command palette (⌘P): scope/matching/ranking/grouping
-//! over already-real app state (open sessions, the loaded file tree, a fixed command list),
+//! over already-real app state (open agents, the loaded file tree, a fixed command list),
 //! kept unit-testable without a live GPUI window. `crate::palette::render` turns the
 //! result into `gpui::Div` trees and real click/key handlers, since it owns the `Context<AdeApp>`
 //! those need. Every [`PaletteCommand`] variant maps one-to-one onto an existing `AdeApp` method
@@ -8,14 +8,14 @@
 //! Matching is a plain, deterministic, case-insensitive (ASCII-fold) leftmost substring search
 //! ([`substring_match`]), not fuzzy/skip-char matching, so a match highlights one contiguous
 //! span per row rather than scattered characters. Results rank by how early the match starts;
-//! an entry that only matched via a secondary field (a session's branch, a file's directory, a
+//! an entry that only matched via a secondary field (an agent's branch, a file's directory, a
 //! command's keywords) still qualifies but ranks after every primary-label match - see
 //! [`match_against`].
 
 use std::path::PathBuf;
 
 use crate::rail::status::Status;
-use crate::work_surface::sessions::{SessionId, SessionKind};
+use crate::work_surface::agents::{AgentId, AgentKind};
 
 /// Cap on how many rows a single group ([`PaletteGroup`]) contributes, independent of how many
 /// candidates matched - a palette meant to answer "which of these am I looking for" at a glance
@@ -85,12 +85,12 @@ pub fn typed_scope_prefix(ch: char) -> Option<PaletteScope> {
     }
 }
 
-/// An already-open session, reduced to what a palette row needs - built from the same live
-/// `crate::work_surface::sessions::Sessions` list the rail (`crate::rail::state::SessionRow`) renders.
+/// An already-open agent, reduced to what a palette row needs - built from the same live
+/// `crate::work_surface::agents::Agents` list the rail (`crate::rail::state::AgentRow`) renders.
 #[derive(Debug, Clone, PartialEq)]
-pub struct SessionCandidate {
-    pub id: SessionId,
-    pub kind: SessionKind,
+pub struct AgentCandidate {
+    pub id: AgentId,
+    pub kind: AgentKind,
     pub title: String,
     pub branch: Option<String>,
     pub status: Status,
@@ -101,12 +101,12 @@ pub struct SessionCandidate {
 /// never a stub.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PaletteCommand {
-    /// `crate::root::AdeApp::new_session(SessionKind::Shell, ..)`, same as the rail's `+`/⌘N.
+    /// `crate::root::AdeApp::new_agent(AgentKind::Shell, ..)`, same as the rail's `+`/⌘N.
     NewShell,
-    /// `crate::root::AdeApp::new_session(SessionKind::Claude, ..)`.
-    NewClaudeSession,
-    /// `crate::root::AdeApp::new_session(SessionKind::Codex, ..)`.
-    NewCodexSession,
+    /// `crate::root::AdeApp::new_agent(AgentKind::Claude, ..)`.
+    NewClaudeAgent,
+    /// `crate::root::AdeApp::new_agent(AgentKind::Codex, ..)`.
+    NewCodexAgent,
     /// `crate::root::AdeApp::set_right_sidebar_view`, same as the `Files | Changes` control.
     ToggleFilesChanges,
     /// `crate::root::AdeApp::request_prune` - goes through the same two-click confirmation gate
@@ -136,8 +136,8 @@ pub enum PaletteCommand {
 impl PaletteCommand {
     pub const ALL: [PaletteCommand; 10] = [
         PaletteCommand::NewShell,
-        PaletteCommand::NewClaudeSession,
-        PaletteCommand::NewCodexSession,
+        PaletteCommand::NewClaudeAgent,
+        PaletteCommand::NewCodexAgent,
         PaletteCommand::ToggleFilesChanges,
         PaletteCommand::PruneWorktrees,
         PaletteCommand::OpenSettings,
@@ -150,8 +150,8 @@ impl PaletteCommand {
     pub fn label(self) -> &'static str {
         match self {
             PaletteCommand::NewShell => "New Shell",
-            PaletteCommand::NewClaudeSession => "New Claude Session",
-            PaletteCommand::NewCodexSession => "New Codex Session",
+            PaletteCommand::NewClaudeAgent => "New Claude Agent",
+            PaletteCommand::NewCodexAgent => "New Codex Agent",
             PaletteCommand::ToggleFilesChanges => "Toggle Files / Changes",
             PaletteCommand::PruneWorktrees => "Prune Worktrees",
             PaletteCommand::OpenSettings => "Open Settings",
@@ -166,9 +166,9 @@ impl PaletteCommand {
     /// [`match_against`]), so e.g. typing "terminal" still finds "New Shell".
     fn keywords(self) -> &'static str {
         match self {
-            PaletteCommand::NewShell => "shell terminal spawn session",
-            PaletteCommand::NewClaudeSession => "claude agent spawn session cli",
-            PaletteCommand::NewCodexSession => "codex agent spawn session cli",
+            PaletteCommand::NewShell => "shell terminal spawn agent",
+            PaletteCommand::NewClaudeAgent => "claude agent spawn agent cli",
+            PaletteCommand::NewCodexAgent => "codex agent spawn agent cli",
             PaletteCommand::ToggleFilesChanges => "files changes panel sidebar switch",
             PaletteCommand::PruneWorktrees => "prune worktree remove delete cleanup merged",
             PaletteCommand::OpenSettings => "settings preferences agents worktrees config",
@@ -240,7 +240,7 @@ pub struct FileCandidate {
 #[derive(Debug, Clone, PartialEq)]
 pub enum EntryTarget {
     Command(PaletteCommand),
-    Session(SessionId),
+    Agent(AgentId),
     /// The real, absolute file-tree path (`crate::sidebar::file_tree::FileTreeEntry::path`) - not yet
     /// resolved to repo-relative; see `crate::root::AdeApp::open_palette_file_result`'s docs
     /// for how it decides between opening a real diff and revealing the file in the real tree.
@@ -288,13 +288,13 @@ pub struct PaletteEntry {
     pub label: MatchedText,
     pub secondary: String,
     pub shortcut: Option<&'static str>,
-    /// Only set for an [`EntryTarget::Session`] row - the rail's status colour, reused verbatim
+    /// Only set for an [`EntryTarget::Agent`] row - the rail's status colour, reused verbatim
     /// so the palette inherits the rail's colour coding.
     pub status: Option<Status>,
     /// Only set for an [`EntryTarget::File`] row that is an add/delete in the loaded diff.
     pub file_change: Option<FileChangeKind>,
-    /// Only set for an [`EntryTarget::Session`] row - which agent badge/tint to draw.
-    pub session_kind: Option<SessionKind>,
+    /// Only set for an [`EntryTarget::Agent`] row - which agent badge/tint to draw.
+    pub agent_kind: Option<AgentKind>,
     pub target: EntryTarget,
 }
 
@@ -351,7 +351,7 @@ pub fn substring_match(haystack: &str, needle: &str) -> Option<(usize, usize)> {
 /// `Some((highlight_span, rank))` if it matches at all. An empty `query` matches everything with
 /// rank `0` and no highlight (the "browse everything" state). A match in `primary` is
 /// highlighted and ranked by how early it starts (`0` is best). A match found only in `aux` (a
-/// session's branch, a file's directory, a command's keywords) still qualifies but has nothing
+/// agent's branch, a file's directory, a command's keywords) still qualifies but has nothing
 /// for the label to highlight, so it ranks last, at `usize::MAX`.
 fn match_against(
     primary: &str,
@@ -379,9 +379,9 @@ fn finish_group(mut scored: Vec<(usize, PaletteEntry)>) -> Vec<PaletteEntry> {
     scored.into_iter().map(|(_, entry)| entry).collect()
 }
 
-fn filter_sessions(sessions: &[SessionCandidate], query: &str) -> Vec<PaletteEntry> {
+fn filter_agents(agents: &[AgentCandidate], query: &str) -> Vec<PaletteEntry> {
     let mut scored = Vec::new();
-    for candidate in sessions {
+    for candidate in agents {
         let branch = candidate.branch.as_deref().unwrap_or("");
         let aux = [branch, candidate.kind.label()];
         let Some((span, rank)) = match_against(&candidate.title, &aux, query) else {
@@ -398,8 +398,8 @@ fn filter_sessions(sessions: &[SessionCandidate], query: &str) -> Vec<PaletteEnt
                 shortcut: None,
                 status: Some(candidate.status),
                 file_change: None,
-                session_kind: Some(candidate.kind),
-                target: EntryTarget::Session(candidate.id),
+                agent_kind: Some(candidate.kind),
+                target: EntryTarget::Agent(candidate.id),
             },
         ));
     }
@@ -422,7 +422,7 @@ fn filter_commands(commands: &[CommandCandidate], query: &str) -> Vec<PaletteEnt
                 shortcut: candidate.command.shortcut(),
                 status: None,
                 file_change: None,
-                session_kind: None,
+                agent_kind: None,
                 target: EntryTarget::Command(candidate.command),
             },
         ));
@@ -463,7 +463,7 @@ fn filter_files(files: &[FileCandidate], query: &str) -> Vec<PaletteEntry> {
                 shortcut: None,
                 status: None,
                 file_change: candidate.changed,
-                session_kind: None,
+                agent_kind: None,
                 target: EntryTarget::File(candidate.path.clone()),
             },
         ));
@@ -472,10 +472,10 @@ fn filter_files(files: &[FileCandidate], query: &str) -> Vec<PaletteEntry> {
 }
 
 /// Builds the palette's result groups for the current `scope`/`query`. Group order is always
-/// Sessions, Commands, Files; a group with zero matches is omitted entirely rather than shown as
+/// Agents, Commands, Files; a group with zero matches is omitted entirely rather than shown as
 /// an empty header.
 ///
-/// Sessions only appear in [`PaletteScope::All`] - there is no dedicated Sessions segment in the
+/// Agents only appear in [`PaletteScope::All`] - there is no dedicated Agents segment in the
 /// scope control. For an empty query in a scope that shows files, the file candidates are first
 /// narrowed to changed files (`FileCandidate::changed.is_some()`) under a `"Recent Files"`
 /// label: this app has no file-access/mtime history to rank true recency by, so "recent" is
@@ -485,17 +485,17 @@ fn filter_files(files: &[FileCandidate], query: &str) -> Vec<PaletteEntry> {
 pub fn build_groups(
     scope: PaletteScope,
     query: &str,
-    sessions: &[SessionCandidate],
+    agents: &[AgentCandidate],
     commands: &[CommandCandidate],
     files: &[FileCandidate],
 ) -> Vec<PaletteGroup> {
     let mut groups = Vec::new();
 
     if scope == PaletteScope::All {
-        let entries = filter_sessions(sessions, query);
+        let entries = filter_agents(agents, query);
         if !entries.is_empty() {
             groups.push(PaletteGroup {
-                label: "Sessions",
+                label: "Agents",
                 entries,
             });
         }
@@ -625,8 +625,8 @@ mod tests {
         unique.dedup();
         assert_eq!(unique.len(), labels.len(), "no duplicate commands");
         assert!(labels.contains(&"New Shell"));
-        assert!(labels.contains(&"New Claude Session"));
-        assert!(labels.contains(&"New Codex Session"));
+        assert!(labels.contains(&"New Claude Agent"));
+        assert!(labels.contains(&"New Codex Agent"));
         assert!(labels.contains(&"Prune Worktrees"));
         assert!(labels.contains(&"Open Settings"));
     }
@@ -650,15 +650,10 @@ mod tests {
         }
     }
 
-    fn session(
-        id: SessionId,
-        title: &str,
-        branch: Option<&str>,
-        status: Status,
-    ) -> SessionCandidate {
-        SessionCandidate {
+    fn agent(id: AgentId, title: &str, branch: Option<&str>, status: Status) -> AgentCandidate {
+        AgentCandidate {
             id,
-            kind: SessionKind::Claude,
+            kind: AgentKind::Claude,
             title: title.to_string(),
             branch: branch.map(str::to_string),
             status,
@@ -694,8 +689,8 @@ mod tests {
     }
 
     #[test]
-    fn empty_query_all_scope_shows_sessions_commands_and_recent_files_together() {
-        let sessions = vec![session(1, "Fix rate limiter", Some("fix/rl"), Status::Run)];
+    fn empty_query_all_scope_shows_agents_commands_and_recent_files_together() {
+        let agents = vec![agent(1, "Fix rate limiter", Some("fix/rl"), Status::Run)];
         let commands: Vec<CommandCandidate> = PaletteCommand::ALL
             .into_iter()
             .map(command_candidate)
@@ -705,13 +700,13 @@ mod tests {
             file("src/unchanged.rs", None),
         ];
 
-        let groups = build_groups(PaletteScope::All, "", &sessions, &commands, &files);
+        let groups = build_groups(PaletteScope::All, "", &agents, &commands, &files);
 
         let labels: Vec<&str> = groups.iter().map(|g| g.label).collect();
         assert_eq!(
             labels,
-            vec!["Sessions", "Commands", "Recent Files"],
-            "real order: Sessions, Commands, Files - matching Jerry.dc.html's own fixture"
+            vec!["Agents", "Commands", "Recent Files"],
+            "real order: Agents, Commands, Files - matching Jerry.dc.html's own fixture"
         );
         let files_group = groups.iter().find(|g| g.label == "Recent Files").unwrap();
         assert_eq!(
@@ -762,17 +757,17 @@ mod tests {
     }
 
     #[test]
-    fn sessions_never_appear_outside_all_scope() {
-        let sessions = vec![session(1, "Fix rate limiter", None, Status::Run)];
-        let groups = build_groups(PaletteScope::Commands, "", &sessions, &[], &[]);
-        assert!(groups.iter().all(|g| g.label != "Sessions"));
-        let groups = build_groups(PaletteScope::Files, "", &sessions, &[], &[]);
-        assert!(groups.iter().all(|g| g.label != "Sessions"));
+    fn agents_never_appear_outside_all_scope() {
+        let agents = vec![agent(1, "Fix rate limiter", None, Status::Run)];
+        let groups = build_groups(PaletteScope::Commands, "", &agents, &[], &[]);
+        assert!(groups.iter().all(|g| g.label != "Agents"));
+        let groups = build_groups(PaletteScope::Files, "", &agents, &[], &[]);
+        assert!(groups.iter().all(|g| g.label != "Agents"));
     }
 
     #[test]
     fn a_query_matching_nothing_yields_no_groups_at_all() {
-        let sessions = vec![session(1, "Fix rate limiter", None, Status::Run)];
+        let agents = vec![agent(1, "Fix rate limiter", None, Status::Run)];
         let commands: Vec<CommandCandidate> = PaletteCommand::ALL
             .into_iter()
             .map(command_candidate)
@@ -782,7 +777,7 @@ mod tests {
         let groups = build_groups(
             PaletteScope::All,
             "zzz_no_such_thing",
-            &sessions,
+            &agents,
             &commands,
             &files,
         );
@@ -830,15 +825,15 @@ mod tests {
     fn flatten_preserves_group_then_row_order() {
         let groups = vec![
             PaletteGroup {
-                label: "Sessions",
+                label: "Agents",
                 entries: vec![PaletteEntry {
                     label: MatchedText::plain("s1"),
                     secondary: String::new(),
                     shortcut: None,
                     status: None,
                     file_change: None,
-                    session_kind: None,
-                    target: EntryTarget::Session(1),
+                    agent_kind: None,
+                    target: EntryTarget::Agent(1),
                 }],
             },
             PaletteGroup {
@@ -849,14 +844,14 @@ mod tests {
                     shortcut: None,
                     status: None,
                     file_change: None,
-                    session_kind: None,
+                    agent_kind: None,
                     target: EntryTarget::Command(PaletteCommand::NewShell),
                 }],
             },
         ];
         let flat = flatten(&groups);
         assert_eq!(flat.len(), 2);
-        assert_eq!(flat[0].target, EntryTarget::Session(1));
+        assert_eq!(flat[0].target, EntryTarget::Agent(1));
         assert_eq!(
             flat[1].target,
             EntryTarget::Command(PaletteCommand::NewShell)
@@ -864,17 +859,17 @@ mod tests {
     }
 
     #[test]
-    fn session_matches_via_branch_still_qualifies_without_highlighting_the_title() {
-        let sessions = vec![session(
+    fn agent_matches_via_branch_still_qualifies_without_highlighting_the_title() {
+        let agents = vec![agent(
             1,
             "Fix rate limiter",
             Some("fix/auth-token-race"),
             Status::Run,
         )];
-        let groups = build_groups(PaletteScope::All, "token", &sessions, &[], &[]);
-        let sessions_group = groups.iter().find(|g| g.label == "Sessions").unwrap();
-        assert_eq!(sessions_group.entries.len(), 1);
-        assert_eq!(sessions_group.entries[0].label.mid, "");
-        assert_eq!(sessions_group.entries[0].label.pre, "Fix rate limiter");
+        let groups = build_groups(PaletteScope::All, "token", &agents, &[], &[]);
+        let agents_group = groups.iter().find(|g| g.label == "Agents").unwrap();
+        assert_eq!(agents_group.entries.len(), 1);
+        assert_eq!(agents_group.entries[0].label.mid, "");
+        assert_eq!(agents_group.entries[0].label.pre, "Fix rate limiter");
     }
 }

--- a/crates/app/src/rail/mod.rs
+++ b/crates/app/src/rail/mod.rs
@@ -1,4 +1,4 @@
-//! Zone 1, the session rail: everything about one feature, in one folder.
+//! Zone 1, the agent rail: everything about one feature, in one folder.
 //!
 //! Split the way every feature folder in this crate is split - pure, GPUI-window-free
 //! logic separate from the `gpui::Div`-building code that draws it:
@@ -6,7 +6,7 @@
 //! - [`repo`] - one added git repository (`Repo`/`RepoId`), the rail's group level
 //!   (Revision R12 Phase 0), plus its own crash-safe `~/.config/jerry/repos.toml`
 //!   persistence, mirroring [`crate::sidebar::fold_state`]'s pattern.
-//! - [`state`] - the pure row model: one row per worktree, aggregating every session open
+//! - [`state`] - the pure row model: one row per worktree, aggregating every agent open
 //!   in it, plus the filter/grouping rules. No `gpui::Window`.
 //! - [`worktrees`] - maps `wt-core`'s raw worktree list into that row model's input shape, plus
 //!   the pure selection-recovery state machine (GitHub issue #12).
@@ -14,7 +14,7 @@
 //!   panel's live refresh (GitHub issue #12). No `gpui` dependency either - it hands back a
 //!   plain `AtomicBool` flag; `render::AdeApp::start_worktree_watch` is the `gpui`-side loop
 //!   that reads it.
-//! - [`status`] - derives a session's `Status` ("who needs me") from already-read process
+//! - [`status`] - derives an agent's `Status` ("who needs me") from already-read process
 //!   signals; the rail's whole reason for existing, and shared with the tab strip and
 //!   status bar that surface the same answer.
 //! - [`render`] - the real GPUI rail, its rows, hover affordances and click handlers, as
@@ -26,7 +26,7 @@
 
 use crate::keymap;
 use crate::rail::state::{
-    self as rail, RepoGroup, RepoWorktrees, SessionRow, WorktreeEntry, WorktreeNote, WorktreeRow,
+    self as rail, AgentRow, RepoGroup, RepoWorktrees, WorktreeEntry, WorktreeNote, WorktreeRow,
 };
 use crate::rail::status::Status;
 #[cfg(test)]
@@ -34,7 +34,7 @@ use crate::rail::worktrees::WorktreeItem;
 use crate::root::*;
 use crate::status_bar::process_stats;
 use crate::theme;
-use crate::work_surface::sessions::SessionKind;
+use crate::work_surface::agents::AgentKind;
 use crate::work_surface::state as work_surface;
 use gpui::{div, font, prelude::*, px, App, ClickEvent, Context, KeyDownEvent, Window};
 use std::collections::{HashMap, HashSet};

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -24,19 +24,19 @@ fn agent_state_word(status: Status) -> &'static str {
 /// input` (the dot and state word are the whole message), the live activity for `running`, the
 /// exit code for `failed`, the review's file count for `review ready`, and `resumable · Nh` for
 /// `paused`.
-fn agent_trailing_text(session: &SessionRow) -> String {
-    match session.status {
+fn agent_trailing_text(agent: &AgentRow) -> String {
+    match agent.status {
         Status::Ask => String::new(),
-        Status::Run => session.activity.clone().unwrap_or_default(),
-        Status::Fail => session
+        Status::Run => agent.activity.clone().unwrap_or_default(),
+        Status::Fail => agent
             .exit_code
             .map(|code| format!("exit {code}"))
             .unwrap_or_default(),
-        Status::Review => session
+        Status::Review => agent
             .review_file_count
             .map(|count| format!("{count} file{}", if count == 1 { "" } else { "s" }))
             .unwrap_or_default(),
-        Status::Idle => format!("resumable \u{b7} {}", rail::format_elapsed(session.elapsed)),
+        Status::Idle => format!("resumable \u{b7} {}", rail::format_elapsed(agent.elapsed)),
     }
 }
 
@@ -103,23 +103,23 @@ impl AdeApp {
         }
     }
 
-    /// Builds the rail's per-session rows from live state: each session's `TerminalPane`
+    /// Builds the rail's per-agent rows from live state: each agent's `TerminalPane`
     /// (process signal, question preview), the matching worktree's branch name, and the diff
     /// summary from [`Self::diff_cache`] (refreshed by the periodic task started in
-    /// `Self::new`). A session with no diff data yet simply shows `0`/`0` until the next
+    /// `Self::new`). An agent with no diff data yet simply shows `0`/`0` until the next
     /// status-poll tick fills it in.
-    pub(crate) fn build_session_rows(&self, cx: &App) -> Vec<SessionRow> {
-        self.sessions
+    pub(crate) fn build_agent_rows(&self, cx: &App) -> Vec<AgentRow> {
+        self.agents
             .iter()
-            .map(|session| {
-                let status_value = self.session_status(session, cx);
-                let pane = session.pane.read(cx);
-                let diff = self.diff_cache.get(&session.cwd).copied();
+            .map(|agent| {
+                let status_value = self.agent_status(agent, cx);
+                let pane = agent.pane.read(cx);
+                let diff = self.diff_cache.get(&agent.cwd).copied();
 
                 let branch = self
                     .worktrees
                     .iter()
-                    .find(|item| item.path == session.cwd)
+                    .find(|item| item.path == agent.cwd)
                     .and_then(|item| item.branch.clone());
 
                 let question_preview = if status_value == Status::Ask {
@@ -131,26 +131,23 @@ impl AdeApp {
                     None
                 };
 
-                let title = match session.cwd.file_name() {
+                let title = match agent.cwd.file_name() {
                     Some(name) => name.to_string_lossy().into_owned(),
-                    None => session.cwd.display().to_string(),
+                    None => agent.cwd.display().to_string(),
                 };
 
-                // See `SessionRow::review_file_count`'s own docs: a review-ready session outside
+                // See `AgentRow::review_file_count`'s own docs: a review-ready agent outside
                 // the one worktree currently loaded in Zone 3 (`Self::diff_root`) has no diff data
                 // to report and stays `None` rather than a fabricated count. Within that worktree,
-                // the count is only unambiguous when this session is the sole agent there - with
+                // the count is only unambiguous when this agent is the sole agent there - with
                 // more than one agent sharing the worktree, attributing which files are "this
-                // session's" needs real per-agent authorship tracking, which doesn't exist yet (see
+                // agent's" needs real per-agent authorship tracking, which doesn't exist yet (see
                 // `crate::sidebar::changes::Authorship`'s own docs), so that case also stays `None`
                 // rather than reporting every agent's row as authoring zero files.
                 let review_file_count =
-                    if status_value == Status::Review && session.cwd == self.diff_root {
-                        let agents_in_worktree = self
-                            .sessions
-                            .iter()
-                            .filter(|s| s.cwd == session.cwd)
-                            .count();
+                    if status_value == Status::Review && agent.cwd == self.diff_root {
+                        let agents_in_worktree =
+                            self.agents.iter().filter(|s| s.cwd == agent.cwd).count();
                         if agents_in_worktree <= 1 {
                             self.current_diff().map(|diff| diff.files.len())
                         } else {
@@ -160,32 +157,32 @@ impl AdeApp {
                         None
                     };
 
-                SessionRow {
-                    id: session.id,
-                    kind: session.kind,
+                AgentRow {
+                    id: agent.id,
+                    kind: agent.kind,
                     title,
-                    cwd: session.cwd.clone(),
+                    cwd: agent.cwd.clone(),
                     status: status_value,
                     branch,
                     add: diff.map(|summary| summary.add).unwrap_or(0),
                     del: diff.map(|summary| summary.del).unwrap_or(0),
                     question_preview,
                     exit_code: pane.exit_status().map(|status| status.exit_code()),
-                    // See `SessionRow::activity`'s own docs: no real PTY-activity heuristic is
+                    // See `AgentRow::activity`'s own docs: no real PTY-activity heuristic is
                     // wired up yet, so every row threads `None` through for now.
                     activity: None,
-                    elapsed: session.spawned_at.elapsed(),
+                    elapsed: agent.spawned_at.elapsed(),
                     review_file_count,
                 }
             })
             .collect()
     }
 
-    /// Builds one [`WorktreeRow`] per worktree, folding in every currently open session
+    /// Builds one [`WorktreeRow`] per worktree, folding in every currently open agent
     /// (`crate::rail::state::build_worktree_rows`) - the single real per-render source both rail modes
     /// now build their list from (see [`Self::render_rail_list`]).
     pub(in crate::rail) fn build_worktree_rows(&self, cx: &App) -> Vec<WorktreeRow> {
-        rail::build_worktree_rows(&self.build_worktree_entries(), &self.build_session_rows(cx))
+        rail::build_worktree_rows(&self.build_worktree_entries(), &self.build_agent_rows(cx))
     }
 
     /// Builds the worktree list: every worktree `wt_core::list_worktrees` reported, including
@@ -237,8 +234,8 @@ impl AdeApp {
     }
 
     /// Starts the rail's periodic status background refresh (see [`STATUS_POLL_INTERVAL`]'s
-    /// docs). Every tick: snapshots the current worktree paths, open sessions' cwds, and open
-    /// sessions' real pids on the foreground thread (cheap, no I/O), computes a
+    /// docs). Every tick: snapshots the current worktree paths, open agents' cwds, and open
+    /// agents' real pids on the foreground thread (cheap, no I/O), computes a
     /// [`rail::StatusSnapshot`] *and* a real [`process_stats::sample_processes`] reading on the
     /// background executor, then writes both results back into
     /// [`Self::diff_cache`]/[`Self::worktree_notes`]/[`Self::ahead_behind_cache`]/
@@ -269,15 +266,12 @@ impl AdeApp {
                             is_locked: item.is_locked,
                         })
                         .collect();
-                    let diff_paths: Vec<PathBuf> = this
-                        .sessions
-                        .iter()
-                        .map(|session| session.cwd.clone())
-                        .collect();
+                    let diff_paths: Vec<PathBuf> =
+                        this.agents.iter().map(|agent| agent.cwd.clone()).collect();
                     let pids: Vec<u32> = this
-                        .sessions
+                        .agents
                         .iter()
-                        .filter_map(|session| session.pane.read(cx).pid())
+                        .filter_map(|agent| agent.pane.read(cx).pid())
                         .collect();
                     (worktrees, diff_paths, pids)
                 }) else {
@@ -363,7 +357,7 @@ impl AdeApp {
     }
 
     /// The prune candidate list: every worktree that is a prune candidate on its own merits
-    /// ([`rail::is_prunable`]) **and** has no live session running with its cwd inside it -
+    /// ([`rail::is_prunable`]) **and** has no live agent running with its cwd inside it -
     /// see [`rail::prunable_worktree_paths`]'s docs for why that second condition matters.
     /// Shared by the footer's displayed count and [`Self::execute_prune`], so what's shown
     /// always matches what a click will do.
@@ -374,12 +368,9 @@ impl AdeApp {
             .filter(|item| item.error.is_none())
             .map(|item| item.path.clone())
             .collect();
-        let live_session_cwds: HashSet<PathBuf> = self
-            .sessions
-            .iter()
-            .map(|session| session.cwd.clone())
-            .collect();
-        rail::prunable_worktree_paths(&worktree_paths, &self.worktree_notes, &live_session_cwds)
+        let live_agent_cwds: HashSet<PathBuf> =
+            self.agents.iter().map(|agent| agent.cwd.clone()).collect();
+        rail::prunable_worktree_paths(&worktree_paths, &self.worktree_notes, &live_agent_cwds)
     }
 
     /// The footer `prune` button's click handler. Destructive, so this is deliberately a
@@ -477,13 +468,13 @@ impl AdeApp {
         self._prune_task = Some(task);
     }
 
-    /// The whole session rail (`design_handoff_jerry_ade/README.md`'s Zone 1): header,
-    /// filter row, the real scrollable session/worktree list, and the footer - see the
+    /// The whole agent rail (`design_handoff_jerry_ade/README.md`'s Zone 1): header,
+    /// filter row, the real scrollable agent/worktree list, and the footer - see the
     /// README's "Rail chrome" section for the exact band heights this composes
     /// (`theme::band::{RAIL_HEADER,FILTER_ROW,SURFACE_FOOTER}`).
     pub(crate) fn render_rail(&self, cx: &mut Context<Self>) -> impl IntoElement {
         div()
-            .id("session-rail")
+            .id("agent-rail")
             // The app's real "nowhere else to put focus" fallback target - see
             // `AdeApp::rail_focus_handle`'s own docs for why the fallback lives on this
             // deliberately context-less root rather than on the filter row below it.
@@ -509,7 +500,7 @@ impl AdeApp {
                     .min_h_0()
                     .child(
                         div()
-                            .id("session-rail-list")
+                            .id("agent-rail-list")
                             .flex_1()
                             .min_h_0()
                             .overflow_y_scroll()
@@ -528,7 +519,7 @@ impl AdeApp {
 
     /// A visible error banner for [`Self::worktrees_error`] (`wt_core::list_worktrees_porcelain`
     /// failing outright, e.g. a corrupt repository) - shown as a standing banner rather than
-    /// replacing the whole session list, so already-open sessions stay usable even when the
+    /// replacing the whole agent list, so already-open agents stay usable even when the
     /// worktree listing itself is broken.
     pub(in crate::rail) fn render_worktrees_error_banner(&self) -> Option<impl IntoElement> {
         let error = self.worktrees_error.as_ref()?;
@@ -584,7 +575,7 @@ impl AdeApp {
         )
     }
 
-    /// Header 36 (`Sessions` label, grouping toggle, `+`/⌘N) - README's "Rail chrome".
+    /// Header 36 (`Agents` label, grouping toggle, `+`/⌘N) - README's "Rail chrome".
     pub(in crate::rail) fn render_rail_header(&self, cx: &mut Context<Self>) -> impl IntoElement {
         div()
             .id("rail-header")
@@ -602,27 +593,27 @@ impl AdeApp {
                     .font_weight(gpui::FontWeight::SEMIBOLD)
                     .text_size(self.ui_text_size(10.0))
                     .text_color(theme::text::FAINT)
-                    .child("SESSIONS"),
+                    .child("AGENTS"),
             )
             .child(
                 div()
                     .flex()
                     .items_center()
                     .gap(px(8.0))
-                    .child(self.render_new_session_button(cx)),
+                    .child(self.render_new_agent_button(cx)),
             )
     }
 
     /// The `+` control with its real, platform-resolved `mod+N` keycap pair (`⌘N` on macOS,
     /// `Ctrl N` on Windows/Linux - `crate::keymap::resolve_combo`) - spawns a real new shell
-    /// session (see [`NewSession`]'s docs for the judgment call on the keybinding side of
+    /// agent (see [`NewAgent`]'s docs for the judgment call on the keybinding side of
     /// this).
-    pub(in crate::rail) fn render_new_session_button(
+    pub(in crate::rail) fn render_new_agent_button(
         &self,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
         div()
-            .id("rail-new-session")
+            .id("rail-new-agent")
             .flex()
             .items_center()
             .gap(px(4.0))
@@ -642,7 +633,7 @@ impl AdeApp {
                 KeycapSize::Standard,
             ))
             .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
-                this.new_session(SessionKind::Shell, window, cx);
+                this.new_agent(AgentKind::Shell, window, cx);
             }))
     }
 
@@ -700,7 +691,7 @@ impl AdeApp {
                             .child(if has_query {
                                 self.filter_query.as_str().to_string()
                             } else {
-                                "filter sessions".to_string()
+                                "filter agents".to_string()
                             }),
                     )
                     .child(self.render_simple_input_caret()),
@@ -832,8 +823,8 @@ impl AdeApp {
     /// Whether `row`'s agent rows are currently shown - an explicit per-worktree override in
     /// [`Self::rail_collapse_overrides`] if the caret has ever been clicked for this path,
     /// otherwise the real default (§2.2: "Worktrees whose most urgent agent is idle start
-    /// collapsed"). A session-less row has no caret at all, so this is only ever consulted
-    /// (via [`Self::render_worktree_row`]) when `row.sessions` is non-empty.
+    /// collapsed"). An agent-less row has no caret at all, so this is only ever consulted
+    /// (via [`Self::render_worktree_row`]) when `row.agents` is non-empty.
     pub(in crate::rail) fn worktree_is_expanded(&self, row: &WorktreeRow) -> bool {
         match self.rail_collapse_overrides.get(&row.path) {
             Some(expanded) => *expanded,
@@ -918,8 +909,8 @@ impl AdeApp {
                 .into_any_element();
         }
 
-        let is_selected = self.active_session_cwd() == row.path;
-        let has_agents = !row.sessions.is_empty();
+        let is_selected = self.active_agent_cwd() == row.path;
+        let has_agents = !row.agents.is_empty();
         let is_expanded = has_agents && self.worktree_is_expanded(row);
         let status = row.aggregate_status();
 
@@ -983,7 +974,7 @@ impl AdeApp {
         if has_agents {
             if !is_expanded {
                 let mut dot_statuses: Vec<Status> =
-                    row.sessions.iter().map(|session| session.status).collect();
+                    row.agents.iter().map(|agent| agent.status).collect();
                 dot_statuses.sort_by_key(|status| status.urgency_rank());
                 trailing = trailing.child(div().flex().items_center().gap(px(3.0)).children(
                     dot_statuses.into_iter().map(|status| {
@@ -1058,8 +1049,8 @@ impl AdeApp {
             .flex_col()
             .child(header);
         if is_expanded {
-            for session in &row.sessions {
-                container = container.child(self.render_agent_row(session, cx));
+            for agent in &row.agents {
+                container = container.child(self.render_agent_row(agent, cx));
             }
         }
 
@@ -1086,14 +1077,14 @@ impl AdeApp {
             container = container.tooltip(text_tooltip(tooltip_text));
         }
 
-        // The most urgently-waiting open session's own question preview, if any - matches the
-        // old per-session row's card exactly, just picked from among this worktree's several
+        // The most urgently-waiting open agent's own question preview, if any - matches the
+        // old per-agent row's card exactly, just picked from among this worktree's several
         // possible tabs rather than always having exactly one to show.
         let question_preview = row
-            .sessions
+            .agents
             .iter()
-            .filter(|session| session.status == Status::Ask)
-            .find_map(|session| session.question_preview.as_ref());
+            .filter(|agent| agent.status == Status::Ask)
+            .find_map(|agent| agent.question_preview.as_ref());
         if let Some(preview) = question_preview {
             container = container.child(
                 div()
@@ -1115,30 +1106,30 @@ impl AdeApp {
     }
 
     /// One agent row (§2.3): indented 13, a 1px spine (2px and status-coloured when this is the
-    /// globally active session - `Self::sessions::active_id`), exactly two lines - chip/title/
+    /// globally active agent - `Self::agents::active_id`), exactly two lines - chip/title/
     /// elapsed, then status dot/state word/trailing text/model. Clicking it selects this
-    /// session's tab *and* its worktree (`Self::select_session` - already does both: it's the
-    /// same real entry point the palette/tab-strip use to jump straight to one session).
+    /// agent's tab *and* its worktree (`Self::select_agent` - already does both: it's the
+    /// same real entry point the palette/tab-strip use to jump straight to one agent).
     pub(in crate::rail) fn render_agent_row(
         &self,
-        session: &SessionRow,
+        agent: &AgentRow,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        let is_selected = self.sessions.active_id() == Some(session.id);
-        let status = session.status;
-        let (chip_fg, chip_bg) = work_surface::agent_tint(session.kind);
-        let chip_glyph = work_surface::agent_initial(session.kind);
+        let is_selected = self.agents.active_id() == Some(agent.id);
+        let status = agent.status;
+        let (chip_fg, chip_bg) = work_surface::agent_tint(agent.kind);
+        let chip_glyph = work_surface::agent_initial(agent.kind);
         let state_color: gpui::Rgba = match status {
             Status::Ask | Status::Fail => status.color(),
             _ => theme::text::FAINT.into(),
         };
-        let trailing_text = agent_trailing_text(session);
+        let trailing_text = agent_trailing_text(agent);
         let trailing_color: gpui::Rgba = if status == Status::Fail {
             theme::button::DANGER_FG.into()
         } else {
             theme::text::FAINT.into()
         };
-        let id = session.id;
+        let id = agent.id;
 
         div()
             .id(("agent-row", id))
@@ -1160,7 +1151,7 @@ impl AdeApp {
                 el.hover(|el| el.bg(theme::rail::WORKTREE_HOVER_BG))
             })
             .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
-                this.select_session(id, window, cx);
+                this.select_agent(id, window, cx);
             }))
             .child(
                 // Line 1: chip · task title · elapsed.
@@ -1196,7 +1187,7 @@ impl AdeApp {
                             } else {
                                 theme::text::BODY
                             })
-                            .child(session.title.clone()),
+                            .child(agent.title.clone()),
                     )
                     .child(
                         div()
@@ -1204,7 +1195,7 @@ impl AdeApp {
                             .font(font(theme::font::MONO))
                             .text_size(self.ui_text_size(9.5))
                             .text_color(theme::text::GHOST)
-                            .child(rail::format_elapsed(session.elapsed)),
+                            .child(rail::format_elapsed(agent.elapsed)),
                     ),
             )
             .child(
@@ -1247,7 +1238,7 @@ impl AdeApp {
                             .font(font(theme::font::MONO))
                             .text_size(self.ui_text_size(9.5))
                             .text_color(theme::text::PATH)
-                            .child(session.kind.label()),
+                            .child(agent.kind.label()),
                     ),
             )
     }
@@ -1420,7 +1411,7 @@ mod prune_regression_tests {
 
     /// Wires up `app.worktrees`/`app.worktree_notes` directly with one prunable worktree,
     /// bypassing the periodic status-poll computation - `Self::prunable_worktree_paths` only
-    /// reads these two fields plus `self.sessions`, so this exercises the same code
+    /// reads these two fields plus `self.agents`, so this exercises the same code
     /// `Self::request_prune`/`Self::execute_prune` run in production.
     fn seed_one_prunable_worktree(app: &mut AdeApp, path: PathBuf, branch: &str) {
         app.worktrees.push(WorktreeItem {
@@ -1532,7 +1523,7 @@ mod prune_regression_tests {
 /// Real, `Context<AdeApp>`-driven coverage for Revision R12's rail rewrite: the repo-group →
 /// worktree-row → agent-row structure (`design_handoff_jerry_ade/revision 3/
 /// REVISION-2026-07-31.md` §2), the per-worktree collapse memory, and the agent row's "select
-/// the worktree and raise this session's tab" click behaviour.
+/// the worktree and raise this agent's tab" click behaviour.
 #[cfg(test)]
 mod rail_row_tests {
     use super::*;
@@ -1558,7 +1549,7 @@ mod rail_row_tests {
     }
 
     /// §2.2: "Worktrees whose most urgent agent is idle start collapsed" - proven here against
-    /// a real running session (never collapsed by default) and a real idle one (collapsed by
+    /// a real running agent (never collapsed by default) and a real idle one (collapsed by
     /// default), through `Self::worktree_is_expanded`, the single real place that default lives.
     #[gpui::test]
     fn worktree_is_expanded_defaults_to_the_real_idle_rooted_rule(cx: &mut TestAppContext) {
@@ -1571,13 +1562,8 @@ mod rail_row_tests {
         });
         app.update_in(cx, |app, window, cx| {
             app.select_worktree(0, window, cx);
-            app.sessions.spawn(
-                SessionKind::Shell,
-                wt.path().to_path_buf(),
-                12.0,
-                window,
-                cx,
-            );
+            app.agents
+                .spawn(AgentKind::Shell, wt.path().to_path_buf(), 12.0, window, cx);
         });
         // The pty spawn itself is async (`TerminalPane::spawn_process`), so the process isn't
         // observably running yet the instant `spawn` returns - let it actually start before
@@ -1600,12 +1586,12 @@ mod rail_row_tests {
             "a worktree whose most urgent agent is running must default to expanded"
         );
 
-        // Force the same row into Idle without waiting on a real clock: a session-less
-        // `WorktreeRow` (same path, no sessions) aggregates to `Status::Idle` exactly the way a
+        // Force the same row into Idle without waiting on a real clock: an agent-less
+        // `WorktreeRow` (same path, no agents) aggregates to `Status::Idle` exactly the way a
         // real shell does once it goes quiet past `status::RUN_RECENT_OUTPUT_WINDOW` - the same
         // `aggregate_status` code path `Self::worktree_is_expanded` itself reads.
         let idle_row = rail::WorktreeRow {
-            sessions: Vec::new(),
+            agents: Vec::new(),
             ..running_row
         };
         assert_eq!(idle_row.aggregate_status(), Status::Idle, "sanity check");
@@ -1629,13 +1615,8 @@ mod rail_row_tests {
         });
         app.update_in(cx, |app, window, cx| {
             app.select_worktree(0, window, cx);
-            app.sessions.spawn(
-                SessionKind::Shell,
-                wt.path().to_path_buf(),
-                12.0,
-                window,
-                cx,
-            );
+            app.agents
+                .spawn(AgentKind::Shell, wt.path().to_path_buf(), 12.0, window, cx);
         });
         // See the identical `run_until_parked` call/comment in
         // `worktree_is_expanded_defaults_to_the_real_idle_rooted_rule` just above.
@@ -1672,12 +1653,12 @@ mod rail_row_tests {
     }
 
     /// §2.3: "Clicking an agent selects its worktree **and** raises that agent's tab." -
-    /// `Self::render_agent_row`'s own click handler calls exactly `Self::select_session`, so this
+    /// `Self::render_agent_row`'s own click handler calls exactly `Self::select_agent`, so this
     /// exercises that same real call: starting from worktree A selected/focused, selecting a
-    /// session that lives in worktree B must move the rail's selection to B *and* make that
-    /// exact session the active tab - not just one half of the pair.
+    /// agent that lives in worktree B must move the rail's selection to B *and* make that
+    /// exact agent the active tab - not just one half of the pair.
     #[gpui::test]
-    fn selecting_an_agent_session_selects_its_worktree_and_raises_its_tab(cx: &mut TestAppContext) {
+    fn selecting_an_agent_selects_its_worktree_and_raises_its_tab(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
         let wt_a = tempfile::tempdir().expect("tempdir a");
         let wt_b = tempfile::tempdir().expect("tempdir b");
@@ -1689,18 +1670,18 @@ mod rail_row_tests {
                 worktree_item(wt_b.path().to_path_buf(), "wt-b"),
             ];
         });
-        let session_in_b = app.update_in(cx, |app, window, cx| {
+        let agent_in_b = app.update_in(cx, |app, window, cx| {
             app.select_worktree(0, window, cx);
-            app.sessions.spawn(
-                SessionKind::Shell,
+            app.agents.spawn(
+                AgentKind::Shell,
                 wt_a.path().to_path_buf(),
                 12.0,
                 window,
                 cx,
             );
             app.select_worktree(0, window, cx);
-            app.sessions.spawn(
-                SessionKind::Shell,
+            app.agents.spawn(
+                AgentKind::Shell,
                 wt_b.path().to_path_buf(),
                 12.0,
                 window,
@@ -1716,18 +1697,18 @@ mod rail_row_tests {
         assert_eq!(app.read_with(cx, |app, _| app.selected), Some(0));
 
         app.update_in(cx, |app, window, cx| {
-            app.select_session(session_in_b, window, cx);
+            app.select_agent(agent_in_b, window, cx);
         });
 
         assert_eq!(
             app.read_with(cx, |app, _| app.selected),
             Some(1),
-            "selecting a session in worktree B must select worktree B in the rail"
+            "selecting an agent in worktree B must select worktree B in the rail"
         );
         assert_eq!(
-            app.read_with(cx, |app, _| app.sessions.active_id()),
-            Some(session_in_b),
-            "and that exact session must become the active tab"
+            app.read_with(cx, |app, _| app.agents.active_id()),
+            Some(agent_in_b),
+            "and that exact agent must become the active tab"
         );
     }
 
@@ -1753,15 +1734,15 @@ mod rail_row_tests {
         });
         app.update_in(cx, |app, window, cx| {
             app.select_worktree(1, window, cx);
-            app.sessions.spawn(
-                SessionKind::Claude,
+            app.agents.spawn(
+                AgentKind::Claude,
                 busy_wt.path().to_path_buf(),
                 12.0,
                 window,
                 cx,
             );
-            app.sessions.spawn(
-                SessionKind::Codex,
+            app.agents.spawn(
+                AgentKind::Codex,
                 busy_wt.path().to_path_buf(),
                 12.0,
                 window,

--- a/crates/app/src/rail/repo.rs
+++ b/crates/app/src/rail/repo.rs
@@ -36,7 +36,7 @@ use crate::rail::worktrees::WorktreeItem;
 /// Stable identity for one added repo. A plain, process-local monotonic counter
 /// (`crate::root::AdeApp::next_repo_id`) - **not** derived from the path, since a repo can be
 /// removed and re-added (or its directory renamed) without the identity a worktree's `repo:`
-/// reference points at needing to change mid-session. Never persisted itself: [`RepoState`]
+/// reference points at needing to change mid-agent. Never persisted itself: [`RepoState`]
 /// re-derives a fresh id per entry on every load (see that type's docs), since nothing durable
 /// outside one running process needs to reference a specific numeric id across a restart yet.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/crates/app/src/rail/state.rs
+++ b/crates/app/src/rail/state.rs
@@ -1,4 +1,4 @@
-//! The session rail's data model: pure, GPUI-free types and functions for grouping and
+//! The agent rail's data model: pure, GPUI-free types and functions for grouping and
 //! filtering (`design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md`'s Zone 1). No `gpui`
 //! dependency, so this logic is unit-testable without a real window, terminal, or git state.
 //! `crate::root` gathers the real signals (`TerminalPane`, `wt_core::list_worktrees`,
@@ -16,16 +16,16 @@ use std::time::Duration;
 
 use crate::rail::repo::RepoId;
 use crate::rail::status::Status;
-use crate::work_surface::sessions::SessionKind;
+use crate::work_surface::agents::AgentKind;
 use wt_core::diff::{AheadBehind, DiffBase, DiffLineKind, WorktreeDiff, WorktreeMergeStatus};
 
-/// One session, reduced to exactly what the rail row needs to render - built in `crate::root`
-/// from a `crate::work_surface::sessions::Session` plus a `wt_core::diff::diff_against_base` result for its
+/// One agent, reduced to exactly what the rail row needs to render - built in `crate::root`
+/// from a `crate::work_surface::agents::Agent` plus a `wt_core::diff::diff_against_base` result for its
 /// worktree. See `crate::rail::status::derive_status` for how `status` was computed.
 #[derive(Debug, Clone, PartialEq)]
-pub struct SessionRow {
-    pub id: crate::work_surface::sessions::SessionId,
-    pub kind: SessionKind,
+pub struct AgentRow {
+    pub id: crate::work_surface::agents::AgentId,
+    pub kind: AgentKind,
     pub title: String,
     pub cwd: PathBuf,
     pub status: Status,
@@ -34,7 +34,7 @@ pub struct SessionRow {
     /// every changed file. Both `0` if the diff hasn't loaded yet or there are no changes.
     pub add: usize,
     pub del: usize,
-    /// Tail-of-pty text for a waiting session (`TerminalPane::visible_text_lines`, trimmed to
+    /// Tail-of-pty text for a waiting agent (`TerminalPane::visible_text_lines`, trimmed to
     /// the last non-blank line) - the design's "question preview". Only populated for
     /// [`Status::Ask`] rows.
     pub question_preview: Option<String>,
@@ -55,10 +55,10 @@ pub struct SessionRow {
     /// **Always `None` today.** The real PTY-output-to-activity-text heuristic is a separate,
     /// parallel piece of work (this revision's Phase 0 is data-model-and-persistence only); this
     /// field exists so that work has a real, already-plumbed-through place to write into -
-    /// [`crate::rail::render::AdeApp::build_session_rows`] is where a live value would be filled
+    /// [`crate::rail::render::AdeApp::build_agent_rows`] is where a live value would be filled
     /// in, the same real construction site [`Self::question_preview`] is already filled in from.
     pub activity: Option<String>,
-    /// Wall-clock time since `crate::work_surface::sessions::Session::spawned_at` - the agent
+    /// Wall-clock time since `crate::work_surface::agents::Agent::spawned_at` - the agent
     /// row's line-1 elapsed time (§2.3: "elapsed 9.5px mono right"). See [`format_elapsed`] for
     /// how this becomes the rendered `4m`/`1h` text.
     pub elapsed: Duration,
@@ -70,17 +70,17 @@ pub struct SessionRow {
     /// whose worktree diff isn't the one currently loaded in Zone 3 (`crate::root::AdeApp::
     /// diff_root` only tracks one diff at a time, so a row outside it has no diff data at all),
     /// or a worktree with more than one agent sharing it - attributing which of the diff's files
-    /// are "this session's" needs real per-agent authorship tracking, which doesn't exist yet
+    /// are "this agent's" needs real per-agent authorship tracking, which doesn't exist yet
     /// (see `crate::sidebar::changes::Authorship`'s own docs), so every agent sharing that
     /// worktree would otherwise report the same full count, or - if sourced from `Authorship`
     /// instead - a uniformly fabricated zero. With exactly one agent in the worktree there's no
-    /// such ambiguity: every file in the diff is unambiguously that session's.
+    /// such ambiguity: every file in the diff is unambiguously that agent's.
     pub review_file_count: Option<usize>,
 }
 
-impl SessionRow {
+impl AgentRow {
     /// Whether this row matches a rail filter query - case-insensitive substring match
-    /// against the title, branch name, and session kind label.
+    /// against the title, branch name, and agent kind label.
     pub fn matches_filter(&self, query: &str) -> bool {
         let query = query.trim();
         if query.is_empty() {
@@ -96,15 +96,15 @@ impl SessionRow {
     }
 }
 
-/// Filters `rows` down to those matching `query` - see [`SessionRow::matches_filter`]. A
+/// Filters `rows` down to those matching `query` - see [`AgentRow::matches_filter`]. A
 /// blank query matches everything.
-pub fn filter_sessions<'a>(rows: &'a [SessionRow], query: &str) -> Vec<&'a SessionRow> {
+pub fn filter_agents<'a>(rows: &'a [AgentRow], query: &str) -> Vec<&'a AgentRow> {
     rows.iter()
         .filter(|row| row.matches_filter(query))
         .collect()
 }
 
-/// `+added -deleted` totals for one worktree/session cwd, summed across every changed file's
+/// `+added -deleted` totals for one worktree/agent cwd, summed across every changed file's
 /// hunks via [`sum_diff_stat`]. `has_changes` mirrors `crate::rail::status::derive_status`'s
 /// `has_reviewable_diff` input.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -134,14 +134,14 @@ pub fn sum_diff_stat(diff: &WorktreeDiff) -> (usize, usize) {
     (add, del)
 }
 
-/// Real per-status counts across every session row, in [`Status::ORDER`] - the status bar's
+/// Real per-status counts across every agent row, in [`Status::ORDER`] - the status bar's
 /// five urgency-counter squares (`design_handoff_jerry_ade/revision/CHANGELOG.md`'s change 7).
 /// Unlike [`group_worktrees_by_repo`], a status with zero matching rows still gets a real `0`
 /// entry rather than being omitted, since the status bar always shows all five squares. Built
 /// from the
-/// same per-session [`Status`] every [`SessionRow`] already carries - not a second, independent
+/// same per-agent [`Status`] every [`AgentRow`] already carries - not a second, independent
 /// status classification.
-pub fn urgency_counts(rows: &[SessionRow]) -> [(Status, usize); 5] {
+pub fn urgency_counts(rows: &[AgentRow]) -> [(Status, usize); 5] {
     Status::ORDER.map(|status| {
         (
             status,
@@ -174,7 +174,7 @@ impl WorktreeNote {
     /// `wt_core::remove_worktree`'s own dirty-tree refusal up front), and merged into its
     /// detected base.
     ///
-    /// Not sufficient on its own to remove a worktree - says nothing about a live session
+    /// Not sufficient on its own to remove a worktree - says nothing about a live agent
     /// running inside it. See [`prunable_worktree_paths`] for that additional exclusion.
     pub fn is_prunable(&self) -> bool {
         !self.is_main
@@ -183,7 +183,7 @@ impl WorktreeNote {
             && self.merge.as_ref().is_some_and(|status| status.merged)
     }
 
-    /// The real note text shown on a session-less worktree row.
+    /// The real note text shown on an agent-less worktree row.
     pub fn label(&self) -> String {
         let locked_suffix = if self.is_locked { " · locked" } else { "" };
 
@@ -259,35 +259,35 @@ pub struct WorktreeEntry {
     pub error: Option<String>,
 }
 
-/// One rail row: a single worktree, with **every** session currently open in it (not just the
-/// first one found) folded in as tabs - the real "one worktree = one rail entry, N sessions =
+/// One rail row: a single worktree, with **every** agent currently open in it (not just the
+/// first one found) folded in as tabs - the real "one worktree = one rail entry, N agents =
 /// N tabs" model this revision introduces, replacing the old `ProjectChild` shape whose
-/// `sessions.iter().find(...)` silently hid every session past the first in the same worktree.
+/// `agents.iter().find(...)` silently hid every agent past the first in the same worktree.
 #[derive(Debug, Clone, PartialEq)]
 pub struct WorktreeRow {
     pub path: PathBuf,
     pub label: String,
     pub branch: Option<String>,
-    /// Clean/merged note - only meaningful (and only ever shown) when [`Self::sessions`] is
-    /// empty; a worktree with an open session shows its sessions' own real status instead.
+    /// Clean/merged note - only meaningful (and only ever shown) when [`Self::agents`] is
+    /// empty; a worktree with an open agent shows its agents' own real status instead.
     pub note: WorktreeNote,
     /// `Some(message)` if this worktree's metadata failed to read - see [`WorktreeEntry::error`]'s
     /// own docs; a worktree row in this state is never interactive.
     pub error: Option<String>,
-    /// Every session currently open in this worktree, in tab-strip order (creation order,
-    /// matching `crate::work_surface::sessions::Sessions::iter_for_cwd`).
-    pub sessions: Vec<SessionRow>,
+    /// Every agent currently open in this worktree, in tab-strip order (creation order,
+    /// matching `crate::work_surface::agents::Agents::iter_for_cwd`).
+    pub agents: Vec<AgentRow>,
 }
 
 impl WorktreeRow {
-    /// The aggregate status shown on this row: the most urgent status among its open sessions
+    /// The aggregate status shown on this row: the most urgent status among its open agents
     /// (`Status::urgency_rank`, lower = more urgent - the same ranking the old
-    /// `status_dot_cluster` already used to sort a worktree's per-session dots), or
-    /// [`Status::Idle`] when no session is open at all - mirroring
+    /// `status_dot_cluster` already used to sort a worktree's per-agent dots), or
+    /// [`Status::Idle`] when no agent is open at all - mirroring
     /// `crate::rail::status::derive_status`'s own `ProcessSignal::NoProcess => Status::Idle`, since
-    /// "no process running" is exactly what a session-less worktree is.
+    /// "no process running" is exactly what an agent-less worktree is.
     pub fn aggregate_status(&self) -> Status {
-        self.sessions
+        self.agents
             .iter()
             .map(|row| row.status)
             .min_by_key(|status| status.urgency_rank())
@@ -303,14 +303,14 @@ impl WorktreeRow {
     /// `needs input`/`failed`/`review ready`/`running`/`paused` - map one-to-one onto
     /// [`Status::Ask`]/[`Status::Fail`]/[`Status::Review`]/[`Status::Run`]/[`Status::Idle`], see
     /// that enum's own docs), reused rather than re-derived. The last two only apply to a
-    /// session-less row, which [`Self::aggregate_status`] alone can't distinguish from a row
-    /// whose one open session is genuinely [`Status::Idle`] - both would otherwise rank 4. A
+    /// agent-less row, which [`Self::aggregate_status`] alone can't distinguish from a row
+    /// whose one open agent is genuinely [`Status::Idle`] - both would otherwise rank 4. A
     /// worktree with no agents at all is never the "same kind of quiet" as one with an idle
     /// agent still attached, so this splits that case using [`WorktreeNote::is_prunable`], the
     /// same real merged/clean/locked facts §2.2's "Bare worktrees `#22262a`, prunable
     /// `#2f353a`" left-edge colours already key off.
     pub fn urgency_rank(&self) -> u8 {
-        if self.sessions.is_empty() {
+        if self.agents.is_empty() {
             if self.note.is_prunable() {
                 6
             } else {
@@ -321,20 +321,20 @@ impl WorktreeRow {
         }
     }
 
-    /// The real `+added -deleted` totals summed across every open session's own diff summary -
-    /// double-counting is impossible since every session in [`Self::sessions`] shares this same
+    /// The real `+added -deleted` totals summed across every open agent's own diff summary -
+    /// double-counting is impossible since every agent in [`Self::agents`] shares this same
     /// worktree's `cwd`, so they'd all report the identical per-worktree diff anyway; this just
     /// reads the first one rather than literally summing duplicates.
     pub fn diff_totals(&self) -> (usize, usize) {
-        self.sessions
+        self.agents
             .first()
             .map(|row| (row.add, row.del))
             .unwrap_or((0, 0))
     }
 
     /// Whether this row matches a rail filter query - its own label/branch/path (see
-    /// [`matches_filter_worktree_entry`]) or any of its open sessions' own title/branch/kind
-    /// (see [`SessionRow::matches_filter`]).
+    /// [`matches_filter_worktree_entry`]) or any of its open agents' own title/branch/kind
+    /// (see [`AgentRow::matches_filter`]).
     pub fn matches_filter(&self, query: &str) -> bool {
         let trimmed = query.trim();
         if trimmed.is_empty() {
@@ -349,25 +349,22 @@ impl WorktreeRow {
                     .is_some_and(|branch| branch.to_lowercase().contains(&query))
                 || self.path.to_string_lossy().to_lowercase().contains(&query)
         };
-        entry_matches || self.sessions.iter().any(|row| row.matches_filter(trimmed))
+        entry_matches || self.agents.iter().any(|row| row.matches_filter(trimmed))
     }
 }
 
-/// Builds one [`WorktreeRow`] per worktree, in the given order, folding in **every** session
+/// Builds one [`WorktreeRow`] per worktree, in the given order, folding in **every** agent
 /// whose `cwd` matches that worktree's path (not just the first one - the real fix for the bug
-/// the old `ProjectChild`-based `build_project_children` had: `sessions.iter().find(...)` only
-/// ever surfaced one session per worktree, silently hiding any additional ones). Every worktree
-/// appears here, including ones with no session (e.g. `main`, or a merged/prunable leftover).
-pub fn build_worktree_rows(
-    worktrees: &[WorktreeEntry],
-    sessions: &[SessionRow],
-) -> Vec<WorktreeRow> {
+/// the old `ProjectChild`-based `build_project_children` had: `agents.iter().find(...)` only
+/// ever surfaced one agent per worktree, silently hiding any additional ones). Every worktree
+/// appears here, including ones with no agent (e.g. `main`, or a merged/prunable leftover).
+pub fn build_worktree_rows(worktrees: &[WorktreeEntry], agents: &[AgentRow]) -> Vec<WorktreeRow> {
     worktrees
         .iter()
         .map(|worktree| {
-            let sessions: Vec<SessionRow> = sessions
+            let agents: Vec<AgentRow> = agents
                 .iter()
-                .filter(|session| session.cwd == worktree.path)
+                .filter(|agent| agent.cwd == worktree.path)
                 .cloned()
                 .collect();
             WorktreeRow {
@@ -376,15 +373,15 @@ pub fn build_worktree_rows(
                 branch: worktree.branch.clone(),
                 note: worktree.note.clone(),
                 error: worktree.error.clone(),
-                sessions,
+                agents,
             }
         })
         .collect()
 }
 
 /// Filters a [`WorktreeRow`] list down to those matching `query` - applied *after*
-/// [`build_worktree_rows`], so which worktrees have open sessions folded in is always decided
-/// from the complete, unfiltered session list first.
+/// [`build_worktree_rows`], so which worktrees have open agents folded in is always decided
+/// from the complete, unfiltered agent list first.
 pub fn filter_worktree_rows<'a>(rows: &'a [WorktreeRow], query: &str) -> Vec<&'a WorktreeRow> {
     rows.iter()
         .filter(|row| row.matches_filter(query))
@@ -423,7 +420,7 @@ impl RepoGroup {
         self.rows
             .iter()
             .filter(|row| {
-                !row.sessions.is_empty()
+                !row.agents.is_empty()
                     && matches!(row.aggregate_status(), Status::Ask | Status::Fail)
             })
             .count()
@@ -454,7 +451,7 @@ impl RepoGroup {
 /// `crate::rail::repo::Repo::worktrees` isn't wired to live `wt_core::list_worktrees` data yet
 /// for any *other* repo (see that field's own docs) - there is no UI to add a second repo yet
 /// either (this revision deliberately doesn't build one), so in practice `repos` holds exactly
-/// one entry and this is a no-op in every real session; the general mechanism is still built
+/// one entry and this is a no-op in every real agent; the general mechanism is still built
 /// correctly so a later phase that wires up multi-repo data has a real, tested place to plug
 /// into rather than a single-repo special case to unwind.
 pub fn group_worktrees_by_repo(repos: Vec<RepoWorktrees>) -> Vec<RepoGroup> {
@@ -474,8 +471,8 @@ pub fn group_worktrees_by_repo(repos: Vec<RepoWorktrees>) -> Vec<RepoGroup> {
     groups
 }
 
-/// Whether a bare worktree row (no open session) matches a rail filter query - the "by
-/// project" equivalent of [`SessionRow::matches_filter`], matched against its label, branch,
+/// Whether a bare worktree row (no open agent) matches a rail filter query - the "by
+/// project" equivalent of [`AgentRow::matches_filter`], matched against its label, branch,
 /// and full filesystem path. The path is an additional search target because
 /// `crate::rail::worktrees::WorktreeItem::label` is always a short name (never a full path), so a
 /// query for an ancestor directory component would otherwise never match.
@@ -494,16 +491,16 @@ pub fn matches_filter_worktree_entry(entry: &WorktreeEntry, query: &str) -> bool
 }
 
 /// One completed round of the rail's periodic background refresh: `+N -M` diff totals for
-/// every session's worktree, and clean/merged notes for every listed worktree. Performs
+/// every agent's worktree, and clean/merged notes for every listed worktree. Performs
 /// blocking I/O (`git diff`/`git status`, `gix` object-database reads) - always run via a
 /// background executor, never on the GPUI foreground thread.
 pub struct StatusSnapshot {
-    /// Keyed by worktree/session cwd - deduplicated by path since more than one open session
+    /// Keyed by worktree/agent cwd - deduplicated by path since more than one open agent
     /// can share a worktree.
     pub diffs: HashMap<PathBuf, DiffSummary>,
     /// Keyed by worktree path.
     pub worktree_notes: HashMap<PathBuf, WorktreeNote>,
-    /// Real `wt_core::diff::ahead_behind_against_base` result per worktree/session cwd - the
+    /// Real `wt_core::diff::ahead_behind_against_base` result per worktree/agent cwd - the
     /// status bar's `↑2 ↓0` indicator. Keyed and deduplicated the same way as [`Self::diffs`];
     /// a path with no detectable base (or whose `ahead_behind_against_base` call itself failed)
     /// simply has no entry, rather than a fabricated `{0, 0}`.
@@ -585,8 +582,8 @@ pub fn compute_status_snapshot(
 }
 
 /// Whether `path` is a prune candidate on its own merits - see [`WorktreeNote::is_prunable`].
-/// Does **not** know about live sessions; see [`prunable_worktree_paths`] for the function
-/// that combines this with the live-session exclusion before anything is offered for removal.
+/// Does **not** know about live agents; see [`prunable_worktree_paths`] for the function
+/// that combines this with the live-agent exclusion before anything is offered for removal.
 pub fn is_prunable(worktree_notes: &HashMap<PathBuf, WorktreeNote>, path: &Path) -> bool {
     worktree_notes
         .get(path)
@@ -595,9 +592,9 @@ pub fn is_prunable(worktree_notes: &HashMap<PathBuf, WorktreeNote>, path: &Path)
 
 /// The final list of worktree paths `crate::root::AdeApp::prune_worktrees` is allowed to
 /// remove: every path that is a prune candidate per [`is_prunable`] **and** has no live
-/// session running with its cwd inside it.
+/// agent running with its cwd inside it.
 ///
-/// The live-session check isn't implied by `is_prunable`'s dirty check: a running process
+/// The live-agent check isn't implied by `is_prunable`'s dirty check: a running process
 /// with no uncommitted changes still leaves a clean tree, but removing its worktree directory
 /// out from under it is real data loss - `wt_core::remove_worktree`'s own safety check has no
 /// way to catch that. This exclusion happens once here, before `remove_worktree` is called
@@ -605,12 +602,12 @@ pub fn is_prunable(worktree_notes: &HashMap<PathBuf, WorktreeNote>, path: &Path)
 pub fn prunable_worktree_paths(
     worktree_paths: &[PathBuf],
     worktree_notes: &HashMap<PathBuf, WorktreeNote>,
-    live_session_cwds: &HashSet<PathBuf>,
+    live_agent_cwds: &HashSet<PathBuf>,
 ) -> Vec<PathBuf> {
     worktree_paths
         .iter()
         .filter(|path| is_prunable(worktree_notes, path))
-        .filter(|path| !live_session_cwds.contains(*path))
+        .filter(|path| !live_agent_cwds.contains(*path))
         .cloned()
         .collect()
 }
@@ -680,10 +677,10 @@ pub fn format_bytes(bytes: u64) -> String {
 mod tests {
     use super::*;
 
-    fn row(id: u64, status: Status, title: &str, cwd: &str) -> SessionRow {
-        SessionRow {
+    fn row(id: u64, status: Status, title: &str, cwd: &str) -> AgentRow {
+        AgentRow {
             id,
-            kind: SessionKind::Claude,
+            kind: AgentKind::Claude,
             title: title.to_string(),
             cwd: PathBuf::from(cwd),
             status,
@@ -698,7 +695,7 @@ mod tests {
         }
     }
 
-    /// [`SessionRow::activity`] is a plain, independent field - carrying a value must not change
+    /// [`AgentRow::activity`] is a plain, independent field - carrying a value must not change
     /// filtering (it isn't title/branch/kind text) or anything else about the row's identity.
     #[test]
     fn activity_is_independent_of_filtering_and_defaults_to_none() {
@@ -736,38 +733,38 @@ mod tests {
     }
 
     #[test]
-    fn urgency_counts_with_no_sessions_is_all_zero_not_omitted() {
+    fn urgency_counts_with_no_agents_is_all_zero_not_omitted() {
         let counts = urgency_counts(&[]);
         assert_eq!(counts.len(), 5);
         assert!(counts.iter().all(|(_, count)| *count == 0));
     }
 
     #[test]
-    fn filter_sessions_matches_title_branch_and_kind_case_insensitively() {
+    fn filter_agents_matches_title_branch_and_kind_case_insensitively() {
         let rows = vec![
             row(1, Status::Run, "Fix Rate Limiter", "/a"),
             row(2, Status::Run, "Unrelated Work", "/b"),
         ];
 
-        assert_eq!(filter_sessions(&rows, "rate").len(), 1);
-        assert_eq!(filter_sessions(&rows, "RATE").len(), 1);
+        assert_eq!(filter_agents(&rows, "rate").len(), 1);
+        assert_eq!(filter_agents(&rows, "RATE").len(), 1);
         assert_eq!(
-            filter_sessions(&rows, "feature-x").len(),
+            filter_agents(&rows, "feature-x").len(),
             2,
             "both share the same branch"
         );
         assert_eq!(
-            filter_sessions(&rows, "claude").len(),
+            filter_agents(&rows, "claude").len(),
             2,
-            "both are Claude sessions"
+            "both are Claude agents"
         );
-        assert_eq!(filter_sessions(&rows, "nonexistent").len(), 0);
+        assert_eq!(filter_agents(&rows, "nonexistent").len(), 0);
         assert_eq!(
-            filter_sessions(&rows, "  ").len(),
+            filter_agents(&rows, "  ").len(),
             2,
             "blank query matches everything"
         );
-        assert_eq!(filter_sessions(&rows, "").len(), 2);
+        assert_eq!(filter_agents(&rows, "").len(), 2);
     }
 
     #[test]
@@ -914,60 +911,60 @@ mod tests {
     }
 
     #[test]
-    fn build_worktree_rows_includes_worktrees_with_no_session_as_empty_rows() {
+    fn build_worktree_rows_includes_worktrees_with_no_agent_as_empty_rows() {
         let worktrees = vec![
             worktree_entry("/repo", clean_note(true)),
             worktree_entry("/repo-wt/leftover", clean_note(false)),
         ];
-        let sessions: Vec<SessionRow> = Vec::new();
+        let agents: Vec<AgentRow> = Vec::new();
 
-        let rows = build_worktree_rows(&worktrees, &sessions);
+        let rows = build_worktree_rows(&worktrees, &agents);
         assert_eq!(rows.len(), 2);
-        assert!(rows[0].sessions.is_empty());
-        assert!(rows[1].sessions.is_empty());
+        assert!(rows[0].agents.is_empty());
+        assert!(rows[1].agents.is_empty());
         assert_eq!(rows[0].aggregate_status(), Status::Idle);
     }
 
     #[test]
-    fn build_worktree_rows_folds_every_session_in_a_worktree_not_just_the_first() {
+    fn build_worktree_rows_folds_every_agent_in_a_worktree_not_just_the_first() {
         let worktrees = vec![
             worktree_entry("/repo", clean_note(true)),
             worktree_entry("/repo-wt/active", clean_note(false)),
         ];
-        // Two sessions in the SAME worktree - the real bug the old `ProjectChild`-based
-        // `build_project_children` had: `sessions.iter().find(...)` only ever surfaced the
+        // Two agents in the SAME worktree - the real bug the old `ProjectChild`-based
+        // `build_project_children` had: `agents.iter().find(...)` only ever surfaced the
         // first, silently hiding the second.
-        let sessions = vec![
+        let agents = vec![
             row(1, Status::Run, "Fix bug", "/repo-wt/active"),
             row(2, Status::Ask, "Second tab", "/repo-wt/active"),
         ];
 
-        let rows = build_worktree_rows(&worktrees, &sessions);
+        let rows = build_worktree_rows(&worktrees, &agents);
         assert_eq!(
             rows.len(),
             2,
             "every worktree still produces exactly one row"
         );
-        assert!(rows[0].sessions.is_empty());
+        assert!(rows[0].agents.is_empty());
         assert_eq!(
-            rows[1].sessions.len(),
+            rows[1].agents.len(),
             2,
-            "both sessions in the same worktree must be folded into its one row, not just the \
+            "both agents in the same worktree must be folded into its one row, not just the \
              first one found"
         );
-        assert_eq!(rows[1].sessions[0].id, 1);
-        assert_eq!(rows[1].sessions[1].id, 2);
+        assert_eq!(rows[1].agents[0].id, 1);
+        assert_eq!(rows[1].agents[1].id, 2);
     }
 
     #[test]
-    fn aggregate_status_picks_the_most_urgent_contained_session() {
+    fn aggregate_status_picks_the_most_urgent_contained_agent() {
         let worktrees = vec![worktree_entry("/repo-wt/a", clean_note(false))];
-        let sessions = vec![
+        let agents = vec![
             row(1, Status::Run, "run", "/repo-wt/a"),
             row(2, Status::Ask, "ask", "/repo-wt/a"),
             row(3, Status::Idle, "idle", "/repo-wt/a"),
         ];
-        let rows = build_worktree_rows(&worktrees, &sessions);
+        let rows = build_worktree_rows(&worktrees, &agents);
         assert_eq!(
             rows[0].aggregate_status(),
             Status::Ask,
@@ -976,22 +973,22 @@ mod tests {
     }
 
     #[test]
-    fn urgency_rank_matches_status_rank_for_a_worktree_with_sessions() {
+    fn urgency_rank_matches_status_rank_for_a_worktree_with_agents() {
         let worktrees = vec![
             worktree_entry("/repo-wt/asking", clean_note(false)),
             worktree_entry("/repo-wt/running", clean_note(false)),
         ];
-        let sessions = vec![
+        let agents = vec![
             row(1, Status::Ask, "ask", "/repo-wt/asking"),
             row(2, Status::Run, "run", "/repo-wt/running"),
         ];
-        let rows = build_worktree_rows(&worktrees, &sessions);
+        let rows = build_worktree_rows(&worktrees, &agents);
         assert_eq!(rows[0].urgency_rank(), Status::Ask.urgency_rank());
         assert_eq!(rows[1].urgency_rank(), Status::Run.urgency_rank());
     }
 
     #[test]
-    fn urgency_rank_splits_bare_and_prunable_below_every_session_status() {
+    fn urgency_rank_splits_bare_and_prunable_below_every_agent_status() {
         let mut prunable_note = clean_note(false);
         prunable_note.merge = Some(WorktreeMergeStatus {
             base_branch: "main".to_string(),
@@ -1009,13 +1006,13 @@ mod tests {
         assert_eq!(
             rows[0].urgency_rank(),
             5,
-            "a session-less, non-prunable worktree ranks 'bare' - below every real session \
+            "an agent-less, non-prunable worktree ranks 'bare' - below every real agent \
              status but above prunable"
         );
         assert_eq!(
             rows[1].urgency_rank(),
             6,
-            "a session-less, prunable worktree ranks last of all - §2.1's \
+            "an agent-less, prunable worktree ranks last of all - §2.1's \
              'input → failed → review → running → idle → bare → prunable'"
         );
         assert!(
@@ -1026,7 +1023,7 @@ mod tests {
             Status::ORDER
                 .iter()
                 .all(|status| status.urgency_rank() < rows[0].urgency_rank()),
-            "every real session status must outrank a bare worktree"
+            "every real agent status must outrank a bare worktree"
         );
     }
 
@@ -1045,13 +1042,13 @@ mod tests {
             worktree_entry("/repo-wt/asking", clean_note(false)),
             worktree_entry("/repo-wt/running", clean_note(false)),
         ];
-        let sessions = vec![
+        let agents = vec![
             row(1, Status::Run, "run", "/repo-wt/running"),
             row(2, Status::Ask, "ask", "/repo-wt/asking"),
         ];
         // Deliberately built in a non-urgency order, so a passing test proves the function
         // itself sorts rather than merely preserving input order.
-        let rows = build_worktree_rows(&worktrees, &sessions);
+        let rows = build_worktree_rows(&worktrees, &agents);
 
         let groups = group_worktrees_by_repo(vec![repo_worktrees(0, "jerry-core", rows)]);
         assert_eq!(groups.len(), 1);
@@ -1063,7 +1060,7 @@ mod tests {
         assert_eq!(
             labels,
             vec!["asking", "running", "bare"],
-            "asking (rank 0) before running (rank 3) before a session-less bare row (rank 5)"
+            "asking (rank 0) before running (rank 3) before an agent-less bare row (rank 5)"
         );
     }
 
@@ -1073,8 +1070,8 @@ mod tests {
         let quiet_rows = build_worktree_rows(&quiet_worktrees, &[]);
 
         let urgent_worktrees = vec![worktree_entry("/urgent-repo/wt", clean_note(false))];
-        let urgent_sessions = vec![row(1, Status::Ask, "ask", "/urgent-repo/wt")];
-        let urgent_rows = build_worktree_rows(&urgent_worktrees, &urgent_sessions);
+        let urgent_agents = vec![row(1, Status::Ask, "ask", "/urgent-repo/wt")];
+        let urgent_rows = build_worktree_rows(&urgent_worktrees, &urgent_agents);
 
         // Built with the quiet (less urgent) repo listed first, so a passing test proves this
         // is a real sort, not insertion order surviving by coincidence.
@@ -1113,12 +1110,12 @@ mod tests {
             worktree_entry("/repo-wt/running", clean_note(false)),
             worktree_entry("/repo-wt/bare", clean_note(false)),
         ];
-        let sessions = vec![
+        let agents = vec![
             row(1, Status::Ask, "ask", "/repo-wt/asking"),
             row(2, Status::Fail, "fail", "/repo-wt/failed"),
             row(3, Status::Run, "run", "/repo-wt/running"),
         ];
-        let rows = build_worktree_rows(&worktrees, &sessions);
+        let rows = build_worktree_rows(&worktrees, &agents);
         let groups = group_worktrees_by_repo(vec![repo_worktrees(0, "jerry-core", rows)]);
         assert_eq!(
             groups[0].waiting_count(),
@@ -1151,38 +1148,38 @@ mod tests {
     }
 
     #[test]
-    fn filter_worktree_rows_matches_session_title_worktree_label_or_worktree_path() {
-        let with_session = {
+    fn filter_worktree_rows_matches_agent_title_worktree_label_or_worktree_path() {
+        let with_agent = {
             let worktrees = vec![worktree_entry("/a", clean_note(false))];
-            let sessions = vec![row(1, Status::Run, "Fix rate limiter", "/a")];
-            build_worktree_rows(&worktrees, &sessions).remove(0)
+            let agents = vec![row(1, Status::Run, "Fix rate limiter", "/a")];
+            build_worktree_rows(&worktrees, &agents).remove(0)
         };
         // "leftover-branch" is the label (leaf name only); "repo-worktrees" can only match
         // via the path fallback, not the label.
-        let session_less = {
+        let agent_less = {
             let worktrees = vec![worktree_entry(
                 "/repo-worktrees/leftover-branch",
                 clean_note(false),
             )];
             build_worktree_rows(&worktrees, &[]).remove(0)
         };
-        let rows = vec![with_session, session_less];
+        let rows = vec![with_agent, agent_less];
 
         assert_eq!(filter_worktree_rows(&rows, "").len(), 2);
         assert_eq!(
             filter_worktree_rows(&rows, "rate").len(),
             1,
-            "matches only the row with the session, via its title"
+            "matches only the row with the agent, via its title"
         );
         assert_eq!(
             filter_worktree_rows(&rows, "leftover").len(),
             1,
-            "matches only the session-less row, via its real (leaf-name) label"
+            "matches only the agent-less row, via its real (leaf-name) label"
         );
         assert_eq!(
             filter_worktree_rows(&rows, "repo-worktrees").len(),
             1,
-            "matches only the session-less row, via its real path - the label alone never \
+            "matches only the agent-less row, via its real path - the label alone never \
              contains a directory component like this"
         );
     }
@@ -1208,7 +1205,7 @@ mod tests {
     }
 
     #[test]
-    fn prunable_worktree_paths_excludes_a_path_with_a_live_session_even_if_otherwise_prunable() {
+    fn prunable_worktree_paths_excludes_a_path_with_a_live_agent_even_if_otherwise_prunable() {
         let merged_clean_path = PathBuf::from("/repo-wt/merged-clean-but-in-use");
         let mut notes = HashMap::new();
         notes.insert(
@@ -1230,20 +1227,20 @@ mod tests {
         );
 
         let worktree_paths = vec![merged_clean_path.clone()];
-        let mut live_session_cwds = HashSet::new();
-        live_session_cwds.insert(merged_clean_path.clone());
+        let mut live_agent_cwds = HashSet::new();
+        live_agent_cwds.insert(merged_clean_path.clone());
 
-        let candidates = prunable_worktree_paths(&worktree_paths, &notes, &live_session_cwds);
+        let candidates = prunable_worktree_paths(&worktree_paths, &notes, &live_agent_cwds);
         assert!(
             candidates.is_empty(),
-            "a worktree with a live session tracked against its path must never appear in \
+            "a worktree with a live agent tracked against its path must never appear in \
              the prune candidate list, even though it is otherwise prunable"
         );
 
-        // Same worktree, no live session anywhere near it - now it's really a candidate.
-        let candidates_without_session =
+        // Same worktree, no live agent anywhere near it - now it's really a candidate.
+        let candidates_without_agent =
             prunable_worktree_paths(&worktree_paths, &notes, &HashSet::new());
-        assert_eq!(candidates_without_session, vec![merged_clean_path]);
+        assert_eq!(candidates_without_agent, vec![merged_clean_path]);
     }
 
     #[test]
@@ -1268,14 +1265,14 @@ mod tests {
         }
 
         let worktree_paths = vec![a.clone(), b.clone()];
-        let mut live_session_cwds = HashSet::new();
-        live_session_cwds.insert(a.clone());
+        let mut live_agent_cwds = HashSet::new();
+        live_agent_cwds.insert(a.clone());
 
-        let candidates = prunable_worktree_paths(&worktree_paths, &notes, &live_session_cwds);
+        let candidates = prunable_worktree_paths(&worktree_paths, &notes, &live_agent_cwds);
         assert_eq!(
             candidates,
             vec![b],
-            "only the worktree with a live session should be excluded; unrelated prunable \
+            "only the worktree with a live agent should be excluded; unrelated prunable \
              worktrees are unaffected"
         );
     }

--- a/crates/app/src/rail/status.rs
+++ b/crates/app/src/rail/status.rs
@@ -1,8 +1,8 @@
-//! Session-status derivation - the "who needs me" mechanism `design_handoff_jerry_ade/README.md`
-//! calls the whole point of the session rail.
+//! Agent-status derivation - the "who needs me" mechanism `design_handoff_jerry_ade/README.md`
+//! calls the whole point of the agent rail.
 //!
 //! GPUI-free and pty/process-free: takes small, already-read signals ([`ProcessSignal`], a
-//! `has_reviewable_diff` bool, a [`crate::work_surface::sessions::SessionKind`]) and returns a [`Status`], so
+//! `has_reviewable_diff` bool, a [`crate::work_surface::agents::AgentKind`]) and returns a [`Status`], so
 //! the decision logic is unit testable without a window or a child process. Gathering those
 //! signals from a live [`crate::terminal::pane::TerminalPane`] and `wt_core::diff::diff_against_base`
 //! lives in `crate::rail::state`/`crate::root`.
@@ -28,24 +28,24 @@
 //! - [`RUN_RECENT_OUTPUT_WINDOW`] (2s) is the boundary between "actively streaming" and "merely
 //!   paused" for any live process.
 //! - [`AGENT_ASK_IDLE_THRESHOLD`] (15s) is a second, longer threshold that only matters for
-//!   [`crate::work_surface::sessions::SessionKind::Claude`]/[`crate::work_surface::sessions::SessionKind::Codex`] sessions:
+//!   [`crate::work_surface::agents::AgentKind::Claude`]/[`crate::work_surface::agents::AgentKind::Codex`] agents:
 //!   an agent CLI commonly pauses for several seconds between a tool call and its result, so
 //!   treating every pause past 2s as "needs input" would flicker the rail on normal agent
-//!   latency. Only past the longer window is a session flagged [`Status::Ask`].
+//!   latency. Only past the longer window is an agent flagged [`Status::Ask`].
 //!
-//! A plain [`crate::work_surface::sessions::SessionKind::Shell`] has no such grace window: a shell sitting at
+//! A plain [`crate::work_surface::agents::AgentKind::Shell`] has no such grace window: a shell sitting at
 //! its prompt isn't "asking a question", it's just idle - so it falls straight to
 //! [`Status::Idle`] once [`RUN_RECENT_OUTPUT_WINDOW`] elapses, never [`Status::Ask`].
 
 use std::time::Duration;
 
-use crate::work_surface::sessions::SessionKind;
+use crate::work_surface::agents::AgentKind;
 
 /// How long a live process must have produced output within to count as "recently active" - the
 /// short end of the Run/Ask heuristic (see the module docs).
 pub const RUN_RECENT_OUTPUT_WINDOW: Duration = Duration::from_secs(2);
 
-/// How long an agent-CLI session ([`SessionKind::Claude`]/[`SessionKind::Codex`]) must have
+/// How long an agent-CLI agent ([`AgentKind::Claude`]/[`AgentKind::Codex`]) must have
 /// been quiet before it's flagged [`Status::Ask`] - see the module docs for why this is longer
 /// than [`RUN_RECENT_OUTPUT_WINDOW`].
 pub const AGENT_ASK_IDLE_THRESHOLD: Duration = Duration::from_secs(15);
@@ -61,7 +61,7 @@ pub enum Status {
     /// Exited 0 with a real, non-empty diff against base.
     Review,
     /// Alive and has produced output within [`RUN_RECENT_OUTPUT_WINDOW`], or alive and merely
-    /// paused (not yet past its own ask threshold, for agent sessions).
+    /// paused (not yet past its own ask threshold, for agents).
     Run,
     /// No process running, or a shell that's just sitting there.
     Idle,
@@ -103,7 +103,7 @@ impl Status {
         }
     }
 
-    /// The status pill's background colour (`design_handoff_jerry_ade/README.md`'s "Session
+    /// The status pill's background colour (`design_handoff_jerry_ade/README.md`'s "Agent
     /// context bar" spec) - `crate::theme::status::*_BG`, one per [`Status`].
     pub fn pill_bg(self) -> gpui::Rgba {
         match self {
@@ -136,29 +136,25 @@ pub enum ProcessSignal {
     /// The child process has exited (or a spawn attempt failed outright, treated the same as a
     /// non-zero exit - see `crate::rail::state`'s docs).
     Exited { success: bool },
-    /// No process has ever run in this session slot (or one is mid-async-spawn - see
+    /// No process has ever run in this agent slot (or one is mid-async-spawn - see
     /// `crate::rail::state`'s docs).
     NoProcess,
 }
 
-/// Derives the [`Status`] for one session from its process signal and whether it has a
+/// Derives the [`Status`] for one agent from its process signal and whether it has a
 /// non-empty diff against its worktree's base - see the module docs for the Run/Ask split.
-pub fn derive_status(
-    kind: SessionKind,
-    signal: ProcessSignal,
-    has_reviewable_diff: bool,
-) -> Status {
+pub fn derive_status(kind: AgentKind, signal: ProcessSignal, has_reviewable_diff: bool) -> Status {
     match signal {
         ProcessSignal::NoProcess => Status::Idle,
         ProcessSignal::Running { idle } => match kind {
-            SessionKind::Shell => {
+            AgentKind::Shell => {
                 if idle < RUN_RECENT_OUTPUT_WINDOW {
                     Status::Run
                 } else {
                     Status::Idle
                 }
             }
-            SessionKind::Claude | SessionKind::Codex => {
+            AgentKind::Claude | AgentKind::Codex => {
                 if idle < AGENT_ASK_IDLE_THRESHOLD {
                     Status::Run
                 } else {
@@ -187,11 +183,11 @@ mod tests {
     #[test]
     fn no_process_is_idle_regardless_of_kind_or_diff() {
         assert_eq!(
-            derive_status(SessionKind::Shell, ProcessSignal::NoProcess, true),
+            derive_status(AgentKind::Shell, ProcessSignal::NoProcess, true),
             Status::Idle
         );
         assert_eq!(
-            derive_status(SessionKind::Claude, ProcessSignal::NoProcess, true),
+            derive_status(AgentKind::Claude, ProcessSignal::NoProcess, true),
             Status::Idle
         );
     }
@@ -201,18 +197,9 @@ mod tests {
         let signal = ProcessSignal::Running {
             idle: Duration::from_millis(500),
         };
-        assert_eq!(
-            derive_status(SessionKind::Shell, signal, false),
-            Status::Run
-        );
-        assert_eq!(
-            derive_status(SessionKind::Claude, signal, false),
-            Status::Run
-        );
-        assert_eq!(
-            derive_status(SessionKind::Codex, signal, false),
-            Status::Run
-        );
+        assert_eq!(derive_status(AgentKind::Shell, signal, false), Status::Run);
+        assert_eq!(derive_status(AgentKind::Claude, signal, false), Status::Run);
+        assert_eq!(derive_status(AgentKind::Codex, signal, false), Status::Run);
     }
 
     #[test]
@@ -221,7 +208,7 @@ mod tests {
             idle: RUN_RECENT_OUTPUT_WINDOW + Duration::from_secs(1),
         };
         assert_eq!(
-            derive_status(SessionKind::Shell, signal, false),
+            derive_status(AgentKind::Shell, signal, false),
             Status::Idle,
             "a shell sitting at its prompt is idle, not \"needs input\" - it isn't asking anything"
         );
@@ -235,14 +222,8 @@ mod tests {
         let signal = ProcessSignal::Running {
             idle: RUN_RECENT_OUTPUT_WINDOW + Duration::from_secs(1),
         };
-        assert_eq!(
-            derive_status(SessionKind::Claude, signal, false),
-            Status::Run
-        );
-        assert_eq!(
-            derive_status(SessionKind::Codex, signal, false),
-            Status::Run
-        );
+        assert_eq!(derive_status(AgentKind::Claude, signal, false), Status::Run);
+        assert_eq!(derive_status(AgentKind::Codex, signal, false), Status::Run);
     }
 
     #[test]
@@ -250,25 +231,16 @@ mod tests {
         let signal = ProcessSignal::Running {
             idle: AGENT_ASK_IDLE_THRESHOLD + Duration::from_secs(1),
         };
-        assert_eq!(
-            derive_status(SessionKind::Claude, signal, false),
-            Status::Ask
-        );
-        assert_eq!(
-            derive_status(SessionKind::Codex, signal, false),
-            Status::Ask
-        );
+        assert_eq!(derive_status(AgentKind::Claude, signal, false), Status::Ask);
+        assert_eq!(derive_status(AgentKind::Codex, signal, false), Status::Ask);
     }
 
     #[test]
     fn nonzero_exit_is_fail_regardless_of_diff() {
         let signal = ProcessSignal::Exited { success: false };
+        assert_eq!(derive_status(AgentKind::Shell, signal, true), Status::Fail);
         assert_eq!(
-            derive_status(SessionKind::Shell, signal, true),
-            Status::Fail
-        );
-        assert_eq!(
-            derive_status(SessionKind::Claude, signal, false),
+            derive_status(AgentKind::Claude, signal, false),
             Status::Fail
         );
     }
@@ -277,7 +249,7 @@ mod tests {
     fn zero_exit_with_a_real_diff_is_review() {
         let signal = ProcessSignal::Exited { success: true };
         assert_eq!(
-            derive_status(SessionKind::Claude, signal, true),
+            derive_status(AgentKind::Claude, signal, true),
             Status::Review
         );
     }
@@ -286,7 +258,7 @@ mod tests {
     fn zero_exit_with_no_diff_is_idle_not_review() {
         let signal = ProcessSignal::Exited { success: true };
         assert_eq!(
-            derive_status(SessionKind::Claude, signal, false),
+            derive_status(AgentKind::Claude, signal, false),
             Status::Idle
         );
     }

--- a/crates/app/src/rail/worktrees.rs
+++ b/crates/app/src/rail/worktrees.rs
@@ -47,7 +47,7 @@ pub struct WorktreeItem {
     /// worktree move`, ...). Issue #12's "prunable / missing worktrees ... are marked as broken
     /// rather than silently listed as healthy" criterion. When `true`, [`Self::error`] is also
     /// `Some`, so every existing "is this worktree usable" check elsewhere in this crate
-    /// (selecting it, spawning a session in it, computing its disk usage, ...) already treats
+    /// (selecting it, spawning an agent in it, computing its disk usage, ...) already treats
     /// it as unusable with no separate call site needing to learn about this field.
     pub is_broken: bool,
     /// The reason `git` gives for [`Self::is_broken`], if any and non-empty.
@@ -259,7 +259,7 @@ mod tests {
 
     /// The central "don't silently list a broken worktree as healthy" guarantee (issue #12):
     /// a prunable entry must be both flagged via `is_broken`/`broken_reason` *and* rejected by
-    /// the plain `error.is_none()` gate every existing selection/session-spawn/diff call site
+    /// the plain `error.is_none()` gate every existing selection/agent-spawn/diff call site
     /// already uses, with no changes needed at those call sites.
     #[test]
     fn a_prunable_entry_is_marked_broken_and_unusable() {

--- a/crates/app/src/root/focus.rs
+++ b/crates/app/src/root/focus.rs
@@ -23,11 +23,11 @@ impl AdeApp {
     /// [`OverlayFocus`]). Reproduced by this branch's own adversarial audit: opening a file from
     /// the palette with no tab yet captured `palette_focus_handle`, and closing that tab then
     /// focused it. Each overlay already holds the real pre-overlay target in its own
-    /// `OverlayFocus`; declining to capture here leaves `restore_focus`'s active-session-pane
+    /// `OverlayFocus`; declining to capture here leaves `restore_focus`'s active-agent-pane
     /// fallback as the honest answer instead of a handle that is certain to be wrong.
     pub(crate) fn focus_code_surface(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if self.open_change.is_none() && !self.focus_is_on_an_overlay(window, cx) {
-            self.code_focus.capture(window, &self.sessions, cx);
+            self.code_focus.capture(window, &self.agents, cx);
         }
         window.focus(&self.code_focus_handle, cx);
     }
@@ -50,13 +50,13 @@ impl AdeApp {
     /// something else".
     pub(crate) fn open_palette(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.palette_open = true;
-        // The tab strip's `+` menu, the title bar's File/Edit/View/Session/Help dropdown, and
+        // The tab strip's `+` menu, the title bar's File/Edit/View/Agent/Help dropdown, and
         // the "New file" prompt are all unconditional siblings of the palette - see
         // `Self::plus_menu_open`'s/`Self::title_menu_open`'s/`Self::new_file_input`'s own docs.
         self.plus_menu_open = false;
         self.title_menu_open = None;
         self.new_file_input = None;
-        self.palette_focus.capture(window, &self.sessions, cx);
+        self.palette_focus.capture(window, &self.agents, cx);
         self.palette_scope = palette::PaletteScope::default();
         // A reopened palette is a genuinely new widget instance, so its predecessor's undo
         // history must not be reachable from it - `reset`, not `clear` (which is itself a real,
@@ -80,13 +80,13 @@ impl AdeApp {
             // palette was opened while Settings was already open and is now dismissing back
             // down to it) - focus belongs on `settings_focus_handle`, the same handle
             // `open_settings` itself uses, not on `palette_focus`'s restore target or the
-            // active session's pane (neither is actually rendered right now).
+            // active agent's pane (neither is actually rendered right now).
             window.focus(&self.settings_focus_handle, cx);
             self.palette_focus.clear();
             cx.notify();
             return;
         }
-        restore_focus(&self.sessions, &mut self.palette_focus, window, cx);
+        restore_focus(&self.agents, &mut self.palette_focus, window, cx);
         cx.notify();
     }
 
@@ -97,7 +97,7 @@ impl AdeApp {
     /// two closing paths are chosen between.
     ///
     /// Deliberately *not* `restore_focus` with a pre-cleared [`OverlayFocus`]: that function
-    /// falls back to the active session's terminal pane when it has no captured target, so
+    /// falls back to the active agent's terminal pane when it has no captured target, so
     /// clearing first would have moved focus off the file that was just opened and into the
     /// terminal - the same class of wrong-place focus this whole mechanism exists to stop. The
     /// captured target is discarded via [`OverlayFocus::clear`] instead, which is exactly what
@@ -141,7 +141,7 @@ impl AdeApp {
         self.tree_context_menu = None;
         self.tree_inline_edit = None;
         self.settings_open = true;
-        self.settings_focus.capture(window, &self.sessions, cx);
+        self.settings_focus.capture(window, &self.agents, cx);
         self.prune_confirm_armed = false;
         self.discard_confirm_armed = None;
         self.custom_theme_remove_armed = None;
@@ -159,7 +159,7 @@ impl AdeApp {
         // `App::intercept_keystrokes` subscription - it must never survive leaving the Settings
         // surface, or every keystroke in the whole app would keep being silently swallowed.
         self.cancel_keybinding_recording(cx);
-        restore_focus(&self.sessions, &mut self.settings_focus, window, cx);
+        restore_focus(&self.agents, &mut self.settings_focus, window, cx);
         cx.notify();
     }
 }
@@ -224,7 +224,7 @@ pub(crate) mod palette_focus_tests {
     }
 
     /// A fresh window starts with `Window::focus == None` - without `AdeApp::new` giving the
-    /// initial session's pane focus up front, the very first ⌘P would silently do nothing.
+    /// initial agent's pane focus up front, the very first ⌘P would silently do nothing.
     #[gpui::test]
     fn toggle_palette_works_on_a_fresh_window_with_nothing_clicked_yet(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
@@ -239,15 +239,15 @@ pub(crate) mod palette_focus_tests {
         );
     }
 
-    /// Spawning a session from the palette swaps the active session; verifies `close_palette`
-    /// focuses the *new* session's pane instead of the stale captured handle (see
-    /// [`OverlayFocus`]'s `opened_session` field).
+    /// Spawning an agent from the palette swaps the active agent; verifies `close_palette`
+    /// focuses the *new* agent's pane instead of the stale captured handle (see
+    /// [`OverlayFocus`]'s `opened_agent` field).
     #[gpui::test]
     fn toggle_palette_still_works_after_a_palette_spawned_new_shell(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
         let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
-        let initial_session_id = app.read_with(cx, |app, _| app.sessions.active_id());
+        let initial_agent_id = app.read_with(cx, |app, _| app.agents.active_id());
 
         cx.dispatch_action(TogglePalette);
         app.update_in(cx, |app, window, cx| {
@@ -260,17 +260,17 @@ pub(crate) mod palette_focus_tests {
             app.close_palette(window, cx);
         });
 
-        let new_session_id = app.read_with(cx, |app, _| app.sessions.active_id());
+        let new_agent_id = app.read_with(cx, |app, _| app.agents.active_id());
         assert_ne!(
-            initial_session_id, new_session_id,
-            "sanity check: New Shell should have made a different session active"
+            initial_agent_id, new_agent_id,
+            "sanity check: New Shell should have made a different agent active"
         );
 
         cx.dispatch_action(TogglePalette);
         assert!(
             app.read_with(cx, |app, _| app.palette_open),
             "secondary-p after a palette-spawned New Shell should still open the palette - the \
-             center pane now renders a different session's terminal pane than the one focus \
+             center pane now renders a different agent's terminal pane than the one focus \
              was captured from, so close_palette must not restore that now-stale handle"
         );
     }
@@ -403,46 +403,46 @@ mod tab_strip_keybinding_tests {
     /// `crate::default_key_bindings`), so it's simulated literally rather than branching on
     /// `cfg!(target_os = "macos")`.
     #[gpui::test]
-    fn ctrl_shift_t_spawns_a_real_shell_session_through_the_real_key_bindings(
+    fn ctrl_shift_t_spawns_a_real_shell_agent_through_the_real_key_bindings(
         cx: &mut TestAppContext,
     ) {
         let repo = tempfile::tempdir().expect("tempdir");
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
 
-        let sessions_before = app.read_with(cx, |app, _| app.sessions.iter().count());
+        let agents_before = app.read_with(cx, |app, _| app.agents.iter().count());
 
         cx.simulate_keystrokes("ctrl-shift-t");
 
-        let (sessions_after, active_kind) = app.read_with(cx, |app, _| {
+        let (agents_after, active_kind) = app.read_with(cx, |app, _| {
             (
-                app.sessions.iter().count(),
-                app.sessions.active().map(|session| session.kind),
+                app.agents.iter().count(),
+                app.agents.active().map(|agent| agent.kind),
             )
         });
         assert_eq!(
-            sessions_after,
-            sessions_before + 1,
+            agents_after,
+            agents_before + 1,
             "a real, simulated ctrl-shift-t keystroke should have spawned exactly one new \
-             session through crate::default_key_bindings' real ctrl-shift-t -> NewTerminal \
+             agent through crate::default_key_bindings' real ctrl-shift-t -> NewTerminal \
              binding"
         );
         assert_eq!(
             active_kind,
-            Some(SessionKind::Shell),
-            "New terminal always spawns a real Shell session"
+            Some(AgentKind::Shell),
+            "New terminal always spawns a real Shell agent"
         );
     }
 
     #[gpui::test]
-    fn secondary_shift_n_spawns_a_real_agent_session_through_the_real_key_bindings(
+    fn secondary_shift_n_spawns_a_real_agent_through_the_real_key_bindings(
         cx: &mut TestAppContext,
     ) {
         let repo = tempfile::tempdir().expect("tempdir");
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
 
-        let sessions_before = app.read_with(cx, |app, _| app.sessions.iter().count());
+        let agents_before = app.read_with(cx, |app, _| app.agents.iter().count());
 
         let secondary_shift_n = if cfg!(target_os = "macos") {
             "cmd-shift-n"
@@ -455,12 +455,12 @@ mod tab_strip_keybinding_tests {
         // other background-dispatching test in this crate calls `run_until_parked`.
         cx.run_until_parked();
 
-        let sessions_after = app.read_with(cx, |app, _| app.sessions.iter().count());
+        let agents_after = app.read_with(cx, |app, _| app.agents.iter().count());
         assert_eq!(
-            sessions_after,
-            sessions_before + 1,
+            agents_after,
+            agents_before + 1,
             "a real, simulated {secondary_shift_n} keystroke should have spawned exactly one \
-             new agent session through crate::default_key_bindings' real \
+             new agent through crate::default_key_bindings' real \
              secondary-shift-n -> NewAgentPane binding"
         );
     }
@@ -479,15 +479,15 @@ mod tab_strip_keybinding_tests {
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
 
-        // Explicitly focus the initial shell session - the real, concrete "a terminal pane
+        // Explicitly focus the initial shell agent - the real, concrete "a terminal pane
         // genuinely has keyboard focus" state this test's own name promises, rather than relying
         // on whatever `AdeApp::new_with_settings` happens to leave focus on by default.
         app.update_in(cx, |app, window, cx| {
-            app.sessions.focus_active(window, cx);
+            app.agents.focus_active(window, cx);
         });
         assert!(
-            app.read_with(cx, |app, _| app.sessions.active_id().is_some()),
-            "sanity check: a real terminal session must be focused for this test to mean anything"
+            app.read_with(cx, |app, _| app.agents.active_id().is_some()),
+            "sanity check: a real terminal agent must be focused for this test to mean anything"
         );
         assert!(
             !app.read_with(cx, |app, _| app.palette_open),
@@ -517,9 +517,9 @@ mod tab_strip_keybinding_tests {
         }
     }
 
-    /// With a file tab active (so `render_center_pane` shows the file, not any session's pane),
-    /// spawning a new session via `ctrl-shift-t` must not leave `Window::focus` on a pane that
-    /// isn't rendered anywhere that frame - `Sessions::spawn` used to move focus there
+    /// With a file tab active (so `render_center_pane` shows the file, not any agent's pane),
+    /// spawning a new agent via `ctrl-shift-t` must not leave `Window::focus` on a pane that
+    /// isn't rendered anywhere that frame - `Agents::spawn` used to move focus there
     /// unconditionally, silently killing every bound shortcut until the next click.
     #[gpui::test]
     fn ctrl_p_still_works_after_ctrl_shift_t_with_a_file_tab_active(cx: &mut TestAppContext) {
@@ -539,8 +539,8 @@ mod tab_strip_keybinding_tests {
 
         cx.simulate_keystrokes("ctrl-shift-t");
         assert!(
-            app.read_with(cx, |app, _| app.sessions.iter().count()) >= 2,
-            "sanity check: ctrl-shift-t should have spawned a real new session"
+            app.read_with(cx, |app, _| app.agents.iter().count()) >= 2,
+            "sanity check: ctrl-shift-t should have spawned a real new agent"
         );
 
         let key = secondary_p();
@@ -549,27 +549,27 @@ mod tab_strip_keybinding_tests {
         assert!(
             app.read_with(cx, |app, _| app.palette_open),
             "a real {key} keystroke after ctrl-shift-t, with a file tab active, must still open \
-             the palette - before the fix, Sessions::spawn's unconditional focus pointed \
-             Window::focus at the new session's pane even though render_center_pane was still \
+             the palette - before the fix, Agents::spawn's unconditional focus pointed \
+             Window::focus at the new agent's pane even though render_center_pane was still \
              showing the file tab, leaving no real dispatch path to any on_action handler"
         );
     }
 
-    /// The identical gap in `Sessions::close`: closing the active session's tab picks a new
-    /// active session but must also move focus onto it, or every bound shortcut dies until the
+    /// The identical gap in `Agents::close`: closing the active agent's tab picks a new
+    /// active agent but must also move focus onto it, or every bound shortcut dies until the
     /// next click.
     #[gpui::test]
-    fn ctrl_p_still_works_after_closing_the_active_session_tab(cx: &mut TestAppContext) {
+    fn ctrl_p_still_works_after_closing_the_active_agent_tab(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
 
         let first_id = app.read_with(cx, |app, _| {
-            app.sessions.active_id().expect("the initial shell session")
+            app.agents.active_id().expect("the initial shell agent")
         });
         app.update_in(cx, |app, window, cx| {
-            app.sessions.spawn(
-                SessionKind::Shell,
+            app.agents.spawn(
+                AgentKind::Shell,
                 repo.path().to_path_buf(),
                 app.settings.appearance.terminal_font_size,
                 window,
@@ -577,16 +577,16 @@ mod tab_strip_keybinding_tests {
             )
         });
         app.update_in(cx, |app, window, cx| {
-            app.select_session(first_id, window, cx);
+            app.select_agent(first_id, window, cx);
         });
         assert_eq!(
-            app.read_with(cx, |app, _| app.sessions.active_id()),
+            app.read_with(cx, |app, _| app.agents.active_id()),
             Some(first_id),
-            "sanity check: the first session should be active again before closing it"
+            "sanity check: the first agent should be active again before closing it"
         );
 
         app.update_in(cx, |app, window, cx| {
-            app.close_session(first_id, window, cx);
+            app.close_agent(first_id, window, cx);
         });
 
         let key = secondary_p();
@@ -594,26 +594,26 @@ mod tab_strip_keybinding_tests {
 
         assert!(
             app.read_with(cx, |app, _| app.palette_open),
-            "a real {key} keystroke after closing the active session's own tab must still open \
-             the palette - Sessions::close must move real keyboard focus onto whichever session \
+            "a real {key} keystroke after closing the active agent's own tab must still open \
+             the palette - Agents::close must move real keyboard focus onto whichever agent \
              became active as a result, not leave Window::focus dangling"
         );
     }
 
-    /// The other path to the same `Sessions::close` gap: archiving the active session from the
-    /// rail (`AdeApp::archive_session`, which delegates to `Self::close_session`).
+    /// The other path to the same `Agents::close` gap: archiving the active agent from the
+    /// rail (`AdeApp::archive_agent`, which delegates to `Self::close_agent`).
     #[gpui::test]
-    fn ctrl_p_still_works_after_archiving_the_active_session(cx: &mut TestAppContext) {
+    fn ctrl_p_still_works_after_archiving_the_active_agent(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
 
         let first_id = app.read_with(cx, |app, _| {
-            app.sessions.active_id().expect("the initial shell session")
+            app.agents.active_id().expect("the initial shell agent")
         });
         app.update_in(cx, |app, window, cx| {
-            app.sessions.spawn(
-                SessionKind::Shell,
+            app.agents.spawn(
+                AgentKind::Shell,
                 repo.path().to_path_buf(),
                 app.settings.appearance.terminal_font_size,
                 window,
@@ -621,16 +621,16 @@ mod tab_strip_keybinding_tests {
             )
         });
         app.update_in(cx, |app, window, cx| {
-            app.select_session(first_id, window, cx);
+            app.select_agent(first_id, window, cx);
         });
         assert_eq!(
-            app.read_with(cx, |app, _| app.sessions.active_id()),
+            app.read_with(cx, |app, _| app.agents.active_id()),
             Some(first_id),
-            "sanity check: the first session should be active again before archiving it"
+            "sanity check: the first agent should be active again before archiving it"
         );
 
         app.update_in(cx, |app, window, cx| {
-            app.archive_session(first_id, window, cx);
+            app.archive_agent(first_id, window, cx);
         });
 
         let key = secondary_p();
@@ -638,8 +638,8 @@ mod tab_strip_keybinding_tests {
 
         assert!(
             app.read_with(cx, |app, _| app.palette_open),
-            "a real {key} keystroke after archiving the active session must still open the \
-             palette - archiving goes through the same Sessions::close real focus-restore path \
+            "a real {key} keystroke after archiving the active agent must still open the \
+             palette - archiving goes through the same Agents::close real focus-restore path \
              closing a tab does"
         );
     }
@@ -756,11 +756,11 @@ mod tab_strip_keybinding_tests {
         );
     }
 
-    /// Spawns four extra real shell sessions (five total, including the one `AdeApp::new` starts)
-    /// and confirms `secondary-3` really jumps to the third one in real session order - not just
-    /// that `AdeApp::jump_to_session_at(3, ..)` does when called directly.
+    /// Spawns four extra real shell agents (five total, including the one `AdeApp::new` starts)
+    /// and confirms `secondary-3` really jumps to the third one in real agent order - not just
+    /// that `AdeApp::jump_to_agent_at(3, ..)` does when called directly.
     #[gpui::test]
-    fn secondary_3_jumps_to_the_third_real_session_through_the_real_key_bindings(
+    fn secondary_3_jumps_to_the_third_real_agent_through_the_real_key_bindings(
         cx: &mut TestAppContext,
     ) {
         let repo = tempfile::tempdir().expect("tempdir");
@@ -769,20 +769,20 @@ mod tab_strip_keybinding_tests {
 
         for _ in 0..4 {
             app.update_in(cx, |app, window, cx| {
-                app.new_session(SessionKind::Shell, window, cx);
+                app.new_agent(AgentKind::Shell, window, cx);
             });
         }
         let third_id = app.read_with(cx, |app, _| {
-            app.sessions
+            app.agents
                 .iter()
                 .nth(2)
-                .map(|session| session.id)
-                .expect("five real sessions should exist by now")
+                .map(|agent| agent.id)
+                .expect("five real agents should exist by now")
         });
         assert_ne!(
-            app.read_with(cx, |app, _| app.sessions.active_id()),
+            app.read_with(cx, |app, _| app.agents.active_id()),
             Some(third_id),
-            "sanity check: the most recently spawned session (the fifth), not the third, should \
+            "sanity check: the most recently spawned agent (the fifth), not the third, should \
              be active before the jump"
         );
 
@@ -794,28 +794,28 @@ mod tab_strip_keybinding_tests {
         cx.simulate_keystrokes(secondary_3);
 
         assert_eq!(
-            app.read_with(cx, |app, _| app.sessions.active_id()),
+            app.read_with(cx, |app, _| app.agents.active_id()),
             Some(third_id),
-            "a real, simulated {secondary_3} keystroke must activate the session at position 3 \
-             through crate::default_key_bindings' real secondary-3 -> JumpToSession3 binding"
+            "a real, simulated {secondary_3} keystroke must activate the agent at position 3 \
+             through crate::default_key_bindings' real secondary-3 -> JumpToAgent3 binding"
         );
     }
 
-    /// [`AdeApp::jump_to_session_at`]'s own direct-call coverage (as opposed to the keystroke
-    /// simulation above) for every position 1..=8, plus the real "fewer sessions than the
+    /// [`AdeApp::jump_to_agent_at`]'s own direct-call coverage (as opposed to the keystroke
+    /// simulation above) for every position 1..=8, plus the real "fewer agents than the
     /// position" no-op.
     #[gpui::test]
-    fn jump_to_session_at_activates_the_right_session_by_position(cx: &mut TestAppContext) {
+    fn jump_to_agent_at_activates_the_right_agent_by_position(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
 
         let mut ids = vec![app.read_with(cx, |app, _| {
-            app.sessions.active_id().expect("the initial shell session")
+            app.agents.active_id().expect("the initial shell agent")
         })];
         for _ in 0..3 {
             let id = app.update_in(cx, |app, window, cx| {
-                app.sessions.spawn(
-                    SessionKind::Shell,
+                app.agents.spawn(
+                    AgentKind::Shell,
                     repo.path().to_path_buf(),
                     app.settings.appearance.terminal_font_size,
                     window,
@@ -824,29 +824,29 @@ mod tab_strip_keybinding_tests {
             });
             ids.push(id);
         }
-        // Four real sessions now exist, in spawn order `ids[0..4]`.
+        // Four real agents now exist, in spawn order `ids[0..4]`.
 
         for (position, expected_id) in ids.iter().enumerate() {
             let position = position + 1;
             app.update_in(cx, |app, window, cx| {
-                app.jump_to_session_at(position, window, cx);
+                app.jump_to_agent_at(position, window, cx);
             });
             assert_eq!(
-                app.read_with(cx, |app, _| app.sessions.active_id()),
+                app.read_with(cx, |app, _| app.agents.active_id()),
                 Some(*expected_id),
-                "position {position} should activate session {expected_id}"
+                "position {position} should activate agent {expected_id}"
             );
         }
 
-        // A real no-op: there is no fifth session.
-        let active_before = app.read_with(cx, |app, _| app.sessions.active_id());
+        // A real no-op: there is no fifth agent.
+        let active_before = app.read_with(cx, |app, _| app.agents.active_id());
         app.update_in(cx, |app, window, cx| {
-            app.jump_to_session_at(5, window, cx);
+            app.jump_to_agent_at(5, window, cx);
         });
         assert_eq!(
-            app.read_with(cx, |app, _| app.sessions.active_id()),
+            app.read_with(cx, |app, _| app.agents.active_id()),
             active_before,
-            "jumping to a position with no real session there must be a no-op"
+            "jumping to a position with no real agent there must be a no-op"
         );
     }
 }
@@ -942,18 +942,18 @@ mod settings_focus_tests {
         );
     }
 
-    /// A session tab opened before Settings was shown is still there, and still active, after an
+    /// An agent tab opened before Settings was shown is still there, and still active, after an
     /// open/close round-trip - Settings swaps which body `Render::render` draws
-    /// ([`AdeApp::render_workspace_body`]) without touching `AdeApp::sessions` itself.
+    /// ([`AdeApp::render_workspace_body`]) without touching `AdeApp::agents` itself.
     #[gpui::test]
-    fn closing_settings_leaves_open_session_tabs_intact(cx: &mut TestAppContext) {
+    fn closing_settings_leaves_open_agent_tabs_intact(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
 
-        let sessions_before = app.read_with(cx, |app, _| app.sessions.iter().count());
-        let active_before = app.read_with(cx, |app, _| app.sessions.active_id());
+        let agents_before = app.read_with(cx, |app, _| app.agents.iter().count());
+        let active_before = app.read_with(cx, |app, _| app.agents.active_id());
         assert_eq!(
-            sessions_before, 1,
+            agents_before, 1,
             "AdeApp::new starts with exactly one real shell tab"
         );
 
@@ -963,11 +963,11 @@ mod settings_focus_tests {
         cx.simulate_keystrokes("escape");
         assert!(!app.read_with(cx, |app, _| app.settings_open));
 
-        let sessions_after = app.read_with(cx, |app, _| app.sessions.iter().count());
-        let active_after = app.read_with(cx, |app, _| app.sessions.active_id());
+        let agents_after = app.read_with(cx, |app, _| app.agents.iter().count());
+        let active_after = app.read_with(cx, |app, _| app.agents.active_id());
         assert_eq!(
-            sessions_after, sessions_before,
-            "the real session tab opened before Settings was shown must still exist after \
+            agents_after, agents_before,
+            "the real agent tab opened before Settings was shown must still exist after \
              closing Settings"
         );
         assert_eq!(
@@ -1255,7 +1255,7 @@ mod code_focus_tests {
     }
 
     /// Closing the File view ([`AdeApp::close_change_diff`]) must restore focus onto the active
-    /// session's pane, not leave it dangling on [`AdeApp::code_focus_handle`].
+    /// agent's pane, not leave it dangling on [`AdeApp::code_focus_handle`].
     #[gpui::test]
     fn closing_the_file_view_restores_real_focus_and_actions_keep_working(cx: &mut TestAppContext) {
         let (app, cx, file_path) = open_test_app_with_a_plain_text_file(cx);
@@ -1274,7 +1274,7 @@ mod code_focus_tests {
         assert!(
             app.read_with(cx, |app, _| app.settings_open),
             "secondary-, must still reach handle_toggle_settings_action after closing the File view - \
-             AdeApp::close_change_diff must have restored real focus onto the active session's \
+             AdeApp::close_change_diff must have restored real focus onto the active agent's \
              terminal pane, not left it dangling on code_focus_handle"
         );
     }
@@ -1351,7 +1351,7 @@ mod text_undo_scoping_tests {
         );
 
         // Close the file tab: `close_file_tab` deliberately keeps the `edit_buffers` entry (and
-        // so its whole undo history) alive while restoring real focus to the active session's
+        // so its whole undo history) alive while restoring real focus to the active agent's
         // terminal pane - exactly the overlapping state this test needs.
         app.update_in(cx, |app, window, cx| {
             app.close_change_diff(window, cx);
@@ -1497,7 +1497,7 @@ mod text_undo_scoping_tests {
         );
     }
 
-    /// The rail's session filter - the fourth and last of this app's hand-rolled single-line
+    /// The rail's agent filter - the fourth and last of this app's hand-rolled single-line
     /// inputs. Also covers that `Esc`-clearing a filter is a real, undoable step rather than a
     /// silent loss.
     #[gpui::test]

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -1,5 +1,5 @@
 //! The top-level three-pane window: a left worktree sidebar, a tabbed center pane of
-//! terminal sessions, and a right file tree, composed as GPUI entities.
+//! terminal agents, and a right file tree, composed as GPUI entities.
 //!
 //! ## What lives here, and what doesn't
 //!
@@ -29,22 +29,22 @@
 //! resolves. `crate::sidebar::file_tree::build_file_tree`'s `std::fs::read_dir` walk follows the same
 //! pattern.
 //!
-//! ## One rail row per worktree; sessions are tabs scoped to it
+//! ## One rail row per worktree; agents are tabs scoped to it
 //!
-//! [`crate::work_surface::sessions::Sessions`] holds any number of independent, simultaneously-running
-//! terminal sessions (a plain shell, or an agent CLI), each pinned to the worktree it was
-//! started in. The session rail shows exactly one row per worktree
-//! (`crate::rail::state::WorktreeRow`, aggregating every session open in it), and the centre pane's tab
+//! [`crate::work_surface::agents::Agents`] holds any number of independent, simultaneously-running
+//! terminal agents (a plain shell, or an agent CLI), each pinned to the worktree it was
+//! started in. The agent rail shows exactly one row per worktree
+//! (`crate::rail::state::WorktreeRow`, aggregating every agent open in it), and the centre pane's tab
 //! strip (`AdeApp::render_tab_strip`) only ever shows the *currently selected* worktree's own
-//! sessions - never a flat, unscoped list of every session across every worktree.
+//! agents - never a flat, unscoped list of every agent across every worktree.
 //!
 //! Selecting a worktree in the sidebar still never spawns or kills anything - but, unlike
-//! before this revision, it *does* change which session is "active"
-//! (`crate::work_surface::sessions::Sessions::activate_for_worktree`, called from [`AdeApp::select_worktree`]):
-//! the active session must always belong to the selected worktree, or the centre pane would show
+//! before this revision, it *does* change which agent is "active"
+//! (`crate::work_surface::agents::Agents::activate_for_worktree`, called from [`AdeApp::select_worktree`]):
+//! the active agent must always belong to the selected worktree, or the centre pane would show
 //! one worktree's terminal while the rail highlights another. [`AdeApp::selected`] itself still
-//! drives the file tree, and which worktree `active_session_cwd` resolves to for the *next* "New
-//! terminal"/"New agent pane" click - that part is unchanged. Spawning a session is still always
+//! drives the file tree, and which worktree `active_agent_cwd` resolves to for the *next* "New
+//! terminal"/"New agent pane" click - that part is unchanged. Spawning an agent is still always
 //! its own explicit action, never an implicit side effect of browsing.
 
 use std::collections::{HashMap, HashSet};
@@ -83,7 +83,7 @@ use crate::status_bar::process_stats;
 use crate::text_history;
 use crate::theme;
 use crate::title_bar::menu as title_bar;
-use crate::work_surface::sessions::{SessionId, SessionKind, Sessions};
+use crate::work_surface::agents::{AgentId, AgentKind, Agents};
 use crate::work_surface::state as work_surface;
 use crate::worktree_history::flow as worktree_history;
 
@@ -104,7 +104,7 @@ use crate::sidebar::render::RightSidebarView;
 // read-only viewer, and a hover must already have resolved before F12 can navigate. No-ops when
 // nothing has been clicked yet, or the click wasn't on a `.rs` file.
 //
-// `JumpToSession1`..`JumpToSession8` are eight distinct zero-sized actions, one per keystroke,
+// `JumpToAgent1`..`JumpToAgent8` are eight distinct zero-sized actions, one per keystroke,
 // since a bound `KeyBinding` maps one literal keystroke to one action value and `actions!`-
 // generated unit structs carry no data a single handler could branch on by position.
 // The `Editor*` actions below (Revision R8.5a) back the File view's real text editing -
@@ -129,21 +129,21 @@ use crate::sidebar::render::RightSidebarView;
 actions!(
     app,
     [
-        NewSession,
+        NewAgent,
         TogglePalette,
         ToggleSettings,
         GotoDefinition,
         NewTerminal,
         NewAgentPane,
         NextChangedFile,
-        JumpToSession1,
-        JumpToSession2,
-        JumpToSession3,
-        JumpToSession4,
-        JumpToSession5,
-        JumpToSession6,
-        JumpToSession7,
-        JumpToSession8,
+        JumpToAgent1,
+        JumpToAgent2,
+        JumpToAgent3,
+        JumpToAgent4,
+        JumpToAgent5,
+        JumpToAgent6,
+        JumpToAgent7,
+        JumpToAgent8,
         EditorBackspace,
         EditorDelete,
         EditorEnter,
@@ -192,7 +192,7 @@ actions!(
 
 /// How often `crate::rail::state::compute_status_snapshot`'s background `git` status/diff refresh
 /// re-runs. Coarser than `crate::terminal::pane`'s 8ms poll since this spawns real `git` child
-/// processes per worktree/session path, not a cheap channel `try_recv`.
+/// processes per worktree/agent path, not a cheap channel `try_recv`.
 pub(crate) const STATUS_POLL_INTERVAL: Duration = Duration::from_secs(3);
 
 /// GitHub issue #12's "keep a low-frequency polling fallback" - the worktree list is re-parsed
@@ -268,7 +268,7 @@ pub struct AdeApp {
     /// `design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §2.0).
     pub(crate) repos: Vec<Repo>,
     /// Which of [`Self::repos`] is "the" repo for every currently-single-repo-scoped piece of
-    /// state this app still has (the file tree, the diff, a fresh session's cwd, `worktrees`
+    /// state this app still has (the file tree, the diff, a fresh agent's cwd, `worktrees`
     /// below) - see [`Self::focused_repo`]/[`Self::focused_repo_path`]. `None` only when
     /// [`Self::repos`] is empty, which nothing in this phase's startup path (`Self::
     /// new_with_settings`) ever produces - it always adds and focuses exactly one repo, mirroring
@@ -318,12 +318,12 @@ pub struct AdeApp {
     /// later refresh on its own, since refreshes happen every few seconds and a notice that
     /// vanished before it could be read would defeat the point of showing it.
     pub(crate) worktree_selection_notice: Option<String>,
-    /// The session rail's own real overlay scrollbar handle (GitHub issue #30) - a plain
+    /// The agent rail's own real overlay scrollbar handle (GitHub issue #30) - a plain
     /// `gpui::ScrollHandle`: `crate::rail::render::AdeApp::render_rail_list` renders every row
     /// eagerly, not through a `uniform_list`.
     pub(crate) rail_scroll_handle: gpui::ScrollHandle,
     pub(crate) selected: Option<usize>,
-    pub(crate) sessions: Sessions,
+    pub(crate) agents: Agents,
     pub(crate) file_tree: Vec<FileTreeEntry>,
     pub(crate) file_tree_root: PathBuf,
     pub(crate) file_tree_error: Option<String>,
@@ -349,7 +349,7 @@ pub struct AdeApp {
     /// [`Self::current_diff`]'s docs for exactly which [`DiffLoadState`]/[`DiffBase`]
     /// combinations count).
     pub(crate) diff_totals: Option<(u32, u32)>,
-    /// Which agent session(s) wrote each file in [`Self::diff_state`]'s currently loaded diff
+    /// Which agent(s) wrote each file in [`Self::diff_state`]'s currently loaded diff
     /// (`design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §4's `by: 's1'`/`by:
     /// ['s1','s9']` record) - see [`changes::Authorship`]'s own docs for why this is always empty
     /// today (no real authorship tracking exists yet; this phase only defines the shape a later
@@ -415,7 +415,7 @@ pub struct AdeApp {
     /// bind-mounted `$HOME` with an unbounded budget would allocate millions of `PathBuf`s on a
     /// background thread and then hand them all to `rebuild_palette_file_candidates`. Each click
     /// raises the bound and the row keeps reporting where the walk stopped, so the listing is
-    /// never *silently* cut off - which is what issue #18 §4 actually asks for. Session-scoped
+    /// never *silently* cut off - which is what issue #18 §4 actually asks for. Agent-scoped
     /// and per-worktree: reset on every worktree switch, since "show me more of *this* tree"
     /// says nothing about the next one.
     pub(crate) file_tree_limit_override: Option<usize>,
@@ -441,7 +441,7 @@ pub struct AdeApp {
     /// The file tree's keyboard-focus target. `track_focus`'d by
     /// `crate::sidebar::render::AdeApp::render_file_tree`'s container, which is also the node
     /// carrying the `"file-tree"` `key_context` every tree keybinding is scoped to - so
-    /// `Ctrl+C`/`Ctrl+X`/`Ctrl+V` can never match while a terminal session has focus. See
+    /// `Ctrl+C`/`Ctrl+X`/`Ctrl+V` can never match while a terminal agent has focus. See
     /// `crate::sidebar::tree_ops`'s module docs.
     pub(crate) tree_focus_handle: FocusHandle,
     /// The file tree container's real painted bounds, captured by a `gpui::canvas` child each
@@ -464,17 +464,17 @@ pub struct AdeApp {
     /// its checkbox is checked. No backend "review" concept exists yet; this is purely local UI
     /// state that `Self::render_changes_header`'s progress bar and count read directly.
     pub(crate) reviewed_files: HashSet<PathBuf>,
-    /// Ordered list of currently-open file tabs, rendered after every session's own tab by
+    /// Ordered list of currently-open file tabs, rendered after every agent's own tab by
     /// `Self::render_tab_strip`. No duplicates: opening an already-open file just activates its
     /// existing entry (`Self::push_open_file`). Removed only on explicit tab close
     /// (`Self::close_file_tab`) or leaving the owning worktree (`reset_per_worktree_ui_state`) -
     /// these are worktree-relative paths, meaningless (or collision-prone) once the worktree
     /// changes.
     pub(crate) open_files: Vec<PathBuf>,
-    /// Which file tab (if any) the centre pane is showing instead of a session -
+    /// Which file tab (if any) the centre pane is showing instead of an agent -
     /// `Some(path)` iff `path` is also in [`Self::open_files`]. Set by a Changes row
     /// (`Self::open_change_diff`), a Files-tree row (`Self::open_file_view`), or an already-open
-    /// tab (`Self::activate_file_tab`); cleared by selecting a session tab or closing the active
+    /// tab (`Self::activate_file_tab`); cleared by selecting an agent tab or closing the active
     /// tab down to none left.
     pub(crate) open_change: Option<PathBuf>,
     /// `Some(path)` for one real "arming" click/keystroke on a *dirty* file tab's close
@@ -711,18 +711,18 @@ pub struct AdeApp {
     /// arrow keys and run by Enter.
     pub(crate) palette_selected: usize,
     pub(crate) palette_focus_handle: FocusHandle,
-    /// Pre-open focus target and active session for [`Self::palette_focus_handle`] - see
+    /// Pre-open focus target and active agent for [`Self::palette_focus_handle`] - see
     /// [`OverlayFocus`]/[`restore_focus`].
     pub(crate) palette_focus: OverlayFocus,
     /// The palette's file-candidate list (`crate::palette::state::FileCandidate`, one per non-directory
     /// [`Self::file_tree`] entry, up to `Settings.file_tree.max_entries`) - built once by
     /// [`Self::rebuild_palette_file_candidates`] when `file_tree`/the diff reload, not rebuilt on
     /// every `Self::build_palette_groups` call (which runs on every render while the palette is
-    /// open, up to ~30x/sec during a streaming session). Session/command candidates aren't
-    /// cached the same way: they're few, and a session's status dot is genuinely live per-render
+    /// open, up to ~30x/sec during a streaming agent). Agent/command candidates aren't
+    /// cached the same way: they're few, and an agent's status dot is genuinely live per-render
     /// data with no stable invalidation point.
     pub(crate) palette_file_candidates: Vec<palette::FileCandidate>,
-    /// The session rail's user-adjustable width (240-340px), dragged via the resize handle on
+    /// The agent rail's user-adjustable width (240-340px), dragged via the resize handle on
     /// the rail's right edge (see [`Self::apply_pane_resize`]/`crate::root::layout::rail_width_for_cursor`).
     pub(crate) rail_width: Pixels,
     /// The files/changes panel's user-adjustable width - see [`Self::rail_width`]'s docs,
@@ -744,7 +744,7 @@ pub struct AdeApp {
     /// The rail's filter query - filters the rendered worktree/agent rows (see
     /// `crate::rail::state::filter_worktree_rows`). Carries a real per-widget undo history
     /// (GitHub issue #17 - see [`text_history::TextField`]); unlike the palette's, this widget
-    /// lives for the whole session, so its history does too.
+    /// lives for the whole agent, so its history does too.
     pub(crate) filter_query: text_history::TextField,
     /// Explicit per-worktree expand/collapse overrides for the rail's worktree rows
     /// (`design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §2.2: "caret state is
@@ -756,31 +756,31 @@ pub struct AdeApp {
     pub(crate) rail_collapse_overrides: HashMap<PathBuf, bool>,
     pub(crate) filter_focus_handle: FocusHandle,
     /// The rail's *root container*'s focus handle - the app's real "nowhere else to put focus"
-    /// fallback target (`Self::select_worktree`, `Self::close_session`, `Self::cancel_new_file`),
+    /// fallback target (`Self::select_worktree`, `Self::close_agent`, `Self::cancel_new_file`),
     /// deliberately **not** [`Self::filter_focus_handle`].
     ///
     /// Those three sites used to fall back onto the filter field itself, which an adversarial
     /// audit found had become a real, reachable bug once GitHub issue #17 tagged that field
-    /// `"text-input"`: closing the last session focused a text input the user never asked to type
+    /// `"text-input"`: closing the last agent focused a text input the user never asked to type
     /// in, and `Ctrl+Z` there resolved to `TextUndo` against an empty field - a silently swallowed
     /// keystroke with no feedback. The rail's root div carries no key context of its own, so
     /// focusing *it* keeps the focused `FocusId` genuinely findable in the next rendered frame -
     /// the actual invariant the fallback exists to protect - without claiming to be a text widget.
     pub(crate) rail_focus_handle: FocusHandle,
-    /// Real `+N -M`/has-changes totals per worktree or session cwd, refreshed by the
+    /// Real `+N -M`/has-changes totals per worktree or agent cwd, refreshed by the
     /// periodic background task started in `Self::new` - see `crate::rail::state::
     /// compute_status_snapshot`'s docs. Read (never written outside that task's completion
-    /// callback) by `Self::build_session_rows` each render.
+    /// callback) by `Self::build_agent_rows` each render.
     pub(crate) diff_cache: HashMap<PathBuf, rail::DiffSummary>,
     /// Real clean/merged notes per worktree path, from the same periodic refresh as
-    /// [`Self::diff_cache`] - powers "by project" mode's session-less worktree rows and the
+    /// [`Self::diff_cache`] - powers "by project" mode's agent-less worktree rows and the
     /// rail footer's `prune` action.
     pub(crate) worktree_notes: HashMap<PathBuf, rail::WorktreeNote>,
-    /// Real `wt_core::diff::AheadBehind` counts per worktree/session cwd, from the same
+    /// Real `wt_core::diff::AheadBehind` counts per worktree/agent cwd, from the same
     /// periodic refresh as [`Self::diff_cache`] - the status bar's `↑2 ↓0` indicator for the
-    /// active session's worktree.
+    /// active agent's worktree.
     pub(crate) ahead_behind_cache: HashMap<PathBuf, wt_core::diff::AheadBehind>,
-    /// Real, live per-pid CPU%/memory samples for every currently open session's process
+    /// Real, live per-pid CPU%/memory samples for every currently open agent's process
     /// (`crate::status_bar::process_stats`), refreshed by the same periodic background task as
     /// [`Self::diff_cache`] - see `Self::start_status_polling`'s docs for why this rides the
     /// same timer rather than a second, independent polling loop. Keyed by OS pid; an entry is
@@ -813,7 +813,7 @@ pub struct AdeApp {
     /// busy label ("keeping…"/"discarding…") can honestly reflect what's actually running instead
     /// of guessing from which button happens to be visible (a real, live-reproduced bug an audit
     /// caught: a running "keep all changes" made every visible `Discard worktree` button across
-    /// every session read "discarding…"). A single field shared across both, not two independent
+    /// every agent read "discarding…"). A single field shared across both, not two independent
     /// guards: these are the only operations that ever mutate real git history or a worktree's
     /// own existence for this feature, so fully serializing them (a second click of either while
     /// one is in flight is a no-op, mirroring [`Self::prune_in_flight`]'s own
@@ -827,9 +827,9 @@ pub struct AdeApp {
     /// deliberately its own render slot, independent of [`Self::prune_status`] (see that
     /// method's own docs for why sharing one slot with `prune_status` was a real bug: an
     /// unrelated prune click could permanently hide every future worktree-history status for the
-    /// rest of the session).
+    /// rest of the agent).
     pub(crate) worktree_history_status: Option<String>,
-    /// `Some(id)` after one click on session `id`'s "Discard worktree" footer button, cleared by
+    /// `Some(id)` after one click on agent `id`'s "Discard worktree" footer button, cleared by
     /// most other gestures in the meantime (mirroring [`Self::prune_confirm_armed`]'s own "most
     /// other gestures disarm it" discipline, applied everywhere that field is - see
     /// `crate::worktree_history::flow::AdeApp::request_discard_worktree`'s own docs for why this
@@ -838,7 +838,7 @@ pub struct AdeApp {
     /// arming *this* field's own sibling ([`Self::prune_confirm_armed`]'s first, arming click)
     /// does not clear this one, and vice versa - only each field's own confirm/cancel/execute
     /// paths, and a handful of other real navigation gestures, clear it.
-    pub(crate) discard_confirm_armed: Option<SessionId>,
+    pub(crate) discard_confirm_armed: Option<AgentId>,
     /// Whether the Settings surface is currently replacing the three-zone body - see
     /// [`Self::open_settings`]/[`Self::close_settings`], which use the same
     /// capture-and-restore shape as [`Self::palette_open`].
@@ -863,7 +863,7 @@ pub struct AdeApp {
     /// if run inline. `Vec::new()` until the first load completes.
     pub(crate) agent_rows: Vec<settings::AgentRow>,
     /// The context bar's `Merge` action and Surface D's conflict-resolution flow - see
-    /// [`crate::merge::state::MergeFlow`]'s docs. `None` when no session has an in-flight merge or
+    /// [`crate::merge::state::MergeFlow`]'s docs. `None` when no agent has an in-flight merge or
     /// unresolved conflict.
     pub(crate) merge_flow: Option<merge::MergeFlow>,
     /// `true` for the duration of an in-flight `Complete merge`/`Abort merge` git operation -
@@ -889,7 +889,7 @@ pub struct AdeApp {
     /// [`Self::edit_buffers`]. `None` whenever no hand-edit is in progress, including while a
     /// merge conflict is showing but the user hasn't toggled hand-edit mode on for the active
     /// file. Torn down (`crate::merge::flow::AdeApp::clear_merge_edit_state`) at every real
-    /// merge-flow-ending point (abort/complete/dismiss/session-close) and by a fresh
+    /// merge-flow-ending point (abort/complete/dismiss/agent-close) and by a fresh
     /// [`Self::start_merge`], and whenever the flow's own active file (matched by path) advances
     /// past whatever file this hand-edit is for.
     pub(crate) merge_edit: Option<merge::MergeEditState>,
@@ -976,7 +976,7 @@ pub struct AdeApp {
     pub(crate) _worktree_history_task: Option<Task<()>>,
     pub(crate) _agent_rows_task: Option<Task<()>>,
     pub(crate) _merge_task: Option<Task<()>>,
-    /// `Self::clear_merge_flow_for_closed_session`'s best-effort abort - kept separate from
+    /// `Self::clear_merge_flow_for_closed_agent`'s best-effort abort - kept separate from
     /// [`Self::_merge_task`] so a cleanup-triggered abort can never overwrite (and thus cancel)
     /// an in-flight `complete_merge_flow`/`abort_merge_flow` commit, which would strand
     /// [`Self::merge_op_in_flight`] at `true` and let `git merge --abort` race an in-flight
@@ -1248,7 +1248,7 @@ pub struct AdeApp {
     pub(crate) title_menu_button_bounds: [gpui::Bounds<Pixels>; title_bar::TitleMenu::ALL.len()],
     /// Every in-flight [`Self::new_agent_pane`] background `$PATH` detection - a [`TaskPool`]
     /// rather than a single slot, so two rapid "New agent pane" clicks each produce their own
-    /// session instead of the second cancelling the first's still-in-flight search.
+    /// agent instead of the second cancelling the first's still-in-flight search.
     pub(crate) _new_agent_pane_task: TaskPool,
     /// Real "New file" creation state (`crate::root::new_file`) - `Some` only while the inline
     /// name prompt is showing. See [`new_file::NewFileInputState`]'s own docs.
@@ -1259,11 +1259,11 @@ pub struct AdeApp {
     /// convention. Cleared by [`Self::start_new_file`]/[`Self::create_new_file`]'s own success
     /// path.
     pub(crate) new_file_error: Option<String>,
-    /// Each worktree's own real, drag-chosen tab order (GitHub issue #16) - session and file
+    /// Each worktree's own real, drag-chosen tab order (GitHub issue #16) - agent and file
     /// tabs interleaved, keyed by that worktree's cwd. Never itself the source of truth for
-    /// which tabs exist (`Sessions`/[`Self::open_files`] still are - see
+    /// which tabs exist (`Agents`/[`Self::open_files`] still are - see
     /// [`Self::combined_tab_order`]'s own docs); only [`Self::reorder_tab`] writes to it, and a
-    /// worktree with no entry here simply renders its sessions then its files, exactly the old
+    /// worktree with no entry here simply renders its agents then its files, exactly the old
     /// two-block layout.
     pub(crate) tab_order: HashMap<PathBuf, Vec<work_surface::TabRef>>,
     /// The unified tab strip's real, precise drop-target indicator (GitHub issue #16's "better
@@ -1585,7 +1585,7 @@ impl AdeApp {
     /// Makes `id` [`Self::focused_repo`] - a no-op if `id` isn't (or is no longer) in
     /// [`Self::repos`], so a stale id from a closed-over click handler can never point focus at
     /// nothing. Deliberately synchronous and cheap: unlike [`Self::select_worktree`], changing
-    /// which *repo* is focused doesn't yet reload anything (the file tree/diff/sessions are still
+    /// which *repo* is focused doesn't yet reload anything (the file tree/diff/agents are still
     /// single-repo-scoped fields this phase doesn't rewire - see [`Self::worktrees`]'s own docs),
     /// so there is nothing to kick off here beyond the assignment itself.
     pub(crate) fn focus_repo(&mut self, id: RepoId) {
@@ -1685,21 +1685,21 @@ impl Render for AdeApp {
             // frame, so `!terminal` (and any future negated-context predicate) evaluates its
             // real, intended logic everywhere.
             .key_context("app")
-            .on_action(cx.listener(Self::handle_new_session_action))
+            .on_action(cx.listener(Self::handle_new_agent_action))
             .on_action(cx.listener(Self::handle_toggle_palette_action))
             .on_action(cx.listener(Self::handle_toggle_settings_action))
             .on_action(cx.listener(Self::handle_goto_definition_action))
             .on_action(cx.listener(Self::handle_new_terminal_action))
             .on_action(cx.listener(Self::handle_new_agent_pane_action))
             .on_action(cx.listener(Self::handle_next_changed_file_action))
-            .on_action(cx.listener(Self::handle_jump_to_session_1_action))
-            .on_action(cx.listener(Self::handle_jump_to_session_2_action))
-            .on_action(cx.listener(Self::handle_jump_to_session_3_action))
-            .on_action(cx.listener(Self::handle_jump_to_session_4_action))
-            .on_action(cx.listener(Self::handle_jump_to_session_5_action))
-            .on_action(cx.listener(Self::handle_jump_to_session_6_action))
-            .on_action(cx.listener(Self::handle_jump_to_session_7_action))
-            .on_action(cx.listener(Self::handle_jump_to_session_8_action))
+            .on_action(cx.listener(Self::handle_jump_to_agent_1_action))
+            .on_action(cx.listener(Self::handle_jump_to_agent_2_action))
+            .on_action(cx.listener(Self::handle_jump_to_agent_3_action))
+            .on_action(cx.listener(Self::handle_jump_to_agent_4_action))
+            .on_action(cx.listener(Self::handle_jump_to_agent_5_action))
+            .on_action(cx.listener(Self::handle_jump_to_agent_6_action))
+            .on_action(cx.listener(Self::handle_jump_to_agent_7_action))
+            .on_action(cx.listener(Self::handle_jump_to_agent_8_action))
             .on_action(cx.listener(Self::handle_close_focused_tab_action))
             .child(self.render_title_bar(cx))
             // The Settings surface (`design_handoff_jerry_ade/README.md`: "a separate surface,
@@ -1755,7 +1755,7 @@ impl Render for AdeApp {
 }
 
 impl AdeApp {
-    /// The three-zone workspace body (session rail, centre pane, files/changes panel) - pulled
+    /// The three-zone workspace body (agent rail, centre pane, files/changes panel) - pulled
     /// out of [`Render::render`] so it and [`Self::render_settings`] can both be
     /// [`gpui::AnyElement`]-branched as a single child, the same pattern
     /// `vendor/zed/crates/gpui/src/util.rs`'s `Styled::when_else` uses.
@@ -1866,33 +1866,33 @@ pub(crate) struct OverlayFocus {
     /// The focus target in place immediately before this overlay opened (`window.focused(cx)`,
     /// `None` on a fresh window) - restored by [`restore_focus`] on close.
     return_focus: Option<FocusHandle>,
-    /// Which session was active when [`Self::capture`] ran - compared against the active
-    /// session at restore time so [`restore_focus`] can tell whether `return_focus` is still
-    /// safe to restore (it may belong to a session that's no longer active).
-    opened_session: Option<SessionId>,
+    /// Which agent was active when [`Self::capture`] ran - compared against the active
+    /// agent at restore time so [`restore_focus`] can tell whether `return_focus` is still
+    /// safe to restore (it may belong to an agent that's no longer active).
+    opened_agent: Option<AgentId>,
 }
 
 impl OverlayFocus {
-    /// Records the current focus target and active session. Callers that must only capture on
+    /// Records the current focus target and active agent. Callers that must only capture on
     /// a genuine closed-to-open transition (not every subsequent navigation while already open -
     /// see [`AdeApp::focus_code_surface`]) guard the call themselves; this always captures
     /// unconditionally when called.
-    pub(crate) fn capture(&mut self, window: &Window, sessions: &Sessions, cx: &App) {
+    pub(crate) fn capture(&mut self, window: &Window, agents: &Agents, cx: &App) {
         self.return_focus = window.focused(cx);
-        self.opened_session = sessions.active_id();
+        self.opened_agent = agents.active_id();
     }
 
     /// Discards captured state without restoring it. Three real callers: [`AdeApp::close_palette`]'s
     /// Settings-showing-underneath branch and [`AdeApp::close_palette_keeping_result_focus`],
     /// both of which put focus somewhere real themselves instead of going through
-    /// [`restore_focus`], and `crate::work_surface::render`'s session teardown.
+    /// [`restore_focus`], and `crate::work_surface::render`'s agent teardown.
     pub(crate) fn clear(&mut self) {
         self.return_focus = None;
-        self.opened_session = None;
+        self.opened_agent = None;
     }
 
     /// Forgets a captured target that is about to stop being rendered, leaving [`restore_focus`]
-    /// to fall back to the active session's pane instead of focusing a node GPUI can no longer
+    /// to fall back to the active agent's pane instead of focusing a node GPUI can no longer
     /// find in the frame.
     ///
     /// This exists for a real, reproduced case (found by the `tree-focus-bugfixes` branch's own
@@ -1913,31 +1913,28 @@ impl OverlayFocus {
 /// The shared focus-restore-on-close step for every overlay that captured a pre-open target via
 /// [`OverlayFocus::capture`] - see this type's own docs for the invariant this closes.
 ///
-/// If the active session changed while the surface was open, the captured handle is skipped in
-/// favor of the *current* active session's terminal pane (a handle from a no-longer-active
-/// session would be just as dangling as the overlay's own). Otherwise the captured handle is
-/// restored, falling back to the active session's pane if nothing was focused before. A free
+/// If the active agent changed while the surface was open, the captured handle is skipped in
+/// favor of the *current* active agent's terminal pane (a handle from a no-longer-active
+/// agent would be just as dangling as the overlay's own). Otherwise the captured handle is
+/// restored, falling back to the active agent's pane if nothing was focused before. A free
 /// function, not an `AdeApp` method, since every caller already holds `&mut self` and needs to
 /// pass `&mut self.some_field` alongside it. Deliberately doesn't call `cx.notify()` - every
 /// caller has its own surface-specific state change around this call and issues its own single
 /// `cx.notify()` once everything, this restore included, is done.
 pub(crate) fn restore_focus(
-    sessions: &Sessions,
+    agents: &Agents,
     overlay_focus: &mut OverlayFocus,
     window: &mut Window,
     cx: &mut App,
 ) {
-    let session_changed = sessions.active_id() != overlay_focus.opened_session;
-    let restore_target = if session_changed {
+    let agent_changed = agents.active_id() != overlay_focus.opened_agent;
+    let restore_target = if agent_changed {
         None
     } else {
         overlay_focus.return_focus.take()
     };
-    let focus_target = restore_target.or_else(|| {
-        sessions
-            .active()
-            .map(|session| session.pane.focus_handle(cx))
-    });
+    let focus_target =
+        restore_target.or_else(|| agents.active().map(|agent| agent.pane.focus_handle(cx)));
     if let Some(handle) = focus_target {
         window.focus(&handle, cx);
     }

--- a/crates/app/src/root/new_file.rs
+++ b/crates/app/src/root/new_file.rs
@@ -4,7 +4,7 @@
 //! Naming UI: a small, hand-rolled append/backspace-only inline text field
 //! (`Self::handle_new_file_key_down`), the same minimal shape `Self::handle_filter_key_down`
 //! already established for the rail's filter row - there is no existing "rename"/"create" text
-//! prompt anywhere else in this app to match instead (sessions have no user-assigned names at
+//! prompt anywhere else in this app to match instead (agents have no user-assigned names at
 //! all), and a single-line name prompt doesn't warrant pulling in the full `EntityInputHandler`
 //! machinery the File view's real text editing uses (`vendor/zed/crates/gpui/examples/input.rs`).
 
@@ -50,22 +50,22 @@ impl AdeApp {
         // somewhere still real and rendered rather than leaving it dangling on the now-hidden
         // prompt field (`Self::new_file_focus_handle`) - onto the code surface's own focus
         // target if a file tab is showing (an earlier version of this method only ever checked
-        // `self.sessions.focus_active`, which is a no-op while a file tab occupies the centre
+        // `self.agents.focus_active`, which is a no-op while a file tab occupies the centre
         // pane, so cancelling "New file" while a file was open left focus dangling on the
         // now-unrendered prompt - the exact "focus left pointing at something no longer
-        // rendered" class this project keeps re-finding), or the active session's pane otherwise
-        // (the same guard `Self::focus_newly_spawned_session` uses). If neither is showing - no
-        // file tab *and* no active session, a real, reachable state under the tabs rework
-        // (`Sessions::active_id`'s own docs, and `Self::select_worktree`'s identical fallback) -
-        // `Sessions::focus_active` is a genuine no-op, so fall back to the rail's own filter
+        // rendered" class this project keeps re-finding), or the active agent's pane otherwise
+        // (the same guard `Self::focus_newly_spawned_agent` uses). If neither is showing - no
+        // file tab *and* no active agent, a real, reachable state under the tabs rework
+        // (`Agents::active_id`'s own docs, and `Self::select_worktree`'s identical fallback) -
+        // `Agents::focus_active` is a genuine no-op, so fall back to the rail's own filter
         // root container (`Self::rail_focus_handle`) the same way `Self::select_worktree` does -
         // deliberately the rail's root, not its filter field, which this used to target; see that
         // handle's own docs for the real keystroke-swallowing bug that was - rather
         // than leaving `Window::focus` dangling on the just-closed prompt field.
         if self.open_change.is_some() {
             window.focus(&self.code_focus_handle, cx);
-        } else if self.sessions.active_id().is_some() {
-            self.sessions.focus_active(window, cx);
+        } else if self.agents.active_id().is_some() {
+            self.agents.focus_active(window, cx);
         } else {
             window.focus(&self.rail_focus_handle, cx);
         }
@@ -412,14 +412,14 @@ mod tests {
     }
 
     /// Real, live-reproduced coverage for the case [`super::AdeApp::cancel_new_file`] didn't
-    /// handle before this revision's own self-audit: no file tab open *and* no active session at
-    /// all (every session in the worktree already closed) - a real, reachable state under the
-    /// tabs rework (`crate::work_surface::sessions::Sessions::active_id`'s own docs, and
+    /// handle before this revision's own self-audit: no file tab open *and* no active agent at
+    /// all (every agent in the worktree already closed) - a real, reachable state under the
+    /// tabs rework (`crate::work_surface::agents::Agents::active_id`'s own docs, and
     /// `crate::root::AdeApp::select_worktree`'s identical fallback for the same case). Before the
-    /// fix, `Sessions::focus_active` was a genuine no-op here, leaving `Window::focus` dangling
+    /// fix, `Agents::focus_active` was a genuine no-op here, leaving `Window::focus` dangling
     /// on the just-closed prompt field.
     #[gpui::test]
-    fn cancelling_new_file_with_no_file_tab_and_no_active_session_does_not_leave_focus_dangling(
+    fn cancelling_new_file_with_no_file_tab_and_no_active_agent_does_not_leave_focus_dangling(
         cx: &mut TestAppContext,
     ) {
         let repo = tempfile::tempdir().expect("tempdir");
@@ -427,14 +427,14 @@ mod tests {
         cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
 
         let initial_id = app.read_with(cx, |app, _| {
-            app.sessions.active_id().expect("initial shell session")
+            app.agents.active_id().expect("initial shell agent")
         });
         app.update_in(cx, |app, window, cx| {
-            app.close_session(initial_id, window, cx);
+            app.close_agent(initial_id, window, cx);
         });
         assert!(
-            app.read_with(cx, |app, _| app.sessions.active_id().is_none()),
-            "sanity check: closing the only session should leave none active"
+            app.read_with(cx, |app, _| app.agents.active_id().is_none()),
+            "sanity check: closing the only agent should leave none active"
         );
 
         app.update_in(cx, |app, window, cx| {
@@ -451,8 +451,8 @@ mod tests {
         assert!(
             app.read_with(cx, |app, _| app.palette_open),
             "a real {key} keystroke after cancelling \"New file\" with no file tab and no \
-             active session must still open the palette - before the fix, \
-             Sessions::focus_active was a no-op here and Window::focus was left dangling on the \
+             active agent must still open the palette - before the fix, \
+             Agents::focus_active was a no-op here and Window::focus was left dangling on the \
              now-hidden prompt field"
         );
     }

--- a/crates/app/src/root/scrollbar.rs
+++ b/crates/app/src/root/scrollbar.rs
@@ -1,7 +1,7 @@
 //! Real, themed, overlay scrollbars (GitHub issue #30) for every scrollable region audited in
 //! that issue: the file tree and Changes list (`crate::sidebar`), the code editor and merge
 //! hand-edit buffer (`crate::code_surface`, `crate::merge`), Settings' nav/content columns
-//! (`crate::settings`), the session rail's worktree list (`crate::rail`), the command palette's
+//! (`crate::settings`), the agent rail's worktree list (`crate::rail`), the command palette's
 //! result list (`crate::palette`), and the read-only diff view (`crate::code_surface::diff_view`).
 //!
 //! ## Why one shared component, not nine hand-copied ones

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -48,7 +48,7 @@ impl AdeApp {
         // here - not just the one `repo_path` names below - so "which repos are added" genuinely
         // survives a restart; nothing yet *renders* more than the focused one (see
         // `Self::worktrees`'s own docs), so a returning user with several repos added in a
-        // previous session sees exactly the same single-repo view they always have, just with the
+        // previous agent sees exactly the same single-repo view they always have, just with the
         // rest of their repos already known to `Self::repos` for the rail-rendering phase that
         // will actually show them.
         let repo_state_path = settings_path.as_deref().map(repo::repo_state_path_for);
@@ -125,7 +125,7 @@ impl AdeApp {
             worktree_selection_notice: None,
             rail_scroll_handle: gpui::ScrollHandle::new(),
             selected: None,
-            sessions: Sessions::new(),
+            agents: Agents::new(),
             file_tree: Vec::new(),
             file_tree_error: None,
             right_sidebar_view: RightSidebarView::Files,
@@ -169,7 +169,7 @@ impl AdeApp {
             code_focus_handle,
             code_focus: OverlayFocus::default(),
             // `true`/`Task::ready(())`: no blink loop is running yet (nothing is focused at
-            // construction - a fresh window focuses the initial session's terminal pane, not
+            // construction - a fresh window focuses the initial agent's terminal pane, not
             // the code editor, a few lines below), and `Self::start_caret_blink` will replace
             // this the moment a real caret-bearing handle is - see
             // `crate::root::caret_blink`'s module docs.
@@ -366,17 +366,17 @@ impl AdeApp {
         }
         this.apply_theme_selection(cx);
         // A fresh window starts with one shell in the repo root, as a tab like any other.
-        // `focus_active` below moves real keyboard focus onto it - see `Sessions::focus_active`'s
+        // `focus_active` below moves real keyboard focus onto it - see `Agents::focus_active`'s
         // docs and this crate's `OverlayFocus`/`restore_focus` docs for why a fresh window must
         // never start with `Window::focus == None`.
-        this.sessions.spawn(
-            SessionKind::Shell,
+        this.agents.spawn(
+            AgentKind::Shell,
             repo_path.clone(),
             this.settings.appearance.terminal_font_size,
             window,
             cx,
         );
-        this.sessions.focus_active(window, cx);
+        this.agents.focus_active(window, cx);
         this.load_worktrees(cx);
         this.load_file_tree(repo_path.clone(), cx);
         this.load_diff(repo_path, cx);
@@ -575,11 +575,11 @@ impl AdeApp {
         self._load_file_tree_task = Some(task);
     }
 
-    /// The worktree a *new* session should be spawned into: the selected worktree's real
+    /// The worktree a *new* agent should be spawned into: the selected worktree's real
     /// path if one is selected and readable, otherwise the repo root - see the module docs'
-    /// "Sessions/tabs" section for why this is resolved at spawn time rather than tracked as
+    /// "Agents/tabs" section for why this is resolved at spawn time rather than tracked as
     /// a per-tab "current worktree".
-    pub(crate) fn active_session_cwd(&self) -> PathBuf {
+    pub(crate) fn active_agent_cwd(&self) -> PathBuf {
         match self.selected.and_then(|index| self.worktrees.get(index)) {
             Some(item) if item.error.is_none() => item.path.clone(),
             _ => self.focused_repo_path(),
@@ -604,13 +604,13 @@ impl AdeApp {
         // A real, explicit user selection supersedes any stale "fell back to main" notice a
         // previous refresh may have left up - see `Self::worktree_selection_notice`'s own docs.
         self.worktree_selection_notice = None;
-        // Makes this worktree's own last-active tab (or its first session, or none) the
-        // globally active one - see `Sessions::activate_for_worktree`'s own docs for why this
-        // invariant ("the active session always belongs to the selected worktree") is the real
-        // fix this revision makes: before it, selecting a worktree never touched `self.sessions`
+        // Makes this worktree's own last-active tab (or its first agent, or none) the
+        // globally active one - see `Agents::activate_for_worktree`'s own docs for why this
+        // invariant ("the active agent always belongs to the selected worktree") is the real
+        // fix this revision makes: before it, selecting a worktree never touched `self.agents`
         // at all, so the centre pane could keep showing a completely different worktree's
         // terminal after a rail click.
-        self.sessions.activate_for_worktree(&path, cx);
+        self.agents.activate_for_worktree(&path, cx);
         // Browsing to a different worktree disarms a pending prune confirmation - see
         // `Self::request_prune`'s docs.
         self.prune_confirm_armed = false;
@@ -618,7 +618,7 @@ impl AdeApp {
         // Reset per-worktree UI state (see `reset_per_worktree_ui_state`'s docs) so switching
         // worktrees never leaks a "reviewed" checkbox, open diff, or collapsed-dir entry from
         // the worktree just left. Deliberately runs *before* the focus-fallback block below: both
-        // `focus_newly_spawned_session` and the `filter_focus_handle` fallback branch on
+        // `focus_newly_spawned_agent` and the `filter_focus_handle` fallback branch on
         // `self.open_change`, and until this call runs, `open_change` can still reflect the
         // worktree just *left* (a file tab open there) rather than the real post-switch state -
         // evaluating either guard first (a real, live-reproduced bug found in this revision's own
@@ -664,9 +664,9 @@ impl AdeApp {
         self.file_tree_limit_override = None;
         self.file_tree_truncated = false;
         self.file_tree_complete = false;
-        // `focus_newly_spawned_session` (despite its name - its body has no "newly spawned" logic
+        // `focus_newly_spawned_agent` (despite its name - its body has no "newly spawned" logic
         // in it, just the shared "move focus unless a file tab/Settings is showing" guard) closes
-        // the dangling-focus risk this switch creates: the previously-active session's pane may
+        // the dangling-focus risk this switch creates: the previously-active agent's pane may
         // no longer be part of the rendered tree at all once the tab strip's own per-worktree
         // filter (`Self::render_tab_strip`) applies, so keyboard focus left pointing at it would
         // silently break every keybinding until the next click - the same "focus left pointing at
@@ -674,15 +674,15 @@ impl AdeApp {
         // `restore_focus` mechanism exists to prevent, applied here to a plain worktree switch
         // rather than an overlay open/close. `open_change` above is already this switch's real
         // post-reset value by the time this runs, so the guard it checks is genuine.
-        self.focus_newly_spawned_session(window, cx);
-        // `focus_newly_spawned_session` is a real no-op when the newly selected worktree has no
-        // open session at all (`Sessions::focus_active` has nothing to focus) - so if a
-        // previously-focused session's pane belonged to the worktree just left, it's now exactly
-        // as dangling as the case the comment above already covers, just with no session to
+        self.focus_newly_spawned_agent(window, cx);
+        // `focus_newly_spawned_agent` is a real no-op when the newly selected worktree has no
+        // open agent at all (`Agents::focus_active` has nothing to focus) - so if a
+        // previously-focused agent's pane belonged to the worktree just left, it's now exactly
+        // as dangling as the case the comment above already covers, just with no agent to
         // redirect *onto*. Fall back to the rail's own root container
         // (`Self::rail_focus_handle`), which is part of the rendered tree whenever the
         // workspace body is showing (never while Settings has replaced it - `!self.settings_open`
-        // guards that the same way `focus_newly_spawned_session` itself does). Deliberately the
+        // guards that the same way `focus_newly_spawned_agent` itself does). Deliberately the
         // rail's root, not its filter field, which this used to target - see
         // `Self::rail_focus_handle`'s own docs for the real, audit-found keystroke-swallowing bug
         // that became once the filter field started carrying a `"text-input"` key context. It
@@ -691,8 +691,7 @@ impl AdeApp {
         // dispatch fall back to a disconnected root with no real `on_action` handlers at all, not
         // just this worktree's own missing ones - silently breaking every global keybinding (⌘P
         // included) until the next click.
-        if self.sessions.active_id().is_none() && self.open_change.is_none() && !self.settings_open
-        {
+        if self.agents.active_id().is_none() && self.open_change.is_none() && !self.settings_open {
             window.focus(&self.rail_focus_handle, cx);
         }
         // The File view's own per-worktree state (a cached parse and diff lookup that are about

--- a/crates/app/src/root/widgets.rs
+++ b/crates/app/src/root/widgets.rs
@@ -334,7 +334,7 @@ pub(crate) const MENU_GROUP_DIVIDER_HEIGHT: Pixels = px(9.0);
 /// [`theme::border::DIVIDER`], the same token the title bar's own left-cluster rule uses, inset
 /// `mx(10.0)` so it lines up flush with a menu row's own `px(10.0)` label column.
 ///
-/// The app's one in-menu divider, shared by the title bar's File/Edit/View/Session/Help menus
+/// The app's one in-menu divider, shared by the title bar's File/Edit/View/Agent/Help menus
 /// (where it was first built, as `title_bar::menu`'s `render_title_menu_divider`) and the file
 /// tree's right-click context menu, whose groups (GitHub issue #19 §1) shipped with no visual
 /// separation at all. See [`MENU_GROUP_DIVIDER_HEIGHT`] for the height both of those menus

--- a/crates/app/src/settings/mod.rs
+++ b/crates/app/src/settings/mod.rs
@@ -36,7 +36,7 @@ use crate::settings::store as settings_store;
 use crate::sidebar::file_tree;
 use crate::theme;
 #[cfg(test)]
-use crate::work_surface::sessions::SessionKind;
+use crate::work_surface::agents::AgentKind;
 use crate::work_surface::state as work_surface;
 
 pub mod custom_theme;

--- a/crates/app/src/settings/render.rs
+++ b/crates/app/src/settings/render.rs
@@ -46,7 +46,7 @@ impl AdeApp {
     /// with no feedback at all.
     ///
     /// The dangling-focus mechanism itself long predates GitHub issue #17 (it is the same class
-    /// `OverlayFocus`/`restore_focus` exists for, and which `close_session`/`select_worktree`/
+    /// `OverlayFocus`/`restore_focus` exists for, and which `close_agent`/`select_worktree`/
     /// `cancel_new_file` already handle). What that issue changed is that this specific site
     /// became *silent*: before the filter field carried a `"text-input"` context there was nothing
     /// here for a stale focus to be pointing at in the first place. Found by an independent
@@ -587,8 +587,8 @@ impl AdeApp {
     }
 
     /// The Installed card's footer - `design_handoff_jerry_ade/README.md`: "Card footer ...
-    /// '+ Add an agent — any binary that speaks a resumable session on stdin'." Rendered dimmed
-    /// and inert (no `on_click`) - `crate::work_surface::sessions::SessionKind` is a fixed Rust enum, so there
+    /// '+ Add an agent — any binary that speaks a resumable agent on stdin'." Rendered dimmed
+    /// and inert (no `on_click`) - `crate::work_surface::agents::AgentKind` is a fixed Rust enum, so there
     /// is no runtime "register a new agent binary" flow to wire this to yet.
     pub(in crate::settings) fn render_settings_agents_footer(&self) -> impl IntoElement {
         div()
@@ -618,7 +618,7 @@ impl AdeApp {
                     .font(font(theme::font::SANS))
                     .text_size(px(10.5))
                     .text_color(theme::text::GHOST)
-                    .child("\u{2014} any binary that speaks a resumable session on stdin"),
+                    .child("\u{2014} any binary that speaks a resumable agent on stdin"),
             )
     }
 
@@ -727,7 +727,7 @@ impl AdeApp {
     /// command palette's `Prune Worktrees` command call: there is no "prune only this one
     /// worktree" code path, since the one safety-checked removal primitive
     /// (`Self::prunable_worktree_paths` + `Self::execute_prune`) always operates on every
-    /// currently-prunable worktree at once, live-session-excluded. A row's `Prune` button only
+    /// currently-prunable worktree at once, live-agent-excluded. A row's `Prune` button only
     /// shows when that row's own worktree is one of those candidates
     /// (`settings::worktree_row_action`), so clicking it always includes this worktree - it just
     /// isn't scoped to *only* this worktree if others are also prunable at the same moment.
@@ -885,10 +885,10 @@ impl AdeApp {
     /// detection - Revision R6's job, per the doc comment this replaced) - the same chip the
     /// status bar and terminal footer render, not a fourth copy.
     ///
-    /// `Restore sessions on launch` and `Confirm before discarding a worktree` - two more rows
+    /// `Restore agents on launch` and `Confirm before discarding a worktree` - two more rows
     /// `Jerry.dc.html`'s own `settingsRows.general` fixture shows - stay left out for the same
     /// reason as the Agents/Worktrees toggle sections (see `crate::settings::state`'s module docs):
-    /// session-restore-on-launch and a discard-confirmation flow are app behaviour this build
+    /// agent-restore-on-launch and a discard-confirmation flow are app behaviour this build
     /// doesn't have, not settings plumbing around behaviour that already exists.
     pub(in crate::settings) fn render_settings_general_page(
         &self,
@@ -923,7 +923,7 @@ impl AdeApp {
         );
         let environment_row = self.render_settings_row(
             "Default environment",
-            "Where new sessions run - real WSL detection on Windows, real CPU architecture \
+            "Where new agents run - real WSL detection on Windows, real CPU architecture \
              elsewhere. The same chip shown in the status bar and terminal footer.",
             render_env_chip(),
         );
@@ -2386,9 +2386,9 @@ impl AdeApp {
     /// same edit path the Appearance page's stepper click invokes, rather than a second,
     /// test-only setter.
     ///
-    /// The new value isn't only persisted - it's also pushed into every currently open session's
+    /// The new value isn't only persisted - it's also pushed into every currently open agent's
     /// [`crate::terminal::pane::TerminalPane`] via
-    /// [`crate::work_surface::sessions::Sessions::set_terminal_font_size`], so already-open panes pick it up
+    /// [`crate::work_surface::agents::Agents::set_terminal_font_size`], so already-open panes pick it up
     /// too, not just newly spawned ones.
     pub(in crate::settings) fn adjust_terminal_font_size(
         &mut self,
@@ -2398,7 +2398,7 @@ impl AdeApp {
         self.settings.appearance.terminal_font_size = (self.settings.appearance.terminal_font_size
             + delta)
             .clamp(settings_store::FONT_SIZE_MIN, settings_store::FONT_SIZE_MAX);
-        self.sessions
+        self.agents
             .set_terminal_font_size(self.settings.appearance.terminal_font_size, cx);
         self.persist_settings(cx);
         cx.notify();
@@ -3138,17 +3138,17 @@ mod terminal_font_size_tests {
         cx.run_until_parked();
 
         let pane = app
-            .read_with(cx, |app, _| app.sessions.active().map(|s| s.pane.clone()))
-            .expect("a fresh test window has one real, active shell session");
+            .read_with(cx, |app, _| app.agents.active().map(|s| s.pane.clone()))
+            .expect("a fresh test window has one real, active shell agent");
 
         // `grid_dimensions` reports `(cols, rows)` but `resize_sync_state_for_test` reports
         // `(rows, cols)` - hence the swap below.
         let before_dims = pane.read_with(cx, |pane, _| pane.grid_dimensions());
         let before_dims_rows_cols = (before_dims.1, before_dims.0);
-        let (_, before_session_sync) =
+        let (_, before_agent_sync) =
             pane.read_with(cx, |pane, _| pane.resize_sync_state_for_test());
         assert_eq!(
-            before_session_sync,
+            before_agent_sync,
             Some(before_dims_rows_cols),
             "the initial spawn's own resize must have already reached the real live pty"
         );
@@ -3172,7 +3172,7 @@ mod terminal_font_size_tests {
             "a real font-size change must actually recompute the grid's real (cols, rows)"
         );
 
-        let (after_grid_sync, after_session_sync) =
+        let (after_grid_sync, after_agent_sync) =
             pane.read_with(cx, |pane, _| pane.resize_sync_state_for_test());
         assert_eq!(
             after_grid_sync,
@@ -3180,7 +3180,7 @@ mod terminal_font_size_tests {
             "the grid itself must be resized to the new dimensions"
         );
         assert_eq!(
-            after_session_sync,
+            after_agent_sync,
             Some(after_dims_rows_cols),
             "the real, live child pty must also have been informed of the new size - not just \
              the local grid repainting at a size the process underneath it doesn't know about"
@@ -3188,23 +3188,23 @@ mod terminal_font_size_tests {
     }
 
     #[gpui::test]
-    fn a_terminal_font_size_edit_reaches_every_open_session_not_just_new_ones(
+    fn a_terminal_font_size_edit_reaches_every_open_agent_not_just_new_ones(
         cx: &mut TestAppContext,
     ) {
         let repo = tempfile::tempdir().expect("tempdir");
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
-        // A second real session, spawned at whatever the default font size already was.
+        // A second real agent, spawned at whatever the default font size already was.
         app.update_in(cx, |app, window, cx| {
-            app.new_session(SessionKind::Shell, window, cx);
+            app.new_agent(AgentKind::Shell, window, cx);
         });
         cx.run_until_parked();
 
         let panes: Vec<_> = app.read_with(cx, |app, _| {
-            app.sessions.iter().map(|s| s.pane.clone()).collect()
+            app.agents.iter().map(|s| s.pane.clone()).collect()
         });
-        assert_eq!(panes.len(), 2, "expected two real open sessions");
+        assert_eq!(panes.len(), 2, "expected two real open agents");
 
         app.update(cx, |app, cx| {
             app.adjust_terminal_font_size(20.0 - app.settings.appearance.terminal_font_size, cx);
@@ -3215,7 +3215,7 @@ mod terminal_font_size_tests {
             assert_eq!(
                 pane.read_with(cx, |pane, _| pane.font_size_px_for_test()),
                 20.0,
-                "every already-open session's pane must pick up the new font size, not just \
+                "every already-open agent's pane must pick up the new font size, not just \
                  whichever one happens to be active"
             );
         }

--- a/crates/app/src/settings/state.rs
+++ b/crates/app/src/settings/state.rs
@@ -29,7 +29,7 @@
 use std::path::PathBuf;
 
 use crate::rail::state::WorktreeNote;
-use crate::work_surface::sessions::SessionKind;
+use crate::work_surface::agents::AgentKind;
 
 /// Every page `Jerry.dc.html`'s `settingsNavDefs` fixture lists, in the order the design's four
 /// nav groups present them (see [`nav_groups`]).
@@ -127,7 +127,7 @@ impl SettingsPage {
                 "Which agent binaries Jerry can actually find on PATH right now - detected live, not configured."
             }
             SettingsPage::Worktrees => {
-                "Every session gets its own worktree. This is where they live, their real disk usage, and what's safe to prune."
+                "Every agent gets its own worktree. This is where they live, their real disk usage, and what's safe to prune."
             }
             SettingsPage::Appearance => {
                 "These sizes and scale are saved for real, but nothing in the interface renders at them yet."
@@ -192,15 +192,15 @@ pub fn nav_groups() -> Vec<NavGroup> {
     ]
 }
 
-/// Agent kinds this app can spawn as an "agent" - `SessionKind::Shell` is deliberately excluded,
+/// Agent kinds this app can spawn as an "agent" - `AgentKind::Shell` is deliberately excluded,
 /// since the Settings › Agents card lists agent CLIs, not shells.
-pub const AGENT_KINDS: [SessionKind; 2] = [SessionKind::Claude, SessionKind::Codex];
+pub const AGENT_KINDS: [AgentKind; 2] = [AgentKind::Claude, AgentKind::Codex];
 
 /// One row for the Agents page's Installed card - see [`detect_agent_rows`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentRow {
-    pub kind: SessionKind,
-    /// The exact command name `SessionKind::agent_binary_name` hands to `TerminalSpec::command`
+    pub kind: AgentKind,
+    /// The exact command name `AgentKind::agent_binary_name` hands to `TerminalSpec::command`
     /// at spawn time - the same name [`Self::resolved_path`] was searched for.
     pub binary_name: &'static str,
     /// `Some(path)` if a real `$PATH` search found the binary, `None` if it genuinely isn't
@@ -256,7 +256,7 @@ pub enum WorktreeDotStatus {
     /// Uncommitted changes - matches [`WorktreeNote::clean`] being `Some(false)`.
     Dirty,
     /// A prune candidate on its own merits (see [`WorktreeNote::is_prunable`]) - not the final
-    /// "safe to remove right now" answer, since a live session could still exclude it (see
+    /// "safe to remove right now" answer, since a live agent could still exclude it (see
     /// `crate::rail::state::prunable_worktree_paths`); just this row's own local state.
     Prunable,
     /// `wt_core::is_dirty` failed for this path - genuinely unknown, not a guess.
@@ -372,7 +372,7 @@ pub struct LspLanguage {
     pub binary: &'static str,
     /// Generic descriptive copy, not a live count - `Jerry.dc.html`'s own `lspDefs` notes mix
     /// this with fabricated live data ("1,284 crates indexed") this app has no per-language
-    /// session summary to back (`crate::lsp::client`'s server clients are keyed by worktree, not
+    /// agent summary to back (`crate::lsp::client`'s server clients are keyed by worktree, not
     /// surfaced here). Every note here is deliberately the descriptive kind only.
     pub note: &'static str,
     /// This server's real official install/docs page - see
@@ -516,21 +516,21 @@ pub struct KeybindingRow {
 /// a raw `gpui::Action::name()` compiler identifier in a user-facing error.
 pub(crate) fn action_label(action: &dyn gpui::Action) -> Option<&'static str> {
     match action.name() {
-        "app::NewSession" => Some("New session"),
+        "app::NewAgent" => Some("New agent"),
         "app::TogglePalette" => Some("Command palette"),
         "app::ToggleSettings" => Some("Open settings"),
         "app::GotoDefinition" => Some("Go to definition"),
         "app::NewTerminal" => Some("New terminal"),
         "app::NewAgentPane" => Some("New agent pane"),
         "app::NextChangedFile" => Some("Next changed file"),
-        "app::JumpToSession1" => Some("Jump to session 1"),
-        "app::JumpToSession2" => Some("Jump to session 2"),
-        "app::JumpToSession3" => Some("Jump to session 3"),
-        "app::JumpToSession4" => Some("Jump to session 4"),
-        "app::JumpToSession5" => Some("Jump to session 5"),
-        "app::JumpToSession6" => Some("Jump to session 6"),
-        "app::JumpToSession7" => Some("Jump to session 7"),
-        "app::JumpToSession8" => Some("Jump to session 8"),
+        "app::JumpToAgent1" => Some("Jump to agent 1"),
+        "app::JumpToAgent2" => Some("Jump to agent 2"),
+        "app::JumpToAgent3" => Some("Jump to agent 3"),
+        "app::JumpToAgent4" => Some("Jump to agent 4"),
+        "app::JumpToAgent5" => Some("Jump to agent 5"),
+        "app::JumpToAgent6" => Some("Jump to agent 6"),
+        "app::JumpToAgent7" => Some("Jump to agent 7"),
+        "app::JumpToAgent8" => Some("Jump to agent 8"),
         "app::EditorBackspace" => Some("Editor: delete backward"),
         "app::EditorDelete" => Some("Editor: delete forward"),
         "app::EditorEnter" => Some("Editor: insert newline"),
@@ -638,7 +638,7 @@ pub fn keybinding_rows(
 
 /// The Keybindings page's filter row logic (`CHANGELOG.md`'s change 3: "filter row (`/ filter N
 /// bindings`, right-aligned count)") - a case-insensitive substring match against a row's
-/// command name or context, matching `crate::rail::state::filter_sessions`'s shape. An empty (or
+/// command name or context, matching `crate::rail::state::filter_agents`'s shape. An empty (or
 /// all-whitespace) query matches every row.
 pub fn filter_keybinding_rows<'a>(
     rows: &'a [KeybindingRow],
@@ -784,7 +784,7 @@ mod tests {
         assert!(rows.iter().all(|row| row.status_label() == "ready"));
         let claude = rows
             .iter()
-            .find(|row| row.kind == SessionKind::Claude)
+            .find(|row| row.kind == AgentKind::Claude)
             .expect("a Claude row should exist");
         assert_eq!(claude.binary_name, "claude");
         assert_eq!(claude.resolved_path, Some(PathBuf::from("/usr/bin/claude")));
@@ -809,11 +809,11 @@ mod tests {
         });
         let claude = rows
             .iter()
-            .find(|row| row.kind == SessionKind::Claude)
+            .find(|row| row.kind == AgentKind::Claude)
             .expect("claude row");
         let codex = rows
             .iter()
-            .find(|row| row.kind == SessionKind::Codex)
+            .find(|row| row.kind == AgentKind::Codex)
             .expect("codex row");
         assert!(claude.is_ready());
         assert!(!codex.is_ready());
@@ -1167,7 +1167,7 @@ mod tests {
         assert_eq!(
             commands,
             vec![
-                "New session",
+                "New agent",
                 "Command palette",
                 "Open settings",
                 "Text: undo",
@@ -1177,14 +1177,14 @@ mod tests {
                 "New terminal",
                 "New agent pane",
                 "Next changed file",
-                "Jump to session 1",
-                "Jump to session 2",
-                "Jump to session 3",
-                "Jump to session 4",
-                "Jump to session 5",
-                "Jump to session 6",
-                "Jump to session 7",
-                "Jump to session 8",
+                "Jump to agent 1",
+                "Jump to agent 2",
+                "Jump to agent 3",
+                "Jump to agent 4",
+                "Jump to agent 5",
+                "Jump to agent 6",
+                "Jump to agent 7",
+                "Jump to agent 8",
                 "Editor: delete backward",
                 "Editor: delete forward",
                 "Editor: insert newline",
@@ -1291,7 +1291,7 @@ mod tests {
         // Revision R8.5a added a second real scoped context (`"file-editor"`, the real File
         // view text-editing actions) alongside the pre-existing `"diff"` one (`]` ->
         // `NextChangedFile`) - both are deliberately non-global for the same real reason
-        // (swallowing ordinary keystrokes in a focused terminal session), so the scoped count
+        // (swallowing ordinary keystrokes in a focused terminal agent), so the scoped count
         // grew from 1 to 1 + 19 real `Editor*` bindings (a fix round added `EditorSaveAnyway`,
         // the real escape hatch for a permanently-stuck `AdeApp::file_external_conflict`). A
         // later fix round changed `]`'s own registered predicate from `Some("diff")` to

--- a/crates/app/src/settings/store.rs
+++ b/crates/app/src/settings/store.rs
@@ -65,7 +65,7 @@
 //! `AdeApp::code_zoom_percent` multiplier that got reset to 100% on every worktree switch
 //! (`AdeApp::select_worktree`); and an optional `AdeApp::file_zoom_percent` per-open-file
 //! override, gated by a `per_tab_zoom` toggle. None of the last two survived an app restart, and
-//! the worktree-reset meant even a single session's zoom wasn't stable while browsing worktrees.
+//! the worktree-reset meant even a single agent's zoom wasn't stable while browsing worktrees.
 //! `editor_zoom_percent` replaces both: one real, `settings.toml`-persisted multiplier, applied
 //! uniformly to every open file, in every worktree, exactly like `editor_font_size` itself
 //! already was. `per_tab_zoom`, `AdeApp::file_zoom_percent`, and the worktree-reset are gone

--- a/crates/app/src/sidebar/changes.rs
+++ b/crates/app/src/sidebar/changes.rs
@@ -12,10 +12,10 @@ use std::path::{Path, PathBuf};
 use gpui::Rgba;
 
 use crate::theme;
-use crate::work_surface::sessions::SessionId;
+use crate::work_surface::agents::AgentId;
 use wt_core::diff::{DiffFile, DiffHunk, DiffLineKind, FileChangeStatus};
 
-/// Which agent session(s) wrote each changed file in one worktree's diff -
+/// Which agent(s) wrote each changed file in one worktree's diff -
 /// `design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §4 ("Where numbers live")'s
 /// `by: 's1'`, or `by: ['s1', 's9']` when more than one agent touched the same file. Keyed by a
 /// [`DiffFile::path`] (or `old_path`, before a rename - callers decide which path they're asking
@@ -31,7 +31,7 @@ use wt_core::diff::{DiffFile, DiffHunk, DiffLineKind, FileChangeStatus};
 /// yet", never fabricated as "no agent touched it".
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Authorship {
-    by_path: HashMap<PathBuf, Vec<SessionId>>,
+    by_path: HashMap<PathBuf, Vec<AgentId>>,
 }
 
 impl Authorship {
@@ -39,24 +39,24 @@ impl Authorship {
         Self::default()
     }
 
-    /// Every session id recorded as having written `path`, in the order [`Self::record`] saw
+    /// Every agent id recorded as having written `path`, in the order [`Self::record`] saw
     /// them - empty (never fabricated) when nothing has recorded authorship for it yet, which
     /// today is every path (see this type's own docs).
-    pub fn authors_for(&self, path: &Path) -> &[SessionId] {
+    pub fn authors_for(&self, path: &Path) -> &[AgentId] {
         self.by_path.get(path).map(Vec::as_slice).unwrap_or(&[])
     }
 
-    /// Records `session` as (one of) `path`'s authors. Idempotent: recording the same session
+    /// Records `agent` as (one of) `path`'s authors. Idempotent: recording the same agent
     /// against the same path twice does not duplicate the entry, so [`Self::authors_for`]'s
     /// length is always the real distinct-author count, not an edit-tool-call count.
-    pub fn record(&mut self, path: PathBuf, session: SessionId) {
+    pub fn record(&mut self, path: PathBuf, agent: AgentId) {
         let authors = self.by_path.entry(path).or_default();
-        if !authors.contains(&session) {
-            authors.push(session);
+        if !authors.contains(&agent) {
+            authors.push(agent);
         }
     }
 
-    /// `true` when more than one distinct session has written `path` - the design's amber
+    /// `true` when more than one distinct agent has written `path` - the design's amber
     /// shared-file warning: the rail's worktree-row `⚠ N` and the Changes panel's amber
     /// author-chip ring both key off this per-file check.
     pub fn has_multiple_authors(&self, path: &Path) -> bool {
@@ -72,7 +72,7 @@ impl Authorship {
             .count()
     }
 
-    /// How many of `paths` `session` is a recorded author of - the rail agent row's
+    /// How many of `paths` `agent` is a recorded author of - the rail agent row's
     /// `review ready` trailing text (`design_handoff_jerry_ade/revision 3/
     /// REVISION-2026-07-31.md` §2.3: "`12 files` ... here the count **is** the ask - the size of
     /// the review handed to you"). Deliberately per-agent, unlike [`Self::shared_file_count`]
@@ -80,12 +80,12 @@ impl Authorship {
     /// is mine".
     pub fn file_count_for<'a>(
         &self,
-        session: SessionId,
+        agent: AgentId,
         paths: impl IntoIterator<Item = &'a Path>,
     ) -> usize {
         paths
             .into_iter()
-            .filter(|path| self.authors_for(path).contains(&session))
+            .filter(|path| self.authors_for(path).contains(&agent))
             .count()
     }
 }
@@ -678,13 +678,13 @@ mod tests {
         let authorship = Authorship::new();
         assert_eq!(
             authorship.authors_for(Path::new("src/main.rs")),
-            &[] as &[SessionId]
+            &[] as &[AgentId]
         );
         assert!(!authorship.has_multiple_authors(Path::new("src/main.rs")));
     }
 
     #[test]
-    fn recording_one_session_makes_it_the_sole_author() {
+    fn recording_one_agent_makes_it_the_sole_author() {
         let mut authorship = Authorship::new();
         authorship.record(PathBuf::from("src/main.rs"), 1);
         assert_eq!(authorship.authors_for(Path::new("src/main.rs")), &[1]);
@@ -692,7 +692,7 @@ mod tests {
     }
 
     #[test]
-    fn recording_the_same_session_twice_does_not_duplicate_it() {
+    fn recording_the_same_agent_twice_does_not_duplicate_it() {
         let mut authorship = Authorship::new();
         authorship.record(PathBuf::from("src/main.rs"), 1);
         authorship.record(PathBuf::from("src/main.rs"), 1);
@@ -700,7 +700,7 @@ mod tests {
     }
 
     #[test]
-    fn two_distinct_sessions_writing_the_same_file_is_a_shared_file() {
+    fn two_distinct_agents_writing_the_same_file_is_a_shared_file() {
         let mut authorship = Authorship::new();
         authorship.record(PathBuf::from("src/main.rs"), 1);
         authorship.record(PathBuf::from("src/main.rs"), 9);
@@ -734,7 +734,7 @@ mod tests {
     }
 
     #[test]
-    fn file_count_for_only_counts_paths_this_session_authored() {
+    fn file_count_for_only_counts_paths_this_agent_authored() {
         let mut authorship = Authorship::new();
         authorship.record(PathBuf::from("src/main.rs"), 1);
         authorship.record(PathBuf::from("src/main.rs"), 9);
@@ -750,17 +750,17 @@ mod tests {
         assert_eq!(
             authorship.file_count_for(1, paths.iter().map(PathBuf::as_path)),
             2,
-            "session 1 wrote main.rs and lib.rs, not other.rs or untouched.rs"
+            "agent 1 wrote main.rs and lib.rs, not other.rs or untouched.rs"
         );
         assert_eq!(
             authorship.file_count_for(9, paths.iter().map(PathBuf::as_path)),
             2,
-            "session 9 wrote main.rs and other.rs, not lib.rs or untouched.rs"
+            "agent 9 wrote main.rs and other.rs, not lib.rs or untouched.rs"
         );
         assert_eq!(
             authorship.file_count_for(42, paths.iter().map(PathBuf::as_path)),
             0,
-            "a session with no recorded authorship anywhere gets a real 0, not a stray match"
+            "an agent with no recorded authorship anywhere gets a real 0, not a stray match"
         );
     }
 }

--- a/crates/app/src/sidebar/file_ops.rs
+++ b/crates/app/src/sidebar/file_ops.rs
@@ -288,7 +288,7 @@ pub enum DeleteMechanism {
 ///
 /// - **Linux / FreeBSD (and any other Unix)**: real `gio trash -- <path>`. `gio` is GLib's own
 ///   CLI, and `gio trash` is a direct wrapper around `g_file_trash`, which implements the
-///   freedesktop.org trash specification for local files entirely in-process (no session bus, no
+///   freedesktop.org trash specification for local files entirely in-process (no agent bus, no
 ///   gvfs daemon needed for a local path). Verified for real in this project's own environment,
 ///   not assumed: trashing both a file and a non-empty directory succeeded and both appeared in
 ///   `~/.local/share/Trash/files`. The `--` is a real, supported `gio` argument terminator and is

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -40,7 +40,7 @@ impl AdeApp {
             self.tree_context_menu = None;
             self.tree_inline_edit = None;
             if self.tree_focus_handle.is_focused(window) {
-                restore_focus(&self.sessions, &mut self.code_focus, window, cx);
+                restore_focus(&self.agents, &mut self.code_focus, window, cx);
             }
             // 1 again, one level removed, and invisible to the check above: an *overlay* can be
             // holding the tree's handle as its own return target while the overlay itself has
@@ -1453,7 +1453,7 @@ impl AdeApp {
 
     /// The Changes row's 12×12 review checkbox - toggled via [`Self::toggle_reviewed`]. Stops
     /// propagation on click so checking a box never also opens the row's diff, mirroring
-    /// `Self::render_session_tab`'s nested-clickable-child pattern (its tab-close `×`).
+    /// `Self::render_agent_tab`'s nested-clickable-child pattern (its tab-close `×`).
     pub(in crate::sidebar) fn render_review_checkbox(
         &self,
         path: PathBuf,
@@ -1617,7 +1617,7 @@ impl AdeApp {
     ///
     /// Speaks this app's own established dropdown-row language rather than one invented here.
     /// Every value below is `crate::work_surface::render::render_dropdown_menu_row`'s - the row
-    /// shared by the tab strip's `+` menu and the title bar's File/Edit/View/Session/Help menus,
+    /// shared by the tab strip's `+` menu and the title bar's File/Edit/View/Agent/Help menus,
     /// and the closest thing this app has to a specified menu row (the design handoff's
     /// `revision/CHANGELOG.md` specifies that popover; it has no context-menu spec of its own).
     /// That function is deliberately *not* reused: its row is a fixed chip + label + sub-label +
@@ -2583,7 +2583,7 @@ mod fold_state_tests {
         );
     }
 
-    /// §2: a mid-session refresh of the same worktree (what an agent creating or deleting files
+    /// §2: a mid-agent refresh of the same worktree (what an agent creating or deleting files
     /// causes, via `create_new_file`'s own reload) must not reset fold state.
     #[gpui::test]
     fn reloading_the_same_worktrees_tree_keeps_the_fold_state(cx: &mut TestAppContext) {

--- a/crates/app/src/sidebar/tree_ops.rs
+++ b/crates/app/src/sidebar/tree_ops.rs
@@ -106,7 +106,7 @@ impl InlineEditKind {
 /// #19 §4's "a watcher refresh must not clobber an in-progress editor" requirement.** The file
 /// tree is a `Vec<FileTreeEntry>` that `AdeApp::load_file_tree`'s background walk *replaces
 /// wholesale* every time it completes - which is exactly what happens when an agent CLI creates
-/// or deletes a file mid-session and something triggers a re-walk. Any editor state stored in
+/// or deletes a file mid-agent and something triggers a re-walk. Any editor state stored in
 /// that vector, or keyed by an index into it, would be silently destroyed by that replacement,
 /// mid-keystroke. Keeping it here means the walk can replace every row without the typed text
 /// ever being at risk, and the renderer re-locates the editor's anchor row by *path* on each
@@ -884,7 +884,7 @@ impl AdeApp {
         cx: &mut Context<Self>,
     ) {
         // The one hard boundary on the app's single irreversible operation: whatever route got
-        // here, the path must be a plain, normal-component path genuinely inside the session's
+        // here, the path must be a plain, normal-component path genuinely inside the agent's
         // worktree. Every real caller already satisfies this (the targets come from the tree's
         // own walk), which is exactly why it is worth stating as a checked precondition rather
         // than an assumption - a future caller that passes something else gets a refusal, not a
@@ -980,7 +980,7 @@ impl AdeApp {
     /// `lsp_opened_files`/`lsp_document_versions` entries behind. That last one is not cosmetic:
     /// `crate::lsp::client`'s `didOpen` dispatch early-returns for a path already in
     /// `lsp_opened_files`, so recreating a file at the deleted path would silently get no
-    /// diagnostics and no completions for the rest of the session.
+    /// diagnostics and no completions for the rest of the agent.
     ///
     /// Deliberately **not** a `close_file_tab` call: that method restores focus and picks a
     /// neighbouring tab, both of which need a `Window` this async completion handler doesn't
@@ -1372,7 +1372,7 @@ fn remap_path_set(set: &mut HashSet<PathBuf>, old: &Path, new: &Path) {
 
 /// Whether `path` is a plain, normal-component-only path inside `root` - the guard every
 /// tree-originated operation runs before touching the filesystem, so a `..` that somehow reached
-/// one of these methods can't act outside the session's worktree.
+/// one of these methods can't act outside the agent's worktree.
 pub(crate) fn is_inside_worktree(root: &Path, path: &Path) -> bool {
     let Ok(relative) = path.strip_prefix(root) else {
         return false;
@@ -1722,7 +1722,7 @@ mod tree_ops_regression_tests {
             "premise: the editor must be a real painted row before the reload"
         );
 
-        // An agent CLI creating a file mid-session, followed by the real re-walk.
+        // An agent CLI creating a file mid-agent, followed by the real re-walk.
         fs::write(repo.path().join("src/agent-made.rs"), "// new\n").expect("write");
         app.update(cx, |app, cx| {
             let root = app.file_tree_root.clone();
@@ -2106,7 +2106,7 @@ mod tree_ops_regression_tests {
             // A real selection, so the tree binding would genuinely have something to copy if it
             // fired - otherwise this test could pass for the wrong reason.
             app.selected_tree_path = Some(repo.path().join("README.md"));
-            app.sessions.focus_active(window, cx);
+            app.agents.focus_active(window, cx);
         });
         cx.run_until_parked();
 
@@ -2466,7 +2466,7 @@ mod tree_ops_regression_tests {
         /// `crate::lsp::client`'s `didOpen` dispatch early-returns for a path already in
         /// `lsp_opened_files`, and that set is documented as never being cleared on close. So a
         /// rename (or a delete) that left the old absolute path in it meant recreating a file at
-        /// that path silently got no diagnostics and no completions for the rest of the session.
+        /// that path silently got no diagnostics and no completions for the rest of the agent.
         #[gpui::test]
         fn renaming_and_deleting_both_clear_the_lsp_per_document_bookkeeping(
             cx: &mut TestAppContext,

--- a/crates/app/src/status_bar/mod.rs
+++ b/crates/app/src/status_bar/mod.rs
@@ -21,12 +21,12 @@ use crate::lsp::diagnostics as diagnostics_view;
 use crate::rail::state as rail;
 use crate::root::*;
 use crate::theme;
-// `Session` itself is only named inside `render::render_status_agents_cluster`'s real
-// `#[cfg(target_os = "linux")]` variant (`Vec<&Session>`) - the non-Linux twin only needs
-// `SessionKind`, so a Windows/macOS build genuinely never references `Session` here.
+// `Agent` itself is only named inside `render::render_status_agents_cluster`'s real
+// `#[cfg(target_os = "linux")]` variant (`Vec<&Agent>`) - the non-Linux twin only needs
+// `AgentKind`, so a Windows/macOS build genuinely never references `Agent` here.
 #[cfg(target_os = "linux")]
-use crate::work_surface::sessions::Session;
-use crate::work_surface::sessions::SessionKind;
+use crate::work_surface::agents::Agent;
+use crate::work_surface::agents::AgentKind;
 use gpui::{div, font, prelude::*, px, ClickEvent, Context};
 #[cfg(test)]
 use std::path::PathBuf;

--- a/crates/app/src/status_bar/process_stats.rs
+++ b/crates/app/src/status_bar/process_stats.rs
@@ -192,7 +192,7 @@ pub fn sample_processes(
 }
 
 /// Aggregates real per-pid [`ProcessSample`]s across `pids` into a total CPU% and total RSS
-/// bytes - the status bar's `X% cpu · Y GB` summary across every currently open agent session's
+/// bytes - the status bar's `X% cpu · Y GB` summary across every currently open agent's
 /// real pid.
 ///
 /// An empty `pids` list is a real, honest `(Some(0.0), Some(0))` (the sum over zero processes is
@@ -205,7 +205,7 @@ pub fn sample_processes(
 /// contribution. A single un-sampleable agent must never blank the whole cluster for every other
 /// agent that *can* be read - that was routine, not rare: a pty child kept alive during its EOF
 /// poll (see `crate::terminal::pane`'s `MAX_EOF_POLL_TICKS`) is a real zombie for up to ~10s, and
-/// a freshly-opened session's first CPU tick has no delta to compute a rate from for a full poll
+/// a freshly-opened agent's first CPU tick has no delta to compute a rate from for a full poll
 /// interval.
 ///
 /// A field is only `None` when *nothing at all* is known about it yet - not one pid in `pids`

--- a/crates/app/src/status_bar/render.rs
+++ b/crates/app/src/status_bar/render.rs
@@ -2,17 +2,17 @@ use super::*;
 use crate::root::widgets::{render_env_chip, render_keycap_row, text_tooltip, KeycapSize};
 
 /// The 28px status bar (`CHANGELOG.md`'s change 7 - height 26 -> 28, gap 12 -> 9, every value
-/// 10px mono), rebuilt from the old single `8 sessions · 2 waiting · …` summary string into a
+/// 10px mono), rebuilt from the old single `8 agents · 2 waiting · …` summary string into a
 /// left/right cluster layout. Every field here reads a real, already-live data source - see each
 /// render helper's own docs for exactly which one, and [`AdeApp::status_bar_active_parsed_file`]
 /// for the one shared gate that keeps the file-scoped fields (`ln N`, indent, line-ending,
 /// `UTF-8`, the diagnostics error count) from ever showing stale data left over from a
 /// previously-viewed file.
 ///
-/// The mockup's second `⌘⇧K sessions` palette hint is still omitted for the same reason the old
+/// The mockup's second `⌘⇧K agents` palette hint is still omitted for the same reason the old
 /// bar omitted it: that binding is never wired up anywhere in this codebase, so a keycap for it
 /// would advertise a shortcut that silently does nothing. The real `secondary-1`..`secondary-8`
-/// session-jump keycaps (reused from `Self::render_tab_strip`'s own right-aligned cluster) are
+/// agent-jump keycaps (reused from `Self::render_tab_strip`'s own right-aligned cluster) are
 /// shown instead, since those genuinely are bound.
 impl AdeApp {
     pub(crate) fn render_status_bar(&self, cx: &mut Context<Self>) -> impl IntoElement {
@@ -61,7 +61,7 @@ impl AdeApp {
     /// (`Self::render_rail_footer`) - an audit found two real problems with that shared slot:
     /// [`AdeApp::prune_status`] took priority there and is never cleared once set (see that
     /// field's own docs), so a single prune click permanently hid every future worktree-history
-    /// status for the rest of the session; and the rail footer disappears entirely while Settings
+    /// status for the rest of the agent; and the rail footer disappears entirely while Settings
     /// is open (`AdeApp::render_workspace_body` isn't called - `root/mod.rs`'s `Render` impl
     /// swaps it out for `Self::render_settings`), leaving *no* real status surface at all for
     /// this feedback while Settings is open. The status bar is rendered as an unconditional
@@ -86,7 +86,7 @@ impl AdeApp {
     }
 
     /// Environment chip + real LSP server/error counts, the real file/editor cluster, then the
-    /// palette/session keycap hints - divided the same way as the left side.
+    /// palette/agent keycap hints - divided the same way as the left side.
     fn render_status_bar_right(&self, cx: &mut Context<Self>) -> gpui::AnyElement {
         let env_and_servers = div()
             .flex()
@@ -100,7 +100,7 @@ impl AdeApp {
             .items_center()
             .gap(px(16.0))
             .child(self.render_status_palette_hint(cx))
-            .child(self.render_status_session_hint());
+            .child(self.render_status_agent_hint());
 
         render_status_segment_row(vec![
             env_and_servers.into_any_element(),
@@ -111,20 +111,20 @@ impl AdeApp {
         .into_any_element()
     }
 
-    /// The active session's real branch name (`self.worktrees`, the same lookup
-    /// `Self::render_session_context_bar` already does - not a second copy) plus its real
+    /// The active agent's real branch name (`self.worktrees`, the same lookup
+    /// `Self::render_agent_context_bar` already does - not a second copy) plus its real
     /// `↑ahead ↓behind` from [`Self::ahead_behind_cache`] (populated by the same periodic
     /// `wt_core::diff::ahead_behind_against_base` refresh as [`Self::diff_cache`]). `None` (the
-    /// whole cluster hidden) only when there is no active session at all - a detached `HEAD`
-    /// still shows real text (`"(detached)"`), matching the session context bar's own
+    /// whole cluster hidden) only when there is no active agent at all - a detached `HEAD`
+    /// still shows real text (`"(detached)"`), matching the agent context bar's own
     /// convention, and a not-yet-computed ahead/behind is honestly omitted rather than shown as
     /// a fabricated `↑0 ↓0`.
     fn render_status_branch_cluster(&self) -> Option<gpui::AnyElement> {
-        let session = self.sessions.active()?;
+        let agent = self.agents.active()?;
         let branch = self
             .worktrees
             .iter()
-            .find(|item| item.path == session.cwd)
+            .find(|item| item.path == agent.cwd)
             .and_then(|item| item.branch.clone())
             .unwrap_or_else(|| "(detached)".to_string());
 
@@ -134,7 +134,7 @@ impl AdeApp {
             .gap(px(6.0))
             .child(self.render_status_text(branch));
 
-        if let Some(ahead_behind) = self.ahead_behind_cache.get(&session.cwd) {
+        if let Some(ahead_behind) = self.ahead_behind_cache.get(&agent.cwd) {
             row = row.child(self.render_status_text(format!(
                 "\u{2191}{} \u{2193}{}",
                 ahead_behind.ahead, ahead_behind.behind
@@ -146,21 +146,21 @@ impl AdeApp {
 
     /// Five real 5×5 radius-1 urgency-counter squares, one per [`Status`] in
     /// [`Status::ORDER`] (amber/red/green/blue/grey), each with a real count aggregated across
-    /// every currently open session - [`rail::urgency_counts`] over [`Self::build_session_rows`],
-    /// the exact same per-session status classification the rail's own urgency grouping uses
-    /// (`Self::session_status` under the hood), not a second, independent classification.
+    /// every currently open agent - [`rail::urgency_counts`] over [`Self::build_agent_rows`],
+    /// the exact same per-agent status classification the rail's own urgency grouping uses
+    /// (`Self::agent_status` under the hood), not a second, independent classification.
     ///
     /// Known, low-priority redundancy: [`Self::render_rail_list`] already calls
-    /// `build_session_rows` once earlier in the very same frame, so this is a second, real (if
+    /// `build_agent_rows` once earlier in the very same frame, so this is a second, real (if
     /// cheap - no I/O, per that method's own docs) computation of the identical rows, including,
-    /// for any [`Status::Ask`] session, a fresh `Vec<String>` allocation of that session's whole
+    /// for any [`Status::Ask`] agent, a fresh `Vec<String>` allocation of that agent's whole
     /// visible terminal grid. Not fixed here: both `Self::render_rail`/`Self::render_rail_list`
     /// and this status bar are `&self` methods (not `&mut self`), so caching this frame's rows
     /// on `self` for reuse here would need either widening several rail-render signatures to
     /// `&mut self` or a `RefCell`-style interior-mutability cache - both a more invasive
     /// restructure than this redundant-but-cheap computation is worth fixing in this pass.
     fn render_status_urgency_counters(&self, cx: &mut Context<Self>) -> impl IntoElement {
-        let rows = self.build_session_rows(cx);
+        let rows = self.build_agent_rows(cx);
         div().flex().items_center().gap(px(8.0)).children(
             rail::urgency_counts(&rows)
                 .into_iter()
@@ -182,8 +182,8 @@ impl AdeApp {
     }
 
     /// `N agents · X% cpu · Y GB` - agent count is a real count of currently open
-    /// [`SessionKind::Claude`]/[`SessionKind::Codex`] sessions; cpu/mem are the real,
-    /// periodically-sampled [`Self::process_stats`] aggregated across those sessions' real pids
+    /// [`AgentKind::Claude`]/[`AgentKind::Codex`] agents; cpu/mem are the real,
+    /// periodically-sampled [`Self::process_stats`] aggregated across those agents' real pids
     /// via [`process_stats::aggregate_process_stats`]. A field with no real sample known yet for
     /// *any* agent shows `...` for that one piece rather than a fabricated `0%`/`0 B` - see that
     /// function's own docs for exactly when that is: a single un-sampleable pid (e.g. a real
@@ -192,9 +192,9 @@ impl AdeApp {
     /// `agent_pids` isn't additionally filtered on `TerminalPane::is_running()`: a pid mid-EOF-
     /// poll (the routine "just exited, not yet reaped" case the aggregation fix above targets)
     /// still reports `is_running() == true` for up to `MAX_EOF_POLL_TICKS` by design, so that
-    /// filter wouldn't actually exclude the zombie pid this fix cares about. A pid whose session
+    /// filter wouldn't actually exclude the zombie pid this fix cares about. A pid whose agent
     /// has genuinely gone (`is_running() == false`) already has no pid at all
-    /// (`TerminalPane::pid` returns `None` once its `session` is cleared), so it's already
+    /// (`TerminalPane::pid` returns `None` once its `agent` is cleared), so it's already
     /// excluded by the `filter_map` below without a separate `is_running` check.
     ///
     /// CPU% is normalized to total real system capacity (0-100%) by dividing the raw,
@@ -210,15 +210,15 @@ impl AdeApp {
     /// the cpu/mem fields entirely rather than showing a `...% cpu` that can never resolve.
     #[cfg(target_os = "linux")]
     fn render_status_agents_cluster(&self, cx: &mut Context<Self>) -> impl IntoElement {
-        let agent_sessions: Vec<&Session> = self
-            .sessions
+        let agents: Vec<&Agent> = self
+            .agents
             .iter()
-            .filter(|session| matches!(session.kind, SessionKind::Claude | SessionKind::Codex))
+            .filter(|agent| matches!(agent.kind, AgentKind::Claude | AgentKind::Codex))
             .collect();
-        let agent_count = agent_sessions.len();
-        let agent_pids: Vec<u32> = agent_sessions
+        let agent_count = agents.len();
+        let agent_pids: Vec<u32> = agents
             .iter()
-            .filter_map(|session| session.pane.read(cx).pid())
+            .filter_map(|agent| agent.pane.read(cx).pid())
             .collect();
 
         let (cpu_total, rss_total) =
@@ -250,9 +250,9 @@ impl AdeApp {
     #[cfg(not(target_os = "linux"))]
     fn render_status_agents_cluster(&self, _cx: &mut Context<Self>) -> impl IntoElement {
         let agent_count = self
-            .sessions
+            .agents
             .iter()
-            .filter(|session| matches!(session.kind, SessionKind::Claude | SessionKind::Codex))
+            .filter(|agent| matches!(agent.kind, AgentKind::Claude | AgentKind::Codex))
             .count();
         self.render_status_text(format!("{agent_count} agents"))
     }
@@ -292,7 +292,7 @@ impl AdeApp {
 
     /// Whichever [`code_view::ParsedFile`] is genuinely, currently on screen in Surface C's File
     /// view - `None` whenever that's not true (Settings is open and covering the whole
-    /// workspace, a session tab is active, the Diff view is showing, or
+    /// workspace, an agent tab is active, the Diff view is showing, or
     /// [`Self::file_view_cache`] hasn't caught up with a just-opened file yet). The shared gate
     /// for every status-bar field that only makes sense for a real, currently-viewed file
     /// (`ln N`, indent width, line-ending, `UTF-8`, the diagnostics error count) - without it,
@@ -437,11 +437,11 @@ impl AdeApp {
             }))
     }
 
-    /// The real session-jump keycap hint (`secondary-1`..`secondary-8`) - reuses
-    /// [`Self::session_jump_keys`], the exact same computation `Self::render_tab_strip`'s own
+    /// The real agent-jump keycap hint (`secondary-1`..`secondary-8`) - reuses
+    /// [`Self::agent_jump_keys`], the exact same computation `Self::render_tab_strip`'s own
     /// right-aligned cluster uses, not a second copy that could drift from what's really bound.
-    fn render_status_session_hint(&self) -> impl IntoElement {
-        let jump_keys = self.session_jump_keys();
+    fn render_status_agent_hint(&self) -> impl IntoElement {
+        let jump_keys = self.agent_jump_keys();
         div()
             .flex()
             .items_center()
@@ -453,7 +453,7 @@ impl AdeApp {
                     .font_weight(gpui::FontWeight::MEDIUM)
                     .text_size(self.ui_text_size(10.5))
                     .text_color(theme::text::FAINT)
-                    .child("session"),
+                    .child("agent"),
             )
     }
 

--- a/crates/app/src/terminal/links.rs
+++ b/crates/app/src/terminal/links.rs
@@ -130,7 +130,7 @@ pub fn find_links(text: &str) -> Vec<LinkMatch> {
 /// Lexically collapses `..`/`.` path components - no filesystem access (no
 /// `Path::canonicalize()`, which resolves symlinks via a blocking `stat` and requires the path
 /// to exist). [`resolve`] runs once per detected link on every rendered terminal row, on every
-/// frame a streaming session re-renders on, so a filesystem-touching normalization here would
+/// frame a streaming agent re-renders on, so a filesystem-touching normalization here would
 /// be a real per-frame cost for a purely textual concern. (It is per *frame*, not per
 /// `crate::terminal::pane::POLL_INTERVAL` poll tick as this used to claim: a tick that drains
 /// bytes calls `cx.notify()`, but GPUI coalesces however many invalidations land between two
@@ -154,7 +154,7 @@ fn normalize_lexically(path: &Path) -> PathBuf {
 
 /// Resolves a detected link's path against `cwd` - an absolute `path` is returned as-is
 /// (`PathBuf::join`'s own documented behavior), a relative one is joined onto `cwd`. Callers
-/// pass the session's own `TerminalSpec::cwd`, never `std::env::current_dir()`.
+/// pass the agent's own `TerminalSpec::cwd`, never `std::env::current_dir()`.
 ///
 /// ## Deliberate: `..` is normalized away, and a path landing outside `cwd` is still allowed
 ///
@@ -163,7 +163,7 @@ fn normalize_lexically(path: &Path) -> PathBuf {
 /// directory: ../../../etc/shadow.conf`). This does **not** then reject a normalized path that
 /// lands outside `cwd`/the worktree: this is a read-only file *viewer*, not a write path, and
 /// `crate::code_surface::tabs::AdeApp::open_terminal_link`'s own `path.is_file()` existence
-/// check is what actually gates a bogus link from opening a tab. A real terminal session
+/// check is what actually gates a bogus link from opening a tab. A real terminal agent
 /// legitimately prints paths outside its own worktree constantly (a `$CARGO_HOME` registry
 /// file, another checked-out worktree, a global config file); refusing to resolve those would
 /// make this viewer less useful than a real terminal's own "click to open" for no safety gain.

--- a/crates/app/src/terminal/mod.rs
+++ b/crates/app/src/terminal/mod.rs
@@ -1,4 +1,4 @@
-//! Real terminal sessions: everything about one feature, in one folder.
+//! Real terminal agents: everything about one feature, in one folder.
 //!
 //! Split by what each half is responsible for, keeping the window-free parts window-free:
 //!

--- a/crates/app/src/terminal/pane.rs
+++ b/crates/app/src/terminal/pane.rs
@@ -4,8 +4,8 @@
 //! terminal grid, not a scrolling plain-text log (see `crate::terminal::grid`'s module docs
 //! for why that distinction matters for agent CLIs). What gets spawned is described by
 //! [`TerminalSpec`] - `TerminalPane` itself has no notion of "shell" vs. "agent CLI". The
-//! session/tab bookkeeping that decides which spec to use, and that owns more than one
-//! `TerminalPane` as tabs, lives in `crate::work_surface::sessions`/`crate::root`, one layer up.
+//! agent/tab bookkeeping that decides which spec to use, and that owns more than one
+//! `TerminalPane` as tabs, lives in `crate::work_surface::agents`/`crate::root`, one layer up.
 //!
 //! ## Offloading blocking work off the GPUI foreground thread
 //!
@@ -15,7 +15,7 @@
 //! `PtySession::output()` is a bounded `std::sync::mpsc::Receiver<Vec<u8>>`; rather than a
 //! second dedicated OS thread to bridge it, this drains it with non-blocking `try_recv()`
 //! from inside a GPUI foreground async task that wakes every [`POLL_INTERVAL`] (or, for a
-//! pane whose session isn't the globally active tab, every [`BACKGROUND_POLL_INTERVAL`] -
+//! pane whose agent isn't the globally active tab, every [`BACKGROUND_POLL_INTERVAL`] -
 //! see [`tick_cadence`]) via `cx.background_executor().timer(..)`. `try_recv()` never
 //! blocks, but see [`MAX_BYTES_PER_TICK`] for why the drain loop itself is still bounded -
 //! "never blocks" isn't the same as "bounded work per call".
@@ -76,7 +76,7 @@ use crate::terminal::grid::{GridCell, TerminalGrid, DEFAULT_BACKGROUND, DEFAULT_
 use crate::terminal::links::{self as terminal_links, LinkMatch};
 use crate::theme;
 
-/// How often the poll task of the *globally active* session's pane (see
+/// How often the poll task of the *globally active* agent's pane (see
 /// [`TerminalPane::set_foreground`]; every other pane uses [`BACKGROUND_POLL_INTERVAL`]) wakes
 /// up to drain any pty output that has arrived and, if there was any, re-render.
 ///
@@ -101,7 +101,7 @@ use crate::theme;
 /// uses a 4ms window for the same job (it coalesces pty events for 4ms before re-rendering).
 const POLL_INTERVAL: Duration = Duration::from_millis(8);
 
-/// [`POLL_INTERVAL`]'s counterpart for a pane whose session is *not* the globally active tab
+/// [`POLL_INTERVAL`]'s counterpart for a pane whose agent is *not* the globally active tab
 /// (see [`TerminalPane::set_foreground`]) - nobody can see a background pane's output live, so
 /// polling it twice per frame buys nothing. 33ms (the pre-tightening interval, ~30 drains/s)
 /// keeps a background agent's status/activity signal fresh to within a frame or two while
@@ -109,12 +109,12 @@ const POLL_INTERVAL: Duration = Duration::from_millis(8);
 ///
 /// This split exists because the 8ms/[`MAX_BYTES_PER_TICK`] tightening, correct for the *one*
 /// visible pane, was measured to be a real multi-pane regression: it raised every pane's
-/// drainable throughput ~5x, and this app's whole point is running many sessions at once. With
+/// drainable throughput ~5x, and this app's whole point is running many agents at once. With
 /// 25 concurrently-firehosing panes (release build, real X11), all-panes-at-8ms measured
 /// 10-12fps with 60-70ms invalidation-to-paint latency and the foreground thread at ~80%
 /// saturation, vs 17-19fps / ~27ms before the tightening - the aggregate decode work, not the
 /// wake frequency, is what scales with pane count. Keying cadence on real tab visibility keeps
-/// the measured single-session throughput fix without paying it once per open session.
+/// the measured single-agent throughput fix without paying it once per open agent.
 const BACKGROUND_POLL_INTERVAL: Duration = Duration::from_millis(33);
 
 /// Defensive cap on how many output *bytes* a single poll tick will drain and decode on the
@@ -147,7 +147,7 @@ const MAX_BYTES_PER_TICK: usize = 256 * 1024;
 /// [`BACKGROUND_POLL_INTERVAL`]'s docs for the measured multi-pane regression this split
 /// fixes). 32KiB per 33ms tick caps a background pane's *delivered* throughput at ~1MB/s -
 /// deliberately about what the pre-tightening cadence delivered (the old 64-chunk cap measured
-/// ~0.8MB/s against a real firehose), so a wall of background sessions can never generate more
+/// ~0.8MB/s against a real firehose), so a wall of background agents can never generate more
 /// aggregate foreground decode work than the app handled before the tightening. The child
 /// isn't harmed: `pty-core`'s bounded channel backpressures it, exactly as it did for every
 /// pane pre-tightening, and the pane returns to the full [`MAX_BYTES_PER_TICK`] budget the
@@ -155,7 +155,7 @@ const MAX_BYTES_PER_TICK: usize = 256 * 1024;
 const BACKGROUND_MAX_BYTES_PER_TICK: usize = 32 * 1024;
 
 /// The poll cadence - (sleep interval, per-tick drain byte budget) - for one tick of
-/// [`TerminalPane::spawn_process`]'s loop, given whether this pane's session is the globally
+/// [`TerminalPane::spawn_process`]'s loop, given whether this pane's agent is the globally
 /// active tab and whether pty EOF is already pending.
 ///
 /// `eof_pending` forces the foreground cadence regardless of visibility: [`MAX_EOF_POLL_TICKS`]
@@ -307,7 +307,7 @@ impl TerminalSpec {
 /// `Event::Open(MaybeNavigationTarget)` uses for the same "a click resolved to a navigation
 /// target" case (`vendor/zed/crates/terminal/src/terminal.rs:1823`). `TerminalPane` itself has
 /// no notion of tabs/file-opening (see the module docs), so it can only announce "a link was
-/// clicked"; `crate::work_surface::sessions::Sessions::spawn` subscribes and turns this into a
+/// clicked"; `crate::work_surface::agents::Agents::spawn` subscribes and turns this into a
 /// `crate::root::AdeApp::open_terminal_link` call, since that layer owns tab state.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TerminalPaneEvent {
@@ -368,28 +368,28 @@ pub struct TerminalPane {
     /// this cancels whatever the previous task was doing, stopping an old session's poll loop
     /// from racing a new one over the same struct fields.
     _task: Option<Task<()>>,
-    /// Whether this pane's session is the *globally active* tab
-    /// (`crate::work_surface::sessions::Sessions::active`). Drives [`tick_cadence`]: only the active
-    /// session's pane gets the frame-accurate [`POLL_INTERVAL`]/[`MAX_BYTES_PER_TICK`]
+    /// Whether this pane's agent is the *globally active* tab
+    /// (`crate::work_surface::agents::Agents::active`). Drives [`tick_cadence`]: only the active
+    /// agent's pane gets the frame-accurate [`POLL_INTERVAL`]/[`MAX_BYTES_PER_TICK`]
     /// cadence; every other pane polls at the coarser background cadence.
     ///
     /// Deliberately "globally active", not "actually visible on screen right now": a file tab
     /// (`AdeApp::open_change`) or Settings can occupy the centre pane while the active
-    /// session's pane keeps its foreground cadence. That costs at most *one* full-cadence
+    /// agent's pane keeps its foreground cadence. That costs at most *one* full-cadence
     /// pane - the multi-pane aggregate this flag exists to bound is unaffected - and keeps
-    /// the flag derivable from `Sessions::active` alone, rather than also tracking
+    /// the flag derivable from `Agents::active` alone, rather than also tracking
     /// `open_change`/`settings_open` transitions here (more writers, more ways to go stale -
     /// this codebase's recurring bug class).
     ///
-    /// Maintained solely by `crate::work_surface::sessions::Sessions::sync_pane_cadence` (the single
-    /// writer, resynced on every active-session change); `true` at construction because
-    /// `Sessions::spawn` makes a new session active in the same step.
+    /// Maintained solely by `crate::work_surface::agents::Agents::sync_pane_cadence` (the single
+    /// writer, resynced on every active-agent change); `true` at construction because
+    /// `Agents::spawn` makes a new agent active in the same step.
     is_foreground: bool,
 }
 
 impl TerminalPane {
     /// `font_size_px` is the caller-supplied starting font size - every production caller
-    /// (`crate::work_surface::sessions::Sessions::spawn`) passes the live
+    /// (`crate::work_surface::agents::Agents::spawn`) passes the live
     /// `crate::settings::store::AppearanceSettings::terminal_font_size`, never a hardcoded
     /// literal.
     /// Clamped via [`sanitized_font_size_px`] the same way [`Self::set_font_size`] clamps a
@@ -419,7 +419,7 @@ impl TerminalPane {
 
     /// Applies a Settings › Appearance "Terminal font size" edit
     /// (`crate::root::AdeApp`'s `adjust_terminal_font_size`, via
-    /// `crate::work_surface::sessions::Sessions::set_terminal_font_size`) to this already-live pane - a
+    /// `crate::work_surface::agents::Agents::set_terminal_font_size`) to this already-live pane - a
     /// no-op if the sanitized value is unchanged (e.g. a stepper click already at a clamp
     /// boundary).
     ///
@@ -493,9 +493,9 @@ impl TerminalPane {
         self.exit_status.as_ref()
     }
 
-    /// Tells this pane whether its session is the globally active tab - see
+    /// Tells this pane whether its agent is the globally active tab - see
     /// [`Self::is_foreground`]'s field docs. Called (only) by
-    /// `crate::work_surface::sessions::Sessions::sync_pane_cadence` on every active-session change; the poll
+    /// `crate::work_surface::agents::Agents::sync_pane_cadence` on every active-agent change; the poll
     /// loop reads the flag afresh each tick, so a change takes effect within one tick of
     /// whichever cadence the pane was on. Deliberately no `cx.notify()`: the flag changes
     /// polling cadence, never anything rendered.
@@ -676,7 +676,7 @@ impl TerminalPane {
                     this.session = Some(session);
                     // A freshly started process hasn't produced output yet, but it just
                     // demonstrably did something (started) - counting that as activity keeps
-                    // a still-spawning session from being immediately misread as long-idle by
+                    // a still-spawning agent from being immediately misread as long-idle by
                     // `crate::rail::status::derive_status`.
                     this.activity_at = Some(std::time::Instant::now());
                     // The pane may already have rendered (and computed a target grid size)
@@ -1086,7 +1086,7 @@ fn keystroke_to_bytes(keystroke: &Keystroke) -> Option<Vec<u8>> {
     // Never forward a platform (⌘ on macOS, Super/Meta on Linux)-modified keystroke as
     // literal pty input: it would type garbage into the child process, and - since
     // `handle_key_down` calls `cx.stop_propagation()` after a successful write - it would
-    // swallow an app-level shortcut (e.g. the rail's secondary-N "new session") before it
+    // swallow an app-level shortcut (e.g. the rail's secondary-N "new agent") before it
     // reaches its `KeyBinding`, just because a terminal tab happened to have focus. Must run
     // before the fallthrough `key_char` branch below, which returns a character for any
     // keystroke that has one, including platform-modified ones.
@@ -1575,7 +1575,7 @@ mod cadence_tests {
         assert_eq!(
             tick_cadence(true, false),
             (POLL_INTERVAL, MAX_BYTES_PER_TICK),
-            "the visible pane must keep the measured single-session throughput fix"
+            "the visible pane must keep the measured single-agent throughput fix"
         );
     }
 

--- a/crates/app/src/text_history.rs
+++ b/crates/app/src/text_history.rs
@@ -102,7 +102,7 @@ pub const MAX_EDITS_PER_GROUP: usize = 10_000;
 /// `code_view::MAX_FILE_BYTES` (2 MiB). 200 external rewrites of a 2 MiB file - an agent CLI
 /// rewriting a file in a loop, which is this app's whole domain - would retain roughly 800 MB in a
 /// single buffer, times one per open file. Bounding bytes as well as groups is what actually closes
-/// that. Generous enough that no ordinary editing session ever reaches it (a full undo stack of
+/// that. Generous enough that no ordinary editing agent ever reaches it (a full undo stack of
 /// real keystrokes is kilobytes), so this only ever bites the pathological case it exists for.
 pub const MAX_HISTORY_BYTES: usize = 16 * 1024 * 1024;
 
@@ -600,7 +600,7 @@ impl TextHistory {
 }
 
 /// One of the app's five hand-rolled single-line text inputs (the command-palette query, the rail
-/// session filter, the Settings › Keybindings filter, the New file name prompt, and the file
+/// agent filter, the Settings › Keybindings filter, the New file name prompt, and the file
 /// tree's inline New File / New Folder / Rename editor - `crate::sidebar::tree_ops::TreeInlineEdit`,
 /// which became one of these when GitHub issue #19's tree met issue #17's undo work at a merge)
 /// with a real undo history attached. All five are append/backspace-only with no caret of their own - see

--- a/crates/app/src/theme.rs
+++ b/crates/app/src/theme.rs
@@ -505,7 +505,7 @@ pub mod rail {
     pub const WORKTREE_ACTIVE_BG: ColorToken = hex(0x181c1f);
     /// Worktree row hover background (§2.2: "hover `#16191c`").
     pub const WORKTREE_HOVER_BG: ColorToken = hex(0x16191c);
-    /// A prunable (merged, clean, session-less) worktree's 2px left edge (§2.2: "prunable
+    /// A prunable (merged, clean, agent-less) worktree's 2px left edge (§2.2: "prunable
     /// `#2f353a`"). A bare-but-not-prunable worktree reuses [`super::status::IDLE_BG`]
     /// (`#22262a`), an exact match for the spec's "Bare worktrees `#22262a`".
     pub const PRUNABLE_EDGE: ColorToken = hex(0x2f353a);
@@ -939,7 +939,7 @@ pub mod settings {
     /// distinct from [`super::border::CARD_FIELD`] (`#22272b`).
     pub const CARD_ROW_SEP: ColorToken = hex(0x1f2327);
     /// A binary-found status dot on the Agents page. Same hex as [`super::status::REVIEW`],
-    /// kept as its own token: the session `Status` palette is reserved for session urgency
+    /// kept as its own token: the agent `Status` palette is reserved for agent urgency
     /// (`README.md`'s "Status vocabulary — use nowhere else"), and "this binary resolved on
     /// `$PATH`" is a different fact that just happens to want the same green.
     pub const AGENT_READY: ColorToken = hex(0x5cb87f);
@@ -965,7 +965,7 @@ pub mod settings {
 /// invisible browser/OS scrolling), so these are a deliberate, judgment-call derivation from
 /// existing neutral tokens rather than a transcription. `THUMB` aliases [`text::GUTTER`] (the
 /// line-number gutter's own muted grey - already the UI's "quiet structural chrome" colour) and
-/// `THUMB_HOVER` aliases [`status::IDLE`] (a session's resting-state grey, one step brighter) so
+/// `THUMB_HOVER` aliases [`status::IDLE`] (an agent's resting-state grey, one step brighter) so
 /// the two states read as "the same neutral family, one step apart" rather than inventing a third
 /// hex pair. Both are painted at reduced opacity (see `crate::root::scrollbar`) rather than full
 /// strength, matching the "overlay, not a solid rail" requirement.
@@ -1002,7 +1002,7 @@ pub mod band {
     pub const SURFACE_FOOTER: Pixels = px(28.0);
     pub const PTY_HEADER: Pixels = px(27.0);
     /// The terminal pane's info footer band (`pid` · grid dimensions · environment chip ·
-    /// right-aligned static copy) - distinct from [`SURFACE_FOOTER`] (the session-level
+    /// right-aligned static copy) - distinct from [`SURFACE_FOOTER`] (the agent-level
     /// Interrupt/Retry/Archive action footer, rendered separately below it).
     pub const PTY_INFO_FOOTER: Pixels = px(26.0);
     pub const BREADCRUMB: Pixels = px(26.0);
@@ -1061,10 +1061,10 @@ pub mod shadow {
 ///
 /// ## Which real surfaces read this
 ///
-/// Scaled: the session rail (`crate::rail::render`); the title bar/status bar
+/// Scaled: the agent rail (`crate::rail::render`); the title bar/status bar
 /// (`crate::status_bar::render`); the command palette's row labels/hints
 /// (`crate::palette::render`); the Files/Changes sidebar's row labels, footer hint, and
-/// tree caret (`crate::sidebar::render`); the file/session tab strip's tab labels
+/// tree caret (`crate::sidebar::render`); the file/agent tab strip's tab labels
 /// (`crate::work_surface::render`); and every Settings row's label/hint *and* control
 /// (stepper value, choice-segment labels, config banner text, snippet block text - all in
 /// `crate::settings::widgets`).
@@ -1074,7 +1074,7 @@ pub mod shadow {
 /// `Settings.appearance.terminal_font_size`) that a second multiplier would compound with;
 /// chips/badges/keycaps/close-tab glyphs app-wide are small, fixed-size shapes the design treats
 /// as part of a component rather than running text; and the rest of `crate::work_surface::render`'s own
-/// chrome (session context bar, toolbar buttons, `+` menu, footer action buttons) is real,
+/// chrome (agent context bar, toolbar buttons, `+` menu, footer action buttons) is real,
 /// currently out of scope.
 pub mod ui_scale {
     use super::px;

--- a/crates/app/src/title_bar/menu.rs
+++ b/crates/app/src/title_bar/menu.rs
@@ -1,4 +1,4 @@
-//! The Windows/Linux title bar's five real `File Edit View Session Help` dropdowns -
+//! The Windows/Linux title bar's five real `File Edit View Agent Help` dropdowns -
 //! which rows each one offers, and which already-existing real `AdeApp` method every row
 //! calls. Split out of [`super::render`] (the band's own chrome) because the two answer
 //! genuinely different questions: "what does the title bar look like" versus "what can I
@@ -10,7 +10,7 @@ use crate::root::focus::palette_focus_tests;
 use crate::root::widgets::render_menu_group_divider;
 use crate::work_surface::render::render_dropdown_menu_row;
 
-/// The Windows/Linux title bar's five real menu dropdowns (`File Edit View Session Help`) - see
+/// The Windows/Linux title bar's five real menu dropdowns (`File Edit View Agent Help`) - see
 /// [`Self::label`] for each one's real display text and [`render_title_menu`] for what each now
 /// genuinely opens. [`Self::index`] keeps this in lockstep with [`AdeApp::title_menu_button_bounds`],
 /// which is captured in [`Self::ALL`]'s own order.
@@ -22,7 +22,7 @@ use crate::work_surface::render::render_dropdown_menu_row;
 /// hover-only labels with no `cursor_pointer()`/`on_click()` - a deliberate choice over a
 /// dropdown that looked openable but showed nothing. Every row in every one of these five real
 /// dropdowns now calls a real, already-existing `AdeApp` method (the same ones the tab strip's
-/// `+` menu, the command palette, and the session footer already call) - never a placeholder row
+/// `+` menu, the command palette, and the agent footer already call) - never a placeholder row
 /// that only closes the menu.
 ///
 /// ## One source of truth, not two parallel arrays
@@ -36,7 +36,7 @@ pub(crate) enum TitleMenu {
     File,
     Edit,
     View,
-    Session,
+    Agent,
     Help,
 }
 
@@ -45,7 +45,7 @@ impl TitleMenu {
         TitleMenu::File,
         TitleMenu::Edit,
         TitleMenu::View,
-        TitleMenu::Session,
+        TitleMenu::Agent,
         TitleMenu::Help,
     ];
 
@@ -54,7 +54,7 @@ impl TitleMenu {
             TitleMenu::File => 0,
             TitleMenu::Edit => 1,
             TitleMenu::View => 2,
-            TitleMenu::Session => 3,
+            TitleMenu::Agent => 3,
             TitleMenu::Help => 4,
         }
     }
@@ -65,7 +65,7 @@ impl TitleMenu {
             TitleMenu::File => "File",
             TitleMenu::Edit => "Edit",
             TitleMenu::View => "View",
-            TitleMenu::Session => "Session",
+            TitleMenu::Agent => "Agent",
             TitleMenu::Help => "Help",
         }
     }
@@ -93,7 +93,7 @@ impl AdeApp {
     /// This menu is mouse-only - clicking a [`TitleMenu::label`] is the only way to open it, and
     /// there is no `gpui::KeyBinding` for it in `crate::default_key_bindings`. That's a
     /// deliberate scope decision: this project has repeatedly hit real, live-reproduced bugs
-    /// where a *global* keybinding stole a keystroke a focused terminal/agent session needed
+    /// where a *global* keybinding stole a keystroke a focused terminal/agent needed
     /// (`crate::default_key_bindings`'s own docs cover several it scoped away from this exact
     /// way - unscoped `"]"`, unscoped `secondary-z` - and one, `secondary-p`, it ultimately
     /// accepted stealing anyway as a deliberate, discussed tradeoff). A title-bar menu has no
@@ -113,7 +113,7 @@ impl AdeApp {
             TitleMenu::File => self.file_menu_rows(macos, cx),
             TitleMenu::Edit => self.edit_menu_rows(macos, cx),
             TitleMenu::View => self.view_menu_rows(cx),
-            TitleMenu::Session => self.session_menu_rows(macos, cx),
+            TitleMenu::Agent => self.agent_menu_rows(macos, cx),
             TitleMenu::Help => self.help_menu_rows(cx),
         };
 
@@ -430,30 +430,30 @@ impl AdeApp {
         rows
     }
 
-    /// The Session menu: spawn a terminal or agent pane (the same two real actions the `+`
-    /// menu's own top two rows call), cycle the active session tab
-    /// ([`crate::work_surface::render::AdeApp::select_relative_session`]), and the real,
-    /// per-active-session worktree-history actions - archive, "Keep all changes", and "Discard
+    /// The Agent menu: spawn a terminal or agent pane (the same two real actions the `+`
+    /// menu's own top two rows call), cycle the active agent tab
+    /// ([`crate::work_surface::render::AdeApp::select_relative_agent`]), and the real,
+    /// per-active-agent worktree-history actions - archive, "Keep all changes", and "Discard
     /// worktree". The last two reuse the exact same real methods
     /// ([`crate::worktree_history::flow::AdeApp::keep_all_changes`]/`request_discard_worktree`)
     /// and the same busy/two-click-confirm state
-    /// ([`AdeApp::worktree_history_op_in_flight`]/[`AdeApp::discard_confirm_armed`]) the session
+    /// ([`AdeApp::worktree_history_op_in_flight`]/[`AdeApp::discard_confirm_armed`]) the agent
     /// footer's own buttons already use - a first click on "Discard worktree" only arms
     /// confirmation and deliberately does **not** close the menu (so the row's own label can
     /// swap to "confirm discard?" for a real second click); every other row closes the menu on
     /// click, matching the `+` menu's own convention.
-    fn session_menu_rows(&self, macos: bool, cx: &mut Context<Self>) -> Vec<gpui::AnyElement> {
+    fn agent_menu_rows(&self, macos: bool, cx: &mut Context<Self>) -> Vec<gpui::AnyElement> {
         let resolved_kind = self.resolved_new_agent_kind();
         let (agent_fg, agent_bg) = work_surface::agent_tint(resolved_kind);
         let agent_initial = work_surface::agent_initial(resolved_kind);
         let agent_label = resolved_kind.label();
-        // Scoped to the *currently selected worktree*'s own sessions, matching
-        // `AdeApp::select_relative_session`'s own real cycling scope (see that method's docs) -
+        // Scoped to the *currently selected worktree*'s own agents, matching
+        // `AdeApp::select_relative_agent`'s own real cycling scope (see that method's docs) -
         // otherwise this row could show "enabled" while the real cycle it drives is a genuine
         // no-op (or worse, silently jumps to a different worktree) whenever other worktrees have
-        // sessions open but this one doesn't have a second one of its own.
-        let can_cycle = self.current_worktree_sessions().count() > 1;
-        let active_id = self.sessions.active_id();
+        // agents open but this one doesn't have a second one of its own.
+        let can_cycle = self.current_worktree_agents().count() > 1;
+        let active_id = self.agents.active_id();
 
         let mut rows = vec![
             render_dropdown_menu_row(
@@ -501,21 +501,21 @@ impl AdeApp {
                 if can_cycle {
                     row = row.on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
                         this.title_menu_open = None;
-                        this.select_relative_session($delta, window, cx);
+                        this.select_relative_agent($delta, window, cx);
                     }));
                 }
                 rows.push(row.into_any_element());
             }};
         }
-        cyclic_row!("\u{203a}", "Next Session", 1isize);
-        cyclic_row!("\u{2039}", "Previous Session", -1isize);
+        cyclic_row!("\u{203a}", "Next Agent", 1isize);
+        cyclic_row!("\u{2039}", "Previous Agent", -1isize);
         rows.push(Self::render_title_menu_divider());
 
         let mut archive_row = render_dropdown_menu_row(
             "A",
             theme::text::DIM.into(),
             theme::surface::CHIP_NEUTRAL.into(),
-            "Archive Session",
+            "Archive Agent",
             "close the active tab".to_string(),
             Vec::new(),
             active_id.is_some(),
@@ -524,7 +524,7 @@ impl AdeApp {
             archive_row =
                 archive_row.on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
                     this.title_menu_open = None;
-                    this.archive_session(id, window, cx);
+                    this.archive_agent(id, window, cx);
                 }));
         }
         rows.push(archive_row.into_any_element());
@@ -584,7 +584,7 @@ impl AdeApp {
                         // The first click only arms confirmation
                         // (`AdeApp::discard_confirm_armed`) - keep the menu open so this row's
                         // own label can swap to "confirm discard?" for a real second click,
-                        // mirroring the session footer's identical two-step button
+                        // mirroring the agent footer's identical two-step button
                         // (`crate::work_surface::render::AdeApp::render_footer_action_button`).
                         // Only the second click - which actually executes and clears the arm
                         // flag - closes the menu.
@@ -660,7 +660,7 @@ impl AdeApp {
     }
 }
 
-/// Real, interactive coverage for the five File/Edit/View/Session/Help dropdowns
+/// Real, interactive coverage for the five File/Edit/View/Agent/Help dropdowns
 /// ([`render_title_menu`]) - opening each via a genuine simulated click on its own painted label
 /// (not just flipping [`AdeApp::title_menu_open`] directly), and clicking a representative real
 /// row from each menu, asserting the real effect that row's own doc comment promises actually
@@ -916,10 +916,10 @@ mod title_menu_tests {
     }
 
     #[gpui::test]
-    fn clicking_the_session_label_opens_the_real_session_menu(cx: &mut TestAppContext) {
+    fn clicking_the_agent_label_opens_the_real_agent_menu(cx: &mut TestAppContext) {
         let (app, cx) = open_windows_variant(cx);
         let bounds = app.read_with(cx, |app, _| {
-            app.title_menu_button_bounds[TitleMenu::Session.index()]
+            app.title_menu_button_bounds[TitleMenu::Agent.index()]
         });
 
         cx.simulate_click(center_of(bounds), gpui::Modifiers::none());
@@ -927,24 +927,24 @@ mod title_menu_tests {
 
         assert_eq!(
             app.read_with(cx, |app, _| app.title_menu_open),
-            Some(TitleMenu::Session)
+            Some(TitleMenu::Agent)
         );
     }
 
-    /// The Session menu's first row ("New Terminal") really spawns a new real session tab (the
-    /// same real `Sessions::spawn` call the tab strip's own `+` menu row and `secondary-n` use),
-    /// not just a decoration - the session count genuinely increases.
+    /// The Agent menu's first row ("New Terminal") really spawns a new real agent tab (the
+    /// same real `Agents::spawn` call the tab strip's own `+` menu row and `secondary-n` use),
+    /// not just a decoration - the agent count genuinely increases.
     #[gpui::test]
-    fn session_menu_new_terminal_row_spawns_a_real_session(cx: &mut TestAppContext) {
+    fn agent_menu_new_terminal_row_spawns_a_real_agent(cx: &mut TestAppContext) {
         let (app, cx) = open_windows_variant(cx);
-        let sessions_before = app.read_with(cx, |app, _| app.sessions.iter().count());
+        let agents_before = app.read_with(cx, |app, _| app.agents.iter().count());
         app.update(cx, |app, cx| {
-            app.title_menu_open = Some(TitleMenu::Session);
+            app.title_menu_open = Some(TitleMenu::Agent);
             cx.notify();
         });
         cx.run_until_parked();
         let bounds = app.read_with(cx, |app, _| {
-            app.title_menu_button_bounds[TitleMenu::Session.index()]
+            app.title_menu_button_bounds[TitleMenu::Agent.index()]
         });
 
         cx.simulate_click(first_row_click_point(bounds), gpui::Modifiers::none());
@@ -952,9 +952,9 @@ mod title_menu_tests {
 
         app.read_with(cx, |app, _| {
             assert_eq!(
-                app.sessions.iter().count(),
-                sessions_before + 1,
-                "the real New Terminal row should have spawned one real new session"
+                app.agents.iter().count(),
+                agents_before + 1,
+                "the real New Terminal row should have spawned one real new agent"
             );
             assert_eq!(app.title_menu_open, None);
         });
@@ -1021,7 +1021,7 @@ mod title_menu_tests {
         );
     }
 
-    /// The Session menu's "Discard worktree" row's real two-step confirm - mirrors the session
+    /// The Agent menu's "Discard worktree" row's real two-step confirm - mirrors the agent
     /// footer's own identical two-click button
     /// (`crate::work_surface::render::AdeApp::render_footer_action_button`), reusing the
     /// exact same real [`AdeApp::request_discard_worktree`]/[`AdeApp::discard_confirm_armed`]
@@ -1030,7 +1030,7 @@ mod title_menu_tests {
     /// unconditionally refuses on the main worktree), so this sets one up the same way
     /// `crate::worktree_history::flow::worktree_history_regression_tests::add_worktree` does.
     #[gpui::test]
-    fn session_menu_discard_row_arms_then_executes_a_real_discard(cx: &mut TestAppContext) {
+    fn agent_menu_discard_row_arms_then_executes_a_real_discard(cx: &mut TestAppContext) {
         use std::process::Command;
 
         fn git(dir: &std::path::Path, args: &[&str]) {
@@ -1070,8 +1070,8 @@ mod title_menu_tests {
             app.set_window_controls_style(WindowControlsStyle::WindowsLinuxStyle, cx);
         });
         let id = app.update_in(cx, |app, window, cx| {
-            app.sessions.spawn(
-                SessionKind::Shell,
+            app.agents.spawn(
+                AgentKind::Shell,
                 worktree_path.clone(),
                 app.settings.appearance.terminal_font_size,
                 window,
@@ -1079,11 +1079,11 @@ mod title_menu_tests {
             )
         });
         app.update_in(cx, |app, window, cx| {
-            app.select_session(id, window, cx);
+            app.select_agent(id, window, cx);
         });
         cx.run_until_parked();
 
-        // Session>Discard worktree is the last row - two dividers and three earlier rows above
+        // Agent>Discard worktree is the last row - two dividers and three earlier rows above
         // it, so this drives the real handler directly (`request_discard_worktree`) rather than
         // computing that row's exact pixel offset. What's under real test here is the *result*
         // of two real calls through the exact same real method the row's `on_click` calls - the
@@ -1128,7 +1128,7 @@ mod title_menu_tests {
     /// never actually catch a bug in the real rendered row's own click wiring (e.g. a wrong
     /// bounds computation, or the row silently missing its `on_click` entirely).
     #[gpui::test]
-    fn session_menu_discard_row_stays_open_while_armed_and_closes_once_confirmed(
+    fn agent_menu_discard_row_stays_open_while_armed_and_closes_once_confirmed(
         cx: &mut TestAppContext,
     ) {
         use std::process::Command;
@@ -1170,8 +1170,8 @@ mod title_menu_tests {
             app.set_window_controls_style(WindowControlsStyle::WindowsLinuxStyle, cx);
         });
         let id = app.update_in(cx, |app, window, cx| {
-            app.sessions.spawn(
-                SessionKind::Shell,
+            app.agents.spawn(
+                AgentKind::Shell,
                 worktree_path.clone(),
                 app.settings.appearance.terminal_font_size,
                 window,
@@ -1179,21 +1179,21 @@ mod title_menu_tests {
             )
         });
         app.update_in(cx, |app, window, cx| {
-            app.select_session(id, window, cx);
+            app.select_agent(id, window, cx);
         });
         cx.run_until_parked();
         app.update(cx, |app, cx| {
-            app.title_menu_open = Some(TitleMenu::Session);
+            app.title_menu_open = Some(TitleMenu::Agent);
             cx.notify();
         });
         cx.run_until_parked();
 
-        // The Discard row is the 7th real row (index 6, 0-based) in the Session menu: New
-        // Terminal, New Agent Pane, [divider], Next Session, Previous Session, [divider],
-        // Archive Session, Keep All Changes, Discard Worktree - six real rows and two dividers
-        // sit above it (see `AdeApp::session_menu_rows`'s own row order).
+        // The Discard row is the 7th real row (index 6, 0-based) in the Agent menu: New
+        // Terminal, New Agent Pane, [divider], Next Agent, Previous Agent, [divider],
+        // Archive Agent, Keep All Changes, Discard Worktree - six real rows and two dividers
+        // sit above it (see `AdeApp::agent_menu_rows`'s own row order).
         let bounds = app.read_with(cx, |app, _| {
-            app.title_menu_button_bounds[TitleMenu::Session.index()]
+            app.title_menu_button_bounds[TitleMenu::Agent.index()]
         });
         let discard_row_point = nth_row_click_point(bounds, 6, 2);
 
@@ -1207,7 +1207,7 @@ mod title_menu_tests {
         );
         assert_eq!(
             app.read_with(cx, |app, _| app.title_menu_open),
-            Some(TitleMenu::Session),
+            Some(TitleMenu::Agent),
             "an arming first click must leave the menu open"
         );
         assert!(
@@ -1236,27 +1236,25 @@ mod title_menu_tests {
         );
     }
 
-    /// [`crate::work_surface::render::AdeApp::select_relative_session`] (the Session menu's
-    /// "Next Session"/"Previous Session" rows) - real coverage of the cyclic-index logic itself:
-    /// cycling forward through three real sessions wraps back to the first, and cycling backward
-    /// from the first wraps to the last, via the same real [`AdeApp::select_session`] every
+    /// [`crate::work_surface::render::AdeApp::select_relative_agent`] (the Agent menu's
+    /// "Next Agent"/"Previous Agent" rows) - real coverage of the cyclic-index logic itself:
+    /// cycling forward through three real agents wraps back to the first, and cycling backward
+    /// from the first wraps to the last, via the same real [`AdeApp::select_agent`] every
     /// tab-strip click already goes through.
     ///
     /// Also real, live-reproduced coverage for this revision's own self-audit finding: an
-    /// earlier version of `select_relative_session` cycled the flat `self.sessions` list
-    /// directly rather than [`AdeApp::current_worktree_sessions`], so "Next Session" could jump
-    /// to a *different* worktree's session entirely - which `AdeApp::select_session` then
+    /// earlier version of `select_relative_agent` cycled the flat `self.agents` list
+    /// directly rather than [`AdeApp::current_worktree_agents`], so "Next Agent" could jump
+    /// to a *different* worktree's agent entirely - which `AdeApp::select_agent` then
     /// silently promotes into a full `AdeApp::select_worktree` switch, discarding any unsaved
-    /// `edit_buffers` content for the worktree just left. Spawning every test session into the
+    /// `edit_buffers` content for the worktree just left. Spawning every test agent into the
     /// *same* worktree (as an earlier version of this test did) can't distinguish that bug from
-    /// correct behaviour at all - this seeds a **second** worktree with its own session
+    /// correct behaviour at all - this seeds a **second** worktree with its own agent
     /// alongside the three under test, and asserts cycling never leaves the first worktree
     /// (`AdeApp::selected` stays put) and never clears a real unsaved edit sitting in
     /// `AdeApp::edit_buffers`.
     #[gpui::test]
-    fn select_relative_session_cycles_through_real_sessions_and_wraps_around(
-        cx: &mut TestAppContext,
-    ) {
+    fn select_relative_agent_cycles_through_real_agents_and_wraps_around(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
         let other_wt = tempfile::tempdir().expect("tempdir b");
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
@@ -1297,38 +1295,38 @@ mod title_menu_tests {
             app.select_worktree(0, window, cx);
         });
 
-        // `open_test_app` already spawns one real shell session in the first worktree; add two
-        // more real sessions there so there are three to cycle through.
+        // `open_test_app` already spawns one real shell agent in the first worktree; add two
+        // more real agents there so there are three to cycle through.
         app.update_in(cx, |app, window, cx| {
-            app.sessions.spawn(
-                SessionKind::Shell,
+            app.agents.spawn(
+                AgentKind::Shell,
                 repo.path().to_path_buf(),
                 app.settings.appearance.terminal_font_size,
                 window,
                 cx,
             );
-            app.sessions.spawn(
-                SessionKind::Shell,
+            app.agents.spawn(
+                AgentKind::Shell,
                 repo.path().to_path_buf(),
                 app.settings.appearance.terminal_font_size,
                 window,
                 cx,
             );
         });
-        // The second worktree's own session - real coverage that cycling stays scoped to the
+        // The second worktree's own agent - real coverage that cycling stays scoped to the
         // selected worktree rather than this flat list.
         app.update_in(cx, |app, window, cx| {
-            app.sessions.spawn(
-                SessionKind::Shell,
+            app.agents.spawn(
+                AgentKind::Shell,
                 other_wt.path().to_path_buf(),
                 app.settings.appearance.terminal_font_size,
                 window,
                 cx,
             );
         });
-        // Spawning into the second worktree above made its own session globally active - re-
+        // Spawning into the second worktree above made its own agent globally active - re-
         // select the first worktree to restore it as the one under test (its own last-active tab
-        // via `Sessions::activate_for_worktree`).
+        // via `Agents::activate_for_worktree`).
         app.update_in(cx, |app, window, cx| {
             app.select_worktree(0, window, cx);
         });
@@ -1351,27 +1349,27 @@ mod title_menu_tests {
             );
         });
 
-        let ids: Vec<SessionId> = app.read_with(cx, |app, _| {
-            app.current_worktree_sessions().map(|s| s.id).collect()
+        let ids: Vec<AgentId> = app.read_with(cx, |app, _| {
+            app.current_worktree_agents().map(|s| s.id).collect()
         });
         assert_eq!(
             ids.len(),
             3,
-            "should have three real sessions in the first worktree to cycle through"
+            "should have three real agents in the first worktree to cycle through"
         );
         assert_eq!(
-            app.read_with(cx, |app, _| app.sessions.active_id()),
+            app.read_with(cx, |app, _| app.agents.active_id()),
             Some(ids[2]),
             "re-selecting the first worktree should restore its own last-active tab"
         );
 
         app.update_in(cx, |app, window, cx| {
-            app.select_relative_session(1, window, cx);
+            app.select_relative_agent(1, window, cx);
         });
         assert_eq!(
-            app.read_with(cx, |app, _| app.sessions.active_id()),
+            app.read_with(cx, |app, _| app.agents.active_id()),
             Some(ids[0]),
-            "cycling forward from the last real session should wrap around to the first"
+            "cycling forward from the last real agent should wrap around to the first"
         );
         assert_eq!(
             app.read_with(cx, |app, _| app.selected),
@@ -1380,12 +1378,12 @@ mod title_menu_tests {
         );
 
         app.update_in(cx, |app, window, cx| {
-            app.select_relative_session(-1, window, cx);
+            app.select_relative_agent(-1, window, cx);
         });
         assert_eq!(
-            app.read_with(cx, |app, _| app.sessions.active_id()),
+            app.read_with(cx, |app, _| app.agents.active_id()),
             Some(ids[2]),
-            "cycling backward from the first real session should wrap around to the last"
+            "cycling backward from the first real agent should wrap around to the last"
         );
         assert_eq!(
             app.read_with(cx, |app, _| app.selected),

--- a/crates/app/src/title_bar/mod.rs
+++ b/crates/app/src/title_bar/mod.rs
@@ -6,7 +6,7 @@
 //!
 //! - [`render`] - the band itself: the macOS traffic-light cluster, the Windows/Linux
 //!   caption buttons, and the left/right cluster composition.
-//! - [`menu`] - the Windows/Linux `File Edit View Session Help` dropdowns: which rows each
+//! - [`menu`] - the Windows/Linux `File Edit View Agent Help` dropdowns: which rows each
 //!   one offers and what real `AdeApp` method each row calls.
 //!
 //! Both glob-import this module (`use super::*`), which is why the shared imports they need
@@ -27,7 +27,7 @@ use crate::settings::state as settings;
 use crate::theme;
 use crate::title_bar::menu::TitleMenu;
 #[cfg(test)]
-use crate::work_surface::sessions::{SessionId, SessionKind};
+use crate::work_surface::agents::{AgentId, AgentKind};
 use crate::work_surface::state as work_surface;
 use crate::worktree_history::flow as worktree_history;
 #[cfg(test)]

--- a/crates/app/src/title_bar/render.rs
+++ b/crates/app/src/title_bar/render.rs
@@ -1,6 +1,6 @@
 //! The title-bar band itself: the macOS traffic-light cluster, the Windows/Linux caption
 //! buttons (minimise/maximise/close), and the left/right cluster composition around them.
-//! The five `File Edit View Session Help` dropdowns those labels open live in
+//! The five `File Edit View Agent Help` dropdowns those labels open live in
 //! [`super::menu`].
 
 use super::*;

--- a/crates/app/src/work_surface/agents.rs
+++ b/crates/app/src/work_surface/agents.rs
@@ -1,15 +1,15 @@
-//! Session/tab bookkeeping: ties a spawned terminal process (a [`TerminalPane`]) to the
-//! worktree it's running in, and tracks which sessions are open and which one is active for
+//! Agent/tab bookkeeping: ties a spawned terminal process (a [`TerminalPane`]) to the
+//! worktree it's running in, and tracks which agents are open and which one is active for
 //! the tabbed center pane. `TerminalPane` itself has no notion of tabs or of "which
 //! worktree" - see its module docs - this is that one layer up.
 //!
 //! ## Per-worktree tab scoping
 //!
-//! Every session belongs to exactly one worktree (its [`Session::cwd`]), and the centre pane's
-//! tab strip (`crate::root::AdeApp::render_tab_strip`) only ever shows the sessions belonging to
-//! whichever worktree is currently selected - so [`Self::active`] doubles as "which session is
-//! shown in the centre pane" *and* must always name a session in the currently selected
-//! worktree (or be `None`, if that worktree has no open session at all). [`Self::active_by_cwd`]
+//! Every agent belongs to exactly one worktree (its [`Agent::cwd`]), and the centre pane's
+//! tab strip (`crate::root::AdeApp::render_tab_strip`) only ever shows the agents belonging to
+//! whichever worktree is currently selected - so [`Self::active`] doubles as "which agent is
+//! shown in the centre pane" *and* must always name an agent in the currently selected
+//! worktree (or be `None`, if that worktree has no open agent at all). [`Self::active_by_cwd`]
 //! is the second half of that invariant: a per-worktree "last active tab" memory, so switching
 //! back and forth between two worktrees each restores whichever tab you were last looking at in
 //! each, rather than always landing on the first one. [`Self::activate_for_worktree`] is the one
@@ -24,26 +24,26 @@ use gpui::{App, AppContext as _, Context, Entity, Focusable as _, Subscription, 
 use crate::root::AdeApp;
 use crate::terminal::pane::{TerminalPane, TerminalPaneEvent, TerminalSpec};
 
-/// What kind of process a session runs. Purely descriptive - drives the tab label and which
-/// "New ... Session" button created it; `TerminalPane` itself has no branching for
+/// What kind of process an agent runs. Purely descriptive - drives the tab label and which
+/// "New ... Agent" button created it; `TerminalPane` itself has no branching for
 /// "shell" vs. "agent CLI".
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SessionKind {
+pub enum AgentKind {
     Shell,
     /// The `claude` CLI (Claude Code), spawned with no arguments in the chosen worktree.
     /// Resolved via `PATH`; if not installed, spawning fails and the pane shows
     /// `TerminalPane::spawn_error`.
     Claude,
-    /// The `codex` CLI, spawned the same way as [`SessionKind::Claude`].
+    /// The `codex` CLI, spawned the same way as [`AgentKind::Claude`].
     Codex,
 }
 
-impl SessionKind {
+impl AgentKind {
     pub fn label(self) -> &'static str {
         match self {
-            SessionKind::Shell => "Shell",
-            SessionKind::Claude => "Claude",
-            SessionKind::Codex => "Codex",
+            AgentKind::Shell => "Shell",
+            AgentKind::Claude => "Claude",
+            AgentKind::Codex => "Codex",
         }
     }
 
@@ -56,7 +56,7 @@ impl SessionKind {
         }
     }
 
-    /// The literal command name this kind spawns as - `None` for [`SessionKind::Shell`],
+    /// The literal command name this kind spawns as - `None` for [`AgentKind::Shell`],
     /// which resolves `$SHELL` rather than a fixed binary name.
     ///
     /// Public so `crate::settings::state`'s Agents page can look up the same `$PATH` name this
@@ -64,53 +64,53 @@ impl SessionKind {
     /// list that could drift from what's actually spawned.
     pub fn agent_binary_name(self) -> Option<&'static str> {
         match self {
-            SessionKind::Shell => None,
-            SessionKind::Claude => Some("claude"),
-            SessionKind::Codex => Some("codex"),
+            AgentKind::Shell => None,
+            AgentKind::Claude => Some("claude"),
+            AgentKind::Codex => Some("codex"),
         }
     }
 }
 
-/// A monotonically increasing session id, stable across other sessions closing - used
+/// A monotonically increasing agent id, stable across other agents closing - used
 /// instead of a `Vec` index so a click handler capturing an id can't end up referring to the
 /// wrong tab once some other tab closes and later indices shift down.
-pub type SessionId = u64;
+pub type AgentId = u64;
 
-pub struct Session {
-    pub id: SessionId,
-    pub kind: SessionKind,
-    /// The worktree (or repo root) this session's process was started in. Kept for the tab
+pub struct Agent {
+    pub id: AgentId,
+    pub kind: AgentKind,
+    /// The worktree (or repo root) this agent's process was started in. Kept for the tab
     /// label/title; `TerminalPane` doesn't expose its own `cwd` back out.
     pub cwd: PathBuf,
     pub pane: Entity<TerminalPane>,
-    /// When this session was spawned - the rail agent row's real elapsed-time trailing text
+    /// When this agent was spawned - the rail agent row's real elapsed-time trailing text
     /// (`design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §2.3: "elapsed 9.5px mono
     /// right"). Set once, here, and never mutated afterwards - this app has no
     /// pause/resume-with-a-fresh-clock concept (see `crate::work_surface::state::pty_state_label`'s
     /// docs), so "elapsed" is simply wall-clock time since this real process was spawned.
     pub spawned_at: Instant,
-    /// Keeps [`Sessions::spawn`]'s link-click-opens-a-file subscription (see
-    /// [`TerminalPaneEvent`]) alive for this session's lifetime - never read, only held.
+    /// Keeps [`Agents::spawn`]'s link-click-opens-a-file subscription (see
+    /// [`TerminalPaneEvent`]) alive for this agent's lifetime - never read, only held.
     _link_subscription: Subscription,
 }
 
-/// Owns every open session/tab and which one is active.
-pub struct Sessions {
-    sessions: Vec<Session>,
-    active: Option<SessionId>,
-    /// The last-active session id for each worktree that has (or has ever had) one - see the
+/// Owns every open agent/tab and which one is active.
+pub struct Agents {
+    agents: Vec<Agent>,
+    active: Option<AgentId>,
+    /// The last-active agent id for each worktree that has (or has ever had) one - see the
     /// module docs' "Per-worktree tab scoping" section. An entry is removed once its worktree
-    /// has no open sessions left (see [`Self::close`]), rather than left pointing at a closed
+    /// has no open agents left (see [`Self::close`]), rather than left pointing at a closed
     /// id, so [`Self::activate_for_worktree`] can tell "never visited"/"visited but now empty"
     /// apart from "has a real tab to restore" by nothing more than `HashMap::get`.
-    active_by_cwd: HashMap<PathBuf, SessionId>,
-    next_id: SessionId,
+    active_by_cwd: HashMap<PathBuf, AgentId>,
+    next_id: AgentId,
 }
 
-impl Sessions {
+impl Agents {
     pub fn new() -> Self {
         Self {
-            sessions: Vec::new(),
+            agents: Vec::new(),
             active: None,
             active_by_cwd: HashMap::new(),
             next_id: 0,
@@ -118,58 +118,56 @@ impl Sessions {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.sessions.is_empty()
+        self.agents.is_empty()
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = &Session> {
-        self.sessions.iter()
+    pub fn iter(&self) -> impl Iterator<Item = &Agent> {
+        self.agents.iter()
     }
 
-    /// Every currently open session whose [`Session::cwd`] is exactly `cwd` - the tab strip's
-    /// real per-worktree filter (`crate::root::AdeApp::current_worktree_sessions`), in the same
+    /// Every currently open agent whose [`Agent::cwd`] is exactly `cwd` - the tab strip's
+    /// real per-worktree filter (`crate::root::AdeApp::current_worktree_agents`), in the same
     /// stable creation order [`Self::iter`] itself returns. Takes `cwd` by value (rather than
     /// borrowing it) so the returned iterator doesn't need to borrow a caller-local `PathBuf` for
     /// as long as `self` - it owns its own copy instead, closed over by the filter closure.
-    pub fn iter_for_cwd(&self, cwd: PathBuf) -> impl Iterator<Item = &Session> {
-        self.sessions
-            .iter()
-            .filter(move |session| session.cwd == cwd)
+    pub fn iter_for_cwd(&self, cwd: PathBuf) -> impl Iterator<Item = &Agent> {
+        self.agents.iter().filter(move |agent| agent.cwd == cwd)
     }
 
-    pub fn active_id(&self) -> Option<SessionId> {
+    pub fn active_id(&self) -> Option<AgentId> {
         self.active
     }
 
-    pub fn active(&self) -> Option<&Session> {
+    pub fn active(&self) -> Option<&Agent> {
         let id = self.active?;
-        self.sessions.iter().find(|session| session.id == id)
+        self.agents.iter().find(|agent| agent.id == id)
     }
 
-    /// Spawns a new session of `kind` into `cwd` (the caller resolves this - see
-    /// `crate::root::AdeApp::active_session_cwd`), appends it as a new tab, and makes it
+    /// Spawns a new agent of `kind` into `cwd` (the caller resolves this - see
+    /// `crate::root::AdeApp::active_agent_cwd`), appends it as a new tab, and makes it
     /// active (both globally, [`Self::active`], and as `cwd`'s own remembered tab,
-    /// [`Self::active_by_cwd`]). Returns the new session's id.
+    /// [`Self::active_by_cwd`]). Returns the new agent's id.
     ///
     /// Deliberately does not move keyboard focus itself: only the caller
     /// (`crate::root::AdeApp`) knows whether a file tab is currently occupying the centre
-    /// pane, and focusing a session's pane while a file tab is showing points
+    /// pane, and focusing an agent's pane while a file tab is showing points
     /// `Window::focus` at a node nothing in the rendered tree tracks. Every real call site
-    /// guards this via `crate::root::AdeApp::focus_newly_spawned_session`, whose own docs
+    /// guards this via `crate::root::AdeApp::focus_newly_spawned_agent`, whose own docs
     /// cover the bug this avoids.
     ///
     /// Subscribes to the new pane's [`TerminalPaneEvent`]s so a click on a detected
-    /// path/`path:line` link in this session's terminal output opens it as a file tab
+    /// path/`path:line` link in this agent's terminal output opens it as a file tab
     /// (`crate::root::AdeApp::open_terminal_link`). `terminal_font_size_px` is read fresh
     /// from live settings by every call site, so a freshly spawned pane never starts out
     /// mismatched from what Settings › Appearance shows.
     pub fn spawn(
         &mut self,
-        kind: SessionKind,
+        kind: AgentKind,
         cwd: PathBuf,
         terminal_font_size_px: f32,
         window: &mut Window,
         cx: &mut Context<AdeApp>,
-    ) -> SessionId {
+    ) -> AgentId {
         let id = self.next_id;
         self.next_id += 1;
 
@@ -181,7 +179,7 @@ impl Sessions {
                 app.open_terminal_link(path.clone(), *line, window, cx);
             });
 
-        self.sessions.push(Session {
+        self.agents.push(Agent {
             id,
             kind,
             cwd: cwd.clone(),
@@ -196,70 +194,70 @@ impl Sessions {
     }
 
     /// Re-derives every open pane's poll cadence from [`Self::active`]: exactly the active
-    /// session's pane is foreground (`TerminalPane::set_foreground`), every other pane is
-    /// background. Called at the end of **every** mutator that can change which session is
+    /// agent's pane is foreground (`TerminalPane::set_foreground`), every other pane is
+    /// background. Called at the end of **every** mutator that can change which agent is
     /// active ([`Self::spawn`], [`Self::set_active`], [`Self::activate_for_worktree`],
     /// [`Self::close`]) - a full re-derivation over all panes rather than a delta update at
     /// each site, so no future mutator can leave a pane's cadence stale by forgetting the
     /// "demote the old one" half (this codebase's recurring stale-state bug class; a pane
     /// wrongly left background would lag visibly, one wrongly left foreground would quietly
     /// re-grow the multi-pane drain cost this flag exists to bound). Cheap enough for that:
-    /// one flag write per open session.
+    /// one flag write per open agent.
     fn sync_pane_cadence(&self, cx: &mut Context<AdeApp>) {
-        for session in &self.sessions {
-            let foreground = Some(session.id) == self.active;
-            session
+        for agent in &self.agents {
+            let foreground = Some(agent.id) == self.active;
+            agent
                 .pane
                 .update(cx, |pane, _| pane.set_foreground(foreground));
         }
     }
 
     /// Applies a Settings › Appearance "Terminal font size" edit to every currently open
-    /// session's pane, not just newly spawned ones. `TerminalPane::set_font_size` is a no-op
+    /// agent's pane, not just newly spawned ones. `TerminalPane::set_font_size` is a no-op
     /// for a pane already at that size, so calling this on every edit is cheap.
     pub fn set_terminal_font_size(&mut self, font_size_px: f32, cx: &mut Context<AdeApp>) {
-        for session in &self.sessions {
-            session
+        for agent in &self.agents {
+            agent
                 .pane
                 .update(cx, |pane, cx| pane.set_font_size(font_size_px, cx));
         }
     }
 
-    /// Makes `id` the globally active session, and remembers it as its own worktree's active
-    /// tab too - a no-op if `id` doesn't name a currently open session. Takes `cx` (unlike a
-    /// plain setter) because the active session is what drives every pane's poll cadence -
+    /// Makes `id` the globally active agent, and remembers it as its own worktree's active
+    /// tab too - a no-op if `id` doesn't name a currently open agent. Takes `cx` (unlike a
+    /// plain setter) because the active agent is what drives every pane's poll cadence -
     /// see [`Self::sync_pane_cadence`].
-    pub fn set_active(&mut self, id: SessionId, cx: &mut Context<AdeApp>) {
-        if let Some(session) = self.sessions.iter().find(|session| session.id == id) {
+    pub fn set_active(&mut self, id: AgentId, cx: &mut Context<AdeApp>) {
+        if let Some(agent) = self.agents.iter().find(|agent| agent.id == id) {
             self.active = Some(id);
-            self.active_by_cwd.insert(session.cwd.clone(), id);
+            self.active_by_cwd.insert(agent.cwd.clone(), id);
             self.sync_pane_cadence(cx);
         }
     }
 
     /// Makes `cwd`'s own last-active tab (see [`Self::active_by_cwd`]) the globally active
-    /// session - or, if `cwd` has never had one recorded (a worktree just visited for the
-    /// first time this window), its first open session in creation order. `None` if `cwd`
-    /// currently has no open sessions at all.
+    /// agent - or, if `cwd` has never had one recorded (a worktree just visited for the
+    /// first time this window), its first open agent in creation order. `None` if `cwd`
+    /// currently has no open agents at all.
     ///
     /// This is the real fix for the bug this revision exists to close: before it,
     /// [`Self::active`] was a single value entirely independent of which worktree was
     /// selected in the rail, so switching worktrees could leave the centre pane showing a
     /// completely different worktree's terminal. `crate::root::AdeApp::select_worktree` calls
     /// this on every switch - see that method's own docs for why it must also move real
-    /// keyboard focus in the same step (the previously-active session's pane may no longer be
+    /// keyboard focus in the same step (the previously-active agent's pane may no longer be
     /// rendered at all once the tab strip's own per-worktree filter applies).
     pub fn activate_for_worktree(&mut self, cwd: &Path, cx: &mut Context<AdeApp>) {
         let remembered = self
             .active_by_cwd
             .get(cwd)
             .copied()
-            .filter(|id| self.sessions.iter().any(|session| session.id == *id));
+            .filter(|id| self.agents.iter().any(|agent| agent.id == *id));
         let id = remembered.or_else(|| {
-            self.sessions
+            self.agents
                 .iter()
-                .find(|session| session.cwd == cwd)
-                .map(|session| session.id)
+                .find(|agent| agent.cwd == cwd)
+                .map(|agent| agent.id)
         });
         self.active = id;
         if let Some(id) = id {
@@ -268,12 +266,12 @@ impl Sessions {
         self.sync_pane_cadence(cx);
     }
 
-    /// Moves keyboard focus onto the currently active session's terminal pane, if there is
+    /// Moves keyboard focus onto the currently active agent's terminal pane, if there is
     /// one - a no-op when [`Self::active`] is `None`. See [`Self::spawn`]'s docs for why
     /// callers, not this method, decide whether it's safe to call.
     pub fn focus_active(&self, window: &mut Window, cx: &mut App) {
-        if let Some(session) = self.active() {
-            window.focus(&session.pane.focus_handle(cx), cx);
+        if let Some(agent) = self.active() {
+            window.focus(&agent.pane.focus_handle(cx), cx);
         }
     }
 
@@ -281,54 +279,54 @@ impl Sessions {
     /// the `Entity<TerminalPane>`, so closing a tab never just hides it while its process
     /// leaks.
     ///
-    /// The fallback for what becomes active next is scoped to the closed session's *own
+    /// The fallback for what becomes active next is scoped to the closed agent's *own
     /// worktree*, never a same-`Vec`-neighbor from a different one (pre-redesign, every
-    /// session shared one flat tab strip, so any neighbor was a reasonable fallback; now that
+    /// agent shared one flat tab strip, so any neighbor was a reasonable fallback; now that
     /// the tab strip is per-worktree, falling back across worktrees would silently switch the
     /// centre pane to an unrelated worktree's terminal): the sibling that was immediately to
     /// the closed tab's right (in creation order, within the same `cwd`), falling back to its
     /// left, falling back to `None` if this was the worktree's last open tab - in which case
-    /// its rail row simply reverts to the same "no active session" state a worktree the user
+    /// its rail row simply reverts to the same "no active agent" state a worktree the user
     /// hasn't started anything in already shows (see `crate::rail::state::WorktreeRow`'s own docs);
-    /// deliberately not auto-respawning a fresh shell, since a session-less worktree is already
+    /// deliberately not auto-respawning a fresh shell, since an agent-less worktree is already
     /// a normal, existing state this app models everywhere else.
     ///
-    /// Only moves focus (via [`Self::focus_active`]) when the closed session was the *globally*
+    /// Only moves focus (via [`Self::focus_active`]) when the closed agent was the *globally*
     /// active one - closing a background tab in a worktree that isn't currently selected must
-    /// never steal focus - unless `skip_focus_move` says the centre pane isn't showing a
-    /// session's pane right now anyway (a file tab occupies it, or the whole workspace body is
-    /// currently swapped out for Settings) - the caller, `crate::root::AdeApp::close_session`,
+    /// never steal focus - unless `skip_focus_move` says the centre pane isn't showing an
+    /// agent's pane right now anyway (a file tab occupies it, or the whole workspace body is
+    /// currently swapped out for Settings) - the caller, `crate::root::AdeApp::close_agent`,
     /// computes that from `AdeApp::open_change`/`AdeApp::settings_open` - see [`Self::spawn`]'s
     /// docs for why this can't be decided here.
     pub fn close(
         &mut self,
-        id: SessionId,
+        id: AgentId,
         skip_focus_move: bool,
         window: &mut Window,
         cx: &mut Context<AdeApp>,
     ) {
-        let Some(index) = self.sessions.iter().position(|session| session.id == id) else {
+        let Some(index) = self.agents.iter().position(|agent| agent.id == id) else {
             return;
         };
-        let cwd = self.sessions[index].cwd.clone();
+        let cwd = self.agents[index].cwd.clone();
 
-        self.sessions[index]
+        self.agents[index]
             .pane
             .update(cx, |pane, cx| pane.shutdown(cx));
-        self.sessions.remove(index);
+        self.agents.remove(index);
 
         let sibling_indices: Vec<usize> = self
-            .sessions
+            .agents
             .iter()
             .enumerate()
-            .filter(|(_, session)| session.cwd == cwd)
+            .filter(|(_, agent)| agent.cwd == cwd)
             .map(|(sibling_index, _)| sibling_index)
             .collect();
         let new_cwd_active = sibling_indices
             .iter()
             .find(|&&sibling_index| sibling_index >= index)
             .or_else(|| sibling_indices.last())
-            .map(|&sibling_index| self.sessions[sibling_index].id);
+            .map(|&sibling_index| self.agents[sibling_index].id);
 
         if self.active_by_cwd.get(&cwd) == Some(&id) {
             match new_cwd_active {
@@ -351,7 +349,7 @@ impl Sessions {
     }
 }
 
-impl Default for Sessions {
+impl Default for Agents {
     fn default() -> Self {
         Self::new()
     }
@@ -361,18 +359,18 @@ impl Default for Sessions {
 mod tests {
     use super::*;
 
-    /// `close`/`activate_for_worktree` both need a real `Session` (a real `Entity<TerminalPane>`,
-    /// only buildable via `Sessions::spawn` inside a real GPUI window) to exercise meaningfully,
+    /// `close`/`activate_for_worktree` both need a real `Agent` (a real `Entity<TerminalPane>`,
+    /// only buildable via `Agents::spawn` inside a real GPUI window) to exercise meaningfully,
     /// so that coverage lives in `work_surface::render`'s GPUI-test module (`tab_scoping_tests`)
     /// instead, alongside the rest of this revision's worktree/tab scoping coverage (and the
     /// combined tab-order drag-to-reorder coverage - see `work_surface::state`'s own
     /// `reconcile_tab_order`/`move_tab_order` for the tab strip's real ordering layer, which
-    /// tracks position on top of `Sessions` rather than inside it). This module only holds the
+    /// tracks position on top of `Agents` rather than inside it). This module only holds the
     /// plain, GPUI-free checks that don't need a real pane at all.
     #[test]
-    fn a_fresh_sessions_collection_has_no_active_session() {
-        let sessions = Sessions::new();
-        assert_eq!(sessions.active_id(), None);
-        assert!(sessions.is_empty());
+    fn a_fresh_agents_collection_has_no_active_agent() {
+        let agents = Agents::new();
+        assert_eq!(agents.active_id(), None);
+        assert!(agents.is_empty());
     }
 }

--- a/crates/app/src/work_surface/mod.rs
+++ b/crates/app/src/work_surface/mod.rs
@@ -3,11 +3,11 @@
 //! Split the way every feature folder in this crate is split - pure, GPUI-window-free
 //! logic separate from the `gpui::Div`-building code that draws it:
 //!
-//! - [`state`] - the pure mapping from already-known facts (a `SessionKind`, a `Status`, a
+//! - [`state`] - the pure mapping from already-known facts (an `AgentKind`, a `Status`, a
 //!   bool) onto which colours/labels/actions a Zone 2 element shows. No `gpui::Window`.
-//! - [`sessions`] - session/tab bookkeeping: which sessions are open, which worktree each
+//! - [`agents`] - agent/tab bookkeeping: which agents are open, which worktree each
 //!   belongs to, and which one is active for the centre pane.
-//! - [`render`] - the real GPUI tab strip, session context bar, terminal pane
+//! - [`render`] - the real GPUI tab strip, agent context bar, terminal pane
 //!   header/footer and centre-pane composition, as `impl AdeApp` methods.
 //!
 //! `render` glob-imports this module (`use super::*`), which is why the shared imports it
@@ -24,13 +24,13 @@ use crate::root::*;
 use crate::settings::state as settings;
 use crate::sidebar::file_tree::{self};
 use crate::theme;
-use crate::work_surface::sessions::{Session, SessionId, SessionKind};
+use crate::work_surface::agents::{Agent, AgentId, AgentKind};
 use crate::work_surface::state as work_surface;
 use crate::worktree_history::flow as worktree_history;
 use gpui::{div, font, prelude::*, px, App, BoxShadow, ClickEvent, Context, Window};
 use std::path::{Path, PathBuf};
 
-pub mod sessions;
+pub mod agents;
 pub mod state;
 
 pub(crate) mod render;

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -5,11 +5,11 @@ use crate::root::widgets::{
 };
 use gpui::DragMoveEvent;
 
-/// Defines one `JumpToSessionN` action handler forwarding a literal position to
-/// [`AdeApp::jump_to_session_at`]. Each `actions!`-generated struct is a distinct action type
+/// Defines one `JumpToAgentN` action handler forwarding a literal position to
+/// [`AdeApp::jump_to_agent_at`]. Each `actions!`-generated struct is a distinct action type
 /// with no positional data, so GPUI needs one `on_action` handler per keystroke regardless; this
 /// macro just keeps the eight near-identical bodies from drifting from each other.
-macro_rules! session_jump_action_handler {
+macro_rules! agent_jump_action_handler {
     ($fn_name:ident, $action:ty, $position:expr) => {
         pub(crate) fn $fn_name(
             &mut self,
@@ -17,65 +17,65 @@ macro_rules! session_jump_action_handler {
             window: &mut Window,
             cx: &mut Context<Self>,
         ) {
-            self.jump_to_session_at($position, window, cx);
+            self.jump_to_agent_at($position, window, cx);
         }
     };
 }
 
 impl AdeApp {
-    pub(crate) fn new_session(
+    pub(crate) fn new_agent(
         &mut self,
-        kind: SessionKind,
+        kind: AgentKind,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let cwd = self.active_session_cwd();
-        self.sessions.spawn(
+        let cwd = self.active_agent_cwd();
+        self.agents.spawn(
             kind,
             cwd,
             self.settings.appearance.terminal_font_size,
             window,
             cx,
         );
-        self.focus_newly_spawned_session(window, cx);
+        self.focus_newly_spawned_agent(window, cx);
         self.prune_confirm_armed = false;
         self.discard_confirm_armed = None;
         cx.notify();
     }
 
-    /// Moves focus onto the session [`Sessions::spawn`] just made active - but only when neither
+    /// Moves focus onto the agent [`Agents::spawn`] just made active - but only when neither
     /// a file tab ([`Self::render_center_pane`] renders the file tab in that case, not a
-    /// session's `TerminalPane`) nor Settings ([`Self::settings_open`] - Settings replaces the
-    /// entire workspace body, per `crate::root::mod`'s own docs, so no session's pane is
+    /// agent's `TerminalPane`) nor Settings ([`Self::settings_open`] - Settings replaces the
+    /// entire workspace body, per `crate::root::mod`'s own docs, so no agent's pane is
     /// rendered anywhere while it's showing) is occupying the centre pane instead, since focusing
-    /// a session's pane while either is true would point `Window::focus` at a node nothing in the
-    /// rendered tree tracks. Reachable with Settings open via the title bar's Session menu (New
+    /// an agent's pane while either is true would point `Window::focus` at a node nothing in the
+    /// rendered tree tracks. Reachable with Settings open via the title bar's Agent menu (New
     /// Terminal/New Agent Pane), which is an unconditional sibling of the Settings/workspace-body
     /// swap.
-    pub(crate) fn focus_newly_spawned_session(
+    pub(crate) fn focus_newly_spawned_agent(
         &mut self,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         if self.open_change.is_none() && !self.settings_open {
-            self.sessions.focus_active(window, cx);
+            self.agents.focus_active(window, cx);
         }
     }
 
-    pub(crate) fn handle_new_session_action(
+    pub(crate) fn handle_new_agent_action(
         &mut self,
-        _action: &NewSession,
+        _action: &NewAgent,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.new_session(SessionKind::Shell, window, cx);
+        self.new_agent(AgentKind::Shell, window, cx);
     }
 
     /// `Ctrl+W` (GitHub issue #26) - closes whichever tab the centre pane is genuinely showing
     /// right now: a file tab (via [`crate::code_surface::tabs::AdeApp::request_close_file_tab`],
     /// the real unsaved-changes-confirming entry point every other close gesture already uses) if
-    /// [`AdeApp::open_change`] is `Some`, else the globally active session tab (via
-    /// [`Self::close_session`], which already tears down its real child process cleanly - SIGHUP,
+    /// [`AdeApp::open_change`] is `Some`, else the globally active agent tab (via
+    /// [`Self::close_agent`], which already tears down its real child process cleanly - SIGHUP,
     /// a bounded grace period, then `SIGKILL` - see `pty_core::PtySession::shutdown`'s own docs;
     /// nothing here reimplements that). A genuine no-op, never a window close, whenever there is
     /// no real tab to close: Settings is showing over the workspace body (`AdeApp::settings_open`,
@@ -106,25 +106,25 @@ impl AdeApp {
             self.request_close_file_tab(path, window, cx);
             return;
         }
-        if let Some(id) = self.sessions.active_id() {
-            self.close_session(id, window, cx);
+        if let Some(id) = self.agents.active_id() {
+            self.close_agent(id, window, cx);
             cx.notify();
         }
     }
 
-    /// Activates session `id`'s tab and, if it maps to a currently-listed worktree, also selects
-    /// that worktree, keeping the file tree/diff sidebar in sync with the session just clicked
-    /// (the sidebar is still driven by [`Self::selected`] - a `focused_session`-driven Zone 2/3
+    /// Activates agent `id`'s tab and, if it maps to a currently-listed worktree, also selects
+    /// that worktree, keeping the file tree/diff sidebar in sync with the agent just clicked
+    /// (the sidebar is still driven by [`Self::selected`] - a `focused_agent`-driven Zone 2/3
     /// hasn't been rebuilt yet). If a file tab was active, this deactivates it
     /// (`Self::open_change = None`, without closing it - it stays in [`Self::open_files`]) and
-    /// restores focus onto the session's pane via [`restore_focus`].
-    pub(crate) fn select_session(
+    /// restores focus onto the agent's pane via [`restore_focus`].
+    pub(crate) fn select_agent(
         &mut self,
-        id: SessionId,
+        id: AgentId,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.sessions.set_active(id, cx);
+        self.agents.set_active(id, cx);
         self.prune_confirm_armed = false;
         self.discard_confirm_armed = None;
         if self.open_change.is_some() {
@@ -136,22 +136,22 @@ impl AdeApp {
             self.dismiss_completions();
             if self.settings_open {
                 // Settings is showing over the whole workspace body right now (reachable here
-                // via the title bar's Session menu cycle rows/Archive Session, unconditional
+                // via the title bar's Agent menu cycle rows/Archive Agent, unconditional
                 // siblings of the Settings/workspace-body swap) - real focus already correctly
                 // lives on `settings_focus_handle`. Discard the captured pre-file-tab target
-                // rather than restoring it onto a session pane `Self::render_settings` isn't
+                // rather than restoring it onto an agent pane `Self::render_settings` isn't
                 // drawing, mirroring `Self::close_palette`'s identical Settings-aware branch
                 // (`self.palette_focus.clear()`).
                 self.code_focus.clear();
             } else {
-                restore_focus(&self.sessions, &mut self.code_focus, window, cx);
+                restore_focus(&self.agents, &mut self.code_focus, window, cx);
             }
         }
         let cwd = self
-            .sessions
+            .agents
             .iter()
-            .find(|session| session.id == id)
-            .map(|session| session.cwd.clone());
+            .find(|agent| agent.id == id)
+            .map(|agent| agent.cwd.clone());
         if let Some(cwd) = cwd {
             if let Some(index) = self.worktrees.iter().position(|item| item.path == cwd) {
                 if self.selected != Some(index) {
@@ -163,12 +163,12 @@ impl AdeApp {
         cx.notify();
     }
 
-    /// Derives the [`Status`] for a live session - the single source of truth both
-    /// [`Self::build_session_rows`] (the rail) and the work surface (status pill, pane header/
-    /// footer) read, so the rail and the work surface can never disagree about a session's
+    /// Derives the [`Status`] for a live agent - the single source of truth both
+    /// [`Self::build_agent_rows`] (the rail) and the work surface (status pill, pane header/
+    /// footer) read, so the rail and the work surface can never disagree about an agent's
     /// status.
-    pub(crate) fn session_status(&self, session: &Session, cx: &App) -> Status {
-        let pane = session.pane.read(cx);
+    pub(crate) fn agent_status(&self, agent: &Agent, cx: &App) -> Status {
+        let pane = agent.pane.read(cx);
         let signal = if pane.is_running() {
             status::ProcessSignal::Running {
                 idle: pane.idle_duration().unwrap_or_default(),
@@ -186,121 +186,111 @@ impl AdeApp {
         };
         let has_diff = self
             .diff_cache
-            .get(&session.cwd)
+            .get(&agent.cwd)
             .map(|summary| summary.has_changes)
             .unwrap_or(false);
-        status::derive_status(session.kind, signal, has_diff)
+        status::derive_status(agent.kind, signal, has_diff)
     }
 
     /// The context bar's and idle-status footer's `Archive` action - closes the tab via
-    /// [`Self::close_session`] (see that method's docs for why every close path must go through
-    /// it rather than `Sessions::close` directly).
-    pub(crate) fn archive_session(
+    /// [`Self::close_agent`] (see that method's docs for why every close path must go through
+    /// it rather than `Agents::close` directly).
+    pub(crate) fn archive_agent(
         &mut self,
-        id: SessionId,
+        id: AgentId,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.close_session(id, window, cx);
+        self.close_agent(id, window, cx);
         self.prune_confirm_armed = false;
         self.discard_confirm_armed = None;
         cx.notify();
     }
 
-    /// Closes session `id`'s tab (`Sessions::close` tears down its child process and moves focus
-    /// onto whichever session becomes active) and, if `id` is the session whose `Merge` click
+    /// Closes agent `id`'s tab (`Agents::close` tears down its child process and moves focus
+    /// onto whichever agent becomes active) and, if `id` is the agent whose `Merge` click
     /// started [`Self::merge_flow`], cleans that up too (see
-    /// [`Self::clear_merge_flow_for_closed_session`]).
+    /// [`Self::clear_merge_flow_for_closed_agent`]).
     ///
-    /// Every close path - [`Self::archive_session`], [`Self::respawn_session`]'s
+    /// Every close path - [`Self::archive_agent`], [`Self::respawn_agent`]'s
     /// close-then-respawn, and the tab strip's own `×` - must go through this function rather
-    /// than `Sessions::close` directly: previously only `archive_session` cleared `merge_flow`,
-    /// so archiving (or retrying) a mid-merge session left `merge_flow.session_id` pointing at a
-    /// session that no longer existed, permanently disabling the `Merge` button for every
-    /// session (`Self::render_merge_button`'s disabled check never cleared).
+    /// than `Agents::close` directly: previously only `archive_agent` cleared `merge_flow`,
+    /// so archiving (or retrying) a mid-merge agent left `merge_flow.agent_id` pointing at a
+    /// agent that no longer existed, permanently disabling the `Merge` button for every
+    /// agent (`Self::render_merge_button`'s disabled check never cleared).
     ///
-    /// Tells `Sessions::close` to skip its own focus move whenever the centre pane isn't
-    /// actually showing a session's pane right now - a file tab is open, *or* Settings has
-    /// replaced the whole workspace body (`Self::settings_open`, see the title bar's Session
-    /// menu docs - Archive Session is reachable from there while Settings is showing, and
+    /// Tells `Agents::close` to skip its own focus move whenever the centre pane isn't
+    /// actually showing an agent's pane right now - a file tab is open, *or* Settings has
+    /// replaced the whole workspace body (`Self::settings_open`, see the title bar's Agent
+    /// menu docs - Archive Agent is reachable from there while Settings is showing, and
     /// moving focus onto a pane `Self::render_settings` isn't drawing would dangle it exactly
     /// like the file-tab case this guard already covered).
     ///
-    /// If closing `id` leaves its worktree with no session at all (and no file tab either), real
+    /// If closing `id` leaves its worktree with no agent at all (and no file tab either), real
     /// keyboard focus falls back onto [`Self::rail_focus_handle`] - the same fallback
     /// [`Self::select_worktree`] uses for the identical "nothing left to focus" case - so
     /// `Window::focus` never stays pointed at the just-`shutdown()`, no-longer-rendered pane. The
     /// rail's *root*, not its filter field (which this used to target): see
     /// [`Self::rail_focus_handle`]'s own docs for the real keystroke-swallowing bug that was.
-    pub(crate) fn close_session(
-        &mut self,
-        id: SessionId,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
+    pub(crate) fn close_agent(&mut self, id: AgentId, window: &mut Window, cx: &mut Context<Self>) {
         let skip_focus_move = self.open_change.is_some() || self.settings_open;
-        self.sessions.close(id, skip_focus_move, window, cx);
+        self.agents.close(id, skip_focus_move, window, cx);
         if self
             .merge_flow
             .as_ref()
-            .is_some_and(|flow| flow.session_id == id)
+            .is_some_and(|flow| flow.agent_id == id)
         {
-            self.clear_merge_flow_for_closed_session(cx);
+            self.clear_merge_flow_for_closed_agent(cx);
         }
-        if self.sessions.active_id().is_none() && self.open_change.is_none() && !self.settings_open
-        {
+        if self.agents.active_id().is_none() && self.open_change.is_none() && !self.settings_open {
             window.focus(&self.rail_focus_handle, cx);
         }
     }
 
-    /// The surface footer's `Interrupt ⌃C` action - sends `Ctrl-C` to the session's pty via
+    /// The surface footer's `Interrupt ⌃C` action - sends `Ctrl-C` to the agent's pty via
     /// `TerminalPane::interrupt`.
-    pub(in crate::work_surface) fn interrupt_session(
-        &mut self,
-        id: SessionId,
-        cx: &mut Context<Self>,
-    ) {
-        let Some(session) = self.sessions.iter().find(|session| session.id == id) else {
+    pub(in crate::work_surface) fn interrupt_agent(&mut self, id: AgentId, cx: &mut Context<Self>) {
+        let Some(agent) = self.agents.iter().find(|agent| agent.id == id) else {
             return;
         };
-        let pane = session.pane.clone();
+        let pane = agent.pane.clone();
         pane.update(cx, |pane, cx| pane.interrupt(cx));
     }
 
-    /// The surface footer's `Retry ⌘R` (failed sessions) / `Resume ⌘⏎` (idle sessions) action.
-    /// This app has no saved-session resumability to resume *from* (see
+    /// The surface footer's `Retry ⌘R` (failed agents) / `Resume ⌘⏎` (idle agents) action.
+    /// This app has no saved-agent resumability to resume *from* (see
     /// `crate::work_surface::state::pty_state_label`'s docs), so the honest equivalent is: close this
-    /// tab, then spawn a fresh session of the same kind into the same worktree - not literally
+    /// tab, then spawn a fresh agent of the same kind into the same worktree - not literally
     /// "resume where it left off" (`crate::work_surface::state::ActionKind::Respawn`'s docs name this
     /// trade-off).
-    pub(in crate::work_surface) fn respawn_session(
+    pub(in crate::work_surface) fn respawn_agent(
         &mut self,
-        id: SessionId,
+        id: AgentId,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let Some(session) = self.sessions.iter().find(|session| session.id == id) else {
+        let Some(agent) = self.agents.iter().find(|agent| agent.id == id) else {
             return;
         };
-        let kind = session.kind;
-        let cwd = session.cwd.clone();
-        self.close_session(id, window, cx);
-        self.sessions.spawn(
+        let kind = agent.kind;
+        let cwd = agent.cwd.clone();
+        self.close_agent(id, window, cx);
+        self.agents.spawn(
             kind,
             cwd,
             self.settings.appearance.terminal_font_size,
             window,
             cx,
         );
-        self.focus_newly_spawned_session(window, cx);
+        self.focus_newly_spawned_agent(window, cx);
         self.prune_confirm_armed = false;
         self.discard_confirm_armed = None;
         cx.notify();
     }
 
-    /// The surface footer's `Open terminal` action - selects an already-open `Shell` session in
-    /// the same worktree, or spawns one if none exists. Each session is its own independent tab/
-    /// process (`crate::work_surface::sessions`'s module docs), so "open terminal" just means "get me a shell
+    /// The surface footer's `Open terminal` action - selects an already-open `Shell` agent in
+    /// the same worktree, or spawns one if none exists. Each agent is its own independent tab/
+    /// process (`crate::work_surface::agents`'s module docs), so "open terminal" just means "get me a shell
     /// in this worktree", the same capability as the rail's "+ New Shell" button.
     pub(in crate::work_surface) fn open_companion_terminal(
         &mut self,
@@ -309,21 +299,21 @@ impl AdeApp {
         cx: &mut Context<Self>,
     ) {
         let existing = self
-            .sessions
+            .agents
             .iter()
-            .find(|session| session.kind == SessionKind::Shell && session.cwd == cwd)
-            .map(|session| session.id);
+            .find(|agent| agent.kind == AgentKind::Shell && agent.cwd == cwd)
+            .map(|agent| agent.id);
         match existing {
-            Some(id) => self.select_session(id, window, cx),
+            Some(id) => self.select_agent(id, window, cx),
             None => {
-                self.sessions.spawn(
-                    SessionKind::Shell,
+                self.agents.spawn(
+                    AgentKind::Shell,
                     cwd,
                     self.settings.appearance.terminal_font_size,
                     window,
                     cx,
                 );
-                self.focus_newly_spawned_session(window, cx);
+                self.focus_newly_spawned_agent(window, cx);
                 self.prune_confirm_armed = false;
                 self.discard_confirm_armed = None;
                 cx.notify();
@@ -331,33 +321,33 @@ impl AdeApp {
         }
     }
 
-    /// The active worktree's real combined tab order (GitHub issue #16) - every session and file
+    /// The active worktree's real combined tab order (GitHub issue #16) - every agent and file
     /// tab currently open in it, interleaved exactly as [`Self::render_tab_strip`] draws them,
-    /// instead of always "every session, then every file". Reconciled fresh from
+    /// instead of always "every agent, then every file". Reconciled fresh from
     /// [`Self::tab_order`]'s stored order plus whatever's *actually* open right now
     /// (`work_surface::state::reconcile_tab_order`'s own docs on why this is safe to call on
     /// every render rather than caching a mutated copy) - [`Self::tab_order`] itself only records
-    /// a user's real drag-chosen order, never which tabs exist; that's still `Sessions`/
+    /// a user's real drag-chosen order, never which tabs exist; that's still `Agents`/
     /// [`Self::open_files`]'s job.
     pub(crate) fn combined_tab_order(&self) -> Vec<work_surface::TabRef> {
-        let cwd = self.active_session_cwd();
+        let cwd = self.active_agent_cwd();
         let stored = self.tab_order.get(&cwd).map(Vec::as_slice).unwrap_or(&[]);
-        let session_ids: Vec<SessionId> = self
-            .sessions
+        let agent_ids: Vec<AgentId> = self
+            .agents
             .iter_for_cwd(cwd.clone())
-            .map(|session| session.id)
+            .map(|agent| agent.id)
             .collect();
-        work_surface::reconcile_tab_order(stored, &session_ids, &self.open_files)
+        work_surface::reconcile_tab_order(stored, &agent_ids, &self.open_files)
     }
 
     /// The unified tab strip's real drag-to-reorder entry point (GitHub issue #16) - moves
     /// `dragged` to sit immediately before (or, if `insert_after`, immediately after) `target` in
-    /// the active worktree's own combined tab order, regardless of whether either is a session or
+    /// the active worktree's own combined tab order, regardless of whether either is an agent or
     /// a file tab (`work_surface::state::move_tab_order`'s own docs on why this is one function,
     /// not a per-kind pair). Persists the result into [`Self::tab_order`], keyed by the active
     /// worktree's cwd, so it survives the next render's [`Self::combined_tab_order`]
-    /// reconciliation and, for session tabs, a later worktree switch away and back. Never
-    /// restarts a pty or reloads a file buffer - `Sessions`/[`Self::open_files`] themselves are
+    /// reconciliation and, for agent tabs, a later worktree switch away and back. Never
+    /// restarts a pty or reloads a file buffer - `Agents`/[`Self::open_files`] themselves are
     /// untouched; only this ordering layer changes.
     pub(in crate::work_surface) fn reorder_tab(
         &mut self,
@@ -366,14 +356,14 @@ impl AdeApp {
         insert_after: bool,
         cx: &mut Context<Self>,
     ) {
-        let cwd = self.active_session_cwd();
+        let cwd = self.active_agent_cwd();
         let mut order = self.combined_tab_order();
         work_surface::move_tab_order(&mut order, &dragged, &target, insert_after);
         self.tab_order.insert(cwd, order);
         cx.notify();
     }
 
-    /// One tab's own `on_drag_move::<DraggedTab>` handler (both [`Self::render_session_tab`] and
+    /// One tab's own `on_drag_move::<DraggedTab>` handler (both [`Self::render_agent_tab`] and
     /// [`Self::render_file_tab`] register this, each closing over its own `hovered` [`work_surface::
     /// TabRef`]) - real per-tab mouse tracking during a drag, not a container-level listener:
     /// `on_drag_move`'s own doc comment and `crate::root::scrollbar`'s module docs both confirm
@@ -407,7 +397,7 @@ impl AdeApp {
         }
     }
 
-    /// One tab's own `on_drop::<DraggedTab>` handler (both [`Self::render_session_tab`] and
+    /// One tab's own `on_drop::<DraggedTab>` handler (both [`Self::render_agent_tab`] and
     /// [`Self::render_file_tab`] register this) - reads which half of `target`'s own tab the
     /// cursor last landed on from [`Self::tab_drag_insertion`] (defaulting to "before" if the
     /// drop lands on a tab [`Self::update_tab_drag_insertion`] never actually recorded for - a
@@ -427,28 +417,26 @@ impl AdeApp {
         self.tab_drag_insertion = None;
     }
 
-    /// Every session open in the *currently selected* worktree (`Self::active_session_cwd`), in
-    /// the same order [`Self::combined_tab_order`] renders them - never Sessions' own raw
-    /// creation order once a real drag has interleaved them differently, and never every session
+    /// Every agent open in the *currently selected* worktree (`Self::active_agent_cwd`), in
+    /// the same order [`Self::combined_tab_order`] renders them - never Agents' own raw
+    /// creation order once a real drag has interleaved them differently, and never every agent
     /// across every worktree, per this revision's whole point (see `crate::root::mod`'s "One
     /// rail row per worktree" docs). The real per-worktree tab-strip order both
-    /// [`Self::render_tab_strip`] and [`Self::session_jump_keys`]/[`Self::jump_to_session_at`]
+    /// [`Self::render_tab_strip`] and [`Self::agent_jump_keys`]/[`Self::jump_to_agent_at`]
     /// share, so the tabs shown and the tabs a jump keycap can reach can never disagree.
-    pub(crate) fn current_worktree_sessions(&self) -> impl Iterator<Item = &Session> {
+    pub(crate) fn current_worktree_agents(&self) -> impl Iterator<Item = &Agent> {
         let order = self.combined_tab_order();
         order.into_iter().filter_map(move |tab_ref| match tab_ref {
-            work_surface::TabRef::Session(id) => {
-                self.sessions.iter().find(|session| session.id == id)
-            }
+            work_surface::TabRef::Agent(id) => self.agents.iter().find(|agent| agent.id == id),
             work_surface::TabRef::File(_) => None,
         })
     }
 
     /// The tab strip: one tab per entry of [`Self::combined_tab_order`], in that exact order -
-    /// [`Self::render_session_tab`] for a `TabRef::Session`, [`Self::render_file_tab`] for a
-    /// `TabRef::File` - so a session tab and a file tab can sit side by side in either order
-    /// (GitHub issue #16), rather than always "every session, then every file" - followed by the
-    /// `+` menu button ([`Self::render_tab_strip_plus`]) and right-aligned session-jump keycaps.
+    /// [`Self::render_agent_tab`] for a `TabRef::Agent`, [`Self::render_file_tab`] for a
+    /// `TabRef::File` - so an agent tab and a file tab can sit side by side in either order
+    /// (GitHub issue #16), rather than always "every agent, then every file" - followed by the
+    /// `+` menu button ([`Self::render_tab_strip_plus`]) and right-aligned agent-jump keycaps.
     pub(in crate::work_surface) fn render_tab_strip(
         &self,
         cx: &mut Context<Self>,
@@ -465,9 +453,9 @@ impl AdeApp {
 
         for tab_ref in self.combined_tab_order() {
             match tab_ref {
-                work_surface::TabRef::Session(id) => {
-                    if let Some(session) = self.sessions.iter().find(|session| session.id == id) {
-                        bar = bar.child(self.render_session_tab(session, cx));
+                work_surface::TabRef::Agent(id) => {
+                    if let Some(agent) = self.agents.iter().find(|agent| agent.id == id) {
+                        bar = bar.child(self.render_agent_tab(agent, cx));
                     }
                 }
                 work_surface::TabRef::File(path) => {
@@ -478,7 +466,7 @@ impl AdeApp {
 
         bar = bar.child(self.render_tab_strip_plus(cx));
 
-        let jump_keys = self.session_jump_keys();
+        let jump_keys = self.agent_jump_keys();
 
         bar.child(div().flex_1()).child(
             div()
@@ -493,21 +481,21 @@ impl AdeApp {
                         .font(font(theme::font::SANS))
                         .text_size(px(10.0))
                         .text_color(theme::text::PATH)
-                        .child("session"),
+                        .child("agent"),
                 ),
         )
     }
 
-    /// The real `secondary-1`..`secondary-8` session-jump keycap labels: one per session open in
-    /// the *currently selected* worktree (`Self::current_worktree_sessions`), capped at 8 since
+    /// The real `secondary-1`..`secondary-8` agent-jump keycap labels: one per agent open in
+    /// the *currently selected* worktree (`Self::current_worktree_agents`), capped at 8 since
     /// those are the only ones actually bound (`crate::default_key_bindings`) - never a keycap
     /// advertising a shortcut that silently does nothing. Shared by [`Self::render_tab_strip`]'s
-    /// own right-aligned cluster and the status bar's session hint (`status_bar::render::
-    /// render_status_session_hint`), so the two can never independently drift on what's really
+    /// own right-aligned cluster and the status bar's agent hint (`status_bar::render::
+    /// render_status_agent_hint`), so the two can never independently drift on what's really
     /// bound.
-    pub(crate) fn session_jump_keys(&self) -> Vec<String> {
-        let session_count = self.current_worktree_sessions().count().min(8);
-        (1..=session_count).map(|n| n.to_string()).collect()
+    pub(crate) fn agent_jump_keys(&self) -> Vec<String> {
+        let agent_count = self.current_worktree_agents().count().min(8);
+        (1..=agent_count).map(|n| n.to_string()).collect()
     }
 
     /// A file tab: language chip (`file_tree::lang_chip_for_name`, dimmed via
@@ -517,8 +505,8 @@ impl AdeApp {
     /// [`crate::code_surface::tabs::AdeApp::request_close_file_tab`] (never [`Self::close_file_tab`]
     /// directly - see that method's own docs for the real unsaved-changes confirmation this keeps
     /// every close gesture honest about), stopping propagation so a close never also activates
-    /// (the same pattern [`render_session_tab`]'s close button uses). Shares active/inactive bg/
-    /// underline/label colours with session tabs (`work_surface::tab_colors`).
+    /// (the same pattern [`render_agent_tab`]'s close button uses). Shares active/inactive bg/
+    /// underline/label colours with agent tabs (`work_surface::tab_colors`).
     pub(in crate::work_surface) fn render_file_tab(
         &self,
         path: &Path,
@@ -585,7 +573,7 @@ impl AdeApp {
                     this.request_close_file_tab(middle_click_path.clone(), window, cx);
                 }),
             )
-            // Real drag-to-reorder, unified across session and file tabs (GitHub issue #16) -
+            // Real drag-to-reorder, unified across agent and file tabs (GitHub issue #16) -
             // see `DraggedTab`'s own docs for the shared mechanism.
             .on_drag(drag_value, |dragged, _position, _window, cx| {
                 cx.new(|_| dragged.clone())
@@ -686,7 +674,7 @@ impl AdeApp {
 
     /// The tab strip's `+` menu button - toggles [`Self::plus_menu_open`] (unconditionally
     /// spawning a shell is the rail's separate `+` -
-    /// [`crate::rail::render::render_new_session_button`]). A `gpui::canvas` child captures
+    /// [`crate::rail::render::render_new_agent_button`]). A `gpui::canvas` child captures
     /// this button's painted bounds into [`Self::plus_button_bounds`] every render, which
     /// [`Self::render_plus_menu`] positions the popover off of. Opening the menu also refreshes
     /// [`Self::load_agent_rows`], so the "New agent pane" row's sub-label
@@ -747,7 +735,7 @@ impl AdeApp {
     /// the panel stops that click from bubbling up (`cx.stop_propagation()`). Positioned off
     /// [`Self::plus_button_bounds`].
     ///
-    /// Five rows: *New terminal* ([`Self::new_session`] with [`SessionKind::Shell`]), *New file*
+    /// Five rows: *New terminal* ([`Self::new_agent`] with [`AgentKind::Shell`]), *New file*
     /// ([`Self::start_new_file`]), *New agent pane* ([`Self::new_agent_pane`]), *Open file…*
     /// ([`Self::open_palette`], scoped to [`palette::PaletteScope::Files`]), and *Next changed
     /// file* ([`Self::next_changed_file`]). *New terminal*, *New agent pane*, and *Next changed
@@ -816,7 +804,7 @@ impl AdeApp {
                         )
                         .on_click(cx.listener(
                             |this, _event: &ClickEvent, window, cx| {
-                                this.new_session(SessionKind::Shell, window, cx);
+                                this.new_agent(AgentKind::Shell, window, cx);
                                 this.plus_menu_open = false;
                                 cx.notify();
                             },
@@ -838,7 +826,7 @@ impl AdeApp {
                         .on_click(cx.listener(
                             |this, _event: &ClickEvent, window, cx| {
                                 this.plus_menu_open = false;
-                                let cwd = this.active_session_cwd();
+                                let cwd = this.active_agent_cwd();
                                 this.start_new_file(cwd, window, cx);
                             },
                         )),
@@ -910,7 +898,7 @@ impl AdeApp {
     /// installed, or `AGENT_KINDS[0]` if none are (or `agent_rows` hasn't been populated yet).
     /// Display-only - [`Self::new_agent_pane`] runs its own detection independently, off the
     /// foreground thread, at the moment it actually spawns.
-    pub(crate) fn resolved_new_agent_kind(&self) -> SessionKind {
+    pub(crate) fn resolved_new_agent_kind(&self) -> AgentKind {
         settings::AGENT_KINDS
             .into_iter()
             .find(|kind| {
@@ -927,11 +915,11 @@ impl AdeApp {
     /// installed, rather than blocking the click on a filesystem walk.
     ///
     /// If no configured agent is installed, this spawns `AGENT_KINDS[0]` anyway, same as the
-    /// session toolbar's `+ claude`/`+ codex` buttons when that binary isn't on `$PATH`: the
+    /// agent toolbar's `+ claude`/`+ codex` buttons when that binary isn't on `$PATH`: the
     /// process fails to spawn and a non-panicking spawn error shows in the new tab
     /// (`TerminalPane::spawn_error`).
     pub(in crate::work_surface) fn new_agent_pane(&mut self, cx: &mut Context<Self>) {
-        let cwd = self.active_session_cwd();
+        let cwd = self.active_agent_cwd();
         let task = cx.spawn(async move |this, cx| {
             let installed = cx
                 .background_executor()
@@ -943,18 +931,18 @@ impl AdeApp {
                     })
                 })
                 .await;
-            // Needs `Window` access to move focus onto the newly spawned session's pane
-            // (`Self::focus_newly_spawned_session`) - `Entity::update_in` provides it.
+            // Needs `Window` access to move focus onto the newly spawned agent's pane
+            // (`Self::focus_newly_spawned_agent`) - `Entity::update_in` provides it.
             let _ = this.update_in(cx, |this, window, cx| {
                 let kind = installed.unwrap_or(settings::AGENT_KINDS[0]);
-                this.sessions.spawn(
+                this.agents.spawn(
                     kind,
                     cwd,
                     this.settings.appearance.terminal_font_size,
                     window,
                     cx,
                 );
-                this.focus_newly_spawned_session(window, cx);
+                this.focus_newly_spawned_agent(window, cx);
                 this.prune_confirm_armed = false;
                 cx.notify();
             });
@@ -967,7 +955,7 @@ impl AdeApp {
 
     /// The `+` menu's "Next changed file" action (`]`) - opens the next changed file after the
     /// active file tab as a tab, wrapping around to the first once the last is passed (so a
-    /// repeated `]` press cycles indefinitely, matching how the session-jump keycaps and palette
+    /// repeated `]` press cycles indefinitely, matching how the agent-jump keycaps and palette
     /// arrow keys already treat "next"/"previous"). If the active file isn't itself a changed
     /// file, or nothing is active, this opens the first changed file. No-op if there's no loaded
     /// diff, or it has no changed files.
@@ -992,11 +980,11 @@ impl AdeApp {
         self.open_change_diff(next_path, window, cx);
     }
 
-    /// The tab strip's session-jump keycaps (`secondary-1`..`secondary-8`) - jumps to the
-    /// session at 1-indexed `position` in the same order [`Self::render_tab_strip`] iterates
-    /// (`Self::current_worktree_sessions`), via [`Self::select_session`]. No-op if fewer than
-    /// `position` sessions are currently open in the selected worktree.
-    pub(crate) fn jump_to_session_at(
+    /// The tab strip's agent-jump keycaps (`secondary-1`..`secondary-8`) - jumps to the
+    /// agent at 1-indexed `position` in the same order [`Self::render_tab_strip`] iterates
+    /// (`Self::current_worktree_agents`), via [`Self::select_agent`]. No-op if fewer than
+    /// `position` agents are currently open in the selected worktree.
+    pub(crate) fn jump_to_agent_at(
         &mut self,
         position: usize,
         window: &mut Window,
@@ -1004,41 +992,41 @@ impl AdeApp {
     ) {
         let Some(id) = position
             .checked_sub(1)
-            .and_then(|index| self.current_worktree_sessions().nth(index))
-            .map(|session| session.id)
+            .and_then(|index| self.current_worktree_agents().nth(index))
+            .map(|agent| agent.id)
         else {
             return;
         };
-        self.select_session(id, window, cx);
+        self.select_agent(id, window, cx);
     }
 
-    /// The Windows/Linux title bar's Session menu "Next session"/"Previous session" rows
+    /// The Windows/Linux title bar's Agent menu "Next agent"/"Previous agent" rows
     /// (`crate::title_bar::menu::AdeApp::render_title_menu`) - `delta` is `1`/`-1`. Cycles
-    /// through [`Self::current_worktree_sessions`] in the same order
-    /// [`Self::jump_to_session_at`] indexes - **never** every session across every worktree
+    /// through [`Self::current_worktree_agents`] in the same order
+    /// [`Self::jump_to_agent_at`] indexes - **never** every agent across every worktree
     /// (a real, live-reproduced bug found in this revision's own self-audit: an earlier version
-    /// cycled `self.sessions` directly, so "Next Session" could jump to a *different* worktree's
-    /// session, which [`Self::select_session`] then silently promotes into a full
+    /// cycled `self.agents` directly, so "Next Agent" could jump to a *different* worktree's
+    /// agent, which [`Self::select_agent`] then silently promotes into a full
     /// [`Self::select_worktree`] switch - discarding any unsaved `edit_buffers` content for the
     /// worktree just left via `reset_per_worktree_ui_state`. A menu row labeled "cycle tabs" must
     /// never have that side effect) - wrapping around both ends (mirroring
     /// [`Self::next_changed_file`]'s own cyclic-index convention for "next" over an existing
-    /// ordered list), via the same real [`Self::select_session`] every tab-strip click and jump
-    /// keycap already goes through - no separate "next session" subsystem, just a cyclic index
-    /// over the existing per-worktree list. No-op with fewer than two sessions in the selected
-    /// worktree (nothing to cycle to) or no active session at all (both real, reachable states -
-    /// the latter only while every session has been closed).
-    pub(crate) fn select_relative_session(
+    /// ordered list), via the same real [`Self::select_agent`] every tab-strip click and jump
+    /// keycap already goes through - no separate "next agent" subsystem, just a cyclic index
+    /// over the existing per-worktree list. No-op with fewer than two agents in the selected
+    /// worktree (nothing to cycle to) or no active agent at all (both real, reachable states -
+    /// the latter only while every agent has been closed).
+    pub(crate) fn select_relative_agent(
         &mut self,
         delta: isize,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let ids: Vec<SessionId> = self.current_worktree_sessions().map(|s| s.id).collect();
+        let ids: Vec<AgentId> = self.current_worktree_agents().map(|s| s.id).collect();
         if ids.len() < 2 {
             return;
         }
-        let Some(active_id) = self.sessions.active_id() else {
+        let Some(active_id) = self.agents.active_id() else {
             return;
         };
         let Some(current_index) = ids.iter().position(|id| *id == active_id) else {
@@ -1046,18 +1034,18 @@ impl AdeApp {
         };
         let len = ids.len() as isize;
         let next_index = (current_index as isize + delta).rem_euclid(len) as usize;
-        self.select_session(ids[next_index], window, cx);
+        self.select_agent(ids[next_index], window, cx);
     }
 
     /// [`NewTerminal`]'s `ctrl-shift-T` action handler - the `+` menu's "New terminal" row's own
-    /// keybinding, spawning a [`SessionKind::Shell`] session like the row's click handler does.
+    /// keybinding, spawning a [`AgentKind::Shell`] agent like the row's click handler does.
     pub(crate) fn handle_new_terminal_action(
         &mut self,
         _action: &NewTerminal,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.new_session(SessionKind::Shell, window, cx);
+        self.new_agent(AgentKind::Shell, window, cx);
     }
 
     /// [`NewAgentPane`]'s `secondary-shift-n` action handler - see [`Self::new_agent_pane`].
@@ -1080,39 +1068,39 @@ impl AdeApp {
         self.next_changed_file(window, cx);
     }
 
-    session_jump_action_handler!(handle_jump_to_session_1_action, JumpToSession1, 1);
-    session_jump_action_handler!(handle_jump_to_session_2_action, JumpToSession2, 2);
-    session_jump_action_handler!(handle_jump_to_session_3_action, JumpToSession3, 3);
-    session_jump_action_handler!(handle_jump_to_session_4_action, JumpToSession4, 4);
-    session_jump_action_handler!(handle_jump_to_session_5_action, JumpToSession5, 5);
-    session_jump_action_handler!(handle_jump_to_session_6_action, JumpToSession6, 6);
-    session_jump_action_handler!(handle_jump_to_session_7_action, JumpToSession7, 7);
-    session_jump_action_handler!(handle_jump_to_session_8_action, JumpToSession8, 8);
+    agent_jump_action_handler!(handle_jump_to_agent_1_action, JumpToAgent1, 1);
+    agent_jump_action_handler!(handle_jump_to_agent_2_action, JumpToAgent2, 2);
+    agent_jump_action_handler!(handle_jump_to_agent_3_action, JumpToAgent3, 3);
+    agent_jump_action_handler!(handle_jump_to_agent_4_action, JumpToAgent4, 4);
+    agent_jump_action_handler!(handle_jump_to_agent_5_action, JumpToAgent5, 5);
+    agent_jump_action_handler!(handle_jump_to_agent_6_action, JumpToAgent6, 6);
+    agent_jump_action_handler!(handle_jump_to_agent_7_action, JumpToAgent7, 7);
+    agent_jump_action_handler!(handle_jump_to_agent_8_action, JumpToAgent8, 8);
 
     /// One tab: a 14×14 kind chip, the label (resolved binary name for an agent CLI tab, or
-    /// `terminal` for a shell tab), and a `×` that closes it (`Sessions::close`, tearing down
+    /// `terminal` for a shell tab), and a `×` that closes it (`Agents::close`, tearing down
     /// the process). Split into a `flex_1` clickable content row plus a `flex_none` 1px
     /// underline bar, rather than a single div with two differently-coloured borders, because
     /// GPUI's `Style::border_color` is one colour for every edge
     /// (`vendor/zed/crates/gpui/src/style.rs`) - it can't give the right border (always
     /// `theme::border::INNER`) and the active/inactive-dependent underline two different colours
     /// on the same div.
-    pub(in crate::work_surface) fn render_session_tab(
+    pub(in crate::work_surface) fn render_agent_tab(
         &self,
-        session: &Session,
+        agent: &Agent,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        let id = session.id;
-        let is_active = self.sessions.active_id() == Some(id);
-        let chip_kind = work_surface::tab_chip_kind(session.kind);
+        let id = agent.id;
+        let is_active = self.agents.active_id() == Some(id);
+        let chip_kind = work_surface::tab_chip_kind(agent.kind);
         let label = match chip_kind {
-            work_surface::TabChipKind::Cli => session.pane.read(cx).program_label(),
+            work_surface::TabChipKind::Cli => agent.pane.read(cx).program_label(),
             work_surface::TabChipKind::Term => "terminal".to_string(),
         };
         let is_mono = matches!(chip_kind, work_surface::TabChipKind::Cli);
         let colors = work_surface::tab_colors(is_active);
-        let tab_ref = work_surface::TabRef::Session(id);
-        let drag_value = DraggedTab::Session {
+        let tab_ref = work_surface::TabRef::Agent(id);
+        let drag_value = DraggedTab::Agent {
             id,
             label: label.clone(),
         };
@@ -1122,7 +1110,7 @@ impl AdeApp {
         };
 
         div()
-            .id(("session-tab", id))
+            .id(("agent-tab", id))
             .relative()
             .flex()
             .flex_none()
@@ -1130,18 +1118,18 @@ impl AdeApp {
             .border_r_1()
             .border_color(theme::border::INNER)
             .bg(colors.bg)
-            // Middle-click closes any session/terminal tab too (GitHub issue #26) - the same
-            // `Self::close_session` real teardown (`TerminalPane::shutdown`'s SIGHUP/grace/
+            // Middle-click closes any agent/terminal tab too (GitHub issue #26) - the same
+            // `Self::close_agent` real teardown (`TerminalPane::shutdown`'s SIGHUP/grace/
             // SIGKILL - see that method's own docs) every other close path already uses.
             .on_mouse_down(
                 gpui::MouseButton::Middle,
                 cx.listener(move |this, _event: &gpui::MouseDownEvent, window, cx| {
                     cx.stop_propagation();
-                    this.close_session(id, window, cx);
+                    this.close_agent(id, window, cx);
                     cx.notify();
                 }),
             )
-            // Real drag-to-reorder, unified across session and file tabs (GitHub issue #16) -
+            // Real drag-to-reorder, unified across agent and file tabs (GitHub issue #16) -
             // see `DraggedTab`'s own docs for the shared mechanism. No `can_drop` predicate
             // needed - the `on_drop::<DraggedTab>` type parameter alone already rejects a drop of
             // any other dragged-value type.
@@ -1165,7 +1153,7 @@ impl AdeApp {
             })
             .child(
                 div()
-                    .id(("session-tab-hit", id))
+                    .id(("agent-tab-hit", id))
                     .flex_1()
                     .flex()
                     .items_center()
@@ -1173,9 +1161,9 @@ impl AdeApp {
                     .px(px(13.0))
                     .cursor_pointer()
                     .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
-                        this.select_session(id, window, cx);
+                        this.select_agent(id, window, cx);
                     }))
-                    .child(render_tab_chip(session.kind, is_active))
+                    .child(render_tab_chip(agent.kind, is_active))
                     .child(
                         div()
                             .font(font(if is_mono {
@@ -1190,7 +1178,7 @@ impl AdeApp {
                     )
                     .child(
                         div()
-                            .id(("close-session-tab", id))
+                            .id(("close-agent-tab", id))
                             .px(px(2.0))
                             .cursor_pointer()
                             .font(font(theme::font::MONO))
@@ -1200,7 +1188,7 @@ impl AdeApp {
                             .child("\u{d7}")
                             .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
                                 cx.stop_propagation();
-                                this.close_session(id, window, cx);
+                                this.close_agent(id, window, cx);
                                 cx.notify();
                             })),
                     ),
@@ -1208,31 +1196,31 @@ impl AdeApp {
             .child(div().flex_none().w_full().h(px(1.0)).bg(colors.underline))
     }
 
-    /// The session context bar: agent badge/name, a divider, branch, the worktree path (the one
+    /// The agent context bar: agent badge/name, a divider, branch, the worktree path (the one
     /// flexible, ellipsising child - every other child is `flex_none` and non-wrapping, so the
     /// bar never wraps when the centre narrows), a status pill, and `Merge`/`Archive`.
-    pub(in crate::work_surface) fn render_session_context_bar(
+    pub(in crate::work_surface) fn render_agent_context_bar(
         &self,
-        session: &Session,
+        agent: &Agent,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        let status_value = self.session_status(session, cx);
-        let (agent_fg, agent_bg) = work_surface::agent_tint(session.kind);
-        let agent_initial = work_surface::agent_initial(session.kind);
-        // `SessionKind` only tracks which CLI binary is running, not which model it's
-        // configured to use, so `session.kind.label()` ("Claude"/"Codex"/"Shell") is the
+        let status_value = self.agent_status(agent, cx);
+        let (agent_fg, agent_bg) = work_surface::agent_tint(agent.kind);
+        let agent_initial = work_surface::agent_initial(agent.kind);
+        // `AgentKind` only tracks which CLI binary is running, not which model it's
+        // configured to use, so `agent.kind.label()` ("Claude"/"Codex"/"Shell") is the
         // closest honest substitute for a model name this app never actually observes.
-        let agent_label = session.kind.label();
+        let agent_label = agent.kind.label();
         let branch = self
             .worktrees
             .iter()
-            .find(|item| item.path == session.cwd)
+            .find(|item| item.path == agent.cwd)
             .and_then(|item| item.branch.clone());
-        let worktree_path = session.cwd.display().to_string();
-        let id = session.id;
+        let worktree_path = agent.cwd.display().to_string();
+        let id = agent.id;
 
         div()
-            .id("session-context-bar")
+            .id("agent-context-bar")
             .flex()
             .flex_none()
             .items_center()
@@ -1298,19 +1286,19 @@ impl AdeApp {
     }
 
     /// The context bar's `Merge` button - starts [`Self::start_merge`]. Disabled (dimmed,
-    /// non-interactive) whenever any merge flow is already active, own session or not (only one
+    /// non-interactive) whenever any merge flow is already active, own agent or not (only one
     /// runs at a time - see [`Self::start_merge`]'s docs), and shows `Merging…` in place of
-    /// `Merge` while this session's own attempt is the one running.
+    /// `Merge` while this agent's own attempt is the one running.
     pub(in crate::work_surface) fn render_merge_button(
         &self,
-        id: SessionId,
+        id: AgentId,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        let active_for_this_session = self
+        let active_for_this_agent = self
             .merge_flow
             .as_ref()
-            .is_some_and(|flow| flow.session_id == id);
-        let running = active_for_this_session
+            .is_some_and(|flow| flow.agent_id == id);
+        let running = active_for_this_agent
             && matches!(
                 self.merge_flow.as_ref().map(|flow| &flow.state),
                 Some(merge::MergeFlowState::Running)
@@ -1347,10 +1335,10 @@ impl AdeApp {
         }
     }
 
-    /// The context bar's `Archive` button - see [`Self::archive_session`].
+    /// The context bar's `Archive` button - see [`Self::archive_agent`].
     pub(in crate::work_surface) fn render_archive_button(
         &self,
-        id: SessionId,
+        id: AgentId,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
         div()
@@ -1369,14 +1357,14 @@ impl AdeApp {
             .hover(|el| el.bg(theme::surface::ROW_HOVER_ALT))
             .child("Archive")
             .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
-                this.archive_session(id, window, cx);
+                this.archive_agent(id, window, cx);
             }))
     }
 
-    /// Surface A/B's shared header: the resolved program label (this app has no saved-session
-    /// resumability, so there's no resume argument to show alongside it), a `Shell` session's
+    /// Surface A/B's shared header: the resolved program label (this app has no saved-agent
+    /// resumability, so there's no resume argument to show alongside it), a `Shell` agent's
     /// cwd, and a hint row (`mod + click a path to open it`, and a click-only `clear`) rendered
-    /// for every session kind - `TerminalPane` behaves identically for shell and agent sessions
+    /// for every agent kind - `TerminalPane` behaves identically for shell and agents
     /// (see its module docs), so link-click and `clear` are exactly as real for a `Claude`/
     /// `Codex` panic frame as for a shell prompt.
     ///
@@ -1386,7 +1374,7 @@ impl AdeApp {
     /// rather than showing a decorative keycap for one (the same precedent
     /// [`Self::render_plus_menu`]'s "Open file…" row sets).
     ///
-    /// A `Claude`/`Codex` session's pid is shown once, in the info footer below
+    /// A `Claude`/`Codex` agent's pid is shown once, in the info footer below
     /// ([`Self::render_pty_info_footer`]) - not duplicated here.
     ///
     /// `clear` is click-only, not a global keybinding, even though the design shows `mod+K`:
@@ -1402,16 +1390,16 @@ impl AdeApp {
     /// never reaches the pty in the first place (`crate::terminal::pane::keystroke_to_bytes`).
     pub(in crate::work_surface) fn render_pty_header(
         &self,
-        session: &Session,
+        agent: &Agent,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        let pane = session.pane.read(cx);
+        let pane = agent.pane.read(cx);
         let program_label = pane.program_label();
         let is_running = pane.is_running();
         let exit_code = pane.exit_status().map(|status| status.exit_code());
-        let status_value = self.session_status(session, cx);
+        let status_value = self.agent_status(agent, cx);
         let state_label = work_surface::pty_state_label(is_running, status_value, exit_code);
-        let is_wsl_shell = session.kind == SessionKind::Shell && env_info::is_wsl();
+        let is_wsl_shell = agent.kind == AgentKind::Shell && env_info::is_wsl();
         let label_text = if is_wsl_shell {
             format!("{program_label} \u{b7} wsl")
         } else {
@@ -1438,8 +1426,8 @@ impl AdeApp {
                     .child(label_text),
             );
 
-        let header = match session.kind {
-            SessionKind::Shell => header.child(
+        let header = match agent.kind {
+            AgentKind::Shell => header.child(
                 div()
                     .flex_none()
                     .max_w(px(280.0))
@@ -1448,15 +1436,15 @@ impl AdeApp {
                     .font(font(theme::font::MONO))
                     .text_size(px(10.5))
                     .text_color(theme::text::GHOST)
-                    .child(session.cwd.display().to_string()),
+                    .child(agent.cwd.display().to_string()),
             ),
-            // No per-kind header content for an agent session - pid is shown once, in the info
+            // No per-kind header content for an agent - pid is shown once, in the info
             // footer below.
-            SessionKind::Claude | SessionKind::Codex => header,
+            AgentKind::Claude | AgentKind::Codex => header,
         };
 
         let macos = self.window_controls_style().is_macos();
-        let pane_entity = session.pane.clone();
+        let pane_entity = agent.pane.clone();
         let header = header.child(div().flex_1()).child(
             div()
                 .id("pty-header-hints")
@@ -1492,17 +1480,17 @@ impl AdeApp {
     }
 
     /// The terminal pane's info footer: pid, grid dimensions, the environment chip, and a hint
-    /// about file:line references. Rendered for every session kind - `TerminalPane` is the same
+    /// about file:line references. Rendered for every agent kind - `TerminalPane` is the same
     /// component behind a `Shell` tab and a `Claude`/`Codex` tab (see that module's docs), so pid
     /// and grid dimensions are equally meaningful for either. Distinct from, and rendered
-    /// alongside, [`Self::render_pty_footer`] - the session-level Interrupt/Retry/Archive action
+    /// alongside, [`Self::render_pty_footer`] - the agent-level Interrupt/Retry/Archive action
     /// footer.
     pub(in crate::work_surface) fn render_pty_info_footer(
         &self,
-        session: &Session,
+        agent: &Agent,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        let pane = session.pane.read(cx);
+        let pane = agent.pane.read(cx);
         let pid = pane.pid();
         let (cols, rows) = pane.grid_dimensions();
 
@@ -1554,21 +1542,21 @@ impl AdeApp {
         )
     }
 
-    /// Surface A/B's shared footer: git-level actions appropriate to the session's status - see
+    /// Surface A/B's shared footer: git-level actions appropriate to the agent's status - see
     /// `crate::work_surface::state::footer_actions`/[`Self::render_footer_action_button`] for which
     /// actions are implemented vs. disabled. No longer shows a `JERRY` wordmark (deliberate
     /// deviation from the design mockup, per direct user request - see this crate's `lib.rs`/
     /// `BUILD-LOG.md` for context, not a bug fix).
     pub(in crate::work_surface) fn render_pty_footer(
         &self,
-        session: &Session,
+        agent: &Agent,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        let status_value = self.session_status(session, cx);
-        let is_running = session.pane.read(cx).is_running();
+        let status_value = self.agent_status(agent, cx);
+        let is_running = agent.pane.read(cx).is_running();
         let actions = work_surface::footer_actions(status_value);
-        let id = session.id;
-        let cwd = session.cwd.clone();
+        let id = agent.id;
+        let cwd = agent.cwd.clone();
 
         let mut footer = div()
             .id("pty-footer")
@@ -1586,7 +1574,7 @@ impl AdeApp {
             let mut enabled = action.implemented;
             // A live, merely-idle shell has nothing to "resume" (see
             // `crate::work_surface::state::ActionKind::Respawn`'s docs) - disable it in that case
-            // rather than letting a click spawn a redundant duplicate session.
+            // rather than letting a click spawn a redundant duplicate agent.
             if action.kind == work_surface::ActionKind::Respawn
                 && status_value == Status::Idle
                 && is_running
@@ -1609,7 +1597,7 @@ impl AdeApp {
             // Busy labels are keyed off the *specific* in-flight kind, not just "something is
             // running" - a real, live-reproduced bug an audit caught: keying this off the bare
             // in-flight flag alone made every visible `Discard worktree` button across every
-            // session read "discarding…" while an unrelated `Keep all` was running.
+            // agent read "discarding…" while an unrelated `Keep all` was running.
             let label = match action.kind {
                 work_surface::ActionKind::DiscardWorktree
                     if self.worktree_history_op_in_flight
@@ -1648,7 +1636,7 @@ impl AdeApp {
     /// a button that looks clickable but silently does nothing.
     pub(in crate::work_surface) fn render_footer_action_button(
         &self,
-        id: SessionId,
+        id: AgentId,
         cwd: PathBuf,
         action: work_surface::FooterAction,
         label: String,
@@ -1718,12 +1706,12 @@ impl AdeApp {
                 .hover(|el| el.bg(theme::surface::ROW_HOVER_ALT))
                 .on_click(
                     cx.listener(move |this, _event: &ClickEvent, window, cx| match kind {
-                        work_surface::ActionKind::Interrupt => this.interrupt_session(id, cx),
+                        work_surface::ActionKind::Interrupt => this.interrupt_agent(id, cx),
                         work_surface::ActionKind::OpenTerminal => {
                             this.open_companion_terminal(cwd.clone(), window, cx)
                         }
-                        work_surface::ActionKind::Respawn => this.respawn_session(id, window, cx),
-                        work_surface::ActionKind::Archive => this.archive_session(id, window, cx),
+                        work_surface::ActionKind::Respawn => this.respawn_agent(id, window, cx),
+                        work_surface::ActionKind::Archive => this.archive_agent(id, window, cx),
                         work_surface::ActionKind::KeepAllChanges => this.keep_all_changes(id, cx),
                         work_surface::ActionKind::DiscardWorktree => {
                             this.request_discard_worktree(id, window, cx)
@@ -1740,7 +1728,7 @@ impl AdeApp {
 
     /// The centre pane's content: the unified tab strip ([`Self::render_tab_strip`]) always
     /// renders first, above either the active file tab's Surface C
-    /// (`Self::render_code_surface`) if [`Self::open_change`] names one, or the active session's
+    /// (`Self::render_code_surface`) if [`Self::open_change`] names one, or the active agent's
     /// toolbar/context-bar/pty otherwise.
     ///
     /// A file opened via a Changes-row click (`Self::open_change_diff`) always has a `DiffFile`
@@ -1781,14 +1769,14 @@ impl AdeApp {
             self.open_diff_file_cache = diff_file;
         }
 
-        match self.sessions.active() {
-            Some(session) => {
+        match self.agents.active() {
+            Some(agent) => {
                 let body = if self
                     .merge_flow
                     .as_ref()
-                    .is_some_and(|flow| flow.session_id == session.id)
+                    .is_some_and(|flow| flow.agent_id == agent.id)
                 {
-                    self.render_merge_flow_surface(session, cx)
+                    self.render_merge_flow_surface(agent, cx)
                 } else {
                     div()
                         .id("pty-surface")
@@ -1799,21 +1787,21 @@ impl AdeApp {
                         .min_w_0()
                         .overflow_hidden()
                         .bg(theme::surface::PTY)
-                        .child(self.render_pty_header(session, cx))
+                        .child(self.render_pty_header(agent, cx))
                         .child(
                             div()
                                 .flex_1()
                                 .min_h_0()
                                 .min_w_0()
                                 .overflow_hidden()
-                                .child(session.pane.clone().into_any_element()),
+                                .child(agent.pane.clone().into_any_element()),
                         )
-                        .child(self.render_pty_info_footer(session, cx))
-                        .child(self.render_pty_footer(session, cx))
+                        .child(self.render_pty_info_footer(agent, cx))
+                        .child(self.render_pty_footer(agent, cx))
                         .into_any_element()
                 };
                 surface
-                    .child(self.render_session_context_bar(session, cx))
+                    .child(self.render_agent_context_bar(agent, cx))
                     .child(body)
             }
             None => surface.child(
@@ -1827,7 +1815,7 @@ impl AdeApp {
                     .text_size(px(11.5))
                     .text_color(theme::text::FAINT)
                     .child(
-                        "no sessions open in this worktree - start one with the tab strip's + menu",
+                        "no agents open in this worktree - start one with the tab strip's + menu",
                     ),
             ),
         }
@@ -1842,7 +1830,7 @@ impl AdeApp {
 /// (`crate::keymap::resolve_combo`'s output), rendered via [`render_keycap_row`] at
 /// [`KeycapSize::Hint`].
 /// One row in either the tab strip's `+` menu ([`AdeApp::render_plus_menu`]) or the Windows/
-/// Linux title bar's real File/Edit/View/Session/Help dropdowns
+/// Linux title bar's real File/Edit/View/Agent/Help dropdowns
 /// (`crate::title_bar::menu::AdeApp::render_title_menu`) - shared here since both are the same
 /// "labeled trigger opens a small popover of real actions" pattern, first built for the `+`
 /// menu and reused as-is (not re-derived) for the title-bar menus.
@@ -1925,14 +1913,11 @@ pub(crate) fn render_dropdown_menu_row(
     .child(render_keycap_row(&keys, KeycapSize::Hint))
 }
 
-/// The tab strip's 14×14 kind chip - a `❯` glyph tinted with the session's agent colour for
+/// The tab strip's 14×14 kind chip - a `❯` glyph tinted with the agent's agent colour for
 /// agent CLI tabs, or a pane glyph (a bar plus a prompt mark) for terminal tabs. Turns
 /// `work_surface::tab_chip_kind`/`tab_chip_colors`'s mapping into GPUI elements; no
 /// chip-selection logic lives here.
-pub(in crate::work_surface) fn render_tab_chip(
-    kind: SessionKind,
-    active: bool,
-) -> gpui::AnyElement {
+pub(in crate::work_surface) fn render_tab_chip(kind: AgentKind, active: bool) -> gpui::AnyElement {
     let colors = work_surface::tab_chip_colors(kind, active);
     let base = div()
         .flex_none()
@@ -1979,9 +1964,9 @@ pub(in crate::work_surface) fn render_tab_chip(
 }
 
 /// The unified tab strip's drag-to-reorder value (GitHub issue #16) - both
-/// [`AdeApp::render_session_tab`] and [`AdeApp::render_file_tab`]'s `on_drag`/`on_drag_move`/
+/// [`AdeApp::render_agent_tab`] and [`AdeApp::render_file_tab`]'s `on_drag`/`on_drag_move`/
 /// `on_drop` share this one type (rather than the two separate, kind-locked types this revision
-/// replaces) precisely so a session tab can be dropped onto a file tab and vice versa: GPUI's
+/// replaces) precisely so an agent tab can be dropped onto a file tab and vice versa: GPUI's
 /// `on_drop::<T>`/`on_drag_move::<T>` dispatch purely on the dragged value's concrete type
 /// (verified against `vendor/zed/crates/gpui/src/elements/div.rs`, and
 /// `crate::root::scrollbar`'s own module docs on that exact dispatch rule), so two distinct types
@@ -1993,14 +1978,14 @@ pub(in crate::work_surface) fn render_tab_chip(
 /// the same choice Zed's own `DraggedTab` makes - keeps what's being dragged legible.
 #[derive(Clone)]
 pub(in crate::work_surface) enum DraggedTab {
-    Session { id: SessionId, label: String },
+    Agent { id: AgentId, label: String },
     File { path: PathBuf, label: String },
 }
 
 impl DraggedTab {
     fn label(&self) -> &str {
         match self {
-            DraggedTab::Session { label, .. } => label,
+            DraggedTab::Agent { label, .. } => label,
             DraggedTab::File { label, .. } => label,
         }
     }
@@ -2009,7 +1994,7 @@ impl DraggedTab {
     /// [`AdeApp::reorder_tab`] actually moves, regardless of which concrete kind was dragged.
     pub(in crate::work_surface) fn tab_ref(&self) -> work_surface::TabRef {
         match self {
-            DraggedTab::Session { id, .. } => work_surface::TabRef::Session(*id),
+            DraggedTab::Agent { id, .. } => work_surface::TabRef::Agent(*id),
             DraggedTab::File { path, .. } => work_surface::TabRef::File(path.clone()),
         }
     }
@@ -2048,7 +2033,7 @@ fn render_tab_insertion_caret(insert_after: bool) -> impl IntoElement {
         .when(!insert_after, |el| el.left(px(0.0)))
 }
 
-/// The session context bar's status pill: a coloured dot plus label in the status colour.
+/// The agent context bar's status pill: a coloured dot plus label in the status colour.
 pub(in crate::work_surface) fn render_status_pill(status: Status) -> impl IntoElement {
     div()
         .flex_none()
@@ -2079,9 +2064,9 @@ pub(in crate::work_surface) fn render_status_pill(status: Status) -> impl IntoEl
 }
 
 /// Regression coverage for this revision's core claim: each worktree gets one rail entry, and
-/// its sessions become tabs scoped to whichever worktree's rail row is selected - the exact
+/// its agents become tabs scoped to whichever worktree's rail row is selected - the exact
 /// behavior `crate::root::mod`'s "One rail row per worktree" module docs describe. Also covers
-/// the real drag-to-reorder mechanism (`DraggedSessionTab`'s own docs).
+/// the real drag-to-reorder mechanism (`DraggedAgentTab`'s own docs).
 #[cfg(test)]
 mod tab_scoping_tests {
     use super::*;
@@ -2111,11 +2096,11 @@ mod tab_scoping_tests {
     }
 
     /// The exact bug `crate::rail::state::build_worktree_rows` fixes at the pure-logic level
-    /// (`crate::rail::state::tests::build_worktree_rows_folds_every_session_in_a_worktree_not_just_the_first`),
-    /// proven here end to end through the real `Sessions`/`AdeApp` plumbing: two sessions
+    /// (`crate::rail::state::tests::build_worktree_rows_folds_every_agent_in_a_worktree_not_just_the_first`),
+    /// proven here end to end through the real `Agents`/`AdeApp` plumbing: two agents
     /// spawned into the same worktree must both show up as that worktree's tabs.
     #[gpui::test]
-    fn multiple_sessions_in_one_worktree_all_show_as_tabs_under_it(cx: &mut TestAppContext) {
+    fn multiple_agents_in_one_worktree_all_show_as_tabs_under_it(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
         let wt_a = tempfile::tempdir().expect("tempdir a");
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
@@ -2125,15 +2110,15 @@ mod tab_scoping_tests {
         });
         app.update_in(cx, |app, window, cx| {
             app.select_worktree(0, window, cx);
-            app.sessions.spawn(
-                SessionKind::Shell,
+            app.agents.spawn(
+                AgentKind::Shell,
                 wt_a.path().to_path_buf(),
                 12.0,
                 window,
                 cx,
             );
-            app.sessions.spawn(
-                SessionKind::Claude,
+            app.agents.spawn(
+                AgentKind::Claude,
                 wt_a.path().to_path_buf(),
                 12.0,
                 window,
@@ -2141,26 +2126,26 @@ mod tab_scoping_tests {
             );
         });
 
-        let ids: Vec<SessionId> = app.read_with(cx, |app, _| {
-            app.current_worktree_sessions().map(|s| s.id).collect()
+        let ids: Vec<AgentId> = app.read_with(cx, |app, _| {
+            app.current_worktree_agents().map(|s| s.id).collect()
         });
         assert_eq!(
             ids.len(),
             2,
-            "both sessions spawned into wt-a must show as tabs under it - not just the first \
+            "both agents spawned into wt-a must show as tabs under it - not just the first \
              one found (the exact bug the old ProjectChild model had)"
         );
     }
 
     /// The real gap this revision's own self-audit found: switching to a worktree with *no*
-    /// open session leaves `Sessions::focus_active` with nothing to focus (a genuine no-op), so
-    /// a previously-focused session's pane - now unrendered once the tab strip's own
+    /// open agent leaves `Agents::focus_active` with nothing to focus (a genuine no-op), so
+    /// a previously-focused agent's pane - now unrendered once the tab strip's own
     /// per-worktree filter applies - would otherwise leave `Window::focus` dangling, breaking
     /// every global keybinding (including ⌘P itself) until the next click.
     /// `Self::select_worktree`'s own fallback (redirecting focus to `Self::filter_focus_handle`
-    /// whenever the newly selected worktree has no session to focus) closes this.
+    /// whenever the newly selected worktree has no agent to focus) closes this.
     #[gpui::test]
-    fn ctrl_p_still_works_after_switching_to_a_worktree_with_no_open_session(
+    fn ctrl_p_still_works_after_switching_to_a_worktree_with_no_open_agent(
         cx: &mut TestAppContext,
     ) {
         let repo = tempfile::tempdir().expect("tempdir");
@@ -2172,11 +2157,11 @@ mod tab_scoping_tests {
             app.worktrees = vec![worktree_item(wt_empty.path().to_path_buf(), "empty")];
         });
 
-        // Explicitly focus the initial shell session (the real, concrete "focus is on a live
-        // terminal pane" starting state this bug needs), then switch to the session-less
+        // Explicitly focus the initial shell agent (the real, concrete "focus is on a live
+        // terminal pane" starting state this bug needs), then switch to the agent-less
         // worktree - the exact transition the fix targets.
         app.update_in(cx, |app, window, cx| {
-            app.sessions.focus_active(window, cx);
+            app.agents.focus_active(window, cx);
             app.select_worktree(0, window, cx);
         });
 
@@ -2189,7 +2174,7 @@ mod tab_scoping_tests {
 
         assert!(
             app.read_with(cx, |app, _| app.palette_open),
-            "a real {key} keystroke after switching to a session-less worktree must still open \
+            "a real {key} keystroke after switching to an agent-less worktree must still open \
              the palette - before the fix, focus was left dangling on the previous worktree's \
              now-unrendered terminal pane"
         );
@@ -2198,7 +2183,7 @@ mod tab_scoping_tests {
     /// Switching the rail selection to a different worktree must show that worktree's own tabs,
     /// not the previously selected worktree's - the centre-pane-follows-the-rail invariant, and
     /// the exact behavior `crate::root::mod`'s "One rail row per worktree" docs describe: never
-    /// showing/pointing at the previously selected worktree's session.
+    /// showing/pointing at the previously selected worktree's agent.
     #[gpui::test]
     fn switching_worktree_selection_shows_that_worktrees_own_tabs(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
@@ -2212,16 +2197,16 @@ mod tab_scoping_tests {
 
         let (id_a, id_b) = app.update_in(cx, |app, window, cx| {
             app.select_worktree(0, window, cx);
-            let id_a = app.sessions.spawn(
-                SessionKind::Shell,
+            let id_a = app.agents.spawn(
+                AgentKind::Shell,
                 wt_a.path().to_path_buf(),
                 12.0,
                 window,
                 cx,
             );
             app.select_worktree(1, window, cx);
-            let id_b = app.sessions.spawn(
-                SessionKind::Shell,
+            let id_b = app.agents.spawn(
+                AgentKind::Shell,
                 wt_b.path().to_path_buf(),
                 12.0,
                 window,
@@ -2230,20 +2215,20 @@ mod tab_scoping_tests {
             (id_a, id_b)
         });
 
-        // Still on wt-b (the last selection) - its tab strip must show only its own session.
-        let current: Vec<SessionId> = app.read_with(cx, |app, _| {
-            app.current_worktree_sessions().map(|s| s.id).collect()
+        // Still on wt-b (the last selection) - its tab strip must show only its own agent.
+        let current: Vec<AgentId> = app.read_with(cx, |app, _| {
+            app.current_worktree_agents().map(|s| s.id).collect()
         });
         assert_eq!(current, vec![id_b]);
         assert_eq!(
-            app.read_with(cx, |app, _| app.sessions.active_id()),
+            app.read_with(cx, |app, _| app.agents.active_id()),
             Some(id_b)
         );
 
         // Switch back to wt-a - must show id_a, never id_b.
         app.update_in(cx, |app, window, cx| app.select_worktree(0, window, cx));
-        let current: Vec<SessionId> = app.read_with(cx, |app, _| {
-            app.current_worktree_sessions().map(|s| s.id).collect()
+        let current: Vec<AgentId> = app.read_with(cx, |app, _| {
+            app.current_worktree_agents().map(|s| s.id).collect()
         });
         assert_eq!(
             current,
@@ -2251,9 +2236,9 @@ mod tab_scoping_tests {
             "switching back to wt-a must show its own tab, not wt-b's"
         );
         assert_eq!(
-            app.read_with(cx, |app, _| app.sessions.active_id()),
+            app.read_with(cx, |app, _| app.agents.active_id()),
             Some(id_a),
-            "the active session must follow the selected worktree"
+            "the active agent must follow the selected worktree"
         );
     }
 
@@ -2272,15 +2257,15 @@ mod tab_scoping_tests {
 
         let (id1, id2) = app.update_in(cx, |app, window, cx| {
             app.select_worktree(0, window, cx);
-            let id1 = app.sessions.spawn(
-                SessionKind::Shell,
+            let id1 = app.agents.spawn(
+                AgentKind::Shell,
                 wt_a.path().to_path_buf(),
                 12.0,
                 window,
                 cx,
             );
-            let id2 = app.sessions.spawn(
-                SessionKind::Shell,
+            let id2 = app.agents.spawn(
+                AgentKind::Shell,
                 wt_a.path().to_path_buf(),
                 12.0,
                 window,
@@ -2289,37 +2274,37 @@ mod tab_scoping_tests {
             (id1, id2)
         });
         assert_eq!(
-            app.read_with(cx, |app, _| app.sessions.active_id()),
+            app.read_with(cx, |app, _| app.agents.active_id()),
             Some(id2)
         );
 
-        app.update_in(cx, |app, window, cx| app.close_session(id2, window, cx));
+        app.update_in(cx, |app, window, cx| app.close_agent(id2, window, cx));
 
         assert_eq!(
-            app.read_with(cx, |app, _| app.sessions.active_id()),
+            app.read_with(cx, |app, _| app.agents.active_id()),
             Some(id1),
             "closing the active tab must fall back to the remaining sibling in the same worktree"
         );
-        let current: Vec<SessionId> = app.read_with(cx, |app, _| {
-            app.current_worktree_sessions().map(|s| s.id).collect()
+        let current: Vec<AgentId> = app.read_with(cx, |app, _| {
+            app.current_worktree_agents().map(|s| s.id).collect()
         });
         assert_eq!(current, vec![id1]);
     }
 
-    /// The degenerate case, and the real reason `Sessions::close`'s fallback had to become
+    /// The degenerate case, and the real reason `Agents::close`'s fallback had to become
     /// worktree-scoped rather than a same-`Vec` neighbor: closing the *last* tab in one worktree
-    /// must never fall back to a different worktree's own still-open session, even though it
+    /// must never fall back to a different worktree's own still-open agent, even though it
     /// might sit right next to it in the flat underlying storage.
     ///
     /// Also real, live-reproduced coverage for another instance of this project's own "focus
     /// left pointing at something unrendered" bug class (see `crate::root::focus`'s module doc):
-    /// before the fix, `Self::close_session` left `Window::focus` dangling on the
-    /// just-`shutdown()` `TerminalPane` in this exact case (`self.sessions.active = None`, and
-    /// `Sessions::focus_active` is a real no-op with nothing active) - so a real ⌘P afterward,
+    /// before the fix, `Self::close_agent` left `Window::focus` dangling on the
+    /// just-`shutdown()` `TerminalPane` in this exact case (`self.agents.active = None`, and
+    /// `Agents::focus_active` is a real no-op with nothing active) - so a real ⌘P afterward,
     /// not just checking `active_id() == None`, is what actually proves focus isn't dangling,
     /// matching every other test for this bug class in this project.
     #[gpui::test]
-    fn closing_the_last_tab_in_a_worktree_never_falls_back_to_a_different_worktrees_session(
+    fn closing_the_last_tab_in_a_worktree_never_falls_back_to_a_different_worktrees_agent(
         cx: &mut TestAppContext,
     ) {
         let repo = tempfile::tempdir().expect("tempdir");
@@ -2333,8 +2318,8 @@ mod tab_scoping_tests {
 
         let id_a = app.update_in(cx, |app, window, cx| {
             app.select_worktree(0, window, cx);
-            app.sessions.spawn(
-                SessionKind::Shell,
+            app.agents.spawn(
+                AgentKind::Shell,
                 wt_a.path().to_path_buf(),
                 12.0,
                 window,
@@ -2343,8 +2328,8 @@ mod tab_scoping_tests {
         });
         app.update_in(cx, |app, window, cx| {
             app.select_worktree(1, window, cx);
-            app.sessions.spawn(
-                SessionKind::Shell,
+            app.agents.spawn(
+                AgentKind::Shell,
                 wt_b.path().to_path_buf(),
                 12.0,
                 window,
@@ -2354,14 +2339,14 @@ mod tab_scoping_tests {
 
         app.update_in(cx, |app, window, cx| {
             app.select_worktree(0, window, cx);
-            app.close_session(id_a, window, cx);
+            app.close_agent(id_a, window, cx);
         });
 
         assert_eq!(
-            app.read_with(cx, |app, _| app.sessions.active_id()),
+            app.read_with(cx, |app, _| app.agents.active_id()),
             None,
-            "closing the only tab in wt-a must leave it with no active session, never silently \
-             fall back to wt-b's own still-open session"
+            "closing the only tab in wt-a must leave it with no active agent, never silently \
+             fall back to wt-b's own still-open agent"
         );
 
         let key = if cfg!(target_os = "macos") {
@@ -2374,30 +2359,30 @@ mod tab_scoping_tests {
             app.read_with(cx, |app, _| app.palette_open),
             "a real {key} keystroke after closing the last tab in a worktree must still open \
              the palette - before the fix, Window::focus was left dangling on the just-closed \
-             session's now-unmounted pane, with nothing real for the next keystroke to reach"
+             agent's now-unmounted pane, with nothing real for the next keystroke to reach"
         );
     }
 
-    /// Real drag-to-reorder, unified across session and file tabs (GitHub issue #16): dropping
-    /// one session tab onto another must actually change the *combined* tab order
-    /// (`Self::current_worktree_sessions`, which now reads `Self::combined_tab_order` rather than
-    /// `Sessions`' own raw creation order - see that method's own docs on why).
+    /// Real drag-to-reorder, unified across agent and file tabs (GitHub issue #16): dropping
+    /// one agent tab onto another must actually change the *combined* tab order
+    /// (`Self::current_worktree_agents`, which now reads `Self::combined_tab_order` rather than
+    /// `Agents`' own raw creation order - see that method's own docs on why).
     #[gpui::test]
-    fn drag_reordering_two_session_tabs_changes_their_order(cx: &mut TestAppContext) {
+    fn drag_reordering_two_agent_tabs_changes_their_order(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
 
         let (initial_id, id2, id3) = app.update_in(cx, |app, window, cx| {
-            let initial_id = app.sessions.active_id().expect("initial shell session");
-            let id2 = app.sessions.spawn(
-                SessionKind::Shell,
+            let initial_id = app.agents.active_id().expect("initial shell agent");
+            let id2 = app.agents.spawn(
+                AgentKind::Shell,
                 repo.path().to_path_buf(),
                 12.0,
                 window,
                 cx,
             );
-            let id3 = app.sessions.spawn(
-                SessionKind::Shell,
+            let id3 = app.agents.spawn(
+                AgentKind::Shell,
                 repo.path().to_path_buf(),
                 12.0,
                 window,
@@ -2406,23 +2391,23 @@ mod tab_scoping_tests {
             (initial_id, id2, id3)
         });
 
-        let before: Vec<SessionId> = app.read_with(cx, |app, _| {
-            app.current_worktree_sessions().map(|s| s.id).collect()
+        let before: Vec<AgentId> = app.read_with(cx, |app, _| {
+            app.current_worktree_agents().map(|s| s.id).collect()
         });
         assert_eq!(before, vec![initial_id, id2, id3]);
 
         // The real drop handler's own logic: drag id3, drop it before `initial_id`'s tab.
         app.update(cx, |app, cx| {
             app.reorder_tab(
-                work_surface::TabRef::Session(id3),
-                work_surface::TabRef::Session(initial_id),
+                work_surface::TabRef::Agent(id3),
+                work_surface::TabRef::Agent(initial_id),
                 false,
                 cx,
             );
         });
 
-        let after: Vec<SessionId> = app.read_with(cx, |app, _| {
-            app.current_worktree_sessions().map(|s| s.id).collect()
+        let after: Vec<AgentId> = app.read_with(cx, |app, _| {
+            app.current_worktree_agents().map(|s| s.id).collect()
         });
         assert_eq!(
             after,
@@ -2440,32 +2425,32 @@ mod tab_scoping_tests {
         let repo = tempfile::tempdir().expect("tempdir");
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
         let initial_id = app.read_with(cx, |app, _| {
-            app.sessions.active_id().expect("initial shell session")
+            app.agents.active_id().expect("initial shell agent")
         });
 
         app.update(cx, |app, cx| {
             app.reorder_tab(
-                work_surface::TabRef::Session(initial_id),
-                work_surface::TabRef::Session(initial_id),
+                work_surface::TabRef::Agent(initial_id),
+                work_surface::TabRef::Agent(initial_id),
                 false,
                 cx,
             );
             app.reorder_tab(
-                work_surface::TabRef::Session(9999),
-                work_surface::TabRef::Session(initial_id),
+                work_surface::TabRef::Agent(9999),
+                work_surface::TabRef::Agent(initial_id),
                 false,
                 cx,
             );
             app.reorder_tab(
-                work_surface::TabRef::Session(initial_id),
-                work_surface::TabRef::Session(9999),
+                work_surface::TabRef::Agent(initial_id),
+                work_surface::TabRef::Agent(9999),
                 false,
                 cx,
             );
         });
 
-        let after: Vec<SessionId> = app.read_with(cx, |app, _| {
-            app.current_worktree_sessions().map(|s| s.id).collect()
+        let after: Vec<AgentId> = app.read_with(cx, |app, _| {
+            app.current_worktree_agents().map(|s| s.id).collect()
         });
         assert_eq!(
             after,
@@ -2474,24 +2459,24 @@ mod tab_scoping_tests {
         );
     }
 
-    /// Exactly the globally active session's pane may poll at the frame-accurate foreground
+    /// Exactly the globally active agent's pane may poll at the frame-accurate foreground
     /// cadence (`TerminalPane::is_foreground`); every other open pane must be demoted to the
-    /// background cadence - through every real mutator of "which session is active": spawn,
-    /// tab click (`select_session`), closing the active tab, and switching to a session-less
+    /// background cadence - through every real mutator of "which agent is active": spawn,
+    /// tab click (`select_agent`), closing the active tab, and switching to an agent-less
     /// worktree. A pane wrongly left foreground silently re-grows the measured multi-pane
     /// foreground-drain regression this flag exists to bound (see
     /// `crate::terminal::pane::BACKGROUND_POLL_INTERVAL`'s docs); one wrongly left background would lag
     /// the very pane the user is watching.
     #[gpui::test]
-    fn only_the_active_sessions_pane_polls_at_the_foreground_cadence(cx: &mut TestAppContext) {
+    fn only_the_active_agents_pane_polls_at_the_foreground_cadence(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
         let wt_empty = tempfile::tempdir().expect("tempdir empty");
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
 
         let foreground_ids =
-            |app: &gpui::Entity<AdeApp>, cx: &mut TestAppContext| -> Vec<SessionId> {
+            |app: &gpui::Entity<AdeApp>, cx: &mut TestAppContext| -> Vec<AgentId> {
                 app.read_with(cx, |app, cx| {
-                    app.sessions
+                    app.agents
                         .iter()
                         .filter(|s| s.pane.read(cx).is_foreground())
                         .map(|s| s.id)
@@ -2500,9 +2485,9 @@ mod tab_scoping_tests {
             };
 
         let (first_id, second_id) = app.update_in(cx, |app, window, cx| {
-            let first_id = app.sessions.active_id().expect("initial shell session");
-            let second_id = app.sessions.spawn(
-                SessionKind::Shell,
+            let first_id = app.agents.active_id().expect("initial shell agent");
+            let second_id = app.agents.spawn(
+                AgentKind::Shell,
                 repo.path().to_path_buf(),
                 12.0,
                 window,
@@ -2511,16 +2496,16 @@ mod tab_scoping_tests {
             (first_id, second_id)
         });
 
-        // Spawning made the new session active - it alone must be foreground.
+        // Spawning made the new agent active - it alone must be foreground.
         assert_eq!(
             foreground_ids(&app, cx),
             vec![second_id],
-            "after spawn, only the newly active session's pane may be foreground"
+            "after spawn, only the newly active agent's pane may be foreground"
         );
 
-        // A real tab click: the clicked session's pane is promoted, the old one demoted.
+        // A real tab click: the clicked agent's pane is promoted, the old one demoted.
         app.update_in(cx, |app, window, cx| {
-            app.select_session(first_id, window, cx);
+            app.select_agent(first_id, window, cx);
         });
         assert_eq!(
             foreground_ids(&app, cx),
@@ -2530,7 +2515,7 @@ mod tab_scoping_tests {
 
         // Closing the active tab promotes the surviving sibling.
         app.update_in(cx, |app, window, cx| {
-            app.sessions.close(first_id, false, window, cx);
+            app.agents.close(first_id, false, window, cx);
         });
         assert_eq!(
             foreground_ids(&app, cx),
@@ -2538,7 +2523,7 @@ mod tab_scoping_tests {
             "closing the active tab must hand the foreground cadence to the promoted sibling"
         );
 
-        // Switching to a worktree with no sessions: nothing is active, nothing is watchable -
+        // Switching to a worktree with no agents: nothing is active, nothing is watchable -
         // every pane must be background.
         app.update(cx, |app, _cx| {
             app.worktrees = vec![worktree_item(wt_empty.path().to_path_buf(), "empty")];
@@ -2548,28 +2533,28 @@ mod tab_scoping_tests {
         });
         assert_eq!(
             foreground_ids(&app, cx),
-            Vec::<SessionId>::new(),
-            "with no active session, no pane may keep the foreground cadence"
+            Vec::<AgentId>::new(),
+            "with no active agent, no pane may keep the foreground cadence"
         );
     }
 
     /// The real cross-kind capability GitHub issue #16 exists to unlock: a file tab dragged so it
-    /// lands between two session tabs must actually interleave them in the combined tab order,
+    /// lands between two agent tabs must actually interleave them in the combined tab order,
     /// not just reorder within its own kind - the exact case the old, kind-locked
-    /// `DraggedSessionTab`/`DraggedFileTab` types could never produce (GPUI's `on_drop::<T>`
+    /// `DraggedAgentTab`/`DraggedFileTab` types could never produce (GPUI's `on_drop::<T>`
     /// dispatches purely on the dragged value's concrete type, so a `DraggedFileTab` could never
-    /// be dropped onto a session tab's `on_drop::<DraggedSessionTab>` handler or vice versa).
+    /// be dropped onto an agent tab's `on_drop::<DraggedAgentTab>` handler or vice versa).
     #[gpui::test]
-    fn dragging_a_file_tab_between_two_session_tabs_interleaves_them(cx: &mut TestAppContext) {
+    fn dragging_a_file_tab_between_two_agent_tabs_interleaves_them(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
         let file_path = repo.path().join("a.txt");
         std::fs::write(&file_path, "hello\n").expect("write a.txt");
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
 
         let (initial_id, second_id) = app.update_in(cx, |app, window, cx| {
-            let initial_id = app.sessions.active_id().expect("initial shell session");
-            let second_id = app.sessions.spawn(
-                SessionKind::Shell,
+            let initial_id = app.agents.active_id().expect("initial shell agent");
+            let second_id = app.agents.spawn(
+                AgentKind::Shell,
                 repo.path().to_path_buf(),
                 12.0,
                 window,
@@ -2583,19 +2568,19 @@ mod tab_scoping_tests {
         assert_eq!(
             before,
             vec![
-                work_surface::TabRef::Session(initial_id),
-                work_surface::TabRef::Session(second_id),
+                work_surface::TabRef::Agent(initial_id),
+                work_surface::TabRef::Agent(second_id),
                 work_surface::TabRef::File(PathBuf::from("a.txt")),
             ],
-            "with no drag yet, sessions come first (creation order), then files - the old \
+            "with no drag yet, agents come first (creation order), then files - the old \
              two-block layout"
         );
 
-        // The real cross-kind drop: drag the file tab so it lands between the two session tabs.
+        // The real cross-kind drop: drag the file tab so it lands between the two agent tabs.
         app.update(cx, |app, cx| {
             app.reorder_tab(
                 work_surface::TabRef::File(PathBuf::from("a.txt")),
-                work_surface::TabRef::Session(second_id),
+                work_surface::TabRef::Agent(second_id),
                 false,
                 cx,
             );
@@ -2605,11 +2590,11 @@ mod tab_scoping_tests {
         assert_eq!(
             after,
             vec![
-                work_surface::TabRef::Session(initial_id),
+                work_surface::TabRef::Agent(initial_id),
                 work_surface::TabRef::File(PathBuf::from("a.txt")),
-                work_surface::TabRef::Session(second_id),
+                work_surface::TabRef::Agent(second_id),
             ],
-            "the file tab must now sit between the two session tabs - the real cross-group \
+            "the file tab must now sit between the two agent tabs - the real cross-group \
              interleaving this revision exists to unlock"
         );
     }
@@ -2625,9 +2610,9 @@ mod tab_scoping_tests {
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
 
         let (initial_id, second_id) = app.update_in(cx, |app, window, cx| {
-            let initial_id = app.sessions.active_id().expect("initial shell session");
-            let second_id = app.sessions.spawn(
-                SessionKind::Shell,
+            let initial_id = app.agents.active_id().expect("initial shell agent");
+            let second_id = app.agents.spawn(
+                AgentKind::Shell,
                 repo.path().to_path_buf(),
                 12.0,
                 window,
@@ -2639,13 +2624,13 @@ mod tab_scoping_tests {
         // Simulates what a real `on_drag_move` tick over the right half of `second_id`'s tab
         // would already have recorded, just before the drop.
         app.update(cx, |app, _cx| {
-            app.tab_drag_insertion = Some((work_surface::TabRef::Session(second_id), true));
+            app.tab_drag_insertion = Some((work_surface::TabRef::Agent(second_id), true));
         });
 
         app.update(cx, |app, cx| {
             app.drop_dragged_tab(
-                work_surface::TabRef::Session(initial_id),
-                work_surface::TabRef::Session(second_id),
+                work_surface::TabRef::Agent(initial_id),
+                work_surface::TabRef::Agent(second_id),
                 cx,
             );
         });
@@ -2654,8 +2639,8 @@ mod tab_scoping_tests {
         assert_eq!(
             order,
             vec![
-                work_surface::TabRef::Session(second_id),
-                work_surface::TabRef::Session(initial_id),
+                work_surface::TabRef::Agent(second_id),
+                work_surface::TabRef::Agent(initial_id),
             ],
             "insert_after == true must land the dragged tab immediately after the target, not \
              before"

--- a/crates/app/src/work_surface/state.rs
+++ b/crates/app/src/work_surface/state.rs
@@ -1,8 +1,8 @@
-//! Pure logic for Zone 2 (work surface): tab strip, session context bar, and the
+//! Pure logic for Zone 2 (work surface): tab strip, agent context bar, and the
 //! CLI/terminal pane header/footer.
 //!
 //! Deliberately GPUI-free, mirroring `crate::rail::status`'s own split: this module only maps
-//! already-known facts (a [`SessionKind`], a [`Status`], a `bool`) onto *which*
+//! already-known facts (a [`AgentKind`], a [`Status`], a `bool`) onto *which*
 //! colours/labels/actions a Zone 2 element should show, so that mapping is directly
 //! unit-testable without a live GPUI window. Turning these into actual `gpui::Div` trees (and
 //! wiring click handlers) happens one layer up, in `crate::root`, which has the
@@ -15,49 +15,49 @@ use gpui::Rgba;
 use crate::rail::status::Status;
 use crate::sidebar::file_tree::LangChip;
 use crate::theme;
-use crate::work_surface::sessions::{SessionId, SessionKind};
+use crate::work_surface::agents::{AgentId, AgentKind};
 
-/// One entry in a worktree's combined tab-strip order (GitHub issue #16) - either a session tab
-/// or a file tab. `Sessions`/`crate::root::AdeApp::open_files` remain the real storage for
+/// One entry in a worktree's combined tab-strip order (GitHub issue #16) - either an agent tab
+/// or a file tab. `Agents`/`crate::root::AdeApp::open_files` remain the real storage for
 /// *existence* and all process/buffer behaviour (spawning, closing, PTY lifecycle, edit-buffer
 /// state) - this only records where a tab sits *visually*, so the two groups can interleave in
 /// one strip instead of always rendering as two rigid blocks.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TabRef {
-    Session(SessionId),
+    Agent(AgentId),
     File(PathBuf),
 }
 
 /// Reconciles a worktree's stored tab order (`crate::root::AdeApp::tab_order`) against what's
-/// *actually* open right now: drops any entry that no longer exists (a closed session, a closed
-/// file tab), then appends anything open that isn't in `stored` yet (a freshly spawned session,
-/// a freshly opened file) in `sessions_for_cwd`/`open_files`'s own order - the same "just append
+/// *actually* open right now: drops any entry that no longer exists (a closed agent, a closed
+/// file tab), then appends anything open that isn't in `stored` yet (a freshly spawned agent,
+/// a freshly opened file) in `agents_for_cwd`/`open_files`'s own order - the same "just append
 /// at the end" position a brand new tab has always landed at.
 ///
 /// Pure and idempotent: calling it again on its own output, with the same
-/// `sessions_for_cwd`/`open_files`, changes nothing. That's what lets
+/// `agents_for_cwd`/`open_files`, changes nothing. That's what lets
 /// `crate::root::AdeApp::combined_tab_order` call this fresh on every render instead of caching
 /// a mutated copy - only a real drag-drop (`crate::root::AdeApp::reorder_tab`) needs to persist a
 /// changed `Vec<TabRef>` back into `tab_order`.
 pub fn reconcile_tab_order(
     stored: &[TabRef],
-    sessions_for_cwd: &[SessionId],
+    agents_for_cwd: &[AgentId],
     open_files: &[PathBuf],
 ) -> Vec<TabRef> {
     let mut order: Vec<TabRef> = stored
         .iter()
         .filter(|tab_ref| match tab_ref {
-            TabRef::Session(id) => sessions_for_cwd.contains(id),
+            TabRef::Agent(id) => agents_for_cwd.contains(id),
             TabRef::File(path) => open_files.contains(path),
         })
         .cloned()
         .collect();
-    for id in sessions_for_cwd {
+    for id in agents_for_cwd {
         if !order
             .iter()
-            .any(|tab_ref| matches!(tab_ref, TabRef::Session(existing) if existing == id))
+            .any(|tab_ref| matches!(tab_ref, TabRef::Agent(existing) if existing == id))
         {
-            order.push(TabRef::Session(*id));
+            order.push(TabRef::Agent(*id));
         }
     }
     for path in open_files {
@@ -74,7 +74,7 @@ pub fn reconcile_tab_order(
 /// Moves `dragged` to sit immediately before `target` (or immediately after it, if
 /// `insert_after`) in `order` - the real backing for the unified tab strip's drag-to-reorder
 /// gesture (`crate::root::AdeApp::reorder_tab`), used regardless of whether `dragged`/`target`
-/// are the same kind (`TabRef::Session`/`TabRef::File`) or not, which is GitHub issue #16's real
+/// are the same kind (`TabRef::Agent`/`TabRef::File`) or not, which is GitHub issue #16's real
 /// "any tab can cross into either group" ask - there is no separate per-kind reorder function to
 /// keep in sync. A no-op if either entry is missing from `order`, or if they're the same entry.
 pub fn move_tab_order(
@@ -114,26 +114,26 @@ pub const TRANSPARENT: Rgba = Rgba {
     a: 0.0,
 };
 
-/// The agent tint `(fg, bg)` for a session's badge/chip. [`SessionKind::Shell`] isn't an agent,
+/// The agent tint `(fg, bg)` for an agent's badge/chip. [`AgentKind::Shell`] isn't an agent,
 /// so it gets a neutral chip instead of an invented tint.
-pub fn agent_tint(kind: SessionKind) -> (Rgba, Rgba) {
+pub fn agent_tint(kind: AgentKind) -> (Rgba, Rgba) {
     match kind {
-        SessionKind::Claude => (theme::agent::SONNET.0.into(), theme::agent::SONNET.1.into()),
-        SessionKind::Codex => (theme::agent::CODEX.0.into(), theme::agent::CODEX.1.into()),
-        SessionKind::Shell => (theme::text::DIM.into(), theme::surface::CHIP_NEUTRAL.into()),
+        AgentKind::Claude => (theme::agent::SONNET.0.into(), theme::agent::SONNET.1.into()),
+        AgentKind::Codex => (theme::agent::CODEX.0.into(), theme::agent::CODEX.1.into()),
+        AgentKind::Shell => (theme::text::DIM.into(), theme::surface::CHIP_NEUTRAL.into()),
     }
 }
 
 /// The agent badge's single-character initial.
-pub fn agent_initial(kind: SessionKind) -> &'static str {
+pub fn agent_initial(kind: AgentKind) -> &'static str {
     match kind {
-        SessionKind::Claude => "C",
-        SessionKind::Codex => "X",
-        SessionKind::Shell => "$",
+        AgentKind::Claude => "C",
+        AgentKind::Codex => "X",
+        AgentKind::Shell => "$",
     }
 }
 
-/// Which of the tab strip's two chip shapes a session's tab draws: agent CLI gets a `❯` glyph,
+/// Which of the tab strip's two chip shapes an agent's tab draws: agent CLI gets a `❯` glyph,
 /// terminal gets the pane glyph.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TabChipKind {
@@ -141,10 +141,10 @@ pub enum TabChipKind {
     Term,
 }
 
-pub fn tab_chip_kind(kind: SessionKind) -> TabChipKind {
+pub fn tab_chip_kind(kind: AgentKind) -> TabChipKind {
     match kind {
-        SessionKind::Claude | SessionKind::Codex => TabChipKind::Cli,
-        SessionKind::Shell => TabChipKind::Term,
+        AgentKind::Claude | AgentKind::Codex => TabChipKind::Cli,
+        AgentKind::Shell => TabChipKind::Term,
     }
 }
 
@@ -156,7 +156,7 @@ pub struct ChipColors {
     pub fg: Rgba,
 }
 
-pub fn tab_chip_colors(kind: SessionKind, active: bool) -> ChipColors {
+pub fn tab_chip_colors(kind: AgentKind, active: bool) -> ChipColors {
     if active {
         let (fg, bg) = agent_tint(kind);
         ChipColors { bg, fg }
@@ -169,7 +169,7 @@ pub fn tab_chip_colors(kind: SessionKind, active: bool) -> ChipColors {
 }
 
 /// A file tab's chip colours - the file's language chip when active, dimmed to the exact same
-/// `bg`/`fg` [`tab_chip_colors`] dims a session tab's chip to when inactive.
+/// `bg`/`fg` [`tab_chip_colors`] dims an agent tab's chip to when inactive.
 pub fn file_tab_chip_colors(lang: LangChip, active: bool) -> ChipColors {
     if active {
         ChipColors {
@@ -211,8 +211,8 @@ pub fn tab_colors(active: bool) -> TabColors {
 }
 
 /// The CLI/terminal pane header's pty-state text (`attached · waiting on stdin` / `attached ·
-/// streaming` / `exited N` / `not started`). This app has no detach/resume concept (a session is
-/// exactly one live process for its whole lifetime - see `crate::work_surface::sessions`), so a `detached ·
+/// streaming` / `exited N` / `not started`). This app has no detach/resume concept (an agent is
+/// exactly one live process for its whole lifetime - see `crate::work_surface::agents`), so a `detached ·
 /// resumable` state is never produced. Reads the same `is_running`/exit-code facts
 /// `crate::rail::status::derive_status` consumes, rather than a second heuristic that could drift from
 /// the status pill shown right next to it.
@@ -291,19 +291,19 @@ pub fn action_button_colors(style: ActionStyle) -> ActionColors {
 /// clickable but silently does nothing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ActionKind {
-    /// Sends a `Ctrl-C` to the session's pty (`TerminalPane::interrupt`).
+    /// Sends a `Ctrl-C` to the agent's pty (`TerminalPane::interrupt`).
     Interrupt,
-    /// Finds-or-spawns a `Shell` session in the same cwd and selects it.
+    /// Finds-or-spawns a `Shell` agent in the same cwd and selects it.
     OpenTerminal,
-    /// Closes this tab and spawns a fresh session of the same kind/cwd - an approximate
-    /// stand-in for `Retry`/`Resume` (this app has no saved-session resumability to actually
+    /// Closes this tab and spawns a fresh agent of the same kind/cwd - an approximate
+    /// stand-in for `Retry`/`Resume` (this app has no saved-agent resumability to actually
     /// resume *from* - see [`pty_state_label`] on the same gap).
     Respawn,
-    /// Closes this tab (`Sessions::close`) - the same action as the context bar's own `Archive`
+    /// Closes this tab (`Agents::close`) - the same action as the context bar's own `Archive`
     /// button.
     Archive,
     /// `crate::worktree_history::flow::AdeApp::keep_all_changes` (Revision R10): a real,
-    /// undoable `wt_core::undo::commit_all_changes` on this session's worktree.
+    /// undoable `wt_core::undo::commit_all_changes` on this agent's worktree.
     KeepAllChanges,
     /// `crate::worktree_history::flow::AdeApp::request_discard_worktree` (Revision R10): a real
     /// `wt_core::undo::discard_worktree`, behind the same two-click confirmation as the rail
@@ -326,7 +326,7 @@ pub struct FooterAction {
     pub keycap: Option<&'static str>,
     pub style: ActionStyle,
     /// Whether this action kind has real backing logic wired up at all (a *static* fact,
-    /// independent of this session's current state - the render call site layers further,
+    /// independent of this agent's current state - the render call site layers further,
     /// state-dependent enablement on top of this). `false` always means rendered dimmed and
     /// non-interactive, never a clickable-looking no-op.
     pub implemented: bool,
@@ -461,9 +461,9 @@ mod tests {
 
     #[test]
     fn agent_kinds_get_the_cli_chip_and_shell_gets_the_terminal_chip() {
-        assert_eq!(tab_chip_kind(SessionKind::Claude), TabChipKind::Cli);
-        assert_eq!(tab_chip_kind(SessionKind::Codex), TabChipKind::Cli);
-        assert_eq!(tab_chip_kind(SessionKind::Shell), TabChipKind::Term);
+        assert_eq!(tab_chip_kind(AgentKind::Claude), TabChipKind::Cli);
+        assert_eq!(tab_chip_kind(AgentKind::Codex), TabChipKind::Cli);
+        assert_eq!(tab_chip_kind(AgentKind::Shell), TabChipKind::Term);
     }
 
     fn same(a: Rgba, b: Rgba) -> bool {
@@ -472,8 +472,8 @@ mod tests {
 
     #[test]
     fn an_active_cli_chip_is_tinted_with_its_own_agent_colour_not_a_shared_default() {
-        let claude = tab_chip_colors(SessionKind::Claude, true);
-        let codex = tab_chip_colors(SessionKind::Codex, true);
+        let claude = tab_chip_colors(AgentKind::Claude, true);
+        let codex = tab_chip_colors(AgentKind::Codex, true);
         assert!(
             !same(claude.bg, codex.bg),
             "two different agents must not share a tab chip colour"
@@ -496,22 +496,22 @@ mod tests {
     }
 
     #[test]
-    fn an_inactive_file_tab_chip_is_dimmed_to_the_same_neutral_a_session_tab_chip_uses() {
+    fn an_inactive_file_tab_chip_is_dimmed_to_the_same_neutral_a_agent_tab_chip_uses() {
         let rs = LangChip {
             label: "rs",
             fg: theme::lang::RS.0.into(),
             bg: theme::lang::RS.1.into(),
         };
         let file_colors = file_tab_chip_colors(rs, false);
-        let session_colors = tab_chip_colors(SessionKind::Shell, false);
-        assert!(same(file_colors.bg, session_colors.bg));
-        assert!(same(file_colors.fg, session_colors.fg));
+        let agent_colors = tab_chip_colors(AgentKind::Shell, false);
+        assert!(same(file_colors.bg, agent_colors.bg));
+        assert!(same(file_colors.fg, agent_colors.fg));
     }
 
     #[test]
     fn an_inactive_chip_is_always_dimmed_to_the_same_neutral_regardless_of_kind() {
-        let claude = tab_chip_colors(SessionKind::Claude, false);
-        let shell = tab_chip_colors(SessionKind::Shell, false);
+        let claude = tab_chip_colors(AgentKind::Claude, false);
+        let shell = tab_chip_colors(AgentKind::Shell, false);
         assert!(same(claude.bg, shell.bg));
         assert!(same(claude.fg, shell.fg));
         assert!(same(claude.bg, theme::border::ZONE.into()));
@@ -557,7 +557,7 @@ mod tests {
     }
 
     #[test]
-    fn a_running_and_recently_active_session_reports_streaming() {
+    fn a_running_and_recently_active_agent_reports_streaming() {
         assert_eq!(
             pty_state_label(true, Status::Run, None),
             "attached \u{b7} streaming"
@@ -646,12 +646,12 @@ mod tests {
         }
     }
 
-    /// A fresh worktree (nothing dragged yet) must render its sessions first, in creation order,
+    /// A fresh worktree (nothing dragged yet) must render its agents first, in creation order,
     /// then its file tabs, in `open_files`' own order - exactly the old two-block layout, so this
     /// revision's interleaving layer is a strict superset of the old behaviour, not a visible
     /// change until a real drag happens.
     #[test]
-    fn reconcile_with_no_stored_order_appends_sessions_then_files_in_their_own_order() {
+    fn reconcile_with_no_stored_order_appends_agents_then_files_in_their_own_order() {
         let order = reconcile_tab_order(
             &[],
             &[1, 2],
@@ -660,8 +660,8 @@ mod tests {
         assert_eq!(
             order,
             vec![
-                TabRef::Session(1),
-                TabRef::Session(2),
+                TabRef::Agent(1),
+                TabRef::Agent(2),
                 TabRef::File(PathBuf::from("a.rs")),
                 TabRef::File(PathBuf::from("b.rs")),
             ]
@@ -669,71 +669,71 @@ mod tests {
     }
 
     /// The real interleaving case (GitHub issue #16): a stored order with a file tab sitting
-    /// between two session tabs must survive reconciliation unchanged, as long as every entry in
+    /// between two agent tabs must survive reconciliation unchanged, as long as every entry in
     /// it still exists.
     #[test]
     fn reconcile_preserves_a_stored_interleaved_order() {
         let stored = vec![
-            TabRef::Session(1),
+            TabRef::Agent(1),
             TabRef::File(PathBuf::from("a.rs")),
-            TabRef::Session(2),
+            TabRef::Agent(2),
         ];
         let order = reconcile_tab_order(&stored, &[1, 2], &[PathBuf::from("a.rs")]);
         assert_eq!(order, stored);
     }
 
-    /// A session closed (or a file tab closed) since the order was last stored must be dropped,
+    /// A agent closed (or a file tab closed) since the order was last stored must be dropped,
     /// not left as a dangling reference to something `crate::root::AdeApp::render_tab_strip`
     /// would otherwise try to render.
     #[test]
     fn reconcile_drops_entries_that_no_longer_exist() {
         let stored = vec![
-            TabRef::Session(1),
+            TabRef::Agent(1),
             TabRef::File(PathBuf::from("a.rs")),
-            TabRef::Session(2),
+            TabRef::Agent(2),
         ];
         let order = reconcile_tab_order(&stored, &[2], &[]);
-        assert_eq!(order, vec![TabRef::Session(2)]);
+        assert_eq!(order, vec![TabRef::Agent(2)]);
     }
 
-    /// A brand new session/file not yet in the stored order must be appended at the end, never
+    /// A brand new agent/file not yet in the stored order must be appended at the end, never
     /// silently dropped or inserted somewhere the user never asked for.
     #[test]
     fn reconcile_appends_newly_opened_tabs_not_yet_in_the_stored_order() {
-        let stored = vec![TabRef::Session(1)];
+        let stored = vec![TabRef::Agent(1)];
         let order = reconcile_tab_order(&stored, &[1, 2], &[PathBuf::from("a.rs")]);
         assert_eq!(
             order,
             vec![
-                TabRef::Session(1),
-                TabRef::Session(2),
+                TabRef::Agent(1),
+                TabRef::Agent(2),
                 TabRef::File(PathBuf::from("a.rs")),
             ]
         );
     }
 
     /// The real cross-kind drag this revision exists to unlock: dropping a file tab so it lands
-    /// immediately before a session tab must actually interleave them, not just reorder within
+    /// immediately before an agent tab must actually interleave them, not just reorder within
     /// each tab's own kind.
     #[test]
-    fn move_tab_order_drops_a_file_tab_before_a_session_tab() {
+    fn move_tab_order_drops_a_file_tab_before_a_agent_tab() {
         let mut order = vec![
-            TabRef::Session(1),
-            TabRef::Session(2),
+            TabRef::Agent(1),
+            TabRef::Agent(2),
             TabRef::File(PathBuf::from("a.rs")),
         ];
         move_tab_order(
             &mut order,
             &TabRef::File(PathBuf::from("a.rs")),
-            &TabRef::Session(2),
+            &TabRef::Agent(2),
             false,
         );
         assert_eq!(
             order,
             vec![
-                TabRef::Session(1),
+                TabRef::Agent(1),
                 TabRef::File(PathBuf::from("a.rs")),
-                TabRef::Session(2),
+                TabRef::Agent(2),
             ]
         );
     }
@@ -743,11 +743,11 @@ mod tests {
     /// half of the hovered tab) is for.
     #[test]
     fn move_tab_order_respects_insert_after() {
-        let mut order = vec![TabRef::Session(1), TabRef::Session(2), TabRef::Session(3)];
-        move_tab_order(&mut order, &TabRef::Session(1), &TabRef::Session(2), true);
+        let mut order = vec![TabRef::Agent(1), TabRef::Agent(2), TabRef::Agent(3)];
+        move_tab_order(&mut order, &TabRef::Agent(1), &TabRef::Agent(2), true);
         assert_eq!(
             order,
-            vec![TabRef::Session(2), TabRef::Session(1), TabRef::Session(3)]
+            vec![TabRef::Agent(2), TabRef::Agent(1), TabRef::Agent(3)]
         );
     }
 
@@ -755,11 +755,11 @@ mod tests {
     /// an unknown dragged entry, or an unknown target must all be real no-ops.
     #[test]
     fn move_tab_order_is_a_no_op_for_an_unknown_or_identical_entry() {
-        let original = vec![TabRef::Session(1), TabRef::File(PathBuf::from("a.rs"))];
+        let original = vec![TabRef::Agent(1), TabRef::File(PathBuf::from("a.rs"))];
         let mut order = original.clone();
-        move_tab_order(&mut order, &TabRef::Session(1), &TabRef::Session(1), false);
-        move_tab_order(&mut order, &TabRef::Session(99), &TabRef::Session(1), false);
-        move_tab_order(&mut order, &TabRef::Session(1), &TabRef::Session(99), false);
+        move_tab_order(&mut order, &TabRef::Agent(1), &TabRef::Agent(1), false);
+        move_tab_order(&mut order, &TabRef::Agent(99), &TabRef::Agent(1), false);
+        move_tab_order(&mut order, &TabRef::Agent(1), &TabRef::Agent(99), false);
         assert_eq!(order, original);
     }
 }

--- a/crates/app/src/worktree_history/flow.rs
+++ b/crates/app/src/worktree_history/flow.rs
@@ -43,16 +43,16 @@ impl AdeApp {
     }
 
     /// The Review footer's `Keep all` action - a real `wt_core::undo::commit_all_changes` on
-    /// session `id`'s worktree. Not gated by any confirmation (unlike
+    /// agent `id`'s worktree. Not gated by any confirmation (unlike
     /// [`Self::request_discard_worktree`]): it's non-destructive.
-    pub(crate) fn keep_all_changes(&mut self, id: SessionId, cx: &mut Context<Self>) {
+    pub(crate) fn keep_all_changes(&mut self, id: AgentId, cx: &mut Context<Self>) {
         if self.worktree_history_op_in_flight.is_some() {
             return;
         }
-        let Some(session) = self.sessions.iter().find(|session| session.id == id) else {
+        let Some(agent) = self.agents.iter().find(|agent| agent.id == id) else {
             return;
         };
-        let worktree_path = session.cwd.clone();
+        let worktree_path = agent.cwd.clone();
         let branch_display = self.branch_display_for(&worktree_path);
         self.prune_confirm_armed = false;
         self.discard_confirm_armed = None;
@@ -91,10 +91,10 @@ impl AdeApp {
     /// force-removes a worktree directory, preserving uncommitted/untracked content in a real git
     /// stash first (see [`wt_core::undo::discard_worktree`]'s own docs), but not undoable from
     /// within this app). The first click only arms [`AdeApp::discard_confirm_armed`] for `id`; a
-    /// second click on the *same* session's button while armed actually runs it.
+    /// second click on the *same* agent's button while armed actually runs it.
     pub(crate) fn request_discard_worktree(
         &mut self,
-        id: SessionId,
+        id: AgentId,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -114,21 +114,21 @@ impl AdeApp {
     /// Runs the real, already-confirmed discard - only ever reached through
     /// [`Self::request_discard_worktree`]'s second click. `_window` is accepted (not read
     /// directly) purely to match every other footer-button click handler's signature - the real
-    /// `Window` [`Self::close_session`] needs on success is obtained fresh, asynchronously, via
+    /// `Window` [`Self::close_agent`] needs on success is obtained fresh, asynchronously, via
     /// `update_in` in the completion handler below (see this module's own docs).
     pub(in crate::worktree_history) fn execute_discard_worktree(
         &mut self,
-        id: SessionId,
+        id: AgentId,
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         if self.worktree_history_op_in_flight.is_some() {
             return;
         }
-        let Some(session) = self.sessions.iter().find(|session| session.id == id) else {
+        let Some(agent) = self.agents.iter().find(|agent| agent.id == id) else {
             return;
         };
-        let worktree_path = session.cwd.clone();
+        let worktree_path = agent.cwd.clone();
         let repo_path = self.focused_repo_path();
         let branch_display = self.branch_display_for(&worktree_path);
         self.worktree_history_op_in_flight = Some(WorktreeHistoryOpKind::Discard);
@@ -141,7 +141,7 @@ impl AdeApp {
                 .spawn(async move { wt_core::undo::discard_worktree(&repo_path, &worktree_path) })
                 .await;
             // `update_in` (not plain `update`): a successful discard closes the now-cwd-less
-            // session tab, and `Self::close_session` needs a real `Window` to move focus off it -
+            // agent tab, and `Self::close_agent` needs a real `Window` to move focus off it -
             // see `vendor/zed/crates/gpui/src/app/async_context.rs`'s `AsyncApp::with_window`,
             // the same mechanism `Self::trigger_goto_definition`'s own completion handler already
             // relies on for the identical reason.
@@ -161,8 +161,8 @@ impl AdeApp {
                         } else {
                             format!("discarded {branch_display}")
                         });
-                        // The session's cwd no longer exists.
-                        this.close_session(id, window, cx);
+                        // The agent's cwd no longer exists.
+                        this.close_agent(id, window, cx);
                         this.refresh_after_worktree_history_op(cx);
                     }
                     Err(err) => {
@@ -243,16 +243,16 @@ mod worktree_history_regression_tests {
         path
     }
 
-    /// Spawns a real `Shell` session (a real pty) in `cwd` and returns its id - the same
-    /// `sessions.spawn` call `AdeApp::new_session` itself makes.
-    fn spawn_session(
+    /// Spawns a real `Shell` agent (a real pty) in `cwd` and returns its id - the same
+    /// `agents.spawn` call `AdeApp::new_agent` itself makes.
+    fn spawn_agent(
         app: &Entity<AdeApp>,
         cx: &mut gpui::VisualTestContext,
         cwd: PathBuf,
-    ) -> SessionId {
+    ) -> AgentId {
         app.update_in(cx, |app, window, cx| {
-            app.sessions.spawn(
-                SessionKind::Shell,
+            app.agents.spawn(
+                AgentKind::Shell,
                 cwd,
                 app.settings.appearance.terminal_font_size,
                 window,
@@ -268,7 +268,7 @@ mod worktree_history_regression_tests {
         fs::write(feature.join("new.txt"), "from feature\n").expect("write");
 
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        let id = spawn_session(&app, cx, feature.clone());
+        let id = spawn_agent(&app, cx, feature.clone());
         let head_before = git_output(&feature, &["rev-parse", "HEAD"]);
 
         app.update(cx, |app, cx| app.keep_all_changes(id, cx));
@@ -305,8 +305,8 @@ mod worktree_history_regression_tests {
         fs::write(feature_b.join("b.txt"), "b\n").expect("write");
 
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        let id_a = spawn_session(&app, cx, feature_a.clone());
-        let id_b = spawn_session(&app, cx, feature_b.clone());
+        let id_a = spawn_agent(&app, cx, feature_a.clone());
+        let id_b = spawn_agent(&app, cx, feature_b.clone());
 
         app.update(cx, |app, cx| app.keep_all_changes(id_a, cx));
         assert!(app.read_with(cx, |app, _| app.worktree_history_op_in_flight.is_some()));
@@ -330,15 +330,13 @@ mod worktree_history_regression_tests {
     }
 
     #[gpui::test]
-    fn discard_worktree_two_click_confirm_removes_it_and_closes_its_session(
-        cx: &mut TestAppContext,
-    ) {
+    fn discard_worktree_two_click_confirm_removes_it_and_closes_its_agent(cx: &mut TestAppContext) {
         let repo = init_repo();
         let feature = add_worktree(repo.path(), "feature", "feature-wt");
         fs::write(feature.join("scratch.txt"), "wip\n").expect("write untracked");
 
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        let id = spawn_session(&app, cx, feature.clone());
+        let id = spawn_agent(&app, cx, feature.clone());
 
         // Click 1: arm.
         app.update_in(cx, |app, window, cx| {
@@ -363,11 +361,11 @@ mod worktree_history_regression_tests {
         );
         assert!(
             app.read_with(cx, |app, _| app
-                .sessions
+                .agents
                 .iter()
                 .find(|s| s.id == id)
                 .is_none()),
-            "the now-cwd-less session tab must have been closed"
+            "the now-cwd-less agent tab must have been closed"
         );
     }
 
@@ -390,7 +388,7 @@ mod worktree_history_regression_tests {
         .expect("write ignored file");
 
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        let id = spawn_session(&app, cx, feature.clone());
+        let id = spawn_agent(&app, cx, feature.clone());
         app.update_in(cx, |app, window, cx| {
             app.request_discard_worktree(id, window, cx)
         });

--- a/crates/app/src/worktree_history/mod.rs
+++ b/crates/app/src/worktree_history/mod.rs
@@ -7,9 +7,9 @@
 //! of that file - the same convention `crate::root` established for its own submodules.
 
 use crate::root::*;
-use crate::work_surface::sessions::SessionId;
+use crate::work_surface::agents::AgentId;
 #[cfg(test)]
-use crate::work_surface::sessions::SessionKind;
+use crate::work_surface::agents::AgentKind;
 use gpui::{Context, Window};
 use std::path::Path;
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Stacked on #57 (`revision-r12-rail-rewrite`). Pure rename, zero behavior change: `Session`/`SessionId`/`SessionKind`/`SessionRow`/the `Sessions` collection all become `Agent`/`AgentId`/`AgentKind`/`AgentRow`/`Agents`, and `work_surface/sessions.rs` moves to `work_surface/agents.rs`.

Motivation: the design spec (`design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §1) explicitly frames "Session" as the old, pre-redesign concept that fused agent and worktree into one object. The code's actual semantics already match the new model (a session's `cwd` is the worktree it runs in; several can share one `cwd`) — only the name hadn't caught up. This makes every file after it in the stack consistent with the vocabulary the spec actually uses.

Deliberately left alone (different concepts, confirmed by reading before leaving them): `SessionKind`'s own variant names `Shell`/`Claude`/`Codex`; `pty_core::PtySession` (a different crate's own type); `TerminalPane`'s internal `session: Option<PtySession>` field (the raw OS pty handle, distinct from which `Agent` owns it); a literal quote of the spec's own now-removed `groupSessions` prop name.

Also fixed a literal `"SESSIONS"` rail-header label the rename's case-sensitive grep sweep initially missed (all-caps doesn't match `[Ss]ession`) — now `"AGENTS"`.

One thing checked and deliberately not changed: the rail's own `+` button has no text label (just a `+` glyph) and spawns `AgentKind::Shell` into the current worktree — i.e. it's the same action as the tab-strip's own "New terminal" menu item, not "New agent". Relabeling it "New agent" would have been factually wrong, so its render body is untouched beyond the identifier rename.

## Testing

Independently re-verified (not just agent-reported):
- `cargo fmt --all -- --check` — clean
- `cargo build --workspace` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace --lib -- --test-threads=1` — 1098 + 44 + 14 + 107 = 1263 passed, 0 failed
- Final `grep -rn "[Ss]ession" crates/app/src/` swept manually — every remaining hit confirmed to be a different, legitimately-unrenamed concept
- The one test that failed once during verification (`diff_render_tests::repeated_refreshes_of_the_same_open_diff_reuse_the_cached_highlighting`) was re-run 5x in isolation (4/5 pass) — confirmed as this repo's known pre-existing flake, not a rename regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)