### PR TITLE
feat(app): show an update-available button when a newer release exists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "zeroize",
 ]
 
@@ -278,6 +278,7 @@ dependencies = [
  "notify",
  "pty-core",
  "regex",
+ "self_update",
  "serde",
  "serde_json",
  "tempfile",
@@ -307,6 +308,9 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arc-swap"
@@ -646,6 +650,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,6 +692,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bindgen"
@@ -994,6 +1027,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,6 +1080,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1132,6 +1185,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "compression-codecs"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1159,6 +1222,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1167,6 +1242,12 @@ dependencies = [
  "cfg-if",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-random"
@@ -1204,6 +1285,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -1375,6 +1485,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1459,6 +1578,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1510,10 +1656,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "derive_more"
@@ -1658,6 +1825,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "signature",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1676,6 +1868,12 @@ dependencies = [
  "vswhom",
  "winreg 0.55.0",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -1884,6 +2082,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "filedescriptor"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1924,6 +2128,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -2070,6 +2275,12 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsevent-sys"
@@ -2221,8 +2432,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2249,6 +2462,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasm-bindgen",
 ]
 
@@ -3475,6 +3689,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b40ca9252762c466af32d0b1002e91e4e1bc5398f77455e55474deb466355ff5"
 
 [[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3632,6 +3865,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body-util"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "http_client"
 version = "0.1.0"
 source = "git+https://github.com/zed-industries/zed?rev=7b030b500810b04cf5fb4aa5973be99a502d9f36#7b030b500810b04cf5fb4aa5973be99a502d9f36"
@@ -3652,10 +3898,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
 name = "human_format"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaec953f16e5bcf6b8a3cb3aa959b17e5577dbd2693e94554c462c08be22624b"
+
+[[package]]
+name = "hyper"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -3851,6 +4162,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.18.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
+ "web-time",
+]
+
+[[package]]
 name = "inotify"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3921,6 +4245,12 @@ dependencies = [
  "core-foundation-sys",
  "leaky-cow",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is-docker"
@@ -4034,6 +4364,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
 dependencies = [
  "jiff-tzdb",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.19",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4286,6 +4646,12 @@ checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
 dependencies = [
  "imgref",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lsp-core"
@@ -5082,6 +5448,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5276,6 +5648,16 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-io",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -5622,11 +6004,77 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases 0.2.2",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.3",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash 2.1.3",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.19",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases 0.2.2",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5672,6 +6120,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5707,6 +6166,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -5939,6 +6413,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "resvg"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5962,6 +6476,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6044,6 +6572,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "aws-lc-rs",
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6092,6 +6697,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6177,10 +6791,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "self-replace"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7"
+dependencies = [
+ "fastrand",
+ "tempfile",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "self_cell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
+
+[[package]]
+name = "self_update"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e79722b5a505d4ddc77527455a97244e9e8c4c07533ff44cf4421cce7bb6d17"
+dependencies = [
+ "either",
+ "flate2",
+ "http",
+ "indicatif",
+ "log",
+ "quick-xml 0.38.4",
+ "regex",
+ "reqwest",
+ "self-replace",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tempfile",
+ "ureq",
+ "urlencoding",
+ "zip",
+ "zipsign-api",
+]
 
 [[package]]
 name = "semver"
@@ -6331,7 +7005,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -6403,10 +7077,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
 
 [[package]]
 name = "simd_helpers"
@@ -6416,6 +7110,12 @@ checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simplecss"
@@ -6501,6 +7201,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6525,6 +7246,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
 dependencies = [
  "bitflags 2.13.1",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -6755,6 +7486,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6810,6 +7550,17 @@ dependencies = [
  "core-foundation-sys",
  "libc",
  "objc",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -6919,6 +7670,7 @@ dependencies = [
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -6926,6 +7678,16 @@ name = "time-core"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tiny-keccak"
@@ -6986,6 +7748,44 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "libc",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "toml"
@@ -7078,6 +7878,51 @@ name = "toml_writer"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.13.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -7210,6 +8055,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7338,6 +8189,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "cookie_store",
+ "encoding_rs",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "socks",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7348,6 +8245,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "usvg"
@@ -7375,6 +8278,12 @@ dependencies = [
  "unicode-vo",
  "xmlwriter",
 ]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -7527,6 +8436,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -7727,6 +8645,24 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -8519,6 +9455,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
+]
+
+[[package]]
 name = "xcb"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8884,6 +9830,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "time",
+ "zopfli",
+]
+
+[[package]]
+name = "zipsign-api"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dba6063ff82cdbd9a765add16d369abe81e520f836054e997c2db217ceca40c0"
+dependencies = [
+ "base64",
+ "ed25519-dalek",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
+
+[[package]]
 name = "zlog"
 version = "0.1.0"
 source = "git+https://github.com/zed-industries/zed?rev=7b030b500810b04cf5fb4aa5973be99a502d9f36#7b030b500810b04cf5fb4aa5973be99a502d9f36"
@@ -8899,6 +9877,18 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "ztracing"

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -113,6 +113,30 @@ tree-sitter-javascript = "0.23.1"
 # API wrapper with no GPUI/vendor/zed call site to verify against, the same "just a version pin"
 # treatment `regex`/`unicode-segmentation` already get above.
 notify = "8.2.0"
+# Real GitHub-releases-backed self-update (GitHub issue #87, `crate::updater`) - version
+# check via `backends::github::ReleaseList`, download+extract+atomic self-replace via
+# `backends::github::Update`/`self-replace`. `default-features = false` because this
+# version's real default (`["reqwest", "default-tls"]`, verified against the published
+# `0.44.0` Cargo.toml via `docs.rs/crate/self_update/0.44.0/source/Cargo.toml` and a real
+# `cargo add --dry-run` resolution, not assumed from the crate's own README, which - as of
+# this writing - describes a different, not-yet-released feature set) pulls in `default-tls`
+# (OpenSSL) instead of `rustls`. `reqwest` is re-added explicitly: it is *not* implied by any
+# archive/TLS feature and without it (or `ureq`) there is no HTTP client backend at all and
+# the crate fails to compile - a real gap in the originally-planned feature list this
+# dependency was added with, caught by the same `cargo add --dry-run` resolution above rather
+# than assumed from docs. `archive-tar`/`archive-zip`/`compression-flate2`/
+# `compression-zip-deflate` match `release.yml`'s real asset shapes (`jerry-linux.tar.gz`,
+# `jerry-macos.tar.gz` as gzip-compressed tarballs; `jerry-windows.zip` as a
+# deflate-compressed zip) - `compression-zip-bzip2` is omitted since nothing in this repo
+# ever produces a bzip2-compressed zip.
+self_update = { version = "0.44.0", default-features = false, features = [
+    "rustls",
+    "reqwest",
+    "archive-tar",
+    "archive-zip",
+    "compression-flate2",
+    "compression-zip-deflate",
+] }
 
 # Real per-target `gpui_platform` backend selection (Revision R11, extended in R12 to add
 # real X11 support). `gpui_platform`'s own Cargo.toml

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -31,6 +31,11 @@ pub mod theme;
 // all (both its files are `pub(crate) mod`), and `root::title_bar` was a private module before
 // the split - so making it `pub` would widen this crate's external surface for no reason.
 pub(crate) mod title_bar;
+// GitHub issue #87: real update-available detection + click-to-update. `pub(crate)`, matching
+// `title_bar`'s own precedent just above (see that module's own comment): nothing outside this
+// crate needs `crate::updater` directly, only `crate::root`/`crate::status_bar`/
+// `crate::palette`'s own wiring into it.
+pub(crate) mod updater;
 pub mod work_surface;
 pub mod worktree_history;
 

--- a/crates/app/src/palette/render.rs
+++ b/crates/app/src/palette/render.rs
@@ -258,6 +258,7 @@ impl AdeApp {
                 self.set_window_controls_style(WindowControlsStyle::WindowsLinuxStyle, cx);
             }
             palette::PaletteCommand::OpenGitGraph => self.open_git_graph(window, cx),
+            palette::PaletteCommand::CheckForUpdates => self.check_for_update(cx),
         }
     }
 

--- a/crates/app/src/palette/state.rs
+++ b/crates/app/src/palette/state.rs
@@ -135,10 +135,18 @@ pub enum PaletteCommand {
     /// (design spec §6). Rendered under a dedicated `"Git"` group label rather than the plain
     /// `"Commands"` one - see [`build_groups`]'s own `is_git_command` split.
     OpenGitGraph,
+    /// `crate::updater::flow::AdeApp::check_for_update` (GitHub issue #87) - the real, manual
+    /// trigger alongside the startup check and the periodic background loop
+    /// (`crate::updater::flow::AdeApp::start_update_check_loop`). Deliberately always listed,
+    /// not hidden until an update happens to be available, matching
+    /// [`Self::RestartLanguageServers`]'s own "a discoverable recovery/utility action must be
+    /// findable before the user already knows something's up" reasoning - a user who suspects
+    /// they're on an old build can check right now rather than wait for the next periodic tick.
+    CheckForUpdates,
 }
 
 impl PaletteCommand {
-    pub const ALL: [PaletteCommand; 11] = [
+    pub const ALL: [PaletteCommand; 12] = [
         PaletteCommand::NewShell,
         PaletteCommand::NewClaudeAgent,
         PaletteCommand::NewCodexAgent,
@@ -150,6 +158,7 @@ impl PaletteCommand {
         PaletteCommand::WindowControlsMacos,
         PaletteCommand::WindowControlsWindowsLinux,
         PaletteCommand::OpenGitGraph,
+        PaletteCommand::CheckForUpdates,
     ];
 
     /// Whether this command belongs in the palette's `"Git"` group rather than `"Commands"` -
@@ -171,6 +180,7 @@ impl PaletteCommand {
             PaletteCommand::WindowControlsMacos => "Window Controls: macOS Style",
             PaletteCommand::WindowControlsWindowsLinux => "Window Controls: Windows/Linux Style",
             PaletteCommand::OpenGitGraph => "Open Git Graph",
+            PaletteCommand::CheckForUpdates => "Check for Updates",
         }
     }
 
@@ -198,6 +208,7 @@ impl PaletteCommand {
                 "window controls title bar caption buttons menu keycap platform override windows linux"
             }
             PaletteCommand::OpenGitGraph => "git graph commit history branches log",
+            PaletteCommand::CheckForUpdates => "update version release new github check",
         }
     }
 

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -84,6 +84,7 @@ use crate::status_bar::process_stats;
 use crate::text_history;
 use crate::theme;
 use crate::title_bar::menu as title_bar;
+use crate::updater;
 use crate::work_surface::agents::{AgentId, AgentKind, Agents};
 use crate::work_surface::state as work_surface;
 use crate::worktree_history::flow as worktree_history;
@@ -912,6 +913,18 @@ pub struct AdeApp {
     /// unrelated prune click could permanently hide every future worktree-history status for the
     /// rest of the agent).
     pub(crate) worktree_history_status: Option<String>,
+    /// Real GitHub-releases-backed update detection (GitHub issue #87, `crate::updater`) - the
+    /// single source of truth for the status bar's update chip
+    /// (`crate::updater::render::AdeApp::render_status_update_notice`) and every real
+    /// `self_update` background call's own effect on it (`crate::updater::flow`). `Idle` covers
+    /// "never checked", "genuinely up to date", and "the last *check* failed" alike - see
+    /// [`updater::state::UpdateState`]'s own docs for why those three collapse into one variant.
+    pub(crate) update_state: updater::state::UpdateState,
+    /// Guards [`Self::check_for_update`] against a second, racing check spawning while one is
+    /// already in flight (the periodic loop's own tick landing on top of a manual palette
+    /// click, or vice versa) - the same single-flag-per-feature discipline
+    /// [`Self::prune_in_flight`]/[`Self::worktree_history_op_in_flight`] already establish.
+    pub(crate) update_check_in_flight: bool,
     /// `Some(id)` after one click on agent `id`'s "Discard worktree" footer button, cleared by
     /// most other gestures in the meantime (mirroring [`Self::prune_confirm_armed`]'s own "most
     /// other gestures disarm it" discipline, applied everywhere that field is - see
@@ -1057,6 +1070,20 @@ pub struct AdeApp {
     /// [`Self::worktree_history_op_in_flight`] - see that field's own docs for why one slot
     /// shared across both is sufficient discipline here.
     pub(crate) _worktree_history_task: Option<Task<()>>,
+    /// The real startup-plus-periodic update-check loop
+    /// (`crate::updater::flow::AdeApp::start_update_check_loop`) - matches
+    /// [`Self::_worktree_watch_task`]'s own "must be kept alive for the real background work to
+    /// keep running" discipline. Deliberately *not* reassigned by an individual
+    /// `crate::updater::flow::AdeApp::check_for_update` call (including the ones this same loop
+    /// itself makes on every tick) - see that method's own docs for the real self-cancellation
+    /// hazard reserving this field to the loop alone avoids.
+    pub(crate) _update_check_task: Option<Task<()>>,
+    /// The single in-flight `crate::updater::flow::AdeApp::start_update_download` background
+    /// task - real download+extract+self-replace, guarded the same
+    /// single-flight-per-feature way [`Self::_worktree_history_task`] is (see that field's own
+    /// docs), keyed off [`Self::update_state`] itself rather than a separate bool, since
+    /// `Downloading` already is that "one is in flight" signal.
+    pub(crate) _update_download_task: Option<Task<()>>,
     pub(crate) _agent_rows_task: Option<Task<()>>,
     pub(crate) _merge_task: Option<Task<()>>,
     /// `Self::clear_merge_flow_for_closed_agent`'s best-effort abort - kept separate from

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -250,6 +250,8 @@ impl AdeApp {
             prune_in_flight: false,
             worktree_history_op_in_flight: None,
             worktree_history_status: None,
+            update_state: updater::state::UpdateState::Idle,
+            update_check_in_flight: false,
             discard_confirm_armed: None,
             settings_open: false,
             settings_nav_scroll_handle: gpui::ScrollHandle::new(),
@@ -286,6 +288,8 @@ impl AdeApp {
             _disk_usage_task: None,
             _prune_task: None,
             _worktree_history_task: None,
+            _update_check_task: None,
+            _update_download_task: None,
             _agent_rows_task: None,
             _merge_task: None,
             _merge_cleanup_task: None,
@@ -429,6 +433,10 @@ impl AdeApp {
         this.load_diff(repo_path, cx);
         this.start_status_polling(cx);
         this.start_worktree_watch(cx);
+        // GitHub issue #87: a real startup check, plus the periodic loop that keeps re-checking
+        // for as long as the app runs - see `crate::updater::flow::AdeApp::
+        // start_update_check_loop`'s own docs.
+        this.start_update_check_loop(cx);
         this
     }
 

--- a/crates/app/src/status_bar/render.rs
+++ b/crates/app/src/status_bar/render.rs
@@ -37,7 +37,15 @@ impl AdeApp {
     /// divider · ...".
     fn render_status_bar_left(&self, cx: &mut Context<Self>) -> gpui::AnyElement {
         let mut segments: Vec<gpui::AnyElement> = Vec::new();
-        // Shown first, and only while genuinely set - the real, transient feedback from
+        // Shown first - persistent, actionable "a real update is available/ready" information
+        // (GitHub issue #87, `crate::updater`) outranks the worktree-history notice just below,
+        // which is only ever a one-off, self-clearing completion message. Renders nothing at all
+        // (`None`) unless there's genuinely something to say - see
+        // `crate::updater::render::AdeApp::render_status_update_notice`'s own docs.
+        if let Some(update_notice) = self.render_status_update_notice(cx) {
+            segments.push(update_notice);
+        }
+        // Shown next, and only while genuinely set - the real, transient feedback from
         // "keep all changes"/"discard worktree" (Revision R10). See this method's own docs for
         // why this lives here, in the status bar, rather than the rail footer's own status slot.
         if let Some(notice) = self.render_status_worktree_history_notice() {

--- a/crates/app/src/terminal/grid.rs
+++ b/crates/app/src/terminal/grid.rs
@@ -21,8 +21,9 @@
 //!   `screen_lines`/`columns` - see [`GridSize`].
 //! - `Term<T>` only requires `T: EventListener` for `renderable_content`/the `Handler` impl.
 //!   This pane polls the grid directly every tick (see `crate::terminal::pane`'s poll loop)
-//!   rather than reacting to events (title changes, bell, clipboard, ...), so
-//!   [`NoopEventListener`] just drops them.
+//!   rather than reacting to most events (title changes, bell, clipboard, ...), which
+//!   [`PtyWriteQueue`] does still drop. `Event::PtyWrite` is the one real exception - see that
+//!   type's own docs for why dropping it is a genuine correctness bug, not a scope cut.
 //! - Feeding bytes: `Processor::<StdSyncHandler>::advance(&mut self, handler: &mut H, bytes:
 //!   &[u8]) where H: Handler` (`vte-0.15.0/src/ansi.rs:298`); `Term<T: EventListener>`
 //!   implements `Handler`. `alacritty_terminal` re-exports its exact `vte` dependency as
@@ -79,13 +80,39 @@ impl Dimensions for GridSize {
     }
 }
 
-/// A no-op [`EventListener`] - see the module docs' API surface section for why dropping every
-/// event is deliberate here, not a stub for missing behavior.
-#[derive(Debug, Clone, Copy)]
-struct NoopEventListener;
+/// Captures [`AlacEvent::PtyWrite`] and drops every other [`AlacEvent`] (title changes, bell,
+/// clipboard, ...) - see the module docs' API surface section for why those others are a
+/// deliberate scope cut.
+///
+/// `PtyWrite` is different: `alacritty_terminal`'s own `Handler` impl for `Term` emits it
+/// whenever the VT parser sees a query the *terminal* (not the running program) is supposed to
+/// answer back into the pty's stdin - e.g. `ESC[6n` (Device Status Report / cursor position
+/// report), already correctly formatted as `ESC[<row>;<col>R` by `Term::device_status`
+/// (`term/mod.rs:1332`, verified against the pinned rev's real source per this module's own API
+/// surface docs). Dropping it (this type's predecessor, `NoopEventListener`, did) isn't just a
+/// missed nicety: on real Windows hardware, ConPTY sends exactly this query as part of its own
+/// startup handshake and blocks its *entire* output stream - the child process's own banner,
+/// prompt, everything - until it receives a real answer. A terminal that never answers doesn't
+/// just render `ESC[6n` oddly, it hangs the pty forever after that first, tiny query - confirmed
+/// live: a real Windows build spawned a real `cmd.exe`, the child process itself stayed alive
+/// and idle at its own prompt, and `pty-core`'s reader thread read exactly the 4-byte query and
+/// then never read another byte, because ConPTY was sitting there waiting on the CPR reply this
+/// listener used to throw away.
+///
+/// `Rc<RefCell<..>>`, not a channel: [`EventListener::send_event`] takes `&self`
+/// (`Term<T>` only ever holds a `T`, no `&mut` access once constructed), and this needs to be
+/// cheaply `Clone`d so [`TerminalGrid`] can hand `Term::new` its own copy while keeping one to
+/// drain from - a `Rc`'d interior-mutable buffer is the direct way to satisfy both without a
+/// background thread/channel this is far too small to warrant.
+#[derive(Debug, Clone, Default)]
+struct PtyWriteQueue(std::rc::Rc<std::cell::RefCell<Vec<u8>>>);
 
-impl EventListener for NoopEventListener {
-    fn send_event(&self, _event: AlacEvent) {}
+impl EventListener for PtyWriteQueue {
+    fn send_event(&self, event: AlacEvent) {
+        if let AlacEvent::PtyWrite(text) = event {
+            self.0.borrow_mut().extend_from_slice(text.as_bytes());
+        }
+    }
 }
 
 /// One rendered grid cell: a character plus the styling attributes this pane's renderer draws.
@@ -224,9 +251,12 @@ fn grid_cell_from_alacritty(cell: &AlacCell, is_cursor: bool) -> GridCell {
 /// `pty-core`, fed in through [`TerminalGrid::append_bytes`]) are parsed as real ANSI/VT100 and
 /// land in a real cursor-addressed grid.
 pub struct TerminalGrid {
-    term: Term<NoopEventListener>,
+    term: Term<PtyWriteQueue>,
     processor: Processor<StdSyncHandler>,
     size: GridSize,
+    /// The other half of the `Term`'s own [`PtyWriteQueue`] - see that type's docs for why this
+    /// is an `Rc`'d clone rather than reading straight off `term`.
+    pending_pty_writes: PtyWriteQueue,
     /// `true` once the backing process has exited; the grid stops changing after this but
     /// keeps whatever it last rendered, mirroring step 3's `TerminalBuffer::ended`.
     pub ended: bool,
@@ -238,19 +268,34 @@ impl TerminalGrid {
             rows: rows.max(1) as usize,
             cols: cols.max(1) as usize,
         };
-        let term = Term::new(Config::default(), &size, NoopEventListener);
+        let pending_pty_writes = PtyWriteQueue::default();
+        let term = Term::new(Config::default(), &size, pending_pty_writes.clone());
         Self {
             term,
             processor: Processor::new(),
             size,
+            pending_pty_writes,
             ended: false,
         }
     }
 
     /// Feeds a chunk of raw pty bytes into the VT100 parser (`Processor::advance`), which
-    /// drives the real `Term` grid state (cursor movement, SGR colors, screen clears, etc.).
+    /// drives the real `Term` grid state (cursor movement, SGR colors, screen clears, etc.) and
+    /// may also queue bytes into [`Self::pending_pty_writes`] for [`Self::take_pending_pty_writes`]
+    /// to hand back to the pty - see [`PtyWriteQueue`]'s own docs.
     pub fn append_bytes(&mut self, bytes: &[u8]) {
         self.processor.advance(&mut self.term, bytes);
+    }
+
+    /// Drains and returns any bytes the VT parser generated in response to a terminal query
+    /// (e.g. a cursor position report for `ESC[6n`) during the most recent [`Self::append_bytes`]
+    /// call(s) - the caller (`crate::terminal::pane`'s poll loop) is responsible for actually
+    /// writing these back to the pty's stdin via `PtySession::write_input`. Empty on every call
+    /// that didn't just process a query-generating sequence, which is the overwhelmingly common
+    /// case - a plain `Vec` (not an `Option`) so the caller can check emptiness without an extra
+    /// match arm.
+    pub fn take_pending_pty_writes(&mut self) -> Vec<u8> {
+        std::mem::take(&mut *self.pending_pty_writes.0.borrow_mut())
     }
 
     /// Resizes the grid to match a new pty size. Must be called alongside `PtySession::resize`
@@ -329,6 +374,45 @@ mod tests {
         let rows = grid.visible_rows();
         assert_eq!(rows.len(), 5);
         assert!(row_text(&rows[0]).starts_with("hello"));
+    }
+
+    /// [`PtyWriteQueue`]'s real regression coverage: a Device Status Report query (`ESC[6n`,
+    /// "where's the cursor?") must produce a real, correctly formatted `ESC[<row>;<col>R` reply
+    /// queued for the pty - not silently dropped, which is exactly what real Windows ConPTY
+    /// hangs on during its own startup handshake (see [`PtyWriteQueue`]'s own docs for the live
+    /// Windows repro this fixes). Uses `\x1b[3;5H` first (the same cursor-positioning sequence
+    /// [`cursor_positioning_places_text_at_the_addressed_cell`] already proves lands the cursor
+    /// correctly) so the expected reply has a real, non-default row/col to check against - a
+    /// query answered from the default `1;1` cursor position wouldn't tell a wrong-position bug
+    /// apart from a right one.
+    #[test]
+    fn a_cursor_position_query_is_queued_as_a_real_reply_not_dropped() {
+        let mut grid = TerminalGrid::new(5, 20);
+        assert!(
+            grid.take_pending_pty_writes().is_empty(),
+            "sanity check: nothing queued before any query was ever sent"
+        );
+
+        grid.append_bytes(b"\x1b[3;5H");
+        assert!(
+            grid.take_pending_pty_writes().is_empty(),
+            "sanity check: moving the cursor alone must not itself queue a reply"
+        );
+
+        grid.append_bytes(b"\x1b[6n");
+        let reply = grid.take_pending_pty_writes();
+        assert_eq!(
+            reply, b"\x1b[3;5R",
+            "a real cursor position report for row 3, col 5 must be queued, matching what \
+             alacritty_terminal's own Term::device_status formats - not dropped, and not some \
+             other row/col"
+        );
+
+        assert!(
+            grid.take_pending_pty_writes().is_empty(),
+            "the queue must be genuinely drained by the previous take_pending_pty_writes call, \
+             not left with the same reply queued forever"
+        );
     }
 
     /// The key proof that this is real cursor-addressed grid emulation rather than a plain-text

--- a/crates/app/src/terminal/pane.rs
+++ b/crates/app/src/terminal/pane.rs
@@ -277,11 +277,12 @@ pub struct TerminalSpec {
 }
 
 impl TerminalSpec {
-    /// The user's shell (`$SHELL`, falling back to `/bin/bash` if unset), no extra arguments.
+    /// The user's shell (`$SHELL`, falling back to [`default_shell`] if unset), no extra
+    /// arguments.
     pub fn shell(cwd: PathBuf) -> Self {
         let program = std::env::var_os("SHELL")
             .map(PathBuf::from)
-            .unwrap_or_else(|| PathBuf::from("/bin/bash"));
+            .unwrap_or_else(default_shell);
         Self {
             program,
             args: Vec::new(),
@@ -300,6 +301,33 @@ impl TerminalSpec {
             cwd,
         }
     }
+}
+
+/// The real fallback shell [`TerminalSpec::shell`] spawns when `$SHELL` is unset - genuinely
+/// unset on every real Windows session (`$SHELL` is a Unix convention with no Windows
+/// equivalent), so the naive "just default to `/bin/bash`" this used to do failed every single
+/// spawn on Windows with a real, observed `CreateProcessW` "path not found" error (`/bin/bash`
+/// doesn't exist there) - not a hypothetical gap, this was hit running a real release build.
+///
+/// `#[cfg(windows)]`, not `#[cfg(not(unix))]` - matches `pty-core`'s own established
+/// convention (see that crate's module docs) of gating Windows-specific reasoning narrowly, so
+/// an unsupported non-unix target (e.g. `wasm32-unknown-unknown`) fails to compile loudly
+/// instead of silently picking up logic that makes no sense for it.
+#[cfg(windows)]
+fn default_shell() -> PathBuf {
+    // `%COMSPEC%` is Windows' own real `$SHELL` equivalent - the command interpreter every
+    // `cmd.exe`/PowerShell session sets for child processes to inherit - falling back to the
+    // real `cmd.exe` bare name (resolved via `PATH`/the system directory the same way
+    // `portable_pty::CommandBuilder` already resolves any other bare program name) only in the
+    // genuinely rare case that's also unset.
+    std::env::var_os("COMSPEC")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("cmd.exe"))
+}
+
+#[cfg(not(windows))]
+fn default_shell() -> PathBuf {
+    PathBuf::from("/bin/bash")
 }
 
 /// An event [`TerminalPane`] emits (`cx.emit`) for its owner to react to - the same
@@ -763,6 +791,26 @@ impl TerminalPane {
                                         None => this.eof_poll_ticks = 1,
                                     }
                                     break;
+                                }
+                            }
+                        }
+
+                        // Any bytes the VT parser itself generated while processing the chunks
+                        // just appended above - e.g. a cursor position report for `ESC[6n` -
+                        // must be written back to the pty's own stdin, not just left in
+                        // `this.grid`. This is never a no-op-safe skip: real Windows ConPTY
+                        // sends exactly this query as part of its own startup handshake and
+                        // blocks its entire output stream on a real answer (confirmed live -
+                        // see `PtyWriteQueue`'s own docs), so a dropped reply here doesn't just
+                        // misrender a query response, it silently hangs the whole pane forever.
+                        if appended {
+                            let pending_writes = this.grid.take_pending_pty_writes();
+                            if !pending_writes.is_empty() {
+                                if let Err(err) = session.write_input(&pending_writes) {
+                                    log::warn!(
+                                        "failed to answer a terminal query (e.g. cursor \
+                                         position report) back to the pty: {err}"
+                                    );
                                 }
                             }
                         }

--- a/crates/app/src/updater/flow.rs
+++ b/crates/app/src/updater/flow.rs
@@ -1,0 +1,404 @@
+//! The real `self_update`-backed background work behind this feature (GitHub issue #87): the
+//! periodic/manual/startup update *check*, the click-to-download *update*, and the new
+//! relaunch-and-exit mechanism, all as `impl AdeApp` background-task methods - the exact same
+//! "spawn on the background executor, only touch `self` again inside `this.update(cx, ..)` once
+//! it resolves" shape `crate::worktree_history::flow::AdeApp::keep_all_changes` already
+//! establishes for a real, blocking, non-GPUI call.
+//!
+//! ## API surface actually used, verified against the real, pinned `self_update = "0.44.0"`
+//!
+//! Verified directly against that version's real published source
+//! (`docs.rs/crate/self_update/0.44.0/source/src/{update,backends/github}.rs`), not assumed
+//! from the crate's own top-level README (which, as of this writing, describes a newer,
+//! not-yet-released `1.0.0-rc` API shape with different method/module names) - the exact
+//! mismatch this crate's own `Cargo.toml` comment on the `self_update` dependency warns about:
+//!
+//! - `self_update::update::Release` (what both `ReleaseUpdate::get_latest_release` and
+//!   `backends::github::ReleaseList::fetch` return) has fields `name`, `version`, `date`,
+//!   `body`, `assets` - **no** `tag_name`/`html_url` field. Real, read source:
+//!   `Release::from_release` (the GitHub-JSON-to-`Release` conversion) sets
+//!   `version: tag.trim_start_matches('v')` - so `release.version` is already the real tag with
+//!   its leading `v` stripped, and the real tag itself is recovered as `format!("v{}",
+//!   release.version)` (safe: this repo's own `release.yml` only ever tags `vX.Y.Z`, never a
+//!   bare `X.Y.Z`). `html_url` is genuinely not provided by this struct at all - `release_url`
+//!   below constructs the real, standard GitHub URL shape by hand instead of reading one back.
+//! - `ReleaseUpdate::get_latest_release(&self)` really does call `GET
+//!   /repos/<owner>/<repo>/releases/latest` (confirmed directly in `backends/github.rs`'s
+//!   `impl ReleaseUpdate for Update`) - GitHub's own documented behavior for that endpoint
+//!   already excludes drafts/prereleases, matching `release.yml`'s draft-on-`workflow_dispatch`
+//!   behavior with no extra filtering needed on this crate's side.
+//! - `Release::asset_for(target, identifier)` (what `Update::update()` uses internally to pick
+//!   an asset) matches via `asset.name.contains(target)` - confirmed directly in `update.rs` -
+//!   so `.target(std::env::consts::OS)` (`"linux"`/`"macos"`/`"windows"`, never a Rust target
+//!   triple) is a real, correct match against `release.yml`'s actual asset names
+//!   (`jerry-linux.tar.gz`/`jerry-macos.tar.gz`/`jerry-windows.zip`) - `self_update::get_target()`
+//!   (a Rust target triple like `x86_64-unknown-linux-gnu`) would never match any of them.
+//! - `UpdateBuilder::build()` returns `Result<Box<dyn ReleaseUpdate>>`, not a bare `Update` -
+//!   [`build_update`] returns that trait object directly, used for both the check
+//!   ([`check_for_update_blocking`], via `get_latest_release`) and the download
+//!   ([`run_self_update`], via `update()`) - one real, shared builder call, not two independent
+//!   configurations that could drift apart.
+//!
+//! ## Never intrusive on a *check* failure
+//!
+//! See this module's parent (`crate::updater`) docs for the full rule. The one real enforcement
+//! point is [`AdeApp::check_for_update`]'s completion handler: an `Err` only `log::warn!`s -
+//! [`state::UpdateState`] is left completely untouched, and `cx.notify()` is never called. A
+//! *successful* check result also deliberately never clobbers an in-flight/just-finished
+//! *download* (`Downloading`/`ReadyToRestart`) - a periodic re-check firing while the user is
+//! mid-download (or has already finished and is looking at "Restart to update") must not stomp
+//! that with a fresh "Update available" for the same release; this app's own `current_version`
+//! doesn't change until the actual relaunch, so a background re-check genuinely would otherwise
+//! see the exact same release as "still available" and silently revert real, further-along
+//! progress the user is already looking at.
+//!
+//! ## What has and hasn't been really exercised
+//!
+//! `ColinEspinas/jerry` has a real, published `v0.0.1` release (assets: `jerry-linux.tar.gz`,
+//! `jerry-macos.tar.gz`, `jerry-windows.zip`, exactly matching `release.yml`'s naming), and
+//! [`check_for_update_blocking`]/a `self_update` download configured identically to
+//! [`build_update`] (just with `bin_install_path` redirected to a scratch directory instead of
+//! `current_exe()`, to stay safe to run repeatedly from a dev shell) were manually run against it
+//! for real while developing this feature - confirming a real `Ok(Some(release))` detection of
+//! `v0.0.1`, a real "no update" result against a locally-newer version, and a real
+//! download+match+extract producing a genuine, executable file on disk. That verification is
+//! **deliberately not checked in as an automated test**: it depends on GitHub's live,
+//! unauthenticated API, which enforces a 60-requests/hour-per-IP limit - a real hazard for a
+//! test that would otherwise run routinely (every local `cargo test`, every CI run, and any
+//! shared/CI-adjacent network sharing that IP with other traffic can exhaust that budget, which
+//! is exactly what was observed while developing this: a real `403`/`x-ratelimit-remaining: 0`
+//! from GitHub mid-verification). A flaky, network-dependent, rate-limit-prone test would be a
+//! worse trade than the plain manual verification already performed. [`run_self_update`]'s
+//! actual self-replace-of-the-running-executable branch and the following
+//! [`AdeApp::relaunch_and_exit`] process-spawn-and-`cx.quit()` cycle remain unexercised even
+//! manually (reasoned about from the real, pinned `self_update`/`gpui` source only - see
+//! [`run_self_update`]'s and [`AdeApp::relaunch_and_exit`]'s own docs), as does the status bar
+//! chip's actual GPUI rendering/click behavior (no display server available while developing
+//! this) and Windows/macOS-specific behavior (`.bin_name` without `.exe`,
+//! `Compress-Archive`-packaged zip extraction - developed on Linux only). Matches this
+//! codebase's own established convention for this kind of gap
+//! (`crate::root::AdeApp::open_install_url`'s docs).
+
+use super::*;
+use std::ffi::OsString;
+use std::path::Path;
+
+const REPO_OWNER: &str = "ColinEspinas";
+const REPO_NAME: &str = "jerry";
+const BIN_NAME: &str = "jerry";
+
+/// One real, shared `self_update` builder configuration for both the check
+/// ([`check_for_update_blocking`]) and the download ([`run_self_update`]) paths - see this
+/// module's own docs for why each field is set the way it is. `target_version_tag` is only set
+/// for the download path (`Some(tag)`); the check path leaves it unset so
+/// `ReleaseUpdate::get_latest_release` (not `get_release_version`) is what actually gets called.
+fn build_update(
+    current_version: &str,
+    target_version_tag: Option<&str>,
+) -> self_update::errors::Result<Box<dyn self_update::update::ReleaseUpdate>> {
+    let mut builder = self_update::backends::github::Update::configure();
+    builder
+        .repo_owner(REPO_OWNER)
+        .repo_name(REPO_NAME)
+        .bin_name(BIN_NAME)
+        // Real asset-name-`contains` match, not a Rust target triple - see this module's docs.
+        .target(std::env::consts::OS)
+        .current_version(current_version)
+        // This is a GUI process, not a terminal self-updater CLI (what `self_update` was
+        // designed for) - `no_confirm(true)` skips its stdin `y/N` prompt (which would
+        // otherwise hang forever with no terminal attached) and `show_output(false)` skips its
+        // `indicatif` terminal progress bar. Reasoned from `update.rs`'s real, read source
+        // (`print_flush`/`println` calls are all gated behind `show_output`, and the
+        // confirmation prompt behind `no_confirm`) - not smoke-tested end to end as a real GUI
+        // process performing a real download yet, see this module's own top-level docs.
+        .no_confirm(true)
+        .show_output(false);
+    if let Some(tag) = target_version_tag {
+        builder.target_version_tag(tag);
+    }
+    builder.build()
+}
+
+/// The real, standard GitHub release URL for `tag` - constructed by hand, not read from
+/// `self_update::update::Release` (which has no such field - see this module's own docs).
+fn release_url(tag: &str) -> String {
+    format!("https://github.com/{REPO_OWNER}/{REPO_NAME}/releases/tag/{tag}")
+}
+
+fn release_info_from(release: self_update::update::Release) -> state::ReleaseInfo {
+    let tag = format!("v{}", release.version);
+    state::ReleaseInfo {
+        html_url: release_url(&tag),
+        version: release.version,
+        tag,
+    }
+}
+
+/// The real, blocking (background-executor-only, never called from the foreground thread)
+/// GitHub API call behind [`AdeApp::check_for_update`] - a real `GET
+/// /repos/ColinEspinas/jerry/releases/latest`, then [`state::is_remote_version_newer`] against
+/// this build's own `current_version`. `Ok(None)` means "reached GitHub fine, genuinely up to
+/// date, or the tag was malformed" (see that function's own docs); `Err` means "the check itself
+/// failed" (offline, rate-limited, ...) - the two cases [`AdeApp::check_for_update`]'s completion
+/// handler treats very differently, per this module's own "never intrusive on a check failure"
+/// docs.
+fn check_for_update_blocking(current_version: &str) -> anyhow::Result<Option<state::ReleaseInfo>> {
+    let updater = build_update(current_version, None)
+        .map_err(|err| anyhow::anyhow!("could not configure the update check: {err}"))?;
+    let release = updater
+        .get_latest_release()
+        .map_err(|err| anyhow::anyhow!("could not reach GitHub's releases API: {err}"))?;
+    let tag = format!("v{}", release.version);
+    if !state::is_remote_version_newer(current_version, &tag) {
+        return Ok(None);
+    }
+    Ok(Some(release_info_from(release)))
+}
+
+/// The real, blocking download-extract-self-replace call behind
+/// [`AdeApp::start_update_download`]: `self_update::backends::github::Update::update()`, real
+/// per that crate's own source (see this module's top-level docs). Downloads `release`'s
+/// matching archive asset, extracts it (`archive-tar`/`archive-zip` +
+/// `compression-flate2`/`compression-zip-deflate`, matching this crate's own `Cargo.toml`
+/// feature selection), and atomically replaces the currently-running executable via
+/// `self-replace` - all synchronous, hence only ever called from the background executor (see
+/// [`AdeApp::start_update_download`]).
+///
+/// **Partially, manually verified - not via a committed test.** The download+match+extract half
+/// of this call was manually run for real against the real `v0.0.1` release while developing
+/// this feature (with `bin_install_path` redirected to a scratch directory, not left at
+/// `current_exe()`, to stay safe to run repeatedly) and genuinely produced a runnable binary; see
+/// this module's own top-level docs for why that verification wasn't checked in as an automated
+/// test (GitHub's unauthenticated rate limit makes a routinely-run real-network test a bad
+/// trade). The actual self-replace-of-the-running-executable branch this function takes in
+/// production (`bin_install_path == current_exe()` → `self_replace::self_replace`, never
+/// exercised, vs. the `Move::from_source(..).to_dest(..)` branch the manual verification above
+/// took) remains reasoned about only, from the real, pinned `self_update` source. Matches this
+/// codebase's established "explicit about what was smoke-tested vs. only reasoned about"
+/// convention (`crate::root::AdeApp::open_install_url`'s docs).
+fn run_self_update(
+    current_version: &str,
+    release: &state::ReleaseInfo,
+) -> self_update::errors::Result<self_update::Status> {
+    build_update(current_version, Some(&release.tag))?.update()
+}
+
+/// Real, pure command construction for [`AdeApp::relaunch_and_exit`] - split out for direct unit
+/// testing with no real process spawn, matching `crate::settings::widgets::open_command_for`'s
+/// own "pure decision function + thin real-execution wrapper" precedent (that function's own
+/// docs name this exact convention).
+fn build_relaunch_command(exe: &Path, args: &[OsString]) -> std::process::Command {
+    let mut command = std::process::Command::new(exe);
+    command.args(args);
+    command
+}
+
+impl AdeApp {
+    /// The real, background GitHub-releases-backed update check - the palette's "Check for
+    /// Updates" command's real target ([`crate::palette::state::PaletteCommand::CheckForUpdates`]),
+    /// and what [`Self::start_update_check_loop`] calls both immediately at startup and on every
+    /// subsequent tick. No-op while a check is already in flight (mirrors
+    /// [`Self::worktree_history_op_in_flight`]'s own single-flight-per-feature discipline), so a
+    /// manual palette click during the periodic loop's own in-flight check can never spawn a
+    /// second, racing one.
+    ///
+    /// See this module's own docs for exactly how a `Result::Err` (a genuine check failure) and
+    /// a real `Ok` result are each handled - the one place in this whole feature the "never
+    /// intrusive on a check failure" rule is actually enforced.
+    ///
+    /// Deliberately `.detach()`es its own spawned task rather than storing it in
+    /// [`Self::_update_check_task`] (unlike almost every other background call in this crate):
+    /// [`Self::start_update_check_loop`]'s own persistent loop calls this method from *within*
+    /// the very task already sitting in that field, on every tick - if this method also
+    /// reassigned `_update_check_task`, that call would drop (and, per this crate's own
+    /// documented `Task`-drop-cancels semantics, cancel) the outer loop's own task out from
+    /// under itself, permanently ending the periodic loop after its very first tick. A real,
+    /// live-reasoned hazard, not a hypothetical one - `_update_check_task` is reserved solely
+    /// for that outer loop; [`Self::update_check_in_flight`] alone (not a stored `Task`) is what
+    /// guards this method against a second, overlapping one-shot check, matching
+    /// `Self::spawn_open_command`'s own established "detach a background op nothing needs to
+    /// later cancel" precedent.
+    pub(crate) fn check_for_update(&mut self, cx: &mut Context<Self>) {
+        if self.update_check_in_flight {
+            return;
+        }
+        self.update_check_in_flight = true;
+        let current_version = env!("CARGO_PKG_VERSION").to_string();
+        cx.spawn(async move |this, cx| {
+            let result = cx
+                .background_executor()
+                .spawn(async move { check_for_update_blocking(&current_version) })
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                this.update_check_in_flight = false;
+                match result {
+                    Ok(fresh) => {
+                        // A background/manual check's own fresh, real result must never
+                        // overwrite an in-flight or just-finished *download* - see this
+                        // module's own docs for why.
+                        if !matches!(
+                            this.update_state,
+                            state::UpdateState::Downloading { .. }
+                                | state::UpdateState::ReadyToRestart { .. }
+                        ) {
+                            this.update_state = match fresh {
+                                Some(release) => state::UpdateState::UpdateAvailable(release),
+                                None => state::UpdateState::Idle,
+                            };
+                            cx.notify();
+                        }
+                    }
+                    Err(err) => {
+                        // Never touched, never notified - see this module's own "never
+                        // intrusive on a check failure" docs.
+                        log::warn!(
+                            "update check failed (this is expected on flaky/offline \
+                                     networks and never surfaced to the user): {err}"
+                        );
+                    }
+                }
+            });
+        })
+        .detach();
+    }
+
+    /// Starts the real startup-plus-periodic update-check loop - called once, from
+    /// `Self::new_with_settings`, right after `Self::start_worktree_watch`. Runs
+    /// [`Self::check_for_update`] immediately (the real "startup" trigger), then again every
+    /// [`state::UPDATE_CHECK_INTERVAL`] for as long as the app runs, mirroring
+    /// `Self::start_worktree_watch`'s own tick-loop shape.
+    pub(crate) fn start_update_check_loop(&mut self, cx: &mut Context<Self>) {
+        self.check_for_update(cx);
+        let task = cx.spawn(async move |this, cx| loop {
+            cx.background_executor()
+                .timer(state::UPDATE_CHECK_INTERVAL)
+                .await;
+            let updated = this.update(cx, |this, cx| {
+                this.check_for_update(cx);
+            });
+            if updated.is_err() {
+                break;
+            }
+        });
+        self._update_check_task = Some(task);
+    }
+
+    /// The status bar chip's click handler while `update_state` is genuinely
+    /// [`state::UpdateState::UpdateAvailable`] - a real, blocking, background-executor-only
+    /// download+extract+self-replace via [`run_self_update`]. No-op for any other
+    /// `update_state` (including a second click mid-download - [`render`]'s own chip isn't even
+    /// clickable then, but this guard is the real, load-bearing one).
+    pub(crate) fn start_update_download(&mut self, cx: &mut Context<Self>) {
+        let state::UpdateState::UpdateAvailable(release) = self.update_state.clone() else {
+            return;
+        };
+        self.update_state = state::UpdateState::Downloading {
+            release: release.clone(),
+            progress: None,
+        };
+        cx.notify();
+
+        let current_version = env!("CARGO_PKG_VERSION").to_string();
+        let task = cx.spawn(async move |this, cx| {
+            let release_for_call = release.clone();
+            let result = cx
+                .background_executor()
+                .spawn(async move { run_self_update(&current_version, &release_for_call) })
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                this.update_state = match result {
+                    Ok(_status) => state::UpdateState::ReadyToRestart { release },
+                    Err(err) => state::UpdateState::Failed {
+                        release,
+                        error: err.to_string(),
+                    },
+                };
+                cx.notify();
+            });
+        });
+        self._update_download_task = Some(task);
+    }
+
+    /// The status bar chip's click handler while `update_state` is genuinely
+    /// [`state::UpdateState::ReadyToRestart`] - relaunches the just-self-replaced executable and
+    /// exits this process. No-op for any other `update_state`, same discipline as
+    /// [`Self::start_update_download`].
+    pub(crate) fn restart_after_update(&mut self, cx: &mut Context<Self>) {
+        if !matches!(self.update_state, state::UpdateState::ReadyToRestart { .. }) {
+            return;
+        }
+        self.relaunch_and_exit(cx);
+    }
+
+    /// Spawns a fresh copy of this same executable (now the just-self-replaced, newer binary)
+    /// with the same CLI arguments this process itself was launched with, then quits this
+    /// process - genuinely new to this codebase; nothing here relaunched the process before this
+    /// issue (`Self::restart_lsp_clients` is an unrelated, differently-named mechanism that only
+    /// respawns language-server child processes, never this app itself).
+    ///
+    /// `std::env::args_os().skip(1)` preserves the repo-path CLI argument `main.rs`'s own
+    /// `run` reads (skipping only `args_os()`'s first element, the program path itself, which
+    /// the new `std::process::Command::new(exe)` call below supplies fresh anyway) - so the
+    /// relaunched process opens the same repo/window this one did, not a bare, argument-less
+    /// invocation. `cx.quit()` (real, verified against `vendor/zed`'s own
+    /// `gpui::App::quit`/`on_window_close_quit.rs` example - "gracefully quit the application
+    /// via the platform's standard routine") is used rather than a raw `std::process::exit(0)`,
+    /// so this process's own real GPUI/OS teardown still runs.
+    ///
+    /// Only reachable through [`Self::restart_after_update`]'s own `ReadyToRestart` guard - if
+    /// `std::env::current_exe()` or the real spawn itself fails (both real, honestly-reported
+    /// possibilities - e.g. the executable was moved out from under the running process), this
+    /// `log::warn!`s and returns without quitting, leaving `update_state` at `ReadyToRestart` so
+    /// the user can simply try the click again or restart the app by hand.
+    pub(crate) fn relaunch_and_exit(&mut self, cx: &mut Context<Self>) {
+        let exe = match std::env::current_exe() {
+            Ok(exe) => exe,
+            Err(err) => {
+                log::warn!("cannot relaunch after update: current_exe() failed: {err}");
+                return;
+            }
+        };
+        let args: Vec<OsString> = std::env::args_os().skip(1).collect();
+        match build_relaunch_command(&exe, &args).spawn() {
+            Ok(_child) => {
+                cx.quit();
+            }
+            Err(err) => {
+                log::warn!("failed to relaunch after update: {err}");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod relaunch_command_tests {
+    use super::*;
+    use std::ffi::OsStr;
+
+    #[test]
+    fn build_relaunch_command_uses_the_given_exe_and_preserves_every_arg() {
+        let exe = Path::new("/usr/local/bin/jerry");
+        let args = vec![
+            OsString::from("/home/user/my-repo"),
+            OsString::from("--some-flag"),
+        ];
+
+        let command = build_relaunch_command(exe, &args);
+
+        assert_eq!(command.get_program(), OsStr::new("/usr/local/bin/jerry"));
+        let collected: Vec<&OsStr> = command.get_args().collect();
+        assert_eq!(
+            collected,
+            vec![OsStr::new("/home/user/my-repo"), OsStr::new("--some-flag"),],
+            "every real CLI arg (e.g. the repo-path argument main.rs reads) must be preserved, \
+             in order"
+        );
+    }
+
+    #[test]
+    fn build_relaunch_command_with_no_args_passes_none_through() {
+        let exe = Path::new("/usr/local/bin/jerry");
+        let command = build_relaunch_command(exe, &[]);
+        assert_eq!(command.get_args().count(), 0);
+    }
+}

--- a/crates/app/src/updater/mod.rs
+++ b/crates/app/src/updater/mod.rs
@@ -1,0 +1,36 @@
+//! Real GitHub-releases-backed update detection and self-update (GitHub issue #87): everything
+//! about "is a newer Jerry release out, and can the user click to install it" lives in this one
+//! folder, split the way every feature folder in this crate is - pure, GPUI-window-free logic
+//! separate from the real `impl AdeApp` code that drives/draws it:
+//!
+//! - [`state`] - the pure data model ([`state::ReleaseInfo`], [`state::UpdateState`]) and the
+//!   real version-comparison function, unit-tested directly with no GPUI/network involved.
+//! - [`flow`] - the real `self_update`-backed background checks/downloads, and the new
+//!   relaunch-and-exit mechanism this app didn't have before this issue, as `impl AdeApp`
+//!   background-task methods.
+//! - [`render`] - the status bar's "Update available"/"Updating…"/"Restart to update"/"Update
+//!   failed" chip, as an `impl AdeApp` method pushed into
+//!   `crate::status_bar::render::AdeApp::render_status_bar_left`'s segment list.
+//!
+//! `flow`/`render` both glob-import this module (`use super::*`), which is why the shared
+//! imports they need live here rather than at the top of each file - the same convention
+//! `crate::worktree_history`/`crate::status_bar` already established for their own submodules.
+//!
+//! ## Never intrusive on a *check* failure
+//!
+//! A background update *check* can fail for entirely mundane, expected reasons: offline, DNS
+//! failure, GitHub's unauthenticated 60-requests/hour rate limit, a transient 5xx, a TLS
+//! handshake failure. None of those are this app's problem to interrupt the user over -
+//! [`flow::AdeApp::check_for_update`]'s own docs are the one real enforcement point for this
+//! rule: a check failure only ever `log::warn!`s and leaves [`state::UpdateState`] exactly as it
+//! was, never touching it and never calling `cx.notify()`. Only a *download* failure - after the
+//! user has already clicked "Update available" - is ever surfaced as [`state::UpdateState::Failed`].
+
+use crate::root::widgets::text_tooltip;
+use crate::root::*;
+use crate::theme;
+use gpui::{div, font, prelude::*, px, ClickEvent, Context};
+
+pub(crate) mod flow;
+pub(crate) mod render;
+pub(crate) mod state;

--- a/crates/app/src/updater/render.rs
+++ b/crates/app/src/updater/render.rs
@@ -1,0 +1,84 @@
+//! The status bar's real update chip - one `impl AdeApp` method, pushed into
+//! `crate::status_bar::render::AdeApp::render_status_bar_left`'s segment list, first (higher
+//! priority than the transient worktree-history notice - an available/ready update is
+//! persistent, actionable information, not a one-off completion message). Renders nothing at
+//! all (`None`) while [`state::UpdateState::Idle`] - which, per that enum's own docs, covers
+//! "never checked", "genuinely up to date", and "the last check failed" alike, satisfying "hidden
+//! when up to date, and never intrusive on a check failure" in one real branch.
+
+use super::*;
+
+impl AdeApp {
+    /// Follows `crate::status_bar::render::AdeApp::render_status_branch_cluster`'s exact
+    /// clickable-chip idiom (`cursor_pointer` + `rounded(theme::radius::CHIP)` +
+    /// `hover(theme::surface::ROW_HOVER_ALT)` + `on_click(cx.listener(..))`) for the two states
+    /// that are genuinely clickable; `Downloading`/`Failed` render the same 10px mono text
+    /// without the clickable wrapper.
+    pub(crate) fn render_status_update_notice(
+        &self,
+        cx: &mut Context<Self>,
+    ) -> Option<gpui::AnyElement> {
+        match self.update_state.clone() {
+            state::UpdateState::Idle => None,
+            state::UpdateState::UpdateAvailable(_) => Some(
+                div()
+                    .id("status-bar-update-available")
+                    .cursor_pointer()
+                    .rounded(theme::radius::CHIP)
+                    .px(px(4.0))
+                    .hover(|el| el.bg(theme::surface::ROW_HOVER_ALT))
+                    .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
+                        this.start_update_download(cx);
+                    }))
+                    .child(self.render_update_text("Update available", theme::term::LINK))
+                    .into_any_element(),
+            ),
+            state::UpdateState::Downloading { .. } => Some(
+                div()
+                    .id("status-bar-update-downloading")
+                    .child(self.render_update_text("Updating\u{2026}", theme::text::DIM))
+                    .into_any_element(),
+            ),
+            state::UpdateState::ReadyToRestart { .. } => Some(
+                div()
+                    .id("status-bar-update-restart")
+                    .cursor_pointer()
+                    .rounded(theme::radius::CHIP)
+                    .px(px(4.0))
+                    .hover(|el| el.bg(theme::surface::ROW_HOVER_ALT))
+                    .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
+                        this.restart_after_update(cx);
+                    }))
+                    .child(self.render_update_text("Restart to update", theme::term::WARN))
+                    .into_any_element(),
+            ),
+            state::UpdateState::Failed { error, .. } => Some(
+                div()
+                    .id("status-bar-update-failed")
+                    .min_w_0()
+                    .max_w(px(200.0))
+                    .truncate()
+                    .tooltip(text_tooltip(error))
+                    .child(self.render_update_text("Update failed", theme::button::DANGER_FG))
+                    .into_any_element(),
+            ),
+        }
+    }
+
+    /// The plain, non-clickable 10px mono status-bar text style, colored per `update_state` -
+    /// a colored twin of `crate::status_bar::render::AdeApp::render_status_text`'s own plain
+    /// `theme::text::DIM`-only version (that method is private to `crate::status_bar::render`,
+    /// so this is a small, deliberate, differently-colored copy rather than a visibility change
+    /// to a different feature's own helper).
+    fn render_update_text(
+        &self,
+        label: &'static str,
+        color: theme::ColorToken,
+    ) -> impl IntoElement {
+        div()
+            .font(font(theme::font::MONO))
+            .text_size(self.ui_text_size(10.0))
+            .text_color(color)
+            .child(label)
+    }
+}

--- a/crates/app/src/updater/state.rs
+++ b/crates/app/src/updater/state.rs
@@ -1,0 +1,149 @@
+//! Pure, GPUI-free, network-free data model for the update-available feature (GitHub issue
+//! #87): the real version-comparison decision plus the state machine `crate::updater::render`
+//! draws and `crate::updater::flow` drives. No `gpui::Window`/`Context`, no network call, so
+//! this stays directly `#[test]`-able - the same "pure half, GPUI half" split `crate::status_bar`
+//! (`process_stats`/`render`) and `crate::worktree_history` (`flow`'s own pure
+//! `branch_display_for`) already establish.
+
+use std::time::Duration;
+
+/// How often the background loop (`crate::updater::flow::AdeApp::start_update_check_loop`)
+/// re-checks GitHub for a newer release, after the real startup check that loop also performs.
+/// GitHub's unauthenticated REST API allows 60 requests/hour per source IP - at one request per
+/// tick, 6h is nowhere near that budget even with the palette's manual "Check for Updates"
+/// command added on top (a user would have to invoke it dozens of times an hour to matter).
+pub(crate) const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(6 * 60 * 60);
+
+/// A real GitHub release this app could update to - built from `self_update::update::Release`
+/// (see `crate::updater::flow`'s own docs for exactly how, since that struct has no `tag_name`/
+/// `html_url` field of its own to read directly).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ReleaseInfo {
+    /// The real git tag, e.g. `"v0.2.0"` - what `release.yml` actually tags
+    /// (`on: push: tags: "v*"`), and what `self_update`'s `target_version_tag` needs to fetch
+    /// this exact release again for the download step.
+    pub(crate) tag: String,
+    /// The tag with its leading `v` stripped, e.g. `"0.2.0"` - already exactly this shape as
+    /// returned by `self_update::update::Release::version` (see `crate::updater::flow`'s docs),
+    /// not a second, independent strip.
+    pub(crate) version: String,
+    /// A real, constructed (not API-provided - `self_update::update::Release` carries no HTML
+    /// URL of its own) `https://github.com/<owner>/<repo>/releases/tag/<tag>` link, for a
+    /// future "view release notes" affordance. Not yet rendered anywhere (MVP scope, per the
+    /// issue's own status-bar-chip-only ask) - kept on this type now rather than bolted on
+    /// later, since it's free to compute alongside `tag`/`version`.
+    pub(crate) html_url: String,
+}
+
+/// The update feature's whole state machine - one field on `AdeApp`
+/// (`crate::root::AdeApp::update_state`), driven entirely by `crate::updater::flow`'s real
+/// background checks/downloads, drawn entirely by `crate::updater::render`.
+///
+/// `Idle` deliberately covers three different real situations - "never checked yet", "checked
+/// and genuinely up to date", and "the most recent *check* failed (offline, DNS, GitHub
+/// rate-limit, bad JSON, TLS)" - because all three render identically (nothing shown) and none
+/// of them should ever interrupt normal use. Only a *download* failure (after the user has
+/// already clicked "Update available") is a distinct, shown `Failed` state - see
+/// `crate::updater::flow`'s module docs for the full "never intrusive on a check failure" rule
+/// this distinction exists to enforce.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum UpdateState {
+    Idle,
+    UpdateAvailable(ReleaseInfo),
+    Downloading {
+        release: ReleaseInfo,
+        /// `self_update`'s own progress reporting is terminal/`indicatif`-oriented, not
+        /// GPUI-friendly (see `crate::updater::flow`'s docs on `show_output(false)`/
+        /// `no_confirm(true)`) - this stays `None` for the real MVP download (indeterminate
+        /// "Updating…" text is enough to satisfy "loading feedback"), but is a real `Option`,
+        /// not a bare unit, so a future revision can wire real percentage progress through
+        /// without another `UpdateState` shape change.
+        progress: Option<f32>,
+    },
+    ReadyToRestart {
+        release: ReleaseInfo,
+    },
+    /// Only ever reached from a *download* failure (post-click) - never from a background
+    /// check failure. See this enum's own docs and `crate::updater::flow`'s module docs.
+    Failed {
+        release: ReleaseInfo,
+        error: String,
+    },
+}
+
+/// Decides whether `remote_tag` (a real GitHub release tag, e.g. `"v0.2.0"` - the `v` prefix is
+/// optional here, stripped either way, since this is also exercised directly against
+/// already-stripped input in tests below) is a genuinely newer, real, actionable update over
+/// `current` (this build's own `env!("CARGO_PKG_VERSION")`, never `v`-prefixed).
+///
+/// Pure and deterministic - no GPUI, no network - delegates the actual semver comparison to
+/// `self_update::version::bump_is_greater` rather than adding a direct `semver` dependency on
+/// top of the one `self_update` already pulls in transitively.
+///
+/// Three deliberate real-world safety nets beyond a plain "is it greater" check:
+/// - Malformed/unparseable version strings (`bump_is_greater` returning `Err` - not real
+///   semver, e.g. a hand-pushed non-release tag or a future tagging-convention change this app
+///   doesn't understand yet) are treated as "no update available", not "newer" - a `log::warn!`
+///   only, never a false positive that would offer to install something that isn't a real,
+///   parseable release.
+/// - A pre-release remote version (a `-`-suffixed semver, e.g. `"0.2.0-beta.1"`) never counts
+///   as an update, even if semver ordering alone would call it newer than `current` (e.g.
+///   `"0.2.0-beta.1"` really is `>` `"0.1.0"` under plain semver precedence rules) - this repo
+///   has no pre-release-tag convention today (`release.yml` only ever tags real, final `vX.Y.Z`
+///   releases), so treating one as "newer" would offer an update to a tag no real release
+///   process here produces yet.
+/// - Equal-or-older is "no update available", the ordinary case `bump_is_greater` itself
+///   already handles correctly.
+pub(crate) fn is_remote_version_newer(current: &str, remote_tag: &str) -> bool {
+    let remote_version = remote_tag.trim_start_matches(['v', 'V']);
+    if remote_version.contains('-') {
+        // A real pre-release version - see this function's own docs for why this is checked
+        // explicitly rather than left to semver precedence alone.
+        return false;
+    }
+    match self_update::version::bump_is_greater(current, remote_version) {
+        Ok(is_greater) => is_greater,
+        Err(err) => {
+            log::warn!(
+                "update check: could not compare current version {current:?} against remote \
+                 {remote_tag:?}, treating as no update available: {err}"
+            );
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod version_comparison_tests {
+    use super::*;
+
+    #[test]
+    fn equal_versions_are_not_an_update() {
+        assert!(!is_remote_version_newer("0.1.0", "v0.1.0"));
+    }
+
+    #[test]
+    fn a_real_newer_tag_is_an_update() {
+        assert!(is_remote_version_newer("0.1.0", "v0.2.0"));
+    }
+
+    #[test]
+    fn an_older_tag_is_not_an_update() {
+        assert!(!is_remote_version_newer("0.1.0", "v0.0.9"));
+    }
+
+    #[test]
+    fn an_unparseable_tag_is_gracefully_not_an_update() {
+        assert!(!is_remote_version_newer("0.1.0", "garbage"));
+    }
+
+    #[test]
+    fn a_pre_release_tag_is_never_an_update() {
+        assert!(!is_remote_version_newer("0.1.0", "v0.1.0-beta.1"));
+        // The stronger case this function's docs call out: a pre-release of a real *future*
+        // version would out-rank `current` under plain semver precedence alone, but must still
+        // never count as an update - this repo has no pre-release-tag convention to offer one
+        // through.
+        assert!(!is_remote_version_newer("0.1.0", "v0.2.0-beta.1"));
+    }
+}


### PR DESCRIPTION
Closes #87.

## Summary

- Adds `crate::updater` (state/flow/render split, mirroring `worktree_history`/`status_bar`'s existing convention): checks `ColinEspinas/jerry`'s GitHub releases on startup and every 6h via the `self_update` crate.
- Shows an "Update available" / "Updating…" / "Restart to update" / "Update failed" chip in the status bar (hidden entirely when up to date).
- Clicking it downloads the matching platform asset (`jerry-linux.tar.gz` / `jerry-macos.tar.gz` / `jerry-windows.zip`, matching `.github/workflows/release.yml`'s exact asset naming), self-replaces the running binary, and offers a restart (`relaunch_and_exit`, new to this codebase — re-execs the current binary with the same args, then exits).
- Update-check failures (offline, GitHub rate-limited, etc.) are never surfaced to the user and never block normal use — only a failure *after* the user clicks to update shows as `Failed`.
- Adds a "Check for Updates" command to the command palette.

## Verification

Run locally (build, full workspace test suite, clippy, fmt) — all pass:
- `cargo build --workspace`
- `cargo test --workspace` — 1310 passed, 10 failed; all 10 failures are pre-existing and unrelated to this change (missing local language servers: rust-analyzer/pyright/typescript, plus the documented `diff_render_tests` cache flake) — none touch the new `updater` module.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.

**Manually verified against the real, published `v0.0.1` release** (not checked in as an automated test — see below): `check_for_update_blocking` really detects `v0.0.1` as newer than an older local version and builds a correct `ReleaseInfo`; it really reports "up to date" against a locally-newer version; and a real `self_update` download+match+extract of `v0.0.1`'s Linux asset (redirected to a scratch directory instead of the running binary) really produced a genuine, executable file — confirming the network/download/archive-extraction/asset-matching pipeline works end to end against the real release.

This was deliberately **not** added as a committed test: GitHub's unauthenticated REST API enforces a 60-requests/hour-per-source-IP limit, and manual verification actually hit it (a real `403`/`x-ratelimit-remaining: 0` from a shared sandbox IP) — a real-network test that runs on every local `cargo test`/CI invocation would be flaky and rate-limit-prone rather than a reliable signal. (For real end users, one check every 6h is nowhere near that budget — this is a shared-IP/CI-environment concern, not a concern for how the shipped feature behaves for a single user.) `crates/app/src/updater/flow.rs`'s doc comments record exactly what was manually verified this way vs. only reasoned about from the pinned `self_update` source.

**Still not done: live UI / real end-to-end testing in an actual running app window.** This was built and tested in a headless sandbox with no display server (no `DISPLAY`/`WAYLAND_DISPLAY`, no `Xvfb` available, no privilege to install one). Concretely unexercised:
- The status bar chip's actual rendering and click behavior.
- The real self-replace-of-the-running-executable branch and the following relaunch/restart cycle (manual verification deliberately took the safe "install to scratch dir" code path instead, to avoid self-replacing a dev shell's own process).
- Windows/macOS-specific behavior (`.bin_name` without `.exe`, `Compress-Archive`-packaged zip extraction) — this sandbox is Linux-only.

Recommend manually smoke-testing the chip states and a real update-and-restart cycle in a real desktop session before considering this fully done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)