### PR TITLE
feat(app): Changes-panel commit composer with real git staging

### DIFF
--- a/BUILD-LOG.md
+++ b/BUILD-LOG.md
@@ -5381,3 +5381,25 @@ it passed, and the subsequent full run was clean with no re-run needed. All seve
 `commit_composer_tests` and both new `wt-core::undo::tests::commit_paths_*` tests were each
 independently confirmed to fail against the pre-fix code and pass against the fix, not just pass
 by construction.
+
+## Rebasing the commit-composer work onto the rail rewrite (Revision R12 stacking)
+
+This branch had drifted onto an old master tip and, separately, carried its own copy of the
+Revision R12 repo-data-model commit (`feat(app): repo data model - Revision R12 Phase 0`) - the
+same content already proposed independently as PR #56 (`revision-r12-repo-model`). It also
+touches `rail/render.rs`, `rail/state.rs`, `rail/mod.rs`, `root/mod.rs`, `root/state.rs`,
+`sidebar/changes.rs`, and `theme.rs` - all substantially rewritten by PR #57
+(`revision-r12-rail-rewrite`, itself stacked on the repo-model PR).
+
+Rather than target `master` directly (which would re-propose the repo-model diff a second time
+and conflict hard with the rail rewrite), rebased onto `origin/revision-r12-rail-rewrite`. The
+duplicate repo-model commit became empty once rebased on top of a branch that already contains
+its content and was dropped automatically; the real conflicts in the overlapping rail/root/sidebar
+files were resolved by keeping the rail-rewrite side's structural changes and re-applying this
+branch's own commit-composer and Changes-panel additions on top of them.
+
+**Verification** (independently re-run, not just agent-reported): `cargo fmt --all -- --check`,
+`cargo build --workspace`, `cargo clippy --workspace --all-targets -- -D warnings` - all clean.
+`cargo test --workspace --lib --test-threads=1`: **1114 + 44 + 14 + 111 = 1283 passed, 0 failed**
+across all four crates. No conflict markers or unresolved merge artifacts remained in source after
+the rebase (grep for `<<<<<<<`/`=======`/`>>>>>>>` outside test fixture strings came back empty).

--- a/BUILD-LOG.md
+++ b/BUILD-LOG.md
@@ -5403,3 +5403,48 @@ branch's own commit-composer and Changes-panel additions on top of them.
 `cargo test --workspace --lib --test-threads=1`: **1114 + 44 + 14 + 111 = 1283 passed, 0 failed**
 across all four crates. No conflict markers or unresolved merge artifacts remained in source after
 the rebase (grep for `<<<<<<<`/`=======`/`>>>>>>>` outside test fixture strings came back empty).
