### PR TITLE
fix(code-surface): show File before Diff in the toggle order

### DIFF
--- a/crates/app/src/code_surface/render.rs
+++ b/crates/app/src/code_surface/render.rs
@@ -1,6 +1,6 @@
 //! Surface C's shell: which of the two views (Diff or File) an active tab actually shows,
 //! the key context that decides which keybindings are live over it, and the segmented
-//! Diff/File toggle that switches between them.
+//! File/Diff toggle that switches between them.
 
 use super::diff_view::render_accept_file_button;
 use super::*;
@@ -38,7 +38,7 @@ impl AdeApp {
 
     /// The centre's single-file Surface C, opened by a Changes-row click (`diff_file` always
     /// `Some`) or a Files-tree row click (`diff_file` may be `None`): a toolbar (dir/name, tag
-    /// pill, +n/-n stats, the `Diff | File` toggle, the zoom group, `Accept file`, close) over
+    /// pill, +n/-n stats, the `File | Diff` toggle, the zoom group, `Accept file`, close) over
     /// either [`Self::render_diff_file_detail`]'s folded hunk content or [`Self::render_file_view`]'s
     /// syntax-highlighted content, both zoom-scoped through [`zoom_scoped`].
     ///
@@ -294,7 +294,7 @@ impl AdeApp {
             .into_any_element()
     }
 
-    /// The toolbar's segmented `Diff | File` toggle. `Diff` is only clickable when `has_diff` is
+    /// The toolbar's segmented `File | Diff` toggle. `Diff` is only clickable when `has_diff` is
     /// true ([`ChoiceOption::enabled_if`] disables it otherwise); `File` is always clickable.
     /// Shares [`Self::render_choice_control`] with the other segmented toggles in this file.
     pub(in crate::code_surface) fn render_diff_file_toggle(
@@ -310,16 +310,18 @@ impl AdeApp {
         self.render_choice_control(
             "diff-file-toggle",
             &[
-                ChoiceOption::enabled_if("Diff", has_diff),
+                // GitHub issue #153: `File` first, `Diff` second - the order the segments
+                // themselves paint in, matching the issue's own reference screenshot.
                 ChoiceOption::new("File"),
+                ChoiceOption::enabled_if("Diff", has_diff),
             ],
             selected.to_string(),
             cx,
             |this, index, _window, cx| {
-                // Index 0 is `Diff`, index 1 is `File`, per the options array above.
+                // Index 0 is `File`, index 1 is `Diff`, per the options array above.
                 this.code_view = match index {
-                    0 => code_view::CodeView::Diff,
-                    _ => code_view::CodeView::File,
+                    0 => code_view::CodeView::File,
+                    _ => code_view::CodeView::Diff,
                 };
                 cx.notify();
             },
@@ -379,7 +381,7 @@ impl AdeApp {
     }
 }
 
-/// Proves the segmented `Diff | File` toggle's dispatch (`render_diff_file_toggle`, via the
+/// Proves the segmented `File | Diff` toggle's dispatch (`render_diff_file_toggle`, via the
 /// shared `render_choice_control`) is driven by each segment's structural position, not its
 /// display label - the R5.5 audit found the prior label-string dispatch could silently select
 /// the wrong value if a label was renamed without updating `on_select`, with no compile error or
@@ -433,30 +435,30 @@ mod choice_control_dispatch_tests {
             "sanity: opening a changed file's diff lands in Diff view by default"
         );
 
-        // Segment at structural index 1 ("File") - clicked by its position-based selector,
+        // Segment at structural index 0 ("File") - clicked by its position-based selector,
         // never by searching for its label text.
         let file_bounds = cx
-            .debug_bounds("choice-diff-file-toggle-1")
+            .debug_bounds("choice-diff-file-toggle-0")
             .expect("the File segment must have painted at least once");
         cx.simulate_click(file_bounds.center(), gpui::Modifiers::none());
         cx.run_until_parked();
         assert_eq!(
             app.read_with(cx, |app, _| app.code_view),
             code_view::CodeView::File,
-            "clicking the segment at structural index 1 must select File - position-based \
+            "clicking the segment at structural index 0 must select File - position-based \
              dispatch, not a re-match on whatever that segment's label currently says"
         );
 
-        // Segment at structural index 0 ("Diff") - back the other way, same mechanism.
+        // Segment at structural index 1 ("Diff") - back the other way, same mechanism.
         let diff_bounds = cx
-            .debug_bounds("choice-diff-file-toggle-0")
+            .debug_bounds("choice-diff-file-toggle-1")
             .expect("the Diff segment must have painted at least once");
         cx.simulate_click(diff_bounds.center(), gpui::Modifiers::none());
         cx.run_until_parked();
         assert_eq!(
             app.read_with(cx, |app, _| app.code_view),
             code_view::CodeView::Diff,
-            "clicking the segment at structural index 0 must select Diff"
+            "clicking the segment at structural index 1 must select Diff"
         );
     }
 }

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -584,7 +584,7 @@ pub struct AdeApp {
     /// read on every visible row every frame) is the only real query this needs - row order comes
     /// from the tree itself, not from this field, whenever an operation needs an ordered list.
     pub(crate) additional_tree_selection: HashSet<PathBuf>,
-    /// Surface C's `Diff | File` toggle for whichever file [`Self::open_change`] names - set to
+    /// Surface C's `File | Diff` toggle for whichever file [`Self::open_change`] names - set to
     /// `Diff` by [`Self::open_change_diff`] and `File` by [`Self::open_file_view`], read by
     /// [`Self::render_code_surface`] alongside a "does this file even have a diff" check (a
     /// diff-less file always renders as `File` regardless of this field).


### PR DESCRIPTION
## Summary
- The Surface C toolbar's segmented toggle painted `Diff` first and `File` second; swapped so `File` is first, matching the order in issue #153's reference screenshot. Updated doc comments and the structural-dispatch test's segment indices to match.
- While verifying this with a full test-suite run, found and fixed a real, deterministic bug behind a test that's been intermittently flaky all session: `tree_undo_backup_root()` was keyed only by `std::process::id()`, so two different `#[gpui::test]`s in the same `cargo test` process (same pid) could collide on the same backup path when deleting same-named files, since each fresh `AdeApp`'s backup counter restarts at 0. Confirmed via GPUI's seed-sweep tooling (`ITERATIONS=200` reproduced it deterministically), fixed by giving each `AdeApp` instance its own id from a process-wide atomic counter, verified clean across 500 swept seeds, and added a regression test that fails without the fix.

Fixes #153

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib -- --test-threads=1` (1443 passed, 0 failed, no flakes)
- [x] `ITERATIONS=500` seed sweep of the previously-flaky delete/undo/redo test - all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)