### PR TITLE
fix(app): terminal focus and rail idle-collapse bugs when switching terminals from the sidebar

### DIFF
--- a/BUILD-LOG.md
+++ b/BUILD-LOG.md
@@ -7154,3 +7154,43 @@ failed** - all 10 failures are pre-existing and environment-specific (LSP wiring
 network access for `npm install typescript@5`, `rust-analyzer`/`pyright` readiness timeouts in
 this sandbox, and one GPU-paint check), none in `work_surface::render` or touching agent-focus
 logic; the new test and every other `work_surface::render` test pass.
+
+## Follow-up on the same live report: the rail was auto-collapsing the worktree the user was actively looking at (GitHub issue #112)
+
+After the focus fix above, a live follow-up report from the same user described a related but
+distinct symptom on the fixed build: switching between two open terminals in the rail eventually
+"closed" both, leaving a single row labeled with the worktree's branch (e.g. `main`) - but the tab
+strip still listed both terminals the whole time, so nothing had actually closed.
+
+Root cause, unrelated to the focus bug: `Self::worktree_is_expanded`
+(`crates/app/src/rail/render.rs`) collapses a worktree's rail row to a single summary line whenever
+its most urgent agent's status is `Status::Idle`, absent an explicit per-worktree override from the
+collapse caret (§2.2: "Worktrees whose most urgent agent is idle start collapsed" - real, spec'd,
+covered by `worktree_is_expanded_defaults_to_the_real_idle_rooted_rule`). A shell agent reads as
+`Idle` once it's gone quiet past `status::RUN_RECENT_OUTPUT_WINDOW` - an ordinary, real occurrence
+(a shell sitting at its prompt between commands), not a fault. The gap: the *currently selected*
+worktree - the one whose terminals the user is actively switching between - was never exempted
+from this default, so its row could silently collapse mid-use, replacing both visible terminal rows
+with the one-line summary the report described. Purely a rail rendering/collapse-state issue; the
+real `Agents` list (and so the tab strip) was never touched, which is exactly why both terminals
+stayed listed there throughout.
+
+Confirmed with the user directly (not assumed) that the intended fix is to exempt the active
+worktree, not to change the idle-collapse default itself for every other worktree - it still
+reduces rail clutter for worktrees the user isn't currently looking at, same as before.
+
+Fixed by adding one condition to `worktree_is_expanded`'s no-override branch:
+`self.active_agent_cwd() == row.path` (the same real comparison `render_worktree_row`'s own
+`is_selected` already uses) as an alternative to the plain non-idle check. An explicit caret click
+still wins over this exemption, unchanged from how it already won over the plain idle default -
+deliberately collapsing the active worktree stays possible and remembered.
+
+New regression test `the_selected_worktree_never_idle_collapses_by_default`
+(`rail::render::rail_row_tests`) proves the exemption itself, and also proves the override still
+wins over it. The existing `worktree_is_expanded_defaults_to_the_real_idle_rooted_rule` was
+adjusted to select a second, unrelated worktree instead of the one it inspects - otherwise this fix
+would have made it vacuous (the row it checks would itself become exempt).
+
+**Verification**: `cargo test --workspace -p app rail::render::rail_row_tests` - 6 passed, 0
+failed. `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all -- --check` -
+both clean.

