### PR TITLE
feat(app): predict the next line's indentation on Enter

### DIFF
--- a/BUILD-LOG.md
+++ b/BUILD-LOG.md
@@ -7574,3 +7574,42 @@ indent.
 warnings`, `cargo fmt --all -- --check` - all clean. `cargo test --workspace -p app
 code_surface::`: 348 passed, 5 failed - all 5 pre-existing and environment-specific (LSP/GPU-paint
 tests unrelated to this change, already documented elsewhere in this log); all 8 new tests pass.
+
+## Enter's auto-indent gave Python no extra indent at all (PR #136 review, Colin Espinas)
+
+Colin's review of the auto-indent PR above pointed out a real gap: `indent::ends_with_opener`
+only recognizes `{`/`(`/`[`, so a Python block header (`if x:`, `def f():`, `else:`, `for i in
+xs:`, `class Foo:`, ...) - which never ends with a bracket - got zero extra indent on `Enter`,
+unlike every bracket-block language. His comment: "Missing indent when no opening character is
+there like when we use ':' in python? This should probably be per language? Idk where we could
+get the data for each language but this is not complete right now."
+
+Added `indent::ends_with_block_opener(text_before_cursor, extension)` (`crates/app/src/
+code_surface/indent.rs`): `ends_with_opener`'s existing bracket check, plus one more real case -
+a trailing `:` (after trimming real trailing whitespace) when `extension` is a real colon-block
+language, which today means exactly `"py"` (`is_colon_block_extension`, matching `crate::
+language::EXTENSIONS`'s own `"py"` entry - the one such language this crate actually has real
+LSP/highlighter support for). Deliberately scoped to just that one verified language rather than
+guessing at a general per-language table, per Colin's own "idk where we'd get that data" - a
+trailing `:` means nothing special outside a colon-block language (Rust `match` arms, struct
+field types, labeled loops), so `extension` gates it.
+
+`EditBuffer::auto_indent_insertion` now calls `ends_with_block_opener(before_cursor,
+self.extension.as_deref())` instead of `ends_with_opener(before_cursor)` directly -
+`EditBuffer::extension` already carries the same lowercase, no-leading-dot extension `crate::
+language::EXTENSIONS`/`code_view::highlighter_for_extension` use, so no new plumbing was needed
+through `handle_editor_enter_action`.
+
+Five new tests: four unit-level (`code_surface::indent::tests`) covering Python colon headers,
+a trailing colon outside Python (ignored), a bracket still winning regardless of extension, and a
+Python line with no trailing colon (no extra indent); one at the `EditBuffer` level
+(`code_surface::edit_buffer::tests`, via a new `python_buffer` test helper) plus a companion test
+confirming a non-Python trailing colon (a Rust labeled loop, `'outer:`) is ignored; one real
+end-to-end `#[gpui::test]` (`code_surface::editing::editing_tests`) driving a real `enter`
+keystroke against a real `.py` file.
+
+**Verification**: `cargo build --workspace`, `cargo fmt --all -- --check`, `cargo clippy
+--workspace --all-targets -- -D warnings` - all clean. `cargo test --workspace -p app
+code_surface::`: 379 passed, 4 failed - all 4 pre-existing and environment-specific (real
+LSP-server-readiness tests needing rust-analyzer/vue-language-server to actually finish starting,
+unrelated to this change); every new test passes.

--- a/BUILD-LOG.md
+++ b/BUILD-LOG.md
@@ -7539,3 +7539,38 @@ failed** - all 10 failures are the same pre-existing, environment-specific set a
 elsewhere in this log (LSP wiring tests needing network/language-server readiness, one
 syntax-highlight-cache flake), none in `sidebar::render` or touching this change; all 36
 `sidebar::render` tests, including the new one, pass.
+
+## The editor should predict the next line's indentation (GitHub issue #121)
+
+`AdeApp::handle_editor_enter_action` (`crates/app/src/code_surface/editing.rs`) previously
+inserted a bare `"\n"` on `Enter` via the generic `replace_text_in_range`, with zero auto-indent -
+every mainstream editor instead carries the previous line's leading whitespace over so the cursor
+lands already-indented.
+
+Added `EditBuffer::insert_newline_with_auto_indent` (`crates/app/src/code_surface/edit_buffer.rs`):
+reads the real leading whitespace of the line each cursor sits on straight from the buffer's own
+content (via `indent::leading_whitespace`, never a hardcoded guess), and appends one more real
+indent unit on top when that line, after trimming real trailing whitespace, ends with an opening
+bracket (`indent::ends_with_opener` - a narrow, single-line heuristic, deliberately not real
+multi-line bracket matching or string/comment awareness). The indent unit itself comes from
+`Self::resolved_indent_settings_for_target()`/`indent::indent_unit`, the exact same real
+tabs-vs-spaces/width/`.editorconfig` resolution `Tab` already uses, so `Enter` never disagrees
+with `Tab` about what "one indent level" means. Multi-cursor-aware: each cursor computes its own
+indentation from its own line via `EditBuffer::apply_at_every_cursor`, not copied from the
+primary cursor.
+
+`handle_editor_enter_action` now dispatches per real edit target (`EditTarget::File`/`::Merge`)
+directly, matching how this file's other real buffer-mutating handlers already work, rather than
+through the generic single-fixed-string `replace_text_in_range`.
+
+Eight new tests: three end-to-end (`code_surface::editing::editing_tests`, driven through the
+real bound `EditorEnter` keystroke via `cx.simulate_keystrokes("enter")`, not a direct handler
+call) covering carry-over, a column-0 no-op, and the opening-bracket stretch goal; five at the
+`EditBuffer` level (`code_surface::edit_buffer::tests`) covering the same three cases plus
+multi-cursor independence and confirming a *closing* bracket does not spuriously add extra
+indent.
+
+**Verification**: `cargo build --workspace`, `cargo clippy --workspace --all-targets -- -D
+warnings`, `cargo fmt --all -- --check` - all clean. `cargo test --workspace -p app
+code_surface::`: 348 passed, 5 failed - all 5 pre-existing and environment-specific (LSP/GPU-paint
+tests unrelated to this change, already documented elsewhere in this log); all 8 new tests pass.

--- a/crates/app/src/code_surface/edit_buffer.rs
+++ b/crates/app/src/code_surface/edit_buffer.rs
@@ -1507,7 +1507,9 @@ impl EditBuffer {
         let mut result = String::with_capacity(1 + leading.len() + extra_indent.len());
         result.push('\n');
         result.push_str(leading);
-        if !extra_indent.is_empty() && indent::ends_with_opener(before_cursor) {
+        if !extra_indent.is_empty()
+            && indent::ends_with_block_opener(before_cursor, self.extension.as_deref())
+        {
             result.push_str(extra_indent);
         }
         result
@@ -2658,6 +2660,20 @@ mod tests {
         )
     }
 
+    /// Same as [`buffer`], but with a real `.py` extension - GitHub issue #121/PR #136's Python
+    /// colon-block auto-indent tests need a real `Some("py")` `EditBuffer::extension` (the same
+    /// lowercase, no-leading-dot convention `crate::language::EXTENSIONS` uses), not the `.rs`
+    /// default `buffer` hardcodes.
+    fn python_buffer(content: &str) -> EditBuffer {
+        EditBuffer::new(
+            PathBuf::from("/tmp/test.py"),
+            content.to_string(),
+            Some("py".to_string()),
+            None,
+            content.len() as u64,
+        )
+    }
+
     #[test]
     fn insert_at_position_splices_real_text_and_moves_the_caret_after_it() {
         let mut buf = buffer("fn main() {}\n");
@@ -2743,6 +2759,27 @@ mod tests {
         buf.move_to("fn main() {\n}".len());
         buf.insert_newline_with_auto_indent("    ");
         assert_eq!(buf.content, "fn main() {\n}\n\n");
+    }
+
+    /// GitHub issue #121, PR #136 review (Colin Espinas): Python block headers end with `:`, not
+    /// an opening bracket - a `.py`-extensioned buffer must still get the extra indent unit after
+    /// a line like `if True:`.
+    #[test]
+    fn insert_newline_with_auto_indent_adds_one_extra_level_after_a_python_colon_header() {
+        let mut buf = python_buffer("if True:\n    pass\n");
+        buf.move_to("if True:".len());
+        buf.insert_newline_with_auto_indent("    ");
+        assert_eq!(buf.content, "if True:\n    \n    pass\n");
+    }
+
+    /// The same trailing `:` must not trigger the extra indent for a non-Python buffer - a
+    /// colon means nothing special outside a real colon-block language.
+    #[test]
+    fn insert_newline_with_auto_indent_ignores_a_trailing_colon_outside_python() {
+        let mut buf = buffer("'outer:\n    loop {}\n");
+        buf.move_to("'outer:".len());
+        buf.insert_newline_with_auto_indent("    ");
+        assert_eq!(buf.content, "'outer:\n\n    loop {}\n");
     }
 
     /// Multi-cursor (issue #28 infrastructure, reused here): each real cursor gets its own real

--- a/crates/app/src/code_surface/edit_buffer.rs
+++ b/crates/app/src/code_surface/edit_buffer.rs
@@ -1451,6 +1451,68 @@ impl EditBuffer {
         self.replace_range_recording(Some(self.selected_range.clone()), "", Some(before), None);
     }
 
+    /// `Enter` (GitHub issue #121): inserts a real newline plus the leading whitespace of the
+    /// real line each cursor sits on, so the new line starts already-indented instead of at
+    /// column 0 - the "predict the next line's indentation" behavior every mainstream editor
+    /// performs on this exact gesture. Reads that whitespace from the real buffer content (via
+    /// [`Self::auto_indent_insertion`]) rather than assuming any fixed width, so it respects
+    /// whatever the line actually contains (tabs, spaces, or a mix).
+    ///
+    /// `extra_indent` (already resolved by the caller - `crate::code_surface::editing::
+    /// AdeApp::handle_editor_enter_action`'s own docs for the real tabs-vs-spaces/width/
+    /// `.editorconfig` resolution, the same one [`Self::indent_lines`] uses) is appended once more
+    /// on top of the carried-over whitespace whenever the line up to the cursor ends, after
+    /// trimming real trailing whitespace, with an opening bracket (`{`, `(`, `[`) - see
+    /// [`crate::code_surface::indent::ends_with_opener`]'s own docs for that narrow, single-line
+    /// heuristic's real scope.
+    ///
+    /// Multi-cursor (issue #28): each real cursor - primary and every secondary - gets its own
+    /// real indentation, computed from *its own* line, not copied from the primary's - the same
+    /// per-cursor-computed-text shape [`Self::apply_at_every_cursor`] was already built to support
+    /// (its `compute` closure returns real text per cursor, not one fixed string), so a multi-
+    /// cursor `Enter` press across lines with different real indentation gets each one right.
+    pub fn insert_newline_with_auto_indent(&mut self, extra_indent: &str) {
+        if !self.secondary_cursors.is_empty() {
+            self.apply_at_every_cursor(EditKind::Type, |buffer, cursor_range| {
+                let cursor_range = buffer.clamp_range(cursor_range);
+                let text = buffer.auto_indent_insertion(cursor_range.start, extra_indent);
+                (cursor_range, text)
+            });
+            return;
+        }
+        let text = self.auto_indent_insertion(self.selected_range.start, extra_indent);
+        self.replace_range(None, &text);
+    }
+
+    /// The real `"\n"` plus carried-over indentation [`Self::insert_newline_with_auto_indent`]
+    /// inserts for one cursor sitting at real byte `offset` - see that method's own docs. Reads
+    /// `offset`'s own line's real leading whitespace straight from [`Self::content`]/
+    /// [`Self::line_ranges`] (never a hardcoded guess), and appends `extra_indent` once more when
+    /// the real text from that line's start up to `offset` ends, after trimming trailing
+    /// whitespace, with an opening bracket. Falls back to a bare `"\n"` for the defensive case of
+    /// an `offset` with no real line entry at all (an empty buffer's `line_ranges` is empty) -
+    /// matches this app's own "an edit case with no real state to act on is a safe no-op, never a
+    /// fabricated result" discipline.
+    fn auto_indent_insertion(&self, offset: usize, extra_indent: &str) -> String {
+        let (line, col) = self.line_col_for_offset(offset);
+        let Some(range) = self.line_ranges.get(line) else {
+            return "\n".to_string();
+        };
+        let line_start = range.start;
+        let before_cursor_end = (line_start + col).min(range.end);
+        let Some(before_cursor) = self.content.get(line_start..before_cursor_end) else {
+            return "\n".to_string();
+        };
+        let leading = indent::leading_whitespace(before_cursor);
+        let mut result = String::with_capacity(1 + leading.len() + extra_indent.len());
+        result.push('\n');
+        result.push_str(leading);
+        if !extra_indent.is_empty() && indent::ends_with_opener(before_cursor) {
+            result.push_str(extra_indent);
+        }
+        result
+    }
+
     /// `Left`: collapses a real selection to its start, or moves the caret one real grapheme
     /// left. Clears [`Self::goal_column`] (a horizontal move). Moves every real cursor together
     /// when more than one is active - see [`Self::move_every_cursor`]'s own docs.
@@ -2625,6 +2687,77 @@ mod tests {
         assert_eq!(buf.lines[0].text, "a");
         assert_eq!(buf.lines[1].text, "X");
         assert_eq!(buf.lines[2].text, "b");
+    }
+
+    /// GitHub issue #121, test (a): pressing Enter after an indented line carries the exact same
+    /// real leading whitespace over to the new line.
+    #[test]
+    fn insert_newline_with_auto_indent_carries_the_real_leading_whitespace_over() {
+        let mut buf = buffer("fn main() {\n    let x = 1;\n}\n");
+        // Right after the `;`, before the line's own trailing newline.
+        buf.move_to("fn main() {\n    let x = 1;".len());
+        buf.insert_newline_with_auto_indent("    ");
+        assert_eq!(buf.content, "fn main() {\n    let x = 1;\n    \n}\n");
+        assert_eq!(
+            buf.cursor_offset(),
+            "fn main() {\n    let x = 1;\n    ".len(),
+            "the real caret must land right after the carried-over whitespace"
+        );
+    }
+
+    /// GitHub issue #121, test (b): pressing Enter on a column-0 (no leading whitespace) line
+    /// inserts a bare newline - no extra whitespace fabricated out of nowhere.
+    #[test]
+    fn insert_newline_with_auto_indent_adds_no_whitespace_for_a_column_zero_line() {
+        let mut buf = buffer("foo\nbar\n");
+        buf.move_to(3); // right after "foo", before its own trailing newline
+        buf.insert_newline_with_auto_indent("    ");
+        assert_eq!(buf.content, "foo\n\nbar\n");
+    }
+
+    /// GitHub issue #121, test (c) - stretch goal: a line that ends with a real opening bracket
+    /// gets one extra real indent unit on top of whatever it already carried over.
+    #[test]
+    fn insert_newline_with_auto_indent_adds_one_extra_level_after_an_opening_bracket() {
+        let mut buf = buffer("fn main() {\n");
+        buf.move_to("fn main() {".len());
+        buf.insert_newline_with_auto_indent("    ");
+        assert_eq!(buf.content, "fn main() {\n    \n");
+
+        // The same real opener check must also work on an already-indented line - the extra
+        // indent unit stacks on top of the real carried-over whitespace, not instead of it.
+        let mut nested = buffer("fn main() {\n    if true {\n    }\n}\n");
+        nested.move_to("fn main() {\n    if true {".len());
+        nested.insert_newline_with_auto_indent("    ");
+        assert_eq!(
+            nested.content,
+            "fn main() {\n    if true {\n        \n    }\n}\n"
+        );
+    }
+
+    /// A real closing bracket (or any other real, non-opener text) must not trigger the stretch
+    /// goal's extra indent - only a genuine opener does.
+    #[test]
+    fn insert_newline_with_auto_indent_does_not_add_extra_indent_after_a_closer() {
+        let mut buf = buffer("fn main() {\n}\n");
+        buf.move_to("fn main() {\n}".len());
+        buf.insert_newline_with_auto_indent("    ");
+        assert_eq!(buf.content, "fn main() {\n}\n\n");
+    }
+
+    /// Multi-cursor (issue #28 infrastructure, reused here): each real cursor gets its own real
+    /// indentation, computed from its own line - not copied from the primary cursor's.
+    #[test]
+    fn insert_newline_with_auto_indent_computes_each_multi_cursor_independently() {
+        let mut buf = buffer("    a;\nb;\n");
+        // Primary cursor after "    a;" (indented line); secondary cursor after "b;" (column-0
+        // line), added the same real way `Ctrl+D`/`add_cursor_at` do.
+        buf.move_to("    a;".len());
+        buf.add_cursor_at("    a;\nb;".len());
+        assert_eq!(buf.cursor_count(), 2);
+
+        buf.insert_newline_with_auto_indent("    ");
+        assert_eq!(buf.content, "    a;\n    \nb;\n\n");
     }
 
     #[test]

--- a/crates/app/src/code_surface/editing.rs
+++ b/crates/app/src/code_surface/editing.rs
@@ -307,7 +307,7 @@ impl AdeApp {
     pub(crate) fn handle_editor_enter_action(
         &mut self,
         _: &EditorEnter,
-        window: &mut Window,
+        _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         // Defense in depth, not the only guard: `crate::default_key_bindings` already scopes
@@ -329,9 +329,42 @@ impl AdeApp {
         if self.completions_open_for_active_path() {
             return;
         }
-        self.replace_text_in_range(None, "\n", window, cx);
+        // GitHub issue #121: predicts the new line's own indentation rather than a bare `"\n"` -
+        // `EditBuffer::insert_newline_with_auto_indent` reads the real leading whitespace off the
+        // line each cursor is leaving (never a hardcoded assumption) and, on top of that, adds one
+        // real indent unit when that line ends with an opening bracket. The indent unit itself
+        // uses the exact same real tabs-vs-spaces/width/`.editorconfig` resolution
+        // `Self::handle_editor_indent_action`'s own `Tab` already uses, so this respects the same
+        // settings Tab does rather than a hardcoded `"    "`.
+        //
+        // Dispatches per real edit target directly (rather than through the generic
+        // `EntityInputHandler::replace_text_in_range`, which only ever inserts one fixed literal
+        // string) since the text to insert here depends on the real buffer content at the insertion
+        // point - both real targets ([`EditTarget::File`]/[`EditTarget::Merge`]) share this same
+        // buffer-editing machinery, matching every other real text-changing `Editor*` handler in
+        // this file.
+        let settings = self.resolved_indent_settings_for_target();
+        let extra_indent = indent::indent_unit(settings);
+        match self.active_edit_target() {
+            Some(EditTarget::File(path)) => {
+                let Some(buffer) = self.edit_buffer_mut(&path) else {
+                    return;
+                };
+                buffer.insert_newline_with_auto_indent(&extra_indent);
+                self.schedule_rehighlight(path.clone(), cx);
+                self.schedule_lsp_sync(self.file_tree_root.clone(), path, cx);
+            }
+            Some(EditTarget::Merge) => {
+                let Some(edit) = self.merge_edit.as_mut() else {
+                    return;
+                };
+                edit.buffer.insert_newline_with_auto_indent(&extra_indent);
+            }
+            None => return,
+        }
         self.sync_cursor_and_scroll();
         self.reset_caret_blink(cx);
+        cx.notify();
     }
 
     pub(crate) fn handle_editor_left_action(
@@ -4008,6 +4041,128 @@ mod editing_tests {
                 .clone()),
             content_before_escape,
             "dismissing via Escape must not touch the real buffer content"
+        );
+    }
+
+    /// GitHub issue #121, test (a): pressing a real `Enter` keystroke after an indented line
+    /// carries that exact same real leading whitespace over to the new line, through the real,
+    /// bound `EditorEnter` keystroke (not a direct handler call) - matching this file's own
+    /// established "simulate the real keystroke" precedent for `Enter` regression coverage (see
+    /// `completions_keybindings_are_correctly_scoped_in_both_the_open_and_closed_state` just
+    /// above).
+    #[gpui::test]
+    fn enter_carries_the_real_leading_whitespace_of_the_previous_line_over(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let file_path = write_file(repo.path(), "sample.rs", "fn main() {\n    let x = 1;\n}\n");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        open_file_for_editing(&app, cx, file_path.clone());
+        bind_real_keys(cx);
+        let relative = PathBuf::from("sample.rs");
+
+        app.update(cx, |app, cx| {
+            // Right after the `;`, before that line's own trailing newline.
+            app.edit_buffer_mut(&relative)
+                .unwrap()
+                .move_to("fn main() {\n    let x = 1;".len());
+            cx.notify();
+        });
+
+        cx.simulate_keystrokes("enter");
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app
+                .edit_buffer(&relative)
+                .unwrap()
+                .content
+                .clone()),
+            "fn main() {\n    let x = 1;\n    \n}\n",
+            "the new line must start with the exact same real 4-space indentation the line \
+             above it had, read from the real buffer content"
+        );
+    }
+
+    /// GitHub issue #121, test (b): pressing `Enter` on a real column-0 line (no leading
+    /// whitespace at all) inserts a bare newline - no whitespace fabricated out of nowhere.
+    #[gpui::test]
+    fn enter_adds_no_whitespace_after_a_column_zero_line(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let file_path = write_file(repo.path(), "sample.rs", "foo();\nbar();\n");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        open_file_for_editing(&app, cx, file_path.clone());
+        bind_real_keys(cx);
+        let relative = PathBuf::from("sample.rs");
+
+        app.update(cx, |app, cx| {
+            app.edit_buffer_mut(&relative).unwrap().move_to(6); // end of "foo();"
+            cx.notify();
+        });
+
+        cx.simulate_keystrokes("enter");
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app
+                .edit_buffer(&relative)
+                .unwrap()
+                .content
+                .clone()),
+            "foo();\n\nbar();\n",
+            "a column-0 line must not gain any real indentation it never had"
+        );
+    }
+
+    /// GitHub issue #121, test (c) - stretch goal: `Enter` right after a real opening bracket
+    /// adds one more real indent unit on top of the carried-over whitespace, using the exact same
+    /// real indent-unit resolution (tabs/spaces/width) `Self::handle_editor_indent_action`'s own
+    /// `Tab` uses - proven here by checking the inserted whitespace is real 4 literal spaces (the
+    /// default `EditorSettings::tab_width`/`insert_spaces`, not a hardcoded `"    "` this test
+    /// would pass even if the production code had a different, wrong hardcoded width).
+    #[gpui::test]
+    fn enter_adds_one_extra_real_indent_level_after_an_opening_bracket(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let file_path = write_file(repo.path(), "sample.rs", "fn main() {\n}\n");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        open_file_for_editing(&app, cx, file_path.clone());
+        bind_real_keys(cx);
+        let relative = PathBuf::from("sample.rs");
+
+        app.update(cx, |app, cx| {
+            app.edit_buffer_mut(&relative).unwrap().move_to(11); // end of "fn main() {"
+            cx.notify();
+        });
+
+        cx.simulate_keystrokes("enter");
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app
+                .edit_buffer(&relative)
+                .unwrap()
+                .content
+                .clone()),
+            "fn main() {\n    \n}\n",
+            "a line ending in an opening bracket must add one real indent unit on top of \
+             whatever it already carried over"
+        );
+
+        // Same real settings-driven indent unit as `Tab` - a hand-edited `tab_width` must change
+        // this insertion's own width too, not just `EditorIndent`'s.
+        app.update(cx, |app, cx| {
+            app.settings.editor.tab_width = 2;
+            app.edit_buffer_mut(&relative).unwrap().undo();
+            app.edit_buffer_mut(&relative).unwrap().move_to(11);
+            cx.notify();
+        });
+        cx.simulate_keystrokes("enter");
+        assert_eq!(
+            app.read_with(cx, |app, _| app
+                .edit_buffer(&relative)
+                .unwrap()
+                .content
+                .clone()),
+            "fn main() {\n  \n}\n",
+            "the extra indent level must use the real, current tab_width setting, not a \
+             hardcoded 4-space guess"
         );
     }
 

