### PR TITLE
fix(app): scope open file tabs and unsaved edits to their worktree

### DIFF
--- a/BUILD-LOG.md
+++ b/BUILD-LOG.md
@@ -4973,3 +4973,125 @@ user-facing copy that isn't clearly in scope.
 failed** across all four crates, both before and after the final text-only `"SESSIONS"` →
 `"AGENTS"` edit. 54 files touched in `crates/app` (53 modified, one renamed:
 `work_surface/sessions.rs` → `work_surface/agents.rs`); nothing outside `crates/app` changed.
+
+## Worktree-scoping `open_files`/`edit_buffers`, and a scope mismatch on the third assigned bug
+
+Three bugs were assigned, all supposedly rooted in `AdeApp::select_worktree`/
+`reset_per_worktree_ui_state`: `open_files` cleared instead of scoped per worktree, `edit_buffers`
+cleared instead of scoped (real, silent unsaved-edit data loss), and a UI-only `staged_files`
+checkbox that never touched real git and never got re-derived from it. The first two were real and
+are fixed here. The third does not exist in this branch - see its own section below for why, and
+what was done about it instead.
+
+### Root cause
+
+`design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §1/§3 are explicit: the open file
+tabs and the active tab are worktree-scoped, and "switching worktrees swaps the whole strip - each
+worktree remembers its own active tab and its own open files." `AdeApp::select_worktree`'s helper
+`reset_per_worktree_ui_state` instead treated `open_files: Vec<PathBuf>` and
+`edit_buffers: HashMap<PathBuf, EditBuffer>` as flat, single-worktree state and unconditionally
+cleared both on every switch - so a worktree's open tabs vanished the instant you clicked away,
+and, far worse, a real unsaved edit sitting in `edit_buffers` was silently discarded with no
+confirm dialog at all. Both fields were keyed by a worktree-*relative* path with no worktree
+component in the key, so there was no way to keep more than one worktree's entries around at once
+without them colliding on a shared relative path (`src/main.rs` in worktree A and `src/main.rs` in
+worktree B are unrelated files).
+
+The user had already ruled out a confirm-before-switching dialog for the `edit_buffers` case - real
+friction in a tool whose whole point is fluidly hopping between worktrees with several agents
+running in parallel. The fix is to make the state genuinely per-worktree instead, mirroring how
+`AdeApp::tab_order: HashMap<PathBuf, Vec<TabRef>>` (same struct, same file) already does this
+correctly for tab ordering.
+
+### The new shapes
+
+- **`open_files`** → `open_files_by_worktree: HashMap<PathBuf, Vec<PathBuf>>`, keyed by
+  `AdeApp::file_tree_root` (the same root every `open_files` entry's relative path is already
+  computed against, via `strip_prefix`). Two new accessors, `AdeApp::open_files()` /
+  `AdeApp::open_files_mut()`, resolve the *current* worktree's slice/`Vec` - an empty slice for a
+  worktree that has never opened a file, never a panic. Every call site (`push_open_file`,
+  `close_file_tab`, `rename_open_paths`, `forget_deleted_paths`, `combined_tab_order`, the palette,
+  ~20 call sites total) now goes through one of these two methods instead of touching a flat field.
+- **`edit_buffers`** → key changed from `PathBuf` to `(PathBuf, PathBuf)` - `(worktree, relative
+  path)` - rather than nesting a second `HashMap` per worktree (`HashMap<PathBuf,
+  HashMap<PathBuf, EditBuffer>>`): a composite tuple key needs no `.entry(cwd).or_default()`
+  ceremony at every read site, and `AdeApp::edit_buffer`/`edit_buffer_mut`/
+  `edit_buffer_contains`/`insert_edit_buffer` (resolving the worktree half from the *current*
+  `file_tree_root`) cover the ~140 synchronous call sites the same way `open_files`'s two methods
+  do.
+- **A second, explicit-key pair for async continuations**: `AdeApp::edit_buffer_at`/
+  `edit_buffer_at_mut` take a `cwd: &Path` argument instead of reading `self.file_tree_root`.
+  Every real `cx.spawn` task that reads or writes an edit buffer *after* an `.await`
+  (`code_surface::tabs::spawn_file_load`, `code_surface::editing::schedule_rehighlight`'s debounce
+  continuation, `code_surface::editing::spawn_file_save_loop`'s per-iteration write, and
+  `lsp::client::schedule_lsp_sync`'s debounce continuation via `prepare_lsp_sync`, which also
+  gained an explicit `cwd` parameter) now captures `cwd = self.file_tree_root.clone()` *before* its
+  first `.await` and threads it through, rather than re-deriving the worktree half of the key from
+  whatever `file_tree_root` happens to be once the task resumes - which could by then name a
+  worktree the user switched to while the task was in flight, silently corrupting a *different*
+  worktree's buffer. This mirrors the identity-guard discipline `load_file_tree` already uses for
+  `file_tree_root` itself, applied here to a keyed map instead of a single field.
+
+  Worth being honest about: `AdeApp::select_worktree` already drops (and so cancels, since a GPUI
+  `Task` cancels on drop unless detached) every task-holding field these continuations live in -
+  `_file_load_task`, `_rehighlight_tasks`, `_file_save_tasks`, `_lsp_sync_tasks` - on every switch,
+  and does so synchronously, so none of these specific continuations can actually resume with a
+  stale `file_tree_root` *today*. The explicit-`cwd` plumbing is real defense-in-depth, not a fix
+  for a currently-live race - it's what keeps this correct if any of those tasks is ever detached
+  later (e.g. to let an in-flight save finish on disk even after the user switches away, which is a
+  plausible thing to want), rather than silently becoming exploitable then.
+
+- **`reset_per_worktree_ui_state`** no longer touches either field at all. Once both are looked up
+  *through* the worktree they belong to, the reassignment of `file_tree_root` a few lines later in
+  `select_worktree` is itself what makes the worktree just left stop being "current" - nothing
+  needs to delete its entries, and deleting them was exactly the bug. The function's signature
+  shrank from six parameters to four (`reviewed_files`, `open_change`, `expanded_dirs`,
+  `selected_tree_path` - none of which were in scope for this fix).
+
+New tests: `open_files_by_worktree_keeps_each_worktree_s_tabs_independent`/
+`edit_buffers_composite_key_never_collides_across_worktrees` (`root/state.rs`, pure data-shape
+proofs) plus two real, `AdeApp`-driven regression tests through genuine `select_worktree` switches
+across two real temp-directory worktrees: `code_surface::tabs::multi_file_tab_tests::
+switching_worktrees_and_back_preserves_each_worktree_s_open_file_tabs` and
+`code_surface::editing::editing_tests::
+switching_worktrees_and_back_preserves_unsaved_edits_without_cross_worktree_collision` - the
+second deliberately gives both worktrees a file at the *identical* relative path (`sample.txt`)
+with different real unsaved content in each, and proves neither a switch-and-back nor the shared
+relative path ever merges or overwrites the other's buffer.
+
+**Left alone, flagged rather than silently expanded**: `AdeApp::reviewed_files`/`open_change`
+still clear on every switch, same as before. `reviewed_files` exhibits the identical "flat state
+that should probably be per-worktree" shape `open_files` had, and `open_change` (which tab is
+*active*) is the other half of §3's "own active tab" - but neither was named in the three assigned
+bugs, and expanding scope to them wasn't asked for. Worth a follow-up.
+
+### The third bug does not exist on this branch
+
+The assigned bug named `AdeApp::staged_files: HashSet<PathBuf>`, `toggle_staged` in
+`sidebar/render.rs`, `wt_core::undo::commit_paths`, `commit_staged_files`, and a test named
+`commit_paths_never_commits_a_path_that_was_staged_by_something_else`. None of these identifiers
+exist anywhere in this repository (`grep -rn` across `crates/app` and `crates/wt-core` for every
+one of them: zero matches). What exists instead is `AdeApp::reviewed_files: HashSet<PathBuf>` and
+`sidebar::render::toggle_reviewed` - a real, but *different*, feature: a purely local "mark this
+Changes row reviewed" checkbox with no relationship to git staging at all, predating this
+revision's design and still matching the base `README.md`'s own "dimmed once reviewed" framing
+(not the revision doc's "the checkbox **is** staging").
+
+The described staging/commit-composer infrastructure is real, but lives on a **sibling, unmerged
+branch** - `revision-r12-tabs-changes` (commits `dd9cf6b`/`10a8452`/`d66adff`, the last one
+literally titled "rebasing the commit composer onto rail-rewrite"). That branch shares this one's
+own base (`f6df444`, the rail rewrite) but the two have diverged since and neither is an ancestor
+of the other - `git merge-base --is-ancestor dd9cf6b HEAD` fails. Implementing the assigned fix
+here would have meant either building a second, competing staging/commit-composer implementation
+from scratch (duplicate work, guaranteed to conflict messily whichever branch merges second) or
+merging an entire sibling feature branch's worth of unrelated, in-progress work into a PR scoped
+to three named worktree-state bugs. Neither is a defensible substitute for "fix the bug as
+described," so this PR does not touch staging at all - it fixes the two bugs that are real on this
+branch and reports this one as a scope mismatch rather than silently reinterpreting or fabricating
+it. `AdeApp::reviewed_files` was left exhibiting the same per-switch-clearing pattern `open_files`
+had (see above) since it wasn't part of either the real or the described third bug.
+
+**Verification**: `cargo fmt --all -- --check`, `cargo build --workspace`,
+`cargo clippy --workspace --all-targets -- -D warnings` - all clean.
+`cargo test --workspace --lib -- --test-threads=1`: **1100 + 44 + 14 + 107 = 1265 passed, 0
+failed** across all four crates (1263 baseline + 2 new tests). No flakes observed in this run.

--- a/crates/app/src/code_surface/editing.rs
+++ b/crates/app/src/code_surface/editing.rs
@@ -146,14 +146,14 @@ impl AdeApp {
 
     pub(crate) fn active_edit_buffer(&self) -> Option<&EditBuffer> {
         match self.active_edit_target()? {
-            EditTarget::File(path) => self.edit_buffers.get(&path),
+            EditTarget::File(path) => self.edit_buffer(&path),
             EditTarget::Merge => self.merge_edit.as_ref().map(|edit| &edit.buffer),
         }
     }
 
     fn active_edit_buffer_mut(&mut self) -> Option<&mut EditBuffer> {
         match self.active_edit_target()? {
-            EditTarget::File(path) => self.edit_buffers.get_mut(&path),
+            EditTarget::File(path) => self.edit_buffer_mut(&path),
             EditTarget::Merge => self.merge_edit.as_mut().map(|edit| &mut edit.buffer),
         }
     }
@@ -166,7 +166,7 @@ impl AdeApp {
     pub(crate) fn sync_cursor_and_scroll(&mut self) {
         match self.active_edit_target() {
             Some(EditTarget::File(path)) => {
-                let Some(buffer) = self.edit_buffers.get(&path) else {
+                let Some(buffer) = self.edit_buffer(&path) else {
                     return;
                 };
                 let (line, _) = buffer.line_col_for_offset(buffer.cursor_offset());
@@ -192,7 +192,7 @@ impl AdeApp {
     /// (cancels) whatever earlier debounce timer for the same path was still waiting, so only the
     /// most recent keystroke's timer ever actually fires - real debounce, not a queue.
     pub(crate) fn schedule_rehighlight(&mut self, path: PathBuf, cx: &mut Context<Self>) {
-        let Some(buffer) = self.edit_buffers.get(&path) else {
+        let Some(buffer) = self.edit_buffer(&path) else {
             return;
         };
         if !buffer.highlight_dirty {
@@ -203,12 +203,16 @@ impl AdeApp {
             // "no highlighter -> plain text" behavior) - the plain rebuild already done by
             // `EditBuffer::rebuild_plain` is the final, correct rendering; just clear the flag
             // rather than debouncing work that would never run.
-            if let Some(buffer) = self.edit_buffers.get_mut(&path) {
+            if let Some(buffer) = self.edit_buffer_mut(&path) {
                 buffer.highlight_dirty = false;
             }
             return;
         };
         let content_snapshot = buffer.content.clone();
+        // Captured now (synchronously, before the real debounce timer below) rather than
+        // re-read from `self.file_tree_root` once this task resumes - see `AdeApp::
+        // edit_buffers`'s own docs for the stale-worktree bug class this prevents.
+        let cwd = self.file_tree_root.clone();
         let task = cx.spawn({
             let path = path.clone();
             let content_snapshot = content_snapshot.clone();
@@ -225,7 +229,7 @@ impl AdeApp {
                     })
                     .await;
                 let _ = this.update(cx, |this, cx| {
-                    if let Some(buffer) = this.edit_buffers.get_mut(&path) {
+                    if let Some(buffer) = this.edit_buffer_at_mut(&cwd, &path) {
                         if buffer.apply_highlight(&content_snapshot, lines) {
                             cx.notify();
                         }
@@ -250,12 +254,12 @@ impl AdeApp {
         // for a different bug class.
         match self.active_edit_target() {
             Some(EditTarget::File(path)) => {
-                let Some(buffer) = self.edit_buffers.get_mut(&path) else {
+                let Some(buffer) = self.edit_buffer_mut(&path) else {
                     return;
                 };
                 buffer.backspace();
                 self.schedule_rehighlight(path.clone(), cx);
-                self.schedule_lsp_sync(path, cx);
+                self.schedule_lsp_sync(self.file_tree_root.clone(), path, cx);
             }
             Some(EditTarget::Merge) => {
                 let Some(edit) = self.merge_edit.as_mut() else {
@@ -280,12 +284,12 @@ impl AdeApp {
         // `EditBuffer::delete_forward` for the same real reason.
         match self.active_edit_target() {
             Some(EditTarget::File(path)) => {
-                let Some(buffer) = self.edit_buffers.get_mut(&path) else {
+                let Some(buffer) = self.edit_buffer_mut(&path) else {
                     return;
                 };
                 buffer.delete_forward();
                 self.schedule_rehighlight(path.clone(), cx);
-                self.schedule_lsp_sync(path, cx);
+                self.schedule_lsp_sync(self.file_tree_root.clone(), path, cx);
             }
             Some(EditTarget::Merge) => {
                 let Some(edit) = self.merge_edit.as_mut() else {
@@ -575,13 +579,13 @@ impl AdeApp {
         let unit = indent::indent_unit(settings);
         let changed = match self.active_edit_target() {
             Some(EditTarget::File(path)) => {
-                let Some(buffer) = self.edit_buffers.get_mut(&path) else {
+                let Some(buffer) = self.edit_buffer_mut(&path) else {
                     return;
                 };
                 let changed = buffer.indent_lines(&unit);
                 if changed {
                     self.schedule_rehighlight(path.clone(), cx);
-                    self.schedule_lsp_sync(path, cx);
+                    self.schedule_lsp_sync(self.file_tree_root.clone(), path, cx);
                 }
                 changed
             }
@@ -614,13 +618,13 @@ impl AdeApp {
         let settings = self.resolved_indent_settings_for_target();
         let changed = match self.active_edit_target() {
             Some(EditTarget::File(path)) => {
-                let Some(buffer) = self.edit_buffers.get_mut(&path) else {
+                let Some(buffer) = self.edit_buffer_mut(&path) else {
                     return;
                 };
                 let changed = buffer.dedent_lines(settings.tab_width);
                 if changed {
                     self.schedule_rehighlight(path.clone(), cx);
-                    self.schedule_lsp_sync(path, cx);
+                    self.schedule_lsp_sync(self.file_tree_root.clone(), path, cx);
                 }
                 changed
             }
@@ -653,7 +657,7 @@ impl AdeApp {
             tab_width: self.settings.editor.tab_width,
         };
         match self.active_edit_target() {
-            Some(EditTarget::File(path)) => match self.edit_buffers.get(&path) {
+            Some(EditTarget::File(path)) => match self.edit_buffer(&path) {
                 Some(buffer) => indent::indent_settings_for_path(
                     &buffer.path,
                     &self.file_tree_root,
@@ -833,7 +837,7 @@ impl AdeApp {
     fn step_edit_history(&mut self, cx: &mut Context<Self>, undo: bool) {
         match self.active_edit_target() {
             Some(EditTarget::File(path)) => {
-                let Some(buffer) = self.edit_buffers.get_mut(&path) else {
+                let Some(buffer) = self.edit_buffer_mut(&path) else {
                     return;
                 };
                 let changed = if undo { buffer.undo() } else { buffer.redo() };
@@ -844,7 +848,7 @@ impl AdeApp {
                 // meaningless - the same reasoning `Self::move_active_buffer` already applies.
                 self.dismiss_completions();
                 self.schedule_rehighlight(path.clone(), cx);
-                self.schedule_lsp_sync(path, cx);
+                self.schedule_lsp_sync(self.file_tree_root.clone(), path, cx);
             }
             Some(EditTarget::Merge) => {
                 let Some(edit) = self.merge_edit.as_mut() else {
@@ -909,7 +913,7 @@ impl AdeApp {
         let Some(path) = self.active_editable_path() else {
             return;
         };
-        let Some(buffer) = self.edit_buffers.get(&path) else {
+        let Some(buffer) = self.edit_buffer(&path) else {
             return;
         };
 
@@ -980,7 +984,7 @@ impl AdeApp {
         let Some(path) = self.active_editable_path() else {
             return;
         };
-        let Some(buffer) = self.edit_buffers.get(&path) else {
+        let Some(buffer) = self.edit_buffer(&path) else {
             return;
         };
         if !buffer.is_dirty() {
@@ -1004,7 +1008,13 @@ impl AdeApp {
             return;
         }
         self.file_save_running.insert(path.clone());
-        self.spawn_file_save_loop(path, cx);
+        // Captured now (synchronously - `enqueue_save` is only ever reached from a real
+        // keystroke/action handler) rather than re-read from `self.file_tree_root` inside the
+        // loop below, which spans real `.await`s and so could otherwise resolve against whatever
+        // worktree the user has since switched to. See `AdeApp::edit_buffers`'s own docs for the
+        // stale-worktree bug class this prevents.
+        let cwd = self.file_tree_root.clone();
+        self.spawn_file_save_loop(cwd, path, cx);
     }
 
     /// The real serial writer loop for one path - see [`AdeApp::save_active_file`]'s docs. Reads
@@ -1015,18 +1025,20 @@ impl AdeApp {
     /// [`AdeApp::file_save_running`] must be cleared on *every* real exit path from the loop
     /// below, not just one of them - a real, if previously only latent, bug an audit caught: an
     /// earlier version only cleared it in the "no pending save left" branch, so a pending save
-    /// whose [`AdeApp::edit_buffers`] entry vanished before this loop got to check it (currently
-    /// only reachable via `state::reset_per_worktree_ui_state`, which happens to clear
-    /// `file_save_running` too today - so this was latent, not live, but one future refactor away
-    /// from becoming real) left `file_save_running` stuck containing that path forever, since the
-    /// closure below returned `None` without clearing it and the loop broke on exactly that
-    /// `None`. [`Self::enqueue_save`] then treats any path still in `file_save_running` as "a
-    /// writer loop is already alive for it" and silently no-ops every future save for that path -
+    /// whose [`AdeApp::edit_buffers`] entry vanished before this loop got to check it (a real,
+    /// live path - `crate::sidebar::tree_ops::AdeApp::forget_deleted_paths` really does remove a
+    /// deleted file's buffer entry via `edit_buffers.retain`, and a save can genuinely still be
+    /// pending for it at that moment; also directly simulated in this module's own tests via the
+    /// test-only `AdeApp::remove_edit_buffer`) left `file_save_running` stuck containing that path
+    /// forever, since the closure below returned `None` without clearing it and the loop broke on
+    /// exactly that `None`. [`Self::enqueue_save`] then treats any path still in
+    /// `file_save_running` as "a writer loop is already alive for it" and silently no-ops every
+    /// future save for that path -
     /// a real, silent, permanent, data-loss-adjacent failure the user would have no way to notice
     /// (Ctrl+S would appear to do nothing, forever, for that one file). Restructured so there is
     /// exactly one real place this flag is set ([`Self::enqueue_save`]) and every `None`-producing
     /// branch here clears it before returning `None`, impossible to desync.
-    fn spawn_file_save_loop(&mut self, path: PathBuf, cx: &mut Context<Self>) {
+    fn spawn_file_save_loop(&mut self, cwd: PathBuf, path: PathBuf, cx: &mut Context<Self>) {
         let task = cx.spawn({
             let path = path.clone();
             async move |this, cx| {
@@ -1036,7 +1048,7 @@ impl AdeApp {
                             this.file_save_running.remove(&path);
                             return None;
                         }
-                        match this.edit_buffers.get(&path) {
+                        match this.edit_buffer_at(&cwd, &path) {
                             Some(buffer) => Some((buffer.path.clone(), buffer.content.clone())),
                             None => {
                                 // The buffer vanished while a save was still pending for it -
@@ -1072,7 +1084,7 @@ impl AdeApp {
                     let _ = this.update(cx, |this, cx| {
                         match write_result {
                             Ok((mtime, len, written_content)) => {
-                                if let Some(buffer) = this.edit_buffers.get_mut(&path) {
+                                if let Some(buffer) = this.edit_buffer_at_mut(&cwd, &path) {
                                     buffer.mark_saved(written_content, mtime, len);
                                 }
                                 this.file_save_error = None;
@@ -1158,13 +1170,13 @@ impl EntityInputHandler for AdeApp {
     ) {
         match self.active_edit_target() {
             Some(EditTarget::File(path)) => {
-                let Some(buffer) = self.edit_buffers.get_mut(&path) else {
+                let Some(buffer) = self.edit_buffer_mut(&path) else {
                     return;
                 };
                 let range = range_utf16.map(|range_utf16| buffer.range_from_utf16(&range_utf16));
                 buffer.replace_range(range, text);
                 self.schedule_rehighlight(path.clone(), cx);
-                self.schedule_lsp_sync(path, cx);
+                self.schedule_lsp_sync(self.file_tree_root.clone(), path, cx);
             }
             Some(EditTarget::Merge) => {
                 let Some(edit) = self.merge_edit.as_mut() else {
@@ -1191,13 +1203,13 @@ impl EntityInputHandler for AdeApp {
     ) {
         match self.active_edit_target() {
             Some(EditTarget::File(path)) => {
-                let Some(buffer) = self.edit_buffers.get_mut(&path) else {
+                let Some(buffer) = self.edit_buffer_mut(&path) else {
                     return;
                 };
                 let range = range_utf16.map(|range_utf16| buffer.range_from_utf16(&range_utf16));
                 buffer.replace_and_mark_range(range, new_text, new_selected_range_utf16);
                 self.schedule_rehighlight(path.clone(), cx);
-                self.schedule_lsp_sync(path, cx);
+                self.schedule_lsp_sync(self.file_tree_root.clone(), path, cx);
             }
             Some(EditTarget::Merge) => {
                 let Some(edit) = self.merge_edit.as_mut() else {
@@ -1224,7 +1236,7 @@ impl EntityInputHandler for AdeApp {
     ) -> Option<Bounds<Pixels>> {
         match self.active_edit_target()? {
             EditTarget::File(path) => {
-                let buffer = self.edit_buffers.get(&path)?;
+                let buffer = self.edit_buffer(&path)?;
                 let (last_path, last_line) = self.file_view_last_layout_for.clone()?;
                 if last_path != path {
                     return None;
@@ -1258,7 +1270,7 @@ impl EntityInputHandler for AdeApp {
     ) -> Option<usize> {
         match self.active_edit_target()? {
             EditTarget::File(path) => {
-                let buffer = self.edit_buffers.get(&path)?;
+                let buffer = self.edit_buffer(&path)?;
                 let (last_path, last_line) = self.file_view_last_layout_for.clone()?;
                 if last_path != path {
                     return None;
@@ -1748,7 +1760,7 @@ pub(in crate::code_surface) fn render_editable_file_view_line(
                 // real double-lease, and GPUI's `EntityMap::read` panics on exactly that
                 // (confirmed live: "cannot read app::root::AdeApp while it is already being
                 // updated") - every real left-click on an editable row hit this, unconditionally.
-                let Some(buffer) = this.edit_buffers.get(&row_path) else {
+                let Some(buffer) = this.edit_buffer(&row_path) else {
                     return;
                 };
                 let Some(line_range) = buffer.line_ranges.get(click_line_index).cloned() else {
@@ -1769,7 +1781,7 @@ pub(in crate::code_surface) fn render_editable_file_view_line(
                 // no longer describes - see `Self::move_active_buffer`'s own docs for the same
                 // real dismiss-on-caret-move reasoning.
                 this.dismiss_completions();
-                if let Some(buffer) = this.edit_buffers.get_mut(&row_path) {
+                if let Some(buffer) = this.edit_buffer_mut(&row_path) {
                     // Alt+click (Revision R13, issue #28): adds a brand-new cursor at the click
                     // point, keeping every existing real cursor - `EditBuffer::add_cursor_at`'s
                     // own docs. Checked first, before the click-count/shift chain below, so an
@@ -1852,14 +1864,14 @@ pub(in crate::code_surface) fn render_editable_file_view_line(
                     return;
                 };
                 let local_offset = shaped.closest_index_for_x(local_point.x);
-                let Some(buffer) = this.edit_buffers.get(&drag_row_path) else {
+                let Some(buffer) = this.edit_buffer(&drag_row_path) else {
                     return;
                 };
                 let Some(line_range) = buffer.line_ranges.get(click_line_index).cloned() else {
                     return;
                 };
                 let absolute_offset = line_range.start + local_offset;
-                let Some(buffer) = this.edit_buffers.get_mut(&drag_row_path) else {
+                let Some(buffer) = this.edit_buffer_mut(&drag_row_path) else {
                     return;
                 };
                 buffer.select_to(absolute_offset);
@@ -2267,8 +2279,7 @@ mod editing_tests {
         });
 
         let content = app.read_with(cx, |app, _| {
-            app.edit_buffers
-                .get(&relative)
+            app.edit_buffer(&relative)
                 .expect("buffer should exist")
                 .content
                 .clone()
@@ -2276,7 +2287,7 @@ mod editing_tests {
         assert_eq!(content, "fn foo(x: i32) {}\n");
 
         let (dirty_immediately, kinds_immediately) = app.read_with(cx, |app, _| {
-            let buffer = app.edit_buffers.get(&relative).expect("buffer");
+            let buffer = app.edit_buffer(&relative).expect("buffer");
             (
                 buffer.highlight_dirty,
                 buffer.lines[0]
@@ -2314,7 +2325,7 @@ mod editing_tests {
         cx.run_until_parked();
 
         let (dirty_after, kinds_after) = app.read_with(cx, |app, _| {
-            let buffer = app.edit_buffers.get(&relative).expect("buffer");
+            let buffer = app.edit_buffer(&relative).expect("buffer");
             (
                 buffer.highlight_dirty,
                 buffer.lines[0]
@@ -2351,8 +2362,7 @@ mod editing_tests {
 
         assert_eq!(
             app.read_with(cx, |app, _| app
-                .edit_buffers
-                .get(&relative)
+                .edit_buffer(&relative)
                 .unwrap()
                 .selected_range
                 .clone()),
@@ -2362,11 +2372,7 @@ mod editing_tests {
         cx.simulate_keystrokes("right right right");
 
         let selected = app.read_with(cx, |app, _| {
-            app.edit_buffers
-                .get(&relative)
-                .unwrap()
-                .selected_range
-                .clone()
+            app.edit_buffer(&relative).unwrap().selected_range.clone()
         });
         assert_eq!(
             selected,
@@ -2377,11 +2383,7 @@ mod editing_tests {
 
         cx.simulate_keystrokes("left");
         let selected = app.read_with(cx, |app, _| {
-            app.edit_buffers
-                .get(&relative)
-                .unwrap()
-                .selected_range
-                .clone()
+            app.edit_buffer(&relative).unwrap().selected_range.clone()
         });
         assert_eq!(
             selected,
@@ -2404,11 +2406,7 @@ mod editing_tests {
         cx.simulate_keystrokes("shift-right shift-right shift-right");
 
         let selected = app.read_with(cx, |app, _| {
-            app.edit_buffers
-                .get(&relative)
-                .unwrap()
-                .selected_range
-                .clone()
+            app.edit_buffer(&relative).unwrap().selected_range.clone()
         });
         assert_eq!(
             selected,
@@ -2440,11 +2438,7 @@ mod editing_tests {
         cx.simulate_keystrokes(select_word_right);
 
         let selected = app.read_with(cx, |app, _| {
-            app.edit_buffers
-                .get(&relative)
-                .unwrap()
-                .selected_range
-                .clone()
+            app.edit_buffer(&relative).unwrap().selected_range.clone()
         });
         assert_eq!(
             selected,
@@ -2461,7 +2455,7 @@ mod editing_tests {
         };
         cx.simulate_keystrokes(word_left);
         let cursor = app.read_with(cx, |app, _| {
-            app.edit_buffers.get(&relative).unwrap().cursor_offset()
+            app.edit_buffer(&relative).unwrap().cursor_offset()
         });
         assert_eq!(
             cursor, 0,
@@ -2501,7 +2495,7 @@ mod editing_tests {
         });
 
         let selected_text = app.read_with(cx, |app, _| {
-            let buffer = app.edit_buffers.get(&relative).unwrap();
+            let buffer = app.edit_buffer(&relative).unwrap();
             buffer.content[buffer.selected_range.clone()].to_string()
         });
         assert_eq!(
@@ -2519,7 +2513,7 @@ mod editing_tests {
         });
 
         let selected_text = app.read_with(cx, |app, _| {
-            let buffer = app.edit_buffers.get(&relative).unwrap();
+            let buffer = app.edit_buffer(&relative).unwrap();
             buffer.content[buffer.selected_range.clone()].to_string()
         });
         assert_eq!(
@@ -2554,7 +2548,7 @@ mod editing_tests {
 
         // A real selection on line 1 (offsets 0..4, "line").
         app.update(cx, |app, cx| {
-            let buffer = app.edit_buffers.get_mut(&relative).unwrap();
+            let buffer = app.edit_buffer_mut(&relative).unwrap();
             buffer.move_to(0);
             buffer.select_to(4);
             cx.notify();
@@ -2563,8 +2557,7 @@ mod editing_tests {
 
         assert_eq!(
             app.read_with(cx, |app, _| app
-                .edit_buffers
-                .get(&relative)
+                .edit_buffer(&relative)
                 .unwrap()
                 .selection_within_line(0)),
             Some(0..4),
@@ -2606,8 +2599,7 @@ mod editing_tests {
 
         assert_eq!(
             app.read_with(cx, |app, _| app
-                .edit_buffers
-                .get(&relative)
+                .edit_buffer(&relative)
                 .unwrap()
                 .selection_within_line(0)),
             Some(0..4),
@@ -2634,17 +2626,13 @@ mod editing_tests {
         let relative = PathBuf::from("sample.txt");
 
         app.update(cx, |app, cx| {
-            app.edit_buffers.get_mut(&relative).unwrap().move_to(1);
+            app.edit_buffer_mut(&relative).unwrap().move_to(1);
             cx.notify();
         });
 
         cx.simulate_keystrokes("ctrl-d");
         let after_first = app.read_with(cx, |app, _| {
-            app.edit_buffers
-                .get(&relative)
-                .unwrap()
-                .selected_range
-                .clone()
+            app.edit_buffer(&relative).unwrap().selected_range.clone()
         });
         assert_eq!(
             after_first,
@@ -2654,7 +2642,7 @@ mod editing_tests {
 
         cx.simulate_keystrokes("ctrl-d");
         let cursor_count = app.read_with(cx, |app, _| {
-            app.edit_buffers.get(&relative).unwrap().cursor_count()
+            app.edit_buffer(&relative).unwrap().cursor_count()
         });
         assert_eq!(
             cursor_count, 2,
@@ -2665,7 +2653,7 @@ mod editing_tests {
             app.replace_text_in_range(None, "x", window, cx);
         });
         let content = app.read_with(cx, |app, _| {
-            app.edit_buffers.get(&relative).unwrap().content.clone()
+            app.edit_buffer(&relative).unwrap().content.clone()
         });
         assert_eq!(
             content, "x + x\n",
@@ -2686,14 +2674,14 @@ mod editing_tests {
         let relative = PathBuf::from("sample.txt");
 
         app.update(cx, |app, cx| {
-            app.edit_buffers.get_mut(&relative).unwrap().move_to(1);
+            app.edit_buffer_mut(&relative).unwrap().move_to(1);
             cx.notify();
         });
 
         cx.simulate_keystrokes("ctrl-shift-l");
 
         let cursor_count = app.read_with(cx, |app, _| {
-            app.edit_buffers.get(&relative).unwrap().cursor_count()
+            app.edit_buffer(&relative).unwrap().cursor_count()
         });
         assert_eq!(
             cursor_count, 3,
@@ -2716,7 +2704,7 @@ mod editing_tests {
         let relative = PathBuf::from("sample.txt");
 
         app.update(cx, |app, cx| {
-            app.edit_buffers.get_mut(&relative).unwrap().move_to(1);
+            app.edit_buffer_mut(&relative).unwrap().move_to(1);
             cx.notify();
         });
         cx.simulate_keystrokes("ctrl-d"); // selects the first "value"
@@ -2724,7 +2712,7 @@ mod editing_tests {
         cx.simulate_keystrokes("ctrl-k ctrl-d");
 
         let (cursor_count, selected) = app.read_with(cx, |app, _| {
-            let buffer = app.edit_buffers.get(&relative).unwrap();
+            let buffer = app.edit_buffer(&relative).unwrap();
             (buffer.cursor_count(), buffer.selected_range.clone())
         });
         assert_eq!(cursor_count, 1, "skip must not add a cursor");
@@ -2743,15 +2731,14 @@ mod editing_tests {
         let relative = PathBuf::from("sample.txt");
 
         app.update(cx, |app, cx| {
-            app.edit_buffers.get_mut(&relative).unwrap().move_to(1);
+            app.edit_buffer_mut(&relative).unwrap().move_to(1);
             cx.notify();
         });
         cx.simulate_keystrokes("ctrl-d");
         cx.simulate_keystrokes("ctrl-d");
         assert_eq!(
             app.read_with(cx, |app, _| app
-                .edit_buffers
-                .get(&relative)
+                .edit_buffer(&relative)
                 .unwrap()
                 .cursor_count()),
             2
@@ -2761,8 +2748,7 @@ mod editing_tests {
 
         assert_eq!(
             app.read_with(cx, |app, _| app
-                .edit_buffers
-                .get(&relative)
+                .edit_buffer(&relative)
                 .unwrap()
                 .cursor_count()),
             1,
@@ -2783,15 +2769,14 @@ mod editing_tests {
         let relative = PathBuf::from("sample.txt");
 
         app.update(cx, |app, cx| {
-            app.edit_buffers.get_mut(&relative).unwrap().move_to(2);
+            app.edit_buffer_mut(&relative).unwrap().move_to(2);
             cx.notify();
         });
 
         cx.simulate_keystrokes("backspace");
         assert_eq!(
             app.read_with(cx, |app, _| app
-                .edit_buffers
-                .get(&relative)
+                .edit_buffer(&relative)
                 .unwrap()
                 .content
                 .clone()),
@@ -2801,8 +2786,7 @@ mod editing_tests {
         cx.simulate_keystrokes("delete");
         assert_eq!(
             app.read_with(cx, |app, _| app
-                .edit_buffers
-                .get(&relative)
+                .edit_buffer(&relative)
                 .unwrap()
                 .content
                 .clone()),
@@ -2824,11 +2808,7 @@ mod editing_tests {
         app.update_in(cx, |app, window, cx| {
             app.replace_text_in_range(None, "well ", window, cx);
         });
-        assert!(app.read_with(cx, |app, _| app
-            .edit_buffers
-            .get(&relative)
-            .unwrap()
-            .is_dirty()));
+        assert!(app.read_with(cx, |app, _| app.edit_buffer(&relative).unwrap().is_dirty()));
 
         let secondary_s = if cfg!(target_os = "macos") {
             "cmd-s"
@@ -2844,11 +2824,7 @@ mod editing_tests {
             "the real file on disk should hold the real edit"
         );
         assert!(
-            !app.read_with(cx, |app, _| app
-                .edit_buffers
-                .get(&relative)
-                .unwrap()
-                .is_dirty()),
+            !app.read_with(cx, |app, _| app.edit_buffer(&relative).unwrap().is_dirty()),
             "the dirty flag should be cleared by a successful real save"
         );
         assert!(app.read_with(cx, |app, _| app.file_save_error.is_none()));
@@ -2873,11 +2849,7 @@ mod editing_tests {
         app.update_in(cx, |app, window, cx| {
             app.replace_text_in_range(None, "edited ", window, cx);
         });
-        assert!(app.read_with(cx, |app, _| app
-            .edit_buffers
-            .get(&relative)
-            .unwrap()
-            .is_dirty()));
+        assert!(app.read_with(cx, |app, _| app.edit_buffer(&relative).unwrap().is_dirty()));
 
         // A real external change, bypassing this app entirely.
         std::fs::write(&file_path, "changed on disk, a completely different size\n")
@@ -2908,11 +2880,7 @@ mod editing_tests {
             "save must refuse rather than silently overwrite the real external change"
         );
         assert!(
-            app.read_with(cx, |app, _| app
-                .edit_buffers
-                .get(&relative)
-                .unwrap()
-                .is_dirty()),
+            app.read_with(cx, |app, _| app.edit_buffer(&relative).unwrap().is_dirty()),
             "the user's own real unsaved edit must not have been silently discarded either"
         );
         assert!(app.read_with(cx, |app, _| app.file_save_error.is_some()));
@@ -2941,11 +2909,7 @@ mod editing_tests {
 
         assert!(app.read_with(cx, |app, _| app.file_save_error.is_none()));
         assert!(!app.read_with(cx, |app, _| app.file_external_conflict.contains(&relative)));
-        assert!(!app.read_with(cx, |app, _| app
-            .edit_buffers
-            .get(&relative)
-            .unwrap()
-            .is_dirty()));
+        assert!(!app.read_with(cx, |app, _| app.edit_buffer(&relative).unwrap().is_dirty()));
         let on_disk = std::fs::read_to_string(&file_path).expect("read back");
         assert_eq!(on_disk, "well hello\n");
     }
@@ -3020,7 +2984,7 @@ mod editing_tests {
         let relative = PathBuf::from("sample.txt");
 
         app.update(cx, |app, cx| {
-            app.edit_buffers.get_mut(&relative).unwrap().move_to(1);
+            app.edit_buffer_mut(&relative).unwrap().move_to(1);
             cx.notify();
         });
 
@@ -3029,7 +2993,7 @@ mod editing_tests {
         });
 
         let (content, marked) = app.read_with(cx, |app, _| {
-            let buffer = app.edit_buffers.get(&relative).unwrap();
+            let buffer = app.edit_buffer(&relative).unwrap();
             (buffer.content.clone(), buffer.marked_range.clone())
         });
         assert_eq!(content, "anb\n");
@@ -3043,7 +3007,7 @@ mod editing_tests {
             app.unmark_text(window, cx);
         });
         let (content_after, marked_after) = app.read_with(cx, |app, _| {
-            let buffer = app.edit_buffers.get(&relative).unwrap();
+            let buffer = app.edit_buffer(&relative).unwrap();
             (buffer.content.clone(), buffer.marked_range.clone())
         });
         assert_eq!(
@@ -3112,8 +3076,7 @@ mod editing_tests {
         // buggy handler that *did* fire against the wrong file would show up here as a real,
         // unexpected `EditBuffer` entry.
         assert!(app.read_with(cx, |app, _| !app
-            .edit_buffers
-            .contains_key(&PathBuf::from("sample.rs"))));
+            .edit_buffer_contains(&PathBuf::from("sample.rs"))));
         assert!(app.read_with(cx, |app, _| app.file_save_error.is_none()));
     }
 
@@ -3177,7 +3140,7 @@ mod editing_tests {
         cx.run_until_parked();
 
         let (cursor_line, selected_range) = app.read_with(cx, |app, _| {
-            let buffer = app.edit_buffers.get(&relative).expect("buffer");
+            let buffer = app.edit_buffer(&relative).expect("buffer");
             (
                 buffer.line_col_for_offset(buffer.cursor_offset()).0,
                 buffer.selected_range.clone(),
@@ -3233,7 +3196,7 @@ mod editing_tests {
         cx.run_until_parked();
 
         let (cursor_line, cursor_col) = app.read_with(cx, |app, _| {
-            let buffer = app.edit_buffers.get(&relative).expect("buffer");
+            let buffer = app.edit_buffer(&relative).expect("buffer");
             buffer.line_col_for_offset(buffer.cursor_offset())
         });
         assert_eq!(
@@ -3278,7 +3241,7 @@ mod editing_tests {
         cx.run_until_parked();
 
         let (cursor_line, cursor_col) = app.read_with(cx, |app, _| {
-            let buffer = app.edit_buffers.get(&relative).expect("buffer");
+            let buffer = app.edit_buffer(&relative).expect("buffer");
             buffer.line_col_for_offset(buffer.cursor_offset())
         });
         assert_eq!(
@@ -3321,11 +3284,11 @@ mod editing_tests {
         cx.run_until_parked();
 
         let expected_end = app.read_with(cx, |app, _| {
-            let buffer = app.edit_buffers.get(&relative).expect("buffer");
+            let buffer = app.edit_buffer(&relative).expect("buffer");
             buffer.content.len()
         });
         let (cursor_offset, selected_range) = app.read_with(cx, |app, _| {
-            let buffer = app.edit_buffers.get(&relative).expect("buffer");
+            let buffer = app.edit_buffer(&relative).expect("buffer");
             (buffer.cursor_offset(), buffer.selected_range.clone())
         });
         assert_eq!(
@@ -3365,7 +3328,7 @@ mod editing_tests {
             "the file should have really loaded (read-only) with its real invalid-UTF-8 flag set"
         );
         assert!(
-            app.read_with(cx, |app, _| !app.edit_buffers.contains_key(&relative)),
+            app.read_with(cx, |app, _| !app.edit_buffer_contains(&relative)),
             "a file whose real bytes aren't valid UTF-8 must not get a real edit buffer - saving \
              one would silently corrupt the file with U+FFFD replacement characters"
         );
@@ -3431,11 +3394,7 @@ mod editing_tests {
              user's own edits"
         );
         assert!(
-            !app.read_with(cx, |app, _| app
-                .edit_buffers
-                .get(&relative)
-                .unwrap()
-                .is_dirty()),
+            !app.read_with(cx, |app, _| app.edit_buffer(&relative).unwrap().is_dirty()),
             "a successful force-save should clear the real dirty flag"
         );
         assert!(
@@ -3478,11 +3437,7 @@ mod editing_tests {
         let relative = PathBuf::from("sample.txt");
 
         assert!(
-            !app.read_with(cx, |app, _| app
-                .edit_buffers
-                .get(&relative)
-                .unwrap()
-                .is_dirty()),
+            !app.read_with(cx, |app, _| app.edit_buffer(&relative).unwrap().is_dirty()),
             "a freshly-opened buffer should start clean"
         );
         let mtime_before = std::fs::metadata(&file_path)
@@ -3538,7 +3493,7 @@ mod editing_tests {
         // The buffer vanishes before the (already-spawned, not-yet-polled) writer loop task gets
         // to check it.
         app.update(cx, |app, _cx| {
-            app.edit_buffers.remove(&relative);
+            app.remove_edit_buffer(&relative);
         });
         cx.run_until_parked();
 
@@ -3592,8 +3547,7 @@ mod editing_tests {
         let relative = PathBuf::from("sample.txt");
 
         app.update(cx, |app, cx| {
-            app.edit_buffers
-                .get_mut(&relative)
+            app.edit_buffer_mut(&relative)
                 .unwrap()
                 .move_to("prefix ".len());
             cx.notify();
@@ -3612,7 +3566,7 @@ mod editing_tests {
         });
 
         let (content, selected_range) = app.read_with(cx, |app, _| {
-            let buffer = app.edit_buffers.get(&relative).unwrap();
+            let buffer = app.edit_buffer(&relative).unwrap();
             (buffer.content.clone(), buffer.selected_range.clone())
         });
         assert_eq!(content, "prefix \u{65e5}\u{672c}\u{8a9e}ok\n");
@@ -3632,7 +3586,7 @@ mod editing_tests {
             app.replace_text_in_range(None, "!", window, cx);
         });
         let content_after = app.read_with(cx, |app, _| {
-            app.edit_buffers.get(&relative).unwrap().content.clone()
+            app.edit_buffer(&relative).unwrap().content.clone()
         });
         assert_eq!(content_after, "prefix \u{65e5}\u{672c}!\u{8a9e}ok\n");
     }
@@ -3660,7 +3614,7 @@ mod editing_tests {
         let relative = PathBuf::from("sample.rs");
 
         app.update(cx, |app, cx| {
-            app.edit_buffers.get_mut(&relative).unwrap().move_to(3);
+            app.edit_buffer_mut(&relative).unwrap().move_to(3);
             cx.notify();
         });
 
@@ -3668,8 +3622,7 @@ mod editing_tests {
 
         assert_eq!(
             app.read_with(cx, |app, _| app
-                .edit_buffers
-                .get(&relative)
+                .edit_buffer(&relative)
                 .unwrap()
                 .content
                 .clone()),
@@ -3706,14 +3659,13 @@ mod editing_tests {
         // State 1: no popup open - `up`/`down`/`enter` must behave exactly like the plain
         // editor actions always have.
         app.update(cx, |app, cx| {
-            app.edit_buffers.get_mut(&relative).unwrap().move_to(1);
+            app.edit_buffer_mut(&relative).unwrap().move_to(1);
             cx.notify();
         });
         cx.simulate_keystrokes("down");
         assert_eq!(
             app.read_with(cx, |app, _| app
-                .edit_buffers
-                .get(&relative)
+                .edit_buffer(&relative)
                 .unwrap()
                 .cursor_offset()),
             4,
@@ -3723,8 +3675,7 @@ mod editing_tests {
         cx.simulate_keystrokes("enter");
         assert_eq!(
             app.read_with(cx, |app, _| app
-                .edit_buffers
-                .get(&relative)
+                .edit_buffer(&relative)
                 .unwrap()
                 .content
                 .clone()),
@@ -3750,10 +3701,10 @@ mod editing_tests {
         });
 
         let cursor_before = app.read_with(cx, |app, _| {
-            app.edit_buffers.get(&relative).unwrap().cursor_offset()
+            app.edit_buffer(&relative).unwrap().cursor_offset()
         });
         let content_before = app.read_with(cx, |app, _| {
-            app.edit_buffers.get(&relative).unwrap().content.clone()
+            app.edit_buffer(&relative).unwrap().content.clone()
         });
         cx.simulate_keystrokes("down");
         assert_eq!(
@@ -3774,8 +3725,7 @@ mod editing_tests {
         );
         assert_eq!(
             app.read_with(cx, |app, _| app
-                .edit_buffers
-                .get(&relative)
+                .edit_buffer(&relative)
                 .unwrap()
                 .cursor_offset()),
             cursor_before,
@@ -3783,8 +3733,7 @@ mod editing_tests {
         );
         assert_eq!(
             app.read_with(cx, |app, _| app
-                .edit_buffers
-                .get(&relative)
+                .edit_buffer(&relative)
                 .unwrap()
                 .content
                 .clone()),
@@ -3794,7 +3743,7 @@ mod editing_tests {
 
         cx.simulate_keystrokes("enter");
         let content_after_enter = app.read_with(cx, |app, _| {
-            app.edit_buffers.get(&relative).unwrap().content.clone()
+            app.edit_buffer(&relative).unwrap().content.clone()
         });
         assert!(
             content_after_enter.contains("beta"),
@@ -3819,7 +3768,7 @@ mod editing_tests {
             cx.notify();
         });
         let content_before_escape = app.read_with(cx, |app, _| {
-            app.edit_buffers.get(&relative).unwrap().content.clone()
+            app.edit_buffer(&relative).unwrap().content.clone()
         });
         cx.simulate_keystrokes("escape");
         assert!(
@@ -3828,8 +3777,7 @@ mod editing_tests {
         );
         assert_eq!(
             app.read_with(cx, |app, _| app
-                .edit_buffers
-                .get(&relative)
+                .edit_buffer(&relative)
                 .unwrap()
                 .content
                 .clone()),
@@ -3871,7 +3819,7 @@ mod editing_tests {
             ),
         ] {
             app.update(cx, |app, cx| {
-                app.edit_buffers.get_mut(&relative).unwrap().move_to(1);
+                app.edit_buffer_mut(&relative).unwrap().move_to(1);
                 app.completions = Some(crate::lsp::completion_popup::CompletionsEntry {
                     path: relative.clone(),
                     status,
@@ -3888,11 +3836,11 @@ mod editing_tests {
             );
 
             let content_before = app.read_with(cx, |app, _| {
-                app.edit_buffers.get(&relative).unwrap().content.clone()
+                app.edit_buffer(&relative).unwrap().content.clone()
             });
             cx.simulate_keystrokes("enter");
             let content_after_enter = app.read_with(cx, |app, _| {
-                app.edit_buffers.get(&relative).unwrap().content.clone()
+                app.edit_buffer(&relative).unwrap().content.clone()
             });
             assert_ne!(
                 content_after_enter, content_before,
@@ -3910,7 +3858,7 @@ mod editing_tests {
             // re-seed a fresh `Loading`/`Failed` entry (the Enter above already dismissed the
             // previous one via `Self::move_active_buffer`'s own caret-move dismissal).
             app.update(cx, |app, cx| {
-                let buffer = app.edit_buffers.get_mut(&relative).unwrap();
+                let buffer = app.edit_buffer_mut(&relative).unwrap();
                 buffer.move_to(1);
                 let status = match label {
                     "Loading" => crate::lsp::completion_popup::CompletionsStatus::Loading,
@@ -3925,11 +3873,11 @@ mod editing_tests {
                 cx.notify();
             });
             let cursor_before_down = app.read_with(cx, |app, _| {
-                app.edit_buffers.get(&relative).unwrap().cursor_offset()
+                app.edit_buffer(&relative).unwrap().cursor_offset()
             });
             cx.simulate_keystrokes("down");
             let cursor_after_down = app.read_with(cx, |app, _| {
-                app.edit_buffers.get(&relative).unwrap().cursor_offset()
+                app.edit_buffer(&relative).unwrap().cursor_offset()
             });
             assert_ne!(
                 cursor_after_down, cursor_before_down,
@@ -3965,8 +3913,7 @@ mod editing_tests {
         relative: &Path,
     ) -> String {
         app.read_with(cx, |app, _| {
-            app.edit_buffers
-                .get(relative)
+            app.edit_buffer(relative)
                 .expect("buffer should exist")
                 .content
                 .clone()
@@ -3989,7 +3936,7 @@ mod editing_tests {
         cx.simulate_input("hello");
         assert_eq!(buffer_content(&app, cx, &relative), "helloab\ncd\n");
         let caret_after_typing = app.read_with(cx, |app, _| {
-            app.edit_buffers.get(&relative).unwrap().cursor_offset()
+            app.edit_buffer(&relative).unwrap().cursor_offset()
         });
         assert_eq!(caret_after_typing, 5);
 
@@ -4001,8 +3948,7 @@ mod editing_tests {
         );
         assert_eq!(
             app.read_with(cx, |app, _| app
-                .edit_buffers
-                .get(&relative)
+                .edit_buffer(&relative)
                 .unwrap()
                 .cursor_offset()),
             0,
@@ -4013,8 +3959,7 @@ mod editing_tests {
         assert_eq!(buffer_content(&app, cx, &relative), "helloab\ncd\n");
         assert_eq!(
             app.read_with(cx, |app, _| app
-                .edit_buffers
-                .get(&relative)
+                .edit_buffer(&relative)
                 .unwrap()
                 .cursor_offset()),
             5,
@@ -4180,11 +4125,7 @@ mod editing_tests {
         });
         cx.run_until_parked();
         assert!(
-            app.read_with(cx, |app, _| !app
-                .edit_buffers
-                .get(&relative)
-                .unwrap()
-                .is_dirty()),
+            app.read_with(cx, |app, _| !app.edit_buffer(&relative).unwrap().is_dirty()),
             "sanity check: the buffer must really be clean before the external rewrite"
         );
 
@@ -4239,11 +4180,7 @@ mod editing_tests {
         let relative = PathBuf::from("sample.txt");
 
         cx.simulate_input("MINE");
-        assert!(app.read_with(cx, |app, _| app
-            .edit_buffers
-            .get(&relative)
-            .unwrap()
-            .is_dirty()));
+        assert!(app.read_with(cx, |app, _| app.edit_buffer(&relative).unwrap().is_dirty()));
 
         std::thread::sleep(std::time::Duration::from_millis(20));
         std::fs::write(&file_path, "theirs\n").expect("external rewrite");
@@ -4272,6 +4209,121 @@ mod editing_tests {
             buffer_content(&app, cx, &relative),
             "original\n",
             "and the user's own undo history must be exactly as it was"
+        );
+    }
+
+    /// Real, live-reproduced coverage for `design_handoff_jerry_ade/revision 3/
+    /// REVISION-2026-07-31.md` §1 ("the open file tabs, the active tab ... the commit composer"
+    /// is worktree-scoped) and the coordinator's own explicit call-out: a user with an unsaved
+    /// edit open who switches worktrees must never lose it - real data loss, no confirm dialog,
+    /// nothing, was the bug. Drives two *real* worktrees (temp directories) that both have a file
+    /// at the identical relative path `sample.txt`, edits both with different, real unsaved
+    /// content, and proves: (1) each survives a switch away and back to its own worktree with the
+    /// buffer's real content and dirty flag intact, and (2) the two same-relative-path buffers
+    /// never merge or overwrite each other - the "worse than the current bug" collision risk the
+    /// coordinator flagged for `AdeApp::edit_buffers`'s composite `(worktree, path)` key.
+    #[gpui::test]
+    fn switching_worktrees_and_back_preserves_unsaved_edits_without_cross_worktree_collision(
+        cx: &mut TestAppContext,
+    ) {
+        let repo_a = tempfile::tempdir().expect("tempdir a");
+        let repo_b = tempfile::tempdir().expect("tempdir b");
+        // Deliberately the *same* relative path in both worktrees - the real collision risk this
+        // test exists to rule out.
+        let file_a = write_file(repo_a.path(), "sample.txt", "worktree a original\n");
+        let file_b = write_file(repo_b.path(), "sample.txt", "worktree b original\n");
+        let relative = PathBuf::from("sample.txt");
+
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        app.update(cx, |app, _cx| {
+            app.worktrees = vec![
+                crate::rail::worktrees::WorktreeItem {
+                    path: repo_a.path().to_path_buf(),
+                    label: "wt-a".to_string(),
+                    branch: Some("wt-a".to_string()),
+                    is_main: true,
+                    is_locked: false,
+                    error: None,
+                },
+                crate::rail::worktrees::WorktreeItem {
+                    path: repo_b.path().to_path_buf(),
+                    label: "wt-b".to_string(),
+                    branch: Some("wt-b".to_string()),
+                    is_main: false,
+                    is_locked: false,
+                    error: None,
+                },
+            ];
+        });
+        app.update_in(cx, |app, window, cx| {
+            app.select_worktree(0, window, cx);
+        });
+        cx.run_until_parked();
+
+        // A real, unsaved edit in worktree A.
+        open_file_for_editing(&app, cx, file_a);
+        app.update_in(cx, |app, window, cx| {
+            app.replace_text_in_range(None, "A-EDIT ", window, cx);
+        });
+        assert_eq!(
+            buffer_content(&app, cx, &relative),
+            "A-EDIT worktree a original\n",
+            "sanity check: worktree A's own buffer should hold its own real edit"
+        );
+
+        // Switch to worktree B, which has never opened this path - a real independent buffer, not
+        // a leaked or collided view of A's.
+        app.update_in(cx, |app, window, cx| {
+            app.select_worktree(1, window, cx);
+        });
+        cx.run_until_parked();
+        assert!(
+            app.read_with(cx, |app, _| app.edit_buffer(&relative).is_none()),
+            "worktree B must not see worktree A's buffer for the identical relative path"
+        );
+        open_file_for_editing(&app, cx, file_b);
+        assert_eq!(
+            buffer_content(&app, cx, &relative),
+            "worktree b original\n",
+            "worktree B's freshly opened buffer must hold its own real on-disk content, not \
+             worktree A's"
+        );
+        app.update_in(cx, |app, window, cx| {
+            app.replace_text_in_range(None, "B-EDIT ", window, cx);
+        });
+        assert_eq!(
+            buffer_content(&app, cx, &relative),
+            "B-EDIT worktree b original\n"
+        );
+
+        // Switch back to worktree A: its own real unsaved edit must be exactly as it was left -
+        // the real fix. Before this revision, `reset_per_worktree_ui_state` cleared
+        // `edit_buffers` on every switch, so this would have come back empty.
+        app.update_in(cx, |app, window, cx| {
+            app.select_worktree(0, window, cx);
+        });
+        cx.run_until_parked();
+        assert_eq!(
+            buffer_content(&app, cx, &relative),
+            "A-EDIT worktree a original\n",
+            "switching back to worktree A must restore its own real unsaved edit, not discard it"
+        );
+        assert!(
+            app.read_with(cx, |app, _| app.edit_buffer(&relative).unwrap().is_dirty()),
+            "the restored buffer must still be genuinely dirty, not silently marked clean"
+        );
+
+        // And worktree B's own edit must still be exactly as it was left too - proof the two
+        // never merged in either direction.
+        app.update_in(cx, |app, window, cx| {
+            app.select_worktree(1, window, cx);
+        });
+        cx.run_until_parked();
+        assert_eq!(
+            buffer_content(&app, cx, &relative),
+            "B-EDIT worktree b original\n",
+            "worktree B's own real unsaved edit must survive too, untouched by worktree A's \
+             identical-relative-path buffer"
         );
     }
 }

--- a/crates/app/src/code_surface/editing.rs
+++ b/crates/app/src/code_surface/editing.rs
@@ -2262,7 +2262,7 @@ mod editing_tests {
         let relative = PathBuf::from("sample.rs");
 
         let initial_kinds = app.read_with(cx, |app, _| {
-            app.edit_buffers.get(&relative).unwrap().lines[0]
+            app.edit_buffer(&relative).unwrap().lines[0]
                 .runs
                 .iter()
                 .map(|(_, kind)| *kind)
@@ -4242,7 +4242,13 @@ mod editing_tests {
                     label: "wt-a".to_string(),
                     branch: Some("wt-a".to_string()),
                     is_main: true,
+                    is_bare: false,
+                    is_detached: false,
+                    short_sha: None,
                     is_locked: false,
+                    lock_reason: None,
+                    is_broken: false,
+                    broken_reason: None,
                     error: None,
                 },
                 crate::rail::worktrees::WorktreeItem {
@@ -4250,7 +4256,13 @@ mod editing_tests {
                     label: "wt-b".to_string(),
                     branch: Some("wt-b".to_string()),
                     is_main: false,
+                    is_bare: false,
+                    is_detached: false,
+                    short_sha: None,
                     is_locked: false,
+                    lock_reason: None,
+                    is_broken: false,
+                    broken_reason: None,
                     error: None,
                 },
             ];

--- a/crates/app/src/code_surface/file_view.rs
+++ b/crates/app/src/code_surface/file_view.rs
@@ -90,7 +90,7 @@ impl AdeApp {
         // actual data loss, but the *visible warning* disappearing on its own would have been a
         // real, deceptive regression from "surface a real warning".
         if should_check {
-            match self.edit_buffers.get(relative_path) {
+            match self.edit_buffer(relative_path) {
                 Some(buffer) if buffer.is_dirty() => {
                     let metadata = std::fs::metadata(&absolute_path).ok();
                     let disk_mtime = metadata.as_ref().and_then(|meta| meta.modified().ok());
@@ -250,7 +250,7 @@ impl AdeApp {
                     // closes. `file_view_cache`/`parsed.lines` is still the real fallback for a
                     // file with no edit buffer at all (still-loading, or truncated/non-UTF-8 and
                     // thus permanently read-only - see `EditBuffer`'s own docs).
-                    match self.edit_buffers.get(&relative_path_buf) {
+                    match self.edit_buffer(&relative_path_buf) {
                         Some(buffer) => {
                             diagnostics_view::index_diagnostics_by_line(&diagnostics, &buffer.lines)
                         }
@@ -302,8 +302,7 @@ impl AdeApp {
         // `Self::render_file_view`'s own top docs on the throttled `std::fs::metadata` check);
         // diagnostics/hover now track the *live* buffer instead, per Revision R8.5b, above.
         let line_count = self
-            .edit_buffers
-            .get(&relative_path_buf)
+            .edit_buffer(&relative_path_buf)
             .map(|buffer| buffer.lines.len())
             .unwrap_or_else(|| parsed.lines.len());
         // `true` while the real edit buffer for this file has genuine unsaved changes.
@@ -320,8 +319,7 @@ impl AdeApp {
         // - a line shifted by typing would still misalign that marker onto the wrong row, so
         // suppressing it while dirty is still the honest choice, not a leftover gap.
         let buffer_dirty = self
-            .edit_buffers
-            .get(&relative_path_buf)
+            .edit_buffer(&relative_path_buf)
             .is_some_and(|buffer| buffer.is_dirty());
         // GitHub issue #29: the current line's real, already-cached inline git blame label -
         // `None` while the buffer is dirty, while the setting is off, or while no fresh cache
@@ -344,7 +342,7 @@ impl AdeApp {
         // Captured here, before `relative_path_buf` is moved into the row-builder closure below
         // (`cx.processor`'s own `move` closure takes it by value) - the real fallback click
         // handler further down (see its own docs) needs its own independent copy of both.
-        let has_buffer = self.edit_buffers.contains_key(&relative_path_buf);
+        let has_buffer = self.edit_buffer_contains(&relative_path_buf);
         let below_content_click_path = relative_path_buf.clone();
         let minimap_relative_path = relative_path_buf.clone();
 
@@ -353,11 +351,10 @@ impl AdeApp {
             line_count,
             cx.processor(move |this: &mut Self, range: Range<usize>, _window, cx| {
                 let relative_path = relative_path_buf.clone();
-                let has_buffer = this.edit_buffers.contains_key(&relative_path);
+                let has_buffer = this.edit_buffer_contains(&relative_path);
                 if has_buffer {
                     let total = this
-                        .edit_buffers
-                        .get(&relative_path)
+                        .edit_buffer(&relative_path)
                         .map(|buffer| buffer.lines.len())
                         .unwrap_or(0);
                     let start = range.start.min(total);
@@ -375,12 +372,11 @@ impl AdeApp {
                         .retain(|line_number, _| visible_line_numbers.contains(line_number));
                     let cursor_line = this.code_cursor;
                     let cursor_line_index = this
-                        .edit_buffers
-                        .get(&relative_path)
+                        .edit_buffer(&relative_path)
                         .map(|buffer| buffer.line_col_for_offset(buffer.cursor_offset()).0);
                     let mut rows = Vec::with_capacity(end.saturating_sub(start));
                     for index in start..end {
-                        let Some(buffer) = this.edit_buffers.get(&relative_path) else {
+                        let Some(buffer) = this.edit_buffer(&relative_path) else {
                             break;
                         };
                         let Some(line) = buffer.lines.get(index) else {
@@ -522,7 +518,7 @@ impl AdeApp {
                     // almost certainly no longer describes - same real dismiss-on-caret-move
                     // reasoning as the per-row click handler in `crate::code_surface::editing`.
                     this.dismiss_completions();
-                    let Some(buffer) = this.edit_buffers.get_mut(&click_path) else {
+                    let Some(buffer) = this.edit_buffer_mut(&click_path) else {
                         return;
                     };
                     let end = buffer.content.len();
@@ -581,7 +577,7 @@ impl AdeApp {
         // outcome (the setting is off, or the file is too large - see that module's own docs),
         // not a placeholder.
         let minimap_lines: Option<&[code_view::RenderedLine]> =
-            if let Some(buffer) = self.edit_buffers.get(&minimap_relative_path) {
+            if let Some(buffer) = self.edit_buffer(&minimap_relative_path) {
                 Some(buffer.lines.as_slice())
             } else {
                 self.file_view_cache

--- a/crates/app/src/code_surface/render.rs
+++ b/crates/app/src/code_surface/render.rs
@@ -167,8 +167,8 @@ impl AdeApp {
         // The Diff view still genuinely never receives these bindings: `is_file_editor` is false
         // whenever `effective_view` isn't `File`, so the context string never gains
         // `"file-editor"` in that case.
-        let is_file_editor = effective_view == code_view::CodeView::File
-            && self.edit_buffers.contains_key(relative_path);
+        let is_file_editor =
+            effective_view == code_view::CodeView::File && self.edit_buffer_contains(relative_path);
         // Real Completions popup context (Revision R8.5b) - added the same way `"file-editor"`
         // itself is, only while a popup is genuinely, *actionably* open *for this exact file*
         // (matching `Self::completions_open_for_active_path`'s own guard, though that reads the

--- a/crates/app/src/code_surface/tabs.rs
+++ b/crates/app/src/code_surface/tabs.rs
@@ -71,8 +71,8 @@ impl AdeApp {
     /// every source that opens a file tab, so the tab list can't drift from what `open_change`
     /// points at.
     fn push_open_file(&mut self, path: &Path) {
-        if !self.open_files.iter().any(|open| open.as_path() == path) {
-            self.open_files.push(path.to_path_buf());
+        if !self.open_files().iter().any(|open| open.as_path() == path) {
+            self.open_files_mut().push(path.to_path_buf());
         }
     }
 
@@ -297,8 +297,7 @@ impl AdeApp {
         cx: &mut Context<Self>,
     ) {
         let is_dirty = self
-            .edit_buffers
-            .get(&path)
+            .edit_buffer(&path)
             .is_some_and(|buffer| buffer.is_dirty());
         if is_dirty && self.close_tab_confirm_armed.as_deref() != Some(path.as_path()) {
             self.close_tab_confirm_armed = Some(path);
@@ -315,13 +314,13 @@ impl AdeApp {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let Some(index) = self.open_files.iter().position(|open| open == &path) else {
+        let Some(index) = self.open_files().iter().position(|open| open == &path) else {
             return;
         };
         if self.close_tab_confirm_armed.as_deref() == Some(path.as_path()) {
             self.close_tab_confirm_armed = None;
         }
-        self.open_files.remove(index);
+        self.open_files_mut().remove(index);
         self._lsp_sync_tasks.remove(&path);
         if self
             .completions
@@ -334,10 +333,10 @@ impl AdeApp {
         if was_active {
             // After removal, the tab that was to the right (if any) has shifted into `index`;
             // fall back to `index - 1` only if there's nothing there.
-            let neighbor = self.open_files.get(index).cloned().or_else(|| {
+            let neighbor = self.open_files().get(index).cloned().or_else(|| {
                 index
                     .checked_sub(1)
-                    .and_then(|left| self.open_files.get(left).cloned())
+                    .and_then(|left| self.open_files().get(left).cloned())
             });
             match neighbor {
                 Some(next_path) => {
@@ -423,6 +422,15 @@ impl AdeApp {
             .strip_prefix(&self.file_tree_root)
             .map(|stripped| stripped.to_path_buf())
             .unwrap_or_else(|_| path.clone());
+        // The *worktree* half of `Self::edit_buffers`' composite key, captured now - before the
+        // real `.await` below - rather than re-read from `self.file_tree_root` once this task
+        // resumes. This load can genuinely outlive a worktree switch (a real background
+        // `std::fs::read_to_string` + tree-sitter parse, not instant), and `self.file_tree_root`
+        // would then already name whatever worktree the user switched *to*; resolving the key
+        // from that at completion time would silently seed or reload the *new* worktree's buffer
+        // for this same relative path instead of the one this load was actually for. See
+        // `Self::edit_buffers`'s own docs for the stale-worktree bug class this prevents.
+        let cwd = self.file_tree_root.clone();
         let extension = path
             .extension()
             .and_then(|ext| ext.to_str())
@@ -470,7 +478,7 @@ impl AdeApp {
                         let save_in_flight = this.file_save_pending.contains(&relative_path)
                             || this.file_save_running.contains(&relative_path);
                         if !parsed.truncated && parsed.is_valid_utf8 {
-                            match this.edit_buffers.get_mut(&relative_path) {
+                            match this.edit_buffer_at_mut(&cwd, &relative_path) {
                                 // An existing buffer with **no** unsaved edits, whose file has
                                 // since been rewritten on disk by someone else (an agent CLI
                                 // running in this very worktree - this app's whole domain - a
@@ -537,7 +545,8 @@ impl AdeApp {
                                 // block's own docs above for why a truncated/invalid-UTF-8 file
                                 // deliberately never reaches here at all.
                                 None => {
-                                    this.edit_buffers.insert(
+                                    this.insert_edit_buffer_at(
+                                        cwd.clone(),
                                         relative_path.clone(),
                                         edit_buffer::EditBuffer::from_highlighted(
                                             path.clone(),
@@ -552,7 +561,7 @@ impl AdeApp {
                             }
                         }
                         if reloaded {
-                            this.schedule_lsp_sync(relative_path.clone(), cx);
+                            this.schedule_lsp_sync(cwd.clone(), relative_path.clone(), cx);
                         }
                         // Whether this load is a *different* file arriving in the view, as
                         // opposed to a freshness re-read of the one already showing. Read before
@@ -1276,7 +1285,7 @@ mod multi_file_tab_tests {
         cx.run_until_parked();
 
         assert_eq!(
-            app.read_with(cx, |app, _| app.open_files.len()),
+            app.read_with(cx, |app, _| app.open_files().len()),
             1,
             "opening an already-open file a second time must activate the existing tab, not \
              append a duplicate"
@@ -1318,7 +1327,7 @@ mod multi_file_tab_tests {
         });
 
         assert_eq!(
-            app.read_with(cx, |app, _| app.open_files.clone()),
+            app.read_with(cx, |app, _| app.open_files().to_vec()),
             vec![a_rel.clone(), c_rel.clone()],
             "b should be gone from the tab list"
         );
@@ -1347,7 +1356,7 @@ mod multi_file_tab_tests {
             app.close_file_tab(active, window, cx);
         });
         assert_eq!(app.read_with(cx, |app, _| app.open_change.clone()), None);
-        assert!(app.read_with(cx, |app, _| app.open_files.is_empty()));
+        assert!(app.read_with(cx, |app, _| app.open_files().is_empty()));
     }
 
     /// Closing a tab that is *not* the active one must not change what's currently active - the
@@ -1384,7 +1393,7 @@ mod multi_file_tab_tests {
             Some(a_rel),
             "closing a tab that wasn't active must leave the active tab unchanged"
         );
-        assert_eq!(app.read_with(cx, |app, _| app.open_files.len()), 1);
+        assert_eq!(app.read_with(cx, |app, _| app.open_files().len()), 1);
     }
 
     /// Clicking an agent tab while a file tab is active deactivates the file (it stops being
@@ -1421,7 +1430,7 @@ mod multi_file_tab_tests {
             "selecting an agent tab should deactivate the file tab"
         );
         assert_eq!(
-            app.read_with(cx, |app, _| app.open_files.clone()),
+            app.read_with(cx, |app, _| app.open_files().to_vec()),
             vec![a_rel],
             "the file tab must still be in open_files, just not active"
         );
@@ -1662,6 +1671,111 @@ mod multi_file_tab_tests {
              view, which always has real content, instead of staying a dead no-op"
         );
     }
+
+    /// Real, live-reproduced coverage for `design_handoff_jerry_ade/revision 3/
+    /// REVISION-2026-07-31.md` §3 ("Switching worktrees swaps the whole strip. Each worktree
+    /// remembers its own ... open files") - the real bug this revision fixes: `AdeApp::
+    /// select_worktree` used to clear `open_files` unconditionally on every switch, so a
+    /// worktree's tabs were lost the moment you navigated away. Drives two *real* worktrees
+    /// (temp directories, real `AdeApp::select_worktree` switches, real `open_file_view` calls),
+    /// not the pure free-function `reset_per_worktree_ui_state` unit tests already covering the
+    /// helper in isolation.
+    #[gpui::test]
+    fn switching_worktrees_and_back_preserves_each_worktree_s_open_file_tabs(
+        cx: &mut TestAppContext,
+    ) {
+        let repo_a = tempfile::tempdir().expect("tempdir a");
+        let repo_b = tempfile::tempdir().expect("tempdir b");
+        let ((a1, a2, _), (a1_rel, a2_rel, _)) = write_three_files(repo_a.path());
+        let b1 = repo_b.path().join("notes.txt");
+        std::fs::write(&b1, "notes\n").expect("write notes.txt");
+        let b1_rel = PathBuf::from("notes.txt");
+
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        app.update(cx, |app, _cx| {
+            app.worktrees = vec![
+                crate::rail::worktrees::WorktreeItem {
+                    path: repo_a.path().to_path_buf(),
+                    label: "wt-a".to_string(),
+                    branch: Some("wt-a".to_string()),
+                    is_main: true,
+                    is_locked: false,
+                    error: None,
+                },
+                crate::rail::worktrees::WorktreeItem {
+                    path: repo_b.path().to_path_buf(),
+                    label: "wt-b".to_string(),
+                    branch: Some("wt-b".to_string()),
+                    is_main: false,
+                    is_locked: false,
+                    error: None,
+                },
+            ];
+        });
+        app.update_in(cx, |app, window, cx| {
+            app.select_worktree(0, window, cx);
+        });
+        cx.run_until_parked();
+
+        // Two real tabs opened in worktree A.
+        app.update_in(cx, |app, window, cx| {
+            app.open_file_view(a1, window, cx);
+        });
+        app.update_in(cx, |app, window, cx| {
+            app.open_file_view(a2, window, cx);
+        });
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.open_files().to_vec()),
+            vec![a1_rel.clone(), a2_rel.clone()],
+            "sanity check: both real tabs should be open in worktree A"
+        );
+
+        // Switching to worktree B - a worktree that has never opened anything - must show a
+        // real, honest empty tab strip, never worktree A's tabs.
+        app.update_in(cx, |app, window, cx| {
+            app.select_worktree(1, window, cx);
+        });
+        cx.run_until_parked();
+        assert!(
+            app.read_with(cx, |app, _| app.open_files().is_empty()),
+            "a worktree that has never opened a file must show a real empty tab strip, not \
+             worktree A's leftover tabs"
+        );
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_file_view(b1, window, cx);
+        });
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.open_files().to_vec()),
+            vec![b1_rel.clone()],
+            "sanity check: worktree B's own real tab should be open"
+        );
+
+        // Switching back to worktree A must restore its own two tabs exactly - the real fix.
+        app.update_in(cx, |app, window, cx| {
+            app.select_worktree(0, window, cx);
+        });
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.open_files().to_vec()),
+            vec![a1_rel, a2_rel],
+            "switching back to worktree A must restore exactly the tabs it was left with, not \
+             lose them to the switch away and back"
+        );
+
+        // And worktree B's own tab must still be there too, untouched by A's own switch back.
+        app.update_in(cx, |app, window, cx| {
+            app.select_worktree(1, window, cx);
+        });
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.open_files().to_vec()),
+            vec![b1_rel],
+            "worktree B's own tab must survive being switched away from and back to as well"
+        );
+    }
 }
 
 /// Revision R8.5b audit finding 3's direct regression coverage: a genuine data-corruption bug -
@@ -1790,7 +1904,7 @@ mod stale_completions_popup_tests {
              dangling for a file that's no longer open"
         );
         assert!(
-            app.read_with(cx, |app, _| !app.open_files.contains(&a_rel)),
+            app.read_with(cx, |app, _| !app.open_files().contains(&a_rel)),
             "sanity check: a's tab should genuinely be closed"
         );
 
@@ -1896,10 +2010,10 @@ mod terminal_link_click_tests {
                 "a real mod-held click on the detected link must open the real file as the \
                  active tab - got open_change = {:?}, open_files = {:?}",
                 app.open_change,
-                app.open_files,
+                app.open_files(),
             );
             assert!(
-                app.open_files.contains(&PathBuf::from("src/main.rs")),
+                app.open_files().contains(&PathBuf::from("src/main.rs")),
                 "the opened file must appear in the real tab list too"
             );
         });
@@ -1925,7 +2039,7 @@ mod terminal_link_click_tests {
                 "a bare click (no mod held) on a detected link must not open anything"
             );
             assert!(
-                app.open_files.is_empty(),
+                app.open_files().is_empty(),
                 "a bare click must not add a real tab either"
             );
         });
@@ -1987,7 +2101,7 @@ mod terminal_link_click_tests {
                 app.open_change,
             );
             assert!(
-                app.open_files.is_empty(),
+                app.open_files().is_empty(),
                 "a link to a nonexistent path must not add a real tab either"
             );
         });

--- a/crates/app/src/code_surface/tabs.rs
+++ b/crates/app/src/code_surface/tabs.rs
@@ -592,7 +592,7 @@ impl AdeApp {
                         // opened for the very first time has a fresh buffer at offset 0, so this
                         // reduces to exactly "line 1, scrolled to top" with no special case.
                         let buffer_cursor_line =
-                            this.edit_buffers.get(&relative_path).map(|buffer| {
+                            this.edit_buffer_at(&cwd, &relative_path).map(|buffer| {
                                 let (line, _) = buffer.line_col_for_offset(buffer.cursor_offset());
                                 line + 1
                             });
@@ -1161,7 +1161,7 @@ mod reopened_file_caret_tests {
         });
         cx.run_until_parked();
         let moved = app.read_with(cx, |app, _| {
-            let buffer = app.edit_buffers.get(&relative).expect("buffer");
+            let buffer = app.edit_buffer(&relative).expect("buffer");
             buffer.line_col_for_offset(buffer.cursor_offset()).0
         });
         assert_eq!(
@@ -1185,7 +1185,7 @@ mod reopened_file_caret_tests {
         cx.run_until_parked();
 
         app.read_with(cx, |app, _| {
-            let buffer = app.edit_buffers.get(&relative).expect("buffer");
+            let buffer = app.edit_buffer(&relative).expect("buffer");
             assert_eq!(
                 buffer.line_col_for_offset(buffer.cursor_offset()).0,
                 200,
@@ -1232,8 +1232,7 @@ mod reopened_file_caret_tests {
         app.read_with(cx, |app, _| {
             assert_eq!(app.code_cursor, Some(1));
             assert_eq!(
-                app.edit_buffers
-                    .get(Path::new("fresh.txt"))
+                app.edit_buffer(Path::new("fresh.txt"))
                     .expect("buffer")
                     .cursor_offset(),
                 0
@@ -1699,7 +1698,13 @@ mod multi_file_tab_tests {
                     label: "wt-a".to_string(),
                     branch: Some("wt-a".to_string()),
                     is_main: true,
+                    is_bare: false,
+                    is_detached: false,
+                    short_sha: None,
                     is_locked: false,
+                    lock_reason: None,
+                    is_broken: false,
+                    broken_reason: None,
                     error: None,
                 },
                 crate::rail::worktrees::WorktreeItem {
@@ -1707,7 +1712,13 @@ mod multi_file_tab_tests {
                     label: "wt-b".to_string(),
                     branch: Some("wt-b".to_string()),
                     is_main: false,
+                    is_bare: false,
+                    is_detached: false,
+                    short_sha: None,
                     is_locked: false,
+                    lock_reason: None,
+                    is_broken: false,
+                    broken_reason: None,
                     error: None,
                 },
             ];

--- a/crates/app/src/code_surface/zoom.rs
+++ b/crates/app/src/code_surface/zoom.rs
@@ -439,7 +439,9 @@ mod code_zoom_tests {
             app.close_file_tab(PathBuf::from("a.rs"), window, cx);
         });
         assert!(
-            !app.read_with(cx, |app, _| app.open_files.contains(&PathBuf::from("a.rs"))),
+            !app.read_with(cx, |app, _| app
+                .open_files()
+                .contains(&PathBuf::from("a.rs"))),
             "closing the tab must really remove it from open_files"
         );
 

--- a/crates/app/src/lsp/client.rs
+++ b/crates/app/src/lsp/client.rs
@@ -1233,13 +1233,28 @@ impl AdeApp {
     /// answering completions against stale, pre-edit content - a real correctness bug, not just a
     /// latency one; only the diagnostics-*pull* retry loop, the actual multi-second offender, is
     /// being decoupled here.
-    pub(crate) fn schedule_lsp_sync(&mut self, relative_path: PathBuf, cx: &mut Context<Self>) {
+    ///
+    /// `cwd` is the worktree [`AdeApp::edit_buffers`]'s composite key needs to find `relative_
+    /// path`'s buffer - the caller's own current [`AdeApp::file_tree_root`] when called
+    /// synchronously (every direct `crate::code_surface::editing` call site), or a `cwd` that
+    /// caller itself already captured before its own `.await` when this is called from inside
+    /// another real `cx.spawn` continuation (`crate::code_surface::tabs::AdeApp::spawn_file_load`'s
+    /// "reloaded" branch) - never re-derived from `self.file_tree_root` once *this* method's own
+    /// debounce timer resumes below, which could by then name a worktree the user has since
+    /// switched away to. See [`AdeApp::edit_buffers`]'s own docs for the stale-worktree bug class
+    /// this prevents.
+    pub(crate) fn schedule_lsp_sync(
+        &mut self,
+        cwd: PathBuf,
+        relative_path: PathBuf,
+        cx: &mut Context<Self>,
+    ) {
         let task = cx.spawn({
             let relative_path = relative_path.clone();
             async move |this, cx| {
                 cx.background_executor().timer(LSP_SYNC_DEBOUNCE).await;
                 let Ok(Some(plan)) = this.update(cx, |this, cx| {
-                    this.prepare_lsp_sync(&relative_path, cx, false)
+                    this.prepare_lsp_sync(&cwd, &relative_path, cx, false)
                 }) else {
                     return;
                 };
@@ -1491,7 +1506,12 @@ impl AdeApp {
         relative_path: PathBuf,
         cx: &mut Context<Self>,
     ) {
-        let Some(plan) = self.prepare_lsp_sync(&relative_path, cx, true) else {
+        // Called synchronously (`Ctrl+Space`, no `.await` between here and `Self::
+        // prepare_lsp_sync`'s own read), so `self.file_tree_root` genuinely is "now" - unlike
+        // `Self::schedule_lsp_sync`'s debounced continuation, which must capture its own `cwd`
+        // before waiting out the debounce instead.
+        let cwd = self.file_tree_root.clone();
+        let Some(plan) = self.prepare_lsp_sync(&cwd, &relative_path, cx, true) else {
             return;
         };
         let LspSyncPlan { sync, completion } = plan;
@@ -1582,11 +1602,12 @@ impl AdeApp {
     /// (`force_completion: false`, from [`AdeApp::schedule_lsp_sync`]).
     fn prepare_lsp_sync(
         &mut self,
+        cwd: &Path,
         relative_path: &Path,
         cx: &mut Context<Self>,
         force_completion: bool,
     ) -> Option<LspSyncPlan> {
-        let buffer = self.edit_buffers.get(relative_path)?;
+        let buffer = self.edit_buffer_at(cwd, relative_path)?;
         let absolute_path = buffer.path.clone();
         // A single owned clone, reused for everything below (Revision R8.5b audit finding 7's
         // fix) - see `LspSyncRequest::content`'s own docs for the real, honest minimum this was
@@ -3832,7 +3853,7 @@ mod lsp_diagnostics_wiring_tests {
             let relative = app
                 .active_editable_path()
                 .expect("a real editable File view tab should be active");
-            let buffer = app.edit_buffers.get_mut(&relative).expect("a real buffer");
+            let buffer = app.edit_buffer_mut(&relative).expect("a real buffer");
             buffer.move_to(offset);
             app.replace_text_in_range(None, text, window, cx);
         });
@@ -3934,8 +3955,7 @@ mod lsp_diagnostics_wiring_tests {
         // sequence completing, retrying, or its own timer ever advancing.
         let relative = PathBuf::from("src/main.rs");
         let completion_trigger_offset = app.read_with(cx, |app, _| {
-            app.edit_buffers
-                .get(&relative)
+            app.edit_buffer(&relative)
                 .expect("a real buffer")
                 .content
                 .len()
@@ -3990,11 +4010,7 @@ mod lsp_diagnostics_wiring_tests {
         cx.run_until_parked();
 
         app.read_with(cx, |app, _| {
-            let content = &app
-                .edit_buffers
-                .get(&relative)
-                .expect("a real buffer")
-                .content;
+            let content = &app.edit_buffer(&relative).expect("a real buffer").content;
             assert!(
                 content.contains("println"),
                 "accepting the real completion should have spliced its real text into the \
@@ -4085,8 +4101,7 @@ mod lsp_diagnostics_wiring_tests {
 
         let relative = PathBuf::from("main.ts");
         let completion_trigger_offset = app.read_with(cx, |app, _| {
-            app.edit_buffers
-                .get(&relative)
+            app.edit_buffer(&relative)
                 .expect("a real buffer")
                 .content
                 .len()
@@ -4124,11 +4139,7 @@ mod lsp_diagnostics_wiring_tests {
         });
         cx.run_until_parked();
         app.read_with(cx, |app, _| {
-            let content = &app
-                .edit_buffers
-                .get(&relative)
-                .expect("a real buffer")
-                .content;
+            let content = &app.edit_buffer(&relative).expect("a real buffer").content;
             assert!(
                 content.contains("console"),
                 "accepting the real completion should have spliced its real text into the \
@@ -4193,8 +4204,7 @@ mod lsp_diagnostics_wiring_tests {
 
         let relative = PathBuf::from("main.py");
         let completion_trigger_offset = app.read_with(cx, |app, _| {
-            app.edit_buffers
-                .get(&relative)
+            app.edit_buffer(&relative)
                 .expect("a real buffer")
                 .content
                 .len()
@@ -4232,11 +4242,7 @@ mod lsp_diagnostics_wiring_tests {
         });
         cx.run_until_parked();
         app.read_with(cx, |app, _| {
-            let content = &app
-                .edit_buffers
-                .get(&relative)
-                .expect("a real buffer")
-                .content;
+            let content = &app.edit_buffer(&relative).expect("a real buffer").content;
             assert!(
                 content.contains("print"),
                 "accepting the real completion should have spliced its real text into the \

--- a/crates/app/src/lsp/client.rs
+++ b/crates/app/src/lsp/client.rs
@@ -3138,7 +3138,7 @@ process.stdin.on('data', (d) => {
         // A real, armed sync task through the real production entry point - and a real check that
         // it is genuinely armed, so this can't quietly become a test of nothing.
         app.update(cx, |app, cx| {
-            app.schedule_lsp_sync(relative.clone(), cx);
+            app.schedule_lsp_sync(root.clone(), relative.clone(), cx);
         });
         app.read_with(cx, |app, _| {
             assert!(

--- a/crates/app/src/lsp/completion_popup.rs
+++ b/crates/app/src/lsp/completion_popup.rs
@@ -233,7 +233,7 @@ impl AdeApp {
             self.reset_caret_blink(cx);
             return;
         };
-        let Some(buffer) = self.edit_buffers.get_mut(&entry.path) else {
+        let Some(buffer) = self.edit_buffer_mut(&entry.path) else {
             cx.notify();
             self.replace_text_in_range(None, "\n", window, cx);
             self.sync_cursor_and_scroll();
@@ -251,7 +251,7 @@ impl AdeApp {
         buffer.replace_range(Some(range), &text);
         buffer.seal_history();
         self.schedule_rehighlight(path.clone(), cx);
-        self.schedule_lsp_sync(path, cx);
+        self.schedule_lsp_sync(self.file_tree_root.clone(), path, cx);
         self.sync_cursor_and_scroll();
         self.reset_caret_blink(cx);
         cx.notify();
@@ -272,7 +272,7 @@ impl AdeApp {
         if self.active_editable_path().as_deref() != Some(entry.path.as_path()) {
             return None;
         }
-        let buffer = self.edit_buffers.get(&entry.path)?;
+        let buffer = self.edit_buffer(&entry.path)?;
         let (last_path, last_line) = self.file_view_last_layout_for.clone()?;
         if last_path != entry.path {
             return None;

--- a/crates/app/src/merge/flow.rs
+++ b/crates/app/src/merge/flow.rs
@@ -2034,8 +2034,7 @@ mod merge_regression_tests {
 
         let relative_notes = PathBuf::from("notes.txt");
         let file_content = app.read_with(cx, |app, _| {
-            app.edit_buffers
-                .get(&relative_notes)
+            app.edit_buffer(&relative_notes)
                 .expect("notes.txt buffer")
                 .content
                 .clone()
@@ -2108,8 +2107,7 @@ mod merge_regression_tests {
              got {merge_edit_content_final:?}"
         );
         let file_content_after_stale_tab = app.read_with(cx, |app, _| {
-            app.edit_buffers
-                .get(&relative_notes)
+            app.edit_buffer(&relative_notes)
                 .expect("notes.txt buffer")
                 .content
                 .clone()

--- a/crates/app/src/root/focus.rs
+++ b/crates/app/src/root/focus.rs
@@ -1342,8 +1342,7 @@ mod text_undo_scoping_tests {
         cx.simulate_input("TYPED");
         assert_eq!(
             app.read_with(cx, |app, _| app
-                .edit_buffers
-                .get(&relative)
+                .edit_buffer(&relative)
                 .unwrap()
                 .content
                 .clone()),
@@ -1359,7 +1358,7 @@ mod text_undo_scoping_tests {
         cx.run_until_parked();
         assert_eq!(app.read_with(cx, |app, _| app.open_change.clone()), None);
         assert!(
-            app.read_with(cx, |app, _| app.edit_buffers.contains_key(&relative)),
+            app.read_with(cx, |app, _| app.edit_buffer_contains(&relative)),
             "sanity check: the buffer (and its history) must still be alive, or this test would \
              pass for the wrong reason"
         );
@@ -1370,8 +1369,7 @@ mod text_undo_scoping_tests {
 
         assert_eq!(
             app.read_with(cx, |app, _| app
-                .edit_buffers
-                .get(&relative)
+                .edit_buffer(&relative)
                 .unwrap()
                 .content
                 .clone()),
@@ -1397,7 +1395,7 @@ mod text_undo_scoping_tests {
 
         cx.simulate_input("EDITED");
         let content_before = app.read_with(cx, |app, _| {
-            app.edit_buffers.get(&relative).unwrap().content.clone()
+            app.edit_buffer(&relative).unwrap().content.clone()
         });
         assert_eq!(content_before, "EDITEDhello\n");
 
@@ -1420,8 +1418,7 @@ mod text_undo_scoping_tests {
         );
         assert_eq!(
             app.read_with(cx, |app, _| app
-                .edit_buffers
-                .get(&relative)
+                .edit_buffer(&relative)
                 .unwrap()
                 .content
                 .clone()),

--- a/crates/app/src/root/focus.rs
+++ b/crates/app/src/root/focus.rs
@@ -1691,9 +1691,9 @@ mod palette_result_focus_tests {
                 Some(relative.as_path()),
                 "the palette must have opened the file's tab"
             );
-            assert_eq!(app.open_files, vec![relative.clone()]);
+            assert_eq!(app.open_files(), vec![relative.clone()]);
             assert!(
-                app.edit_buffers.contains_key(&relative),
+                app.edit_buffer_contains(&relative),
                 "and a real edit buffer must be backing it"
             );
         });
@@ -1726,8 +1726,7 @@ mod palette_result_focus_tests {
 
         assert_eq!(
             app.read_with(cx, |app, _| app
-                .edit_buffers
-                .get(&relative)
+                .edit_buffer(&relative)
                 .expect("buffer")
                 .content
                 .clone()),
@@ -1748,8 +1747,7 @@ mod palette_result_focus_tests {
 
         assert_eq!(
             app.read_with(cx, |app, _| app
-                .edit_buffers
-                .get(&relative)
+                .edit_buffer(&relative)
                 .expect("buffer")
                 .cursor_offset()),
             0,
@@ -1761,8 +1759,7 @@ mod palette_result_focus_tests {
 
         assert_eq!(
             app.read_with(cx, |app, _| app
-                .edit_buffers
-                .get(&relative)
+                .edit_buffer(&relative)
                 .expect("buffer")
                 .cursor_offset()),
             1,
@@ -1795,7 +1792,7 @@ mod palette_result_focus_tests {
         cx.run_until_parked();
         app.read_with(cx, |app, _| {
             assert_eq!(
-                app.edit_buffers.get(&relative).expect("buffer").content,
+                app.edit_buffer(&relative).expect("buffer").content,
                 "Afn main() {}\n",
                 "premise: with the tree focused, a keystroke must not reach the buffer"
             );
@@ -1807,12 +1804,12 @@ mod palette_result_focus_tests {
 
         app.read_with(cx, |app, _| {
             assert_eq!(
-                app.open_files,
+                app.open_files(),
                 vec![relative.clone()],
                 "reopening the same file must reuse its tab, never append a second one"
             );
             assert_eq!(
-                app.edit_buffers.get(&relative).expect("buffer").content,
+                app.edit_buffer(&relative).expect("buffer").content,
                 "ABfn main() {}\n",
                 "both keystrokes must have landed in the same real buffer - and `B` lands \
                  *after* `A` because the buffer kept its own caret (offset 1) across the \
@@ -1846,8 +1843,7 @@ mod palette_result_focus_tests {
         cx.run_until_parked();
         assert_eq!(
             app.read_with(cx, |app, _| app
-                .edit_buffers
-                .get(&relative)
+                .edit_buffer(&relative)
                 .expect("buffer")
                 .content
                 .clone()),
@@ -1895,8 +1891,7 @@ mod palette_result_focus_tests {
         cx.run_until_parked();
         assert_eq!(
             app.read_with(cx, |app, _| app
-                .edit_buffers
-                .get(&relative)
+                .edit_buffer(&relative)
                 .expect("buffer")
                 .content
                 .clone()),
@@ -2039,8 +2034,7 @@ mod palette_result_focus_tests {
         cx.run_until_parked();
         assert_eq!(
             app.read_with(cx, |app, _| app
-                .edit_buffers
-                .get(&relative)
+                .edit_buffer(&relative)
                 .expect("buffer")
                 .content
                 .clone()),

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -465,12 +465,18 @@ pub struct AdeApp {
     /// state that `Self::render_changes_header`'s progress bar and count read directly.
     pub(crate) reviewed_files: HashSet<PathBuf>,
     /// Ordered list of currently-open file tabs, rendered after every agent's own tab by
-    /// `Self::render_tab_strip`. No duplicates: opening an already-open file just activates its
-    /// existing entry (`Self::push_open_file`). Removed only on explicit tab close
-    /// (`Self::close_file_tab`) or leaving the owning worktree (`reset_per_worktree_ui_state`) -
-    /// these are worktree-relative paths, meaningless (or collision-prone) once the worktree
-    /// changes.
-    pub(crate) open_files: Vec<PathBuf>,
+    /// `Self::render_tab_strip` - **per worktree**, keyed by [`Self::file_tree_root`]
+    /// (`design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §3: "Switching worktrees
+    /// swaps the whole strip. Each worktree remembers its own ... open files"). No duplicates
+    /// within one worktree's list: opening an already-open file just activates its existing entry
+    /// (`Self::push_open_file`). Removed only on explicit tab close (`Self::close_file_tab`) -
+    /// **not** on a worktree switch: these are worktree-*relative* paths, which is exactly why a
+    /// flat, unscoped list would be collision-prone (two worktrees sharing a relative path) if it
+    /// weren't split per worktree like this. Read through [`Self::open_files`] (a method, not this
+    /// field, outside this struct) and written through [`Self::open_files_mut`] - both resolve the
+    /// *current* worktree's entry, creating it empty on first access rather than requiring a
+    /// separate "new worktree" seeding step.
+    pub(crate) open_files_by_worktree: HashMap<PathBuf, Vec<PathBuf>>,
     /// Which file tab (if any) the centre pane is showing instead of an agent -
     /// `Some(path)` iff `path` is also in [`Self::open_files`]. Set by a Changes row
     /// (`Self::open_change_diff`), a Files-tree row (`Self::open_file_view`), or an already-open
@@ -602,25 +608,39 @@ pub struct AdeApp {
     /// [`Self::ensure_blame_commit_message`]), off-thread.
     pub(crate) blame_commit_messages: HashMap<String, CommitMessageState>,
     pub(crate) _blame_message_tasks: HashMap<String, Task<()>>,
-    /// Real, live per-tab text-editing state for the File view (Revision R8.5a) - keyed the same
-    /// way as [`Self::open_files`] (a worktree-relative path), so switching between open file
-    /// tabs never loses unsaved edits in a background tab. Created lazily the first time a file
-    /// is opened in File view (see
+    /// Real, live per-tab text-editing state for the File view (Revision R8.5a) - keyed by
+    /// **both** the owning worktree ([`Self::file_tree_root`] at the time the buffer was created)
+    /// and the worktree-relative path, exactly like [`Self::open_files_by_worktree`]'s own outer
+    /// key, so an unsaved edit survives a worktree switch away and back
+    /// (`design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §1/§3) and two worktrees that
+    /// happen to share a relative path can never merge or overwrite each other's in-memory
+    /// content. Created lazily the first time a file is opened in File view (see
     /// [`crate::code_surface::file_view::AdeApp::render_file_view`]), seeded from the exact same
     /// background read [`Self::spawn_file_load`] already performs. [`Self::file_view_cache`]
     /// stays the freshness-check/diagnostics/hover source of truth (the last-*saved* snapshot,
     /// per this phase's own scope); this map is what's actually on screen and what an explicit
     /// save writes. Deliberately **not** removed on an ordinary tab close
-    /// ([`crate::code_surface::tabs::AdeApp::close_file_tab`]) - dropping unsaved edits just
-    /// because a tab was closed (with no "save before closing?" prompt - out of scope this
-    /// phase) would be a real, silent data-loss risk; reopening the same file later restores the
-    /// exact in-memory buffer. Reset alongside `open_files` in `reset_per_worktree_ui_state` so a
-    /// worktree switch doesn't leak another worktree's buffers, matching the same
-    /// per-worktree-reset convention `open_files` already follows. (Editor zoom used to be
-    /// reset the same way too - see `settings_store`'s "Editor zoom is one global, persisted
-    /// number now" docs for why it no longer is: it moved to `Settings.appearance.
-    /// editor_zoom_percent`, a real persisted field, not per-worktree UI state.)
-    pub(crate) edit_buffers: HashMap<PathBuf, edit_buffer::EditBuffer>,
+    /// ([`crate::code_surface::tabs::AdeApp::close_file_tab`]) **or** a worktree switch -
+    /// dropping unsaved edits just because a tab was closed or a different worktree was clicked
+    /// (with no "save before closing?"/"discard this edit?" prompt - the design's own explicit
+    /// call: fluidly hopping between worktrees must never carry that friction) would be a real,
+    /// silent data-loss risk; reopening the same file (in the same worktree) later restores the
+    /// exact in-memory buffer. Read through [`Self::edit_buffer`]/written through
+    /// [`Self::edit_buffer_mut`]/[`Self::insert_edit_buffer`]/[`Self::remove_edit_buffer`] for
+    /// every *synchronous* call site (these resolve the worktree half of the key from whatever
+    /// [`Self::file_tree_root`] is right now); a real `cx.spawn` task that reads or writes a
+    /// buffer *after* an `.await` must instead go through [`Self::edit_buffer_at`]/
+    /// [`Self::edit_buffer_at_mut`] with a `cwd` captured **before** the await - by the time such
+    /// a task resumes, [`Self::file_tree_root`] may already name a different worktree entirely
+    /// (the user switched away while the task was in flight), and resolving the key from the
+    /// *current* one at that point would silently read or write the wrong worktree's buffer -
+    /// exactly the stale-async-task bug class `Self::load_file_tree`'s own `file_tree_root`
+    /// identity guard exists to prevent, applied here to a keyed map instead of a single field.
+    /// (Editor zoom used to be reset on a worktree switch too - see `settings_store`'s "Editor
+    /// zoom is one global, persisted number now" docs for why it no longer is: it moved to
+    /// `Settings.appearance.editor_zoom_percent`, a real persisted field, not per-worktree UI
+    /// state.)
+    pub(crate) edit_buffers: HashMap<(PathBuf, PathBuf), edit_buffer::EditBuffer>,
     /// Every visible File-view row's real painted bounds and shaped line, captured by
     /// `crate::code_surface::editing`'s per-row `gpui::canvas` paint callback each render - read back by
     /// a row's own click handler to hit-test a click into a real byte offset

--- a/crates/app/src/root/new_file.rs
+++ b/crates/app/src/root/new_file.rs
@@ -343,11 +343,11 @@ impl AdeApp {
         self.focus_code_surface(window, cx);
         self.pending_cursor_line = None;
         if !self
-            .open_files
+            .open_files()
             .iter()
             .any(|open| open.as_path() == relative.as_path())
         {
-            self.open_files.push(relative.clone());
+            self.open_files_mut().push(relative.clone());
         }
         self.open_change = Some(relative.clone());
         self.code_view = code_view::CodeView::File;
@@ -357,7 +357,7 @@ impl AdeApp {
         // showing at all. Same real reveal - and same recorded expansions - as the palette's own
         // "reveal in tree".
         self.reveal_in_tree(&absolute_path, cx);
-        self.edit_buffers.insert(
+        self.insert_edit_buffer(
             relative,
             edit_buffer::EditBuffer::new(absolute_path, String::new(), extension, None, 0),
         );

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -160,7 +160,7 @@ impl AdeApp {
             _tree_delete_task: None,
             _tree_copy_task: None,
             reviewed_files: HashSet::new(),
-            open_files: Vec::new(),
+            open_files_by_worktree: HashMap::new(),
             open_change: None,
             close_tab_confirm_armed: None,
             open_diff_file_cache: None,
@@ -627,11 +627,9 @@ impl AdeApp {
         // statement later.
         reset_per_worktree_ui_state(
             &mut self.reviewed_files,
-            &mut self.open_files,
             &mut self.open_change,
             &mut self.expanded_dirs,
             &mut self.selected_tree_path,
-            &mut self.edit_buffers,
         );
         // The tree's fold state is per-worktree *persisted* state, not merely per-worktree
         // transient state: the reset above clears the live set, and this re-derives it from the
@@ -774,6 +772,117 @@ impl AdeApp {
         cx.notify();
     }
 
+    /// The current worktree's open file tabs (`design_handoff_jerry_ade/revision 3/
+    /// REVISION-2026-07-31.md` §3) - an empty slice for a worktree that has never opened one,
+    /// never a panic or a fabricated default. See [`Self::open_files_by_worktree`]'s own docs for
+    /// why this is keyed by [`Self::file_tree_root`] rather than a flat, unscoped `Vec`.
+    pub(crate) fn open_files(&self) -> &[PathBuf] {
+        self.open_files_by_worktree
+            .get(&self.file_tree_root)
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
+    }
+
+    /// The current worktree's open file tabs, mutably - creates an empty entry for a worktree
+    /// that has never opened one rather than requiring a separate seeding step. Every real
+    /// mutation of [`Self::open_files_by_worktree`] (push/remove/rename-remap) goes through this,
+    /// matching [`Self::open_files`]'s own read-side resolution.
+    pub(crate) fn open_files_mut(&mut self) -> &mut Vec<PathBuf> {
+        self.open_files_by_worktree
+            .entry(self.file_tree_root.clone())
+            .or_default()
+    }
+
+    /// The `(worktree, worktree-relative path)` composite key [`Self::edit_buffers`] is keyed by,
+    /// resolved from whatever [`Self::file_tree_root`] is *right now* - safe for any synchronous
+    /// call site, but never for a real `cx.spawn` task resuming after an `.await` (see
+    /// [`Self::edit_buffers`]'s own docs on why; use [`Self::edit_buffer_at`]/
+    /// [`Self::edit_buffer_at_mut`] there instead, with a `cwd` captured before the await).
+    fn edit_buffer_key(&self, path: &std::path::Path) -> (PathBuf, PathBuf) {
+        (self.file_tree_root.clone(), path.to_path_buf())
+    }
+
+    /// The current worktree's edit buffer for `path`, if one exists. See [`Self::edit_buffer_key`]
+    /// for why this is only safe from a synchronous call site.
+    pub(crate) fn edit_buffer(&self, path: &std::path::Path) -> Option<&edit_buffer::EditBuffer> {
+        self.edit_buffers.get(&self.edit_buffer_key(path))
+    }
+
+    /// Mutable sibling of [`Self::edit_buffer`] - same synchronous-only caveat.
+    pub(crate) fn edit_buffer_mut(
+        &mut self,
+        path: &std::path::Path,
+    ) -> Option<&mut edit_buffer::EditBuffer> {
+        let key = self.edit_buffer_key(path);
+        self.edit_buffers.get_mut(&key)
+    }
+
+    /// `true` iff the current worktree has a real edit buffer for `path`. Same synchronous-only
+    /// caveat as [`Self::edit_buffer`].
+    pub(crate) fn edit_buffer_contains(&self, path: &std::path::Path) -> bool {
+        self.edit_buffers.contains_key(&self.edit_buffer_key(path))
+    }
+
+    /// Inserts (or replaces) `buffer` for `path` in the *current* worktree - the same
+    /// synchronous-only caveat as [`Self::edit_buffer`] applies to which worktree "current" means.
+    pub(crate) fn insert_edit_buffer(
+        &mut self,
+        path: PathBuf,
+        buffer: edit_buffer::EditBuffer,
+    ) -> Option<edit_buffer::EditBuffer> {
+        let key = self.edit_buffer_key(&path);
+        self.edit_buffers.insert(key, buffer)
+    }
+
+    /// Explicit-key read for a real `cx.spawn` task resuming after an `.await` - `cwd` must be
+    /// captured **before** the await (typically alongside `path` itself, in the same closure
+    /// capture list), never re-derived from [`Self::file_tree_root`] once the task resumes. See
+    /// [`Self::edit_buffers`]'s own docs for the stale-worktree bug this exists to prevent.
+    pub(crate) fn edit_buffer_at(
+        &self,
+        cwd: &std::path::Path,
+        path: &std::path::Path,
+    ) -> Option<&edit_buffer::EditBuffer> {
+        self.edit_buffers
+            .get(&(cwd.to_path_buf(), path.to_path_buf()))
+    }
+
+    /// Mutable sibling of [`Self::edit_buffer_at`] - same "capture `cwd` before the await" rule.
+    pub(crate) fn edit_buffer_at_mut(
+        &mut self,
+        cwd: &std::path::Path,
+        path: &std::path::Path,
+    ) -> Option<&mut edit_buffer::EditBuffer> {
+        self.edit_buffers
+            .get_mut(&(cwd.to_path_buf(), path.to_path_buf()))
+    }
+
+    /// Removes and returns the current worktree's edit buffer for `path`, if any. Same
+    /// synchronous-only caveat as [`Self::edit_buffer`]. Test-only seam (no real production call
+    /// site removes a single buffer directly - see [`Self::edit_buffers`]'s own "deliberately not
+    /// removed" docs for why): used to simulate a buffer vanishing mid-flight, e.g. in
+    /// `crate::code_surface::editing::editing_tests`'s writer-loop coverage.
+    #[cfg(test)]
+    pub(crate) fn remove_edit_buffer(
+        &mut self,
+        path: &std::path::Path,
+    ) -> Option<edit_buffer::EditBuffer> {
+        let key = self.edit_buffer_key(path);
+        self.edit_buffers.remove(&key)
+    }
+
+    /// Explicit-key insert, the [`Self::insert_edit_buffer`] sibling for a real `cx.spawn` task
+    /// resuming after an `.await` - same "capture `cwd` before the await" rule as
+    /// [`Self::edit_buffer_at`].
+    pub(crate) fn insert_edit_buffer_at(
+        &mut self,
+        cwd: PathBuf,
+        path: PathBuf,
+        buffer: edit_buffer::EditBuffer,
+    ) -> Option<edit_buffer::EditBuffer> {
+        self.edit_buffers.insert((cwd, path), buffer)
+    }
+
     /// Selects a worktree by its real path (rather than an index into
     /// [`Self::worktrees`], which project-mode rows don't carry) - used by a plain worktree
     /// row's click handler in "by project" mode. Falls back to doing nothing if the path
@@ -791,33 +900,38 @@ impl AdeApp {
 }
 
 /// Clears every piece of per-worktree UI state that would otherwise survive a worktree switch -
-/// called from [`AdeApp::select_worktree`] on every switch. `reviewed_files`/`open_files`/
-/// `open_change` are keyed by repo-relative paths with no per-worktree scoping of their own, so
-/// without this reset a file reviewed or opened in worktree A would read as already-reviewed (or
-/// reopen) in worktree B if it shares the same relative path. `expanded_dirs` is keyed by
-/// absolute path, so it doesn't bleed the same way - but it must still be emptied here, because
+/// called from [`AdeApp::select_worktree`] on every switch. `reviewed_files`/`open_change` are
+/// keyed by repo-relative paths with no per-worktree scoping of their own, so without this reset
+/// a file reviewed or opened in worktree A would read as already-reviewed (or reopen) in worktree
+/// B if it shares the same relative path. `expanded_dirs` is keyed by absolute path, so it
+/// doesn't bleed the same way - but it must still be emptied here, because
 /// [`AdeApp::select_worktree`] re-derives it from the *new* worktree's own persisted fold state
 /// immediately afterwards, and a leftover entry from the worktree just left would otherwise
 /// survive that (its absolute path simply never matches anything in the new tree, so nothing
 /// would ever remove it). A free, `gpui`-free function so this is unit-testable without constructing an
 /// `AdeApp`.
+///
+/// **Deliberately does *not* touch `open_files`/`edit_buffers` anymore.** Both moved to real,
+/// per-worktree-keyed storage (`AdeApp::open_files_by_worktree`, keyed by
+/// [`AdeApp::file_tree_root`]; `AdeApp::edit_buffers`, keyed by `(file_tree_root, path)`) -
+/// `design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §1/§3's explicit requirement that
+/// each worktree remembers its own open files, and that an unsaved edit must survive fluidly
+/// hopping between worktrees rather than being silently discarded. Clearing them here used to be
+/// how this function kept one worktree's tabs/buffers from leaking into another's; now that both
+/// are looked up *through* the worktree they belong to, the worktree switch happening around this
+/// call (`AdeApp::select_worktree` reassigning `file_tree_root` a few lines below) is itself what
+/// makes the old worktree's entries stop being "current" - nothing here needs to delete them, and
+/// deleting them would be exactly the silent data loss this revision set out to fix.
 pub(super) fn reset_per_worktree_ui_state(
     reviewed_files: &mut HashSet<PathBuf>,
-    open_files: &mut Vec<PathBuf>,
     open_change: &mut Option<PathBuf>,
     expanded_dirs: &mut HashSet<PathBuf>,
     selected_tree_path: &mut Option<PathBuf>,
-    edit_buffers: &mut HashMap<PathBuf, edit_buffer::EditBuffer>,
 ) {
     reviewed_files.clear();
-    open_files.clear();
     *open_change = None;
     expanded_dirs.clear();
     *selected_tree_path = None;
-    // Real, live unsaved-edit state (Revision R8.5a) is just as worktree-relative-path-keyed as
-    // `open_files` above - without this, a same-named file in a different worktree could
-    // silently inherit another worktree's in-memory buffer/cursor/selection.
-    edit_buffers.clear();
 }
 
 #[cfg(test)]
@@ -829,71 +943,33 @@ mod tests {
         let mut reviewed_files = HashSet::new();
         reviewed_files.insert(PathBuf::from("src/main.rs"));
         reviewed_files.insert(PathBuf::from("Cargo.toml"));
-        let mut open_files = Vec::new();
         let mut open_change = Some(PathBuf::from("src/main.rs"));
         let mut expanded_dirs = HashSet::new();
         let mut selected_tree_path = None;
-        let mut edit_buffers = HashMap::new();
 
         reset_per_worktree_ui_state(
             &mut reviewed_files,
-            &mut open_files,
             &mut open_change,
             &mut expanded_dirs,
             &mut selected_tree_path,
-            &mut edit_buffers,
         );
 
         assert!(reviewed_files.is_empty());
         assert_eq!(open_change, None);
     }
 
-    /// Every open tab from the worktree just left must be gone, not just deactivated.
-    #[test]
-    fn reset_per_worktree_ui_state_clears_every_open_file_tab() {
-        let mut reviewed_files = HashSet::new();
-        let mut open_files = vec![
-            PathBuf::from("src/main.rs"),
-            PathBuf::from("Cargo.toml"),
-            PathBuf::from("README.md"),
-        ];
-        let mut open_change = Some(PathBuf::from("Cargo.toml"));
-        let mut expanded_dirs = HashSet::new();
-        let mut selected_tree_path = None;
-        let mut edit_buffers = HashMap::new();
-
-        reset_per_worktree_ui_state(
-            &mut reviewed_files,
-            &mut open_files,
-            &mut open_change,
-            &mut expanded_dirs,
-            &mut selected_tree_path,
-            &mut edit_buffers,
-        );
-
-        assert!(
-            open_files.is_empty(),
-            "every open file tab from the worktree just left must be cleared, not just \
-             deactivated"
-        );
-    }
-
     #[test]
     fn reset_per_worktree_ui_state_is_a_no_op_when_already_empty() {
         let mut reviewed_files = HashSet::new();
-        let mut open_files = Vec::new();
         let mut open_change = None;
         let mut expanded_dirs = HashSet::new();
         let mut selected_tree_path = None;
-        let mut edit_buffers = HashMap::new();
 
         reset_per_worktree_ui_state(
             &mut reviewed_files,
-            &mut open_files,
             &mut open_change,
             &mut expanded_dirs,
             &mut selected_tree_path,
-            &mut edit_buffers,
         );
 
         assert!(reviewed_files.is_empty());
@@ -904,21 +980,17 @@ mod tests {
     #[test]
     fn reset_per_worktree_ui_state_clears_expanded_dirs_too() {
         let mut reviewed_files = HashSet::new();
-        let mut open_files = Vec::new();
         let mut open_change = None;
         let mut expanded_dirs = HashSet::new();
         let mut selected_tree_path = None;
-        let mut edit_buffers = HashMap::new();
         expanded_dirs.insert(PathBuf::from("/repo/worktree-a/src"));
         expanded_dirs.insert(PathBuf::from("/repo/worktree-a/tests"));
 
         reset_per_worktree_ui_state(
             &mut reviewed_files,
-            &mut open_files,
             &mut open_change,
             &mut expanded_dirs,
             &mut selected_tree_path,
-            &mut edit_buffers,
         );
 
         assert!(expanded_dirs.is_empty());
@@ -927,56 +999,99 @@ mod tests {
     #[test]
     fn reset_per_worktree_ui_state_clears_selected_tree_path() {
         let mut reviewed_files = HashSet::new();
-        let mut open_files = Vec::new();
         let mut open_change = None;
         let mut expanded_dirs = HashSet::new();
         let mut selected_tree_path = Some(PathBuf::from("/repo/worktree-a/src/main.rs"));
-        let mut edit_buffers = HashMap::new();
 
         reset_per_worktree_ui_state(
             &mut reviewed_files,
-            &mut open_files,
             &mut open_change,
             &mut expanded_dirs,
             &mut selected_tree_path,
-            &mut edit_buffers,
         );
 
         assert_eq!(selected_tree_path, None);
     }
 
-    /// `edit_buffers` is keyed the same way as `open_files`; without this reset, a same-named
-    /// file's real unsaved edits from one worktree could silently reappear (or be silently
-    /// overwritten by) an unrelated file in a different worktree.
+    /// [`AdeApp::open_files`]/[`AdeApp::open_files_mut`] resolve through
+    /// [`AdeApp::open_files_by_worktree`], keyed by [`AdeApp::file_tree_root`] - a worktree that
+    /// has never opened a file reads as a real empty slice, and two different worktree keys never
+    /// see each other's entries.
     #[test]
-    fn reset_per_worktree_ui_state_clears_edit_buffers() {
-        let mut reviewed_files = HashSet::new();
-        let mut open_files = Vec::new();
-        let mut open_change = None;
-        let mut expanded_dirs = HashSet::new();
-        let mut selected_tree_path = None;
-        let mut edit_buffers = HashMap::new();
+    fn open_files_by_worktree_keeps_each_worktree_s_tabs_independent() {
+        let mut open_files_by_worktree: HashMap<PathBuf, Vec<PathBuf>> = HashMap::new();
+        let worktree_a = PathBuf::from("/repo/worktree-a");
+        let worktree_b = PathBuf::from("/repo/worktree-b");
+
+        open_files_by_worktree
+            .entry(worktree_a.clone())
+            .or_default()
+            .push(PathBuf::from("src/main.rs"));
+
+        assert_eq!(
+            open_files_by_worktree
+                .get(&worktree_a)
+                .map(Vec::as_slice)
+                .unwrap_or_default(),
+            &[PathBuf::from("src/main.rs")][..],
+            "worktree A must see the tab it opened"
+        );
+        assert_eq!(
+            open_files_by_worktree
+                .get(&worktree_b)
+                .map(Vec::as_slice)
+                .unwrap_or_default(),
+            <&[PathBuf]>::default(),
+            "an unrelated worktree that never opened anything must read as a real empty slice, \
+             never worktree A's tabs"
+        );
+    }
+
+    /// `edit_buffers` is keyed by `(worktree, worktree-relative path)` - a same-named file open
+    /// with different unsaved content in two worktrees must never collide or merge.
+    #[test]
+    fn edit_buffers_composite_key_never_collides_across_worktrees() {
+        let mut edit_buffers: HashMap<(PathBuf, PathBuf), edit_buffer::EditBuffer> = HashMap::new();
+        let worktree_a = PathBuf::from("/repo/worktree-a");
+        let worktree_b = PathBuf::from("/repo/worktree-b");
+        let relative = PathBuf::from("src/main.rs");
+
         edit_buffers.insert(
-            PathBuf::from("src/main.rs"),
+            (worktree_a.clone(), relative.clone()),
             edit_buffer::EditBuffer::new(
-                PathBuf::from("/repo/worktree-a/src/main.rs"),
-                "fn main() {}".to_string(),
+                worktree_a.join(&relative),
+                "fn main() { a() }".to_string(),
                 Some("rs".to_string()),
                 None,
-                13,
+                17,
+            ),
+        );
+        edit_buffers.insert(
+            (worktree_b.clone(), relative.clone()),
+            edit_buffer::EditBuffer::new(
+                worktree_b.join(&relative),
+                "fn main() { b() }".to_string(),
+                Some("rs".to_string()),
+                None,
+                17,
             ),
         );
 
-        reset_per_worktree_ui_state(
-            &mut reviewed_files,
-            &mut open_files,
-            &mut open_change,
-            &mut expanded_dirs,
-            &mut selected_tree_path,
-            &mut edit_buffers,
+        assert_eq!(
+            edit_buffers
+                .get(&(worktree_a.clone(), relative.clone()))
+                .map(|buffer| buffer.content.as_str()),
+            Some("fn main() { a() }"),
+            "worktree A's buffer for this relative path must stay worktree A's own content"
         );
-
-        assert!(edit_buffers.is_empty());
+        assert_eq!(
+            edit_buffers
+                .get(&(worktree_b, relative))
+                .map(|buffer| buffer.content.as_str()),
+            Some("fn main() { b() }"),
+            "worktree B's buffer for the identical relative path must never merge with or \
+             overwrite worktree A's"
+        );
     }
 }
 

--- a/crates/app/src/sidebar/tree_ops.rs
+++ b/crates/app/src/sidebar/tree_ops.rs
@@ -991,10 +991,16 @@ impl AdeApp {
         let under_relative = |path: &Path| file_ops::is_self_or_descendant(&deleted_relative, path);
         let under_absolute = |path: &Path| file_ops::is_self_or_descendant(deleted, path);
 
-        self.open_files.retain(|open| !under_relative(open));
-        self.edit_buffers.retain(|key, _| !under_relative(key));
+        // Scoped to the *current* worktree - `open_files_by_worktree`/`edit_buffers` are now
+        // per-worktree-keyed (see their own docs), and `deleted`/`deleted_relative` only ever
+        // name a path inside whichever worktree this delete was run against, so a same-named
+        // file in an unrelated worktree must never be swept up by the same relative-path match.
+        let current_root = self.file_tree_root.clone();
+        self.open_files_mut().retain(|open| !under_relative(open));
+        self.edit_buffers
+            .retain(|(cwd, relative), _| !(*cwd == current_root && under_relative(relative)));
         if self.open_change.as_deref().is_some_and(under_relative) {
-            self.open_change = self.open_files.first().cloned();
+            self.open_change = self.open_files().first().cloned();
         }
         if self
             .selected_tree_path
@@ -1217,7 +1223,7 @@ impl AdeApp {
         let old_relative = self.worktree_relative(old);
         let new_relative = self.worktree_relative(new);
 
-        for open in self.open_files.iter_mut() {
+        for open in self.open_files_mut().iter_mut() {
             if let Some(moved) = remap_path(open, &old_relative, &new_relative) {
                 *open = moved;
             }
@@ -1228,18 +1234,27 @@ impl AdeApp {
             }
         }
 
-        // The buffer map is keyed by the worktree-relative path *and* each buffer carries the
-        // absolute path an explicit save writes to - both have to move, or a save after a rename
-        // would write the old file back into existence.
+        // The buffer map is keyed by `(worktree, worktree-relative path)` and each buffer also
+        // carries the absolute path an explicit save writes to - both have to move, or a save
+        // after a rename would write the old file back into existence. Only the *current*
+        // worktree's entries are ever eligible: `old`/`new`/`old_relative`/`new_relative` all name
+        // paths inside it, so an unrelated worktree's same-named entry (a different `cwd` half of
+        // the key) must pass through completely untouched rather than being remapped by a
+        // relative-path match that says nothing about which worktree it belongs to.
+        let current_root = self.file_tree_root.clone();
         let buffers = std::mem::take(&mut self.edit_buffers);
         self.edit_buffers = buffers
             .into_iter()
-            .map(|(key, mut buffer)| {
-                let key = remap_path(&key, &old_relative, &new_relative).unwrap_or(key);
+            .map(|((cwd, relative), mut buffer)| {
+                if cwd != current_root {
+                    return ((cwd, relative), buffer);
+                }
+                let relative =
+                    remap_path(&relative, &old_relative, &new_relative).unwrap_or(relative);
                 if let Some(moved) = remap_path(&buffer.path, old, new) {
                     buffer.path = moved;
                 }
-                (key, buffer)
+                ((cwd, relative), buffer)
             })
             .collect();
 
@@ -1430,7 +1445,7 @@ mod tree_ops_regression_tests {
         cx.run_until_parked();
         app.read_with(cx, |app, _| {
             assert!(
-                app.edit_buffers.contains_key(Path::new("src/main.rs")),
+                app.edit_buffer_contains(Path::new("src/main.rs")),
                 "premise: opening the file must have created a real buffer keyed by its \
                  worktree-relative path"
             );
@@ -1449,7 +1464,7 @@ mod tree_ops_regression_tests {
 
         app.read_with(cx, |app, _| {
             assert_eq!(
-                app.open_files,
+                app.open_files().to_vec(),
                 vec![PathBuf::from("src/renamed.rs")],
                 "the open tab must follow the rename"
             );
@@ -1458,13 +1473,12 @@ mod tree_ops_regression_tests {
                 Some(Path::new("src/renamed.rs"))
             );
             assert!(
-                !app.edit_buffers.contains_key(Path::new("src/main.rs")),
+                !app.edit_buffer_contains(Path::new("src/main.rs")),
                 "an orphaned buffer still keyed by the old path is exactly what this must not \
                  leave behind"
             );
             let buffer = app
-                .edit_buffers
-                .get(Path::new("src/renamed.rs"))
+                .edit_buffer(Path::new("src/renamed.rs"))
                 .expect("the buffer must be re-keyed, not dropped");
             assert_eq!(
                 buffer.path,
@@ -1506,12 +1520,12 @@ mod tree_ops_regression_tests {
         assert!(repo.path().join("lib/main.rs").exists());
         app.read_with(cx, |app, _| {
             assert_eq!(
-                app.open_files,
+                app.open_files().to_vec(),
                 vec![PathBuf::from("lib/main.rs"), PathBuf::from("lib/util.rs")],
                 "every tab under the renamed folder must follow it"
             );
-            assert!(app.edit_buffers.contains_key(Path::new("lib/util.rs")));
-            assert!(!app.edit_buffers.contains_key(Path::new("src/util.rs")));
+            assert!(app.edit_buffer_contains(Path::new("lib/util.rs")));
+            assert!(!app.edit_buffer_contains(Path::new("src/util.rs")));
             assert!(
                 app.expanded_dirs.contains(&repo.path().join("lib"))
                     && !app.expanded_dirs.contains(&repo.path().join("src")),
@@ -1586,10 +1600,10 @@ mod tree_ops_regression_tests {
         );
         app.read_with(cx, |app, _| {
             assert!(
-                !app.open_files.contains(&PathBuf::from("src/util.rs")),
+                !app.open_files().contains(&PathBuf::from("src/util.rs")),
                 "the deleted file's tab must not survive it"
             );
-            assert!(!app.edit_buffers.contains_key(Path::new("src/util.rs")));
+            assert!(!app.edit_buffer_contains(Path::new("src/util.rs")));
             assert!(app.tree_delete_confirm.is_none());
         });
     }
@@ -1687,8 +1701,8 @@ mod tree_ops_regression_tests {
         assert!(!source.exists());
         assert!(repo.path().join("dest/util.rs").exists());
         app.read_with(cx, |app, _| {
-            assert!(app.open_files.contains(&PathBuf::from("dest/util.rs")));
-            assert!(!app.edit_buffers.contains_key(Path::new("src/util.rs")));
+            assert!(app.open_files().contains(&PathBuf::from("dest/util.rs")));
+            assert!(!app.edit_buffer_contains(Path::new("src/util.rs")));
             assert!(
                 app.tree_clipboard.is_none(),
                 "a cut is consumed by its paste - a second paste would target a path that no \

--- a/crates/app/src/title_bar/menu.rs
+++ b/crates/app/src/title_bar/menu.rs
@@ -849,8 +849,7 @@ mod title_menu_tests {
         let relative = PathBuf::from("notes.txt");
         assert_eq!(
             app.read_with(cx, |app, _| app
-                .edit_buffers
-                .get(&relative)
+                .edit_buffer(&relative)
                 .expect("buffer")
                 .content
                 .clone()),
@@ -864,8 +863,7 @@ mod title_menu_tests {
 
         assert_eq!(
             app.read_with(cx, |app, _| app
-                .edit_buffers
-                .get(&relative)
+                .edit_buffer(&relative)
                 .expect("buffer")
                 .content
                 .clone()),
@@ -1246,13 +1244,16 @@ mod title_menu_tests {
     /// earlier version of `select_relative_agent` cycled the flat `self.agents` list
     /// directly rather than [`AdeApp::current_worktree_agents`], so "Next Agent" could jump
     /// to a *different* worktree's agent entirely - which `AdeApp::select_agent` then
-    /// silently promotes into a full `AdeApp::select_worktree` switch, discarding any unsaved
-    /// `edit_buffers` content for the worktree just left. Spawning every test agent into the
-    /// *same* worktree (as an earlier version of this test did) can't distinguish that bug from
-    /// correct behaviour at all - this seeds a **second** worktree with its own agent
-    /// alongside the three under test, and asserts cycling never leaves the first worktree
-    /// (`AdeApp::selected` stays put) and never clears a real unsaved edit sitting in
-    /// `AdeApp::edit_buffers`.
+    /// silently promotes into a full `AdeApp::select_worktree` switch, landing the user on the
+    /// wrong worktree's `edit_buffers` entries (keyed by `(worktree, path)` - see that field's
+    /// own docs) rather than the one they were actually cycling through. Spawning every test
+    /// agent into the *same* worktree (as an earlier version of this test did) can't distinguish
+    /// that bug from correct behaviour at all - this seeds a **second** worktree with its own
+    /// agent alongside the three under test, and asserts cycling never leaves the first worktree
+    /// (`AdeApp::selected` stays put) and a real unsaved edit seeded in the first worktree's
+    /// `AdeApp::edit_buffers` entry is still resolvable there after cycling - which an accidental
+    /// jump to the second (buffer-less) worktree would break, since [`AdeApp::edit_buffer_contains`]
+    /// resolves through whichever worktree is genuinely current.
     #[gpui::test]
     fn select_relative_agent_cycles_through_real_agents_and_wraps_around(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
@@ -1333,11 +1334,13 @@ mod title_menu_tests {
         cx.run_until_parked();
 
         // A real, unsaved edit in the first worktree, seeded only after every real
-        // `select_worktree` switch above (each one genuinely clears `edit_buffers` via
-        // `reset_per_worktree_ui_state`, by design - that's not what's under test here) - a
-        // same-worktree cycle below must never discard this.
+        // `select_worktree` switch above so it's unambiguously keyed to *this* worktree
+        // (`AdeApp::edit_buffers`' `(worktree, path)` composite key - see that field's own docs) -
+        // a same-worktree cycle below must never lose sight of it, and an accidental jump to the
+        // second worktree (the bug this test guards against) would, since `edit_buffer_contains`
+        // resolves against whichever worktree is genuinely current.
         app.update(cx, |app, _cx| {
-            app.edit_buffers.insert(
+            app.insert_edit_buffer(
                 PathBuf::from("a.txt"),
                 edit_buffer::EditBuffer::new(
                     repo.path().join("a.txt"),
@@ -1392,9 +1395,10 @@ mod title_menu_tests {
         );
         app.read_with(cx, |app, _| {
             assert!(
-                app.edit_buffers.contains_key(std::path::Path::new("a.txt")),
-                "a same-worktree cycle must never discard unsaved edits via \
-                 reset_per_worktree_ui_state - only a real select_worktree switch should do that"
+                app.edit_buffer_contains(std::path::Path::new("a.txt")),
+                "cycling within one worktree must never silently jump to a different one - if it \
+                 did, this lookup would resolve against the second (buffer-less) worktree and \
+                 find nothing"
             );
         });
     }

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -337,7 +337,7 @@ impl AdeApp {
             .iter_for_cwd(cwd.clone())
             .map(|agent| agent.id)
             .collect();
-        work_surface::reconcile_tab_order(stored, &agent_ids, &self.open_files)
+        work_surface::reconcile_tab_order(stored, &agent_ids, self.open_files())
     }
 
     /// The unified tab strip's real drag-to-reorder entry point (GitHub issue #16) - moves
@@ -541,8 +541,7 @@ impl AdeApp {
         // tab with no buffer yet (still loading, or a truncated/read-only file - see
         // `AdeApp::edit_buffers`' own docs), never a fabricated placeholder.
         let is_dirty = self
-            .edit_buffers
-            .get(path)
+            .edit_buffer(path)
             .is_some_and(|buffer| buffer.is_dirty());
         let tab_ref = work_surface::TabRef::File(path.to_path_buf());
         let drag_value = DraggedTab::File {
@@ -1007,9 +1006,10 @@ impl AdeApp {
     /// (a real, live-reproduced bug found in this revision's own self-audit: an earlier version
     /// cycled `self.agents` directly, so "Next Agent" could jump to a *different* worktree's
     /// agent, which [`Self::select_agent`] then silently promotes into a full
-    /// [`Self::select_worktree`] switch - discarding any unsaved `edit_buffers` content for the
-    /// worktree just left via `reset_per_worktree_ui_state`. A menu row labeled "cycle tabs" must
-    /// never have that side effect) - wrapping around both ends (mirroring
+    /// [`Self::select_worktree`] switch - landing the user on the wrong worktree entirely (a menu
+    /// row labeled "cycle tabs" must never have that side effect), including its `edit_buffers`
+    /// entries, which are real, live per-worktree state (see that field's own docs) rather than
+    /// something a switch discards - wrapping around both ends (mirroring
     /// [`Self::next_changed_file`]'s own cyclic-index convention for "next" over an existing
     /// ordered list), via the same real [`Self::select_agent`] every tab-strip click and jump
     /// keycap already goes through - no separate "next agent" subsystem, just a cyclic index


### PR DESCRIPTION
## Summary

Stacked on the Session->Agent rename PR. Fixes two real bugs in `AdeApp::select_worktree`/`reset_per_worktree_ui_state`, both violating §1/§3's "worktree-scoped" requirements:

1. **Open file tabs weren't per-worktree.** `open_files: Vec<PathBuf>` was cleared (not swapped/remembered) on every worktree switch, contradicting §3: "Switching worktrees swaps the whole strip... each worktree remembers its own open files." Now `open_files_by_worktree: HashMap<PathBuf, Vec<PathBuf>>`, keyed by worktree root, with accessors resolving the current worktree's slice.

2. **Unsaved edits were silently discarded on switch — real data loss, zero warning.** `edit_buffers` was cleared the same way. Rather than add a confirm-before-switching dialog (real friction for a tool built around fluidly hopping between worktrees with parallel agents), the fix makes `edit_buffers` genuinely per-worktree too: keyed by `(worktree, relative path)` so switching back restores unsaved edits exactly as left, and two worktrees with the same relative path open never collide. Async continuations that touch a buffer after an `.await` (file load, LSP sync, debounced save/rehighlight) now capture the worktree explicitly before their first await rather than re-deriving it from `file_tree_root` at resume time, as defense-in-depth against a future detached-task scenario.

**A third assigned bug (UI-only staging checkbox not touching real git) does not exist on this branch** — traced to a separate, unmerged sibling branch (`revision-r12-tabs-changes`) that has diverged from this one. Rather than fabricate a competing implementation, this PR leaves staging untouched; the real fix belongs on that branch once it's rebased onto this stack. Documented in BUILD-LOG.

## Testing

Independently re-verified (not just agent-reported):
- `cargo fmt --all -- --check` — clean
- `cargo build --workspace` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace --lib -- --test-threads=1` — 1100 + 44 + 14 + 107 = 1265 passed, 0 failed (2 new tests)

Two real regression tests through genuine `AdeApp::select_worktree` switches across real temp-directory worktrees: open file tabs survive a switch away and back; an unsaved edit survives a switch away and back, and two worktrees with the identical relative path (`sample.txt`) open with different unsaved content never merge or collide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)