### PR TITLE
feat(app): real file-tree live sync with fs changes

### DIFF
--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -218,6 +218,18 @@ pub(crate) const WORKTREE_WATCH_TICK: Duration = Duration::from_millis(300);
 /// the one refresh that follows it, rather than each one triggering its own.
 pub(crate) const WORKTREE_WATCH_SETTLE: Duration = Duration::from_millis(200);
 
+/// GitHub issue #13's own "keep a low-frequency polling fallback" - the file tree is re-walked
+/// at least this often even if [`AdeApp::_file_tree_watcher`] never fires (setup failed, or an
+/// OS-level watch-descriptor budget was exhausted on a very large tree - see
+/// `crate::sidebar::file_tree_watch::spawn_file_tree_watcher`'s own docs). Same interval as
+/// [`WORKTREE_WATCH_POLL_INTERVAL`], not independently tuned - there's no reason the two should
+/// disagree about what an acceptable "worst case, no watcher at all" staleness looks like.
+pub(crate) const FILE_TREE_WATCH_POLL_INTERVAL: Duration = WORKTREE_WATCH_POLL_INTERVAL;
+
+/// [`AdeApp::start_file_tree_watch`]'s own [`WORKTREE_WATCH_TICK`]/[`WORKTREE_WATCH_SETTLE`].
+pub(crate) const FILE_TREE_WATCH_TICK: Duration = WORKTREE_WATCH_TICK;
+pub(crate) const FILE_TREE_WATCH_SETTLE: Duration = WORKTREE_WATCH_SETTLE;
+
 /// How often [`AdeApp::render_file_view`] calls `std::fs::metadata` for its freshness check -
 /// throttled rather than unconditional-per-render (see
 /// [`AdeApp::file_view_last_freshness_check`]).
