### PR TITLE
feat(app): open/remember folders and support new windows (issue #90)

### DIFF
--- a/crates/app/src/graph_view/render.rs
+++ b/crates/app/src/graph_view/render.rs
@@ -17,6 +17,22 @@ impl AdeApp {
     /// through this). Idempotent: re-invoking while already open just re-activates it (used by
     /// the tab's own click handler too, so there is exactly one open/activate code path).
     pub(crate) fn open_git_graph(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        // GitHub issue #90: a genuinely empty window has no real repo to graph at all - an
+        // independent audit found this reachable two real ways with no focused repo (`mod+shift+G`
+        // is bound with no key context, so it dispatches regardless, and the palette's own "Open
+        // git graph" entry - see `crate::palette::render::AdeApp`'s own gating on this same guard)
+        // and two real consequences: `window.focus(&self.graph_focus_handle, cx)` below would
+        // dangle, since `graph_focus_handle` is only ever tracked inside `Self::render_center_pane`
+        // - part of `Self::render_workspace_body`, never rendered while `Self::render_empty_state`
+        // is showing instead (the same class of bug `Self::open_repo_in_current_window`'s own
+        // `empty_state_focus_handle` forgetting fixes) - and `Self::load_graph` reads
+        // `self.diff_root`, an empty `PathBuf` in this state, which `wt_core::graph::build_graph`
+        // hands to `gix::open`, which resolves an empty path relative to the *process's* real
+        // working directory - silently showing whatever unrelated repo `jerry` happened to be
+        // launched from, a real, confusing (if read-only) wrong-repo display.
+        if self.focused_repo().is_none() {
+            return;
+        }
         // Mirrors `Self::open_settings`'s own defensive top-of-function close: reachable directly
         // (the status bar cluster, the `+` menu, `mod+shift+G`) while the palette also happens to
         // be open, not just via `crate::palette::render::AdeApp::execute_palette_command`'s own
@@ -5084,6 +5100,63 @@ mod graph_focus_tests {
              `AdeApp::wire_caret_blink`, so nothing would have reacted to it losing focus at \
              all, and the caret would have stayed solid/visible until whatever timer the \
              earlier keystroke started eventually fired on its own"
+        );
+    }
+
+    /// GitHub issue #90 (independent audit, second round): a genuinely empty window has no real
+    /// repo to graph at all. `mod+shift+G` is bound with no key context - see
+    /// `crate::default_key_bindings`'s own docs - so it dispatches on the root element regardless
+    /// of whether a repo is focused, reaching `AdeApp::open_git_graph` directly. Before this fix,
+    /// that call would move real keyboard focus onto `graph_focus_handle` - a handle only ever
+    /// tracked inside `Self::render_center_pane` (part of `Self::render_workspace_body`, never
+    /// rendered while `Self::render_empty_state` is showing instead) - dangling it exactly like
+    /// the `empty_state_focus_handle` bug `AdeApp::open_repo_in_current_window`'s own
+    /// `forget_target` calls fix - and would load a real graph from `self.diff_root`, an empty
+    /// `PathBuf` in this state, which `gix::open` silently resolves relative to the process's own
+    /// real working directory.
+    #[gpui::test]
+    fn open_git_graph_is_a_no_op_with_no_focused_repo(cx: &mut TestAppContext) {
+        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+
+        let (app, cx) = cx.add_window_view(|window, cx| {
+            AdeApp::new_with_settings(
+                None,
+                true,
+                crate::settings::store::Settings::default(),
+                Some(settings_path),
+                window,
+                cx,
+            )
+        });
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.focused_repo(), None, "sanity check: starts empty");
+        });
+
+        let empty_state_handle = app.read_with(cx, |app, _| app.empty_state_focus_handle.clone());
+        app.update_in(cx, |app, window, cx| {
+            window.focus(&empty_state_handle, cx);
+            app.handle_new_git_graph_action(&NewGitGraph, window, cx);
+        });
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert!(
+                !app.graph_tab_open,
+                "mod+shift+G with no focused repo must not open the graph tab"
+            );
+            assert!(!app.graph_tab_active);
+            assert!(
+                matches!(app.graph_state.load, GraphLoadState::NotLoaded),
+                "no real graph load may be triggered against an empty/wrong repo path"
+            );
+        });
+        let focused = app.update_in(cx, |_app, window, cx| window.focused(cx));
+        assert_eq!(
+            focused,
+            Some(empty_state_handle),
+            "focus must never move off the still-rendered empty-state handle onto the \
+             unrendered graph view"
         );
     }
 }

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -19,6 +19,11 @@ pub mod language;
 pub mod lsp;
 pub mod merge;
 pub mod palette;
+// `pub(crate)`: a single small lock shared by `rail::repo`/`sidebar::fold_state`/
+// `work_surface::tab_order_state`'s own `save_merged_at` methods - see its own module docs for
+// the real intra-process concurrent-writer hazard (GitHub issue #90's "New Window") this exists
+// to close. Nothing outside this crate has any business calling it directly.
+pub(crate) mod persisted_state_lock;
 pub mod rail;
 pub mod root;
 pub mod settings;
@@ -507,10 +512,49 @@ pub fn default_key_bindings() -> Vec<gpui::KeyBinding> {
     ]
 }
 
+/// The [`WindowOptions`] every ADE window opens with - both the one real window [`run`] itself
+/// opens at process startup, and every window `crate::title_bar::menu`'s "New Window" row opens
+/// later (GitHub issue #90) - one shared literal so the two can never silently drift apart, the
+/// same "no second copy of a decision" reasoning [`default_key_bindings`]'s own docs give.
+/// `Bounds::centered` needs a real `&App` to read the display it's centering against
+/// (`vendor/zed/crates/gpui/src/geometry.rs:740`), which both real call sites have (the launch
+/// callback's own `&mut App`, and a menu row's `Context<AdeApp>`, which derefs to `App` -
+/// `vendor/zed/crates/gpui/src/app/context.rs:25-37`).
+pub(crate) fn default_window_options(cx: &App) -> WindowOptions {
+    let bounds = Bounds::centered(None, size(px(1440.0), px(928.0)), cx);
+    WindowOptions {
+        window_bounds: Some(WindowBounds::Windowed(bounds)),
+        // The design's title-bar band (`crate::title_bar`) draws its own close/minimize/maximize
+        // controls, so the OS/compositor shouldn't also draw a native titlebar - matching
+        // `vendor/zed/crates/zed/src/zed.rs`'s own `titlebar`/`window_decorations` combination.
+        titlebar: Some(TitlebarOptions {
+            title: None,
+            appears_transparent: true,
+            traffic_light_position: None,
+        }),
+        window_decorations: Some(WindowDecorations::Client),
+        window_min_size: Some(Size {
+            width: px(720.0),
+            height: px(480.0),
+        }),
+        ..Default::default()
+    }
+}
+
 /// Opens the ADE window against `repo_path` and runs the GPUI event loop until the window is
 /// closed. Blocks the calling thread for the application's lifetime, mirroring
 /// `gpui::Application::run`'s own contract (`vendor/zed/crates/gpui/examples/hello_world.rs`).
