### PR TITLE
feat(app): git graph tab - real fetch, pull, and push (issue #1 phase c)

### DIFF
--- a/crates/app/src/graph_view/mod.rs
+++ b/crates/app/src/graph_view/mod.rs
@@ -11,16 +11,24 @@
 //!   row list, the row `⋯` menu, the Push `▾` menu, and the Commit/Branches right panel, plus
 //!   the `impl AdeApp` glue that opens/closes/loads the tab.
 //!
-//! ## Scope (phase (a) only)
+//! ## Scope
 //!
-//! This is read-only. The row `⋯` menu's Branch/Apply/Reset groups are real, visible menu rows
-//! (per the design spec) but every entry that would perform a destructive git operation (check
-//! out, cherry-pick, revert, rebase, reset, force-push, "start an agent from this commit") is
-//! rendered **disabled** - `crate::work_surface::render::render_dropdown_menu_row`'s existing
-//! `enabled: false` treatment, with no `.on_click` attached - because none of those operations
-//! exist in `wt_core` yet (that's a separate, later phase). Only the Copy group's entries
-//! (real clipboard writes of already-loaded data) and the toolbar's read-only scope segment are
-//! actually wired. Agent-to-commit correlation (which agent authored a commit) is a
+//! Phase (a) shipped read-only. Phase (c) (GitHub issue #1's own "push (force with lease,
+//! force, no force)"/"pull") has since wired the toolbar's Fetch/Pull and the Push `▾` menu's
+//! Push/Force-with-lease/Force rows to real `wt_core::remote` calls
+//! (`AdeApp::request_graph_fetch`/`request_graph_pull`/`request_graph_push`) - see that
+//! module's own docs for the fetch/pull/push implementations and
+//! [`state::GraphTabState::push_force_confirm_armed`] for the real two-click confirmation the
+//! two force variants require. The row `⋯` menu's Branch/Apply/Reset groups remain real,
+//! visible menu rows (per the design spec) but every entry that would perform a *different*
+//! destructive git operation (check out, cherry-pick, revert, rebase, reset, "start an agent
+//! from this commit") is still rendered **disabled** -
+//! `crate::work_surface::render::render_dropdown_menu_row`'s existing `enabled: false`
+//! treatment, with no `.on_click` attached - because none of those specific operations exist in
+//! `wt_core` yet (real, separate follow-up work, not yet started). Only the Copy group's
+//! entries (real clipboard writes of already-loaded data), the toolbar's read-only scope
+//! segment, and now Fetch/Pull/Push are actually wired. Agent-to-commit correlation (which agent
+//! authored a commit) is a
 //! separate, later feature too; a first draft carried an always-empty per-commit agent column
 //! for it, but `design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §6.2 removed that
 //! column outright rather than leave it honestly empty - a commit belongs to a worktree, which

--- a/crates/app/src/graph_view/render.rs
+++ b/crates/app/src/graph_view/render.rs
@@ -378,18 +378,98 @@ impl AdeApp {
         cx.notify();
     }
 
-    /// The honest not-yet-wired response for Fetch/Pull/Push (and their menu entries): real,
-    /// visible feedback rather than a silent no-op or a fabricated success - see `super`'s module
-    /// docs for why none of these are actually implemented in phase (a). Still does one real
-    /// thing: reloads the graph, so a click at least confirms nothing crashed and the view is
-    /// current.
-    pub(crate) fn graph_action_not_yet_wired(&mut self, action: &str, cx: &mut Context<Self>) {
-        self.graph_state.status_message = Some(format!("{action} - not implemented yet"));
+    /// Real `git fetch` for the current worktree, off the UI thread - GitHub issue #1's own
+    /// "Fetch" toolbar button. Updates remote-tracking refs only, so the graph reload afterward
+    /// (which recomputes [`GraphTabState::upstream_counts`]) is what actually makes a fetch
+    /// *visible*: the ahead/behind counts and any newly-visible remote branch chips.
+    pub(crate) fn request_graph_fetch(&mut self, cx: &mut Context<Self>) {
+        self.run_graph_remote_op("Fetch", cx, |root| wt_core::remote::fetch(&root));
+    }
+
+    /// Real `git pull` (fetch + merge into the current branch) for the current worktree, off the
+    /// UI thread - GitHub issue #1's own "Pull" toolbar button. A real merge conflict surfaces
+    /// as [`GraphTabState::status_message`] showing git's own error text (see
+    /// `wt_core::remote`'s own module docs on why this doesn't attempt to resolve one itself) -
+    /// the worktree is left exactly where a real `git pull` on the command line would leave it,
+    /// for the user to resolve through the Changes panel or a real terminal.
+    pub(crate) fn request_graph_pull(&mut self, cx: &mut Context<Self>) {
+        self.run_graph_remote_op("Pull", cx, |root| wt_core::remote::pull(&root));
+    }
+
+    /// The Push menu's `force` row click handler - GitHub issue #1's own "push (force with
+    /// lease, force, no force)". `force == PushForce::None` (the plain "Push" row) runs
+    /// immediately, exactly like Fetch/Pull: it can only ever fast-forward the remote, never
+    /// lose anyone's work. `WithLease`/`Force` are real, remote-history-losing operations
+    /// (`wt_core::remote::PushForce::Force`'s own docs), so this applies the same two-click
+    /// confirmation `crate::rail::render::AdeApp::request_prune` uses for worktree removal: the
+    /// first click on a force row only arms [`GraphTabState::push_force_confirm_armed`] and
+    /// re-labels the row (see `Self::render_graph_push_menu`), without pushing anything; a
+    /// second click on that *same* force value is what actually runs [`wt_core::remote::push`].
+    pub(crate) fn request_graph_push(
+        &mut self,
+        force: wt_core::remote::PushForce,
+        cx: &mut Context<Self>,
+    ) {
+        use wt_core::remote::PushForce;
+
+        if force != PushForce::None && self.graph_state.push_force_confirm_armed != Some(force) {
+            self.graph_state.push_force_confirm_armed = Some(force);
+            self.graph_state.status_message = Some(match force {
+                PushForce::WithLease => "click Force with lease again to really push".to_string(),
+                PushForce::Force => "click Force again to really push".to_string(),
+                PushForce::None => unreachable!("guarded above"),
+            });
+            cx.notify();
+            return;
+        }
+        self.graph_state.push_force_confirm_armed = None;
+
+        let action = match force {
+            PushForce::None => "Push",
+            PushForce::WithLease => "Force-with-lease push",
+            PushForce::Force => "Force push",
+        };
+        self.run_graph_remote_op(action, cx, move |root| wt_core::remote::push(&root, force));
+    }
+
+    /// Shared plumbing behind [`Self::request_graph_fetch`]/[`Self::request_graph_pull`]/
+    /// [`Self::request_graph_push`]: guards against a double-click starting a second, overlapping
+    /// git subprocess (`GraphTabState::remote_op_in_flight`), runs `op` on the background
+    /// executor (every `wt_core::remote` function performs real blocking I/O), then surfaces a
+    /// real success or a real git error message and reloads the graph either way - a fetch/pull/
+    /// push always changes what the graph/ahead-behind counts should show, success or not (a
+    /// failed pull can still have fetched new remote-tracking data, for one).
+    fn run_graph_remote_op(
+        &mut self,
+        action: &'static str,
+        cx: &mut Context<Self>,
+        op: impl FnOnce(std::path::PathBuf) -> Result<(), wt_core::Error> + Send + 'static,
+    ) {
+        if self.graph_state.remote_op_in_flight {
+            return;
+        }
+        let root = self.diff_root.clone();
+        self.graph_state.remote_op_in_flight = true;
         self.graph_state.push_menu_open = false;
         self.graph_state.row_menu_open = None;
-        // The one real thing this honestly can do: reload, so a click at least confirms the view
-        // is current rather than doing visibly nothing beyond the status line.
-        self.load_graph(cx);
+        self.graph_state.status_message = Some(format!("{action}\u{2026}"));
+        cx.notify();
+
+        let task = cx.spawn(async move |this, cx| {
+            let result = cx
+                .background_executor()
+                .spawn(async move { op(root) })
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                this.graph_state.remote_op_in_flight = false;
+                this.graph_state.status_message = Some(match result {
+                    Ok(()) => action.to_string(),
+                    Err(err) => format!("{action} failed: {err}"),
+                });
+                this.load_graph(cx);
+            });
+        });
+        self.graph_state._remote_op_task = Some(task);
     }
 
     pub(in crate::graph_view) fn handle_branches_filter_key_down(
@@ -697,7 +777,7 @@ impl AdeApp {
             .child(
                 render_graph_toolbar_button("Fetch", false, false).on_click(cx.listener(
                     |this, _event: &ClickEvent, _window, cx| {
-                        this.graph_action_not_yet_wired("Fetch", cx);
+                        this.request_graph_fetch(cx);
                     },
                 )),
             )
@@ -708,7 +788,7 @@ impl AdeApp {
                     false,
                 )
                 .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
-                    this.graph_action_not_yet_wired("Pull", cx);
+                    this.request_graph_pull(cx);
                 })),
             )
             .child(self.render_graph_push_button(cx))