@@ -1064,6 +1076,15 @@ pub struct AdeApp {
     /// [`Self::load_worktrees`] - see that method's own docs.
     pub(crate) _worktree_watch_task: Option<Task<()>>,
     pub(crate) _load_file_tree_task: Option<Task<()>>,
+    /// The live `notify` filesystem watcher on [`Self::file_tree_root`] (GitHub issue #13,
+    /// `crate::sidebar::file_tree_watch`) - re-armed on a fresh root every real
+    /// [`Self::set_file_tree_root`] call, unlike [`Self::_worktree_watcher`]'s "once, for the
+    /// whole app lifetime" own scope. Same "`None` on honest setup failure, poll fallback still
+    /// runs" contract as that field.
+    pub(crate) _file_tree_watcher: Option<notify::RecommendedWatcher>,
+    /// The debounced-watcher-plus-poll-fallback refresh loop (`Self::start_file_tree_watch`) that
+    /// calls [`Self::load_file_tree`] - see that method's own docs.
+    pub(crate) _file_tree_watch_task: Option<Task<()>>,
     pub(crate) _load_diff_task: Option<Task<()>>,
     /// The in-flight `code_view::load_file` task for whichever path [`FileLoadState::Loading`]
     /// names - dropping it (a fresh assignment, or `Self::select_worktree`'s reset) cancels that

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -349,6 +349,8 @@ impl AdeApp {
             _worktree_watcher: None,
             _worktree_watch_task: None,
             _load_file_tree_task: None,
+            _file_tree_watcher: None,
+            _file_tree_watch_task: None,
             _load_diff_task: None,
             _file_load_task: None,
             _status_poll_task: None,
@@ -471,7 +473,7 @@ impl AdeApp {
             // See the `expanded_dirs`/`fold_state_root_key` note in the literal above: resolving
             // the worktree key here, through the one function that ever resolves it, is what
             // keeps the startup path and every later worktree switch structurally identical.
-            this.set_file_tree_root(path.clone());
+            this.set_file_tree_root(path.clone(), cx);
             this.reload_expanded_dirs_from_fold_state();
         }
         // Applies `this.settings.keymap.overrides` on top of `crate::default_key_bindings()` -
@@ -593,7 +595,7 @@ impl AdeApp {
                             .and_then(|index| this.worktrees.get(index))
                             .map(|item| item.path.clone())
                             .unwrap_or_else(|| this.focused_repo_path());
-                        this.set_file_tree_root(new_root.clone());
+                        this.set_file_tree_root(new_root.clone(), cx);
                         this.file_tree = Vec::new();
                         this.reload_expanded_dirs_from_fold_state();
                         this.load_file_tree(new_root.clone(), cx);
@@ -663,16 +665,20 @@ impl AdeApp {
         };
     }
 
-    pub(crate) fn set_file_tree_root(&mut self, root: PathBuf) {
+    pub(crate) fn set_file_tree_root(&mut self, root: PathBuf, cx: &mut Context<Self>) {
         if self.file_tree_root == root && self.fold_state_root_key.is_some() {
             return;
         }
         self.fold_state_root_key = fold_state::worktree_key(&root);
         self.file_tree_root = root;
+        // Re-arms the real filesystem watch on the *new* root (GitHub issue #13) - see
+        // `Self::start_file_tree_watch`'s own docs on why this only happens on a genuine root
+        // change, guarded by the early return above, rather than on every `load_file_tree` call.
+        self.start_file_tree_watch(cx);
     }
 
     pub(crate) fn load_file_tree(&mut self, root: PathBuf, cx: &mut Context<Self>) {
-        self.set_file_tree_root(root.clone());
+        self.set_file_tree_root(root.clone(), cx);
         // Always a real bound - see [`Self::file_tree_limit_override`] for why even the "load
         // more" escape hatch raises the cap rather than removing it.
         let limit = Some(
@@ -721,6 +727,88 @@ impl AdeApp {
             });
         });
         self._load_file_tree_task = Some(task);
+    }
+
+    /// Starts (or, via [`Self::set_file_tree_root`], re-starts on a new worktree) the real
+    /// filesystem-watch-plus-poll-fallback loop behind GitHub issue #13's "the file list...
+    /// drifts out of sync with the actual state on disk" - the same debounced-watcher-plus-
+    /// poll-fallback shape `Self::start_worktree_watch` already established for the worktree
+    /// list, just scoped to [`Self::file_tree_root`] and reloading via [`Self::load_file_tree`]
+    /// instead. Assigning fresh values to [`Self::_file_tree_watcher`]/
+    /// [`Self::_file_tree_watch_task`] drops (and so silently stops) whatever watcher/loop was
+    /// previously watching the worktree just left - `Self::set_file_tree_root`'s own early
+    /// return is what keeps this from happening on every unrelated `load_file_tree` call, not
+    /// this method itself re-checking anything.
+    ///
+    /// A no-op (clearing both fields rather than starting anything) unless both:
+    /// - `root` is really part of a git worktree (production never has a non-git
+    ///   [`Self::file_tree_root`] - see
+    ///   `crate::sidebar::file_tree_watch::spawn_file_tree_watcher`'s own docs on that gate), and
+    /// - [`Self::settings_path`] is real (`Some`) - the same "this is a real, persisted session,
+    ///   not a throwaway test instance" signal [`Self::persist_settings`] already gates its own
+    ///   real disk write on (see that method's own docs).
+    ///
+    /// Both checks matter operationally, not just semantically: a real, reproduced regression
+    /// found while building this - a real `notify::RecommendedWatcher` OS thread/instance spun
+    /// up for essentially every one of this crate's own GPUI tests (the overwhelming majority
+    /// construct an `AdeApp` against a real git repo purely for unrelated reasons, e.g. `wt_core`
+    /// diff/merge/undo coverage, with a `None` settings path per `root::focus::palette_focus_
+    /// tests::open_test_app`'s own docs) - was enough cumulative resource pressure, across a full
+    /// `cargo test` run, to start starving `crate::rail::worktree_watch`'s own real-OS-thread-
+    /// driven tests past their real-time budget. The `settings_path` check alone would already
+    /// fix that (it's `None` for effectively every test but the handful that deliberately opt
+    /// into a real settings path to test real persistence), but the git-repo check is kept too
+    /// since it's independently correct for production, matching
+    /// `crate::rail::worktree_watch::spawn_worktree_watcher`'s own identical gate.
+    pub(crate) fn start_file_tree_watch(&mut self, cx: &mut Context<Self>) {
+        let root = self.file_tree_root.clone();
+        if self.settings_path.is_none() || wt_core::git_common_dir(&root).is_err() {
+            self._file_tree_watcher = None;
+            self._file_tree_watch_task = None;
+            return;
+        }
+        let dirty: crate::rail::worktree_watch::DirtyFlag =
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        self._file_tree_watcher =
+            crate::sidebar::file_tree_watch::spawn_file_tree_watcher(&root, dirty.clone());
+
+        let task = cx.spawn(async move |this, cx| {
+            let mut last_refresh = Instant::now();
+            loop {
+                cx.background_executor().timer(FILE_TREE_WATCH_TICK).await;
+
+                let watcher_fired = dirty.load(std::sync::atomic::Ordering::SeqCst);
+                if watcher_fired {
+                    // Let a burst of events from one save/build/checkout settle before acting,
+                    // then clear whatever accumulated during the settle window too - see
+                    // `Self::start_worktree_watch`'s identical own reasoning.
+                    cx.background_executor().timer(FILE_TREE_WATCH_SETTLE).await;
+                    dirty.store(false, std::sync::atomic::Ordering::SeqCst);
+                }
+                let poll_due = last_refresh.elapsed() >= FILE_TREE_WATCH_POLL_INTERVAL;
+
+                if !watcher_fired && !poll_due {
+                    continue;
+                }
+                last_refresh = Instant::now();
+
+                let updated = this.update(cx, |this, cx| {
+                    // The active worktree may have changed since this loop's own last tick (a
+                    // fresh loop for the new root already started - see this method's own docs -
+                    // so this one only needs to stop cleanly rather than reload the wrong root).
+                    if this.file_tree_root != root {
+                        return false;
+                    }
+                    this.load_file_tree(root.clone(), cx);
+                    true
+                });
+                match updated {
+                    Ok(true) => {}
+                    Ok(false) | Err(_) => break,
+                }
+            }
+        });
+        self._file_tree_watch_task = Some(task);
     }
 
     /// The worktree a *new* agent should be spawned into: the selected worktree's real
@@ -826,7 +914,7 @@ impl AdeApp {
         // new root's expanded set - and a click on one of those stale rows would reach
         // `set_dir_expanded` with a path from an entirely different worktree/repo. Clearing
         // `file_tree` makes that window render an honestly empty tree instead.
-        self.set_file_tree_root(new_root.clone());
+        self.set_file_tree_root(new_root.clone(), cx);
         self.file_tree = Vec::new();
         self.reload_expanded_dirs_from_fold_state();
         // Every one of these holds an absolute path in whatever was just left (GitHub issue #19):
@@ -1576,6 +1664,129 @@ mod load_worktrees_integration_tests {
             app.read_with(cx, |app, _| app.worktree_selection_notice.clone()),
             None,
             "a real user re-selection must clear the stale fallback notice"
+        );
+    }
+}
+
+/// GitHub issue #13's own real, end-to-end wiring proof: opening the app arms a real file-tree
+/// watcher, and switching worktrees re-arms it onto the new root rather than leaking the old
+/// one. The watcher's own OS-level event delivery/`.git/`-filtering already has real, non-`gpui`
+/// coverage in `crate::sidebar::file_tree_watch`'s own test module - see
+/// `load_worktrees_integration_tests`'s identical own docs for why the debounced polling loop
+/// itself isn't driven end to end through a `gpui` test's deterministic clock.
+#[cfg(test)]
+mod file_tree_watch_integration_tests {
+    use crate::root::AdeApp;
+    use crate::settings::store as settings_store;
+    use gpui::TestAppContext;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+    use tempfile::TempDir;
+
+    fn git(dir: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .output()
+            .expect("failed to spawn git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed in {:?}",
+            args,
+            dir
+        );
+    }
+
+    fn init_repo() -> TempDir {
+        let dir = TempDir::new().expect("tempdir");
+        git(dir.path(), &["init", "-b", "main"]);
+        git(dir.path(), &["config", "user.email", "test@example.com"]);
+        git(dir.path(), &["config", "user.name", "Test User"]);
+        fs::write(dir.path().join("base.txt"), "base\n").expect("write");
+        git(dir.path(), &["add", "base.txt"]);
+        git(dir.path(), &["commit", "-m", "initial"]);
+        dir
+    }
+
+    /// `Self::start_file_tree_watch` only ever arms a real watcher for a real, `Some` settings
+    /// path (see that method's own docs on why) - `root::focus::palette_focus_tests::
+    /// open_test_app`'s own `None` path would make every assertion in this module vacuous, so
+    /// these tests need their own real-settings-path open helper instead.
+    fn open_test_app_with_real_settings_path(
+        cx: &mut TestAppContext,
+        repo_path: PathBuf,
+    ) -> (gpui::Entity<AdeApp>, &mut gpui::VisualTestContext) {
+        let config_dir = tempfile::tempdir().expect("tempdir");
+        let settings_path = config_dir.path().join("settings.toml");
+        // Leaked deliberately: `config_dir` must outlive the returned `AdeApp`, and this helper
+        // has no later point to drop it at - the OS reclaims it at process exit either way, the
+        // same real tradeoff `tempfile::TempDir::into_path` documents for this exact situation.
+        std::mem::forget(config_dir);
+        cx.add_window_view(|window, cx| {
+            AdeApp::new_with_settings(
+                repo_path,
+                settings_store::Settings::default(),
+                Some(settings_path),
+                window,
+                cx,
+            )
+        })
+    }
+
+    #[gpui::test]
+    fn opening_the_app_arms_a_real_file_tree_watcher(cx: &mut TestAppContext) {
+        let repo = init_repo();
+        let (app, cx) = open_test_app_with_real_settings_path(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        assert!(
+            app.read_with(cx, |app, _| app._file_tree_watcher.is_some()),
+            "startup must arm a real watcher on the initial file tree root"
+        );
+    }
+
+    #[gpui::test]
+    fn selecting_a_different_worktree_re_arms_the_watcher_on_the_new_root(cx: &mut TestAppContext) {
+        let repo = init_repo();
+        let container = TempDir::new().expect("tempdir");
+        let linked_path = container.path().join("added-wt");
+        drop(container);
+        git(
+            repo.path(),
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "feature",
+                linked_path.to_str().expect("utf8 path"),
+            ],
+        );
+
+        let (app, cx) = open_test_app_with_real_settings_path(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        app.update(cx, |app, cx| app.load_worktrees(cx));
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.worktrees.len()),
+            2,
+            "premise: the linked worktree above must really be there to select"
+        );
+
+        app.update_in(cx, |app, window, cx| {
+            app.select_worktree(1, window, cx);
+        });
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.file_tree_root.clone()),
+            linked_path,
+            "premise: selecting the linked worktree must really move the file tree root"
+        );
+        assert!(
+            app.read_with(cx, |app, _| app._file_tree_watcher.is_some()),
+            "switching worktrees must re-arm a real watcher on the newly selected root, not \
+             leave the previous worktree's watcher (or none at all) in place"
         );
     }
 }

