### PR TITLE
fix(app): add hover feedback to every clickable row that was missing it

### DIFF
--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -561,6 +561,13 @@ impl AdeApp {
                 .px(px(10.0))
                 .py(px(6.0))
                 .bg(theme::status::ASK_BG)
+                // GitHub issue #128: the tooltip already says "Click to dismiss," but nothing
+                // visually confirmed a hover was even registered. No dedicated hover token for
+                // this status-coloured bg exists, so this dims it slightly rather than inventing
+                // a one-off theme constant - the same `.resolve().opacity(...)` technique
+                // `crate::code_surface::minimap`'s scrollbar thumb hover already uses for an
+                // analogous "still the same colour, just a distinguishable second state" need.
+                .hover(|el| el.bg(theme::status::ASK_BG.resolve().opacity(0.7)))
                 .border_b_1()
                 .border_color(theme::border::RAIL_INNER)
                 .font(font(theme::font::MONO))
@@ -1003,6 +1010,10 @@ impl AdeApp {
                     .font(font(theme::font::MONO))
                     .text_size(self.ui_text_size(8.0))
                     .text_color(theme::text::FAINT)
+                    // GitHub issue #128 - same lightweight text-only hover
+                    // `Self::render_status_zoom_value` uses for an equally small, box-free
+                    // clickable glyph.
+                    .hover(|el| el.text_color(theme::text::SELECTED))
                     .child(if is_expanded { "\u{25be}" } else { "\u{25b8}" })
                     .on_click(cx.listener(move |this, _event: &ClickEvent, _window, cx| {
                         cx.stop_propagation();

--- a/crates/app/src/root/widgets.rs
+++ b/crates/app/src/root/widgets.rs
@@ -207,6 +207,30 @@ fn render_action_keycap(
         .child(label.into())
 }
 
+/// This app's standard clickable-row hover fill - just `.hover(|el| el.bg(fill))`. GitHub issue
+/// #128 found eight rows across six files that each needed this and had each reimplemented the
+/// same one-line wiring independently (several not at all, which was the bug); a single generic
+/// helper is what keeps that from drifting apart again the way GitHub issue #129 later had to
+/// clean up for a different set of copy-pasted tokens (menu bg/border/radius/shadow) - see that
+/// issue's own `theme.rs` docs for the sibling problem. For a row that only wants this while some
+/// condition holds (e.g. "not already the active tab"), wrap the call in the builder's own
+/// `.when(cond, |el| hover_bg(el, fill))` rather than adding a second flag here - `.when` is
+/// already this crate's one real "conditionally apply a transform" idiom.
+pub(crate) fn hover_bg<E: InteractiveElement>(el: E, fill: impl Into<gpui::Fill>) -> E {
+    let fill = fill.into();
+    el.hover(move |style| style.bg(fill))
+}
+
+/// This app's "clickable keycap row" hover shape - a rounded chip-style fill, used by every
+/// plain clickable row whose only content is a keycap (or keycap + short label) with no
+/// surrounding padding box of its own: the settings panel's `esc`-to-close row and the status
+/// bar's "commands / ⌘P" hint. See [`hover_bg`]'s own docs for why this is a shared helper
+/// rather than copy-pasted per call site.
+pub(crate) fn hover_keycap_row<E: InteractiveElement + Styled>(el: E) -> E {
+    el.rounded(theme::radius::CHIP)
+        .hover(|style| style.bg(theme::surface::ROW_HOVER_ALT))
+}
+
 /// A plain, real GPUI tooltip view - just the given text, styled to match this app's other
 /// small popovers (`theme::surface::POPOVER`/`theme::border::POPOVER`, the same tokens
 /// `lsp::completion_popup`'s own completion popup uses). Backs [`text_tooltip`]; see that function's

--- a/crates/app/src/settings/render.rs
+++ b/crates/app/src/settings/render.rs
@@ -172,6 +172,11 @@ impl AdeApp {
                         div()
                             .id("settings-close")
                             .cursor_pointer()
+                            .rounded(theme::radius::CHIP)
+                            // GitHub issue #128 - same treatment as
+                            // `crate::status_bar::render::AdeApp::render_status_palette_hint`,
+                            // the app's other clickable keycap row.
+                            .hover(|el| el.bg(theme::surface::ROW_HOVER_ALT))
                             .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
                                 this.close_settings(window, cx);
                             }))
@@ -1156,6 +1161,11 @@ impl AdeApp {
                 theme::settings::CARD_SELECTED_BG
             } else {
                 theme::settings::CARD_UNSELECTED_BG
+            })
+            // GitHub issue #128 - matches `Self::render_theme_card`'s own identical hover, the
+            // adjacent card widget this one is otherwise styled just like.
+            .when(!is_selected, |el| {
+                el.hover(|el| el.border_color(theme::settings::THEME_CARD_HOVER_BORDER))
             })
             .px(px(10.0))
             .py(px(9.0))

--- a/crates/app/src/settings/render.rs
+++ b/crates/app/src/settings/render.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::root::widgets::{render_env_chip, render_keycap_row, KeycapSize};
+use crate::root::widgets::{hover_keycap_row, render_env_chip, render_keycap_row, KeycapSize};
 use crate::settings::widgets::ChoiceOption;
 
 impl AdeApp {
@@ -169,14 +169,8 @@ impl AdeApp {
                             .child("Settings"),
                     )
                     .child(
-                        div()
-                            .id("settings-close")
-                            .cursor_pointer()
-                            .rounded(theme::radius::CHIP)
-                            // GitHub issue #128 - same treatment as
-                            // `crate::status_bar::render::AdeApp::render_status_palette_hint`,
-                            // the app's other clickable keycap row.
-                            .hover(|el| el.bg(theme::surface::ROW_HOVER_ALT))
+                        // GitHub issue #128.
+                        hover_keycap_row(div().id("settings-close").cursor_pointer())
                             .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
                                 this.close_settings(window, cx);
                             }))

--- a/crates/app/src/settings/widgets.rs
+++ b/crates/app/src/settings/widgets.rs
@@ -549,6 +549,15 @@ impl AdeApp {
                         on_select(this, index, window, cx);
                     },
                 ));