--- a/BUILD-LOG.md
+++ b/BUILD-LOG.md
@@ -7113,3 +7113,44 @@ The independent audit that caught this also verified, exhaustively (not spot-che
 `cargo clippy --workspace --all-targets -- -D warnings` - all clean. `cargo test --workspace --lib
 --test-threads=1`: **1221 + 44 + 14 + 141 = 1420 passed, 0 failed** across all four crates (1 new
 test - `a_merge_commit_that_is_also_head_still_gets_the_merge_dot_kind`).
+
+## Fix: switching terminals from the rail with no file tab open never moved keyboard focus (GitHub issue #112)
+
+Live report: with several terminals open, switching between them from the rail eventually made
+them appear to "merge" into one - typed input seemed to go nowhere, or land on the wrong tab.
+
+`AdeApp::select_agent` (`crates/app/src/work_surface/render.rs`) only ever moved real
+`Window::focus` in two of its three reachable branches: when it deactivated an open file tab (via
+`restore_focus`), and when the clicked agent belonged to a *different* worktree (via
+`select_worktree`, which itself routes through `reset_repo_scoped_state`'s own
+`focus_newly_spawned_agent` call). Switching between two terminals already open in the *same*
+worktree with no file tab active - the ordinary case for a rail click - fell through to
+`cx.notify()` with no focus call at all. `render_center_pane` only mounts the newly active
+agent's `TerminalPane`, so `Window::focus` stayed pointed at the previous terminal's now-unmounted
+handle; GPUI's `focus_node_id_in_rendered_frame` then falls back to the window root once a
+handle isn't found in the rendered frame, which sits outside `TerminalPane`'s `"terminal"` key
+context - typed keys either went nowhere or fell through to normally-suppressed global bindings
+(e.g. Ctrl+W). This is the same "an active-agent switch forgot to move `Window::focus`" bug class
+already found and fixed for `Agents::spawn`/`close`/`archive_agent` (see this file's own history);
+`select_agent`'s same-worktree branch was the one path that had never been covered.
+
+Fixed by capturing whether a file tab was open (`had_open_file_tab`, before the branch that clears
+`Self::open_change`) and calling the existing `focus_newly_spawned_agent(window, cx)` helper - the
+same shared "move focus unless a file tab/Settings is showing" guard `reset_repo_scoped_state`
+already reuses for the cross-worktree case, despite its spawn-specific name - only when that flag
+is `false`. Deliberately not an unconditional call after the existing branches: `restore_focus`'s
+fallback for a *reselected* already-active agent (that had a file tab open) restores a more
+precise captured target than "the active agent's pane," and calling `focus_newly_spawned_agent`
+unconditionally would silently override that.
+
+New regression test `window_focus_follows_a_same_worktree_terminal_switch`
+(`work_surface::render::tab_scoping_tests`) spawns two shell agents in one worktree and asserts
+`window.focused(cx)` lands on each one's own pane after `select_agent`, matching this file's
+existing `ctrl_p_still_works_after_...`-style focus regression tests for the sibling bugs.
+
+**Verification**: `cargo build --workspace`, `cargo clippy --workspace --all-targets -- -D
+warnings`, `cargo fmt --all -- --check` - all clean. `cargo test --workspace`: **1388 passed, 10
+failed** - all 10 failures are pre-existing and environment-specific (LSP wiring tests needing
+network access for `npm install typescript@5`, `rust-analyzer`/`pyright` readiness timeouts in
+this sandbox, and one GPU-paint check), none in `work_surface::render` or touching agent-focus
+logic; the new test and every other `work_surface::render` test pass.

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -865,10 +865,23 @@ impl AdeApp {
     /// otherwise the real default (§2.2: "Worktrees whose most urgent agent is idle start
     /// collapsed"). An agent-less row has no caret at all, so this is only ever consulted
     /// (via [`Self::render_worktree_row`]) when `row.agents` is non-empty.
+    ///
+    /// GitHub issue #112 (live follow-up report): the worktree currently selected
+    /// ([`Self::active_agent_cwd`] - the same real comparison [`Self::render_worktree_row`]'s own
+    /// `is_selected` uses) is exempt from the idle-collapse default, absent an explicit override.
+    /// Without this, a worktree the user is actively switching terminals within could silently
+    /// collapse out from under them the moment its most urgent agent's status crossed into
+    /// `Idle` (an ordinary, real occurrence - a shell sitting at its prompt between commands),
+    /// replacing both visible terminal rows with a single collapsed summary row and reading, from
+    /// the report, as the terminals having "merged into one" - no data was ever lost (the tab
+    /// strip stays untouched by this purely rail-side collapse), but the row the user was looking
+    /// at should never vanish out from under active use. An explicit caret click still always
+    /// wins over this, same as it already does over the plain idle default - a user who
+    /// deliberately collapses the active worktree gets to keep it collapsed.
     pub(in crate::rail) fn worktree_is_expanded(&self, row: &WorktreeRow) -> bool {
         match self.rail_collapse_overrides.get(&row.path) {
             Some(expanded) => *expanded,
-            None => row.aggregate_status() != Status::Idle,
+            None => self.active_agent_cwd() == row.path || row.aggregate_status() != Status::Idle,
         }
     }
 
@@ -1575,17 +1588,30 @@ mod rail_row_tests {
     /// §2.2: "Worktrees whose most urgent agent is idle start collapsed" - proven here against
     /// a real running agent (never collapsed by default) and a real idle one (collapsed by
     /// default), through `Self::worktree_is_expanded`, the single real place that default lives.
+    ///
+    /// Selects a *second*, unrelated worktree rather than `wt` itself (GitHub issue #112 live
+    /// follow-up: the currently selected worktree is now exempt from this default - see
+    /// `Self::worktree_is_expanded`'s own docs) so this test keeps proving the plain idle-rooted
+    /// rule in isolation; `the_selected_worktree_never_idle_collapses_by_default` below covers
+    /// the exemption itself.
     #[gpui::test]
     fn worktree_is_expanded_defaults_to_the_real_idle_rooted_rule(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
         let wt = tempfile::tempdir().expect("tempdir wt");
+        let other_wt = tempfile::tempdir().expect("tempdir other wt");
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
-            app.worktrees = vec![worktree_item(wt.path().to_path_buf(), "wt")];
+            app.worktrees = vec![
+                worktree_item(wt.path().to_path_buf(), "wt"),
+                worktree_item(other_wt.path().to_path_buf(), "other-wt"),
+            ];
         });
         app.update_in(cx, |app, window, cx| {
-            app.select_worktree(0, window, cx);
+            // Select `other_wt`, not `wt` - `wt` (whose row this test inspects) must be the
+            // real not-currently-selected case, or the new selected-worktree exemption would
+            // make this test vacuous.
+            app.select_worktree(1, window, cx);
             app.agents
                 .spawn(AgentKind::Shell, wt.path().to_path_buf(), 12.0, window, cx);
         });
@@ -1622,6 +1648,66 @@ mod rail_row_tests {
         assert!(
             !app.read_with(cx, |app, _| app.worktree_is_expanded(&idle_row)),
             "an idle-rooted worktree must default to collapsed"
+        );
+    }
+
+    /// GitHub issue #112 (live follow-up report): a worktree the user is actively switching
+    /// terminals within - the one [`crate::root::AdeApp::active_agent_cwd`] currently reports -
+    /// must never auto-collapse just because its most urgent agent's status happens to cross into
+    /// `Idle` (an ordinary occurrence - a shell sitting at its prompt between commands). Before
+    /// this exemption, that real, wall-clock-driven Idle transition would silently collapse the
+    /// row out from under active use, replacing both visible terminal rows with a single
+    /// collapsed summary line and reading, from the report, as the terminals having "merged into
+    /// one" - even though nothing was ever closed (the tab strip stayed untouched the whole
+    /// time). An explicit caret click still wins over the exemption, same as it already wins over
+    /// the plain idle default.
+    #[gpui::test]
+    fn the_selected_worktree_never_idle_collapses_by_default(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let wt = tempfile::tempdir().expect("tempdir wt");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+
+        app.update(cx, |app, _cx| {
+            app.worktrees = vec![worktree_item(wt.path().to_path_buf(), "wt")];
+        });
+        app.update_in(cx, |app, window, cx| {
+            app.select_worktree(0, window, cx);
+            app.agents
+                .spawn(AgentKind::Shell, wt.path().to_path_buf(), 12.0, window, cx);
+        });
+        cx.run_until_parked();
+
+        let running_row = app.read_with(cx, |app, cx| {
+            app.build_worktree_rows(cx)
+                .into_iter()
+                .find(|row| row.path == wt.path())
+                .expect("the seeded worktree must produce a row")
+        });
+        assert_eq!(
+            app.read_with(cx, |app, _| app.active_agent_cwd()),
+            wt.path(),
+            "premise: `wt` really is the currently selected worktree"
+        );
+
+        // Same idle-forcing technique as the sibling test above.
+        let idle_row = rail::WorktreeRow {
+            agents: Vec::new(),
+            ..running_row
+        };
+        assert_eq!(idle_row.aggregate_status(), Status::Idle, "sanity check");
+        assert!(
+            app.read_with(cx, |app, _| app.worktree_is_expanded(&idle_row)),
+            "the selected worktree must stay expanded even once idle, with no explicit override"
+        );
+
+        // An explicit caret click still wins over the selection exemption - the user's own
+        // choice to collapse the active worktree must be honored, not silently overridden back.
+        app.update(cx, |app, cx| {
+            app.toggle_worktree_collapsed(wt.path().to_path_buf(), true, cx);
+        });
+        assert!(
+            !app.read_with(cx, |app, _| app.worktree_is_expanded(&idle_row)),
+            "an explicit collapse override must still win even for the selected worktree"
         );
     }
 

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -179,7 +179,8 @@ impl AdeApp {
         // *after* `set_active` above: its `restore_focus` fallback resolves to
         // `Self::agents.active()`, which by this point is already the agent just selected.
         self.leave_graph_tab(window, cx);
-        if self.open_change.is_some() {
+        let had_open_file_tab = self.open_change.is_some();
+        if had_open_file_tab {
             self.open_change = None;
             self.refresh_open_diff_file_cache();
             self.hover = None;
@@ -211,6 +212,22 @@ impl AdeApp {
                     return;
                 }
             }
+        }
+        // GitHub issue #112: when no file tab was showing, nothing above moves real keyboard
+        // focus - `restore_focus` only runs inside the `had_open_file_tab` branch, and a
+        // same-worktree agent switch (the common case for a rail/tab-strip click between two
+        // already-open terminals) never reaches `select_worktree` either. Left as-is, `Window::
+        // focus` stays on the previously-active agent's `TerminalPane` handle, which
+        // `render_center_pane` no longer mounts once a different agent becomes active - GPUI's
+        // dispatch then falls back to the window root, outside the `"terminal"` key context, so
+        // typed input silently goes nowhere and normally-suppressed global bindings (e.g. Ctrl+W)
+        // fire instead. `had_open_file_tab` is checked, not `self.open_change.is_none()` (always
+        // true here since the branch above clears it): reusing `focus_newly_spawned_agent`
+        // unconditionally would override `restore_focus`'s more precise restore target when
+        // re-selecting an already-active agent that had a file tab open (Revision R8.5b's
+        // captured-overlay-focus mechanism).
+        if !had_open_file_tab {
+            self.focus_newly_spawned_agent(window, cx);
         }
         cx.notify();
     }
@@ -2540,7 +2557,7 @@ mod tab_scoping_tests {
     use super::*;
     use crate::rail::worktrees::WorktreeItem;
     use crate::root::focus::palette_focus_tests;
-    use gpui::TestAppContext;
+    use gpui::{Focusable, TestAppContext};
 
     fn worktree_item(path: PathBuf, label: &str) -> WorktreeItem {
         WorktreeItem {
@@ -3793,6 +3810,70 @@ mod tab_scoping_tests {
                 .any(|tab_ref| matches!(tab_ref, work_surface::TabRef::File(path) if path == &PathBuf::from("README.md"))),
             "the file tab must reappear once the worktree is no longer bare - its state was \
              preserved, not destroyed, while suppressed"
+        );
+    }
+
+    /// GitHub issue #112: switching between two terminals open in the *same* worktree - the
+    /// common case for a rail/tab-strip click - must move real keyboard focus onto the newly
+    /// selected terminal's own pane. Before the fix, `select_agent`'s same-worktree/no-file-tab
+    /// branch never called `Window::focus` at all: `Window::focus` stayed on the previously
+    /// active terminal's now-unmounted `TerminalPane` handle, so GPUI's dispatch fell back to
+    /// the window root - outside the `"terminal"` key context - and typed input into the
+    /// terminal that visibly looked selected silently went nowhere (or fell through to
+    /// normally-suppressed global bindings instead), which reads to a user as the two terminals
+    /// having "merged" into one.
+    #[gpui::test]
+    fn window_focus_follows_a_same_worktree_terminal_switch(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+
+        let first_id = app.read_with(cx, |app, _| {
+            app.agents.active_id().expect("the initial shell agent")
+        });
+        let second_id = app.update_in(cx, |app, window, cx| {
+            app.agents.spawn(
+                AgentKind::Shell,
+                repo.path().to_path_buf(),
+                12.0,
+                window,
+                cx,
+            )
+        });
+
+        app.update_in(cx, |app, window, cx| {
+            app.select_agent(first_id, window, cx);
+        });
+        let first_pane_handle = app.update(cx, |app, cx| {
+            app.agents
+                .active()
+                .expect("the first agent")
+                .pane
+                .focus_handle(cx)
+        });
+        assert_eq!(
+            app.update_in(cx, |_app, window, cx| window.focused(cx))
+                .as_ref(),
+            Some(&first_pane_handle),
+            "premise: selecting the first terminal moves real focus onto its own pane"
+        );
+
+        app.update_in(cx, |app, window, cx| {
+            app.select_agent(second_id, window, cx);
+        });
+        let second_pane_handle = app.update(cx, |app, cx| {
+            app.agents
+                .active()
+                .expect("the second agent")
+                .pane
+                .focus_handle(cx)
+        });
+        assert_eq!(
+            app.update_in(cx, |_app, window, cx| window.focused(cx))
+                .as_ref(),
+            Some(&second_pane_handle),
+            "switching to the second terminal (no file tab open, same worktree) must move real \
+             keyboard focus onto its own pane too, not leave it dangling on the first terminal's \
+             now-unmounted handle"
         );
     }
 


### PR DESCRIPTION
Closes #112

## 1. Terminal focus never moved on a same-worktree rail switch

`select_agent` never called `Window::focus` when switching between two open terminals in the same worktree with no file tab active — the ordinary case for a rail/tab-strip click. `Window::focus` stayed pointed at the previously active terminal's now-unmounted `TerminalPane` handle; once GPUI's `focus_node_id_in_rendered_frame` couldn't find that handle in the rendered frame, dispatch fell back to the window root, outside `TerminalPane`'s `"terminal"` key context — so typed input into the terminal that visibly looked selected silently went nowhere, or fell through to normally-suppressed global bindings instead.

Fix reuses this codebase's existing `focus_newly_spawned_agent` focus-restore helper for exactly the missing same-worktree/no-file-tab branch, without touching the two branches that already worked correctly.

## 2. Live follow-up: the rail auto-collapsed the worktree you were actively using

After testing the first fix, a follow-up report described a related but distinct symptom: switching between two terminals in the rail eventually "closed" both, leaving one row labeled with the branch (e.g. `main`) — but the tab strip still listed both terminals the whole time, so nothing was actually closing.

Root cause: `worktree_is_expanded` collapses a worktree's rail row to a single summary line whenever its most urgent agent goes `Idle` (a real, spec'd default — §2.2), with no exemption for the worktree currently selected. A shell reads as idle once it's been quiet a short while, an ordinary occurrence — so the row you were actively looking at could silently collapse mid-use, replacing both terminal rows with the summary line. Purely a rail rendering/collapse-state bug — the real `Agents` list was never touched.

Fixed by exempting the currently selected worktree (`active_agent_cwd() == row.path`) from the idle-collapse default. An explicit caret click still overrides the exemption either way.

## Testing

- `window_focus_follows_a_same_worktree_terminal_switch` (`work_surface::render::tab_scoping_tests`)
- `the_selected_worktree_never_idle_collapses_by_default` (`rail::render::rail_row_tests`) — also proves the caret override still wins
- `worktree_is_expanded_defaults_to_the_real_idle_rooted_rule` adjusted to select a different worktree than the one it inspects, since the fix above would otherwise make it vacuous
- `cargo build --workspace` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅ (0 warnings)
- `cargo fmt --all -- --check` ✅
- `cargo test --workspace`: 1388 passed, 10 failed — all 10 pre-existing and environment-specific (LSP wiring tests needing network/language-server readiness in this sandbox, one GPU-paint check), none touching `work_surface::render`, `rail::render`, or agent-focus logic