@@ -831,33 +911,69 @@ impl AdeApp {
                     .on_click(cx.listener(|_this, _event: &ClickEvent, _window, cx| {
                         cx.stop_propagation();
                     }))
-                    .child(render_dropdown_menu_row(
-                        "\u{2191}",
-                        theme::button::BLUE_FG.into(),
-                        theme::button::BLUE_BG.into(),
-                        "Push",
-                        "not implemented yet".to_string(),
-                        Vec::new(),
-                        false,
-                    ))
-                    .child(render_dropdown_menu_row(
-                        "\u{2191}",
-                        theme::button::DANGER_FG.into(),
-                        theme::surface::CHIP_NEUTRAL.into(),
-                        "Force with lease",
-                        "aborts if the remote moved - not implemented yet".to_string(),
-                        Vec::new(),
-                        false,
-                    ))
-                    .child(render_dropdown_menu_row(
-                        "\u{2191}",
-                        theme::button::DANGER_FG.into(),
-                        theme::surface::CHIP_NEUTRAL.into(),
-                        "Force",
-                        "not implemented yet".to_string(),
-                        Vec::new(),
-                        false,
-                    )),
+                    .child(
+                        render_dropdown_menu_row(
+                            "\u{2191}",
+                            theme::button::BLUE_FG.into(),
+                            theme::button::BLUE_BG.into(),
+                            "Push",
+                            "fast-forwards the remote branch".to_string(),
+                            Vec::new(),
+                            true,
+                        )
+                        .on_click(cx.listener(
+                            |this, _event: &ClickEvent, _window, cx| {
+                                cx.stop_propagation();
+                                this.request_graph_push(wt_core::remote::PushForce::None, cx);
+                            },
+                        )),
+                    )
+                    .child(
+                        render_dropdown_menu_row(
+                            "\u{2191}",
+                            theme::button::DANGER_FG.into(),
+                            theme::surface::CHIP_NEUTRAL.into(),
+                            "Force with lease",
+                            if self.graph_state.push_force_confirm_armed
+                                == Some(wt_core::remote::PushForce::WithLease)
+                            {
+                                "click again to really push".to_string()
+                            } else {
+                                "aborts if the remote moved".to_string()
+                            },
+                            Vec::new(),
+                            true,
+                        )
+                        .on_click(cx.listener(
+                            |this, _event: &ClickEvent, _window, cx| {
+                                cx.stop_propagation();
+                                this.request_graph_push(wt_core::remote::PushForce::WithLease, cx);
+                            },
+                        )),
+                    )
+                    .child(
+                        render_dropdown_menu_row(
+                            "\u{2191}",
+                            theme::button::DANGER_FG.into(),
+                            theme::surface::CHIP_NEUTRAL.into(),
+                            "Force",
+                            if self.graph_state.push_force_confirm_armed
+                                == Some(wt_core::remote::PushForce::Force)
+                            {
+                                "click again to really push".to_string()
+                            } else {
+                                "overwrites the remote unconditionally".to_string()
+                            },
+                            Vec::new(),
+                            true,
+                        )
+                        .on_click(cx.listener(
+                            |this, _event: &ClickEvent, _window, cx| {
+                                cx.stop_propagation();
+                                this.request_graph_push(wt_core::remote::PushForce::Force, cx);
+                            },
+                        )),
+                    ),
             )
     }
 
