### PR TITLE
fix(sidebar): give every AdeApp instance its own tree-undo backup root

### DIFF
--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -469,6 +469,15 @@ pub struct AdeApp {
     /// guaranteeing two deletes of same-named files never collide there, without pulling in a
     /// UUID dependency for something this local.
     pub(crate) tree_undo_backup_counter: u64,
+    /// This `AdeApp` instance's own share of [`Self::tree_undo_backup_root`], assigned once at
+    /// construction from a process-wide atomic counter. `std::process::id()` alone identifies the
+    /// *process*, not the instance - every `#[gpui::test]` in a `cargo test` binary runs in the
+    /// same process, so two tests each starting `tree_undo_backup_counter` back at 0 would
+    /// otherwise write their first delete's backup to the exact same path, and the second test's
+    /// backup would silently fail with `AlreadyExists` (or worse, its cleanup would delete the
+    /// first test's still-referenced backup). This is what actually caused GitHub issue #105's
+    /// undo/redo delete test to fail intermittently in full-suite runs while always passing alone.
+    pub(crate) tree_undo_instance_id: u64,
     /// The most recent file-operation failure (a refused rename, a failed trash command),
     /// surfaced under the tree rather than dropped into the log - the same small, honest error
     /// surface [`Self::file_save_error`] uses for a failed save.

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -1,6 +1,11 @@
 use super::*;
 use crate::code_surface::state::{DiffLoadState, FileLoadState};
 use crate::sidebar::render::RightSidebarView;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Backs [`AdeApp::tree_undo_instance_id`] - see that field's own docs for why per-process
+/// uniqueness isn't enough.
+static NEXT_TREE_UNDO_INSTANCE_ID: AtomicU64 = AtomicU64::new(0);
 
 impl AdeApp {
     /// Production entry point - loads `~/.config/jerry/settings.toml` (`Settings::load_or_init`)
@@ -234,6 +239,7 @@ impl AdeApp {
             tree_undo_stack: Vec::new(),
             tree_redo_stack: Vec::new(),
             tree_undo_backup_counter: 0,
+            tree_undo_instance_id: NEXT_TREE_UNDO_INSTANCE_ID.fetch_add(1, Ordering::Relaxed),
             tree_op_error: None,
             tree_focus_handle,
             file_tree_bounds: gpui::Bounds::default(),

--- a/crates/app/src/sidebar/tree_ops.rs
+++ b/crates/app/src/sidebar/tree_ops.rs
@@ -1273,9 +1273,14 @@ impl AdeApp {
     /// OS temp directory, not anywhere under the worktree itself: a delete's own undo must
     /// survive the delete succeeding, so it can never live inside what was just removed, and it
     /// must never show up in the tree's own walk or `git status` as a stray file. Scoped by this
-    /// process's own pid so two running instances never collide.
+    /// process's own pid *and* this `AdeApp`'s own [`Self::tree_undo_instance_id`] - see that
+    /// field's own docs for why the pid alone isn't enough to keep two instances from colliding.
     fn tree_undo_backup_root(&self) -> PathBuf {
-        std::env::temp_dir().join(format!("jerry-tree-undo-{}", std::process::id()))
+        std::env::temp_dir().join(format!(
+            "jerry-tree-undo-{}-{}",
+            std::process::id(),
+            self.tree_undo_instance_id
+        ))
     }
 
     /// A fresh, real path under [`Self::tree_undo_backup_root`] to back a about-to-be-deleted
@@ -2115,6 +2120,64 @@ mod tree_ops_regression_tests {
             assert!(app.tree_redo_stack.is_empty());
             assert_eq!(app.tree_undo_stack.len(), 1);
         });
+    }
+
+    /// Two separate `AdeApp` instances (as any two `#[gpui::test]`s in the same `cargo test`
+    /// binary really are - one process, one pid) each delete a same-named file. Before
+    /// [`AdeApp::tree_undo_instance_id`] existed, [`AdeApp::tree_undo_backup_root`] was keyed by
+    /// `std::process::id()` alone and [`AdeApp::tree_undo_backup_counter`] always restarted at 0,
+    /// so both deletes' first backup landed at the exact same path - the second app's backup copy
+    /// failed with `AlreadyExists`, silently leaving its "deleted" file still on disk. This is
+    /// what actually made `undoing_then_redoing_a_delete_restores_then_removes_the_file_again`
+    /// fail intermittently in full-suite runs while always passing alone.
+    #[gpui::test]
+    fn two_app_instances_deleting_a_same_named_file_never_collide_on_their_backup_paths(
+        cx: &mut TestAppContext,
+    ) {
+        let repo_a = TempDir::new().expect("tempdir a");
+        seed(&repo_a);
+        let repo_b = TempDir::new().expect("tempdir b");
+        seed(&repo_b);
+
+        let (app_a, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        cx.run_until_parked();
+        let (app_b, cx) = palette_focus_tests::open_test_app(cx, repo_b.path().to_path_buf());
+        cx.run_until_parked();
+
+        app_a.read_with(cx, |a, _| {
+            app_b.read_with(cx, |b, _| {
+                assert_ne!(
+                    a.tree_undo_instance_id, b.tree_undo_instance_id,
+                    "two AdeApp instances in the same process must never share an instance id"
+                );
+            })
+        });
+
+        let victim_a = repo_a.path().join("src/util.rs");
+        let victim_b = repo_b.path().join("src/util.rs");
+        app_a.update(cx, |a, cx| {
+            a.request_tree_delete_with_mechanism_for_test(
+                victim_a.clone(),
+                false,
+                DeleteMechanism::Permanent,
+                cx,
+            );
+        });
+        app_b.update(cx, |b, cx| {
+            b.request_tree_delete_with_mechanism_for_test(
+                victim_b.clone(),
+                false,
+                DeleteMechanism::Permanent,
+                cx,
+            );
+        });
+        cx.run_until_parked();
+
+        assert!(!victim_a.exists(), "app a's own delete must really happen");
+        assert!(
+            !victim_b.exists(),
+            "app b's own delete must really happen too, unblocked by a's"
+        );
     }
 
     /// The same real undo/redo, for a rename - the other half of GitHub issue #105's scope


### PR DESCRIPTION
## Summary

While verifying PR #159 (issue #153), I ran the full test suite and found `undoing_then_redoing_a_delete_restores_then_removes_the_file_again` failing again - a test that had been dismissed all session as "known pre-existing flaky". Used GPUI's seed-sweep tooling (`ITERATIONS=200`) to actually reproduce it deterministically rather than re-verifying and moving on, and found a real bug:

`tree_undo_backup_root()` was keyed only by `std::process::id()`, and `tree_undo_backup_counter` always restarts at 0 for a fresh `AdeApp`. That's fine in production (one process, one instance), but every `#[gpui::test]` in a `cargo test` binary runs in the *same* process - so two different tests each deleting a same-named file could write their first backup to the identical path. The second write failed with `AlreadyExists`, silently leaving that test's "deleted" file still on disk.

Fixed by giving each `AdeApp` instance its own id from a process-wide atomic counter and folding it into the backup root. Verified clean across 500 swept scheduler seeds (previously reproducible failure at seed 1 within 200), and added a regression test that fails without the fix (two `AdeApp` instances deleting a same-named file no longer collide).

Note: this commit was originally pushed to `issue-153-file-diff-toggle-order` (PR #159), but that PR had already been merged (containing only the unrelated toggle-order fix) before this commit landed, so it never reached master. This is the same fix, cherry-picked cleanly onto current master and re-verified.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib -- --test-threads=1` (1443 passed, 0 failed)
- [x] `ITERATIONS=500` scheduler-seed sweep of the previously-flaky test - all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)