### PR TITLE
feat(app): make the git graph tab draggable/movable (issue #93)

### DIFF
--- a/crates/app/src/graph_view/render.rs
+++ b/crates/app/src/graph_view/render.rs
@@ -6,8 +6,11 @@ use super::*;
 use crate::root::widgets::{render_sidebar_message, render_tag_pill};
 use crate::settings::widgets;
 use crate::sidebar::changes;
-use crate::work_surface::render::render_dropdown_menu_row;
-use gpui::{BoxShadow, KeyDownEvent, Pixels};
+use crate::work_surface::render::{
+    render_dropdown_menu_row, render_tab_insertion_caret, tab_settle_animation_id, DraggedTab,
+    TAB_SETTLE_ANIMATION_DURATION,
+};
+use gpui::{Animation, AnimationExt, BoxShadow, DragMoveEvent, KeyDownEvent, Pixels};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use wt_core::graph::{DotKind, ElbowKind, Graph, GraphRow, GraphScope, RefKind};
 
@@ -569,7 +572,7 @@ impl AdeApp {
 /// two-collection shape rather than unifying into one `Tab` enum (see that function's docs, and
 /// this project's own note that a forced unification wasn't the right call here). Rendered only
 /// while `AdeApp::graph_tab_open` is `true`.
-pub(crate) fn render_graph_tab(app: &AdeApp, cx: &mut Context<AdeApp>) -> impl IntoElement {
+pub(crate) fn render_graph_tab(app: &AdeApp, cx: &mut Context<AdeApp>) -> gpui::AnyElement {
     let is_active = app.graph_tab_active;
     let colors = work_surface::tab_colors(is_active);
     let close_color = if is_active {
@@ -577,16 +580,33 @@ pub(crate) fn render_graph_tab(app: &AdeApp, cx: &mut Context<AdeApp>) -> impl I
     } else {
         theme::text::DISABLED
     };
+    let tab_ref = work_surface::TabRef::Graph;
+    let drag_value = DraggedTab::Graph {
+        label: "Git graph".to_string(),
+    };
+    let insertion_caret = match &app.tab_drag_insertion {
+        Some((target, insert_after)) if *target == tab_ref => Some(*insert_after),
+        _ => None,
+    };
+    let is_dragging = app.dragging_tab.as_ref() == Some(&tab_ref);
+    let settle_animation_id = tab_settle_animation_id(&app.dropped_tab_settle, &tab_ref);
+    let this_entity = cx.entity();
+    let tab_ref_for_drag = tab_ref.clone();
 
-    div()
+    let tab_div = div()
         .id("graph-tab")
         .debug_selector(|| "graph-tab".to_string())
+        .relative()
         .flex()
         .flex_none()
         .flex_col()
         .border_r_1()
         .border_color(theme::border::INNER)
         .bg(colors.bg)
+        // Mirrors `AdeApp::render_file_tab`'s own dimmed-original-slot precedent (GitHub issue
+        // #16) - see `AdeApp::dragging_tab`'s own docs for why this can't be derived from GPUI's
+        // `has_active_drag()` alone.
+        .when(is_dragging, |el| el.opacity(0.4))
         // Middle-click closes the graph tab too (GitHub issue #26) - the same real
         // `close_git_graph_tab` teardown the `×` button already uses, matching file/agent tabs.
         .on_mouse_down(
@@ -596,6 +616,29 @@ pub(crate) fn render_graph_tab(app: &AdeApp, cx: &mut Context<AdeApp>) -> impl I
                 this.close_git_graph_tab(window, cx);
             }),
         )
+        // Real drag-to-reorder, unified with agent/file tabs (GitHub issue #93) - see
+        // `AdeApp::render_file_tab`'s own docs for the shared mechanism.
+        .on_drag(drag_value, move |dragged, _position, _window, cx| {
+            this_entity.update(cx, |this, cx| {
+                this.start_dragging_tab(tab_ref_for_drag.clone(), cx);
+            });
+            cx.new(|_| dragged.clone())
+        })
+        .on_drag_move(cx.listener({
+            let tab_ref = tab_ref.clone();
+            move |this, event: &DragMoveEvent<DraggedTab>, _window, cx| {
+                this.update_tab_drag_insertion(&tab_ref, event, cx);
+            }
+        }))
+        .on_drop(cx.listener({
+            let target = tab_ref.clone();
+            move |this, dragged: &DraggedTab, _window, cx| {
+                this.drop_dragged_tab(dragged.tab_ref(), target.clone(), cx);
+            }
+        }))
+        .when_some(insertion_caret, |el, insert_after| {
+            el.child(render_tab_insertion_caret(insert_after))
+        })
         .child(
             div()
                 .id("graph-tab-hit")
@@ -638,7 +681,21 @@ pub(crate) fn render_graph_tab(app: &AdeApp, cx: &mut Context<AdeApp>) -> impl I
                         })),
                 ),
         )