-pub fn run(repo_path: PathBuf) {
+///
+/// GitHub issue #90: `repo_path` is now optional. `Some(path)` behaves exactly as before (the
+/// real CLI-argument case, `crate::main`'s own docs). `None` - a fresh launch with no CLI
+/// argument - is handed straight through to `root::AdeApp::new`/`new_with_settings`, which
+/// resolves it against whatever repo (if any) was last focused and persisted to `repos.toml`:
+/// reopen that one, or - if nothing was ever persisted, or the remembered path no longer exists -
+/// a genuinely empty window with no folder open at all. This is the real fix for "launching the
+/// editor should be in an 'empty' state by default": there is no `env::current_dir()` fallback
+/// anywhere in this path anymore (removed from `crate::main` itself) for `None` to silently
+/// become.
+pub fn run(repo_path: Option<PathBuf>) {
     // `with_assets` registers `fonts::Assets` as the app's `AssetSource`
     // (`vendor/zed/crates/gpui/src/app.rs:198`) before the launch callback runs, since
     // `fonts::load_embedded_fonts` needs `cx.asset_source()` already wired up.
@@ -526,31 +570,19 @@ pub fn run(repo_path: PathBuf) {
 
             cx.bind_keys(default_key_bindings());
 
-            let bounds = Bounds::centered(None, size(px(1440.0), px(928.0)), cx);
-            let opened = cx.open_window(
-                WindowOptions {
-                    window_bounds: Some(WindowBounds::Windowed(bounds)),
-                    // The design's title-bar band (`crate::title_bar`) draws its own
-                    // close/minimize/maximize controls, so the OS/compositor shouldn't also
-                    // draw a native titlebar - matching `vendor/zed/crates/zed/src/zed.rs`'s
-                    // own `titlebar`/`window_decorations` combination.
-                    titlebar: Some(TitlebarOptions {
-                        title: None,
-                        appears_transparent: true,
-                        traffic_light_position: None,
-                    }),
-                    window_decorations: Some(WindowDecorations::Client),
-                    window_min_size: Some(Size {
-                        width: px(720.0),
-                        height: px(480.0),
-                    }),
-                    ..Default::default()
-                },
-                {
-                    let repo_path = repo_path.clone();
-                    move |window, cx| cx.new(|cx| root::AdeApp::new(repo_path.clone(), window, cx))
-                },
-            );
+            let options = default_window_options(cx);
+            let opened = cx.open_window(options, {
+                let repo_path = repo_path.clone();
+                // `true`: the real process-launch path, which is exactly the one case GitHub
+                // issue #90 wants a remembered folder auto-reopened for - unlike a "New Window"
+                // menu row later in the same running process (`crate::title_bar::menu`'s own
+                // handler), which deliberately passes `false` for a genuinely empty window
+                // regardless of what's persisted. See `root::AdeApp::new`'s own docs for exactly
+                // what this flag controls.
+                move |window, cx| {
+                    cx.new(|cx| root::AdeApp::new(repo_path.clone(), true, window, cx))
+                }
+            });
 
             match opened {
                 Ok(_) => cx.activate(true),

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -1,5 +1,11 @@
-//! Binary entry point: resolves the target repository path (an optional CLI argument,
-//! defaulting to the current working directory) and hands off to `app::run`.
+//! Binary entry point: resolves the target repository path from an optional CLI argument.
+//!
+//! GitHub issue #90: this deliberately no longer falls back to `env::current_dir()` - a fresh
+//! launch with no CLI argument now hands `app::run` a real `None` instead of silently forcing
+//! whatever directory the process happened to be started from open as a "repo". `app::run` (and,
+//! beneath it, `root::AdeApp::new_with_settings`) resolves what to do with `None` itself: reopen
+//! the last-remembered folder if one was persisted, or a genuinely empty window if not - see
+//! those functions' own docs.
 
 use std::env;
 use std::path::PathBuf;
@@ -8,16 +14,7 @@ use std::process::ExitCode;
 fn main() -> ExitCode {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
-    let repo_path = match env::args_os().nth(1) {
-        Some(arg) => PathBuf::from(arg),
-        None => match env::current_dir() {
-            Ok(dir) => dir,
-            Err(err) => {
-                eprintln!("failed to determine the current working directory: {err}");
-                return ExitCode::FAILURE;
-            }
-        },
-    };
+    let repo_path = env::args_os().nth(1).map(PathBuf::from);
 
     app::run(repo_path);
     ExitCode::SUCCESS

--- a/crates/app/src/palette/render.rs
+++ b/crates/app/src/palette/render.rs
@@ -78,7 +78,7 @@ impl AdeApp {
             RightSidebarView::Files => "Changes",
             RightSidebarView::Changes => "Files",
         };
-        let commands = vec![
+        let mut commands = vec![
             palette::CommandCandidate {
                 command: palette::PaletteCommand::NewShell,
                 secondary: format!("spawn a shell in {}", active_cwd.display()),
@@ -127,11 +127,19 @@ impl AdeApp {
                     WindowControlsStyle::WindowsLinuxStyle,
                 ),
             },
-            palette::CommandCandidate {
+        ];
+        // GitHub issue #90: a genuinely empty window has no real repo to graph -
+        // `crate::graph_view::render::AdeApp::open_git_graph`'s own guard now refuses outright
+        // with no focused repo, so this entry is dropped from the results entirely rather than
+        // listed as a real command that would silently do nothing if picked (this app has no
+        // existing "greyed out but still listed" convention for palette rows, unlike the title
+        // bar's dropdown menus - dropping the entry is the simpler, equally honest fix).
+        if self.focused_repo().is_some() {
+            commands.push(palette::CommandCandidate {
                 command: palette::PaletteCommand::OpenGitGraph,
                 secondary: "commit history, branches, lanes".to_string(),
-            },
-        ];
+            });
+        }
 
         palette::build_groups(
             self.palette_scope,

--- a/crates/app/src/persisted_state_lock.rs
+++ b/crates/app/src/persisted_state_lock.rs
@@ -1,0 +1,43 @@
+//! A single process-wide lock, shared by every real "merged, multi-writer-safe persisted file"
+//! this app has - `crate::rail::repo::RepoState` (`repos.toml`), `crate::sidebar::fold_state::
+//! FoldState` (`file-tree-state.toml`), and `crate::work_surface::tab_order_state::TabOrderState`
+//! (`tab-order.toml`). All three follow the identical shape: load whatever is currently on disk,
+//! merge in only the keys *this* instance owns, write the result back
+//! (`*::save_merged_at` on each) - already safe against two separate `jerry` *processes* sharing
+//! one `~/.config/jerry` (see `RepoState::save_merged_at`'s own docs for the full reasoning that
+//! shape exists for).
+//!
+//! GitHub issue #90's "New Window" introduced a real hazard none of the three had before: two
+//! independent `AdeApp` instances - each with its own async writer loop - now genuinely run
+//! *inside the same process*, and can call `save_merged_at` on the exact same file at (as near
+//! as makes no difference) the same instant. The `owned`-scoped merge above only protects against
+//! two writers whose `load_at` calls are properly ordered relative to each other's writes -
+//! two truly concurrent calls can both read the same pre-write state, merge their own keys into
+//! their own independent copy, and whichever `save_at` lands second silently discards the first's
+//! freshly-written keys.
+//!
+//! [`with_locked_merge`] closes that window: every one of the three `save_merged_at` methods
+//! wraps its whole read-modify-write cycle in this same lock, so real in-process concurrent
+//! writers now genuinely serialize instead of racing. Deliberately **one** global lock, not three
+//! independent ones and not one keyed per real file path: this app only ever has one real path
+//! for each of the three files in production, and serializing an unrelated pair of test temp-dir
+//! paths against each other costs nothing worth a per-path lock registry's own added complexity -
+//! the identical tradeoff `RepoState::save_merged_at`'s own first version of this already made
+//! before this module existed to share it.
+
+use std::sync::{Mutex, OnceLock};
+
+/// Runs `f` while holding the shared lock - see the module's own docs for exactly what real
+/// hazard this closes and why one global lock is enough. A prior panic while holding the lock
+/// poisons the underlying [`Mutex`]; recovered via [`std::sync::PoisonError::into_inner`] rather
+/// than propagating (a merged-save failure is already handled by its own caller as a plain
+/// `io::Result` - a poisoned lock must not additionally cascade into every *other* future call
+/// that never itself did anything wrong).
+pub(crate) fn with_locked_merge<T>(f: impl FnOnce() -> T) -> T {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    let _guard = LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    f()
+}

--- a/crates/app/src/rail/repo.rs
+++ b/crates/app/src/rail/repo.rs
@@ -123,6 +123,14 @@ pub fn repo_key(path: &Path) -> Option<String> {
 #[serde(default)]
 pub struct RepoState {
     pub repos: BTreeMap<String, RepoRecord>,
+    /// GitHub issue #90's "remembers the last-opened folder" - the [`repo_key`] of whichever
+    /// repo [`crate::root::AdeApp::focus_repo`] most recently focused, so a fresh launch with no
+    /// CLI argument can reopen it automatically. `None` for a user who has never focused a repo
+    /// at all (or an on-disk file predating this field - `#[serde(default)]` on the struct
+    /// covers that the same way every other field here already does). Deliberately a bare key,
+    /// not a `PathBuf`: it is only ever compared against [`Self::repos`]' own keys
+    /// ([`Self::last_focused_existing_path`]), never read as a path directly.
+    pub last_focused: Option<String>,
 }
 
 /// One repo's persisted record - just its display name today. The map key (a [`repo_key`]) is
@@ -255,14 +263,63 @@ impl RepoState {
         path: &Path,
         owned: &std::collections::BTreeSet<String>,
     ) -> io::Result<()> {
-        let mut merged = RepoState::load_at(path);
-        for key in owned {
-            match self.repos.get(key) {
-                Some(entry) => merged.repos.insert(key.clone(), entry.clone()),
-                None => merged.repos.remove(key),
-            };
+        // GitHub issue #90: "New Window" made this file's own load-merge-save cycle reachable
+        // *concurrently within one process* for the first time - two independent `AdeApp`
+        // instances, each with its own async writer loop (`crate::root::AdeApp::
+        // persist_repo_state`), can now both be mid-`save_merged_at` against the exact same real
+        // `repos.toml` at once. The `owned`-scoped merge below already protects against two
+        // separate *processes* stomping each other's keys (see this method's own docs above), but
+        // that protection assumes each `load_at` genuinely observes the other's already-completed
+        // write - which two truly concurrent calls do not guarantee: both could `load_at` the same
+        // pre-write state, merge their own `owned` keys into their own independent copy, and then
+        // whichever `save_at` lands second would silently overwrite the first's freshly-written
+        // keys with its own now-stale copy of everything else. `persisted_state_lock::
+        // with_locked_merge` closes that window - see its own module docs for why one shared,
+        // process-wide (not per-path) lock is enough, and why `crate::sidebar::fold_state`/
+        // `crate::work_surface::tab_order_state`'s own `save_merged_at` methods share the exact
+        // same lock rather than each rolling an independent copy.
+        crate::persisted_state_lock::with_locked_merge(|| {
+            let mut merged = RepoState::load_at(path);
+            for key in owned {
+                match self.repos.get(key) {
+                    Some(entry) => merged.repos.insert(key.clone(), entry.clone()),
+                    None => merged.repos.remove(key),
+                };
+            }
+            // `last_focused` is a single global value, not per-repo, so it doesn't fit the
+            // per-key `owned` merge loop above - `self.last_focused` (this process's own current
+            // idea of "which repo did I last focus") always wins over whatever another process
+            // last wrote, the same last-writer-wins tradeoff this file's own multi-instance design
+            // already accepts for everything else it persists. Only overwritten when `self`
+            // genuinely has an opinion: `Self::repo_state_snapshot`'s only real caller derives
+            // this from a live `AdeApp::focused_repo()`, which is `None` only when `Self::repos`
+            // is itself empty - a state `persist_repo_state`'s own callers (`add_repo`/
+            // `focus_repo`) never reach, but guarded here anyway rather than let some future
+            // caller silently blank out a real remembered repo another process just wrote.
+            if self.last_focused.is_some() {
+                merged.last_focused = self.last_focused.clone();
+            }
+            merged.save_at(path)
+        })
+    }
+
+    /// GitHub issue #90's own real "still valid" check for [`Self::last_focused`]: `None` unless
+    /// it names a repo genuinely present in [`Self::repos`] *and* that repo's own path still
+    /// exists on disk right now. A remembered repo that was since deleted or moved must fall back
+    /// to a genuinely empty startup rather than a broken/error one - see
+    /// `crate::root::AdeApp::new_with_settings`'s own docs for how the caller uses this.
+    pub fn last_focused_existing_path(&self) -> Option<PathBuf> {
+        let key = self.last_focused.as_ref()?;
+        if !self.repos.contains_key(key) {
+            return None;
         }
-        merged.save_at(path)
+        let path = PathBuf::from(key);
+        // `is_dir`, not `exists` - an independent audit's real finding: a repo's own real
+        // checkout is a directory, so a real path that now names a plain file (replaced by hand,
+        // or by some other program, after this was last remembered) must fall back to empty the
+        // same way a fully deleted path already does, rather than being treated as "still a real
+        // repo" and failing downstream once something tries to actually read it as one.
+        path.is_dir().then_some(path)
     }
 }
 
@@ -421,6 +478,173 @@ mod tests {
         assert!(
             !RepoState::load_at(&path).repos.contains_key("/repo/a"),
             "removing a repo must survive the merge as a real deletion"
+        );
+    }
+
+    /// GitHub issue #90's own real "still valid" check - the four cases
+    /// [`RepoState::last_focused_existing_path`]'s own docs enumerate.
+    #[test]
+    fn last_focused_existing_path_is_none_when_nothing_was_ever_remembered() {
+        let state = RepoState::default();
+        assert_eq!(state.last_focused_existing_path(), None);
+    }
+
+    #[test]
+    fn last_focused_existing_path_is_none_when_the_key_is_not_a_known_repo() {
+        // `last_focused` names a key that was never actually added to `repos` (e.g. a hand-
+        // edited file, or a repo since removed) - must not resolve to a path anyway.
+        let state = RepoState {
+            last_focused: Some("/repo/never-added".to_string()),
+            ..RepoState::default()
+        };
+        assert_eq!(state.last_focused_existing_path(), None);
+    }
+
+    #[test]
+    fn last_focused_existing_path_is_none_when_the_remembered_directory_no_longer_exists() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let gone = dir.path().join("deleted-repo");
+        std::fs::create_dir(&gone).expect("mkdir");
+        let key = gone.to_str().expect("utf8 path").to_string();
+
+        let mut state = RepoState::default();
+        state.repos.insert(
+            key.clone(),
+            RepoRecord {
+                name: "deleted-repo".to_string(),
+            },
+        );
+        state.last_focused = Some(key);
+        // The directory is removed *after* being recorded - simulating a repo that was open,
+        // remembered, and has since been deleted or moved.
+        std::fs::remove_dir(&gone).expect("rmdir");
+
+        assert_eq!(
+            state.last_focused_existing_path(),
+            None,
+            "a deleted/moved remembered folder must fall back to empty, not a broken path"
+        );
+    }
+
+    /// The other real "no longer a usable repo" case an independent audit found this method
+    /// missing: the remembered path still `exists()` (so a plain `exists()` check would wrongly
+    /// accept it), but a real directory was replaced by a plain file - `is_dir()` is the real
+    /// check that must reject this, not merely "something is there".
+    #[test]
+    fn last_focused_existing_path_is_none_when_the_remembered_path_was_replaced_by_a_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let replaced = dir.path().join("was-a-repo");
+        std::fs::create_dir(&replaced).expect("mkdir");
+        let key = replaced.to_str().expect("utf8 path").to_string();
+
+        let mut state = RepoState::default();
+        state.repos.insert(
+            key.clone(),
+            RepoRecord {
+                name: "was-a-repo".to_string(),
+            },
+        );
+        state.last_focused = Some(key);
+
+        // The directory is removed and replaced with a plain file of the same name - the path
+        // still `exists()`, but is no longer a real, usable repo checkout.
+        std::fs::remove_dir(&replaced).expect("rmdir");
+        std::fs::write(&replaced, "not a repo").expect("write");
+        assert!(replaced.exists(), "sanity check: the path still exists");
+        assert!(
+            !replaced.is_dir(),
+            "sanity check: it is a file now, not a directory"
+        );
+
+        assert_eq!(
+            state.last_focused_existing_path(),
+            None,
+            "a remembered path replaced by a plain file must fall back to empty, not be treated \
+             as a still-usable repo"
+        );
+    }
+
+    #[test]
+    fn last_focused_existing_path_resolves_a_real_known_and_still_existing_repo() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key = dir.path().to_str().expect("utf8 path").to_string();
+
+        let mut state = RepoState::default();
+        state.repos.insert(
+            key.clone(),
+            RepoRecord {
+                name: "repo".to_string(),
+            },
+        );
+        state.last_focused = Some(key);
+
+        assert_eq!(
+            state.last_focused_existing_path(),
+            Some(dir.path().to_path_buf())
+        );
+    }
+
+    /// [`RepoState::save_merged_at`] must persist `last_focused` too, not just `repos` - the
+    /// real mechanism GitHub issue #90's "remembers the last-opened folder" needs.
+    #[test]
+    fn save_merged_at_persists_last_focused() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("repos.toml");
+        let owned: std::collections::BTreeSet<String> =
+            ["/repo/a".to_string()].into_iter().collect();
+
+        let mut state = RepoState::default();
+        state.repos.insert(
+            "/repo/a".to_string(),
+            RepoRecord {
+                name: "a".to_string(),
+            },
+        );
+        state.last_focused = Some("/repo/a".to_string());
+        state.save_merged_at(&path, &owned).expect("save");
+
+        let reloaded = RepoState::load_at(&path);
+        assert_eq!(reloaded.last_focused, Some("/repo/a".to_string()));
+    }
+
+    /// `last_focused` is a real, single global value - a later save from the same instance with
+    /// a genuine new focus must overwrite whatever the previous save left, even across two
+    /// separate `save_merged_at` calls simulating two real `AdeApp::focus_repo` calls.
+    #[test]
+    fn save_merged_at_overwrites_a_previous_last_focused_with_a_newer_one() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("repos.toml");
+        let owned: std::collections::BTreeSet<String> =
+            ["/repo/a".to_string(), "/repo/b".to_string()]
+                .into_iter()
+                .collect();
+
+        let mut state = RepoState::default();
+        state.repos.insert(
+            "/repo/a".to_string(),
+            RepoRecord {
+                name: "a".to_string(),
+            },
+        );
+        state.repos.insert(
+            "/repo/b".to_string(),
+            RepoRecord {
+                name: "b".to_string(),
+            },
+        );
+        state.last_focused = Some("/repo/a".to_string());
+        state.save_merged_at(&path, &owned).expect("save a focused");
+        assert_eq!(
+            RepoState::load_at(&path).last_focused,
+            Some("/repo/a".to_string())
+        );
+
+        state.last_focused = Some("/repo/b".to_string());
+        state.save_merged_at(&path, &owned).expect("save b focused");
+        assert_eq!(
+            RepoState::load_at(&path).last_focused,
+            Some("/repo/b".to_string()),
+            "focusing repo B afterwards must really overwrite the previously persisted repo A"
         );
     }
 }

--- a/crates/app/src/root/focus.rs
+++ b/crates/app/src/root/focus.rs
@@ -199,7 +199,8 @@ pub(crate) mod palette_focus_tests {
     ) -> (Entity<AdeApp>, &mut gpui::VisualTestContext) {
         cx.add_window_view(|window, cx| {
             AdeApp::new_with_settings(
-                repo_path,
+                Some(repo_path),
+                true,
                 settings_store::Settings::default(),
                 None,
                 window,

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -851,6 +851,12 @@ pub struct AdeApp {
     /// focusing *it* keeps the focused `FocusId` genuinely findable in the next rendered frame -
     /// the actual invariant the fallback exists to protect - without claiming to be a text widget.
     pub(crate) rail_focus_handle: FocusHandle,
+    /// GitHub issue #90's empty-state view's own focus target (`Self::render_empty_state`) - the
+    /// same "focus something real rather than leave `Window::focus == None`" discipline
+    /// [`Self::rail_focus_handle`]'s own docs give, applied to a window with no repo focused at
+    /// all, where the rail (and everything else `render_workspace_body` renders) isn't part of
+    /// the tree in the first place.
+    pub(crate) empty_state_focus_handle: FocusHandle,
     /// Real `+N -M`/has-changes totals per worktree or agent cwd, refreshed by the
     /// periodic background task started in `Self::new` - see `crate::rail::state::
     /// compute_status_snapshot`'s docs. Read (never written outside that task's completion
@@ -1460,6 +1466,11 @@ pub struct AdeApp {
     /// (`Self::start_choose_icon_pack_folder`) - a single slot, matching
     /// [`Self::_custom_theme_import_task`]'s own one-dialog-at-a-time reasoning.
     pub(crate) _icon_pack_choose_task: Option<Task<()>>,
+    /// The in-flight "Open Folder…" real native directory-picker task (GitHub issue #90,
+    /// `Self::start_choose_repo_folder`, wired to the File menu's own row -
+    /// `crate::title_bar::menu::AdeApp::file_menu_rows`) - a single slot, matching
+    /// [`Self::_icon_pack_choose_task`]'s own one-dialog-at-a-time reasoning.
+    pub(crate) _repo_folder_choose_task: Option<Task<()>>,
 }
 
 impl AdeApp {
@@ -1675,16 +1686,23 @@ impl AdeApp {
             .and_then(|id| self.repos.iter().find(|repo| repo.id == id))
     }
 
-    /// [`Self::focused_repo`]'s path, falling back to [`Self::repos`]' first entry (defensive,
-    /// should [`Self::focused_repo`] ever point at an id no longer in the list) and finally to an
-    /// empty path when [`Self::repos`] itself is empty - not reachable today (every real startup
-    /// path, [`Self::new_with_settings`], always adds and focuses one repo first, and this phase
-    /// has no way to remove one afterward), but an honest fallback rather than a panic if that
-    /// ever changes.
+    /// [`Self::focused_repo`]'s path, or an empty [`PathBuf`] when nothing is focused at all
+    /// (GitHub issue #90's genuinely empty window, or a stale [`Self::focused_repo`] id no longer
+    /// in [`Self::repos`] - defensive, not reachable through any real mutator today).
+    ///
+    /// Deliberately **not** `self.repos.first()` - an independent audit found this exact fallback
+    /// was a real, reachable bug: [`Self::repos`] is populated from the *whole* persisted
+    /// `repos.toml` (every repo this user has ever opened, in any window), not just the one this
+    /// window has focused, so falling back to its first entry could silently resolve to a
+    /// completely different, unopened repo's real path - and every real repo-scoped operation
+    /// this app has (spawning an agent, committing, discarding a worktree) reads its target
+    /// through this method or [`Self::active_agent_cwd`]. Every call site that can run with no
+    /// repo focused must check [`Self::focused_repo`]/[`Self::focused_repo_path`]'s emptiness
+    /// itself instead - see [`crate::work_surface::render::AdeApp::new_agent`]'s own docs for the
+    /// concrete exploit this was found through and the real guard that closes it.
     pub(crate) fn focused_repo_path(&self) -> PathBuf {
         self.focused_repo()
             .map(|repo| repo.path.clone())
-            .or_else(|| self.repos.first().map(|repo| repo.path.clone()))
             .unwrap_or_default()
     }
 
@@ -1730,10 +1748,147 @@ impl AdeApp {
     /// which *repo* is focused doesn't yet reload anything (the file tree/diff/agents are still
     /// single-repo-scoped fields this phase doesn't rewire - see [`Self::worktrees`]'s own docs),
     /// so there is nothing to kick off here beyond the assignment itself.
-    pub(crate) fn focus_repo(&mut self, id: RepoId) {
+    ///
+    /// GitHub issue #90: also persists this as [`repo::RepoState::last_focused`] (via
+    /// [`Self::persist_repo_state`], the same real writer [`Self::add_repo`] already calls) - "the
+    /// app remembers the last-opened folder and reopens it automatically next launch" needs every
+    /// real focus change recorded, not just the one a fresh repo's own `add_repo` call happens to
+    /// trigger. A no-op call (unknown `id`) persists nothing new, since [`Self::focused_repo`]
+    /// never actually changed.
+    pub(crate) fn focus_repo(&mut self, id: RepoId, cx: &mut Context<Self>) {
         if self.repos.iter().any(|repo| repo.id == id) {
             self.focused_repo = Some(id);
+            self.persist_repo_state(cx);
         }
+    }
+
+    /// GitHub issue #90's "Open Folder…" (`crate::title_bar::menu`'s File-menu row) and the
+    /// empty-state view's own "Open Folder" button (`Self::render_empty_state`) both funnel
+    /// through here: `path` becomes a real, focused repo in the *current* window, and every
+    /// single-repo-scoped piece of state this app still has is reset/reloaded against it via
+    /// [`Self::reset_repo_scoped_state`] (the exact same reset [`Self::select_worktree`] applies
+    /// on every worktree switch, extracted so this real "switch to an entirely different repo"
+    /// gesture can share it rather than reimplementing a partial copy) - unlike plain
+    /// [`Self::add_repo`] + [`Self::focus_repo`] alone, which (per their own docs) don't reload
+    /// anything, since until now the only place that combination ran was startup, where the
+    /// caller went on to do the reload itself right afterwards ([`Self::new_with_settings`]).
+    ///
+    /// An independent audit of this method's first version found (and this now fixes) three real
+    /// gaps beyond the incomplete state reset above:
+    /// - it never (re)started [`Self::start_worktree_watch`]/[`Self::start_status_polling`] - a
+    ///   window that starts empty and only later opens a folder never got rail status polling at
+    ///   all, and a window switching from repo A to repo B kept its watcher bound to A's path.
+    ///   Both are safe to call unconditionally here: assigning a fresh `Task`/watcher to their own
+    ///   field drops (and so cancels) whatever was previously running there, so this can never
+    ///   leave two loops running at once.
+    /// - a genuinely empty window's Settings/palette overlay may have captured
+    ///   [`Self::empty_state_focus_handle`] as its own "return focus to" target
+    ///   ([`OverlayFocus::capture`]) - once a real repo is focused, [`Self::render_empty_state`]
+    ///   stops being part of the rendered tree at all, so restoring focus to it later would
+    ///   silently dangle every global keybinding. [`OverlayFocus::forget_target`] is this
+    ///   project's own established fix for exactly this class of bug (see its own docs).
+    /// - every agent open before this call belonged to whatever repo (or the empty state) was
+    ///   focused *before* it - this app's worktree list/tab-strip filtering is still single-
+    ///   repo-scoped (see [`Self::repos`]' own docs: nothing yet renders more than the focused
+    ///   repo's own worktrees), so once focus moves to `path` none of them can be reached through
+    ///   this window's UI ever again. A deliberate choice, not an accidental process leak: shut
+    ///   every one of them down cleanly via the same real PTY teardown [`Self::close_agent`]
+    ///   always uses, rather than leaving their processes running invisibly until the whole
+    ///   window closes. Skipped entirely when `path` resolves to the repo *already* focused (a
+    ///   plain re-affirmation, not a real switch) - closing and immediately not respawning that
+    ///   exact repo's own agents would be a real, surprising regression for that case.
+    ///
+    /// Idempotent against a repo already known to this window (re-opening an already-added repo
+    /// just re-focuses and reloads it, rather than duplicating anything) - the same
+    /// [`Self::add_repo`] guarantee this builds on. A repo with no agent open yet in its own root
+    /// (a genuinely new repo, or one added but never focused before - by construction, always the
+    /// case whenever `path` differs from what was focused before, now that stale agents are
+    /// closed above) gets one spawned here, the same "a fresh window starts with one shell in the
+    /// repo root" default [`Self::new_with_settings`] gives a CLI-launched repo.
+    pub(crate) fn open_repo_in_current_window(
+        &mut self,
+        path: PathBuf,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let previously_focused_id = self.focused_repo().map(|repo| repo.id);
+        let id = self.add_repo(path.clone(), cx);
+        let switching_repos = previously_focused_id != Some(id);
+        self.focus_repo(id, cx);
+
+        self.settings_focus
+            .forget_target(&self.empty_state_focus_handle);
+        self.palette_focus
+            .forget_target(&self.empty_state_focus_handle);
+
+        if switching_repos {
+            let stale_ids: Vec<AgentId> = self.agents.iter().map(|agent| agent.id).collect();
+            for stale_id in stale_ids {
+                self.close_agent(stale_id, window, cx);
+            }
+        }
+
+        if self.agents.iter_for_cwd(path.clone()).next().is_none() {
+            self.agents.spawn(
+                AgentKind::Shell,
+                path.clone(),
+                self.settings.appearance.terminal_font_size,
+                window,
+                cx,
+            );
+        }
+        self.agents.activate_for_worktree(&path, cx);
+        self.selected = None;
+        self.worktree_selection_notice = None;
+        self.reset_repo_scoped_state(path, window, cx);
+        self.load_worktrees(cx);
+        self.start_worktree_watch(cx);
+        self.start_status_polling(cx);
+    }
+
+    /// GitHub issue #90's real, native "Open Folder…" picker - `gpui::App::prompt_for_paths`
+    /// (`directories: true`), the identical real API `crate::settings::render::AdeApp::
+    /// start_choose_icon_pack_folder` already uses for the same reason (a native OS directory
+    /// dialog, not an in-app fake one). On a real chosen directory, hands it to
+    /// [`Self::open_repo_in_current_window`] - via `this.update_in`, not a plain `this.update`,
+    /// since that reload needs a real `&mut Window` (moving keyboard focus onto whatever agent
+    /// ends up active) that a background task resuming after this dialog's own `.await` doesn't
+    /// otherwise have.
+    pub(crate) fn start_choose_repo_folder(&mut self, cx: &mut Context<Self>) {
+        // Guards against a real, reachable re-entry bug an independent audit found: a second
+        // click (the File menu's own row, or the empty-state view's button) while a real native
+        // picker from the *first* click is still open would otherwise replace
+        // `_repo_folder_choose_task`, dropping (and so cancelling, per GPUI's "dropping a `Task`
+        // cancels it" semantics - `crate::work_surface::agents::Agents::spawn`'s own docs use the
+        // identical reasoning) the first click's still-pending picker task out from under the
+        // dialog the user is actually looking at. A no-op second click here is the honest fix -
+        // exactly one native "Open" dialog can be in flight from this app at a time. The spawned
+        // task below clears this same field back to `None` the instant the dialog resolves
+        // (whichever way), so this guard only ever blocks a real second click while one is
+        // genuinely still open - never every click after the first.
+        if self._repo_folder_choose_task.is_some() {
+            return;
+        }
+        let paths_receiver = cx.prompt_for_paths(gpui::PathPromptOptions {
+            files: false,
+            directories: true,
+            multiple: false,
+            prompt: Some("Open".into()),
+        });
+        let task = cx.spawn(async move |this, cx| {
+            let result = paths_receiver.await;
+            let _ = this.update_in(cx, |this, window, cx| {
+                this._repo_folder_choose_task = None;
+                let Ok(Ok(Some(mut paths))) = result else {
+                    return;
+                };
+                let Some(path) = paths.pop() else {
+                    return;
+                };
+                this.open_repo_in_current_window(path, window, cx);
+            });
+        });
+        self._repo_folder_choose_task = Some(task);
     }
 
     /// [`Self::repos`], reduced to the on-disk shape [`repo::RepoState::save_merged_at`] expects -
@@ -1752,6 +1907,12 @@ impl AdeApp {
                 );
             }
         }
+        // GitHub issue #90: the real "last opened folder" this instance currently believes -
+        // `None` only when nothing is focused at all (a genuinely empty window that has never
+        // opened a repo, e.g. from `crate::title_bar::menu`'s "New Window" row), which
+        // `RepoState::save_merged_at`'s own docs already explain is deliberately never persisted
+        // over another process's real remembered value.
+        state.last_focused = self.focused_repo().and_then(|r| repo::repo_key(&r.path));
         state
     }
 
@@ -1852,6 +2013,16 @@ impl Render for AdeApp {
             // `settings_open`.
             .child(if self.settings_open {
                 self.render_settings(cx).into_any_element()
+            } else if self.focused_repo().is_none() {
+                // GitHub issue #90: a genuinely empty window (no CLI argument, nothing ever
+                // persisted/remembered, or `crate::title_bar::menu`'s own "New Window" row) - see
+                // `Self::render_empty_state`'s own docs. Checked before `render_workspace_body`
+                // because that method (and everything it renders - the rail, tab strip, file
+                // tree) assumes a real focused repo throughout; this is deliberately *not*
+                // `self.repos.is_empty()`, since a "New Window" can genuinely have known-but-
+                // unfocused repos in that list (loaded from the same persisted `repos.toml`
+                // every window in this process shares) while still wanting its own empty view.
+                self.render_empty_state(cx).into_any_element()
             } else {
                 self.render_workspace_body(cx).into_any_element()
             })
@@ -2008,6 +2179,67 @@ impl AdeApp {
                     .child(self.render_resize_handle(ResizeTarget::Panel, cx)),
             )
     }
+
+    /// GitHub issue #90's genuinely empty state - rendered by [`Render::render`] in place of
+    /// [`Self::render_workspace_body`] whenever [`Self::focused_repo`] is `None`: a fresh launch
+    /// with no CLI argument and nothing ever persisted (or a remembered folder that no longer
+    /// exists), or a brand-new window opened via `crate::title_bar::menu`'s "New Window" row.
+    ///
+    /// Deliberately minimal - a centered message plus one real, working affordance - rather than
+    /// an inert placeholder: the "Open Folder…" button below calls the exact same
+    /// [`Self::start_choose_repo_folder`] real native-picker flow the File menu's own "Open
+    /// Folder…" row does (`crate::title_bar::menu::AdeApp::file_menu_rows`), so a user landing
+    /// here has a genuine way out of the empty state without needing to already know about the
+    /// title bar. The title bar and status bar stay real, unconditional siblings around this (see
+    /// [`Render::render`]'s own docs), so Settings/File-menu/Quit are all still reachable from
+    /// here exactly as they are from the normal workspace view.
+    ///
+    /// `track_focus`es [`Self::empty_state_focus_handle`] - the same "never leave `Window::focus`
+    /// dangling" reasoning [`Self::rail_focus_handle`]'s own docs give, applied to a window whose
+    /// rendered tree has no rail/tab-strip/file-tree at all to fall back onto instead.
+    fn render_empty_state(&mut self, cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .id("empty-state")
+            .track_focus(&self.empty_state_focus_handle)
+            .flex()
+            .flex_col()
+            .flex_1()
+            .min_h_0()
+            .size_full()
+            .items_center()
+            .justify_center()
+            .gap(px(10.0))
+            .bg(theme::surface::WINDOW)
+            .child(
+                div()
+                    .font(font(theme::font::SANS))
+                    .font_weight(gpui::FontWeight::MEDIUM)
+                    .text_size(px(14.0))
+                    .text_color(theme::text::STRONG)
+                    .child("No folder open"),
+            )
+            .child(
+                div()
+                    .font(font(theme::font::SANS))
+                    .text_size(px(11.0))
+                    .text_color(theme::text::DIM)
+                    .child("Open a folder to browse its files, worktrees, and agents."),
+            )
+            .child(
+                div().pt(px(6.0)).child(
+                    widgets::render_modal_button(
+                        "empty-state-open-folder",
+                        "Open Folder\u{2026}",
+                        false,
+                    )
+                    .on_click(cx.listener(
+                        |this, _event: &ClickEvent, _window, cx| {
+                            this.start_choose_repo_folder(cx);
+                        },
+                    )),
+                ),
+            )
+    }
 }
 
 /// The real "where to restore keyboard focus to once this overlay closes, and whether that
@@ -2143,7 +2375,8 @@ mod settings_persist_tests {
     ) -> (gpui::Entity<AdeApp>, &mut gpui::VisualTestContext) {
         cx.add_window_view(|window, cx| {
             AdeApp::new_with_settings(
-                repo_path,
+                Some(repo_path),
+                true,
                 settings_store::Settings::default(),
                 Some(settings_path),
                 window,
@@ -2304,7 +2537,8 @@ mod repo_list_tests {
     ) -> (gpui::Entity<AdeApp>, &mut gpui::VisualTestContext) {
         cx.add_window_view(|window, cx| {
             AdeApp::new_with_settings(
-                repo_path,
+                Some(repo_path),
+                true,
                 settings_store::Settings::default(),
                 Some(settings_path),
                 window,
@@ -2384,7 +2618,7 @@ mod repo_list_tests {
         let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
 
         let repo_b_id = app.update(cx, |app, cx| app.add_repo(repo_b.path().to_path_buf(), cx));
-        app.update(cx, |app, _cx| app.focus_repo(repo_b_id));
+        app.update(cx, |app, cx| app.focus_repo(repo_b_id, cx));
 
         app.read_with(cx, |app, _| {
             assert_eq!(app.focused_repo_path(), repo_b.path());
@@ -2400,7 +2634,7 @@ mod repo_list_tests {
         let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
         let focused_before = app.read_with(cx, |app, _| app.focused_repo_path());
 
-        app.update(cx, |app, _cx| app.focus_repo(RepoId(u64::MAX)));
+        app.update(cx, |app, cx| app.focus_repo(RepoId(u64::MAX), cx));
 
         app.read_with(cx, |app, _| {
             assert_eq!(app.focused_repo_path(), focused_before);
@@ -2487,6 +2721,544 @@ mod repo_list_tests {
             "this instance's own save must not have erased the other instance's already-\
              persisted repo"
         );
+    }
+
+    /// GitHub issue #90: a window with no CLI argument (`repo_path: None`) that is allowed to
+    /// consult persisted state (`use_remembered_repo: true` - the real process-launch case) and
+    /// a fresh settings directory - nothing has ever been persisted - opens in a genuinely empty
+    /// state: no repo focused, and none of the single-repo-scoped startup work
+    /// (`Self::new_with_settings`'s own docs) ran at all.
+    #[gpui::test]
+    fn no_cli_arg_and_nothing_persisted_is_a_genuinely_empty_window(cx: &mut TestAppContext) {
+        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+
+        let (app, _cx) = cx.add_window_view(|window, cx| {
+            AdeApp::new_with_settings(
+                None,
+                true,
+                settings_store::Settings::default(),
+                Some(settings_path),
+                window,
+                cx,
+            )
+        });
+
+        app.read_with(_cx, |app, _| {
+            assert!(app.repos.is_empty(), "nothing was ever added or persisted");
+            assert_eq!(app.focused_repo(), None);
+            assert!(
+                app.agents.is_empty(),
+                "a genuinely empty window must not spawn an initial shell agent - there is no \
+                 repo root to spawn one into"
+            );
+        });
+    }
+
+    /// GitHub issue #90's own headline behaviour: focusing a repo (via [`AdeApp::focus_repo`])
+    /// persists it as [`RepoState::last_focused`], and a *second*, independently-constructed
+    /// `AdeApp` sharing the same real settings path, given `repo_path: None,
+    /// use_remembered_repo: true` (the real process-launch path with no CLI argument), reopens
+    /// that exact repo automatically - "the app remembers the last-opened folder and reopens it
+    /// automatically next launch".
+    #[gpui::test]
+    fn a_fresh_launch_with_no_cli_arg_reopens_the_remembered_last_focused_repo(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+
+        // "Launch 1": a real CLI-argument launch against `repo`, which focuses (and so persists)
+        // it.
+        let (_first, cx) = open_test_app_with_real_settings_path(
+            cx,
+            repo.path().to_path_buf(),
+            settings_path.clone(),
+        );
+        cx.run_until_parked();
+
+        // "Launch 2": an independent `AdeApp`, sharing the same real settings path, with no CLI
+        // argument at all.
+        let (second, cx) = cx.add_window_view(|window, cx| {
+            AdeApp::new_with_settings(
+                None,
+                true,
+                settings_store::Settings::default(),
+                Some(settings_path),
+                window,
+                cx,
+            )
+        });
+        cx.run_until_parked();
+
+        second.read_with(cx, |app, _| {
+            assert_eq!(
+                app.focused_repo_path(),
+                repo.path(),
+                "the second launch must have reopened the first launch's own remembered repo"
+            );
+            assert_eq!(app.repos.len(), 1);
+            assert!(
+                !app.agents.is_empty(),
+                "a real, reopened repo must get its usual initial shell agent, exactly like a \
+                 real CLI-argument launch does"
+            );
+        });
+    }
+
+    /// The other half of "remembers the last-opened folder": a remembered repo whose directory
+    /// has since been deleted or moved must fall back to a genuinely empty window, not a broken
+    /// or crashing one.
+    #[gpui::test]
+    fn a_remembered_repo_that_no_longer_exists_falls_back_to_a_genuinely_empty_window(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let repo_path = repo.path().to_path_buf();
+        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+
+        let (_first, cx) =
+            open_test_app_with_real_settings_path(cx, repo_path.clone(), settings_path.clone());
+        cx.run_until_parked();
+
+        // The remembered repo's own directory is now gone.
+        drop(repo);
+        assert!(!repo_path.exists());
+
+        let (second, cx) = cx.add_window_view(|window, cx| {
+            AdeApp::new_with_settings(
+                None,
+                true,
+                settings_store::Settings::default(),
+                Some(settings_path),
+                window,
+                cx,
+            )
+        });
+        cx.run_until_parked();
+
+        second.read_with(cx, |app, _| {
+            assert_eq!(
+                app.focused_repo(),
+                None,
+                "a deleted/moved remembered repo must never be focused"
+            );
+            assert!(app.agents.is_empty());
+        });
+    }
+
+    /// GitHub issue #90's "New Window" semantics: `use_remembered_repo: false` (what
+    /// `crate::title_bar::menu`'s "New Window" row passes) must open a genuinely empty window
+    /// even when a real, still-existing last-focused repo *is* on record - unlike the real
+    /// process-launch path (`use_remembered_repo: true`, proven by
+    /// [`a_fresh_launch_with_no_cli_arg_reopens_the_remembered_last_focused_repo`] above), which
+    /// would reopen this exact repo.
+    #[gpui::test]
+    fn use_remembered_repo_false_stays_empty_even_with_a_real_remembered_repo(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+
+        let (_first, cx) = open_test_app_with_real_settings_path(
+            cx,
+            repo.path().to_path_buf(),
+            settings_path.clone(),
+        );
+        cx.run_until_parked();
+
+        let (second, cx) = cx.add_window_view(|window, cx| {
+            AdeApp::new_with_settings(
+                None,
+                false,
+                settings_store::Settings::default(),
+                Some(settings_path),
+                window,
+                cx,
+            )
+        });
+        cx.run_until_parked();
+
+        second.read_with(cx, |app, _| {
+            assert_eq!(
+                app.focused_repo(),
+                None,
+                "a 'New Window' must open empty regardless of what's remembered"
+            );
+            assert!(app.agents.is_empty());
+        });
+    }
+
+    /// [`AdeApp::open_repo_in_current_window`] - the shared real flow behind both the File menu's
+    /// "Open Folder…" row and the empty-state view's own button - genuinely focuses the chosen
+    /// repo in an already-running, previously-empty window and reloads its worktrees/file tree/
+    /// diff/initial agent, mirroring what a real CLI-argument launch does.
+    #[gpui::test]
+    fn open_repo_in_current_window_focuses_and_reloads_a_real_repo_from_empty(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        std::fs::write(repo.path().join("a.txt"), "hello\n").expect("write");
+        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+
+        let (app, cx) = cx.add_window_view(|window, cx| {
+            AdeApp::new_with_settings(
+                None,
+                true,
+                settings_store::Settings::default(),
+                Some(settings_path),
+                window,
+                cx,
+            )
+        });
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.focused_repo(), None, "sanity check: starts empty");
+        });
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_repo_in_current_window(repo.path().to_path_buf(), window, cx);
+        });
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.focused_repo_path(), repo.path());
+            assert!(
+                !app.agents.is_empty(),
+                "opening a folder must spawn a real initial shell agent for it"
+            );
+            assert!(
+                !app.file_tree.is_empty(),
+                "opening a folder must really load its file tree"
+            );
+        });
+    }
+
+    /// Critical fix (independent audit): `Self::open_repo_in_current_window` used to only reset
+    /// four fields (`staged_files`/`open_change`/`expanded_dirs`/`selected_tree_path`), leaving
+    /// every other per-repo UI control - a tree error banner, the commit composer popover, an
+    /// armed prune confirmation, and more - still armed against the *old* repo after switching to
+    /// a new one. `Self::reset_repo_scoped_state` (shared with `Self::select_worktree`) now
+    /// covers all of it; this proves a representative sample of the fields the original version
+    /// missed are really cleared by a real Open Folder switch, not just the original four.
+    #[gpui::test]
+    fn open_repo_in_current_window_clears_stale_ui_state_from_the_previous_repo(
+        cx: &mut TestAppContext,
+    ) {
+        let repo_a = tempfile::tempdir().expect("tempdir");
+        let repo_b = tempfile::tempdir().expect("tempdir");
+        std::fs::write(repo_b.path().join("y.txt"), "b\n").expect("write");
+
+        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        cx.run_until_parked();
+
+        // Arm several pieces of real per-repo UI state against repo A - the same kinds of state
+        // `Self::select_worktree` already resets on every worktree switch (GitHub issues #12/#19),
+        // which the original `open_repo_in_current_window` did not.
+        app.update(cx, |app, cx| {
+            app.tree_op_error = Some("stale tree error from repo A".to_string());
+            app.commit_menu_open = true;
+            app.prune_confirm_armed = true;
+            cx.notify();
+        });
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_repo_in_current_window(repo_b.path().to_path_buf(), window, cx);
+        });
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.focused_repo_path(), repo_b.path());
+            assert_eq!(
+                app.tree_op_error, None,
+                "opening a different folder must clear a stale tree error from the old repo"
+            );
+            assert!(
+                !app.commit_menu_open,
+                "the old repo's commit composer popover must not stay open"
+            );
+            assert!(
+                !app.prune_confirm_armed,
+                "an armed prune confirmation from the old repo must not survive the switch"
+            );
+        });
+    }
+
+    fn git(dir: &std::path::Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .output()
+            .expect("failed to spawn git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
+            args,
+            dir,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    /// Critical fix (independent audit): the original `open_repo_in_current_window` never
+    /// (re)started the real status-polling loop or the worktree filesystem watcher - a window
+    /// that starts empty and only later opens a folder never got either at all. `repo` is a real
+    /// `git init`-ed directory, not a bare `tempfile::tempdir()`: `spawn_worktree_watcher` returns
+    /// `None` for a path that isn't inside a real git repository at all
+    /// (`wt_core::git_common_dir` failing), so a bare tempdir would make this test pass "by
+    /// accident" - `_worktree_watcher` would read `None` regardless of whether the real fix ever
+    /// ran, proving nothing about the watcher half of the fix.
+    #[gpui::test]
+    fn open_repo_in_current_window_starts_status_polling_and_worktree_watch(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        git(repo.path(), &["init", "-b", "main"]);
+        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+
+        let (app, cx) = cx.add_window_view(|window, cx| {
+            AdeApp::new_with_settings(
+                None,
+                true,
+                settings_store::Settings::default(),
+                Some(settings_path),
+                window,
+                cx,
+            )
+        });
+        app.read_with(cx, |app, _| {
+            assert!(
+                app._status_poll_task.is_none(),
+                "sanity check: a genuinely empty window never starts real status polling"
+            );
+            assert!(
+                app._worktree_watch_task.is_none(),
+                "sanity check: a genuinely empty window never starts the real worktree watcher"
+            );
+            assert!(app._worktree_watcher.is_none());
+        });
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_repo_in_current_window(repo.path().to_path_buf(), window, cx);
+        });
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert!(
+                app._status_poll_task.is_some(),
+                "opening a folder must start real status polling"
+            );
+            assert!(
+                app._worktree_watch_task.is_some(),
+                "opening a folder must start the real worktree watcher's own poll-fallback loop"
+            );
+            assert!(
+                app._worktree_watcher.is_some(),
+                "opening a real git repo must really start a real OS-level filesystem watcher \
+                 for it, not just the poll-fallback loop"
+            );
+        });
+    }
+
+    /// The other real half of Critical fix 2: a window switching from one real repo to another
+    /// must *rebind* the watcher to the new path, not leave it silently still watching the old
+    /// one. Proven by making the second repo a bare, non-git directory:
+    /// `spawn_worktree_watcher` can only ever return `None` for it
+    /// (`wt_core::git_common_dir` fails for a non-repository path) - so `_worktree_watcher`
+    /// reading `None` after the switch is genuine proof `Self::start_worktree_watch` really ran
+    /// again with repo B's own path, not proof of nothing (a stale watcher still pointed at repo
+    /// A - a real git repo - would have kept this field `Some`, silently masking the bug this
+    /// test exists to catch).
+    #[gpui::test]
+    fn open_repo_in_current_window_rebinds_the_worktree_watcher_to_the_new_repo(
+        cx: &mut TestAppContext,
+    ) {
+        let repo_a = tempfile::tempdir().expect("tempdir");
+        git(repo_a.path(), &["init", "-b", "main"]);
+        let repo_b = tempfile::tempdir().expect("tempdir");
+
+        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| {
+            assert!(
+                app._worktree_watcher.is_some(),
+                "sanity check: repo A is a real git repo, so startup should have gotten a real \
+                 watcher for it"
+            );
+        });
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_repo_in_current_window(repo_b.path().to_path_buf(), window, cx);
+        });
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert!(
+                app._worktree_watcher.is_none(),
+                "switching to repo B (not a real git repository) must really rebind the watcher \
+                 to B's own path and get a real None back for it - a stale watcher left over \
+                 from repo A would still read Some here"
+            );
+        });
+    }
+
+    /// Critical fix (independent audit): switching folders used to leave the previous repo's real
+    /// agent processes running but permanently unreachable through this window's own UI (this
+    /// app's worktree list/tab strip are still single-repo-scoped - see `Self::repos`' own docs).
+    /// A deliberate choice, not an accidental leak: `Self::open_repo_in_current_window` now shuts
+    /// every one of them down cleanly via the same real PTY teardown `Self::close_agent` always
+    /// uses.
+    #[gpui::test]
+    fn open_repo_in_current_window_closes_the_previous_repos_agents(cx: &mut TestAppContext) {
+        let repo_a = tempfile::tempdir().expect("tempdir");
+        let repo_b = tempfile::tempdir().expect("tempdir");
+
+        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.agents.iter().count(),
+                1,
+                "sanity check: repo A's own initial shell agent"
+            );
+        });
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_repo_in_current_window(repo_b.path().to_path_buf(), window, cx);
+        });
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.agents
+                    .iter()
+                    .filter(|agent| agent.cwd == repo_a.path())
+                    .count(),
+                0,
+                "repo A's own agent must have really been closed, not merely hidden from the UI"
+            );
+            assert_eq!(
+                app.agents.iter().count(),
+                1,
+                "repo B should have exactly its own fresh initial shell agent"
+            );
+        });
+    }
+
+    /// Critical fix (independent audit): a genuinely empty window's Settings overlay can capture
+    /// [`AdeApp::empty_state_focus_handle`] as its own "return focus to" target
+    /// ([`OverlayFocus::capture`]) - once a real repo is focused, `Self::render_empty_state` stops
+    /// being part of the rendered tree at all, so restoring focus there later would silently
+    /// dangle every global keybinding. `Self::open_repo_in_current_window` must forget that target
+    /// ([`OverlayFocus::forget_target`]) before Settings closes.
+    #[gpui::test]
+    fn open_repo_in_current_window_forgets_a_dangling_empty_state_focus_target(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+
+        let (app, cx) = cx.add_window_view(|window, cx| {
+            AdeApp::new_with_settings(
+                None,
+                true,
+                settings_store::Settings::default(),
+                Some(settings_path),
+                window,
+                cx,
+            )
+        });
+
+        let empty_state_handle = app.read_with(cx, |app, _| app.empty_state_focus_handle.clone());
+        app.update_in(cx, |app, window, cx| {
+            window.focus(&empty_state_handle, cx);
+            app.open_settings(window, cx);
+        });
+        cx.run_until_parked();
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_repo_in_current_window(repo.path().to_path_buf(), window, cx);
+        });
+        cx.run_until_parked();
+
+        app.update_in(cx, |app, window, cx| {
+            app.close_settings(window, cx);
+        });
+        cx.run_until_parked();
+
+        let focused = app.update_in(cx, |_app, window, cx| window.focused(cx));
+        assert_ne!(
+            focused.as_ref(),
+            Some(&empty_state_handle),
+            "closing Settings must never restore focus onto the no-longer-rendered empty-state \
+             handle"
+        );
+    }
+
+    /// Critical fix (independent audit): a genuinely empty window has no real repo root to spawn
+    /// a new agent into - `Self::focused_repo_path`'s own `Self::repos.first()` fallback (removed)
+    /// used to let `Self::active_agent_cwd` silently resolve to some *other*, unopened repo's real
+    /// path, so `secondary-n`/`ctrl-shift-T`'s own handlers could spawn a real, invisible PTY
+    /// there. `Self::new_agent`/`Self::new_agent_pane` now refuse outright with no focused repo -
+    /// this proves both real entry points genuinely spawn nothing.
+    #[gpui::test]
+    fn new_agent_and_new_agent_pane_are_no_ops_with_no_focused_repo(cx: &mut TestAppContext) {
+        let other_repo = tempfile::tempdir().expect("tempdir");
+        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+
+        // A real *other* repo is known to this process (persisted from a previous focus) - the
+        // exact precondition the audit's concrete exploit needed (`Self::repos` non-empty while
+        // this window's own `Self::focused_repo` is `None`).
+        let repo_state_path = repo::repo_state_path_for(&settings_path);
+        let mut seed = RepoState::default();
+        let canonical = repo::repo_key(other_repo.path()).expect("repo key");
+        seed.repos.insert(
+            canonical,
+            crate::rail::repo::RepoRecord {
+                name: "other-repo".to_string(),
+            },
+        );
+        seed.save_at(&repo_state_path).expect("seed save");
+
+        let (app, cx) = cx.add_window_view(|window, cx| {
+            AdeApp::new_with_settings(
+                None,
+                true,
+                settings_store::Settings::default(),
+                Some(settings_path),
+                window,
+                cx,
+            )
+        });
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.focused_repo(), None, "sanity check: starts empty");
+            assert!(
+                !app.repos.is_empty(),
+                "sanity check: a real other repo is known, just not focused"
+            );
+        });
+
+        app.update_in(cx, |app, window, cx| {
+            app.new_agent(AgentKind::Shell, window, cx);
+        });
+        app.update_in(cx, |app, window, cx| {
+            app.handle_new_agent_pane_action(&NewAgentPane, window, cx);
+        });
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.agents.is_empty(),
+                "neither real entry point may spawn a PTY with no repo genuinely focused, even \
+                 with an unrelated real repo known to this process"
+            );
+        });
     }
 }
 

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -7,10 +7,29 @@ impl AdeApp {
     /// and delegates to [`Self::new_with_settings`]. Blocking the foreground thread here is a
     /// deliberate exception to this codebase's usual rule: it's a single tiny file read that
     /// runs exactly once, before a window even exists, not a per-render or per-poll cost.
-    pub fn new(repo_path: PathBuf, window: &mut Window, cx: &mut Context<Self>) -> Self {
+    ///
+    /// GitHub issue #90: `repo_path` is `None` for a fresh launch with no CLI argument (there is
+    /// deliberately no `env::current_dir()` fallback anywhere upstream of this - see
+    /// `crate::main`'s own docs) or for a brand-new window opened via `crate::title_bar::menu`'s
+    /// "New Window" row. `use_remembered_repo` disambiguates those two `None` cases from each
+    /// other - see [`Self::new_with_settings`]'s own docs for exactly what it controls; `Some`
+    /// makes it irrelevant either way, since an explicit path always wins.
+    pub fn new(
+        repo_path: Option<PathBuf>,
+        use_remembered_repo: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
         let settings_path = settings_store::settings_toml_path();
         let settings = settings_store::Settings::load_or_init();
-        Self::new_with_settings(repo_path, settings, settings_path, window, cx)
+        Self::new_with_settings(
+            repo_path,
+            use_remembered_repo,
+            settings,
+            settings_path,
+            window,
+            cx,
+        )
     }
 
     /// The real constructor - takes an already-resolved [`Settings`] and its optional source
@@ -19,8 +38,35 @@ impl AdeApp {
     /// can each supply their own. Test instances get in-memory-only defaults and a `None` path,
     /// so [`Self::persist_settings`] is a genuine no-op for them, never a write to whatever
     /// machine happens to run `cargo test`.
+    ///
+    /// ## `repo_path`/`use_remembered_repo` (GitHub issue #90)
+    ///
+    /// `repo_path`:
+    /// - `Some(path)`: behaves exactly as this app always has - `path` is added and focused,
+    ///   unconditionally. `use_remembered_repo` has no effect in this case.
+    /// - `None`, `use_remembered_repo == true` (the real process-launch path, `Self::new`'s own
+    ///   `run` caller): looks at whatever [`repo::RepoState`] was just loaded into `repos` below
+    ///   for a real, still-existing last-focused repo
+    ///   ([`repo::RepoState::last_focused_existing_path`]) and focuses that one if there is one -
+    ///   "the app remembers the last-opened folder and reopens it automatically next launch". If
+    ///   there is no such repo (nothing was ever persisted, or the remembered directory has since
+    ///   been deleted/moved), the window opens in a genuinely empty state instead: no crash, no
+    ///   silent fallback to a hardcoded path, just [`Self::focused_repo`] staying `None`.
+    /// - `None`, `use_remembered_repo == false` (`crate::title_bar::menu`'s "New Window" row):
+    ///   always a genuinely empty state, even if a real last-focused repo *is* on record - the
+    ///   issue's own words are explicit that a new window opens empty, "not" whatever folder the
+    ///   window it was opened from happens to have open.
+    ///
+    /// A genuinely empty window ([`Self::focused_repo`] left `None`) skips every single-repo-
+    /// scoped piece of startup work below that would otherwise need a real path to run against -
+    /// no initial shell agent is spawned, and `Self::load_worktrees`/`load_file_tree`/`load_diff`/
+    /// `start_status_polling`/`start_worktree_watch` are never called at all. [`Render`]'s own
+    /// `AdeApp` impl (`crate::root::mod`) renders a dedicated empty-state view instead of the
+    /// three-zone workspace body whenever [`Self::focused_repo`] is `None` - see
+    /// `Self::render_empty_state`'s own docs.
     pub(crate) fn new_with_settings(
-        repo_path: PathBuf,
+        repo_path: Option<PathBuf>,
+        use_remembered_repo: bool,
         settings: settings_store::Settings,
         settings_path: Option<PathBuf>,
         window: &mut Window,
@@ -79,6 +125,20 @@ impl AdeApp {
             next_repo_id += 1;
         }
 
+        // GitHub issue #90: the one real resolution point for "what repo (if any) should this
+        // window start focused on" - see `Self::new_with_settings`'s own docs for the full
+        // decision table. An explicit `repo_path` always wins outright; otherwise, only the real
+        // process-launch path (`use_remembered_repo == true`) ever consults the just-loaded
+        // `RepoState`'s own last-focused marker, and only if it still names a real, existing
+        // directory - `RepoState::last_focused_existing_path` is the one place that "still
+        // exists" check happens, so a deleted/moved remembered folder can never surface as a
+        // broken/error startup state here, only as a genuinely empty one.
+        let resolved_repo_path: Option<PathBuf> = match repo_path {
+            Some(path) => Some(path),
+            None if use_remembered_repo => loaded_repo_state.last_focused_existing_path(),
+            None => None,
+        };
+
         // Built before the `Self` literal below (rather than inline as `cx.focus_handle()` at
         // their own field positions, as every other focus handle in this literal is) because
         // `AdeApp::wire_caret_blink` needs real, already-constructed handles to subscribe to -
@@ -118,9 +178,15 @@ impl AdeApp {
             None => (Vec::new(), Vec::new()),
         };
 
+        // A genuinely empty startup (no `resolved_repo_path`) has no real root to point these
+        // at yet - an empty `PathBuf` is an honest placeholder, never read by anything: every
+        // consumer of `file_tree_root`/`diff_root` lives inside `Self::render_workspace_body`,
+        // which `Render`'s own `AdeApp` impl never calls while `Self::focused_repo` is `None`
+        // (see `Self::render_empty_state`'s own docs).
+        let initial_root = resolved_repo_path.clone().unwrap_or_default();
         let mut this = Self {
-            file_tree_root: repo_path.clone(),
-            diff_root: repo_path.clone(),
+            file_tree_root: initial_root.clone(),
+            diff_root: initial_root,
             repos,
             // Resolved just below the literal, via `Self::add_repo`/`Self::focus_repo` - there is
             // no `self` yet at this point in construction to call them against.
@@ -239,6 +305,7 @@ impl AdeApp {
             rail_collapse_overrides: HashMap::new(),
             filter_focus_handle,
             rail_focus_handle: cx.focus_handle(),
+            empty_state_focus_handle: cx.focus_handle(),
             diff_cache: HashMap::new(),
             worktree_notes: HashMap::new(),
             ahead_behind_cache: HashMap::new(),
@@ -362,6 +429,7 @@ impl AdeApp {
             custom_theme_remove_armed: None,
             icon_pack_status: None,
             _icon_pack_choose_task: None,
+            _repo_folder_choose_task: None,
         };
         // GitHub issue #45 ("Input blink only on focused input or file") / a live follow-up
         // report of missing carets: `graph_state.branches_filter_focus_handle` (added later, in
@@ -383,59 +451,81 @@ impl AdeApp {
         );
         this._caret_blink_subscriptions
             .extend(extra_caret_blink_subscriptions);
-        // Real "add this one repo on startup" (Revision R12 Phase 0): the CLI argument (or a
-        // test's own `repo_path`) becomes the first, focused entry of `Self::repos` rather than a
-        // separate field - `Self::add_repo` is idempotent against whatever `loaded_repo_state`
-        // above already restored, so a repeat launch of the same path never duplicates it. Every
-        // other single-repo-scoped field below (`file_tree_root`/`diff_root`/the initial shell's
-        // cwd/`load_worktrees`) still reads `repo_path` directly rather than
-        // `Self::focused_repo_path()` - they're the same value here by construction, and `Self::
-        // focused_repo_path()` becomes the real accessor once a repo switch is more than "one repo
-        // was ever set".
-        let focused_repo_id = this.add_repo(repo_path.clone(), cx);
-        this.focus_repo(focused_repo_id);
-        // See the `expanded_dirs`/`fold_state_root_key` note in the literal above: resolving the
-        // worktree key here, through the one function that ever resolves it, is what keeps the
-        // startup path and every later worktree switch structurally identical.
-        this.set_file_tree_root(repo_path.clone());
-        this.reload_expanded_dirs_from_fold_state();
+        // Real "add this one repo on startup" (Revision R12 Phase 0, extended by GitHub issue
+        // #90 to a genuinely optional repo): `resolved_repo_path` - the CLI argument, the
+        // remembered last-focused repo, or nothing at all, per `Self::new_with_settings`'s own
+        // decision table above - becomes the first, focused entry of `Self::repos` rather than a
+        // separate field whenever it's `Some`. `Self::add_repo` is idempotent against whatever
+        // `loaded_repo_state` above already restored, so a repeat launch of the same path (or
+        // reopening the same remembered repo) never duplicates it. Every other single-repo-
+        // scoped piece of startup work below (`set_file_tree_root`/the initial shell's cwd/
+        // `load_worktrees`/`load_file_tree`/`load_diff`/the watchers) only runs at all when there
+        // is a real path to run it against - a genuinely empty startup does none of it, and
+        // `Self::focused_repo` simply stays `None`.
+        if let Some(path) = resolved_repo_path.clone() {
+            let focused_repo_id = this.add_repo(path.clone(), cx);
+            this.focus_repo(focused_repo_id, cx);
+            // See the `expanded_dirs`/`fold_state_root_key` note in the literal above: resolving
+            // the worktree key here, through the one function that ever resolves it, is what
+            // keeps the startup path and every later worktree switch structurally identical.
+            this.set_file_tree_root(path.clone());
+            this.reload_expanded_dirs_from_fold_state();
+        }
         // Applies `this.settings.keymap.overrides` on top of `crate::default_key_bindings()` -
         // see `Self::apply_effective_key_bindings`'s own docs. Must run before this constructor
         // returns and the entity's first render, so a persisted rebind is live from the very
         // first frame, not just after the next settings change - real "apply overrides at
-        // startup", not only "apply overrides when later edited".
+        // startup", not only "apply overrides when later edited". Unconditional: a rebound
+        // keymap applies just as much to a genuinely empty window as a focused one.
         this.apply_effective_key_bindings(cx);
         // Applies the real, persisted theme selection at startup (`Self::apply_theme_selection`)
         // - if `follow_system` is also on, the real, current OS appearance takes priority over
         // whatever `theme.name` was last persisted as, matching `Self::sync_theme_to_system_
         // appearance`'s own live behavior (see that method's docs); `apply_theme_selection`'s own
         // call at the end is always run regardless, since `apply_follow_system_appearance` is a
-        // no-op (and doesn't itself apply anything) when the resolved name already matches.
+        // no-op (and doesn't itself apply anything) when the resolved name already matches. Also
+        // unconditional, for the same reason as the keybindings above.
         if this.settings.theme.follow_system {
             let appearance = window.appearance();
             this.apply_follow_system_appearance(appearance, cx);
         }
         this.apply_theme_selection(cx);
-        // A fresh window starts with one shell in the repo root, as a tab like any other.
-        // `focus_active` below moves real keyboard focus onto it - see `Agents::focus_active`'s
-        // docs and this crate's `OverlayFocus`/`restore_focus` docs for why a fresh window must
-        // never start with `Window::focus == None`.
-        this.agents.spawn(
-            AgentKind::Shell,
-            repo_path.clone(),
-            this.settings.appearance.terminal_font_size,
-            window,
-            cx,
-        );
-        this.agents.focus_active(window, cx);
-        this.load_worktrees(cx);
-        this.load_file_tree(repo_path.clone(), cx);
-        this.load_diff(repo_path, cx);
-        this.start_status_polling(cx);
-        this.start_worktree_watch(cx);
+        match resolved_repo_path {
+            Some(path) => {
+                // A fresh window starts with one shell in the repo root, as a tab like any
+                // other. `focus_active` below moves real keyboard focus onto it - see
+                // `Agents::focus_active`'s docs and this crate's `OverlayFocus`/`restore_focus`
+                // docs for why a *focused* window must never start with `Window::focus == None`.
+                this.agents.spawn(
+                    AgentKind::Shell,
+                    path.clone(),
+                    this.settings.appearance.terminal_font_size,
+                    window,
+                    cx,
+                );
+                this.agents.focus_active(window, cx);
+                this.load_worktrees(cx);
+                this.load_file_tree(path.clone(), cx);
+                this.load_diff(path, cx);
+                this.start_status_polling(cx);
+                this.start_worktree_watch(cx);
+            }
+            None => {
+                // A genuinely empty window (GitHub issue #90) has no code surface/rail/tab strip
+                // in its rendered tree at all (`Self::render_empty_state`) - nothing above moved
+                // real keyboard focus anywhere, so this is the same "never leave `Window::focus`
+                // dangling" discipline `Self::select_worktree`'s own fallback branch already
+                // uses when a worktree switch leaves no agent to focus: the rail's own root
+                // container, which - unlike a genuinely empty window's own body - is *not* part
+                // of the rendered tree here, so `Self::render_empty_state`'s own focus handle is
+                // used instead. See that method's docs.
+                window.focus(&this.empty_state_focus_handle, cx);
+            }
+        }
         // GitHub issue #87: a real startup check, plus the periodic loop that keeps re-checking
         // for as long as the app runs - see `crate::updater::flow::AdeApp::
-        // start_update_check_loop`'s own docs.
+        // start_update_check_loop`'s own docs. Unconditional for the same reason the keybindings/
+        // theme setup above is: it has nothing to do with which (if any) repo is focused.
         this.start_update_check_loop(cx);
         this
     }
@@ -666,24 +756,55 @@ impl AdeApp {
         // at all, so the centre pane could keep showing a completely different worktree's
         // terminal after a rail click.
         self.agents.activate_for_worktree(&path, cx);
-        // Browsing to a different worktree disarms a pending prune confirmation - see
-        // `Self::request_prune`'s docs.
+        self.reset_repo_scoped_state(path, window, cx);
+    }
+
+    /// The shared core of "something completely different is now the single-repo-scoped root
+    /// this window revolves around" - every piece of per-worktree/per-repo transient UI state
+    /// this app has, reset, plus the real reload ([`Self::load_file_tree`]/[`Self::load_diff`]/
+    /// [`Self::evict_stale_lsp_clients`]/a graph-tab refresh if open) against `new_root`.
+    ///
+    /// Two real callers, extracted here (an independent audit's own finding) so they can never
+    /// drift apart on which state gets reset: [`Self::select_worktree`] (switching worktrees
+    /// *within* the same repo) and [`Self::open_repo_in_current_window`] (GitHub issue #90's
+    /// "Open Folder", switching to an entirely different repo, or out of a genuinely empty
+    /// window). Both are the same real invariant - "nothing here may still point at whatever was
+    /// open before" - reached through different UI gestures; before this extraction,
+    /// `open_repo_in_current_window` only reset four of these fields
+    /// (`staged_files`/`open_change`/`expanded_dirs`/`selected_tree_path`), leaving every other
+    /// one - `tree_delete_confirm`, `tree_clipboard`, `tree_context_menu`, `tree_inline_edit`,
+    /// `discard_confirm_armed`, `prune_confirm_armed`, `commit_menu_open`, every file/LSP/blame
+    /// cache and in-flight task - armed against whatever repo was open *before* the folder was
+    /// switched. Concretely: arming a delete confirmation on `<old repo>/x`, opening a different
+    /// folder, and confirming the still-rendered modal used to delete inside the *old* repo.
+    ///
+    /// Callers are responsible for whatever is genuinely different between "switching worktrees"
+    /// and "switching repos" themselves: `self.selected`/`self.agents.activate_for_worktree`
+    /// (`select_worktree`) vs. `self.focused_repo`/spawning an initial agent
+    /// (`open_repo_in_current_window`) - this only owns the part identical to both.
+    pub(crate) fn reset_repo_scoped_state(
+        &mut self,
+        new_root: PathBuf,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        // Browsing away disarms a pending prune confirmation - see `Self::request_prune`'s docs.
         self.prune_confirm_armed = false;
         self.discard_confirm_armed = None;
         // Same reasoning for the commit composer's own split-button popover (Revision R12 §5) -
-        // it targets the *previously* selected worktree's staged set, so it must not stay open
+        // it targets whatever was previously selected's staged set, so it must not stay open
         // pointed at the wrong one.
         self.commit_menu_open = false;
         // Reset per-worktree UI state (see `reset_per_worktree_ui_state`'s docs) so switching
-        // worktrees never leaks a staged checkbox, open diff, or collapsed-dir entry from
-        // the worktree just left. Deliberately runs *before* the focus-fallback block below: both
-        // `focus_newly_spawned_agent` and the `filter_focus_handle` fallback branch on
+        // never leaks a staged checkbox, open diff, or collapsed-dir entry from whatever was open
+        // before. Deliberately runs *before* the focus-fallback block below: both
+        // `focus_newly_spawned_agent` and the fallback branch after it key off
         // `self.open_change`, and until this call runs, `open_change` can still reflect the
-        // worktree just *left* (a file tab open there) rather than the real post-switch state -
-        // evaluating either guard first (a real, live-reproduced bug found in this revision's own
-        // self-audit) made both branches see a stale `Some` and skip moving focus at all, leaving
-        // `Window::focus` dangling on `code_focus_handle` once `open_change` was cleared one
-        // statement later.
+        // worktree/repo just *left* (a file tab open there) rather than the real post-switch
+        // state - evaluating either guard first (a real, live-reproduced bug found in this
+        // revision's own self-audit) made both branches see a stale `Some` and skip moving focus
+        // at all, leaving `Window::focus` dangling on `code_focus_handle` once `open_change` was
+        // cleared one statement later.
         reset_per_worktree_ui_state(
             &mut self.staged_files,
             &mut self.open_change,
@@ -691,33 +812,33 @@ impl AdeApp {
             &mut self.selected_tree_path,
         );
         // The tree's fold state is per-worktree *persisted* state, not merely per-worktree
-        // transient state: the reset above clears the live set, and this re-derives it from the
-        // worktree genuinely being switched *to*. A worktree with no recorded state (a freshly
-        // created one, say) gets an empty set and so opens fully collapsed - the issue's own
-        // suggested answer to "does a fresh worktree inherit anything".
+        // transient state: the reset above clears the live set, and this re-derives it from
+        // whatever is genuinely being switched *to*. A worktree/repo with no recorded state (a
+        // freshly created or freshly opened one) gets an empty set and so opens fully collapsed -
+        // the issue's own suggested answer to "does a fresh worktree inherit anything".
         //
         // `file_tree_root`/`file_tree` move in the *same* step, deliberately: `load_file_tree`
         // below sets the root too, but its walk is asynchronous, so without this the frames
-        // between here and the walk landing would render the worktree just left's rows against
-        // the new worktree's expanded set - and a click on one of those stale rows would reach
-        // `set_dir_expanded` with a path from a different worktree entirely. Clearing
+        // between here and the walk landing would render whatever was left's rows against the
+        // new root's expanded set - and a click on one of those stale rows would reach
+        // `set_dir_expanded` with a path from an entirely different worktree/repo. Clearing
         // `file_tree` makes that window render an honestly empty tree instead.
-        self.set_file_tree_root(path.clone());
+        self.set_file_tree_root(new_root.clone());
         self.file_tree = Vec::new();
         self.reload_expanded_dirs_from_fold_state();
-        // Every one of these holds an absolute path in the worktree being *left* (GitHub issue
-        // #19): an open context menu targeting a row that is about to stop existing, a
-        // half-typed name for a folder in the old tree, a cut/copied entry a paste here would
-        // move across worktrees, and an armed delete for a path in the old tree. Cleared
-        // together, in the same step as `file_tree`/`expanded_dirs` above and for the same
-        // reason - the window between here and the new walk landing must not leave a control
-        // pointing at the old worktree.
+        // Every one of these holds an absolute path in whatever was just left (GitHub issue #19):
+        // an open context menu targeting a row that is about to stop existing, a half-typed name
+        // for a folder in the old tree, a cut/copied entry a paste here would move across
+        // worktrees/repos, and an armed delete for a path in the old tree. Cleared together, in
+        // the same step as `file_tree`/`expanded_dirs` above and for the same reason - the window
+        // between here and the new walk landing must not leave a control pointing at the old
+        // worktree/repo.
         self.tree_context_menu = None;
         self.tree_inline_edit = None;
         self.tree_clipboard = None;
         self.tree_delete_confirm = None;
         self.tree_op_error = None;
-        // "Show me the whole listing" was a decision about the worktree being left.
+        // "Show me the whole listing" was a decision about whatever was left.
         self.file_tree_limit_override = None;
         self.file_tree_truncated = false;
         self.file_tree_complete = false;
@@ -728,32 +849,34 @@ impl AdeApp {
         // filter (`Self::render_tab_strip`) applies, so keyboard focus left pointing at it would
         // silently break every keybinding until the next click - the same "focus left pointing at
         // something no longer rendered" bug class this project's own `OverlayFocus`/
-        // `restore_focus` mechanism exists to prevent, applied here to a plain worktree switch
-        // rather than an overlay open/close. `open_change` above is already this switch's real
-        // post-reset value by the time this runs, so the guard it checks is genuine.
+        // `restore_focus` mechanism exists to prevent, applied here to a plain worktree/repo
+        // switch rather than an overlay open/close. `open_change` above is already this switch's
+        // real post-reset value by the time this runs, so the guard it checks is genuine.
         self.focus_newly_spawned_agent(window, cx);
-        // `focus_newly_spawned_agent` is a real no-op when the newly selected worktree has no
+        // `focus_newly_spawned_agent` is a real no-op when whatever was just switched to has no
         // open agent at all (`Agents::focus_active` has nothing to focus) - so if a
-        // previously-focused agent's pane belonged to the worktree just left, it's now exactly
-        // as dangling as the case the comment above already covers, just with no agent to
-        // redirect *onto*. Fall back to the rail's own root container
-        // (`Self::rail_focus_handle`), which is part of the rendered tree whenever the
-        // workspace body is showing (never while Settings has replaced it - `!self.settings_open`
-        // guards that the same way `focus_newly_spawned_agent` itself does). Deliberately the
-        // rail's root, not its filter field, which this used to target - see
-        // `Self::rail_focus_handle`'s own docs for the real, audit-found keystroke-swallowing bug
-        // that became once the filter field started carrying a `"text-input"` key context. It
-        // keeps the focused `FocusId` genuinely findable in the next rendered frame, which is the
-        // actual invariant this exists to protect: a dangling `FocusId` makes GPUI's action
-        // dispatch fall back to a disconnected root with no real `on_action` handlers at all, not
-        // just this worktree's own missing ones - silently breaking every global keybinding (⌘P
-        // included) until the next click.
+        // previously-focused agent's pane belonged to whatever was left, it's now exactly as
+        // dangling as the case the comment above already covers, just with no agent to redirect
+        // *onto*. Fall back to the rail's own root container (`Self::rail_focus_handle`), which
+        // is part of the rendered tree whenever the workspace body is showing (never while
+        // Settings has replaced it - `!self.settings_open` guards that the same way
+        // `focus_newly_spawned_agent` itself does, and never while a genuinely empty window is
+        // showing `Self::render_empty_state` instead, which has no rail at all - callers switching
+        // *out of* empty state are responsible for their own focus, same as
+        // `Self::open_repo_in_current_window` already is). Deliberately the rail's root, not its
+        // filter field, which this used to target - see `Self::rail_focus_handle`'s own docs for
+        // the real, audit-found keystroke-swallowing bug that became once the filter field
+        // started carrying a `"text-input"` key context. It keeps the focused `FocusId` genuinely
+        // findable in the next rendered frame, which is the actual invariant this exists to
+        // protect: a dangling `FocusId` makes GPUI's action dispatch fall back to a disconnected
+        // root with no real `on_action` handlers at all, not just this worktree's own missing
+        // ones - silently breaking every global keybinding (⌘P included) until the next click.
         if self.agents.active_id().is_none() && self.open_change.is_none() && !self.settings_open {
             window.focus(&self.rail_focus_handle, cx);
         }
         // The File view's own per-worktree state (a cached parse and diff lookup that are about
         // to belong to a different `file_tree_root`) - reset for the same reason as above.
-        // Dropping `_file_load_task` cancels any in-flight load for the worktree just left.
+        // Dropping `_file_load_task` cancels any in-flight load for whatever was left.
         self.code_view = code_view::CodeView::Diff;
         self.file_view_cache = None;
         self.file_load_state = FileLoadState::Idle;
@@ -764,8 +887,7 @@ impl AdeApp {
         // The real text-editing state above (`edit_buffers`) is per-worktree-reset via the shared
         // helper; its own transient/task-shaped siblings - which don't fit that helper's plain
         // free-function signature - are reset directly here for the same reason. Dropping the
-        // task maps cancels every in-flight debounced re-highlight/save for the worktree just
-        // left, matching `_file_load_task`'s own reset above.
+        // task maps cancels every in-flight debounced re-highlight/save for whatever was left.
         self.file_view_row_layout = HashMap::new();
         self.file_view_last_layout = None;
         self.file_view_last_bounds = None;
@@ -773,11 +895,11 @@ impl AdeApp {
         self._rehighlight_tasks = HashMap::new();
         // Real live LSP sync/completions state (Revision R8.5b) is worktree-relative-path-keyed
         // (or entirely path-scoped) the same way `edit_buffers` above is - reset alongside it so
-        // a worktree switch can't leak a stale "already synced this content" record or a dangling
-        // popup from the worktree just left. `lsp_document_versions`/`lsp_uri_cache` are keyed by
-        // *absolute* path (see their own docs), so neither ever actually collides across
-        // worktrees and both are left to `evict_stale_lsp_clients`'s own root-scoped pruning
-        // instead of a blanket reset here.
+        // a switch can't leak a stale "already synced this content" record or a dangling popup
+        // from whatever was left. `lsp_document_versions`/`lsp_uri_cache` are keyed by *absolute*
+        // path (see their own docs), so neither ever actually collides across worktrees/repos and
+        // both are left to `evict_stale_lsp_clients`'s own root-scoped pruning instead of a
+        // blanket reset here.
         self._lsp_sync_tasks = HashMap::new();
         self._completions_request_task = None;
         self.lsp_last_synced_content = HashMap::new();
@@ -789,18 +911,17 @@ impl AdeApp {
         self.file_save_running = HashSet::new();
         self.file_save_error = None;
         self.file_external_conflict = HashSet::new();
-        // The Diff view's syntax-highlight cache is keyed on a whole `DiffFile` from the
-        // worktree just left - reset alongside `open_diff_file_cache` above for the same reason
-        // (and so it can't retain a full file's highlighting from a worktree that's no longer
-        // active).
+        // The Diff view's syntax-highlight cache is keyed on a whole `DiffFile` from whatever was
+        // left - reset alongside `open_diff_file_cache` above for the same reason (and so it
+        // can't retain a full file's highlighting from a worktree/repo that's no longer active).
         self.diff_highlight_cache = None;
         self._file_load_task = None;
         // Editor zoom (`Settings.appearance.editor_zoom_percent`) is a real, globally-persisted
         // Settings field now - see `settings_store`'s "Editor zoom is one global, persisted
         // number now" docs - so it deliberately does *not* get reset here anymore.
         //
-        // The hover cache is per-file - clear it too, or a hover card from the worktree just
-        // left could reappear the instant a same-named file opens in the new one. The real
+        // The hover cache is per-file - clear it too, or a hover card from whatever was left
+        // could reappear the instant a same-named file opens in the new one. The real
         // Completions popup is already dropped above (alongside `_lsp_sync_tasks`/
         // `lsp_last_synced_content`) via `Self::dismiss_completions()` - repeated here,
         // idempotently, right next to `hover`'s own reset for the same reason every other real
@@ -812,30 +933,30 @@ impl AdeApp {
         self.pending_cursor_line = None;
         // Real blame state (GitHub issue #29) is absolute-path-keyed - cleared alongside the
         // hover cache above for the identical reason: without this, a same-named file's blame
-        // from the worktree just left could reappear (wrongly attributed) the instant a
-        // same-named file opens in the new one, and a stale `Loading`/in-flight task from the
-        // old worktree has no reason to keep running once its own worktree is no longer active.
+        // from whatever was left could reappear (wrongly attributed) the instant a same-named
+        // file opens in the new one, and a stale `Loading`/in-flight task from the old worktree/
+        // repo has no reason to keep running once it's no longer active.
         self.blame_cache.clear();
         self.blame_state.clear();
         self._blame_tasks.clear();
         self.blame_last_freshness_check = None;
         // Commit messages are sha-keyed, not path-keyed - a sha means the same real commit
-        // regardless of which worktree it's viewed from, so this cache deliberately survives a
-        // worktree switch (the same "safe to keep, sha is a real global identity" reasoning
+        // regardless of which worktree/repo it's viewed from, so this cache deliberately survives
+        // a switch (the same "safe to keep, sha is a real global identity" reasoning
         // `AdeApp::lsp_uri_cache`'s own root-scoped-only pruning already applies elsewhere).
-        self.load_file_tree(path.clone(), cx);
-        // `load_file_tree` above already set `self.file_tree_root = path` synchronously, so
-        // `path` is the active root by the time eviction runs.
-        self.evict_stale_lsp_clients(&path, cx);
-        self.load_diff(path, cx);
+        self.load_file_tree(new_root.clone(), cx);
+        // `load_file_tree` above already set `self.file_tree_root = new_root` synchronously, so
+        // `new_root` is the active root by the time eviction runs.
+        self.evict_stale_lsp_clients(&new_root, cx);
+        self.load_diff(new_root, cx);
         // The graph tab is repo-scoped, not worktree-scoped (design spec §1: "the graph is
         // repo-scoped"), but the toolbar's `HEAD` chip/upstream counts and the Worktrees scope
         // (`wt_core::graph::GraphScope::Worktrees`, driven by real worktree HEADs) are real facts
-        // about *this* worktree - without this, switching worktrees while the graph tab is open
-        // silently left it showing the previous worktree's data (a real, adversarial-audit-found
-        // gap), and the Commit panel's cached "Files changed" could even fail against the wrong
-        // repo path. `load_diff` above already updated `Self::diff_root` synchronously, so
-        // `load_graph` (which reads it) picks up the new worktree correctly.
+        // about whatever is genuinely current now - without this, switching while the graph tab
+        // is open silently left it showing stale data (a real, adversarial-audit-found gap), and
+        // the Commit panel's cached "Files changed" could even fail against the wrong repo path.
+        // `load_diff` above already updated `Self::diff_root` synchronously, so `load_graph`
+        // (which reads it) picks up the new root correctly.
         if self.graph_tab_open {
             self.load_graph(cx);
         }

--- a/crates/app/src/settings/render.rs
+++ b/crates/app/src/settings/render.rs
@@ -3628,7 +3628,14 @@ mod keybinding_rebind_tests {
         settings_path: PathBuf,
     ) -> (gpui::Entity<AdeApp>, &mut gpui::VisualTestContext) {
         cx.add_window_view(|window, cx| {
-            AdeApp::new_with_settings(repo_path, settings, Some(settings_path), window, cx)
+            AdeApp::new_with_settings(
+                Some(repo_path),
+                true,
+                settings,
+                Some(settings_path),
+                window,
+                cx,
+            )
         })
     }
 
@@ -4041,7 +4048,14 @@ mod custom_theme_settings_tests {
         settings_path: PathBuf,
     ) -> (gpui::Entity<AdeApp>, &mut gpui::VisualTestContext) {
         cx.add_window_view(|window, cx| {
-            AdeApp::new_with_settings(repo_path, settings, Some(settings_path), window, cx)
+            AdeApp::new_with_settings(
+                Some(repo_path),
+                true,
+                settings,
+                Some(settings_path),
+                window,
+                cx,
+            )
         })
     }
 

--- a/crates/app/src/sidebar/fold_state.rs
+++ b/crates/app/src/sidebar/fold_state.rs
@@ -309,15 +309,24 @@ impl FoldState {
     /// `owned` is the set of [`worktree_key`]s this instance has recorded anything for. Keys in
     /// `owned` are taken from `self` (including *absence* - that's how "collapse all" deletes an
     /// entry); every other key on disk is passed through untouched.
+    ///
+    /// GitHub issue #90: wrapped in `crate::persisted_state_lock::with_locked_merge` - "New
+    /// Window" made this load-merge-save cycle reachable *concurrently within one process*, not
+    /// just across two separate `jerry` processes (which the `owned`-scoped merge above already
+    /// handled) - see that module's own docs for the real race two truly concurrent callers could
+    /// otherwise hit, and why one process-wide lock, shared with `crate::rail::repo::RepoState`/
+    /// `crate::work_surface::tab_order_state::TabOrderState`'s own identical methods, is enough.
     pub fn save_merged_at(&self, path: &Path, owned: &BTreeSet<String>) -> io::Result<()> {
-        let mut merged = FoldState::load_at(path);
-        for key in owned {
-            match self.worktrees.get(key) {
-                Some(entry) => merged.worktrees.insert(key.clone(), entry.clone()),
-                None => merged.worktrees.remove(key),
-            };
-        }
-        merged.save_at(path)
+        crate::persisted_state_lock::with_locked_merge(|| {
+            let mut merged = FoldState::load_at(path);
+            for key in owned {
+                match self.worktrees.get(key) {
+                    Some(entry) => merged.worktrees.insert(key.clone(), entry.clone()),
+                    None => merged.worktrees.remove(key),
+                };
+            }
+            merged.save_at(path)
+        })
     }
 
     /// Every directory currently recorded as expanded for `root`, as absolute paths ready to be

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -3109,7 +3109,14 @@ mod fold_state_tests {
         settings: settings_store::Settings,
     ) -> (gpui::Entity<AdeApp>, &mut gpui::VisualTestContext) {
         cx.add_window_view(|window, cx| {
-            AdeApp::new_with_settings(repo_path, settings, Some(settings_path), window, cx)
+            AdeApp::new_with_settings(
+                Some(repo_path),
+                true,
+                settings,
+                Some(settings_path),
+                window,
+                cx,
+            )
         })
     }
 

--- a/crates/app/src/sidebar/tree_ops.rs
+++ b/crates/app/src/sidebar/tree_ops.rs
@@ -1776,7 +1776,8 @@ mod tree_ops_regression_tests {
         let fold_path = crate::sidebar::fold_state::fold_state_path_for(&settings_path);
         let (app, cx) = cx.add_window_view(|window, cx| {
             AdeApp::new_with_settings(
-                repo.path().to_path_buf(),
+                Some(repo.path().to_path_buf()),
+                true,
                 settings_store::Settings::default(),
                 Some(settings_path),
                 window,

--- a/crates/app/src/title_bar/menu.rs
+++ b/crates/app/src/title_bar/menu.rs
@@ -166,8 +166,9 @@ impl AdeApp {
     }
 
     /// The File menu: open a file (the same real, files-scoped command palette the `+` menu's
-    /// own "Open file…" row opens), save the active file (real, same handler `secondary-s`
-    /// dispatches - a safe no-op with nothing dirty to save, per
+    /// own "Open file…" row opens), open a folder or a brand-new empty window (GitHub issue #90,
+    /// see [`Self::render_title_menu`]'s own row-by-row docs below), save the active file (real,
+    /// same handler `secondary-s` dispatches - a safe no-op with nothing dirty to save, per
     /// [`crate::code_surface::editing::AdeApp::save_active_file`]'s own guard), open Settings, and quit
     /// (the same real [`Window::remove_window`] the title bar's own close control uses).
     fn file_menu_rows(&self, macos: bool, cx: &mut Context<Self>) -> Vec<gpui::AnyElement> {
@@ -210,8 +211,76 @@ impl AdeApp {
                 cx.notify();
             }))
             .into_any_element(),
-            save_row.into_any_element(),
+            // GitHub issue #90's "Open Folder…" - a real native OS directory picker
+            // ([`AdeApp::start_choose_repo_folder`], the same `gpui::App::prompt_for_paths`
+            // shape `crate::settings::render::AdeApp::start_choose_icon_pack_folder` already
+            // uses), opening the chosen folder as a real, focused repo in *this* window - unlike
+            // the "New Window" row just below, which deliberately opens a brand-new, empty one.
+            // No keybinding (`Vec::new()` combo), matching this menu's own "Open File…" row just
+            // above: this app never binds a keystroke that could also be a plain character a
+            // focused terminal/agent needs, and this row isn't part of `crate::default_key_bindings`
+            // for that same reason.
+            render_dropdown_menu_row(
+                "F",
+                theme::text::DIM.into(),
+                theme::surface::CHIP_NEUTRAL.into(),
+                "Open Folder\u{2026}",
+                "open a repository".to_string(),
+                Vec::new(),
+                true,
+            )
+            .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
+                this.title_menu_open = None;
+                this.start_choose_repo_folder(cx);
+                cx.notify();
+            }))
+            .into_any_element(),
+            // GitHub issue #90's "New Window" - a brand-new ADE window in a genuinely empty
+            // state (`AdeApp::new_with_settings`'s own `use_remembered_repo` docs), not this
+            // window's repo and deliberately not whatever folder was last remembered either - the
+            // issue's own wording is explicit that a new window starts empty. Shares
+            // `crate::default_window_options` with [`crate::run`]'s own real startup window, so
+            // the two can never silently drift apart on bounds/titlebar/decorations.
+            //
+            // Deliberately calls `AdeApp::new_with_settings` with *this* window's own already-
+            // loaded `self.settings`/`self.settings_path` - not `AdeApp::new`, which would re-run
+            // `settings_store::Settings::load_or_init()` from scratch. Two real reasons, not just
+            // one: the new window should show the exact settings/keymap/theme this one already
+            // has loaded rather than risk a second, independent disk read racing a concurrent
+            // edit; and `Settings::load_or_init` really does write a fresh default file to disk
+            // the first time it's ever called (`Settings::load_or_init_at`'s own docs) - firing
+            // that unconditionally from a menu click (including from a test that clicks this real
+            // row, per this codebase's own test rule that a test must never touch the real
+            // settings file - `crate::root::focus::palette_focus_tests::open_test_app`'s own
+            // docs) would be a real, surprising side effect a plain "open another window" click
+            // has no business causing.
+            render_dropdown_menu_row(
+                "N",
+                theme::text::DIM.into(),
+                theme::surface::CHIP_NEUTRAL.into(),
+                "New Window",
+                "empty window".to_string(),
+                Vec::new(),
+                true,
+            )
+            .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
+                this.title_menu_open = None;
+                let options = crate::default_window_options(cx);
+                let settings = this.settings.clone();
+                let settings_path = this.settings_path.clone();
+                let opened = cx.open_window(options, move |window, cx| {
+                    cx.new(|cx| {
+                        AdeApp::new_with_settings(None, false, settings, settings_path, window, cx)
+                    })
+                });
+                if let Err(err) = opened {
+                    log::error!("failed to open a new ADE window: {err}");
+                }
+                cx.notify();
+            }))
+            .into_any_element(),
             Self::render_title_menu_divider(),
+            save_row.into_any_element(),
             render_dropdown_menu_row(
                 "P",
                 theme::text::DIM.into(),
@@ -454,36 +523,49 @@ impl AdeApp {
         // agents open but this one doesn't have a second one of its own.
         let can_cycle = self.current_worktree_agents().count() > 1;
         let active_id = self.agents.active_id();
+        // GitHub issue #90: a genuinely empty window has no real repo root to spawn a new agent
+        // into - see `crate::work_surface::render::AdeApp::new_agent`'s own docs for the real
+        // guard these two rows must agree with, and the concrete bug (a PTY silently spawned
+        // against a different, unopened repo) an independent audit found here.
+        let has_focused_repo = self.focused_repo().is_some();
+
+        let mut new_terminal_row = render_dropdown_menu_row(
+            "\u{276f}",
+            theme::text::DIM.into(),
+            theme::surface::CHIP_NEUTRAL.into(),
+            "New Terminal",
+            "in this worktree".to_string(),
+            keymap::resolve_combo("ctrl+shift+T", macos),
+            has_focused_repo,
+        );
+        if has_focused_repo {
+            new_terminal_row =
+                new_terminal_row.on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
+                    this.title_menu_open = None;
+                    this.handle_new_terminal_action(&NewTerminal, window, cx);
+                }));
+        }
+        let mut new_agent_pane_row = render_dropdown_menu_row(
+            agent_initial,
+            agent_fg,
+            agent_bg,
+            "New Agent Pane",
+            agent_label.to_string(),
+            keymap::resolve_combo("mod+shift+N", macos),
+            has_focused_repo,
+        );
+        if has_focused_repo {
+            new_agent_pane_row = new_agent_pane_row.on_click(cx.listener(
+                |this, _event: &ClickEvent, window, cx| {
+                    this.title_menu_open = None;
+                    this.handle_new_agent_pane_action(&NewAgentPane, window, cx);
+                },
+            ));
+        }
 
         let mut rows = vec![
-            render_dropdown_menu_row(
-                "\u{276f}",
-                theme::text::DIM.into(),
-                theme::surface::CHIP_NEUTRAL.into(),
-                "New Terminal",
-                "in this worktree".to_string(),
-                keymap::resolve_combo("ctrl+shift+T", macos),
-                true,
-            )
-            .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
-                this.title_menu_open = None;
-                this.handle_new_terminal_action(&NewTerminal, window, cx);
-            }))
-            .into_any_element(),
-            render_dropdown_menu_row(
-                agent_initial,
-                agent_fg,
-                agent_bg,
-                "New Agent Pane",
-                agent_label.to_string(),
-                keymap::resolve_combo("mod+shift+N", macos),
-                true,
-            )
-            .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
-                this.title_menu_open = None;
-                this.handle_new_agent_pane_action(&NewAgentPane, window, cx);
-            }))
-            .into_any_element(),
+            new_terminal_row.into_any_element(),
+            new_agent_pane_row.into_any_element(),
             Self::render_title_menu_divider(),
         ];
 
@@ -779,6 +861,104 @@ mod title_menu_tests {
             assert_eq!(
                 app.title_menu_open, None,
                 "picking a real row should close the title menu"
+            );
+        });
+    }
+
+    /// GitHub issue #90's "Open Folder…" row - the File menu's second row. Drives it through a
+    /// real simulated click plus a real simulated native-picker response
+    /// (`TestAppContext::simulate_path_prompt_response`, the same real `gpui::App::
+    /// prompt_for_paths` seam `AdeApp::start_choose_repo_folder` itself calls), and asserts the
+    /// real effect: the chosen folder becomes this window's own focused repo, not merely that a
+    /// dialog was requested.
+    #[gpui::test]
+    fn file_menu_open_folder_row_focuses_a_real_chosen_folder_in_this_window(
+        cx: &mut TestAppContext,
+    ) {
+        let original_repo = tempfile::tempdir().expect("tempdir");
+        let chosen_repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, original_repo.path().to_path_buf());
+        app.update(cx, |app, cx| {
+            app.set_window_controls_style(WindowControlsStyle::WindowsLinuxStyle, cx);
+        });
+        cx.run_until_parked();
+        app.update(cx, |app, cx| {
+            app.title_menu_open = Some(TitleMenu::File);
+            cx.notify();
+        });
+        cx.run_until_parked();
+        let bounds = app.read_with(cx, |app, _| {
+            app.title_menu_button_bounds[TitleMenu::File.index()]
+        });
+
+        let chosen = chosen_repo.path().to_path_buf();
+        // "Open Folder…" is the File menu's second row (index 1): Open File, Open Folder, New
+        // Window, [divider], Save, Settings, Quit - see `AdeApp::file_menu_rows`'s own order.
+        cx.simulate_click(nth_row_click_point(bounds, 1, 0), gpui::Modifiers::none());
+        cx.simulate_path_prompt_response(move |_options| Some(vec![chosen]));
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.focused_repo_path(),
+                chosen_repo.path(),
+                "the real chosen folder should now be this window's own focused repo"
+            );
+            assert_eq!(
+                app.title_menu_open, None,
+                "picking a real row should close the title menu"
+            );
+        });
+    }
+
+    /// GitHub issue #90's "New Window" row: opens a genuinely *second*, empty-state window -
+    /// never this window's own repo, and never whatever repo happens to be focused here - even
+    /// though this window under test starts with a real repo focused.
+    #[gpui::test]
+    fn file_menu_new_window_row_opens_a_second_genuinely_empty_window(cx: &mut TestAppContext) {
+        let (app, cx) = open_windows_variant(cx);
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.focused_repo().is_some(),
+                "sanity check: this window starts focused on a real repo"
+            );
+        });
+        let windows_before = cx.windows();
+
+        app.update(cx, |app, cx| {
+            app.title_menu_open = Some(TitleMenu::File);
+            cx.notify();
+        });
+        cx.run_until_parked();
+        let bounds = app.read_with(cx, |app, _| {
+            app.title_menu_button_bounds[TitleMenu::File.index()]
+        });
+
+        cx.simulate_click(nth_row_click_point(bounds, 2, 0), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.title_menu_open),
+            None,
+            "picking a real row should close the title menu"
+        );
+
+        let new_window = cx
+            .windows()
+            .into_iter()
+            .find(|window| !windows_before.contains(window))
+            .expect("New Window should have opened a real second window");
+        let new_app = new_window
+            .downcast::<AdeApp>()
+            .expect("the new window's root view should be a real AdeApp")
+            .root(cx)
+            .expect("the new window should have a real root entity");
+        new_app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.focused_repo(),
+                None,
+                "New Window must open a genuinely empty window, even though the window it was \
+                 opened from has a real repo focused"
             );
         });
     }

