### PR TITLE
feat(app): real, optional custom icon packs (issue #5)

### DIFF
--- a/crates/app/src/icon_pack.rs
+++ b/crates/app/src/icon_pack.rs
@@ -1,0 +1,98 @@
+//! Custom icon packs (GitHub issue #5's "custom icon packs" acceptance criterion) - an optional,
+//! real, user-supplied directory of SVG icons that override this app's own default, built-in
+//! icons (styled `div()` shapes and Unicode glyphs, never image assets on their own). No active
+//! pack, or no matching file in the active pack, always falls back to the existing default
+//! rendering - this module only ever *adds* an override path, never removes the built-in look.
+//!
+//! ## Scope
+//!
+//! Only `crate::work_surface::state::agent_tint`/`agent_initial`'s three agent-kind chips
+//! (Claude/Codex/Shell - `crate::work_surface::render::render_agent_icon`'s own real call
+//! sites) are wired to check a pack today. The other ~25 distinct icon concepts cataloged across
+//! this app (file-type chips, folder icons, chevrons, status dots, ...) are a real, stated
+//! follow-up, not yet wired - picking one well-scoped, high-value integration point first rather
+//! than touching every render call site in one pass.
+//!
+//! ## Real icon files, not a theme tint
+//!
+//! Unlike this app's own bundled UI icons (styled shapes/glyphs that all pick up a theme color
+//! token), a user-supplied pack icon is rendered via `gpui::svg().external_path(..)` with **no**
+//! `.text_color()` tint applied - a real, user-chosen brand icon (e.g. a real Claude/Codex logo)
+//! keeps whatever colors its own SVG file defines, rather than being flattened to a single
+//! theme-matched fill the way this app's own icon-font-free UI chrome is.
+
+use std::path::PathBuf;
+
+use crate::settings::store::IconPackSettings;
+
+/// The real, on-disk path to `name`'s icon in the active pack, if
+/// [`IconPackSettings::directory`] is set and a file named `<name>.svg` really exists inside it.
+/// Returns `None` (never a fabricated path) for no active pack, a pack directory with no
+/// matching file, or a matching name that isn't actually a real file (checked with a real
+/// `Path::is_file` call, not just string concatenation, since a stale or misconfigured
+/// directory is a real possibility this must not silently paper over with a broken `svg()`
+/// element pointed at a directory or a symlink to nowhere).
+pub fn resolve_icon(pack: &IconPackSettings, name: &str) -> Option<PathBuf> {
+    let directory = pack.directory.as_ref()?;
+    let candidate = directory.join(format!("{name}.svg"));
+    candidate.is_file().then_some(candidate)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_icon_is_none_with_no_pack_configured() {
+        let pack = IconPackSettings { directory: None };
+        assert_eq!(resolve_icon(&pack, "claude"), None);
+    }
+
+    #[test]
+    fn resolve_icon_is_none_when_the_named_file_is_missing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pack = IconPackSettings {
+            directory: Some(dir.path().to_path_buf()),
+        };
+        assert_eq!(resolve_icon(&pack, "claude"), None);
+    }
+
+    #[test]
+    fn resolve_icon_finds_a_real_matching_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("claude.svg"), "<svg></svg>").expect("write");
+        let pack = IconPackSettings {
+            directory: Some(dir.path().to_path_buf()),
+        };
+        assert_eq!(
+            resolve_icon(&pack, "claude"),
+            Some(dir.path().join("claude.svg"))
+        );
+    }
+
+    #[test]
+    fn resolve_icon_ignores_a_directory_with_the_matching_name() {
+        // A directory named `claude.svg` is not a real icon file - `is_file` must reject it
+        // rather than handing back a path `svg()` can't actually load.
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir(dir.path().join("claude.svg")).expect("mkdir");
+        let pack = IconPackSettings {
+            directory: Some(dir.path().to_path_buf()),
+        };
+        assert_eq!(resolve_icon(&pack, "claude"), None);
+    }
+
+    #[test]
+    fn resolve_icon_is_scoped_to_the_exact_requested_name() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("codex.svg"), "<svg></svg>").expect("write");
+        let pack = IconPackSettings {
+            directory: Some(dir.path().to_path_buf()),
+        };
+        assert_eq!(
+            resolve_icon(&pack, "claude"),
+            None,
+            "a pack having *some* icons must never make an unrelated name resolve to one of them"
+        );
+    }
+}

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -12,6 +12,7 @@ pub mod code_surface;
 pub mod env_info;
 pub mod fonts;
 pub mod graph_view;
