### PR TITLE
HTML and CSS support, including inside markdown files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,8 +285,10 @@ dependencies = [
  "toml 0.8.23",
  "tree-sitter",
  "tree-sitter-c",
+ "tree-sitter-css",
  "tree-sitter-go",
  "tree-sitter-highlight",
+ "tree-sitter-html",
  "tree-sitter-javascript",
  "tree-sitter-json",
  "tree-sitter-md",
@@ -8014,6 +8016,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-css"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5cbc5e18f29a2c6d6435891f42569525cf95435a3e01c2f1947abcde178686f"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-go"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8033,6 +8045,16 @@ dependencies = [
  "streaming-iterator",
  "thiserror 2.0.19",
  "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-html"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261b708e5d92061ede329babaaa427b819329a9d427a1d710abb0f67bbef63ee"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
 ]
 
 [[package]]

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -153,6 +153,17 @@ tree-sitter-yaml = "0.7.2"
 tree-sitter-go = "0.25.0"
 tree-sitter-c = "0.24.2"
 tree-sitter-md = "0.5.3"
+# GitHub issue #154 ("Add html and css support. Including in the markdown files."), same plain
+# crates.io treatment as every grammar above. Note the two crates export their query constants
+# under *different* names - `tree-sitter-html::HIGHLIGHTS_QUERY`/`INJECTIONS_QUERY` (plural on
+# both) versus `tree-sitter-css::HIGHLIGHTS_QUERY` and no injections file at all - checked
+# against each crate's own `bindings/rust/lib.rs`, not assumed from the neighbouring entries
+# (`tree-sitter-c` and `tree-sitter-javascript`, for instance, both use the *singular*
+# `HIGHLIGHT_QUERY`). `tree-sitter-html` also ships a real `queries/injections.scm` that
+# `crate::code_surface::code_view` genuinely drives - `<style>` content into the CSS grammar and
+# `<script>` content into this crate's TypeScript grammar - which is why these two land together.
+tree-sitter-html = "0.23.2"
+tree-sitter-css = "0.25.0"
 
 # Real per-target `gpui_platform` backend selection (Revision R11, extended in R12 to add
 # real X11 support). `gpui_platform`'s own Cargo.toml

--- a/crates/app/src/code_surface/code_view.rs
+++ b/crates/app/src/code_surface/code_view.rs
@@ -5,10 +5,19 @@
 //! (only [`gpui::Rgba`] is used, for plain colour data), mirroring this crate's split between
 //! pure logic modules and `crate::root`'s `Div` construction.
 //!
-//! `.rs`/`.ts`/`.tsx`/`.js`/`.jsx`/`.py`/`.toml`/`.go`/`.json`/`.yaml`/`.yml`/`.c`/`.h` get real
-//! syntax spans; other extensions (including `.vue` - see `crate::language`'s docs for why this
-//! phase doesn't spawn an LSP client for it, unrelated to highlighting, and `.md`/`.sql` - a real,
-//! stated follow-up, GitHub issue #32's own remaining scope) render as plain monospace text.
+//! `.rs`/`.ts`/`.tsx`/`.js`/`.jsx`/`.py`/`.toml`/`.go`/`.json`/`.yaml`/`.yml`/`.c`/`.h`/`.md`/
+//! `.html`/`.htm`/`.css` get real syntax spans; other extensions (including `.vue` - see
+//! `crate::language`'s docs for why this phase doesn't spawn an LSP client for it, unrelated to
+//! highlighting, and `.sql` - a real, stated follow-up, GitHub issue #32's own remaining scope)
+//! render as plain monospace text.
+//!
+//! Markdown additionally drives **real cross-language injection** (GitHub issue #154): a fenced
+//! code block's content is reparsed with whatever language its info string names, resolved against
+//! this crate's own registry through [`Grammar::for_injection_name`], and raw HTML written into a
+//! markdown document - block-level or inline - reaches `tree-sitter-html`. HTML in turn injects
+//! its own `<style>`/`<script>` bodies into CSS/JavaScript. See [`MARKDOWN_INJECTION_QUERY`] and
+//! [`MARKDOWN_BLOCK_HIGHLIGHTS_SUPPLEMENT`] for the two real, empirically-found repairs that
+//! actually takes.
 //!
 //! ## How highlighting actually works here
 //!
@@ -193,7 +202,7 @@ pub fn language_name_for_extension(extension: Option<&str>) -> &'static str {
 /// consolidation of what used to be a second, independent extension -> highlighter `match`
 /// statement `load_file` maintained on its own, invisible to that registry). `None` for an
 /// extension absent from the registry, or present with no real grammar wired
-/// ([`crate::language::ExtensionEntry::highlighter`] itself `None` - TOML/Markdown/SQL/Vue/Go).
+/// ([`crate::language::ExtensionEntry::highlighter`] itself `None` - only SQL and Vue, today).
 pub fn highlighter_for_extension(
     extension: Option<&str>,
 ) -> Option<crate::language::HighlighterFn> {
@@ -316,13 +325,22 @@ enum Grammar {
     /// through [`Grammar::Markdown`]'s own injection callback - never a file's own top-level
     /// grammar.
     MarkdownInline,
+    /// GitHub issue #154: `tree-sitter-html`, the real top-level grammar for `.html`/`.htm`. Also
+    /// reached as an *injection* target - from Markdown's own `(html_block)`/`(html_tag)` patterns
+    /// (see [`MARKDOWN_INJECTION_QUERY`] / [`MARKDOWN_INLINE_INJECTION_QUERY`]) - which is the
+    /// "including in the markdown files" half of that issue.
+    Html,
+    /// GitHub issue #154: `tree-sitter-css`, the real top-level grammar for `.css`. Also reached as
+    /// an injection target from [`Grammar::Html`]'s own bundled `injections.scm`, which routes a
+    /// `<style>` element's `(raw_text)` here.
+    Css,
 }
 
 impl Grammar {
     /// Every real grammar, in [`Grammar::index`] order - the single list both
     /// [`HIGHLIGHT_CONFIGS`]' slot count and this module's own coverage tests are derived from, so
     /// adding a grammar cannot leave either behind.
-    const ALL: [Grammar; 11] = [
+    const ALL: [Grammar; 13] = [
         Grammar::Rust,
         Grammar::TypeScript,
         Grammar::Tsx,
@@ -334,6 +352,8 @@ impl Grammar {
         Grammar::C,
         Grammar::Markdown,
         Grammar::MarkdownInline,
+        Grammar::Html,
+        Grammar::Css,
     ];
 
     const COUNT: usize = Self::ALL.len();
@@ -354,6 +374,8 @@ impl Grammar {
             Grammar::C => 8,
             Grammar::Markdown => 9,
             Grammar::MarkdownInline => 10,
+            Grammar::Html => 11,
+            Grammar::Css => 12,
         }
     }
 
@@ -370,6 +392,8 @@ impl Grammar {
             Grammar::C => tree_sitter_c::LANGUAGE.into(),
             Grammar::Markdown => tree_sitter_md::LANGUAGE.into(),
             Grammar::MarkdownInline => tree_sitter_md::INLINE_LANGUAGE.into(),
+            Grammar::Html => tree_sitter_html::LANGUAGE.into(),
+            Grammar::Css => tree_sitter_css::LANGUAGE.into(),
         }
     }
 
@@ -386,7 +410,74 @@ impl Grammar {
             Grammar::C => "c",
             Grammar::Markdown => "markdown",
             Grammar::MarkdownInline => "markdown_inline",
+            Grammar::Html => "html",
+            Grammar::Css => "css",
         }
+    }
+
+    /// The grammar an `@injection.language` capture or a `#set! injection.language` predicate
+    /// naming `name` should resolve to - the single real resolver behind
+    /// [`injection_config`], which every [`Highlighter::highlight`] call in this module
+    /// passes as its injection callback.
+    ///
+    /// Two vocabularies genuinely feed into this, which is why it is two lookups rather than one
+    /// table:
+    ///
+    /// 1. **A grammar's own internal name** ([`Grammar::name`]), which is what a hard-coded
+    ///    `#set!` predicate in a bundled `injections.scm` says: `tree-sitter-md`'s
+    ///    `"markdown_inline"` and `"html"`, `tree-sitter-html`'s `"css"`.
+    /// 2. **A fenced code block's own info string**, which is free-form author-written text
+    ///    (` ```rust `, ` ```py `, ` ```yml `) and is matched through
+    ///    [`crate::language::extension_for_fence_language`] - the one shared fence-tag alias table
+    ///    this crate has, also used by `crate::code_surface::markdown_preview`'s rendered code
+    ///    blocks, so source-view and preview-mode fences can never disagree about what ` ```py `
+    ///    means.
+    ///
+    /// An unrecognized name returns `None`, which `tree-sitter-highlight` handles by simply not
+    /// creating an injected layer (`highlight.rs:910-917`, read directly) - the content then stays
+    /// exactly as the outer grammar classified it. That is the honest fallback for a ` ```zig `
+    /// fence this app has no grammar for, and for `tree-sitter-md`'s own `"latex"` injection: no
+    /// panic, no fabricated colouring.
+    fn for_injection_name(name: &str) -> Option<Grammar> {
+        if let Some(grammar) = Grammar::ALL
+            .into_iter()
+            .find(|grammar| grammar.name() == name)
+        {
+            return Some(grammar);
+        }
+        Grammar::for_extension(crate::language::extension_for_fence_language(name)?)
+    }
+
+    /// The real grammar behind a [`crate::language::EXTENSIONS`] extension key. Kept honest
+    /// against that registry by `every_registry_extension_with_a_highlighter_has_an_injectable_
+    /// grammar`, so an extension that gains a highlighter but not an entry here (and would then
+    /// silently stop working as a markdown fence language) fails a test rather than degrading
+    /// quietly.
+    ///
+    /// This deliberately does *not* try to derive itself from `ExtensionEntry::highlighter`'s own
+    /// `fn` pointer: comparing function pointers for equality is not something Rust guarantees
+    /// (identical monomorphisations may be merged), so a table that looked derived would in fact
+    /// be relying on unspecified behaviour. An explicit match plus a real drift test is the honest
+    /// version of the same guarantee.
+    fn for_extension(extension: &str) -> Option<Grammar> {
+        Some(match extension {
+            "rs" => Grammar::Rust,
+            // `.js` reuses the plain TypeScript grammar, `.jsx` the TSX one - see
+            // [`highlight_typescript`]'s own docs, and `crate::language::EXTENSIONS`' `js`/`jsx`
+            // entries, which wire exactly this pairing.
+            "ts" | "js" => Grammar::TypeScript,
+            "tsx" | "jsx" => Grammar::Tsx,
+            "py" => Grammar::Python,
+            "toml" => Grammar::Toml,
+            "go" => Grammar::Go,
+            "json" => Grammar::Json,
+            "yaml" | "yml" => Grammar::Yaml,
+            "c" | "h" => Grammar::C,
+            "md" => Grammar::Markdown,
+            "html" | "htm" => Grammar::Html,
+            "css" => Grammar::Css,
+            _ => return None,
+        })
     }
 }
 