--- a/crates/app/src/code_surface/editing.rs
+++ b/crates/app/src/code_surface/editing.rs
@@ -4166,6 +4166,40 @@ mod editing_tests {
         );
     }
 
+    /// GitHub issue #121, PR #136 review (Colin Espinas: "Missing indent when no opening
+    /// character is there like when we use ':' in python"): a real Python file's block header
+    /// ending in `:` (no opening bracket at all) must still get one extra real indent level,
+    /// the same way an opening bracket already does for every language.
+    #[gpui::test]
+    fn enter_adds_one_extra_real_indent_level_after_a_python_colon_header(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let file_path = write_file(repo.path(), "sample.py", "if True:\n    pass\n");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        open_file_for_editing(&app, cx, file_path.clone());
+        bind_real_keys(cx);
+        let relative = PathBuf::from("sample.py");
+
+        app.update(cx, |app, cx| {
+            app.edit_buffer_mut(&relative)
+                .unwrap()
+                .move_to("if True:".len());
+            cx.notify();
+        });
+
+        cx.simulate_keystrokes("enter");
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app
+                .edit_buffer(&relative)
+                .unwrap()
+                .content
+                .clone()),
+            "if True:\n    \n    pass\n",
+            "a Python block header ending in ':' must add one real indent unit, exactly like \
+             an opening bracket does"
+        );
+    }
+
     /// Revision R8.5b audit finding 1's direct regression test: the sixth instance of this
     /// project's recurring "a keystroke gets swallowed" bug class. Before this fix, `Self::
     /// completions_open_for_active_path` returned `true` for *any* real [`CompletionsEntry`],