--- a/crates/app/src/title_bar/render.rs
+++ b/crates/app/src/title_bar/render.rs
@@ -201,10 +201,14 @@ impl AdeApp {
     /// render_windows_title_bar_left`] all stop propagation on their own mouse-down, so pressing
     /// any of those controls can never also arm this drag.
     pub(crate) fn render_title_bar(&self, cx: &mut Context<Self>) -> impl IntoElement {
-        let project_name = self
-            .focused_repo()
-            .map(|repo| repo.name.clone())
-            .unwrap_or_else(|| self.focused_repo_path().display().to_string());
+        // GitHub issue #90: a genuinely empty window (`Self::render_empty_state`) has no real
+        // repo to name - `Self::focused_repo_path`'s own defensive fallback would otherwise
+        // silently show a *different*, merely-known-but-unfocused repo's name here (or an empty
+        // string), which would misleadingly suggest something is open when nothing is.
+        let project_name = match self.focused_repo() {
+            Some(repo) => repo.name.clone(),
+            None => "No Folder Open".to_string(),
+        };
         let branch = self
             .worktrees
             .iter()

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -23,12 +23,30 @@ macro_rules! agent_jump_action_handler {
 }
 
 impl AdeApp {
+    /// Spawns a new agent tab into [`Self::active_agent_cwd`] - the single real chokepoint every
+    /// "new terminal"/"new shell" entry point in this app funnels through: `secondary-n`/
+    /// `ctrl-shift-T`'s own `handle_new_agent_action`/`handle_new_terminal_action`, the `+` menu's
+    /// row, the title bar's Agent menu row (`crate::title_bar::menu::AdeApp::agent_menu_rows`),
+    /// and the palette's `PaletteCommand::NewShell`.
+    ///
+    /// GitHub issue #90: a genuinely empty window (no [`Self::focused_repo`]) has no real repo
+    /// root to spawn into at all - a real, live-reproduced bug (independent audit) found that
+    /// without this guard, [`Self::active_agent_cwd`] fell through to [`Self::focused_repo_path`],
+    /// which itself used to fall back to *some other, unopened* known repo's real path (`Self::
+    /// repos.first()`), silently spawning a real PTY - and, from there, reachable real destructive
+    /// git operations (`Keep All Changes`/`Discard Worktree`) - against a repo the user never
+    /// opened and can't even see (the empty-state view renders no tab strip at all, so the tab
+    /// this spawned would have been invisible). A no-op here is the honest fix: there is nothing
+    /// this app can offer to spawn an agent into until a real repo is opened.
     pub(crate) fn new_agent(
         &mut self,
         kind: AgentKind,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if self.focused_repo().is_none() {
+            return;
+        }
         let cwd = self.active_agent_cwd();
         self.agents.spawn(
             kind,
@@ -1103,6 +1121,11 @@ impl AdeApp {
     /// process fails to spawn and a non-panicking spawn error shows in the new tab
     /// (`TerminalPane::spawn_error`).
     pub(in crate::work_surface) fn new_agent_pane(&mut self, cx: &mut Context<Self>) {
+        // GitHub issue #90: the same real "nothing to spawn into yet" guard [`Self::new_agent`]'s
+        // own docs explain - see those for the concrete bug this closes.
+        if self.focused_repo().is_none() {
+            return;
+        }
         let cwd = self.active_agent_cwd();
         let task = cx.spawn(async move |this, cx| {
             let installed = cx
@@ -3316,7 +3339,8 @@ mod tab_order_persistence_tests {
     ) -> (gpui::Entity<AdeApp>, &mut gpui::VisualTestContext) {
         cx.add_window_view(|window, cx| {
             AdeApp::new_with_settings(
-                repo_path,
+                Some(repo_path),
+                true,
                 settings_store::Settings::default(),
                 Some(settings_path),
                 window,

--- a/crates/app/src/work_surface/tab_order_state.rs
+++ b/crates/app/src/work_surface/tab_order_state.rs
@@ -206,15 +206,22 @@ impl TabOrderState {
     /// actually owns into whatever is currently on disk, then writes the result via
     /// [`Self::save_at`] - identical reasoning to
     /// `crate::sidebar::fold_state::FoldState::save_merged_at`.
+    ///
+    /// GitHub issue #90: wrapped in `crate::persisted_state_lock::with_locked_merge` - see that
+    /// module's own docs for the real intra-process concurrent-writer race "New Window" made
+    /// reachable here, and why one process-wide lock, shared with `crate::rail::repo::RepoState`/
+    /// `crate::sidebar::fold_state::FoldState`'s own identical methods, is enough to close it.
     pub fn save_merged_at(&self, path: &Path, owned: &BTreeSet<String>) -> io::Result<()> {
-        let mut merged = TabOrderState::load_at(path);
-        for key in owned {
-            match self.worktrees.get(key) {
-                Some(entry) => merged.worktrees.insert(key.clone(), entry.clone()),
-                None => merged.worktrees.remove(key),
-            };
-        }
-        merged.save_at(path)
+        crate::persisted_state_lock::with_locked_merge(|| {
+            let mut merged = TabOrderState::load_at(path);
+            for key in owned {
+                match self.worktrees.get(key) {
+                    Some(entry) => merged.worktrees.insert(key.clone(), entry.clone()),
+                    None => merged.worktrees.remove(key),
+                };
+            }
+            merged.save_at(path)
+        })
     }
 
     /// `root`'s real, currently-recorded file order, as absolute paths ready to feed into


### PR DESCRIPTION
## Summary
- The app previously always defaulted to opening the current working directory as a project, with no way to open a different folder or start a fresh window. This adds a true empty (no folder open) default state instead of a hardcoded cwd fallback.
- **Open Folder…** in the File menu: real OS folder picker, switches the current window to a different repo, fully reloading worktrees/file tree/diff/watchers and resetting per-repo UI state (delete/discard/prune confirmations, clipboard, caches) so nothing from the previous repo leaks into the new one.
- **Remembers the last-opened folder** across restarts (persisted alongside the existing `repos.toml` state), validated against the path still existing as a directory before being reopened.
- **New Window** in the File menu: opens a second, fully independent window in genuine empty state.
- Repo-scoped actions (new terminal/agent, git graph) are gated on having a focused repo, since an empty window still loads the shared `repos.toml` list and could otherwise silently target an unopened repo.
- A process-wide lock now guards the read-modify-write cycle for `repos.toml`/`fold_state.toml`/`tab_order_state.toml`, since multiple windows can now write them concurrently.

Fixes #90

## Test plan
- [x] `cargo fmt -p app -- --check`
- [x] `cargo clippy -p app --all-targets -- -D warnings`
- [x] `cargo build -p app`
- [x] `cargo test -p app --lib` — 1336 passed, 9 pre-existing/unrelated LSP-integration failures (require external language servers not available in this sandbox)
- [x] Two rounds of adversarial code review across the empty-state/window-switch state machine (unopened-repo action gating, watcher/polling rebinding on folder switch, stale per-repo UI state reset, dangling focus handles, orphaned agent teardown, git-graph reachability, concurrent settings writes)
- [ ] Manual verification (empty launch, Open Folder, remembered-folder relaunch, New Window) — will be done by @lucasboinet once this is up

🤖 Generated with [Claude Code](https://claude.com/claude-code)