-        .child(div().flex_none().w_full().h(px(1.0)).bg(colors.underline))
+        .child(div().flex_none().w_full().h(px(1.0)).bg(colors.underline));
+
+    // A real drop's own settle-in fade (GitHub issue #16 §5, extended to the graph tab by
+    // GitHub issue #93) - see `tab_settle_animation_id`'s own docs for why this branches to
+    // `gpui::AnyElement` rather than a plain `.when_some`.
+    match settle_animation_id {
+        Some(id) => tab_div
+            .with_animation(
+                id,
+                Animation::new(TAB_SETTLE_ANIMATION_DURATION),
+                |el, delta| el.opacity(0.55 + 0.45 * delta),
+            )
+            .into_any_element(),
+        None => tab_div.into_any_element(),
+    }
 }
 
 /// The tab's own fork-glyph chip: `#2a2030` bg, `#c98fbf` fork glyph drawn from four rects (two

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -407,7 +407,7 @@ impl AdeApp {
             .iter()
             .any(|agent| agent.kind != AgentKind::Shell);
         let open_files: &[PathBuf] = if is_bare { &[] } else { self.open_files() };
-        work_surface::reconcile_tab_order(stored, &agent_ids, open_files)
+        work_surface::reconcile_tab_order(stored, &agent_ids, open_files, self.graph_tab_open)
     }
 
     /// The unified tab strip's real drag-to-reorder entry point (GitHub issue #16) - moves
