### PR TITLE
Terminal: real copy, paste and mouse text selection

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -550,6 +550,49 @@ pub fn default_key_bindings() -> Vec<gpui::KeyBinding> {
             root::TerminalClear,
             Some("terminal"),
         ),
+        // GitHub issue #158: with the terminal focused, copy and paste did nothing at all -
+        // there was no binding of any kind scoped to `"terminal"` for either. `secondary-c`/
+        // `secondary-v` above are `Some("file-editor")`/`Some("merge-editor")`/
+        // `Some("file-tree && !tree-editing")`, none of which is ever live over a focused
+        // terminal, so both keystrokes fell straight through to `crate::terminal::pane::
+        // keystroke_to_bytes` - and its control-byte branch turned Ctrl+C into `0x03`
+        // (`SIGINT`) and Ctrl+V into `0x16` (readline `quoted-insert`). That is *correct*
+        // behavior for the unshifted keys and must stay: a terminal that can't interrupt a
+        // running agent CLI is broken in a much worse way. Hence the shifted variants, the
+        // universal terminal-emulator answer to exactly this conflict (GNOME Terminal, Konsole,
+        // Windows Terminal, Alacritty and Zed all put terminal copy/paste on
+        // `Ctrl+Shift+C`/`Ctrl+Shift+V` for this reason), following the same
+        // `cfg!(target_os = "macos")` split `TerminalClear` immediately above already uses and
+        // for the same reason: on macOS `cmd-c`/`cmd-v` never reach the pty at all
+        // (`keystroke_to_bytes` returns `None` for any `modifiers.platform` keystroke), while on
+        // Linux/Windows its control-byte formula ignores shift entirely, so `ctrl-shift-c` is a
+        // real, distinct `KeyBinding` match that leaves plain Ctrl+C's `SIGINT` byte untouched.
+        //
+        // Note that the shifted keystroke needing its own binding is not optional: without one,
+        // `keystroke_to_bytes`'s shift-ignoring control-byte branch means pressing Ctrl+Shift+C
+        // over a terminal *interrupts the running process*. A bound action wins - GPUI
+        // dispatches matching `KeyBinding`s before any `on_key_down` listener and an action
+        // handler stops propagation by default in the bubble phase (`vendor/zed/crates/gpui/
+        // src/window.rs:5205-5218` and `:5450`), so `TerminalPane::handle_key_down` never sees
+        // the keystroke.
+        gpui::KeyBinding::new(
+            if cfg!(target_os = "macos") {
+                "cmd-c"
+            } else {
+                "ctrl-shift-c"
+            },
+            root::TerminalCopy,
+            Some("terminal"),
+        ),
+        gpui::KeyBinding::new(
+            if cfg!(target_os = "macos") {
+                "cmd-v"
+            } else {
+                "ctrl-shift-v"
+            },
+            root::TerminalPaste,
+            Some("terminal"),
+        ),
     ]
 }
 
@@ -769,6 +812,76 @@ mod undo_scoping_matrix_tests {
             assert_eq!(
                 text_enabled, wants_text,
                 "text undo enablement for {description}"
+            );
+        }
+    }
+
+    /// GitHub issue #158's root cause, asserted directly: before the fix there was **no**
+    /// binding of any kind that reached an action while a terminal had focus for either copy or
+    /// paste, so both keystrokes fell through to `crate::terminal::pane::keystroke_to_bytes`
+    /// and did something else entirely. This fails against the pre-fix keymap.
+    #[test]
+    fn a_focused_terminal_has_real_copy_and_paste_bindings() {
+        let contexts = stack(&["app", "terminal"]);
+        for action in ["app::TerminalCopy", "app::TerminalPaste"] {
+            let live: Vec<_> = crate::default_key_bindings()
+                .into_iter()
+                .filter(|binding| binding.action().name() == action && enabled(binding, &contexts))
+                .collect();
+            assert_eq!(
+                live.len(),
+                1,
+                "exactly one real {action} binding must be live while a terminal has focus"
+            );
+        }
+    }
+
+    /// The copy/paste bindings must be *terminal-only*. A global one would claim the keystroke
+    /// over the File view and the file tree, where `secondary-c`/`secondary-v` already have
+    /// their own real, differently-scoped bindings - the exact "keystroke reaches the wrong
+    /// handler" bug class this whole matrix exists for.
+    #[test]
+    fn terminal_copy_and_paste_are_dead_everywhere_but_a_terminal() {
+        for parts in real_context_stacks() {
+            if parts.contains(&"terminal") {
+                continue;
+            }
+            let contexts = stack(&parts);
+            for binding in crate::default_key_bindings() {
+                let name = binding.action().name();
+                if name != "app::TerminalCopy" && name != "app::TerminalPaste" {
+                    continue;
+                }
+                assert!(
+                    !enabled(&binding, &contexts),
+                    "{name} must not be live on the {parts:?} context stack"
+                );
+            }
+        }
+    }
+
+    /// Plain `Ctrl+C`/`Ctrl+V` must stay genuinely unbound over a terminal - they are the pty's
+    /// own `SIGINT` (`0x03`) and readline `quoted-insert` (`0x16`) bytes. This is what forces
+    /// issue #158's copy/paste onto the shifted variants instead of the obvious `secondary-c`/
+    /// `secondary-v`, so it is asserted rather than left as a comment. (On macOS `secondary-` is
+    /// `cmd-`, which is a different physical keystroke from `ctrl-c` and never reaches the pty
+    /// anyway, so the literal `ctrl-` keystrokes are what matters on every platform.)
+    #[test]
+    fn plain_ctrl_c_and_ctrl_v_are_never_claimed_over_a_focused_terminal() {
+        let contexts = stack(&["app", "terminal"]);
+        for binding in crate::default_key_bindings() {
+            if binding.keystrokes().len() != 1 {
+                continue;
+            }
+            let keystroke = binding.keystrokes()[0].inner().unparse();
+            if keystroke != "ctrl-c" && keystroke != "ctrl-v" {
+                continue;
+            }
+            assert!(
+                !enabled(&binding, &contexts),
+                "{} must not claim {keystroke} while a terminal has focus - that byte belongs \
+                 to the running process",
+                binding.action().name()
             );
         }
     }

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -194,6 +194,8 @@ actions!(
         FileTreeUndo,
         FileTreeRedo,
         TerminalClear,
+        TerminalCopy,
+        TerminalPaste,
     ]
 );
 
@@ -2233,6 +2235,8 @@ impl Render for AdeApp {
             .on_action(cx.listener(Self::handle_jump_to_agent_8_action))
             .on_action(cx.listener(Self::handle_close_focused_tab_action))
             .on_action(cx.listener(Self::handle_terminal_clear_action))
+            .on_action(cx.listener(Self::handle_terminal_copy_action))
+            .on_action(cx.listener(Self::handle_terminal_paste_action))
             .child(self.render_title_bar(cx))
             // The Settings surface (`design_handoff_jerry_ade/README.md`: "a separate surface,
             // not a modal: it replaces the three zones while the title bar and status bar

--- a/crates/app/src/settings/state.rs
+++ b/crates/app/src/settings/state.rs
@@ -582,6 +582,9 @@ pub(crate) fn action_label(action: &dyn gpui::Action) -> Option<&'static str> {
         "app::FileTreeUndo" => Some("Files tree: undo"),
         "app::FileTreeRedo" => Some("Files tree: redo"),
         "app::TerminalClear" => Some("Terminal: clear"),
+        // GitHub issue #158.
+        "app::TerminalCopy" => Some("Terminal: copy selection"),
+        "app::TerminalPaste" => Some("Terminal: paste"),
         _ => None,
     }
 }
@@ -1317,6 +1320,9 @@ mod tests {
                 "Close focused tab",
                 // GitHub issue #20's terminal footer `clear`, scoped `Some("terminal")`.
                 "Terminal: clear",
+                // GitHub issue #158's terminal copy/paste, both scoped `Some("terminal")`.
+                "Terminal: copy selection",
+                "Terminal: paste",
             ]
         );
     }