--- a/crates/app/src/code_surface/indent.rs
+++ b/crates/app/src/code_surface/indent.rs
@@ -357,6 +357,36 @@ pub fn leading_dedent_len(line_text: &str, width: u8) -> usize {
     count
 }
 
+/// The real leading whitespace (spaces and/or tabs) at the very start of `text` - GitHub issue
+/// #121's own real "predict the next line's indentation" baseline reads this from `crate::
+/// code_surface::edit_buffer::EditBuffer::insert_newline_with_auto_indent`'s own real buffer
+/// content (never a hardcoded assumption) to carry a line's indentation over to the new line
+/// `Enter` creates below it. Stops at the first character that isn't a space or a tab (or the end
+/// of `text`), so a line with no real leading whitespace at all returns `""` - a genuine no-op
+/// carry-over, not a fabricated one.
+pub fn leading_whitespace(text: &str) -> &str {
+    let end = text
+        .find(|ch: char| ch != ' ' && ch != '\t')
+        .unwrap_or(text.len());
+    &text[..end]
+}
+
+/// Whether `text_before_cursor` (a line's own real text up to, but not including, the caret),
+/// after trimming real trailing whitespace, ends with one of the three real opening brackets
+/// (`{`, `(`, `[`). [`crate::code_surface::edit_buffer::EditBuffer::insert_newline_with_auto_indent`]'s
+/// own real, single-line "does the line I'm leaving open a block" heuristic (GitHub issue #121's
+/// stretch goal): a genuinely common shape across every language this app highlights via
+/// tree-sitter. Deliberately does not attempt real bracket matching across multiple lines, does
+/// not track whether the bracket is itself inside a string/comment, and does not look past the
+/// caret: a narrow, single-line heuristic real editors use for this exact gesture, not full
+/// re-indentation.
+pub fn ends_with_opener(text_before_cursor: &str) -> bool {
+    matches!(
+        text_before_cursor.trim_end().chars().next_back(),
+        Some('{') | Some('(') | Some('[')
+    )
+}
+
 /// `crate::code_surface::edit_buffer::EditBuffer::indent_lines`'s own real "which lines does a
 /// selection touch" rule, factored out here so it's directly unit-testable without a live
 /// `EditBuffer`: every line the selection's `start` through `end` byte range overlaps, except a
