### PR TITLE
fix(lsp-core): simplify verbatim Windows paths before spawning a server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4291,6 +4291,7 @@ dependencies = [
 name = "lsp-core"
 version = "0.1.0"
 dependencies = [
+ "dunce",
  "log",
  "lsp-types",
  "nix",

--- a/crates/lsp-core/Cargo.toml
+++ b/crates/lsp-core/Cargo.toml
@@ -43,6 +43,16 @@ url = "2"
 # never the `.cmd`/`.bat` shim `npm install -g` actually produces on that platform, even
 # though it's genuinely on `PATH` and `resolve_on_path` already finds it).
 pty-core = { path = "../pty-core" }
+# GitHub issue #46's own remaining, real Windows gotcha after the `.cmd`-resolution fix above:
+# `std::fs::canonicalize` on Windows returns a verbatim `\\?\C:\...`-prefixed path, which many
+# real Windows programs (rust-analyzer very plausibly among them, given the reported symptom -
+# see `LspClient::spawn`'s own docs) don't handle the same way as the legacy `C:\...` form. A
+# small, focused, no-dependency-of-its-own crate purpose-built for exactly this - not worth
+# hand-rolling the real edge cases (when a verbatim path genuinely can't be simplified, e.g. one
+# that's actually too long for the legacy form) - see `crate::client::canonicalize`'s own docs.
+# A real no-op on non-Windows (verified directly against its own source: `#[cfg(not(windows))]
+# fn canonicalize(path) { fs::canonicalize(path) }`), so this is zero behavioral change there.
+dunce = "1.0.5"
 
 # Process-tree kill (SIGTERM-then-SIGKILL, plus a `/proc` descendant sweep so a `cargo
 # check`/`rustc` child rust-analyzer spawned while indexing doesn't survive as an orphan) -

--- a/crates/lsp-core/src/client.rs
+++ b/crates/lsp-core/src/client.rs
@@ -470,10 +470,12 @@ impl LspClient {
         // Canonicalized so the `file://` URI sent as this workspace folder's root is the same
         // symlink-resolved path every other `path_to_uri` call (e.g. from `did_open`) will
         // independently arrive at for a file underneath it, rather than assuming the caller
-        // already passed a canonical path.
-        let repo_root = repo_root
-            .canonicalize()
-            .map_err(|_| LspError::InvalidRoot(repo_root.to_path_buf()))?;
+        // already passed a canonical path. `canonicalize` (this module's own, not
+        // `Path::canonicalize`) - see that function's own docs for the real Windows gotcha this
+        // avoids in both the `current_dir` this becomes below and the `rootUri` [`path_to_uri`]
+        // builds from it.
+        let repo_root =
+            canonicalize(repo_root).map_err(|_| LspError::InvalidRoot(repo_root.to_path_buf()))?;
 
         let name = config.name;
         let resolved_binary = resolve_server_binary(name, config.binary)?;
@@ -1369,12 +1371,27 @@ fn path_to_uri(path: &Path) -> Result<Uri, LspError> {
     // Best-effort canonicalization for consistency with `LspClient::spawn`'s own root-URI
     // canonicalization; falls back to the given path as-is if canonicalization fails (e.g. a
     // caller checking a path that doesn't exist on disk).
-    let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    let canonical = canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
     let url = url::Url::from_file_path(&canonical)
         .map_err(|_| LspError::InvalidPath(path.to_path_buf()))?;
     url.as_str()
         .parse::<Uri>()
         .map_err(|_| LspError::InvalidPath(path.to_path_buf()))
+}
+
+/// `std::fs::canonicalize`, except on Windows it also simplifies the result away from the
+/// verbatim `\\?\C:\...` UNC-prefixed form back to the legacy `C:\...` one whenever that's safe
+/// (`dunce::canonicalize`'s own real job - see this crate's `Cargo.toml` for why a small, focused
+/// dependency rather than a hand-rolled reimplementation) - GitHub issue #46's real, remaining
+/// Windows gotcha after the `.cmd`-shim resolution fix above: `std::fs::canonicalize` itself
+/// always returns the verbatim form on Windows, and plenty of real, non-UNC-aware Windows
+/// programs - a native binary like rust-analyzer, not an npm shim, so unaffected by that earlier
+/// fix - don't reliably accept it as a working directory or handle a `file://` URI built from
+/// one. A real no-op on every other platform (verified directly against `dunce`'s own source:
+/// its `#[cfg(not(windows))]` branch is a bare `fs::canonicalize` passthrough), so this changes
+/// nothing here on Linux/macOS.
+fn canonicalize(path: &Path) -> std::io::Result<PathBuf> {
+    dunce::canonicalize(path)
 }
 
 /// The inverse of [`path_to_uri`] - see [`LspClient::path_for_uri`]'s docs for why this
@@ -1668,6 +1685,30 @@ fn run_stderr_drain_loop(stderr: std::process::ChildStderr, server: &'static str
 mod tests {
     use super::*;
     use std::time::Instant;
+
+    /// GitHub issue #46's own real, remaining Windows gotcha - `canonicalize`'s own docs. Not a
+    /// no-op check: this is a genuine round trip against a real temp directory, proving the
+    /// function still resolves a real path correctly (matching `std::fs::canonicalize`'s own
+    /// contract on every platform this test actually runs on, and - documented, not run here,
+    /// see `crate::client::canonicalize`'s own docs on why this sandbox can't verify the
+    /// Windows-specific simplification directly - `dunce`'s own real behavior on Windows).
+    #[test]
+    fn canonicalize_resolves_a_real_directory() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let resolved = canonicalize(dir.path()).expect("a real, existing directory must resolve");
+        assert!(resolved.is_dir());
+        assert_eq!(
+            resolved,
+            std::fs::canonicalize(dir.path()).expect("std canonicalize")
+        );
+    }
+
+    #[test]
+    fn canonicalize_reports_a_real_error_for_a_missing_path() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let missing = dir.path().join("does-not-exist");
+        assert!(canonicalize(&missing).is_err());
+    }
 
     /// Writes a minimal, valid cargo project to a fresh tempdir: a `Cargo.toml` and a
     /// `src/main.rs`. No external crates.io dependencies, so `cargo metadata`/rust-analyzer's


### PR DESCRIPTION
Relates to #46 (does not fully close it - see below)

## Summary
Issue #46 reports two real Windows LSP failures. This PR addresses what static code review can responsibly establish about each, honestly, without overclaiming.

**TypeScript half** ("%1 n'est pas une application win32 valide", os error 193): already fixed on `master` by `bfc65b4` (`LspClient::spawn` now resolves the binary through `pty_core::resolve_on_path`, which correctly finds npm's `.cmd` shim on Windows instead of handing a bare name straight to `Command::new`, which only ever looks for a literal `.exe`). That commit predates this issue's own filing. Nothing further needed there - flagging it here so the issue can be updated/closed for that half once confirmed.

**rust-analyzer half** ("rust-analyser closed the connection"): no confirmed root cause - rust-analyzer ships as a native `.exe`, so the `.cmd`-resolution fix above is irrelevant to it, and this sandbox has no real Windows machine to reproduce the symptom on. The strongest real, well-documented candidate found by code review: `std::fs::canonicalize` on Windows always returns the verbatim `\\?\C:\...` UNC-prefixed path form, and `LspClient::spawn` was handing that straight to the child's `current_dir`, with `path_to_uri` building the `rootUri` from the same value. Plenty of real, non-UNC-aware Windows programs don't reliably accept that form - a plain native console binary like rust-analyzer (not launched through a shell that would normalize it) is a real plausible candidate.

## Fix
Routes both `canonicalize()` call sites through a new local wrapper backed by the `dunce` crate, which simplifies a verbatim path back to its legacy form when safe, and is a real no-op on every non-Windows platform (verified directly against its own source - a bare `fs::canonicalize` passthrough under `#[cfg(not(windows))]`). Zero behavior change on Linux/macOS.

## Honest limitation
This is a real, defensible, low-risk improvement for a well-documented Windows path gotcha - **not** a confirmed fix for the specific reported "closed the connection" symptom, since it could not be reproduced or verified against real Windows hardware in this environment. If this doesn't resolve the rust-analyzer report, the issue should stay open with that context.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib -- --test-threads=1` (1316+51+14+171 passing, 0 failed)
- [x] New tests for the `canonicalize` wrapper (real directory resolves, real missing-path error) - the Windows-specific simplification itself is documented but not runnable here, matching this crate's own pre-existing, explicitly-stated caveat for its other Windows-only code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)