### PR TITLE
feat(app): git graph tab - real cherry-pick and revert (issue #1)

### DIFF
--- a/crates/app/src/graph_view/render.rs
+++ b/crates/app/src/graph_view/render.rs
@@ -432,6 +432,28 @@ impl AdeApp {
         self.run_graph_remote_op(action, cx, move |root| wt_core::remote::push(&root, force));
     }
 
+    /// The row menu's "Cherry-pick" action - GitHub issue #1's own "cherry pick". Applies
+    /// `sha`'s changes as a new commit on top of the current worktree's branch
+    /// (`wt_core::rewrite::cherry_pick`). A real conflict surfaces through
+    /// [`Self::run_graph_remote_op`]'s own status-message path exactly like a conflicting
+    /// [`Self::request_graph_pull`] does: the worktree is left in the real conflicted state for
+    /// the user to resolve, not silently rolled back.
+    pub(crate) fn request_graph_cherry_pick(&mut self, sha: String, cx: &mut Context<Self>) {
+        self.run_graph_remote_op("Cherry-pick", cx, move |root| {
+            wt_core::rewrite::cherry_pick(&root, &sha)
+        });
+    }
+
+    /// The row menu's "Revert" action - GitHub issue #1's own "revert commit". Creates a new
+    /// commit undoing `sha`'s changes (`wt_core::rewrite::revert`); see
+    /// [`Self::request_graph_cherry_pick`]'s own docs on real-conflict handling, which applies
+    /// identically here.
+    pub(crate) fn request_graph_revert(&mut self, sha: String, cx: &mut Context<Self>) {
+        self.run_graph_remote_op("Revert", cx, move |root| {
+            wt_core::rewrite::revert(&root, &sha)
+        });
+    }
+
     /// Shared plumbing behind [`Self::request_graph_fetch`]/[`Self::request_graph_pull`]/
     /// [`Self::request_graph_push`]: guards against a double-click starting a second, overlapping
     /// git subprocess (`GraphTabState::remote_op_in_flight`), runs `op` on the background
@@ -1294,13 +1316,23 @@ impl AdeApp {
                     ))
                     .child(render_graph_row_menu_header("Apply"))
                     .child(render_dropdown_menu_row(
-                        "\u{2398}", theme::text::GHOST.into(), theme::surface::CHIP_NEUTRAL.into(),
-                        "Cherry-pick", "not implemented yet".to_string(), Vec::new(), false,
-                    ))
+                        "\u{2398}", theme::button::BLUE_FG.into(), theme::surface::CHIP_NEUTRAL.into(),
+                        "Cherry-pick", String::new(), Vec::new(), true,
+                    ).on_click(cx.listener({
+                        let sha = sha.clone();
+                        move |this, _event: &ClickEvent, _window, cx| {
+                            this.request_graph_cherry_pick(sha.clone(), cx);
+                        }
+                    })))
                     .child(render_dropdown_menu_row(
-                        "\u{21b6}", theme::text::GHOST.into(), theme::surface::CHIP_NEUTRAL.into(),
-                        "Revert", "not implemented yet".to_string(), Vec::new(), false,
-                    ))
+                        "\u{21b6}", theme::button::AMBER_FG.into(), theme::surface::CHIP_NEUTRAL.into(),
+                        "Revert", String::new(), Vec::new(), true,
+                    ).on_click(cx.listener({
+                        let sha = sha.clone();
+                        move |this, _event: &ClickEvent, _window, cx| {
+                            this.request_graph_revert(sha.clone(), cx);
+                        }
+                    })))
                     .child(render_dropdown_menu_row(
                         "\u{2191}", theme::text::GHOST.into(), theme::surface::CHIP_NEUTRAL.into(),
                         "Rebase onto this commit", "not implemented yet".to_string(), Vec::new(), false,
@@ -1387,7 +1419,7 @@ impl AdeApp {
             ));
 
         let body = match self.graph_state.right_panel {
-            GraphRightPanel::Commit => self.render_graph_commit_panel(),
+            GraphRightPanel::Commit => self.render_graph_commit_panel(cx),
             GraphRightPanel::Branches => self.render_graph_branches_panel(cx),
         };
 
@@ -1402,7 +1434,7 @@ impl AdeApp {
             .into_any_element()
     }
 
-    fn render_graph_commit_panel(&self) -> gpui::AnyElement {
+    fn render_graph_commit_panel(&self, cx: &mut Context<Self>) -> gpui::AnyElement {
         let Some(index) = self.graph_state.selected_row else {
             return render_sidebar_message(
                 "select a commit to see its details".to_string(),
@@ -1502,8 +1534,32 @@ impl AdeApp {
                     .flex()
                     .gap(px(8.0))
                     .pt(px(8.0))
-                    .child(render_graph_disabled_footer_button("Cherry-pick"))
-                    .child(render_graph_disabled_footer_button("Revert")),
+                    .child(
+                        render_graph_footer_action_button(
+                            "graph-commit-panel-cherry-pick",
+                            "Cherry-pick",
+                            theme::button::BLUE_FG.into(),
+                        )
+                        .on_click(cx.listener({
+                            let sha = row.commit.id.clone();
+                            move |this, _event: &ClickEvent, _window, cx| {
+                                this.request_graph_cherry_pick(sha.clone(), cx);
+                            }
+                        })),
+                    )
+                    .child(
+                        render_graph_footer_action_button(
+                            "graph-commit-panel-revert",
+                            "Revert",
+                            theme::button::AMBER_FG.into(),
+                        )
+                        .on_click(cx.listener({
+                            let sha = row.commit.id.clone();
+                            move |this, _event: &ClickEvent, _window, cx| {
+                                this.request_graph_revert(sha.clone(), cx);
+                            }
+                        })),
+                    ),
             )
             .into_any_element()
     }
@@ -1664,16 +1720,28 @@ fn render_graph_meta_row(label: &'static str, value: String) -> impl IntoElement
         .child(div().flex_1().text_color(theme::text::DIM).child(value))
 }
 
-fn render_graph_disabled_footer_button(label: &'static str) -> impl IntoElement {
+/// The commit detail panel's own Cherry-pick/Revert buttons - a real, clickable twin of the
+/// row menu's "Apply" section rows (`Self::render_graph_row_menu`) for the currently-selected
+/// commit, since a commit already open in this panel is a real, common place to want the same
+/// action from without reopening the `⋯` menu.
+fn render_graph_footer_action_button(
+    id: &'static str,
+    label: &'static str,
+    color: gpui::Rgba,
+) -> gpui::Stateful<gpui::Div> {
     div()
+        .id(id)
+        .debug_selector(move || id.to_string())
+        .cursor_pointer()
         .px(px(10.0))
         .py(px(5.0))
         .rounded(theme::radius::BUTTON)
         .border_1()
-        .border_color(theme::border::BUTTON_DISABLED)
+        .border_color(theme::border::BUTTON)
+        .hover(move |el| el.bg(theme::surface::ROW_HOVER_ALT))
         .font(font(theme::font::SANS))
         .text_size(px(10.5))
-        .text_color(theme::text::DISABLED)
+        .text_color(color)
         .child(label)
 }
 
@@ -5292,6 +5360,115 @@ mod graph_remote_action_tests {
         assert!(
             !app.read_with(cx, |app, _| app.graph_state.remote_op_in_flight),
             "the in-flight guard must still clear even when the operation fails"
+        );
+    }
+
+    /// A real local repo (no remote needed) with a `main` branch and a `feature` branch that
+    /// diverged from it - `Self::request_graph_cherry_pick`/`Self::request_graph_revert`'s own
+    /// tests only ever need one worktree, unlike the push/pull tests above.
+    fn open_seeded_local_repo(
+        cx: &mut TestAppContext,
+    ) -> (
+        tempfile::TempDir,
+        Entity<AdeApp>,
+        &mut gpui::VisualTestContext,
+    ) {
+        let local = tempfile::tempdir().expect("tempdir");
+        git(local.path(), &["init", "-b", "main"]);
+        git(local.path(), &["config", "user.email", "test@example.com"]);
+        git(local.path(), &["config", "user.name", "Test User"]);
+        commit(local.path(), "a.txt", "base", "base");
+
+        let (app, cx) = palette_focus_tests::open_test_app(cx, local.path().to_path_buf());
+        (local, app, cx)
+    }
+
+    #[gpui::test]
+    async fn cherry_pick_really_applies_the_commit_and_reports_success(cx: &mut TestAppContext) {
+        let (local, app, cx) = open_seeded_local_repo(cx);
+        git(local.path(), &["checkout", "-b", "feature"]);
+        commit(local.path(), "b.txt", "feature content", "feature work");
+        let feature_sha = git_output(local.path(), &["rev-parse", "HEAD"]);
+        git(local.path(), &["checkout", "main"]);
+
+        app.update_in(cx, |app, _window, cx| {
+            app.request_graph_cherry_pick(feature_sha, cx);
+        });
+        cx.run_until_parked();
+
+        let head_subject = git_output(local.path(), &["log", "-1", "--format=%s"]);
+        assert_eq!(
+            head_subject, "feature work",
+            "the real click must have run a real git cherry-pick onto the current branch"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.graph_state.status_message.clone()),
+            Some("Cherry-pick".to_string()),
+            "a successful cherry-pick must report real success, not the old 'not implemented \
+             yet' stub text"
+        );
+        assert!(
+            !app.read_with(cx, |app, _| app.graph_state.remote_op_in_flight),
+            "the in-flight guard must clear once the real cherry-pick completes"
+        );
+    }
+
+    #[gpui::test]
+    async fn cherry_pick_a_real_conflict_surfaces_as_a_real_status_message_not_a_crash(
+        cx: &mut TestAppContext,
+    ) {
+        let (local, app, cx) = open_seeded_local_repo(cx);
+        git(local.path(), &["checkout", "-b", "feature"]);
+        commit(local.path(), "a.txt", "feature change", "feature work");
+        let feature_sha = git_output(local.path(), &["rev-parse", "HEAD"]);
+        git(local.path(), &["checkout", "main"]);
+        commit(
+            local.path(),
+            "a.txt",
+            "conflicting main change",
+            "main diverges",
+        );
+
+        app.update_in(cx, |app, _window, cx| {
+            app.request_graph_cherry_pick(feature_sha, cx);
+        });
+        cx.run_until_parked();
+
+        let status = app.read_with(cx, |app, _| app.graph_state.status_message.clone());
+        assert!(
+            status
+                .as_deref()
+                .is_some_and(|text| text.starts_with("Cherry-pick failed:")),
+            "a real conflicting cherry-pick must surface as a real, visible failure message, \
+             not a silent success or a panic - got {status:?}"
+        );
+        assert!(
+            local.path().join(".git/CHERRY_PICK_HEAD").exists(),
+            "the worktree must be left in the real conflicted state for the user to resolve"
+        );
+    }
+
+    #[gpui::test]
+    async fn revert_really_creates_an_undo_commit_and_reports_success(cx: &mut TestAppContext) {
+        let (local, app, cx) = open_seeded_local_repo(cx);
+        commit(local.path(), "a.txt", "changed", "the change to undo");
+        let to_revert = git_output(local.path(), &["rev-parse", "HEAD"]);
+
+        app.update_in(cx, |app, _window, cx| {
+            app.request_graph_revert(to_revert, cx);
+        });
+        cx.run_until_parked();
+
+        assert_eq!(
+            std::fs::read_to_string(local.path().join("a.txt")).expect("read a.txt"),
+            "base",
+            "the real click must have run a real git revert restoring the file's prior content"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.graph_state.status_message.clone()),
+            Some("Revert".to_string()),
+            "a successful revert must report real success, not the old 'not implemented yet' \
+             stub text"
         );
     }
 }

--- a/crates/wt-core/src/lib.rs
+++ b/crates/wt-core/src/lib.rs
@@ -25,6 +25,7 @@ mod error;
 pub mod graph;
 pub mod merge;
 pub mod remote;
+pub mod rewrite;
 pub mod stage;
 pub mod undo;
 

--- a/crates/wt-core/src/rewrite.rs
+++ b/crates/wt-core/src/rewrite.rs
@@ -1,0 +1,189 @@
+//! Real git commit-rewriting operations: cherry-pick and revert - GitHub issue #1's own
+//! acceptance criteria ("cherry pick", "revert commit"). Every mutation shells out to a real
+//! `git` subprocess and surfaces git's own real stderr on failure ([`Error::GitCommand`]),
+//! exactly `crate::remote`'s own discipline.
+//!
+//! Neither function resolves a real conflict itself - a conflicting cherry-pick or revert
+//! leaves the worktree exactly where the equivalent command-line invocation would (a real
+//! `CHERRY_PICK_HEAD`/`REVERT_HEAD` and conflict markers in the working tree), for the caller to
+//! resolve through this app's own conflict-resolution surface or a real terminal, matching
+//! [`crate::remote::pull`]'s own "surfaces whatever git reports, honestly" precedent. Both run
+//! with `--no-edit`: this app has no surface for editing a commit message mid-operation, so the
+//! original commit's own message is kept unchanged rather than blocking on an editor that can
+//! never open (`crate::git_command`'s stdin is always closed).
+
+use std::ffi::OsString;
+use std::path::Path;
+
+use crate::error::Error;
+use crate::{check_success, run_git};
+
+/// Real `git cherry-pick --no-edit <commit>` for `worktree_path`: applies `commit`'s changes as
+/// a new commit on top of the current branch.
+///
+/// Performs blocking I/O.
+pub fn cherry_pick(worktree_path: &Path, commit: &str) -> Result<(), Error> {
+    let args: Vec<OsString> = vec!["cherry-pick".into(), "--no-edit".into(), commit.into()];
+    let output = run_git(worktree_path, &args)?;
+    check_success(&args, &output)
+}
+
+/// Real `git revert --no-edit <commit>` for `worktree_path`: creates a new commit that undoes
+/// `commit`'s changes, leaving `commit` itself in history.
+///
+/// Performs blocking I/O.
+pub fn revert(worktree_path: &Path, commit: &str) -> Result<(), Error> {
+    let args: Vec<OsString> = vec!["revert".into(), "--no-edit".into(), commit.into()];
+    let output = run_git(worktree_path, &args)?;
+    check_success(&args, &output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::process::Command;
+    use tempfile::TempDir;
+
+    fn git(dir: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .output()
+            .expect("failed to spawn git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
+            args,
+            dir,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git_output(dir: &Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .output()
+            .expect("failed to spawn git");
+        assert!(output.status.success(), "git {args:?} failed in {dir:?}");
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    fn init_repo() -> TempDir {
+        let dir = TempDir::new().expect("tempdir");
+        git(dir.path(), &["init", "-b", "main"]);
+        git(dir.path(), &["config", "user.email", "test@example.com"]);
+        git(dir.path(), &["config", "user.name", "Test User"]);
+        dir
+    }
+
+    fn commit(dir: &Path, file: &str, contents: &str, message: &str) -> String {
+        fs::write(dir.join(file), contents).expect("write file");
+        git(dir, &["add", file]);
+        git(dir, &["commit", "-m", message]);
+        git_output(dir, &["rev-parse", "HEAD"])
+    }
+
+    #[test]
+    fn cherry_pick_really_applies_the_commits_change_on_top_of_head() {
+        let repo = init_repo();
+        commit(repo.path(), "a.txt", "base", "base");
+        // A second, unrelated branch line whose tip we'll cherry-pick back onto main.
+        git(repo.path(), &["checkout", "-b", "feature"]);
+        let feature_sha = commit(repo.path(), "b.txt", "feature content", "feature work");
+        git(repo.path(), &["checkout", "main"]);
+
+        cherry_pick(repo.path(), &feature_sha).expect("cherry-pick");
+
+        let head_subject = git_output(repo.path(), &["log", "-1", "--format=%s"]);
+        assert_eq!(head_subject, "feature work");
+        assert_eq!(
+            fs::read_to_string(repo.path().join("b.txt")).expect("read b.txt"),
+            "feature content",
+            "the cherry-picked file must really exist with its real content on the new commit"
+        );
+    }
+
+    #[test]
+    fn cherry_pick_a_real_conflict_surfaces_as_a_real_error_leaving_conflict_state_behind() {
+        let repo = init_repo();
+        commit(repo.path(), "a.txt", "base", "base");
+        git(repo.path(), &["checkout", "-b", "feature"]);
+        let feature_sha = commit(repo.path(), "a.txt", "feature change", "feature work");
+        git(repo.path(), &["checkout", "main"]);
+        commit(
+            repo.path(),
+            "a.txt",
+            "conflicting main change",
+            "main diverges",
+        );
+
+        let result = cherry_pick(repo.path(), &feature_sha);
+        assert!(
+            result.is_err(),
+            "a genuinely conflicting cherry-pick must surface as a real error"
+        );
+        match result.unwrap_err() {
+            Error::GitCommand { stderr, .. } => {
+                assert!(!stderr.is_empty(), "git's own stderr must be preserved");
+            }
+            other => panic!("expected Error::GitCommand, got {other:?}"),
+        }
+        assert!(
+            repo.path().join(".git/CHERRY_PICK_HEAD").exists(),
+            "the worktree must be left in the real conflicted cherry-pick state, not silently \
+             reset, so the user's own conflict-resolution flow can pick it up"
+        );
+    }
+
+    #[test]
+    fn revert_really_creates_a_new_commit_undoing_the_targets_change() {
+        let repo = init_repo();
+        commit(repo.path(), "a.txt", "base", "base");
+        let to_revert = commit(repo.path(), "a.txt", "changed", "the change to undo");
+
+        revert(repo.path(), &to_revert).expect("revert");
+
+        assert_eq!(
+            fs::read_to_string(repo.path().join("a.txt")).expect("read a.txt"),
+            "base",
+            "reverting must really restore the file's prior content"
+        );
+        let log = git_output(repo.path(), &["log", "--format=%s"]);
+        assert!(
+            log.contains("the change to undo"),
+            "revert must leave the original commit in history, not rewrite it away"
+        );
+    }
+
+    #[test]
+    fn revert_a_real_conflict_surfaces_as_a_real_error_leaving_conflict_state_behind() {
+        let repo = init_repo();
+        commit(repo.path(), "a.txt", "base", "base");
+        let to_revert = commit(repo.path(), "a.txt", "changed", "the change to undo");
+        commit(
+            repo.path(),
+            "a.txt",
+            "changed again differently",
+            "later edit",
+        );
+
+        let result = revert(repo.path(), &to_revert);
+        assert!(
+            result.is_err(),
+            "a genuinely conflicting revert must surface as a real error"
+        );
+        match result.unwrap_err() {
+            Error::GitCommand { stderr, .. } => {
+                assert!(!stderr.is_empty(), "git's own stderr must be preserved");
+            }
+            other => panic!("expected Error::GitCommand, got {other:?}"),
+        }
+        assert!(
+            repo.path().join(".git/REVERT_HEAD").exists(),
+            "the worktree must be left in the real conflicted revert state, not silently reset"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `wt_core::rewrite::cherry_pick`/`revert`: real `git cherry-pick --no-edit`/`git revert --no-edit`, following `wt_core::remote`'s own discipline of shelling out and surfacing git's real stderr rather than paraphrasing it. A genuine conflict leaves the worktree in the real `CHERRY_PICK_HEAD`/`REVERT_HEAD` state for the user to resolve, matching how a real conflicting `pull` is already handled.
- Wires both into the graph tab's row `⋯` menu ("Apply" section, previously disabled "not implemented yet" rows) and the commit detail panel's footer buttons (previously inert, no `on_click` at all).
- Reuses the existing `run_graph_remote_op` plumbing (background executor, in-flight guard, status message, graph reload) that fetch/pull/push already established - same shape, same tests style.

## Out of scope
- Rebase (onto commit / interactive rebase) - issue #1's remaining acceptance criterion. Needs its own conflict-resolution and commit-reordering UI; a real, stated follow-up, not squeezed into this slice.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib -- --test-threads=1` (1316+49+14+171 passing, 0 failed)
- [x] New `wt-core` tests cover both a clean apply and a real conflict (asserting the real `CHERRY_PICK_HEAD`/`REVERT_HEAD` file exists afterward) for each operation.
- [x] New `app` tests drive `request_graph_cherry_pick`/`request_graph_revert` directly against a real local git repo and assert the real resulting git state (file content, commit subject) and status message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)