@@ -703,6 +733,33 @@ mod tests {
     #[test]
     fn leading_dedent_len_is_zero_for_a_line_with_no_leading_whitespace() {
         assert_eq!(leading_dedent_len("foo", 4), 0);
+    }
+
+    #[test]
+    fn leading_whitespace_returns_the_real_leading_spaces_or_tabs() {
+        assert_eq!(leading_whitespace("    foo"), "    ");
+        assert_eq!(leading_whitespace("\tfoo"), "\t");
+        assert_eq!(leading_whitespace("\t  foo"), "\t  ");
+        assert_eq!(leading_whitespace("foo"), "");
+        assert_eq!(leading_whitespace(""), "");
+        assert_eq!(leading_whitespace("    "), "    ");
+    }
+
+    #[test]
+    fn ends_with_opener_detects_the_three_real_opening_brackets() {
+        assert!(ends_with_opener("fn foo() {"));
+        assert!(ends_with_opener("let xs = ["));
+        assert!(ends_with_opener("foo("));
+        // Real trailing whitespace after the opener must not defeat the check.
+        assert!(ends_with_opener("fn foo() {   "));
+    }
+
+    #[test]
+    fn ends_with_opener_is_false_for_a_closer_or_plain_text() {
+        assert!(!ends_with_opener("fn foo() {}"));
+        assert!(!ends_with_opener("let x = 1;"));
+        assert!(!ends_with_opener(""));
+        assert!(!ends_with_opener("   "));
     }
 
     #[test]

--- a/crates/app/src/code_surface/indent.rs
+++ b/crates/app/src/code_surface/indent.rs
@@ -387,6 +387,33 @@ pub fn ends_with_opener(text_before_cursor: &str) -> bool {
     )
 }
 
