### PR TITLE
fix(app): tab-strip plus-menu items and bare-worktree tab suppression

### DIFF
--- a/BUILD-LOG.md
+++ b/BUILD-LOG.md
@@ -6983,3 +6983,110 @@ tiling test beside it still passes - the precise blind spot, now covered.
 `lsp::client::lsp_diagnostics_wiring_tests::rust_analyzer_tracks_a_real_live_unsaved_edit_for_both_diagnostics_and_completions`
 blow its wall-clock deadline under load; it passes 3/3 in isolation in ~3s and the clean rerun
 above passes it too - a real-rust-analyzer timing flake, not a regression.
+
+
+## GitHub issue #45 and a live report: carets glued to the end of placeholder text, and two real inputs never wired to the shared blink loop at all
+
+Two reports, investigated together since the live one's symptoms ("displays at the end of the
+placeholder", "a lot of inputs are missing carets") pointed straight at issue #45's own title
+("Input blink only on focused input or file"): whichever mechanism drives the caret was, in some
+sense, only really correct for a couple of surfaces.
+
+### Inventory: exactly six real, hand-rolled text inputs, not a sprawling pile
+
+`grep -rn "TextField::new()" crates/app/src/` found the app's *entire* real inventory of
+hand-rolled single-line inputs (the code editor and the merge-conflict editor use a completely
+different, already-correct, real-cursor-position-aware `EditBuffer` - out of scope, per the
+task, and untouched here):
+
+- `AdeApp::palette_query` (command palette search) - `crate::palette::render::render_palette_caret`
+- `AdeApp::filter_query` (rail agent/worktree filter) - `crate::rail::render`
+- `AdeApp::settings_keymap_filter` (Settings › Keybindings filter) - `crate::settings::render`
+- the file tree's inline rename/new-file/new-folder editor - `crate::sidebar::tree_ops`
+- `GraphTabState::branches_filter` (git graph tab's Branches panel filter) - `crate::graph_view::render`
+- `NewFileInputState::name` (the "New file" prompt) - `crate::root::new_file`
+
+Two of these (the palette, the tree's inline editor) were already correct. The other four had
+two independent, real bugs:
+
+**Bug 1 - caret glued to the end of the placeholder.** `crate::root::widgets::AdeApp::
+render_simple_input_caret` is the one shared helper `render_rail_filter_row` and
+`render_settings_keymap_filter_row` both used, and it was always rendered as the row's *last*
+child, regardless of whether the row's other child was the real typed text or the placeholder
+string. With an empty filter, that put a blinking bar visually appended after `"filter worktrees
+and agents"`/`"filter N bindings"` - exactly the live report's "displays at the end of the
+placeholder but should not". `crate::palette::render::render_palette_caret` had already solved
+this correctly (caret before the placeholder at the real cursor position, 0; after the real text
+once there's any) - `render_simple_input_caret` just never got the same treatment.
+
+**Bug 2 - two inputs' carets weren't wired into the shared blink loop, or rendered at all.**
+`AdeApp::wire_caret_blink` (called once, from `Self::new_with_settings`) is the one place that
+threads a caret-bearing `FocusHandle` into the shared `on_focus`/`on_blur` subscriptions that
+start/stop the blink loop. It listed six handles. `GraphTabState::branches_filter_focus_handle`
+(added later, when the git graph tab's Branches panel shipped) and `AdeApp::new_file_focus_handle`
+were never among them - and, compounding it, `render_graph_branches_filter_row` and
+`render_new_file_prompt` never called `render_simple_input_caret` (or anything else) at all, so
+these two fields had no caret element in the tree whatsoever. That's the live report's "a lot of
+inputs are missing carets" - not hyperbole, a literal, confirmed-by-reading-the-render-code gap
+in two real, reachable surfaces.
+
+### The fix
+
+- `render_simple_input_caret` now takes a `debug_selector` and each call site places it the same
+  way the palette already does: before the placeholder while the field is empty, after the real
+  text once there's any (`crates/app/src/root/widgets.rs`,
+  `crates/app/src/rail/render.rs:render_rail_filter_row`,
+  `crates/app/src/settings/render.rs:render_settings_keymap_filter_row`).
+- `render_graph_branches_filter_row` and `render_new_file_prompt` gained the same caret, in the
+  same shared helper, rather than a third hand-rolled implementation.
+- `Self::new_with_settings` (`crates/app/src/root/state.rs`) threads
+  `branches_filter_focus_handle` and `new_file_focus_handle` into `AdeApp::wire_caret_blink` too -
+  in a second call right after the constructor's own `Self { .. }` literal, since both handles
+  live *inside* `this` (one nested in `graph_state`) and don't exist yet at the point the first
+  six are wired.
+- `handle_branches_filter_key_down`/`handle_new_file_key_down` gained the same
+  `self.reset_caret_blink(cx)` call on every real keystroke every other hand-rolled field's own
+  key handler already had (issue #27's "solid mid-keystroke") - missing here is exactly why
+  neither field ever blinked at all before this, wiring or not.
+
+Left alone, deliberately: the Changes panel's commit-message box, which the live report's own
+phrasing plausibly meant - reading `render_commit_composer`, it's genuinely non-interactive
+today (no `track_focus`, no `on_key_down` - "no real agent-drafted message generation to redraft
+*from* yet" per its own doc comment), so there's no caret bug there because there's no real text
+input there yet. Six inputs, not "every hand-rolled field reimplements this slightly
+differently, several of them wrong" at some much larger scale - a small, closed set, matching the
+task's own "if this turns out to be a couple of real callers, fix it" case rather than its
+"stop and report" one.
+
+### Tests
+
+Four new position tests (one per fixed field) measure the caret's real painted x position via
+`VisualTestContext::debug_bounds`, mirroring `palette_caret_tests`' own established technique:
+before the placeholder when empty, at or after the real text once typed, and genuinely different
+between the two states. Reverting each fix (restoring the caret to its old fixed trailing
+position, or removing it outright for the two previously-caretless fields) fails the matching
+test with the real symptom - confirmed non-vacuous by hand for all four before restoring.
+
+The two wiring-specific tests (`blurring_the_branches_filter_stops_the_real_shared_blink_loop`,
+`blurring_the_new_file_prompt_stops_the_real_shared_blink_loop`) needed a real, subtle harness
+fact: GPUI's `on_focus`/`on_blur` listeners only fire while the window itself is considered
+"active" (`Window::window_active`, gated in `crates/gpui/src/window.rs`'s own focus-event code),
+and a fresh `gpui::test` window starts out *not* active - `window.activate_window()` (which a
+real, focused desktop window always effectively has already) is required before either listener
+ever fires at all. Without it, every attempt at a focus/blur-driven test passed or failed for the
+wrong reason (a same-field `reset_caret_blink` call on typing masks a missing `wire_caret_blink`
+subscription entirely) - the tests instead check that *blurring* a freshly-focused, freshly-typed
+field immediately pins the shared caret to dimmed (`AdeApp::stop_caret_blink`'s own synchronous
+effect), the one observable behaviour that only a genuine `on_blur` subscription produces and a
+keystroke's own `reset_caret_blink` cannot explain. Reverting the `wire_caret_blink` addition in
+`Self::new_with_settings` alone (leaving the render fix and the keystroke-time `reset_caret_blink`
+calls in place) fails both, confirming they test the wiring specifically, not the render fix.
+
+### Gates
+
+`cargo fmt --all -- --check`, `cargo build --workspace`, `cargo clippy --workspace --all-targets --
+-D warnings` all clean. `cargo test --workspace --lib -- --test-threads=1`: **1229 + 44 + 14 + 141
+= 1428 passed, 0 failed** (8 new tests). One run hit the documented
+`code_surface::diff_view::diff_render_tests::switching_the_open_diff_to_a_different_file_recomputes_the_highlight_cache`
+flake; passed 5/5 re-run in isolation and the full suite passed clean on a second full run -
+unrelated syntax-highlighting code, not a regression from this change.

--- a/BUILD-LOG.md
+++ b/BUILD-LOG.md
@@ -6799,3 +6799,94 @@ way: `doc_lazy_continuation` on a doc comment where a mid-sentence `- see ...` r
 unindented markdown list continuation - reworded, not suppressed). `cargo test --workspace --lib
 --test-threads=1`: **1212 + 44 + 14 + 139 = 1409 passed, 0 failed** across all four crates - no
 `code_surface::diff_view` flake this run.
+
+## Git graph: the boxy multi-row elbow rectangle
+
+Reported again as "the git graph's lane/elbow alignment is broken", with a screenshot showing long
+vertical lines running down for many rows and terminating in one flat, boxy horizontal bar, plus
+dots that appeared to have no line reaching them at all. The obvious suspicion - that one of the
+earlier elbow fixes had been lost in one of this branch's two rebases - turned out to be wrong.
+`git diff 0b059f0 HEAD -- crates/app/src/graph_view/render.rs` touches nothing in
+`elbow_geometry`, `CurveBox`, `StraightSegment` or `render_graph_lane_canvas`'s elbow loop, and
+every one of the twenty existing `elbow_geometry_tests` still passed. All the prior fixes are
+intact.
+
+### The real root cause
+
+Every one of those tests builds exactly **one** elbow. A row can hold many, and that is the case
+nobody had ever looked at.
+
+`elbow_geometry`'s `waist_y` is a function of the row height and the elbow kind and nothing else,
+so every `Converging` elbow in one row paints its horizontal stroke on the *same* pixel row, and
+their spans nest - the elbow arriving from lane 8 covers every column the elbow arriving from lane
+1 occupies, including the arc that turns lane 1's line onto the waist. `render_graph_lane_canvas`
+painted them in `row.elbows`' own order, and `wt_core::graph::layout_lanes` Step 2 emits
+`Converging` elbows by *ascending* lane. So the furthest lane was painted last, on top, and wiped
+out every nearer elbow outright.
+
+This repository's own history renders exactly that shape. Dumping `build_graph`'s real output for
+`/home/colin/spike/ade` (a scratch `examples/dump_graph.rs`, since removed) shows master's `HEAD`
+row as:
+
+```
+50 lane=0 Head segs=[0,1e,2e,3e,4e,5e,6e,7e,8e,9s] elbows=[1->0C,...,8->0C,0->9D]
+```
+
+Eight worktree branches share that commit as their parent, so eight lanes run straight down for
+sixteen rows and then all converge in one row. Rasterizing the real geometry to ASCII (a throwaway
+harness that replays `elbow_geometry`/`lane_segment_span`/the stub-skip logic into a character
+grid) made the failure unmistakable. Before:
+
+```
+30 |         0          111           222           333           444
+31 |         0   44444444444444444444444444444444444444444444444444
+32 |         0 444
+```
+
+One flat full-width bar in lane 4's colour, and lanes 1-3 simply stop dead. Long verticals plus a
+flat bar is precisely the "boxy rectangle" in the screenshot, and lanes whose arc got overpainted
+are precisely the "dots with no line reaching them". After:
+
+```
+30 |         0          111           222           333           444
+31 |         0   11111111222222222222223333333333333344444444444444
+32 |         0 111
+```
+
+Each lane visibly curves onto the waist in its own colour, the horizontal changes colour at every
+lane it crosses, and the innermost elbow owns the arc that lands on the dot - the shape a commit
+graph actually wants.
+
+### The change
+
+One new pure function, `elbow_paint_order`, and one call site. It pairs each elbow with its own
+index in `GraphRow::elbows` (so the `graph-row-N-elbow-K-...` debug selectors keep pointing at the
+layout's numbering, not at paint position) and sorts by *descending* horizontal lane span, stably.
+Longest first, shortest last. Nothing about the single-elbow geometry moved - it was never wrong.
+
+The `Diverging` mirror (an octopus merge opening several lanes off one dot) had the identical
+latent defect and is covered by the same ordering; the two kinds sit on opposite waists so they
+never contend with each other.
+
+### Tests
+
+- `every_elbow_in_a_crowded_row_keeps_its_own_lanes_arc_visible` - the real regression test, and
+  deliberately stated on painted pixels rather than on the sort. It replays a whole row's elbows
+  into a per-column owner map in `elbow_paint_order`'s order, using each elbow's real
+  `elbow_geometry` output, and asserts that every elbow's own far-lane column still belongs to
+  that elbow afterwards. Three rows: this repository's real eight-`Converging` `HEAD` row, a
+  four-way `Diverging` octopus merge, and a non-contiguous `[1, 3, 6]` set that includes an
+  adjacent-lane elbow whose two curve boxes overlap. Reverting the sort to the old order fails it
+  with `lane 1's own arc column was painted over by elbow Elbow { from_lane: 8, to_lane: 0, kind:
+  Converging }` - it is not passing by construction.
+- `the_paint_order_keeps_each_elbows_own_layout_index_for_its_debug_tag` - pins that reordering
+  the paint sequence does not renumber the debug selectors the existing
+  `graph_elbow_render_tests` look real paint bounds up by.
+
+### Gates
+
+`cargo fmt --all -- --check`, `cargo build --workspace` and
+`cargo clippy --workspace --all-targets -- -D warnings` all clean. `cargo test --workspace --lib
+--test-threads=1`: **1220 + 44 + 14 + 139 = 1417 passed, 0 failed** across all four crates - no
+`code_surface::diff_view` flake this run either.
+

--- a/BUILD-LOG.md
+++ b/BUILD-LOG.md
@@ -6931,3 +6931,55 @@ the user's own report showed, then re-verified clean once the fix was restored.
 `cargo clippy --workspace --all-targets -- -D warnings` - all clean.
 `cargo test --workspace --lib --test-threads=1`: **1220 + 44 + 14 + 140 = 1424 passed, 0 failed**
 across all four crates (1 new test).
+
+### Follow-up: the elbows were painted half a pixel off the row grid
+
+The fix above was real but it was not the whole report. Pressed again with "the lines and elbows
+do not align correctly vertically", the answer turned out to be a subpixel layout bug that every
+existing test was structurally blind to.
+
+`render_graph_row` is `.h(ROW).border_b_1()` on a `.flex().items_center()` row, and GPUI's taffy
+layout is **border-box**: `Style::to_taffy` (`vendor/zed/crates/gpui/src/taffy.rs`) maps `size` and
+`border` across and fills the rest with `..Default::default()`, never setting `box_sizing`, so
+taffy's own `BoxSizing::BorderBox` default applies. The row is therefore 26px on the outside but
+its *content* box is only 25px, while `render_graph_lane_canvas` is a full `ROW` = 26px. Under
+`.items_center()` that centres to `(25 - 26) / 2` = **-0.5px**. Measured on real painted bounds,
+every row:
+
+```
+row 0: row.y=129px | canvas.y=128.5px | delta=-0.5px
+row 1: row.y=155px | canvas.y=154.5px | delta=-0.5px
+```
+
+Every horizontal 1px stroke in the canvas - the elbow bridge's `h(px(1.0))` and both curve boxes'
+`border_t_1()`/`border_b_1()` - then sat on a half-pixel boundary and rendered smeared across two
+physical pixel rows at half intensity, while the vertical lane lines (x is untouched) stayed
+crisp. Crisp verticals against smeared horizontals is exactly what "elbows don't line up
+vertically" looks like, and it is very probably why four earlier rounds of 1px elbow-seam fixes
+each only half-worked: the geometry was computed on an integer grid, every test measured that same
+integer grid, and then the whole canvas was painted half a pixel off it.
+
+Fixed with `.self_start()` on the lane canvas. The row has no *top* border, so its content-box top
+is its border-box top; pinning there puts the canvas back on whole pixels and keeps consecutive
+canvases exactly `ROW` apart. The 1px it now overflows past the content box is the row's own
+separator border, which lane lines have to run through anyway for a line to read as continuous
+across rows.
+
+Why nothing caught it: `consecutive_lane_canvases_tile_exactly_so_the_row_clip_loses_no_line` only
+ever compares one lane canvas against *another* lane canvas. A constant offset shared by every row
+keeps both its invariants (each canvas is `ROW` tall, each sits `ROW` below the last) perfectly
+intact. It passes against the bug - verified by reverting the fix and re-running it.
+
+New test `every_lane_canvas_sits_on_whole_pixels_at_its_own_rows_top_edge` closes that gap by
+measuring the canvas against **its own row**: `canvas.origin.y == row.origin.y`, and
+`y == y.round()`. Reverting `.self_start()` fails it with `left: 128.5px / right: 129px` while the
+tiling test beside it still passes - the precise blind spot, now covered.
+
+### Gates (both changes)
+
+`cargo fmt --all -- --check`, `cargo build --workspace`, `cargo clippy --workspace --all-targets --
+-D warnings` all clean. `cargo test --workspace --lib -- --test-threads=1`: **1221 + 44 + 14 + 140
+= 1419 passed, 0 failed**. One run of the full serialized suite had
+`lsp::client::lsp_diagnostics_wiring_tests::rust_analyzer_tracks_a_real_live_unsaved_edit_for_both_diagnostics_and_completions`
+blow its wall-clock deadline under load; it passes 3/3 in isolation in ~3s and the clean rerun
+above passes it too - a real-rust-analyzer timing flake, not a regression.

--- a/BUILD-LOG.md
+++ b/BUILD-LOG.md
@@ -6890,3 +6890,44 @@ never contend with each other.
 --test-threads=1`: **1220 + 44 + 14 + 139 = 1417 passed, 0 failed** across all four crates - no
 `code_surface::diff_view` flake this run either.
 
+## The Changes panel could fail outright on a real, unremarkable git state: an unreadable index
+
+A user-reported error, shown raw in the Changes panel: `failed to compute diff: git add
+--intent-to-add -A -- . exited with status 128: ... fatal: unable to write new index file`, with
+`warning: adding embedded git repository: vendor/zed` printed just before it. The warning turned
+out to be a red herring - confirmed directly: a real repo with 18 real embedded/nested-`.git`
+directories (this project's own checkout, full of `.wt-*` worktree directories) still lets `git
+add -A -- .` succeed with exit 0, warnings and all. Embedded-repo warnings alone are advisory, not
+fatal.
+
+The real bug is in `wt_core::diff::prepare_shadow_index`, and it doesn't need an embedded repo to
+trigger: it builds a throwaway, `--intent-to-add`-augmented copy of the worktree's real index
+(so `git diff` picks up untracked files as additions) by copying the real index's bytes into a
+`tempfile::NamedTempFile`. Its own doc comment claimed that if the real index can't be read (a
+fresh worktree with no index written yet, or - the far more likely real-world trigger in this
+app specifically - an agent CLI's own concurrent `git add`/`git commit` rewriting the index at the
+exact moment this reads it), falling back to leaving the temp file empty "mirrors git's own
+missing index == empty index behavior." Verified directly with real git commands that this claim
+is false: `GIT_INDEX_FILE` pointed at a path that genuinely does not exist is treated as a fresh,
+empty index (`git add` succeeds); pointed at an *existing* empty (0-byte) file, it fails hard -
+`fatal: ... index file smaller than expected`, exit 128 - a completely different code path,
+because `NamedTempFile::new()` had already created a real, empty file on disk at that path before
+the fallback ever ran.
+
+Fixed by deleting the placeholder file (`std::fs::remove_file`) instead of leaving it empty
+whenever the real index can't be read, so the path `GIT_INDEX_FILE` names is genuinely missing,
+not merely empty - `git add` then creates a real index there from scratch, exactly as it would
+for a brand-new repository's very first `git add`.
+
+New regression test `a_missing_or_unreadable_real_index_does_not_fail_the_whole_diff`: deletes the
+real index (via the same `git rev-parse --git-path index` resolution `prepare_shadow_index` itself
+uses) after a real commit, then asserts `diff_against_base` still succeeds and still sees a real
+untracked file. Confirmed non-vacuous by temporarily reverting just the fix (restoring the old
+"leave it empty" fallback) and re-running this one test alone: it fails with the exact
+`GitCommand { ... exit: Code(128), stderr: "fatal: ... index file smaller than expected" }` shape
+the user's own report showed, then re-verified clean once the fix was restored.
+
+**Verification**: `cargo fmt --all -- --check`, `cargo build --workspace`,
+`cargo clippy --workspace --all-targets -- -D warnings` - all clean.
+`cargo test --workspace --lib --test-threads=1`: **1220 + 44 + 14 + 140 = 1424 passed, 0 failed**
+across all four crates (1 new test).

--- a/BUILD-LOG.md
+++ b/BUILD-LOG.md
@@ -6691,3 +6691,111 @@ describing a historical, deleted concept, not live code.
 `cargo clippy --workspace --all-targets -- -D warnings` - all clean.
 `cargo test --workspace --lib --test-threads=1`: **1198 + 44 + 14 + 139 = 1395 passed, 0 failed**
 across all four crates.
+
+## Closing the two real §3 gaps a coordinator audit found: the `+` menu's item list, and bare-worktree tab suppression
+
+### The bare-worktree header-bar swap was not, in fact, already on this branch
+
+The audit that kicked this step off reported the bare-worktree label/header-bar swap (`Start an
+agent` button, greyed `no agent` text) as already correct, verified in an earlier pass - only the
+"only the shell tab" suppression was supposedly missing. Checking the real current code before
+touching anything (per this project's own standing rule) found that claim didn't hold: neither
+`current_worktree_is_bare`, `bare_worktree_shell_label`, nor `render_start_agent_button` existed
+anywhere on this branch. `git log`/`git branch --contains` traced why - that whole feature landed
+in `78ea1eb` on the sibling `revision-r12-tabstrip` branch, and this branch (`issue-1-git-graph-a`
+and everything stacked on it) diverged from the shared git-staging commit *before* `78ea1eb`
+landed, so it never got it. The earlier audit was almost certainly run against the sibling branch's
+worktree, not this one's actual head.
+
+`78ea1eb`'s parent is exactly the git-staging commit this branch also descends from, so
+`git cherry-pick -n 78ea1eb` applied cleanly with a real (non-conflicting) auto-merge and the
+whole workspace still built and passed clippy afterward with zero changes needed. Committed that
+cherry-pick on its own before writing anything new, so the bare-worktree label swap, `Start an
+agent` button, and the (unrelated but same-commit) tab-label ordinal disambiguation all exist here
+for real before layering the tab-suppression fix on top of them.
+
+### Gap 1: the `+` menu's item list
+
+The menu already had a real `Git graph` row (added by the git-graph rebase, unrelated to this
+step) - but it sat last, after `Next changed file`, not third as §3 specifies. Moved it up.
+`New agent pane`'s label became `New agent`, and its secondary text - which read the *agent kind's
+model label* (`agent.kind.label()`, e.g. `"Claude"`) - now reads `runs in <branch>` with the real
+selected worktree's branch substituted in, via a new pure helper,
+`work_surface::new_agent_menu_secondary_text`, unit-tested directly (real branch, and the
+`(detached)` fallback for a worktree with no recorded branch) rather than left as an inline
+`format!` only exercisable through the full render path.
+
+`New file` came out. Before deleting it, checked whether it was the *only* way to create a file
+in this app - it is not: the file tree already carries a real, always-visible replacement
+(`crate::sidebar::render::render_file_tree_row`'s per-directory `+` and
+`render_right_sidebar_toggle`'s root-level `+`, both calling the same `Self::start_new_file` the
+menu row called), added independently of this menu row and present regardless of it. Confirmed
+this is a real second entry point, not a hypothetical one, by reading both call sites and their
+own doc comments. So removing the row drops no reachable functionality - no coordinator sign-off
+needed, this one had a real answer. Updated `root/new_file.rs`'s module doc and its
+`NewFileInputState::parent_dir` field doc, both of which described the now-gone menu row as one of
+the two entry points.
+
+### Gap 2: bare worktrees weren't suppressing their file tabs
+
+`current_worktree_is_bare` (from the cherry-pick above) already existed and was already correct;
+what wasn't wired up was `Self::combined_tab_order` actually consulting it. Re-read §3's own
+reasoning for why tab state is worktree-scoped at all (§1: "the open file tabs... the active tab"
+are worktree-scoped facts, and §3: "Each worktree remembers its own active tab and its own open
+files") before picking an implementation: the conservative, spec-consistent reading is
+render-only suppression, never destruction - a worktree going bare (its last real agent archived)
+must not silently forget which files were open, the same way switching worktrees never does.
+
+Implemented in `combined_tab_order` itself, not in the render layer: when every agent for the
+active worktree is a `Shell` (the same bareness test `current_worktree_is_bare` uses, computed
+locally here rather than by calling that method - it goes through `current_worktree_agents` which
+itself calls `combined_tab_order`, so calling it back from inside `combined_tab_order` would
+recurse), the file list handed to `work_surface::reconcile_tab_order` is an empty slice instead of
+the real `Self::open_files()`. `reconcile_tab_order` then drops every `TabRef::File` already in
+the stored order (its own `open_files.contains(path)` filter) and appends none back - but neither
+`Self::open_files_by_worktree` (the real per-worktree storage) nor `Self::tab_order` (the
+persisted drag order) is touched, so the moment a real agent spawns again and the worktree stops
+being bare, the very next `combined_tab_order` call reconciles against the real, untouched
+open-files list and the same file tabs reappear in their original position - nothing was reopened,
+nothing was lost, it just wasn't rendered while bare. Centralizing this in `combined_tab_order`
+rather than only in `render_tab_strip` means the tab-strip drag/drop, jump-keys, and
+`current_worktree_agents` machinery all agree with what's actually shown, for free.
+
+This did surface one real, pre-existing test whose premise no longer held:
+`dragging_a_file_tab_between_two_agent_tabs_interleaves_them` spawned two `Shell` agents (an
+arbitrary choice made before this branch had any bare-worktree concept at all) plus a file tab, to
+exercise drag-reorder interleaving - which is now a genuinely bare worktree by definition, so its
+own file tab got correctly suppressed and the test's first assertion failed. Fixed by changing the
+second spawned agent to a real `Claude` agent instead of a second `Shell` - the test's actual
+subject is cross-kind drag interleaving, which has nothing to do with bareness, and the dedicated
+bare-worktree test below covers that behavior directly instead.
+
+### Tests
+
+Four new ones, plus two pure-logic unit tests for the branch-substitution helper:
+
+- `the_plus_menus_five_rows_match_revision_r12_3_in_order_with_no_new_file_row` - opens the real
+  menu, reads each row's real painted bounds via a new `debug_selector` on
+  `render_dropdown_menu_row` (previously only `.id()`, which `cx.debug_bounds` doesn't read),
+  confirms the five rows sit top-to-bottom in §3's exact order, and confirms both `New file` and
+  the old `New agent pane` label are genuinely absent.
+- `a_real_click_on_the_plus_menus_git_graph_row_opens_the_graph_tab` - a real
+  `cx.simulate_click` against the row's own captured bounds (not a direct `open_git_graph` call),
+  confirming `graph_tab_open`/`graph_tab_active` both flip and the menu closes behind it.
+- `the_new_agent_rows_secondary_text_uses_the_real_selected_worktrees_branch` - seeds a worktree
+  with a real, distinctive branch name, confirms `current_worktree_branch()` resolves it, and
+  confirms the exact composition `render_plus_menu` performs never falls back to a model label.
+- `a_bare_worktrees_tab_strip_shows_only_its_shell_tab_and_preserves_file_tab_state` - spawns a
+  real `Shell` and a real `Claude` agent plus a file tab, confirms all three show up, archives the
+  `Claude` agent, confirms the worktree is now genuinely bare and its file tab is gone from
+  `combined_tab_order` while its entry in `open_files()` survives untouched, then spawns a
+  `Codex` agent and confirms the file tab reappears with no extra work.
+
+### Gates
+
+`cargo fmt --all -- --check`, `cargo build --workspace`, and
+`cargo clippy --workspace --all-targets -- -D warnings` all clean (one real clippy hit along the
+way: `doc_lazy_continuation` on a doc comment where a mid-sentence `- see ...` read as an
+unindented markdown list continuation - reworded, not suppressed). `cargo test --workspace --lib
+--test-threads=1`: **1212 + 44 + 14 + 139 = 1409 passed, 0 failed** across all four crates - no
+`code_surface::diff_view` flake this run.

--- a/BUILD-LOG.md
+++ b/BUILD-LOG.md
@@ -6929,8 +6929,13 @@ the user's own report showed, then re-verified clean once the fix was restored.
 
 **Verification**: `cargo fmt --all -- --check`, `cargo build --workspace`,
 `cargo clippy --workspace --all-targets -- -D warnings` - all clean.
-`cargo test --workspace --lib --test-threads=1`: **1220 + 44 + 14 + 140 = 1424 passed, 0 failed**
-across all four crates (1 new test).
+`cargo test --workspace --lib --test-threads=1`: **1221 + 44 + 14 + 140 = 1419 passed, 0 failed**
+across all four crates (1 new test) - independently re-verified by the coordinator, not just
+agent-reported. One run hit the documented `code_surface::diff_view::diff_render_tests` flake
+under unusually high system load (several concurrent agents active this session); re-ran the
+failing test alone (2/3 clean) and the full suite once more (clean) to confirm it was load, not a
+regression - the failing test is in unrelated syntax-highlighting code with no plausible link to
+either this fix or the elbow-ordering fix above it.
 
 ### Follow-up: the elbows were painted half a pixel off the row grid
 
@@ -7090,3 +7095,21 @@ calls in place) fails both, confirming they test the wiring specifically, not th
 `code_surface::diff_view::diff_render_tests::switching_the_open_diff_to_a_different_file_recomputes_the_highlight_cache`
 flake; passed 5/5 re-run in isolation and the full suite passed clean on a second full run -
 unrelated syntax-highlighting code, not a regression from this change.
+
+## Four real spec deviations found by the user directly inspecting the running app, plus a real git graph correctness bug
+
+Direct testing of the running app (pointed at this real repo) surfaced four real, concrete gaps against §2.1/§3/§4 that survived earlier audits, all fixed here:
+
+1. **Rail header still said `"AGENTS"`.** §2.1 is explicit: "Rail header keeps only the `+` new-session button." The label was a leftover from the pre-R12 flat rail - the earlier `Session`→`Agent` rename found and relabeled it (`SESSIONS`→`AGENTS`) as a pure vocabulary fix without checking it against this requirement, since the rename predates this branch's own audit work. Removed entirely; the header now holds only the `+` button, right-aligned.
+2. **Agent/shell tabs had a `×` close button they shouldn't.** §3: "agent and shell tabs do not [close]." Replaced with the real, spec'd 5px status square (§3: "Agent tab: 14px chip · model name · **5px status square** that keeps reporting while you read another tab") - reads the same `Self::agent_status` the rail row and context bar already derive their own colour from, so the tab strip can never disagree with either about an agent's real state. Middle-click still closes the tab (a separate, pre-existing GitHub issue #26 mechanism, untouched).
+3. **Filter placeholder said `"filter agents"`.** §2.1's exact text is `"filter worktrees and agents"`. One-line fix.
+4. **Title-bar agent-status chips hugged the left edge instead of being pushed right.** `agent_state_chips` was added as a child *before* the layout's `div().flex_1()` spacer, so the spacer (added after it) never had anything to push. Swapped the order.
+
+**A real git graph data bug**, found via an independent audit dispatched after this repo's own real, complex history (an 8-way branch fan-out, several real PR-merge commits) raised a "merges without commits" concern: `dot_kind` in `crates/wt-core/src/graph.rs` checked `Some(*id) == head_id` *before* `commit.is_merge()`, so a commit that is honestly both - this very repository's own `master` tip is one right now, a real `Merge pull request` commit `HEAD` currently sits on - lost its merge styling entirely. The single most merge-shaped row in the whole graph (8 real `Converging` elbows arriving at it) rendered as a plain `Head` dot instead of a hollow merge ring. Reordered to check `is_merge()` first: `HEAD` is already shown separately and unambiguously via the branch's own `RefChip::is_head` ref-chip styling next to the row, so prioritizing the merge visual loses no real information. New regression test confirmed non-vacuous (fails with the exact `Head` misclassification against the old order, passes against the fix).
+
+The independent audit that caught this also verified, exhaustively (not spot-checked) across all 181 rows of this real repository's graph: every parent list matches `git log --parents` exactly; zero fake merge dots; every `Diverging`/`Converging` elbow traces to a real lane genuinely present in an adjacent row; zero phantom elbows; lane continuity holds in both directions across all 181 rows. The "several unrelated lines converging into one plain commit dot" pattern the user's report may have partly been reacting to is real, correct git semantics (a shared non-merge ancestor several branches happen to reach), not a defect - `git log --graph` draws the identical `|/` shape at the same rows.
+
+**Verification**: `cargo fmt --all -- --check`, `cargo build --workspace`,
+`cargo clippy --workspace --all-targets -- -D warnings` - all clean. `cargo test --workspace --lib
+--test-threads=1`: **1221 + 44 + 14 + 141 = 1420 passed, 0 failed** across all four crates (1 new
+test - `a_merge_commit_that_is_also_head_still_gets_the_merge_dot_kind`).

--- a/crates/app/src/graph_view/render.rs
+++ b/crates/app/src/graph_view/render.rs
@@ -1911,6 +1911,37 @@ fn elbow_color_lane(kind: ElbowKind, from_lane: usize, to_lane: usize) -> usize 
     }
 }
 
+/// The order `render_graph_lane_canvas` paints one row's elbows in, paired with each elbow's own
+/// index in `row.elbows` so its `debug_selector` tag stays tied to the layout's own numbering
+/// rather than to paint position.
+///
+/// Every elbow of one kind in one row shares a single `waist_y` (see [`elbow_geometry`] - it is a
+/// function of the row height and the kind, nothing else), so *N* elbows landing on the same lane
+/// all paint their horizontal stroke on the very same pixel row, and their spans nest: the elbow
+/// from the furthest lane covers the whole stretch every nearer one occupies, its own arc columns
+/// included.
+///
+/// In `row.elbows`' own order that is fatal. `wt_core::graph::layout_lanes` Step 2 emits
+/// `Converging` elbows by ascending lane, so the *furthest* lane is painted **last** and wipes out
+/// every nearer elbow outright - not just its bridge but the arc that turns that lane's line onto
+/// the waist. This repository's own history renders exactly that: master's `HEAD` is the shared
+/// parent of eight worktree branches, so its row carries eight `Converging` elbows, and it painted
+/// as one flat full-width bar in lane 8's colour with the other seven lanes' lines stopping dead at
+/// the top of the row - a boxy rectangle where eight separate coloured curves belong. The
+/// single-elbow geometry was never wrong (`elbow_geometry_tests` covers one elbow exhaustively and
+/// all of it still passes); what was missing is that a row can hold more than one.
+///
+/// Painting longest span first and shortest last nests them the other way up, which is the shape a
+/// commit graph actually wants: the horizontal changes colour at every lane it crosses, each lane's
+/// own arc sits on top of the strokes running past it, and the innermost elbow owns the arc that
+/// lands on the dot. `sort_by_key` is stable, so equal spans keep the layout's own order.
+fn elbow_paint_order(elbows: &[wt_core::graph::Elbow]) -> Vec<(usize, wt_core::graph::Elbow)> {
+    let mut ordered: Vec<(usize, wt_core::graph::Elbow)> =
+        elbows.iter().copied().enumerate().collect();
+    ordered.sort_by_key(|(_, elbow)| std::cmp::Reverse(elbow.from_lane.abs_diff(elbow.to_lane)));
+    ordered
+}
+
 /// The vertical span (`top`, `height`) one plain lane segment occupies in its row.
 ///
 /// Pure and GPUI-element-free, like `elbow_geometry`/`elbow_color_lane`, so it is directly testable
@@ -2051,6 +2082,25 @@ fn render_graph_lane_canvas(
     let mut canvas = div()
         .relative()
         .flex_none()
+        // Pinned to the row's own top edge, never centred in it. `render_graph_row` is
+        // `.h(ROW).border_b_1()` and GPUI's taffy layout is *border-box* (`Style::to_taffy`,
+        // `vendor/zed/crates/gpui/src/taffy.rs`, never sets `box_sizing`, so taffy's own
+        // `BoxSizing::BorderBox` default applies) - so the row is 26 tall on the outside but its
+        // content box is only 25, while this canvas is a full `ROW` = 26. Under the row's
+        // `.items_center()` that centres to `(25 - 26) / 2` = **-0.5px**, and every horizontal 1px
+        // stroke in here - the elbow bridge's `h(px(1.0))` and both curve boxes' `border_t_1()`/
+        // `border_b_1()` - then lands on a half-pixel boundary and renders smeared across two
+        // physical pixel rows at half intensity, while the vertical lane lines (x is untouched)
+        // stay crisp. That is the reported "the lines and elbows do not align correctly
+        // vertically", and it is also why four earlier rounds of 1px elbow-seam fixes each only
+        // half-worked: the geometry was computed on an integer grid and every test measured that
+        // integer grid, but the whole canvas was painted half a pixel off it.
+        //
+        // The row has no *top* border, so its content-box top is its border-box top: pinning here
+        // puts the canvas on whole pixels and keeps consecutive canvases exactly `ROW` apart. The
+        // 1px it now overflows past the content box is the row's own separator border, which lane
+        // lines must run through anyway for a line to read as continuous across rows.
+        .self_start()
         .overflow_hidden()
         .w(graph_lane_canvas_width(lane_count))
         .h(row_h)
@@ -2104,7 +2154,7 @@ fn render_graph_lane_canvas(
         canvas = canvas.child(line);
     }
 
-    for (elbow_index, elbow) in row.elbows.iter().enumerate() {
+    for (elbow_index, elbow) in elbow_paint_order(&row.elbows) {
         let x_from = lane_x(elbow.from_lane);
         let x_to = lane_x(elbow.to_lane);
         let geo = elbow_geometry(elbow.kind, x_from, x_to, row_h);
@@ -3570,6 +3620,131 @@ mod elbow_geometry_tests {
         }
     }
 
+    /// The x-range one whole elbow paints on its own `waist_y` row. Both curve boxes contribute
+    /// their *full* box width, not just the straight part of the border: a rounded corner's arc
+    /// still terminates on the waist row at the far end of the corner square, so the whole width is
+    /// ink. The bridge is included for completeness - it always sits between the two boxes.
+    fn waist_ink(geo: &ElbowGeometry) -> (Pixels, Pixels) {
+        let left = geo.entry.left.min(geo.exit.left).min(geo.straight.left);
+        let right = geo
+            .entry
+            .right()
+            .max(geo.exit.right())
+            .max(geo.straight.left + geo.straight.width);
+        (left, right)
+    }
+
+    fn column(x: Pixels) -> usize {
+        f32::from(x).round() as usize
+    }
+
+    #[test]
+    fn every_elbow_in_a_crowded_row_keeps_its_own_lanes_arc_visible() {
+        // The real regression test for a row carrying *several* elbows at once - the case every
+        // other test in this module misses, because they all build exactly one elbow.
+        //
+        // `elbow_geometry`'s `waist_y` depends only on the row height and the elbow kind, so every
+        // elbow of one kind in one row paints its horizontal stroke on the very same pixel row, and
+        // their spans nest: an elbow reaching lane 8 covers every column an elbow reaching lane 1
+        // occupies, that nearer elbow's own arc included. Painted in `row.elbows`' own order
+        // (`layout_lanes` emits `Converging` by ascending lane) the furthest one lands last and
+        // erases all the rest - which is exactly what this repository's own history rendered:
+        // master's `HEAD` is the shared parent of eight worktree branches, and its row painted as
+        // one flat full-width bar in the highest lane's colour with seven lanes' lines stopping
+        // dead at the top of the row, instead of eight separate coloured curves.
+        //
+        // The invariant that has to hold, stated on painted pixels rather than on the sort itself:
+        // after the whole row is painted in `elbow_paint_order`, the column of each elbow's own
+        // *far* lane - the branch end that has to visibly turn onto the waist - still belongs to
+        // that elbow. Under the old order every lane but the furthest fails this.
+        for (kind, far_lanes, dot_lane) in [
+            // Eight branch tips sharing one ancestor: this repository's own real `HEAD` row.
+            (
+                ElbowKind::Converging,
+                vec![1usize, 2, 3, 4, 5, 6, 7, 8],
+                0usize,
+            ),
+            // The mirror: an octopus merge opening several lanes from one dot.
+            (ElbowKind::Diverging, vec![1, 2, 3, 4], 0),
+            // Non-contiguous lanes, and one adjacent-lane elbow whose two boxes overlap.
+            (ElbowKind::Converging, vec![1, 3, 6], 0),
+        ] {
+            let elbows: Vec<wt_core::graph::Elbow> = far_lanes
+                .iter()
+                .map(|&far| match kind {
+                    ElbowKind::Converging => wt_core::graph::Elbow {
+                        from_lane: far,
+                        to_lane: dot_lane,
+                        kind,
+                    },
+                    ElbowKind::Diverging => wt_core::graph::Elbow {
+                        from_lane: dot_lane,
+                        to_lane: far,
+                        kind,
+                    },
+                })
+                .collect();
+
+            let lane_count = far_lanes.iter().max().expect("at least one lane") + 1;
+            let mut owner: Vec<Option<usize>> =
+                vec![None; column(graph_lane_canvas_width(lane_count))];
+            for (index, elbow) in elbow_paint_order(&elbows) {
+                let geo = elbow_geometry(
+                    elbow.kind,
+                    lane_x(elbow.from_lane),
+                    lane_x(elbow.to_lane),
+                    ROW_H,
+                );
+                let (left, right) = waist_ink(&geo);
+                for cell in owner.iter_mut().take(column(right)).skip(column(left)) {
+                    *cell = Some(index);
+                }
+            }
+
+            for (index, (elbow, &far)) in elbows.iter().zip(far_lanes.iter()).enumerate() {
+                assert_eq!(
+                    owner[column(lane_x(far))],
+                    Some(index),
+                    "{kind:?} row {far_lanes:?}: lane {far}'s own arc column was painted over by \
+                     elbow {:?} - that lane's line ends in mid-air instead of curving onto the \
+                     waist, which is the boxy full-width bar this ordering exists to prevent",
+                    owner[column(lane_x(far))]
+                        .map(|winner| elbows[winner])
+                        .expect("some elbow must own the column"),
+                );
+                let _ = elbow;
+            }
+        }
+    }
+
+    #[test]
+    fn the_paint_order_keeps_each_elbows_own_layout_index_for_its_debug_tag() {
+        // Reordering must not renumber the `graph-row-N-elbow-K-...` selectors: `K` is the elbow's
+        // index in `GraphRow::elbows` (what `graph_elbow_render_tests` looks paint bounds up by),
+        // not its position in the paint sequence.
+        let elbows = vec![
+            wt_core::graph::Elbow {
+                from_lane: 1,
+                to_lane: 0,
+                kind: ElbowKind::Converging,
+            },
+            wt_core::graph::Elbow {
+                from_lane: 5,
+                to_lane: 0,
+                kind: ElbowKind::Converging,
+            },
+        ];
+        let ordered = elbow_paint_order(&elbows);
+        assert_eq!(
+            ordered.iter().map(|(index, _)| *index).collect::<Vec<_>>(),
+            vec![1, 0],
+            "the widest elbow paints first, but both keep their own layout index"
+        );
+        for (index, elbow) in ordered {
+            assert_eq!(elbow, elbows[index]);
+        }
+    }
+
     #[test]
     fn a_diverging_elbows_color_follows_the_branch_merged_in_not_the_branch_it_lands_in() {
         // from_lane is always own_lane (the branch merged *into*) for Diverging - a real user
@@ -4051,6 +4226,63 @@ mod graph_elbow_render_tests {
             "the Diverging elbow itself must still be painted - lane 1's connection must not be \
              lost, only de-duplicated"
         );
+    }
+
+    /// The real regression test for the reported "the lines and elbows do not align correctly
+    /// vertically", and for a whole class of subpixel bugs the sibling tiling test below cannot
+    /// see: it only ever compares one lane canvas against *another* lane canvas, so a constant
+    /// offset shared by every row passes it untouched.
+    ///
+    /// `render_graph_row` is `.h(ROW).border_b_1()`, and GPUI's taffy layout is border-box
+    /// (`Style::to_taffy` in `vendor/zed/crates/gpui/src/taffy.rs` never sets `box_sizing`, so
+    /// taffy's `BoxSizing::BorderBox` default applies) - so the row's *content* box is 25px while
+    /// the lane canvas is a full `ROW` = 26px. The row's own `.items_center()` then centred it to
+    /// `(25 - 26) / 2` = -0.5px, and every horizontal 1px stroke in the canvas - the elbow's
+    /// straight bridge and both curve boxes' horizontal borders - landed on a half-pixel boundary,
+    /// rendering smeared over two physical pixel rows while the vertical lane lines stayed crisp.
+    /// `render_graph_lane_canvas`'s `.self_start()` is what holds this.
+    ///
+    /// Asserted on the canvas' offset *within its own row*, and on the offset being a whole
+    /// pixel - the two facts the centring broke, neither of which any existing test looked at.
+    #[gpui::test]
+    fn every_lane_canvas_sits_on_whole_pixels_at_its_own_rows_top_edge(cx: &mut TestAppContext) {
+        let (_repo, app, cx) = open_seeded(cx, seed_converging_history);
+        let row_count = app.read_with(cx, |app, _| {
+            let GraphLoadState::Loaded(graph) = &app.graph_state.load else {
+                panic!("graph must have loaded");
+            };
+            graph.rows.len()
+        });
+        assert!(
+            row_count >= 4,
+            "sanity check: this fixture must produce several real rows, got {row_count}"
+        );
+
+        for index in 0..row_count {
+            let row_selector: &'static str =
+                Box::leak(format!("graph-row-{index}").into_boxed_str());
+            let canvas_selector: &'static str =
+                Box::leak(format!("graph-row-{index}-lane-canvas").into_boxed_str());
+            let row = cx
+                .debug_bounds(row_selector)
+                .unwrap_or_else(|| panic!("{row_selector} must be painted"));
+            let canvas = cx
+                .debug_bounds(canvas_selector)
+                .unwrap_or_else(|| panic!("{canvas_selector} must be painted"));
+
+            assert_eq!(
+                canvas.origin.y, row.origin.y,
+                "row {index}'s lane canvas must start on its row's own top edge, not be centred \
+                 in the shorter content box the row's bottom border leaves behind"
+            );
+            let y = f32::from(canvas.origin.y);
+            assert_eq!(
+                y,
+                y.round(),
+                "row {index}'s lane canvas sits at {y}, off the whole-pixel grid - every 1px \
+                 horizontal stroke inside it renders smeared across two physical pixel rows"
+            );
+        }
     }
 
     /// The layout fact `render_graph_lane_canvas`'s `overflow_hidden()` rests on, and the real

--- a/crates/app/src/graph_view/render.rs
+++ b/crates/app/src/graph_view/render.rs
@@ -402,6 +402,10 @@ impl AdeApp {
         if keystroke.modifiers.platform || keystroke.modifiers.control || keystroke.modifiers.alt {
             return;
         }
+        // GitHub issue #27's "solid mid-keystroke" - see `crate::rail::render::AdeApp::
+        // handle_filter_key_down`'s identical reasoning. Missing here (GitHub issue #45) is
+        // exactly why this field never blinked in the first place.
+        self.reset_caret_blink(cx);
         let changed = match keystroke.key.as_str() {
             "backspace" => self.graph_state.branches_filter.pop(Instant::now()),
             "escape" => self.graph_state.branches_filter.clear(Instant::now()),
@@ -1466,17 +1470,37 @@ impl AdeApp {
             .child(
                 div()
                     .flex_1()
-                    .font(font(theme::font::MONO))
-                    .text_size(px(10.5))
-                    .text_color(if has_query {
-                        theme::text::DIM
-                    } else {
-                        theme::text::GHOST
+                    .flex()
+                    .items_center()
+                    .gap(px(2.0))
+                    // GitHub issue #45 / live report: this filter row had *no* caret element at
+                    // all - `branches_filter_focus_handle` was never threaded into
+                    // `AdeApp::wire_caret_blink` (see `Self::new_with_settings`'s own comment on
+                    // why it's wired separately, after `graph_state` exists), so there was
+                    // nothing to paint here regardless. Now matches
+                    // `crate::rail::render::AdeApp::render_rail_filter_row`'s own fixed
+                    // before-placeholder / after-text placement.
+                    .when(!has_query, |el| {
+                        el.child(self.render_simple_input_caret("graph-branches-filter-caret"))
                     })
-                    .child(if has_query {
-                        self.graph_state.branches_filter.as_str().to_string()
-                    } else {
-                        "filter branches".to_string()
+                    .child(
+                        div()
+                            .font(font(theme::font::MONO))
+                            .text_size(px(10.5))
+                            .text_color(if has_query {
+                                theme::text::DIM
+                            } else {
+                                theme::text::GHOST
+                            })
+                            .child(if has_query {
+                                self.graph_state.branches_filter.as_str().to_string()
+                            } else {
+                                "filter branches".to_string()
+                            })
+                            .debug_selector(|| "graph-branches-filter-text".to_string()),
+                    )
+                    .when(has_query, |el| {
+                        el.child(self.render_simple_input_caret("graph-branches-filter-caret"))
                     }),
             )
             .child(
@@ -4735,6 +4759,141 @@ mod graph_focus_tests {
         assert!(
             !app.read_with(cx, |app, _| app.graph_tab_open),
             "middle-clicking the graph tab must close it, same as a file or agent tab"
+        );
+    }
+
+    /// GitHub issue #45 ("Input blink only on focused input or file") plus a live follow-up
+    /// report: this filter row had *no* caret element at all - confirmed by reading
+    /// `render_graph_branches_filter_row` before this fix, and `branches_filter_focus_handle`
+    /// was never threaded through `AdeApp::wire_caret_blink` either (it didn't exist yet when
+    /// that call in `Self::new_with_settings` was first wired - the Branches panel is a later
+    /// Revision R12 addition). Real interaction coverage, mirroring
+    /// `crate::rail::render::rail_filter_caret_tests`' own measured-bounds technique.
+    #[gpui::test]
+    fn caret_sits_before_the_placeholder_when_empty_and_after_the_text_once_typed(
+        cx: &mut TestAppContext,
+    ) {
+        let (_repo, app, cx) = open_seeded(cx);
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_git_graph(window, cx);
+            app.set_graph_right_panel(GraphRightPanel::Branches, cx);
+            window.focus(&app.graph_state.branches_filter_focus_handle, cx);
+        });
+        cx.run_until_parked();
+
+        let empty_caret = cx.debug_bounds("graph-branches-filter-caret").expect(
+            "the caret should have really painted with an empty filter - before this fix, \
+                 no caret element existed here at all, so this selector would never resolve",
+        );
+        let placeholder = cx
+            .debug_bounds("graph-branches-filter-text")
+            .expect("the placeholder text should have really painted");
+        assert!(
+            empty_caret.origin.x <= placeholder.origin.x,
+            "with an empty filter, the real caret must sit before (at or left of) the \
+             placeholder's own start x, not after it - got caret {:?} vs placeholder {:?}",
+            empty_caret,
+            placeholder,
+        );
+
+        cx.simulate_input("main");
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app
+                .graph_state
+                .branches_filter
+                .as_str()
+                .to_string()),
+            "main",
+            "sanity check: real typed filter"
+        );
+
+        let typed_caret = cx
+            .debug_bounds("graph-branches-filter-caret")
+            .expect("the caret should have really painted with a typed filter");
+        let typed_text = cx
+            .debug_bounds("graph-branches-filter-text")
+            .expect("the real typed text should have really painted");
+        assert!(
+            typed_caret.origin.x >= typed_text.origin.x + typed_text.size.width,
+            "with a typed filter, the real caret must sit at or after the typed text's own \
+             right edge, not before it - got caret {:?} vs text {:?}",
+            typed_caret,
+            typed_text,
+        );
+        assert!(
+            typed_caret.origin.x > empty_caret.origin.x,
+            "the caret's real measured horizontal position must differ between the \
+             empty-filter state (before the placeholder) and a typed-filter state (after the \
+             real text) - got {:?} vs {:?}",
+            empty_caret.origin.x,
+            typed_caret.origin.x,
+        );
+    }
+
+    /// GitHub issue #45's own title, taken literally: before this fix,
+    /// `branches_filter_focus_handle` was never wired into `AdeApp::wire_caret_blink` at all, so
+    /// *blurring* it never called the real [`AdeApp::stop_caret_blink`] that pins the shared
+    /// flag straight to "dimmed" the instant focus leaves - the same real, immediate effect
+    /// every already-wired handle has always had.
+    ///
+    /// This deliberately checks *blur*, not *focus*: typing into the field also calls
+    /// `Self::reset_caret_blink` directly (`Self::handle_branches_filter_key_down`'s own real
+    /// "solid mid-keystroke" behaviour, GitHub issue #27) regardless of whether
+    /// `branches_filter_focus_handle` is wired into the shared loop at all - so a test that only
+    /// focuses-then-types would pass even with the wiring gap this fix closes, and prove
+    /// nothing about it. Blurring is the one real effect that only a genuine `AdeApp::
+    /// wire_caret_blink` subscription produces: an *immediate*, synchronous flip to
+    /// `caret_blink_visible == false`, not something that could be explained by the still-live
+    /// timer from the earlier keystroke (which hasn't been given time to fire - the background
+    /// clock is never advanced in this test).
+    #[gpui::test]
+    fn blurring_the_branches_filter_stops_the_real_shared_blink_loop(cx: &mut TestAppContext) {
+        let (_repo, app, cx) = open_seeded(cx);
+        app.update_in(cx, |_app, window, _cx| window.activate_window());
+        cx.run_until_parked();
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_git_graph(window, cx);
+            app.set_graph_right_panel(GraphRightPanel::Branches, cx);
+            window.focus(&app.graph_state.branches_filter_focus_handle, cx);
+        });
+        // `open_git_graph` kicks off a real, async `load_graph` (a background `gix` commit
+        // walk) - the Branches panel only actually renders its filter row (rather than the
+        // "open the graph to see branches" placeholder `render_graph_branches_panel` shows
+        // while `current_graph()` is still `None`) once that finishes. Parked here first, the
+        // same way the sibling position test above does, so `cx.simulate_input` below dispatches
+        // against a frame that genuinely has the filter row - and therefore its focus - in it.
+        cx.run_until_parked();
+
+        cx.simulate_input("m");
+        assert!(
+            app.read_with(cx, |app, _| app.caret_blink_visible),
+            "sanity check: typing must leave the caret solid/visible, whether that came from \
+             this fix's own on-focus wiring or `handle_branches_filter_key_down`'s pre-existing \
+             `reset_caret_blink` call"
+        );
+
+        // Move real keyboard focus to a genuinely different, real, *unwired* handle
+        // (`AdeApp::rail_focus_handle`, the rail's own always-present container fallback, never
+        // itself a caret-bearing input) - and force the same real redraw a live blur event
+        // needs to be observed (`rail::render::rail_filter_caret_tests`' own identical
+        // `cx.simulate_input`-forces-a-redraw finding), via a harmless, unbound plain keystroke
+        // rather than typing into a real field.
+        app.update_in(cx, |app, window, cx| {
+            window.focus(&app.rail_focus_handle, cx);
+        });
+        cx.simulate_keystrokes("x");
+
+        assert!(
+            !app.read_with(cx, |app, _| app.caret_blink_visible),
+            "blurring the branches filter must have immediately pinned the shared caret to \
+             dimmed/non-blinking (`AdeApp::stop_caret_blink`) - before this fix, \
+             `branches_filter_focus_handle` was never threaded through \
+             `AdeApp::wire_caret_blink`, so nothing would have reacted to it losing focus at \
+             all, and the caret would have stayed solid/visible until whatever timer the \
+             earlier keystroke started eventually fired on its own"
         );
     }
 }

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -679,6 +679,16 @@ impl AdeApp {
                     .flex()
                     .items_center()
                     .gap(px(2.0))
+                    // GitHub issue #45 / live report: the caret used to be a fixed trailing
+                    // child, which put it visually *after* the placeholder text whenever
+                    // `filter_query` was empty. It now sits before the placeholder (the real
+                    // cursor position, 0, for an empty field - matching
+                    // `crate::palette::render::AdeApp::render_palette_caret`'s own empty-query
+                    // placement) and after the real typed text once there is any, never
+                    // appended past whatever placeholder string happens to render.
+                    .when(!has_query, |el| {
+                        el.child(self.render_simple_input_caret("rail-filter-caret"))
+                    })
                     .child(
                         div()
                             .font(font(theme::font::MONO))
@@ -692,9 +702,12 @@ impl AdeApp {
                                 self.filter_query.as_str().to_string()
                             } else {
                                 "filter agents".to_string()
-                            }),
+                            })
+                            .debug_selector(|| "rail-filter-text".to_string()),
                     )
-                    .child(self.render_simple_input_caret()),
+                    .when(has_query, |el| {
+                        el.child(self.render_simple_input_caret("rail-filter-caret"))
+                    }),
             )
     }
 
@@ -1841,6 +1854,116 @@ mod rail_row_tests {
             1,
             "sanity check: the *displayed* rows really did narrow to the one matching worktree \
              - proving the filter query took effect at all, just not on the header count"
+        );
+    }
+}
+
+/// GitHub issue #45 ("Input blink only on focused input or file") plus a live follow-up report:
+/// the rail filter's caret used to be a fixed trailing child, painted *after* the placeholder
+/// text whenever `filter_query` was empty, instead of at the real cursor position (0). Real
+/// interaction coverage, mirroring `crate::palette::render::palette_caret_tests`' own
+/// measured-bounds technique rather than only reading the render code.
+#[cfg(test)]
+mod rail_filter_caret_tests {
+    use crate::root::focus::palette_focus_tests;
+    use gpui::TestAppContext;
+    use std::time::Duration;
+
+    #[gpui::test]
+    fn caret_sits_before_the_placeholder_when_empty_and_after_the_text_once_typed(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+
+        app.update_in(cx, |app, window, cx| {
+            window.focus(&app.filter_focus_handle, cx);
+        });
+        cx.run_until_parked();
+
+        let empty_caret = cx
+            .debug_bounds("rail-filter-caret")
+            .expect("the caret should have really painted with an empty filter");
+        let placeholder = cx
+            .debug_bounds("rail-filter-text")
+            .expect("the placeholder text should have really painted");
+        assert!(
+            empty_caret.origin.x <= placeholder.origin.x,
+            "with an empty filter, the real caret must sit before (at or left of) the \
+             placeholder's own start x, not after it - got caret {:?} vs placeholder {:?}",
+            empty_caret,
+            placeholder,
+        );
+
+        cx.simulate_input("main");
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.filter_query.as_str().to_string()),
+            "main",
+            "sanity check: real typed filter"
+        );
+
+        let typed_caret = cx
+            .debug_bounds("rail-filter-caret")
+            .expect("the caret should have really painted with a typed filter");
+        let typed_text = cx
+            .debug_bounds("rail-filter-text")
+            .expect("the real typed text should have really painted");
+        assert!(
+            typed_caret.origin.x >= typed_text.origin.x + typed_text.size.width,
+            "with a typed filter, the real caret must sit at or after the typed text's own \
+             right edge, not before it - got caret {:?} vs text {:?}",
+            typed_caret,
+            typed_text,
+        );
+        assert!(
+            typed_caret.origin.x > empty_caret.origin.x,
+            "the caret's real measured horizontal position must differ between the \
+             empty-filter state (before the placeholder) and a typed-filter state (after the \
+             real text) - got {:?} vs {:?}",
+            empty_caret.origin.x,
+            typed_caret.origin.x,
+        );
+    }
+
+    /// GitHub issue #45's own title, taken literally: the caret must actually *blink* (not just
+    /// exist) once this field is focused - proving `filter_focus_handle`'s real wiring into
+    /// `crate::root::caret_blink`'s shared loop by advancing the real (simulated) clock past one
+    /// full interval and observing `caret_blink_visible` really flip, the same live-loop proof
+    /// `crate::code_surface::editing`'s own rehighlight-debounce tests use for their timers.
+    /// `cx.simulate_input` (not a bare `window.focus`) is what actually forces the window to
+    /// redraw and diff its own focus path in this test harness - the real trigger
+    /// `on_focus`/`on_blur` listeners fire from (see `gpui::Window::focus`'s own deferred-effect
+    /// doc comment) - matching how a real user always focuses a field by clicking or tabbing
+    /// into it and then typing, never focus with no further interaction.
+    #[gpui::test]
+    fn focusing_the_rail_filter_starts_the_real_shared_blink_loop(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        // `on_focus`/`on_blur` (`AdeApp::wire_caret_blink`'s own mechanism) only fire while GPUI
+        // considers the window itself "active" - a real, freshly opened test window starts out
+        // not active at all.
+        app.update_in(cx, |_app, window, _cx| window.activate_window());
+        cx.run_until_parked();
+
+        app.update_in(cx, |app, window, cx| {
+            window.focus(&app.filter_focus_handle, cx);
+        });
+        cx.simulate_input("m");
+        assert!(
+            app.read_with(cx, |app, _| app.caret_blink_visible),
+            "a fresh focus must start solid/visible"
+        );
+
+        cx.background_executor.advance_clock(
+            crate::root::caret_blink::CARET_BLINK_INTERVAL + Duration::from_millis(50),
+        );
+        cx.run_until_parked();
+        assert!(
+            !app.read_with(cx, |app, _| app.caret_blink_visible),
+            "focusing the rail filter must have started the real, live shared blink task - if \
+             `filter_focus_handle` were never wired into `AdeApp::wire_caret_blink`, no timer \
+             would be running at all and this flag would still be stuck solid"
         );
     }
 }

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -575,33 +575,22 @@ impl AdeApp {
         )
     }
 