+                // GitHub issue #128: every other clickable row in the app gives hover feedback -
+                // this shared widget (behind the Diff/File toggle, right-sidebar toggle, palette
+                // scope control, and the settings TOML/JSON toggle) didn't. Only the *inactive*
+                // segments need it - the active one already reads as selected via
+                // `SEGMENT_ACTIVE` above, and layering a second bg on top of that would just
+                // muddy it.
+                if !is_active {
+                    segment = segment.hover(|el| el.bg(theme::surface::ROW_HOVER_ALT));
+                }
             }
             track = track.child(segment);
         }

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -1,8 +1,8 @@
 use super::*;
 use crate::keymap;
 use crate::root::widgets::{
-    render_keycap_row, render_menu_group_divider, render_sidebar_message, render_tag_pill,
-    text_tooltip, KeycapSize,
+    hover_bg, render_keycap_row, render_menu_group_divider, render_sidebar_message,
+    render_tag_pill, text_tooltip, KeycapSize,
 };
 use crate::settings::widgets::ChoiceOption;
 use crate::worktree_history::flow as worktree_history;
@@ -330,7 +330,8 @@ impl AdeApp {
         cx: &mut Context<Self>,
     ) -> Option<impl IntoElement> {
         let (_, message) = self.staging_error.clone()?;
-        Some(
+        // GitHub issue #128.
+        let row = hover_bg(
             div()
                 .id("staging-error")
                 .debug_selector(|| "staging-error".to_string())
@@ -341,10 +342,11 @@ impl AdeApp {
                 .font(font(theme::font::MONO))
                 .text_size(self.ui_text_size(10.0))
                 .text_color(theme::status::FAIL)
-                .cursor_pointer()
-                // GitHub issue #128.
-                .hover(|el| el.bg(theme::surface::ROW_HOVER))
-                .tooltip(text_tooltip("Click to dismiss"))
+                .cursor_pointer(),
+            theme::surface::ROW_HOVER,
+        );
+        Some(
+            row.tooltip(text_tooltip("Click to dismiss"))
                 .child(message)
                 .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
                     this.staging_error = None;
@@ -710,7 +712,8 @@ impl AdeApp {
         // The real, honest surface for a failed file operation (a refused rename, a trash
         // command that didn't run) - next to the tree it happened in, not buried in the log.
         if let Some(error) = self.tree_op_error.clone() {
-            column = column.child(
+            // GitHub issue #128.
+            let row = hover_bg(
                 div()
                     .id("file-tree-op-error")
                     .debug_selector(|| "file-tree-op-error".to_string())
@@ -721,10 +724,11 @@ impl AdeApp {
                     .font(font(theme::font::MONO))
                     .text_size(self.ui_text_size(10.0))
                     .text_color(theme::status::FAIL)
-                    .cursor_pointer()
-                    // GitHub issue #128.
-                    .hover(|el| el.bg(theme::surface::ROW_HOVER))
-                    .tooltip(text_tooltip("Click to dismiss"))
+                    .cursor_pointer(),
+                theme::surface::ROW_HOVER,
+            );
+            column = column.child(
+                row.tooltip(text_tooltip("Click to dismiss"))
                     .child(error)
                     .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
                         this.tree_op_error = None;

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -342,6 +342,8 @@ impl AdeApp {
                 .text_size(self.ui_text_size(10.0))
                 .text_color(theme::status::FAIL)
                 .cursor_pointer()
+                // GitHub issue #128.
+                .hover(|el| el.bg(theme::surface::ROW_HOVER))
                 .tooltip(text_tooltip("Click to dismiss"))
                 .child(message)
                 .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
@@ -720,6 +722,8 @@ impl AdeApp {
                     .text_size(self.ui_text_size(10.0))
                     .text_color(theme::status::FAIL)
                     .cursor_pointer()
+                    // GitHub issue #128.
+                    .hover(|el| el.bg(theme::surface::ROW_HOVER))
                     .tooltip(text_tooltip("Click to dismiss"))
                     .child(error)
                     .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
@@ -2239,6 +2243,13 @@ impl AdeApp {
 /// leading chip (unlike `crate::work_surface::render::render_dropdown_menu_row`, which this
 /// deliberately doesn't reuse: the design has no per-row glyph here). Always dimmed and
 /// non-interactive - see [`AdeApp::render_commit_menu`]'s own docs for why.
+///
+/// Deliberately no `.hover()` - `crate::work_surface::render::AdeApp::render_footer_action`'s own
+/// docs already establish this codebase's rule for an unimplemented action: never a clickable-
+/// looking no-op. The real gap GitHub issue #128 found wasn't a missing hover, it was that
+/// nothing dimmed the row enough to read as disabled *without* one - the `.opacity()` below is
+/// that fix, at the same whole-row grain `crate::graph_view::render`'s dashed elbow segments use
+/// for an analogous "still real, just visually de-emphasized" treatment.
 fn render_commit_menu_row(label: &'static str, sub: String) -> impl IntoElement {
     div()
         .id(format!("commit-menu-row-{label}"))
@@ -2249,6 +2260,7 @@ fn render_commit_menu_row(label: &'static str, sub: String) -> impl IntoElement 
         .px(px(10.0))
         .py(px(5.0))
         .cursor_default()
+        .opacity(0.5)
         .child(
             div()
                 .font(font(theme::font::SANS))

--- a/crates/app/src/status_bar/render.rs
+++ b/crates/app/src/status_bar/render.rs
@@ -439,6 +439,9 @@ impl AdeApp {
         div()
             .id("status-bar-open-palette")
             .cursor_pointer()
+            .rounded(theme::radius::CHIP)
+            // GitHub issue #128.
+            .hover(|el| el.bg(theme::surface::ROW_HOVER_ALT))
             .flex()
             .items_center()
             .gap(px(6.0))

--- a/crates/app/src/status_bar/render.rs
+++ b/crates/app/src/status_bar/render.rs
@@ -1,5 +1,7 @@
 use super::*;
-use crate::root::widgets::{render_env_chip, render_keycap_row, text_tooltip, KeycapSize};
+use crate::root::widgets::{
+    hover_keycap_row, render_env_chip, render_keycap_row, text_tooltip, KeycapSize,
+};
 
 /// The 28px status bar (`CHANGELOG.md`'s change 7 - height 26 -> 28, gap 12 -> 9, every value
 /// 10px mono), rebuilt from the old single `8 agents · 2 waiting · …` summary string into a
@@ -436,12 +438,8 @@ impl AdeApp {
     /// The `⌘P commands` hint: clicking it (or pressing the bound `secondary-p` - see
     /// [`TogglePalette`]) opens the command palette.
     fn render_status_palette_hint(&self, cx: &mut Context<Self>) -> impl IntoElement {
-        div()
-            .id("status-bar-open-palette")
-            .cursor_pointer()
-            .rounded(theme::radius::CHIP)
-            // GitHub issue #128.
-            .hover(|el| el.bg(theme::surface::ROW_HOVER_ALT))
+        // GitHub issue #128.
+        hover_keycap_row(div().id("status-bar-open-palette").cursor_pointer())
             .flex()
             .items_center()
             .gap(px(6.0))

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::root::widgets::{
-    render_action_keycap_row, render_env_chip, render_hint_pair, render_keycap_row, text_tooltip,
-    KeycapSize,
+    hover_bg, render_action_keycap_row, render_env_chip, render_hint_pair, render_keycap_row,
+    text_tooltip, KeycapSize,
 };
 use gpui::{Animation, AnimationExt, DragMoveEvent};
 use std::time::Duration;
@@ -891,6 +891,14 @@ impl AdeApp {
                     .gap(px(7.0))
                     .px(px(13.0))
                     .cursor_pointer()
+                    // GitHub issue #128: only a tab's own `×` close glyph gave any hover feedback
+                    // - the much larger click target that actually activates the tab gave none.
+                    // Skipped for the already-active tab: it already reads as selected via
+                    // `colors.bg` (`theme::surface::CENTER`) on the outer tab div above, and
+                    // layering a second bg here would just muddy that. Fixed once, here, in the
+                    // shared chrome every tab kind (file, agent, graph) renders through - not
+                    // per call site.
+                    .when(!is_active, |el| hover_bg(el, theme::surface::ROW_HOVER))
                     .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
                         on_activate(this, window, cx);
                     }))


### PR DESCRIPTION
## Summary
- Adds `.hover()` to eight rows flagged in the issue's own file:line audit, all real `cursor_pointer()` + `on_click()` with zero hover feedback: the shared segmented-control widget (`render_choice_control` - covers the Diff/File toggle, right-sidebar toggle, palette scope control, and settings TOML/JSON toggle in one fix), the file-tab and agent-tab click areas, the interface-scale preview cards (matching the adjacent theme-card widget's own existing hover), the settings `esc`-to-close row, the status bar's "commands / Cmd+P" hint, three click-to-dismiss notice/error rows (rail selection notice, staging error, file-tree-op error), and the worktree row's expand/collapse chevron.
- One deliberate exception: the commit menu's four rows. They're documented as "honestly non-interactive" - this codebase's own established rule (`crate::work_surface::render`) is never to give a disabled/unimplemented action a clickable-looking hover. Instead dims the whole row via `.opacity(0.5)`, which is what the issue's actual complaint ("nothing dims them enough to read as disabled") was really asking for.

Fixes #128.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib -- --test-threads=1` (one known pre-existing flake, `diff_render_tests::opening_a_real_diff_renders_real_syntax_highlighted_rows`, confirmed passing in isolation)
- These are pure `:hover` pseudo-state paint changes with no new observable app state (GPUI's hover reads `Hitbox::is_hovered` directly at paint time, not testable through this app's `VisualTestContext` harness - consistent with how this codebase has always handled hover-only changes) - manual verification recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)