--- a/crates/app/src/sidebar/file_tree_watch.rs
+++ b/crates/app/src/sidebar/file_tree_watch.rs
@@ -1,0 +1,253 @@
+//! Real OS-level filesystem watching that backs the Files tab's live refresh (GitHub issue #13:
+//! "the file list is currently a snapshot taken at load time... drifts out of sync with the
+//! actual state on disk"). The same split `crate::rail::worktree_watch` already established for
+//! the worktree list: this module only ever sets a flag from a real OS watcher callback; the
+//! `gpui`-side poll loop that reads it and actually reloads the tree is
+//! `crate::root::AdeApp::start_file_tree_watch`.
+//!
+//! ## One watch, re-armed per worktree
+//!
+//! Unlike `worktree_watch` (set up once, for the repository's own `$GIT_COMMON_DIR`, which never
+//! changes over the app's lifetime), the *active worktree* changes constantly - so this watch is
+//! re-armed every time [`crate::root::AdeApp::set_file_tree_root`] points at a new root, watching
+//! exactly the worktree currently shown rather than every worktree the repo has.
+//!
+//! ## `.git/` is filtered out, not merely unwatched
+//!
+//! A recursive `notify` watch has no path-exclusion option of its own - filtering happens in the
+//! event callback, not the watch registration itself. Without it, git's own constant internal
+//! writes under `<root>/.git/` (the index, `HEAD`, loose objects, `refs/`) would mark the file
+//! tree dirty on every commit, stage, and status check `wt_core` itself performs - exactly the
+//! "recursive watch fires on every object-database write" noise
+//! [`crate::rail::worktree_watch::spawn_worktree_watcher`]'s own docs already call out avoiding
+//! for its own, separate `.git`-only watch.
+use std::path::{Path, PathBuf};
+use std::sync::atomic::Ordering;
+
+use notify::{RecommendedWatcher, RecursiveMode, Watcher};
+
+use crate::rail::worktree_watch::DirtyFlag;
+
+/// Starts a real filesystem watcher rooted at `worktree_root` (the Files tab's current root -
+/// see the module docs on why this is re-armed per worktree rather than set up once) and returns
+/// the live [`RecommendedWatcher`] - as with `worktree_watch::spawn_worktree_watcher`, it must be
+/// kept alive by the caller for the OS-level watch to keep running.
+///
+/// Returns `None` if `worktree_root` doesn't exist, isn't really part of a git worktree, or if
+/// the underlying OS watcher couldn't be constructed or armed - all honestly-reported "there is
+/// nothing to watch" cases, not fatal: `crate::root::AdeApp::start_file_tree_watch`'s own poll
+/// fallback still runs regardless. A very large tree (e.g. an unignored `node_modules`) can also
+/// exhaust the OS's real watch-descriptor budget (inotify's `max_user_watches` on Linux) - the
+/// same honest degrade applies there too, not a special case.
+///
+/// The `wt_core::git_common_dir` check below is a real gate, not just an optimization: every
+/// real [`crate::root::AdeApp::file_tree_root`] this app ever sets is a real git worktree's path
+/// (production has no other kind), so a directory that fails it genuinely has nothing this app
+/// would ever watch in real use - mirroring
+/// [`crate::rail::worktree_watch::spawn_worktree_watcher`]'s own identical gate. It matters
+/// operationally too: without it, every test that constructs an `AdeApp` against a plain,
+/// non-git temp directory (the overwhelming majority of this crate's own GPUI tests) would arm a
+/// real OS-level `notify` watcher it never needed, and a real, reproduced regression from an
+/// earlier version of this function did exactly that - exhausting the sandbox's `inotify`
+/// instance budget partway through a full `cargo test` run and taking
+/// `crate::rail::worktree_watch`'s own, unrelated tests down with it.
+///
+/// Performs blocking I/O (`git_common_dir`'s own `git rev-parse`, and the initial recursive
+/// directory walk `notify` does to arm the watch).
+pub fn spawn_file_tree_watcher(
+    worktree_root: &Path,
+    dirty: DirtyFlag,
+) -> Option<RecommendedWatcher> {
+    if !worktree_root.is_dir() {
+        return None;
+    }
+    wt_core::git_common_dir(worktree_root).ok()?;
+    let git_dir: PathBuf = worktree_root.join(".git");
+
+    let mut watcher = notify::recommended_watcher(move |result: notify::Result<notify::Event>| {
+        let Ok(event) = result else {
+            return;
+        };
+        // Only a change with at least one real path outside `.git/` counts - see the module docs
+        // on why `.git/`'s own churn must never mark the tree dirty.
+        let outside_git = event.paths.iter().any(|path| !path.starts_with(&git_dir));
+        if outside_git {
+            dirty.store(true, Ordering::SeqCst);
+        }
+    })
+    .ok()?;
+
+    watcher
+        .watch(worktree_root, RecursiveMode::Recursive)
+        .ok()?;
+    Some(watcher)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::process::Command;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+    use tempfile::TempDir;
+
+    fn git(dir: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .output()
+            .expect("failed to spawn git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed in {:?}",
+            args,
+            dir
+        );
+    }
+
+    /// A real git repository - see [`spawn_file_tree_watcher`]'s own docs on why its
+    /// `wt_core::git_common_dir` gate means every one of this module's tests needs a real repo,
+    /// not just a plain temp directory.
+    fn init_repo() -> TempDir {
+        let dir = TempDir::new().expect("tempdir");
+        git(dir.path(), &["init", "-b", "main"]);
+        git(dir.path(), &["config", "user.email", "test@example.com"]);
+        git(dir.path(), &["config", "user.name", "Test User"]);
+        fs::write(dir.path().join("base.txt"), "base\n").expect("write");
+        git(dir.path(), &["add", "base.txt"]);
+        git(dir.path(), &["commit", "-m", "initial"]);
+        dir
+    }
+
+    /// Real-time bounded wait for the watcher's async, OS-thread-delivered callback to fire - see
+    /// `crate::rail::worktree_watch::tests::wait_until_dirty`'s identical own docs for why this
+    /// can't be a simulated/deterministic clock.
+    fn wait_until_dirty(dirty: &DirtyFlag) -> bool {
+        let deadline = Instant::now() + Duration::from_secs(3);
+        while Instant::now() < deadline {
+            if dirty.swap(false, Ordering::SeqCst) {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        false
+    }
+
+    /// The inverse of [`wait_until_dirty`]: asserts the flag stays clear for a real, bounded
+    /// window - used to prove `.git/` churn is genuinely filtered out, not just "usually" missed
+    /// by a race.
+    fn assert_stays_clean(dirty: &DirtyFlag) {
+        std::thread::sleep(Duration::from_millis(500));
+        assert!(
+            !dirty.load(Ordering::SeqCst),
+            "a change confined to .git/ must never mark the file tree dirty"
+        );
+    }
+
+    #[test]
+    fn a_real_new_file_is_noticed() {
+        let dir = init_repo();
+        let dirty: DirtyFlag = Arc::new(AtomicBool::new(false));
+        let _watcher =
+            spawn_file_tree_watcher(dir.path(), dirty.clone()).expect("spawn_file_tree_watcher");
+
+        fs::write(dir.path().join("new.txt"), "content").expect("write");
+
+        assert!(
+            wait_until_dirty(&dirty),
+            "creating a real file must be observed within the real-time budget"
+        );
+    }
+
+    #[test]
+    fn a_real_file_edit_in_a_nested_directory_is_noticed() {
+        let dir = init_repo();
+        fs::create_dir_all(dir.path().join("src/nested")).expect("mkdir");
+        let file = dir.path().join("src/nested/a.rs");
+        fs::write(&file, "fn main() {}").expect("write");
+
+        let dirty: DirtyFlag = Arc::new(AtomicBool::new(false));
+        let _watcher =
+            spawn_file_tree_watcher(dir.path(), dirty.clone()).expect("spawn_file_tree_watcher");
+
+        fs::write(&file, "fn main() { println!(\"hi\"); }").expect("write");
+
+        assert!(
+            wait_until_dirty(&dirty),
+            "editing a real file nested several directories deep must be observed"
+        );
+    }
+
+    #[test]
+    fn a_real_deletion_is_noticed() {
+        let dir = init_repo();
+        let file = dir.path().join("gone.txt");
+        fs::write(&file, "content").expect("write");
+
+        let dirty: DirtyFlag = Arc::new(AtomicBool::new(false));
+        let _watcher =
+            spawn_file_tree_watcher(dir.path(), dirty.clone()).expect("spawn_file_tree_watcher");
+
+        fs::remove_file(&file).expect("remove");
+
+        assert!(
+            wait_until_dirty(&dirty),
+            "deleting a real file must be observed"
+        );
+    }
+
+    #[test]
+    fn a_change_confined_to_dot_git_is_filtered_out() {
+        let dir = init_repo();
+
+        let dirty: DirtyFlag = Arc::new(AtomicBool::new(false));
+        let _watcher =
+            spawn_file_tree_watcher(dir.path(), dirty.clone()).expect("spawn_file_tree_watcher");
+
+        // Real churn genuinely confined to `.git/` alone - unlike `git checkout` (which can
+        // legitimately touch tracked working-tree files' own mtimes even when their content is
+        // unchanged, a real git behavior this test must not mistake for a filter bug), `git
+        // update-ref` only ever writes inside `.git/` itself.
+        git(dir.path(), &["update-ref", "refs/heads/other", "HEAD"]);
+
+        assert_stays_clean(&dirty);
+    }
+
+    #[test]
+    fn a_real_change_alongside_dot_git_churn_is_still_noticed() {
+        let dir = init_repo();
+
+        let dirty: DirtyFlag = Arc::new(AtomicBool::new(false));
+        let _watcher =
+            spawn_file_tree_watcher(dir.path(), dirty.clone()).expect("spawn_file_tree_watcher");
+
+        git(dir.path(), &["update-ref", "refs/heads/other", "HEAD"]);
+        fs::write(dir.path().join("real.txt"), "real content").expect("write");
+
+        assert!(
+            wait_until_dirty(&dirty),
+            "a real change outside .git/ must still be observed even alongside .git/ churn"
+        );
+    }
+
+    #[test]
+    fn a_missing_directory_yields_no_watcher_rather_than_panicking() {
+        let dir = init_repo();
+        let missing = dir.path().join("does-not-exist");
+        let dirty: DirtyFlag = Arc::new(AtomicBool::new(false));
+        assert!(spawn_file_tree_watcher(&missing, dirty).is_none());
+    }
+
+    #[test]
+    fn a_non_git_directory_yields_no_watcher() {
+        let dir = TempDir::new().expect("tempdir");
+        let dirty: DirtyFlag = Arc::new(AtomicBool::new(false));
+        assert!(
+            spawn_file_tree_watcher(dir.path(), dirty).is_none(),
+            "a plain, non-git directory must never arm a real watcher - see \
+             `spawn_file_tree_watcher`'s own docs on why this gate is real, not incidental"
+        );
+    }
+}

--- a/crates/app/src/sidebar/mod.rs
+++ b/crates/app/src/sidebar/mod.rs
@@ -6,6 +6,9 @@
 //! - [`file_tree`] - the pure `std::fs::read_dir` walk that flattens a directory into the
 //!   indented row list the Files tab shows, plus the pure indent-guide geometry that list
 //!   draws.
+//! - [`file_tree_watch`] - the real `notify`-backed filesystem watcher behind the Files tab's
+//!   live refresh (GitHub issue #13) - the same "OS watch sets a flag, a `gpui` background loop
+//!   polls it" split `crate::rail::worktree_watch` established for the worktree list.
 //! - [`fold_state`] - the real, on-disk (`~/.config/jerry/file-tree-state.toml`) per-worktree
 //!   record of which folders are expanded, and its atomic write path.
 //! - [`changes`] - the pure mapping from `wt_core::diff` data to the Changes tab's row
@@ -41,6 +44,7 @@ pub mod changes;
 pub mod context_menu;
 pub mod file_ops;
 pub mod file_tree;
+pub mod file_tree_watch;
 pub mod fold_state;
 
 pub(crate) mod render;


### PR DESCRIPTION
Closes #13

## Summary
- Adds `crate::sidebar::file_tree_watch`: a real `notify`-backed OS watcher on the active worktree's root, the same "watcher sets a flag, a `gpui` poll loop reads it" split `crate::rail::worktree_watch` already established for the worktree list (issue #12) - now applied to the file tree, which was previously a load-time snapshot that never refreshed.
- `.git/`'s own constant internal writes are filtered out of the dirty signal (not just left unwatched), matching `worktree_watch`'s own reasoning for avoiding that exact noise.
- Re-armed on every real worktree switch via `AdeApp::set_file_tree_root` (unlike `worktree_watch`, which is set up once for the app's whole lifetime) since the file tree's own root changes constantly as the user browses worktrees.

## A real regression found and fixed before this shipped
Spawning the watcher/poll task unconditionally on every `AdeApp` construction created enough background-thread/`notify`-instance pressure across this crate's ~1300 GPUI tests (most of which construct a real git repo for entirely unrelated reasons - `wt_core` diff/merge/undo coverage, etc.) to start starving `worktree_watch`'s own real-OS-thread tests past their real-time budget, intermittently breaking unrelated, previously-stable tests. Root-caused via direct A/B isolation (not guessed), fixed by gating the whole watch - task included, not just the OS watcher - on `settings_path` being real (`Some`), the same "this is a real session, not a throwaway test instance" signal `persist_settings` already uses, plus keeping the git-repo check for production correctness. Verified stable across two full-suite runs after the fix, reproducibly broken before it.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib -- --test-threads=1` (1325+49+14+171 passing, 0 failed) - run twice to confirm stability
- [x] New `file_tree_watch` module tests: real file create/edit/delete detection, `.git/`-churn filtering (using genuine `git update-ref`, not hand-rolled files, since `git checkout` itself can touch tracked file mtimes), missing/non-git directory rejection.
- [x] New app-level integration tests: opening the app arms a real watcher, and switching worktrees re-arms it onto the new root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)