### PR TITLE
File tree: drag rows to move them into a folder

### DIFF
--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -448,6 +448,11 @@ pub struct AdeApp {
     /// The tree's own cut/copy buffer - a real filesystem entry, deliberately not the system
     /// clipboard (see `crate::sidebar::tree_ops::TreeClipboard`).
     pub(crate) tree_clipboard: Option<tree_ops::TreeClipboard>,
+    /// GitHub issue #148: which directory row a real in-progress file-tree drag is currently
+    /// hovering, if any - the drop-target highlight `crate::sidebar::render::AdeApp::
+    /// render_file_tree_row` paints, and the folder `Self::move_paths_into_dir` moves into on a
+    /// real drop. `None` whenever no drag is over the tree at all.
+    pub(crate) tree_drag_hover_target: Option<PathBuf>,
     /// Real, already-applied file-tree operations (delete, rename, cut/paste move) that
     /// `crate::sidebar::tree_ops::AdeApp::undo_tree_op` can reverse, most recent last - the
     /// file-tree's own undo history, distinct from each text field's own `text_history::

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -230,6 +230,7 @@ impl AdeApp {
             tree_context_menu: None,
             tree_inline_edit: None,
             tree_clipboard: None,
+            tree_drag_hover_target: None,
             tree_undo_stack: Vec::new(),
             tree_redo_stack: Vec::new(),
             tree_undo_backup_counter: 0,

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -806,6 +806,17 @@ impl AdeApp {
                     );
                 }),
             )
+            // GitHub issue #148: the empty area is also a real drop target - "move to the
+            // worktree root", the same `destination_dir` every other empty-area action
+            // (New File/New Folder/Paste) already resolves to. Any row's own `on_drop` calls
+            // `cx.stop_propagation()`, so this only ever fires for a drop that genuinely misses
+            // every row.
+            .on_drop(
+                cx.listener(move |this, dragged: &TreeDragPayload, _window, cx| {
+                    let root = this.file_tree_root.clone();
+                    this.move_paths_into_dir(&dragged.paths, &root, cx);
+                }),
+            )
             .child({
                 // Where a keyboard-opened menu (`Shift+F10`) anchors - the same real
                 // `gpui::canvas` bounds-capture pattern `Self::render_tab_strip_plus` uses for
@@ -1022,7 +1033,18 @@ impl AdeApp {
             .pr(px(8.0))
             .font(font(theme::font::MONO))
             .text_size(self.ui_text_size(11.5))
-            .when(is_selected, |el| el.bg(theme::surface::ROW_SELECTED));
+            .when(is_selected, |el| el.bg(theme::surface::ROW_SELECTED))
+            // GitHub issue #148: the drop-target folder while a real file-tree drag is over it -
+            // `theme::status::ASK_BG`, the same "you can act here" amber this app already uses
+            // for its other real actionable notices, not a new one-off token. Deliberately
+            // overrides `is_selected`'s own bg (a `.when` after it, not combined into one
+            // condition) - a drop target reads as "drop here", not "also selected", even for the
+            // rare case of dragging onto an already-selected folder.
+            .when(
+                entry.is_dir
+                    && self.tree_drag_hover_target.as_deref() == Some(entry.path.as_path()),
+                |el| el.bg(theme::status::ASK_BG),
+            );
 
         // Indent guides (issue #18 §3), one per level of nesting between this row and the root.
         //
@@ -1103,6 +1125,74 @@ impl AdeApp {
                     );
                 }),
             );