@@ -4894,6 +5010,282 @@ mod graph_focus_tests {
              `AdeApp::wire_caret_blink`, so nothing would have reacted to it losing focus at \
              all, and the caret would have stayed solid/visible until whatever timer the \
              earlier keystroke started eventually fired on its own"
+        );
+    }
+}
+
+/// Real interaction coverage for GitHub issue #1's "push (force with lease, force, no force)"/
+/// "pull" acceptance criteria - `AdeApp::request_graph_fetch`/`request_graph_pull`/
+/// `request_graph_push` really shelling out to `wt_core::remote`, not just the not-yet-wired
+/// stub these replaced.
+#[cfg(test)]
+mod graph_remote_action_tests {
+    use crate::root::focus::palette_focus_tests;
+    use crate::root::AdeApp;
+    use gpui::{Entity, TestAppContext};
+    use std::path::Path;
+    use wt_core::remote::PushForce;
+
+    fn git(dir: &Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .output()
+            .expect("failed to spawn git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
+            args,
+            dir,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git_output(dir: &Path, args: &[&str]) -> String {
+        let output = std::process::Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .output()
+            .expect("failed to spawn git");
+        assert!(output.status.success(), "git {args:?} failed in {dir:?}");
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    fn commit(dir: &Path, file: &str, contents: &str, message: &str) {
+        std::fs::write(dir.join(file), contents).expect("write file");
+        git(dir, &["add", file]);
+        git(dir, &["commit", "-m", message]);
+    }
+
+    /// A real bare remote plus a real clone of it, with a real committer identity and one
+    /// tracked file - the app is opened against the clone, matching how a real user's worktree
+    /// would already have a configured upstream.
+    fn open_seeded_with_remote(
+        cx: &mut TestAppContext,
+    ) -> (
+        tempfile::TempDir,
+        tempfile::TempDir,
+        Entity<AdeApp>,
+        &mut gpui::VisualTestContext,
+    ) {
+        let remote = tempfile::tempdir().expect("tempdir");
+        git(remote.path(), &["init", "--bare", "-b", "main"]);
+
+        let seed = tempfile::tempdir().expect("tempdir");
+        git(
+            seed.path(),
+            &["clone", remote.path().to_str().expect("utf8"), "."],
+        );
+        git(seed.path(), &["config", "user.email", "test@example.com"]);
+        git(seed.path(), &["config", "user.name", "Test User"]);
+        commit(seed.path(), "a.txt", "1", "base");
+        git(seed.path(), &["push", "origin", "main"]);
+
+        let local = tempfile::tempdir().expect("tempdir");
+        git(
+            local.path(),
+            &["clone", remote.path().to_str().expect("utf8"), "."],
+        );
+        git(local.path(), &["config", "user.email", "test@example.com"]);
+        git(local.path(), &["config", "user.name", "Test User"]);
+
+        let (app, cx) = palette_focus_tests::open_test_app(cx, local.path().to_path_buf());
+        (remote, local, app, cx)
+    }
+
+    #[gpui::test]
+    async fn fetch_really_updates_the_remote_tracking_ref_and_the_status_line(
+        cx: &mut TestAppContext,
+    ) {
+        let (remote, local, app, cx) = open_seeded_with_remote(cx);
+
+        // Advance the remote past what the local clone knows about, so fetch has something real
+        // to do.
+        let seed_dir = tempfile::tempdir().expect("tempdir");
+        git(
+            seed_dir.path(),
+            &["clone", remote.path().to_str().expect("utf8"), "."],
+        );
+        git(
+            seed_dir.path(),
+            &["config", "user.email", "test@example.com"],
+        );
+        git(seed_dir.path(), &["config", "user.name", "Test User"]);
+        commit(seed_dir.path(), "b.txt", "1", "second");
+        git(seed_dir.path(), &["push", "origin", "main"]);
+
+        app.update_in(cx, |app, _window, cx| {
+            app.request_graph_fetch(cx);
+        });
+        cx.run_until_parked();
+
+        let remote_tracking_subject =
+            git_output(local.path(), &["log", "-1", "--format=%s", "origin/main"]);
+        assert_eq!(
+            remote_tracking_subject, "second",
+            "the real click must have run a real git fetch that updated the remote-tracking ref"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.graph_state.status_message.clone()),
+            Some("Fetch".to_string()),
+            "a successful fetch must report real success, not the old 'not implemented yet' \
+             stub text"
+        );
+        assert!(
+            !app.read_with(cx, |app, _| app.graph_state.remote_op_in_flight),
+            "the in-flight guard must clear once the real fetch completes"
+        );
+    }
+
+    #[gpui::test]
+    async fn plain_push_runs_on_a_single_click_and_really_updates_the_remote(
+        cx: &mut TestAppContext,
+    ) {
+        let (remote, local, app, cx) = open_seeded_with_remote(cx);
+        commit(local.path(), "b.txt", "1", "local work");
+
+        app.update_in(cx, |app, _window, cx| {
+            app.request_graph_push(PushForce::None, cx);
+        });
+        cx.run_until_parked();
+
+        let remote_subject = git_output(remote.path(), &["log", "-1", "--format=%s", "main"]);
+        assert_eq!(
+            remote_subject, "local work",
+            "a plain Push click must run immediately and really update the remote - it can \
+             only ever fast-forward, so it must never require the two-click confirmation"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.graph_state.push_force_confirm_armed),
+            None,
+            "a plain push must never arm the force-confirmation state"
+        );
+    }
+
+    #[gpui::test]
+    async fn force_push_requires_a_real_second_click_on_the_same_variant(cx: &mut TestAppContext) {
+        let (remote, local, app, cx) = open_seeded_with_remote(cx);
+        // Diverge local history from the remote so a plain push would be a non-fast-forward -
+        // the real case Force exists for.
+        commit(local.path(), "b.txt", "1", "local work");
+        git(
+            local.path(),
+            &["commit", "--amend", "-m", "amended local work"],
+        );
+
+        app.update_in(cx, |app, _window, cx| {
+            app.request_graph_push(PushForce::Force, cx);
+        });
+        cx.run_until_parked();
+
+        let remote_subject_after_first_click =
+            git_output(remote.path(), &["log", "-1", "--format=%s", "main"]);
+        assert_eq!(
+            remote_subject_after_first_click, "base",
+            "the first click on Force must only arm the confirmation, never touch the real \
+             remote"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.graph_state.push_force_confirm_armed),
+            Some(PushForce::Force),
+            "the first click must arm exactly the Force variant that was clicked"
+        );
+
+        app.update_in(cx, |app, _window, cx| {
+            app.request_graph_push(PushForce::Force, cx);
+        });
+        cx.run_until_parked();
+
+        let remote_subject_after_second_click =
+            git_output(remote.path(), &["log", "-1", "--format=%s", "main"]);
+        assert_eq!(
+            remote_subject_after_second_click, "amended local work",
+            "the second click on the same armed variant must really run the force push"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.graph_state.push_force_confirm_armed),
+            None,
+            "the confirmation must disarm once the real push has actually run"
+        );
+    }
+
+    #[gpui::test]
+    async fn clicking_a_different_row_disarms_the_previous_confirmation(cx: &mut TestAppContext) {
+        let (remote, local, app, cx) = open_seeded_with_remote(cx);
+        commit(local.path(), "b.txt", "1", "local work");
+        git(
+            local.path(),
+            &["commit", "--amend", "-m", "amended local work"],
+        );
+
+        app.update_in(cx, |app, _window, cx| {
+            app.request_graph_push(PushForce::WithLease, cx);
+        });
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.graph_state.push_force_confirm_armed),
+            Some(PushForce::WithLease),
+            "premise: With lease is armed by its own first click"
+        );
+
+        // A click on the *other* danger row must not accidentally inherit the first row's arm -
+        // switching rows disarms rather than carrying over a confirmation the user never gave
+        // for this specific variant.
+        app.update_in(cx, |app, _window, cx| {
+            app.request_graph_push(PushForce::Force, cx);
+        });
+        cx.run_until_parked();
+
+        let remote_subject = git_output(remote.path(), &["log", "-1", "--format=%s", "main"]);
+        assert_eq!(
+            remote_subject, "base",
+            "switching rows must never let one row's confirmation authorize a different row's \
+             push"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.graph_state.push_force_confirm_armed),
+            Some(PushForce::Force),
+            "the click must have armed the newly-clicked Force row instead"
+        );
+    }
+
+    #[gpui::test]
+    async fn pull_surfaces_a_real_conflict_as_a_real_status_message_not_a_crash(
+        cx: &mut TestAppContext,
+    ) {
+        let (remote, local, app, cx) = open_seeded_with_remote(cx);
+
+        let seed_dir = tempfile::tempdir().expect("tempdir");
+        git(
+            seed_dir.path(),
+            &["clone", remote.path().to_str().expect("utf8"), "."],
+        );
+        git(
+            seed_dir.path(),
+            &["config", "user.email", "test@example.com"],
+        );
+        git(seed_dir.path(), &["config", "user.name", "Test User"]);
+        commit(seed_dir.path(), "a.txt", "remote change", "remote diverges");
+        git(seed_dir.path(), &["push", "origin", "main"]);
+        commit(local.path(), "a.txt", "local change", "local diverges");
+
+        app.update_in(cx, |app, _window, cx| {
+            app.request_graph_pull(cx);
+        });
+        cx.run_until_parked();
+
+        let status = app.read_with(cx, |app, _| app.graph_state.status_message.clone());
+        assert!(
+            status
+                .as_deref()
+                .is_some_and(|text| text.starts_with("Pull failed:")),
+            "a real conflicting pull must surface as a real, visible failure message, not a \
+             silent success or a panic - got {status:?}"
+        );
+        assert!(
+            !app.read_with(cx, |app, _| app.graph_state.remote_op_in_flight),
+            "the in-flight guard must still clear even when the operation fails"
         );
     }
 }