-    /// Header 36 (`Agents` label, grouping toggle, `+`/⌘N) - README's "Rail chrome".
+    /// Header 36 - Revision R12 §2.1: "Rail header keeps only the `+` new-session button." No
+    /// section-title label - this used to say `AGENTS` (a leftover from the pre-R12 flat rail,
+    /// carried through a rename to fix its vocabulary without checking it against this
+    /// requirement) but the spec is explicit that the header has nothing but the button itself.
     pub(in crate::rail) fn render_rail_header(&self, cx: &mut Context<Self>) -> impl IntoElement {
         div()
             .id("rail-header")
             .flex()
             .flex_none()
             .items_center()
-            .justify_between()
+            .justify_end()
             .px(px(10.0))
             .h(theme::band::RAIL_HEADER)
             .border_b_1()
             .border_color(theme::border::RAIL_INNER)
-            .child(
-                div()
-                    .font(font(theme::font::SANS))
-                    .font_weight(gpui::FontWeight::SEMIBOLD)
-                    .text_size(self.ui_text_size(10.0))
-                    .text_color(theme::text::FAINT)
-                    .child("AGENTS"),
-            )
-            .child(
-                div()
-                    .flex()
-                    .items_center()
-                    .gap(px(8.0))
-                    .child(self.render_new_agent_button(cx)),
-            )
+            .child(self.render_new_agent_button(cx))
     }
 
     /// The `+` control with its real, platform-resolved `mod+N` keycap pair (`⌘N` on macOS,