+
+## Rebasing onto the Agent rename + worktree-state-safety + title-bar-chips stack, and making the Changes-panel checkbox real git staging
+
+Three more branches landed on top of the same rail-rewrite base since the last rebase above:
+`revision-r12-agent-rename` (`Session`→`Agent` throughout `crates/app`), `revision-r12-worktree-
+state-safety` (`open_files`/`edit_buffers` re-keyed to be genuinely per-worktree instead of
+cleared on every switch), and `revision-r12-title-bar-chips` (an isolated `title_bar/*` addition).
+Rebased onto the last of the three; conflicts were every site still saying `Session`/`self.sessions`
+(mechanically updated to `Agent`/`self.agents`), every direct `self.open_files`/`self.edit_buffers`
+touch (routed through the new `open_files()`/`open_files_mut()` and `edit_buffer()`/
+`edit_buffer_mut()`/`insert_edit_buffer()` accessors), and a `BUILD-LOG.md` append conflict
+(resolved by keeping both sides' entries in commit order).
+
+Separately, a coordinator-found real bug: the Changes-panel staging checkbox
+(`AdeApp::toggle_staged`) only ever flipped an in-memory `HashSet<PathBuf>` - real git never saw
+anything until the commit composer's own `git add` ran at commit time
+(`wt_core::undo::commit_paths`). That contradicts the design's own §5 framing, "the checkbox **is**
+staging," taken literally rather than as a UI-only intent. New `wt_core::stage` module:
+`stage_path`/`unstage_path` (real, immediate `git add -- <path>` / `git reset -- <path>`) and
+`staged_paths` (`git diff --cached --name-only`, worktree-relative), each with real tests verifying
+the actual `git status --porcelain` index state, not just an in-memory flag.
+
+`toggle_staged` now flips `AdeApp::staged_files` optimistically and synchronously (so the checkbox
+responds with no perceptible delay), then runs the real git mutation on the background executor;
+a real failure reverts the optimistic flip and surfaces the error next to the composer
+(`AdeApp::staging_error`, `render_staging_error`) rather than silently reverting behind the user's
+back. `AdeApp::load_diff` now also re-derives `staged_files` from a fresh `staged_paths` query on
+every diff load - a live re-query, not a per-worktree cache like `open_files`/`edit_buffers`,
+because real git staging can change out from under this app at any moment (an agent CLI's own
+`git add`/`git reset` in the same worktree) and a cache would need its own invalidation story on
+top of the one `load_diff` already runs through on every switch/tree-op/post-commit reload. This
+is also what makes a worktree with something already staged in real git *before* Jerry ever opened
+it read as staged from the first frame, instead of starting at an honest-looking but wrong "0
+staged." `wt_core::undo::commit_paths`'s own leading `git add` is kept as a deliberate, documented
+idempotent safety net (a per-path staging failure that got silently reverted, or a worktree-switch
+race, can each leave the app's own idea of "staged" briefly behind the real index) rather than
+removed as now-redundant.
+
+Also checked against §5's other requirements while in this code: the commit composer's `▾`
+split-button menu already correctly renders its three unimplemented rows (push / amend / stash) as
+honestly disabled, not fake-clickable - unchanged, no fix needed there.
+
+**Verification**: `cargo fmt --all -- --check`, `cargo build --workspace`,
+`cargo clippy --workspace --all-targets -- -D warnings` - all clean. `cargo test --workspace --lib
+--test-threads=1`: **1130 + 44 + 14 + 119 = 1307 passed, 0 failed** across all four crates.

--- a/BUILD-LOG.md
+++ b/BUILD-LOG.md
@@ -5252,3 +5252,132 @@ untouched by this change) on an earlier run; re-ran that single test in isolatio
 it fail once more (4/5 clean) - consistent with the ~1-in-5 rate already on file for that family,
 not a regression from this change. Two files touched: `crates/app/src/rail/state.rs`,
 `crates/app/src/rail/render.rs`.
+
+## Real test coverage for the Changes-panel commit composer, plus two real click-through bugs and a real "commits more than N files" bug it caught along the way
+
+A prior session on this branch had already built a substantial, real, already-integrated commit
+composer for the Changes panel (`AdeApp::render_commit_composer`/`render_commit_menu`,
+Revision R12 §5): a header (`COMMIT` · `N of M staged` · staged diffstat), a pre-drafted message
+box, a primary `Commit N files` button wired to a real `AdeApp::commit_staged_files` →
+`wt_core::undo::commit_paths` (`git add` + `git commit`), and a `▾` split-button popover with four
+menu rows, three of which are deliberately dimmed/inert since no real push/amend/stash plumbing
+exists yet. It had zero test coverage. This entry adds real, paint-based interaction tests for it
+- and, in the process of proving the claims in its own doc comments, found and fixed three real
+bugs the doc comments either enabled or papered over.
+
+**Test infra note.** Neither the primary button, the menu toggle, the scrim, the popover, nor its
+rows had a `.debug_selector()` - only `.id(...)`, which drives GPUI's click plumbing but not
+`VisualTestContext::debug_bounds` (confirmed by reading `gpui`'s own `div.rs`: `debug_selector` is
+a distinct field the paint code checks separately, the same split `code_surface::lsp_ui`'s
+`hover-card` selector's own comment already documents - "`debug_bounds` reads this, not `.id(..)`"
+- so nothing in this file could previously be clicked or measured by a test at all. Added
+selectors matching this crate's existing convention throughout, including baking the real
+staged-count/diffstat/branch/message text directly into a few selector strings
+(`commit-composer-progress-{staged}-of-{total}`, `commit-composer-stat-{+add −del}`, etc.) so a
+test can prove the composer reflects real computed state without GPUI needing a general
+"read back painted text" API - the same trick `merge::render`'s `merge-{side}-code-row-{n}` and
+this file's own `file-tree-row-{name}` selectors already use.
+
+**Six new `commit_composer_tests`** (a real feature-branch repo, `simulate_click` +
+`debug_bounds`, matching `virtualization_tests`'/`status_bar_zoom_click_tests`' own discipline):
+the composer's header/diffstat/branch/message genuinely track real `staged_subset`/diff state
+across a real stage-toggle, not a hardcoded string (including the exact real `+1 −0` line count
+for a one-line real edit, not just "some non-empty diffstat"); the primary button is a genuine
+no-op with nothing staged (no commit, no in-flight flag, no in-flight *status string* either -
+see below on why that second check matters); a real click on the wired button reaches
+`commit_paths` for real (git commit count increments, `staged_files` clears, the diff reloads);
+the menu toggle genuinely opens and closes `commit_menu_open`; every non-primary menu row is
+genuinely inert (menu stays open, no commit, `staged_files` untouched); and two tests that
+specifically target the scrim/popover's click-blocking - see below.
+
+**Bug 1, found while writing the toggle-open/close test: the menu's scrim had no `.occlude()`.**
+GPUI's `Window::hit_test` (`vendor/zed/crates/gpui/src/window.rs`) walks *underneath* a
+non-occluding hitbox and keeps every hitbox it finds "hovered" unless something in front sets
+`HitboxBehavior::BlockMouse` - so a click on the still-visible primary button or menu-toggle,
+while positioned underneath the transparent (but not occluding) scrim, was genuinely reaching
+*both* the scrim's own close handler *and* the real button underneath in the same click. Proved
+real, not theoretical, by temporarily removing `.occlude()` and watching two tests fail for real:
+a second click on the toggle re-opened the menu instead of closing it (the scrim's `set false`
+firing, then the toggle's own `!self.commit_menu_open` firing right after and flipping it back to
+`true`), and a click on the primary button's own position, while the menu was open, created a
+real extra git commit. Fixed with the same `.occlude()` `root::resize::render_resize_handle`
+already uses for the identical "receives the mouse, not whatever's underneath" reason. A second,
+related gap the checker agent (below) found: the four-row popover paints *taller* than the short
+composer it hangs off, so its own top edge genuinely paints above the composer - outside the
+scrim's bounds entirely - over the real Changes-row list behind it; only the popover's own
+`.on_click(stop_propagation)` protected that region, which only worked by registration-order
+luck, not a structural guarantee. Gave the popover its own `.occlude()` too, and added a seventh
+test (`the_popover_blocks_a_click_even_where_it_paints_above_the_composers_own_bounds`) clicking
+right at the popover's real painted top edge and asserting no Changes-row diff opens.
+
+**Bug 2, found by the checker agent: `commit_paths` could commit more than the N files the button
+promised.** `wt_core::undo::commit_paths` did `git add -- <paths>` followed by a bare
+`git commit -m <message>` - and a bare `git commit` commits the *entire index*, not just what that
+call just staged. Reproduced directly with real git commands (and then as a real, failing wt-core
+test before the fix): stage `b.txt` via a separate `git add` first (standing in for an agent CLI
+running its own `git add` in this same worktree - the exact interleaving hazard
+`commit_all_changes`'s own doc already calls out for a sibling function), then call
+`commit_paths(&["a.txt"], ...)` - the resulting commit contained both files, silently including
+`b.txt` even though the UI's `Commit 1 file` button never claimed to touch it. Fixed by
+pathspec-limiting the commit itself (`git commit -m <message> -- <paths>`, not just the preceding
+`add`), verified independently with real git commands showing the pathspec-limited form leaves
+`b.txt` staged-but-uncommitted as it should. Added a real wt-core regression test,
+`commit_paths_never_commits_a_path_that_was_staged_by_something_else`, confirmed to fail against
+the pre-fix code and pass against the fix.
+
+**Bug 3, also found by the checker agent: a real, dead `⌘⏎`/`Ctrl+Enter` keycap on the primary
+button.** The composer painted a real keycap row for `mod+enter`, but no such global binding
+exists anywhere in `default_key_bindings` and the button has no focus handle for GPUI's own
+Enter/Space-activates-a-focused-element path to reach either - a keystroke that visibly promises
+an action and does nothing. This is the exact thing `work_surface::state::footer_actions`'s own
+`Keep all` row docs already name and deliberately avoid ("an audit caught this row still
+advertising the keycap after being promoted from `implemented: false` - a real keycap must never
+render for a keystroke that does nothing"), for the same underlying reason (`Ctrl+Enter` is a
+plausible "submit" gesture an agent CLI running in one of this app's own terminals could
+reasonably want for itself, so it isn't a safe global binding to add casually). Removed the
+keycap entirely from the composer rather than invent a new global binding, matching that
+precedent's own resolution.
+
+Two doc comments were also corrected to match what the code actually does, found while writing
+tests against their literal claims rather than trusting them: `commit_staged_files`'s doc claimed
+committed files "drop out of the Changes list" - false in the normal case, since `wt_core::diff`
+diffs the working tree against the merge-base with the default branch (not the previous commit),
+so a file committed on a feature branch that still differs from `main` correctly stays in the
+list (confirmed with real git commands before rewriting the comment, and reflected in the
+`clicking_the_primary_button_reaches_the_real_commit_staged_files_action` test's own assertion,
+which was originally written to expect the false behavior and had to be corrected too); and the
+same doc's parenthetical about staged paths surviving an in-flight commit was tightened to say
+precisely what the code does - it clears every committed path unconditionally once the commit
+finishes, even one a user un-staged and re-staged mid-flight (the staging checkbox isn't gated on
+`worktree_history_op_in_flight`), since `staged_files` is plain UI bookkeeping with no per-path
+history that could tell a genuine re-stage apart from an untouched one.
+
+**Adversarial check.** A fresh checker agent (read-only, given the whole diff but not this
+narrative) found bugs 2 and 3 above, the popover-occlusion gap, two real-but-weak spots in the
+first draft of the tests (the "disabled click never even starts the operation" assertion couldn't
+actually distinguish "never started" from "started and already finished" once `run_until_parked`
+had let it complete - strengthened to also check the synchronous `worktree_history_status` string;
+and the diffstat test only checked the empty-state selector's presence/absence, never a real
+number - strengthened to assert the exact `+1 −0` for the real one-line edit in the fixture), and
+confirmed clean on several other axes checked explicitly: no stale-read path from render to the
+real git-mutating call (`commit_staged_files` re-reads `staged_files`/`current_diff()`/
+`diff_root` synchronously in the click handler itself, snapshotting only *after* every guard
+passes), no unwrap/panic/blocking-IO-on-the-foreground-thread in the new code, and the other
+composer elements (message box, `redraft`, chip, branch label) have no click handlers to leak
+through in the first place. It also flagged one pre-existing, out-of-scope instance of the same
+scrim-occlusion bug class in `work_surface::render::render_plus_menu` (which this composer's own
+doc cites as the shape it matches) and a durable-state gap in `commit_paths` (a `git add` that
+succeeds followed by a `git commit` that fails, e.g. a rejecting pre-commit hook, leaves the real
+git index staged with nothing in the app surfacing it) - both noted here rather than fixed, since
+neither is reachable through this composer's own diff and each needs its own separate change.
+
+**Verification**: `export LIBRARY_PATH=/tmp/x11-deps/prefix/usr/lib/x86_64-linux-gnu`, then
+`cargo fmt --all -- --check`, `cargo build --workspace`, `cargo clippy --workspace --all-targets
+-- -D warnings`, all clean. `cargo test --workspace --lib --test-threads=1`: **1095 + 44 + 14 +
+111 = 1264 passed, 0 failed** across all four crates (`app` 1095, `lsp-core` 44, `pty-core` 14,
+`wt-core` 111 - the last including both new `commit_paths` tests). One earlier full run hit the
+already-documented pre-existing `code_surface::diff_view::diff_render_tests` flake; re-run alone
+it passed, and the subsequent full run was clean with no re-run needed. All seven
+`commit_composer_tests` and both new `wt-core::undo::tests::commit_paths_*` tests were each
+independently confirmed to fail against the pre-fix code and pass against the fix, not just pass
+by construction.

--- a/crates/app/src/code_surface/tabs.rs
+++ b/crates/app/src/code_surface/tabs.rs
@@ -11,6 +11,21 @@ impl AdeApp {
     /// Loads (or reloads) the diff of `root` against its detected base branch. Runs on
     /// `cx.background_executor()` since `diff_against_base` does blocking I/O (gix reads plus a
     /// spawned `git diff` process) and must not run on the GPUI foreground thread.
+    ///
+    /// Also genuinely re-derives [`Self::staged_files`] from `root`'s real git index
+    /// (`wt_core::stage::staged_paths` - a real `git diff --cached --name-only`), in the same
+    /// background task, rather than caching a per-worktree copy the way
+    /// [`Self::open_files_by_worktree`]/[`Self::edit_buffers`] do: `staged_files` isn't purely
+    /// this app's own state the way an open-tab list is - real git staging can change out from
+    /// under it at any moment (an agent CLI process running its own `git add`/`git reset` in this
+    /// same worktree, exactly the interleaving hazard `wt_core::undo::commit_paths`'s own docs
+    /// already call out), so a cache would need its own invalidation story on top of the one
+    /// `load_diff` already has. Re-querying fresh every time this - the one real chokepoint every
+    /// worktree switch, tree operation, and post-commit reload already runs through - reloads the
+    /// diff is a live mirror of real git state instead, at the cost of one extra fast local `git`
+    /// call per reload. This is also what makes a worktree with something already staged in real
+    /// git *before* Jerry ever opened it read as staged the moment it's loaded, rather than
+    /// starting at an empty, UI-only set the way it used to.
     pub(crate) fn load_diff(&mut self, root: PathBuf, cx: &mut Context<Self>) {
         self.diff_root = root.clone();
         self.diff_state = DiffLoadState::Loading;
@@ -22,14 +37,14 @@ impl AdeApp {
         self.file_authorship = changes::Authorship::default();
         cx.notify();
         let task = cx.spawn(async move |this, cx| {
-            let result = cx
+            let (diff_result, staged_result) = cx
                 .background_executor()
                 .spawn({
                     let root = root.clone();
                     async move {
                         // Fold the +n/-n totals here, off the UI thread, rather than
                         // recomputing them on every render.
-                        wt_core::diff::diff_against_base(&root).map(|base| {
+                        let diff_result = wt_core::diff::diff_against_base(&root).map(|base| {
                             let totals = match &base {
                                 DiffBase::Diff(diff) => Some(diff.files.iter().fold(
                                     (0u32, 0u32),
@@ -41,12 +56,14 @@ impl AdeApp {
                                 DiffBase::NoBaseFound | DiffBase::OnDefaultBranch { .. } => None,
                             };
                             (base, totals)
-                        })
+                        });
+                        let staged_result = wt_core::stage::staged_paths(&root);
+                        (diff_result, staged_result)
                     }
                 })
                 .await;
             let _ = this.update(cx, |this, cx| {
-                match result {
+                match diff_result {
                     Ok((base, totals)) => {
                         this.diff_state = DiffLoadState::Loaded(base);
                         this.diff_totals = totals;
@@ -55,6 +72,14 @@ impl AdeApp {
                         this.diff_state = DiffLoadState::Error(err.to_string());
                         this.diff_totals = None;
                     }
+                }
+                // A failed `staged_paths` query (an unreadable/non-git `root`, the same real
+                // failure modes `diff_against_base` itself can hit) leaves `staged_files` as it
+                // was rather than silently emptying a real staged set this call simply couldn't
+                // confirm - `diff_state`'s own `Error` arm above already surfaces the underlying
+                // problem honestly.
+                if let Ok(staged) = staged_result {
+                    this.staged_files = staged;
                 }
                 // The reloaded diff may have changed whether `open_change`'s path has a
                 // `DiffFile`, so refresh the cache immediately rather than leaving it stale.

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -467,10 +467,29 @@ pub struct AdeApp {
     /// `git add`/unstage - see its own docs). `Self::render_changes_header`'s progress bar/count
     /// and `Self::render_commit_composer` both read this directly. Keyed by worktree, not agent
     /// (§5's own "staging is keyed by worktree, not agent") - it holds exactly one set at a time,
-    /// re-derived from the real git index on every worktree switch by
-    /// `crate::root::state::reset_per_worktree_ui_state` rather than merely cleared (see that
-    /// function's own docs for why a live re-query, not a cache, is honest here).
+    /// cleared synchronously on every worktree switch by
+    /// `crate::root::state::reset_per_worktree_ui_state` (so nothing from the worktree just left
+    /// can flash before the new one's real state lands) and then genuinely re-derived from the
+    /// real git index (`wt_core::stage::staged_paths`) inside `Self::load_diff`'s own background
+    /// task - see that method's docs for why this is a live re-query on every diff load rather
+    /// than a per-worktree cache, and why that means a worktree with something already staged in
+    /// real git before Jerry ever opened it still reads as staged once loaded.
     pub(crate) staged_files: HashSet<PathBuf>,
+    /// The most recent real staging/unstaging failure from [`Self::toggle_staged`] - `(path,
+    /// message)`. Surfaced next to the commit composer (`Self::render_staging_error`) the same
+    /// honest way [`Self::tree_op_error`] surfaces a failed tree operation, rather than silently
+    /// swallowing a real `git add`/`git reset` failure behind an optimistic UI update that
+    /// quietly reverts. Cleared on dismiss, on the next successful toggle of the same path, and
+    /// (implicitly, since it names a worktree-relative path) whenever a worktree switch clears
+    /// [`Self::staged_files`] out from under it.
+    pub(crate) staging_error: Option<(PathBuf, String)>,
+    /// Every in-flight [`Self::toggle_staged`] background `git add`/`git reset` - a [`TaskPool`],
+    /// not a single slot, for the same "independent operations" reason as
+    /// [`Self::_merge_write_tasks`]: two different Changes rows' checkboxes clicked in quick
+    /// succession are two genuinely independent real git operations, and a shared single slot
+    /// would silently cancel (and so leave un-applied) whichever one didn't win the race for the
+    /// slot.
+    pub(crate) _stage_tasks: TaskPool,
     /// Whether the commit composer's `▾` split-button popover (Revision R12 §5: *Commit and
     /// push* / *Commit all N files* / *Amend last commit* / *Stash staged files*) is open. Closed
     /// on every worktree switch (`Self::select_worktree`) since it targets that worktree's own

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -460,10 +460,22 @@ pub struct AdeApp {
     /// letting it finish, and the two have different destinations (each is
     /// `file_ops::unique_destination`-resolved) so they cannot collide with each other.
     pub(crate) _tree_copy_task: Option<Task<()>>,
-    /// Per-file "reviewed" toggle state for the Changes list - a file's path is in this set iff
-    /// its checkbox is checked. No backend "review" concept exists yet; this is purely local UI
-    /// state that `Self::render_changes_header`'s progress bar and count read directly.
-    pub(crate) reviewed_files: HashSet<PathBuf>,
+    /// Per-file staging state for the Changes list (Revision R12 §5: "the checkbox **is**
+    /// staging, not 'reviewed'") - a file's path is in this set iff its checkbox is checked, i.e.
+    /// it would be included in the commit composer's next commit **and is really staged in the
+    /// real git index** (`crate::sidebar::render::AdeApp::toggle_staged` does a real, immediate
+    /// `git add`/unstage - see its own docs). `Self::render_changes_header`'s progress bar/count
+    /// and `Self::render_commit_composer` both read this directly. Keyed by worktree, not agent
+    /// (§5's own "staging is keyed by worktree, not agent") - it holds exactly one set at a time,
+    /// re-derived from the real git index on every worktree switch by
+    /// `crate::root::state::reset_per_worktree_ui_state` rather than merely cleared (see that
+    /// function's own docs for why a live re-query, not a cache, is honest here).
+    pub(crate) staged_files: HashSet<PathBuf>,
+    /// Whether the commit composer's `▾` split-button popover (Revision R12 §5: *Commit and
+    /// push* / *Commit all N files* / *Amend last commit* / *Stash staged files*) is open. Closed
+    /// on every worktree switch (`Self::select_worktree`) since it targets that worktree's own
+    /// staged set.
+    pub(crate) commit_menu_open: bool,
     /// Ordered list of currently-open file tabs, rendered after every agent's own tab by
     /// `Self::render_tab_strip` - **per worktree**, keyed by [`Self::file_tree_root`]
     /// (`design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §3: "Switching worktrees

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -160,6 +160,8 @@ impl AdeApp {
             _tree_delete_task: None,
             _tree_copy_task: None,
             staged_files: HashSet::new(),
+            staging_error: None,
+            _stage_tasks: TaskPool::new(),
             commit_menu_open: false,
             open_files_by_worktree: HashMap::new(),
             open_change: None,
@@ -915,6 +917,17 @@ impl AdeApp {
 /// survive that (its absolute path simply never matches anything in the new tree, so nothing
 /// would ever remove it). A free, `gpui`-free function so this is unit-testable without constructing an
 /// `AdeApp`.
+///
+/// `staged_files` is cleared here too, but only as the *synchronous* half of a two-step reset:
+/// this stops the worktree just left's staged set from flashing on screen for the frame or two
+/// before the new worktree's own diff lands, but it is not itself where the new worktree's real
+/// staged set comes from. `AdeApp::select_worktree` calls `AdeApp::load_diff` immediately after
+/// this function returns, and `load_diff`'s own background task re-derives `staged_files` from a
+/// real `git diff --cached --name-only` (`wt_core::stage::staged_paths`) against the worktree
+/// being switched *to* - so a file already staged in the real index before Jerry ever opened this
+/// worktree reads as staged once the load lands, rather than this reset leaving it looking
+/// unstaged forever (see `load_diff`'s own docs for why this is a live re-query on every diff
+/// load, not a per-worktree cache).
 ///
 /// **Deliberately does *not* touch `open_files`/`edit_buffers` anymore.** Both moved to real,
 /// per-worktree-keyed storage (`AdeApp::open_files_by_worktree`, keyed by

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -159,7 +159,8 @@ impl AdeApp {
             file_tree_bounds: gpui::Bounds::default(),
             _tree_delete_task: None,
             _tree_copy_task: None,
-            reviewed_files: HashSet::new(),
+            staged_files: HashSet::new(),
+            commit_menu_open: false,
             open_files_by_worktree: HashMap::new(),
             open_change: None,
             close_tab_confirm_armed: None,
@@ -615,8 +616,12 @@ impl AdeApp {
         // `Self::request_prune`'s docs.
         self.prune_confirm_armed = false;
         self.discard_confirm_armed = None;
+        // Same reasoning for the commit composer's own split-button popover (Revision R12 §5) -
+        // it targets the *previously* selected worktree's staged set, so it must not stay open
+        // pointed at the wrong one.
+        self.commit_menu_open = false;
         // Reset per-worktree UI state (see `reset_per_worktree_ui_state`'s docs) so switching
-        // worktrees never leaks a "reviewed" checkbox, open diff, or collapsed-dir entry from
+        // worktrees never leaks a staged checkbox, open diff, or collapsed-dir entry from
         // the worktree just left. Deliberately runs *before* the focus-fallback block below: both
         // `focus_newly_spawned_agent` and the `filter_focus_handle` fallback branch on
         // `self.open_change`, and until this call runs, `open_change` can still reflect the
@@ -626,7 +631,7 @@ impl AdeApp {
         // `Window::focus` dangling on `code_focus_handle` once `open_change` was cleared one
         // statement later.
         reset_per_worktree_ui_state(
-            &mut self.reviewed_files,
+            &mut self.staged_files,
             &mut self.open_change,
             &mut self.expanded_dirs,
             &mut self.selected_tree_path,
@@ -900,11 +905,11 @@ impl AdeApp {
 }
 
 /// Clears every piece of per-worktree UI state that would otherwise survive a worktree switch -
-/// called from [`AdeApp::select_worktree`] on every switch. `reviewed_files`/`open_change` are
-/// keyed by repo-relative paths with no per-worktree scoping of their own, so without this reset
-/// a file reviewed or opened in worktree A would read as already-reviewed (or reopen) in worktree
-/// B if it shares the same relative path. `expanded_dirs` is keyed by absolute path, so it
-/// doesn't bleed the same way - but it must still be emptied here, because
+/// called from [`AdeApp::select_worktree`] on every switch. `open_change` is keyed by
+/// repo-relative paths with no per-worktree scoping of its own, so without this reset a file
+/// opened in worktree A would reopen in worktree B if it shares the same relative path.
+/// `expanded_dirs` is keyed by absolute path, so it doesn't bleed the same way - but it must
+/// still be emptied here, because
 /// [`AdeApp::select_worktree`] re-derives it from the *new* worktree's own persisted fold state
 /// immediately afterwards, and a leftover entry from the worktree just left would otherwise
 /// survive that (its absolute path simply never matches anything in the new tree, so nothing
@@ -923,12 +928,12 @@ impl AdeApp {
 /// makes the old worktree's entries stop being "current" - nothing here needs to delete them, and
 /// deleting them would be exactly the silent data loss this revision set out to fix.
 pub(super) fn reset_per_worktree_ui_state(
-    reviewed_files: &mut HashSet<PathBuf>,
+    staged_files: &mut HashSet<PathBuf>,
     open_change: &mut Option<PathBuf>,
     expanded_dirs: &mut HashSet<PathBuf>,
     selected_tree_path: &mut Option<PathBuf>,
 ) {
-    reviewed_files.clear();
+    staged_files.clear();
     *open_change = None;
     expanded_dirs.clear();
     *selected_tree_path = None;
@@ -939,47 +944,47 @@ mod tests {
     use super::*;
 
     #[test]
-    fn reset_per_worktree_ui_state_clears_reviewed_files_and_open_change() {
-        let mut reviewed_files = HashSet::new();
-        reviewed_files.insert(PathBuf::from("src/main.rs"));
-        reviewed_files.insert(PathBuf::from("Cargo.toml"));
+    fn reset_per_worktree_ui_state_clears_staged_files_and_open_change() {
+        let mut staged_files = HashSet::new();
+        staged_files.insert(PathBuf::from("src/main.rs"));
+        staged_files.insert(PathBuf::from("Cargo.toml"));
         let mut open_change = Some(PathBuf::from("src/main.rs"));
         let mut expanded_dirs = HashSet::new();
         let mut selected_tree_path = None;
 
         reset_per_worktree_ui_state(
-            &mut reviewed_files,
+            &mut staged_files,
             &mut open_change,
             &mut expanded_dirs,
             &mut selected_tree_path,
         );
 
-        assert!(reviewed_files.is_empty());
+        assert!(staged_files.is_empty());
         assert_eq!(open_change, None);
     }
 
     #[test]
     fn reset_per_worktree_ui_state_is_a_no_op_when_already_empty() {
-        let mut reviewed_files = HashSet::new();
+        let mut staged_files = HashSet::new();
         let mut open_change = None;
         let mut expanded_dirs = HashSet::new();
         let mut selected_tree_path = None;
 
         reset_per_worktree_ui_state(
-            &mut reviewed_files,
+            &mut staged_files,
             &mut open_change,
             &mut expanded_dirs,
             &mut selected_tree_path,
         );
 
-        assert!(reviewed_files.is_empty());
+        assert!(staged_files.is_empty());
         assert_eq!(open_change, None);
         assert!(expanded_dirs.is_empty());
     }
 
     #[test]
     fn reset_per_worktree_ui_state_clears_expanded_dirs_too() {
-        let mut reviewed_files = HashSet::new();
+        let mut staged_files = HashSet::new();
         let mut open_change = None;
         let mut expanded_dirs = HashSet::new();
         let mut selected_tree_path = None;
@@ -987,7 +992,7 @@ mod tests {
         expanded_dirs.insert(PathBuf::from("/repo/worktree-a/tests"));
 
         reset_per_worktree_ui_state(
-            &mut reviewed_files,
+            &mut staged_files,
             &mut open_change,
             &mut expanded_dirs,
             &mut selected_tree_path,
@@ -998,13 +1003,13 @@ mod tests {
 
     #[test]
     fn reset_per_worktree_ui_state_clears_selected_tree_path() {
-        let mut reviewed_files = HashSet::new();
+        let mut staged_files = HashSet::new();
         let mut open_change = None;
         let mut expanded_dirs = HashSet::new();
         let mut selected_tree_path = Some(PathBuf::from("/repo/worktree-a/src/main.rs"));
 
         reset_per_worktree_ui_state(
-            &mut reviewed_files,
+            &mut staged_files,
             &mut open_change,
             &mut expanded_dirs,
             &mut selected_tree_path,

--- a/crates/app/src/sidebar/changes.rs
+++ b/crates/app/src/sidebar/changes.rs
@@ -540,7 +540,10 @@ mod tests {
 
     #[test]
     fn staged_progress_fraction_handles_zero_total_without_dividing_by_zero() {
-        let progress = StagedProgress { staged: 0, total: 0 };
+        let progress = StagedProgress {
+            staged: 0,
+            total: 0,
+        };
         assert_eq!(progress.fraction(), 0.0);
     }
 

--- a/crates/app/src/sidebar/changes.rs
+++ b/crates/app/src/sidebar/changes.rs
@@ -6,7 +6,7 @@
 //! shows lives here; `gpui::Div` construction happens in `crate::root`, which owns the
 //! `Context<AdeApp>` the click handlers (review-toggle, open-in-centre) need.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use gpui::Rgba;
@@ -222,22 +222,23 @@ pub fn stat_bar_segments(add: u32, del: u32) -> [StatSegment; STAT_BAR_LEN] {
     segments
 }
 
-/// Review progress for the Changes header's `3 reviewed` label and progress bar - `reviewed`/
-/// `total` are counted by the caller from real state (how many files are in the reviewed set),
-/// never tracked as an independent counter that could drift.
+/// Staged progress for the Changes header's `N of M staged` label and progress bar (Revision R12
+/// §5: the checkbox **is** staging, not "reviewed") - `staged`/`total` are counted by the caller
+/// from real state (how many files are in [`crate::root::AdeApp::staged_files`]), never tracked
+/// as an independent counter that could drift.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub struct ReviewProgress {
-    pub reviewed: usize,
+pub struct StagedProgress {
+    pub staged: usize,
     pub total: usize,
 }
 
-impl ReviewProgress {
-    /// `0.0` (not `NaN`) when there is nothing to review.
+impl StagedProgress {
+    /// `0.0` (not `NaN`) when there is nothing to stage.
     pub fn fraction(&self) -> f32 {
         if self.total == 0 {
             0.0
         } else {
-            self.reviewed as f32 / self.total as f32
+            self.staged as f32 / self.total as f32
         }
     }
 }
@@ -289,6 +290,53 @@ pub fn empty_hunks_message(status: FileChangeStatus) -> &'static str {
         "no line changes (rename only)"
     } else {
         "no line changes"
+    }
+}
+
+/// The staged subset of `files`, in the same relative order - the one place the commit
+/// composer's file list, diffstat, and action-button count are all derived from (Revision R12
+/// §5: "derive the staged set once, early, since the header count/diffstat/composer/action-
+/// button all read from it").
+pub fn staged_subset<'a>(files: &'a [DiffFile], staged: &HashSet<PathBuf>) -> Vec<&'a DiffFile> {
+    files
+        .iter()
+        .filter(|file| staged.contains(&file.path))
+        .collect()
+}
+
+/// The staged subset's combined `+add`/`\u{2212}del`, summed the same way [`diff_file_stats`]
+/// counts a single file - the commit composer header's right-aligned diffstat (`#5f9c78`).
+pub fn staged_diff_stats(staged: &[&DiffFile]) -> (u32, u32) {
+    staged.iter().fold((0, 0), |(add, del), file| {
+        let (file_add, file_del) = diff_file_stats(file);
+        (add + file_add, del + file_del)
+    })
+}
+
+/// The commit composer's primary-button label: a ghost `Commit` with nothing staged, or `Commit
+/// N files` (singular for exactly one) once something is.
+pub fn commit_button_label(staged_count: usize) -> String {
+    if staged_count == 0 {
+        "Commit".to_string()
+    } else {
+        format!(
+            "Commit {staged_count} file{}",
+            if staged_count == 1 { "" } else { "s" }
+        )
+    }
+}
+
+/// A placeholder commit message, standing in for real agent-drafted commit-message generation -
+/// **out of scope for this task**: no such system exists anywhere in this codebase yet (this
+/// phase only wires the Changes panel's real staging/composer UI against real data, per this
+/// module's own `Authorship` precedent for "real API, honestly incomplete data"). Deterministic
+/// and derived straight from the staged file list rather than fabricated prose, and empty when
+/// nothing is staged - the composer only ever shows this with something real to say.
+pub fn draft_commit_message(staged: &[&DiffFile]) -> String {
+    match staged {
+        [] => String::new(),
+        [only] => format!("Update {}", only.path.display()),
+        many => format!("Update {} files", many.len()),
     }
 }
 
@@ -491,18 +539,15 @@ mod tests {
     }
 
     #[test]
-    fn review_progress_fraction_handles_zero_total_without_dividing_by_zero() {
-        let progress = ReviewProgress {
-            reviewed: 0,
-            total: 0,
-        };
+    fn staged_progress_fraction_handles_zero_total_without_dividing_by_zero() {
+        let progress = StagedProgress { staged: 0, total: 0 };
         assert_eq!(progress.fraction(), 0.0);
     }
 
     #[test]
-    fn review_progress_fraction_is_reviewed_over_total() {
-        let progress = ReviewProgress {
-            reviewed: 3,
+    fn staged_progress_fraction_is_staged_over_total() {
+        let progress = StagedProgress {
+            staged: 3,
             total: 12,
         };
         assert!((progress.fraction() - 0.25).abs() < f32::EPSILON);
@@ -762,5 +807,90 @@ mod tests {
             0,
             "an agent with no recorded authorship anywhere gets a real 0, not a stray match"
         );
+    }
+
+    fn changed_file(path: &str, add_lines: u32, del_lines: u32) -> DiffFile {
+        let mut lines = Vec::new();
+        for _ in 0..add_lines {
+            lines.push(line(DiffLineKind::Added, "a"));
+        }
+        for _ in 0..del_lines {
+            lines.push(line(DiffLineKind::Removed, "d"));
+        }
+        DiffFile {
+            path: PathBuf::from(path),
+            old_path: None,
+            status: FileChangeStatus::Modified,
+            is_binary: false,
+            hunks: vec![DiffHunk {
+                header: "@@ -1,1 +1,1 @@".to_string(),
+                lines,
+            }],
+            truncated: false,
+        }
+    }
+
+    #[test]
+    fn staged_subset_only_keeps_files_in_the_staged_set() {
+        let files = vec![
+            changed_file("src/a.rs", 1, 0),
+            changed_file("src/b.rs", 2, 0),
+            changed_file("src/c.rs", 0, 3),
+        ];
+        let mut staged = HashSet::new();
+        staged.insert(PathBuf::from("src/b.rs"));
+
+        let subset = staged_subset(&files, &staged);
+        assert_eq!(subset.len(), 1);
+        assert_eq!(subset[0].path, PathBuf::from("src/b.rs"));
+    }
+
+    #[test]
+    fn staged_subset_is_empty_when_nothing_is_staged() {
+        let files = vec![changed_file("src/a.rs", 1, 0)];
+        let subset = staged_subset(&files, &HashSet::new());
+        assert!(subset.is_empty());
+    }
+
+    #[test]
+    fn staged_diff_stats_sums_only_the_staged_files() {
+        let a = changed_file("src/a.rs", 3, 1);
+        let b = changed_file("src/b.rs", 2, 5);
+        assert_eq!(staged_diff_stats(&[&a, &b]), (5, 6));
+        assert_eq!(staged_diff_stats(&[&a]), (3, 1));
+        assert_eq!(staged_diff_stats(&[]), (0, 0));
+    }
+
+    #[test]
+    fn commit_button_label_is_a_bare_ghost_commit_with_nothing_staged() {
+        assert_eq!(commit_button_label(0), "Commit");
+    }
+
+    #[test]
+    fn commit_button_label_is_singular_for_exactly_one_staged_file() {
+        assert_eq!(commit_button_label(1), "Commit 1 file");
+    }
+
+    #[test]
+    fn commit_button_label_is_plural_for_more_than_one_staged_file() {
+        assert_eq!(commit_button_label(3), "Commit 3 files");
+    }
+
+    #[test]
+    fn draft_commit_message_is_empty_with_nothing_staged() {
+        assert_eq!(draft_commit_message(&[]), "");
+    }
+
+    #[test]
+    fn draft_commit_message_names_the_one_file_when_exactly_one_is_staged() {
+        let a = changed_file("src/a.rs", 1, 0);
+        assert_eq!(draft_commit_message(&[&a]), "Update src/a.rs");
+    }
+
+    #[test]
+    fn draft_commit_message_names_a_count_when_several_files_are_staged() {
+        let a = changed_file("src/a.rs", 1, 0);
+        let b = changed_file("src/b.rs", 1, 0);
+        assert_eq!(draft_commit_message(&[&a, &b]), "Update 2 files");
     }
 }

--- a/crates/app/src/sidebar/mod.rs
+++ b/crates/app/src/sidebar/mod.rs
@@ -28,6 +28,7 @@
 use crate::root::*;
 use crate::sidebar::file_tree::{FileTreeEntry, LangChip};
 use crate::theme;
+use crate::work_surface::agents::{AgentId, AgentKind};
 use crate::work_surface::state as work_surface;
 use gpui::{div, font, prelude::*, px, uniform_list, ClickEvent, Context, Pixels, Window};
 use std::collections::{HashMap, HashSet};

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -1,8 +1,8 @@
 use super::*;
 use crate::keymap;
 use crate::root::widgets::{
-    modal_scrim_bg, render_action_keycap_row, render_keycap_row, render_menu_group_divider,
-    render_modal_button, render_sidebar_message, render_tag_pill, text_tooltip, KeycapSize,
+    modal_scrim_bg, render_keycap_row, render_menu_group_divider, render_modal_button,
+    render_sidebar_message, render_tag_pill, text_tooltip, KeycapSize,
 };
 use crate::settings::widgets::ChoiceOption;
 use crate::worktree_history::flow as worktree_history;

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -6,6 +6,7 @@ use crate::root::widgets::{
 };
 use crate::settings::widgets::ChoiceOption;
 use crate::worktree_history::flow as worktree_history;
+use gpui::BoxShadow;
 
 impl AdeApp {
     /// Switches which data source the right sidebar shows. Switching *to* the Changes view
@@ -274,9 +275,24 @@ impl AdeApp {
     /// worktree-history operation is already in flight (shares
     /// [`Self::worktree_history_op_in_flight`] with `Keep all changes`/`Discard worktree`/`Undo`/
     /// `Redo` - see `worktree_history::flow`'s own module docs for why one flag is enough
-    /// discipline here). On success, clears exactly the committed paths from
-    /// [`Self::staged_files`] (a file staged again after this call started is left alone) and
-    /// reloads the diff so the committed files drop out of the Changes list for real.
+    /// discipline here). On success, clears exactly the committed `paths` (captured once, up
+    /// front, before the async git work starts) from [`Self::staged_files`] - any *other* path
+    /// staged or unstaged during the in-flight window is untouched, since the removal loop only
+    /// ever iterates that fixed snapshot. This is unconditional for the paths that *were*
+    /// committed, though: [`Self::staged_files`] is plain UI bookkeeping with no per-path
+    /// staged/committed history, so if a user un-stages and re-stages one of the very paths this
+    /// call just committed while it was still in flight (the staging checkbox itself isn't
+    /// gated on [`Self::worktree_history_op_in_flight`]), that path is still cleared once the
+    /// commit finishes - there is no way to tell that re-staging apart from it never having been
+    /// touched. Reloads the diff so it reflects the real post-commit state. That reload does
+    /// **not**
+    /// generally drop the just-committed files out of the Changes list: `wt_core::diff`'s own
+    /// docs are explicit that `diff_against_base` diffs the working tree against the
+    /// **merge-base with the default branch**, not against the previous commit, so a file
+    /// committed on a feature branch that still differs from that branch's content keeps
+    /// showing up - correctly, since it is still an uncommitted-relative-to-`main` change worth
+    /// reviewing, only now with its content latched into a real commit instead of sitting
+    /// uncommitted.
     ///
     /// No `Undo`/`Redo` integration yet, unlike the other four `worktree_history_op_in_flight`
     /// operations - a real, stated gap (see `wt_core::undo::commit_paths`'s own docs), not a
@@ -1635,6 +1651,477 @@ impl AdeApp {
                 this.toggle_staged(path.clone(), cx);
             }))
     }
+
+    /// The commit composer at the foot of the Changes panel (Revision R12 §5): header row
+    /// (`COMMIT` · `N of M staged` · staged diffstat), a pre-drafted message box, and the primary
+    /// commit action with its `▾` split-button menu. The staged set is derived once, early
+    /// (`changes::staged_subset`), so the header count/diffstat/message/action-button all read
+    /// from the exact same list, per the design's own "derive the staged set once" rule.
+    ///
+    /// Always rendered, even with nothing staged - the primary action just drops to a disabled-
+    /// looking ghost `Commit` in that case (never hidden outright).
+    pub(in crate::sidebar) fn render_commit_composer(
+        &self,
+        diff: &WorktreeDiff,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let staged = changes::staged_subset(&diff.files, &self.staged_files);
+        let staged_count = staged.len();
+        let total = diff.files.len();
+        let (add, del) = changes::staged_diff_stats(&staged);
+        let stat_text = if staged_count > 0 {
+            format!("+{add} \u{2212}{del}")
+        } else {
+            String::new()
+        };
+
+        let branch = self
+            .worktrees
+            .iter()
+            .find(|item| item.path == self.diff_root)
+            .and_then(|item| item.branch.clone())
+            .unwrap_or_else(|| "(detached)".to_string());
+
+        // The agent whose tint/initial the message box's chip shows - the current worktree's
+        // first real agent, if any. There is no per-message "which agent drafted this"
+        // fact to read (`changes::draft_commit_message`'s own docs cover why the message itself
+        // is a deterministic placeholder, not real agent output) - `AgentKind::Shell`'s
+        // existing neutral chip (`work_surface::agent_tint`'s own docs: "isn't an agent, so it
+        // gets a neutral chip instead of an invented tint") is the honest fallback with none.
+        let drafting_kind = self
+            .current_worktree_agents()
+            .find(|agent| agent.kind != AgentKind::Shell)
+            .map(|agent| agent.kind);
+        let drafted_by = match drafting_kind {
+            Some(kind) => format!("drafted by {}", kind.label()),
+            None => "drafted by no agent".to_string(),
+        };
+        let chip_kind = drafting_kind.unwrap_or(AgentKind::Shell);
+        let (chip_fg, chip_bg) = work_surface::agent_tint(chip_kind);
+        let chip_initial = work_surface::agent_initial(chip_kind);
+
+        let message = if staged.is_empty() {
+            String::new()
+        } else {
+            changes::draft_commit_message(&staged)
+        };
+
+        let busy = self.worktree_history_op_in_flight.is_some();
+        let committing = self.worktree_history_op_in_flight
+            == Some(worktree_history::WorktreeHistoryOpKind::Commit);
+        let can_commit = staged_count > 0 && !busy;
+        let label = if committing {
+            "committing\u{2026}".to_string()
+        } else {
+            changes::commit_button_label(staged_count)
+        };
+        // Visual state (green vs. ghost) tracks whether anything is staged, independent of
+        // `can_commit`'s click-gating - the same "keep the enabled look while a busy label
+        // shows" precedent `Self::render_footer_action_button` already follows for its own
+        // `discarding…`/`keeping…` busy labels.
+        let has_staged = staged_count > 0;
+        let (primary_bg, primary_border, primary_fg): (gpui::Rgba, gpui::Rgba, gpui::Rgba) =
+            if has_staged {
+                (
+                    theme::button::GREEN_BG.into(),
+                    theme::button::GREEN_BG.into(),
+                    theme::button::GREEN_FG.into(),
+                )
+            } else {
+                (
+                    work_surface::TRANSPARENT,
+                    // No exact token for the mockup's disabled-state `#262b30` - reused
+                    // `theme::border::BUTTON` (`#2a2f34`, the closest ported outline-button
+                    // border), the same reuse-nearest-token convention
+                    // `work_surface::state::tab_colors`'s own docs establish for
+                    // `theme::text::DIMMER` standing in for the design's `#767d84`.
+                    theme::border::BUTTON.into(),
+                    theme::text::FAINTER.into(),
+                )
+            };
+        // No `⌘⏎`/`Ctrl+Enter` keycap on the primary button: the mockup shows one, but this app
+        // has no real global keybinding for it - the same "app-level shortcut steals terminal
+        // input" risk `work_surface::state::footer_actions`'s own `Keep all` row docs this exact
+        // omission for (this app's whole domain is running agent CLIs in terminals, and
+        // Ctrl+Enter/Cmd+Enter is a plausible "submit" gesture one of them could reasonably use
+        // itself). That row's own docs are explicit that an audit once caught a keycap still
+        // rendering after a promotion to "real" with no binding behind it - "a real keycap must
+        // never render for a keystroke that does nothing" - so this composer never grows one in
+        // the first place.
+        let menu_open = self.commit_menu_open;
+
+        // Test-only (no-op outside `cfg(test)`/`test-support`, matching every other
+        // `debug_selector` in this file - see e.g. `Self::render_status_zoom_value`'s own
+        // comment): the real staged/total counts baked directly into the selector string, so a
+        // real interaction test can prove this header reflects real `staged_subset`/diff state
+        // rather than a hardcoded string, without GPUI needing a general "read back the painted
+        // text" API.
+        let header_selector = format!("commit-composer-progress-{staged_count}-of-{total}");
+        let stat_selector = format!("commit-composer-stat-{stat_text}");
+        let branch_selector = format!("commit-composer-branch-{branch}");
+        let message_selector = if message.is_empty() {
+            "commit-composer-message-empty".to_string()
+        } else {
+            format!("commit-composer-message-{message}")
+        };
+
+        let mut composer = div()
+            .id("commit-composer")
+            .relative()
+            .flex_none()
+            .flex()
+            .flex_col()
+            .px(px(12.0))
+            .pt(px(9.0))
+            .pb(px(10.0))
+            .border_t_1()
+            .border_color(theme::border::INNER)
+            .bg(theme::surface::FOOTER)
+            .child(
+                // Header row: `COMMIT` · `N of M staged` · staged diffstat, right-aligned.
+                div()
+                    .flex_none()
+                    .flex()
+                    .items_center()
+                    .gap(px(8.0))
+                    .pb(px(7.0))
+                    .child(
+                        div()
+                            .font(font(theme::font::SANS))
+                            .font_weight(gpui::FontWeight::SEMIBOLD)
+                            .text_size(px(9.5))
+                            .text_color(theme::palette::GROUP_HEADER)
+                            .child("COMMIT"),
+                    )
+                    .child(
+                        div()
+                            .debug_selector(move || header_selector)
+                            .font(font(theme::font::MONO))
+                            .text_size(px(10.0))
+                            .text_color(theme::text::DIM)
+                            .child(format!("{staged_count} of {total} staged")),
+                    )
+                    .child(div().flex_1())
+                    .child(
+                        div()
+                            .debug_selector(move || stat_selector)
+                            .font(font(theme::font::MONO))
+                            .text_size(px(10.0))
+                            .text_color(theme::diff::STAT_ADD)
+                            .child(stat_text),
+                    ),
+            )
+            .child(
+                // The pre-drafted message box.
+                div()
+                    .flex_none()
+                    .border_1()
+                    .border_color(theme::border::CARD)
+                    .rounded(theme::radius::CARD_SM)
+                    .bg(theme::surface::CARD_SUNK)
+                    .px(px(9.0))
+                    .pt(px(7.0))
+                    .pb(px(8.0))
+                    .child(
+                        div()
+                            .flex()
+                            .items_center()
+                            .gap(px(6.0))
+                            .pb(px(5.0))
+                            .child(
+                                div()
+                                    .flex_none()
+                                    .w(px(13.0))
+                                    .h(px(13.0))
+                                    .rounded(theme::radius::CHIP)
+                                    .bg(chip_bg)
+                                    .flex()
+                                    .items_center()
+                                    .justify_center()
+                                    .font(font(theme::font::MONO))
+                                    .font_weight(gpui::FontWeight::MEDIUM)
+                                    .text_size(px(7.5))
+                                    .text_color(chip_fg)
+                                    .child(chip_initial),
+                            )
+                            .child(
+                                div()
+                                    .flex_1()
+                                    .min_w_0()
+                                    .overflow_hidden()
+                                    .truncate()
+                                    .font(font(theme::font::SANS))
+                                    .text_size(px(9.5))
+                                    .text_color(theme::text::FAINTER)
+                                    .child(drafted_by),
+                            )
+                            .child(
+                                // Non-interactive by design: there is no real agent-drafted
+                                // message generation to redraft *from* yet - see
+                                // `changes::draft_commit_message`'s own docs. Shown, never
+                                // clickable-looking (no cursor/hover), matching this codebase's
+                                // `ActionKind::Unimplemented` convention for a real, visible,
+                                // honestly-inert affordance.
+                                div()
+                                    .flex_none()
+                                    .font(font(theme::font::SANS))
+                                    .font_weight(gpui::FontWeight::MEDIUM)
+                                    .text_size(px(9.5))
+                                    .text_color(theme::text::DIMMER)
+                                    .child("redraft"),
+                            ),
+                    )
+                    .child(
+                        div().flex().items_start().child(
+                            div()
+                                .debug_selector(move || message_selector)
+                                .flex_1()
+                                .min_w_0()
+                                .font(font(theme::font::SANS))
+                                .text_size(px(11.5))
+                                .line_height(px(17.0))
+                                .text_color(if message.is_empty() {
+                                    theme::text::FAINT
+                                } else {
+                                    theme::text::STRONG
+                                })
+                                .child(if message.is_empty() {
+                                    "no files staged yet".to_string()
+                                } else {
+                                    message
+                                }),
+                        ),
+                    ),
+            )
+            .child(
+                // Primary action + split-button menu + right-aligned target branch.
+                div()
+                    .flex_none()
+                    .flex()
+                    .items_center()
+                    .gap(px(6.0))
+                    .pt(px(8.0))
+                    .child({
+                        let mut button = div()
+                            .id("commit-composer-primary")
+                            .debug_selector(|| "commit-composer-primary".to_string())
+                            .flex_none()
+                            .h(px(24.0))
+                            .px(px(10.0))
+                            .rounded(theme::radius::BUTTON)
+                            .flex()
+                            .items_center()
+                            .gap(px(7.0))
+                            .bg(primary_bg)
+                            .border_1()
+                            .border_color(primary_border)
+                            .child(
+                                div()
+                                    .font(font(theme::font::SANS))
+                                    .font_weight(gpui::FontWeight::MEDIUM)
+                                    .text_size(px(11.0))
+                                    .text_color(primary_fg)
+                                    .child(label),
+                            );
+                        button = if can_commit {
+                            button
+                                .cursor_pointer()
+                                .hover(|el| el.bg(theme::button::GREEN_BG_HOVER))
+                                .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
+                                    this.commit_staged_files(cx);
+                                }))
+                        } else {
+                            button.cursor_default()
+                        };
+                        button
+                    })
+                    .child(
+                        div()
+                            .id("commit-composer-menu-toggle")
+                            .debug_selector(|| "commit-composer-menu-toggle".to_string())
+                            .flex_none()
+                            .w(px(24.0))
+                            .h(px(24.0))
+                            .rounded(theme::radius::BUTTON)
+                            .border_1()
+                            .border_color(theme::border::BUTTON)
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .cursor_pointer()
+                            .hover(|el| el.bg(theme::surface::ROW_HOVER_ALT))
+                            .font(font(theme::font::MONO))
+                            .text_size(px(8.5))
+                            .text_color(theme::text::DIMMER)
+                            .child("\u{25be}")
+                            .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
+                                this.commit_menu_open = !this.commit_menu_open;
+                                cx.notify();
+                            })),
+                    )
+                    .child(div().flex_1().min_w_0())
+                    .child(
+                        div()
+                            .debug_selector(move || branch_selector)
+                            .flex_none()
+                            .max_w(px(120.0))
+                            .overflow_hidden()
+                            .truncate()
+                            .font(font(theme::font::MONO))
+                            .text_size(px(10.0))
+                            .text_color(theme::text::PATH)
+                            .child(branch),
+                    ),
+            );
+
+        if menu_open {
+            composer = composer.child(self.render_commit_menu(cx));
+        }
+
+        composer
+    }
+
+    /// The commit composer's `▾` split-button popover (Revision R12 §5): *Commit and push* /
+    /// *Commit all N files* / *Amend last commit* / *Stash staged files*. Opens **upward** -
+    /// `bottom`-anchored, not `top` - since the button it hangs off sits near the bottom of the
+    /// Changes panel. A transparent, `.occlude()`d scrim confined to the composer's own bounds
+    /// (matching [`crate::work_surface::render::AdeApp::render_plus_menu`]'s click-away-
+    /// dismisses shape, scoped smaller here since the composer itself is the only positioned
+    /// ancestor available) closes the menu on a click anywhere else *within the composer* -
+    /// this is not a window-wide click-away like `render_plus_menu`'s own scrim, only the
+    /// composer's own footprint; the popover panel itself also `.occlude()`s and stops that
+    /// click from bubbling further.
+    ///
+    /// Every row is real, visible, and **honestly non-interactive**: only the primary `Commit N
+    /// files` button (`Self::commit_staged_files`, backed by a real `wt_core::undo::commit_paths`)
+    /// has real backing today. Push credentials, amend, and stash all need real git plumbing this
+    /// phase doesn't add - each row is dimmed and un-clickable, the same
+    /// `work_surface::state::ActionKind::Unimplemented` convention this codebase already uses for
+    /// "visible, real, but not wired up yet" (never a clickable-looking no-op).
+    fn render_commit_menu(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let (shadow_x, shadow_y, shadow_blur) = theme::shadow::COMMIT_MENU;
+        let branch = self
+            .worktrees
+            .iter()
+            .find(|item| item.path == self.diff_root)
+            .and_then(|item| item.branch.clone())
+            .unwrap_or_else(|| "(detached)".to_string());
+        let total = self
+            .current_diff()
+            .map(|diff| diff.files.len())
+            .unwrap_or(0);
+
+        div()
+            .id("commit-menu-scrim")
+            .debug_selector(|| "commit-menu-scrim".to_string())
+            .absolute()
+            .top(px(0.0))
+            .left(px(0.0))
+            .right(px(0.0))
+            .bottom(px(0.0))
+            // Without this, `Window::hit_test` (`vendor/zed/crates/gpui/src/window.rs`) keeps
+            // walking *underneath* this transparent overlay and includes whatever real button
+            // sits at the same screen position as still "hovered" - so a click that lands on,
+            // say, the still-visible `Self::render_commit_composer` menu-toggle button beneath
+            // this scrim would fire *both* the scrim's own close handler *and* that button's
+            // real handler in the same click. `.occlude()` is the same fix
+            // `root::resize::render_resize_handle`'s own handle already uses for exactly this
+            // "receives the mouse, not whatever's underneath" reason. Proved genuinely necessary
+            // (not cargo-culted) by `commit_composer_tests::
+            // opening_the_commit_menu_blocks_a_real_click_on_the_primary_button_underneath` and
+            // `commit_composer_tests::clicking_the_menu_toggle_genuinely_opens_and_closes_the_
+            // commit_menu`, both of which fail without it.
+            .occlude()
+            .bg(work_surface::TRANSPARENT)
+            .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
+                this.commit_menu_open = false;
+                cx.notify();
+            }))
+            .child(
+                div()
+                    .id("commit-menu-popover")
+                    .debug_selector(|| "commit-menu-popover".to_string())
+                    .absolute()
+                    .left(px(12.0))
+                    .right(px(12.0))
+                    .bottom(px(44.0))
+                    // The composer itself is short (~135px of header/message-box/button-row),
+                    // shorter than this four-row popover (`bottom(px(44.0))` plus its own real
+                    // painted height) - so the popover's *top* genuinely paints above the
+                    // composer's own top edge, over the Changes rows behind it, which is outside
+                    // the scrim's own bounds (`top(0)/bottom(0)` relative to the composer, not
+                    // the whole sidebar - see this fn's own docs on the scrim being "confined to
+                    // the composer's own bounds"). Without its own `.occlude()` here, a click in
+                    // that overflow region only avoids reaching a real Changes row underneath by
+                    // relying on `Window::dispatch_mouse_event`'s bubble-phase registration
+                    // order happening to run this popover's own `stop_propagation` listener
+                    // first - a coincidence of paint order, not a structural guarantee. This
+                    // makes the block real regardless of ordering, the same reasoning as the
+                    // scrim's own `.occlude()` above.
+                    .occlude()
+                    .py(px(4.0))
+                    .bg(theme::surface::PALETTE)
+                    .border_1()
+                    .border_color(theme::border::POPOVER)
+                    .rounded(theme::radius::CARD)
+                    .shadow(vec![BoxShadow::new(
+                        shadow_x,
+                        shadow_y,
+                        gpui::black().opacity(0.5),
+                    )
+                    .blur_radius(shadow_blur)])
+                    .on_click(cx.listener(|_this, _event: &ClickEvent, _window, cx| {
+                        cx.stop_propagation();
+                    }))
+                    .child(render_commit_menu_row(
+                        "Commit and push",
+                        format!("origin/{branch}"),
+                    ))
+                    .child(render_commit_menu_row(
+                        "Commit all files",
+                        format!("stages the rest first \u{2022} {total} total"),
+                    ))
+                    .child(render_commit_menu_row(
+                        "Amend last commit",
+                        "rewrites the tip".to_string(),
+                    ))
+                    .child(render_commit_menu_row(
+                        "Stash staged files",
+                        "keeps the worktree clean".to_string(),
+                    )),
+            )
+    }
+}
+
+/// One row of [`AdeApp::render_commit_menu`]'s split-button popover - label + sub-label, no
+/// leading chip (unlike `crate::work_surface::render::render_dropdown_menu_row`, which this
+/// deliberately doesn't reuse: the design has no per-row glyph here). Always dimmed and
+/// non-interactive - see [`AdeApp::render_commit_menu`]'s own docs for why.
+fn render_commit_menu_row(label: &'static str, sub: String) -> impl IntoElement {
+    div()
+        .id(format!("commit-menu-row-{label}"))
+        .debug_selector(move || format!("commit-menu-row-{label}"))
+        .flex()
+        .flex_col()
+        .gap(px(1.0))
+        .px(px(10.0))
+        .py(px(5.0))
+        .cursor_default()
+        .child(
+            div()
+                .font(font(theme::font::SANS))
+                .font_weight(gpui::FontWeight::MEDIUM)
+                .text_size(px(11.0))
+                .text_color(theme::text::GHOSTER)
+                .child(label),
+        )
+        .child(
+            div()
+                .font(font(theme::font::MONO))
+                .text_size(px(9.5))
+                .text_color(theme::text::FAINTER)
+                .child(sub),
+        )
 }
 
 /// One author chip in a Changes row's chip group (Revision R12 §5) - the same 13×13 visual
@@ -3565,6 +4052,451 @@ mod indent_guide_tests {
         assert!(
             cx.debug_bounds("file-tree-guide-idle-b-0").is_some(),
             "the still-visible `b` row keeps its own level-0 guide"
+        );
+    }
+}
+
+/// Real interaction coverage for the commit composer (Revision R12 §5,
+/// `Self::render_commit_composer`/`Self::render_commit_menu`): a real repo, a real diff, and real
+/// `simulate_click`s - matching `virtualization_tests`' and `status_bar_zoom_click_tests`' own
+/// `debug_bounds` + `simulate_click` discipline - rather than trusting the composer's own doc
+/// comments about what is and isn't wired.
+#[cfg(test)]
+mod commit_composer_tests {
+    use super::*;
+    use crate::root::focus::palette_focus_tests;
+    use gpui::TestAppContext;
+    use std::process::Command;
+    use tempfile::TempDir;
+
+    /// `.output()`, not `.status()` - see `virtualization_tests::git`'s own comment for why.
+    fn git(dir: &std::path::Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .expect("failed to spawn git");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git_output(dir: &std::path::Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .expect("failed to spawn git");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    fn commit_count(dir: &std::path::Path) -> usize {
+        git_output(dir, &["rev-list", "--count", "HEAD"])
+            .parse()
+            .expect("git rev-list --count must print a real integer")
+    }
+
+    /// A real feature-branch repo with two files genuinely changed relative to `main`'s
+    /// merge-base - the same shape
+    /// `virtualization_tests::a_changes_row_far_below_the_viewport_is_never_painted` already
+    /// establishes for `AdeApp::current_diff` to be real and `Some` (there is no base to diff
+    /// against on the default branch itself - `wt_core::diff::DiffBase::OnDefaultBranch`).
+    fn changes_test_repo() -> TempDir {
+        let repo = TempDir::new().expect("tempdir");
+        git(repo.path(), &["init", "-b", "main"]);
+        git(repo.path(), &["config", "user.email", "test@example.com"]);
+        git(repo.path(), &["config", "user.name", "Test User"]);
+        std::fs::write(repo.path().join("a.txt"), "one\ntwo\nthree\n").expect("write a.txt");
+        std::fs::write(repo.path().join("b.txt"), "uno\ndos\ntres\n").expect("write b.txt");
+        git(repo.path(), &["add", "."]);
+        git(repo.path(), &["commit", "-m", "initial"]);
+        git(repo.path(), &["checkout", "-b", "feature"]);
+        std::fs::write(repo.path().join("a.txt"), "one\ntwo\nthree\nfour\n").expect("write a.txt");
+        std::fs::write(repo.path().join("b.txt"), "uno\ndos\ntres\ncuatro\n").expect("write b.txt");
+        repo
+    }
+
+    fn open_changes_view<'a>(
+        cx: &'a mut TestAppContext,
+        repo: &TempDir,
+    ) -> (gpui::Entity<AdeApp>, &'a mut gpui::VisualTestContext) {
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        app.update_in(cx, |app, window, cx| {
+            app.set_right_sidebar_view(RightSidebarView::Changes, window, cx);
+        });
+        cx.run_until_parked();
+        (app, cx)
+    }
+
+    #[gpui::test]
+    fn the_composer_reflects_real_staged_count_diffstat_branch_and_message(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = changes_test_repo();
+        let (app, cx) = open_changes_view(cx, &repo);
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.current_diff().map(|d| d.files.len())),
+            Some(2),
+            "sanity check: both changed files must really be in the loaded diff, otherwise the \
+             assertions below would pass for the wrong reason"
+        );
+
+        assert!(
+            cx.debug_bounds("commit-composer-progress-0-of-2").is_some(),
+            "nothing is staged yet, so the header must show 0 of the real 2 changed files - not \
+             a hardcoded or stale count"
+        );
+        assert!(
+            cx.debug_bounds("commit-composer-branch-feature").is_some(),
+            "the branch label must show the worktree's real current branch (checked out as \
+             `feature`), not a placeholder"
+        );
+        assert!(
+            cx.debug_bounds("commit-composer-message-empty").is_some(),
+            "with nothing staged the message box must show the honest empty state, not a \
+             fabricated draft"
+        );
+        assert!(
+            cx.debug_bounds("commit-composer-stat-").is_some(),
+            "with nothing staged the diffstat must be genuinely empty, not a stale or invented \
+             +/- count"
+        );
+
+        let a_path = PathBuf::from("a.txt");
+        app.update(cx, |app, cx| {
+            app.toggle_staged(a_path.clone(), cx);
+        });
+        cx.run_until_parked();
+
+        assert!(
+            cx.debug_bounds("commit-composer-progress-1-of-2").is_some(),
+            "staging exactly one of the two real changed files must move the header to a real \
+             1 of 2 - a hardcoded header would never move"
+        );
+        assert!(
+            cx.debug_bounds("commit-composer-progress-0-of-2").is_none(),
+            "the stale 0-of-2 header must not still be painted alongside the new one"
+        );
+        assert!(
+            cx.debug_bounds("commit-composer-message-Update a.txt")
+                .is_some(),
+            "with only a.txt staged, the message box must show \
+             `changes::draft_commit_message`'s real single-file draft for that exact path - the \
+             same fixture shape `changes::tests::draft_commit_message_names_the_one_file_when_\
+             exactly_one_is_staged` already establishes"
+        );
+        assert!(
+            cx.debug_bounds("commit-composer-stat-").is_none(),
+            "once something real is staged the diffstat selector must change away from the \
+             empty-state string"
+        );
+        // The real number, not just "it changed": `a.txt` went from `"one\ntwo\nthree\n"` to
+        // `"one\ntwo\nthree\nfour\n"` - a single appended line, so a real `git diff` against the
+        // merge-base (confirmed independently with a real `git diff` in this same fixture shape
+        // while writing this test) reports exactly one added line and zero removed - `+1 −0`
+        // (`\u{2212}`, the real minus sign `changes::staged_diff_stats`'s caller formats with,
+        // not a plain hyphen).
+        assert!(
+            cx.debug_bounds("commit-composer-stat-+1 \u{2212}0")
+                .is_some(),
+            "the diffstat must show the real +1/-0 line count for a.txt's actual change, not a \
+             placeholder or a count that merely happens to be non-empty"
+        );
+    }
+
+    #[gpui::test]
+    fn the_primary_button_is_a_genuine_no_op_with_nothing_staged(cx: &mut TestAppContext) {
+        let repo = changes_test_repo();
+        let (app, cx) = open_changes_view(cx, &repo);
+
+        let commits_before = commit_count(repo.path());
+
+        let bounds = cx
+            .debug_bounds("commit-composer-primary")
+            .expect("the primary button must really paint even with nothing staged");
+        cx.simulate_click(bounds.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        assert_eq!(
+            commit_count(repo.path()),
+            commits_before,
+            "a real click on the primary button with nothing staged must never create a real \
+             commit"
+        );
+        assert!(
+            app.read_with(cx, |app, _| app.worktree_history_op_in_flight.is_none()),
+            "a disabled click must never even start the real commit_staged_files operation"
+        );
+        // `worktree_history_op_in_flight.is_none()` alone can't tell "never started" apart from
+        // "started and already finished" (`Self::commit_staged_files`'s own async task clears it
+        // back to `None` on completion too) - `worktree_history_status` is the stronger signal:
+        // `commit_staged_files` sets a real "committing…" string *synchronously*, before it ever
+        // spawns the background git work, so if the click had reached it at all, this would be
+        // `Some` even immediately after `run_until_parked`.
+        assert!(
+            app.read_with(cx, |app, _| app.worktree_history_status.is_none()),
+            "a disabled click must never even set the real \"committing…\" status - proof the \
+             operation truly never started, not just that it already finished"
+        );
+    }
+
+    #[gpui::test]
+    fn clicking_the_primary_button_reaches_the_real_commit_staged_files_action(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = changes_test_repo();
+        let (app, cx) = open_changes_view(cx, &repo);
+
+        let a_path = PathBuf::from("a.txt");
+        app.update(cx, |app, cx| {
+            app.toggle_staged(a_path.clone(), cx);
+        });
+        cx.run_until_parked();
+
+        let commits_before = commit_count(repo.path());
+
+        let bounds = cx
+            .debug_bounds("commit-composer-primary")
+            .expect("the primary button must really paint once something is staged");
+        cx.simulate_click(bounds.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        assert_eq!(
+            commit_count(repo.path()),
+            commits_before + 1,
+            "a real click on the wired primary button must create exactly one real git commit \
+             via wt_core::undo::commit_paths"
+        );
+        assert!(
+            !app.read_with(cx, |app, _| app.staged_files.contains(&a_path)),
+            "the just-committed path must be cleared from the real staged set"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.current_diff().map(|d| d.files.len())),
+            Some(2),
+            "the diff must be reloaded for real after the commit - both files still genuinely \
+             differ from the merge-base with main (wt_core::diff diffs the working tree against \
+             the merge-base, not the previous commit, per that module's own docs), so the \
+             just-committed a.txt correctly stays in the Changes list rather than vanishing"
+        );
+        assert!(
+            app.read_with(cx, |app, _| app.worktree_history_op_in_flight.is_none()),
+            "the in-flight flag must clear once the real async commit task finishes"
+        );
+    }
+
+    #[gpui::test]
+    fn clicking_the_menu_toggle_genuinely_opens_and_closes_the_commit_menu(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = changes_test_repo();
+        let (app, cx) = open_changes_view(cx, &repo);
+
+        assert!(
+            !app.read_with(cx, |app, _| app.commit_menu_open),
+            "the menu must start closed"
+        );
+        assert!(
+            cx.debug_bounds("commit-menu-scrim").is_none(),
+            "an unopened menu's scrim must not be painted at all"
+        );
+
+        let toggle_bounds = cx
+            .debug_bounds("commit-composer-menu-toggle")
+            .expect("the ▾ toggle must really paint");
+        cx.simulate_click(toggle_bounds.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        assert!(
+            app.read_with(cx, |app, _| app.commit_menu_open),
+            "a real click on the toggle must open the real commit_menu_open state"
+        );
+        assert!(
+            cx.debug_bounds("commit-menu-scrim").is_some(),
+            "opening the menu must really paint its scrim"
+        );
+        assert!(
+            cx.debug_bounds("commit-menu-popover").is_some(),
+            "opening the menu must really paint its popover"
+        );
+
+        cx.simulate_click(toggle_bounds.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        assert!(
+            !app.read_with(cx, |app, _| app.commit_menu_open),
+            "a second click on the toggle must close the menu again"
+        );
+        assert!(
+            cx.debug_bounds("commit-menu-scrim").is_none(),
+            "closing the menu must really unpaint its scrim"
+        );
+    }
+
+    #[gpui::test]
+    fn every_commit_menu_row_except_the_primary_button_is_genuinely_inert(cx: &mut TestAppContext) {
+        let repo = changes_test_repo();
+        let (app, cx) = open_changes_view(cx, &repo);
+
+        let a_path = PathBuf::from("a.txt");
+        app.update(cx, |app, cx| {
+            app.toggle_staged(a_path, cx);
+        });
+        cx.run_until_parked();
+
+        let toggle_bounds = cx
+            .debug_bounds("commit-composer-menu-toggle")
+            .expect("the ▾ toggle must really paint");
+        cx.simulate_click(toggle_bounds.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+        assert!(
+            app.read_with(cx, |app, _| app.commit_menu_open),
+            "sanity check: the menu must really be open before this test's own click on the \
+             toggle can be told apart from the rows' clicks below"
+        );
+
+        let commits_before = commit_count(repo.path());
+        let staged_before = app.read_with(cx, |app, _| app.staged_files.clone());
+
+        // Literal selectors, not `format!` - `debug_bounds` takes a `&'static str` (the same
+        // constraint `guide_alignment_tests`' own comment documents).
+        for selector in [
+            "commit-menu-row-Commit and push",
+            "commit-menu-row-Commit all files",
+            "commit-menu-row-Amend last commit",
+            "commit-menu-row-Stash staged files",
+        ] {
+            let row_bounds = cx
+                .debug_bounds(selector)
+                .unwrap_or_else(|| panic!("{selector} must really paint while the menu is open"));
+            cx.simulate_click(row_bounds.center(), gpui::Modifiers::none());
+            cx.run_until_parked();
+
+            assert!(
+                app.read_with(cx, |app, _| app.commit_menu_open),
+                "a real click on {selector} must not silently do the scrim's job and close the \
+                 menu - it has no real action of its own, so it must also have no side effect \
+                 that only coincidentally resembles one"
+            );
+            assert_eq!(
+                commit_count(repo.path()),
+                commits_before,
+                "a real click on {selector} must never create a real git commit - it is dimmed \
+                 and unwired on purpose"
+            );
+            assert_eq!(
+                app.read_with(cx, |app, _| app.staged_files.clone()),
+                staged_before,
+                "a real click on {selector} must never change the real staged set"
+            );
+        }
+    }
+
+    #[gpui::test]
+    fn opening_the_commit_menu_blocks_a_real_click_on_the_primary_button_underneath(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = changes_test_repo();
+        let (app, cx) = open_changes_view(cx, &repo);
+
+        let a_path = PathBuf::from("a.txt");
+        app.update(cx, |app, cx| {
+            app.toggle_staged(a_path, cx);
+        });
+        cx.run_until_parked();
+
+        let primary_bounds = cx
+            .debug_bounds("commit-composer-primary")
+            .expect("the primary button must really paint once something is staged");
+        let toggle_bounds = cx
+            .debug_bounds("commit-composer-menu-toggle")
+            .expect("the ▾ toggle must really paint");
+        cx.simulate_click(toggle_bounds.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+        assert!(
+            app.read_with(cx, |app, _| app.commit_menu_open),
+            "sanity check: the menu must really be open for this to be a real test of the \
+             scrim's own click-blocking, not a no-op"
+        );
+
+        let commits_before = commit_count(repo.path());
+
+        // The scrim spans the composer's full bounds (`top(0)/left(0)/right(0)/bottom(0)` on a
+        // `.relative()` parent) - including the still-visible primary-button row underneath the
+        // popover panel, which itself only covers the composer's upper portion
+        // (`bottom(px(44.0))`, leaving the button row exposed below it). A real click at the
+        // primary button's own screen position, while the menu is open, must be caught by the
+        // scrim - not fall through to the real commit action painted underneath it (the
+        // `.occlude()`-less-scrim click-through bug class this codebase has hit for real
+        // before, e.g. `root::resize::render_resize_handle`'s own `.occlude()`).
+        cx.simulate_click(primary_bounds.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        assert_eq!(
+            commit_count(repo.path()),
+            commits_before,
+            "a click on the primary button's own screen position, while the scrim covers it, \
+             must not reach the real commit action painted underneath"
+        );
+    }
+
+    #[gpui::test]
+    fn the_popover_blocks_a_click_even_where_it_paints_above_the_composers_own_bounds(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = changes_test_repo();
+        let (app, cx) = open_changes_view(cx, &repo);
+
+        let a_path = PathBuf::from("a.txt");
+        app.update(cx, |app, cx| {
+            app.toggle_staged(a_path, cx);
+        });
+        cx.run_until_parked();
+        assert!(
+            app.read_with(cx, |app, _| app.open_change.is_none()),
+            "sanity check: no diff file is open yet"
+        );
+
+        let toggle_bounds = cx
+            .debug_bounds("commit-composer-menu-toggle")
+            .expect("the ▾ toggle must really paint");
+        cx.simulate_click(toggle_bounds.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+        assert!(
+            app.read_with(cx, |app, _| app.commit_menu_open),
+            "sanity check: the menu must really be open"
+        );
+
+        let popover_bounds = cx
+            .debug_bounds("commit-menu-popover")
+            .expect("the popover must really paint");
+        // The four-row popover paints taller than the short composer it hangs off, so its own
+        // top edge genuinely sits above the composer's - outside the scrim's bounds (see
+        // `Self::render_commit_menu`'s own docs). A real click right at that top edge is the
+        // case most likely to fall through to a real Changes row underneath if the popover
+        // relied only on registration-order luck instead of its own `.occlude()`.
+        let click_position =
+            gpui::point(popover_bounds.center().x, popover_bounds.origin.y + px(2.0));
+        cx.simulate_click(click_position, gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        assert!(
+            app.read_with(cx, |app, _| app.commit_menu_open),
+            "a click on the popover's own bounds must not close the menu - that is the scrim's \
+             job for a click outside the popover, not the popover's own click"
+        );
+        assert!(
+            app.read_with(cx, |app, _| app.open_change.is_none()),
+            "a click on the popover, even where it paints above the composer over the real \
+             Changes rows, must never open one of those rows' diffs"
         );
     }
 }

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -259,11 +259,96 @@ impl AdeApp {
     /// Toggles a file's staged state (Revision R12 §5: the checkbox **is** staging) - the
     /// Changes row checkbox's click handler. `Self::render_change_row` stops propagation at the
     /// call site so checking a box never also opens that file's diff.
+    ///
+    /// Real, immediate git staging, not a UI-only intent recorded for later: checking the box
+    /// runs a real `git add -- <path>` (`wt_core::stage::stage_path`); unchecking it runs a real
+    /// `git reset -- <path>` (`wt_core::stage::unstage_path`) - the design's own "the checkbox
+    /// **is** staging" framing, taken literally. [`Self::staged_files`] flips optimistically,
+    /// synchronously, in the same click (so the checkbox visibly responds with no perceptible
+    /// delay) and the real git mutation runs on the background executor right after, matching
+    /// every other real git-mutating action in this app
+    /// (`crate::worktree_history::flow`'s own "never block the foreground thread" discipline).
+    ///
+    /// If the real git call fails, the optimistic flip is reverted (back to whatever
+    /// [`Self::staged_files`] would have read before this click) and the real error is recorded
+    /// in [`Self::staging_error`] - never left as a silent success that only *looked* like it
+    /// worked. A late-resolving revert can theoretically race a newer click on the *same* path
+    /// that started after this one failed (e.g. stage, fail, immediately re-stage by hand before
+    /// the failure's `this.update` runs) and clobber that newer click's own optimistic state;
+    /// this is accepted as a rare, honest tradeoff rather than added generation-counter machinery
+    /// for a failure mode (a `git add`/`git reset` on a path this app itself just resolved from a
+    /// real, loaded diff) that real-repo testing never actually produces.
     pub(in crate::sidebar) fn toggle_staged(&mut self, path: PathBuf, cx: &mut Context<Self>) {
-        if !self.staged_files.remove(&path) {
-            self.staged_files.insert(path);
+        let should_stage = !self.staged_files.remove(&path);
+        if should_stage {
+            self.staged_files.insert(path.clone());
         }
+        self.staging_error = None;
         cx.notify();
+
+        let worktree_path = self.diff_root.clone();
+        let git_path = path.clone();
+        let revert_path = path.clone();
+        let task = cx.spawn(async move |this, cx| {
+            let result = cx
+                .background_executor()
+                .spawn(async move {
+                    if should_stage {
+                        wt_core::stage::stage_path(&worktree_path, &git_path)
+                    } else {
+                        wt_core::stage::unstage_path(&worktree_path, &git_path)
+                    }
+                })
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                if let Err(err) = result {
+                    // Revert the optimistic flip - the real index never actually changed, so
+                    // the checkbox must not keep claiming it did.
+                    if should_stage {
+                        this.staged_files.remove(&revert_path);
+                    } else {
+                        this.staged_files.insert(revert_path.clone());
+                    }
+                    let verb = if should_stage { "stage" } else { "unstage" };
+                    this.staging_error = Some((revert_path, format!("failed to {verb}: {err}")));
+                    cx.notify();
+                }
+            });
+        });
+        // Two different rows' checkboxes clicked in quick succession are independent real git
+        // operations - see `Self::_stage_tasks`'s own docs for why this can't be a single
+        // `Option<Task<()>>` slot.
+        self._stage_tasks.push(task);
+    }
+
+    /// The real, honest surface for a failed real staging/unstaging call
+    /// ([`Self::staging_error`]) - the Changes-panel sibling of [`Self::tree_op_error`]'s own
+    /// render site, next to the composer the failed checkbox lives above rather than buried in
+    /// the log.
+    pub(in crate::sidebar) fn render_staging_error(
+        &self,
+        cx: &mut Context<Self>,
+    ) -> Option<impl IntoElement> {
+        let (_, message) = self.staging_error.clone()?;
+        Some(
+            div()
+                .id("staging-error")
+                .debug_selector(|| "staging-error".to_string())
+                .flex_none()
+                .w_full()
+                .px(px(10.0))
+                .py(px(5.0))
+                .font(font(theme::font::MONO))
+                .text_size(self.ui_text_size(10.0))
+                .text_color(theme::status::FAIL)
+                .cursor_pointer()
+                .tooltip(text_tooltip("Click to dismiss"))
+                .child(message)
+                .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
+                    this.staging_error = None;
+                    cx.notify();
+                })),
+        )
     }
 
     /// The commit composer's primary action (Revision R12 §5) - a real `git add -- <staged
@@ -1254,6 +1339,7 @@ impl AdeApp {
                                 .min_h_0()
                                 .child(self.render_changes_rows(cx)),
                         )
+                        .children(self.render_staging_error(cx))
                         .child(self.render_commit_composer(diff, cx))
                         .child(render_changes_footer(self.ui_text_size(10.0)))
                 }
@@ -4497,6 +4583,140 @@ mod commit_composer_tests {
             app.read_with(cx, |app, _| app.open_change.is_none()),
             "a click on the popover, even where it paints above the composer over the real \
              Changes rows, must never open one of those rows' diffs"
+        );
+    }
+
+    /// Real, immediate git staging (Revision R12 §5: "the checkbox **is** staging") -
+    /// `Self::toggle_staged` is the Changes row checkbox's real click handler
+    /// (`Self::render_staging_checkbox`'s `.on_click`), so calling it directly here exercises
+    /// exactly the same code path a real click reaches, matching this module's own established
+    /// `the_composer_reflects_real_staged_count_diffstat_branch_and_message` precedent for
+    /// driving the checkbox. Verified with real `git status --porcelain` reads, the same
+    /// real-index-verification discipline `wt_core::undo::tests::
+    /// commit_paths_never_commits_a_path_that_was_staged_by_something_else` already established
+    /// for this codebase's staging-adjacent tests.
+    #[gpui::test]
+    fn toggle_staged_really_stages_and_unstages_the_real_git_index(cx: &mut TestAppContext) {
+        let repo = changes_test_repo();
+        let (app, cx) = open_changes_view(cx, &repo);
+        let a_path = PathBuf::from("a.txt");
+
+        // Sanity check the real starting state: a.txt is really modified but not staged.
+        assert_eq!(
+            git_output(repo.path(), &["status", "--porcelain", "a.txt"]),
+            "M a.txt",
+            "sanity check: a.txt must start out modified but genuinely unstaged"
+        );
+
+        app.update(cx, |app, cx| {
+            app.toggle_staged(a_path.clone(), cx);
+        });
+        cx.run_until_parked();
+
+        assert_eq!(
+            git_output(repo.path(), &["status", "--porcelain", "a.txt"]),
+            "M  a.txt",
+            "checking the box must really stage a.txt in the real git index (two-space \
+             porcelain form), not just flip an in-memory flag"
+        );
+        assert!(
+            app.read_with(cx, |app, _| app.staged_files.contains(&a_path)),
+            "the in-memory staged set must agree with the real index it just changed"
+        );
+
+        app.update(cx, |app, cx| {
+            app.toggle_staged(a_path.clone(), cx);
+        });
+        cx.run_until_parked();
+
+        assert_eq!(
+            git_output(repo.path(), &["status", "--porcelain", "a.txt"]),
+            "M a.txt",
+            "unchecking the box must really unstage a.txt in the real git index - back to the \
+             one-space, working-tree-only porcelain form - not merely forget about it in memory \
+             while leaving it staged for real"
+        );
+        assert!(
+            app.read_with(cx, |app, _| !app.staged_files.contains(&a_path)),
+            "the in-memory staged set must agree with the real index after the real unstage too"
+        );
+    }
+
+    /// Revision R12 §5's staging model has no "Jerry-only" staged state: the checkbox mirrors
+    /// the real git index, so a file already staged by something else - a user's own shell, an
+    /// agent CLI - before this worktree is ever loaded must read as staged from the very first
+    /// frame, not start at an honest-looking but wrong "0 staged".
+    #[gpui::test]
+    fn a_file_already_staged_in_real_git_before_the_worktree_is_ever_loaded_reads_as_staged(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = changes_test_repo();
+        // Stages a.txt with a real, direct `git add` *before* the app ever opens this worktree -
+        // standing in for a user's own shell or an agent CLI having staged it first.
+        git(repo.path(), &["add", "a.txt"]);
+
+        let (app, cx) = open_changes_view(cx, &repo);
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.staged_files.clone()),
+            [PathBuf::from("a.txt")].into_iter().collect(),
+            "a.txt must read as staged the moment this worktree is loaded - re-derived from the \
+             real index `load_diff` just queried, not started at an empty, UI-only set"
+        );
+        assert!(
+            cx.debug_bounds("commit-composer-progress-1-of-2").is_some(),
+            "the composer header must reflect the real pre-staged count too, not just the \
+             internal `staged_files` set - a stale `0 of 2` here would mean the UI itself never \
+             actually saw the real staged state"
+        );
+    }
+
+    /// Switching to a worktree that already has something staged in real git must show it as
+    /// staged too, not just the worktree the window happened to start on - the same real
+    /// re-derivation, exercised through `AdeApp::select_worktree` instead of the initial load.
+    #[gpui::test]
+    fn switching_to_a_worktree_with_something_already_staged_in_real_git_shows_it_as_staged(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = changes_test_repo();
+        let second_wt = repo.path().join("second-wt");
+        git(
+            repo.path(),
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "second",
+                second_wt.to_str().expect("utf8 path"),
+            ],
+        );
+        std::fs::write(second_wt.join("c.txt"), "real change\n").expect("write c.txt");
+        // Staged in the *second* worktree's own real index, before Jerry ever selects it.
+        git(&second_wt, &["add", "c.txt"]);
+
+        let (app, cx) = open_changes_view(cx, &repo);
+        assert!(
+            app.read_with(cx, |app, _| app.staged_files.is_empty()),
+            "sanity check: the worktree the window started on has nothing staged"
+        );
+
+        let index = app.read_with(cx, |app, _| {
+            app.worktrees
+                .iter()
+                .position(|item| item.path == second_wt)
+                .expect("the newly created second worktree must be in the real worktree list")
+        });
+        app.update_in(cx, |app, window, cx| {
+            app.select_worktree(index, window, cx);
+        });
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.staged_files.clone()),
+            [PathBuf::from("c.txt")].into_iter().collect(),
+            "switching into the second worktree must re-derive staged_files from *its* real \
+             index (c.txt, staged before this switch ever happened), not carry over the first \
+             worktree's empty set or silently stay empty"
         );
     }
 }

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -1,10 +1,11 @@
 use super::*;
 use crate::keymap;
 use crate::root::widgets::{
-    modal_scrim_bg, render_keycap_row, render_menu_group_divider, render_modal_button,
-    render_sidebar_message, render_tag_pill, text_tooltip, KeycapSize,
+    modal_scrim_bg, render_action_keycap_row, render_keycap_row, render_menu_group_divider,
+    render_modal_button, render_sidebar_message, render_tag_pill, text_tooltip, KeycapSize,
 };
 use crate::settings::widgets::ChoiceOption;
+use crate::worktree_history::flow as worktree_history;
 
 impl AdeApp {
     /// Switches which data source the right sidebar shows. Switching *to* the Changes view
@@ -254,14 +255,86 @@ impl AdeApp {
         self.load_file_tree(self.file_tree_root.clone(), cx);
     }
 
-    /// Toggles a file's reviewed state - the Changes row checkbox's click handler.
-    /// `Self::render_change_row` stops propagation at the call site so checking a box never
-    /// also opens that file's diff.
-    pub(in crate::sidebar) fn toggle_reviewed(&mut self, path: PathBuf, cx: &mut Context<Self>) {
-        if !self.reviewed_files.remove(&path) {
-            self.reviewed_files.insert(path);
+    /// Toggles a file's staged state (Revision R12 §5: the checkbox **is** staging) - the
+    /// Changes row checkbox's click handler. `Self::render_change_row` stops propagation at the
+    /// call site so checking a box never also opens that file's diff.
+    pub(in crate::sidebar) fn toggle_staged(&mut self, path: PathBuf, cx: &mut Context<Self>) {
+        if !self.staged_files.remove(&path) {
+            self.staged_files.insert(path);
         }
         cx.notify();
+    }
+
+    /// The commit composer's primary action (Revision R12 §5) - a real `git add -- <staged
+    /// paths>` + `git commit` (`wt_core::undo::commit_paths`) on [`Self::diff_root`] (the
+    /// worktree the currently-shown diff/staged set belongs to), using
+    /// `changes::draft_commit_message`'s placeholder message (see that function's own docs for
+    /// why real agent-drafted messages are out of scope here). A genuine no-op - never a
+    /// clickable-looking op that silently does nothing - with nothing staged, or while another
+    /// worktree-history operation is already in flight (shares
+    /// [`Self::worktree_history_op_in_flight`] with `Keep all changes`/`Discard worktree`/`Undo`/
+    /// `Redo` - see `worktree_history::flow`'s own module docs for why one flag is enough
+    /// discipline here). On success, clears exactly the committed paths from
+    /// [`Self::staged_files`] (a file staged again after this call started is left alone) and
+    /// reloads the diff so the committed files drop out of the Changes list for real.
+    ///
+    /// No `Undo`/`Redo` integration yet, unlike the other four `worktree_history_op_in_flight`
+    /// operations - a real, stated gap (see `wt_core::undo::commit_paths`'s own docs), not a
+    /// fake "undo" that would only look like it worked.
+    pub(in crate::sidebar) fn commit_staged_files(&mut self, cx: &mut Context<Self>) {
+        if self.worktree_history_op_in_flight.is_some() {
+            return;
+        }
+        let Some(diff) = self.current_diff() else {
+            return;
+        };
+        let staged = changes::staged_subset(&diff.files, &self.staged_files);
+        if staged.is_empty() {
+            return;
+        }
+        let message = changes::draft_commit_message(&staged);
+        let paths: Vec<PathBuf> = staged.iter().map(|file| file.path.clone()).collect();
+        let worktree_path = self.diff_root.clone();
+        let branch_display = self.branch_display_for(&worktree_path);
+        let file_count = paths.len();
+
+        self.worktree_history_op_in_flight = Some(worktree_history::WorktreeHistoryOpKind::Commit);
+        self.worktree_history_status = Some(format!(
+            "committing {file_count} file{} in {branch_display}\u{2026}",
+            if file_count == 1 { "" } else { "s" }
+        ));
+        cx.notify();
+
+        let commit_paths = paths.clone();
+        let commit_worktree_path = worktree_path.clone();
+        let task = cx.spawn(async move |this, cx| {
+            let result = cx
+                .background_executor()
+                .spawn(async move {
+                    wt_core::undo::commit_paths(&commit_worktree_path, &commit_paths, &message)
+                })
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                this.worktree_history_op_in_flight = None;
+                match result {
+                    Ok(_outcome) => {
+                        this.worktree_history_status = Some(format!(
+                            "committed {file_count} file{} in {branch_display}",
+                            if file_count == 1 { "" } else { "s" }
+                        ));
+                        for path in &paths {
+                            this.staged_files.remove(path);
+                        }
+                        this.load_diff(worktree_path.clone(), cx);
+                    }
+                    Err(err) => {
+                        this.worktree_history_status = Some(format!("commit failed: {err}"));
+                    }
+                }
+                cx.notify();
+            });
+        });
+        self._worktree_history_task = Some(task);
     }
 
     /// The `A`/`M` change marks for every changed file in the currently loaded diff, keyed by
@@ -1165,6 +1238,7 @@ impl AdeApp {
                                 .min_h_0()
                                 .child(self.render_changes_rows(cx)),
                         )
+                        .child(self.render_commit_composer(diff, cx))
                         .child(render_changes_footer(self.ui_text_size(10.0)))
                 }
                 // This arm keeps its `.overflow_y_scroll()`: it renders a single message, never
@@ -1182,20 +1256,25 @@ impl AdeApp {
         }
     }
 
-    /// The Changes header: file count, a review-progress bar, and `N reviewed` count, both
-    /// computed directly from [`Self::reviewed_files`]'s membership against `diff`'s file
-    /// list rather than an independently tracked counter that could drift.
+    /// The Changes header: file count, a staged-progress bar, and `N staged` count, both
+    /// computed directly from [`Self::staged_files`]'s membership against `diff`'s file
+    /// list rather than an independently tracked counter that could drift. Distinct wording from
+    /// the commit composer's own `N of M staged` count just below it (Revision R12 §5/§4's "no
+    /// two counters in the window may share wording while counting different units") - this one
+    /// answers "how many of the worktree's changed files are staged", the composer's answers
+    /// "how many of those staged files is the next commit about to include" (today the same set,
+    /// but a distinct question).
     pub(in crate::sidebar) fn render_changes_header(
         &self,
         diff: &WorktreeDiff,
     ) -> impl IntoElement {
         let total = diff.files.len();
-        let reviewed = diff
+        let staged = diff
             .files
             .iter()
-            .filter(|file| self.reviewed_files.contains(&file.path))
+            .filter(|file| self.staged_files.contains(&file.path))
             .count();
-        let progress = changes::ReviewProgress { reviewed, total };
+        let progress = changes::StagedProgress { staged, total };
         let fraction = progress.fraction();
         const BAR_WIDTH: f32 = 56.0;
 
@@ -1240,7 +1319,7 @@ impl AdeApp {
                     .font(font(theme::font::MONO))
                     .text_size(self.ui_text_size(10.0))
                     .text_color(theme::text::DIM)
-                    .child(format!("{reviewed} reviewed")),
+                    .child(format!("{staged} staged")),
             )
     }
 
@@ -1354,11 +1433,13 @@ impl AdeApp {
         column.into_any_element()
     }
 
-    /// One Changes row: a review checkbox, `dir`/`name`, an optional tag pill, `+n`/`−n`, and
-    /// the five-segment stat bar. Clicking anywhere on the row other than the checkbox itself
-    /// (see [`Self::render_review_checkbox`]'s `stop_propagation`) opens the file's diff via
-    /// [`Self::open_change_diff`] - which, since GitHub issue #15, also reveals and highlights
-    /// that file in the Files tree, the same as every other way of opening a file in this app.
+    /// One Changes row: a staging checkbox, `dir`/`name`, a `flex:none` per-author chip group
+    /// (Revision R12 §5, multi-agent worktrees only - see [`Self::render_change_author_chips`]),
+    /// an optional tag pill, `+n`/`−n`, and the five-segment stat bar. Clicking anywhere on the
+    /// row other than the checkbox itself (see [`Self::render_staging_checkbox`]'s
+    /// `stop_propagation`) opens the file's diff via [`Self::open_change_diff`] - the checkbox
+    /// **is** staging, not "reviewed": it has its own click target, entirely separate from the
+    /// row body's.
     pub(in crate::sidebar) fn render_change_row(
         &self,
         file: &DiffFile,
@@ -1366,12 +1447,13 @@ impl AdeApp {
     ) -> impl IntoElement {
         let path = file.path.clone();
         let open_path = path.clone();
-        let reviewed = self.reviewed_files.contains(&file.path);
+        let staged = self.staged_files.contains(&file.path);
         let selected = self.open_change.as_deref() == Some(file.path.as_path());
         let (add, del) = changes::diff_file_stats(file);
         let (dir, name) = changes::split_dir_name(&file.path);
         let tag = changes::change_tag(file.status);
         let segments = changes::stat_bar_segments(add, del);
+        let author_chips = self.render_change_author_chips(&file.path);
 
         // See `Self::render_file_tree_row`'s own `debug_selector` for why this exists, and why
         // the closure borrows `file` instead of capturing an owned `String`.
@@ -1399,7 +1481,7 @@ impl AdeApp {
             .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
                 this.open_change_diff(open_path.clone(), window, cx);
             }))
-            .child(self.render_review_checkbox(path, reviewed, cx))
+            .child(self.render_staging_checkbox(path, staged, cx))
             .when(!dir.is_empty(), |el| {
                 el.child(
                     div()
@@ -1418,13 +1500,17 @@ impl AdeApp {
                     .font(font(theme::font::MONO))
                     .font_weight(gpui::FontWeight::MEDIUM)
                     .text_size(self.ui_text_size(11.5))
-                    .text_color(if reviewed {
-                        theme::text::DIMMER
-                    } else {
+                    // Staged rows read at full strength; unstaged drop to `theme::text::DIM` -
+                    // the exact inverse of the old "reviewed" dimming this replaces (Revision R12
+                    // §5), never both conventions at once.
+                    .text_color(if staged {
                         theme::text::STRONG
+                    } else {
+                        theme::text::DIM
                     })
                     .child(name),
             )
+            .when_some(author_chips, |el, chips| el.child(chips))
             .when_some(tag, |el, tag| el.child(render_tag_pill(tag)))
             // A rename-only file gets no `tag` from `changes::change_tag` (a plain rename
             // isn't `new`/`del`), so without this it looked identical to an unchanged file.
@@ -1451,17 +1537,80 @@ impl AdeApp {
             .child(render_stat_bar(segments))
     }
 
-    /// The Changes row's 12×12 review checkbox - toggled via [`Self::toggle_reviewed`]. Stops
-    /// propagation on click so checking a box never also opens the row's diff, mirroring
-    /// `Self::render_agent_tab`'s nested-clickable-child pattern (its tab-close `×`).
-    pub(in crate::sidebar) fn render_review_checkbox(
+    /// The Changes row's `flex:none` per-file author chip group (Revision R12 §5): one
+    /// [`render_change_author_chip`] per agent [`AdeApp::file_authorship`] records as having
+    /// written this file, with a 1px amber ring (`theme::status::ASK_CARD_EDGE`) once it has more
+    /// than one. `None` (never an empty-but-present group) unless the currently selected
+    /// worktree has more than one agent - [`Self::current_worktree_agent_count`] is this
+    /// gate, per the design's own reasoning: with a single agent every chip would be identical
+    /// and carry no information.
+    ///
+    /// `file_authorship` is real, wired data (`crate::sidebar::changes::Authorship::authors_for`)
+    /// that today is always empty - the heuristic that records edits into it lives on a separate,
+    /// not-yet-merged branch (see [`crate::root::AdeApp::file_authorship`]'s own docs) - so a
+    /// multi-agent worktree renders a real, ringless, chip-less group until that heuristic lands,
+    /// rather than fabricating a chip for an agent nobody recorded.
+    pub(in crate::sidebar) fn render_change_author_chips(
+        &self,
+        path: &Path,
+    ) -> Option<impl IntoElement> {
+        if self.current_worktree_agent_count() <= 1 {
+            return None;
+        }
+        let ring: gpui::Rgba = if self.file_authorship.has_multiple_authors(path) {
+            theme::status::ASK_CARD_EDGE.into()
+        } else {
+            work_surface::TRANSPARENT
+        };
+        let mut group = div()
+            .flex_none()
+            .flex()
+            .gap(px(2.0))
+            .p(px(1.0))
+            .rounded(theme::radius::BUTTON)
+            .border_1()
+            .border_color(ring);
+        for &id in self.file_authorship.authors_for(path) {
+            if let Some(kind) = self.agent_kind_for(id) {
+                group = group.child(render_change_author_chip(kind));
+            }
+        }
+        Some(group)
+    }
+
+    /// Resolves a recorded author's [`AgentKind`] for chip tinting - `None` if that agent has
+    /// since closed (its process exited, its tab closed), in which case
+    /// [`Self::render_change_author_chips`] simply omits the chip rather than guessing a kind for
+    /// an agent that no longer exists.
+    fn agent_kind_for(&self, id: AgentId) -> Option<AgentKind> {
+        self.agents
+            .iter()
+            .find(|agent| agent.id == id)
+            .map(|agent| agent.kind)
+    }
+
+    /// How many distinct agent (non-`Shell`) processes are running in the currently selected
+    /// worktree - Revision R12 §5's gate for the Changes row author chip group. Reuses
+    /// [`Self::current_worktree_agents`] (`crate::work_surface::render`) so this and the tab
+    /// strip can never disagree about which agents belong to the selected worktree.
+    pub(in crate::sidebar) fn current_worktree_agent_count(&self) -> usize {
+        self.current_worktree_agents()
+            .filter(|agent| agent.kind != AgentKind::Shell)
+            .count()
+    }
+
+    /// The Changes row's 12×12 staging checkbox (Revision R12 §5: the checkbox **is** staging,
+    /// not "reviewed") - toggled via [`Self::toggle_staged`]. Stops propagation on click so
+    /// checking a box never also opens the row's diff, mirroring `Self::render_agent_tab`'s
+    /// nested-clickable-child pattern (its tab-close `×`).
+    pub(in crate::sidebar) fn render_staging_checkbox(
         &self,
         path: PathBuf,
         checked: bool,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
         div()
-            .id(format!("review-checkbox-{}", path.display()))
+            .id(format!("stage-checkbox-{}", path.display()))
             .flex_none()
             .w(px(12.0))
             .h(px(12.0))
@@ -1476,15 +1625,41 @@ impl AdeApp {
                     .border_color(theme::toggle::TRACK_ON)
             })
             .when(!checked, |el| el.border_color(theme::border::BUTTON))
+            .hover(|el| el.border_color(theme::toggle::CHECKBOX_HOVER))
             .font(font(theme::font::MONO))
             .text_size(self.ui_text_size(9.0))
             .text_color(theme::button::GREEN_FG)
             .when(checked, |el| el.child("\u{2713}"))
             .on_click(cx.listener(move |this, _event: &ClickEvent, _window, cx| {
                 cx.stop_propagation();
-                this.toggle_reviewed(path.clone(), cx);
+                this.toggle_staged(path.clone(), cx);
             }))
     }
+}
+
+/// One author chip in a Changes row's chip group (Revision R12 §5) - the same 13×13 visual
+/// template `Self::render_lang_chip` uses for the file tree's language chip
+/// (`crate::sidebar::file_tree::LangChip`), tinted per-agent via
+/// `work_surface::agent_tint`/`work_surface::agent_initial` (`work_surface::state`'s existing
+/// per-agent colour convention, already the tab strip's own source of truth) rather than a
+/// second, independently-tinted chip style.
+pub(in crate::sidebar) fn render_change_author_chip(kind: AgentKind) -> impl IntoElement {
+    let (fg, bg) = work_surface::agent_tint(kind);
+    let initial = work_surface::agent_initial(kind);
+    div()
+        .flex_none()
+        .w(px(13.0))
+        .h(px(13.0))
+        .rounded(theme::radius::CHIP)
+        .bg(bg)
+        .flex()
+        .items_center()
+        .justify_center()
+        .font(font(theme::font::MONO))
+        .font_weight(gpui::FontWeight::MEDIUM)
+        .text_size(px(7.5))
+        .text_color(fg)
+        .child(initial)
 }
 
 /// Which data source the right sidebar currently shows for the selected worktree - Zone 3's

--- a/crates/app/src/sidebar/tree_ops.rs
+++ b/crates/app/src/sidebar/tree_ops.rs
@@ -975,7 +975,7 @@ impl AdeApp {
     ///
     /// Structurally the *mirror* of [`Self::rename_open_paths`], and reviewed as one: every field
     /// that method remaps, this one drops. An earlier version handled only tabs, buffers and the
-    /// selection, which left a deleted file's `reviewed_files` entry, its
+    /// selection, which left a deleted file's `staged_files` entry, its
     /// `file_external_conflict` flag, its `file_save_error`, and - worst - its
     /// `lsp_opened_files`/`lsp_document_versions` entries behind. That last one is not cosmetic:
     /// `crate::lsp::client`'s `didOpen` dispatch early-returns for a path already in
@@ -1018,7 +1018,7 @@ impl AdeApp {
         }
 
         // The same field list `Self::rename_open_paths` remaps - see this method's own docs.
-        self.reviewed_files.retain(|path| !under_relative(path));
+        self.staged_files.retain(|path| !under_relative(path));
         self.file_external_conflict
             .retain(|path| !under_relative(path));
         self.file_save_pending.retain(|path| !under_relative(path));
@@ -1200,11 +1200,11 @@ impl AdeApp {
     /// "open tabs / the diff view follow the renamed path - no orphaned buffers").
     ///
     /// Handles a renamed *directory* too, by prefix: every open tab, edit buffer, expanded
-    /// folder and reviewed-file entry underneath it is remapped, not just an exact match.
+    /// folder and staged-file entry underneath it is remapped, not just an exact match.
     ///
     /// **Half of this app's path-keyed state is worktree-relative and half is absolute**, and
     /// getting one wrong is a silent no-op rather than a compile error (`strip_prefix` simply
-    /// fails and the entry is left alone) - see the `reviewed_files` line below for the real bug
+    /// fails and the entry is left alone) - see the `staged_files` line below for the real bug
     /// that produced. Each field is remapped with the pair matching its own documented key space.
     /// [`Self::forget_deleted_paths`] is this method's mirror and must move field-for-field with
     /// it.
@@ -1259,12 +1259,12 @@ impl AdeApp {
             .collect();
 
         // Worktree-*relative*, like `edit_buffers` above and unlike the absolute-keyed sets
-        // further down: `reviewed_files` is keyed by `wt_core::diff::DiffFile::path`
-        // (`Self::toggle_reviewed`'s own argument, straight off a Changes row). An earlier
+        // further down: `staged_files` is keyed by `wt_core::diff::DiffFile::path`
+        // (`Self::toggle_staged`'s own argument, straight off a Changes row). An earlier
         // version passed the absolute pair here, which made this a guaranteed silent no-op -
-        // `strip_prefix` simply failed for every entry - so a file's reviewed checkbox quietly
+        // `strip_prefix` simply failed for every entry - so a file's staged checkbox quietly
         // reset on every rename. Found in review; the regression test below drives it.
-        remap_path_set(&mut self.reviewed_files, &old_relative, &new_relative);
+        remap_path_set(&mut self.staged_files, &old_relative, &new_relative);
         remap_path_set(
             &mut self.file_external_conflict,
             &old_relative,
@@ -2445,19 +2445,19 @@ mod tree_ops_regression_tests {
         use super::*;
         use crate::sidebar::render::RightSidebarView;
 
-        /// `reviewed_files` is keyed by `wt_core::diff::DiffFile::path` - worktree-*relative* -
+        /// `staged_files` is keyed by `wt_core::diff::DiffFile::path` - worktree-*relative* -
         /// while the paths a rename works in are absolute. Remapping it with the absolute pair
         /// was a guaranteed silent no-op (`strip_prefix` failed for every entry), so a file's
-        /// reviewed checkbox quietly reset on every rename and every cut+paste.
+        /// staged checkbox quietly reset on every rename and every cut+paste.
         #[gpui::test]
-        fn a_rename_carries_the_files_reviewed_checkbox_with_it(cx: &mut TestAppContext) {
+        fn a_rename_carries_the_files_staged_checkbox_with_it(cx: &mut TestAppContext) {
             let repo = TempDir::new().expect("tempdir");
             seed(&repo);
             let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
             cx.run_until_parked();
 
             app.update(cx, |app, cx| {
-                app.toggle_reviewed(PathBuf::from("src/main.rs"), cx);
+                app.toggle_staged(PathBuf::from("src/main.rs"), cx);
             });
             app.update_in(cx, |app, window, cx| {
                 app.start_tree_rename(repo.path().join("src/main.rs"), false, window, cx);
@@ -2469,11 +2469,11 @@ mod tree_ops_regression_tests {
 
             app.read_with(cx, |app, _| {
                 assert!(
-                    app.reviewed_files.contains(Path::new("src/renamed.rs")),
-                    "the reviewed mark must follow the rename - got {:?}",
-                    app.reviewed_files
+                    app.staged_files.contains(Path::new("src/renamed.rs")),
+                    "the staged mark must follow the rename - got {:?}",
+                    app.staged_files
                 );
-                assert!(!app.reviewed_files.contains(Path::new("src/main.rs")));
+                assert!(!app.staged_files.contains(Path::new("src/main.rs")));
             });
         }
 

--- a/crates/app/src/theme.rs
+++ b/crates/app/src/theme.rs
@@ -880,6 +880,10 @@ pub mod toggle {
     pub const TRACK_OFF: ColorToken = hex(0x23272b);
     pub const KNOB_ON: ColorToken = hex(0xc8ecd6);
     pub const KNOB_OFF: ColorToken = hex(0x6b7178);
+    /// The Changes row staging checkbox's hover border (Revision R12 §5) - not in
+    /// `tokens.rs`'s transcribed set (that checkbox previously had no hover treatment at all),
+    /// added here directly.
+    pub const CHECKBOX_HOVER: ColorToken = hex(0x3f7a55);
 }
 
 pub mod tag {
@@ -1051,6 +1055,11 @@ pub mod shadow {
     /// The `+` menu popover's own shadow - distinct from [`PALETTE`]'s `0 12 34`.
     pub const PLUS_MENU: (Pixels, Pixels, Pixels) = (px(0.0), px(14.0), px(30.0));
     // rgba(0,0,0,0.55)
+    /// The commit composer's `▾` split-button popover shadow (Revision R12 §5) - a negative `y`
+    /// since, unlike every other popover in this module, it opens *upward* from a button near the
+    /// bottom of the Changes panel.
+    pub const COMMIT_MENU: (Pixels, Pixels, Pixels) = (px(0.0), px(-10.0), px(26.0));
+    // rgba(0,0,0,0.5)
 }
 
 /// Honestly-scoped application of `Settings.appearance.interface_scale_percent` - text-size

--- a/crates/app/src/work_surface/state.rs
+++ b/crates/app/src/work_surface/state.rs
@@ -233,6 +233,42 @@ pub fn pty_state_label(is_running: bool, status: Status, exit_code: Option<u32>)
     }
 }
 
+/// A bare worktree's shell tab label (Revision R12 §3): the real resolved shell binary name
+/// (`program`, from `TerminalPane::program_label` - never a hardcoded `"zsh"`, even though
+/// that's the design mockup's literal example) joined with the worktree's branch, e.g.
+/// `zsh \u{b7} feature/x`. Falls back to the bare program name for a detached worktree with no
+/// branch, rather than inventing one.
+pub fn bare_worktree_shell_label(program: &str, branch: Option<&str>) -> String {
+    match branch {
+        Some(branch) => format!("{program} \u{b7} {branch}"),
+        None => program.to_string(),
+    }
+}
+
+/// Appends a ` #N` ordinal (1-based, in order of appearance) to every label that repeats within
+/// `labels`, so two agents on the same model in one worktree never render two identical tab
+/// labels (`claude`, `claude` -> `claude #1`, `claude #2` - Revision R12 §3). A label that
+/// appears only once is returned unchanged - a lone `claude` tab never grows a spurious `#1`.
+pub fn disambiguate_tab_labels(labels: Vec<String>) -> Vec<String> {
+    let mut counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    for label in &labels {
+        *counts.entry(label.clone()).or_insert(0) += 1;
+    }
+    let mut seen: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    labels
+        .into_iter()
+        .map(|label| {
+            if counts.get(&label).copied().unwrap_or(0) > 1 {
+                let ordinal = seen.entry(label.clone()).or_insert(0);
+                *ordinal += 1;
+                format!("{label} #{ordinal}")
+            } else {
+                label
+            }
+        })
+        .collect()
+}
+
 /// A footer action button's colour treatment, backed by `theme::button::*`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ActionStyle {
@@ -623,6 +659,49 @@ mod tests {
                 "{status:?} produced no footer actions at all"
             );
         }
+    }
+
+    #[test]
+    fn a_lone_tab_label_is_never_given_a_spurious_ordinal() {
+        let labels = disambiguate_tab_labels(vec!["claude".to_string(), "codex".to_string()]);
+        assert_eq!(labels, vec!["claude", "codex"]);
+    }
+
+    #[test]
+    fn two_agents_on_the_same_model_get_ordinal_suffixes_never_an_identical_label() {
+        let labels = disambiguate_tab_labels(vec![
+            "sonnet-4.5".to_string(),
+            "sonnet-4.5".to_string(),
+            "codex".to_string(),
+        ]);
+        assert_eq!(labels, vec!["sonnet-4.5 #1", "sonnet-4.5 #2", "codex"]);
+        assert_ne!(
+            labels[0], labels[1],
+            "two tabs must never share an identical label"
+        );
+    }
+
+    #[test]
+    fn three_agents_on_the_same_model_all_get_distinct_ordinals_in_appearance_order() {
+        let labels = disambiguate_tab_labels(vec![
+            "claude".to_string(),
+            "claude".to_string(),
+            "claude".to_string(),
+        ]);
+        assert_eq!(labels, vec!["claude #1", "claude #2", "claude #3"]);
+    }
+
+    #[test]
+    fn a_bare_worktrees_shell_label_joins_the_real_program_name_with_its_branch() {
+        assert_eq!(
+            bare_worktree_shell_label("zsh", Some("feature/x")),
+            "zsh \u{b7} feature/x"
+        );
+    }
+
+    #[test]
+    fn a_bare_worktrees_shell_label_falls_back_to_the_program_name_when_detached() {
+        assert_eq!(bare_worktree_shell_label("bash", None), "bash");
     }
 
     #[test]

--- a/crates/app/src/work_surface/state.rs
+++ b/crates/app/src/work_surface/state.rs
@@ -233,42 +233,6 @@ pub fn pty_state_label(is_running: bool, status: Status, exit_code: Option<u32>)
     }
 }
 
-/// A bare worktree's shell tab label (Revision R12 §3): the real resolved shell binary name
-/// (`program`, from `TerminalPane::program_label` - never a hardcoded `"zsh"`, even though
-/// that's the design mockup's literal example) joined with the worktree's branch, e.g.
-/// `zsh \u{b7} feature/x`. Falls back to the bare program name for a detached worktree with no
-/// branch, rather than inventing one.
-pub fn bare_worktree_shell_label(program: &str, branch: Option<&str>) -> String {
-    match branch {
-        Some(branch) => format!("{program} \u{b7} {branch}"),
-        None => program.to_string(),
-    }
-}
-
-/// Appends a ` #N` ordinal (1-based, in order of appearance) to every label that repeats within
-/// `labels`, so two agents on the same model in one worktree never render two identical tab
-/// labels (`claude`, `claude` -> `claude #1`, `claude #2` - Revision R12 §3). A label that
-/// appears only once is returned unchanged - a lone `claude` tab never grows a spurious `#1`.
-pub fn disambiguate_tab_labels(labels: Vec<String>) -> Vec<String> {
-    let mut counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
-    for label in &labels {
-        *counts.entry(label.clone()).or_insert(0) += 1;
-    }
-    let mut seen: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
-    labels
-        .into_iter()
-        .map(|label| {
-            if counts.get(&label).copied().unwrap_or(0) > 1 {
-                let ordinal = seen.entry(label.clone()).or_insert(0);
-                *ordinal += 1;
-                format!("{label} #{ordinal}")
-            } else {
-                label
-            }
-        })
-        .collect()
-}
-
 /// A footer action button's colour treatment, backed by `theme::button::*`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ActionStyle {
@@ -659,49 +623,6 @@ mod tests {
                 "{status:?} produced no footer actions at all"
             );
         }
-    }
-
-    #[test]
-    fn a_lone_tab_label_is_never_given_a_spurious_ordinal() {
-        let labels = disambiguate_tab_labels(vec!["claude".to_string(), "codex".to_string()]);
-        assert_eq!(labels, vec!["claude", "codex"]);
-    }
-
-    #[test]
-    fn two_agents_on_the_same_model_get_ordinal_suffixes_never_an_identical_label() {
-        let labels = disambiguate_tab_labels(vec![
-            "sonnet-4.5".to_string(),
-            "sonnet-4.5".to_string(),
-            "codex".to_string(),
-        ]);
-        assert_eq!(labels, vec!["sonnet-4.5 #1", "sonnet-4.5 #2", "codex"]);
-        assert_ne!(
-            labels[0], labels[1],
-            "two tabs must never share an identical label"
-        );
-    }
-
-    #[test]
-    fn three_agents_on_the_same_model_all_get_distinct_ordinals_in_appearance_order() {
-        let labels = disambiguate_tab_labels(vec![
-            "claude".to_string(),
-            "claude".to_string(),
-            "claude".to_string(),
-        ]);
-        assert_eq!(labels, vec!["claude #1", "claude #2", "claude #3"]);
-    }
-
-    #[test]
-    fn a_bare_worktrees_shell_label_joins_the_real_program_name_with_its_branch() {
-        assert_eq!(
-            bare_worktree_shell_label("zsh", Some("feature/x")),
-            "zsh \u{b7} feature/x"
-        );
-    }
-
-    #[test]
-    fn a_bare_worktrees_shell_label_falls_back_to_the_program_name_when_detached() {
-        assert_eq!(bare_worktree_shell_label("bash", None), "bash");
     }
 
     #[test]

--- a/crates/app/src/worktree_history/flow.rs
+++ b/crates/app/src/worktree_history/flow.rs
@@ -1,31 +1,56 @@
 //! Real backing for the work surface footer's `Keep all`/`Discard worktree` buttons
-//! ([`work_surface::ActionKind::KeepAllChanges`]/[`work_surface::ActionKind::DiscardWorktree`]).
+//! ([`work_surface::ActionKind::KeepAllChanges`]/[`work_surface::ActionKind::DiscardWorktree`])
+//! and, since Revision R12 §5, the Changes panel commit composer's "commit staged files"
+//! (`crate::sidebar::render::AdeApp::commit_staged_files`).
 //!
-//! ## One in-flight flag for both operations
+//! ## One in-flight flag for all three operations
 //!
-//! [`AdeApp::worktree_history_op_in_flight`] serializes "keep all changes" and "discard
-//! worktree": a click for either while the flag is `true` is a no-op, mirroring
-//! [`AdeApp::prune_in_flight`]'s own single-flag-per-feature precedent (`crate::rail::render`).
-//! Every completion handler still only mutates [`AdeApp`] state from inside
-//! `this.update`/`this.update_in`, after its real `wt_core::undo::*` call has actually resolved,
-//! matching every other real git-backed action in this app.
+//! [`AdeApp::worktree_history_op_in_flight`] serializes "keep all changes", "discard worktree",
+//! and "commit staged files": a click for any of the three while the flag is `true` is a no-op,
+//! mirroring [`AdeApp::prune_in_flight`]'s own single-flag-per-feature precedent
+//! (`crate::rail::render`). Every completion handler still only mutates [`AdeApp`] state from
+//! inside `this.update`/`this.update_in`, after its real `wt_core::undo::*` call has actually
+//! resolved, matching every other real git-backed action in this app.
+//!
+//! `commit_staged_files` is real (`wt_core::undo::commit_paths`: a real `git add -- <paths>` +
+//! `git commit`), and, like `Keep`/`Discard`, has no undo integration - this project's
+//! worktree-level undo/redo action was removed outright (GitHub issue #47), not merely left
+//! unwired here.
 
 use super::*;
 
-/// Which of the two real, mutually-exclusive-in-flight operations
+/// Which of the three real, mutually-exclusive-in-flight operations
 /// [`AdeApp::worktree_history_op_in_flight`] currently names - see that field's own docs for why
 /// this is a real, named kind rather than a bare `bool`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum WorktreeHistoryOpKind {
     Keep,
     Discard,
+    /// The Changes panel commit composer's "commit staged files" (Revision R12 §5) -
+    /// `crate::sidebar::render::AdeApp::commit_staged_files`.
+    Commit,
+}
+
+/// Whether `a` and `b` refer to the same real path, canonicalizing both sides first - mirrors
+/// `wt_core::undo::is_main_worktree`'s own canonicalization (see its docs) so a relative,
+/// symlinked, or otherwise differently-spelled path still matches correctly rather than silently
+/// failing closed. Falls back to a raw comparison if either side can't be canonicalized (e.g. it
+/// no longer exists) - the same fallback `is_main_worktree` itself uses.
+fn canonical_paths_match(a: &Path, b: &Path) -> bool {
+    let a_canon = std::fs::canonicalize(a).unwrap_or_else(|_| a.to_path_buf());
+    let b_canon = std::fs::canonicalize(b).unwrap_or_else(|_| b.to_path_buf());
+    a_canon == b_canon
 }
 
 impl AdeApp {
-    /// Looks up worktree `path`'s branch name for display (status-line text) - falls back to the
-    /// path itself if the worktree list doesn't (yet, or any more) have an entry for it.
-    /// Display-only: never consulted by a real `wt_core::undo::*` call.
-    fn branch_display_for(&self, path: &Path) -> String {
+    /// Looks up worktree `path`'s branch name for display (History/status-line text) - falls
+    /// back to the path itself if the worktree list doesn't (yet, or any more) have an entry for
+    /// it. Display-only: never consulted by a real `wt_core::undo::*` call.
+    ///
+    /// `pub(crate)`, not private: `crate::sidebar::render::AdeApp::commit_staged_files` (Revision
+    /// R12 §5's commit composer) reuses this same lookup for its own status-line text rather than
+    /// duplicating it.
+    pub(crate) fn branch_display_for(&self, path: &Path) -> String {
         self.worktrees
             .iter()
             .find(|item| item.path == path)

--- a/crates/app/src/worktree_history/flow.rs
+++ b/crates/app/src/worktree_history/flow.rs
@@ -31,17 +31,6 @@ pub(crate) enum WorktreeHistoryOpKind {
     Commit,
 }
 
-/// Whether `a` and `b` refer to the same real path, canonicalizing both sides first - mirrors
-/// `wt_core::undo::is_main_worktree`'s own canonicalization (see its docs) so a relative,
-/// symlinked, or otherwise differently-spelled path still matches correctly rather than silently
-/// failing closed. Falls back to a raw comparison if either side can't be canonicalized (e.g. it
-/// no longer exists) - the same fallback `is_main_worktree` itself uses.
-fn canonical_paths_match(a: &Path, b: &Path) -> bool {
-    let a_canon = std::fs::canonicalize(a).unwrap_or_else(|_| a.to_path_buf());
-    let b_canon = std::fs::canonicalize(b).unwrap_or_else(|_| b.to_path_buf());
-    a_canon == b_canon
-}
-
 impl AdeApp {
     /// Looks up worktree `path`'s branch name for display (History/status-line text) - falls
     /// back to the path itself if the worktree list doesn't (yet, or any more) have an entry for

--- a/crates/wt-core/src/lib.rs
+++ b/crates/wt-core/src/lib.rs
@@ -23,6 +23,7 @@ pub mod blame;
 pub mod diff;
 mod error;
 pub mod merge;
+pub mod stage;
 pub mod undo;
 
 pub use error::{Error, GitExit};

--- a/crates/wt-core/src/stage.rs
+++ b/crates/wt-core/src/stage.rs
@@ -1,0 +1,231 @@
+//! Real git-index staging primitives for the Changes panel's staging checkbox
+//! (`design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §5: "The checkbox **is**
+//! staging"). Before this module existed, `app::sidebar::render::AdeApp::toggle_staged` only
+//! flipped an in-memory `HashSet<PathBuf>` - real git never saw anything until the commit
+//! composer's own `git add` ran at commit time (`crate::undo::commit_paths`). That contradicted
+//! the design's explicit framing: checking the box is supposed to be real, immediate staging,
+//! not a UI-only intent recorded for later.
+//!
+//! [`stage_path`]/[`unstage_path`] are the real, immediate mutations `toggle_staged` now calls
+//! on every click. [`staged_paths`] is the read side: a real `git diff --cached --name-only`
+//! query, used both to re-derive `AdeApp::staged_files` when a worktree is first loaded or
+//! switched to (so a file already staged in the real index before Jerry ever touched it reads as
+//! staged, rather than starting every worktree at an empty, UI-only set) and by this module's own
+//! tests to verify the real index changed.
+//!
+//! Performs blocking I/O everywhere in this module (shells out to `git`); see the crate-level
+//! docs on offloading this to a background thread.
+
+use std::collections::HashSet;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+use crate::error::Error;
+use crate::{check_success, run_git};
+
+/// Real, immediate `git add -- <path>` - stages `path` (relative to `worktree_path`, or
+/// absolute so long as it resolves inside it) in the real git index. Works identically for a
+/// modified tracked file, a new untracked file, or a deleted tracked file (`git add` stages a
+/// deletion too, the same way `wt_core::undo::commit_paths`'s own `git add -- <paths>` already
+/// relies on for its "stage exactly these paths, including deletions" behavior).
+///
+/// Performs blocking I/O.
+pub fn stage_path(worktree_path: &Path, path: &Path) -> Result<(), Error> {
+    let args: Vec<OsString> = vec!["add".into(), "--".into(), path.as_os_str().to_owned()];
+    let output = run_git(worktree_path, &args)?;
+    check_success(&args, &output)
+}
+
+/// Real, immediate unstage: `git reset -- <path>` removes `path` from the real git index
+/// without touching the working tree - the exact inverse of [`stage_path`]. A no-op (real,
+/// successful exit) if `path` was already unstaged, matching `git reset`'s own idempotent
+/// behavior, so a caller never needs to check [`staged_paths`] first just to avoid an error.
+///
+/// Performs blocking I/O.
+pub fn unstage_path(worktree_path: &Path, path: &Path) -> Result<(), Error> {
+    let args: Vec<OsString> = vec!["reset".into(), "--".into(), path.as_os_str().to_owned()];
+    let output = run_git(worktree_path, &args)?;
+    check_success(&args, &output)
+}
+
+/// The real, current set of staged paths in `worktree_path`'s git index (`git diff --cached
+/// --name-only`), worktree-relative. The live source of truth [`app::root::AdeApp::staged_files`]
+/// re-derives from on every worktree load/switch, rather than starting empty and silently
+/// disagreeing with a file already staged in the real index before Jerry ever opened this
+/// worktree.
+///
+/// Performs blocking I/O.
+pub fn staged_paths(worktree_path: &Path) -> Result<HashSet<PathBuf>, Error> {
+    let args: Vec<OsString> = vec!["diff".into(), "--cached".into(), "--name-only".into()];
+    let output = run_git(worktree_path, &args)?;
+    check_success(&args, &output)?;
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|line| !line.is_empty())
+        .map(PathBuf::from)
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::process::Command;
+    use tempfile::TempDir;
+
+    fn git(dir: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .output()
+            .expect("failed to spawn git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
+            args,
+            dir,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git_output(dir: &Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .output()
+            .expect("failed to spawn git");
+        assert!(output.status.success(), "git {args:?} failed in {dir:?}");
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    fn init_repo() -> TempDir {
+        let dir = TempDir::new().expect("tempdir");
+        git(dir.path(), &["init", "-b", "main"]);
+        git(dir.path(), &["config", "user.email", "test@example.com"]);
+        git(dir.path(), &["config", "user.name", "Test User"]);
+        fs::write(dir.path().join("file.txt"), "hello\n").expect("write file");
+        git(dir.path(), &["add", "file.txt"]);
+        git(dir.path(), &["commit", "-m", "initial commit"]);
+        dir
+    }
+
+    #[test]
+    fn stage_path_really_adds_a_modified_file_to_the_real_index() {
+        let repo = init_repo();
+        fs::write(repo.path().join("file.txt"), "changed\n").expect("modify");
+
+        stage_path(repo.path(), Path::new("file.txt")).expect("stage_path");
+
+        let status = git_output(repo.path(), &["status", "--porcelain", "file.txt"]);
+        assert_eq!(
+            status, "M  file.txt",
+            "file.txt must be staged (M in the index column), not merely modified on disk"
+        );
+    }
+
+    #[test]
+    fn stage_path_really_adds_a_new_untracked_file() {
+        let repo = init_repo();
+        fs::write(repo.path().join("new.txt"), "new\n").expect("write new file");
+
+        stage_path(repo.path(), Path::new("new.txt")).expect("stage_path");
+
+        let status = git_output(repo.path(), &["status", "--porcelain", "new.txt"]);
+        assert_eq!(
+            status, "A  new.txt",
+            "a new file must be staged as an addition"
+        );
+    }
+
+    #[test]
+    fn unstage_path_really_removes_a_path_from_the_real_index_without_touching_the_working_tree() {
+        let repo = init_repo();
+        fs::write(repo.path().join("file.txt"), "changed\n").expect("modify");
+        git(repo.path(), &["add", "file.txt"]);
+        let staged_before = git_output(repo.path(), &["status", "--porcelain", "file.txt"]);
+        assert_eq!(staged_before, "M  file.txt");
+
+        unstage_path(repo.path(), Path::new("file.txt")).expect("unstage_path");
+
+        // `git_output` trims the whole string, so the leading `X` status char of a real
+        // `" M file.txt"` porcelain line (unstaged-only modification: `X` is a blank index
+        // column, `Y` is `M`) is trimmed away along with it - "M file.txt" (one space, not two)
+        // is the real, correctly-unstaged shape here, not a staged `"M  file.txt"` (two spaces).
+        let status = git_output(repo.path(), &["status", "--porcelain", "file.txt"]);
+        assert_eq!(
+            status, "M file.txt",
+            "file.txt must be unstaged (working-tree-only M) after a real unstage"
+        );
+        assert_eq!(
+            fs::read_to_string(repo.path().join("file.txt")).expect("read file.txt"),
+            "changed\n",
+            "unstaging must never touch the real working-tree content"
+        );
+    }
+
+    #[test]
+    fn unstage_path_is_a_harmless_no_op_when_already_unstaged() {
+        let repo = init_repo();
+        fs::write(repo.path().join("file.txt"), "changed\n").expect("modify");
+
+        unstage_path(repo.path(), Path::new("file.txt")).expect("unstage_path on a clean index");
+
+        let status = git_output(repo.path(), &["status", "--porcelain", "file.txt"]);
+        assert_eq!(status, "M file.txt");
+    }
+
+    #[test]
+    fn staged_paths_reflects_the_real_git_index_including_files_staged_by_something_else() {
+        let repo = init_repo();
+        fs::write(repo.path().join("file.txt"), "changed\n").expect("modify");
+        fs::write(repo.path().join("also.txt"), "also\n").expect("write");
+        // Staged directly via a real `git add`, standing in for something other than
+        // `stage_path` having touched the index first (an agent CLI, a manual `git add`) -
+        // `staged_paths` must see it regardless of who staged it.
+        git(repo.path(), &["add", "file.txt", "also.txt"]);
+
+        let staged = staged_paths(repo.path()).expect("staged_paths");
+
+        assert_eq!(
+            staged,
+            [PathBuf::from("file.txt"), PathBuf::from("also.txt")]
+                .into_iter()
+                .collect::<HashSet<_>>()
+        );
+    }
+
+    #[test]
+    fn staged_paths_is_empty_on_a_clean_index() {
+        let repo = init_repo();
+        assert!(staged_paths(repo.path()).expect("staged_paths").is_empty());
+    }
+
+    #[test]
+    fn staged_paths_never_includes_an_unstaged_modification() {
+        let repo = init_repo();
+        fs::write(repo.path().join("file.txt"), "changed but not staged\n").expect("modify");
+
+        let staged = staged_paths(repo.path()).expect("staged_paths");
+
+        assert!(
+            staged.is_empty(),
+            "a real, unstaged modification must never appear in staged_paths"
+        );
+    }
+
+    #[test]
+    fn stage_then_unstage_round_trips_back_to_a_clean_staged_set() {
+        let repo = init_repo();
+        fs::write(repo.path().join("file.txt"), "changed\n").expect("modify");
+
+        stage_path(repo.path(), Path::new("file.txt")).expect("stage_path");
+        assert_eq!(
+            staged_paths(repo.path()).expect("staged_paths"),
+            [PathBuf::from("file.txt")].into_iter().collect()
+        );
+
+        unstage_path(repo.path(), Path::new("file.txt")).expect("unstage_path");
+        assert!(staged_paths(repo.path()).expect("staged_paths").is_empty());
+    }
+}

--- a/crates/wt-core/src/undo.rs
+++ b/crates/wt-core/src/undo.rs
@@ -224,6 +224,53 @@ pub fn commit_all_changes(
     })
 }
 
+/// Stage exactly `paths` (`git add -- <paths>`, never `commit_all_changes`'s `-A`) and commit
+/// them with `message` - the Changes panel commit composer's real backing (Revision R12 §5:
+/// "Commit N files" commits only the staged subset, not the whole worktree diff).
+///
+/// Refuses with [`Error::NothingToCommit`] if `paths` is empty, the same "check first, structured
+/// error" convention [`commit_all_changes`] follows for a clean worktree - the composer's own
+/// primary button already disables itself with nothing staged (see
+/// `crate::sidebar::changes::commit_button_label`), so this is a defensive backstop, not the
+/// primary guard.
+///
+/// Returns the same [`CommitAllChangesOutcome`] shape [`commit_all_changes`] does, but this
+/// function has no `undo_commit_paths`/`redo_commit_paths` counterpart yet - a partial commit
+/// isn't wired into [`crate::undo::UndoableAction`] (a real, honest gap, not a fake "undo" that
+/// would only look like it worked).
+///
+/// Performs blocking I/O.
+pub fn commit_paths(
+    worktree_path: &Path,
+    paths: &[std::path::PathBuf],
+    message: &str,
+) -> Result<CommitAllChangesOutcome, Error> {
+    if paths.is_empty() {
+        return Err(Error::NothingToCommit {
+            path: worktree_path.to_path_buf(),
+        });
+    }
+
+    let mut add_args: Vec<OsString> = vec!["add".into(), "--".into()];
+    add_args.extend(paths.iter().map(|path| path.as_os_str().to_owned()));
+    let add_output = run_git(worktree_path, &add_args)?;
+    check_success(&add_args, &add_output)?;
+
+    let commit_args: Vec<OsString> = vec!["commit".into(), "-m".into(), message.into()];
+    let commit_output = run_git(worktree_path, &commit_args)?;
+    check_success(&commit_args, &commit_output)?;
+
+    let commit = rev_parse_head(worktree_path)?;
+    let parent = rev_parse_parent_of(worktree_path, &commit)?;
+    let branch = current_branch(worktree_path)?;
+
+    Ok(CommitAllChangesOutcome {
+        branch,
+        commit,
+        parent,
+    })
+}
+
 /// Undo a [`commit_all_changes`] call: real `git reset --soft <parent>`, returning the worktree
 /// to exactly the uncommitted state it was in right before that commit - see this module's own
 /// docs for why `reset --soft`, not `revert`.
@@ -672,6 +719,7 @@ fn apply_stash(worktree_path: &Path, stash: &str) -> Result<UndoDiscardOutcome, 
 mod tests {
     use super::*;
     use std::fs;
+    use std::path::PathBuf;
     use std::process::Command;
     use tempfile::TempDir;
 
@@ -772,6 +820,66 @@ mod tests {
         let repo = init_repo();
         let err = commit_all_changes(repo.path(), "nothing to do").unwrap_err();
         assert!(matches!(err, Error::NothingToCommit { .. }));
+    }
+
+    // --- commit_paths ----------------------------------------------------------------------
+
+    #[test]
+    fn commit_paths_commits_only_the_given_paths_leaving_other_changes_uncommitted() {
+        let repo = init_repo();
+        fs::write(repo.path().join("file.txt"), "changed\n").expect("modify");
+        fs::write(repo.path().join("untouched.txt"), "not staged\n").expect("new file");
+
+        let before_head = git_output(repo.path(), &["rev-parse", "HEAD"]);
+        let outcome = commit_paths(
+            repo.path(),
+            &[PathBuf::from("file.txt")],
+            "ade: commit staged files",
+        )
+        .expect("commit_paths");
+
+        assert_eq!(outcome.parent.as_deref(), Some(before_head.as_str()));
+        assert_eq!(
+            outcome.commit,
+            git_output(repo.path(), &["rev-parse", "HEAD"])
+        );
+        // The committed file is clean...
+        let status = git_output(repo.path(), &["status", "--porcelain", "file.txt"]);
+        assert_eq!(status, "", "file.txt must be committed, not left staged");
+        // ...but the other real change is genuinely untouched - still there, still uncommitted.
+        let untouched_status =
+            git_output(repo.path(), &["status", "--porcelain", "untouched.txt"]);
+        assert!(
+            untouched_status.contains("untouched.txt"),
+            "a path not passed to commit_paths must be left exactly as it was: {untouched_status:?}"
+        );
+        assert!(is_dirty(repo.path()).expect("is_dirty"));
+    }
+
+    #[test]
+    fn commit_paths_refuses_an_empty_path_list() {
+        let repo = init_repo();
+        fs::write(repo.path().join("file.txt"), "changed\n").expect("modify");
+        let err = commit_paths(repo.path(), &[], "nothing selected").unwrap_err();
+        assert!(matches!(err, Error::NothingToCommit { .. }));
+        assert!(
+            is_dirty(repo.path()).expect("is_dirty"),
+            "refusing must not touch the working tree at all"
+        );
+    }
+
+    #[test]
+    fn commit_paths_real_message_becomes_the_real_commit_message() {
+        let repo = init_repo();
+        fs::write(repo.path().join("file.txt"), "changed\n").expect("modify");
+        commit_paths(
+            repo.path(),
+            &[PathBuf::from("file.txt")],
+            "a distinctive real commit message",
+        )
+        .expect("commit_paths");
+        let subject = git_output(repo.path(), &["log", "-1", "--format=%s"]);
+        assert_eq!(subject, "a distinctive real commit message");
     }
 
     #[test]

--- a/crates/wt-core/src/undo.rs
+++ b/crates/wt-core/src/undo.rs
@@ -256,7 +256,15 @@ pub fn commit_paths(
     let add_output = run_git(worktree_path, &add_args)?;
     check_success(&add_args, &add_output)?;
 
-    let commit_args: Vec<OsString> = vec!["commit".into(), "-m".into(), message.into()];
+    // Pathspec-limited (`-- <paths>`), never a bare `git commit`: a bare `git commit` commits
+    // the *entire* index, not just what this call just `add`ed - anything else already staged
+    // (an agent CLI running its own `git add` in this same worktree, the same interleaving
+    // hazard `commit_all_changes`'s own doc above calls out) would silently ride along into a
+    // commit this function's own doc promises is limited to `paths`. Real regression:
+    // `commit_paths_never_commits_a_path_that_was_staged_by_something_else`.
+    let mut commit_args: Vec<OsString> =
+        vec!["commit".into(), "-m".into(), message.into(), "--".into()];
+    commit_args.extend(paths.iter().map(|path| path.as_os_str().to_owned()));
     let commit_output = run_git(worktree_path, &commit_args)?;
     check_success(&commit_args, &commit_output)?;
 
@@ -847,13 +855,55 @@ mod tests {
         let status = git_output(repo.path(), &["status", "--porcelain", "file.txt"]);
         assert_eq!(status, "", "file.txt must be committed, not left staged");
         // ...but the other real change is genuinely untouched - still there, still uncommitted.
-        let untouched_status =
-            git_output(repo.path(), &["status", "--porcelain", "untouched.txt"]);
+        let untouched_status = git_output(repo.path(), &["status", "--porcelain", "untouched.txt"]);
         assert!(
             untouched_status.contains("untouched.txt"),
             "a path not passed to commit_paths must be left exactly as it was: {untouched_status:?}"
         );
         assert!(is_dirty(repo.path()).expect("is_dirty"));
+    }
+
+    /// A real regression test for a real bug: a bare `git commit` (no pathspec) commits the
+    /// *entire* index, not just whatever this call's own `git add -- <paths>` just staged. The
+    /// previous `commit_paths_commits_only_the_given_paths_leaving_other_changes_uncommitted`
+    /// test above never actually exercised that failure mode - it only ever `write`s
+    /// `untouched.txt` to disk without `git add`ing it, so it was never in the index for a bare
+    /// `git commit` to sweep up in the first place. This test pre-stages the other file for
+    /// real (mirroring an agent CLI running its own `git add` in this same worktree, the exact
+    /// interleaving hazard `commit_all_changes`'s own doc calls out above), so it genuinely
+    /// fails against a bare `git commit` and genuinely passes only once the commit itself is
+    /// pathspec-limited (`-- <paths>`).
+    #[test]
+    fn commit_paths_never_commits_a_path_that_was_staged_by_something_else() {
+        let repo = init_repo();
+        fs::write(repo.path().join("file.txt"), "changed\n").expect("modify");
+        fs::write(repo.path().join("also-staged.txt"), "staged elsewhere\n")
+            .expect("write also-staged.txt");
+        // Simulates something else in this worktree (an agent CLI, a manual `git add`) already
+        // having staged a different file before the composer's own commit runs.
+        git(repo.path(), &["add", "also-staged.txt"]);
+
+        commit_paths(
+            repo.path(),
+            &[PathBuf::from("file.txt")],
+            "ade: commit only file.txt",
+        )
+        .expect("commit_paths");
+
+        let committed_files =
+            git_output(repo.path(), &["show", "--name-only", "--format=", "HEAD"]);
+        assert_eq!(
+            committed_files, "file.txt",
+            "only the requested path must land in the real commit, even though \
+             also-staged.txt was genuinely staged in the index at commit time"
+        );
+        let status = git_output(repo.path(), &["status", "--porcelain", "also-staged.txt"]);
+        assert_eq!(
+            status, "A  also-staged.txt",
+            "also-staged.txt must remain exactly as staged (still added, still uncommitted) - \
+             commit_paths must never silently commit it just because it happened to share an \
+             index with the real, requested commit"
+        );
     }
 
     #[test]

--- a/crates/wt-core/src/undo.rs
+++ b/crates/wt-core/src/undo.rs
@@ -234,6 +234,21 @@ pub fn commit_all_changes(
 /// `crate::sidebar::changes::commit_button_label`), so this is a defensive backstop, not the
 /// primary guard.
 ///
+/// **The leading `git add -- <paths>` is a deliberate, harmless idempotent safety net, not dead
+/// weight.** The Changes panel's staging checkbox (`crate::sidebar::render::AdeApp::
+/// toggle_staged`, backed by [`crate::stage::stage_path`]/[`crate::stage::unstage_path`]) now
+/// really stages/unstages `paths` in the real index the moment each box is clicked, so by the
+/// time the composer's primary button calls this function every path it passes is normally
+/// already staged - but "normally" isn't "always": a real per-path staging failure that got
+/// silently reverted client-side (see `toggle_staged`'s own docs on that failure mode), or a
+/// worktree-switch race where `AdeApp::staged_files` hasn't yet been re-derived from a fresh
+/// `git diff --cached` when the commit fires, can both leave the app's own idea of "staged"
+/// briefly out of sync with the real index. This function's contract is "stage exactly `paths`
+/// and commit them" regardless of what state the index happens to already be in when it's
+/// called, and re-running `git add` on a path that's already staged is a real no-op - so keeping
+/// it here is what makes that contract hold unconditionally rather than only when the click-time
+/// staging already succeeded.
+///
 /// Returns the same [`CommitAllChangesOutcome`] shape [`commit_all_changes`] does, but this
 /// function has no `undo_commit_paths`/`redo_commit_paths` counterpart yet - a partial commit
 /// isn't wired into [`crate::undo::UndoableAction`] (a real, honest gap, not a fake "undo" that


### PR DESCRIPTION
## Summary

Stacked on the rail-header-fix PR (replaces #60, closed only because GitHub wouldn't let a stacked PR's base be retargeted after this branch picked up several more layers underneath it — same branch, same content, just correctly re-based).

Part of the Revision R12 redesign (§5): a real commit composer for the Changes panel (header, staged diffstat, pre-drafted message, primary commit button, split-button menu with honestly-disabled non-primary rows) with real interaction tests — plus, added this round, **real git staging**: the checkbox now does immediate `git add`/`git reset` instead of only flipping an in-memory set, and a worktree's staged state is re-derived from the real git index on every load (so a file already staged in real git before Jerry ever opened it reads as staged, not "0 staged"). New `wt_core::stage` module (`stage_path`/`unstage_path`/`staged_paths`), optimistic UI with real revert-and-surface on failure.

Also includes three real bugs found and fixed while writing tests against the composer's own doc-comment claims: a scrim/popover missing `.occlude()` (click-through double-fire), `commit_paths` committing more than the promised N files via a bare `git commit`, and a dead `⌘⏎` keycap with no real binding.

## Testing

Independently re-verified (not just agent-reported):
- `cargo fmt --all -- --check` — clean
- `cargo build --workspace` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace --lib -- --test-threads=1` — 1130 + 44 + 14 + 119 = 1307 passed, 0 failed

Real git-index-verified tests throughout the new staging module and the checkbox wiring — `git status --porcelain` reads confirm actual index state, not just in-memory flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)