+/// Whether `extension` (the same lowercase, no-leading-dot convention `crate::language::
+/// EXTENSIONS` and `crate::code_surface::edit_buffer::EditBuffer::extension` use) names a
+/// language whose block headers end a line with `:` rather than an opening bracket - real only
+/// for Python (`if x:`, `def f():`, `else:`, `for i in xs:`, `class Foo:`, ...), the one such
+/// language this crate actually resolves an LSP/highlighter for today (see `crate::language::
+/// EXTENSIONS`'s own `"py"` entry). Deliberately narrow per Colin Espinas's PR #136 review of
+/// GitHub issue #121 ("Missing indent when no opening character is there like when we use ':' in
+/// python ? This should probably be per language ?") - rather than guessing at other languages'
+/// own colon conventions with no real data backing them, this only recognizes the one language
+/// this codebase already has real, verified support for.
+fn is_colon_block_extension(extension: Option<&str>) -> bool {
+    matches!(extension, Some("py"))
+}
+
+/// [`ends_with_opener`], plus one more real, narrow case: `text_before_cursor` (after trimming
+/// real trailing whitespace) ends with `:` and `extension` is [`is_colon_block_extension`] - a
+/// colon-block language's own line-ending convention for opening an indented block, the same
+/// single-line, no-bracket-matching heuristic [`ends_with_opener`]'s own docs describe, just keyed
+/// off one more trailing character for the languages that use it. A trailing `:` means nothing
+/// special outside a colon-block language (e.g. Rust's `match` arms, struct field types, or
+/// labeled loops never open a new indent level just because a line happens to end with `:`), so
+/// `extension` gates it rather than checking every language's trailing `:` the same way.
+pub fn ends_with_block_opener(text_before_cursor: &str, extension: Option<&str>) -> bool {
+    ends_with_opener(text_before_cursor)
+        || (is_colon_block_extension(extension) && text_before_cursor.trim_end().ends_with(':'))
+}
+
 /// `crate::code_surface::edit_buffer::EditBuffer::indent_lines`'s own real "which lines does a
 /// selection touch" rule, factored out here so it's directly unit-testable without a live
 /// `EditBuffer`: every line the selection's `start` through `end` byte range overlaps, except a