+        }
+
+        // GitHub issue #148: every row can be dragged - a row already part of a real
+        // multi-selection drags the *whole* selection, matching how a click on it wouldn't
+        // collapse the selection either (a plain click on an *unselected* row still resets the
+        // selection first, the same way `Self::tree_click_select`'s own plain-click branch
+        // does, so the drag that follows only ever carries what's genuinely selected at drag
+        // start). Only real per-row state is read here - never anything that could go stale by
+        // the time the drag actually starts, since `drag_value` is captured once, now.
+        {
+            let is_selected = self.is_tree_path_selected(&entry.path);
+            let drag_paths = if is_selected && self.tree_selection_len() > 1 {
+                self.tree_selected_paths()
+            } else {
+                vec![entry.path.clone()]
+            };
+            let label = if drag_paths.len() > 1 {
+                format!("{} items", drag_paths.len())
+            } else {
+                entry.name.clone()
+            };
+            let drag_value = TreeDragPayload {
+                paths: drag_paths,
+                label,
+            };
+            row = row.on_drag(drag_value, move |dragged, _position, _window, cx| {
+                cx.new(|_| dragged.clone())
+            });
+        }
+        if entry.is_dir {
+            let drop_path = entry.path.clone();
+            let hover_path = entry.path.clone();
+            row = row
+                .on_drag_move(cx.listener(
+                    move |this, event: &gpui::DragMoveEvent<TreeDragPayload>, _window, cx| {
+                        // A folder can't be its own drop target's *visual* indication either -
+                        // `Self::move_paths_into_dir` already refuses the move itself, but
+                        // highlighting a folder that's part of what's being dragged onto it
+                        // would show an affordance for a drop this app is about to reject anyway.
+                        let hovering = event.bounds.contains(&event.event.position)
+                            && !event.drag(cx).paths.contains(&hover_path);
+                        // Only touches state (and repaints) on a real change - matching
+                        // `Self::update_tab_drag_insertion`'s own identical discipline, since
+                        // `on_drag_move` fires on every real mouse-move during the drag.
+                        if hovering {
+                            if this.tree_drag_hover_target.as_deref() != Some(hover_path.as_path())
+                            {
+                                this.tree_drag_hover_target = Some(hover_path.clone());
+                                cx.notify();
+                            }
+                        } else if this.tree_drag_hover_target.as_deref()
+                            == Some(hover_path.as_path())
+                        {
+                            this.tree_drag_hover_target = None;
+                            cx.notify();
+                        }
+                    },
+                ))
+                .on_drop(
+                    cx.listener(move |this, dragged: &TreeDragPayload, _window, cx| {
+                        // Without this, the drop would *also* reach `Self::file_tree_shell`'s own
+                        // root-drop handler right after this row's - moving the same selection into
+                        // the folder it was just dropped on, then straight back out to the root.
+                        cx.stop_propagation();
+                        this.tree_drag_hover_target = None;
+                        this.move_paths_into_dir(&dragged.paths, &drop_path, cx);
+                    }),
+                );
         }
 
         if entry.is_dir {
@@ -2645,6 +2735,35 @@ pub(in crate::sidebar) fn render_file_tree_footer(
 /// keycap in the app.
 pub(in crate::sidebar) const FILE_TREE_CONTEXT_MENU_SPEC: &str = "shift+F10";
 pub(in crate::sidebar) const FILE_TREE_RENAME_SPEC: &str = "F2";
+
+/// GitHub issue #148: what a real file-tree row drag carries - every path the gesture moves
+/// (the whole real selection, if the dragged row was already part of one; just that one row
+/// otherwise - see `AdeApp::render_file_tree_row`'s own `.on_drag` for which). Mirrors
+/// `crate::work_surface::render::DraggedTab`'s exact shape (a small `Render`ed chip showing what's
+/// being dragged) for the tab strip's own drag-and-drop, not a second, differently-behaved
+/// mechanism - GPUI's own `on_drag`/`on_drag_move`/`on_drop` triple is the same either way.
+#[derive(Clone)]
+pub(in crate::sidebar) struct TreeDragPayload {
+    pub(in crate::sidebar) paths: Vec<PathBuf>,
+    label: String,
+}
+
+impl gpui::Render for TreeDragPayload {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .opacity(0.85)
+            .px(px(10.0))
+            .py(px(4.0))
+            .rounded(theme::radius::CHIP)
+            .bg(theme::surface::PALETTE)
+            .border_1()
+            .border_color(theme::border::POPOVER)
+            .font(font(theme::font::SANS))
+            .text_size(px(11.0))
+            .text_color(theme::text::BODY)
+            .child(self.label.clone())
+    }
+}
 
 /// The file tree row's `▾`/`▸` caret, signaling a directory row is clickable/expandable,
 /// distinct from the folder icon itself. Blank but still 8px wide for a file row, to keep

--- a/crates/app/src/sidebar/tree_ops.rs
+++ b/crates/app/src/sidebar/tree_ops.rs
@@ -982,6 +982,75 @@ impl AdeApp {
         }
     }
 
