### PR TITLE
feat(app): tab-strip drag ghost + dimmed original slot (issue #16)

### DIFF
--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -1380,6 +1380,15 @@ pub struct AdeApp {
     /// outside any drop target) can't leave a stale caret painted on a tab no drag is over
     /// anymore.
     pub(crate) tab_drag_insertion: Option<(work_surface::TabRef, bool)>,
+    /// The unified tab strip's real drag-ghost state (GitHub issue #16's "the original slot
+    /// renders dimmed" ask): `Some(tab_ref)` for exactly the tab currently being dragged, from
+    /// its own `on_drag` constructor callback (`Self::render_file_tab`/`Self::render_agent_tab`)
+    /// until either a real drop (`Self::drop_dragged_tab`) or a cancelled drag (the same
+    /// workspace-body `on_mouse_up` that clears [`Self::tab_drag_insertion`] on a cancel clears
+    /// this too). Never two tabs at once: a new drag's own `on_drag` overwrites whatever was
+    /// here, which only matters if a previous drag's cancel-cleanup somehow missed - a defensive
+    /// property, not a real multi-drag scenario GPUI itself allows.
+    pub(crate) dragging_tab: Option<work_surface::TabRef>,
     /// User-authored themes loaded from `~/.config/jerry/themes/*.toml` at construction time
     /// (GitHub issue #5) - real, additional `crate::settings::custom_theme::CustomTheme` entries
     /// layered on top of the six built-in `settings::THEME_DEFS`, not a replacement for them. See
@@ -1920,17 +1929,17 @@ impl AdeApp {
                     this.apply_pane_resize(target, event.event.position.x, cx);
                 },
             ))
