### PR TITLE
fix(wt-core,app): show uncommitted changes when there's no base branch to diff against (issue #108)

### DIFF
--- a/crates/app/src/code_surface/editing.rs
+++ b/crates/app/src/code_surface/editing.rs
@@ -2951,9 +2951,10 @@ mod editing_tests {
     /// are computed from - stayed on whatever it was the last time something else happened to
     /// reload it (a worktree switch, a tree op via `crate::sidebar::tree_ops::AdeApp::
     /// refresh_after_file_op`), never the save itself. This drives a real `git`-backed repo one
-    /// branch off `main` (so there is a real base to diff against - `DiffBase::OnDefaultBranch`
-    /// would otherwise report no changes regardless of what's on disk, per `wt_core::diff::
-    /// diff_against_base`'s own docs), saves a real edit through the app, and asserts the
+    /// branch off `main` (so there is a real base to diff against and this hits `DiffBase::Diff`
+    /// specifically, not the `DiffBase::NoBase` uncommitted-vs-HEAD fallback a same-branch setup
+    /// would also report changes through, per `wt_core::diff::diff_against_base`'s own docs),
+    /// saves a real edit through the app, and asserts the
     /// reloaded `diff_state` reports the file as changed without any other trigger in between.
     #[gpui::test]
     fn saving_a_file_immediately_refreshes_diff_state_for_issue_89(cx: &mut TestAppContext) {

--- a/crates/app/src/code_surface/render.rs
+++ b/crates/app/src/code_surface/render.rs
@@ -19,20 +19,19 @@ impl AdeApp {
                 theme::status::FAIL,
             ),
             DiffLoadState::Loaded(DiffBase::NoBaseFound) => (
-                "no base branch could be detected for this worktree (no origin/HEAD, no \
-                 local main/master, and no fallback branch found)"
+                "no base branch could be detected for this worktree, and HEAD is unborn (no \
+                 commits yet), so there is nothing to diff at all"
                     .to_string(),
                 theme::text::FAINT,
             ),
-            DiffLoadState::Loaded(DiffBase::OnDefaultBranch { branch }) => (
-                format!(
-                    "this worktree is on the default branch ({branch}); nothing to diff against"
-                ),
-                theme::text::FAINT,
-            ),
-            // Unreachable in practice (callers check `current_diff()` first); matched explicitly
-            // so a future `DiffBase` variant isn't silently swallowed by a wildcard.
-            DiffLoadState::Loaded(DiffBase::Diff(_)) => (String::new(), theme::text::FAINT),
+            // Unreachable in practice (callers check `current_diff()` first, which is `Some`
+            // for both real variants below via `DiffBase::diff()` - GitHub issue #108's
+            // uncommitted-vs-HEAD fallback means `NoBase` is never actually "nothing to show").
+            // Matched explicitly so a future `DiffBase` variant isn't silently swallowed by a
+            // wildcard.
+            DiffLoadState::Loaded(DiffBase::Diff(_) | DiffBase::NoBase { .. }) => {
+                (String::new(), theme::text::FAINT)
+            }
         };
         render_sidebar_message(text, color.into())
     }

--- a/crates/app/src/code_surface/tabs.rs
+++ b/crates/app/src/code_surface/tabs.rs
@@ -45,16 +45,12 @@ impl AdeApp {
                         // Fold the +n/-n totals here, off the UI thread, rather than
                         // recomputing them on every render.
                         let diff_result = wt_core::diff::diff_against_base(&root).map(|base| {
-                            let totals = match &base {
-                                DiffBase::Diff(diff) => Some(diff.files.iter().fold(
-                                    (0u32, 0u32),
-                                    |(add, del), file| {
-                                        let (file_add, file_del) = changes::diff_file_stats(file);
-                                        (add + file_add, del + file_del)
-                                    },
-                                )),
-                                DiffBase::NoBaseFound | DiffBase::OnDefaultBranch { .. } => None,
-                            };
+                            let totals = base.diff().map(|diff| {
+                                diff.files.iter().fold((0u32, 0u32), |(add, del), file| {
+                                    let (file_add, file_del) = changes::diff_file_stats(file);
+                                    (add + file_add, del + file_del)
+                                })
+                            });
                             (base, totals)
                         });
                         let staged_result = wt_core::stage::staged_paths(&root);
@@ -741,12 +737,14 @@ impl AdeApp {
         }
     }
 
