### PR TITLE
fix(app): unfocused text-input carets are fully invisible, not dimmed (issue #107)

### DIFF
--- a/crates/app/src/code_surface/editing.rs
+++ b/crates/app/src/code_surface/editing.rs
@@ -1423,10 +1423,11 @@ pub(in crate::code_surface) struct EditableLineContext<'a> {
 /// `start_x` again for [`settings_store::CaretStyle::Line`] callers with nothing convenient to
 /// measure it from.
 ///
-/// Returns `None` exactly when the caret should be invisible this frame: mid-blink "off" phase
-/// while genuinely focused (`is_focused && !blink_visible`) - never while unfocused, which always
-/// paints a real, dimmed, non-blinking caret instead (issue #27's own explicit ask), never
-/// nothing at all.
+/// Returns `None` exactly when the caret should be invisible this frame: the surface isn't
+/// focused at all (GitHub issue #107 - an earlier version instead painted a dimmed, non-blinking
+/// caret while unfocused; Colin asked for it to disappear entirely, like every other
+/// unfocused-state affordance in this app), or - while genuinely focused - mid-blink "off" phase
+/// (`!blink_visible`).
 pub(crate) fn caret_paint_quad(
     start_x: Pixels,
     end_x: Pixels,
@@ -1436,16 +1437,10 @@ pub(crate) fn caret_paint_quad(
     is_focused: bool,
     blink_visible: bool,
 ) -> Option<PaintQuad> {
-    if is_focused && !blink_visible {
+    if !is_focused || !blink_visible {
         return None;
     }
-    let color = if is_focused {
-        theme::syntax::CARET.resolve()
-    } else {
-        theme::syntax::CARET
-            .resolve()
-            .opacity(theme::syntax::CARET_UNFOCUSED_OPACITY)
-    };
+    let color = theme::syntax::CARET.resolve();
     // At most one real char's width (never negative - `end_x` can equal `start_x` for a
     // `Line`-style caller, or a real end-of-line caret with nothing after it to measure).
     let char_width = (end_x - start_x).max(gpui::px(1.0));
@@ -1581,9 +1576,9 @@ pub(in crate::code_surface) fn render_editable_file_view_line(
                 .text_system()
                 .shape_line(line_text.clone(), font_size, &runs, None);
 
-            // GitHub issue #27: "selection remains visible (dimmed) when the editor loses
-            // focus" / "unfocused editors show a dimmed, non-blinking caret" - both the
-            // selection fill and the caret itself read this same real, live focus check, not two
+            // GitHub issue #27's "selection remains visible (dimmed) when the editor loses
+            // focus" and GitHub issue #107's "the caret disappears entirely when unfocused" both
+            // read this same real, live focus check for the selection fill and the caret, not two
             // independently-derived ones that could disagree.
             let is_focused = focus_handle_for_measure.is_focused(window);
             let selection_opacity = if is_focused {
@@ -1660,18 +1655,27 @@ pub(in crate::code_surface) fn render_editable_file_view_line(
                     )
                 })
                 .collect();
-            let secondary_cursor_quads: Vec<_> = secondary_cursors_local
-                .iter()
-                .map(|offset| {
-                    fill(
-                        Bounds::new(
-                            point(bounds.left() + shaped.x_for_index(*offset), bounds.top()),
-                            size(gpui::px(2.0), bounds.bottom() - bounds.top()),
-                        ),
-                        theme::editor::CARET,
-                    )
-                })
-                .collect();
+            // GitHub issue #107: hidden entirely while unfocused, matching the primary caret
+            // above - secondary cursors don't have their own blink treatment (see this row's own
+            // docs on why every cursor stays identically solid whenever visible), but they still
+            // need this same one gate, or an unfocused buffer would show ghost secondary carets
+            // with no primary one, a real, new inconsistency this fix would otherwise introduce.
+            let secondary_cursor_quads: Vec<_> = if is_focused {
+                secondary_cursors_local
+                    .iter()
+                    .map(|offset| {
+                        fill(
+                            Bounds::new(
+                                point(bounds.left() + shaped.x_for_index(*offset), bounds.top()),
+                                size(gpui::px(2.0), bounds.bottom() - bounds.top()),
+                            ),
+                            theme::editor::CARET,
+                        )
+                    })
+                    .collect()
+            } else {
+                Vec::new()
+            };
             (
                 shaped,
                 selection_quad,
@@ -1703,16 +1707,13 @@ pub(in crate::code_surface) fn render_editable_file_view_line(
             for quad in secondary_selection_quads {
                 window.paint_quad(quad);
             }
-            // The primary caret's own visibility (blink phase, unfocused dimming) is already
-            // fully decided by `caret_paint_quad` above - `cursor_quad` is `None` exactly when
-            // it shouldn't paint this frame, so no extra `is_focused` gate belongs here (GitHub
-            // issue #27's own docs on `caret_paint_quad` are explicit about this). Secondary
-            // cursors don't have their own blink/dim treatment yet (see this row's own docs on
-            // why multi-cursor deliberately keeps every cursor identically styled), so they paint
-            // unconditionally too, matching the primary selection's own always-visible-when-
-            // present treatment above - the alternative (secondary cursors vanishing on focus
-            // loss while the primary caret stays dimly visible) would be a real, visible
-            // inconsistency between cursors in the same buffer.
+            // The primary caret's own visibility (blink phase, hidden entirely while unfocused)
+            // is already fully decided by `caret_paint_quad` above - `cursor_quad` is `None`
+            // exactly when it shouldn't paint this frame, so no extra `is_focused` gate belongs
+            // here (that function's own docs are explicit about this). `secondary_cursor_quads`
+            // is built with the matching `is_focused` gate already applied (see its own
+            // computation above), so both paint loops stay consistent with no further checks
+            // needed at the paint site itself.
             if let Some(cursor_quad) = cursor_quad {
                 window.paint_quad(cursor_quad);
             }
@@ -2213,6 +2214,48 @@ fn token_at_offset(
         }
     }
     None
+}
+
+/// GitHub issue #107: an unfocused caret must vanish entirely, not just dim. Pure-function
+/// coverage of [`caret_paint_quad`] directly - no GPUI window needed, since it takes its focus/
+/// blink state as plain arguments.
+#[cfg(test)]
+mod caret_paint_quad_tests {
+    use super::*;
+
+    fn quad(is_focused: bool, blink_visible: bool) -> Option<PaintQuad> {
+        caret_paint_quad(
+            gpui::px(0.0),
+            gpui::px(8.0),
+            gpui::px(0.0),
+            gpui::px(16.0),
+            settings_store::CaretStyle::Line,
+            is_focused,
+            blink_visible,
+        )
+    }
+
+    #[test]
+    fn a_focused_and_blink_visible_caret_paints() {
+        assert!(quad(true, true).is_some());
+    }
+
+    #[test]
+    fn a_focused_but_blinked_off_caret_paints_nothing() {
+        assert!(quad(true, false).is_none());
+    }
+
+    #[test]
+    fn an_unfocused_caret_paints_nothing_regardless_of_blink_phase() {
+        assert!(
+            quad(false, true).is_none(),
+            "unfocused must be invisible even mid-blink-on"
+        );
+        assert!(
+            quad(false, false).is_none(),
+            "unfocused must be invisible mid-blink-off too"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/app/src/graph_view/render.rs
+++ b/crates/app/src/graph_view/render.rs
@@ -5100,8 +5100,8 @@ mod graph_focus_tests {
 
         assert!(
             !app.read_with(cx, |app, _| app.caret_blink_visible),
-            "blurring the branches filter must have immediately pinned the shared caret to \
-             dimmed/non-blinking (`AdeApp::stop_caret_blink`) - before this fix, \
+            "blurring the branches filter must have immediately pinned the shared caret-blink \
+             flag off (`AdeApp::stop_caret_blink`) - before this fix, \
              `branches_filter_focus_handle` was never threaded through \
              `AdeApp::wire_caret_blink`, so nothing would have reacted to it losing focus at \
              all, and the caret would have stayed solid/visible until whatever timer the \

--- a/crates/app/src/palette/render.rs
+++ b/crates/app/src/palette/render.rs
@@ -560,8 +560,8 @@ impl AdeApp {
         // `.track_focus()` of their own, so they never steal keyboard focus away from it. That
         // means this caret is never actually rendered while unfocused (closing the palette stops
         // rendering it at all), so unlike the code editor's own caret there's no separate
-        // "dimmed unfocused" case to paint here - `caret_blink_visible` alone is the real, whole
-        // answer for whether to paint it this frame.
+        // "hidden while unfocused" case to paint here - `caret_blink_visible` alone is the real,
+        // whole answer for whether to paint it this frame.
         let visible = self.caret_blink_visible;
         div()
             .flex_none()

--- a/crates/app/src/root/caret_blink.rs
+++ b/crates/app/src/root/caret_blink.rs
@@ -16,8 +16,8 @@
 //! [`AdeApp::settings`]'s `appearance.caret_blink` (see
 //! `crate::settings::store::AppearanceSettings::caret_blink`'s own docs) is the real, persisted
 //! "no blink" setting the issue asks for: when `false`, [`spawn_blink_task`] never starts a
-//! timer at all, so the caret stays permanently solid (still hidden/dimmed while unfocused,
-//! same as the blinking case - see each surface's own render call site).
+//! timer at all, so the caret stays permanently solid (still hidden while unfocused, same as the
+//! blinking case - see each surface's own render call site).
 //!
 //! `gpui::App::reduce_motion`/`set_reduce_motion` (`vendor` GPUI's real, available mechanism for
 //! "respect reduced motion" - `crates/gpui/src/app.rs:1010,1016` at the pinned revision) is
@@ -76,9 +76,8 @@ impl AdeApp {
     }
 
     /// A real focus loss: the loop stops outright (no timer keeps running against an unfocused
-    /// caret) - each surface's own render call site is responsible for painting the real,
-    /// dimmed, non-blinking unfocused caret (issue #27's own "unfocused editors show a dimmed,
-    /// non-blinking caret"), not this module.
+    /// caret) - each surface's own render call site is responsible for hiding the caret entirely
+    /// while unfocused (GitHub issue #107), not this module.
     pub(crate) fn stop_caret_blink(&mut self, cx: &mut Context<Self>) {
         self.caret_blink_visible = false;
         self._caret_blink_task = Task::ready(());

--- a/crates/app/src/root/new_file.rs
+++ b/crates/app/src/root/new_file.rs
@@ -732,8 +732,8 @@ mod new_file_caret_tests {
 
         assert!(
             !app.read_with(cx, |app, _| app.caret_blink_visible),
-            "blurring the \"New file\" prompt must have immediately pinned the shared caret to \
-             dimmed/non-blinking (`AdeApp::stop_caret_blink`) - before this fix, \
+            "blurring the \"New file\" prompt must have immediately pinned the shared caret-blink \
+             flag off (`AdeApp::stop_caret_blink`) - before this fix, \
              `new_file_focus_handle` was never threaded through `AdeApp::wire_caret_blink`, so \
              nothing would have reacted to it losing focus at all, and the caret would have \
              stayed solid/visible until whatever timer the earlier keystroke started eventually \

--- a/crates/app/src/root/widgets.rs
+++ b/crates/app/src/root/widgets.rs
@@ -291,11 +291,8 @@ impl AdeApp {
     /// paint time - `Window` isn't threaded through every one of this helper's several render-
     /// tree ancestors, and a canvas's paint closures always receive it regardless of what the
     /// surrounding `render_*` call chain's own signatures carry. Mirrors `caret_paint_quad`'s own
-    /// rule exactly: focused *and* blink-visible paints solid, focused-but-blinked-off paints
-    /// nothing, unfocused paints a dim, non-blinking caret (`theme::syntax::
-    /// CARET_UNFOCUSED_OPACITY` - the same constant the code editor's own caret uses, not a
-    /// second, independently-chosen value for this surface) rather than vanishing outright -
-    /// consistent with every other caret-bearing surface's unfocused treatment in this app.
+    /// rule exactly (GitHub issue #107): focused *and* blink-visible paints solid, anything else -
+    /// focused-but-blinked-off, or simply unfocused - paints nothing at all.
     pub(crate) fn render_simple_input_caret(
         &self,
         selector: &'static str,
@@ -329,17 +326,15 @@ impl AdeApp {
 
 /// [`AdeApp::render_simple_input_caret`]'s paint decision, pulled out as a pure function so it's
 /// directly unit-testable without a real GPUI window/focus simulation - mirrors
-/// `crate::code_surface::editing::caret_paint_quad`'s own three-way rule (focused-and-blinking
-/// solid / focused-and-blinked-off nothing / unfocused dim-and-steady) exactly, just returning an
-/// opacity instead of a ready-made [`gpui::PaintQuad`] since this caller's color/bounds aren't
-/// available outside the canvas paint closure.
+/// `crate::code_surface::editing::caret_paint_quad`'s own rule (GitHub issue #107): solid only
+/// while genuinely focused and blink-visible, nothing at all otherwise, just returning an opacity
+/// instead of a ready-made [`gpui::PaintQuad`] since this caller's color/bounds aren't available
+/// outside the canvas paint closure.
 fn simple_input_caret_opacity(is_focused: bool, blink_visible: bool) -> Option<f32> {
-    if is_focused && !blink_visible {
-        None
-    } else if is_focused {
+    if is_focused && blink_visible {
         Some(1.0)
     } else {
-        Some(theme::syntax::CARET_UNFOCUSED_OPACITY)
+        None
     }
 }
 
@@ -502,13 +497,15 @@ mod simple_input_caret_opacity_tests {
         );
     }
 
+    /// GitHub issue #107: an earlier version painted a dim, non-blinking caret while unfocused.
+    /// Colin asked for it to disappear entirely instead, the same way every other unfocused-state
+    /// affordance in this app already does.
     #[test]
-    fn an_unfocused_input_paints_dim_not_invisible() {
+    fn an_unfocused_input_paints_nothing_at_all() {
         assert_eq!(
             simple_input_caret_opacity(false, true),
-            Some(crate::theme::syntax::CARET_UNFOCUSED_OPACITY),
-            "unfocused must still show a real, dim, non-blinking caret - matching every other \
-             caret-bearing surface's unfocused treatment in this app - not vanish outright"
+            None,
+            "unfocused must paint nothing, regardless of the shared blink flag's phase"
         );
     }
 }

--- a/crates/app/src/theme.rs
+++ b/crates/app/src/theme.rs
@@ -696,10 +696,6 @@ pub mod syntax {
     /// "selection remains visible (dimmed) when the editor loses focus") - still genuinely
     /// visible, just clearly de-emphasized relative to the focused case above.
     pub const SELECTION_UNFOCUSED_OPACITY: f32 = 0.14;
-    /// The caret's own opacity while the editor is unfocused (issue #27: "unfocused editors show
-    /// a dimmed, non-blinking caret") - solid, never blinking, just dimmer than the focused
-    /// (1.0-opacity) caret.
-    pub const CARET_UNFOCUSED_OPACITY: f32 = 0.35;
     pub const ERROR_UNDERLINE: ColorToken = hex(0xe0625c); // 2px dotted
     pub const HOVER_UNDERLINE: ColorToken = hex(0x4d7ba8); // 1px solid
 


### PR DESCRIPTION
## Summary
Colin: "the carrets for all the inputs should just be invisible when the input is not focused instead of semi-transparent."

Every caret-bearing surface (the code editor, the merge hand-edit view, and every simple single-line input - palette, rail filter, settings filter, new-file prompt) used to paint a dimmed, non-blinking caret while unfocused (`theme::syntax::CARET_UNFOCUSED_OPACITY`, 0.35). Now hidden entirely instead.

- `caret_paint_quad` (shared by the File view and the merge editor) and `simple_input_caret_opacity` (shared by every simple input) both now return "invisible" whenever the surface isn't focused, not just mid-blink-off while it is.
- Multi-cursor's own secondary carets get the same gate - previously unconditional, so without this an unfocused buffer would show ghost secondary carets with no primary one, a real, new inconsistency this fix would otherwise have introduced.
- `theme::syntax::CARET_UNFOCUSED_OPACITY` is now dead and removed.
- Selection highlighting (issue #27's separate "selection remains visible, dimmed" behavior) is untouched - this is scoped to carets only, per what was asked.

Closes #107.

## Test plan
- [x] New test: `caret_paint_quad` (pure function, direct coverage) paints only when focused and blink-visible, nothing in every other case
- [x] Updated `simple_input_caret_opacity`'s own existing test suite for the new behavior
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib -- --test-threads=1` (1405/1406 passed; the 1 failure, in an unrelated file-tree undo/redo test this branch doesn't touch, is the known resource-contention flake this session has hit repeatedly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)