### PR TITLE
fix(app): file-tree focus-stealing on click + missing Delete shortcut (issue #105)

### DIFF
--- a/crates/app/src/code_surface/tabs.rs
+++ b/crates/app/src/code_surface/tabs.rs
@@ -134,11 +134,23 @@ impl AdeApp {
     /// real on-disk path, used only for the tree reveal. They are passed separately rather than
     /// derived one from the other because the two callers resolve against *different* roots -
     /// see [`Self::open_change_diff`]'s own docs for the real state in which they differ.
+    ///
+    /// `focus_editor` controls point 2 above - `true` for every caller except the Files tree's
+    /// own row click (GitHub issue #105): a click there is a real *selection* gesture the same
+    /// way a folder click already is, and folder clicks have always kept keyboard focus on
+    /// `Self::tree_focus_handle` rather than handing it to the editor. Before this, only file
+    /// rows silently broke that symmetry - `open_and_focus_file` unconditionally moved focus off
+    /// the tree the instant a file was clicked, so every `"file-tree"`-scoped shortcut (`Ctrl+C`/
+    /// `X`/`V`, `F2`, `Shift+F10`) went dead the moment the single most common selection gesture
+    /// happened. `false` never transiently focuses the editor at all (rather than focusing it and
+    /// immediately handing focus back to the tree), so no editor-focus/-blur side effect ever
+    /// fires for a plain tree click.
     fn open_and_focus_file(
         &mut self,
         relative: PathBuf,
         absolute: PathBuf,
         view: code_view::CodeView,
+        focus_editor: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -159,7 +171,9 @@ impl AdeApp {
         // its own `code_focus.capture()` never captures a handle that's about to stop being
         // rendered. See `crate::graph_view::render::AdeApp::leave_graph_tab`'s own docs.
         self.leave_graph_tab(window, cx);
-        self.focus_code_surface(window, cx);
+        if focus_editor {
+            self.focus_code_surface(window, cx);
+        }
         self.push_open_file(&relative);
         self.open_change = Some(relative);
         self.code_view = view;
@@ -215,15 +229,47 @@ impl AdeApp {
         cx: &mut Context<Self>,
     ) {
         let absolute = self.diff_root.join(&path);
-        self.open_and_focus_file(path, absolute, code_view::CodeView::Diff, window, cx);
+        self.open_and_focus_file(path, absolute, code_view::CodeView::Diff, true, window, cx);
     }
 
-    /// Opens `path` (absolute) directly in Surface C's File view - the Files-tree row click
-    /// handler, go-to-definition, a terminal path link, a just-created file, and a palette file
-    /// result with no diff to show.
+    /// Opens `path` (absolute) directly in Surface C's File view - go-to-definition, a terminal
+    /// path link, a just-created file, and a palette file result with no diff to show. The Files
+    /// tree's own row click uses [`Self::open_file_view_from_tree_click`] instead (GitHub issue
+    /// #105) - see that function's own docs for why it needs different focus behavior than every
+    /// other caller here.
     pub(crate) fn open_file_view(
         &mut self,
         path: PathBuf,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.open_file_view_with_focus(path, true, window, cx);
+    }
+
+    /// The Files tree's own row click handler (GitHub issue #105) - opens `path` exactly like
+    /// [`Self::open_file_view`], but never moves keyboard focus onto the editor. A file click is
+    /// a real *selection* gesture, the same as a folder click - and a folder click has always
+    /// kept focus on [`Self::tree_focus_handle`] rather than handing it away. Before this, only
+    /// file rows broke that symmetry: clicking a file silently moved focus off the tree, so every
+    /// `"file-tree"`-scoped shortcut (`Ctrl+C`/`X`/`V`, `F2`, `Shift+F10`) went dead the instant
+    /// the single most common selection gesture happened. Never transiently focuses the editor at
+    /// all (rather than focusing it and immediately handing focus back), so no editor-focus/-blur
+    /// side effect ever fires for a plain tree click - `crate::sidebar::render`'s own row click
+    /// handler is responsible for explicitly (re)confirming tree focus afterward, the same way
+    /// the folder-click handler already does.
+    pub(crate) fn open_file_view_from_tree_click(
+        &mut self,
+        path: PathBuf,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.open_file_view_with_focus(path, false, window, cx);
+    }
+
+    fn open_file_view_with_focus(
+        &mut self,
+        path: PathBuf,
+        focus_editor: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -236,7 +282,14 @@ impl AdeApp {
             .strip_prefix(&self.file_tree_root)
             .map(|relative| relative.to_path_buf())
             .unwrap_or_else(|_| path.clone());
-        self.open_and_focus_file(relative, path, code_view::CodeView::File, window, cx);
+        self.open_and_focus_file(
+            relative,
+            path,
+            code_view::CodeView::File,
+            focus_editor,
+            window,
+            cx,
+        );
     }
 
     /// Activates a file tab (the tab strip's click handler), as opposed to

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -494,6 +494,23 @@ pub fn default_key_bindings() -> Vec<gpui::KeyBinding> {
             root::FileTreePaste,
             Some("file-tree && !tree-editing && !tree-delete-confirm"),
         ),
+        // GitHub issue #105: "remove file" had no keyboard shortcut at all - only reachable via
+        // a right-click's own "Delete" menu row (`crate::sidebar::context_menu::MenuAction::
+        // Delete`'s own `keystroke_spec()` deliberately returns `None`, unlike every other
+        // mutating row) or `Shift+F10` opening the menu. `Some("file-tree && !tree-editing")`
+        // - not `!tree-delete-confirm` too, unlike every binding above it - is deliberate:
+        // `crate::sidebar::tree_ops::AdeApp::handle_file_tree_delete_action` is the one handler
+        // that must fire in *both* halves of the arm/confirm flow (a first press arms via
+        // `request_tree_delete_for_selection`, a second press while the confirmation panel is up
+        // runs the real delete via `confirm_tree_delete`), so excluding `tree-delete-confirm`
+        // here would make the confirming second press unreachable by keyboard. `!tree-editing`
+        // is kept because an inline rename box's own `Delete`/`Backspace` presses must edit the
+        // filename text, not arm a tree delete underneath it.
+        gpui::KeyBinding::new(
+            "delete",
+            root::FileTreeDelete,
+            Some("file-tree && !tree-editing"),
+        ),
         // `Ctrl+W` (GitHub issue #26) - closes the focused tab (file or agent), via
         // `crate::work_surface::render::AdeApp::handle_close_focused_tab_action`'s own docs for
         // exactly what "focused" resolves to and why this can never close the window (this app

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -190,6 +190,7 @@ actions!(
         FileTreeCopy,
         FileTreeCut,
         FileTreePaste,
+        FileTreeDelete,
     ]
 );
 

--- a/crates/app/src/settings/state.rs
+++ b/crates/app/src/settings/state.rs
@@ -1280,6 +1280,10 @@ mod tests {
                 "Files tree: copy",
                 "Files tree: cut",
                 "Files tree: paste",
+                // GitHub issue #105's `Delete` - the only file-tree binding not excluded from
+                // `"tree-delete-confirm"` too, since it must fire on both the arming press and
+                // the confirming one.
+                "Files tree: delete (asks for confirmation)",
                 // GitHub issue #26's `Ctrl+W` - closes the focused tab, scoped `Some("!terminal")`.
                 "Close focused tab",
             ]
@@ -1341,6 +1345,10 @@ mod tests {
         // `EditorCollapseCursors` resolves in the File view), `CompletionsInvoke` under plain
         // `"file-editor"` (1), and `CloseFocusedTab` under `Some("!terminal")` (1, the same real
         // terminal-control-byte conflict class `"ctrl-shift-t"` above already established).
+        // GitHub issue #105 added 1 more real scoped binding, `FileTreeDelete` (`Delete`, `Some(
+        // "file-tree && !tree-editing")`) - see `crate::default_key_bindings`'s own docs for why
+        // it, alone among the file-tree bindings, is not also excluded from
+        // `"tree-delete-confirm"`.
         let bindings = crate::default_key_bindings();
         let rows = keybinding_rows(&bindings, &[]);
         assert!(!rows.is_empty());
@@ -1348,13 +1356,13 @@ mod tests {
             rows.iter().filter(|row| row.context != "global").collect();
         assert_eq!(
             scoped.len(),
-            70,
+            71,
             "expected `] -> NextChangedFile` (1) plus every real Editor* binding (19) plus \
              every real Completions* binding (5) plus every real merge-editor binding (18) plus \
              TextUndo/TextRedo (3, GitHub issue #17) plus every real \
-             file-tree binding (5, GitHub issue #19) plus every real word-wise Editor* binding \
-             (8, GitHub issue #27) plus every real multi-cursor Editor* binding (4, GitHub issue \
-             #28) plus every real GitHub issue #26 binding (7, not counting \
+             file-tree binding (6, GitHub issues #19 and #105) plus every real word-wise Editor* \
+             binding (8, GitHub issue #27) plus every real multi-cursor Editor* binding (4, \
+             GitHub issue #28) plus every real GitHub issue #26 binding (7, not counting \
              EditorCollapseCursors above, which is issue #28's own action) to be scoped, not \
              global"
         );
@@ -1363,7 +1371,7 @@ mod tests {
                 .iter()
                 .filter(|row| row.command.starts_with("Files tree: "))
                 .count()
-                == 5,
+                == 6,
             "every file-tree binding must be reported as scoped - a globally-bound Ctrl+C would \
              be exactly the keystroke-swallowing bug class this list's own docs catalogue"
         );

--- a/crates/app/src/settings/state.rs
+++ b/crates/app/src/settings/state.rs
@@ -584,6 +584,7 @@ pub(crate) fn action_label(action: &dyn gpui::Action) -> Option<&'static str> {
         "app::FileTreeCopy" => Some("Files tree: copy"),
         "app::FileTreeCut" => Some("Files tree: cut"),
         "app::FileTreePaste" => Some("Files tree: paste"),
+        "app::FileTreeDelete" => Some("Files tree: delete (asks for confirmation)"),
         _ => None,
     }
 }

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -775,6 +775,7 @@ impl AdeApp {
             .on_action(cx.listener(Self::handle_file_tree_copy_action))
             .on_action(cx.listener(Self::handle_file_tree_cut_action))
             .on_action(cx.listener(Self::handle_file_tree_paste_action))
+            .on_action(cx.listener(Self::handle_file_tree_delete_action))
             .on_action(cx.listener(Self::handle_tree_text_undo))
             .on_action(cx.listener(Self::handle_tree_text_redo))
             .on_key_down(cx.listener(Self::handle_tree_key_down))
@@ -1085,13 +1086,21 @@ impl AdeApp {
                     this.toggle_dir_expanded(path.clone(), cx);
                 }));
         } else {
-            // Opens the file in Surface C's File view - see `Self::open_file_view`'s docs.
+            // GitHub issue #105: uses `Self::open_file_view_from_tree_click`, not
+            // `Self::open_file_view` - a file click is a real *selection* gesture, the same as a
+            // folder click just above (which has always kept tree focus), so this must never move
+            // keyboard focus onto the editor the way every other `open_file_view` caller wants.
+            // See that function's own docs for the real bug this fixes: every
+            // `"file-tree"`-scoped shortcut (`Ctrl+C`/`X`/`V`, `F2`, `Shift+F10`) went dead the
+            // instant a file was clicked, since that used to be the one tree gesture that silently
+            // handed focus away.
             let path = entry.path.clone();
             row = row
                 .cursor_pointer()
                 .hover(|el| el.bg(theme::surface::ROW_HOVER))
                 .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
-                    this.open_file_view(path.clone(), window, cx);
+                    this.open_file_view_from_tree_click(path.clone(), window, cx);
+                    this.focus_file_tree(window, cx);
                 }));
         }
 

