### PR TITLE
feat(app): git graph tab - real non-interactive rebase (issue #1)

### DIFF
--- a/crates/app/src/graph_view/render.rs
+++ b/crates/app/src/graph_view/render.rs
@@ -454,6 +454,18 @@ impl AdeApp {
         });
     }
 
+    /// The row menu's "Rebase onto this commit" action - GitHub issue #1's own "rebase branch
+    /// (interactive or not)", the non-interactive half. Replays the current worktree's own
+    /// branch on top of `sha` (`wt_core::rewrite::rebase_onto`); see
+    /// [`Self::request_graph_cherry_pick`]'s own docs on real-conflict handling, which applies
+    /// identically here. Interactive rebase (commit reordering/squash/edit) is a real, stated
+    /// follow-up - it needs its own commit-selection UI, not just a single click.
+    pub(crate) fn request_graph_rebase_onto(&mut self, sha: String, cx: &mut Context<Self>) {
+        self.run_graph_remote_op("Rebase", cx, move |root| {
+            wt_core::rewrite::rebase_onto(&root, &sha)
+        });
+    }
+
     /// Shared plumbing behind [`Self::request_graph_fetch`]/[`Self::request_graph_pull`]/
     /// [`Self::request_graph_push`]: guards against a double-click starting a second, overlapping
     /// git subprocess (`GraphTabState::remote_op_in_flight`), runs `op` on the background
@@ -1334,9 +1346,14 @@ impl AdeApp {
                         }
                     })))
                     .child(render_dropdown_menu_row(
-                        "\u{2191}", theme::text::GHOST.into(), theme::surface::CHIP_NEUTRAL.into(),
-                        "Rebase onto this commit", "not implemented yet".to_string(), Vec::new(), false,
-                    ))
+                        "\u{2191}", theme::button::BLUE_FG.into(), theme::surface::CHIP_NEUTRAL.into(),
+                        "Rebase onto this commit", String::new(), Vec::new(), true,
+                    ).on_click(cx.listener({
+                        let sha = sha.clone();
+                        move |this, _event: &ClickEvent, _window, cx| {
+                            this.request_graph_rebase_onto(sha.clone(), cx);
+                        }
+                    })))
                     .child(render_dropdown_menu_row(
                         "\u{2191}", theme::text::GHOST.into(), theme::surface::CHIP_NEUTRAL.into(),
                         "Interactive rebase from here", "not implemented yet".to_string(), Vec::new(), false,
@@ -5469,6 +5486,61 @@ mod graph_remote_action_tests {
             Some("Revert".to_string()),
             "a successful revert must report real success, not the old 'not implemented yet' \
              stub text"
+        );
+    }
+
+    #[gpui::test]
+    async fn rebase_onto_really_replays_the_branch_and_reports_success(cx: &mut TestAppContext) {
+        let (local, app, cx) = open_seeded_local_repo(cx);
+        // A second branch line the app's own worktree branch will be rebased onto.
+        git(local.path(), &["checkout", "-b", "target-branch"]);
+        commit(local.path(), "b.txt", "target content", "target advances");
+        let target_sha = git_output(local.path(), &["rev-parse", "HEAD"]);
+        git(local.path(), &["checkout", "main"]);
+        commit(local.path(), "c.txt", "own content", "own work");
+
+        app.update_in(cx, |app, _window, cx| {
+            app.request_graph_rebase_onto(target_sha, cx);
+        });
+        cx.run_until_parked();
+
+        let log = git_output(local.path(), &["log", "--format=%s"]);
+        assert_eq!(
+            log, "own work\ntarget advances\nbase",
+            "the real click must have run a real git rebase replaying this worktree's own \
+             commit on top of the target branch's tip"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.graph_state.status_message.clone()),
+            Some("Rebase".to_string()),
+            "a successful rebase must report real success, not the old 'not implemented yet' \
+             stub text"
+        );
+    }
+
+    #[gpui::test]
+    async fn rebase_onto_a_real_conflict_surfaces_as_a_real_status_message_not_a_crash(
+        cx: &mut TestAppContext,
+    ) {
+        let (local, app, cx) = open_seeded_local_repo(cx);
+        git(local.path(), &["checkout", "-b", "target-branch"]);
+        commit(local.path(), "a.txt", "target change", "target advances");
+        let target_sha = git_output(local.path(), &["rev-parse", "HEAD"]);
+        git(local.path(), &["checkout", "main"]);
+        commit(local.path(), "a.txt", "conflicting own change", "own work");
+
+        app.update_in(cx, |app, _window, cx| {
+            app.request_graph_rebase_onto(target_sha, cx);
+        });
+        cx.run_until_parked();
+
+        let status = app.read_with(cx, |app, _| app.graph_state.status_message.clone());
+        assert!(
+            status
+                .as_deref()
+                .is_some_and(|text| text.starts_with("Rebase failed:")),
+            "a real conflicting rebase must surface as a real, visible failure message, not a \
+             silent success or a panic - got {status:?}"
         );
     }
 }