@@ -701,7 +690,7 @@ impl AdeApp {
                             .child(if has_query {
                                 self.filter_query.as_str().to_string()
                             } else {
-                                "filter agents".to_string()
+                                "filter worktrees and agents".to_string()
                             })
                             .debug_selector(|| "rail-filter-text".to_string()),
                     )

--- a/crates/app/src/root/focus.rs
+++ b/crates/app/src/root/focus.rs
@@ -1509,9 +1509,13 @@ mod text_undo_scoping_tests {
         );
     }
 
-    /// The rail's agent filter - the fourth and last of this app's hand-rolled single-line
-    /// inputs. Also covers that `Esc`-clearing a filter is a real, undoable step rather than a
-    /// silent loss.
+    /// The rail's agent filter - one of this app's several hand-rolled single-line inputs (this
+    /// comment used to claim it was "the fourth and last", which had already gone stale by the
+    /// time GitHub issue #45's audit found two more real ones - the git graph tab's own branches
+    /// filter and the "New file" prompt - that undo/redo already covered independently but whose
+    /// *carets* had never been wired up at all; see `crate::root::caret_blink`'s own docs).
+    /// Also covers that `Esc`-clearing a filter is a real, undoable step rather than a silent
+    /// loss.
     #[gpui::test]
     fn secondary_z_in_the_rail_filter_undoes_it_including_a_real_escape_clear(
         cx: &mut TestAppContext,

--- a/crates/app/src/root/new_file.rs
+++ b/crates/app/src/root/new_file.rs
@@ -1,5 +1,9 @@
-//! Real "New file" creation - the tab-strip `+` menu's "New file" row and the file tree's own
-//! hover-revealed "+" affordance (`crate::sidebar::render`) both funnel into this module.
+//! Real "New file" creation - the file tree's own always-visible per-directory and root-level
+//! "+" affordances (`crate::sidebar::render`) funnel into this module. The tab-strip `+` menu had
+//! its own "New file" row until Revision R12 §3 pared that menu down to the spec's five items
+//! (*New terminal* / *New agent* / *Git graph* / *Open file…* / *Next changed file*, none of them
+//! "New file"); the file tree's affordances were already a real, always-present second entry
+//! point to this same flow, so removing the menu row dropped no reachable functionality.
 //!
 //! Naming UI: a small, hand-rolled append/backspace-only inline text field
 //! (`Self::handle_new_file_key_down`), the same minimal shape `Self::handle_filter_key_down`
@@ -16,8 +20,8 @@ use std::path::Path;
 /// success) or [`AdeApp::cancel_new_file`] (Escape, or the scrim).
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct NewFileInputState {
-    /// The real directory the new file will be created in - the selected worktree's root (the
-    /// `+` menu row) or the specific directory row the file tree's own hover "+" was clicked on.
+    /// The real directory the new file will be created in - the file tree's own root-level "+"
+    /// (the worktree root) or the specific directory row whose own "+" was clicked.
     pub(super) parent_dir: PathBuf,
     /// The name typed so far - append/backspace only, mirroring [`AdeApp::filter_query`], with
     /// its own real undo history (GitHub issue #17). The history lives and dies with this prompt,

--- a/crates/app/src/root/new_file.rs
+++ b/crates/app/src/root/new_file.rs
@@ -107,6 +107,10 @@ impl AdeApp {
             "backspace" => {
                 if let Some(input) = self.new_file_input.as_mut() {
                     input.name.pop(Instant::now());
+                    // GitHub issue #27's "solid mid-keystroke" - see `crate::rail::render::
+                    // AdeApp::handle_filter_key_down`'s identical reasoning. Missing here
+                    // (GitHub issue #45) is exactly why this field never blinked.
+                    self.reset_caret_blink(cx);
                     cx.notify();
                     cx.stop_propagation();
                 }
@@ -119,6 +123,7 @@ impl AdeApp {
                 {
                     if let Some(input) = self.new_file_input.as_mut() {
                         input.name.push_str(text, Instant::now());
+                        self.reset_caret_blink(cx);
                         cx.notify();
                         cx.stop_propagation();
                     }
@@ -247,21 +252,42 @@ impl AdeApp {
                             .text_color(theme::text::FAINTER)
                             .child(parent_label),
                     )
-                    .child(
+                    .child({
+                        let has_name = !name.is_empty();
                         div()
                             .px(px(8.0))
                             .py(px(5.0))
                             .rounded(theme::radius::CHIP)
                             .bg(theme::surface::SEGMENT_TRACK)
+                            .flex()
+                            .items_center()
+                            .gap(px(2.0))
                             .font(font(theme::font::MONO))
                             .text_size(px(11.5))
                             .text_color(theme::text::BODY)
-                            .child(if name.is_empty() {
-                                "file-name.ext".to_string()
-                            } else {
-                                name
-                            }),
-                    )
+                            // GitHub issue #45 / live report: this prompt had no caret element
+                            // at all before this - just the typed name or its placeholder, no
+                            // insertion-point indicator, and `new_file_focus_handle` was never
+                            // wired into `crate::root::caret_blink` either (see
+                            // `Self::new_with_settings`'s own comment on the fix). Same
+                            // before-placeholder / after-text placement as
+                            // `crate::rail::render::AdeApp::render_rail_filter_row`.
+                            .when(!has_name, |el| {
+                                el.child(self.render_simple_input_caret("new-file-caret"))
+                            })
+                            .child(
+                                div()
+                                    .debug_selector(|| "new-file-name-text".to_string())
+                                    .child(if has_name {
+                                        name
+                                    } else {
+                                        "file-name.ext".to_string()
+                                    }),
+                            )
+                            .when(has_name, |el| {
+                                el.child(self.render_simple_input_caret("new-file-caret"))
+                            })
+                    })
                     .when_some(self.new_file_error.clone(), |el, error| {
                         el.child(
                             div()
@@ -578,5 +604,134 @@ mod tests {
         app.read_with(cx, |app, _| {
             assert!(app.new_file_input.is_none());
         });
+    }
+}
+
+/// GitHub issue #45 ("Input blink only on focused input or file") plus a live follow-up report:
+/// this prompt had no caret element at all - confirmed by reading `render_new_file_prompt`
+/// before this fix, just the typed name or its `"file-name.ext"` placeholder - and
+/// `new_file_focus_handle` was never threaded through `AdeApp::wire_caret_blink` either. Real
+/// interaction coverage, mirroring `crate::rail::render::rail_filter_caret_tests`' own
+/// measured-bounds technique.
+#[cfg(test)]
+mod new_file_caret_tests {
+    use crate::root::focus::palette_focus_tests;
+    use gpui::TestAppContext;
+
+    #[gpui::test]
+    fn caret_sits_before_the_placeholder_when_empty_and_after_the_text_once_typed(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+
+        app.update_in(cx, |app, window, cx| {
+            app.start_new_file(repo.path().to_path_buf(), window, cx);
+        });
+        cx.run_until_parked();
+
+        let empty_caret = cx.debug_bounds("new-file-caret").expect(
+            "the caret should have really painted with an empty name - before this fix, no \
+             caret element existed here at all, so this selector would never resolve",
+        );
+        let placeholder = cx
+            .debug_bounds("new-file-name-text")
+            .expect("the placeholder text should have really painted");
+        assert!(
+            empty_caret.origin.x <= placeholder.origin.x,
+            "with an empty name, the real caret must sit before (at or left of) the \
+             placeholder's own start x, not after it - got caret {:?} vs placeholder {:?}",
+            empty_caret,
+            placeholder,
+        );
+
+        cx.simulate_input("main.rs");
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app
+                .new_file_input
+                .as_ref()
+                .expect("still open")
+                .name
+                .as_str()
+                .to_string()),
+            "main.rs",
+            "sanity check: real typed name"
+        );
+
+        let typed_caret = cx
+            .debug_bounds("new-file-caret")
+            .expect("the caret should have really painted with a typed name");
+        let typed_text = cx
+            .debug_bounds("new-file-name-text")
+            .expect("the real typed name should have really painted");
+        assert!(
+            typed_caret.origin.x >= typed_text.origin.x + typed_text.size.width,
+            "with a typed name, the real caret must sit at or after the typed text's own right \
+             edge, not before it - got caret {:?} vs text {:?}",
+            typed_caret,
+            typed_text,
+        );
+        assert!(
+            typed_caret.origin.x > empty_caret.origin.x,
+            "the caret's real measured horizontal position must differ between the empty-name \
+             state (before the placeholder) and a typed-name state (after the real text) - got \
+             {:?} vs {:?}",
+            empty_caret.origin.x,
+            typed_caret.origin.x,
+        );
+    }
+
+    /// GitHub issue #45's own title, taken literally: before this fix, `new_file_focus_handle`
+    /// was never wired into `AdeApp::wire_caret_blink` at all, so *blurring* it never called the
+    /// real [`crate::root::AdeApp::stop_caret_blink`] that pins the shared flag straight to
+    /// "dimmed" the instant focus leaves.
+    ///
+    /// Checks *blur*, not *focus* - see
+    /// `crate::graph_view::render::graph_focus_tests::blurring_the_branches_filter_stops_the_real_shared_blink_loop`'s
+    /// own docs for why a focus-then-type test can't actually distinguish "wired into
+    /// `wire_caret_blink`" from "`Self::handle_new_file_key_down`'s own real `reset_caret_blink`
+    /// call on every keystroke, regardless of that wiring" - only blur has an effect that's
+    /// unique to the real subscription this fix adds.
+    #[gpui::test]
+    fn blurring_the_new_file_prompt_stops_the_real_shared_blink_loop(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        // `on_focus`/`on_blur` listeners (`AdeApp::wire_caret_blink`'s own mechanism) only
+        // fire while GPUI considers the window itself "active" - a real, freshly opened test
+        // window starts out not active at all, so this is a real, necessary precondition, not
+        // test scaffolding for its own sake.
+        app.update_in(cx, |_app, window, _cx| window.activate_window());
+        cx.run_until_parked();
+
+        app.update_in(cx, |app, window, cx| {
+            app.start_new_file(repo.path().to_path_buf(), window, cx);
+        });
+        cx.simulate_input("m");
+        assert!(
+            app.read_with(cx, |app, _| app.caret_blink_visible),
+            "sanity check: typing must leave the caret solid/visible, whether that came from \
+             this fix's own on-focus wiring or `handle_new_file_key_down`'s pre-existing \
+             `reset_caret_blink` call"
+        );
+
+        // Move real keyboard focus to a genuinely different, real, *unwired* handle
+        // (`AdeApp::rail_focus_handle`, the rail's own always-present container fallback, never
+        // itself a caret-bearing input), then force the same real redraw a live blur event
+        // needs to be observed in this test harness, via a harmless, unbound plain keystroke.
+        app.update_in(cx, |app, window, cx| {
+            window.focus(&app.rail_focus_handle, cx);
+        });
+        cx.simulate_keystrokes("x");
+
+        assert!(
+            !app.read_with(cx, |app, _| app.caret_blink_visible),
+            "blurring the \"New file\" prompt must have immediately pinned the shared caret to \
+             dimmed/non-blinking (`AdeApp::stop_caret_blink`) - before this fix, \
+             `new_file_focus_handle` was never threaded through `AdeApp::wire_caret_blink`, so \
+             nothing would have reacted to it losing focus at all, and the caret would have \
+             stayed solid/visible until whatever timer the earlier keystroke started eventually \
+             fired on its own"
+        );
     }
 }

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -342,6 +342,26 @@ impl AdeApp {
             _custom_theme_create_task: None,
             custom_theme_remove_armed: None,
         };
+        // GitHub issue #45 ("Input blink only on focused input or file") / a live follow-up
+        // report of missing carets: `graph_state.branches_filter_focus_handle` (added later, in
+        // Revision R12's git graph tab) and `new_file_focus_handle` are two more genuine
+        // caret-bearing `FocusHandle`s - real, hand-rolled `text_history::TextField` inputs, the
+        // same shape as the six wired above - that never got threaded through
+        // `Self::wire_caret_blink`. They can't join that earlier call: it runs before `this`
+        // exists, and both handles live *inside* `this` (one nested in `graph_state`, built by
+        // this same literal). Wired here instead, appending onto the very same
+        // `_caret_blink_subscriptions` vec so there's still exactly one place holding every real
+        // caret subscription this app has, not two.
+        let extra_caret_blink_subscriptions = AdeApp::wire_caret_blink(
+            &[
+                &this.graph_state.branches_filter_focus_handle,
+                &this.new_file_focus_handle,
+            ],
+            window,
+            cx,
+        );
+        this._caret_blink_subscriptions
+            .extend(extra_caret_blink_subscriptions);
         // Real "add this one repo on startup" (Revision R12 Phase 0): the CLI argument (or a
         // test's own `repo_path`) becomes the first, focused entry of `Self::repos` rather than a
         // separate field - `Self::add_repo` is idempotent against whatever `loaded_repo_state`

--- a/crates/app/src/root/widgets.rs
+++ b/crates/app/src/root/widgets.rs
@@ -262,12 +262,26 @@ impl AdeApp {
     /// (see its own docs) that these simpler, always-after-the-text fields don't need.
     /// Blinks via the same shared [`crate::root::caret_blink`] loop the code editor/palette/tree
     /// rename field use - see that module's own docs for the whole mechanism.
-    pub(crate) fn render_simple_input_caret(&self) -> impl IntoElement {
+    ///
+    /// GitHub issue #45 ("Input blink only on focused input or file") plus a live follow-up
+    /// report: every real call site used to place this caret unconditionally *after* whichever
+    /// child rendered next in document order, which for an empty field is the *placeholder*
+    /// text - a caret visually glued to the end of "filter worktrees and agents" instead of at
+    /// the real cursor position (0, i.e. before any text at all). `selector` lets each call site
+    /// give this element its own real, measurable `debug_selector` (mirroring
+    /// [`crate::palette::render::AdeApp::render_palette_caret`]'s own `"palette-caret"`) so a
+    /// real interaction test can assert *where* it painted, not just that a doc comment claims
+    /// the right position - see `rail::render::rail_filter_caret_tests`,
+    /// `settings::render::settings_keymap_filter_caret_tests`,
+    /// `graph_view::render::graph_focus_tests`, and `root::new_file::new_file_caret_tests` for
+    /// that coverage.
+    pub(crate) fn render_simple_input_caret(&self, selector: &'static str) -> impl IntoElement {
         div()
             .flex_none()
             .w(px(1.5))
             .h(px(14.0))
             .when(self.caret_blink_visible, |el| el.bg(theme::term::CURSOR))
+            .debug_selector(move || selector.to_string())
     }
 }
 

--- a/crates/app/src/settings/render.rs
+++ b/crates/app/src/settings/render.rs
@@ -1740,6 +1740,13 @@ impl AdeApp {
                     .flex()
                     .items_center()
                     .gap(px(2.0))
+                    // GitHub issue #45 / live report: same fix as
+                    // `crate::rail::render::AdeApp::render_rail_filter_row` - the caret sits
+                    // before the placeholder (real cursor position 0) while the filter is empty,
+                    // never appended after it.
+                    .when(!has_query, |el| {
+                        el.child(self.render_simple_input_caret("settings-keymap-filter-caret"))
+                    })
                     .child(
                         div()
                             .font(font(theme::font::SANS))
@@ -1753,9 +1760,12 @@ impl AdeApp {
                                 self.settings_keymap_filter.as_str().to_string()
                             } else {
                                 format!("filter {total} bindings")
-                            }),
+                            })
+                            .debug_selector(|| "settings-keymap-filter-text".to_string()),
                     )
-                    .child(self.render_simple_input_caret()),
+                    .when(has_query, |el| {
+                        el.child(self.render_simple_input_caret("settings-keymap-filter-caret"))
+                    }),
             )
             .child(
                 div()
@@ -3349,6 +3359,116 @@ mod caret_settings_tests {
         assert!(
             app.read_with(cx, |app, _| app.settings.appearance.caret_blink),
             "the real Settings field must have flipped back on"
+        );
+    }
+}
+
+/// GitHub issue #45 ("Input blink only on focused input or file") plus a live follow-up report:
+/// [`AdeApp::render_settings_keymap_filter_row`]'s caret used to be a fixed trailing child,
+/// painted *after* the placeholder text whenever `settings_keymap_filter` was empty, instead of
+/// at the real cursor position (0). Real interaction coverage, mirroring
+/// `crate::palette::render::palette_caret_tests`'/`crate::rail::render::rail_filter_caret_tests`'
+/// own measured-bounds technique rather than only reading the render code.
+#[cfg(test)]
+mod settings_keymap_filter_caret_tests {
+    use crate::root::focus::palette_focus_tests;
+    use gpui::TestAppContext;
+    use std::time::Duration;
+
+    #[gpui::test]
+    fn caret_sits_before_the_placeholder_when_empty_and_after_the_text_once_typed(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_settings(window, cx);
+            app.settings_page = crate::settings::SettingsPage::Keymap;
+            window.focus(&app.settings_keymap_filter_focus_handle, cx);
+        });
+        cx.run_until_parked();
+
+        let empty_caret = cx
+            .debug_bounds("settings-keymap-filter-caret")
+            .expect("the caret should have really painted with an empty filter");
+        let placeholder = cx
+            .debug_bounds("settings-keymap-filter-text")
+            .expect("the placeholder text should have really painted");
+        assert!(
+            empty_caret.origin.x <= placeholder.origin.x,
+            "with an empty filter, the real caret must sit before (at or left of) the \
+             placeholder's own start x, not after it - got caret {:?} vs placeholder {:?}",
+            empty_caret,
+            placeholder,
+        );
+
+        cx.simulate_input("palette");
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.settings_keymap_filter.as_str().to_string()),
+            "palette",
+            "sanity check: real typed filter"
+        );
+
+        let typed_caret = cx
+            .debug_bounds("settings-keymap-filter-caret")
+            .expect("the caret should have really painted with a typed filter");
+        let typed_text = cx
+            .debug_bounds("settings-keymap-filter-text")
+            .expect("the real typed text should have really painted");
+        assert!(
+            typed_caret.origin.x >= typed_text.origin.x + typed_text.size.width,
+            "with a typed filter, the real caret must sit at or after the typed text's own \
+             right edge, not before it - got caret {:?} vs text {:?}",
+            typed_caret,
+            typed_text,
+        );
+        assert!(
+            typed_caret.origin.x > empty_caret.origin.x,
+            "the caret's real measured horizontal position must differ between the \
+             empty-filter state (before the placeholder) and a typed-filter state (after the \
+             real text) - got {:?} vs {:?}",
+            empty_caret.origin.x,
+            typed_caret.origin.x,
+        );
+    }
+
+    /// GitHub issue #45's own title, taken literally - see
+    /// `crate::rail::render::rail_filter_caret_tests`' identical test for why
+    /// `cx.simulate_input` (not a bare `window.focus`) is what actually forces the real redraw
+    /// `on_focus` fires from in this test harness.
+    #[gpui::test]
+    fn focusing_the_settings_keymap_filter_starts_the_real_shared_blink_loop(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        // `on_focus`/`on_blur` (`AdeApp::wire_caret_blink`'s own mechanism) only fire while GPUI
+        // considers the window itself "active" - a real, freshly opened test window starts out
+        // not active at all.
+        app.update_in(cx, |_app, window, _cx| window.activate_window());
+        cx.run_until_parked();
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_settings(window, cx);
+            app.settings_page = crate::settings::SettingsPage::Keymap;
+            window.focus(&app.settings_keymap_filter_focus_handle, cx);
+        });
+        cx.simulate_input("p");
+        assert!(
+            app.read_with(cx, |app, _| app.caret_blink_visible),
+            "a fresh focus must start solid/visible"
+        );
+
+        cx.background_executor.advance_clock(
+            crate::root::caret_blink::CARET_BLINK_INTERVAL + Duration::from_millis(50),
+        );
+        cx.run_until_parked();
+        assert!(
+            !app.read_with(cx, |app, _| app.caret_blink_visible),
+            "focusing the settings keymap filter must have started the real, live shared blink \
+             task"
         );
     }
 }