+    /// GitHub issue #148: drag-and-drop's own "move these into that folder" - the same real,
+    /// synchronous `file_ops::move_path` + `Self::rename_open_paths` +
+    /// `TreeUndoEntry::Relocate` [`Self::paste_into_dir`]'s own `Cut` branch already uses, just
+    /// generalized to a whole list of sources (a dragged multi-selection) instead of the
+    /// clipboard's single entry - a real second real caller of the same move primitive, not a
+    /// second, parallel move implementation.
+    ///
+    /// Each source is handled independently: one real name collision or one attempt to drop a
+    /// folder into its own subtree reports a real error for *that* source and moves on to the
+    /// rest, rather than a single bad source aborting an otherwise-valid bulk move partway
+    /// through. `sources` already inside `dir` are silently skipped (dropping a selection back
+    /// onto its own current parent is a real no-op, not an error, matching `paste_into_dir`'s
+    /// identical "already exactly where it was asked to go" rule).
+    pub(in crate::sidebar) fn move_paths_into_dir(
+        &mut self,
+        sources: &[PathBuf],
+        dir: &Path,
+        cx: &mut Context<Self>,
+    ) {
+        let mut last_destination = None;
+        for source in sources {
+            let Some(name) = source
+                .file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+            else {
+                continue;
+            };
+            if dir.join(&name) == *source {
+                continue;
+            }
+            // A folder can never be dropped into itself or one of its own descendants - the
+            // filesystem's own `rename` would either fail outright or (worse, on some platforms)
+            // silently do something no drag gesture ever meant to ask for.
+            if dir == source.as_path() || dir.starts_with(source) {
+                self.report_tree_op_error(
+                    format!("can't move {} into its own subtree", source.display()),
+                    cx,
+                );
+                continue;
+            }
+            let destination = match file_ops::unique_destination(dir, &name) {
+                Ok(destination) => destination,
+                Err(err) => {
+                    self.report_tree_op_error(err.to_string(), cx);
+                    continue;
+                }
+            };
+            if let Err(err) = file_ops::move_path(source, &destination) {
+                self.report_tree_op_error(err.to_string(), cx);
+                continue;
+            }
+            self.rename_open_paths(source, &destination, cx);
+            self.push_tree_undo_entry(
+                TreeUndoEntry::Relocate {
+                    old_path: source.clone(),
+                    new_path: destination.clone(),
+                },
+                cx,
+            );
+            last_destination = Some(destination);
+        }
+        if let Some(destination) = last_destination {
+            self.reveal_in_tree(&destination, cx);
+            self.selected_tree_path = Some(destination);
+            self.additional_tree_selection.clear();
+            self.refresh_after_file_op(cx);
+        }
+    }
+
     /// "Duplicate" - a copy next to the original, named by the same
     /// [`file_ops::unique_destination`] rule a paste-into-the-source-folder uses, so the two can
     /// never disagree about what a duplicate is called.