@@ -556,13 +647,12 @@ const HIGHLIGHT_NAMES: &[&str] = &[
     "text.reference",
     "text.strong",
     "text.emphasis",
-    // `tree-sitter-md`'s own block query's `(code_fence_content) @none` - a real, deliberate
-    // "cancel the enclosing `text.literal` colour for this span" instruction (the surrounding
-    // `(fenced_code_block) @text.literal` is still open otherwise), not a typo or an unused
-    // capture. Registering it here as a real recognized name (mapped to `Text` below) is what
-    // makes `HighlightConfiguration::configure`'s own matching rule actually resolve it, instead
-    // of the span silently inheriting whatever the parent already opened.
-    "none",
+    // `"none"` is deliberately **not** registered, and that absence is load-bearing - see
+    // [`MARKDOWN_BLOCK_HIGHLIGHTS_SUPPLEMENT`], which is what makes real per-fence language
+    // injection produce correct spans. GitHub issue #104 originally registered it (mapped to
+    // `Text`) to cancel the enclosing `(fenced_code_block) @text.literal`; issue #154 achieves
+    // the same visible result by cancelling `@text.literal` at its source instead, which - unlike
+    // a registered `"none"` - leaves no parent highlight open across an injected range.
 ];
 
 /// [`HIGHLIGHT_NAMES`]' positional parallel array: which real [`HighlightKind`] each recognized
@@ -637,7 +727,6 @@ const HIGHLIGHT_KINDS: [HighlightKind; HIGHLIGHT_NAMES.len()] = [
     HighlightKind::Link,
     HighlightKind::Strong,
     HighlightKind::Emphasis,
-    HighlightKind::Text,
 ];
 
 /// Real supplement appended after `tree-sitter-python`'s own bundled `queries/highlights.scm`,
@@ -811,6 +900,46 @@ const TYPESCRIPT_HIGHLIGHTS_SUPPLEMENT: &str = r#"
 (predefined_type "void" @type.builtin)
 "#;
 
+/// Real supplement appended after `tree-sitter-md`'s own bundled block `highlights.scm` (GitHub
+/// issue #154). Two lines, and the first one is the single thing that makes real per-fence
+/// language injection produce *correct* spans rather than shifted, half-missing ones.
+///
+/// ## Why a parent highlight over an injected range is actively harmful
+///
+/// `tree_sitter_highlight::Highlighter::highlight` flattens every layer into one event stream, and
+/// its `HighlightEnd` events carry no identity - a consumer can only keep a stack and pop it (see
+/// [`fold_highlight_events`]). That model is only sound while highlights properly nest. They do
+/// not, across layers: at the same start byte the engine emits the *deeper* layer's start first
+/// (`sort_key` orders on `-depth`, `highlight.rs:770-800`), so a shallower highlight spanning the
+/// whole injected range gets pushed **on top of** the injected layer's own first highlight, and
+/// then the injected highlight's `HighlightEnd` pops the wrong entry.
+///
+/// That is not hypothetical - it is exactly what a ` ```rust ` fence produced before this
+/// supplement existed, measured directly off the real event stream: `fn` came out
+/// [`Text`](HighlightKind::Text) (shadowed by the block grammar's own `(code_fence_content)
+/// @none`, which this app used to register as a real `Text` bucket) while the rest of the line
+/// came out `Keyword` (the mis-popped stack). Both symptoms disappear together once no parent
+/// highlight is left open over the fence's content.
+///
+/// 1. **`(fenced_code_block) @none`** cancels the bundled query's own `[(link_title)
+///    (indented_code_block) (fenced_code_block)] @text.literal` for fenced blocks only, by the
+///    "last matching pattern wins" rule cited on [`PYTHON_HIGHLIGHTS_SUPPLEMENT`].
+///    `"none"` is deliberately absent from [`HIGHLIGHT_NAMES`], so it resolves to *no highlight at
+///    all* rather than to a `Text` one - `HighlightConfiguration::configure` leaves an unrecognized
+///    capture's `highlight_indices` entry `None`, and `next()` emits no start event for it
+///    (`highlight.rs:1058-1066`). The bundled `(code_fence_content) @none` now resolves the same
+///    way, for free. Indented code blocks and link titles keep their `@text.literal` colour; only
+///    fenced blocks, the ones that can carry an injection, are cleared.
+/// 2. **`(info_string) @text.literal`** puts back the one visible thing step 1 would otherwise
+///    take away: the language tag after the opening ` ``` ` rendered as
+///    [`String`](HighlightKind::String) before this change (it inherited the fence's own
+///    `@text.literal`), and it still does. Restating the *same* recognized name keeps that exactly
+///    as it was rather than picking a new colour for it.
+const MARKDOWN_BLOCK_HIGHLIGHTS_SUPPLEMENT: &str = r#"
+(fenced_code_block) @none
+(info_string) @text.literal
+"#;
+
 /// The real, composed highlights query source for `grammar`, built from the grammar crates' own
 /// published `queries/*.scm` files (exposed by each crate as a `&'static str` constant, so nothing
 /// here reads from disk or vendors a copy of a query file).
@@ -864,8 +993,16 @@ fn highlight_query_for(grammar: Grammar) -> String {
         ),
         Grammar::Yaml => tree_sitter_yaml::HIGHLIGHTS_QUERY.to_string(),
         Grammar::C => tree_sitter_c::HIGHLIGHT_QUERY.to_string(),
-        Grammar::Markdown => tree_sitter_md::HIGHLIGHT_QUERY_BLOCK.to_string(),
+        Grammar::Markdown => format!(
+            "{}\n{MARKDOWN_BLOCK_HIGHLIGHTS_SUPPLEMENT}",
+            tree_sitter_md::HIGHLIGHT_QUERY_BLOCK
+        ),
         Grammar::MarkdownInline => tree_sitter_md::HIGHLIGHT_QUERY_INLINE.to_string(),
+        // Both plural (`HIGHLIGHTS_QUERY`), unlike `tree-sitter-c`'s and
+        // `tree-sitter-javascript`'s singular `HIGHLIGHT_QUERY` above - checked against each
+        // crate's own `bindings/rust/lib.rs`, not assumed from a neighbour.
+        Grammar::Html => tree_sitter_html::HIGHLIGHTS_QUERY.to_string(),
+        Grammar::Css => tree_sitter_css::HIGHLIGHTS_QUERY.to_string(),
     }
 }
 