--- a/crates/wt-core/src/rewrite.rs
+++ b/crates/wt-core/src/rewrite.rs
@@ -1,16 +1,18 @@
-//! Real git commit-rewriting operations: cherry-pick and revert - GitHub issue #1's own
-//! acceptance criteria ("cherry pick", "revert commit"). Every mutation shells out to a real
-//! `git` subprocess and surfaces git's own real stderr on failure ([`Error::GitCommand`]),
-//! exactly `crate::remote`'s own discipline.
+//! Real git commit-rewriting operations: cherry-pick, revert, and rebase - GitHub issue #1's own
+//! acceptance criteria ("cherry pick", "revert commit", "rebase branch"). Every mutation shells
+//! out to a real `git` subprocess and surfaces git's own real stderr on failure
+//! ([`Error::GitCommand`]), exactly `crate::remote`'s own discipline.
 //!
-//! Neither function resolves a real conflict itself - a conflicting cherry-pick or revert
-//! leaves the worktree exactly where the equivalent command-line invocation would (a real
-//! `CHERRY_PICK_HEAD`/`REVERT_HEAD` and conflict markers in the working tree), for the caller to
-//! resolve through this app's own conflict-resolution surface or a real terminal, matching
-//! [`crate::remote::pull`]'s own "surfaces whatever git reports, honestly" precedent. Both run
-//! with `--no-edit`: this app has no surface for editing a commit message mid-operation, so the
-//! original commit's own message is kept unchanged rather than blocking on an editor that can
-//! never open (`crate::git_command`'s stdin is always closed).
+//! None of these functions resolve a real conflict themselves - a conflicting cherry-pick,
+//! revert, or rebase leaves the worktree exactly where the equivalent command-line invocation
+//! would (a real `CHERRY_PICK_HEAD`/`REVERT_HEAD`/`REBASE_HEAD` and conflict markers in the
+//! working tree), for the caller to resolve through this app's own conflict-resolution surface
+//! or a real terminal, matching [`crate::remote::pull`]'s own "surfaces whatever git reports,
+//! honestly" precedent. [`cherry_pick`]/[`revert`] run with `--no-edit`: this app has no surface
+//! for editing a commit message mid-operation, so the original commit's own message is kept
+//! unchanged rather than blocking on an editor that can never open (`crate::git_command`'s stdin
+//! is always closed). [`rebase_onto`] is deliberately never interactive for the same reason - see
+//! its own docs.
 
 use std::ffi::OsString;
 use std::path::Path;
