### PR TITLE
Chrome fixes: aligned top bars, terminal Clear in footer, dedupe Archive button

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -532,6 +532,28 @@ pub fn default_key_bindings() -> Vec<gpui::KeyBinding> {
         // terminal/agent tab is still always closeable via the tab strip's own `×` or
         // middle-click regardless.
         gpui::KeyBinding::new("ctrl-w", root::CloseFocusedTab, Some("!terminal")),
+        // GitHub issue #20's "stays rebindable" requirement for the terminal footer's `clear`
+        // action (`crate::work_surface::render::AdeApp::handle_terminal_clear_action`). Scoped
+        // `Some("terminal")` (the opposite direction from `"ctrl-w"` above - this one only fires
+        // *while* a terminal is focused) with a keystroke chosen the same way `"ctrl-w"` and
+        // `"ctrl-shift-t"` already reason about the "app-level shortcut steals terminal input"
+        // conflict class: on macOS, `cmd-k` never reaches the pty in the first place
+        // (`keystroke_to_bytes` returns `None` for any `modifiers.platform` keystroke, checked
+        // first, before the plain-Ctrl control-byte branch below it); on Linux/Windows,
+        // `keystroke_to_bytes`'s own control-byte formula ignores the shift modifier entirely, so
+        // `ctrl-shift-l` is a real, distinct `KeyBinding` match (GPUI matches the exact modifier
+        // set) that never collides with plain `Ctrl-L`'s own `0x0c` byte reaching a focused shell -
+        // the same real precedent Zed's own keymap uses for `terminal::Clear` (see that action
+        // handler's own docs).
+        gpui::KeyBinding::new(
+            if cfg!(target_os = "macos") {
+                "cmd-k"
+            } else {
+                "ctrl-shift-l"
+            },
+            root::TerminalClear,
+            Some("terminal"),
+        ),
     ]
 }
 

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -594,7 +594,7 @@ impl AdeApp {
             .items_center()
             .justify_end()
             .px(px(10.0))
-            .h(theme::band::RAIL_HEADER)
+            .h(theme::band::CHROME_HEADER)
             .border_b_1()
             .border_color(theme::border::RAIL_INNER)
             .child(self.render_new_agent_button(cx))

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -193,6 +193,7 @@ actions!(
         FileTreeDelete,
         FileTreeUndo,
         FileTreeRedo,
+        TerminalClear,
     ]
 );
 
@@ -2101,6 +2102,7 @@ impl Render for AdeApp {
             .on_action(cx.listener(Self::handle_jump_to_agent_7_action))
             .on_action(cx.listener(Self::handle_jump_to_agent_8_action))
             .on_action(cx.listener(Self::handle_close_focused_tab_action))
+            .on_action(cx.listener(Self::handle_terminal_clear_action))
             .child(self.render_title_bar(cx))
             // The Settings surface (`design_handoff_jerry_ade/README.md`: "a separate surface,
             // not a modal: it replaces the three zones while the title bar and status bar

--- a/crates/app/src/settings/render.rs
+++ b/crates/app/src/settings/render.rs
@@ -152,7 +152,7 @@ impl AdeApp {
             .child(
                 div()
                     .flex_none()
-                    .h(theme::band::RAIL_HEADER)
+                    .h(theme::band::CHROME_HEADER)
                     .flex()
                     .items_center()
                     .justify_between()

--- a/crates/app/src/settings/state.rs
+++ b/crates/app/src/settings/state.rs
@@ -587,6 +587,7 @@ pub(crate) fn action_label(action: &dyn gpui::Action) -> Option<&'static str> {
         "app::FileTreeDelete" => Some("Files tree: delete"),
         "app::FileTreeUndo" => Some("Files tree: undo"),
         "app::FileTreeRedo" => Some("Files tree: redo"),
+        "app::TerminalClear" => Some("Terminal: clear"),
         _ => None,
     }
 }
@@ -1291,6 +1292,8 @@ mod tests {
                 "Files tree: redo",
                 // GitHub issue #26's `Ctrl+W` - closes the focused tab, scoped `Some("!terminal")`.
                 "Close focused tab",
+                // GitHub issue #20's terminal footer `clear`, scoped `Some("terminal")`.
+                "Terminal: clear",
             ]
         );
     }