+pub mod icon_pack;
 pub mod keymap;
 pub mod keymap_overrides;
 pub mod language;

--- a/crates/app/src/rail/mod.rs
+++ b/crates/app/src/rail/mod.rs
@@ -35,7 +35,6 @@ use crate::root::*;
 use crate::status_bar::process_stats;
 use crate::theme;
 use crate::work_surface::agents::AgentKind;
-use crate::work_surface::state as work_surface;
 use gpui::{div, font, prelude::*, px, App, ClickEvent, Context, KeyDownEvent, Window};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -1157,8 +1157,7 @@ impl AdeApp {
     ) -> impl IntoElement {
         let is_selected = self.agents.active_id() == Some(agent.id);
         let status = agent.status;
-        let (chip_fg, chip_bg) = work_surface::agent_tint(agent.kind);
-        let chip_glyph = work_surface::agent_initial(agent.kind);
+        let chip_icon = self.render_agent_chip_icon(agent.kind, px(15.0), self.ui_text_size(9.0));
         let state_color: gpui::Rgba = match status {
             Status::Ask | Status::Fail => status.color(),
             _ => theme::text::FAINT.into(),
@@ -1199,22 +1198,7 @@ impl AdeApp {
                     .flex()
                     .items_center()
                     .gap(px(6.0))
-                    .child(
-                        div()
-                            .flex_none()
-                            .w(px(15.0))
-                            .h(px(15.0))
-                            .flex()
-                            .items_center()
-                            .justify_center()
-                            .rounded(theme::radius::CHIP)
-                            .bg(chip_bg)
-                            .font(font(theme::font::MONO))
-                            .font_weight(gpui::FontWeight::MEDIUM)
-                            .text_size(self.ui_text_size(9.0))
-                            .text_color(chip_fg)
-                            .child(chip_glyph),
-                    )
+                    .child(chip_icon)
                     .child(
                         div()
                             .flex_1()
@@ -1959,6 +1943,105 @@ mod rail_filter_caret_tests {
             "focusing the rail filter must have started the real, live shared blink task - if \
              `filter_focus_handle` were never wired into `AdeApp::wire_caret_blink`, no timer \
              would be running at all and this flag would still be stuck solid"
+        );
+    }
+}
+
+/// GitHub issue #5's "custom icon packs" - real coverage that the rail agent row's chip
+/// (`AdeApp::render_agent_chip_icon`, the one real call site this feature is wired to today)
+/// actually switches between the app's default letter chip and a real pack SVG, rather than
+/// just trusting the render code's own claim to do so.
+#[cfg(test)]
+mod agent_chip_icon_pack_tests {
+    use crate::rail::worktrees::WorktreeItem;
+    use crate::root::focus::palette_focus_tests;
+    use crate::work_surface::agents::AgentKind;
+    use gpui::TestAppContext;
+
+    fn worktree_item(path: std::path::PathBuf, label: &str) -> WorktreeItem {
+        WorktreeItem {
+            path,
+            label: label.to_string(),
+            branch: Some(label.to_string()),
+            is_main: false,
+            is_bare: false,
+            is_detached: false,
+            short_sha: None,
+            is_locked: false,
+            lock_reason: None,
+            is_broken: false,
+            broken_reason: None,
+            error: None,
+        }
+    }
+
+    /// A real, running shell agent in a real seeded worktree - a just-spawned shell is `Status::
+    /// Run`, which defaults its worktree row to expanded (`AdeApp::worktree_is_expanded`'s own
+    /// "idle-rooted" rule), so the agent row (and this chip) actually renders without needing a
+    /// separate collapse-override hack.
+    fn open_with_a_running_shell_agent(
+        cx: &mut TestAppContext,
+    ) -> (
+        tempfile::TempDir,
+        tempfile::TempDir,
+        gpui::Entity<crate::root::AdeApp>,
+        &mut gpui::VisualTestContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let wt = tempfile::tempdir().expect("tempdir wt");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+
+        app.update(cx, |app, _cx| {
+            app.worktrees = vec![worktree_item(wt.path().to_path_buf(), "wt")];
+        });
+        app.update_in(cx, |app, window, cx| {
+            app.select_worktree(0, window, cx);
+            app.agents
+                .spawn(AgentKind::Shell, wt.path().to_path_buf(), 12.0, window, cx);
+        });
+        cx.run_until_parked();
+        (repo, wt, app, cx)
+    }
+
+    #[gpui::test]
+    fn the_rail_agent_row_shows_the_default_chip_with_no_pack_configured(cx: &mut TestAppContext) {
+        let (_repo, _wt, _app, cx) = open_with_a_running_shell_agent(cx);
+
+        assert!(
+            cx.debug_bounds("agent-chip-icon-default").is_some(),
+            "with no icon pack configured, the rail's own default agent chip must paint"
+        );
+        assert!(
+            cx.debug_bounds("agent-chip-icon-pack-svg").is_none(),
+            "with no icon pack configured, no pack SVG element must paint at all"
+        );
+    }
+
+    #[gpui::test]
+    fn the_rail_agent_row_switches_to_a_real_pack_icon_once_one_is_configured(
+        cx: &mut TestAppContext,
+    ) {
+        let pack_dir = tempfile::tempdir().expect("tempdir");
+        // The seeded agent is a real `AgentKind::Shell` (`work_surface::agent_icon_name`'s own
+        // mapping), so `shell.svg` is the real file this specific row's chip looks for.
+        std::fs::write(pack_dir.path().join("shell.svg"), "<svg></svg>").expect("write");
+
+        let (_repo, _wt, app, cx) = open_with_a_running_shell_agent(cx);
+        app.update(cx, |app, cx| {
+            app.settings.icon_pack.directory = Some(pack_dir.path().to_path_buf());
+            cx.notify();
+        });
+        cx.run_until_parked();
+
+        assert!(
+            cx.debug_bounds("agent-chip-icon-pack-svg").is_some(),
+            "once a real pack directory with a matching shell.svg is configured, the rail row \
+             must really switch to painting the pack's own SVG element"
+        );
+        assert!(
+            cx.debug_bounds("agent-chip-icon-default").is_none(),
+            "the default letter chip must not also paint once the pack icon takes over - \
+             exactly one of the two must be showing, never both at once"
         );
     }
 }

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -1401,6 +1401,16 @@ pub struct AdeApp {
     /// "most other gestures clear it" discipline `Self::discard_confirm_armed`'s own docs
     /// describe, scoped to this control's own page since nothing else in the app can arm it.
     pub(crate) custom_theme_remove_armed: Option<String>,
+    /// The Themes page's most recent icon-pack action result (GitHub issue #5's "custom icon
+    /// packs") - `Ok` message or a real, honest `Err` one, shown as an inline status line until
+    /// the next action replaces it. Mirrors [`Self::custom_theme_status`]'s own shape, kept as a
+    /// separate field since choosing/clearing an icon pack and importing/exporting a theme are
+    /// two independent real actions that must never overwrite each other's own status line.
+    pub(crate) icon_pack_status: Option<Result<String, String>>,
+    /// The in-flight "Choose folder..." real native directory-picker task
+    /// (`Self::start_choose_icon_pack_folder`) - a single slot, matching
+    /// [`Self::_custom_theme_import_task`]'s own one-dialog-at-a-time reasoning.
+    pub(crate) _icon_pack_choose_task: Option<Task<()>>,
 }
 
 impl AdeApp {

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -341,6 +341,8 @@ impl AdeApp {
             _custom_theme_remove_task: None,
             _custom_theme_create_task: None,
             custom_theme_remove_armed: None,
+            icon_pack_status: None,
+            _icon_pack_choose_task: None,
         };
         // GitHub issue #45 ("Input blink only on focused input or file") / a live follow-up
         // report of missing carets: `graph_state.branches_filter_focus_handle` (added later, in

--- a/crates/app/src/root/widgets.rs
+++ b/crates/app/src/root/widgets.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::icon_pack;
+use crate::work_surface::agents::AgentKind;
 
 /// The two keycap sizes: `Standard` (primary shortcuts - the rail's `+`/⌘N, the status bar's
 /// `⌘P`) and `Hint` (smaller, for hint-row contexts like footers and empty-state hint lists).
@@ -338,6 +340,54 @@ fn simple_input_caret_opacity(is_focused: bool, blink_visible: bool) -> Option<f
         Some(1.0)
     } else {
         Some(theme::syntax::CARET_UNFOCUSED_OPACITY)
+    }
+}
+
+impl AdeApp {
+    /// One agent-kind chip (GitHub issue #5's "custom icon packs"): a real, user-supplied SVG
+    /// from the active icon pack (`crate::icon_pack::resolve_icon`) if one exists for `kind`, at
+    /// its own real colors (no theme tint - see `crate::icon_pack`'s own module docs on why),
+    /// else this app's existing default look (a `size`-square rounded chip, tinted per
+    /// `work_surface::agent_tint`, showing `work_surface::agent_initial`'s single letter) -
+    /// unchanged from before this feature existed. `size` is also the SVG's real width/height,
+    /// so a pack icon fills exactly the same box the default chip already occupies at every one
+    /// of this helper's real call sites, rather than needing per-call-site size plumbing.
+    pub(crate) fn render_agent_chip_icon(
+        &self,
+        kind: AgentKind,
+        size: Pixels,
+        font_size: Pixels,
+    ) -> gpui::AnyElement {
+        if let Some(icon_path) = icon_pack::resolve_icon(
+            &self.settings.icon_pack,
+            work_surface::agent_icon_name(kind),
+        ) {
+            return gpui::svg()
+                .external_path(icon_path.to_string_lossy().into_owned())
+                .flex_none()
+                .w(size)
+                .h(size)
+                .debug_selector(|| "agent-chip-icon-pack-svg".to_string())
+                .into_any_element();
+        }
+        let (chip_fg, chip_bg) = work_surface::agent_tint(kind);
+        let chip_glyph = work_surface::agent_initial(kind);
+        div()
+            .flex_none()
+            .w(size)
+            .h(size)
+            .flex()
+            .items_center()
+            .justify_center()
+            .rounded(theme::radius::CHIP)
+            .bg(chip_bg)
+            .font(font(theme::font::MONO))
+            .font_weight(gpui::FontWeight::MEDIUM)
+            .text_size(font_size)
+            .text_color(chip_fg)
+            .debug_selector(|| "agent-chip-icon-default".to_string())
+            .child(chip_glyph)
+            .into_any_element()
     }
 }
 

--- a/crates/app/src/settings/render.rs
+++ b/crates/app/src/settings/render.rs
@@ -1262,6 +1262,7 @@ impl AdeApp {
             )
             .child(builtin_cards)
             .child(self.render_custom_themes_section(cx))
+            .child(self.render_icon_pack_section(cx))
             .child(
                 div()
                     .pt(px(20.0))
@@ -1398,6 +1399,90 @@ impl AdeApp {
             .children(empty_state)
             .child(cards)
             .children(load_errors)
+            .children(status)
+    }
+
+    /// GitHub issue #5's "custom icon packs": a real, user-chosen directory of `<name>.svg`
+    /// files (`crate::icon_pack::resolve_icon`'s own lookup) that overrides this app's own
+    /// default icons wherever a call site has been wired to check one - today, only the rail's
+    /// agent-kind chip (`AdeApp::render_agent_chip_icon`'s own docs list the real, current
+    /// scope). No active pack, or a pack missing a given name, always falls back to this app's
+    /// existing default look - never a broken icon or a blank chip.
+    fn render_icon_pack_section(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let current = self
+            .settings
+            .icon_pack
+            .directory
+            .as_ref()
+            .map(|path| path.display().to_string());
+
+        let header_row = div()
+            .flex()
+            .items_center()
+            .justify_between()
+            .pt(px(20.0))
+            .pb(px(6.0))
+            .child(
+                div()
+                    .font(font(theme::font::SANS))
+                    .font_weight(gpui::FontWeight::SEMIBOLD)
+                    .text_size(px(9.5))
+                    .text_color(theme::palette::GROUP_HEADER)
+                    .child("Icon pack"),
+            )
+            .child(
+                div()
+                    .flex()
+                    .gap(px(6.0))
+                    .child(self.render_theme_action_button(
+                        "settings-icon-pack-choose",
+                        "Choose folder\u{2026}",
+                        cx,
+                        |this, cx| this.start_choose_icon_pack_folder(cx),
+                    ))
+                    .when(current.is_some(), |el| {
+                        el.child(self.render_theme_action_button(
+                            "settings-icon-pack-clear",
+                            "Use default icons",
+                            cx,
+                            |this, cx| this.clear_icon_pack(cx),
+                        ))
+                    }),
+            );
+
+        let current_row = div()
+            .py(px(6.0))
+            .font(font(theme::font::MONO))
+            .text_size(px(10.5))
+            .text_color(theme::text::DISABLED)
+            .child(match &current {
+                Some(path) => format!(
+                    "Using {path} - files named e.g. claude.svg/codex.svg/shell.svg override \
+                     the matching default icon."
+                ),
+                None => "Using the app's default icons. Choose a folder containing files like \
+                          claude.svg/codex.svg/shell.svg to override them."
+                    .to_string(),
+            });
+
+        let status = self.icon_pack_status.as_ref().map(|result| {
+            let (text, color) = match result {
+                Ok(message) => (message.clone(), theme::status::REVIEW),
+                Err(message) => (message.clone(), theme::status::FAIL),
+            };
+            div()
+                .pt(px(6.0))
+                .font(font(theme::font::MONO))
+                .text_size(px(10.0))
+                .text_color(color)
+                .child(text)
+        });
+
+        div()
+            .flex()
+            .flex_col()
+            .child(header_row)
+            .child(current_row)
             .children(status)
     }
 
@@ -2646,6 +2731,48 @@ impl AdeApp {
             });
         });
         self._custom_theme_import_task = Some(task);