@@ -34,6 +36,21 @@ pub fn cherry_pick(worktree_path: &Path, commit: &str) -> Result<(), Error> {
 /// Performs blocking I/O.
 pub fn revert(worktree_path: &Path, commit: &str) -> Result<(), Error> {
     let args: Vec<OsString> = vec!["revert".into(), "--no-edit".into(), commit.into()];
+    let output = run_git(worktree_path, &args)?;
+    check_success(&args, &output)
+}
+
+/// Real `git rebase <onto>` for `worktree_path`: replays the current branch's own commits (the
+/// ones not already reachable from `onto`) on top of `onto` - the row menu's "Rebase onto this
+/// commit" (GitHub issue #1). Always git's own plain, non-interactive replay: this app has no
+/// commit-reordering/squash/edit UI yet (interactive rebase is a real, stated follow-up, not
+/// this function), and a real conflict mid-replay stops exactly where the command-line
+/// equivalent would, `--onto`-less `git rebase` needing no editor at any step (unlike
+/// `cherry_pick`/`revert`, no `--no-edit` is needed here for that reason).
+///
+/// Performs blocking I/O.
+pub fn rebase_onto(worktree_path: &Path, onto: &str) -> Result<(), Error> {
+    let args: Vec<OsString> = vec!["rebase".into(), onto.into()];
     let output = run_git(worktree_path, &args)?;
     check_success(&args, &output)
 }
@@ -184,6 +201,79 @@ mod tests {
         assert!(
             repo.path().join(".git/REVERT_HEAD").exists(),
             "the worktree must be left in the real conflicted revert state, not silently reset"
+        );
+    }
+
+    fn rebase_head_exists(dir: &Path) -> bool {
+        Command::new("git")
+            .current_dir(dir)
+            .args(["rev-parse", "--verify", "--quiet", "REBASE_HEAD"])
+            .output()
+            .expect("failed to spawn git")
+            .status
+            .success()
+    }
+
+    #[test]
+    fn rebase_onto_really_replays_the_current_branchs_commits_on_top_of_the_target() {
+        let repo = init_repo();
+        commit(repo.path(), "a.txt", "base", "base");
+        let base_sha = git_output(repo.path(), &["rev-parse", "HEAD"]);
+
+        git(repo.path(), &["checkout", "-b", "feature", &base_sha]);
+        commit(repo.path(), "b.txt", "feature content", "feature work");
+
+        git(repo.path(), &["checkout", "main"]);
+        let target_sha = commit(repo.path(), "c.txt", "main content", "main advances");
+
+        git(repo.path(), &["checkout", "feature"]);
+        rebase_onto(repo.path(), &target_sha).expect("rebase onto main");
+
+        let log = git_output(repo.path(), &["log", "--format=%s"]);
+        assert_eq!(
+            log, "feature work\nmain advances\nbase",
+            "the feature commit must now sit on top of main's real tip, not its old base"
+        );
+        assert_eq!(
+            fs::read_to_string(repo.path().join("c.txt")).expect("read c.txt"),
+            "main content",
+            "the replayed branch must really contain main's own content too"
+        );
+    }
+
+    #[test]
+    fn rebase_onto_a_real_conflict_surfaces_as_a_real_error_leaving_rebase_state_behind() {
+        let repo = init_repo();
+        commit(repo.path(), "a.txt", "base", "base");
+        let base_sha = git_output(repo.path(), &["rev-parse", "HEAD"]);
+
+        git(repo.path(), &["checkout", "-b", "feature", &base_sha]);
+        commit(repo.path(), "a.txt", "feature change", "feature work");
+
+        git(repo.path(), &["checkout", "main"]);
+        let target_sha = commit(
+            repo.path(),
+            "a.txt",
+            "conflicting main change",
+            "main diverges",
+        );
+
+        git(repo.path(), &["checkout", "feature"]);
+        let result = rebase_onto(repo.path(), &target_sha);
+        assert!(
+            result.is_err(),
+            "a genuinely conflicting rebase must surface as a real error"
+        );
+        match result.unwrap_err() {
+            Error::GitCommand { stderr, .. } => {
+                assert!(!stderr.is_empty(), "git's own stderr must be preserved");
+            }
+            other => panic!("expected Error::GitCommand, got {other:?}"),
+        }
+        assert!(
+            rebase_head_exists(repo.path()),
+            "the worktree must be left in the real conflicted rebase state, not silently reset, \
+             so the user's own conflict-resolution flow can pick it up"
         );
     }
 }


### PR DESCRIPTION
## Summary
- Adds `wt_core::rewrite::rebase_onto`: real `git rebase <onto>`, following the same shell-out-and-surface-real-stderr discipline as `cherry_pick`/`revert` (PR #77). A genuine conflict leaves the worktree in the real `REBASE_HEAD` state for the user to resolve, matching how conflicting cherry-picks/reverts/pulls are already handled.
- Wires it into the graph tab's row `⋯` menu's previously-disabled "Rebase onto this commit" row, reusing the existing `run_graph_remote_op` plumbing (background executor, in-flight guard, status message, graph reload).

## Out of scope
- Interactive rebase ("Interactive rebase from here", still shown disabled) - issue #1's other remaining acceptance criterion. Needs its own commit-reordering/squash/edit UI, a real, separate effort beyond a single click.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib -- --test-threads=1` (1318+49+14+173 passing, 0 failed)
- [x] New `wt-core` tests cover a clean rebase and a real conflict (asserting `REBASE_HEAD` exists afterward via `git rev-parse --verify -q`).
- [x] New `app` tests drive `request_graph_rebase_onto` directly and assert the real resulting git log and status message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)