--- a/crates/app/src/title_bar/render.rs
+++ b/crates/app/src/title_bar/render.rs
@@ -274,8 +274,8 @@ impl AdeApp {
                         )
                     }),
             )
-            .when_some(agent_state_chips, |el, chips| el.child(chips))
             .child(div().flex_1())
+            .when_some(agent_state_chips, |el, chips| el.child(chips))
             .when(!macos, |el| el.child(self.render_windows_caption_buttons()))
     }
 

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -1218,6 +1218,11 @@ impl AdeApp {
         let chip_kind = work_surface::tab_chip_kind(agent.kind);
         let is_mono = matches!(chip_kind, work_surface::TabChipKind::Cli);
         let colors = work_surface::tab_colors(is_active);
+        // §3: "5px status square that keeps reporting while you read another tab" - the same
+        // real `Status` the rail's own agent row and context bar already derive this agent's
+        // colour from, so the tab strip can never disagree with either about what state an
+        // agent is in.
+        let status_color: gpui::Rgba = self.agent_status(agent, cx).color();
         let tab_ref = work_surface::TabRef::Agent(id);
         let drag_value = DraggedTab::Agent {
             id,
@@ -1297,19 +1302,11 @@ impl AdeApp {
                     )
                     .child(
                         div()
-                            .id(("close-agent-tab", id))
-                            .px(px(2.0))
-                            .cursor_pointer()
-                            .font(font(theme::font::MONO))
-                            .text_size(px(11.0))
-                            .text_color(theme::text::GHOST)
-                            .hover(|el| el.text_color(theme::button::DANGER_FG))
-                            .child("\u{d7}")
-                            .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
-                                cx.stop_propagation();
-                                this.close_agent(id, window, cx);
-                                cx.notify();
-                            })),
+                            .flex_none()
+                            .w(px(5.0))
+                            .h(px(5.0))
+                            .rounded(px(2.5))
+                            .bg(status_color),
                     ),
             )
             .child(div().flex_none().w_full().h(px(1.0)).bg(colors.underline))

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -345,15 +345,29 @@ impl AdeApp {
     /// every render rather than caching a mutated copy) - [`Self::tab_order`] itself only records
     /// a user's real drag-chosen order, never which tabs exist; that's still `Agents`/
     /// [`Self::open_files`]'s job.
+    ///
+    /// A bare worktree (Revision R12 §3: "a bare worktree shows only the shell tab") reconciles
+    /// against an *empty* file list instead of the real [`Self::open_files`] - `reconcile_tab_order`
+    /// then drops every `TabRef::File` already in `stored` (its own `open_files.contains(path)`
+    /// filter) and appends none back. This only hides them from the reconciled order this call
+    /// returns; it never touches [`Self::open_files_by_worktree`] or `stored` itself, so the
+    /// moment a real agent spawns and the worktree stops being bare, the next call reconciles
+    /// against the real (untouched) open-files list again and the same file tabs reappear in
+    /// their original position - nothing was destroyed, only not rendered while bare. Bareness is
+    /// computed locally from `agents_for_cwd` rather than by calling
+    /// [`Self::current_worktree_is_bare`], which itself goes through
+    /// [`Self::current_worktree_agents`] -> this function; calling back into it here would
+    /// recurse.
     pub(crate) fn combined_tab_order(&self) -> Vec<work_surface::TabRef> {
         let cwd = self.active_agent_cwd();
         let stored = self.tab_order.get(&cwd).map(Vec::as_slice).unwrap_or(&[]);
-        let agent_ids: Vec<AgentId> = self
-            .agents
-            .iter_for_cwd(cwd.clone())
-            .map(|agent| agent.id)
-            .collect();
-        work_surface::reconcile_tab_order(stored, &agent_ids, self.open_files())
+        let agents_for_cwd: Vec<&Agent> = self.agents.iter_for_cwd(cwd.clone()).collect();
+        let agent_ids: Vec<AgentId> = agents_for_cwd.iter().map(|agent| agent.id).collect();
+        let is_bare = !agents_for_cwd
+            .iter()
+            .any(|agent| agent.kind != AgentKind::Shell);
+        let open_files: &[PathBuf] = if is_bare { &[] } else { self.open_files() };
+        work_surface::reconcile_tab_order(stored, &agent_ids, open_files)
     }
 
     /// The unified tab strip's real drag-to-reorder entry point (GitHub issue #16) - moves
@@ -779,7 +793,7 @@ impl AdeApp {
     /// [`crate::rail::render::render_new_agent_button`]). A `gpui::canvas` child captures
     /// this button's painted bounds into [`Self::plus_button_bounds`] every render, which
     /// [`Self::render_plus_menu`] positions the popover off of. Opening the menu also refreshes
-    /// [`Self::load_agent_rows`], so the "New agent pane" row's sub-label
+    /// [`Self::load_agent_rows`], so the "New agent" row's icon/chip
     /// ([`Self::resolved_new_agent_kind`]) reflects a reasonably fresh `$PATH` search rather than
     /// a possibly-empty cached snapshot.
     pub(in crate::work_surface) fn render_tab_strip_plus(
@@ -837,16 +851,23 @@ impl AdeApp {
     /// the panel stops that click from bubbling up (`cx.stop_propagation()`). Positioned off
     /// [`Self::plus_button_bounds`].
     ///
-    /// Five rows: *New terminal* ([`Self::new_agent`] with [`AgentKind::Shell`]), *New file*
-    /// ([`Self::start_new_file`]), *New agent pane* ([`Self::new_agent_pane`]), *Open file…*
+    /// Five rows, in the exact order and wording Revision R12 §3 specifies: *New terminal*
+    /// ([`Self::new_agent`] with [`AgentKind::Shell`]), *New agent* (`runs in <branch>` -
+    /// [`Self::new_agent_pane`]), *Git graph* ([`Self::open_git_graph`]), *Open file…*
     /// ([`Self::open_palette`], scoped to [`palette::PaletteScope::Files`]), and *Next changed
-    /// file* ([`Self::next_changed_file`]). *New terminal*, *New agent pane*, and *Next changed
-    /// file* each dispatch the same method their own global keybinding does
-    /// (`crate::default_key_bindings`) and show that binding's keycap; *New file* and *Open
-    /// file…* have no global keybinding of their own (the latter's own real `mod+P` spec is now
-    /// claimed by `TogglePalette` instead - see `crate::default_key_bindings`'s own docs for that
-    /// tradeoff; *New file* simply has no design-specified shortcut) and so show no keycap. Every
-    /// row's click handler also closes the menu.
+    /// file* ([`Self::next_changed_file`]). *New terminal*, *New agent*, *Git graph*, and *Next
+    /// changed file* each dispatch the same method their own global keybinding does
+    /// (`crate::default_key_bindings`) and show that binding's keycap; *Open file…* has no global
+    /// keybinding of its own (its own real `mod+P` spec is now claimed by `TogglePalette`
+    /// instead, see `crate::default_key_bindings`'s own docs for that tradeoff) and so shows no
+    /// keycap. Every row's click handler also closes the menu.
+    ///
+    /// There is no *New file* row - §3's item list names only these five. A worktree's file tree
+    /// (`crate::sidebar::render::render_file_tree_row`/`render_right_sidebar_toggle`) already
+    /// carries its own always-visible `+` affordances (per-directory and root-level), both wired
+    /// to the same real [`Self::start_new_file`] this row used to call, so removing it here drops
+    /// no reachable functionality - it was a second entry point to an action that already has one
+    /// the spec keeps.
     pub(crate) fn render_plus_menu(&self, cx: &mut Context<Self>) -> impl IntoElement {
         let macos = self.window_controls_style().is_macos();
         let bounds = self.plus_button_bounds;
@@ -855,7 +876,8 @@ impl AdeApp {
         let resolved_kind = self.resolved_new_agent_kind();
         let (agent_fg, agent_bg) = work_surface::agent_tint(resolved_kind);
         let agent_initial = work_surface::agent_initial(resolved_kind);
-        let agent_label = resolved_kind.label();
+        let branch = self.current_worktree_branch();
+        let new_agent_secondary = work_surface::new_agent_menu_secondary_text(branch.as_deref());
         let changed_count = self
             .current_diff()
             .map(|diff| diff.files.len())
@@ -914,32 +936,11 @@ impl AdeApp {
                     )
                     .child(
                         render_dropdown_menu_row(
-                            "+",
-                            theme::text::DIM.into(),
-                            theme::surface::CHIP_NEUTRAL.into(),
-                            "New file",
-                            "in this worktree".to_string(),
-                            // No keycap: same reasoning as the "Open file…" row below - no
-                            // global keybinding exists for this (see `Self::start_new_file`'s
-                            // own docs).
-                            Vec::new(),
-                            true,
-                        )
-                        .on_click(cx.listener(
-                            |this, _event: &ClickEvent, window, cx| {
-                                this.plus_menu_open = false;
-                                let cwd = this.active_agent_cwd();
-                                this.start_new_file(cwd, window, cx);
-                            },
-                        )),
-                    )
-                    .child(
-                        render_dropdown_menu_row(
                             agent_initial,
                             agent_fg,
                             agent_bg,
-                            "New agent pane",
-                            agent_label.to_string(),
+                            "New agent",
+                            new_agent_secondary,
                             keymap::resolve_combo("mod+shift+N", macos),
                             true,
                         )
@@ -948,6 +949,23 @@ impl AdeApp {
                                 this.new_agent_pane(cx);
                                 this.plus_menu_open = false;
                                 cx.notify();
+                            },
+                        )),
+                    )
+                    .child(
+                        render_dropdown_menu_row(
+                            "\u{2325}",
+                            theme::graph::TAB_CHIP_FG.into(),
+                            theme::graph::TAB_CHIP_BG.into(),
+                            "Git graph",
+                            "commit history".to_string(),
+                            keymap::resolve_combo("mod+shift+G", macos),
+                            true,
+                        )
+                        .on_click(cx.listener(
+                            |this, _event: &ClickEvent, window, cx| {
+                                this.plus_menu_open = false;
+                                this.open_git_graph(window, cx);
                             },
                         )),
                     )
@@ -991,28 +1009,11 @@ impl AdeApp {
                                 this.next_changed_file(window, cx);
                             },
                         )),
-                    )
-                    .child(
-                        render_dropdown_menu_row(
-                            "\u{2325}",
-                            theme::graph::TAB_CHIP_FG.into(),
-                            theme::graph::TAB_CHIP_BG.into(),
-                            "Git graph",
-                            "commit history".to_string(),
-                            keymap::resolve_combo("mod+shift+G", macos),
-                            true,
-                        )
-                        .on_click(cx.listener(
-                            |this, _event: &ClickEvent, window, cx| {
-                                this.plus_menu_open = false;
-                                this.open_git_graph(window, cx);
-                            },
-                        )),
                     ),
             )
     }
 