-            // Defensive cleanup for `Self::tab_drag_insertion`: unlike `PaneResizeDrag` above,
-            // this one *does* need an explicit mouse-up handler, because it isn't derived fresh
-            // from the cursor position on every tick - it's the last tab strip
-            // `on_drag_move::<DraggedTab>` claimed, which stays stale if the drag ends by
-            // releasing outside any tab's own hitbox (a cancelled drag) rather than through a
-            // real `on_drop`. The body spans virtually the whole window below the title bar, so
-            // this reaches almost every real release point.
+            // Defensive cleanup for `Self::tab_drag_insertion`/[`Self::dragging_tab`]: unlike
+            // `PaneResizeDrag` above, these *do* need an explicit mouse-up handler, because
+            // neither is derived fresh from the cursor position on every tick - they're the last
+            // tab strip `on_drag_move::<DraggedTab>`/`on_drag` claimed, which stays stale if the
+            // drag ends by releasing outside any tab's own hitbox (a cancelled drag) rather than
+            // through a real `on_drop`. The body spans virtually the whole window below the
+            // title bar, so this reaches almost every real release point.
             .on_mouse_up(
                 MouseButton::Left,
                 cx.listener(|this, _event: &gpui::MouseUpEvent, _window, cx| {
-                    if this.tab_drag_insertion.take().is_some() {
+                    if this.cancel_any_tab_drag() {
                         cx.notify();
                     }
                 }),

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -348,6 +348,7 @@ impl AdeApp {
             tab_order_owned: std::collections::BTreeSet::new(),
             _tab_order_save_task: None,
             tab_drag_insertion: None,
+            dragging_tab: None,
             custom_themes,
             custom_theme_load_errors,
             custom_theme_status: None,

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -509,6 +509,34 @@ impl AdeApp {
             .is_some_and(|(hovered, after)| *hovered == target && *after);
         self.reorder_tab(dragged, target, insert_after, cx);
         self.tab_drag_insertion = None;
+        self.dragging_tab = None;
+    }
+
+    /// One tab's own `on_drag` constructor callback (both [`Self::render_agent_tab`] and
+    /// [`Self::render_file_tab`] call this) - records `tab_ref` into [`Self::dragging_tab`] so
+    /// that tab's own slot can dim itself while its ghost is the real thing following the
+    /// cursor. A plain method (not inlined into the closure) so it's directly testable without
+    /// simulating a real GPUI drag gesture, matching [`Self::update_tab_drag_insertion`]/
+    /// [`Self::drop_dragged_tab`]'s own precedent.
+    pub(in crate::work_surface) fn start_dragging_tab(
+        &mut self,
+        tab_ref: work_surface::TabRef,
+        cx: &mut Context<Self>,
+    ) {
+        self.dragging_tab = Some(tab_ref);
+        cx.notify();
+    }
+
+    /// Clears any in-progress tab drag's tracked state - the real cancelled-drag path (Esc, or
+    /// releasing outside any tab's own drop target) that GPUI gives no dedicated callback for
+    /// (see [`Self::dragging_tab`]'s own docs). `crate::root::AdeApp`'s workspace-body
+    /// `on_mouse_up` is this method's only real caller; returns whether anything was actually
+    /// cleared so that caller only `cx.notify()`s when something changed, rather than on every
+    /// unrelated click in the window.
+    pub(crate) fn cancel_any_tab_drag(&mut self) -> bool {
+        let cleared_insertion = self.tab_drag_insertion.take().is_some();
+        let cleared_dragging = self.dragging_tab.take().is_some();
+        cleared_insertion || cleared_dragging
     }
 
     /// Every agent open in the *currently selected* worktree (`Self::active_agent_cwd`), in
@@ -733,6 +761,9 @@ impl AdeApp {
             Some((target, insert_after)) if *target == tab_ref => Some(*insert_after),
             _ => None,
         };
+        let is_dragging = self.dragging_tab.as_ref() == Some(&tab_ref);
+        let this_entity = cx.entity();
+        let tab_ref_for_drag = tab_ref.clone();
 
         div()
             .id(format!("file-tab-{key}"))
@@ -743,6 +774,11 @@ impl AdeApp {
             .border_r_1()
             .border_color(theme::border::INNER)
             .bg(colors.bg)
+            // The original slot dims while its own drag ghost (`DraggedTab::render`) is the real
+            // thing following the cursor (GitHub issue #16's "the original slot renders dimmed"
+            // ask) - `Self::dragging_tab`'s own docs on why this can't be derived from GPUI's
+            // `has_active_drag()` alone (no public access to *which* tab is being dragged).
+            .when(is_dragging, |el| el.opacity(0.4))
             // Middle-click closes any file tab outright (GitHub issue #26), same real
             // `request_close_file_tab` entry point as `×`/`Ctrl+W` - so a dirty tab still gets the
             // real unsaved-changes confirmation rather than a middle-click silently bypassing it.
@@ -754,8 +790,14 @@ impl AdeApp {
                 }),
             )
             // Real drag-to-reorder, unified across agent and file tabs (GitHub issue #16) -
-            // see `DraggedTab`'s own docs for the shared mechanism.
-            .on_drag(drag_value, |dragged, _position, _window, cx| {
+            // see `DraggedTab`'s own docs for the shared mechanism. Also records
+            // `Self::dragging_tab` so this tab's own slot can dim itself above - `on_drag`'s own
+            // constructor callback only receives `&mut App`, not `Context<Self>`, hence the
+            // captured `this_entity` handle to reach back into `AdeApp` from it.
+            .on_drag(drag_value, move |dragged, _position, _window, cx| {
+                this_entity.update(cx, |this, cx| {
+                    this.start_dragging_tab(tab_ref_for_drag.clone(), cx);
+                });
                 cx.new(|_| dragged.clone())
             })
             .on_drag_move(cx.listener({
@@ -1296,6 +1338,9 @@ impl AdeApp {
             Some((target, insert_after)) if *target == tab_ref => Some(*insert_after),
             _ => None,
         };
+        let is_dragging = self.dragging_tab.as_ref() == Some(&tab_ref);
+        let this_entity = cx.entity();
+        let tab_ref_for_drag = tab_ref.clone();
 
         div()
             .id(("agent-tab", id))
@@ -1306,6 +1351,9 @@ impl AdeApp {
             .border_r_1()
             .border_color(theme::border::INNER)
             .bg(colors.bg)
+            // The original slot dims while its own drag ghost is the real thing following the
+            // cursor - see `Self::render_file_tab`'s identical `is_dragging` handling for why.
+            .when(is_dragging, |el| el.opacity(0.4))
             // Middle-click closes any agent/terminal tab too (GitHub issue #26) - the same
             // `Self::close_agent` real teardown (`TerminalPane::shutdown`'s SIGHUP/grace/
             // SIGKILL - see that method's own docs) every other close path already uses.
@@ -1320,8 +1368,12 @@ impl AdeApp {
             // Real drag-to-reorder, unified across agent and file tabs (GitHub issue #16) -
             // see `DraggedTab`'s own docs for the shared mechanism. No `can_drop` predicate
             // needed - the `on_drop::<DraggedTab>` type parameter alone already rejects a drop of
-            // any other dragged-value type.
-            .on_drag(drag_value, |dragged, _position, _window, cx| {
+            // any other dragged-value type. Also records `Self::dragging_tab` - see
+            // `Self::render_file_tab`'s identical wiring for why `this_entity` is captured.
+            .on_drag(drag_value, move |dragged, _position, _window, cx| {
+                this_entity.update(cx, |this, cx| {
+                    this.start_dragging_tab(tab_ref_for_drag.clone(), cx);
+                });
                 cx.new(|_| dragged.clone())
             })
             .on_drag_move(cx.listener({
@@ -2253,7 +2305,11 @@ impl DraggedTab {
 
 impl Render for DraggedTab {
     fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        // `.opacity(..)` (GitHub issue #16's "a semi-transparent snapshot of the tab") applies to
+        // the whole subtree, so the border/text fade along with the fill rather than staying
+        // full-strength inside a see-through box.
         div()
+            .opacity(0.85)
             .px(px(10.0))
             .py(px(4.0))
             .rounded(theme::radius::CHIP)
@@ -2907,6 +2963,104 @@ mod tab_scoping_tests {
             app.read_with(cx, |app, _| app.tab_drag_insertion.clone()),
             None,
             "a handled drop must clear the now-stale insertion-caret state"
+        );
+    }
+
+    /// `Self::start_dragging_tab` (the real `on_drag` constructor callback's body, GitHub issue
+    /// #16's "the original slot renders dimmed" ask) must record exactly the tab that started
+    /// the drag, so `Self::render_file_tab`/`Self::render_agent_tab`'s own `is_dragging` check
+    /// dims the right slot and no other.
+    #[gpui::test]
+    fn start_dragging_tab_records_exactly_the_tab_that_started_the_drag(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let initial_id = app.read_with(cx, |app, _| app.agents.active_id().expect("shell agent"));
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.dragging_tab.clone()),
+            None,
+            "premise: nothing is being dragged yet"
+        );
+
+        app.update(cx, |app, cx| {
+            app.start_dragging_tab(work_surface::TabRef::Agent(initial_id), cx);
+        });
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.dragging_tab.clone()),
+            Some(work_surface::TabRef::Agent(initial_id)),
+            "starting a drag must record exactly the tab that started it"
+        );
+    }
+
+    /// A real drop must clear `Self::dragging_tab` alongside `Self::tab_drag_insertion` - a
+    /// dropped tab's slot must never stay dimmed once the drag it was dimmed for is over.
+    #[gpui::test]
+    fn dropping_a_tab_clears_dragging_tab(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+
+        let (initial_id, second_id) = app.update_in(cx, |app, window, cx| {
+            let initial_id = app.agents.active_id().expect("initial shell agent");
+            let second_id = app.agents.spawn(
+                AgentKind::Shell,
+                repo.path().to_path_buf(),
+                12.0,
+                window,
+                cx,
+            );
+            (initial_id, second_id)
+        });
+
+        app.update(cx, |app, cx| {
+            app.start_dragging_tab(work_surface::TabRef::Agent(initial_id), cx);
+        });
+        app.update(cx, |app, cx| {
+            app.drop_dragged_tab(
+                work_surface::TabRef::Agent(initial_id),
+                work_surface::TabRef::Agent(second_id),
+                cx,
+            );
+        });
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.dragging_tab.clone()),
+            None,
+            "a handled drop must clear the now-stale dragging-tab state"
+        );
+    }
+
+    /// `Self::cancel_any_tab_drag` (the workspace body's real cancelled-drag cleanup - GPUI gives
+    /// no dedicated callback for Esc/release-outside-any-target, see `AdeApp::dragging_tab`'s own
+    /// docs) must clear both drag-tracking fields together and report whether it actually did
+    /// anything, so a click that was never a drag doesn't force an unnecessary re-render.
+    #[gpui::test]
+    fn cancel_any_tab_drag_clears_both_fields_and_reports_whether_anything_changed(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let initial_id = app.read_with(cx, |app, _| app.agents.active_id().expect("shell agent"));
+
+        assert!(
+            !app.update(cx, |app, _cx| app.cancel_any_tab_drag()),
+            "with nothing in progress, cancelling must report that nothing changed"
+        );
+
+        app.update(cx, |app, cx| {
+            app.start_dragging_tab(work_surface::TabRef::Agent(initial_id), cx);
+            app.tab_drag_insertion = Some((work_surface::TabRef::Agent(initial_id), true));
+        });
+
+        assert!(
+            app.update(cx, |app, _cx| app.cancel_any_tab_drag()),
+            "with a real in-progress drag, cancelling must report that it actually cleared \
+             something"
+        );
+        assert_eq!(app.read_with(cx, |app, _| app.dragging_tab.clone()), None);
+        assert_eq!(
+            app.read_with(cx, |app, _| app.tab_drag_insertion.clone()),
+            None
         );
     }
 


### PR DESCRIPTION
## Summary
- The unified tab strip's drag preview was an opaque label chip with no visual link back to the tab it came from. Issue #16 asks for "a semi-transparent snapshot... the original slot renders dimmed or as a gap."
- Adds `AdeApp::dragging_tab`, set via a new `start_dragging_tab` (pulled out of the `on_drag` constructor callback into a directly-testable method, matching `update_tab_drag_insertion`/`drop_dragged_tab`'s own precedent) and read by `render_file_tab`/`render_agent_tab` to dim their own slot to 40% opacity while their own drag is active.
- The floating ghost (`DraggedTab::render`) now renders at 85% opacity.
- The existing cancelled-drag cleanup (workspace body's `on_mouse_up` - GPUI has no dedicated drag-cancel callback) is extracted into `cancel_any_tab_drag`, now clearing both `tab_drag_insertion` and `dragging_tab` together, and directly testable.

## Out of scope
- Reflow/settle/cancel animations and a reduced-motion setting - issue #16's remaining asks. This app has no animation primitive in use anywhere yet (confirmed via a full-codebase search before starting this slice), so that's a larger, separate investigation rather than something to fold into this change.
- Cross-group highlight - moot: the tab-group concept this line item was written against no longer exists in the current unified single-strip model (any tab already interleaves freely with any other).

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib -- --test-threads=1` (1319+49+14+171 passing, 0 failed)
- [x] New tests: starting a drag records exactly the dragged tab, a real drop clears it, and `cancel_any_tab_drag` clears both drag-tracking fields together and correctly reports whether anything changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)