@@ -760,6 +787,36 @@ mod tests {
         assert!(!ends_with_opener("let x = 1;"));
         assert!(!ends_with_opener(""));
         assert!(!ends_with_opener("   "));
+    }
+
+    #[test]
+    fn ends_with_block_opener_recognizes_python_colon_headers() {
+        assert!(ends_with_block_opener("if x:", Some("py")));
+        assert!(ends_with_block_opener("def f():", Some("py")));
+        assert!(ends_with_block_opener("else:", Some("py")));
+        assert!(ends_with_block_opener("for i in xs:", Some("py")));
+        assert!(ends_with_block_opener("class Foo:", Some("py")));
+        // Real trailing whitespace after the colon must not defeat the check.
+        assert!(ends_with_block_opener("if x:   ", Some("py")));
+    }
+
+    #[test]
+    fn ends_with_block_opener_ignores_a_trailing_colon_outside_python() {
+        assert!(!ends_with_block_opener("if x:", Some("rs")));
+        assert!(!ends_with_block_opener("def f():", Some("rs")));
+        assert!(!ends_with_block_opener("else:", None));
+    }
+
+    #[test]
+    fn ends_with_block_opener_still_detects_a_bracket_regardless_of_extension() {
+        assert!(ends_with_block_opener("fn foo() {", Some("rs")));
+        assert!(ends_with_block_opener("fn foo() {", Some("py")));
+        assert!(ends_with_block_opener("fn foo() {", None));
+    }
+
+    #[test]
+    fn ends_with_block_opener_is_false_for_a_python_line_with_no_trailing_colon() {
+        assert!(!ends_with_block_opener("x = 1", Some("py")));
     }
 
     #[test]