@@ -3942,6 +4011,137 @@ mod tree_multiselect_tests {
             assert!(
                 app.additional_tree_selection.is_empty(),
                 "opening a real file must collapse whatever stray multi-selection preceded it"
+            );
+        });
+    }
+}
+
+/// GitHub issue #148: `AdeApp::move_paths_into_dir` - the real move `Self::render_file_tree_row`'s
+/// own `.on_drop`/`Self::file_tree_shell`'s root drop both call. Drives the method directly rather
+/// than simulating a real GPUI drag gesture (this app's own test harness has no drag/drop
+/// simulator - `crate::work_surface::render`'s own tab-reorder tests call `AdeApp::reorder_tab`/
+/// `AdeApp::drop_dragged_tab` directly for the identical reason), so this is real coverage of the
+/// move primitive itself, not of the mouse plumbing on top of it (which is the same real
+/// `on_drag`/`on_drag_move`/`on_drop` triple already exercised for tabs).
+#[cfg(test)]
+mod tree_drag_move_tests {
+    use crate::root::focus::palette_focus_tests;
+    use gpui::TestAppContext;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn seed(repo: &TempDir) {
+        fs::create_dir_all(repo.path().join("dest")).expect("mkdir");
+        fs::write(repo.path().join("a.txt"), "a\n").expect("write");
+        fs::write(repo.path().join("b.txt"), "b\n").expect("write");
+    }
+
+    #[gpui::test]
+    fn dropping_a_file_onto_a_folder_moves_it_there_with_a_real_undo_entry(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = TempDir::new().expect("tempdir");
+        seed(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        let a = repo.path().join("a.txt");
+        let dest = repo.path().join("dest");
+        let undo_len_before = app.read_with(cx, |app, _| app.tree_undo_stack.len());
+        app.update(cx, |app, cx| {
+            app.move_paths_into_dir(std::slice::from_ref(&a), &dest, cx);
+        });
+        cx.run_until_parked();
+
+        assert!(!a.exists(), "the old path must be gone");
+        assert!(
+            dest.join("a.txt").exists(),
+            "the file must really be in dest/ now"
+        );
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.tree_undo_stack.len(),
+                undo_len_before + 1,
+                "a drag-move must record a real, undoable Relocate entry - the same as a cut/paste \
+                 move or a rename"
+            );
+            assert_eq!(
+                app.selected_tree_path.as_deref(),
+                Some(dest.join("a.txt").as_path())
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn dropping_a_multi_selection_moves_every_selected_path(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        seed(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        let a = repo.path().join("a.txt");
+        let b = repo.path().join("b.txt");
+        let dest = repo.path().join("dest");
+        app.update(cx, |app, cx| {
+            app.move_paths_into_dir(&[a.clone(), b.clone()], &dest, cx);
+        });
+        cx.run_until_parked();
+
+        assert!(!a.exists());
+        assert!(!b.exists());
+        assert!(dest.join("a.txt").exists());
+        assert!(dest.join("b.txt").exists());
+    }
+
+    #[gpui::test]
+    fn dropping_a_folder_onto_its_own_descendant_is_refused_with_a_real_error(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = TempDir::new().expect("tempdir");
+        seed(&repo);
+        fs::create_dir_all(repo.path().join("dest/inner")).expect("mkdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        let dest = repo.path().join("dest");
+        let inner = repo.path().join("dest/inner");
+        app.update(cx, |app, cx| {
+            app.move_paths_into_dir(std::slice::from_ref(&dest), &inner, cx);
+        });
+        cx.run_until_parked();
+
+        assert!(dest.exists(), "the folder must not have moved at all");
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.tree_op_error.is_some(),
+                "dropping a folder into its own subtree must report a real error, not silently \
+                 no-op or corrupt the tree"
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn dropping_onto_its_own_current_parent_is_a_real_no_op(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        seed(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        let a = repo.path().join("a.txt");
+        let root = repo.path().to_path_buf();
+        let undo_len_before = app.read_with(cx, |app, _| app.tree_undo_stack.len());
+        app.update(cx, |app, cx| {
+            app.move_paths_into_dir(std::slice::from_ref(&a), &root, cx);
+        });
+        cx.run_until_parked();
+
+        assert!(a.exists(), "the file must still be exactly where it was");
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.tree_undo_stack.len(),
+                undo_len_before,
+                "dropping a file back onto its own current folder must not record a real move - \
+                 there is nothing to undo"
             );
         });
     }


### PR DESCRIPTION
## Summary
- Adds real drag-and-drop move for the file tree: drag a file/folder row and drop it onto a directory row (or the tree's empty/root area) to move it there.
- Dragging a row that's part of an active multi-selection carries the whole selection along.
- Reuses the existing move/undo machinery (`file_ops::move_path`, `rename_open_paths`, `TreeUndoEntry::Relocate`, `file_ops::unique_destination`) via a new `AdeApp::move_paths_into_dir`, rather than a second move mechanism — the same primitive already backing rename and cut/paste move.
- Drop targets highlight while hovered; dropping a folder into its own subtree (or onto itself) is refused with a real tree-op error instead of corrupting the tree; dropping back onto the item's current parent is a real no-op.
- Drag source/target wiring follows this app's existing `on_drag`/`on_drag_move`/`on_drop` idiom already used for tab reordering, including the same "only mutate + notify when the hovered target actually changes" discipline.

## Test plan
- [x] New `tree_drag_move_tests` module in `sidebar/tree_ops.rs`: single move with a real undo entry, multi-item move, self-into-own-subtree refusal, no-op onto current parent.
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib -- --test-threads=1` (all green; one pre-existing flaky test reconfirmed passing in isolation)

Fixes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)