### PR TITLE
fix(app): selection highlights clear when focus leaves the tree/graph

### DIFF
--- a/crates/app/src/code_surface/tabs.rs
+++ b/crates/app/src/code_surface/tabs.rs
@@ -748,6 +748,27 @@ impl AdeApp {
             _ => None,
         }
     }
+
+    /// The absolute, on-disk path [`Self::open_change`] really names, resolved against whichever
+    /// root it's actually relative to - [`Self::diff_root`] while [`Self::code_view`] is `Diff`,
+    /// [`Self::file_tree_root`] otherwise (`Self::open_and_focus_file`'s own two callers,
+    /// [`Self::open_change_diff`]/[`Self::open_file_view`], resolve exactly this way). `None` iff
+    /// no file tab is showing at all.
+    ///
+    /// GitHub issue #127: this - not [`Self::selected_tree_path`] - is the Files tree's real
+    /// "which row is the open file" signal, since it stays correct regardless of tree focus and
+    /// survives every way `selected_tree_path` can drift from the centre pane's actual content: a
+    /// directory click (which updates `selected_tree_path` to a path that was never opened at
+    /// all) and switching tabs via the tab strip ([`Self::activate_file_tab`] never touches
+    /// `selected_tree_path`).
+    pub(crate) fn open_change_absolute_path(&self) -> Option<PathBuf> {
+        let relative = self.open_change.as_ref()?;
+        let root = match self.code_view {
+            code_view::CodeView::Diff => &self.diff_root,
+            code_view::CodeView::File => &self.file_tree_root,
+        };
+        Some(root.join(relative))
+    }
 }
 
 /// Regression coverage for `AdeApp::render_file_view`'s cache: re-running an expensive parse on

--- a/crates/app/src/graph_view/render.rs
+++ b/crates/app/src/graph_view/render.rs
@@ -83,6 +83,13 @@ impl AdeApp {
             self.graph_focus.capture(window, &self.agents, cx);
         }
         window.focus(&self.graph_focus_handle, cx);