@@ -893,16 +1030,89 @@ fn highlight_query_for(grammar: Grammar) -> String {
 ///    capture silently fails to fire (confirmed directly: the exact same source highlights
 ///    correctly once this one predicate is added, nothing else changed).
 ///
-/// The bundled file's other real capability - marking fenced-code-block content, HTML blocks, and
-/// YAML/TOML frontmatter for injection into *other* languages by name (`"rust"`, `"html"`, ...) -
-/// is deliberately not reproduced here: this app's `injection_callback` only ever resolves
-/// `"markdown_inline"`, so those patterns would never fire anyway. Real cross-language injection
-/// into an arbitrary fenced code block's own language is a separate, larger feature (fuzzy
-/// matching an arbitrary fence info string against this app's existing per-extension grammar
-/// registry) left for a future revision, not fabricated here.
+/// ## Real cross-language injection (GitHub issue #154)
+///
+/// The three patterns after the `(inline)` one are the feature this constant's own docs used to
+/// describe as "a separate, larger feature ... left for a future revision": a fenced code block's
+/// content is now genuinely reparsed with the language its info string names. Each is copied
+/// **verbatim** from `tree-sitter-md`'s own bundled `tree-sitter-markdown/queries/injections.scm`
+/// (unlike the `(inline)` pattern above, whose two real bugs are described in detail below, these
+/// three are correct as shipped and needed no repair), and each was checked against the block
+/// grammar's own `src/node-types.json` rather than guessed - `(fenced_code_block)` really does
+/// carry an `(info_string)` whose own `(language)` child holds the fence tag, and a separate
+/// `(code_fence_content)` child holding the body.
+///
+/// Two details of that fenced-block pattern are load-bearing and easy to get wrong:
+///
+/// - The language comes from an **`@injection.language` capture**, not a `#set!` predicate.
+///   `tree-sitter-highlight` reads the captured node's own source text as the language name
+///   (`injection_for_match`, `highlight.rs:1262-1269`, read directly), which is what makes an
+///   arbitrary, author-written fence tag resolvable at all. [`Grammar::for_injection_name`] is
+///   what that text is then matched against.
+/// - It deliberately does **not** set `injection.include-children`, the exact opposite of the
+///   `(inline)` pattern above. `(code_fence_content)`'s only real child type is
+///   `(block_continuation)` - the leading `> ` / list-indent prefix repeated on each line of a
+///   fence nested inside a block quote or list item. Excluding children (the engine's default) is
+///   precisely what keeps those prefixes out of the reparsed range, so the injected grammar sees
+///   the code and not the markdown scaffolding around it.
+///
+/// `(html_block)` is the same feature's block-level HTML half, and the `(minus_metadata)`/
+/// `(plus_metadata)` patterns are real YAML/TOML frontmatter, all three now resolvable because
+/// this app has those grammars. The bundled file's remaining pattern - the `(document . (section
+/// . (thematic_break) ...))` frontmatter fallback - is deliberately left out: it is a
+/// heuristic for grammars built *without* the frontmatter extension, and this crate's
+/// `tree-sitter-md` build does have `(minus_metadata)`/`(plus_metadata)`, so including both would
+/// mean two patterns racing for the same bytes.
 const MARKDOWN_INJECTION_QUERY: &str = r#"
 ((inline) @injection.content
  (#set! injection.language "markdown_inline")
+ (#set! injection.include-children))
+
+((fenced_code_block
+   (info_string
+     (language) @injection.language)
+   (code_fence_content) @injection.content)
+ (#set! injection.include-children))
+
+((html_block) @injection.content
+ (#set! injection.language "html")
+ (#set! injection.include-children))
+
+((minus_metadata) @injection.content
+  (#set! injection.language "yaml"))
+
+((plus_metadata) @injection.content
+  (#set! injection.language "toml"))
+"#;
+
+/// `tree-sitter-md`'s **inline** grammar's own bundled `injections.scm`, verbatim (GitHub issue
+/// #154) - the inline half of "including in the markdown files": a raw `<span class="x">` written
+/// inline in a paragraph is an `(html_tag)` node, and now really is parsed by
+/// [`Grammar::Html`].
+///
+/// Both patterns are correctly paren-wrapped upstream, so they need none of the first repair the
+/// block file's `(inline)` pattern needs - but they need the **second** one, for exactly the same
+/// underlying reason, and without it neither fires at all. `(html_tag)` looks like a leaf and is
+/// not: read off a real parse of `Inline <span class="i">tag</span> here.`, its `<span class="i">`
+/// node carries unnamed child tokens for `<`, both `"`s and `>`. `tree-sitter-highlight` excludes
+/// an `@injection.content` node's children from the injected range by default, so what survives
+/// is a shredded, non-contiguous handful of bytes - and `intersect_ranges` can hand back nothing
+/// at all, which the engine silently drops (`highlight.rs:917`, an `if !ranges.is_empty()` with no
+/// else). That silent-drop path is precisely what this constant produced before
+/// `injection.include-children` was added: the callback was called with `"html"`, resolved
+/// correctly, and still highlighted nothing.
+///
+/// `"latex"` is kept rather than stripped: this app has no LaTeX grammar, so
+/// [`Grammar::for_injection_name`] returns `None` for it and `tree-sitter-highlight` simply
+/// creates no layer - the same honest no-op an unrecognized fence tag gets. Keeping it means the
+/// day a LaTeX grammar is added, nothing here needs editing.
+const MARKDOWN_INLINE_INJECTION_QUERY: &str = r#"
+((html_tag) @injection.content
+ (#set! injection.language "html")
+ (#set! injection.include-children))
+
+((latex_block) @injection.content
+ (#set! injection.language "latex")
  (#set! injection.include-children))
 "#;
 
@@ -910,20 +1120,25 @@ const MARKDOWN_INJECTION_QUERY: &str = r#"
 /// [`HighlightConfiguration::configure`]d against [`HIGHLIGHT_NAMES`].
 ///
 /// The locals query is deliberately always empty, and the injection query is empty for every
-/// grammar except [`Grammar::Markdown`] - both real decisions, not gaps left to fill in later:
+/// grammar except the three that genuinely have one - both real decisions, not gaps left to fill
+/// in later:
 ///
-/// - **Injections.** Every grammar except `Markdown` needs none: TSX parses JSX as part of its
-///   own single grammar rather than as an injected language, and the only injections the Rust and
-///   Python query files describe are things like SQL-in-a-string-literal, which this app has no
-///   second grammar to inject *into* anyway. Passing an injection query without a real
-///   `injection_callback` able to supply those grammars would add machinery that could never
-///   fire. None of the five GitHub-issue-#32 grammars bundle a real `queries/injections.scm`
-///   either - verified directly against each one's own `queries/` directory, not assumed.
-///   `Markdown` is the one real exception (GitHub issue #104): its own bundled block grammar
+/// - **Injections.** Only Markdown (block), Markdown (inline) and HTML get one. TSX parses JSX as
+///   part of its own single grammar rather than as an injected language, and the only injections
+///   the Rust and Python query files describe are things like SQL-in-a-string-literal, which this
+///   app has no second grammar to inject *into* anyway. None of the five GitHub-issue-#32 grammars
+///   bundles a real `queries/injections.scm` at all - verified directly against each one's own
+///   `queries/` directory, not assumed - and neither does `tree-sitter-css`.
+///   `Markdown` was the original exception (GitHub issue #104): its own bundled block grammar
 ///   genuinely never parses prose content itself, only the injected `Grammar::MarkdownInline` -
-///   see [`MARKDOWN_INJECTION_QUERY`]'s own docs. `MarkdownInline`'s own `injections.scm` (HTML/
-///   LaTeX) is left empty here for the identical "no callback able to supply those grammars"
-///   reason.
+///   see [`MARKDOWN_INJECTION_QUERY`]'s own docs. GitHub issue #154 added the other two, both
+///   real and both now backed by grammars that actually exist here: `MarkdownInline`'s inline
+///   `(html_tag)` (see [`MARKDOWN_INLINE_INJECTION_QUERY`]), and `tree-sitter-html`'s own bundled
+///   `INJECTIONS_QUERY`, used verbatim - it routes a `<style>` element's `(raw_text)` to
+///   `"css"` and a `<script>` element's to `"javascript"`, and
+///   [`Grammar::for_injection_name`] resolves both (the latter through the fence-alias table's
+///   `"javascript" -> "js"` entry, landing on the plain TypeScript grammar `.js` files already
+///   use).
 /// - **Locals.** `tree-sitter-typescript` ships a `locals.scm`, and feeding it would switch on
 ///   `tree-sitter-highlight`'s local-variable tracking, which exists to let a query colour a
 ///   variable *reference* like its *definition*. This app's buckets do not distinguish variables
@@ -935,6 +1150,8 @@ fn build_highlight_config(
 ) -> Result<HighlightConfiguration, tree_sitter::QueryError> {
     let injection_query = match grammar {
         Grammar::Markdown => MARKDOWN_INJECTION_QUERY,
+        Grammar::MarkdownInline => MARKDOWN_INLINE_INJECTION_QUERY,
+        Grammar::Html => tree_sitter_html::INJECTIONS_QUERY,
         _ => "",
     };
     let mut config = HighlightConfiguration::new(
@@ -995,6 +1212,38 @@ fn highlight_config(grammar: Grammar) -> Option<&'static HighlightConfiguration>
             }
         })
         .as_ref()
+}
+
+/// The single real `injection_callback` every [`Highlighter::highlight`] call in this module
+/// passes (GitHub issue #154). `tree-sitter-highlight` hands it the language name an
+/// `@injection.language` capture or a `#set! injection.language` predicate produced, and takes the
+/// returned configuration as the grammar to reparse that injected range with; returning `None`
+/// means no layer is created at all and the outer grammar's own classification stands
+/// (`highlight.rs:910-917`, read directly).
+///
+/// It is a plain function rather than a closure so that all three real injection sources - a
+/// markdown fence's info string, a markdown `(html_block)`, an HTML `<style>`/`<script>` element -
+/// go through exactly one resolution path. See [`Grammar::for_injection_name`] for what that path
+/// actually matches against.
+///
+/// Recursion is real and terminates for a real, structural reason rather than a depth cap: an
+/// injected range is always strictly inside its host node, so a ` ```markdown ` fence inside a
+/// markdown document reparses strictly less text each time, and a zero-length range is dropped by
+/// the engine before a layer is even built. The [`HIGHLIGHT_CONFIGS`] `OnceLock` slots cannot
+/// deadlock on that recursion either: this callback only ever runs *during*
+/// `Highlighter::highlight`, which is after the outer grammar's own `get_or_init` has already
+/// returned, so no slot is ever re-entered while it is still initialising.
+///
+/// The `'a` return lifetime is deliberate and load-bearing, not noise: `Highlighter::highlight`'s
+/// own signature is `impl FnMut(&str) -> Option<&'a HighlightConfiguration> + 'a` where that same
+/// `'a` also bounds the *source* slice and the `Highlighter` itself
+/// (`tree-sitter-highlight-0.26.9/src/highlight.rs:284-290`). A plain `fn(&str) ->
+/// Option<&'static HighlightConfiguration>` therefore forces `'a == 'static` and makes the whole
+/// call require a `'static` source - a real borrow-check error, not a style preference. Being
+/// generic here lets the caller instantiate `'a` at whatever the borrow actually is; the value
+/// returned is still always a `&'static` one out of [`HIGHLIGHT_CONFIGS`].
+fn injection_config<'a>(name: &str) -> Option<&'a HighlightConfiguration> {
+    highlight_config(Grammar::for_injection_name(name)?)
 }
 
 /// Parses `source` with `tree-sitter-rust` and classifies it through the real, official
@@ -1078,10 +1327,34 @@ pub fn highlight_c(source: &str) -> Vec<HighlightSpan> {
     highlight_with(source, Grammar::C)
 }
 
+/// Parses `source` with `tree-sitter-html` and classifies it the same way [`highlight_rust`] does -
+/// GitHub issue #154. Used for both `.html` and `.htm`.
+///
+/// Unlike most wrappers here this one really does reach two further grammars: `tree-sitter-html`'s
+/// own bundled `INJECTIONS_QUERY` is wired (see [`build_highlight_config`]), so a `<style>`
+/// element's body is genuinely parsed as CSS and a `<script>` element's body as
+/// JavaScript/TypeScript, through [`injection_config`].
+pub fn highlight_html(source: &str) -> Vec<HighlightSpan> {
+    highlight_with(source, Grammar::Html)
+}
+
+/// Parses `source` with `tree-sitter-css` and classifies it the same way [`highlight_rust`] does -
+/// GitHub issue #154. `tree-sitter-css` bundles no `injections.scm`, so this is a plain
+/// single-grammar path.
+pub fn highlight_css(source: &str) -> Vec<HighlightSpan> {
+    highlight_with(source, Grammar::Css)
+}
+
 /// The one real highlighting path every language wrapper above funnels into: run the official
 /// [`tree_sitter_highlight::Highlighter`] over `source` with `grammar`'s real
 /// [`HighlightConfiguration`], and fold the [`HighlightEvent`] stream it emits down into this
 /// app's six [`HighlightKind`] buckets.
+///
+/// [`injection_config`] is passed as the real injection callback for *every* grammar, not only the
+/// ones that have an injection query (GitHub issue #154). That is not speculative machinery: a
+/// grammar built with an empty injection query has no injection capture indices at all, so the
+/// callback is never reached for it, and the three grammars that do have one
+/// ([`build_highlight_config`]) all resolve through the same single path.
 ///
 /// The event stream is a flat, in-order sequence of `HighlightStart`/`Source`/`HighlightEnd`, and
 /// `HighlightStart`s **nest** - a Rust `\n` escape inside a string literal arrives as a real
@@ -1108,7 +1381,8 @@ fn highlight_with(source: &str, grammar: Grammar) -> Vec<HighlightSpan> {
         return Vec::new();
     };
     let mut highlighter = Highlighter::new();
-    let Ok(events) = highlighter.highlight(config, source.as_bytes(), None, |_| None) else {
+    let Ok(events) = highlighter.highlight(config, source.as_bytes(), None, injection_config)
+    else {
         return Vec::new();
     };
     fold_highlight_events(events)
@@ -1118,31 +1392,24 @@ fn highlight_with(source: &str, grammar: Grammar) -> Vec<HighlightSpan> {
 /// `tree-sitter-highlight` engine [`highlight_with`] uses - GitHub issue #104. Unlike every other
 /// grammar in this module, Markdown's own block grammar never parses prose content itself: real
 /// text (emphasis, links, code spans, ...) lives inside `(inline)` nodes the block grammar leaves
-/// opaque, and only [`Grammar::MarkdownInline`] - reached through a real
-/// `injection_callback` this function supplies, resolving exactly the one language name
-/// `MARKDOWN_INJECTION_QUERY`'s own `(#set! injection.language "markdown_inline")` rule ever
-/// requests - actually parses it. Without this callback, every real markdown document would
-/// render as a single flat `Text` region: verified directly by testing this function with
-/// `|_| None` in place first (`inline_content_is_never_left_as_a_single_flat_text_region`'s own
-/// premise).
+/// opaque, and only [`Grammar::MarkdownInline`] - reached through the real injection callback
+/// [`highlight_with`] passes, resolving `MARKDOWN_INJECTION_QUERY`'s own `(#set!
+/// injection.language "markdown_inline")` rule - actually parses it. Without that callback, every
+/// real markdown document would render as a single flat `Text` region: verified directly by
+/// testing this function with `|_| None` in place first
+/// (`inline_content_is_never_left_as_a_single_flat_text_region`'s own premise).
+///
+/// This used to carry its own bespoke, `"markdown_inline"`-only callback and so could not be
+/// expressed as a plain [`highlight_with`] call. GitHub issue #154 replaced that with the shared
+/// [`injection_config`] resolver, which is what makes a ` ```html ` / ` ```rust ` fence's *content*
+/// really reach that language's own grammar - so this is now the same one-line wrapper every other
+/// language here is, and the difference lives entirely in `Markdown`'s injection query.
 pub fn highlight_markdown(source: &str) -> Vec<HighlightSpan> {
-    let Some(block_config) = highlight_config(Grammar::Markdown) else {
-        return Vec::new();
-    };
-    let Some(inline_config) = highlight_config(Grammar::MarkdownInline) else {
-        return Vec::new();
-    };
-    let mut highlighter = Highlighter::new();
-    let Ok(events) = highlighter.highlight(block_config, source.as_bytes(), None, |name| {
-        (name == Grammar::MarkdownInline.name()).then_some(inline_config)
-    }) else {
-        return Vec::new();
-    };
-    fold_highlight_events(events)
+    highlight_with(source, Grammar::Markdown)
 }
 
-/// The one real event-folding path both [`highlight_with`] and [`highlight_markdown`] funnel
-/// into: collapses a [`tree_sitter_highlight::Highlighter::highlight`] event stream down into
+/// The one real event-folding path every highlighting entry point in this module funnels into:
+/// collapses a [`tree_sitter_highlight::Highlighter::highlight`] event stream down into
 /// this app's [`HighlightKind`] buckets.
 ///
 /// The event stream is a flat, in-order sequence of `HighlightStart`/`Source`/`HighlightEnd`, and
@@ -2487,19 +2754,347 @@ mod tests {
         );
     }
 
-    /// `(code_fence_content) @none` (GitHub issue #104) must actually cancel the surrounding
-    /// `(fenced_code_block) @text.literal`'s own `String` colour for the fence's inner content -
-    /// not silently inherit it, which is what would happen if `"none"` were left unregistered in
-    /// `HIGHLIGHT_NAMES` (see that list's own docs on this exact capture).
+    /// Fenced code content must never inherit the enclosing fence's own `@text.literal` `String`
+    /// colour. GitHub issue #104 achieved that by registering `"none"`; GitHub issue #154 achieves
+    /// it by cancelling `@text.literal` at source instead - see
+    /// [`MARKDOWN_BLOCK_HIGHLIGHTS_SUPPLEMENT`] for why the second way is the only one compatible
+    /// with a real injected layer. Either way this assertion is the same one, and it is the guard
+    /// that the swap did not quietly lose it.
     #[test]
     fn markdown_fenced_code_block_content_is_not_colored_like_a_string() {
         let spans = highlight_markdown(SAMPLE_MARKDOWN);
         assert_ne!(
             kind_at(&spans, SAMPLE_MARKDOWN, "fn main"),
             HighlightKind::String,
-            "fenced code content must not inherit the fence's own text.literal colour - this app \
-             does not (yet) inject the fence's own language, so plain Text is the honest result"
+            "fenced code content must not inherit the fence's own text.literal colour"
         );
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // GitHub issue #154: HTML and CSS, as real file types and as real markdown fence languages.
+    // ---------------------------------------------------------------------------------------
+
+    const SAMPLE_HTML: &str = "<!DOCTYPE html>\n<!-- note -->\n<div class=\"card\">\n  <p>Hi</p>\n</div>\n<style>\n.card { color: #ff0000; }\n</style>\n<script>\nconst total = 1;\n</script>\n";
+
+    /// Every real capture `tree-sitter-html`'s own bundled `queries/highlights.scm` emits, in one
+    /// test - the whole file is seven patterns long (read directly), so this is genuinely complete
+    /// coverage of it rather than a sample. Note that not one of them needed a new
+    /// [`HIGHLIGHT_NAMES`] entry: `tag`/`attribute`/`string`/`comment`/`constant`/
+    /// `punctuation.bracket` were all already registered for other languages, and the one name
+    /// that was not (`tag.error`, an unmatched closing tag) resolves through the plain `"tag"`
+    /// entry by the subset rule this module's own docs describe.
+    #[test]
+    fn html_captures_land_in_the_expected_existing_buckets() {
+        let spans = highlight_html(SAMPLE_HTML);
+        assert_eq!(
+            kind_at(&spans, SAMPLE_HTML, "<div"),
+            HighlightKind::PunctuationBracket
+        );
+        assert_eq!(kind_at(&spans, SAMPLE_HTML, "div"), HighlightKind::Tag);
+        assert_eq!(
+            kind_at(&spans, SAMPLE_HTML, "class"),
+            HighlightKind::Attribute
+        );
+        assert_eq!(
+            kind_at(&spans, SAMPLE_HTML, "card\""),
+            HighlightKind::String
+        );
+        assert_eq!(
+            kind_at(&spans, SAMPLE_HTML, "<!-- note -->"),
+            HighlightKind::Comment
+        );
+        assert_eq!(
+            kind_at(&spans, SAMPLE_HTML, "<!DOCTYPE html"),
+            HighlightKind::Constant,
+            "the doctype declaration is `(doctype) @constant`, not a tag"
+        );
+    }
+
+    /// The real reason `tree-sitter-html`'s own `INJECTIONS_QUERY` is wired rather than dropped:
+    /// a `<style>` element's body is genuinely CSS and a `<script>` element's body is genuinely
+    /// JavaScript, and both now reach those grammars for real. `#ff0000` inside `<style>` is a
+    /// `(color_value) @string.special` that only the CSS grammar has any rule for at all - HTML's
+    /// own query would leave the whole `<style>` body as one unclassified `(raw_text)` run.
+    #[test]
+    fn html_style_and_script_bodies_are_injected_into_real_css_and_javascript() {
+        let spans = highlight_html(SAMPLE_HTML);
+        assert_eq!(
+            kind_at(&spans, SAMPLE_HTML, "color"),
+            HighlightKind::Property,
+            "a CSS property name inside <style>"
+        );
+        assert_eq!(
+            kind_at(&spans, SAMPLE_HTML, "#ff0000"),
+            HighlightKind::PunctuationDelimiter,
+            "the `#` of a CSS colour literal is CSS punctuation - only the CSS grammar has any \
+             rule here at all"
+        );
+        assert_eq!(
+            kind_at(&spans, SAMPLE_HTML, "ff0000"),
+            HighlightKind::String,
+            "the colour literal's own digits"
+        );
+        assert_eq!(
+            kind_at(&spans, SAMPLE_HTML, "const"),
+            HighlightKind::Keyword,
+            "a JavaScript keyword inside <script>"
+        );
+        assert_eq!(kind_at(&spans, SAMPLE_HTML, "1;"), HighlightKind::Number);
+    }
+
+    const SAMPLE_CSS: &str =
+        "/* note */\n@media screen {\n  .card > p#main { color: #ff0000; margin: 4px; }\n}\n";
+
+    #[test]
+    fn css_captures_land_in_the_expected_existing_buckets() {
+        let spans = highlight_css(SAMPLE_CSS);
+        assert_eq!(
+            kind_at(&spans, SAMPLE_CSS, "/* note */"),
+            HighlightKind::Comment
+        );
+        assert_eq!(
+            kind_at(&spans, SAMPLE_CSS, "@media"),
+            HighlightKind::Keyword
+        );
+        assert_eq!(
+            kind_at(&spans, SAMPLE_CSS, "card >"),
+            HighlightKind::Property,
+            "a class selector's name is `(class_name) @property`"
+        );
+        assert_eq!(
+            kind_at(&spans, SAMPLE_CSS, "> p"),
+            HighlightKind::Operator,
+            "the child combinator"
+        );
+        assert_eq!(
+            kind_at(&spans, SAMPLE_CSS, "p#main"),
+            HighlightKind::Tag,
+            "a bare element selector is `(tag_name) @tag`, the same bucket JSX element names use"
+        );
+        assert_eq!(
+            kind_at(&spans, SAMPLE_CSS, "margin"),
+            HighlightKind::Property
+        );
+        assert_eq!(kind_at(&spans, SAMPLE_CSS, "4px"), HighlightKind::Number);
+        assert_eq!(
+            kind_at(&spans, SAMPLE_CSS, "px;"),
+            HighlightKind::Type,
+            "`(unit) @type` - a real capture in `tree-sitter-css`'s own bundled query"
+        );
+    }
+
+    /// `(color_value) @string.special` must resolve through the plain `"string"` entry, **not**
+    /// the more specific `"string.special.key"` one that JSON registers: the recognized-name rule
+    /// requires every one of a recognized name's own dot-parts to be present in the capture, and
+    /// `key` is not present in `string.special`.
+    #[test]
+    fn css_color_literal_is_a_string_not_a_json_style_key() {
+        let spans = highlight_css(SAMPLE_CSS);
+        assert_eq!(kind_at(&spans, SAMPLE_CSS, "ff0000"), HighlightKind::String);
+    }
+
+    const SAMPLE_MARKDOWN_FENCES: &str = "# Fences\n\n```html\n<div class=\"card\">hi</div>\n```\n\n```css\n.card { color: red; }\n```\n\n```rust\nfn main() {}\n```\n\n```zig\nconst x = 1;\n```\n\n```\nplain fence\n```\n";
+
+    /// GitHub issue #154's own headline ask - "including in the markdown files". A ` ```html `
+    /// fence's *content* really is reparsed by `tree-sitter-html`: `div` comes out
+    /// [`Tag`](HighlightKind::Tag), which no markdown query has any rule capable of producing.
+    #[test]
+    fn a_markdown_html_fence_really_highlights_its_content_as_html() {
+        let spans = highlight_markdown(SAMPLE_MARKDOWN_FENCES);
+        assert_eq!(
+            kind_at(&spans, SAMPLE_MARKDOWN_FENCES, "div class"),
+            HighlightKind::Tag
+        );
+        assert_eq!(
+            kind_at(&spans, SAMPLE_MARKDOWN_FENCES, "class="),
+            HighlightKind::Attribute
+        );
+        assert_eq!(
+            kind_at(&spans, SAMPLE_MARKDOWN_FENCES, "card\">"),
+            HighlightKind::String
+        );
+    }
+
+    #[test]
+    fn a_markdown_css_fence_really_highlights_its_content_as_css() {
+        let spans = highlight_markdown(SAMPLE_MARKDOWN_FENCES);
+        assert_eq!(
+            kind_at(&spans, SAMPLE_MARKDOWN_FENCES, "card { "),
+            HighlightKind::Property,
+            "the class selector inside the ```css fence"
+        );
+        assert_eq!(
+            kind_at(&spans, SAMPLE_MARKDOWN_FENCES, "color: red"),
+            HighlightKind::Property
+        );
+    }
+
+    /// The proof that this is a real, general mechanism rather than an html/css special case: the
+    /// exact same injection query resolves ` ```rust ` too, with no Rust-specific code anywhere in
+    /// [`MARKDOWN_INJECTION_QUERY`] or [`Grammar::for_injection_name`].
+    #[test]
+    fn a_markdown_rust_fence_really_highlights_its_content_as_rust() {
+        let spans = highlight_markdown(SAMPLE_MARKDOWN_FENCES);
+        assert_eq!(
+            kind_at(&spans, SAMPLE_MARKDOWN_FENCES, "fn main"),
+            HighlightKind::Keyword,
+            "the `fn` keyword - the first token of the fence's content, which is exactly the one \
+             a parent highlight left open over the injected range would silently steal"
+        );
+        assert_eq!(
+            kind_at(&spans, SAMPLE_MARKDOWN_FENCES, "main()"),
+            HighlightKind::Function
+        );
+    }
+
+    /// The honest fallback, both halves of it: a fence tagged with a language this app has no
+    /// grammar for, and a fence with no tag at all, are plain [`Text`](HighlightKind::Text) - not
+    /// a panic, and not some other language's colouring applied speculatively.
+    #[test]
+    fn an_unknown_or_absent_fence_language_falls_back_to_plain_text() {
+        let spans = highlight_markdown(SAMPLE_MARKDOWN_FENCES);
+        assert_eq!(
+            kind_at(&spans, SAMPLE_MARKDOWN_FENCES, "const x = 1;"),
+            HighlightKind::Text,
+            "```zig - a real fence tag with no grammar here"
+        );
+        assert_eq!(
+            kind_at(&spans, SAMPLE_MARKDOWN_FENCES, "plain fence"),
+            HighlightKind::Text,
+            "a fence with no info string at all"
+        );
+    }
+
+    /// The fence's own info string kept its colour through
+    /// [`MARKDOWN_BLOCK_HIGHLIGHTS_SUPPLEMENT`]'s first line cancelling `@text.literal` for the
+    /// fenced block - that is what the supplement's second line is for, and this is the guard on
+    /// it.
+    #[test]
+    fn a_fence_info_string_is_still_colored_like_a_literal() {
+        let spans = highlight_markdown(SAMPLE_MARKDOWN_FENCES);
+        assert_eq!(
+            kind_at(&spans, SAMPLE_MARKDOWN_FENCES, "html\n"),
+            HighlightKind::String
+        );
+    }
+
+    /// The other half of that same supplement's blast radius: it cancels `@text.literal` for
+    /// *fenced* blocks only, and the bundled query's `[(link_title) (indented_code_block)
+    /// (fenced_code_block)] @text.literal` still covers the other two.
+    #[test]
+    fn an_indented_code_block_is_still_colored_like_a_literal() {
+        let source = "Text.\n\n    indented code\n";
+        let spans = highlight_markdown(source);
+        assert_eq!(
+            kind_at(&spans, source, "indented code"),
+            HighlightKind::String
+        );
+    }
+
+    /// The block-level HTML half of "including in the markdown files": a raw `<div>` block written
+    /// straight into a markdown document, which `tree-sitter-md` parses as one opaque
+    /// `(html_block)` and never looks inside.
+    #[test]
+    fn a_raw_html_block_in_markdown_is_injected_into_the_html_grammar() {
+        let source = "Before.\n\n<div class=\"card\">block</div>\n\nAfter.\n";
+        let spans = highlight_markdown(source);
+        assert_eq!(kind_at(&spans, source, "div class"), HighlightKind::Tag);
+        assert_eq!(kind_at(&spans, source, "class="), HighlightKind::Attribute);
+    }
+
+    /// The inline half: a raw tag inside a paragraph is an `(html_tag)` node of the *inline*
+    /// grammar, so this only works because [`MARKDOWN_INLINE_INJECTION_QUERY`] exists and is
+    /// reached through a second level of injection (block -> inline -> html).
+    #[test]
+    fn a_raw_html_tag_inside_a_markdown_paragraph_is_injected_into_the_html_grammar() {
+        let source = "Inline <span class=\"i\">tag</span> here.\n";
+        let spans = highlight_markdown(source);
+        assert_eq!(kind_at(&spans, source, "span class"), HighlightKind::Tag);
+        assert_eq!(kind_at(&spans, source, "class="), HighlightKind::Attribute);
+    }
+
+    /// YAML frontmatter, a third real injection the same mechanism unlocked for free - the block
+    /// grammar's own `(minus_metadata)` node, which is plain `Text` without an injection.
+    #[test]
+    fn yaml_frontmatter_in_markdown_is_injected_into_the_yaml_grammar() {
+        let source = "---\nkey: true\n---\n\n# Title\n";
+        let spans = highlight_markdown(source);
+        assert_eq!(kind_at(&spans, source, "key"), HighlightKind::Property);
+        assert_eq!(
+            kind_at(&spans, source, "true"),
+            HighlightKind::ConstantBuiltin
+        );
+    }
+
+    /// [`Grammar::for_injection_name`]'s first lookup: a `#set! injection.language` predicate
+    /// naming a grammar directly, which is how `tree-sitter-md` requests `"markdown_inline"` and
+    /// `"html"` and how `tree-sitter-html` requests `"css"`.
+    #[test]
+    fn every_grammars_own_name_resolves_back_to_that_grammar() {
+        for grammar in Grammar::ALL {
+            assert_eq!(
+                Grammar::for_injection_name(grammar.name()),
+                Some(grammar),
+                "{}",
+                grammar.name()
+            );
+        }
+    }
+
+    /// The real drift guard over the second lookup. Every extension the registry claims a
+    /// highlighter for must be reachable as a fence language *and* land on a real grammar -
+    /// otherwise a ` ```yml ` fence would silently render as plain text while `.yml` files
+    /// highlight fine, with nothing to catch the gap.
+    #[test]
+    fn every_registry_extension_with_a_highlighter_is_reachable_as_a_fence_language() {
+        for entry in crate::language::EXTENSIONS
+            .iter()
+            .filter(|entry| entry.highlighter.is_some())
+        {
+            let grammar = Grammar::for_injection_name(entry.extension).unwrap_or_else(|| {
+                panic!(
+                    "a fence tagged `{}` must resolve to a real grammar - the registry says that \
+                     extension has a highlighter",
+                    entry.extension
+                )
+            });
+            assert_eq!(
+                Grammar::for_extension(entry.extension),
+                Some(grammar),
+                "{}",
+                entry.extension
+            );
+        }
+    }
+
+    /// The opposite direction: [`Grammar::for_extension`] must not claim an extension the registry
+    /// has no highlighter for, which would mean a fence highlighting in a colour the same file on
+    /// disk never gets.
+    #[test]
+    fn grammar_for_extension_claims_exactly_the_registrys_own_highlighted_extensions() {
+        let mut claimed: Vec<&str> = crate::language::EXTENSIONS
+            .iter()
+            .map(|entry| entry.extension)
+            .filter(|extension| Grammar::for_extension(extension).is_some())
+            .collect();
+        claimed.sort_unstable();
+        let mut with_highlighter: Vec<&str> = crate::language::EXTENSIONS
+            .iter()
+            .filter(|entry| entry.highlighter.is_some())
+            .map(|entry| entry.extension)
+            .collect();
+        with_highlighter.sort_unstable();
+        assert_eq!(claimed, with_highlighter);
+    }
+
+    /// A fence tag nobody has a grammar for resolves to nothing at all, which is what makes
+    /// `an_unknown_or_absent_fence_language_falls_back_to_plain_text` a real fallback rather than
+    /// an accident.
+    #[test]
+    fn an_unknown_injection_name_resolves_to_no_grammar() {
+        assert_eq!(Grammar::for_injection_name("zig"), None);
+        assert_eq!(Grammar::for_injection_name("latex"), None);
+        assert_eq!(Grammar::for_injection_name(""), None);
     }
 
     /// Both halves of the TypeScript query composition, which is the single most breakable part of

--- a/crates/app/src/code_surface/code_view.rs
+++ b/crates/app/src/code_surface/code_view.rs
@@ -3026,6 +3026,38 @@ mod tests {
         );
     }
 
+    /// A fence nested inside a list item or a block quote, which is the case
+    /// [`MARKDOWN_INJECTION_QUERY`]'s `injection.include-children` decision most plausibly puts at
+    /// risk: including children means the `(block_continuation)` nodes carrying each line's `  `
+    /// or `> ` prefix are now inside the injected range too. Both really work - the content
+    /// highlights as Rust, and the block quote's own `> ` markers keep their own colour rather
+    /// than being swallowed by the injected layer.
+    #[test]
+    fn a_fence_nested_in_a_list_or_block_quote_still_highlights_its_real_language() {
+        let list = "- item\n\n  ```rust\n  fn main() {}\n  ```\n";
+        let list_spans = highlight_markdown(list);
+        assert_eq!(
+            kind_at(&list_spans, list, "fn main"),
+            HighlightKind::Keyword
+        );
+        assert_eq!(
+            kind_at(&list_spans, list, "main()"),
+            HighlightKind::Function
+        );
+
+        let quote = "> quote\n>\n> ```rust\n> fn main() {}\n> ```\n";
+        let quote_spans = highlight_markdown(quote);
+        assert_eq!(
+            kind_at(&quote_spans, quote, "fn main"),
+            HighlightKind::Keyword
+        );
+        assert_eq!(
+            kind_at(&quote_spans, quote, "> fn"),
+            HighlightKind::Operator,
+            "the block quote marker on the fence's own content line keeps its markdown colour"
+        );
+    }
+
     /// [`Grammar::for_injection_name`]'s first lookup: a `#set! injection.language` predicate
     /// naming a grammar directly, which is how `tree-sitter-md` requests `"markdown_inline"` and
     /// `"html"` and how `tree-sitter-html` requests `"css"`.

--- a/crates/app/src/code_surface/markdown_preview.rs
+++ b/crates/app/src/code_surface/markdown_preview.rs
@@ -613,31 +613,26 @@ fn build_text_runs(
     }
 }
 
-/// The extension key `code_view::highlighter_for_extension` recognizes for a fenced code block's
-/// own info-string language name - these are two different vocabularies (a fence says `"rust"`,
-/// the registry is keyed by file extension `"rs"`), so this is a real, small alias table, not a
-/// guess: every entry names a real `crate::language::EXTENSIONS` extension.
-fn extension_for_fence_language(language: &str) -> Option<&'static str> {
-    match language.to_ascii_lowercase().as_str() {
-        "rust" | "rs" => Some("rs"),
-        "python" | "py" => Some("py"),
-        "typescript" | "ts" => Some("ts"),
-        "tsx" => Some("tsx"),
-        "javascript" | "js" => Some("js"),
-        "jsx" => Some("js"),
-        "go" | "golang" => Some("go"),
-        "json" => Some("json"),
-        "yaml" | "yml" => Some("yaml"),
-        "toml" => Some("toml"),
-        "c" | "h" => Some("c"),
-        _ => None,
-    }
+/// A preview code card's real, coloured lines - split out of [`render_code_block`] purely so the
+/// colouring itself is testable without building a GPUI element (`AnyElement` exposes nothing to
+/// assert on).
+///
+/// The fence-tag alias table it resolves through used to live here as a private copy; GitHub issue
+/// #154 lifted it into [`crate::language::extension_for_fence_language`] because the *source*
+/// view's own tree-sitter injection callback needs the identical mapping, and two copies could
+/// disagree about what ` ```py ` means. Sharing it is also what gave preview mode real HTML/CSS
+/// fence colouring with no further change here - see that function's own docs.
+fn highlighted_code_block_lines(
+    language: Option<&str>,
+    text: &str,
+) -> Vec<code_view::RenderedLine> {
+    let extension = language.and_then(crate::language::extension_for_fence_language);
+    let lines: Vec<&str> = text.lines().collect();
+    code_view::highlight_block(lines, extension)
 }
 
 fn render_code_block(language: Option<&str>, text: &str) -> AnyElement {
-    let extension = language.and_then(extension_for_fence_language);
-    let lines: Vec<&str> = text.lines().collect();
-    let rendered = code_view::highlight_block(lines, extension);
+    let rendered = highlighted_code_block_lines(language, text);
     let mut card = div()
         .flex()
         .flex_col()
@@ -775,6 +770,70 @@ fn render_table(header: &[String], rows: &[Vec<String>]) -> AnyElement {
         .child(row(header, true))
         .children(rows.iter().map(|cells| row(cells, false)))
         .into_any_element()
+}
+
+#[cfg(test)]
+mod code_block_color_tests {
+    use super::*;
+    use crate::code_surface::code_view::HighlightKind;
+
+    /// The real kind covering the first occurrence of `needle` across a rendered code card's
+    /// lines - the same question `render_code_line` asks when it picks each run's colour.
+    fn kind_of(lines: &[code_view::RenderedLine], needle: &str) -> Option<HighlightKind> {
+        lines
+            .iter()
+            .flat_map(|line| &line.runs)
+            .find(|(text, _)| text.contains(needle))
+            .map(|(_, kind)| *kind)
+    }
+
+    /// GitHub issue #154 in *preview* mode, which is a genuinely separate rendering path from the
+    /// source view's own highlighting: a ` ```html ` fence's card is really coloured by
+    /// `tree-sitter-html`, not left flat.
+    #[test]
+    fn a_preview_html_fence_is_really_colored_by_the_html_grammar() {
+        let lines = highlighted_code_block_lines(Some("html"), "<div class=\"card\">hi</div>\n");
+        assert_eq!(kind_of(&lines, "div"), Some(HighlightKind::Tag));
+        assert_eq!(kind_of(&lines, "class"), Some(HighlightKind::Attribute));
+    }
+
+    #[test]
+    fn a_preview_css_fence_is_really_colored_by_the_css_grammar() {
+        let lines = highlighted_code_block_lines(Some("css"), ".card { color: red; }\n");
+        assert_eq!(kind_of(&lines, "card"), Some(HighlightKind::Property));
+    }
+
+    /// The pre-existing languages must be unaffected by the alias table moving out of this module.
+    #[test]
+    fn a_preview_rust_fence_is_still_colored_by_the_rust_grammar() {
+        let lines = highlighted_code_block_lines(Some("rust"), "fn main() {}\n");
+        assert_eq!(kind_of(&lines, "fn"), Some(HighlightKind::Keyword));
+    }
+
+    /// A real gain the shared table brought with it: this module's own private copy mapped a
+    /// ` ```jsx ` fence to the `"js"` extension, which wires the *plain* TypeScript grammar - one
+    /// that cannot parse JSX at all. It now maps to `"jsx"`, which wires the real TSX grammar.
+    #[test]
+    fn a_preview_jsx_fence_reaches_a_grammar_that_can_actually_parse_jsx() {
+        let lines = highlighted_code_block_lines(Some("jsx"), "const a = <div id=\"x\" />;\n");
+        assert_eq!(kind_of(&lines, "div"), Some(HighlightKind::Tag));
+        assert_eq!(kind_of(&lines, "id"), Some(HighlightKind::Attribute));
+    }
+
+    /// An unrecognized fence tag, and a fence with no tag at all, render as one flat unclassified
+    /// card rather than being force-fitted into some other language.
+    #[test]
+    fn an_unknown_or_absent_preview_fence_language_stays_plain_text() {
+        for language in [Some("zig"), None] {
+            let lines = highlighted_code_block_lines(language, "const x = 1;\n");
+            let kinds: Vec<HighlightKind> = lines
+                .iter()
+                .flat_map(|line| &line.runs)
+                .map(|(_, kind)| *kind)
+                .collect();
+            assert_eq!(kinds, vec![HighlightKind::Text], "{language:?}");
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/app/src/language.rs
+++ b/crates/app/src/language.rs
@@ -13,8 +13,9 @@
 //!
 //! `lsp: Some(..)` for Rust/TypeScript-family/Python/**Vue** - all real, live-tested end to end
 //! (see `lsp_core::client`'s own tests for Rust, and this crate's `language::tests` /
-//! `lsp::client`-adjacent integration tests for the rest). `lsp: None` for TOML/Markdown/SQL (never
-//! had a server) and Go (the user's explicit ask named TypeScript/Vue/Python, not Go; `gopls`
+//! `lsp::client`-adjacent integration tests for the rest). `lsp: None` for TOML/Markdown/SQL/
+//! JSON/YAML/C/HTML/CSS (none ever had a server here - HTML and CSS are GitHub issue #154, whose
+//! text asks for syntax support only) and Go (the user's explicit ask named TypeScript/Vue/Python, not Go; `gopls`
 //! stays PATH-detection-only on the Settings page, matching its pre-existing "not installed" real
 //! state there).
 //!
@@ -718,7 +719,83 @@ pub const EXTENSIONS: &[ExtensionEntry] = &[
         // `crate::code_surface::code_view::highlight_c`'s own docs.
         highlighter: Some(crate::code_surface::code_view::highlight_c),
     },
+    // GitHub issue #154. No `lsp` for either: this module's own scope docs above reserve a real
+    // server for a language an explicit user ask named, and issue #154's text asks for syntax
+    // support only - the same treatment TOML/Markdown/JSON/YAML/C already get.
+    ExtensionEntry {
+        extension: "html",
+        display_name: "HTML",
+        lsp_language_id: "html",
+        chip_label: "htm",
+        chip_colors: theme::lang::HTML,
+        lsp: None,
+        settings_row: None,
+        highlighter: Some(crate::code_surface::code_view::highlight_html),
+    },
+    ExtensionEntry {
+        extension: "htm",
+        display_name: "HTML",
+        lsp_language_id: "html",
+        chip_label: "htm",
+        chip_colors: theme::lang::HTML,
+        lsp: None,
+        settings_row: None,
+        // The same real grammar - `.htm` is a legacy spelling of the identical language, matching
+        // how `.yml`/`.yaml` and `.c`/`.h` already share one grammar here.
+        highlighter: Some(crate::code_surface::code_view::highlight_html),
+    },
+    ExtensionEntry {
+        extension: "css",
+        display_name: "CSS",
+        lsp_language_id: "css",
+        chip_label: "css",
+        chip_colors: theme::lang::CSS,
+        lsp: None,
+        settings_row: None,
+        highlighter: Some(crate::code_surface::code_view::highlight_css),
+    },
 ];
+
+/// The [`EXTENSIONS`] key a fenced code block's own info-string language name maps to - a fence
+/// says ` ```rust `, this registry is keyed by the file extension `"rs"`, and those are genuinely
+/// two different vocabularies, so this is a real, small alias table rather than a guess.
+///
+/// The **one** such table in this crate, deliberately. It started life private to
+/// `crate::code_surface::markdown_preview` (colouring a *rendered* preview's code cards) and was
+/// lifted here by GitHub issue #154, which needed the identical mapping for a second real caller:
+/// `crate::code_surface::code_view`'s tree-sitter injection callback, which resolves a fence's
+/// info string to a real grammar so the fence's content is highlighted in **source** view too.
+/// Two copies would have meant ` ```py ` colouring in one view and not the other, with nothing to
+/// catch it; `tests::every_fence_alias_names_a_real_registry_extension` and
+/// `crate::code_surface::code_view`'s own
+/// `every_registry_extension_with_a_highlighter_is_reachable_as_a_fence_language` are the real
+/// drift guards over that.
+///
+/// `None` for an unrecognized tag (` ```zig `, ` ```console `, or a fence with no tag at all) is
+/// the honest answer both callers already handle by rendering that block as plain text.
+pub fn extension_for_fence_language(language: &str) -> Option<&'static str> {
+    match language.to_ascii_lowercase().as_str() {
+        "rust" | "rs" => Some("rs"),
+        "python" | "py" => Some("py"),
+        "typescript" | "ts" => Some("ts"),
+        "tsx" => Some("tsx"),
+        "javascript" | "js" => Some("js"),
+        "jsx" => Some("jsx"),
+        "go" | "golang" => Some("go"),
+        "json" => Some("json"),
+        "yaml" | "yml" => Some("yaml"),
+        "toml" => Some("toml"),
+        "c" => Some("c"),
+        "h" => Some("h"),
+        // GitHub issue #154's own additions. `"markdown"`/`"md"` is real and not circular: a
+        // markdown fence tagged `markdown` reparses strictly less text than its host document
+        // (see `code_view::injection_config`'s own docs on why that terminates).
+        "html" | "htm" => Some("html"),
+        "css" => Some("css"),
+        "markdown" | "md" => Some("md"),
+        _ => None,
+    }
+}
 
 /// The real, canonical source for `crate::settings::state::LSP_LANGUAGES` - every [`ExtensionEntry`]
 /// with a real [`ExtensionEntry::settings_row`], in [`EXTENSIONS`]' own order.
@@ -1261,8 +1338,8 @@ mod tests {
         assert_eq!(
             with_highlighter,
             vec![
-                "c", "go", "h", "js", "json", "jsx", "md", "py", "rs", "toml", "ts", "tsx", "yaml",
-                "yml"
+                "c", "css", "go", "h", "htm", "html", "js", "json", "jsx", "md", "py", "rs",
+                "toml", "ts", "tsx", "yaml", "yml"
             ],
             "this is the real, current set of extensions with a genuine tree-sitter grammar \
              dependency - a change here should be a deliberate decision, not a silent drift"
@@ -1283,6 +1360,87 @@ mod tests {
                 "{ext} has no real tree-sitter grammar dependency and should not carry a \
                  fabricated highlighter"
             );
+        }
+    }
+
+    /// [`extension_for_fence_language`] must only ever return an extension that really exists in
+    /// [`EXTENSIONS`] - it is the input to two different real grammar/highlighter lookups, both of
+    /// which silently render plain text for an extension they don't recognize, so a typo here
+    /// would be invisible at runtime.
+    #[test]
+    fn every_fence_alias_names_a_real_registry_extension() {
+        for tag in [
+            "rust",
+            "rs",
+            "python",
+            "py",
+            "typescript",
+            "ts",
+            "tsx",
+            "javascript",
+            "js",
+            "jsx",
+            "go",
+            "golang",
+            "json",
+            "yaml",
+            "yml",
+            "toml",
+            "c",
+            "h",
+            "html",
+            "htm",
+            "css",
+            "markdown",
+            "md",
+        ] {
+            let extension = extension_for_fence_language(tag)
+                .unwrap_or_else(|| panic!("fence tag `{tag}` should resolve"));
+            let entry = entry_for_extension(Some(extension)).unwrap_or_else(|| {
+                panic!("fence tag `{tag}` resolved to `{extension}`, which is not a real entry")
+            });
+            assert!(
+                entry.highlighter.is_some(),
+                "fence tag `{tag}` resolves to `{extension}`, which has no real highlighter - a \
+                 fence tagged that way would silently render as plain text"
+            );
+        }
+    }
+
+    /// Fence tags are author-written free text, and the two things that must never happen are a
+    /// panic and a fabricated match. An unknown tag - and an empty one, which is what a bare
+    /// ` ``` ` fence yields - is genuinely `None`.
+    #[test]
+    fn an_unknown_fence_tag_resolves_to_nothing() {
+        assert_eq!(extension_for_fence_language("zig"), None);
+        assert_eq!(extension_for_fence_language("console"), None);
+        assert_eq!(extension_for_fence_language(""), None);
+    }
+
+    /// Fence tags are matched case-insensitively, matching [`entry_for_extension`]'s own
+    /// case-insensitive extension lookup.
+    #[test]
+    fn fence_tags_are_matched_case_insensitively() {
+        assert_eq!(extension_for_fence_language("HTML"), Some("html"));
+        assert_eq!(extension_for_fence_language("Rust"), Some("rs"));
+    }
+
+    /// GitHub issue #154's own registry additions, pinned end to end: a real display name (the
+    /// File view's status-bar label), a real chip, and a real highlighter - and deliberately no
+    /// LSP, per this module's own scope docs.
+    #[test]
+    fn html_and_css_are_real_registry_entries_with_no_language_server() {
+        for (extension, display_name) in [("html", "HTML"), ("htm", "HTML"), ("css", "CSS")] {
+            let entry = entry_for_extension(Some(extension))
+                .unwrap_or_else(|| panic!("{extension} should have a real registry entry"));
+            assert_eq!(entry.display_name, display_name);
+            assert!(entry.highlighter.is_some(), "{extension}");
+            assert!(
+                entry.lsp.is_none(),
+                "{extension} must not spawn a language server - GitHub issue #154 asked for \
+                 syntax support only"
+            );
+            assert!(entry.settings_row.is_none(), "{extension}");
         }
     }
 

--- a/crates/app/src/theme.rs
+++ b/crates/app/src/theme.rs
@@ -881,6 +881,17 @@ pub mod lang {
     pub const JSON: (ColorToken, ColorToken) = (hex(0xb8bcc4), hex(0x24262b)); // "jsn"
     pub const YAML: (ColorToken, ColorToken) = (hex(0x8aa8cf), hex(0x1c2530)); // "yml"
     pub const C: (ColorToken, ColorToken) = (hex(0x9a8cc9), hex(0x231f30)); // "c"
+                                                                            // GitHub issue #154 - two more hues, chosen the same way issue #32's three above were: each
+                                                                            // stays visually distinct from *every* existing chip rather than reusing a near-identical
+                                                                            // tint. Both hues here were genuinely unoccupied before this issue - the existing set spans
+                                                                            // orange-brown (RS), yellow (PY), greens (SQL/VUE), blues (MD/TS/YAML), cyan (GO), purple
+                                                                            // (C) and two greys (TOML/JSON), leaving red and magenta free.
+                                                                            // Enforced, not just asserted in prose, by `lang_token_tests::
+                                                                            // every_lang_chip_color_is_distinct_from_every_other`.
+    pub const HTML: (ColorToken, ColorToken) = (hex(0xd1735f), hex(0x2f1d18)); // "htm"
+                                                                               // Magenta, deliberately not another purple: `C`'s `#9a8cc9` is a blue-leaning violet, this
+                                                                               // is red-leaning, so the two do not read as the same chip at chip size.
+    pub const CSS: (ColorToken, ColorToken) = (hex(0xc47fb0), hex(0x2c1e29)); // "css"
     pub const UNKNOWN: (ColorToken, ColorToken) = (hex(0x6b7178), hex(0x23272b));
     // "."
 }
@@ -1376,6 +1387,14 @@ mod lang_token_tests {
             ("vue", lang::VUE),
             ("py", lang::PY),
             ("go", lang::GO),
+            // GitHub issue #32's three and issue #154's two - the original version of this test
+            // covered only the eight chips that existed when it was written, so every chip added
+            // since had been going unchecked against the very rule its own doc comment claims.
+            ("json", lang::JSON),
+            ("yaml", lang::YAML),
+            ("c", lang::C),
+            ("html", lang::HTML),
+            ("css", lang::CSS),
             ("unknown", lang::UNKNOWN),
         ];
         for (i, (name_a, color_a)) in all.iter().enumerate() {


### PR DESCRIPTION
Fixes #154.

## What this adds

**Two new file types.** `tree-sitter-html` 0.23.2 and `tree-sitter-css` 0.25.0, wired the same way every language since #32 has been: a `Grammar` variant, a `highlight_html`/`highlight_css` wrapper, `.html`/`.htm`/`.css` entries in `crate::language::EXTENSIONS`, and a `theme::lang` chip pair each. `lsp: None` for all three, per this registry's own scope rule — #154 asks for syntax support only.

Neither grammar needed a new `HIGHLIGHT_NAMES` entry. Both bundled `highlights.scm` files are short enough to have been read end to end, and every capture they emit already resolves through a registered name — including HTML's `tag.error` and CSS's `string.special`, both via the subset rule `HighlightConfiguration::configure` implements.

The chip hues (red for HTML, magenta for CSS) are the two the existing twelve chips genuinely left free. `every_lang_chip_color_is_distinct_from_every_other` now covers every chip rather than only the eight that existed when it was written.

**Real cross-language injection in markdown.** "Including in the markdown files" needed the feature `MARKDOWN_INJECTION_QUERY`'s own doc comment described as deliberately deferred. It is now real, and **general** rather than an html/css special case: a fence's info string is resolved against the whole extension registry, so ` ```rust `/` ```py `/` ```yml ` are highlighted by the same mechanism with no per-language code. The same one resolver also serves markdown's block-level `(html_block)`, its inline `(html_tag)`, its YAML/TOML frontmatter, and `tree-sitter-html`'s own bundled injections — so a `<style>` body really is parsed as CSS and a `<script>` body as JavaScript.

## The three real repairs this needed

Each found empirically off the actual event stream, not by reading queries.

1. **`(code_fence_content)` is not a leaf.** It carries unnamed child tokens for `(`, `)`, `{`, `}`, and `tree-sitter-highlight` excludes an injection content node's children by default — so without `#set! injection.include-children` the injected range is shredded and the whole fence highlights at shifted offsets. Same quirk and same fix as the `(inline)` pattern this file already documents. `(html_tag)` in the inline grammar needed it too, where the shredded range came back *empty* and the engine silently dropped the layer (the callback was called with `"html"`, resolved correctly, and still highlighted nothing).

2. **A parent highlight open across an injected range corrupts the flat event stream.** `HighlightEnd` carries no identity, and at a shared start byte the engine emits the deeper layer's start *first* — so the block grammar's `(code_fence_content) @none`, which this app registered as a real `Text` bucket in #104, got pushed on top of the injected layer's first highlight and was then popped by the wrong `HighlightEnd`. Measured symptom: `fn` came out `Text` while the rest of the line came out `Keyword`. Fixed by unregistering `"none"` and cancelling `@text.literal` at its source instead (`MARKDOWN_BLOCK_HIGHLIGHTS_SUPPLEMENT`), leaving no parent highlight over the fence at all. The info string keeps its previous colour via the supplement's second line; indented code blocks and link titles keep theirs untouched.

3. **`@injection.language` had to be a real capture**, not a `#set!` predicate, for an author-written fence tag to be readable at all.

## One table, not two

`markdown_preview`'s private fence-tag alias table moved to `crate::language::extension_for_fence_language` and is now the only one, shared by the preview's rendered code cards and the source view's injection callback — two copies could have disagreed about what ` ```py ` means. Preview mode therefore gained real HTML/CSS fence colouring with no further change, plus a real fix on the way: the old copy mapped a ` ```jsx ` fence to the plain TypeScript grammar, which cannot parse JSX at all.

## Honest fallbacks

An unrecognized fence tag (` ```zig `), a fence with no tag, and `tree-sitter-md`'s own `"latex"` injection all resolve to nothing and leave the content as plain text. No panic, no fabricated match.

## Tests

~30 new tests, all real assertions on real spans: per-language bucket coverage for HTML and CSS, `<style>`/`<script>` injection, fence injection for html/css/rust, both fallback cases, block-level and inline raw HTML in markdown, YAML frontmatter, the info-string and indented-code-block guards on the supplement, preview-mode fence colouring, and three drift guards tying `Grammar::for_extension`, the fence alias table and `EXTENSIONS`' own highlighter set together.

## Gates

- `cargo fmt --all -- --check` clean
- `cargo build --workspace` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace --lib -- --test-threads=1`: 1469 + 51 + 14 + 174 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)