### PR TITLE
feat(app): file tree multi-selection - Ctrl/Cmd+click toggle, Shift+click range-select

### DIFF
--- a/crates/app/src/code_surface/tabs.rs
+++ b/crates/app/src/code_surface/tabs.rs
@@ -191,6 +191,11 @@ impl AdeApp {
         if absolute.starts_with(&self.file_tree_root) {
             self.reveal_in_tree(&absolute, cx);
             self.selected_tree_path = Some(absolute);
+            // GitHub issue #145: opening any single file - from the tree itself, the palette, a
+            // terminal link, go-to-definition, wherever - collapses a stray multi-selection down
+            // to just that file, the same way a plain click on a tree row already did before
+            // multi-selection existed.
+            self.additional_tree_selection.clear();
         }
         self.refresh_open_diff_file_cache();
         // A hover card is only valid for the file it was requested against - and so is a real

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -477,10 +477,14 @@ pub struct AdeApp {
     /// render (the same pattern [`Self::plus_button_bounds`] uses) - where a *keyboard*-opened
     /// context menu (`Shift+F10`) anchors, since there is no cursor position to use.
     pub(crate) file_tree_bounds: gpui::Bounds<Pixels>,
-    /// The in-flight confirmed delete (a real `gio trash` child process, or a real
-    /// `remove_dir_all`), one slot: a second delete can't be requested until the confirmation
-    /// panel is open again, so there is never more than one.
-    pub(crate) _tree_delete_task: Option<Task<()>>,
+    /// Every in-flight confirmed delete (a real `gio trash` child process, or a real
+    /// `remove_dir_all`) - a real `Vec`, not one slot, since GitHub issue #145's bulk delete
+    /// starts one real task per selected path in the same call: a single `Option` overwritten in
+    /// a loop would drop (and, being a `Task`, therefore cancel) every delete but the last one.
+    /// Finished tasks are never removed - `Task<()>` completing is a no-op to poll again, and
+    /// this only ever grows by a handful of entries per bulk delete, not worth the bookkeeping to
+    /// prune.
+    pub(crate) _tree_delete_tasks: Vec<Task<()>>,
     /// The in-flight Duplicate / paste-a-copy - a real, recursive `std::fs` tree copy, run on the
     /// background executor rather than in the click listener that started it (see
     /// `crate::sidebar::tree_ops::AdeApp::spawn_tree_copy`). One slot, superseding: a second copy
@@ -561,8 +565,19 @@ pub struct AdeApp {
     pub(crate) open_diff_file_cache: Option<DiffFile>,
     /// File-tree path last resolved from a palette file result with no diff to open
     /// (`Self::open_palette_file_result`) - highlighted in `Self::render_file_tree_row` like a
-    /// Changes row's own selection highlight.
+    /// Changes row's own selection highlight. GitHub issue #145: also the multi-selection's
+    /// *anchor* - the row a plain click lands on, a Shift+click range starts from, and the only
+    /// row F2/rename ever targets. See [`Self::additional_tree_selection`]'s own docs for the
+    /// rest of a real multi-selection.
     pub(crate) selected_tree_path: Option<PathBuf>,
+    /// GitHub issue #145: every multi-selected file-tree row *besides* the anchor
+    /// ([`Self::selected_tree_path`]) - Ctrl/Cmd+click toggles membership, Shift+click replaces
+    /// this with the range between the anchor and the clicked row. The tree's real selection is
+    /// always this set plus the anchor together (`Self::tree_selected_paths`), never either alone,
+    /// and it's a `HashSet` rather than a `Vec` since membership (`Self::is_tree_path_selected`,
+    /// read on every visible row every frame) is the only real query this needs - row order comes
+    /// from the tree itself, not from this field, whenever an operation needs an ordered list.
+    pub(crate) additional_tree_selection: HashSet<PathBuf>,
     /// Surface C's `Diff | File` toggle for whichever file [`Self::open_change`] names - set to
     /// `Diff` by [`Self::open_change_diff`] and `File` by [`Self::open_file_view`], read by
     /// [`Self::render_code_surface`] alongside a "does this file even have a diff" check (a

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -236,7 +236,7 @@ impl AdeApp {
             tree_op_error: None,
             tree_focus_handle,
             file_tree_bounds: gpui::Bounds::default(),
-            _tree_delete_task: None,
+            _tree_delete_tasks: Vec::new(),
             _tree_copy_task: None,
             staged_files: HashSet::new(),
             staging_error: None,
@@ -247,6 +247,7 @@ impl AdeApp {
             close_tab_confirm_armed: None,
             open_diff_file_cache: None,
             selected_tree_path: None,
+            additional_tree_selection: HashSet::new(),
             code_view: code_view::CodeView::Diff,
             code_focus_handle,
             code_focus: OverlayFocus::default(),
@@ -904,6 +905,7 @@ impl AdeApp {
             &mut self.open_change,
             &mut self.expanded_dirs,
             &mut self.selected_tree_path,
+            &mut self.additional_tree_selection,
         );
         // The tree's fold state is per-worktree *persisted* state, not merely per-worktree
         // transient state: the reset above clears the live set, and this re-derives it from
@@ -1227,11 +1229,13 @@ pub(super) fn reset_per_worktree_ui_state(
     open_change: &mut Option<PathBuf>,
     expanded_dirs: &mut HashSet<PathBuf>,
     selected_tree_path: &mut Option<PathBuf>,
+    additional_tree_selection: &mut HashSet<PathBuf>,
 ) {
     staged_files.clear();
     *open_change = None;
     expanded_dirs.clear();
     *selected_tree_path = None;
+    additional_tree_selection.clear();
 }
 
 #[cfg(test)]
@@ -1246,12 +1250,14 @@ mod tests {
         let mut open_change = Some(PathBuf::from("src/main.rs"));
         let mut expanded_dirs = HashSet::new();
         let mut selected_tree_path = None;
+        let mut additional_tree_selection = HashSet::new();
 
         reset_per_worktree_ui_state(
             &mut staged_files,
             &mut open_change,
             &mut expanded_dirs,
             &mut selected_tree_path,
+            &mut additional_tree_selection,
         );
 
         assert!(staged_files.is_empty());
@@ -1264,12 +1270,14 @@ mod tests {
         let mut open_change = None;
         let mut expanded_dirs = HashSet::new();
         let mut selected_tree_path = None;
+        let mut additional_tree_selection = HashSet::new();
 
         reset_per_worktree_ui_state(
             &mut staged_files,
             &mut open_change,
             &mut expanded_dirs,
             &mut selected_tree_path,
+            &mut additional_tree_selection,
         );
 
         assert!(staged_files.is_empty());
@@ -1283,6 +1291,7 @@ mod tests {
         let mut open_change = None;
         let mut expanded_dirs = HashSet::new();
         let mut selected_tree_path = None;
+        let mut additional_tree_selection = HashSet::new();
         expanded_dirs.insert(PathBuf::from("/repo/worktree-a/src"));
         expanded_dirs.insert(PathBuf::from("/repo/worktree-a/tests"));
 
@@ -1291,6 +1300,7 @@ mod tests {
             &mut open_change,
             &mut expanded_dirs,
             &mut selected_tree_path,
+            &mut additional_tree_selection,
         );
 
         assert!(expanded_dirs.is_empty());
@@ -1302,15 +1312,19 @@ mod tests {
         let mut open_change = None;
         let mut expanded_dirs = HashSet::new();
         let mut selected_tree_path = Some(PathBuf::from("/repo/worktree-a/src/main.rs"));
+        let mut additional_tree_selection = HashSet::new();
+        additional_tree_selection.insert(PathBuf::from("/repo/worktree-a/src/lib.rs"));
 
         reset_per_worktree_ui_state(
             &mut staged_files,
             &mut open_change,
             &mut expanded_dirs,
             &mut selected_tree_path,
+            &mut additional_tree_selection,
         );
 
         assert_eq!(selected_tree_path, None);
+        assert!(additional_tree_selection.is_empty());
     }
 
     /// [`AdeApp::open_files`]/[`AdeApp::open_files_mut`] resolve through

--- a/crates/app/src/sidebar/context_menu.rs
+++ b/crates/app/src/sidebar/context_menu.rs
@@ -21,30 +21,41 @@ use std::path::{Path, PathBuf};
 
 /// What a right-click landed on. `Empty` is a real target, not a fallback: the area below the
 /// last row offers its own menu (New File / New Folder / Paste / Collapse All), scoped to the
-/// worktree root.
+/// worktree root. `Multiple` (GitHub issue #145) is a real, distinct target too, not `File`/
+/// `Folder` with an extra field bolted on: a multi-selection has no single "new file goes here"
+/// destination and no single name to rename, so it deliberately offers a smaller, honest menu
+/// (see [`menu_groups`]) rather than a `File`/`Folder` row set that would silently only ever
+/// apply to one of the selected paths.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ContextTarget {
     File(PathBuf),
     Folder(PathBuf),
+    Multiple(Vec<PathBuf>),
     Empty,
 }
 
 impl ContextTarget {
-    /// The path this target's actions operate *on*, or `None` for the empty area.
+    /// The path this target's actions operate *on* - `None` for the empty area and, honestly,
+    /// for `Multiple` too: there is no single path a multi-selection's actions operate on, and a
+    /// caller that needs the *whole* selection should read [`AdeApp::tree_selected_paths`]
+    /// (`crate::sidebar::tree_ops`) instead of asking this method to pick one arbitrarily.
     pub fn path(&self) -> Option<&Path> {
         match self {
             ContextTarget::File(path) | ContextTarget::Folder(path) => Some(path),
-            ContextTarget::Empty => None,
+            ContextTarget::Multiple(_) | ContextTarget::Empty => None,
         }
     }
 
     /// The directory a "New File"/"New Folder"/"Paste" from this target should land in: the
-    /// folder itself, a file's parent, or the tree root for the empty area.
+    /// folder itself, a file's parent, or the tree root for the empty area. `Multiple` never
+    /// offers those rows (see [`menu_groups`]), so this is never actually read for it - the root
+    /// is returned anyway rather than panicking, matching every other "not really applicable"
+    /// case here.
     pub fn destination_dir<'a>(&'a self, root: &'a Path) -> &'a Path {
         match self {
             ContextTarget::Folder(path) => path,
             ContextTarget::File(path) => path.parent().unwrap_or(root),
-            ContextTarget::Empty => root,
+            ContextTarget::Multiple(_) | ContextTarget::Empty => root,
         }
     }
 }
@@ -195,6 +206,14 @@ pub fn menu_groups(target: &ContextTarget, clipboard_has_entry: bool) -> Vec<Vec
                 MenuItem::enabled(MenuAction::Reveal),
             ],
         ],
+        // GitHub issue #145: deliberately just Delete. Rename has no single name to edit; New
+        // File/New Folder/Paste have no single destination; Cut/Copy/Duplicate/CollapseSubtree/
+        // CopyPath all name a *single* real path each - offering them here would either silently
+        // act on only one of the selected paths or need a second, parallel bulk implementation of
+        // each. Bulk delete alone is real and safe today because `Self::request_tree_delete` was
+        // already immediate and per-path, undo-backed (GitHub issue #105) - looping it over every
+        // selected path needed no new machinery. A real follow-up, not a permanent gap.
+        ContextTarget::Multiple(_) => vec![vec![MenuItem::enabled(MenuAction::Delete)]],
         ContextTarget::Empty => vec![
             vec![
                 MenuItem::enabled(MenuAction::NewFile),

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -985,8 +985,14 @@ impl AdeApp {
         let tree_focused = self.tree_focus_handle.is_focused(window);
         let open_change_path = self.open_change_absolute_path();
         let is_open_file = open_change_path.as_deref() == Some(entry.path.as_path());
+        // GitHub issue #145: a Ctrl/Cmd- or Shift-selected row (beyond the anchor) highlights
+        // exactly like the anchor itself does - same focus gating, since it's a keyboard-
+        // navigation-style selection, not a standing "this is open" marker the way `is_open_file`
+        // is.
         let is_selected = is_open_file
-            || (tree_focused && self.selected_tree_path.as_deref() == Some(entry.path.as_path()));
+            || (tree_focused
+                && (self.selected_tree_path.as_deref() == Some(entry.path.as_path())
+                    || self.additional_tree_selection.contains(&entry.path)));
 
         // `debug_selector` is a no-op outside test builds; lets a real render test assert on
         // which rows this list genuinely painted, which is the only way to prove the
@@ -1104,16 +1110,27 @@ impl AdeApp {
             row = row
                 .cursor_pointer()
                 .hover(|el| el.bg(theme::surface::ROW_HOVER))
-                .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
+                .on_click(cx.listener(move |this, event: &ClickEvent, window, cx| {
                     // Selecting *and* focusing, both real: a folder click is what gives the tree
                     // keyboard focus (so its `Ctrl+C`/`F2`/`Shift+F10` bindings can match at
                     // all) and what gives those bindings a target. Deliberately here, in the
                     // click handler, and not inside `toggle_dir_expanded` - that method is also
                     // called programmatically (`start_tree_new_entry`, the reveal paths), where
                     // moving the selection would be a side effect nobody asked for.
-                    this.selected_tree_path = Some(path.clone());
                     this.focus_file_tree(window, cx);
-                    this.toggle_dir_expanded(path.clone(), cx);
+                    let modifiers = event.modifiers();
+                    // GitHub issue #145: Ctrl/Cmd- or Shift-click only ever adjusts the
+                    // selection, never the expand/collapse state - a modifier-click that also
+                    // toggled the folder open would be a second, unrelated effect nobody asked
+                    // for from what's meant to be a pure selection gesture.
+                    if modifiers.secondary() || modifiers.shift {
+                        this.tree_click_select(path.clone(), modifiers);
+                    } else {
+                        this.selected_tree_path = Some(path.clone());
+                        this.additional_tree_selection.clear();
+                        this.toggle_dir_expanded(path.clone(), cx);
+                    }
+                    cx.notify();
                 }));
         } else {
             // GitHub issue #105: uses `Self::open_file_view_from_tree_click`, not
@@ -1128,9 +1145,20 @@ impl AdeApp {
             row = row
                 .cursor_pointer()
                 .hover(|el| el.bg(theme::surface::ROW_HOVER))
-                .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
-                    this.open_file_view_from_tree_click(path.clone(), window, cx);
+                .on_click(cx.listener(move |this, event: &ClickEvent, window, cx| {
                     this.focus_file_tree(window, cx);
+                    let modifiers = event.modifiers();
+                    // GitHub issue #145: a modifier-click only ever adjusts the selection, never
+                    // opens the file - opening every Ctrl/Cmd- or Shift-selected file at once
+                    // would be a real, surprising side effect of what's meant to be a pure
+                    // selection gesture (and would fight the very "build up a selection" the
+                    // modifier is for).
+                    if modifiers.secondary() || modifiers.shift {
+                        this.tree_click_select(path.clone(), modifiers);
+                        cx.notify();
+                    } else {
+                        this.open_file_view_from_tree_click(path.clone(), window, cx);
+                    }
                 }));
         }
 

--- a/crates/app/src/sidebar/tree_ops.rs
+++ b/crates/app/src/sidebar/tree_ops.rs
@@ -234,6 +234,137 @@ impl AdeApp {
         window.focus(&self.tree_focus_handle, cx);
     }
 
+    // ---------------------------------------------------------------- multi-selection (issue #145)
+
+    /// Whether `path` is part of the tree's real current selection - the anchor
+    /// ([`Self::selected_tree_path`]) or [`Self::additional_tree_selection`], either one.
+    pub(in crate::sidebar) fn is_tree_path_selected(&self, path: &Path) -> bool {
+        self.selected_tree_path.as_deref() == Some(path)
+            || self.additional_tree_selection.contains(path)
+    }
+
+    /// How many rows the tree's real current selection spans - `0` with nothing selected, `1`
+    /// for an ordinary single selection, more once Ctrl/Cmd- or Shift-click has grown it.
+    pub(in crate::sidebar) fn tree_selection_len(&self) -> usize {
+        self.selected_tree_path.iter().count() + self.additional_tree_selection.len()
+    }
+
+    /// The tree's whole real selection - the anchor plus every additionally-selected path -
+    /// ordered the way the tree itself displays them (via [`file_tree::visible_indices`]) rather
+    /// than insertion order, so a bulk action's own visible order (a "delete these 3 files" log,
+    /// say) reads the same way the rows did. A selected path currently hidden inside a collapsed
+    /// ancestor (reachable via Shift+click through an ancestor that was later re-collapsed) sorts
+    /// after every visible one, in whatever order the underlying `HashSet` happens to hold it -
+    /// a real but rare edge case, and still processed, just not in a meaningful order.
+    pub(in crate::sidebar) fn tree_selected_paths(&self) -> Vec<PathBuf> {
+        if self.additional_tree_selection.is_empty() {
+            return self.selected_tree_path.iter().cloned().collect();
+        }
+        let visible = file_tree::visible_indices(&self.file_tree, &self.expanded_dirs);
+        let mut ordered: Vec<PathBuf> = Vec::with_capacity(self.tree_selection_len());
+        let mut remaining = self.additional_tree_selection.clone();
+        if let Some(anchor) = &self.selected_tree_path {
+            remaining.remove(anchor);
+        }
+        for &index in &visible {
+            let path = &self.file_tree[index].path;
+            if remaining.remove(path) || self.selected_tree_path.as_deref() == Some(path.as_path())
+            {
+                ordered.push(path.clone());
+            }
+        }
+        // Whatever's left never appeared in `visible` at all (hidden behind a collapsed
+        // ancestor) - still real selection, appended so nothing silently drops out of a bulk
+        // action just because its parent folder happens to be collapsed right now.
+        ordered.extend(remaining);
+        ordered
+    }
+
+    /// One tree row's real click - the single place `Self::render_file_tree_row`'s file and
+    /// folder click handlers both funnel through, so Ctrl/Cmd-click and Shift-click can never
+    /// mean something different depending on which kind of row was clicked.
+    ///
+    /// - A plain click collapses the selection to just `path` (the existing, pre-#145 behavior).
+    /// - Ctrl/Cmd-click (`Modifiers::secondary`) toggles `path`'s own membership, leaving every
+    ///   other selected row alone. Toggling the anchor itself off promotes an arbitrary remaining
+    ///   member to anchor (there is no real "next" ordering to prefer one over another once the
+    ///   anchor is gone) rather than collapsing the whole selection just because its first member
+    ///   happened to be clicked again.
+    /// - Shift-click range-selects from the anchor to `path`, using the tree's own real display
+    ///   order (`file_tree::visible_indices`) - not insertion order, not a path comparison, since
+    ///   neither would match what the user actually sees between the two rows. Replaces whatever
+    ///   [`Self::additional_tree_selection`] held before (matching every mainstream file
+    ///   manager's own "Shift-click" - a second Shift-click resizes the range, it doesn't extend
+    ///   it further from wherever the first one left off). Falls back to a plain single-select
+    ///   when there is no anchor yet to range from.
+    pub(in crate::sidebar) fn tree_click_select(
+        &mut self,
+        path: PathBuf,
+        modifiers: gpui::Modifiers,
+    ) {
+        if modifiers.shift && self.selected_tree_path.is_some() {
+            self.tree_select_range_to(&path);
+            return;
+        }
+        if modifiers.secondary() {
+            if self.selected_tree_path.as_deref() == Some(path.as_path()) {
+                // Toggling the anchor off - promote another member, if any, so the selection
+                // shrinks rather than silently losing its anchor while other rows stay lit.
+                let promoted = self.additional_tree_selection.iter().next().cloned();
+                if let Some(promoted) = promoted {
+                    self.additional_tree_selection.remove(&promoted);
+                    self.selected_tree_path = Some(promoted);
+                } else {
+                    self.selected_tree_path = None;
+                }
+            } else if !self.additional_tree_selection.remove(&path) {
+                if self.selected_tree_path.is_none() {
+                    self.selected_tree_path = Some(path);
+                } else {
+                    self.additional_tree_selection.insert(path);
+                }
+            }
+            return;
+        }
+        self.selected_tree_path = Some(path);
+        self.additional_tree_selection.clear();
+    }
+
+    /// The Shift-click half of [`Self::tree_click_select`] - see that method's own docs.
+    fn tree_select_range_to(&mut self, path: &Path) {
+        let Some(anchor) = self.selected_tree_path.clone() else {
+            self.selected_tree_path = Some(path.to_path_buf());
+            self.additional_tree_selection.clear();
+            return;
+        };
+        let visible = file_tree::visible_indices(&self.file_tree, &self.expanded_dirs);
+        let anchor_index = visible
+            .iter()
+            .position(|&index| self.file_tree[index].path == anchor);
+        let click_index = visible
+            .iter()
+            .position(|&index| self.file_tree[index].path == *path);
+        let (Some(anchor_index), Some(click_index)) = (anchor_index, click_index) else {
+            // Either endpoint isn't currently visible (a stale anchor from a row that's since
+            // been hidden behind a collapsed ancestor) - a range through rows the user can't see
+            // would be confusing to have selected sight unseen, so fall back to a plain
+            // single-select of the row that was actually clicked.
+            self.selected_tree_path = Some(path.to_path_buf());
+            self.additional_tree_selection.clear();
+            return;
+        };
+        let (start, end) = if anchor_index <= click_index {
+            (anchor_index, click_index)
+        } else {
+            (click_index, anchor_index)
+        };
+        self.additional_tree_selection = visible[start..=end]
+            .iter()
+            .map(|&index| self.file_tree[index].path.clone())
+            .filter(|entry_path| entry_path != &anchor)
+            .collect();
+    }
+
     /// Opens the context menu for `target` at a real click position, clamped so the whole
     /// popover stays inside the window (`context_menu::clamp_menu_origin`).
     ///
@@ -252,6 +383,21 @@ impl AdeApp {
         if self.tree_inline_edit.is_some() {
             self.cancel_tree_inline_edit(window, cx);
         }
+        // GitHub issue #145: a right-click on a row that's already part of a real multi-selection
+        // (more than just the anchor) must act on the *whole* selection, not collapse it down to
+        // just the row under the cursor - the same "right-click within a selection" convention
+        // every mainstream file manager follows. A right-click anywhere else (a fresh row, or the
+        // empty area) still collapses to that one target, exactly like before this issue.
+        let target = match target.path() {
+            Some(path) if self.tree_selection_len() > 1 && self.is_tree_path_selected(path) => {
+                ContextTarget::Multiple(self.tree_selected_paths())
+            }
+            _ => {
+                self.selected_tree_path = target.path().map(Path::to_path_buf);
+                self.additional_tree_selection.clear();
+                target
+            }
+        };
         // The exact rows `crate::sidebar::render::AdeApp::render_tree_context_menu` will paint,
         // group dividers included - measuring the action rows alone would leave the popover 9px
         // per group boundary taller than the clamp believed, so a menu opened near the bottom
@@ -266,7 +412,6 @@ impl AdeApp {
             f32::from(viewport.width),
             f32::from(viewport.height),
         );
-        self.selected_tree_path = target.path().map(Path::to_path_buf);
         self.tree_context_menu = Some(TreeContextMenu {
             target,
             origin_x,
@@ -382,8 +527,21 @@ impl AdeApp {
             // all" button calls - the live set, this worktree's persisted entry, and the queued
             // write all reset in one step. Not a second, parallel mechanism.
             MenuAction::CollapseAll => self.collapse_all_dirs(cx),
+            // GitHub issue #145: `Multiple`'s only real row. Each path gets its own real,
+            // undo-backed delete (`Self::request_tree_delete`, already immediate and per-path
+            // since GitHub issue #105) - a loop, not a second bulk-delete implementation.
             MenuAction::Delete => {
-                if let Some(path) = target_path {
+                if let ContextTarget::Multiple(paths) = &menu.target {
+                    for path in paths.clone() {
+                        let is_dir = self
+                            .file_tree
+                            .iter()
+                            .find(|entry| entry.path == path)
+                            .map(|entry| entry.is_dir)
+                            .unwrap_or_else(|| path.is_dir());
+                        self.request_tree_delete(path, is_dir, cx);
+                    }
+                } else if let Some(path) = target_path {
                     let is_dir = matches!(menu.target, ContextTarget::Folder(_));
                     self.request_tree_delete(path, is_dir, cx);
                 }
@@ -453,12 +611,19 @@ impl AdeApp {
         cx.notify();
     }
 
-    /// `F2`'s handler - renames whatever row is selected.
+    /// `F2`'s handler - renames whatever row is selected. GitHub issue #145: a real no-op with
+    /// more than one row selected - there is no single name to rename a multi-selection to, and
+    /// silently renaming just the anchor while the rest of the selection sat there unrenamed
+    /// would be exactly the "looks like it applies to the whole selection but doesn't" bug this
+    /// codebase's own discipline forbids.
     pub(in crate::sidebar) fn start_tree_rename_for_selection(
         &mut self,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if !self.additional_tree_selection.is_empty() {
+            return;
+        }
         let Some(path) = self.selected_tree_path.clone() else {
             return;
         };
@@ -927,21 +1092,22 @@ impl AdeApp {
 
     /// The `Delete` keyboard shortcut's own handler - mirrors [`Self::start_tree_rename_for_selection`]'s
     /// "resolve `is_dir` off the live tree, not the filesystem" pattern so a stale/renamed
-    /// selection can't race a real `stat` call.
+    /// selection can't race a real `stat` call. GitHub issue #145: deletes the whole real
+    /// selection (`Self::tree_selected_paths`), not just the anchor - each path still gets its
+    /// own real, undo-backed delete (`Self::request_tree_delete`).
     pub(in crate::sidebar) fn request_tree_delete_for_selection(&mut self, cx: &mut Context<Self>) {
-        let Some(path) = self.selected_tree_path.clone() else {
-            return;
-        };
-        if !path.starts_with(&self.file_tree_root) || path == self.file_tree_root {
-            return;
+        for path in self.tree_selected_paths() {
+            if !path.starts_with(&self.file_tree_root) || path == self.file_tree_root {
+                continue;
+            }
+            let is_dir = self
+                .file_tree
+                .iter()
+                .find(|entry| entry.path == path)
+                .map(|entry| entry.is_dir)
+                .unwrap_or_else(|| path.is_dir());
+            self.request_tree_delete(path, is_dir, cx);
         }
-        let is_dir = self
-            .file_tree
-            .iter()
-            .find(|entry| entry.path == path)
-            .map(|entry| entry.is_dir)
-            .unwrap_or_else(|| path.is_dir());
-        self.request_tree_delete(path, is_dir, cx);
     }
 
     /// [`Self::delete_path_with_real_undo`], resolving a real [`DeleteMechanism`] against this
@@ -1060,7 +1226,7 @@ impl AdeApp {
                 cx.notify();
             });
         });
-        self._tree_delete_task = Some(task);
+        self._tree_delete_tasks.push(task);
         cx.notify();
     }
 
@@ -3282,7 +3448,7 @@ mod tree_ops_regression_tests {
     /// run would move a real test fixture into the developer's own trash - the same hygiene
     /// concern `Self::request_tree_delete_with_mechanism_for_test` exists for elsewhere. Mechanism
     /// resolution and spawning the delete task both happen synchronously, before anything
-    /// destructive runs, so checking `_tree_delete_task` right after dispatch - without ever
+    /// destructive runs, so checking `_tree_delete_tasks` right after dispatch - without ever
     /// draining the executor - proves the keystroke reached the real delete path without letting
     /// the real removal command run. `deleting_a_file_removes_it_immediately_and_records_a_real_undo_entry`
     /// covers the real end-to-end removal, with a mechanism it fully controls.
@@ -3303,7 +3469,7 @@ mod tree_ops_regression_tests {
         cx.simulate_keystrokes("delete");
         app.read_with(cx, |app, _| {
             assert!(
-                app._tree_delete_task.is_some(),
+                !app._tree_delete_tasks.is_empty(),
                 "the Delete keystroke must reach AdeApp::request_tree_delete_for_selection and \
                  spawn a real delete task"
             );
@@ -3446,6 +3612,338 @@ mod tree_ops_regression_tests {
                  actually bound to"
             );
         }
+    }
+}
+
+/// GitHub issue #145: Ctrl/Cmd+click toggle, Shift+click range-select, bulk delete, rename
+/// gating, and right-click-within-a-selection all in one place - real coverage for the tree's
+/// own multi-selection, not just the single-target behavior `tree_ops_regression_tests` already
+/// covers.
+#[cfg(test)]
+mod tree_multiselect_tests {
+    use crate::root::focus::palette_focus_tests;
+    use crate::sidebar::context_menu::ContextTarget;
+    use gpui::{Modifiers, TestAppContext};
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Four plain root-level files, alphabetical - `visible_indices`' own display order for a
+    /// worktree with no directories to expand, so a range-select test can reason about exactly
+    /// which paths a Shift+click between two of them should span.
+    fn seed_flat(repo: &TempDir) {
+        for name in ["a.txt", "b.txt", "c.txt", "d.txt"] {
+            fs::write(repo.path().join(name), "x\n").expect("write");
+        }
+    }
+
+    fn secondary_modifiers() -> Modifiers {
+        if cfg!(target_os = "macos") {
+            Modifiers {
+                platform: true,
+                ..Modifiers::none()
+            }
+        } else {
+            Modifiers {
+                control: true,
+                ..Modifiers::none()
+            }
+        }
+    }
+
+    fn shift_modifiers() -> Modifiers {
+        Modifiers {
+            shift: true,
+            ..Modifiers::none()
+        }
+    }
+
+    #[gpui::test]
+    fn secondary_click_toggles_a_row_into_and_back_out_of_the_selection(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        seed_flat(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        let a = repo.path().join("a.txt");
+        let b = repo.path().join("b.txt");
+        app.update(cx, |app, _cx| {
+            app.selected_tree_path = Some(a.clone());
+        });
+
+        app.update(cx, |app, _cx| {
+            app.tree_click_select(b.clone(), secondary_modifiers());
+        });
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.selected_tree_path.as_deref(), Some(a.as_path()));
+            assert!(app.additional_tree_selection.contains(&b));
+            assert_eq!(app.tree_selection_len(), 2);
+        });
+
+        // A second Ctrl/Cmd+click on the same row toggles it back off.
+        app.update(cx, |app, _cx| {
+            app.tree_click_select(b.clone(), secondary_modifiers());
+        });
+        app.read_with(cx, |app, _| {
+            assert!(!app.additional_tree_selection.contains(&b));
+            assert_eq!(app.tree_selection_len(), 1);
+        });
+    }
+
+    #[gpui::test]
+    fn secondary_click_toggling_the_anchor_off_promotes_another_selected_row(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = TempDir::new().expect("tempdir");
+        seed_flat(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        let a = repo.path().join("a.txt");
+        let b = repo.path().join("b.txt");
+        app.update(cx, |app, _cx| {
+            app.selected_tree_path = Some(a.clone());
+            app.tree_click_select(b.clone(), secondary_modifiers());
+            // Ctrl/Cmd+click the anchor itself off.
+            app.tree_click_select(a.clone(), secondary_modifiers());
+        });
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.selected_tree_path.as_deref(),
+                Some(b.as_path()),
+                "the remaining selected row must become the new anchor rather than the whole \
+                 selection collapsing to nothing"
+            );
+            assert!(app.additional_tree_selection.is_empty());
+            assert_eq!(app.tree_selection_len(), 1);
+        });
+    }
+
+    #[gpui::test]
+    fn shift_click_range_selects_between_the_anchor_and_the_clicked_row(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        seed_flat(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        let a = repo.path().join("a.txt");
+        let c = repo.path().join("c.txt");
+        app.update(cx, |app, _cx| {
+            app.selected_tree_path = Some(a.clone());
+            app.tree_click_select(c.clone(), shift_modifiers());
+        });
+        app.read_with(cx, |app, _| {
+            let mut selected = app.tree_selected_paths();
+            selected.sort();
+            let mut expected = vec![a.clone(), repo.path().join("b.txt"), c.clone()];
+            expected.sort();
+            assert_eq!(
+                selected, expected,
+                "a-through-c must select exactly a.txt, b.txt, c.txt - not d.txt"
+            );
+            assert_eq!(
+                app.selected_tree_path.as_deref(),
+                Some(a.as_path()),
+                "the anchor itself must not move on a Shift+click"
+            );
+        });
+
+        // A second Shift+click resizes the range from the same anchor - it does not extend from
+        // wherever the first range left off.
+        let b = repo.path().join("b.txt");
+        app.update(cx, |app, _cx| {
+            app.tree_click_select(b.clone(), shift_modifiers());
+        });
+        app.read_with(cx, |app, _| {
+            let mut selected = app.tree_selected_paths();
+            selected.sort();
+            let mut expected = vec![a.clone(), b.clone()];
+            expected.sort();
+            assert_eq!(selected, expected);
+        });
+    }
+
+    #[gpui::test]
+    fn a_plain_click_collapses_the_selection_to_just_that_row(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        seed_flat(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        let a = repo.path().join("a.txt");
+        let b = repo.path().join("b.txt");
+        let c = repo.path().join("c.txt");
+        app.update(cx, |app, _cx| {
+            app.selected_tree_path = Some(a.clone());
+            app.tree_click_select(b.clone(), secondary_modifiers());
+            assert_eq!(
+                app.tree_selection_len(),
+                2,
+                "premise: a real 2-row selection exists"
+            );
+            app.tree_click_select(c.clone(), Modifiers::none());
+        });
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.selected_tree_path.as_deref(), Some(c.as_path()));
+            assert!(app.additional_tree_selection.is_empty());
+        });
+    }
+
+    #[gpui::test]
+    fn the_delete_key_removes_every_selected_file_not_just_the_anchor(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        seed_flat(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        let a = repo.path().join("a.txt");
+        let b = repo.path().join("b.txt");
+        let c = repo.path().join("c.txt");
+        app.update(cx, |app, _cx| {
+            app.selected_tree_path = Some(a.clone());
+            app.tree_click_select(b.clone(), secondary_modifiers());
+        });
+        app.update(cx, |app, cx| {
+            app.request_tree_delete_for_selection(cx);
+        });
+        cx.run_until_parked();
+
+        assert!(!a.exists(), "the anchor must be deleted");
+        assert!(!b.exists(), "the Ctrl/Cmd-selected row must be deleted too");
+        assert!(c.exists(), "an unselected row must be left alone");
+    }
+
+    #[gpui::test]
+    fn rename_is_a_no_op_with_more_than_one_row_selected(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        seed_flat(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        let a = repo.path().join("a.txt");
+        let b = repo.path().join("b.txt");
+        app.update_in(cx, |app, window, cx| {
+            app.selected_tree_path = Some(a.clone());
+            app.tree_click_select(b.clone(), secondary_modifiers());
+            app.start_tree_rename_for_selection(window, cx);
+        });
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.tree_inline_edit.is_none(),
+                "F2 with a real multi-selection must not open a rename editor at all - there \
+                 is no single name to rename it to"
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn rename_still_works_normally_with_exactly_one_row_selected(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        seed_flat(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        let a = repo.path().join("a.txt");
+        app.update_in(cx, |app, window, cx| {
+            app.selected_tree_path = Some(a.clone());
+            app.start_tree_rename_for_selection(window, cx);
+        });
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.tree_inline_edit.is_some(),
+                "a real single selection must still open the rename editor exactly as before \
+                 GitHub issue #145"
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn right_clicking_a_row_already_inside_a_multi_selection_preserves_the_whole_selection(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = TempDir::new().expect("tempdir");
+        seed_flat(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        let a = repo.path().join("a.txt");
+        let b = repo.path().join("b.txt");
+        app.update_in(cx, |app, window, cx| {
+            app.selected_tree_path = Some(a.clone());
+            app.tree_click_select(b.clone(), secondary_modifiers());
+            // Right-clicking `b` - itself already part of the 2-row selection - must not
+            // collapse it down to just `b`.
+            app.open_tree_context_menu(ContextTarget::File(b.clone()), 10.0, 10.0, window, cx);
+        });
+        app.read_with(cx, |app, _| {
+            let menu = app.tree_context_menu.as_ref().expect("menu must be open");
+            match &menu.target {
+                ContextTarget::Multiple(paths) => {
+                    let mut sorted = paths.clone();
+                    sorted.sort();
+                    let mut expected = vec![a.clone(), b.clone()];
+                    expected.sort();
+                    assert_eq!(sorted, expected);
+                }
+                other => panic!("expected ContextTarget::Multiple, got {other:?}"),
+            }
+            assert_eq!(
+                app.selected_tree_path.as_deref(),
+                Some(a.as_path()),
+                "the anchor must survive a right-click within its own selection"
+            );
+            assert!(app.additional_tree_selection.contains(&b));
+        });
+    }
+
+    #[gpui::test]
+    fn right_clicking_a_row_outside_the_selection_collapses_to_just_that_row(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = TempDir::new().expect("tempdir");
+        seed_flat(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        let a = repo.path().join("a.txt");
+        let b = repo.path().join("b.txt");
+        let c = repo.path().join("c.txt");
+        app.update_in(cx, |app, window, cx| {
+            app.selected_tree_path = Some(a.clone());
+            app.tree_click_select(b.clone(), secondary_modifiers());
+            // Right-clicking `c` - outside the {a, b} selection - must collapse to just `c`.
+            app.open_tree_context_menu(ContextTarget::File(c.clone()), 10.0, 10.0, window, cx);
+        });
+        app.read_with(cx, |app, _| {
+            let menu = app.tree_context_menu.as_ref().expect("menu must be open");
+            assert_eq!(menu.target, ContextTarget::File(c.clone()));
+            assert_eq!(app.selected_tree_path.as_deref(), Some(c.as_path()));
+            assert!(app.additional_tree_selection.is_empty());
+        });
+    }
+
+    #[gpui::test]
+    fn opening_a_file_from_the_tree_collapses_a_stray_multi_selection(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        seed_flat(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        let a = repo.path().join("a.txt");
+        let b = repo.path().join("b.txt");
+        app.update(cx, |app, _cx| {
+            app.selected_tree_path = Some(a.clone());
+            app.additional_tree_selection.insert(b.clone());
+        });
+        app.update_in(cx, |app, window, cx| {
+            app.open_file_view(b.clone(), window, cx);
+        });
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.additional_tree_selection.is_empty(),
+                "opening a real file must collapse whatever stray multi-selection preceded it"
+            );
+        });
     }
 }
 


### PR DESCRIPTION
## Summary
- Real multi-selection for the file tree: Ctrl/Cmd+click toggles a row's membership, Shift+click range-selects between the anchor and the clicked row (using the tree's own real display order, not insertion order), and a plain click still collapses back to a single selection.
- **Bulk delete**: both the context menu row and the `Delete` key now remove every selected path, not just the anchor - each still gets its own real, undo-backed delete (issue #105 already made delete immediate and per-path, so this needed no new delete machinery). Testing this caught a real, pre-existing bug: `AdeApp::_tree_delete_task` was a single `Option<Task<()>>` slot, so looping a bulk delete silently *cancelled* every delete but the last one. Fixed - it's a real `Vec` now.
- Right-click on a row already inside a multi-selection opens a new `ContextTarget::Multiple` menu (Delete only). Right-clicking outside the selection still collapses to that one row, matching the "right-click within a selection" convention every mainstream file manager follows.
- **Deliberate scope decision**: Cut/Copy/Paste stay single-target in this PR. `TreeClipboard` is a single-path struct threaded through ~15 call sites and real undo-entry bookkeeping - bulk-rewriting it safely (per-item collision naming, per-item undo entries) is a real, separate change, not something to rush alongside a bulk-delete change that turned out to have its own real bug to find. Filed as a natural fast-follow, not a permanent gap - Cut/Copy/Rename/New File rows are simply omitted from the `Multiple` menu (never shown as if they'd act on the whole selection when they wouldn't).
- F2/rename is a real no-op with more than one row selected - there's no single name to rename a multi-selection to.
- The row highlight lights up every additionally-selected row too, gated on tree focus the same way the anchor already was (issue #127).

Fixes #145.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib -- --test-threads=1` - 1419 passed, one known pre-existing flake (`undoing_then_redoing_a_delete_restores_then_removes_the_file_again`) confirmed passing in isolation
- [x] 10 new tests: toggle on/off, anchor-removal promotion, range-select (including a second Shift+click resizing from the same anchor), plain-click collapse, bulk delete, rename gating (both the no-op and the still-works-with-one-selected cases), right-click preserving vs. collapsing the selection, and opening a file collapsing a stray selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)