@@ -1385,6 +1391,10 @@ mod tests {
         // GitHub issue #155 removed 1: `FileTreeContextMenu` (`Shift+F10`) - right-click plus
         // each row's own already-bound shortcut covers the same ground, so a second
         // keyboard-only path to the menu had no real justification of its own.
+        // GitHub issue #158 added 2 more real scoped bindings: `TerminalCopy`/`TerminalPaste`
+        // (`cmd-c`/`cmd-v` on macOS, `ctrl-shift-c`/`ctrl-shift-v` elsewhere), both
+        // `Some("terminal")` - see `crate::default_key_bindings`'s own entry for why the shifted
+        // variants, and why leaving them unbound was the bug.
         let bindings = crate::default_key_bindings();
         let rows = keybinding_rows(&bindings, &[]);
         assert!(!rows.is_empty());
@@ -1392,7 +1402,7 @@ mod tests {
             rows.iter().filter(|row| row.context != "global").collect();
         assert_eq!(
             scoped.len(),
-            73,
+            75,
             "expected `] -> NextChangedFile` (1) plus every real Editor* binding (19) plus \
              every real Completions* binding (5) plus every real merge-editor binding (18) plus \
              TextUndo/TextRedo (3, GitHub issue #17) plus every real \
@@ -1401,7 +1411,8 @@ mod tests {
              binding (8, GitHub issue #27) plus every real multi-cursor Editor* binding (4, \
              GitHub issue #28) plus every real GitHub issue #26 binding (7, not counting \
              EditorCollapseCursors above, which is issue #28's own action) plus TerminalClear \
-             (1, GitHub issue #20) to be scoped, not global"
+             (1, GitHub issue #20) plus TerminalCopy/TerminalPaste (2, GitHub issue #158) to be \
+             scoped, not global"
         );
         assert!(
             scoped

--- a/crates/app/src/terminal/grid.rs
+++ b/crates/app/src/terminal/grid.rs
@@ -50,11 +50,27 @@
 //! `Color::Indexed` (matching `vendor/zed/crates/terminal/src/terminal.rs`'s
 //! `get_color_at_index`/`rgb_for_index`, a public xterm convention). A program that repalettes
 //! its own colors via OSC renders with the default palette instead.
+//!
+//! ## Text selection (GitHub issue #158)
+//!
+//! Selection is not tracked here at all - it lives in `alacritty_terminal`'s own
+//! `Term::selection` field (`term/mod.rs:275`, a real `pub Option<Selection>`), driven through
+//! its own `Selection::new`/`Selection::update` API (`selection.rs:125`/`:133`) and read back
+//! through `Term::selection_to_string` (`term/mod.rs:529`). This module only translates between
+//! that API's `Point`/`Side` coordinates and the row/column [`CellPosition`] the pane's mouse
+//! handling produces, so no second, drifting copy of "what is selected" exists. Selection
+//! invalidation is likewise `Term`'s own and not re-implemented here: it rotates the selection
+//! with the grid when the screen scrolls (`Term::scroll_down_relative`/`scroll_up_relative`'s
+//! own `Selection::rotate` calls) and drops it on `ClearMode::All` (`term/mod.rs:1803`) and on
+//! an alt-screen swap (`Term::swap_alt`, `:733`) - which is why [`TerminalGrid::clear`], itself
+//! just an `ESC[2J` through the same parser, needs no selection handling of its own.
 
 use alacritty_terminal::event::{Event as AlacEvent, EventListener};
 use alacritty_terminal::grid::Dimensions;
+use alacritty_terminal::index::{Column, Line, Point as AlacPoint, Side};
+use alacritty_terminal::selection::{Selection, SelectionType};
 use alacritty_terminal::term::cell::{Cell as AlacCell, Flags};
-use alacritty_terminal::term::{Config, Term};
+use alacritty_terminal::term::{Config, Term, TermMode};
 use alacritty_terminal::vte::ansi::{Color, CursorShape, NamedColor, Processor, StdSyncHandler};
 
 /// A concrete [`Dimensions`] impl for a fixed rows/cols grid. Scrollback history is reported as
@@ -127,6 +143,51 @@ pub struct GridCell {
     pub italic: bool,
     pub underline: bool,
     pub strikethrough: bool,
+    /// Whether this cell falls inside the live text selection (GitHub issue #158). Derived
+    /// every [`TerminalGrid::visible_rows`] call from `alacritty_terminal`'s own
+    /// `RenderableContent::selection` (`term/mod.rs:2408`, itself `Term::selection.to_range`),
+    /// never stored - so it can't go stale against the real selection the way a separately
+    /// tracked copy would.
+    pub selected: bool,
+}
+
+/// Which half of a character cell a pointer position fell in - the row/column-space counterpart
+/// of `alacritty_terminal::index::Side` (`index.rs:14`, `pub type Side = Direction`), which is
+/// what decides whether the cell under the pointer is included in a drag selection or not.
+/// Mirrored here rather than re-exporting `Side` so `crate::terminal::pane`'s mouse handling
+/// never touches `alacritty_terminal` types directly, matching this module's existing contract
+/// for [`GridCell`]'s already-resolved RGB colors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CellSide {
+    Left,
+    Right,
+}
+
+impl CellSide {
+    fn to_alacritty(self) -> Side {
+        match self {
+            CellSide::Left => Side::Left,
+            CellSide::Right => Side::Right,
+        }
+    }
+}
+
+/// A position inside the visible grid, in the same viewport row/column space
+/// [`TerminalGrid::visible_rows`] returns (`row` indexes that `Vec`, `column` indexes a row).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CellPosition {
+    pub row: usize,
+    pub column: usize,
+    pub side: CellSide,
+}
+
+impl CellPosition {
+    /// Valid only while `display_offset == 0`, which is always the case here - this module
+    /// never calls `Term::scroll_display` (see the module docs' "no scrollback UI" scope cut),
+    /// so a viewport row index *is* the grid `Line` index.
+    fn to_alacritty(self) -> AlacPoint {
+        AlacPoint::new(Line(self.row as i32), Column(self.column))
+    }
 }
 
 /// Default foreground/background, used both for `NamedColor::Foreground`/`Background` and this
@@ -134,6 +195,14 @@ pub struct GridCell {
 /// `rgb(0x1e1e1e)`).
 pub const DEFAULT_FOREGROUND: (u8, u8, u8) = (0xd4, 0xd4, 0xd4);
 pub const DEFAULT_BACKGROUND: (u8, u8, u8) = (0x1e, 0x1e, 0x1e);
+
+/// The fill painted behind a selected cell (GitHub issue #158). `#264f78` - VS Code's own
+/// `terminal.selectionBackground`, the same source [`NAMED_COLOR_PALETTE`] below already takes
+/// its 16 ANSI values from, rather than `crate::theme::editor::SELECTION`: this module's colors
+/// are deliberately a fixed palette independent of the live theme (see the module docs' palette
+/// scope cut), and a selection fill that tracked the theme while the 16 colors behind it did not
+/// would be the only thing in the terminal that did.
+pub const SELECTION_BACKGROUND: (u8, u8, u8) = (0x26, 0x4f, 0x78);
 
 /// The standard ANSI 16-color palette (VS Code's default terminal theme values), indexed
 /// `0..=15` by `NamedColor`'s own discriminants / `Color::Indexed(0..=15)`.
@@ -224,7 +293,7 @@ fn resolve_color(color: Color) -> (u8, u8, u8) {
     }
 }
 
-fn grid_cell_from_alacritty(cell: &AlacCell, is_cursor: bool) -> GridCell {
+fn grid_cell_from_alacritty(cell: &AlacCell, is_cursor: bool, selected: bool) -> GridCell {
     let mut fg = resolve_color(cell.fg);
     let mut bg = resolve_color(cell.bg);
     if cell.flags.contains(Flags::INVERSE) {
@@ -234,6 +303,7 @@ fn grid_cell_from_alacritty(cell: &AlacCell, is_cursor: bool) -> GridCell {
         std::mem::swap(&mut fg, &mut bg);
     }
     GridCell {
+        selected,
         // An uninitialized-by-any-write cell holds `'\0'` (`Cell::default()` in
         // `term/cell.rs` uses `c: ' '` only as the *constructed* default) - render as a
         // space either way.
@@ -332,11 +402,13 @@ impl TerminalGrid {
 
     /// A snapshot of the currently visible grid (`rows.len() == screen_lines`, each row has
     /// exactly `columns` cells). The cell at the cursor's current position (if visible) has its
-    /// fg/bg swapped, so the renderer doesn't need to separately overlay a cursor glyph.
+    /// fg/bg swapped, so the renderer doesn't need to separately overlay a cursor glyph, and
+    /// every cell inside the live selection is flagged [`GridCell::selected`].
     pub fn visible_rows(&self) -> Vec<Vec<GridCell>> {
         let content = self.term.renderable_content();
         let cursor_point =
             (content.cursor.shape != CursorShape::Hidden).then_some(content.cursor.point);
+        let selection = content.selection;
 
         let mut rows: Vec<Vec<GridCell>> = (0..self.size.rows)
             .map(|_| Vec::with_capacity(self.size.cols))
@@ -352,10 +424,58 @@ impl TerminalGrid {
                 continue;
             };
             let is_cursor = cursor_point == Some(indexed.point);
-            row.push(grid_cell_from_alacritty(indexed.cell, is_cursor));
+            let selected = selection.is_some_and(|range| range.contains(indexed.point));
+            row.push(grid_cell_from_alacritty(indexed.cell, is_cursor, selected));
         }
 
         rows
+    }
+
+    // ------------------------------------------------------------------ selection (issue #158)
+
+    /// Anchors a new selection at `position`, discarding any previous one - what a real
+    /// mouse-down inside the grid does. A selection anchored and never dragged is genuinely
+    /// *empty* (`Selection::is_empty`, `selection.rs:193`), so [`Self::selected_text`] returns
+    /// `None` for it: a plain click therefore clears the selection rather than selecting one
+    /// stray character, without this needing a "was it a drag?" flag of its own.
+    pub fn start_selection(&mut self, position: CellPosition) {
+        self.term.selection = Some(Selection::new(
+            SelectionType::Simple,
+            position.to_alacritty(),
+            position.side.to_alacritty(),
+        ));
+    }
+
+    /// Moves the *end* of the in-progress selection to `position` (`Selection::update`,
+    /// `selection.rs:133`) - what a real mouse-drag does. A no-op when nothing is anchored, so
+    /// an ordinary hover can never conjure a selection out of nothing.
+    pub fn update_selection(&mut self, position: CellPosition) {
+        if let Some(selection) = self.term.selection.as_mut() {
+            selection.update(position.to_alacritty(), position.side.to_alacritty());
+        }
+    }
+
+    pub fn clear_selection(&mut self) {
+        self.term.selection = None;
+    }
+
+    /// The real selected text, straight out of `Term::selection_to_string`
+    /// (`term/mod.rs:529`) - `None` when nothing is selected, when the anchored selection is
+    /// still empty, or when the selected span is entirely blank (a drag across empty screen has
+    /// nothing worth putting on the clipboard, and silently replacing the clipboard with `""`
+    /// would destroy whatever the user copied last).
+    pub fn selected_text(&self) -> Option<String> {
+        self.term
+            .selection_to_string()
+            .filter(|text| !text.is_empty())
+    }
+
+    /// Whether the running program has turned on bracketed-paste mode (`DECSET 2004`), which
+    /// decides how [`crate::terminal::pane::TerminalPane`] frames pasted bytes - see that
+    /// method's own docs. Read live off `Term::mode()` (`term/mod.rs:709`) rather than latched,
+    /// since a program can enable and disable it at any point in its own lifetime.
+    pub fn bracketed_paste_enabled(&self) -> bool {
+        self.term.mode().contains(TermMode::BRACKETED_PASTE)
     }
 }
 
@@ -538,5 +658,179 @@ mod tests {
             "expected 'O' at row 2 col 3, got rows: {rows:?}"
         );
         assert_eq!(rows[1][3].c, 'K');
+    }
+}
+
+/// GitHub issue #158: before this, `TerminalGrid` exposed no selection surface at all -
+/// `Term::selection` was never written and `Term::selection_to_string` never called, so there
+/// was nothing for a Copy binding to copy even once one existed. These cover the real
+/// `alacritty_terminal` selection API this module now drives, with no GPUI window involved.
+#[cfg(test)]
+mod selection_tests {
+    use super::*;
+
+    fn left(row: usize, column: usize) -> CellPosition {
+        CellPosition {
+            row,
+            column,
+            side: CellSide::Left,
+        }
+    }
+
+    fn right(row: usize, column: usize) -> CellPosition {
+        CellPosition {
+            row,
+            column,
+            side: CellSide::Right,
+        }
+    }
+
+    #[test]
+    fn nothing_is_selected_until_a_selection_is_actually_dragged() {
+        let mut grid = TerminalGrid::new(5, 20);
+        grid.append_bytes(b"hello world");
+        assert_eq!(grid.selected_text(), None, "no selection has been anchored");
+
+        // A plain click (anchor, no drag) is genuinely empty - it must clear a selection, not
+        // select the one character under the pointer.
+        grid.start_selection(left(0, 3));
+        assert_eq!(
+            grid.selected_text(),
+            None,
+            "an anchored-but-never-dragged selection must not put a stray character on the \
+             clipboard"
+        );
+    }
+
+    #[test]
+    fn a_drag_across_one_row_selects_exactly_those_characters() {
+        let mut grid = TerminalGrid::new(5, 20);
+        grid.append_bytes(b"hello world");
+
+        // Columns 6..=10 are "world"; anchoring on the left of column 6 and releasing on the
+        // right of column 10 is exactly the span a real left-to-right drag produces.
+        grid.start_selection(left(0, 6));
+        grid.update_selection(right(0, 10));
+
+        assert_eq!(grid.selected_text().as_deref(), Some("world"));
+    }
+
+    #[test]
+    fn a_backwards_drag_selects_the_same_span_as_a_forwards_one() {
+        let mut grid = TerminalGrid::new(5, 20);
+        grid.append_bytes(b"hello world");
+
+        grid.start_selection(right(0, 10));
+        grid.update_selection(left(0, 6));
+
+        assert_eq!(
+            grid.selected_text().as_deref(),
+            Some("world"),
+            "`Selection::to_range` orders its own anchors, so dragging right-to-left must \
+             produce the identical text"
+        );
+    }
+
+    #[test]
+    fn a_multi_row_drag_selects_across_the_line_break() {
+        let mut grid = TerminalGrid::new(5, 20);
+        grid.append_bytes(b"first line\r\nsecond line");
+
+        grid.start_selection(left(0, 6));
+        grid.update_selection(right(1, 5));
+
+        assert_eq!(
+            grid.selected_text().as_deref(),
+            Some("line\nsecond"),
+            "a real cross-row selection keeps the line break `Term::bounds_to_string` inserts"
+        );
+    }
+
+    #[test]
+    fn clearing_the_selection_really_clears_it() {
+        let mut grid = TerminalGrid::new(5, 20);
+        grid.append_bytes(b"hello world");
+        grid.start_selection(left(0, 0));
+        grid.update_selection(right(0, 4));
+        assert_eq!(grid.selected_text().as_deref(), Some("hello"));
+
+        grid.clear_selection();
+        assert_eq!(grid.selected_text(), None);
+    }
+
+    /// Pins the module docs' claim that selection invalidation is `alacritty_terminal`'s job:
+    /// [`TerminalGrid::clear`] is only an `ESC[2J` through the parser and has no selection code
+    /// of its own, so a stale selection surviving a clear would be a real bug (copy would then
+    /// return text that is no longer on screen).
+    #[test]
+    fn clearing_the_screen_drops_the_selection_without_this_module_doing_anything() {
+        let mut grid = TerminalGrid::new(5, 20);
+        grid.append_bytes(b"hello world");
+        grid.start_selection(left(0, 0));
+        grid.update_selection(right(0, 4));
+        assert_eq!(grid.selected_text().as_deref(), Some("hello"));
+
+        grid.clear();
+        assert_eq!(grid.selected_text(), None);
+    }
+
+    #[test]
+    fn a_drag_across_blank_screen_selects_nothing_worth_copying() {
+        let mut grid = TerminalGrid::new(5, 20);
+        grid.start_selection(left(2, 0));
+        grid.update_selection(right(2, 15));
+        assert_eq!(
+            grid.selected_text(),
+            None,
+            "an all-blank span must not overwrite the clipboard with an empty string"
+        );
+    }
+
+    /// The selection has to be *visible*, not just readable - a `GridCell` that never carried
+    /// the flag would leave the renderer with nothing to paint, so a user dragging across the
+    /// terminal would see no feedback at all.
+    #[test]
+    fn selected_cells_are_flagged_for_the_renderer() {
+        let mut grid = TerminalGrid::new(5, 20);
+        grid.append_bytes(b"hello world");
+        grid.start_selection(left(0, 6));
+        grid.update_selection(right(0, 10));
+
+        let rows = grid.visible_rows();
+        let flagged: String = rows[0]
+            .iter()
+            .filter(|cell| cell.selected)
+            .map(|cell| cell.c)
+            .collect();
+        assert_eq!(flagged, "world");
+        assert!(
+            rows[1].iter().all(|cell| !cell.selected),
+            "a single-row selection must not flag cells on any other row"
+        );
+    }
+
+    #[test]
+    fn no_selection_means_no_cell_is_flagged() {
+        let mut grid = TerminalGrid::new(5, 20);
+        grid.append_bytes(b"hello world");
+        let rows = grid.visible_rows();
+        assert!(rows.iter().flatten().all(|cell| !cell.selected));
+    }
+
+    /// Paste framing depends on this being read from the *live* `Term::mode()` - a program that
+    /// turns bracketed paste on (`DECSET 2004`) and later off must be tracked both ways.
+    #[test]
+    fn bracketed_paste_mode_tracks_the_real_terminal_mode() {
+        let mut grid = TerminalGrid::new(5, 20);
+        assert!(
+            !grid.bracketed_paste_enabled(),
+            "bracketed paste is off until a program actually enables it"
+        );
+
+        grid.append_bytes(b"\x1b[?2004h");
+        assert!(grid.bracketed_paste_enabled());
+
+        grid.append_bytes(b"\x1b[?2004l");
+        assert!(!grid.bracketed_paste_enabled());
     }
 }

--- a/crates/app/src/terminal/pane.rs
+++ b/crates/app/src/terminal/pane.rs
@@ -72,7 +72,10 @@ use gpui::{
 };
 use pty_core::{ExitStatus, PtyError, PtySession, SpawnOptions};
 
-use crate::terminal::grid::{GridCell, TerminalGrid, DEFAULT_BACKGROUND, DEFAULT_FOREGROUND};
+use crate::terminal::grid::{
+    CellPosition, CellSide, GridCell, TerminalGrid, DEFAULT_BACKGROUND, DEFAULT_FOREGROUND,
+    SELECTION_BACKGROUND,
+};
 use crate::terminal::links::{self as terminal_links, LinkMatch};
 use crate::theme;
 
@@ -458,6 +461,12 @@ pub struct TerminalPane {
     /// writer, resynced on every active-agent change); `true` at construction because
     /// `Agents::spawn` makes a new agent active in the same step.
     is_foreground: bool,
+    /// `true` between a real left mouse-down inside the grid and the matching mouse-up - i.e.
+    /// while a text-selection drag is genuinely in progress (GitHub issue #158). Gates
+    /// [`Self::handle_mouse_move`] so an ordinary hover never extends a selection; the
+    /// selection *itself* lives in `alacritty_terminal`'s own `Term::selection` (see
+    /// `crate::terminal::grid`'s selection docs), not here.
+    selecting: bool,
 }
 
 impl TerminalPane {
@@ -485,6 +494,7 @@ impl TerminalPane {
             resize_latch: ResizeLatch::default(),
             _task: None,
             is_foreground: true,
+            selecting: false,
         };
         this.spawn_process(cx);
         this
@@ -659,6 +669,130 @@ impl TerminalPane {
         cx.notify();
     }
 
+    // ------------------------------------------------------------ clipboard (GitHub issue #158)
+
+    /// Writes this pane's real current selection to the real OS clipboard
+    /// (`gpui::App::write_to_clipboard`, the same call `crate::sidebar::tree_ops::AdeApp::
+    /// copy_path_to_system_clipboard` already uses for "Copy Path" - one clipboard mechanism in
+    /// this app, not two). Returns whether anything was actually copied.
+    ///
+    /// A no-op when nothing is selected, deliberately: `Ctrl+Shift+C` with no selection must
+    /// leave whatever the user copied earlier alone rather than replacing it with an empty
+    /// string. See [`crate::terminal::grid::TerminalGrid::selected_text`] for what "nothing
+    /// selected" covers (no anchor, an undragged anchor, or an all-blank span).
+    pub fn copy_selection(&mut self, cx: &mut Context<Self>) -> bool {
+        let Some(text) = self.grid.selected_text() else {
+            return false;
+        };
+        cx.write_to_clipboard(gpui::ClipboardItem::new_string(text));
+        true
+    }
+
+    /// Reads the real OS clipboard and feeds it to the child process through
+    /// `PtySession::write_input` - the exact same path [`Self::handle_key_down`] writes typed
+    /// keystrokes through, so a paste is indistinguishable to the child from very fast typing.
+    /// Returns whether bytes were actually written.
+    ///
+    /// Framing is [`paste_payload`]'s job; see its docs for why a raw write of the clipboard
+    /// text would be wrong.
+    pub fn paste_from_clipboard(&mut self, cx: &mut Context<Self>) -> bool {
+        let Some(text) = cx.read_from_clipboard().and_then(|item| item.text()) else {
+            return false;
+        };
+        if text.is_empty() {
+            return false;
+        }
+        let Some(session) = &self.session else {
+            return false;
+        };
+        let payload = paste_payload(&text, self.grid.bracketed_paste_enabled());
+        if let Err(err) = session.write_input(payload.as_bytes()) {
+            self.spawn_error = Some(format!("failed to write input: {err}"));
+            cx.notify();
+            return false;
+        }
+        true
+    }
+
+    /// Maps a window-space pointer position onto the grid cell under it, or `None` before this
+    /// pane has ever painted (no measured [`Self::content_bounds`] to resolve against yet).
+    ///
+    /// The grid's own origin is the pane's padding box inset by [`PANE_PADDING_PX`] (see
+    /// [`Self::maybe_resize_pty`]'s docs for why `content_bounds` is the padding box), pushed
+    /// down one further line when the spawn-error message is occupying the first rendered line:
+    /// `render` draws that message *above* the grid rows, so ignoring it would shift every
+    /// computed row by one on exactly the panes that show it.
+    fn cell_position_at(
+        &mut self,
+        position: gpui::Point<Pixels>,
+        window: &Window,
+    ) -> Option<CellPosition> {
+        let bounds = self.content_bounds?;
+        let cell_size = self.cell_size(window);
+        let leading_rows = if self.spawn_error.is_some() { 1.0 } else { 0.0 };
+        let origin = gpui::point(
+            bounds.origin.x + px(PANE_PADDING_PX),
+            bounds.origin.y + px(PANE_PADDING_PX) + cell_size.height * leading_rows,
+        );
+        let (cols, rows) = self.grid.dimensions();
+        Some(cell_position_in_grid(
+            position, origin, cell_size, rows, cols,
+        ))
+    }
+
+    /// Anchors a fresh selection under the pointer and takes focus - a real left mouse-down
+    /// inside the grid. Anchoring on *every* left mouse-down (not only ones that turn into
+    /// drags) is what makes a plain click clear the previous selection, since an undragged
+    /// anchor is empty - see [`crate::terminal::grid::TerminalGrid::start_selection`]'s docs.
+    fn handle_mouse_down(
+        &mut self,
+        event: &gpui::MouseDownEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        window.focus(&self.focus_handle, cx);
+        let Some(position) = self.cell_position_at(event.position, window) else {
+            return;
+        };
+        self.grid.start_selection(position);
+        self.selecting = true;
+        cx.notify();
+    }
+
+    /// Extends an in-progress selection to the pointer. Gated on [`Self::selecting`] *and* on
+    /// the left button still being held: a mouse-up that happens outside this pane's bounds
+    /// never reaches [`Self::handle_mouse_up`] (GPUI's `on_mouse_up` only fires over a hovered
+    /// hitbox), so without the second check a drag released elsewhere would leave this pane
+    /// extending its selection on every later hover.
+    fn handle_mouse_move(
+        &mut self,
+        event: &gpui::MouseMoveEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if !self.selecting {
+            return;
+        }
+        if event.pressed_button != Some(gpui::MouseButton::Left) {
+            self.selecting = false;
+            return;
+        }
+        let Some(position) = self.cell_position_at(event.position, window) else {
+            return;
+        };
+        self.grid.update_selection(position);
+        cx.notify();
+    }
+
+    fn handle_mouse_up(
+        &mut self,
+        _event: &gpui::MouseUpEvent,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) {
+        self.selecting = false;
+    }
+
     /// Test-only seam: feeds bytes straight into this pane's grid, exactly as
     /// [`Self::spawn_process`]'s poll loop does for pty output - lets a test put known,
     /// deterministic text on screen without synchronizing against a real child process's
@@ -667,6 +801,31 @@ impl TerminalPane {
     pub(crate) fn inject_bytes_for_test(&mut self, bytes: &[u8], cx: &mut Context<Self>) {
         self.grid.append_bytes(bytes);
         cx.notify();
+    }
+
+    /// Test-only seam: the pane's real current selection text, so a test outside this module
+    /// can assert on what a simulated drag actually selected.
+    #[cfg(test)]
+    pub(crate) fn selected_text_for_test(&self) -> Option<String> {
+        self.grid.selected_text()
+    }
+
+    /// Test-only seam: anchors and drags a selection over the given cell span, exactly as
+    /// [`Self::handle_mouse_down`]/[`Self::handle_mouse_move`] do - lets a test outside this
+    /// module (e.g. the `TerminalCopy` action's own coverage) set up a real selection without
+    /// also depending on painted pixel geometry.
+    #[cfg(test)]
+    pub(crate) fn select_cells_for_test(&mut self, row: usize, columns: std::ops::Range<usize>) {
+        self.grid.start_selection(CellPosition {
+            row,
+            column: columns.start,
+            side: CellSide::Left,
+        });
+        self.grid.update_selection(CellPosition {
+            row,
+            column: columns.end.saturating_sub(1),
+            side: CellSide::Right,
+        });
     }
 
     /// Test-only seam: this pane's measured content-area bounds - lets a test compute a click
@@ -1075,6 +1234,66 @@ fn size_to_grid(size: Size<Pixels>, cell_size: Size<Pixels>) -> (u16, u16) {
     (rows, cols)
 }
 
+/// Maps a window-space pointer position onto the grid cell under it, given the grid's own
+/// painted `origin` (top-left of row 0, column 0), the measured `cell_size`, and the grid's
+/// current `rows`/`cols`. Pure - independent of `Window` and this pane's state - so the
+/// pixel-to-cell arithmetic is directly unit-testable, the same split [`size_to_grid`] uses.
+///
+/// Clamped into the grid on every side rather than returning `None` off-grid: a drag that runs
+/// past the last column or below the last row is an ordinary "select to the end" gesture, and
+/// every terminal treats it that way. The clamped-past-the-right-edge case resolves to
+/// [`CellSide::Right`] specifically, so the final column is genuinely *included* in the
+/// selection - `Selection::to_range`'s own `range_simple` drops the last cell when the
+/// selection ends on a cell's left side (`selection.rs:333`).
+fn cell_position_in_grid(
+    position: gpui::Point<Pixels>,
+    origin: gpui::Point<Pixels>,
+    cell_size: Size<Pixels>,
+    rows: u16,
+    cols: u16,
+) -> CellPosition {
+    // `.max(1.0)`: a degenerate zero cell size can only come from a failed font measurement,
+    // and dividing by it would produce `inf`/`NaN` column indexes.
+    let cell_width = cell_size.width.as_f32().max(1.0);
+    let cell_height = cell_size.height.as_f32().max(1.0);
+    let dx = (position.x - origin.x).as_f32().max(0.0);
+    let dy = (position.y - origin.y).as_f32().max(0.0);
+
+    let last_row = rows.saturating_sub(1) as usize;
+    let last_column = cols.saturating_sub(1) as usize;
+    let row = ((dy / cell_height) as usize).min(last_row);
+    let raw_column = dx / cell_width;
+    let column = (raw_column as usize).min(last_column);
+    let side = if raw_column as usize > last_column || raw_column - column as f32 >= 0.5 {
+        CellSide::Right
+    } else {
+        CellSide::Left
+    };
+
+    CellPosition { row, column, side }
+}
+
+/// Frames clipboard text for writing into a pty, matching
+/// `vendor/zed/crates/terminal/src/terminal.rs`'s own `paste` (`:2306`) rather than writing the
+/// raw string:
+///
+/// - **Bracketed paste on** (`DECSET 2004`, which shells like `zsh`/`fish` and every full-screen
+///   editor turn on): wrap in `ESC[200~`/`ESC[201~` so the program knows this was pasted, not
+///   typed - that is exactly what stops a multi-line paste from auto-executing each line in a
+///   shell, and what lets `vim` skip auto-indent. Any `ESC` inside the pasted text is stripped,
+///   since a payload containing `ESC[201~` could otherwise close the bracket early and have the
+///   rest interpreted as commands.
+/// - **Bracketed paste off**: newlines are normalized to `\r`, the byte the Enter key actually
+///   sends ([`keystroke_to_bytes`]'s own `"enter" => b"\r"`). A raw `\n` is a line *feed*, not a
+///   carriage return, and a shell reading it in canonical mode would not run the line.
+fn paste_payload(text: &str, bracketed_paste: bool) -> String {
+    if bracketed_paste {
+        format!("\x1b[200~{}\x1b[201~", text.replace('\x1b', ""))
+    } else {
+        text.replace("\r\n", "\r").replace('\n', "\r")
+    }
+}
+
 /// Converts [`TerminalPane::content_bounds`]'s raw padding-box measurement into the content-box
 /// size glyphs actually render into, by subtracting [`PANE_PADDING_PX`] from each side - see
 /// [`TerminalPane::maybe_resize_pty`]'s docs for the padding-box-vs-content-box bug this fixes.
@@ -1232,6 +1451,10 @@ fn same_run_style(a: &GridCell, b: &GridCell) -> bool {
         && a.italic == b.italic
         && a.underline == b.underline
         && a.strikethrough == b.strikethrough
+        // GitHub issue #158: selection is a rendered attribute (it repaints the cell's
+        // background), so a run must break at the selection's own edges - merging across one
+        // would paint unselected characters as selected.
+        && a.selected == b.selected
 }
 
 /// One segment of a grid row - either a span of the row's original style-per-cell text, or a
@@ -1286,7 +1509,11 @@ fn split_segments(row_char_count: usize, links: &[LinkMatch]) -> Vec<RowSegment>
 
 fn plain_span(style: &GridCell, text: String) -> impl IntoElement {
     let mut span = div().text_color(rgb(pack_rgb(style.fg)));
-    if style.bg != DEFAULT_BACKGROUND {
+    // The selection fill wins over the cell's own ANSI background, so a selection is visible
+    // across text a program has coloured - which is most of what an agent CLI prints.
+    if style.selected {
+        span = span.bg(rgb(pack_rgb(SELECTION_BACKGROUND)));
+    } else if style.bg != DEFAULT_BACKGROUND {
         span = span.bg(rgb(pack_rgb(style.bg)));
     }
     if style.bold {
@@ -1330,6 +1557,7 @@ fn render_link_span(
     cwd: &Path,
     row_index: usize,
     link_ordinal: usize,
+    selected: bool,
     cx: &mut Context<TerminalPane>,
 ) -> impl IntoElement {
     let target = terminal_links::resolve(cwd, &link.path);
@@ -1342,6 +1570,9 @@ fn render_link_span(
         .border_b_1()
         .border_color(theme::term::LINK_UNDERLINE)
         .child(text);
+    if selected {
+        span = span.bg(rgb(pack_rgb(SELECTION_BACKGROUND)));
+    }
     span.style().border_style = Some(BorderStyle::Dashed);
 
     span.hover(|mut el| {
@@ -1415,16 +1646,31 @@ fn render_row(
                 }
             }
             RowSegment::Link { start, end, link } => {
-                let text: String = row[start..end].iter().map(|cell| cell.c).collect();
-                line = line.child(render_link_span(
-                    text,
-                    &link,
-                    cwd,
-                    row_index,
-                    link_ordinal,
-                    cx,
-                ));
-                link_ordinal += 1;
+                // A selection can end part-way through a link, so the link is split into one
+                // span per selected/unselected run rather than highlighted as a unit - every
+                // sub-span keeps the same click target, so clicking any part of the link still
+                // opens the same file. In the overwhelmingly common (unselected) case this is
+                // one iteration producing exactly the single span it always did.
+                let mut inner = start;
+                while inner < end {
+                    let selected = row[inner].selected;
+                    let mut run_end = inner + 1;
+                    while run_end < end && row[run_end].selected == selected {
+                        run_end += 1;
+                    }
+                    let text: String = row[inner..run_end].iter().map(|cell| cell.c).collect();
+                    line = line.child(render_link_span(
+                        text,
+                        &link,
+                        cwd,
+                        row_index,
+                        link_ordinal,
+                        selected,
+                        cx,
+                    ));
+                    link_ordinal += 1;
+                    inner = run_end;
+                }
             }
         }
     }
@@ -1467,6 +1713,9 @@ fn render_plain_line_with_links(
                     // own `row_index` never reaches anywhere close to `usize::MAX`).
                     usize::MAX,
                     link_ordinal,
+                    // The spawn-error line is not part of the grid, so it is never part of a
+                    // grid selection.
+                    false,
                     cx,
                 ));
                 link_ordinal += 1;
@@ -1523,6 +1772,15 @@ impl Render for TerminalPane {
             .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
                 window.focus(&this.focus_handle, cx);
             }))
+            // Real mouse text selection (GitHub issue #158). Left-button only: a right-click
+            // has no selection meaning here, and a middle-click is the X11 primary-selection
+            // paste gesture this pane deliberately does not claim.
+            .on_mouse_down(
+                gpui::MouseButton::Left,
+                cx.listener(Self::handle_mouse_down),
+            )
+            .on_mouse_move(cx.listener(Self::handle_mouse_move))
+            .on_mouse_up(gpui::MouseButton::Left, cx.listener(Self::handle_mouse_up))
             .relative()
             .flex()
             .flex_col()
@@ -2236,5 +2494,429 @@ mod clear_pty_signal_tests {
              appear in the grid - this is what actually proves the byte reached the pty, not \
              just that write_input() was called"
         );
+    }
+}
+
+/// GitHub issue #158's pixel-to-cell arithmetic - the half of mouse text selection that has
+/// nothing to do with GPUI. A wrong mapping here is invisible in a screenshot but silently
+/// copies the wrong characters, so it is pinned exactly.
+#[cfg(test)]
+mod cell_position_tests {
+    use super::*;
+    use gpui::{point, size};
+
+    /// A 10x20px cell grid whose origin is at (100, 200) - deliberately not (0, 0), so an
+    /// implementation that forgot to subtract the origin fails instead of accidentally passing.
+    fn at(x: f32, y: f32) -> CellPosition {
+        cell_position_in_grid(
+            point(px(100.0 + x), px(200.0 + y)),
+            point(px(100.0), px(200.0)),
+            size(px(10.0), px(20.0)),
+            24, // rows
+            80, // cols
+        )
+    }
+
+    #[test]
+    fn the_top_left_pixel_is_row_zero_column_zero() {
+        assert_eq!(
+            at(0.0, 0.0),
+            CellPosition {
+                row: 0,
+                column: 0,
+                side: CellSide::Left
+            }
+        );
+    }
+
+    #[test]
+    fn a_position_resolves_to_the_cell_containing_it() {
+        // x = 34px -> column 3 (30..40), 0.4 of the way in -> left half.
+        // y = 55px -> row 2 (40..60).
+        assert_eq!(
+            at(34.0, 55.0),
+            CellPosition {
+                row: 2,
+                column: 3,
+                side: CellSide::Left
+            }
+        );
+    }
+
+    /// The side is what decides whether the cell under the pointer is included in the selection
+    /// at all (`Selection::to_range`'s `range_simple` drops a cell the selection ends left of),
+    /// so the half-cell boundary is real behavior, not a detail.
+    #[test]
+    fn the_right_half_of_a_cell_reports_the_right_side() {
+        assert_eq!(at(35.0, 0.0).side, CellSide::Right);
+        assert_eq!(at(39.9, 0.0).side, CellSide::Right);
+        assert_eq!(at(34.9, 0.0).side, CellSide::Left);
+        assert_eq!(
+            at(35.0, 0.0).column,
+            3,
+            "the column is unchanged by the side"
+        );
+    }
+
+    #[test]
+    fn a_drag_past_the_right_edge_clamps_to_the_last_column_inclusively() {
+        let position = at(10_000.0, 0.0);
+        assert_eq!(position.column, 79);
+        assert_eq!(
+            position.side,
+            CellSide::Right,
+            "clamping to the *left* of the last column would silently drop that column from \
+             the selection"
+        );
+    }
+
+    #[test]
+    fn a_drag_past_the_bottom_clamps_to_the_last_row() {
+        assert_eq!(at(0.0, 10_000.0).row, 23);
+    }
+
+    /// Dragging back above/left of the grid origin (a real gesture - the pointer leaves the
+    /// pane) must clamp to the first cell rather than underflow into a huge `usize`.
+    #[test]
+    fn a_position_above_and_left_of_the_origin_clamps_to_the_first_cell() {
+        let position = cell_position_in_grid(
+            point(px(0.0), px(0.0)),
+            point(px(100.0), px(200.0)),
+            size(px(10.0), px(20.0)),
+            24,
+            80,
+        );
+        assert_eq!(position.row, 0);
+        assert_eq!(position.column, 0);
+    }
+
+    /// A failed font measurement can only produce a zero cell size; dividing by it would make
+    /// every index `inf as usize`. Guarded rather than left to chance.
+    #[test]
+    fn a_degenerate_zero_cell_size_does_not_produce_a_garbage_index() {
+        let position = cell_position_in_grid(
+            point(px(50.0), px(50.0)),
+            point(px(0.0), px(0.0)),
+            size(px(0.0), px(0.0)),
+            24,
+            80,
+        );
+        assert!(position.row < 24);
+        assert!(position.column < 80);
+    }
+}
+
+/// GitHub issue #158's paste framing. Writing the raw clipboard string to the pty is wrong in
+/// both modes for different reasons - see [`paste_payload`]'s own docs.
+#[cfg(test)]
+mod paste_payload_tests {
+    use super::*;
+
+    #[test]
+    fn without_bracketed_paste_newlines_become_carriage_returns() {
+        assert_eq!(paste_payload("one\ntwo", false), "one\rtwo");
+        assert_eq!(
+            paste_payload("one\r\ntwo", false),
+            "one\rtwo",
+            "a CRLF clipboard payload (Windows, or copied out of a browser) must not send two \
+             separate line endings"
+        );
+        assert_eq!(paste_payload("plain", false), "plain");
+    }
+
+    #[test]
+    fn with_bracketed_paste_the_text_is_wrapped_and_left_otherwise_intact() {
+        assert_eq!(
+            paste_payload("one\ntwo", true),
+            "\x1b[200~one\ntwo\x1b[201~",
+            "inside brackets the receiving program decides what a newline means - rewriting it \
+             here is what makes a multi-line paste auto-execute"
+        );
+    }
+
+    /// The real reason `ESC` is stripped: a payload carrying its own `ESC[201~` would close the
+    /// bracket early and have everything after it interpreted as typed input.
+    #[test]
+    fn a_pasted_escape_cannot_close_the_bracket_early() {
+        let payload = paste_payload("safe\x1b[201~rm -rf /", true);
+        assert_eq!(payload.matches("\x1b[201~").count(), 1);
+        assert!(payload.ends_with("\x1b[201~"));
+    }
+}
+
+/// GitHub issue #158, end to end at the pane level: a real selection produces a real OS
+/// clipboard write, and a real clipboard read produces real bytes on a real pty.
+#[cfg(test)]
+mod clipboard_tests {
+    use super::*;
+    use gpui::TestAppContext;
+
+    fn new_pane(cx: &mut TestAppContext, program: &str) -> gpui::Entity<TerminalPane> {
+        cx.new(|cx| {
+            TerminalPane::new(
+                TerminalSpec::command(program, Vec::new(), std::env::temp_dir()),
+                ROW_FONT_SIZE_PX,
+                cx,
+            )
+        })
+    }
+
+    #[gpui::test]
+    fn copying_a_real_selection_writes_it_to_the_real_system_clipboard(cx: &mut TestAppContext) {
+        let pane = new_pane(cx, "cat");
+        cx.run_until_parked();
+
+        cx.update(|cx| cx.write_to_clipboard(gpui::ClipboardItem::new_string("before".into())));
+
+        let copied = pane.update(cx, |pane, cx| {
+            pane.inject_bytes_for_test(b"hello world", cx);
+            pane.grid.start_selection(CellPosition {
+                row: 0,
+                column: 6,
+                side: CellSide::Left,
+            });
+            pane.grid.update_selection(CellPosition {
+                row: 0,
+                column: 10,
+                side: CellSide::Right,
+            });
+            pane.copy_selection(cx)
+        });
+
+        assert!(
+            copied,
+            "a real, non-empty selection must report a real copy"
+        );
+        let text = cx.update(|cx| cx.read_from_clipboard().and_then(|item| item.text()));
+        assert_eq!(text.as_deref(), Some("world"));
+    }
+
+    /// Copy with nothing selected must leave the clipboard alone. Overwriting it with `""` (the
+    /// obvious way to write this) would silently destroy whatever the user copied last, every
+    /// time they hit the shortcut out of habit.
+    #[gpui::test]
+    fn copying_with_no_selection_leaves_the_clipboard_untouched(cx: &mut TestAppContext) {
+        let pane = new_pane(cx, "cat");
+        cx.run_until_parked();
+
+        cx.update(|cx| cx.write_to_clipboard(gpui::ClipboardItem::new_string("keep me".into())));
+
+        let copied = pane.update(cx, |pane, cx| {
+            pane.inject_bytes_for_test(b"hello world", cx);
+            pane.copy_selection(cx)
+        });
+
+        assert!(!copied);
+        let text = cx.update(|cx| cx.read_from_clipboard().and_then(|item| item.text()));
+        assert_eq!(text.as_deref(), Some("keep me"));
+    }
+
+    /// End-to-end proof that paste reaches the *child process*, observed the same way
+    /// [`clear_pty_signal_tests`] proves `clear()`'s byte does: a real `cat` on a real pty
+    /// echoes back what it is fed, so the pasted text appearing in the grid is round-tripped
+    /// evidence the bytes genuinely left the app, not an assertion that `write_input` was
+    /// called.
+    #[gpui::test]
+    fn pasting_writes_the_real_clipboard_text_to_the_real_pty(cx: &mut TestAppContext) {
+        let pane = new_pane(cx, "cat");
+        cx.run_until_parked();
+
+        cx.update(|cx| {
+            cx.write_to_clipboard(gpui::ClipboardItem::new_string("ade-pasted-text".into()))
+        });
+        let pasted = pane.update(cx, |pane, cx| pane.paste_from_clipboard(cx));
+        assert!(pasted, "a live session must accept a real paste");
+
+        let mut saw_pasted_text = false;
+        for _ in 0..50 {
+            cx.background_executor.advance_clock(POLL_INTERVAL);
+            cx.run_until_parked();
+            let lines = pane.read_with(cx, |pane, _| pane.visible_text_lines());
+            if lines.iter().any(|line| line.contains("ade-pasted-text")) {
+                saw_pasted_text = true;
+                break;
+            }
+        }
+        assert!(
+            saw_pasted_text,
+            "expected the real pty's own echo of the pasted bytes to appear in the grid"
+        );
+    }
+
+    #[gpui::test]
+    fn pasting_an_empty_clipboard_writes_nothing(cx: &mut TestAppContext) {
+        let pane = new_pane(cx, "cat");
+        cx.run_until_parked();
+
+        cx.update(|cx| cx.write_to_clipboard(gpui::ClipboardItem::new_string(String::new())));
+        let pasted = pane.update(cx, |pane, cx| pane.paste_from_clipboard(cx));
+        assert!(!pasted);
+    }
+}
+
+/// GitHub issue #158's mouse half, end to end through real GPUI event dispatch: before this,
+/// `TerminalPane` registered no mouse-down/move/up handlers at all, so no amount of dragging
+/// produced a selection and "copy" would have had nothing to copy even with a binding in place.
+///
+/// Backed by a real `cat` child rather than a shell: `cat` writes nothing of its own, so the
+/// grid contains exactly the injected bytes and the pixel geometry the drag is computed from
+/// can't be moved out from under the test by a prompt arriving mid-run.
+#[cfg(test)]
+mod mouse_selection_tests {
+    use super::*;
+    use gpui::{point, Entity, Modifiers, MouseButton, TestAppContext, VisualTestContext};
+
+    /// Opens a real window on a `cat`-backed pane, puts `"hello world"` on row 0, and returns
+    /// the painted geometry a drag position is computed from.
+    fn painted_pane(
+        cx: &mut TestAppContext,
+    ) -> (
+        Entity<TerminalPane>,
+        &mut VisualTestContext,
+        Bounds<Pixels>,
+        Size<Pixels>,
+    ) {
+        let (pane, cx) = cx.add_window_view(|_window, cx| {
+            TerminalPane::new(
+                TerminalSpec::command("cat", Vec::new(), std::env::temp_dir()),
+                ROW_FONT_SIZE_PX,
+                cx,
+            )
+        });
+        cx.run_until_parked();
+
+        pane.update(cx, |pane, cx| {
+            pane.inject_bytes_for_test(b"hello world", cx);
+        });
+        cx.run_until_parked();
+
+        let (bounds, cell_size) = pane.update_in(cx, |pane, window, _cx| {
+            (
+                pane.content_bounds_for_test(),
+                pane.cell_size_for_test(window),
+            )
+        });
+        let bounds = bounds.expect("the pane must have painted at least once");
+        (pane, cx, bounds, cell_size)
+    }
+
+    /// The centre of cell `(row, column)` in window space.
+    fn cell_centre(
+        bounds: Bounds<Pixels>,
+        cell_size: Size<Pixels>,
+        row: usize,
+        column: usize,
+    ) -> gpui::Point<Pixels> {
+        point(
+            bounds.origin.x + px(PANE_PADDING_PX) + cell_size.width * (column as f32 + 0.5),
+            bounds.origin.y + px(PANE_PADDING_PX) + cell_size.height * (row as f32 + 0.5),
+        )
+    }
+
+    #[gpui::test]
+    fn a_real_mouse_drag_selects_the_text_it_dragged_over(cx: &mut TestAppContext) {
+        let (pane, cx, bounds, cell_size) = painted_pane(cx);
+
+        // "hello world": drag from the left edge of 'w' (column 6) to the right edge of 'd'
+        // (column 10). Starting a touch left of centre and ending a touch right of centre is
+        // what a real user's drag looks like, and is what makes both boundary cells included.
+        let start = point(
+            bounds.origin.x + px(PANE_PADDING_PX) + cell_size.width * 6.1,
+            cell_centre(bounds, cell_size, 0, 6).y,
+        );
+        let end = point(
+            bounds.origin.x + px(PANE_PADDING_PX) + cell_size.width * 10.9,
+            cell_centre(bounds, cell_size, 0, 10).y,
+        );
+
+        cx.simulate_mouse_down(start, MouseButton::Left, Modifiers::none());
+        cx.simulate_mouse_move(end, MouseButton::Left, Modifiers::none());
+        cx.simulate_mouse_up(end, MouseButton::Left, Modifiers::none());
+        cx.run_until_parked();
+
+        assert_eq!(
+            pane.read_with(cx, |pane, _| pane.selected_text_for_test())
+                .as_deref(),
+            Some("world"),
+            "a real left-drag across the grid must produce a real alacritty_terminal selection"
+        );
+    }
+
+    /// A plain click is how a user dismisses a selection, and it must not leave a one-character
+    /// one behind.
+    #[gpui::test]
+    fn a_plain_click_clears_a_previous_selection(cx: &mut TestAppContext) {
+        let (pane, cx, bounds, cell_size) = painted_pane(cx);
+
+        let start = cell_centre(bounds, cell_size, 0, 0);
+        let end = cell_centre(bounds, cell_size, 0, 4);
+        cx.simulate_mouse_down(start, MouseButton::Left, Modifiers::none());
+        cx.simulate_mouse_move(end, MouseButton::Left, Modifiers::none());
+        cx.simulate_mouse_up(end, MouseButton::Left, Modifiers::none());
+        cx.run_until_parked();
+        assert!(
+            pane.read_with(cx, |pane, _| pane.selected_text_for_test())
+                .is_some(),
+            "sanity check: the drag must have selected something to then clear"
+        );
+
+        cx.simulate_click(cell_centre(bounds, cell_size, 2, 3), Modifiers::none());
+        cx.run_until_parked();
+        assert_eq!(
+            pane.read_with(cx, |pane, _| pane.selected_text_for_test()),
+            None
+        );
+    }
+
+    /// Moving the mouse over the terminal with no button held must never start or extend a
+    /// selection - the drag has to be gated on a real mouse-down having happened.
+    #[gpui::test]
+    fn hovering_without_a_button_held_selects_nothing(cx: &mut TestAppContext) {
+        let (pane, cx, bounds, cell_size) = painted_pane(cx);
+
+        cx.simulate_mouse_move(
+            cell_centre(bounds, cell_size, 0, 0),
+            None,
+            Modifiers::none(),
+        );
+        cx.simulate_mouse_move(
+            cell_centre(bounds, cell_size, 0, 10),
+            None,
+            Modifiers::none(),
+        );
+        cx.run_until_parked();
+
+        assert_eq!(
+            pane.read_with(cx, |pane, _| pane.selected_text_for_test()),
+            None
+        );
+    }
+
+    /// A drag repaints the cells it covers - the flag has to survive all the way into what
+    /// `render_row` consumes, or the user gets no visual feedback at all while dragging.
+    #[gpui::test]
+    fn a_drag_marks_the_covered_cells_selected_for_the_renderer(cx: &mut TestAppContext) {
+        let (pane, cx, bounds, cell_size) = painted_pane(cx);
+
+        let start = point(
+            bounds.origin.x + px(PANE_PADDING_PX) + cell_size.width * 0.1,
+            cell_centre(bounds, cell_size, 0, 0).y,
+        );
+        let end = point(
+            bounds.origin.x + px(PANE_PADDING_PX) + cell_size.width * 4.9,
+            cell_centre(bounds, cell_size, 0, 4).y,
+        );
+        cx.simulate_mouse_down(start, MouseButton::Left, Modifiers::none());
+        cx.simulate_mouse_move(end, MouseButton::Left, Modifiers::none());
+        cx.run_until_parked();
+
+        let flagged = pane.read_with(cx, |pane, _| {
+            pane.grid.visible_rows()[0]
+                .iter()
+                .filter(|cell| cell.selected)
+                .map(|cell| cell.c)
+                .collect::<String>()
+        });
+        assert_eq!(flagged, "hello");
     }
 }

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -178,6 +178,44 @@ impl AdeApp {
         }
     }
 
+    /// GitHub issue #158's terminal Copy. Scoped to `Some("terminal")` in
+    /// `crate::default_key_bindings` (`Ctrl+Shift+C`, `Cmd+C` on macOS) for the reason that
+    /// scoping exists at all here: plain `Ctrl+C` is the pty's own `SIGINT` byte and must never
+    /// be claimed as a copy shortcut, which is exactly why every terminal emulator puts copy on
+    /// the shifted variant instead. Targets the active agent's pane, matching
+    /// [`Self::handle_terminal_clear_action`]'s own "the centre pane is genuinely showing right
+    /// now" target.
+    pub(crate) fn handle_terminal_copy_action(
+        &mut self,
+        _action: &TerminalCopy,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(agent) = self.agents.active() {
+            agent
+                .pane
+                .clone()
+                .update(cx, |pane, cx| pane.copy_selection(cx));
+        }
+    }
+
+    /// GitHub issue #158's terminal Paste - the counterpart to
+    /// [`Self::handle_terminal_copy_action`], on `Ctrl+Shift+V` (`Cmd+V` on macOS) for the same
+    /// reason (plain `Ctrl+V` is the pty's own `0x16`, readline's `quoted-insert`).
+    pub(crate) fn handle_terminal_paste_action(
+        &mut self,
+        _action: &TerminalPaste,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(agent) = self.agents.active() {
+            agent
+                .pane
+                .clone()
+                .update(cx, |pane, cx| pane.paste_from_clipboard(cx));
+        }
+    }
+
     /// Activates agent `id`'s tab and, if it maps to a currently-listed worktree, also selects
     /// that worktree, keeping the file tree/diff sidebar in sync with the agent just clicked
     /// (the sidebar is still driven by [`Self::selected`] - a `focused_agent`-driven Zone 2/3
@@ -4176,6 +4214,225 @@ mod tab_order_persistence_tests {
             restored_order.iter().position(|t| t == &b_ref)
                 < restored_order.iter().position(|t| t == &a_ref),
             "the drag-reordered position must survive a real restart - got {restored_order:?}"
+        );
+    }
+}
+
+/// GitHub issue #158's `TerminalCopy`/`TerminalPaste` actions - real coverage that dispatching
+/// each one reaches whichever agent is genuinely active right now, and that copy really lands on
+/// the real OS clipboard (checked the same way `crate::sidebar::tree_ops`' own
+/// `copy_relative_path_writes_the_worktree_relative_path` checks "Copy Path", since this app has
+/// exactly one clipboard mechanism and both go through it).
+///
+/// These fail against the pre-fix tree twice over: the actions didn't exist, and neither did any
+/// selection for copy to read.
+#[cfg(test)]
+mod terminal_clipboard_action_tests {
+    use super::*;
+    use crate::root::focus::palette_focus_tests;
+    use gpui::{Focusable, TestAppContext};
+
+    /// Places `text` at a fixed, addressed grid position in the active agent's pane, well below
+    /// where a freshly-spawned shell's own prompt lands, so the row this test then selects can't
+    /// be overwritten by real shell output arriving in the background.
+    fn seed_active_pane(app: &gpui::Entity<AdeApp>, cx: &mut gpui::VisualTestContext, text: &str) {
+        let pane = app
+            .read_with(cx, |app, _| app.agents.active().map(|s| s.pane.clone()))
+            .expect("a fresh test window has one real, active shell agent");
+        pane.update(cx, |pane, cx| {
+            // `ESC[10;1H` - row 10, column 1 (1-indexed), i.e. grid row 9, column 0.
+            pane.inject_bytes_for_test(format!("\x1b[10;1H{text}").as_bytes(), cx);
+            pane.select_cells_for_test(9, 0..text.chars().count());
+        });
+    }
+
+    #[gpui::test]
+    fn dispatching_terminal_copy_puts_the_real_selection_on_the_real_clipboard(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        cx.update(|_window, cx| {
+            cx.write_to_clipboard(gpui::ClipboardItem::new_string("stale".into()))
+        });
+        seed_active_pane(&app, cx, "ade-selected-text");
+
+        cx.dispatch_action(TerminalCopy);
+
+        let text = cx.update(|_window, cx| cx.read_from_clipboard().and_then(|item| item.text()));
+        assert_eq!(
+            text.as_deref(),
+            Some("ade-selected-text"),
+            "TerminalCopy must reach the active agent's pane and write its real selection to \
+             the real system clipboard"
+        );
+    }
+
+    /// Only the *active* agent's selection is copied - the same "which pane does this act on"
+    /// contract `terminal_clear_action_tests` pins for `TerminalClear`.
+    #[gpui::test]
+    fn dispatching_terminal_copy_uses_only_the_active_agents_selection(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        // The window's own initial agent gets a selection first, then a second agent (which
+        // becomes active) gets a different one.
+        seed_active_pane(&app, cx, "background-agent-text");
+        app.update_in(cx, |app, window, cx| {
+            app.agents.spawn(
+                AgentKind::Shell,
+                repo.path().to_path_buf(),
+                12.0,
+                window,
+                cx,
+            );
+        });
+        cx.run_until_parked();
+        seed_active_pane(&app, cx, "active-agent-text");
+
+        cx.dispatch_action(TerminalCopy);
+
+        let text = cx.update(|_window, cx| cx.read_from_clipboard().and_then(|item| item.text()));
+        assert_eq!(text.as_deref(), Some("active-agent-text"));
+    }
+
+    /// The whole point of GitHub issue #158, driven by a **real keystroke** rather than
+    /// `dispatch_action`: with a terminal genuinely focused, the copy shortcut must reach
+    /// `TerminalCopy` and not `TerminalPane::handle_key_down`.
+    ///
+    /// This is the assertion that pins the fix's most load-bearing detail. Without the binding,
+    /// `crate::terminal::pane::keystroke_to_bytes`'s control-byte branch ignores `shift`
+    /// entirely, so `Ctrl+Shift+C` over a focused terminal produced `0x03` - it *interrupted the
+    /// running process* instead of copying. GPUI dispatches matching `KeyBinding`s before any
+    /// `on_key_down` listener and an action handler stops propagation by default in the bubble
+    /// phase, which is what makes a bound action win here.
+    #[gpui::test]
+    fn the_real_copy_keystroke_over_a_focused_terminal_copies_instead_of_typing(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        cx.update(|_window, cx| {
+            cx.write_to_clipboard(gpui::ClipboardItem::new_string("stale".into()))
+        });
+        seed_active_pane(&app, cx, "typed-not-copied");
+
+        // The keystroke can only reach a `"terminal"`-scoped binding while the pane genuinely
+        // holds focus - which is the exact condition the issue reports the bug under.
+        app.update_in(cx, |app, window, cx| {
+            let pane = app.agents.active().expect("an active agent").pane.clone();
+            let handle = pane.read(cx).focus_handle(cx);
+            window.focus(&handle, cx);
+        });
+        cx.run_until_parked();
+
+        cx.simulate_keystrokes(if cfg!(target_os = "macos") {
+            "cmd-c"
+        } else {
+            "ctrl-shift-c"
+        });
+        cx.run_until_parked();
+
+        let text = cx.update(|_window, cx| cx.read_from_clipboard().and_then(|item| item.text()));
+        assert_eq!(
+            text.as_deref(),
+            Some("typed-not-copied"),
+            "the real copy keystroke over a focused terminal must reach TerminalCopy - before              this fix it reached keystroke_to_bytes and sent SIGINT to the child process"
+        );
+    }
+
+    /// The paste counterpart of the keystroke test above, proven by the real pty echo.
+    #[gpui::test]
+    fn the_real_paste_keystroke_over_a_focused_terminal_reaches_the_pty(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        cx.update(|_window, cx| {
+            cx.write_to_clipboard(gpui::ClipboardItem::new_string(
+                "ade-keystroke-paste".into(),
+            ))
+        });
+        app.update_in(cx, |app, window, cx| {
+            let pane = app.agents.active().expect("an active agent").pane.clone();
+            let handle = pane.read(cx).focus_handle(cx);
+            window.focus(&handle, cx);
+        });
+        cx.run_until_parked();
+
+        cx.simulate_keystrokes(if cfg!(target_os = "macos") {
+            "cmd-v"
+        } else {
+            "ctrl-shift-v"
+        });
+
+        let mut saw_pasted_text = false;
+        for _ in 0..50 {
+            cx.background_executor
+                .advance_clock(std::time::Duration::from_millis(8));
+            cx.run_until_parked();
+            let lines = app.read_with(cx, |app, cx| {
+                app.agents
+                    .active()
+                    .expect("an active agent")
+                    .pane
+                    .read(cx)
+                    .visible_text_lines()
+            });
+            if lines
+                .iter()
+                .any(|line| line.contains("ade-keystroke-paste"))
+            {
+                saw_pasted_text = true;
+                break;
+            }
+        }
+        assert!(
+            saw_pasted_text,
+            "the real paste keystroke over a focused terminal must reach TerminalPaste"
+        );
+    }
+
+    /// The paste half, proven by the pty's own echo rather than by asserting `write_input` was
+    /// called - mirroring `terminal_clear_action_tests`' discipline for `TerminalClear`.
+    #[gpui::test]
+    fn dispatching_terminal_paste_reaches_the_active_agents_real_pty(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        cx.update(|_window, cx| {
+            cx.write_to_clipboard(gpui::ClipboardItem::new_string("ade-pasted-marker".into()))
+        });
+        cx.dispatch_action(TerminalPaste);
+
+        let mut saw_pasted_text = false;
+        for _ in 0..50 {
+            cx.background_executor
+                .advance_clock(std::time::Duration::from_millis(8));
+            cx.run_until_parked();
+            let lines = app.read_with(cx, |app, cx| {
+                app.agents
+                    .active()
+                    .expect("an active agent")
+                    .pane
+                    .read(cx)
+                    .visible_text_lines()
+            });
+            if lines.iter().any(|line| line.contains("ade-pasted-marker")) {
+                saw_pasted_text = true;
+                break;
+            }
+        }
+        assert!(
+            saw_pasted_text,
+            "expected the active agent's real pty to echo back the clipboard text \
+             TerminalPaste's handler writes"
         );
     }
 }


### PR DESCRIPTION
Fixes #158

With a terminal focused, copy and paste did nothing. Investigation turned up **three separate real gaps**, all of which had to be closed for either to work.

## Root cause 1 - no copy/paste binding was scoped to the terminal at all

`crates/app/src/lib.rs`'s `default_key_bindings()` had exactly one `Some("terminal")`-scoped binding (`TerminalClear`). `secondary-c`/`secondary-v` exist, but scoped to `Some("file-editor")`, `Some("merge-editor")` and `Some("file-tree && !tree-editing")` - none of which is ever live over a focused terminal. Both keystrokes therefore fell straight through to `crates/app/src/terminal/pane.rs:1178`'s `keystroke_to_bytes`.

That is *correct* for the unshifted keys and must stay - Ctrl+C is the pty's SIGINT byte, and a terminal that can't interrupt a running agent CLI is broken in a much worse way. But `keystroke_to_bytes`'s control-byte branch **ignores the shift modifier entirely**, so `Ctrl+Shift+C` - the keystroke every terminal emulator on Linux/Windows uses for copy - produced `0x03` and *interrupted the running process*.

Fixed by adding real `TerminalCopy`/`TerminalPaste` actions on `Ctrl+Shift+C`/`Ctrl+Shift+V` (`Cmd+C`/`Cmd+V` on macOS), both `Some("terminal")` - the same `cfg!(target_os = "macos")` split `TerminalClear` already uses, and the universal terminal-emulator answer to this exact conflict.

## Root cause 2 - the terminal had no text selection whatsoever

`crates/app/src/terminal/grid.rs` never touched `alacritty_terminal`'s own `Term::selection`, never called `Term::selection_to_string`, and `GridCell` had no notion of being selected. `crates/app/src/terminal/pane.rs` registered no mouse-down/move/up handlers - only an `on_click` that took focus. So even with a correct binding, copy would have had nothing to copy.

Fixed by driving `alacritty_terminal`'s real selection API (`Selection::new`/`Selection::update`/`Term::selection_to_string`) from real left-drag mouse handling, with the covered cells flagged so the drag is actually visible. Selection state lives only in `Term::selection` - no second, drifting copy - so `alacritty_terminal`'s own invalidation on scroll/clear/alt-screen applies for free.

## Root cause 3 - paste had no path to the pty

Nothing anywhere read the OS clipboard for the terminal. Fixed via `gpui::App::read_from_clipboard` (the same mechanism `sidebar::tree_ops`' "Copy Path" already uses - one clipboard mechanism in this app, not two), written to the child through `PtySession::write_input`, the same path typed keystrokes use, with real bracketed-paste framing (`DECSET 2004`) so a multi-line paste doesn't auto-execute each line.

## Regression tests

All verified to fail before the fix.

- `terminal::grid::selection_tests` (10) - real `alacritty_terminal` selection over a real grid: forward/backward drags, multi-row spans, empty-anchor and all-blank cases, per-cell render flags, bracketed-paste mode tracking, and that a clear really drops the selection.
- `terminal::pane::cell_position_tests` (7) - pixel-to-cell mapping, including the half-cell side boundary that decides whether the last character is included, and off-grid clamping.
- `terminal::pane::paste_payload_tests` (3) - CRLF normalization, bracket framing, and that a pasted `ESC` can't close the bracket early.
- `terminal::pane::clipboard_tests` (4) - real OS clipboard writes/reads; paste proven by a real `cat` child on a real pty echoing the bytes back into the grid, not by asserting `write_input` was called.
- `terminal::pane::mouse_selection_tests` (4) - real GPUI mouse-down/move/up dispatch against the pane's real painted geometry in a real window.
- `work_surface::render::terminal_clipboard_action_tests` (5) - including **the real keystroke** over a genuinely focused terminal reaching `TerminalCopy` instead of `keystroke_to_bytes` (confirmed to fail with `Some("stale")` when the binding is removed), plus active-agent targeting and the real pty echo for paste.
- `undo_scoping_matrix_tests` (3) - the bindings are live over a terminal, dead everywhere else, and plain `Ctrl+C`/`Ctrl+V` stay unclaimed over a terminal.

## Gates

`cargo fmt --all -- --check`, `cargo build --workspace` and `cargo clippy --workspace --all-targets -- -D warnings` are clean.

`cargo test --workspace --lib -- --test-threads=1`: 1620 passed, 10 failed - all pre-existing. Nine are filesystem-watcher tests failing on `spawn_file_tree_watcher`; a full-suite run of unmodified `origin/master` in this same environment fails the same class (a different six of them), and every one passes in isolation - inotify instance exhaustion under a 1620-test single-threaded run, not a code fault. The tenth is the already-known `code_surface::diff_view::diff_render_tests` flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)