### PR TITLE
File tree context menu: reference Delete's shortcut, drop Shift+F10

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -461,16 +461,12 @@ pub fn default_key_bindings() -> Vec<gpui::KeyBinding> {
         // the tree's own inline name editors has the keystroke. It follows the
         // `"file-editor && !completions"` shape above.
         //
-        // `shift-f10` is the only context-menu keystroke bound. The dedicated Menu/Application
-        // key that some keyboards also carry is deliberately *not* bound: gpui's key names come
-        // from each platform backend at runtime and nothing in the vendored tree names that key
-        // (it isn't in `vendor/zed/crates/gpui/src/platform/keystroke.rs`'s own key vocabulary),
-        // so any spelling guessed here would be a binding that silently never matches.
-        gpui::KeyBinding::new(
-            "shift-f10",
-            root::FileTreeContextMenu,
-            Some("file-tree && !tree-editing"),
-        ),
+        // GitHub issue #155: there is deliberately no bound keystroke that opens the context
+        // menu itself - a menu-opening gesture is what right-click already is, everywhere else in
+        // this app, and a second keyboard path to it (this list previously bound `Shift+F10`) had
+        // no real justification beyond "some other apps do this" - right-click, plus each row's
+        // own already-bound shortcut below (F2/Copy/Cut/Paste/Delete), covers every real action
+        // the menu itself would just be a picker for.
         gpui::KeyBinding::new(
             "f2",
             root::FileTreeRename,
@@ -492,11 +488,11 @@ pub fn default_key_bindings() -> Vec<gpui::KeyBinding> {
             Some("file-tree && !tree-editing"),
         ),
         // GitHub issue #105: "remove file" had no keyboard shortcut at all - only reachable via
-        // a right-click's own "Delete" menu row (`crate::sidebar::context_menu::MenuAction::
-        // Delete`'s own `keystroke_spec()` deliberately returns `None`, unlike every other
-        // mutating row) or `Shift+F10` opening the menu. Delete runs immediately, with no
-        // confirmation step of its own (undo/redo replaced it - see `crate::sidebar::tree_ops`'s
-        // own module docs), so this needs no different scoping from the bindings just above it.
+        // a right-click's own "Delete" menu row. This binding closed that gap; the menu row's own
+        // `keystroke_spec()` now references it too (GitHub issue #155). Delete runs immediately,
+        // with no confirmation step of its own (undo/redo replaced it - see
+        // `crate::sidebar::tree_ops`'s own module docs), so this needs no different scoping from
+        // the bindings just above it.
         gpui::KeyBinding::new(
             "delete",
             root::FileTreeDelete,

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -186,7 +186,6 @@ actions!(
         TextUndo,
         TextRedo,
         CloseFocusedTab,
-        FileTreeContextMenu,
         FileTreeRename,
         FileTreeCopy,
         FileTreeCut,

--- a/crates/app/src/settings/state.rs
+++ b/crates/app/src/settings/state.rs
@@ -572,14 +572,6 @@ pub(crate) fn action_label(action: &dyn gpui::Action) -> Option<&'static str> {
         "app::TextUndo" => Some("Text: undo"),
         "app::TextRedo" => Some("Text: redo"),
         "app::CloseFocusedTab" => Some("Close focused tab"),
-        // Deliberately says what it is *for*, not just what it opens. This page has no
-        // description column - a row's label is the whole explanation a user ever gets - and
-        // "Files tree: context menu" left a real reader with no idea why the app binds Shift+F10
-        // at all. It is the keyboard equivalent of right-clicking the selected row, which is what
-        // GitHub issue #19 §2 required and what this wording now states outright. The Files
-        // tree's own footer hint strip
-        // (`crate::sidebar::render::render_file_tree_footer`) is the other half of that answer.
-        "app::FileTreeContextMenu" => Some("Files tree: open the selected row's actions menu"),
         "app::FileTreeRename" => Some("Files tree: rename"),
         "app::FileTreeCopy" => Some("Files tree: copy"),
         "app::FileTreeCut" => Some("Files tree: cut"),
@@ -1278,7 +1270,6 @@ mod tests {
                 // `"file-tree && !tree-editing"` - see `crate::default_key_bindings`' own docs
                 // and `crate::sidebar::tree_ops`' module docs for why both halves of that
                 // predicate are load-bearing.
-                "Files tree: open the selected row's actions menu",
                 "Files tree: rename",
                 "Files tree: copy",
                 "Files tree: cut",
@@ -1359,6 +1350,9 @@ mod tests {
         // actions from `TextUndo`/`TextRedo`, all three `Some("file-tree && !tree-editing")`.
         // GitHub issue #20 added 1 more real scoped binding: `TerminalClear`
         // (`cmd-k`/`ctrl-shift-l`), `Some("terminal")`.
+        // GitHub issue #155 removed 1: `FileTreeContextMenu` (`Shift+F10`) - right-click plus
+        // each row's own already-bound shortcut covers the same ground, so a second
+        // keyboard-only path to the menu had no real justification of its own.
         let bindings = crate::default_key_bindings();
         let rows = keybinding_rows(&bindings, &[]);
         assert!(!rows.is_empty());
@@ -1366,11 +1360,12 @@ mod tests {
             rows.iter().filter(|row| row.context != "global").collect();
         assert_eq!(
             scoped.len(),
-            74,
+            73,
             "expected `] -> NextChangedFile` (1) plus every real Editor* binding (19) plus \
              every real Completions* binding (5) plus every real merge-editor binding (18) plus \
              TextUndo/TextRedo (3, GitHub issue #17) plus every real \
-             file-tree binding (8, GitHub issues #19 and #105) plus every real word-wise Editor* \
+             file-tree binding (7, GitHub issues #19 and #105, less 1 for issue #155's removed \
+             FileTreeContextMenu) plus every real word-wise Editor* \
              binding (8, GitHub issue #27) plus every real multi-cursor Editor* binding (4, \
              GitHub issue #28) plus every real GitHub issue #26 binding (7, not counting \
              EditorCollapseCursors above, which is issue #28's own action) plus TerminalClear \
@@ -1381,7 +1376,7 @@ mod tests {
                 .iter()
                 .filter(|row| row.command.starts_with("Files tree: "))
                 .count()
-                == 8,
+                == 7,
             "every file-tree binding must be reported as scoped - a globally-bound Ctrl+C would \
              be exactly the keystroke-swallowing bug class this list's own docs catalogue"
         );

--- a/crates/app/src/sidebar/context_menu.rs
+++ b/crates/app/src/sidebar/context_menu.rs
@@ -114,6 +114,12 @@ impl MenuAction {
             MenuAction::Cut => Some("mod+X"),
             MenuAction::Copy => Some("mod+C"),
             MenuAction::Paste => Some("mod+V"),
+            // GitHub issue #155: every mutating row with a real registered binding should
+            // reference it - `Delete` runs immediately (no confirmation, see
+            // `crate::sidebar::tree_ops`'s own module docs) via the same real `"delete"`
+            // keybinding this row's own click already does, so leaving its hint blank while
+            // Rename/Cut/Copy/Paste all show theirs was the one real inconsistency here.
+            MenuAction::Delete => Some("Delete"),
             _ => None,
         }
     }

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -774,7 +774,6 @@ impl AdeApp {
             .id("file-tree-shell")
             .key_context(key_context)
             .track_focus(&self.tree_focus_handle)
-            .on_action(cx.listener(Self::handle_file_tree_context_menu_action))
             .on_action(cx.listener(Self::handle_file_tree_rename_action))
             .on_action(cx.listener(Self::handle_file_tree_copy_action))
             .on_action(cx.listener(Self::handle_file_tree_cut_action))
@@ -2654,13 +2653,6 @@ pub(in crate::sidebar) fn render_changes_footer(text_size: Pixels) -> impl IntoE
 /// the cursor. (The Changes view's *no-diff* arm still has no footer; that arm renders a single
 /// message rather than a list, so there is nothing for a footer to sit under.)
 ///
-/// This exists to answer a real, reported complaint: `Shift+F10` opens the tree's context menu
-/// (issue #19 §2 required the menu to be reachable from the keyboard, so right-click alone was
-/// never enough) but nothing in the product said so. A user's only encounter with it was a row in
-/// Settings → Keybindings reading "Files tree: context menu", which explains what it does and not
-/// why it exists or that it is the right-click equivalent. Two surfaces now do: that row's own
-/// label (`crate::settings::state::action_label`), and this strip.
-///
 /// The shape is the hint strip the design handoff already specifies for
 /// exactly this job - `design_handoff_jerry_ade/revision/Jerry.dc.html`'s own `diffHints` strip:
 /// `height:28px ... padding:0 12px;background:#111316;border-top:1px solid #1c2023`, hints at
@@ -2669,17 +2661,16 @@ pub(in crate::sidebar) fn render_changes_footer(text_size: Pixels) -> impl IntoE
 /// `theme::band::SURFACE_FOOTER`/`surface::FOOTER`/`border::INNER`/`text::PATH` and the
 /// `KeycapSize::Hint` keycap it already had.
 ///
-/// The keystrokes are resolved through [`keymap::resolve_combo`], the same per-platform
-/// resolution the context menu's own row keycaps use - never a hard-coded keystroke string that
-/// could drift from the real binding, which is also why the tooltip below names no key at all and
-/// points at the keycaps instead. Both hints are for real, registered bindings in
-/// `crate::default_key_bindings`, asserted by
-/// `crate::sidebar::tree_ops`'s own
+/// The keystroke is resolved through [`keymap::resolve_combo`], the same per-platform resolution
+/// the context menu's own row keycaps use - never a hard-coded keystroke string that could drift
+/// from the real binding, which is also why the tooltip below names no key at all and points at
+/// the keycap instead. It names a real, registered binding in `crate::default_key_bindings`,
+/// asserted by `crate::sidebar::tree_ops`'s own
 /// `the_file_tree_footer_only_advertises_real_registered_bindings`.
 ///
-/// `live` is the other half of that honesty: both bindings are scoped
+/// `live` is the other half of that honesty: the binding is scoped
 /// `"file-tree && !tree-editing && !tree-delete-confirm"`, so while an inline name editor or the
-/// delete confirmation is open they genuinely do not fire, and the strip drops its hints rather
+/// delete confirmation is open it genuinely does not fire, and the strip drops its hint rather
 /// than advertising a dead shortcut. The band itself stays, so the tree doesn't jump 28px.
 ///
 /// `text_size` - see [`render_changes_footer`]'s docs for why this takes an already-scaled value.
@@ -2722,18 +2713,11 @@ pub(in crate::sidebar) fn render_file_tree_footer(
             "Right-click a row for file actions. The keycaps here are the keyboard equivalents, \
              for the row currently selected in the tree.",
         ))
-        .when(live, |el| {
-            el.child(hint(FILE_TREE_CONTEXT_MENU_SPEC, "actions"))
-                .child(hint(FILE_TREE_RENAME_SPEC, "rename"))
-        })
+        .when(live, |el| el.child(hint(FILE_TREE_RENAME_SPEC, "rename")))
 }
 
-/// The two `crate::keymap::resolve_combo` specs [`render_file_tree_footer`] advertises, named so
-/// its own test can assert each one really is a registered binding rather than a plausible
-/// string. `shift+F10` has no `mod` in it and so resolves identically on every platform; it still
-/// goes through `resolve_combo` rather than being written out, so the glyphs match every other
-/// keycap in the app.
-pub(in crate::sidebar) const FILE_TREE_CONTEXT_MENU_SPEC: &str = "shift+F10";
+/// The `crate::keymap::resolve_combo` spec [`render_file_tree_footer`] advertises, named so its
+/// own test can assert it really is a registered binding rather than a plausible string.
 pub(in crate::sidebar) const FILE_TREE_RENAME_SPEC: &str = "F2";
 
 /// GitHub issue #148: what a real file-tree row drag carries - every path the gesture moves

--- a/crates/app/src/sidebar/tree_ops.rs
+++ b/crates/app/src/sidebar/tree_ops.rs
@@ -368,8 +368,8 @@ impl AdeApp {
     /// Opens the context menu for `target` at a real click position, clamped so the whole
     /// popover stays inside the window (`context_menu::clamp_menu_origin`).
     ///
-    /// Also focuses the tree and selects the targeted row: a right-click is a real selection
-    /// gesture, and `Shift+F10` afterwards has to have something to target.
+    /// Also focuses the tree and selects the targeted row - a right-click is a real selection
+    /// gesture in its own right, independent of the menu it also opens.
     pub(in crate::sidebar) fn open_tree_context_menu(
         &mut self,
         target: ContextTarget,
@@ -420,40 +420,6 @@ impl AdeApp {
         self.tree_op_error = None;
         self.focus_file_tree(window, cx);
         cx.notify();
-    }
-
-    /// `Shift+F10`'s handler: opens the menu for the currently selected row, or for the empty
-    /// area when nothing in this tree is selected.
-    ///
-    /// The origin is the top-left of the sidebar's own painted bounds plus a small offset rather
-    /// than a mouse position - there is no cursor involved in a keyboard-opened menu, and
-    /// pinning it to the last mouse position would put it somewhere the keyboard user never
-    /// looked. Still routed through the same clamp, so it can't escape the window either.
-    pub(in crate::sidebar) fn open_tree_context_menu_from_keyboard(
-        &mut self,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
-        let target = match self.selected_tree_path.clone() {
-            Some(path) if path.starts_with(&self.file_tree_root) => {
-                let is_dir = self
-                    .file_tree
-                    .iter()
-                    .find(|entry| entry.path == path)
-                    .map(|entry| entry.is_dir)
-                    .unwrap_or_else(|| path.is_dir());
-                if is_dir {
-                    ContextTarget::Folder(path)
-                } else {
-                    ContextTarget::File(path)
-                }
-            }
-            _ => ContextTarget::Empty,
-        };
-        let bounds = self.file_tree_bounds;
-        let x = f32::from(bounds.origin.x) + 12.0;
-        let y = f32::from(bounds.origin.y) + 12.0;
-        self.open_tree_context_menu(target, x, y, window, cx);
     }
 
     pub(in crate::sidebar) fn close_tree_context_menu(&mut self, cx: &mut Context<Self>) {
@@ -1584,16 +1550,6 @@ impl AdeApp {
 
     // ---------------------------------------------------------------- bound actions
 
-    /// `Shift+F10` (`crate::root::FileTreeContextMenu`).
-    pub(in crate::sidebar) fn handle_file_tree_context_menu_action(
-        &mut self,
-        _action: &crate::root::FileTreeContextMenu,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
-        self.open_tree_context_menu_from_keyboard(window, cx);
-    }
-
     /// `F2` (`crate::root::FileTreeRename`).
     pub(in crate::sidebar) fn handle_file_tree_rename_action(
         &mut self,
@@ -2500,76 +2456,6 @@ mod tree_ops_regression_tests {
         );
     }
 
-    /// The positive half of the keyboard-access requirement (§1) - without this, the negative
-    /// tests below could pass simply because the binding never works at all.
-    #[gpui::test]
-    fn shift_f10_with_the_tree_focused_opens_the_menu_for_the_selected_row(
-        cx: &mut TestAppContext,
-    ) {
-        let repo = TempDir::new().expect("tempdir");
-        seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
-        cx.run_until_parked();
-
-        app.update_in(cx, |app, window, cx| {
-            app.selected_tree_path = Some(repo.path().join("README.md"));
-            app.focus_file_tree(window, cx);
-        });
-        cx.run_until_parked();
-
-        cx.simulate_keystrokes("shift-f10");
-        app.read_with(cx, |app, _| {
-            let menu = app
-                .tree_context_menu
-                .as_ref()
-                .expect("shift-f10 with the tree focused must open the menu");
-            assert_eq!(
-                menu.target,
-                ContextTarget::File(repo.path().join("README.md"))
-            );
-        });
-    }
-
-    /// §1 + the keystroke-scoping discipline: `Shift+F10` must not reach the tree while one of
-    /// its own inline name editors has the keyboard - it would open a menu on top of the field
-    /// the user is typing into.
-    #[gpui::test]
-    fn shift_f10_while_an_inline_editor_is_open_neither_opens_a_menu_nor_disturbs_the_name(
-        cx: &mut TestAppContext,
-    ) {
-        let repo = TempDir::new().expect("tempdir");
-        seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
-        cx.run_until_parked();
-
-        app.update_in(cx, |app, window, cx| {
-            app.selected_tree_path = Some(repo.path().join("README.md"));
-            app.start_tree_rename(repo.path().join("README.md"), false, window, cx);
-            app.tree_inline_edit.as_mut().expect("editor").name =
-                text_history::TextField::seeded("in-progress");
-        });
-        cx.run_until_parked();
-
-        cx.simulate_keystrokes("shift-f10");
-        app.read_with(cx, |app, _| {
-            assert!(
-                app.tree_context_menu.is_none(),
-                "the `!tree-editing` half of the binding's context predicate is what stops this"
-            );
-            assert_eq!(
-                app.tree_inline_edit
-                    .as_ref()
-                    .expect("still open")
-                    .name
-                    .as_str(),
-                "in-progress",
-                "and the editor must be untouched"
-            );
-        });
-    }
-
     /// **The merge regression this whole group exists for.** GitHub issue #19 (this file tree)
     /// and issue #17 (per-widget text undo) were built on two branches in parallel and only met
     /// at a merge. Nothing about that merge conflicted textually here, and the merged tree
@@ -2843,7 +2729,6 @@ mod tree_ops_regression_tests {
     fn every_file_tree_binding_is_scoped_away_from_the_inline_editor() {
         let expected = "file-tree && !tree-editing";
         let tree_actions = [
-            "app::FileTreeContextMenu",
             "app::FileTreeRename",
             "app::FileTreeCopy",
             "app::FileTreeCut",
@@ -3545,48 +3430,6 @@ mod tree_ops_regression_tests {
         });
     }
 
-    /// `Shift+F10` must reach the tree only when the tree is really the focused surface. With the
-    /// command palette open - a real, focused text-input surface - it must do nothing at all, and
-    /// the palette must keep taking the keystrokes that follow.
-    ///
-    /// Honest framing: this covers *pre-existing* scoping (`"file-tree && ..."`), not anything
-    /// this branch changed - it passes against the untouched base too. It is here because the
-    /// same branch makes `Shift+F10` more discoverable (the Files-tree footer hint strip and the
-    /// Keybindings-page relabel), and "more people will now press it" is exactly the moment to
-    /// pin down that pressing it in the wrong place costs nothing.
-    #[gpui::test]
-    fn shift_f10_with_the_palette_focused_neither_opens_the_menu_nor_eats_the_next_keystroke(
-        cx: &mut TestAppContext,
-    ) {
-        let repo = TempDir::new().expect("tempdir");
-        seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
-        cx.run_until_parked();
-
-        app.update_in(cx, |app, window, cx| app.open_palette(window, cx));
-        cx.run_until_parked();
-
-        cx.simulate_keystrokes("shift-f10");
-        cx.run_until_parked();
-        app.read_with(cx, |app, _| {
-            assert!(
-                app.tree_context_menu.is_none(),
-                "the binding is scoped to the `file-tree` context precisely so a focused text \
-                 input keeps its own keystrokes"
-            );
-            assert!(app.palette_open, "and the palette must still be open");
-        });
-
-        cx.simulate_input("ab");
-        cx.run_until_parked();
-        assert_eq!(
-            app.read_with(cx, |app, _| app.palette_query.as_str().to_string()),
-            "ab",
-            "and the keystrokes after it must still land in the palette's own query"
-        );
-    }
-
     /// `menu_height` is what the window-edge flip is computed from, so it has to equal what the
     /// popover *actually paints* - not just what its own formula restates. Asserted against real
     /// painted bounds for all three targets, which is the only form of this assertion that can
@@ -3630,57 +3473,53 @@ mod tree_ops_regression_tests {
     /// that named a keystroke nothing dispatches would be worse than no hint.
     #[test]
     fn the_file_tree_footer_only_advertises_real_registered_bindings() {
-        use crate::sidebar::render::{FILE_TREE_CONTEXT_MENU_SPEC, FILE_TREE_RENAME_SPEC};
+        use crate::sidebar::render::FILE_TREE_RENAME_SPEC;
 
         let bindings = crate::default_key_bindings();
-        for (spec, action) in [
-            (FILE_TREE_CONTEXT_MENU_SPEC, "app::FileTreeContextMenu"),
-            (FILE_TREE_RENAME_SPEC, "app::FileTreeRename"),
-        ] {
-            let binding = bindings
-                .iter()
-                .find(|binding| binding.action().name() == action)
-                .unwrap_or_else(|| panic!("{action} must have a real registered binding"));
-            let printed = crate::keymap::resolve_combo(spec, false);
-            let real: Vec<String> = binding
-                .keystrokes()
-                .iter()
-                .flat_map(|keystroke| {
-                    // Every modifier, not just `shift` - a binding that silently gained a Ctrl or
-                    // Alt would otherwise still match, and the footer would keep printing a
-                    // keycap nobody can trigger.
-                    let modifiers = keystroke.modifiers();
-                    let mut parts: Vec<String> = Vec::new();
-                    if modifiers.control {
-                        parts.push("ctrl".to_string());
-                    }
-                    if modifiers.alt {
-                        parts.push("alt".to_string());
-                    }
-                    if modifiers.platform {
-                        parts.push("cmd".to_string());
-                    }
-                    if modifiers.shift {
-                        parts.push("shift".to_string());
-                    }
-                    parts.push(keystroke.key().to_string());
-                    parts
-                })
-                .map(|part| crate::keymap::resolve_combo(&part, false).join(""))
-                .collect();
-            // Case-insensitively: `gpui::Keystroke` normalises `key` to lowercase (`"f10"`),
-            // while the spec - and so the keycap the user reads - carries the conventional
-            // uppercase `"F10"`. The glyph, not its case, is what has to match.
-            let lower = |parts: &[String]| -> Vec<String> {
-                parts.iter().map(|part| part.to_lowercase()).collect()
-            };
-            assert_eq!(
-                lower(&printed),
-                lower(&real),
-                "the footer prints {spec:?} for {action}, which is not what that action is \
-                 actually bound to"
-            );
-        }
+        let (spec, action) = (FILE_TREE_RENAME_SPEC, "app::FileTreeRename");
+        let binding = bindings
+            .iter()
+            .find(|binding| binding.action().name() == action)
+            .unwrap_or_else(|| panic!("{action} must have a real registered binding"));
+        let printed = crate::keymap::resolve_combo(spec, false);
+        let real: Vec<String> = binding
+            .keystrokes()
+            .iter()
+            .flat_map(|keystroke| {
+                // Every modifier, not just `shift` - a binding that silently gained a Ctrl or
+                // Alt would otherwise still match, and the footer would keep printing a
+                // keycap nobody can trigger.
+                let modifiers = keystroke.modifiers();
+                let mut parts: Vec<String> = Vec::new();
+                if modifiers.control {
+                    parts.push("ctrl".to_string());
+                }
+                if modifiers.alt {
+                    parts.push("alt".to_string());
+                }
+                if modifiers.platform {
+                    parts.push("cmd".to_string());
+                }
+                if modifiers.shift {
+                    parts.push("shift".to_string());
+                }
+                parts.push(keystroke.key().to_string());
+                parts
+            })
+            .map(|part| crate::keymap::resolve_combo(&part, false).join(""))
+            .collect();
+        // Case-insensitively: `gpui::Keystroke` normalises `key` to lowercase (`"f10"`),
+        // while the spec - and so the keycap the user reads - carries the conventional
+        // uppercase `"F10"`. The glyph, not its case, is what has to match.
+        let lower = |parts: &[String]| -> Vec<String> {
+            parts.iter().map(|part| part.to_lowercase()).collect()
+        };
+        assert_eq!(
+            lower(&printed),
+            lower(&real),
+            "the footer prints {spec:?} for {action}, which is not what that action is actually \
+             bound to"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

GitHub issue #155's two asks:

1. **Reference each keyboard shortcut when available.** Verified against every other real popover menu in the app first: the file tree's context menu already shares the unified chrome (`menu_popover_chrome`, from issue #129) and already shows per-row keycap hints for Rename/Cut/Copy/Paste via the same `render_keycap_row` + `keymap::resolve_combo` mechanism every other menu uses. The one real gap: `Delete` has had a real registered keybinding since issue #105, but `MenuAction::keystroke_spec()` still returned `None` for it - now it references the real `Delete` binding like every other mutating row.
2. **Drop Shift+F10.** Removed the keybinding, and - since it was the *only* real caller - the now-fully-dead `FileTreeContextMenu` action, its handler, and the keyboard-open helper it alone reached. Right-click, plus each row's own already-bound shortcut, covers every real action the menu offers.

## What did *not* need changing
- The menu's chrome - already unified via `menu_popover_chrome`.
- The row layout/hover/disabled styling - already matches the shared dropdown-row conventions (the row builder's own docs explain why it doesn't reuse `render_dropdown_menu_row` verbatim: that shape has a chip+sub-label slot the tree menu has no honest content for).

## Test plan
- [x] Removed the three Shift+F10-specific tests (positive path, inline-editor scoping, palette-focus scoping) along with the dead code they covered.
- [x] Updated the file-tree binding-scoping drift guard and the footer's real-binding-advertisement test for the removed binding.
- [x] Updated the Settings > Keybindings page drift-guard tests (registration-order list, scoped-binding counts) for the one fewer binding.
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib -- --test-threads=1` (all green; one pre-existing flaky test reconfirmed passing in isolation)

Fixes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)