-    /// The currently loaded diff, if any - `None` while loading/erroring, or when the worktree is
-    /// on its default branch / has no detectable base (see [`wt_core::diff::DiffBase`]). The
-    /// single source every view that shows diff state reads.
+    /// The currently loaded diff, if any - `None` only while loading/erroring, or when `HEAD`
+    /// itself is unborn (see [`wt_core::diff::DiffBase::diff`]). A worktree on its default
+    /// branch or with no detectable base still yields `Some` here, showing its real uncommitted
+    /// changes instead (GitHub issue #108). The single source every view that shows diff state
+    /// reads.
     pub(crate) fn current_diff(&self) -> Option<&WorktreeDiff> {
         match &self.diff_state {
-            DiffLoadState::Loaded(DiffBase::Diff(diff)) => Some(diff),
+            DiffLoadState::Loaded(base) => base.diff(),
             _ => None,
         }
     }

--- a/crates/app/src/rail/state.rs
+++ b/crates/app/src/rail/state.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 use crate::rail::repo::RepoId;
 use crate::rail::status::Status;
 use crate::work_surface::agents::AgentKind;
-use wt_core::diff::{AheadBehind, DiffBase, DiffLineKind, WorktreeDiff, WorktreeMergeStatus};
+use wt_core::diff::{AheadBehind, DiffLineKind, WorktreeDiff, WorktreeMergeStatus};
 
 /// One agent, reduced to exactly what the rail row needs to render - built in `crate::root`
 /// from a `crate::work_surface::agents::Agent` plus a `wt_core::diff::diff_against_base` result for its