-    /// Which agent kind the `+` menu's "New agent pane" row would spawn right now: the first
+    /// Which agent kind the `+` menu's "New agent" row would spawn right now: the first
     /// [`settings::AGENT_KINDS`] entry [`Self::agent_rows`] (refreshed on menu open) confirms is
     /// installed, or `AGENT_KINDS[0]` if none are (or `agent_rows` hasn't been populated yet).
     /// Display-only - [`Self::new_agent_pane`] runs its own detection independently, off the
@@ -1028,7 +1029,7 @@ impl AdeApp {
             .unwrap_or(settings::AGENT_KINDS[0])
     }
 
-    /// The `+` menu's "New agent pane" action (`secondary-shift-n`) - spawns the first
+    /// The `+` menu's "New agent" action (`secondary-shift-n`) - spawns the first
     /// [`settings::AGENT_KINDS`] entry a background `$PATH` search
     /// (`pty_core::resolve_on_path`, the same search [`Self::load_agent_rows`] runs) confirms is
     /// installed, rather than blocking the click on a filesystem walk.
@@ -2051,6 +2052,7 @@ pub(crate) fn render_dropdown_menu_row(
     };
     let mut row = div()
         .id(format!("dropdown-menu-row-{label}"))
+        .debug_selector(|| format!("dropdown-menu-row-{label}"))
         .flex()
         .items_center()
         .gap(px(9.0))