--- a/crates/app/src/graph_view/state.rs
+++ b/crates/app/src/graph_view/state.rs
@@ -3,9 +3,10 @@
 use crate::root::AdeApp;
 use crate::text_history::TextField;
 use crate::theme;
-use gpui::{Bounds, Context, FocusHandle, Pixels};
+use gpui::{Bounds, Context, FocusHandle, Pixels, Task};
 use std::collections::HashMap;
 use wt_core::graph::{Graph, GraphScope};
+use wt_core::remote::PushForce;
 
 /// Which side panel the graph tab's right sidebar shows while it's focused, replacing
 /// Files/Changes (design spec §5).
@@ -84,10 +85,34 @@ pub(crate) struct GraphTabState {
     /// `Self::load` reload - the toolbar's `Pull ↓N` / `Push ↑N` counts. `None` while loading or
     /// when there's genuinely no upstream to compare against, never a fabricated `{0, 0}`.
     pub upstream_counts: Option<wt_core::diff::AheadBehind>,
-    /// An honest, real status line for a not-yet-wired toolbar action (Fetch/Pull/Push) - "not
-    /// implemented yet", never a fake success. `None` when nothing has been clicked since the
+    /// A real, live status line for the toolbar's Fetch/Pull/Push actions - success or a real
+    /// git error message, never a fake success. `None` when nothing has been clicked since the
     /// tab last opened.
     pub status_message: Option<String>,
+    /// `true` while a real `wt_core::remote::{fetch,pull,push}` call is running on the
+    /// background executor - guards Fetch/Pull/Push against a double-click starting a second,
+    /// overlapping git subprocess against the same worktree, mirroring
+    /// `AdeApp::worktree_history_op_in_flight`'s identical single-flight discipline for
+    /// Keep/Discard/Commit (a separate flag, not the same field: a graph-tab remote operation
+    /// and a Changes-panel worktree-history operation are never mutually exclusive with each
+    /// other, only with themselves).
+    pub remote_op_in_flight: bool,
+    /// `Some(force)` for exactly one real click past the two-click confirmation on the Push
+    /// menu's "Force with lease"/"Force" rows (both real, remote-history-losing operations -
+    /// see `wt_core::remote::PushForce::Force`'s own docs) - `None` for the ordinary, single-
+    /// click "Push" row, which is never destructive to already-pushed history. Mirrors
+    /// `crate::rail::render::AdeApp::request_prune`'s own two-click discipline: the *first*
+    /// click on a force row only arms this field and re-labels the row, without pushing
+    /// anything; only a second click on the *same* `force` value actually runs
+    /// [`wt_core::remote::push`]. Clicking a different row (including the plain "Push" row)
+    /// disarms this rather than carrying the arm over onto an operation the user never
+    /// confirmed.
+    pub push_force_confirm_armed: Option<PushForce>,
+    /// The currently in-flight remote operation's own real task - held so it isn't dropped (and
+    /// therefore cancelled) the instant this function returns, matching
+    /// `AdeApp::_worktree_history_task`'s identical one-slot-per-feature pattern. `None` when
+    /// [`Self::remote_op_in_flight`] is `false`.
+    pub _remote_op_task: Option<Task<()>>,
 }
 
 impl GraphTabState {
@@ -106,6 +131,9 @@ impl GraphTabState {
             branches_filter_focus_handle: cx.focus_handle(),
             upstream_counts: None,
             status_message: None,
+            remote_op_in_flight: false,
+            push_force_confirm_armed: None,
+            _remote_op_task: None,
         }
     }
 }