@@ -576,19 +576,23 @@ pub fn compute_status_snapshot(
     let mut ahead_behind = HashMap::with_capacity(unique_diff_paths.len());
     for path in unique_diff_paths {
         let summary = match wt_core::diff::diff_against_base(&path) {
-            Ok(DiffBase::Diff(diff)) => {
-                let (add, del) = sum_diff_stat(&diff);
-                DiffSummary {
-                    add,
-                    del,
-                    has_changes: !diff.files.is_empty(),
+            // `DiffBase::diff()` covers both a real base-branch diff and GitHub issue #108's
+            // on-default-branch/no-base uncommitted-vs-HEAD fallback - either way, real content
+            // worth reflecting in this row's summary.
+            Ok(base) => match base.diff() {
+                Some(diff) => {
+                    let (add, del) = sum_diff_stat(diff);
+                    DiffSummary {
+                        add,
+                        del,
+                        has_changes: !diff.files.is_empty(),
+                    }
                 }
-            }
-            // On the default branch, no base found, or a real error reading this one path:
-            // no reviewable diff, but not a reason to fail the whole snapshot.
-            Ok(DiffBase::OnDefaultBranch { .. } | DiffBase::NoBaseFound) | Err(_) => {
-                DiffSummary::default()
-            }
+                // `HEAD` itself is unborn: a real error reading this one path is treated the
+                // same way - no reviewable diff, but not a reason to fail the whole snapshot.
+                None => DiffSummary::default(),
+            },
+            Err(_) => DiffSummary::default(),
         };
         if let Ok(Some(counts)) = wt_core::diff::ahead_behind_against_base(&path) {
             ahead_behind.insert(path.clone(), counts);

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -3043,10 +3043,10 @@ mod virtualization_tests {
         }
         git(repo.path(), &["add", "."]);
         git(repo.path(), &["commit", "-m", "initial"]);
-        // On the default branch there is no base to diff against
-        // (`wt_core::diff::DiffBase::OnDefaultBranch`), so this has to be a real feature branch
-        // for `AdeApp::current_diff` to ever be `Some` - the same setup this crate's existing
-        // real-diff tests use.
+        // A real feature branch, so this hits `wt_core::diff::DiffBase::Diff` against a real
+        // merge-base rather than `DiffBase::NoBase`'s uncommitted-vs-HEAD fallback (GitHub issue
+        // #108) - the same setup this crate's existing real-diff tests use, and the shape this
+        // test's 40 changed rows need to exercise virtualization against.
         git(repo.path(), &["checkout", "-b", "feature"]);
         for index in 0..40 {
             fs::write(
@@ -4232,8 +4232,8 @@ mod commit_composer_tests {
     /// A real feature-branch repo with two files genuinely changed relative to `main`'s
     /// merge-base - the same shape
     /// `virtualization_tests::a_changes_row_far_below_the_viewport_is_never_painted` already
-    /// establishes for `AdeApp::current_diff` to be real and `Some` (there is no base to diff
-    /// against on the default branch itself - `wt_core::diff::DiffBase::OnDefaultBranch`).
+    /// establishes, so this hits `wt_core::diff::DiffBase::Diff` against a real merge-base
+    /// rather than `DiffBase::NoBase`'s uncommitted-vs-HEAD fallback (GitHub issue #108).
     fn changes_test_repo() -> TempDir {
         let repo = TempDir::new().expect("tempdir");
         git(repo.path(), &["init", "-b", "main"]);

--- a/crates/wt-core/src/diff.rs
+++ b/crates/wt-core/src/diff.rs
@@ -20,8 +20,10 @@
 //!
 //! If none of these yield a branch, or the selected worktree's branch *is* the detected
 //! default branch, or no merge-base exists between the two histories, [`diff_against_base`]
-//! returns [`DiffBase::NoBaseFound`] or [`DiffBase::OnDefaultBranch`] rather than fabricating
-//! a base.
+//! returns [`DiffBase::NoBase`] rather than fabricating a base branch to diff against - but it
+//! still computes a real `git diff HEAD` of uncommitted changes for that case (GitHub issue
+//! #108), so `DiffBase::NoBase` is not "nothing to show". [`DiffBase::NoBaseFound`] is reserved
+//! for the one case where even that fallback is impossible: `HEAD` itself is unborn.
 //!
 //! ## What the diff includes
 //!
@@ -152,16 +154,41 @@ pub struct WorktreeDiff {
 /// The outcome of trying to compute a worktree's diff against its base.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DiffBase {
-    /// A usable base was found; here is the diff against it (possibly with zero changed
+    /// A usable base branch was found; here is the diff against it (possibly with zero changed
     /// files, if the worktree exactly matches its base).
     Diff(WorktreeDiff),
-    /// The worktree's own branch *is* the detected default branch, so there is no meaningful
-    /// "base" to diff against.
-    OnDefaultBranch { branch: String },
-    /// No sensible base could be found at all: no default branch could be detected, `HEAD`
-    /// is unborn (a brand new repository with no commits), or the two histories share no
-    /// common ancestor.
+    /// No meaningful base *branch* to diff against - either this worktree's own branch *is*
+    /// the detected default branch (`branch: Some(name)`), or none could be detected, or the
+    /// two histories share no common ancestor (`branch: None` for either of those). `HEAD` is
+    /// still a real, born commit though, so `uncommitted` is a genuine `git diff HEAD` (staged
+    /// and unstaged local edits) rather than a fabricated "nothing to show" - see GitHub issue
+    /// #108: a worktree on its default branch (or with no detectable base) still deserves to
+    /// show real, reviewable changes if it has any.
+    NoBase {
+        branch: Option<String>,
+        uncommitted: WorktreeDiff,
+    },
+    /// Truly nothing to diff, even uncommitted changes: `HEAD` itself is unborn (a brand new
+    /// repository with no commits yet), so there is no commit to diff the working tree against.
     NoBaseFound,
+}
+
+impl DiffBase {
+    /// The real diff content this outcome carries, if any - `Some` for both [`DiffBase::Diff`]
+    /// (a real base branch) and [`DiffBase::NoBase`] (no real base branch, but real uncommitted
+    /// changes against `HEAD` instead), `None` only for [`DiffBase::NoBaseFound`]. Every
+    /// consumer that wants to *show* a diff regardless of why - the Changes sidebar, tab diff
+    /// stats, the rail's per-worktree summary - should read through this rather than matching
+    /// `Diff` alone, or it would silently drop GitHub issue #108's fallback.
+    pub fn diff(&self) -> Option<&WorktreeDiff> {
+        match self {
+            DiffBase::Diff(diff)
+            | DiffBase::NoBase {
+                uncommitted: diff, ..
+            } => Some(diff),
+            DiffBase::NoBaseFound => None,
+        }
+    }
 }
 
 /// Compute the real diff of the worktree at `worktree_path` against its base, per this
@@ -180,37 +207,68 @@ pub fn diff_against_base(worktree_path: &Path) -> Result<DiffBase, Error> {
 
     let Some(worktree_head_id) = worktree_head_id else {
         // Unborn HEAD: a freshly initialized repository with no commits yet has nothing to
-        // diff against any base.
+        // diff against any base - not even its own uncommitted changes, since there is no
+        // commit to diff the working tree against.
         return Ok(DiffBase::NoBaseFound);
     };
+    let worktree_head_sha = worktree_head_id.detach().to_string();
 
     let Some((base_branch, base_commit_id)) = detect_default_base(&repo)? else {
-        return Ok(DiffBase::NoBaseFound);
+        let uncommitted = compute_diff(
+            worktree_path,
+            &worktree_head_sha,
+            worktree_branch.unwrap_or_default(),
+        )?;
+        return Ok(DiffBase::NoBase {
+            branch: None,
+            uncommitted,
+        });
     };
 
     if worktree_branch.as_deref() == Some(base_branch.as_str()) {
-        return Ok(DiffBase::OnDefaultBranch {
-            branch: base_branch,
+        let uncommitted = compute_diff(worktree_path, &worktree_head_sha, base_branch.clone())?;
+        return Ok(DiffBase::NoBase {
+            branch: Some(base_branch),
+            uncommitted,
         });
     }
 
     let merge_base_id = match repo.merge_base(worktree_head_id.detach(), base_commit_id) {
         Ok(id) => id.detach(),
         Err(gix::repository::merge_base::Error::NotFound { .. }) => {
-            return Ok(DiffBase::NoBaseFound);
+            // A real default branch exists, but shares no common ancestor with this worktree's
+            // history - still real uncommitted changes to show against `HEAD`, same as the
+            // on-default-branch case just above.
+            let uncommitted = compute_diff(worktree_path, &worktree_head_sha, base_branch.clone())?;
+            return Ok(DiffBase::NoBase {
+                branch: Some(base_branch),
+                uncommitted,
+            });
         }
         Err(source) => return Err(Error::MergeBase(Box::new(source))),
     };
 
-    let merge_base_sha = merge_base_id.to_string();
-    // Defensive: this is about to be handed to a spawned `git` process as an argument. It
-    // was just produced by `gix` as a real object id, but double-checking it's actually a
+    let diff = compute_diff(worktree_path, &merge_base_id.to_string(), base_branch)?;
+    Ok(DiffBase::Diff(diff))
+}
+
+/// Runs `git diff <commit_sha>` against the worktree's real working tree (see the module docs'
+/// "What the diff includes" section) and folds the result into a [`WorktreeDiff`]. `label_branch`
+/// is purely descriptive - the real base branch name for [`DiffBase::Diff`], or whatever branch
+/// name is available (possibly none) for the [`DiffBase::NoBase`] uncommitted-vs-`HEAD` fallback.
+fn compute_diff(
+    worktree_path: &Path,
+    commit_sha: &str,
+    label_branch: String,
+) -> Result<WorktreeDiff, Error> {
+    // Defensive: this is about to be handed to a spawned `git` process as an argument. Every
+    // caller just produced it from a real `gix` object id, but double-checking it's actually a
     // hex string (rather than something that could be misparsed as a flag) costs nothing and
     // means a future change to how it's derived can't silently turn into a git-argument
     // injection.
-    if merge_base_sha.is_empty() || !merge_base_sha.bytes().all(|b| b.is_ascii_hexdigit()) {
+    if commit_sha.is_empty() || !commit_sha.bytes().all(|b| b.is_ascii_hexdigit()) {
         return Err(Error::WorktreeIo(std::io::Error::other(
-            "merge-base id was not a hex object id",
+            "commit id was not a hex object id",
         )));
     }
 
@@ -230,7 +288,7 @@ pub fn diff_against_base(worktree_path: &Path) -> Result<DiffBase, Error> {
         "--no-color".into(),
         "--no-ext-diff".into(),
         "-M".into(),
-        merge_base_sha.clone().into(),
+        commit_sha.into(),
     ];
     let (output, output_truncated) = capture_git_stdout(
         worktree_path,
@@ -241,12 +299,12 @@ pub fn diff_against_base(worktree_path: &Path) -> Result<DiffBase, Error> {
     let text = String::from_utf8_lossy(&output);
     let (files, files_truncated) = parse_git_diff(&text);
 
-    Ok(DiffBase::Diff(WorktreeDiff {
-        base_branch,
-        base_commit: merge_base_sha,
+    Ok(WorktreeDiff {
+        base_branch: label_branch,
+        base_commit: commit_sha.to_string(),
         files,
         truncated: output_truncated || files_truncated,
-    }))
+    })
 }
 
 /// Merge-state of a worktree's `HEAD` against the repository's detected default base branch
@@ -1004,15 +1062,49 @@ mod tests {
     }
 
     #[test]
-    fn on_default_branch_yields_no_base() {
+    fn on_default_branch_with_nothing_uncommitted_yields_an_empty_diff() {
         let repo = init_repo();
         let result = diff_against_base(repo.path()).expect("diff_against_base");
-        assert_eq!(
-            result,
-            DiffBase::OnDefaultBranch {
-                branch: "main".to_string()
-            }
+        let DiffBase::NoBase {
+            branch,
+            uncommitted,
+        } = result
+        else {
+            panic!("expected DiffBase::NoBase, got {result:?}");
+        };
+        assert_eq!(branch, Some("main".to_string()));
+        assert!(
+            uncommitted.files.is_empty(),
+            "a clean worktree really has nothing uncommitted to show"
         );
+    }
+
+    /// GitHub issue #108: a worktree left on its own default branch used to report
+    /// `DiffBase::OnDefaultBranch` unconditionally, hiding real uncommitted edits from the
+    /// Changes sidebar. `diff_against_base` must fall back to a real `git diff HEAD` instead.
+    #[test]
+    fn on_default_branch_with_real_uncommitted_changes_shows_them() {
+        let repo = init_repo();
+        fs::write(repo.path().join("file.txt"), "hello\nedited on main\n").expect("write");
+        fs::write(repo.path().join("new.txt"), "brand new\n").expect("write");
+
+        let result = diff_against_base(repo.path()).expect("diff_against_base");
+        // `DiffBase::diff()` - the one accessor every real UI consumer should read through -
+        // must surface this the same way it surfaces a real `Diff`.
+        let via_diff_accessor = result.diff().cloned();
+
+        let DiffBase::NoBase {
+            branch,
+            uncommitted,
+        } = result
+        else {
+            panic!("expected DiffBase::NoBase, got {result:?}");
+        };
+        assert_eq!(branch, Some("main".to_string()));
+        let paths: Vec<&Path> = uncommitted.files.iter().map(|f| f.path.as_path()).collect();
+        assert!(paths.contains(&Path::new("file.txt")));
+        assert!(paths.contains(&Path::new("new.txt")));
+        assert_eq!(via_diff_accessor, Some(uncommitted));
     }
 
     #[test]
@@ -1529,10 +1621,12 @@ mod tests {
     }
 
     #[test]
-    fn unrelated_histories_yield_no_base_found() {
+    fn unrelated_histories_yield_no_base_with_a_real_uncommitted_diff() {
         // Two branches in the same repo with genuinely no common ancestor (an orphan
         // branch) - `gix::Repository::merge_base` must report `NotFound`, which
-        // `diff_against_base` should surface as `NoBaseFound` rather than an `Err`.
+        // `diff_against_base` surfaces as `DiffBase::NoBase` (GitHub issue #108: real
+        // uncommitted changes are still worth showing, even with no comparable base branch)
+        // rather than an `Err` or a fabricated `NoBaseFound`.
         let repo = init_repo();
         git(repo.path(), &["checkout", "--orphan", "unrelated"]);
         git(repo.path(), &["rm", "-rf", "--cached", "."]);
@@ -1544,9 +1638,19 @@ mod tests {
         .expect("write");
         git(repo.path(), &["add", "other.txt"]);
         git(repo.path(), &["commit", "-m", "unrelated root commit"]);
+        fs::write(repo.path().join("other.txt"), "edited after commit\n").expect("write");
 
         let result = diff_against_base(repo.path()).expect("diff_against_base");
-        assert_eq!(result, DiffBase::NoBaseFound);
+        let DiffBase::NoBase {
+            branch,
+            uncommitted,
+        } = result
+        else {
+            panic!("expected DiffBase::NoBase, got {result:?}");
+        };
+        assert_eq!(branch, Some("main".to_string()));
+        assert_eq!(uncommitted.files.len(), 1);
+        assert_eq!(uncommitted.files[0].path, Path::new("other.txt"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
`wt_core::diff::diff_against_base` returned `DiffBase::OnDefaultBranch` (or `NoBaseFound`, for an undetectable base branch or unrelated histories) whenever there was no meaningful *base branch* to diff against - and every consumer treated that as "nothing to show". In practice this meant a worktree left on the repository's own default branch (or with no detectable default branch) silently hid real uncommitted changes from the Changes sidebar, tab diff stats, and the rail's per-worktree summary, even with real edits on disk.

- `DiffBase::OnDefaultBranch` is replaced by `DiffBase::NoBase { branch, uncommitted }`. In every case that used to report "no base", `HEAD` is still a real, born commit, so this now runs a real `git diff HEAD` and carries the result along instead of a bare label.
- `DiffBase::NoBaseFound` is now reserved for the one case where even that's impossible: `HEAD` itself is unborn (a brand-new repo with no commits at all).
- Added `DiffBase::diff() -> Option<&WorktreeDiff>` as the single place that decides "does this outcome carry real diff content". `AdeApp::current_diff()` and every other UI consumer (tab diff-stat totals, the rail's per-worktree `DiffSummary`) now read through it instead of matching `Diff(_)` alone, so the fallback reaches the whole app, not just the diff view's own empty-state message.

Closes #108.

## Test plan
- [x] New test: a worktree on its own default branch with real uncommitted edits reports them via `DiffBase::NoBase`
- [x] New test: `DiffBase::diff()` surfaces the fallback the same way it surfaces a real `Diff`
- [x] Updated test: two branches with unrelated histories now get a real uncommitted-vs-HEAD diff instead of a bare `NoBaseFound`
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib -- --test-threads=1` (1399 + 51 + 14 + 174 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)