### PR TITLE
fix(app): add real scrollbars to the git graph tab

### DIFF
--- a/crates/app/src/graph_view/render.rs
+++ b/crates/app/src/graph_view/render.rs
@@ -1026,7 +1026,8 @@ impl AdeApp {
             .flex_col()
             .flex_1()
             .min_h_0()
-            .overflow_y_scroll();
+            .overflow_y_scroll()
+            .track_scroll(&self.graph_state.rows_scroll_handle);
         for (index, row) in graph.rows.iter().enumerate() {
             list = list.child(self.render_graph_row(index, row, graph.lane_count, now, cx));
         }
@@ -1045,7 +1046,21 @@ impl AdeApp {
                     )),
             );
         }
-        list.into_any_element()
+        // GitHub issue #142.
+        div()
+            .relative()
+            .flex()
+            .flex_col()
+            .flex_1()
+            .min_h_0()
+            .child(list)
+            .children(self.render_vertical_scrollbar(
+                "graph-rows-scrollbar",
+                &self.graph_state.rows_scroll_handle,
+                &[],
+                cx,
+            ))
+            .into_any_element()
     }
 
     /// One row: lane canvas 100 · ref chips · subject (flex) · author 88 · relative time 40
@@ -1479,13 +1494,14 @@ impl AdeApp {
                 .into_any_element(),
         };
 
-        div()
+        let panel = div()
             .id("graph-commit-panel")
             .flex()
             .flex_col()
             .flex_1()
             .min_h_0()
             .overflow_y_scroll()
+            .track_scroll(&self.graph_state.commit_panel_scroll_handle)
             .px(px(12.0))
             .py(px(10.0))
             .gap(px(8.0))
@@ -1560,7 +1576,20 @@ impl AdeApp {
                             }
                         })),
                     ),
-            )
+            );
+        // GitHub issue #142.
+        div()
+            .relative()
+            .flex()
+            .flex_1()
+            .min_h_0()
+            .child(panel)
+            .children(self.render_vertical_scrollbar(
+                "graph-commit-panel-scrollbar",
+                &self.graph_state.commit_panel_scroll_handle,
+                &[],
+                cx,
+            ))
             .into_any_element()
     }
 
@@ -1595,15 +1624,30 @@ impl AdeApp {
             .child(self.render_graph_branches_filter_row(branches.len(), cx))
             .child(
                 div()
-                    .id("graph-branches-list")
+                    .relative()
                     .flex()
-                    .flex_col()
                     .flex_1()
                     .min_h_0()
-                    .overflow_y_scroll()
-                    .children(branches.into_iter().map(|(name, kind, is_head, lane)| {
-                        render_graph_branch_row(name, kind, is_head, lane)
-                    })),
+                    .child(
+                        div()
+                            .id("graph-branches-list")
+                            .flex()
+                            .flex_col()
+                            .flex_1()
+                            .min_h_0()
+                            .overflow_y_scroll()
+                            .track_scroll(&self.graph_state.branches_scroll_handle)
+                            .children(branches.into_iter().map(|(name, kind, is_head, lane)| {
+                                render_graph_branch_row(name, kind, is_head, lane)
+                            })),
+                    )
+                    // GitHub issue #142.
+                    .children(self.render_vertical_scrollbar(
+                        "graph-branches-scrollbar",
+                        &self.graph_state.branches_scroll_handle,
+                        &[],
+                        cx,
+                    )),
             )
             .into_any_element()
     }

--- a/crates/app/src/graph_view/state.rs
+++ b/crates/app/src/graph_view/state.rs
@@ -3,7 +3,7 @@
 use crate::root::AdeApp;
 use crate::text_history::TextField;
 use crate::theme;
-use gpui::{Bounds, Context, FocusHandle, Pixels, Task};
+use gpui::{Bounds, Context, FocusHandle, Pixels, ScrollHandle, Task};
 use std::collections::HashMap;
 use wt_core::graph::{Graph, GraphScope};
 use wt_core::remote::PushForce;
@@ -113,6 +113,15 @@ pub(crate) struct GraphTabState {
     /// `AdeApp::_worktree_history_task`'s identical one-slot-per-feature pattern. `None` when
     /// [`Self::remote_op_in_flight`] is `false`.
     pub _remote_op_task: Option<Task<()>>,
+    /// GitHub issue #142: the commit row list's own scroll position, tracked so
+    /// `crate::root::scrollbar::AdeApp::render_vertical_scrollbar` has a real handle to draw
+    /// against - every other scrollable region in the app has had one since GitHub issue #30;
+    /// the graph tab shipped after that audit and was never retrofitted.
+    pub rows_scroll_handle: ScrollHandle,
+    /// The Commit panel's own scroll position - see [`Self::rows_scroll_handle`]'s docs.
+    pub commit_panel_scroll_handle: ScrollHandle,
+    /// The Branches panel's own scroll position - see [`Self::rows_scroll_handle`]'s docs.
+    pub branches_scroll_handle: ScrollHandle,
 }
 
 impl GraphTabState {
@@ -134,6 +143,9 @@ impl GraphTabState {
             remote_op_in_flight: false,
             push_force_confirm_armed: None,
             _remote_op_task: None,
+            rows_scroll_handle: ScrollHandle::new(),
+            commit_panel_scroll_handle: ScrollHandle::new(),
+            branches_scroll_handle: ScrollHandle::new(),
         }
     }
 }


### PR DESCRIPTION
## Summary
- The git graph tab's three scrollable regions - the commit row list, the Commit panel's file list, and the Branches panel's list - had no scrollbar at all: bare `.overflow_y_scroll()` with no `ScrollHandle` even attached. Every other scrollable region in the app (file tree, Changes list, code editor, merge hand-edit buffer, Settings, rail worktree list, palette results, diff view) has had a real overlay scrollbar since GitHub issue #30 - the graph tab just shipped after that audit and was never retrofitted.
- Adds `rows_scroll_handle`/`commit_panel_scroll_handle`/`branches_scroll_handle` to `GraphTabState` and wires each region through the same shared `AdeApp::render_vertical_scrollbar` component every other surface already uses - no new scrollbar implementation, just three more real callers of the existing one.

Fixes #142.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib -- --test-threads=1` - all 1316 app tests passed clean
- No new tests: this is pure scrollbar wiring identical in shape to the other 8 regions using `render_vertical_scrollbar`, none of which have dedicated tests either - `crate::root::scrollbar_geometry`'s own pure-math tests already cover the thumb length/position logic this reuses. Manual verification of drag-to-scroll recommended, same as every other scrollbar in the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)