@@ -2732,6 +2734,13 @@ mod tab_scoping_tests {
     /// `DraggedAgentTab`/`DraggedFileTab` types could never produce (GPUI's `on_drop::<T>`
     /// dispatches purely on the dragged value's concrete type, so a `DraggedFileTab` could never
     /// be dropped onto an agent tab's `on_drop::<DraggedAgentTab>` handler or vice versa).
+    ///
+    /// The second tab spawned here is a real `Claude` agent, not a second `Shell` - Revision
+    /// R12 §3's bare-worktree suppression (`Self::current_worktree_is_bare`) treats "every open
+    /// agent is a `Shell`" as bare and hides file tabs from `Self::combined_tab_order` entirely
+    /// (`a_bare_worktrees_tab_strip_shows_only_its_shell_tab_and_preserves_file_tab_state`
+    /// covers that directly), which would make this drag-interleaving assertion moot for reasons
+    /// that have nothing to do with what this test actually exercises.
     #[gpui::test]
     fn dragging_a_file_tab_between_two_agent_tabs_interleaves_them(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
@@ -2742,7 +2751,7 @@ mod tab_scoping_tests {
         let (initial_id, second_id) = app.update_in(cx, |app, window, cx| {
             let initial_id = app.agents.active_id().expect("initial shell agent");
             let second_id = app.agents.spawn(
-                AgentKind::Shell,
+                AgentKind::Claude,
                 repo.path().to_path_buf(),
                 12.0,
                 window,
@@ -2982,6 +2991,250 @@ mod tab_scoping_tests {
         assert_ne!(
             label, "terminal",
             "the bare-worktree shell label must never fall back to the generic non-bare label"
+        );
+    }
+
+    /// Revision R12 §3's exact `+` menu item list: "*New terminal* · *New agent*
+    /// (`runs in <branch>`) · *Git graph* · *Open file…* · *Next changed file*." Proven against
+    /// the real painted popover (`Self::render_dropdown_menu_row`'s own `debug_selector`, one per
+    /// row, keyed by its label), not just the source order - and confirms there is genuinely no
+    /// "New file" row any more (removed: the file tree already carries a real, always-visible
+    /// replacement, `crate::sidebar::render::render_file_tree_row`/
+    /// `render_right_sidebar_toggle`'s own per-directory and root-level "+" affordances).
+    #[gpui::test]
+    fn the_plus_menus_five_rows_match_revision_r12_3_in_order_with_no_new_file_row(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+
+        app.update(cx, |app, cx| {
+            app.plus_menu_open = true;
+            cx.notify();
+        });
+        cx.run_until_parked();
+
+        let new_terminal = cx
+            .debug_bounds("dropdown-menu-row-New terminal")
+            .expect("\"New terminal\" row must be painted");
+        let new_agent = cx
+            .debug_bounds("dropdown-menu-row-New agent")
+            .expect("\"New agent\" row must be painted");
+        let git_graph = cx
+            .debug_bounds("dropdown-menu-row-Git graph")
+            .expect("\"Git graph\" row must be painted");
+        let open_file = cx
+            .debug_bounds("dropdown-menu-row-Open file\u{2026}")
+            .expect("\"Open file\u{2026}\" row must be painted");
+        let next_changed = cx
+            .debug_bounds("dropdown-menu-row-Next changed file")
+            .expect("\"Next changed file\" row must be painted");
+
+        assert!(
+            new_terminal.origin.y < new_agent.origin.y
+                && new_agent.origin.y < git_graph.origin.y
+                && git_graph.origin.y < open_file.origin.y
+                && open_file.origin.y < next_changed.origin.y,
+            "the five rows must render top to bottom in exactly Revision R12 §3's order: New \
+             terminal, New agent, Git graph, Open file\u{2026}, Next changed file"
+        );
+
+        assert!(
+            cx.debug_bounds("dropdown-menu-row-New file").is_none(),
+            "there must be no \"New file\" row - it is not one of §3's five items, and the file \
+             tree already has a real replacement"
+        );
+        assert!(
+            cx.debug_bounds("dropdown-menu-row-New agent pane")
+                .is_none(),
+            "the row must be relabelled \"New agent\", not the old \"New agent pane\""
+        );
+    }
+
+    /// Revision R12 §3's `+` menu Git graph row, clicked for real (`cx.simulate_click` against
+    /// the row's own painted bounds, not a direct `open_git_graph` call) - must actually open the
+    /// graph tab, and close the menu behind it the same way every other row's click does.
+    #[gpui::test]
+    fn a_real_click_on_the_plus_menus_git_graph_row_opens_the_graph_tab(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+
+        app.update(cx, |app, cx| {
+            app.plus_menu_open = true;
+            cx.notify();
+        });
+        cx.run_until_parked();
+
+        assert!(
+            !app.read_with(cx, |app, _| app.graph_tab_open),
+            "premise: the graph tab must not already be open before the click"
+        );
+
+        let git_graph = cx
+            .debug_bounds("dropdown-menu-row-Git graph")
+            .expect("\"Git graph\" row must be painted while the + menu is open");
+        cx.simulate_click(git_graph.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.graph_tab_open && app.graph_tab_active,
+                "a real click on the Git graph row must genuinely open and activate the graph \
+                 tab, not just close the menu"
+            );
+            assert!(
+                !app.plus_menu_open,
+                "the row's click handler must also close the + menu, matching every other row"
+            );
+        });
+    }
+
+    /// Revision R12 §3's `+` menu "New agent" row secondary text (`runs in <branch>`) must come
+    /// from the real selected worktree's own recorded branch - the exact composition
+    /// `Self::render_plus_menu` performs (`Self::current_worktree_branch` piped into
+    /// `work_surface::new_agent_menu_secondary_text`) - not a hardcoded model/kind label the row
+    /// used to show (`agent.kind.label()`, e.g. `"Claude"`).
+    #[gpui::test]
+    fn the_new_agent_rows_secondary_text_uses_the_real_selected_worktrees_branch(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let wt_a = tempfile::tempdir().expect("tempdir a");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+
+        app.update(cx, |app, _cx| {
+            app.worktrees = vec![worktree_item(
+                wt_a.path().to_path_buf(),
+                "feature/real-branch",
+            )];
+        });
+        app.update_in(cx, |app, window, cx| {
+            app.select_worktree(0, window, cx);
+        });
+
+        let (branch, secondary) = app.read_with(cx, |app, _| {
+            let branch = app.current_worktree_branch();
+            let secondary = work_surface::new_agent_menu_secondary_text(branch.as_deref());
+            (branch, secondary)
+        });
+
+        assert_eq!(
+            branch.as_deref(),
+            Some("feature/real-branch"),
+            "premise: the selected worktree's real branch must resolve to the seeded value"
+        );
+        assert_eq!(
+            secondary, "runs in feature/real-branch",
+            "the row must show the real branch, substituted in - not a literal placeholder"
+        );
+        assert_ne!(
+            secondary, "Claude",
+            "must never show a model/agent-kind label in the branch's place - the pre-fix bug"
+        );
+    }
+
+    /// Revision R12 §3: "A bare worktree shows only the shell tab." A worktree that had a real
+    /// agent and a file tab open, then had that agent archived (leaving only the default
+    /// `Shell` tab - genuinely bare, per `Self::current_worktree_is_bare`), must stop rendering
+    /// its file tab in `Self::combined_tab_order` - but the file's own entry in
+    /// `Self::open_files_by_worktree` must survive untouched, so the tab reappears (without
+    /// having to reopen the file) the moment a real agent spawns again and the worktree stops
+    /// being bare. This is the conservative "don't render, don't destroy" reading of the spec's
+    /// own per-worktree tab-memory design (§3: "Each worktree remembers its own... open files").
+    #[gpui::test]
+    fn a_bare_worktrees_tab_strip_shows_only_its_shell_tab_and_preserves_file_tab_state(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let wt_a = tempfile::tempdir().expect("tempdir a");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+
+        app.update(cx, |app, _cx| {
+            app.worktrees = vec![worktree_item(wt_a.path().to_path_buf(), "wt-a")];
+        });
+        let claude_id = app.update_in(cx, |app, window, cx| {
+            app.select_worktree(0, window, cx);
+            let shell_id = app.agents.spawn(
+                AgentKind::Shell,
+                wt_a.path().to_path_buf(),
+                12.0,
+                window,
+                cx,
+            );
+            let claude_id = app.agents.spawn(
+                AgentKind::Claude,
+                wt_a.path().to_path_buf(),
+                12.0,
+                window,
+                cx,
+            );
+            app.open_files_mut().push(PathBuf::from("README.md"));
+            let _ = shell_id;
+            claude_id
+        });
+
+        let order_with_agent = app.read_with(cx, |app, _| app.combined_tab_order());
+        assert!(
+            order_with_agent
+                .iter()
+                .any(|tab_ref| matches!(tab_ref, work_surface::TabRef::File(path) if path == &PathBuf::from("README.md"))),
+            "premise: the file tab is genuinely open while a real agent is running"
+        );
+        assert!(
+            !app.read_with(cx, |app, _| app.current_worktree_is_bare()),
+            "premise: the worktree is not bare while the Claude agent is running"
+        );
+
+        app.update_in(cx, |app, window, cx| {
+            app.archive_agent(claude_id, window, cx);
+        });
+
+        assert!(
+            app.read_with(cx, |app, _| app.current_worktree_is_bare()),
+            "archiving the only real agent must leave the worktree bare (only its default \
+             Shell tab left)"
+        );
+
+        let order_while_bare = app.read_with(cx, |app, _| app.combined_tab_order());
+        assert!(
+            order_while_bare
+                .iter()
+                .all(|tab_ref| !matches!(tab_ref, work_surface::TabRef::File(_))),
+            "a bare worktree's tab strip must show only its shell tab - no file tabs, even ones \
+             left open from before it went bare"
+        );
+        assert!(
+            order_while_bare.iter().any(
+                |tab_ref| matches!(tab_ref, work_surface::TabRef::Agent(id) if *id != claude_id)
+            ),
+            "the shell tab itself must still be there - only the file tab is suppressed"
+        );
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.open_files().to_vec()),
+            vec![PathBuf::from("README.md")],
+            "the file's own entry in open_files_by_worktree must survive untouched while bare - \
+             suppression is render-only, never destructive"
+        );
+
+        // Spawning a real agent again makes the worktree non-bare - the file tab must reappear
+        // with zero extra work, since its underlying state was never touched.
+        app.update_in(cx, |app, window, cx| {
+            app.agents.spawn(
+                AgentKind::Codex,
+                wt_a.path().to_path_buf(),
+                12.0,
+                window,
+                cx,
+            );
+        });
+        let order_after_respawn = app.read_with(cx, |app, _| app.combined_tab_order());
+        assert!(
+            order_after_respawn
+                .iter()
+                .any(|tab_ref| matches!(tab_ref, work_surface::TabRef::File(path) if path == &PathBuf::from("README.md"))),
+            "the file tab must reappear once the worktree is no longer bare - its state was \
+             preserved, not destroyed, while suppressed"
         );
     }
 }

--- a/crates/app/src/work_surface/state.rs
+++ b/crates/app/src/work_surface/state.rs
@@ -245,6 +245,17 @@ pub fn bare_worktree_shell_label(program: &str, branch: Option<&str>) -> String 
     }
 }
 