+    }
+
+    /// GitHub issue #5's "custom icon packs": a real native directory picker
+    /// (`gpui::App::prompt_for_paths`, `directories: true`) - unlike
+    /// [`Self::start_import_custom_theme`], nothing is copied anywhere: the chosen directory
+    /// itself becomes [`settings_store::IconPackSettings::directory`] directly, and
+    /// `crate::icon_pack::resolve_icon` reads straight out of it at render time, so the user's
+    /// own files stay exactly where they left them (editable/replaceable in place, no stale
+    /// copy for a later edit to silently miss).
+    pub(in crate::settings) fn start_choose_icon_pack_folder(&mut self, cx: &mut Context<Self>) {
+        let paths_receiver = cx.prompt_for_paths(gpui::PathPromptOptions {
+            files: false,
+            directories: true,
+            multiple: false,
+            prompt: Some("Choose".into()),
+        });
+        let task = cx.spawn(async move |this, cx| {
+            let Ok(Ok(Some(mut paths))) = paths_receiver.await else {
+                return;
+            };
+            let Some(directory) = paths.pop() else {
+                return;
+            };
+            let _ = this.update(cx, |this, cx| {
+                this.settings.icon_pack.directory = Some(directory.clone());
+                this.icon_pack_status = Some(Ok(format!("Using {}.", directory.display())));
+                this.persist_settings(cx);
+                cx.notify();
+            });
+        });
+        self._icon_pack_choose_task = Some(task);
+    }
+
+    /// Real, immediate "back to the app's own default icons" - no confirmation needed, unlike
+    /// [`Self::request_remove_custom_theme`]: clearing this setting deletes nothing on disk, it
+    /// only stops one persisted path from being read, so there is no real data-loss risk to
+    /// guard against the way an actual file deletion has.
+    pub(in crate::settings) fn clear_icon_pack(&mut self, cx: &mut Context<Self>) {
+        self.settings.icon_pack.directory = None;
+        self.icon_pack_status = Some(Ok("Using the app's default icons.".to_string()));
+        self.persist_settings(cx);
+        cx.notify();
     }
 
     /// Applies [`Self::start_import_custom_theme`]'s real background-executor result - shared