--- a/crates/app/src/sidebar/tree_ops.rs
+++ b/crates/app/src/sidebar/tree_ops.rs
@@ -916,6 +916,25 @@ impl AdeApp {
         }
     }
 
+    /// The `Delete` keyboard shortcut's own arming step - mirrors
+    /// [`Self::start_tree_rename_for_selection`]'s "resolve `is_dir` off the live tree, not the
+    /// filesystem" pattern so a stale/renamed selection can't race a real `stat` call.
+    pub(in crate::sidebar) fn request_tree_delete_for_selection(&mut self, cx: &mut Context<Self>) {
+        let Some(path) = self.selected_tree_path.clone() else {
+            return;
+        };
+        if !path.starts_with(&self.file_tree_root) || path == self.file_tree_root {
+            return;
+        }
+        let is_dir = self
+            .file_tree
+            .iter()
+            .find(|entry| entry.path == path)
+            .map(|entry| entry.is_dir)
+            .unwrap_or_else(|| path.is_dir());
+        self.request_tree_delete(path, is_dir, cx);
+    }
+
     /// Runs the confirmed delete. A trash-backed delete shells out to the resolved command on
     /// the background executor (never the foreground thread); a permanent one runs
     /// [`file_ops::delete_permanently`] there for the same reason.
@@ -1147,6 +1166,26 @@ impl AdeApp {
         cx: &mut Context<Self>,
     ) {
         self.paste_into_selection(cx);
+    }
+
+    /// `Delete` while the tree is focused (`crate::root::FileTreeDelete`). Bound with the context
+    /// predicate `"file-tree && !tree-editing"` - deliberately *not* excluding
+    /// `"tree-delete-confirm"` too, unlike Copy/Cut/Paste/Rename, because this single action must
+    /// serve both gestures of the arm/confirm flow: a first press with nothing armed arms the
+    /// confirmation (via [`Self::request_tree_delete_for_selection`]); a second press while the
+    /// panel from that same arming is still up runs the real delete (via
+    /// [`Self::confirm_tree_delete`]), the same as clicking that panel's own confirm button.
+    pub(in crate::sidebar) fn handle_file_tree_delete_action(
+        &mut self,
+        _action: &crate::root::FileTreeDelete,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.tree_delete_confirm.is_some() {
+            self.confirm_tree_delete(cx);
+        } else {
+            self.request_tree_delete_for_selection(cx);
+        }
     }
 
     // ---------------------------------------------------------------- misc actions