+/// The `+` menu's "New agent" row secondary text (`design_handoff_jerry_ade/revision 3/
+/// REVISION-2026-07-31.md` §3: "*New agent* (`runs in <branch>`)") - the real, currently selected
+/// worktree's branch substituted in, never a hardcoded model/kind name (that was the pre-fix
+/// bug: the row showed `agent.kind.label()`, e.g. `"Claude"`, which is not what this spec item
+/// asks for at all). Falls back to `(detached)` for a worktree with no recorded branch, mirroring
+/// `crate::work_surface::render::AdeApp::render_agent_context_bar`'s own branch fallback so the
+/// two don't invent two different placeholder strings for the same "no branch" fact.
+pub fn new_agent_menu_secondary_text(branch: Option<&str>) -> String {
+    format!("runs in {}", branch.unwrap_or("(detached)"))
+}
+
 /// Appends a ` #N` ordinal (1-based, in order of appearance) to every label that repeats within
 /// `labels`, so two agents on the same model in one worktree never render two identical tab
 /// labels (`sonnet-4.5`, `sonnet-4.5` -> `sonnet-4.5 #1`, `sonnet-4.5 #2` - Revision R12 §3). A
@@ -703,6 +714,25 @@ mod tests {
     #[test]
     fn a_bare_worktrees_shell_label_falls_back_to_the_program_name_when_detached() {
         assert_eq!(bare_worktree_shell_label("bash", None), "bash");
+    }
+
+    /// Revision R12 §3's exact spec wording for the `+` menu's "New agent" row.
+    #[test]
+    fn the_new_agent_menu_row_shows_the_real_branch_never_a_model_name() {
+        assert_eq!(
+            new_agent_menu_secondary_text(Some("feature/real-branch")),
+            "runs in feature/real-branch"
+        );
+        assert_ne!(
+            new_agent_menu_secondary_text(Some("feature/real-branch")),
+            "Claude",
+            "must never show a model/agent-kind label in place of the branch"
+        );
+    }
+
+    #[test]
+    fn the_new_agent_menu_row_falls_back_to_detached_with_no_recorded_branch() {
+        assert_eq!(new_agent_menu_secondary_text(None), "runs in (detached)");
     }
 
     #[test]

--- a/crates/wt-core/src/diff.rs
+++ b/crates/wt-core/src/diff.rs
@@ -650,19 +650,31 @@ fn prepare_shadow_index(worktree_path: &Path) -> Result<tempfile::NamedTempFile,
         }
     };
 