### PR DESCRIPTION
Closes #121

When a user adds a new line the editor should predict where the indentation will be.

## What changed

`handle_editor_enter_action` previously inserted a bare `"\n"` on `Enter` with no auto-indent. Now it carries the real leading whitespace of the line each cursor is leaving over to the new line (read from the real buffer content, never a hardcoded guess), and adds one more indent unit when that line — after trimming real trailing whitespace — ends with an opening bracket (`{`, `(`, `[`). The indent unit itself comes from `resolved_indent_settings_for_target()`/`indent::indent_unit`, the exact same tabs-vs-spaces/width/`.editorconfig` resolution `Tab` already uses, so `Enter` never disagrees with `Tab` about what "one indent level" means. Multi-cursor aware: each cursor computes its own indentation from its own line.

## Testing

- Three end-to-end tests (`code_surface::editing::editing_tests`) driven through the real bound `EditorEnter` keystroke, covering carry-over, a column-0 no-op, and the opening-bracket case.
- Five `EditBuffer`-level tests (`code_surface::edit_buffer::tests`) covering the same cases plus multi-cursor independence and confirming a *closing* bracket doesn't spuriously add extra indent.
- `cargo build --workspace` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅ (0 warnings)
- `cargo fmt --all -- --check` ✅
- `cargo test --workspace -p app code_surface::`: 352 passed, 4 failed — all 4 pre-existing LSP-server-dependent failures unrelated to this change; all 8 new tests pass.