+        // GitHub issue #127: set alongside the real `window.focus` call, not via a `cx.on_focus`
+        // subscription - `graph_focus_handle` is only ever `track_focus`'d conditionally
+        // (`Self::render_center_pane` renders `Self::render_graph_view` only while
+        // `graph_tab_active` is `true`), and a live-tested subscription registered before that
+        // first render never actually fired for it. See [`AdeApp::graph_view_focused`]'s own
+        // docs for why the row-selection highlight needs this at all.
+        self.graph_view_focused = true;
 
         if matches!(self.graph_state.load, GraphLoadState::NotLoaded) {
             self.load_graph(cx);
@@ -142,6 +149,10 @@ impl AdeApp {
             return;
         }
         self.graph_tab_active = false;
+        // GitHub issue #127: the tab becoming inactive means `graph_focus_handle` stops being
+        // `track_focus`'d at all (see the comment just below), so it definitionally can't be
+        // focused any more, regardless of which handle `restore_focus` below lands on next.
+        self.graph_view_focused = false;
         // Two handles stop being `track_focus`'d here, not one: `graph_focus_handle` itself, and
         // the Branches panel's real filter box (`graph_state.branches_filter_focus_handle`),
         // which is only rendered while this tab is active and can independently hold real
@@ -375,6 +386,8 @@ impl AdeApp {
         // "which overlay owns the next click" property this change is already about.
         self.graph_state.push_menu_open = false;
         window.focus(&self.graph_focus_handle, cx);
+        // GitHub issue #127 - see `Self::open_git_graph`'s own matching comment.
+        self.graph_view_focused = true;
         cx.notify();
     }
 
@@ -1082,7 +1095,14 @@ impl AdeApp {
         now_unix: i64,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        let selected = self.graph_state.selected_row == Some(index);
+        // GitHub issue #127: the selected-row highlight (background + left edge) must clear once
+        // real keyboard focus genuinely moves away from the graph view, not stay lit forever
+        // against whatever row was last selected. `graph_view_focused` is a plain bool set
+        // explicitly alongside every real `window.focus(&self.graph_focus_handle, ...)`/
+        // graph-tab-exit call site, rather than a live `FocusHandle::is_focused` check here,
+        // since this render call chain never carries a real `&Window` - see that field's own
+        // docs for why.
+        let selected = self.graph_view_focused && self.graph_state.selected_row == Some(index);
         let is_working_tree = row.commit.id.is_empty();
         let relative = if row.commit.id.is_empty() {
             "now".to_string()
@@ -4684,6 +4704,57 @@ mod graph_selection_render_tests {
             "selecting a row must never resize its own content (unselected: {:?}, selected: \
              {:?})",
             bounds_unselected, bounds_selected
+        );
+    }
+
+    /// GitHub issue #127: `AdeApp::graph_view_focused` - the bool `Self::render_graph_row`'s own
+    /// selected-row highlight reads, since that render call chain never carries a real `&Window`
+    /// to check `FocusHandle::is_focused` against directly - is set explicitly alongside every
+    /// real `window.focus(&self.graph_focus_handle, ...)`/graph-tab-exit call site
+    /// (`Self::open_git_graph`, `Self::open_graph_row_menu_at`, `Self::leave_graph_tab`), not via
+    /// a `cx.on_focus` subscription - one was tried and, live-tested, never fired for
+    /// `graph_focus_handle`, since it's only ever `track_focus`'d conditionally
+    /// (`Self::render_center_pane` renders `Self::render_graph_view` only while `graph_tab_active`
+    /// is `true`). Direct coverage of every site that flips the bool.
+    #[gpui::test]
+    fn graph_view_focused_tracks_real_focus_and_blur_of_the_graph_view(cx: &mut TestAppContext) {
+        let (_repo, app, cx) = open_seeded_graph(cx);
+
+        assert!(
+            app.read_with(cx, |app, _| app.graph_view_focused),
+            "premise: opening the graph tab genuinely focuses the graph view"
+        );
+
+        app.update_in(cx, |app, window, cx| {
+            app.leave_graph_tab(window, cx);
+        });
+        cx.run_until_parked();
+        assert!(
+            !app.read_with(cx, |app, _| app.graph_view_focused),
+            "leaving the graph tab must clear it"
+        );
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_git_graph(window, cx);
+        });
+        cx.run_until_parked();
+        assert!(
+            app.read_with(cx, |app, _| app.graph_view_focused),
+            "reopening the graph tab must set it again"
+        );
+
+        app.update_in(cx, |app, window, cx| {
+            app.leave_graph_tab(window, cx);
+        });
+        cx.run_until_parked();
+        app.update_in(cx, |app, window, cx| {
+            app.open_graph_row_menu_at(0, px(0.0), px(0.0), window, cx);
+        });
+        cx.run_until_parked();
+        assert!(
+            app.read_with(cx, |app, _| app.graph_view_focused),
+            "opening a row's context menu must also set it, since it explicitly refocuses \
+             graph_focus_handle to fix keyboard focus after a right-click's own stop_propagation"
         );
     }
 }

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -605,6 +605,22 @@ pub struct AdeApp {
     /// The git graph tab's own keyboard-focus target, `track_focus`'d by
     /// `crate::graph_view::render::AdeApp::render_graph_view`'s container.
     pub(crate) graph_focus_handle: FocusHandle,
+    /// Whether [`Self::graph_focus_handle`] is genuinely focused right now (GitHub issue #127) -
+    /// kept as a plain bool, set directly alongside each real `window.focus(&self.
+    /// graph_focus_handle, ...)` call (`crate::graph_view::render::AdeApp::open_git_graph`/
+    /// `Self::toggle_graph_row_menu`) and cleared in `crate::graph_view::render::AdeApp::
+    /// leave_graph_tab`, rather than read live at render time or driven by a `cx.on_focus`
+    /// subscription. Two real reasons, not one: the row list's own render call chain
+    /// (`crate::graph_view::render::AdeApp::render_graph_row`, reached through `Self::
+    /// render_center_pane`) never carries a real `&Window` to check `FocusHandle::is_focused`
+    /// against (`render_center_pane` is also called as a bare "force a redraw" helper from dozens
+    /// of non-rendering call sites with no window at all); and a `cx.on_focus`/`cx.on_blur`
+    /// subscription registered at construction - the shape `Self::wire_caret_blink` uses
+    /// successfully for other handles - was live-tested here and never fired, since
+    /// `graph_focus_handle` is only ever `track_focus`'d conditionally (only while
+    /// `Self::graph_tab_active`) and the very first focus of it can happen before that node has
+    /// ever been part of a rendered frame.
+    pub(crate) graph_view_focused: bool,
     /// Pre-open focus target for [`Self::graph_focus_handle`] - see [`OverlayFocus`]. Captured
     /// only on the closed-to-open transition and moved on only when something else becomes the
     /// active centre-pane content - see `crate::graph_view::render::AdeApp::leave_graph_tab`.

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -261,6 +261,7 @@ impl AdeApp {
             graph_tab_open: false,
             graph_tab_active: false,
             graph_focus_handle: cx.focus_handle(),
+            graph_view_focused: false,
             graph_focus: OverlayFocus::default(),
             graph_state: graph_view::state::GraphTabState::new(cx),
             _load_graph_task: None,

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -583,7 +583,7 @@ impl AdeApp {
         let list = uniform_list(
             "file-tree-list",
             rendered_count,
-            cx.processor(move |this: &mut Self, range: Range<usize>, _window, cx| {
+            cx.processor(move |this: &mut Self, range: Range<usize>, window, cx| {
                 // Both the row range and each index into `file_tree` are clamped/checked rather
                 // than trusted, so a future divergence degrades to "renders fewer rows" instead
                 // of panicking. `start` is clamped to `end`, not just to the length: clamping
@@ -598,7 +598,7 @@ impl AdeApp {
                             .file_tree
                             .get(*index)
                             .cloned()
-                            .map(|entry| this.render_file_tree_row(&entry, &marks, cx)),
+                            .map(|entry| this.render_file_tree_row(&entry, &marks, window, cx)),
                         TreeRow::InlineEditor => {
                             Some(this.render_tree_inline_edit_row(editor_depth, cx))
                         }
@@ -952,15 +952,22 @@ impl AdeApp {
         &self,
         entry: &FileTreeEntry,
         marks: &HashMap<PathBuf, (&'static str, gpui::Rgba)>,
+        window: &Window,
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
         let indent = px(file_tree::INDENT_STEP * entry.depth as f32);
         let is_open = entry.is_dir && self.expanded_dirs.contains(&entry.path);
         let mark = marks.get(&entry.path).copied();
-        // The Files tree's row-selection highlight (README's Zone 3 "Selected row bg
-        // `#1a1e21`") - set by `Self::open_file_view` (this row's own click handler, below)
-        // and by `Self::open_palette_file_result` for a palette file result with no diff.
-        let is_selected = self.selected_tree_path.as_deref() == Some(entry.path.as_path());
+        // GitHub issue #127: the row-selection highlight (README's Zone 3 "Selected row bg
+        // `#1a1e21`") and the ancestor-chain indent-guide highlight just below both used to key
+        // purely off `Self::selected_tree_path` - the last-opened path, set by `Self::
+        // open_file_view`/`Self::open_palette_file_result` - with no check against real keyboard
+        // focus at all. That left the row looking selected/focused indefinitely after focus
+        // genuinely moved to the editor, a terminal, or the Changes panel. Both now also require
+        // `Self::tree_focus_handle` to really be focused.
+        let tree_focused = self.tree_focus_handle.is_focused(window);
+        let is_selected =
+            tree_focused && self.selected_tree_path.as_deref() == Some(entry.path.as_path());
 
         // `debug_selector` is a no-op outside test builds; lets a real render test assert on
         // which rows this list genuinely painted, which is the only way to prove the
@@ -1007,7 +1014,11 @@ impl AdeApp {
         let active_levels = file_tree::active_guide_levels(
             &self.file_tree_root,
             &entry.path,
-            self.selected_tree_path.as_deref(),
+            // GitHub issue #127: no ancestor-chain highlight at all once the tree genuinely
+            // isn't focused, same reasoning as `is_selected` above.
+            tree_focused
+                .then_some(self.selected_tree_path.as_deref())
+                .flatten(),
         );
         for level in 0..entry.depth {
             let active = level < active_levels;
@@ -3805,6 +3816,48 @@ mod indent_guide_tests {
         (app, cx)
     }
 
+    /// GitHub issue #127: the selected file's own ancestor-chain highlight must clear the moment
+    /// real keyboard focus moves off the tree - not stay lit indefinitely just because
+    /// `Self::selected_tree_path` still names that file. `Self::open_file_view` moves focus to
+    /// the editor (not the tree), which is the exact reported scenario: click a file, then work
+    /// in the editor, and the tree still looked focused.
+    #[gpui::test]
+    fn the_ancestor_chain_highlight_clears_once_focus_leaves_the_tree(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        let (app, cx) = open_deep_tree(cx, &repo);
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_file_view(repo.path().join("a/b/c/deep.txt"), window, cx);
+        });
+        cx.run_until_parked();
+        app.update_in(cx, |app, window, _cx| {
+            assert!(
+                !app.tree_focus_handle.is_focused(window),
+                "premise: opening a file via the normal path focuses the editor, not the tree"
+            );
+        });
+        assert!(
+            cx.debug_bounds("file-tree-guide-idle-deep.txt-0").is_some(),
+            "with the editor (not the tree) focused, the selected file's own chain must render \
+             idle, even though it's still the real selected path"
+        );
+        assert!(
+            cx.debug_bounds("file-tree-guide-active-deep.txt-0")
+                .is_none(),
+            "and must not also render active"
+        );
+
+        app.update_in(cx, |app, window, cx| {
+            app.focus_file_tree(window, cx);
+        });
+        cx.run_until_parked();
+        assert!(
+            cx.debug_bounds("file-tree-guide-active-deep.txt-0")
+                .is_some(),
+            "focusing the tree for the same still-selected file must light the chain back up"
+        );
+    }
+
     /// One guide per nesting level, each at exactly its level's chevron offset from the row's
     /// own left edge, and none at all for a root-level row.
     #[gpui::test]
@@ -4001,6 +4054,10 @@ mod indent_guide_tests {
 
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(repo.path().join("a/b/c/deep.txt"), window, cx);
+            // GitHub issue #127: the ancestor-chain highlight now also requires the tree to be
+            // genuinely focused, not just a real selected path - `open_file_view` moves focus to
+            // the editor, so this test's premise needs a real tree focus afterward too.
+            app.focus_file_tree(window, cx);
         });
         cx.run_until_parked();
 

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -963,11 +963,23 @@ impl AdeApp {
         // purely off `Self::selected_tree_path` - the last-opened path, set by `Self::
         // open_file_view`/`Self::open_palette_file_result` - with no check against real keyboard
         // focus at all. That left the row looking selected/focused indefinitely after focus
-        // genuinely moved to the editor, a terminal, or the Changes panel. Both now also require
-        // `Self::tree_focus_handle` to really be focused.
+        // genuinely moved to the editor, a terminal, or the Changes panel.
+        //
+        // Two genuinely different things were being conflated under one field, though: "this row
+        // is what the centre pane is actually showing" (should stay lit no matter where focus
+        // is, the same way VS Code keeps the open file highlighted in its explorer while you're
+        // typing in the editor) versus "this row is the tree's own keyboard-navigation cursor"
+        // (should go idle the moment focus genuinely leaves the tree - a stale cursor left glowing
+        // over whatever directory you last clicked is exactly the bug this issue was filed for).
+        // `Self::open_change_absolute_path` answers the first question directly from
+        // `Self::open_change` - independent of `selected_tree_path`, which a directory click (or
+        // a tab-strip switch, which never touches it at all) can leave pointing somewhere the
+        // centre pane isn't showing.
         let tree_focused = self.tree_focus_handle.is_focused(window);
-        let is_selected =
-            tree_focused && self.selected_tree_path.as_deref() == Some(entry.path.as_path());
+        let open_change_path = self.open_change_absolute_path();
+        let is_open_file = open_change_path.as_deref() == Some(entry.path.as_path());
+        let is_selected = is_open_file
+            || (tree_focused && self.selected_tree_path.as_deref() == Some(entry.path.as_path()));
 
         // `debug_selector` is a no-op outside test builds; lets a real render test assert on
         // which rows this list genuinely painted, which is the only way to prove the
@@ -1011,15 +1023,16 @@ impl AdeApp {
         // recycle" failure the issue calls out. Each guide spans the row's full 22px height with
         // no gap or inset, so consecutive rows' segments meet exactly and read as one continuous
         // line down the subtree.
-        let active_levels = file_tree::active_guide_levels(
-            &self.file_tree_root,
-            &entry.path,
-            // GitHub issue #127: no ancestor-chain highlight at all once the tree genuinely
-            // isn't focused, same reasoning as `is_selected` above.
+        // GitHub issue #127: highlights the open file's own ancestor chain regardless of focus
+        // (same reasoning as `is_open_file` above - it helps find the open file in a deep,
+        // collapsed tree), falling back to the focus-gated tree cursor otherwise.
+        let active_chain_target = open_change_path.as_deref().or_else(|| {
             tree_focused
                 .then_some(self.selected_tree_path.as_deref())
-                .flatten(),
-        );
+                .flatten()
+        });
+        let active_levels =
+            file_tree::active_guide_levels(&self.file_tree_root, &entry.path, active_chain_target);
         for level in 0..entry.depth {
             let active = level < active_levels;
             row = row.child(
@@ -3816,13 +3829,17 @@ mod indent_guide_tests {
         (app, cx)
     }
 
-    /// GitHub issue #127: the selected file's own ancestor-chain highlight must clear the moment
-    /// real keyboard focus moves off the tree - not stay lit indefinitely just because
-    /// `Self::selected_tree_path` still names that file. `Self::open_file_view` moves focus to
-    /// the editor (not the tree), which is the exact reported scenario: click a file, then work
-    /// in the editor, and the tree still looked focused.
+    /// GitHub issue #127: the *open* file's own ancestor-chain highlight must stay lit regardless
+    /// of where keyboard focus is - `Self::open_file_view` moves focus to the editor (not the
+    /// tree), and the highlight must survive that exactly like VS Code keeps its explorer's open-
+    /// file highlight lit while you're typing. A first draft of this fix instead cleared the
+    /// highlight the moment focus left the tree at all, hiding which file was open the instant
+    /// you started editing it - caught by manual review, not a test, since every prior test here
+    /// only ever checked a *mere selection* (a directory click), never a genuinely open file.
     #[gpui::test]
-    fn the_ancestor_chain_highlight_clears_once_focus_leaves_the_tree(cx: &mut TestAppContext) {
+    fn the_open_files_ancestor_chain_highlight_survives_focus_leaving_the_tree(
+        cx: &mut TestAppContext,
+    ) {
         let repo = TempDir::new().expect("tempdir");
         let (app, cx) = open_deep_tree(cx, &repo);
 
@@ -3837,14 +3854,13 @@ mod indent_guide_tests {
             );
         });
         assert!(
-            cx.debug_bounds("file-tree-guide-idle-deep.txt-0").is_some(),
-            "with the editor (not the tree) focused, the selected file's own chain must render \
-             idle, even though it's still the real selected path"
+            cx.debug_bounds("file-tree-guide-active-deep.txt-0")
+                .is_some(),
+            "the open file's own chain must stay lit even with the editor (not the tree) focused"
         );
         assert!(
-            cx.debug_bounds("file-tree-guide-active-deep.txt-0")
-                .is_none(),
-            "and must not also render active"
+            cx.debug_bounds("file-tree-guide-idle-deep.txt-0").is_none(),
+            "and must not also render idle"
         );
 
         app.update_in(cx, |app, window, cx| {
@@ -3854,7 +3870,51 @@ mod indent_guide_tests {
         assert!(
             cx.debug_bounds("file-tree-guide-active-deep.txt-0")
                 .is_some(),
-            "focusing the tree for the same still-selected file must light the chain back up"
+            "and must stay lit once the tree regains focus too"
+        );
+    }
+
+    /// The counterpart to the test above: a row that was merely *selected* in the tree (a
+    /// directory click, which never opens anything - `Self::open_change` stays `None`) is a real,
+    /// live keyboard-navigation cursor, not a standing "this is open" marker, so *its* chain must
+    /// go idle the instant real focus leaves the tree - the original GitHub issue #127 report: a
+    /// stale highlight glowing over whatever was last clicked long after focus moved away.
+    #[gpui::test]
+    fn a_merely_selected_directorys_ancestor_chain_highlight_clears_once_focus_leaves_the_tree(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = TempDir::new().expect("tempdir");
+        let (app, cx) = open_deep_tree(cx, &repo);
+
+        app.update_in(cx, |app, window, cx| {
+            app.selected_tree_path = Some(repo.path().join("a/b/c"));
+            app.focus_file_tree(window, cx);
+        });
+        cx.run_until_parked();
+        assert!(
+            cx.debug_bounds("file-tree-guide-active-deep.txt-0")
+                .is_some(),
+            "premise: with the tree focused, the selected directory's own chain renders active \
+             (deep.txt sits inside it, at the deepest level the chain reaches)"
+        );
+
+        app.update_in(cx, |app, window, cx| {
+            app.agents.focus_active(window, cx);
+        });
+        cx.run_until_parked();
+        assert!(
+            app.read_with(cx, |app, _| app.open_change.is_none()),
+            "premise: focusing a terminal agent never opens a file tab"
+        );
+        assert!(
+            cx.debug_bounds("file-tree-guide-idle-deep.txt-0").is_some(),
+            "a mere selection - nothing was ever opened - must go idle once focus genuinely \
+             leaves the tree"
+        );
+        assert!(
+            cx.debug_bounds("file-tree-guide-active-deep.txt-0")
+                .is_none(),
+            "and must not also render active"
         );
     }
 


### PR DESCRIPTION
## Summary
- File tree row highlighting (ancestor-chain guide + selected-row background) now gates on real `tree_focus_handle.is_focused(window)`, not just "this is still the last-selected path" — so it goes idle the moment focus genuinely leaves the tree (editor, terminal, Changes panel, etc.), matching this session's broader "lose focus state when no longer focused" pass. The genuinely *open* file (`AdeApp::open_change`) stays highlighted regardless of focus, though - same as VS Code's explorer keeps the open file lit while you're typing in the editor. Only a mere tree selection (e.g. a directory click, which never opens anything) clears on blur.
- Git graph row selection highlight now gates on a new `graph_view_focused` bool, set explicitly alongside every real `window.focus(&self.graph_focus_handle, ...)` call (`open_git_graph`, `open_graph_row_menu_at`) and cleared in `leave_graph_tab`. A `cx.on_focus`/`cx.on_blur` subscription (the pattern `wire_caret_blink` uses successfully elsewhere) was tried first but, live-tested, never fires for `graph_focus_handle` since it's only ever `track_focus`'d conditionally (while the graph tab is active) — the explicit-set approach sidesteps that entirely.
- Also fixes #139: `select_graph_row`/`set_graph_right_panel` could switch the graph's right panel away from Branches while its filter box held real keyboard focus, leaving `Window::focus` dangling on an unrendered node. GPUI's `dispatch_key_event` then falls back to its own synthetic root dispatch node with no registered context/actions, silently killing *every* global keybinding (not just the command palette's `secondary-p`) - this is the real mechanism behind "sometimes we can't open the command palette with the keyboard shortcut."

Fixes #127. Fixes #139.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib -- --test-threads=1` (one known pre-existing flake, `undoing_then_redoing_a_delete_restores_then_removes_the_file_again`, confirmed passing in isolation each time)
- [x] New/updated tests: `the_open_files_ancestor_chain_highlight_survives_focus_leaving_the_tree`, `a_merely_selected_directorys_ancestor_chain_highlight_clears_once_focus_leaves_the_tree`, `graph_view_focused_tracks_real_focus_and_blur_of_the_graph_view`, `selecting_a_row_after_the_branches_filter_was_focused_leaves_the_palette_shortcut_working`

🤖 Generated with [Claude Code](https://claude.com/claude-code)