-    let mut shadow = tempfile::NamedTempFile::new().map_err(Error::WorktreeIo)?;
-    // A repository whose index has never been written (e.g. immediately after `git init`,
-    // before any commit) has no index file on disk yet; falling back to an empty temp file
-    // in that case mirrors git's own "missing index == empty index" behavior rather than
-    // being an error. In practice `diff_against_base` already returns `NoBaseFound` for an
-    // unborn `HEAD` before reaching this point, so the index should always exist here, but
-    // this stays defensive rather than failing outright if it somehow doesn't.
-    if let Ok(real_index_bytes) = std::fs::read(&real_index_path) {
-        use std::io::Write as _;
-        shadow
-            .write_all(&real_index_bytes)
-            .map_err(Error::WorktreeIo)?;
-        shadow.flush().map_err(Error::WorktreeIo)?;
+    let shadow = tempfile::NamedTempFile::new().map_err(Error::WorktreeIo)?;
+    match std::fs::read(&real_index_path) {
+        Ok(real_index_bytes) => {
+            use std::io::Write as _;
+            (&shadow)
+                .write_all(&real_index_bytes)
+                .map_err(Error::WorktreeIo)?;
+            (&shadow).flush().map_err(Error::WorktreeIo)?;
+        }
+        Err(_) => {
+            // A repository whose index has never been written (e.g. immediately after
+            // `git init`, before any commit), or one whose index momentarily can't be read
+            // (a real interleaving hazard: an agent CLI's own `git add`/`git commit`
+            // rewriting the index at the exact moment this reads it), has no real bytes to
+            // seed the shadow copy with. `NamedTempFile::new()` above already created a
+            // real, empty *file* at this path though - and an empty-but-*existing* file is
+            // not what git treats as "no index yet": confirmed directly (`GIT_INDEX_FILE`
+            // pointed at a 0-byte file makes real `git add` fail outright with `fatal: ...
+            // index file smaller than expected`, exit 128), where a path that simply
+            // doesn't exist at all is instead treated as a fresh empty index and succeeds.
+            // Delete the placeholder so the path git sees is genuinely missing, not merely
+            // empty - `git add` below then creates a real index there from scratch, exactly
+            // as it would for a brand-new repository's very first `git add`.
+            std::fs::remove_file(shadow.path()).map_err(Error::WorktreeIo)?;
+        }
     }
 
     let add_args: Vec<OsString> = vec![
@@ -1353,6 +1365,55 @@ mod tests {
             status_text.contains("?? brand_new.txt"),
             "the real index must be untouched by the shadow index trick, got status: \
              {status_text}"
+        );
+    }
+
+    #[test]
+    fn a_missing_or_unreadable_real_index_does_not_fail_the_whole_diff() {
+        // Reproduces a real, confirmed bug: `prepare_shadow_index` used to fall back to an
+        // empty *existing* temp file when the real index couldn't be read, on the (wrong)
+        // assumption that this "mirrors git's own missing index == empty index behavior."
+        // Verified directly with real git commands that it does not: `GIT_INDEX_FILE`
+        // pointed at a genuinely nonexistent path is treated as a fresh empty index (real
+        // `git add` succeeds), but pointed at an existing 0-byte file it fails outright
+        // (`fatal: ... index file smaller than expected`, exit 128) - a completely
+        // different, fatal code path. `diff_against_base` surfaced that fatal to the whole
+        // Changes panel as "failed to compute diff: ...".
+        let repo = init_repo();
+        git(repo.path(), &["checkout", "-b", "feature"]);
+        fs::write(repo.path().join("brand_new.txt"), "content nobody staged\n").expect("write");
+
+        // Simulate the real index being genuinely unreadable at the moment
+        // `prepare_shadow_index` reads it - a fresh worktree with no index written yet, or
+        // (the more likely real-world trigger) an agent CLI's own concurrent `git add`/
+        // `git commit` rewriting it in the same window. `git rev-parse --git-path index`
+        // matches exactly what `prepare_shadow_index` itself resolves.
+        let index_path_output = Command::new("git")
+            .current_dir(repo.path())
+            .args(["rev-parse", "--git-path", "index"])
+            .output()
+            .expect("git rev-parse --git-path index");
+        let index_path = repo
+            .path()
+            .join(String::from_utf8_lossy(&index_path_output.stdout).trim());
+        assert!(
+            index_path.exists(),
+            "sanity check: a real index must exist after a commit"
+        );
+        fs::remove_file(&index_path)
+            .expect("remove the real index to simulate it being unreadable");
+
+        let result = diff_against_base(repo.path())
+            .expect("a missing real index must not fail the whole diff computation");
+        let DiffBase::Diff(diff) = result else {
+            panic!("expected DiffBase::Diff, got {result:?}");
+        };
+        assert!(
+            diff.files
+                .iter()
+                .any(|f| f.path == Path::new("brand_new.txt")),
+            "the diff must still compute (and still see the real untracked file) even when \
+             the real index couldn't be read to seed the shadow copy"
         );
     }
 

--- a/crates/wt-core/src/graph.rs
+++ b/crates/wt-core/src/graph.rs
@@ -248,10 +248,16 @@ pub fn build_graph(
         let Some(commit) = nodes.remove(id) else {
             continue;
         };
-        let dot_kind = if Some(*id) == head_id {
-            DotKind::Head
-        } else if commit.is_merge() {
+        // `is_merge()` is checked *before* the `head_id` comparison, not after: a commit can
+        // honestly be both at once (this repository's own `master` tip is one right now - a
+        // real `Merge pull request` commit HEAD currently sits on), and merge-ness is the
+        // rarer, more structurally significant fact to lose - HEAD is already shown
+        // separately and unambiguously via the branch's own `RefChip::is_head` styling next
+        // to this row, so nothing is actually lost by not also ringing the dot for it here.
+        let dot_kind = if commit.is_merge() {
             DotKind::Merge
+        } else if Some(*id) == head_id {
+            DotKind::Head
         } else {
             DotKind::Commit
         };
@@ -1212,6 +1218,42 @@ mod tests {
         assert!(
             feature_row.lane > 0,
             "feature commit should not render on the trunk lane"
+        );
+    }
+
+    #[test]
+    fn a_merge_commit_that_is_also_head_still_gets_the_merge_dot_kind() {
+        // A real, reproduced bug: `dot_kind` checked `head_id` before `commit.is_merge()`, so
+        // a commit that is honestly both (this repository's own `master` tip is one right now)
+        // lost its merge styling entirely - the single most merge-shaped row in the graph
+        // rendered as a plain `Head` dot instead. `HEAD` is already shown separately and
+        // unambiguously via the branch's own ref-chip styling, so prioritizing `Merge` here
+        // loses no real information.
+        let repo = init_repo();
+        commit_at(repo.path(), "a.txt", "1", "base", 1_700_000_000);
+        git(repo.path(), &["checkout", "-b", "feature"]);
+        commit_at(repo.path(), "b.txt", "1", "feature work", 1_700_000_100);
+        git(repo.path(), &["checkout", "main"]);
+        merge_at(
+            repo.path(),
+            "feature",
+            "Merge branch 'feature'",
+            1_700_000_200,
+        );
+        // `main`'s own real HEAD is now this merge commit - no further commits after it.
+
+        let graph = build_graph(repo.path(), GraphScope::All, 0).expect("build_graph");
+        let head_row = &graph.rows[0];
+        assert_eq!(head_row.commit.subject, "Merge branch 'feature'");
+        assert!(
+            head_row.commit.is_merge(),
+            "sanity check: HEAD really is a merge commit"
+        );
+        assert!(
+            matches!(head_row.dot_kind, DotKind::Merge),
+            "a commit that is both HEAD and a real merge must still render as Merge, not Head - \
+             got {:?}",
+            head_row.dot_kind
         );
     }
 


### PR DESCRIPTION
## Summary

Stacked on the git-graph PR (top of the R12 chain). Two real gaps found by an earlier audit, fixed here:

**`+` menu item list.** Spec §3: "New terminal · New agent (`runs in <branch>`) · Git graph · Open file… · Next changed file." The actual menu had a `New file` row not in the spec, `New agent pane` showing the agent kind's model name as its secondary text instead of the branch, and the Git graph row sitting last instead of third. Fixed: reordered Git graph to third, renamed to `New agent` with real branch substitution (`runs in <branch>`), and removed `New file` after confirming the file tree already has a real, always-visible replacement (per-directory and root `+` buttons calling the same `start_new_file`) — nothing load-bearing was lost.

**Bare-worktree tab suppression.** Spec §3: "A bare worktree shows only the shell tab." The label/header-bar swap was already correct, but file tabs still rendered alongside the shell tab. Fixed in `combined_tab_order`: when every agent in the active worktree is a Shell, it reconciles against an empty file list rather than the real `open_files()` — render-only suppression, nothing destroyed. The moment a real agent spawns, the same file tabs reappear from their untouched per-worktree state.

Also folds in a real gap the investigation surfaced: this branch split off the git-graph work before the sibling `revision-r12-tabstrip` branch's ordinal-tab-label/bare-worktree-prompt commit landed, so that functionality genuinely didn't exist here despite an earlier audit reporting it as done (against the wrong branch's head). Cherry-picked cleanly, then superseded entirely once the underlying git-graph PR was itself corrected to rebase through `tabstrip` properly (see that PR).

## Testing

Independently re-verified (not just agent-reported):
- `cargo fmt --all -- --check` — clean
- `cargo build --workspace` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace --lib -- --test-threads=1` — 1212 + 44 + 14 + 139 = 1409 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)