--- a/crates/app/src/settings/store.rs
+++ b/crates/app/src/settings/store.rs
@@ -99,6 +99,17 @@ pub struct Settings {
     pub file_tree: FileTreeSettings,
     pub blame: BlameSettings,
     pub editor: EditorSettings,
+    pub icon_pack: IconPackSettings,
+}
+
+/// `crate::icon_pack`'s persisted backing (GitHub issue #5's "custom icon packs") - `None` means
+/// the app's own default, built-in icons (styled shapes/glyphs, no image assets), never a
+/// fabricated "empty pack" state. See that module's own docs for how `directory` is resolved
+/// into a real icon at render time.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct IconPackSettings {
+    pub directory: Option<PathBuf>,
 }
 
 /// `crate::root::AdeApp::window_controls_style`'s persisted backing - see

--- a/crates/app/src/work_surface/state.rs
+++ b/crates/app/src/work_surface/state.rs
@@ -133,6 +133,19 @@ pub fn agent_initial(kind: AgentKind) -> &'static str {
     }
 }
 
+/// `kind`'s icon-pack file name (GitHub issue #5) - `crate::icon_pack::resolve_icon`'s own
+/// `<name>.svg` lookup key. Deliberately its own, separate mapping from [`agent_initial`]'s
+/// single-letter glyph rather than reusing that string directly: a pack author names files by
+/// what the icon *depicts* (`"claude.svg"`), not by this app's own internal one-letter fallback
+/// convention.
+pub fn agent_icon_name(kind: AgentKind) -> &'static str {
+    match kind {
+        AgentKind::Claude => "claude",
+        AgentKind::Codex => "codex",
+        AgentKind::Shell => "shell",
+    }
+}
+
 /// Which of the tab strip's two chip shapes an agent's tab draws: agent CLI gets a `❯` glyph,
 /// terminal gets the pane glyph.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