@@ -438,7 +438,7 @@ impl AdeApp {
             .iter()
             .filter_map(|tab_ref| match tab_ref {
                 work_surface::TabRef::File(path) => Some(cwd.join(path)),
-                work_surface::TabRef::Agent(_) => None,
+                work_surface::TabRef::Agent(_) | work_surface::TabRef::Graph => None,
             })
             .collect();
         self.tab_order_state.set_file_order(&cwd, &files);
@@ -491,7 +491,7 @@ impl AdeApp {
     /// the two apart. A no-op while the dragged tab is hovering over *itself* - dropping a tab on
     /// its own slot is always a no-op ([`work_surface::state::move_tab_order`]'s own docs), so no
     /// caret should invite it either.
-    pub(in crate::work_surface) fn update_tab_drag_insertion(
+    pub(crate) fn update_tab_drag_insertion(
         &mut self,
         hovered: &work_surface::TabRef,
         event: &DragMoveEvent<DraggedTab>,
@@ -516,7 +516,7 @@ impl AdeApp {
     /// drop lands on a tab [`Self::update_tab_drag_insertion`] never actually recorded for - a
     /// drop can still fire on a tab the cursor technically never entered, e.g. a very fast
     /// release), then delegates to [`Self::reorder_tab`], and clears the now-stale caret state.
-    pub(in crate::work_surface) fn drop_dragged_tab(
+    pub(crate) fn drop_dragged_tab(
         &mut self,
         dragged: work_surface::TabRef,
         target: work_surface::TabRef,
@@ -539,7 +539,7 @@ impl AdeApp {
     /// cursor. A plain method (not inlined into the closure) so it's directly testable without
     /// simulating a real GPUI drag gesture, matching [`Self::update_tab_drag_insertion`]/
     /// [`Self::drop_dragged_tab`]'s own precedent.
-    pub(in crate::work_surface) fn start_dragging_tab(
+    pub(crate) fn start_dragging_tab(
         &mut self,
         tab_ref: work_surface::TabRef,
         cx: &mut Context<Self>,
@@ -571,7 +571,7 @@ impl AdeApp {
         let order = self.combined_tab_order();
         order.into_iter().filter_map(move |tab_ref| match tab_ref {
             work_surface::TabRef::Agent(id) => self.agents.iter().find(|agent| agent.id == id),
-            work_surface::TabRef::File(_) => None,
+            work_surface::TabRef::File(_) | work_surface::TabRef::Graph => None,
         })
     }
 
@@ -665,7 +665,7 @@ impl AdeApp {
             .iter()
             .filter_map(|tab_ref| match tab_ref {
                 work_surface::TabRef::Agent(id) => Some(*id),
-                work_surface::TabRef::File(_) => None,
+                work_surface::TabRef::File(_) | work_surface::TabRef::Graph => None,
             })
             .collect();
         let labels = self.current_worktree_agent_tab_labels(&agent_ids, cx);
@@ -683,15 +683,15 @@ impl AdeApp {
                 work_surface::TabRef::File(path) => {
                     bar = bar.child(self.render_file_tab(&path, cx));
                 }
+                // GitHub issue #93: the git graph tab is now a real member of the same combined
+                // order every agent/file tab already goes through - draggable, and its own
+                // per-worktree position remembered - rather than a fixed, un-reorderable third
+                // slot always rendered after every other tab. See `crate::graph_view::render::
+                // render_graph_tab`'s own docs for the drag wiring this required.
+                work_surface::TabRef::Graph => {
+                    bar = bar.child(crate::graph_view::render::render_graph_tab(self, cx));
+                }
             }
-        }
-
-        // A third, independent parallel slot for the git graph tab (GitHub issue #1, phase (a)) -
-        // at most one, so a plain `if` rather than a loop over a collection like
-        // `combined_tab_order` above. See `crate::graph_view`'s module docs for why this isn't a
-        // forced three-way `Tab` enum.
-        if self.graph_tab_open {
-            bar = bar.child(crate::graph_view::render::render_graph_tab(self, cx));
         }
 
         bar = bar.child(self.render_tab_strip_plus(cx));
@@ -2337,9 +2337,20 @@ pub(in crate::work_surface) fn render_tab_chip(kind: AgentKind, active: bool) ->
 /// by dragging" pattern itself. `Render`ing the dragged value as its own small floating chip -
 /// the same choice Zed's own `DraggedTab` makes - keeps what's being dragged legible.
 #[derive(Clone)]
-pub(in crate::work_surface) enum DraggedTab {
-    Agent { id: AgentId, label: String },
-    File { path: PathBuf, label: String },
+pub(crate) enum DraggedTab {
+    Agent {
+        id: AgentId,
+        label: String,
+    },
+    File {
+        path: PathBuf,
+        label: String,
+    },
+    /// GitHub issue #93 - the git graph tab, dragged the same way. No id/path payload: like
+    /// [`work_surface::TabRef::Graph`], there is only ever at most one real graph tab.
+    Graph {
+        label: String,
+    },
 }
 
 impl DraggedTab {
@@ -2347,15 +2358,17 @@ impl DraggedTab {
         match self {
             DraggedTab::Agent { label, .. } => label,
             DraggedTab::File { label, .. } => label,
+            DraggedTab::Graph { label } => label,
         }
     }
 
     /// This dragged value's own identity as a [`work_surface::TabRef`] - what
     /// [`AdeApp::reorder_tab`] actually moves, regardless of which concrete kind was dragged.
-    pub(in crate::work_surface) fn tab_ref(&self) -> work_surface::TabRef {
+    pub(crate) fn tab_ref(&self) -> work_surface::TabRef {
         match self {
             DraggedTab::Agent { id, .. } => work_surface::TabRef::Agent(*id),
             DraggedTab::File { path, .. } => work_surface::TabRef::File(path.clone()),
+            DraggedTab::Graph { .. } => work_surface::TabRef::Graph,
         }
     }
 }
@@ -2386,7 +2399,7 @@ impl Render for DraggedTab {
 /// edge if `insert_after` is `true` (immediately after) - replacing the old whole-tab `border_l`
 /// highlight, which never distinguished "before" from "after" the hovered tab, with an
 /// unambiguous "it lands exactly here" caret instead.
-fn render_tab_insertion_caret(insert_after: bool) -> impl IntoElement {
+pub(crate) fn render_tab_insertion_caret(insert_after: bool) -> impl IntoElement {
     div()
         .absolute()
         .top(px(0.0))
@@ -2399,7 +2412,7 @@ fn render_tab_insertion_caret(insert_after: bool) -> impl IntoElement {
 
 /// How long a dropped tab's own settle-in fade runs - short and non-blocking, matching the
 /// design handoff's own "animations are short (~120-180ms)" ask (GitHub issue #16 §5).
-const TAB_SETTLE_ANIMATION_DURATION: Duration = Duration::from_millis(150);
+pub(crate) const TAB_SETTLE_ANIMATION_DURATION: Duration = Duration::from_millis(150);
 
 /// A fresh `gpui::AnimationExt::with_animation` id for `tab_ref`, if [`AdeApp::dropped_tab_settle`]
 /// says it's the tab a real drop most recently placed - `None` for every other tab, and for a
@@ -2409,7 +2422,7 @@ const TAB_SETTLE_ANIMATION_DURATION: Duration = Duration::from_millis(150);
 /// (`vendor/zed/crates/gpui/src/elements/animation.rs`'s `AnimationState`) - reusing the same id
 /// across two different drops of the same tab would resume the *first* drop's already-finished
 /// animation instead of starting a fresh one.
-fn tab_settle_animation_id(
+pub(crate) fn tab_settle_animation_id(
     settle: &Option<(work_surface::TabRef, u64)>,
     tab_ref: &work_surface::TabRef,
 ) -> Option<String> {
@@ -2989,6 +3002,109 @@ mod tab_scoping_tests {
             ],
             "the file tab must now sit between the two agent tabs - the real cross-group \
              interleaving this revision exists to unlock"
+        );
+    }
+
+    /// GitHub issue #93: the git graph tab must be a full, kind-agnostic member of the same
+    /// drag-to-reorder system as agent/file tabs, not a fixed trailing entry - dragging it so it
+    /// lands between two agent tabs must actually interleave it into `Self::combined_tab_order`,
+    /// mirroring `dragging_a_file_tab_between_two_agent_tabs_interleaves_them`'s own file-tab
+    /// case exactly.
+    #[gpui::test]
+    fn dragging_the_graph_tab_between_two_agent_tabs_interleaves_it(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+
+        let (initial_id, second_id) = app.update_in(cx, |app, window, cx| {
+            let initial_id = app.agents.active_id().expect("initial shell agent");
+            let second_id = app.agents.spawn(
+                AgentKind::Claude,
+                repo.path().to_path_buf(),
+                12.0,
+                window,
+                cx,
+            );
+            app.open_git_graph(window, cx);
+            (initial_id, second_id)
+        });
+
+        let before = app.read_with(cx, |app, _| app.combined_tab_order());
+        assert_eq!(
+            before,
+            vec![
+                work_surface::TabRef::Agent(initial_id),
+                work_surface::TabRef::Agent(second_id),
+                work_surface::TabRef::Graph,
+            ],
+            "with no drag yet, agents come first (creation order), then the freshly opened \
+             graph tab"
+        );
+
+        app.update(cx, |app, cx| {
+            app.reorder_tab(
+                work_surface::TabRef::Graph,
+                work_surface::TabRef::Agent(second_id),
+                false,
+                cx,
+            );
+        });
+
+        let after = app.read_with(cx, |app, _| app.combined_tab_order());
+        assert_eq!(
+            after,
+            vec![
+                work_surface::TabRef::Agent(initial_id),
+                work_surface::TabRef::Graph,
+                work_surface::TabRef::Agent(second_id),
+            ],
+            "the graph tab must now sit between the two agent tabs, the same real \
+             cross-kind interleaving file/agent tabs already get"
+        );
+    }
+
+    /// `Self::start_dragging_tab`/`Self::drop_dragged_tab` must treat `TabRef::Graph` exactly
+    /// like any other tab kind - recording it while dragged, then clearing that record once
+    /// dropped - mirroring `start_dragging_tab_records_exactly_the_tab_that_started_the_drag`'s
+    /// own agent-tab case.
+    #[gpui::test]
+    fn dragging_the_graph_tab_dims_its_own_slot_then_clears_on_drop(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+
+        let initial_id = app.update_in(cx, |app, window, cx| {
+            app.open_git_graph(window, cx);
+            app.agents.active_id().expect("initial shell agent")
+        });
+
+        app.update(cx, |app, cx| {
+            app.start_dragging_tab(work_surface::TabRef::Graph, cx);
+        });
+        assert_eq!(
+            app.read_with(cx, |app, _| app.dragging_tab.clone()),
+            Some(work_surface::TabRef::Graph),
+            "starting a drag on the graph tab must record exactly that tab"
+        );
+
+        app.update(cx, |app, cx| {
+            app.drop_dragged_tab(
+                work_surface::TabRef::Graph,
+                work_surface::TabRef::Agent(initial_id),
+                cx,
+            );
+        });
+        assert_eq!(
+            app.read_with(cx, |app, _| app.dragging_tab.clone()),
+            None,
+            "a handled drop must clear the now-stale dragging-tab state, same as any other kind"
+        );
+        // GitHub issue #93's own extension of the settle-fade (GitHub issue #16 §5): dropping
+        // the graph tab must record it into `Self::dropped_tab_settle` exactly like any other
+        // kind - `Self::drop_dragged_tab` is already kind-agnostic here, so this is really
+        // proving `render_graph_tab` reads the same real field, not a separate code path.
+        assert_eq!(
+            app.read_with(cx, |app, _| app.dropped_tab_settle.clone().map(|(t, _)| t)),
+            Some(work_surface::TabRef::Graph),
+            "a real drop of the graph tab must record it for the settle-in fade too"
         );
     }
 

--- a/crates/app/src/work_surface/state.rs
+++ b/crates/app/src/work_surface/state.rs
@@ -17,25 +17,36 @@ use crate::sidebar::file_tree::LangChip;
 use crate::theme;
 use crate::work_surface::agents::{AgentId, AgentKind};
 
-/// One entry in a worktree's combined tab-strip order (GitHub issue #16) - either an agent tab
-/// or a file tab. `Agents`/`crate::root::AdeApp::open_files` remain the real storage for
-/// *existence* and all process/buffer behaviour (spawning, closing, PTY lifecycle, edit-buffer
-/// state) - this only records where a tab sits *visually*, so the two groups can interleave in
-/// one strip instead of always rendering as two rigid blocks.
+/// One entry in a worktree's combined tab-strip order (GitHub issue #16, extended by issue #93
+/// to also cover the git graph tab) - an agent tab, a file tab, or the one real git graph tab.
+/// `Agents`/`crate::root::AdeApp::open_files`/`crate::root::AdeApp::graph_tab_open` remain the
+/// real storage for *existence* and all process/buffer/graph-load behaviour - this only records
+/// where a tab sits *visually*, so every kind can interleave in one strip instead of always
+/// rendering as rigid, un-reorderable blocks. `Graph` carries no payload: unlike agents/files,
+/// there is only ever at most one real graph tab per window (`crate::root::AdeApp::
+/// graph_tab_open`'s own "one per window" docs), so there is nothing to distinguish one from
+/// another the way an `AgentId`/`PathBuf` does for its own kind.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TabRef {
     Agent(AgentId),
     File(PathBuf),
+    Graph,
 }
 
 /// Reconciles a worktree's stored tab order (`crate::root::AdeApp::tab_order`) against what's
 /// *actually* open right now: drops any entry that no longer exists (a closed agent, a closed
-/// file tab), then appends anything open that isn't in `stored` yet (a freshly spawned agent,
-/// a freshly opened file) in `agents_for_cwd`/`open_files`'s own order - the same "just append
-/// at the end" position a brand new tab has always landed at.
+/// file tab, a closed graph tab), then appends anything open that isn't in `stored` yet (a
+/// freshly spawned agent, a freshly opened file, or - GitHub issue #93 - a freshly opened graph
+/// tab) in `agents_for_cwd`/`open_files`/`graph_open`'s own order - the same "just append at the
+/// end" position a brand new tab has always landed at. `graph_open` is a real, live "is the one
+/// graph tab open right now" fact (`crate::root::AdeApp::graph_tab_open`), not itself scoped to
+/// this worktree - only its *position within this worktree's own strip* is, matching how
+/// `crate::root::AdeApp::tab_order` already remembers a different position per worktree for the
+/// same shared agent/file tab identities never do (an agent/file *is* worktree-scoped; the graph
+/// tab's own on-screen slot is what's being remembered here, not a second graph tab).
 ///
 /// Pure and idempotent: calling it again on its own output, with the same
-/// `agents_for_cwd`/`open_files`, changes nothing. That's what lets
+/// `agents_for_cwd`/`open_files`/`graph_open`, changes nothing. That's what lets
 /// `crate::root::AdeApp::combined_tab_order` call this fresh on every render instead of caching
 /// a mutated copy - only a real drag-drop (`crate::root::AdeApp::reorder_tab`) needs to persist a
 /// changed `Vec<TabRef>` back into `tab_order`.
@@ -43,12 +54,14 @@ pub fn reconcile_tab_order(
     stored: &[TabRef],
     agents_for_cwd: &[AgentId],
     open_files: &[PathBuf],
+    graph_open: bool,
 ) -> Vec<TabRef> {
     let mut order: Vec<TabRef> = stored
         .iter()
         .filter(|tab_ref| match tab_ref {
             TabRef::Agent(id) => agents_for_cwd.contains(id),
             TabRef::File(path) => open_files.contains(path),
+            TabRef::Graph => graph_open,
         })
         .cloned()
         .collect();
@@ -67,6 +80,9 @@ pub fn reconcile_tab_order(
         {
             order.push(TabRef::File(path.clone()));
         }
+    }
+    if graph_open && !order.contains(&TabRef::Graph) {
+        order.push(TabRef::Graph);
     }
     order
 }
@@ -779,6 +795,7 @@ mod tests {
             &[],
             &[1, 2],
             &[PathBuf::from("a.rs"), PathBuf::from("b.rs")],
+            false,
         );
         assert_eq!(
             order,
@@ -801,7 +818,7 @@ mod tests {
             TabRef::File(PathBuf::from("a.rs")),
             TabRef::Agent(2),
         ];
-        let order = reconcile_tab_order(&stored, &[1, 2], &[PathBuf::from("a.rs")]);
+        let order = reconcile_tab_order(&stored, &[1, 2], &[PathBuf::from("a.rs")], false);
         assert_eq!(order, stored);
     }
 
@@ -815,7 +832,7 @@ mod tests {
             TabRef::File(PathBuf::from("a.rs")),
             TabRef::Agent(2),
         ];
-        let order = reconcile_tab_order(&stored, &[2], &[]);
+        let order = reconcile_tab_order(&stored, &[2], &[], false);
         assert_eq!(order, vec![TabRef::Agent(2)]);
     }
 
@@ -824,7 +841,7 @@ mod tests {
     #[test]
     fn reconcile_appends_newly_opened_tabs_not_yet_in_the_stored_order() {
         let stored = vec![TabRef::Agent(1)];
-        let order = reconcile_tab_order(&stored, &[1, 2], &[PathBuf::from("a.rs")]);
+        let order = reconcile_tab_order(&stored, &[1, 2], &[PathBuf::from("a.rs")], false);
         assert_eq!(
             order,
             vec![
@@ -833,6 +850,35 @@ mod tests {
                 TabRef::File(PathBuf::from("a.rs")),
             ]
         );
+    }
+
+    /// GitHub issue #93: a freshly opened graph tab, not yet in the stored order, must be
+    /// appended at the end - the same "brand new tab lands last" rule every other kind already
+    /// gets, not silently dropped or given a hardcoded fixed position.
+    #[test]
+    fn reconcile_appends_a_freshly_opened_graph_tab() {
+        let order = reconcile_tab_order(&[], &[1], &[], true);
+        assert_eq!(order, vec![TabRef::Agent(1), TabRef::Graph]);
+    }
+
+    /// The real point of GitHub issue #93: once a drag has recorded the graph tab somewhere
+    /// specific in the stored order, reconciliation must honor that real position - not always
+    /// re-append it at the end - as long as it's still open.
+    #[test]
+    fn reconcile_preserves_a_stored_graph_tab_position() {
+        let stored = vec![TabRef::Graph, TabRef::Agent(1)];
+        let order = reconcile_tab_order(&stored, &[1], &[], true);
+        assert_eq!(order, stored);
+    }
+
+    /// A closed graph tab must be dropped from the order, exactly like a closed agent or file
+    /// tab - not left as a dangling entry `crate::root::AdeApp::render_tab_strip` would try to
+    /// render for a tab that no longer exists.
+    #[test]
+    fn reconcile_drops_a_closed_graph_tab() {
+        let stored = vec![TabRef::Agent(1), TabRef::Graph];
+        let order = reconcile_tab_order(&stored, &[1], &[], false);
+        assert_eq!(order, vec![TabRef::Agent(1)]);
     }
 
     /// The real cross-kind drag this revision exists to unlock: dropping a file tab so it lands


### PR DESCRIPTION
## Summary
The git graph tab was a fixed, always-trailing entry in the tab strip - unlike agent and file tabs, it never participated in GitHub issue #16's unified drag-to-reorder system.

- Extends `work_surface::TabRef` and `DraggedTab` (the drag-payload enum) with a `Graph` variant.
- `reconcile_tab_order`/`combined_tab_order` now interleave the graph tab into the real stored order instead of always appending it last.
- `render_graph_tab` wires the same `on_drag`/`on_drag_move`/`on_drop` trio `render_file_tab`/`render_agent_tab` already use, including the dimmed-original-slot behavior while dragging and the drop-settle fade (GitHub issue #16 §5, re-landed by PR #94) - now `gpui::AnyElement`-returning to match.
- Widens the shared drag machinery (`DraggedTab`, `start_dragging_tab`, `update_tab_drag_insertion`, `drop_dragged_tab`, `render_tab_insertion_caret`, `tab_settle_animation_id`, `TAB_SETTLE_ANIMATION_DURATION`) from `pub(in crate::work_surface)` to `pub(crate)` so `crate::graph_view` can reach it - the same access `render_dropdown_menu_row` already had.

Closes #93.

## Test plan
- `cargo fmt --all -- --check`
- `cargo build --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --lib -- --test-threads=1` (1357/49/14/171 passed across app/lsp-core/pty-core/wt-core, 0 failed)
- New tests: `dragging_the_graph_tab_between_two_agent_tabs_interleaves_it`, `dragging_the_graph_tab_dims_its_own_slot_then_clears_on_drop` (also asserts the settle-fade id records), `reconcile_appends_a_freshly_opened_graph_tab`, `reconcile_preserves_a_stored_graph_tab_position`, `reconcile_drops_a_closed_graph_tab`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>