@@ -2812,6 +2851,97 @@ mod tree_ops_regression_tests {
             Some(PathBuf::from("README.md")),
             "with no menu in the way, a row click must open its file"
         );
+    }
+
+    /// GitHub issue #105: clicking a file used to hand keyboard focus to the editor, silently
+    /// killing every `"file-tree"`-scoped shortcut (`Ctrl+C`/`X`/`V`, `F2`, `Shift+F10`, `Delete`)
+    /// the instant a file was selected. Driven as a real click at the row's own painted bounds -
+    /// not a manual `focus_file_tree` call - because that manual call is exactly what would have
+    /// masked the original bug.
+    #[gpui::test]
+    fn clicking_a_file_row_keeps_the_tree_focused_so_the_next_shortcut_still_fires(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = TempDir::new().expect("tempdir");
+        seed(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
+        cx.run_until_parked();
+
+        let row = cx
+            .debug_bounds("file-tree-row-README.md")
+            .expect("the file row must be painted");
+        cx.simulate_click(row.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        app.update_in(cx, |app, window, _cx| {
+            assert_eq!(
+                app.open_change,
+                Some(PathBuf::from("README.md")),
+                "premise: the click really did open the file"
+            );
+            assert!(
+                app.tree_focus_handle.is_focused(window),
+                "a file click must never move keyboard focus off the tree - it is a selection \
+                 gesture, the same as a folder click"
+            );
+        });
+
+        cx.simulate_keystrokes(&secondary("c"));
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.tree_clipboard.is_some(),
+                "with the tree still focused after the click, Ctrl+C must still reach the \
+                 tree's own copy handler"
+            );
+        });
+    }
+
+    /// GitHub issue #105: `Delete` had no keyboard shortcut at all. This drives the real two-press
+    /// flow through the keymap (not by calling `request_tree_delete`/`confirm_tree_delete`
+    /// directly): a first press arms the confirmation, a second removes the file - the same
+    /// outcome as clicking the row's own context-menu "Delete" then the confirmation panel's
+    /// button, but reachable from the keyboard.
+    #[gpui::test]
+    fn the_delete_key_arms_then_confirms_the_selected_files_removal(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        seed(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
+        cx.run_until_parked();
+
+        let victim = repo.path().join("README.md");
+        let row = cx
+            .debug_bounds("file-tree-row-README.md")
+            .expect("the file row must be painted");
+        cx.simulate_click(row.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        cx.simulate_keystrokes("delete");
+        app.read_with(cx, |app, _| {
+            let pending = app
+                .tree_delete_confirm
+                .as_ref()
+                .expect("the first press must arm the confirmation");
+            assert_eq!(pending.path, victim);
+        });
+        assert!(victim.exists(), "arming must not remove anything");
+
+        // Forced the same way `a_confirmed_delete_really_removes_the_file_and_its_tab` does, so
+        // this test doesn't move a real fixture into a developer machine's own trash.
+        app.update(cx, |app, _cx| {
+            app.tree_delete_confirm.as_mut().expect("armed").mechanism = DeleteMechanism::Permanent;
+        });
+
+        cx.simulate_keystrokes("delete");
+        cx.run_until_parked();
+        assert!(
+            !victim.exists(),
+            "the second press, while already armed, must run the real delete"
+        );
+        app.read_with(cx, |app, _| {
+            assert!(app.tree_delete_confirm.is_none());
+        });
     }
 
     /// `Shift+F10` must reach the tree only when the tree is really the focused surface. With the


### PR DESCRIPTION
## Summary
- Clicking a file row in the Files tree moved keyboard focus to the editor, silently killing every `"file-tree"`-scoped shortcut (Ctrl+C/X/V, F2, Shift+F10) the instant a file was selected. `open_and_focus_file`/`open_file_view` now take a `focus_editor` flag so a tree row click never hands focus away in the first place (the folder-click handler already worked this way; the file-click handler now matches it).
- Adds the missing `Delete` keyboard shortcut for removing a file/folder, wired through the same arm/confirm flow the context menu's own "Delete" row already uses - a first press arms the confirmation, a second press (while it's still up) runs the real delete.

Closes #105 (partially - multi-selection and drag-to-move are tracked as follow-up work, not included here).

## Test plan
- [x] New test: a real click on a file row keeps the tree focused, and a subsequent `Ctrl+C` still reaches the tree's copy handler (regression coverage for the exact reported bug, driven through a real click rather than a manual `focus_file_tree` call)
- [x] New test: a real `Delete` keypress arms the confirmation, and a second real `Delete` keypress (while armed) runs the actual delete
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib -- --test-threads=1` (one unrelated flake in `diff_view::diff_render_tests` on the shared run, confirmed passing in isolation - a known resource-contention flake class, not a regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)