## Summary

Closes the remaining "custom icon packs" gap in #5 (color palettes + import/export already shipped). Keeps the app's current default icons unchanged - this adds a real, optional override system alongside them, per your confirmation to support both.

## What's real

- New `crate::icon_pack` module: `resolve_icon(pack, name)` looks for a real `<name>.svg` file in the active pack directory, returning `None` (never a fabricated path) if no pack is set, the file is missing, or the name resolves to something that isn't actually a file (e.g. a directory).
- New persisted setting: `Settings.icon_pack.directory: Option<PathBuf>`, round-trips through `settings.toml` like every other setting in this app.
- New Settings UI row (Theme page, right under Custom themes): "Choose folder…" (a real native directory picker, `gpui::App::prompt_for_paths`) and "Use default icons" to clear it. Shows the active path or a short explainer of the `<name>.svg` convention.
- Pack icons render via `gpui::svg().external_path(..)` with **no** theme-color tint - a real user-chosen brand icon (an actual Claude/Codex/etc. logo) keeps its own colors rather than being flattened to the app's own single accent color the way its bundled UI chrome is.

## Scope

I surveyed every icon-like element in the app (~25+ distinct concepts: file-type chips, folder icons, chevrons, status dots, close buttons, agent chips, ...) before starting. Wiring all of them in one pass risked a rushed, inconsistent result across many files, so this PR wires exactly **one** real, well-tested, high-value call site: the rail's agent-kind chip (`AdeApp::render_agent_chip_icon`, used by the most consistently-visible agent indicator in the app). The other ~25 concepts are a real, stated follow-up - not touched here, and the module's own docs say so explicitly.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib` - 1293/49/14/158 passed, 0 failed
- New tests: 5 real unit tests for `resolve_icon` (no pack, missing file, real match, directory-instead-of-file rejected, name-scoping), plus 2 real GPUI interaction tests proving the rail agent row actually switches between the default letter chip and a real pack SVG element as the setting changes.