--- a/crates/wt-core/src/lib.rs
+++ b/crates/wt-core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod diff;
 mod error;
 pub mod graph;
 pub mod merge;
+pub mod remote;
 pub mod stage;
 pub mod undo;
 

--- a/crates/wt-core/src/remote.rs
+++ b/crates/wt-core/src/remote.rs
@@ -1,0 +1,452 @@
+//! Real git remote operations: fetch, pull, and push (with force/force-with-lease variants) -
+//! GitHub issue #1's own acceptance criteria ("push (force with lease, force, no force)",
+//! "pull"). Every mutation shells out to a real `git` subprocess and surfaces git's own real
+//! stderr on failure ([`Error::GitCommand`]) rather than inventing a parsed/paraphrased message -
+//! a merge conflict, a rejected non-fast-forward push, or a missing upstream all read as git's
+//! own honest words, the same discipline every other `wt-core` module already follows.
+//!
+//! [`pull`] does not attempt to resolve a real merge conflict itself - it shells out to `git
+//! pull` and surfaces whatever git reports, honestly, rather than leaving the working tree in a
+//! conflicted state with no way back into this app's own conflict-resolution surface
+//! (`crate::merge`, built for a worktree-add flow, not a mid-session pull). A conflicted pull is
+//! a real, stated gap: the caller sees git's own real error text, and the worktree is left
+//! exactly where a real `git pull` on the command line would leave it.
+
+use std::ffi::OsString;
+use std::path::Path;
+
+use crate::error::Error;
+use crate::{check_success, run_git};
+
+/// Real `git fetch` for `worktree_path`'s configured remote (whatever a bare `git fetch` itself
+/// resolves to - almost always `origin`). Updates remote-tracking refs only; never touches the
+/// working tree or the current branch.
+///
+/// Performs blocking I/O.
+pub fn fetch(worktree_path: &Path) -> Result<(), Error> {
+    let args: Vec<OsString> = vec!["fetch".into()];
+    let output = run_git(worktree_path, &args)?;
+    check_success(&args, &output)
+}
+
+/// Real `git pull` (fetch + merge into the current branch) for `worktree_path`. A merge
+/// conflict, a detached HEAD, or uncommitted changes that would be overwritten all surface as
+/// git's own real stderr via [`Error::GitCommand`] - see this module's own docs on why a
+/// conflicted pull is not resolved here.
+///
+/// Performs blocking I/O.
+pub fn pull(worktree_path: &Path) -> Result<(), Error> {
+    let args: Vec<OsString> = vec!["pull".into()];
+    let output = run_git(worktree_path, &args)?;
+    check_success(&args, &output)
+}
+
+/// How hard [`push`] should push - `git push`'s own three real postures (GitHub issue #1's own
+/// "push (force with lease, force, no force)").
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PushForce {
+    /// A plain `git push` - refuses outright on any non-fast-forward.
+    None,
+    /// `git push --force-with-lease` - overwrites the remote branch, but only if it still
+    /// points where this worktree's own remote-tracking ref last saw it (aborts if someone
+    /// else pushed in between).
+    WithLease,
+    /// `git push --force` - overwrites the remote branch unconditionally, even if someone else
+    /// pushed in between. The one real, unguarded way to lose someone else's already-pushed
+    /// work; the UI layer (`app::graph_view`) is responsible for a real, explicit two-step
+    /// confirmation before this variant ever reaches here - this function itself performs no
+    /// confirmation of its own, matching [`crate::undo::discard_worktree`]'s own "the caller
+    /// already confirmed, this is the real mutation" division of responsibility.
+    Force,
+}
+
+/// Real `git push` for `worktree_path`'s current branch, per `force`. A branch with no
+/// configured upstream yet gets `--set-upstream origin <branch>` folded into the same push -
+/// `origin` specifically, matching this codebase's own single-remote assumption
+/// (`wt_core::graph::ahead_behind_against_upstream`'s own upstream detection already assumes a
+/// clone has exactly one remote, so this isn't inventing a new one) - rather than making a
+/// first-ever push fail with git's own comparatively opaque "no upstream" error and requiring a
+/// second, separate recovery step.
+///
+/// Performs blocking I/O.
+pub fn push(worktree_path: &Path, force: PushForce) -> Result<(), Error> {
+    let branch = current_branch_name(worktree_path)?;
+    let has_upstream = has_configured_upstream(worktree_path)?;
+
+    let mut args: Vec<OsString> = vec!["push".into()];
+    match force {
+        PushForce::None => {}
+        PushForce::WithLease => args.push("--force-with-lease".into()),
+        PushForce::Force => args.push("--force".into()),
+    }
+    if !has_upstream {
+        args.push("--set-upstream".into());
+        args.push("origin".into());
+        args.push(branch.into());
+    }
+    let output = run_git(worktree_path, &args)?;
+    check_success(&args, &output)
+}
+
+/// The real, current branch's short name (`git rev-parse --abbrev-ref HEAD`) - used only for
+/// [`push`]'s own `--set-upstream origin <branch>` fallback.
+fn current_branch_name(worktree_path: &Path) -> Result<String, Error> {
+    let args: Vec<OsString> = vec!["rev-parse".into(), "--abbrev-ref".into(), "HEAD".into()];
+    let output = run_git(worktree_path, &args)?;
+    check_success(&args, &output)?;
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// Whether `HEAD` already has a configured upstream - the exact same real `git rev-parse
+/// --abbrev-ref @{upstream}` resolution
+/// [`crate::graph::ahead_behind_against_upstream`] already uses for the identical question, so
+/// the two never independently disagree about what counts as "has an upstream". A non-zero exit
+/// here is the expected, honest "no upstream configured" signal, not a real error to propagate.
+fn has_configured_upstream(worktree_path: &Path) -> Result<bool, Error> {
+    let args: Vec<OsString> = vec![
+        "rev-parse".into(),
+        "--abbrev-ref".into(),
+        "@{upstream}".into(),
+    ];
+    let output = run_git(worktree_path, &args)?;
+    Ok(output.status.success())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::process::Command;
+    use tempfile::TempDir;
+
+    fn git(dir: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .output()
+            .expect("failed to spawn git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
+            args,
+            dir,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git_output(dir: &Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .output()
+            .expect("failed to spawn git");
+        assert!(output.status.success(), "git {args:?} failed in {dir:?}");
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    fn init_bare_remote() -> TempDir {
+        let dir = TempDir::new().expect("tempdir");
+        git(dir.path(), &["init", "--bare", "-b", "main"]);
+        dir
+    }
+
+    fn commit(dir: &Path, file: &str, contents: &str, message: &str) {
+        fs::write(dir.join(file), contents).expect("write file");
+        git(dir, &["add", file]);
+        git(dir, &["commit", "-m", message]);
+    }
+
+    /// A real clone of `remote` with a real committer identity configured (a bare `git init`
+    /// clone has none) - every test in this module needs exactly this starting point.
+    fn clone_of(remote: &Path) -> TempDir {
+        let local = TempDir::new().expect("tempdir");
+        git(
+            local.path(),
+            &["clone", remote.to_str().expect("utf8"), "."],
+        );
+        git(local.path(), &["config", "user.email", "test@example.com"]);
+        git(local.path(), &["config", "user.name", "Test User"]);
+        local
+    }
+
+    #[test]
+    fn fetch_really_updates_the_remote_tracking_ref() {
+        let remote = init_bare_remote();
+        let seed = TempDir::new().expect("tempdir");
+        git(
+            seed.path(),
+            &["clone", remote.path().to_str().expect("utf8"), "."],
+        );
+        git(seed.path(), &["config", "user.email", "test@example.com"]);
+        git(seed.path(), &["config", "user.name", "Test User"]);
+        commit(seed.path(), "a.txt", "1", "base");
+        git(seed.path(), &["push", "origin", "main"]);
+
+        let local = clone_of(remote.path());
+        // Advance the remote again after the local clone, so `fetch` has something real to do.
+        commit(seed.path(), "b.txt", "1", "second");
+        git(seed.path(), &["push", "origin", "main"]);
+
+        fetch(local.path()).expect("fetch");
+
+        let remote_tracking_subject =
+            git_output(local.path(), &["log", "-1", "--format=%s", "origin/main"]);
+        assert_eq!(
+            remote_tracking_subject, "second",
+            "fetch must have updated the real remote-tracking ref to the remote's new tip"
+        );
+        let head_subject = git_output(local.path(), &["log", "-1", "--format=%s", "HEAD"]);
+        assert_eq!(
+            head_subject, "base",
+            "fetch must never touch the local branch/working tree itself"
+        );
+    }
+
+    #[test]
+    fn pull_really_fast_forwards_the_local_branch() {
+        let remote = init_bare_remote();
+        let seed = TempDir::new().expect("tempdir");
+        git(
+            seed.path(),
+            &["clone", remote.path().to_str().expect("utf8"), "."],
+        );
+        git(seed.path(), &["config", "user.email", "test@example.com"]);
+        git(seed.path(), &["config", "user.name", "Test User"]);
+        commit(seed.path(), "a.txt", "1", "base");
+        git(seed.path(), &["push", "origin", "main"]);
+
+        let local = clone_of(remote.path());
+        commit(seed.path(), "b.txt", "1", "second");
+        git(seed.path(), &["push", "origin", "main"]);
+
+        pull(local.path()).expect("pull");
+
+        let head_subject = git_output(local.path(), &["log", "-1", "--format=%s", "HEAD"]);
+        assert_eq!(
+            head_subject, "second",
+            "pull must have really fast-forwarded the local branch to the remote's new tip"
+        );
+    }
+
+    #[test]
+    fn pull_surfaces_a_real_conflict_as_a_real_error_not_a_panic_or_silent_success() {
+        let remote = init_bare_remote();
+        let seed = TempDir::new().expect("tempdir");
+        git(
+            seed.path(),
+            &["clone", remote.path().to_str().expect("utf8"), "."],
+        );
+        git(seed.path(), &["config", "user.email", "test@example.com"]);
+        git(seed.path(), &["config", "user.name", "Test User"]);
+        commit(seed.path(), "a.txt", "1", "base");
+        git(seed.path(), &["push", "origin", "main"]);
+
+        let local = clone_of(remote.path());
+        // Diverge both sides on the same file/line, so the merge really conflicts.
+        commit(seed.path(), "a.txt", "remote change", "remote diverges");
+        git(seed.path(), &["push", "origin", "main"]);
+        commit(local.path(), "a.txt", "local change", "local diverges");
+
+        let result = pull(local.path());
+        assert!(
+            result.is_err(),
+            "a genuinely conflicting pull must surface as a real error, not a silent success"
+        );
+        match result.unwrap_err() {
+            Error::GitCommand { stderr, .. } => {
+                assert!(
+                    !stderr.is_empty(),
+                    "the real git stderr must be preserved for the user to actually read"
+                );
+            }
+            other => panic!("expected Error::GitCommand, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn push_with_no_force_really_updates_the_remote_branch() {
+        let remote = init_bare_remote();
+        let seed = TempDir::new().expect("tempdir");
+        git(
+            seed.path(),
+            &["clone", remote.path().to_str().expect("utf8"), "."],
+        );
+        git(seed.path(), &["config", "user.email", "test@example.com"]);
+        git(seed.path(), &["config", "user.name", "Test User"]);
+        commit(seed.path(), "a.txt", "1", "base");
+        git(seed.path(), &["push", "origin", "main"]);
+
+        let local = clone_of(remote.path());
+        commit(local.path(), "b.txt", "1", "local work");
+
+        push(local.path(), PushForce::None).expect("push");
+
+        let remote_subject = git_output(remote.path(), &["log", "-1", "--format=%s", "main"]);
+        assert_eq!(
+            remote_subject, "local work",
+            "a plain push must really update the real remote branch"
+        );
+    }
+
+    #[test]
+    fn push_with_no_force_refuses_a_real_non_fast_forward() {
+        let remote = init_bare_remote();
+        let seed = TempDir::new().expect("tempdir");
+        git(
+            seed.path(),
+            &["clone", remote.path().to_str().expect("utf8"), "."],
+        );
+        git(seed.path(), &["config", "user.email", "test@example.com"]);
+        git(seed.path(), &["config", "user.name", "Test User"]);
+        commit(seed.path(), "a.txt", "1", "base");
+        git(seed.path(), &["push", "origin", "main"]);
+
+        let local = clone_of(remote.path());
+        commit(seed.path(), "c.txt", "1", "diverged upstream work");
+        git(seed.path(), &["push", "origin", "main"]);
+        commit(local.path(), "b.txt", "1", "local work");
+
+        let result = push(local.path(), PushForce::None);
+        assert!(
+            result.is_err(),
+            "a real non-fast-forward must be refused, not silently forced through"
+        );
+
+        let remote_subject = git_output(remote.path(), &["log", "-1", "--format=%s", "main"]);
+        assert_eq!(
+            remote_subject, "diverged upstream work",
+            "the real remote branch must be completely untouched by the refused push"
+        );
+    }
+
+    #[test]
+    fn push_force_with_lease_overwrites_when_the_remote_matches_the_last_known_state() {
+        let remote = init_bare_remote();
+        let seed = TempDir::new().expect("tempdir");
+        git(
+            seed.path(),
+            &["clone", remote.path().to_str().expect("utf8"), "."],
+        );
+        git(seed.path(), &["config", "user.email", "test@example.com"]);
+        git(seed.path(), &["config", "user.name", "Test User"]);
+        commit(seed.path(), "a.txt", "1", "base");
+        git(seed.path(), &["push", "origin", "main"]);
+
+        let local = clone_of(remote.path());
+        // Rewrite local history (amend) so a plain push would be a non-fast-forward, but the
+        // remote itself has not moved since the clone - the real case force-with-lease exists
+        // for.
+        commit(local.path(), "b.txt", "1", "local work");
+        git(
+            local.path(),
+            &["commit", "--amend", "-m", "amended local work"],
+        );
+
+        push(local.path(), PushForce::WithLease).expect("push with lease");
+
+        let remote_subject = git_output(remote.path(), &["log", "-1", "--format=%s", "main"]);
+        assert_eq!(remote_subject, "amended local work");
+    }
+
+    #[test]
+    fn push_force_with_lease_refuses_when_the_remote_moved_since_the_last_fetch() {
+        let remote = init_bare_remote();
+        let seed = TempDir::new().expect("tempdir");
+        git(
+            seed.path(),
+            &["clone", remote.path().to_str().expect("utf8"), "."],
+        );
+        git(seed.path(), &["config", "user.email", "test@example.com"]);
+        git(seed.path(), &["config", "user.name", "Test User"]);
+        commit(seed.path(), "a.txt", "1", "base");
+        git(seed.path(), &["push", "origin", "main"]);
+
+        let local = clone_of(remote.path());
+        // Someone else pushes to the remote after the local clone's last real knowledge of it.
+        commit(seed.path(), "c.txt", "1", "someone else's push");
+        git(seed.path(), &["push", "origin", "main"]);
+        commit(local.path(), "b.txt", "1", "local work");
+        git(
+            local.path(),
+            &["commit", "--amend", "-m", "amended local work"],
+        );
+
+        let result = push(local.path(), PushForce::WithLease);
+        assert!(
+            result.is_err(),
+            "force-with-lease must refuse when the remote moved since this worktree last saw \
+             it, not blindly overwrite someone else's already-pushed work"
+        );
+        let remote_subject = git_output(remote.path(), &["log", "-1", "--format=%s", "main"]);
+        assert_eq!(
+            remote_subject, "someone else's push",
+            "the real remote branch must be untouched by the refused lease push"
+        );
+    }
+
+    #[test]
+    fn push_force_unconditionally_overwrites_even_when_the_remote_moved() {
+        let remote = init_bare_remote();
+        let seed = TempDir::new().expect("tempdir");
+        git(
+            seed.path(),
+            &["clone", remote.path().to_str().expect("utf8"), "."],
+        );
+        git(seed.path(), &["config", "user.email", "test@example.com"]);
+        git(seed.path(), &["config", "user.name", "Test User"]);
+        commit(seed.path(), "a.txt", "1", "base");
+        git(seed.path(), &["push", "origin", "main"]);
+
+        let local = clone_of(remote.path());
+        commit(seed.path(), "c.txt", "1", "someone else's push");
+        git(seed.path(), &["push", "origin", "main"]);
+        commit(local.path(), "b.txt", "1", "local work");
+        git(
+            local.path(),
+            &["commit", "--amend", "-m", "amended local work"],
+        );
+
+        push(local.path(), PushForce::Force).expect("force push");
+
+        let remote_subject = git_output(remote.path(), &["log", "-1", "--format=%s", "main"]);
+        assert_eq!(
+            remote_subject, "amended local work",
+            "a real --force push must overwrite the remote unconditionally"
+        );
+    }
+
+    #[test]
+    fn push_with_no_upstream_configures_one_via_set_upstream() {
+        let remote = init_bare_remote();
+        let local = TempDir::new().expect("tempdir");
+        git(local.path(), &["init", "-b", "main"]);
+        git(local.path(), &["config", "user.email", "test@example.com"]);
+        git(local.path(), &["config", "user.name", "Test User"]);
+        git(
+            local.path(),
+            &[
+                "remote",
+                "add",
+                "origin",
+                remote.path().to_str().expect("utf8"),
+            ],
+        );
+        commit(local.path(), "a.txt", "1", "first commit, no upstream yet");
+
+        assert!(
+            !has_configured_upstream(local.path()).expect("has_configured_upstream"),
+            "premise: a freshly `remote add`-ed repo has no upstream configured yet"
+        );
+
+        push(local.path(), PushForce::None).expect("push");
+
+        assert!(
+            has_configured_upstream(local.path()).expect("has_configured_upstream"),
+            "push must have configured a real upstream via --set-upstream, not merely \
+             succeeded without one"
+        );
+        let remote_subject = git_output(remote.path(), &["log", "-1", "--format=%s", "main"]);
+        assert_eq!(remote_subject, "first commit, no upstream yet");
+    }
+}


### PR DESCRIPTION
## Summary

Part of #1's phase (c) - real destructive git operations from the graph tab. This slice covers Fetch, Pull, and Push (with Force-with-lease and Force variants), the first and lowest-risk piece of that scope. Cherry-pick, revert, and rebase are **not** included here and remain disabled in the row menu - separate follow-up work.

## What's real

- New `wt_core::remote` module: `fetch`, `pull`, `push(force: PushForce)`. Every function shells out to real `git`, surfacing git's own stderr on failure (`Error::GitCommand`) rather than a paraphrased message - a real merge conflict, a rejected non-fast-forward, or a missing upstream all read as git's own honest words.
- `push` folds in `--set-upstream origin <branch>` automatically when there's no upstream yet, so a first-ever push doesn't need a separate recovery step.
- The toolbar's Fetch/Pull buttons and the Push menu's three rows are wired to real handlers - previously Fetch/Pull hit a "not implemented yet" stub and the Push menu's rows were fully disabled with no click handler at all.
- **Force-with-lease and Force require a real two-click confirmation**, mirroring the rail's own `request_prune` pattern: the first click only arms the confirmation and re-labels the row ("click again to really push"); a second click on the *same* variant is what actually runs it. Clicking a different row disarms the previous confirmation rather than silently carrying it over. A plain push (can only fast-forward) runs immediately, like Fetch/Pull.
- All real git mutations run on the background executor via `cx.spawn`/`cx.background_executor().spawn`, guarded by an in-flight flag against double-clicks.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib` - 1291/49/14/167 passed, 0 failed
- New tests: 9 real two-repo (bare remote + clone) tests in `wt_core::remote` covering fetch, clean pull, conflicting pull, plain push, refused non-fast-forward, force-with-lease success/refusal, unconditional force, and no-upstream `--set-upstream` fallback. Plus 5 real GPUI interaction tests proving the app-level wiring: fetch updates the status line, plain push runs on one click, force push requires a real second click on the same variant, switching rows disarms the previous confirmation, and a conflicting pull surfaces as a real status message rather than a crash.