@@ -1354,6 +1357,8 @@ mod tests {
         // immediately - no confirmation step, so no different scoping from Copy/Cut/Paste/Rename
         // above it) and its own `FileTreeUndo`/`FileTreeRedo` (`Ctrl+Z`/`Ctrl+Shift+Z`) - distinct
         // actions from `TextUndo`/`TextRedo`, all three `Some("file-tree && !tree-editing")`.
+        // GitHub issue #20 added 1 more real scoped binding: `TerminalClear`
+        // (`cmd-k`/`ctrl-shift-l`), `Some("terminal")`.
         let bindings = crate::default_key_bindings();
         let rows = keybinding_rows(&bindings, &[]);
         assert!(!rows.is_empty());
@@ -1361,15 +1366,15 @@ mod tests {
             rows.iter().filter(|row| row.context != "global").collect();
         assert_eq!(
             scoped.len(),
-            73,
+            74,
             "expected `] -> NextChangedFile` (1) plus every real Editor* binding (19) plus \
              every real Completions* binding (5) plus every real merge-editor binding (18) plus \
              TextUndo/TextRedo (3, GitHub issue #17) plus every real \
              file-tree binding (8, GitHub issues #19 and #105) plus every real word-wise Editor* \
              binding (8, GitHub issue #27) plus every real multi-cursor Editor* binding (4, \
              GitHub issue #28) plus every real GitHub issue #26 binding (7, not counting \
-             EditorCollapseCursors above, which is issue #28's own action) to be scoped, not \
-             global"
+             EditorCollapseCursors above, which is issue #28's own action) plus TerminalClear \
+             (1, GitHub issue #20) to be scoped, not global"
         );
         assert!(
             scoped

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -1354,7 +1354,7 @@ impl AdeApp {
 
         div()
             .flex_none()
-            .h(theme::band::PANEL_HEADER)
+            .h(theme::band::CHROME_HEADER)
             .flex()
             .items_center()
             .px(px(10.0))

--- a/crates/app/src/theme.rs
+++ b/crates/app/src/theme.rs
@@ -1156,9 +1156,11 @@ pub mod band {
     use super::{px, Pixels};
 
     pub const TITLE_BAR: Pixels = px(38.0);
-    pub const TAB_STRIP: Pixels = px(34.0);
-    pub const RAIL_HEADER: Pixels = px(36.0);
-    pub const PANEL_HEADER: Pixels = px(36.0);
+    /// Shared height for the work-surface tab strip, the session-rail header, and the
+    /// files/changes panel header - the three sit side by side under the title bar and must
+    /// line up pixel-perfect, so they read off one constant instead of three values that could
+    /// drift independently.
+    pub const CHROME_HEADER: Pixels = px(36.0);
     pub const CONTEXT_BAR: Pixels = px(32.0);
     pub const DIFF_TOOLBAR: Pixels = px(31.0);
     pub const FILTER_ROW: Pixels = px(30.0);

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -159,6 +159,25 @@ impl AdeApp {
         }
     }
 
+    /// GitHub issue #20's "stays rebindable" requirement for the terminal footer's `clear`
+    /// action - see [`Self::render_pty_info_footer`] for the click entry point this shares
+    /// [`crate::terminal::pane::TerminalPane::clear`] with. Scoped to `Some("terminal")` in
+    /// `crate::default_key_bindings`, exactly like [`Self::handle_close_focused_tab_action`]'s
+    /// own `Some("!terminal")` - a real terminal keeps its own control bytes for anything not
+    /// bound here, and this only ever fires while a `TerminalPane` genuinely has focus. Acts on
+    /// whichever agent is currently active, matching `handle_close_focused_tab_action`'s own
+    /// "the centre pane is genuinely showing right now" target.
+    pub(crate) fn handle_terminal_clear_action(
+        &mut self,
+        _action: &TerminalClear,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(agent) = self.agents.active() {
+            agent.pane.clone().update(cx, |pane, cx| pane.clear(cx));
+        }
+    }
+
     /// Activates agent `id`'s tab and, if it maps to a currently-listed worktree, also selects
     /// that worktree, keeping the file tree/diff sidebar in sync with the agent just clicked
     /// (the sidebar is still driven by [`Self::selected`] - a `focused_agent`-driven Zone 2/3
@@ -697,7 +716,7 @@ impl AdeApp {
             .flex()
             .flex_none()
             .items_stretch()
-            .h(theme::band::TAB_STRIP)
+            .h(theme::band::CHROME_HEADER)
             .bg(theme::surface::TITLE_BAR)
             .border_b_1()
             .border_color(theme::border::ZONE);
@@ -1778,10 +1797,9 @@ impl AdeApp {
 
     /// Surface A/B's shared header: the resolved program label (this app has no saved-agent
     /// resumability, so there's no resume argument to show alongside it), a `Shell` agent's
-    /// cwd, and a hint row (`mod + click a path to open it`, and a click-only `clear`) rendered
-    /// for every agent kind - `TerminalPane` behaves identically for shell and agents
-    /// (see its module docs), so link-click and `clear` are exactly as real for a `Claude`/
-    /// `Codex` panic frame as for a shell prompt.
+    /// cwd, and a `mod + click a path to open it` hint, rendered for every agent kind -
+    /// `TerminalPane` behaves identically for shell and agents (see its module docs), so
+    /// link-click is exactly as real for a `Claude`/`Codex` panic frame as for a shell prompt.
     ///
     /// A `Shell` label gets a ` · wsl` suffix when running inside WSL (`crate::env_info::is_wsl`).
     /// The design's third hint, `split`, is deliberately not rendered - this app has no
@@ -1790,19 +1808,10 @@ impl AdeApp {
     /// [`Self::render_plus_menu`]'s "Open file…" row sets).
     ///
     /// A `Claude`/`Codex` agent's pid is shown once, in the info footer below
-    /// ([`Self::render_pty_info_footer`]) - not duplicated here.
-    ///
-    /// `clear` is click-only, not a global keybinding, even though the design shows `mod+K`:
-    /// `Ctrl+K` is a standard readline binding (`kill-line`) every focused shell relies on, and
-    /// `"mod"` resolves to plain `Ctrl` on Linux/Windows (`crate::keymap`'s docs) - binding it
-    /// globally would risk the same "app-level shortcut steals terminal input" class of bug
-    /// `crate::default_key_bindings`'s own `"]"`/`secondary-z` entries deliberately scope away
-    /// from - unlike `secondary-p`, which the project ultimately accepted eating a focused
-    /// terminal's own Ctrl+P as a deliberate, discussed tradeoff (see that binding's own docs),
-    /// there's no equivalent case made here for doing the same to `kill-line`. Zed's own
-    /// keymaps confirm this isn't overcaution: `terminal::Clear` is bound to `ctrl-shift-l` on
-    /// Linux/Windows and reserved for `cmd-k` on macOS alone, where a platform-modified keystroke
-    /// never reaches the pty in the first place (`crate::terminal::pane::keystroke_to_bytes`).
+    /// ([`Self::render_pty_info_footer`]) - not duplicated here. GitHub issue #20 moved `clear`
+    /// into that same info footer, alongside pid/grid-dims/env - see that method's own docs for
+    /// the click entry point, and [`Self::handle_terminal_clear_action`] for the real, rebindable
+    /// keybinding that now sits behind it too.
     pub(in crate::work_surface) fn render_pty_header(
         &self,
         agent: &Agent,
@@ -1859,7 +1868,6 @@ impl AdeApp {
         };
 
         let macos = self.window_controls_style().is_macos();
-        let pane_entity = agent.pane.clone();
         let header = header.child(div().flex_1()).child(
             div()
                 .id("pty-header-hints")
@@ -1869,19 +1877,7 @@ impl AdeApp {
                 .child(render_hint_pair(
                     &keymap::resolve_combo("mod", macos),
                     "click a path to open it",
-                ))
-                .child(
-                    div()
-                        .id("pty-header-clear")
-                        .cursor_pointer()
-                        .rounded(theme::radius::CHIP)
-                        .px(px(3.0))
-                        .hover(|el| el.bg(theme::surface::ROW_HOVER_ALT))
-                        .child(render_hint_pair(&[], "clear"))
-                        .on_click(cx.listener(move |_this, _event: &ClickEvent, _window, cx| {
-                            pane_entity.update(cx, |pane, cx| pane.clear(cx));
-                        })),
-                ),
+                )),
         );
 
         header.child(
@@ -1894,12 +1890,13 @@ impl AdeApp {
         )
     }
 
-    /// The terminal pane's info footer: pid, grid dimensions, the environment chip, and a hint
-    /// about file:line references. Rendered for every agent kind - `TerminalPane` is the same
-    /// component behind a `Shell` tab and a `Claude`/`Codex` tab (see that module's docs), so pid
-    /// and grid dimensions are equally meaningful for either. Distinct from, and rendered
-    /// alongside, [`Self::render_pty_footer`] - the agent-level Interrupt/Retry/Archive action
-    /// footer.
+    /// The terminal pane's info footer: pid, grid dimensions, the environment chip, `clear`
+    /// (GitHub issue #20 - moved here from the header, see [`Self::render_pty_header`]'s own
+    /// docs), and a hint about file:line references. Rendered for every agent kind -
+    /// `TerminalPane` is the same component behind a `Shell` tab and a `Claude`/`Codex` tab (see
+    /// that module's docs), so pid, grid dimensions, and `clear` are equally meaningful for
+    /// either. Distinct from, and rendered alongside, [`Self::render_pty_footer`] - the
+    /// agent-level Interrupt/Retry/Archive action footer.
     pub(in crate::work_surface) fn render_pty_info_footer(
         &self,
         agent: &Agent,
@@ -1942,10 +1939,27 @@ impl AdeApp {
                 .child(mono_text(format!("pid {pid}")))
                 .child(divider());
         }
+        let macos = self.window_controls_style().is_macos();
+        let clear_combo =
+            keymap::resolve_combo(if macos { "mod+K" } else { "ctrl+shift+L" }, macos);
+        let pane_entity = agent.pane.clone();
         footer = footer
             .child(mono_text(format!("{cols}\u{d7}{rows}")))
             .child(divider())
-            .child(render_env_chip());
+            .child(render_env_chip())
+            .child(divider())
+            .child(
+                div()
+                    .id("pty-info-footer-clear")
+                    .cursor_pointer()
+                    .rounded(theme::radius::CHIP)
+                    .px(px(3.0))
+                    .hover(|el| el.bg(theme::surface::ROW_HOVER_ALT))
+                    .child(render_hint_pair(&clear_combo, "clear"))
+                    .on_click(cx.listener(move |_this, _event: &ClickEvent, _window, cx| {
+                        pane_entity.update(cx, |pane, cx| pane.clear(cx));
+                    })),
+            );
 
         footer.child(div().flex_1()).child(
             div()
@@ -2126,7 +2140,6 @@ impl AdeApp {
                             this.open_companion_terminal(cwd.clone(), window, cx)
                         }
                         work_surface::ActionKind::Respawn => this.respawn_agent(id, window, cx),
-                        work_surface::ActionKind::Archive => this.archive_agent(id, window, cx),
                         work_surface::ActionKind::KeepAllChanges => this.keep_all_changes(id, cx),
                         work_surface::ActionKind::DiscardWorktree => {
                             this.request_discard_worktree(id, window, cx)
@@ -3959,6 +3972,90 @@ mod tab_scoping_tests {
             persisted.len(),
             3,
             "the on-disk persisted order must keep all three files"
+        );
+    }
+}
+
+/// GitHub issue #20's `TerminalClear` action - real coverage that dispatching it reaches
+/// whichever agent is genuinely active right now, and only that one, mirroring
+/// `crate::terminal::pane::clear_pty_signal_tests`' own "observe the pty's real echo, not a
+/// direct call" discipline for proving `clear()`'s pty-signal half actually fired.
+#[cfg(test)]
+mod terminal_clear_action_tests {
+    use super::*;
+    use crate::root::focus::palette_focus_tests;
+    use gpui::TestAppContext;
+
+    #[gpui::test]
+    fn dispatching_terminal_clear_signals_only_the_active_agents_pty(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+
+        let (first_id, second_id) = app.update_in(cx, |app, window, cx| {
+            let first = app.agents.spawn(
+                AgentKind::Shell,
+                repo.path().to_path_buf(),
+                12.0,
+                window,
+                cx,
+            );
+            let second = app.agents.spawn(
+                AgentKind::Shell,
+                repo.path().to_path_buf(),
+                12.0,
+                window,
+                cx,
+            );
+            (first, second)
+        });
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.agents.active_id()),
+            Some(second_id),
+            "sanity check: spawning a second agent must make it the active one"
+        );
+
+        cx.dispatch_action(TerminalClear);
+
+        let mut saw_caret_l_on_second = false;
+        for _ in 0..50 {
+            cx.background_executor
+                .advance_clock(std::time::Duration::from_millis(8));
+            cx.run_until_parked();
+            let second_lines = app.read_with(cx, |app, cx| {
+                app.agents
+                    .iter()
+                    .find(|agent| agent.id == second_id)
+                    .expect("second agent")
+                    .pane
+                    .read(cx)
+                    .visible_text_lines()
+            });
+            if second_lines.iter().any(|line| line.contains("^L")) {
+                saw_caret_l_on_second = true;
+                break;
+            }
+        }
+        assert!(
+            saw_caret_l_on_second,
+            "expected the active (second) agent's pty to echo back the real Ctrl-L byte \
+             TerminalClear's handler sends"
+        );
+
+        let first_lines = app.read_with(cx, |app, cx| {
+            app.agents
+                .iter()
+                .find(|agent| agent.id == first_id)
+                .expect("first agent")
+                .pane
+                .read(cx)
+                .visible_text_lines()
+        });
+        assert!(
+            !first_lines.iter().any(|line| line.contains("^L")),
+            "the inactive (first) agent must never receive the clear signal - only the active \
+             agent, matching handle_close_focused_tab_action's own 'act on whichever tab is \
+             genuinely showing right now' target"
         );
     }
 }

--- a/crates/app/src/work_surface/state.rs
+++ b/crates/app/src/work_surface/state.rs
@@ -376,9 +376,6 @@ pub enum ActionKind {
     /// stand-in for `Retry`/`Resume` (this app has no saved-agent resumability to actually
     /// resume *from* - see [`pty_state_label`] on the same gap).
     Respawn,
-    /// Closes this tab (`Agents::close`) - the same action as the context bar's own `Archive`
-    /// button.
-    Archive,
     /// `crate::worktree_history::flow::AdeApp::keep_all_changes` (Revision R10): a real,
     /// undoable `wt_core::undo::commit_all_changes` on this agent's worktree.
     KeepAllChanges,
@@ -413,7 +410,10 @@ pub struct FooterAction {
 /// R10) · `Review diff` (still unimplemented) · `Open in editor` (still unimplemented) ·
 /// `Discard worktree` (real - Revision R10); ask gets `Open terminal` · `Interrupt ⌃C`; fail gets
 /// `Retry ⌘R` · `Open terminal` · `Discard worktree` (real - Revision R10); run gets
-/// `Interrupt ⌃C` · `Open terminal`; idle gets `Resume ⌘⏎` (blue) · `Archive`.
+/// `Interrupt ⌃C` · `Open terminal`; idle gets `Resume ⌘⏎` (blue) alone - `Archive` is
+/// deliberately not repeated here (GitHub issue #20): the context bar's own
+/// `Self::render_archive_button` already renders it unconditionally for every non-bare agent, so
+/// an idle agent used to show it twice.
 pub fn footer_actions(status: Status) -> Vec<FooterAction> {
     match status {
         Status::Review => vec![
@@ -513,22 +513,13 @@ pub fn footer_actions(status: Status) -> Vec<FooterAction> {
                 implemented: true,
             },
         ],
-        Status::Idle => vec![
-            FooterAction {
-                kind: ActionKind::Respawn,
-                label: "Resume",
-                keycap: Some("mod+enter"),
-                style: ActionStyle::PrimaryBlue,
-                implemented: true,
-            },
-            FooterAction {
-                kind: ActionKind::Archive,
-                label: "Archive",
-                keycap: None,
-                style: ActionStyle::Ghost,
-                implemented: true,
-            },
-        ],
+        Status::Idle => vec![FooterAction {
+            kind: ActionKind::Respawn,
+            label: "Resume",
+            keycap: Some("mod+enter"),
+            style: ActionStyle::PrimaryBlue,
+            implemented: true,
+        }],
     }
 }
 
@@ -683,13 +674,14 @@ mod tests {
         assert!(actions.last().unwrap().implemented);
     }
 
+    /// GitHub issue #20: idle no longer repeats `Archive` in the footer - the context bar already
+    /// renders it unconditionally for every non-bare agent (`Self::render_archive_button`).
     #[test]
-    fn idle_actions_are_resume_then_archive_both_real() {
+    fn idle_actions_are_just_a_real_resume_not_a_second_archive() {
         let actions = footer_actions(Status::Idle);
-        assert_eq!(actions.len(), 2);
+        assert_eq!(actions.len(), 1);
         assert_eq!(actions[0].kind, ActionKind::Respawn);
-        assert_eq!(actions[1].kind, ActionKind::Archive);
-        assert!(actions.iter().all(|a| a.implemented));
+        assert!(actions[0].implemented);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Three small, independent chrome fixes bundled into one issue, per its own framing:

### 1. Tab bar height matches the sidebar headers
`theme::band::TAB_STRIP` (34px), `RAIL_HEADER` (36px), and `PANEL_HEADER` (36px) collapse into one shared `theme::band::CHROME_HEADER` (36px) constant, used by the work-surface tab strip, the session-rail header, and the files/changes panel header. Previously two of the three only coincidentally shared a value; now all three read off the same constant so they can never drift independently. Content in all three was already flex `items_center`, so labels/close buttons re-center automatically.

### 2. Terminal: Clear moves into the footer
- Moved from the pane header's hint row into the info footer, next to pid/grid-dims/env chip.
- Added a real, rebindable `TerminalClear` action/keybinding (`cmd-k` on macOS, `ctrl-shift-l` on Linux/Windows, scoped to the terminal key context) - it was previously click-only. The keystrokes are chosen the same way this app's other terminal-adjacent bindings reason about the "app shortcut steals terminal input" conflict class: `cmd-k` never reaches the pty (platform-modified keystrokes are never forwarded), and `ctrl-shift-l` is a distinct GPUI keybinding match that never collides with plain `Ctrl-L`'s own control byte reaching a focused shell - the same precedent Zed's own keymap uses for `terminal::Clear`.
- Now shows up on the Settings > Keybindings page and is discoverable/rebindable there.
- Behavior is unchanged: still clears the emulated grid + scrollback *and* signals the live child with a real `Ctrl-L` byte when a session is running - that pty-signal half was already real, tested behavior (`clear_pty_signal_tests`), so this PR preserves it rather than reinterpreting the issue's paraphrase of it.

### 3. Duplicate Archive button
The footer's `Idle` status action list no longer includes `Archive` - the context bar's own Archive button already renders unconditionally for every non-bare agent, so an idle agent showed it twice. Confirmed Archive is not a no-op (it real-closes the tab via the same path as the tab strip's own `×`), so the fix is deduplication, not a rewrite. `ActionKind::Archive` and its dispatch arm are removed now that nothing constructs it - true hide-but-keep-worktree "archive" semantics (with an Unarchive path) don't exist anywhere in this codebase and would be new feature work well beyond this issue's "small, independent chrome fixes" scope; noting that here rather than silently expanding scope.

## Test plan
- [x] New `terminal_clear_action_tests` module: dispatching `TerminalClear` signals only the currently-active agent's pty (real Ctrl-L echo, not a direct method call), verified against a second, inactive agent that must never receive it.
- [x] Updated `work_surface::state` footer-action tests for the Idle/Archive removal.
- [x] Updated `settings::state` keybinding-registration-order and scoped-binding-count drift guards for the new `TerminalClear` binding.
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib -- --test-threads=1` (all green; the two known pre-existing flaky tests reconfirmed passing in isolation - `diff_render_tests::opening_a_real_diff_renders_real_syntax_highlighted_rows` and `tree_ops_regression_tests::undoing_then_redoing_a_delete_restores_then_removes_the_file_again`)

Fixes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)