### PR TITLE
fix(app): give file tree/header right-side icons real clearance from the scrollbar

### DIFF
--- a/BUILD-LOG.md
+++ b/BUILD-LOG.md
@@ -7501,3 +7501,41 @@ original #113 fix) touches. Every new/modified test this follow-up added ran gre
 (`cargo test -p app --lib rail:: -- --test-threads=4`: 98 passed; `cargo test -p app --lib root::
 -- --test-threads=4`: 110 passed; `cargo test -p app --lib work_surface:: -- --test-threads=4`: 75
 passed) and by exact name in isolation.
+
+## File tree row/header icons collided with the real overlay scrollbar (GitHub issue #123)
+
+Reported with a screenshot: the file tree's right-side icons/buttons sit too close to the
+scrollbar and visually collide with it.
+
+Root cause: `crate::root::scrollbar::SCROLLBAR_SIZE` (the real overlay scrollbar track's width)
+is `8.0`, and every place in `crates/app/src/sidebar/render.rs` giving file-tree/header content
+its own right padding used exactly `pr(px(8.0))` (`render_file_tree_row`,
+`render_tree_inline_edit_row`) or `pr(px(10.0))` (the right-sidebar header's action cluster,
+`render_change_row`) - in every case, at most 2px of real clearance past where the scrollbar's
+own track begins, which reads as flush contact once anti-aliasing and hover states are on
+screen. The scrollbar is painted as an `.absolute()` sibling overlay, not reserved flex space
+(see this module's own docs for why), so content padded only to `SCROLLBAR_SIZE` sits exactly
+where the track starts.
+
+Fixed by adding one shared constant, `crate::root::scrollbar::CONTENT_CLEARANCE =
+SCROLLBAR_SIZE + 6.0`, and using it as the right padding everywhere content sits next to this
+scrollbar (`render_file_tree_row`, `render_tree_inline_edit_row`, `render_change_row`, and the
+right-sidebar header's action cluster in `render_right_sidebar_toggle`) - one real value instead
+of every call site repeating its own guess at "close enough".
+
+New regression test `file_tree_row_and_header_actions_clear_the_real_scrollbar`
+(`sidebar::render::virtualization_tests`) seeds enough files that the tree genuinely overflows
+and the real scrollbar actually paints, then asserts real painted clearance (via `debug_bounds`)
+between both the directory row's own "+" control and the header's "New file" button and the
+scrollbar's own left edge - a genuine geometric assertion (a real, independent minimum-gap
+threshold, not derived from `CONTENT_CLEARANCE` itself) rather than only proving a padding
+*number* changed. This required adding a `debug_selector` to both the scrollbar track itself and
+the per-row "+" button (keyed by the row's real path, matching its own `.id()`), neither of
+which had one before - `.id()` alone doesn't register a `debug_bounds`-queryable selector.
+
+**Verification**: `cargo build --workspace`, `cargo clippy --workspace --all-targets -- -D
+warnings`, `cargo fmt --all -- --check` - all clean. `cargo test --workspace`: **1388 passed, 10
+failed** - all 10 failures are the same pre-existing, environment-specific set already documented
+elsewhere in this log (LSP wiring tests needing network/language-server readiness, one
+syntax-highlight-cache flake), none in `sidebar::render` or touching this change; all 36
+`sidebar::render` tests, including the new one, pass.

--- a/crates/app/src/root/scrollbar.rs
+++ b/crates/app/src/root/scrollbar.rs
@@ -100,6 +100,22 @@ use crate::root::scrollbar_geometry as geometry;
 /// is 22px; a 12px `list_example.rs`-style scrollbar would visually dominate a row that short).
 const SCROLLBAR_SIZE: f32 = 8.0;
 
+/// How much real right-side clearance row/header content next to this scrollbar needs, in
+/// addition to `SCROLLBAR_SIZE` itself - GitHub issue #123 ("Add padding to the file tree right
+/// side icons/buttons"). The scrollbar track is painted as an `.absolute()` sibling overlay
+/// (this module's own top docs explain why), not reserved flex space, so any row/header content
+/// whose own right padding is `<= SCROLLBAR_SIZE` sits exactly where the track begins - flush
+/// contact, not a real gap - whenever the list is scrollable. Before this fix
+/// `crate::sidebar::render::render_change_row` was the one place in the codebase that already
+/// padded further than the bare `SCROLLBAR_SIZE` (`pr(px(10.0))`, i.e. `SCROLLBAR_SIZE + 2.0`),
+/// but 2px of real clearance still reads as "touching" once anti-aliasing and hover states are
+/// on screen (the collision the issue's screenshot shows). `+ 6.0` triples that margin to a
+/// value that's genuinely, unambiguously distinct from the track - still compact enough to match
+/// this UI's generally tight chrome (`theme::band::TREE_ROW` is 22px) - and is reused as the one
+/// shared constant everywhere right-aligned content sits next to this scrollbar, instead of every
+/// call site repeating its own guess at "close enough".
+pub(crate) const CONTENT_CLEARANCE: f32 = SCROLLBAR_SIZE + 6.0;
+
 /// One decoration mark on a vertical scrollbar's track (see this module's own docs) - a coloured
 /// tick at `fraction` (`0.0` = the very top of the full document, `1.0` = the very bottom),
 /// painted over the track underneath the thumb so it stays visible even while scrolled away from
@@ -183,6 +199,12 @@ impl AdeApp {
         Some(
             div()
                 .id(id)
+                // Test-only (a no-op outside test builds, like every other `debug_selector` in
+                // this codebase) - lets a real render test read the track's own painted bounds
+                // back with `VisualTestContext::debug_bounds` to assert genuine geometric
+                // clearance (see `crate::sidebar::render`'s tests), rather than trusting a
+                // padding value's *number* changed without proving what it actually clears.
+                .debug_selector(move || id.to_string())
                 .absolute()
                 .top_0()
                 .right_0()

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::keymap;
+use crate::root::scrollbar;
 use crate::root::widgets::{
     hover_bg, menu_popover_chrome, render_keycap_row, render_menu_group_divider,
     render_sidebar_message, render_tag_pill, text_tooltip, KeycapSize,
@@ -918,7 +919,12 @@ impl AdeApp {
             .w_full()
             .h(theme::band::TREE_ROW)
             .pl(px(file_tree::ROW_LEFT_PAD) + indent)
-            .pr(px(8.0))
+            // GitHub issue #123: real clearance from the file tree's own overlay scrollbar
+            // (`crate::root::scrollbar::CONTENT_CLEARANCE`'s own docs), not the bare
+            // `SCROLLBAR_SIZE` this used to match exactly (flush contact, not a gap). Matches
+            // `Self::render_file_tree_row`'s own row padding below so the inline editor stays
+            // visually aligned with the normal rows around it.
+            .pr(px(scrollbar::CONTENT_CLEARANCE))
             .bg(theme::surface::ROW_SELECTED)
             .font(font(theme::font::MONO))
             .text_size(self.ui_text_size(11.5))
@@ -1029,7 +1035,14 @@ impl AdeApp {
             .gap(px(6.0))
             .h(theme::band::TREE_ROW)
             .pl(px(file_tree::ROW_LEFT_PAD) + indent)
-            .pr(px(8.0))
+            // GitHub issue #123 ("Add padding to the file tree right side icons/buttons"): this
+            // row's own trailing "new file" `+` control (added below, when `entry.is_dir`) used
+            // to sit exactly `SCROLLBAR_SIZE` from the row's right edge - precisely where the
+            // real overlay scrollbar's track begins, i.e. flush contact rather than a real gap,
+            // whenever the tree is tall enough to scroll. See
+            // `crate::root::scrollbar::CONTENT_CLEARANCE`'s own docs for the reasoning behind the
+            // exact value.
+            .pr(px(scrollbar::CONTENT_CLEARANCE))
             .font(font(theme::font::MONO))
             .text_size(self.ui_text_size(11.5))
             .when(is_selected, |el| el.bg(theme::surface::ROW_SELECTED))
@@ -1296,6 +1309,14 @@ impl AdeApp {
             row = row.child(
                 div()
                     .id(format!("file-tree-new-file-{}", entry.path.display()))
+                    // Test-only (see `crate::root::scrollbar`'s own `render_vertical_scrollbar`
+                    // for the identical pattern) - `.id()` alone doesn't register a
+                    // `debug_bounds`-queryable selector, so GitHub issue #123's own geometric
+                    // regression test needs this to read this button's real painted bounds.
+                    .debug_selector({
+                        let path = entry.path.clone();
+                        move || format!("file-tree-new-file-{}", path.display())
+                    })
                     .flex_none()
                     .cursor_pointer()
                     .px(px(4.0))
@@ -1356,7 +1377,17 @@ impl AdeApp {
             .h(theme::band::CHROME_HEADER)
             .flex()
             .items_center()
-            .px(px(10.0))
+            .pl(px(10.0))
+            // GitHub issue #123 ("Add padding to the file tree right side icons/buttons"): this
+            // header sits directly above the file tree's own overlay scrollbar track (same
+            // `w_full` column, same right edge - `Self::render_right_sidebar`'s `container` has
+            // no side padding of its own), so its right-aligned action cluster below (collapse-
+            // all, "New file" `+`) needs the same real clearance the tree's own rows now use,
+            // not the plain `px(10.0)` this used to share on both sides - that left only 2px of
+            // real gap past the scrollbar's own `SCROLLBAR_SIZE`, i.e. barely more than flush,
+            // which is what the issue's screenshot shows. See
+            // `crate::root::scrollbar::CONTENT_CLEARANCE`'s own docs for the value.
+            .pr(px(scrollbar::CONTENT_CLEARANCE))
             .border_b_1()
             .border_color(theme::border::INNER)
             .child(toggle)
@@ -1432,6 +1463,12 @@ impl AdeApp {
                         el.child(
                             div()
                                 .id("file-tree-new-file-root")
+                                // Test-only (see `crate::root::scrollbar`'s own
+                                // `render_vertical_scrollbar` for the identical pattern) - lets a
+                                // real render test read this cluster's actual right-most painted
+                                // bounds back, rather than only proving a padding *number*
+                                // changed.
+                                .debug_selector(|| "file-tree-new-file-root".to_string())
                                 .flex_none()
                                 .cursor_pointer()
                                 .px(px(5.0))
@@ -1748,7 +1785,13 @@ impl AdeApp {
             .gap(px(6.0))
             .h(theme::band::CHANGE_ROW)
             .pl(px(9.0))
-            .pr(px(10.0))
+            // GitHub issue #123: reuses the same shared clearance the file tree's own rows use
+            // (`crate::root::scrollbar::CONTENT_CLEARANCE`'s own docs) - this row sits next to
+            // the identical overlay scrollbar (`Self::render_changes_rows`'s
+            // "changes-rows-scrollbar"), so it needs the same real gap, not just a
+            // similar-looking bare number that happens to already clear the *old*,
+            // insufficient value.
+            .pr(px(scrollbar::CONTENT_CLEARANCE))
             .border_b_1()
             .border_color(theme::border::ROW)
             .cursor_pointer()
@@ -3113,6 +3156,77 @@ mod virtualization_tests {
             cx.debug_bounds("change-row-f-39.txt").is_none(),
             "the 40th changed file's row is past any plausible viewport, so a virtualized \
              list must never build it as an element at all"
+        );
+    }
+
+    /// GitHub issue #123 ("Add padding to the file tree right side icons/buttons"): before this
+    /// revision's fix, a directory row's own trailing "new file" `+` control sat at exactly
+    /// `SCROLLBAR_SIZE` from the row's right edge - precisely where the real overlay scrollbar's
+    /// track begins (`crate::root::scrollbar::render_vertical_scrollbar`'s own `right_0()`
+    /// `.w(px(SCROLLBAR_SIZE))`), i.e. touching it with zero real daylight between them whenever
+    /// the tree genuinely scrolled - the collision the issue's screenshot shows.
+    ///
+    /// This proves the fix with real painted geometry, not merely that a padding *number*
+    /// changed: `min_gap` is a real threshold on its own, independent of whatever
+    /// `crate::root::scrollbar::CONTENT_CLEARANCE` production code currently uses, so this test
+    /// keeps proving genuine daylight even if that constant's value ever changes, rather than
+    /// silently re-checking a value against itself.
+    #[gpui::test]
+    fn file_tree_row_and_header_actions_clear_the_real_scrollbar(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        fs::create_dir(repo.path().join("src")).expect("mkdir");
+        fs::write(repo.path().join("src/main.rs"), "//\n").expect("write");
+        // Enough flat files that the tree genuinely overflows its viewport and the real overlay
+        // scrollbar actually renders - `render_vertical_scrollbar` returns `None`, painting
+        // nothing at all, when the list doesn't overflow (see that function's own early return
+        // on `max_offset <= 0.5`).
+        for index in 0..300 {
+            fs::write(repo.path().join(format!("file-{index:03}.txt")), "x\n").expect("write");
+        }
+        let (_app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        let scrollbar = cx.debug_bounds("file-tree-scrollbar").expect(
+            "the tree must genuinely overflow for this test to prove anything about the real \
+             scrollbar's geometry - if this is `None` the precondition itself is broken",
+        );
+
+        // A real minimum gap - deliberately not derived from `CONTENT_CLEARANCE` itself (see
+        // this test's own docs above).
+        let min_gap = px(4.0);
+
+        // Directories sort before files at the same depth (`file_tree`'s own sort), so "src" is
+        // the tree's very first row - guaranteed to paint inside any plausible viewport,
+        // regardless of virtualization.
+        // `debug_bounds` takes `&'static str`; this codebase's established test-only pattern for
+        // a selector that must embed a real runtime path (see `crate::root::focus`'s own tests)
+        // is a deliberate, test-only leak via `Box::leak`.
+        let row_selector: &'static str = Box::leak(
+            format!("file-tree-new-file-{}", repo.path().join("src").display()).into_boxed_str(),
+        );
+        let row_button = cx
+            .debug_bounds(row_selector)
+            .expect("the \"src\" directory row's own \"+\" control must really paint");
+        assert!(
+            row_button.right() + min_gap <= scrollbar.left(),
+            "the file tree row's own \"+\" control (right edge {:?}) must clear the real \
+             scrollbar's own left edge ({:?}) by a real, visually distinct margin - not just \
+             avoid literal pixel overlap, which is what collided in GitHub issue #123's \
+             screenshot",
+            row_button.right(),
+            scrollbar.left(),
+        );
+
+        let header_button = cx.debug_bounds("file-tree-new-file-root").expect(
+            "the header's own root \"New file\" control must really paint in the Files view",
+        );
+        assert!(
+            header_button.right() + min_gap <= scrollbar.left(),
+            "the header's action cluster (right edge {:?}) must also clear the real \
+             scrollbar's own left edge ({:?}) by a real margin - this is the exact control \
+             GitHub issue #123's screenshot shows colliding with the scrollbar",
+            header_button.right(),
+            scrollbar.left(),
         );
     }
 }

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -1280,6 +1280,7 @@ impl AdeApp {
                     .flex_1()
                     .min_w_0()
                     .overflow_hidden()
+                    .truncate()
                     .text_color(if entry.is_dir {
                         theme::text::SECONDARY
                     } else {


### PR DESCRIPTION
Closes #123

The file tree's right-side icons/buttons sit too close to the scrollbar and collide with it.

## Root cause

`crate::root::scrollbar::SCROLLBAR_SIZE` (the real overlay scrollbar track's width) is `8.0`, and every place giving file-tree/header content its own right padding used exactly `pr(px(8.0))` (`render_file_tree_row`, `render_tree_inline_edit_row`) or `pr(px(10.0))` (the right-sidebar header's action cluster, `render_change_row`) — at most 2px of real clearance past where the scrollbar's track begins, which reads as flush contact once anti-aliasing and hover states render. The scrollbar is painted as an `.absolute()` sibling overlay, not reserved flex space, so content padded only to `SCROLLBAR_SIZE` sits exactly where the track starts.

## Fix

Added one shared constant, `scrollbar::CONTENT_CLEARANCE = SCROLLBAR_SIZE + 6.0`, and applied it as the right padding everywhere content sits next to this scrollbar (file tree rows, the inline rename/new-file row, the Changes rows, and the right-sidebar header's action cluster) — one real value instead of every call site guessing its own "close enough" number.

## Testing

New geometric regression test `file_tree_row_and_header_actions_clear_the_real_scrollbar` seeds enough files that the tree genuinely overflows and the real scrollbar actually paints, then asserts real painted clearance (via `debug_bounds`) between both the directory row's "+" control and the header's "New file" button and the scrollbar's own left edge — an independent minimum-gap threshold, not derived from `CONTENT_CLEARANCE` itself, so it keeps proving real daylight even if that constant's value changes later.

- `cargo build --workspace` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅ (0 warnings)
- `cargo fmt --all -- --check` ✅
- `cargo test --workspace -p app sidebar::render`: 36 passed, 0 failed
- `cargo test --workspace`: 1388 passed, 10 failed — all 10 pre-existing and environment-specific (LSP wiring tests needing network/language-server readiness, one syntax-highlight-cache flake), none touching `sidebar::render` or this change
