### PR TITLE
fix(app): update a stale test-only call site for the optional-repo constructor

### DIFF
--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -1725,7 +1725,8 @@ mod file_tree_watch_integration_tests {
         std::mem::forget(config_dir);
         cx.add_window_view(|window, cx| {
             AdeApp::new_with_settings(
-                repo_path,
+                Some(repo_path),
+                false,
                 settings_store::Settings::default(),
                 Some(settings_path),
                 window,


### PR DESCRIPTION
## Summary
A hotfix for a real regression on master: PR #83's own rebase fixed \`open_test_app_with_real_settings_path\` (issue #13's file-tree-watch test module) to call \`AdeApp::new_with_settings\` with its current, post-issue-#90 signature - but that fix was made in the working tree and never actually committed before the branch was force-pushed and merged, so master currently fails to compile with \`cargo test --workspace\` (test-only, \`cargo build --workspace\` alone is unaffected).

## Test plan
- \`cargo fmt --all -- --check\`
- \`cargo build --workspace --tests\`
- \`cargo clippy --workspace --all-targets -- -D warnings\`
- \`cargo test --workspace --lib file_tree_watch -- --test-threads=1\` (9 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>