### PR TITLE
feat(ci): auto-generate release notes in the release workflow (issue #92)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,9 +135,19 @@ jobs:
       # `workflow_dispatch` runs (no tag) publish a draft instead of a real release, so
       # manually testing this workflow never creates a public release out from under a
       # tag that doesn't exist.
+      #
+      # `generate_release_notes` asks GitHub itself (not this workflow) to diff merged
+      # PRs against the previous published release and write a "What's Changed" body -
+      # issue #92's ask, with zero new scripting since this repo's PR titles already
+      # follow the `type(scope): summary` convention (see CONTRIBUTING.md) that reads
+      # fine as a flat list without any PR-label categorization. On a `workflow_dispatch`
+      # draft there's no real tag to diff from, so the generated notes may be rougher/
+      # less precise - harmless, since that path is manual-testing-only (see `draft:`
+      # above), never a public release.
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
           draft: ${{ github.event_name == 'workflow_dispatch' }}
+          generate_release_notes: true
           files: dist/*
           fail_on_unmatched_files: true


### PR DESCRIPTION
## Summary
- Every published release (including v0.0.1) currently ships with an empty body, since `release.yml`'s `Create release` step never set one.
- Adds `generate_release_notes: true` to the existing `softprops/action-gh-release@v2` step — GitHub itself diffs merged PRs since the previous published release and writes a "What's Changed" list + "Full Changelog" compare link, with zero new scripting.
- This repo's PR titles already follow the `type(scope): summary (issue #N)` convention, so the flat (unlabeled) list reads well without any PR-labeling process.

Fixes #92

## Test plan
- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Trigger a `workflow_dispatch` run after merge to inspect the generated draft release body, then delete the draft (destructive/CI-minute-consuming, so left for manual follow-up rather than done automatically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)