### PR TITLE
fix(app): load the whole file tree, and drop the "load more" row

### DIFF
--- a/BUILD-LOG.md
+++ b/BUILD-LOG.md
@@ -7613,3 +7613,78 @@ keystroke against a real `.py` file.
 code_surface::`: 379 passed, 4 failed - all 4 pre-existing and environment-specific (real
 LSP-server-readiness tests needing rust-analyzer/vue-language-server to actually finish starting,
 unrelated to this change); every new test passes.
+
+## The file tree should load all folders and files (GitHub issue #160)
+
+**The ask.** "Remove the 'Stopped at 20000 entries - load more' button at the bottom of file tree.
+File tree should load all folders and files."
+
+**What the cap actually was.** `file_tree::build_file_tree` took a `limit: Option<usize>` and
+stopped mid-walk when it ran out, setting `FileTreeListing::truncated`. `AdeApp::load_file_tree`
+always passed a real bound (`Settings.file_tree.max_entries`, 20,000 by default, clamped to
+`FILE_TREE_MAX_ENTRIES_MAX` = 100,000). `render_file_tree` grew a footer off `file_tree_truncated`:
+a clickable "Stopped at N entries – load more" row that raised `file_tree_limit_override` tenfold
+and re-walked, degrading to a plain non-interactive disclosure once the ceiling was reached.
+
+**Why it was not just a `git rm` of the check.** The walk itself has always run on
+`cx.background_executor()`, so it was never the thing that could hang a frame. The cap's real
+job - documented on `FILE_TREE_MAX_ENTRIES_MAX` - was to bound two pieces of *foreground* work
+that scaled with the loaded entry count:
+
+1. `rebuild_palette_file_candidates`, called from `load_file_tree`'s completion handler, which
+   allocates a `FileCandidate` (a cloned `PathBuf` plus two `String`s) per file; and
+2. `file_tree::visible_indices`, called once per frame by `render_file_tree`, which scanned
+   *every* loaded entry - including every entry inside a collapsed folder - to decide which rows
+   were showing.
+
+Deleting the cap without touching either would have traded a visible-but-honest "load more" row
+for an invisible per-frame regression on exactly the trees the issue is about. So both were fixed:
+
+- **Candidates now build on the background executor.** `load_file_tree` is a three-step task:
+  walk (background) → snapshot the diff marks (foreground, bounded by the *diff's* size, tens of
+  files) → build the candidates (background) → apply tree + candidates in one `update`. The
+  identity guard (`this.file_tree_root != root`) is re-applied at every point the task touches the
+  app, since there are now three of them. `rebuild_palette_file_candidates` survives for the cheap
+  "same tree, new diff marks" case (`load_diff`, `open_file_tab`) and shares one
+  `build_file_candidates` with the background path, so the two can't disagree.
+- **Visibility resolution is now O(visible rows), not O(loaded entries).** New
+  `file_tree::FileTree` owns the entries plus a derived per-entry subtree span, so a collapsed
+  directory is stepped over in one addition. The spans are private and derived in `FileTree::new`,
+  the only constructor - a stale span wouldn't error, it would silently show a collapsed folder's
+  children, so there is deliberately no way to hand-write one. `FileTree` derefs to
+  `[FileTreeEntry]`, so every read site (indexing, `iter`, `len`) is unchanged.
+
+**Removed.** `FileTreeListing::truncated`, `MAX_LOAD_MORE_ENTRIES`, `AdeApp::file_tree_truncated`,
+`AdeApp::file_tree_limit_override`, `load_more_file_tree_entries`,
+`file_tree_limit_is_at_ceiling`, both footer branches in `render_file_tree`, and the whole
+`FileTreeSettings` section (`file_tree.max_entries` and its three constants) - a persisted setting
+with nothing left to configure would be exactly the "looks wired up but isn't" this project
+forbids. `Settings` has no `deny_unknown_fields`, so an older `settings.toml` still carrying
+`[file_tree]` loads as a no-op rather than falling back to defaults; there is a test for that.
+`FileTreeListing::partial` and `MAX_DEPTH` stay - the depth bound is a stack-overflow guard, not
+an entry budget, and `partial` is still what stops `prune_stale_fold_state` from reading an
+incomplete listing as "these folders were deleted".
+
+**Tests.** Two new ones prove the actual ask, at both levels: `file_tree::tests::
+a_tree_larger_than_the_removed_twenty_thousand_entry_cap_loads_completely` (a real 21,200-entry
+tempdir, asserting the count, `is_complete()`, and that the *last* file of the *last* directory -
+~1,200 entries past the old cut-off - is present by path), and `sidebar::render::file_tree_tests::
+a_tree_past_the_removed_cap_loads_every_entry_with_no_load_more_row` (the same fixture through a
+real window: full entry count, no `file-tree-show-all` element, the palette's candidate list
+covering the whole tree, and a folder past the cut-off expanding into real visible rows).
+`span_based_visibility_matches_the_depth_scan_for_every_expansion` pins the new span-based skip
+against the depth scan it replaced (kept as a `#[cfg(test)]` oracle) across all 32 expansion
+combinations of a real 5-directory tree. The three tests that asserted the old capped behaviour
+are gone; `a_truncated_walk_never_prunes_fold_state` became
+`an_incomplete_walk_never_prunes_fold_state`, driven through the incompleteness that genuinely
+remains - a `chmod 000` directory with the expanded folder inside it - rather than a cap that no
+longer exists.
+
+**Verification**: `cargo fmt --all -- --check`, `cargo build --workspace`, `cargo clippy
+--workspace --all-targets -- -D warnings` - all clean. `cargo test --workspace --lib --
+--test-threads=1`: 1592 passed, 1 failed - `code_surface::diff_view::diff_render_tests::
+opening_a_real_diff_renders_real_syntax_highlighted_rows`, the already-known flake, which passes
+in isolation. An earlier run of the same suite also showed 15 `spawn_*_watcher` failures; those
+were the host running out of inotify instances (measured at 124/128, with three other worktrees'
+suites running concurrently), not this change - no watcher file is touched by it, and all 18
+watcher tests pass once the host has headroom.

--- a/crates/app/src/palette/render.rs
+++ b/crates/app/src/palette/render.rs
@@ -25,6 +25,78 @@ fn window_controls_secondary(current: WindowControlsStyle, option: WindowControl
     }
 }
 
+/// One changed file's contribution to a [`palette::FileCandidate`] - what a diff overlays onto a
+/// row that otherwise comes purely from the file tree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct FileDiffMark {
+    pub add: u32,
+    pub del: u32,
+    pub changed: Option<palette::FileChangeKind>,
+}
+
+/// Every changed file's [`FileDiffMark`], keyed by the repo-relative path `wt_core::diff` reports
+/// (see `crate::sidebar::changes::split_dir_name`'s docs on that shape).
+///
+/// Owned rather than borrowed from the diff, and bounded by the *diff's* size rather than the
+/// tree's, so `AdeApp::load_file_tree` can take a snapshot of it on the foreground thread in
+/// constant-ish time and then hand it to a background task. Built once, not once per file - that
+/// avoids an O(files × diff_files) rescan (the same idiom as `AdeApp::tree_change_marks`).
+pub(crate) type FileDiffMarks = HashMap<PathBuf, FileDiffMark>;
+
+/// Snapshots the currently loaded diff as [`FileDiffMarks`].
+pub(crate) fn file_diff_marks(diff: Option<&wt_core::diff::WorktreeDiff>) -> FileDiffMarks {
+    let Some(diff) = diff else {
+        return FileDiffMarks::default();
+    };
+    diff.files
+        .iter()
+        .map(|file: &DiffFile| {
+            let (add, del) = changes::diff_file_stats(file);
+            let changed = match file.status {
+                FileChangeStatus::Added => Some(palette::FileChangeKind::Added),
+                FileChangeStatus::Deleted => Some(palette::FileChangeKind::Deleted),
+                FileChangeStatus::Modified | FileChangeStatus::Renamed => None,
+            };
+            (file.path.clone(), FileDiffMark { add, del, changed })
+        })
+        .collect()
+}
+
+/// Builds the palette's file-candidate list: one [`palette::FileCandidate`] per non-directory
+/// entry in an already-walked file tree, with `marks` overlaid where the file has a diff.
+///
+/// Pure, and deliberately free of `AdeApp` - this is `O(entries)` with a handful of allocations
+/// each, which since GitHub issue #160 removed the walk's entry cap is unbounded work.
+/// `AdeApp::load_file_tree` therefore runs it on `gpui::BackgroundExecutor`, not in its
+/// walk-completion handler; `AdeApp::rebuild_palette_file_candidates` still calls it directly for
+/// the much cheaper "same tree, new diff marks" case.
+pub(crate) fn build_file_candidates(
+    entries: &[file_tree::FileTreeEntry],
+    root: &std::path::Path,
+    marks: &FileDiffMarks,
+) -> Vec<palette::FileCandidate> {
+    entries
+        .iter()
+        .filter(|entry| !entry.is_dir)
+        .map(|entry| {
+            let relative = entry
+                .path
+                .strip_prefix(root)
+                .unwrap_or(entry.path.as_path());
+            let mark = marks.get(relative).copied();
+            let (dir, name) = changes::split_dir_name(relative);
+            palette::FileCandidate {
+                path: entry.path.clone(),
+                name,
+                dir,
+                add: mark.map(|mark| mark.add).unwrap_or(0),
+                del: mark.map(|mark| mark.del).unwrap_or(0),
+                changed: mark.and_then(|mark| mark.changed),
+            }
+        })
+        .collect()
+}
+
 impl AdeApp {
     pub(crate) fn handle_toggle_palette_action(
         &mut self,
@@ -45,9 +117,11 @@ impl AdeApp {
     /// built fresh every call so what's drawn and what `⏎`/`↑`/`↓` act on can never disagree.
     ///
     /// `agents`/`commands` are cheap (bounded by open-tab count plus 10 fixed commands) and
-    /// built fresh here. `files` is the expensive part (as many entries as the whole loaded
-    /// tree has, bounded by `Settings.file_tree.max_entries`) and is *not* rebuilt here - this reads [`Self::palette_file_candidates`], which
-    /// [`Self::rebuild_palette_file_candidates`] keeps current at its own two mutation points.
+    /// built fresh here. `files` is the expensive part - one candidate per file in the whole
+    /// loaded tree, and since GitHub issue #160 removed the walk's entry cap that is unbounded -
+    /// so it is *not* rebuilt here: this reads the cached [`Self::palette_file_candidates`],
+    /// which is refreshed only at the two points its inputs really change (see
+    /// [`Self::rebuild_palette_file_candidates`] and [`Self::load_file_tree`]).
     pub(crate) fn build_palette_groups(&self, cx: &App) -> Vec<palette::PaletteGroup> {
         let agents: Vec<palette::AgentCandidate> = self
             .agents
@@ -151,55 +225,21 @@ impl AdeApp {
     }
 
     /// Rebuilds [`Self::palette_file_candidates`] from the current real [`Self::file_tree`]/
-    /// [`Self::current_diff`] - called from the two real points either input can change
-    /// ([`Self::load_file_tree`]'s and [`Self::load_diff`]'s completion handlers), never from
-    /// [`Self::build_palette_groups`] itself. See [`Self::palette_file_candidates`]'s docs for
-    /// the real per-render cost this avoids.
+    /// [`Self::current_diff`], on the calling (foreground) thread. This is the *diff* side's
+    /// entry point - [`Self::load_diff`]'s completion handler, and `open_file_tab`'s - where the
+    /// tree is unchanged and only the marks laid over it moved.
+    ///
+    /// The *tree* side no longer comes through here: [`Self::load_file_tree`] builds the same
+    /// candidates on the background executor, in the same task as the walk, because that is the
+    /// one path whose cost scales with the whole loaded tree and GitHub issue #160 removed the
+    /// cap that used to bound it. Both call the same [`build_file_candidates`], so the two can't
+    /// produce different candidates for the same inputs.
     pub(crate) fn rebuild_palette_file_candidates(&mut self) {
-        // Built once, not once per file - avoids an O(files * diff_files) rescan per row (same
-        // idiom as `Self::tree_change_marks`).
-        let diff_by_relative_path: HashMap<&std::path::Path, &DiffFile> = self
-            .current_diff()
-            .map(|diff| {
-                diff.files
-                    .iter()
-                    .map(|file| (file.path.as_path(), file))
-                    .collect()
-            })
-            .unwrap_or_default();
-
-        self.palette_file_candidates = self
-            .file_tree
-            .iter()
-            .filter(|entry| !entry.is_dir)
-            .map(|entry| {
-                let relative = entry
-                    .path
-                    .strip_prefix(&self.file_tree_root)
-                    .unwrap_or(entry.path.as_path());
-                let (add, del, changed) = match diff_by_relative_path.get(relative) {
-                    Some(file) => {
-                        let (add, del) = changes::diff_file_stats(file);
-                        let changed = match file.status {
-                            FileChangeStatus::Added => Some(palette::FileChangeKind::Added),
-                            FileChangeStatus::Deleted => Some(palette::FileChangeKind::Deleted),
-                            FileChangeStatus::Modified | FileChangeStatus::Renamed => None,
-                        };
-                        (add, del, changed)
-                    }
-                    None => (0, 0, None),
-                };
-                let (dir, name) = changes::split_dir_name(relative);
-                palette::FileCandidate {
-                    path: entry.path.clone(),
-                    name,
-                    dir,
-                    add,
-                    del,
-                    changed,
-                }
-            })
-            .collect();
+        self.palette_file_candidates = build_file_candidates(
+            &self.file_tree,
+            &self.file_tree_root,
+            &file_diff_marks(self.current_diff()),
+        );
     }
 
     /// Moves the palette's keyboard selection by `delta` rows (`↑`/`↓`), clamped to the current

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -78,7 +78,7 @@ use crate::settings::state as settings;
 use crate::settings::state::SettingsPage;
 use crate::settings::store::{self as settings_store, CfgFormat, Settings};
 use crate::sidebar::changes::{self, ChangeTag};
-use crate::sidebar::file_tree::{self, FileTreeEntry};
+use crate::sidebar::file_tree;
 use crate::sidebar::fold_state;
 use crate::sidebar::tree_ops;
 use crate::status_bar::process_stats;
@@ -343,7 +343,7 @@ pub struct AdeApp {
     pub(crate) rail_scroll_handle: gpui::ScrollHandle,
     pub(crate) selected: Option<usize>,
     pub(crate) agents: Agents,
-    pub(crate) file_tree: Vec<FileTreeEntry>,
+    pub(crate) file_tree: file_tree::FileTree,
     pub(crate) file_tree_root: PathBuf,
     pub(crate) file_tree_error: Option<String>,
     pub(crate) right_sidebar_view: RightSidebarView,
@@ -418,26 +418,15 @@ pub struct AdeApp {
     pub(crate) fold_state_save_pending: bool,
     /// See [`Self::settings_save_running`] - same contract, for the fold-state file.
     pub(crate) fold_state_save_running: bool,
-    /// Whether the last completed file-tree walk stopped early at its configured entry cap
-    /// (`Settings.file_tree.max_entries`, or [`Self::file_tree_limit_override`]). Drives the
-    /// sidebar's real "load more" action - the explicit replacement for the removed
-    /// "... and N more entries not shown" row.
-    pub(crate) file_tree_truncated: bool,
-    /// Whether that walk was a *complete* inventory of the worktree's directories
-    /// (`file_tree::FileTreeListing::is_complete`) - false when it was truncated, and also when
-    /// it silently skipped an unreadable or too-deep subdirectory. The only condition under
-    /// which `AdeApp::prune_stale_fold_state` may read "not in this listing" as "deleted".
+    /// Whether the last completed file-tree walk was a *complete* inventory of the worktree's
+    /// directories (`file_tree::FileTreeListing::is_complete`) - false when it silently skipped
+    /// an unreadable or too-deep subdirectory. The only condition under which
+    /// `AdeApp::prune_stale_fold_state` may read "not in this listing" as "deleted".
+    ///
+    /// There is no `file_tree_truncated` companion any more: GitHub issue #160 removed the walk's
+    /// entry cap, so "the walk stopped early because it ran out of budget" is no longer a state
+    /// this app can be in.
     pub(crate) file_tree_complete: bool,
-    /// Set by the sidebar's "load more" action (`Self::load_more_file_tree_entries`): the cap
-    /// this worktree's walks use instead of `Settings.file_tree.max_entries`, raised tenfold per
-    /// click. Deliberately still a cap and never `None`: a single click that re-walked a
-    /// bind-mounted `$HOME` with an unbounded budget would allocate millions of `PathBuf`s on a
-    /// background thread and then hand them all to `rebuild_palette_file_candidates`. Each click
-    /// raises the bound and the row keeps reporting where the walk stopped, so the listing is
-    /// never *silently* cut off - which is what issue #18 §4 actually asks for. Agent-scoped
-    /// and per-worktree: reset on every worktree switch, since "show me more of *this* tree"
-    /// says nothing about the next one.
-    pub(crate) file_tree_limit_override: Option<usize>,
     /// The file tree's open right-click context menu (GitHub issue #19 §1), `None` when closed -
     /// see `crate::sidebar::tree_ops::TreeContextMenu`.
     pub(crate) tree_context_menu: Option<tree_ops::TreeContextMenu>,
@@ -877,9 +866,10 @@ pub struct AdeApp {
     /// Pre-open focus target and active agent for [`Self::palette_focus_handle`] - see
     /// [`OverlayFocus`]/[`restore_focus`].
     pub(crate) palette_focus: OverlayFocus,
-    /// The palette's file-candidate list (`crate::palette::state::FileCandidate`, one per non-directory
-    /// [`Self::file_tree`] entry, up to `Settings.file_tree.max_entries`) - built once by
-    /// [`Self::rebuild_palette_file_candidates`] when `file_tree`/the diff reload, not rebuilt on
+    /// The palette's file-candidate list (`crate::palette::state::FileCandidate`, one per
+    /// non-directory [`Self::file_tree`] entry) - built once when `file_tree`/the diff reload
+    /// (on the background executor for the tree walk, see [`Self::load_file_tree`]; via
+    /// [`Self::rebuild_palette_file_candidates`] for the diff), not rebuilt on
     /// every `Self::build_palette_groups` call (which runs on every render while the palette is
     /// open, up to ~30x/sec during a streaming agent). Agent/command candidates aren't
     /// cached the same way: they're few, and an agent's status dot is genuinely live per-render

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::code_surface::state::{DiffLoadState, FileLoadState};
+use crate::palette::render as palette_render;
 use crate::sidebar::render::RightSidebarView;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -210,7 +211,7 @@ impl AdeApp {
             rail_scroll_handle: gpui::ScrollHandle::new(),
             selected: None,
             agents: Agents::new(),
-            file_tree: Vec::new(),
+            file_tree: file_tree::FileTree::default(),
             file_tree_error: None,
             right_sidebar_view: RightSidebarView::Files,
             file_tree_scroll_handle: UniformListScrollHandle::new(),
@@ -230,10 +231,8 @@ impl AdeApp {
             _fold_state_save_task: None,
             fold_state_save_pending: false,
             fold_state_save_running: false,
-            file_tree_truncated: false,
             // Nothing has been walked yet, so nothing may be pruned yet either.
             file_tree_complete: false,
-            file_tree_limit_override: None,
             tree_context_menu: None,
             tree_inline_edit: None,
             tree_clipboard: None,
@@ -617,7 +616,7 @@ impl AdeApp {
                             .map(|item| item.path.clone())
                             .unwrap_or_else(|| this.focused_repo_path());
                         this.set_file_tree_root(new_root.clone(), cx);
-                        this.file_tree = Vec::new();
+                        this.file_tree = file_tree::FileTree::default();
                         this.reload_expanded_dirs_from_fold_state();
                         this.load_file_tree(new_root.clone(), cx);
                         this.load_diff(new_root, cx);
@@ -698,52 +697,96 @@ impl AdeApp {
         self.start_file_tree_watch(cx);
     }
 
+    /// Walks [`Self::file_tree_root`] and applies the result, off the foreground thread.
+    ///
+    /// GitHub issue #160 removed this walk's entry cap ("File tree should load all folders and
+    /// files"), so the amount of work here is now bounded only by what is actually on disk. Two
+    /// steps run on `gpui::BackgroundExecutor` because of it, not one:
+    ///
+    /// 1. the walk itself (`file_tree::build_file_tree`), as it always has; and
+    /// 2. the palette's file-candidate list, which allocates a
+    ///    `crate::palette::state::FileCandidate` per file and used to be built by
+    ///    [`Self::rebuild_palette_file_candidates`] right here in the completion handler - on the
+    ///    foreground thread, which was one of the two real costs the old cap existed to bound.
+    ///
+    /// The diff marks those candidates carry are snapshotted between the two
+    /// (`palette::render::file_diff_marks`), on the foreground, because they live on `self`. That
+    /// snapshot is bounded by the *diff's* size (tens of files), not the tree's, so it is the one
+    /// piece of this that stays on the foreground thread and is genuinely cheap there.
     pub(crate) fn load_file_tree(&mut self, root: PathBuf, cx: &mut Context<Self>) {
         self.set_file_tree_root(root.clone(), cx);
-        // Always a real bound - see [`Self::file_tree_limit_override`] for why even the "load
-        // more" escape hatch raises the cap rather than removing it.
-        let limit = Some(
-            self.file_tree_limit_override
-                .unwrap_or(self.settings.file_tree.max_entries),
-        );
         let task = cx.spawn(async move |this, cx| {
             let result = cx
                 .background_executor()
                 .spawn({
                     let root = root.clone();
-                    async move { file_tree::build_file_tree(&root, limit) }
+                    async move { file_tree::build_file_tree(&root) }
                 })
                 .await;
+
+            // Identity guard, applied at *every* point this task touches the app: a worktree
+            // switch that lands while the walk is still running replaces `_load_file_tree_task`
+            // (cancelling it) *and* moves `file_tree_root` - but a task already past an `await`
+            // point can still reach here. Applying a stale walk would show one worktree's tree
+            // under another's root, and - far worse - prune the *new* worktree's fold state
+            // against the *old* worktree's directory list.
+            let listing = match result {
+                Ok(listing) => listing,
+                Err(err) => {
+                    let _ = this.update(cx, |this, cx| {
+                        if this.file_tree_root != root {
+                            return;
+                        }
+                        this.file_tree = file_tree::FileTree::default();
+                        this.file_tree_complete = false;
+                        this.file_tree_error = Some(err.to_string());
+                        this.rebuild_palette_file_candidates();
+                        cx.notify();
+                    });
+                    return;
+                }
+            };
+
+            let Ok(Some(marks)) = this.update(cx, |this, _| {
+                (this.file_tree_root == root)
+                    .then(|| palette_render::file_diff_marks(this.current_diff()))
+            }) else {
+                return;
+            };
+
+            let complete = listing.is_complete();
+            let (tree, candidates) = cx
+                .background_executor()
+                .spawn({
+                    let root = root.clone();
+                    let marks = marks.clone();
+                    async move {
+                        let candidates =
+                            palette_render::build_file_candidates(&listing.tree, &root, &marks);
+                        (listing.tree, candidates)
+                    }
+                })
+                .await;
+
             let _ = this.update(cx, |this, cx| {
-                // Identity guard: a worktree switch that lands while this walk is still running
-                // replaces `_load_file_tree_task` (cancelling it) *and* moves
-                // `file_tree_root` - but a task already past its `await` point can still reach
-                // here. Applying a stale walk would show one worktree's tree under another's
-                // root, and - far worse now - prune the *new* worktree's fold state against the
-                // *old* worktree's directory list.
                 if this.file_tree_root != root {
                     return;
                 }
-                match result {
-                    Ok(listing) => {
-                        this.file_tree_truncated = listing.truncated;
-                        this.file_tree_complete = listing.is_complete();
-                        this.file_tree = listing.entries;
-                        this.file_tree_error = None;
-                        this.prune_stale_fold_state(cx);
-                    }
-                    Err(err) => {
-                        this.file_tree = Vec::new();
-                        this.file_tree_truncated = false;
-                        this.file_tree_complete = false;
-                        this.file_tree_error = Some(err.to_string());
-                    }
+                this.file_tree_complete = complete;
+                this.file_tree = tree;
+                this.file_tree_error = None;
+                // Applied in the same update as the tree they were built from, so the palette can
+                // never be showing candidates for one walk while the sidebar shows another's rows.
+                this.palette_file_candidates = candidates;
+                // A `load_diff` that landed during the background hop above built its candidates
+                // from the *old* tree, and the ones just applied carry the marks as they were
+                // before it. Re-deriving here is the O(loaded files) foreground pass this whole
+                // arrangement exists to avoid, so it is gated on the marks having genuinely moved
+                // - which needs one cheap comparison over the diff's files, not the tree's.
+                if palette_render::file_diff_marks(this.current_diff()) != marks {
+                    this.rebuild_palette_file_candidates();
                 }
-                // The palette's cached file-candidate list (`Self::palette_file_candidates`) is
-                // derived from `file_tree` - refresh it here, the real point that input changes,
-                // rather than leaving it stale until some unrelated `load_diff` happens to
-                // refresh it too.
-                this.rebuild_palette_file_candidates();
+                this.prune_stale_fold_state(cx);
                 cx.notify();
             });
         });
@@ -937,7 +980,7 @@ impl AdeApp {
         // `set_dir_expanded` with a path from an entirely different worktree/repo. Clearing
         // `file_tree` makes that window render an honestly empty tree instead.
         self.set_file_tree_root(new_root.clone(), cx);
-        self.file_tree = Vec::new();
+        self.file_tree = file_tree::FileTree::default();
         self.reload_expanded_dirs_from_fold_state();
         // Every one of these holds an absolute path in whatever was just left (GitHub issue #19):
         // an open context menu targeting a row that is about to stop existing, a half-typed name
@@ -955,9 +998,6 @@ impl AdeApp {
         // delete backups this leaves unreachable.
         self.clear_tree_undo_history();
         self.tree_op_error = None;
-        // "Show me the whole listing" was a decision about whatever was left.
-        self.file_tree_limit_override = None;
-        self.file_tree_truncated = false;
         self.file_tree_complete = false;
         // `focus_newly_spawned_agent` (despite its name - its body has no "newly spawned" logic
         // in it, just the shared "move focus unless a file tab/Settings is showing" guard) closes

--- a/crates/app/src/settings/store.rs
+++ b/crates/app/src/settings/store.rs
@@ -12,12 +12,10 @@
 //! `crate::settings::render`'s per-page docs for which) - no field exists here "for
 //! completeness" just because the mockup shows a row for it.
 //!
-//! One documented exception, added with GitHub issue #18: [`FileTreeSettings`] is read and
-//! applied for real (`crate::root::AdeApp::load_file_tree` bounds every walk with it) but has no
-//! settings *page* and appears in no config banner - it is a file-only tunable. It is called out
-//! here rather than quietly breaking the rule above: the invariant that still holds for every
-//! field, this one included, is "loaded, saved, and genuinely consumed by real behaviour"; what
-//! this one lacks is a UI surface, not a consumer.
+//! There used to be a documented exception here - `FileTreeSettings::max_entries`, the file tree
+//! walk's entry cap (GitHub issue #18), a real file-only tunable with no settings page. GitHub
+//! issue #160 removed the cap itself ("File tree should load all folders and files"), so the
+//! field went with it rather than staying on as a value nothing reads.
 //!
 //! [`EditorSettings`] (GitHub issue #26) is the same kind of file-only tunable: real, applied
 //! defaults for Tab/Shift+Tab indentation (`crate::code_surface::editing`'s
@@ -98,7 +96,6 @@ pub struct Settings {
     pub appearance: AppearanceSettings,
     pub theme: ThemeSettings,
     pub keymap: KeymapSettings,
-    pub file_tree: FileTreeSettings,
     pub blame: BlameSettings,
     pub editor: EditorSettings,
     pub icon_pack: IconPackSettings,
@@ -307,26 +304,6 @@ pub struct KeybindingOverride {
     pub keystrokes: String,
 }
 
-/// The Files tree's one real tunable (GitHub issue #18 §4): how many entries a single
-/// `crate::sidebar::file_tree::build_file_tree` walk will collect before stopping. Not backed by a
-/// settings *page* (unlike every other section here) - it's the "large, configurable" cap the
-/// issue asks any surviving safety cap to be, edited from `settings.toml` directly, and when it
-/// is hit the sidebar shows a real "load more" action naming the count it stopped at, rather
-/// than a silent cut-off.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(default)]
-pub struct FileTreeSettings {
-    pub max_entries: usize,
-}
-
-impl Default for FileTreeSettings {
-    fn default() -> Self {
-        Self {
-            max_entries: FILE_TREE_MAX_ENTRIES_DEFAULT,
-        }
-    }
-}
-
 /// Inline git blame (GitHub issue #29): whether Surface C's File view shows the current line's
 /// author/relative-date/summary, dimmed, at the end of the line - see
 /// `crate::code_surface::blame_view`'s own module docs for the real off-thread/caching mechanism
@@ -350,35 +327,6 @@ pub struct BlameSettings {
 impl Default for BlameSettings {
     fn default() -> Self {
         Self { show_inline: true }
-    }
-}
-
-/// 20,000 entries - four times the old hard-coded 5,000 bound, and comfortably more than any
-/// real source tree this app is meant for once dot-directories (`.git`, and with them the vast
-/// majority of a repository's loose files) are already skipped by the walk itself.
-pub const FILE_TREE_MAX_ENTRIES_DEFAULT: usize = 20_000;
-
-/// A hand-edited `max_entries` below this can't render a useful tree at all, so it's clamped up
-/// rather than honoured - the same [`AppearanceSettings::sanitize`] discipline applied here.
-pub const FILE_TREE_MAX_ENTRIES_MIN: usize = 100;
-
-/// And a real upper clamp, which the first version of this setting was missing. It is not an
-/// arbitrary round number: two pieces of *foreground-thread* work scale linearly with the number
-/// of loaded entries - `crate::root::AdeApp::rebuild_palette_file_candidates` allocates one
-/// candidate per file in the walk-completion handler, and `render_file_tree` scans every loaded
-/// entry once per frame to resolve which rows are visible. At 100,000 both are real but
-/// absorbable; at the millions a hand-edited file could otherwise ask for, the first is a
-/// multi-second freeze on load and the second is a per-frame one. This is the honest hard
-/// ceiling on how much tree this sidebar holds, and the tree says so (see
-/// `crate::sidebar::render::AdeApp::render_file_tree`'s truncation row) rather than cutting off
-/// silently.
-pub const FILE_TREE_MAX_ENTRIES_MAX: usize = 100_000;
-
-impl FileTreeSettings {
-    pub fn sanitize(&mut self) {
-        self.max_entries = self
-            .max_entries
-            .clamp(FILE_TREE_MAX_ENTRIES_MIN, FILE_TREE_MAX_ENTRIES_MAX);
     }
 }
 
@@ -498,14 +446,12 @@ impl Settings {
     /// doesn't exist yet, writes a default file there (via [`Settings::save_at`]) so the config
     /// file exists on first run; a save failure there is also logged rather than propagated. A
     /// file that does parse still gets every section's own `sanitize` applied
-    /// ([`AppearanceSettings::sanitize`], [`FileTreeSettings::sanitize`],
-    /// [`EditorSettings::sanitize`]).
+    /// ([`AppearanceSettings::sanitize`], [`EditorSettings::sanitize`]).
     pub fn load_or_init_at(path: &Path) -> Settings {
         match std::fs::read_to_string(path) {
             Ok(contents) => match toml::from_str::<Settings>(&contents) {
                 Ok(mut settings) => {
                     settings.appearance.sanitize();
-                    settings.file_tree.sanitize();
                     settings.editor.sanitize();
                     settings
                 }
@@ -713,10 +659,6 @@ mod tests {
             settings.keymap.overrides.is_empty(),
             "a fresh install has no real rebinds yet"
         );
-        assert_eq!(
-            settings.file_tree.max_entries,
-            FILE_TREE_MAX_ENTRIES_DEFAULT
-        );
         assert!(
             settings.editor.minimap_enabled,
             "the minimap is on by default"
@@ -753,28 +695,25 @@ mod tests {
         );
     }
 
+    /// GitHub issue #160 deleted `[file_tree] max_entries` outright. A `settings.toml` written by
+    /// an older build still has that section in it, and it must load as a plain no-op rather than
+    /// failing the whole file back to defaults and quietly losing every other setting with it.
     #[test]
-    fn a_hand_edited_file_tree_cap_round_trips_and_an_absurd_one_is_clamped() {
+    fn a_settings_file_still_carrying_the_removed_file_tree_cap_loads_the_rest_of_it() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("settings.toml");
-        std::fs::write(&path, "[file_tree]\nmax_entries = 50000\n").expect("write");
-        assert_eq!(
-            Settings::load_or_init_at(&path).file_tree.max_entries,
-            50_000
-        );
+        std::fs::write(
+            &path,
+            "[file_tree]\nmax_entries = 50000\n\n[editor]\ntab_width = 2\n",
+        )
+        .expect("write");
 
-        std::fs::write(&path, "[file_tree]\nmax_entries = 5000000\n").expect("write");
-        assert_eq!(
-            Settings::load_or_init_at(&path).file_tree.max_entries,
-            FILE_TREE_MAX_ENTRIES_MAX,
-            "a cap larger than the foreground thread can absorb is clamped down, not honoured"
-        );
+        let loaded = Settings::load_or_init_at(&path);
 
-        std::fs::write(&path, "[file_tree]\nmax_entries = 1\n").expect("write");
         assert_eq!(
-            Settings::load_or_init_at(&path).file_tree.max_entries,
-            FILE_TREE_MAX_ENTRIES_MIN,
-            "a cap too small to render a usable tree is clamped up, not honoured"
+            loaded.editor.tab_width, 2,
+            "the removed section must be ignored, not treated as a parse failure that discards \
+             the whole file"
         );
     }
 

--- a/crates/app/src/sidebar/file_tree.rs
+++ b/crates/app/src/sidebar/file_tree.rs
@@ -5,28 +5,42 @@
 //! importantly, keeping this fast: `.git` can contain many thousands of loose objects, and
 //! walking it would make browsing unusably slow.
 //!
-//! ## No entry is ever hidden without saying so (GitHub issue #18 §4)
+//! ## No entry is hidden, and no entry is left unloaded (GitHub issues #18 §4, #160)
 //!
-//! There is no longer a render-time cap: `crate::sidebar::render::AdeApp::render_file_tree` is a
-//! real virtualized `gpui::uniform_list`, so every visible row is rendered and only the rows
-//! genuinely on screen become elements. The old `MAX_RENDERED_FILE_ENTRIES` (500) cap and its
+//! There is no render-time cap: `crate::sidebar::render::AdeApp::render_file_tree` is a real
+//! virtualized `gpui::uniform_list`, so every visible row is rendered and only the rows genuinely
+//! on screen become elements. The old `MAX_RENDERED_FILE_ENTRIES` (500) cap and its
 //! "... and N more entries not shown" row are gone.
 //!
-//! One cap survives, and it is a *load* bound rather than a render one: the recursive walk is
-//! bounded by [`FileTreeSettings::max_entries`](crate::settings::store::FileTreeSettings), a
-//! real, configurable `settings.toml` value (20,000 by default). It exists because the walk is
-//! eager and synchronous - `crate::root::AdeApp::rebuild_palette_file_candidates` needs the whole
-//! tree for file search, so it cannot be made lazy - and pointing this app at a directory with a
-//! million files should not allocate a million `PathBuf`s before the first frame. When it is hit
-//! the listing reports [`FileTreeListing::truncated`] and the sidebar shows a real
-//! "Stopped at N entries - load more" action
-//! (`crate::sidebar::render::AdeApp::load_more_file_tree_entries`), which re-walks with a
-//! tenfold larger budget. Still a budget, deliberately - see that method's own docs - but the
-//! row always names the count the walk stopped at, so nothing is ever *silently* cut off.
+//! There is no *load*-time cap either, as of issue #160 ("File tree should load all folders and
+//! files"). The walk used to stop at `Settings.file_tree.max_entries` (20,000 by default) and the
+//! sidebar showed a "Stopped at N entries - load more" action that re-walked with a tenfold
+//! larger budget. Both are gone: this walk collects the whole tree.
+//!
+//! Removing that bound was only safe because the two costs it was really guarding no longer scale
+//! with the size of the loaded tree on the foreground thread:
+//!
+//! - The walk itself has always run on `gpui::BackgroundExecutor`
+//!   (`crate::root::AdeApp::load_file_tree`), so a huge `node_modules`/`target` never blocked a
+//!   frame - it only decided *how much* the completion handler then had to do.
+//! - That completion handler used to build the palette's file-candidate list
+//!   (`crate::root::AdeApp::rebuild_palette_file_candidates`, one allocation-heavy
+//!   `crate::palette::state::FileCandidate` per file) on the foreground thread. It is now built on
+//!   the background executor too, in the same task, before anything is applied to the app.
+//! - [`FileTree::visible_indices`] - called once per frame by `render_file_tree` - used to scan
+//!   *every* loaded entry to decide which rows are showing, so a collapsed million-entry subtree
+//!   still cost a million iterations per frame. It now skips a collapsed directory's whole subtree
+//!   in one step using [`FileTree`]'s precomputed spans, making it O(visible rows) instead of
+//!   O(loaded entries).
+//!
+//! What survives is [`MAX_DEPTH`], which is not an entry budget at all but a stack-overflow guard
+//! on a recursive walk, and it reports itself through [`FileTreeListing::partial`] exactly as
+//! before.
 
 use std::collections::HashSet;
 use std::fs;
 use std::io;
+use std::ops::Deref;
 use std::path::{Path, PathBuf};
 
 use gpui::Rgba;
@@ -44,17 +58,121 @@ pub struct FileTreeEntry {
     pub is_dir: bool,
 }
 
-/// A completed walk: the flattened entries, plus the two ways it can be less than the whole
-/// truth. `truncated` is the honest half of the load cap (see the module docs) and is what the
-/// sidebar's "load more" action keys off. `partial` covers the quieter case - a subdirectory the
-/// walk couldn't read, or one that was deeper than [`MAX_DEPTH`] - which is deliberately *not*
-/// surfaced as a user-facing action but must still stop
-/// `crate::sidebar::render::AdeApp::prune_stale_fold_state` from treating this listing as a
-/// complete inventory of the worktree's directories.
+/// The loaded tree: [`build_file_tree`]'s pre-order entries, plus the derived per-entry subtree
+/// spans [`Self::visible_indices`] uses to skip a collapsed directory's descendants in one step.
+///
+/// The spans are deliberately *not* a public field and cannot be supplied by a caller: [`FileTree::new`]
+/// is the only way to make one, and it always derives them from the entries it is given. This is
+/// the same "a derived value gets exactly one assignment point" discipline
+/// `crate::root::AdeApp::set_file_tree_root` applies to `fold_state_root_key` - here it matters
+/// because a stale span wouldn't error, it would silently show a collapsed folder's children.
+///
+/// Derefs to `[FileTreeEntry]`, so everything that just reads rows (`len`, `iter`, indexing) uses
+/// it exactly as it used the old `Vec<FileTreeEntry>`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FileTree {
+    entries: Vec<FileTreeEntry>,
+    /// `subtree_spans[i]` is how many entries immediately following `i` are inside entry `i`'s
+    /// subtree - `0` for every file, and for a directory whose contents the walk never reached.
+    subtree_spans: Vec<usize>,
+}
+
+impl FileTree {
+    /// Wraps a pre-order, depth-annotated entry list (the shape [`build_file_tree`] produces),
+    /// deriving its subtree spans in one O(n) pass. Called on the background executor as the last
+    /// step of the walk, never on the foreground thread.
+    pub fn new(entries: Vec<FileTreeEntry>) -> Self {
+        let subtree_spans = subtree_spans(&entries);
+        Self {
+            entries,
+            subtree_spans,
+        }
+    }
+
+    /// The rows that should be rendered given which directories are **expanded**, as indices into
+    /// this tree. An unexpanded directory's own row still shows; everything nested underneath it
+    /// is skipped.
+    ///
+    /// Keyed on expanded-ness, not collapsed-ness, and that inversion is the whole of GitHub
+    /// issue #18 §1: absence from this set means *collapsed*, so a worktree nobody has ever
+    /// expanded anything in - including a freshly created one - opens showing only its root-level
+    /// entries, with no separate "first open" special case anywhere.
+    ///
+    /// Costs O(visible rows), not O(loaded entries): a collapsed directory is stepped over
+    /// wholesale via its [span](Self::new) rather than by scanning its descendants and discarding
+    /// them one at a time. `crate::sidebar::render::AdeApp::render_file_tree` calls this once per
+    /// frame, so before issue #160 removed the load cap that scan was the per-frame cost the cap
+    /// was partly there to bound.
+    ///
+    /// Indices rather than borrowed entries because `render_file_tree` needs the result inside a
+    /// `'static` closure that cannot hold a borrow of the app; [`Self::visible_entries`] is the
+    /// borrowing twin, defined in terms of this one so the two can never disagree.
+    pub fn visible_indices(&self, expanded: &HashSet<PathBuf>) -> Vec<usize> {
+        let mut visible = Vec::new();
+        let mut index = 0;
+        while let Some(entry) = self.entries.get(index) {
+            visible.push(index);
+            index += if entry.is_dir && !expanded.contains(&entry.path) {
+                // Bounds-checked rather than trusted: a span that was somehow short would render
+                // extra rows, but a `+ 0` step would hang the loop.
+                1 + self.subtree_spans.get(index).copied().unwrap_or(0)
+            } else {
+                1
+            };
+        }
+        visible
+    }
+
+    /// [`Self::visible_indices`]' borrowing twin - the same rows, as entries.
+    pub fn visible_entries(&self, expanded: &HashSet<PathBuf>) -> Vec<&FileTreeEntry> {
+        self.visible_indices(expanded)
+            .into_iter()
+            .map(|index| &self.entries[index])
+            .collect()
+    }
+}
+
+impl Deref for FileTree {
+    type Target = [FileTreeEntry];
+
+    fn deref(&self) -> &Self::Target {
+        &self.entries
+    }
+}
+
+/// Derives every entry's subtree span from the list's own pre-order `depth` shape: an entry's
+/// subtree is the contiguous run of following entries that are deeper than it, which ends at the
+/// first entry whose depth is less than or equal to its own.
+fn subtree_spans(entries: &[FileTreeEntry]) -> Vec<usize> {
+    let mut spans = vec![0usize; entries.len()];
+    // The current entry's open ancestors, outermost first. An entry at depth `d` has exactly `d`
+    // of them, so anything deeper on this stack has just been closed by reaching this entry.
+    let mut open: Vec<usize> = Vec::new();
+    for (index, entry) in entries.iter().enumerate() {
+        while open.len() > entry.depth {
+            if let Some(ancestor) = open.pop() {
+                spans[ancestor] = index - ancestor - 1;
+            }
+        }
+        open.push(index);
+    }
+    while let Some(ancestor) = open.pop() {
+        spans[ancestor] = entries.len() - ancestor - 1;
+    }
+    spans
+}
+
+/// A completed walk: the loaded tree, plus the one way it can still be less than the whole truth.
+/// `partial` covers the quiet cases - a subdirectory the walk couldn't read, or one that was
+/// deeper than [`MAX_DEPTH`] - which are deliberately *not* surfaced as a user-facing action but
+/// must still stop `crate::sidebar::render::AdeApp::prune_stale_fold_state` from treating this
+/// listing as a complete inventory of the worktree's directories.
+///
+/// There is no `truncated` counterpart any more: the walk has no entry budget to stop at (issue
+/// #160 - see the module docs).
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct FileTreeListing {
-    pub entries: Vec<FileTreeEntry>,
-    pub truncated: bool,
+    pub tree: FileTree,
     pub partial: bool,
 }
 
@@ -62,16 +180,9 @@ impl FileTreeListing {
     /// Whether this listing is a complete inventory of the tree - the only condition under which
     /// "a directory isn't in here" may be taken as "that directory no longer exists".
     pub fn is_complete(&self) -> bool {
-        !self.truncated && !self.partial
+        !self.partial
     }
 }
-
-/// The ceiling `crate::sidebar::render::AdeApp::load_more_file_tree_entries` escalates towards.
-/// Deliberately the same number as `crate::settings::store::FILE_TREE_MAX_ENTRIES_MAX` - see that
-/// constant for the real reasoning (two foreground-thread costs that scale with the loaded entry
-/// count). An escape hatch that could exceed the configured maximum would just be the unbounded
-/// walk again, wearing a click.
-pub const MAX_LOAD_MORE_ENTRIES: usize = crate::settings::store::FILE_TREE_MAX_ENTRIES_MAX;
 
 /// How deep the walk will recurse. A defensive bound on stack depth, not a product decision: the
 /// walk is recursive, and while `std::fs::DirEntry::file_type` doesn't follow symlinks (so a
@@ -83,24 +194,29 @@ pub const MAX_DEPTH: usize = 64;
 /// Recursively lists `root`'s contents (directories first, then alphabetically within each
 /// group) as a flattened, depth-annotated list suitable for indented rendering.
 ///
-/// `limit` is the maximum number of entries to collect. `None` is genuinely unbounded and is a
-/// test-only convenience: every production caller passes a real cap (see
-/// `crate::root::AdeApp::load_file_tree`), including the sidebar's own "load more" action.
-pub fn build_file_tree(root: &Path, limit: Option<usize>) -> io::Result<FileTreeListing> {
-    let mut listing = FileTreeListing::default();
-    let mut budget = limit.unwrap_or(usize::MAX);
-    visit(root, 0, &mut budget, &mut listing)?;
-    Ok(listing)
+/// Genuinely unbounded in entry count (GitHub issue #160): every folder and file under `root`
+/// that isn't a dotfile and isn't deeper than [`MAX_DEPTH`] is collected. See the module docs for
+/// why that is safe here and what had to change on the foreground thread to keep it that way.
+pub fn build_file_tree(root: &Path) -> io::Result<FileTreeListing> {
+    let mut walk = Walk::default();
+    visit(root, 0, &mut walk)?;
+    Ok(FileTreeListing {
+        tree: FileTree::new(walk.entries),
+        partial: walk.partial,
+    })
 }
 
-fn visit(
-    dir: &Path,
-    depth: usize,
-    budget: &mut usize,
-    listing: &mut FileTreeListing,
-) -> io::Result<()> {
+/// The walk's own mutable accumulator - deliberately not a [`FileTreeListing`], since the spans a
+/// [`FileTree`] carries can only be derived once the entry list is finished.
+#[derive(Default)]
+struct Walk {
+    entries: Vec<FileTreeEntry>,
+    partial: bool,
+}
+
+fn visit(dir: &Path, depth: usize, walk: &mut Walk) -> io::Result<()> {
     if depth >= MAX_DEPTH {
-        listing.partial = true;
+        walk.partial = true;
         return Ok(());
     }
     let mut children: Vec<fs::DirEntry> = fs::read_dir(dir)?
@@ -111,7 +227,7 @@ fn visit(
             // inventory when it isn't, which is what `prune_stale_fold_state` would then delete
             // real fold state on the strength of.
             Err(_) => {
-                listing.partial = true;
+                walk.partial = true;
                 None
             }
         })
@@ -128,24 +244,18 @@ fn visit(
     });
 
     for child in children {
-        if *budget == 0 {
-            listing.truncated = true;
-            return Ok(());
-        }
-        *budget -= 1;
-
         let path = child.path();
         // A `file_type()` that fails leaves a real directory recorded as a file, so its whole
         // subtree is never walked - the same "incomplete but doesn't look it" hazard as above.
         let is_dir = match child.file_type() {
             Ok(file_type) => file_type.is_dir(),
             Err(_) => {
-                listing.partial = true;
+                walk.partial = true;
                 false
             }
         };
         let name = child.file_name().to_string_lossy().into_owned();
-        listing.entries.push(FileTreeEntry {
+        walk.entries.push(FileTreeEntry {
             path: path.clone(),
             name,
             depth,
@@ -159,8 +269,8 @@ fn visit(
             // though, which `partial` records - without it, an unreadable folder would look
             // exactly like a deleted one to `prune_stale_fold_state`, which would then throw
             // away every fold-state entry beneath it.
-            if visit(&path, depth + 1, budget, listing).is_err() {
-                listing.partial = true;
+            if visit(&path, depth + 1, walk).is_err() {
+                walk.partial = true;
             }
         }
     }
@@ -189,38 +299,13 @@ pub fn lang_chip_for_name(name: &str) -> LangChip {
     LangChip { label, fg, bg }
 }
 
-/// Filters a flattened, depth-annotated [`build_file_tree`] listing down to the rows that should
-/// be rendered given which directories are **expanded** (an unexpanded directory's own row still
-/// shows, but everything nested underneath it is hidden until it is expanded).
-///
-/// Keyed on expanded-ness, not collapsed-ness, and that inversion is the whole of GitHub issue
-/// #18 §1: absence from this set means *collapsed*, so a worktree nobody has ever expanded
-/// anything in - including a freshly created one - opens showing only its root-level entries,
-/// with no separate "first open" special case anywhere.
-///
-/// Relies on `entries` being in [`build_file_tree`]'s pre-order depth-first shape: once an
-/// unexpanded directory at depth `d` is seen, every following entry with `depth > d` is skipped
-/// until one with `depth <= d` is reached. Expanded directories nested inside an already-hidden
-/// subtree need no special case - they're skipped along with the rest of their parent, so a stale
-/// deep expansion can never make a row appear underneath a collapsed ancestor.
-/// Defined in terms of [`visible_indices`] rather than duplicating the walk, so the two can
-/// never disagree about which rows are showing.
-pub fn visible_entries<'a>(
-    entries: &'a [FileTreeEntry],
-    expanded: &HashSet<PathBuf>,
-) -> Vec<&'a FileTreeEntry> {
-    visible_indices(entries, expanded)
-        .into_iter()
-        .map(|index| &entries[index])
-        .collect()
-}
-
-/// [`visible_entries`]'s index-returning twin - the same walk, reporting positions in `entries`
-/// rather than borrowing from it. `crate::sidebar::render::AdeApp::render_file_tree` needs the
-/// result inside a `'static` closure that cannot hold a borrow of the app, and re-running the
-/// walk inside that closure would mean walking the whole loaded tree once per `uniform_list`
-/// pass (three per frame) instead of once per frame.
-pub fn visible_indices(entries: &[FileTreeEntry], expanded: &HashSet<PathBuf>) -> Vec<usize> {
+/// The pre-span definition of [`FileTree::visible_indices`], kept as the oracle its own test
+/// checks the fast, span-based implementation against: once an unexpanded directory at depth `d`
+/// is seen, every following entry with `depth > d` is skipped until one with `depth <= d` is
+/// reached. Correct but O(loaded entries) - which is exactly what issue #160 could not afford to
+/// keep doing once the load cap was gone.
+#[cfg(test)]
+fn visible_indices_by_depth(entries: &[FileTreeEntry], expanded: &HashSet<PathBuf>) -> Vec<usize> {
     let mut visible = Vec::new();
     let mut hidden_below_depth: Option<usize> = None;
 
@@ -302,10 +387,8 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
-    fn tree_of(root: &Path) -> Vec<FileTreeEntry> {
-        build_file_tree(root, None)
-            .expect("build_file_tree")
-            .entries
+    fn tree_of(root: &Path) -> FileTree {
+        build_file_tree(root).expect("build_file_tree").tree
     }
 
     #[test]
@@ -348,43 +431,16 @@ mod tests {
     #[test]
     fn empty_directory_yields_no_entries() {
         let dir = TempDir::new().expect("tempdir");
-        let listing = build_file_tree(dir.path(), None).expect("build_file_tree");
-        assert!(listing.entries.is_empty());
-        assert!(!listing.truncated);
+        let listing = build_file_tree(dir.path()).expect("build_file_tree");
+        assert!(listing.tree.is_empty());
+        assert!(listing.is_complete());
     }
 
     #[test]
     fn nonexistent_root_returns_io_error() {
         let missing = PathBuf::from("/definitely/not/a/real/path/for/ade/file-tree-test");
-        let result = build_file_tree(&missing, None);
+        let result = build_file_tree(&missing);
         assert!(result.is_err());
-    }
-
-    /// The load cap must be honest in both directions: a walk that hits it says so, and one that
-    /// doesn't must never claim it did (which would put a "Show all entries" action in the
-    /// sidebar for a tree that is already complete).
-    #[test]
-    fn a_walk_that_hits_its_limit_reports_truncation_and_one_that_does_not_says_so() {
-        let dir = TempDir::new().expect("tempdir");
-        for index in 0..10 {
-            fs::write(dir.path().join(format!("f-{index}.txt")), "x").expect("write");
-        }
-
-        let capped = build_file_tree(dir.path(), Some(4)).expect("build_file_tree");
-        assert_eq!(capped.entries.len(), 4);
-        assert!(capped.truncated);
-
-        let complete = build_file_tree(dir.path(), Some(10)).expect("build_file_tree");
-        assert_eq!(complete.entries.len(), 10);
-        assert!(
-            !complete.truncated,
-            "a walk that collected everything must not report truncation, even when the entry \
-             count exactly equals the budget"
-        );
-
-        let uncapped = build_file_tree(dir.path(), None).expect("build_file_tree");
-        assert_eq!(uncapped.entries.len(), 10);
-        assert!(!uncapped.truncated);
     }
 
     /// A directory the walk can't read is skipped (so one bad folder never blanks the sidebar),
@@ -411,12 +467,12 @@ mod tests {
             return;
         }
 
-        let listing = build_file_tree(dir.path(), None).expect("build_file_tree");
+        let listing = build_file_tree(dir.path()).expect("build_file_tree");
         // Restore before any assertion can fail, or `TempDir`'s own cleanup fails too.
         fs::set_permissions(&locked, fs::Permissions::from_mode(0o755)).expect("chmod back");
 
         assert!(
-            listing.entries.iter().any(|entry| entry.name == "file.txt"),
+            listing.tree.iter().any(|entry| entry.name == "file.txt"),
             "the readable part of the tree must still be listed"
         );
         assert!(listing.partial, "the skipped directory must be reported");
@@ -424,7 +480,6 @@ mod tests {
             !listing.is_complete(),
             "and so this listing must never be used as a complete inventory"
         );
-        assert!(!listing.truncated, "no entry budget was involved");
     }
 
     /// The recursion bound - a defensive stack guard, reported the same honest way.
@@ -437,11 +492,10 @@ mod tests {
         }
         fs::create_dir_all(&deep).expect("mkdir -p");
 
-        let listing = build_file_tree(dir.path(), None).expect("build_file_tree");
+        let listing = build_file_tree(dir.path()).expect("build_file_tree");
 
-        assert_eq!(listing.entries.len(), MAX_DEPTH);
+        assert_eq!(listing.tree.len(), MAX_DEPTH);
         assert!(listing.partial);
-        assert!(!listing.truncated);
     }
 
     /// The listing has to hold hundreds of entries in a single directory without any cap of its
@@ -454,17 +508,104 @@ mod tests {
             fs::write(dir.path().join(format!("f-{index:03}.txt")), "x").expect("write");
         }
 
-        let listing = build_file_tree(dir.path(), Some(20_000)).expect("build_file_tree");
+        let listing = build_file_tree(dir.path()).expect("build_file_tree");
 
-        assert_eq!(listing.entries.len(), 800);
-        assert!(!listing.truncated);
+        assert_eq!(listing.tree.len(), 800);
+        assert!(listing.is_complete());
         let expanded = HashSet::new();
         assert_eq!(
-            visible_entries(&listing.entries, &expanded).len(),
+            listing.tree.visible_entries(&expanded).len(),
             800,
             "every entry in a flat directory is visible with nothing expanded, and none of them \
              may be dropped by a render cap"
         );
+    }
+
+    /// GitHub issue #160, at the level the walk itself decides it: a tree with more entries than
+    /// the removed 20,000-entry default cap must come back whole, with no truncation flag left
+    /// anywhere to hang a "load more" row off.
+    ///
+    /// Built as a wide, shallow fan (200 directories x 105 files) rather than 21,000 files in one
+    /// folder, so it also exercises the recursive descent the old budget used to cut short
+    /// mid-subtree.
+    #[test]
+    fn a_tree_larger_than_the_removed_twenty_thousand_entry_cap_loads_completely() {
+        const DIRS: usize = 200;
+        const FILES_PER_DIR: usize = 105;
+        // 200 directory rows + 21,000 file rows - comfortably past the 20,000 the walk used to
+        // stop at. Checked at compile time so the fixture can never be shrunk below the removed
+        // cap and go on passing for the wrong reason.
+        const EXPECTED: usize = DIRS + DIRS * FILES_PER_DIR;
+        const _: () = assert!(EXPECTED > 20_000);
+
+        let dir = TempDir::new().expect("tempdir");
+        for d in 0..DIRS {
+            let sub = dir.path().join(format!("d-{d:03}"));
+            fs::create_dir(&sub).expect("mkdir");
+            for f in 0..FILES_PER_DIR {
+                fs::write(sub.join(format!("f-{f:03}.txt")), "x").expect("write");
+            }
+        }
+
+        let listing = build_file_tree(dir.path()).expect("build_file_tree");
+
+        assert_eq!(
+            listing.tree.len(),
+            EXPECTED,
+            "every folder and every file must be loaded - the old cap stopped at 20,000"
+        );
+        assert!(
+            listing.is_complete(),
+            "and a walk that reached everything is a complete inventory"
+        );
+        // The last directory's last file is the entry furthest past the old cut-off; naming it
+        // proves the walk really continued rather than merely counting to a bigger number.
+        let last = dir
+            .path()
+            .join(format!("d-{:03}", DIRS - 1))
+            .join(format!("f-{:03}.txt", FILES_PER_DIR - 1));
+        assert!(
+            listing.tree.iter().any(|entry| entry.path == last),
+            "{} is ~1,000 entries past the removed cap and must still be present",
+            last.display()
+        );
+    }
+
+    /// The span-based skip must agree with the depth-scan it replaced on a real, nested tree -
+    /// for every combination of expanded folders, not just the one a hand-written case picks.
+    #[test]
+    fn span_based_visibility_matches_the_depth_scan_for_every_expansion() {
+        let dir = TempDir::new().expect("tempdir");
+        fs::create_dir_all(dir.path().join("a/b/c")).expect("mkdir -p");
+        fs::create_dir_all(dir.path().join("a/d")).expect("mkdir -p");
+        fs::create_dir(dir.path().join("e")).expect("mkdir");
+        fs::write(dir.path().join("a/b/c/deep.txt"), "x").expect("write");
+        fs::write(dir.path().join("a/b/mid.txt"), "x").expect("write");
+        fs::write(dir.path().join("a/d/other.txt"), "x").expect("write");
+        fs::write(dir.path().join("e/leaf.txt"), "x").expect("write");
+        fs::write(dir.path().join("root.txt"), "x").expect("write");
+
+        let tree = tree_of(dir.path());
+        let dirs: Vec<PathBuf> = tree
+            .iter()
+            .filter(|entry| entry.is_dir)
+            .map(|entry| entry.path.clone())
+            .collect();
+        assert_eq!(dirs.len(), 5, "a/ a/b/ a/b/c/ a/d/ e/");
+
+        for mask in 0..(1u32 << dirs.len()) {
+            let expanded: HashSet<PathBuf> = dirs
+                .iter()
+                .enumerate()
+                .filter(|(bit, _)| mask & (1 << bit) != 0)
+                .map(|(_, path)| path.clone())
+                .collect();
+            assert_eq!(
+                tree.visible_indices(&expanded),
+                visible_indices_by_depth(&tree, &expanded),
+                "span-based visibility diverged from the depth scan for expansion mask {mask:#b}"
+            );
+        }
     }
 
     fn same(a: Rgba, b: Rgba) -> bool {
@@ -520,33 +661,40 @@ mod tests {
         }
     }
 
+    /// Hand-built fixtures go through the same [`FileTree::new`] every real walk does, so the
+    /// subtree spans under test are always the derived ones - there is deliberately no way to
+    /// hand-write a span.
+    fn tree(entries: Vec<FileTreeEntry>) -> FileTree {
+        FileTree::new(entries)
+    }
+
     /// Issue #18 §1's default state, at the level it's actually decided: nothing expanded means
     /// root-level entries only.
     #[test]
     fn nothing_expanded_shows_only_root_level_entries() {
-        let entries = vec![
+        let entries = tree(vec![
             entry("sub", 0, true),
             entry("nested.txt", 1, false),
             entry("a.txt", 0, false),
-        ];
-        let visible = visible_entries(&entries, &HashSet::new());
+        ]);
+        let visible = entries.visible_entries(&HashSet::new());
         let names: Vec<&str> = visible.iter().map(|e| e.name.as_str()).collect();
         assert_eq!(names, vec!["sub", "a.txt"]);
     }
 
     #[test]
     fn expanding_a_directory_reveals_only_its_own_immediate_subtree() {
-        let entries = vec![
+        let entries = tree(vec![
             entry("sub", 0, true),
             entry("nested.txt", 1, false),
             entry("deeper", 1, true),
             entry("deepest.txt", 2, false),
             entry("a.txt", 0, false),
-        ];
+        ]);
         let mut expanded = HashSet::new();
         expanded.insert(PathBuf::from("sub"));
 
-        let visible = visible_entries(&entries, &expanded);
+        let visible = entries.visible_entries(&expanded);
         let names: Vec<&str> = visible.iter().map(|e| e.name.as_str()).collect();
         // "deeper" shows because its parent is expanded, but its own children stay hidden until
         // it is expanded too.
@@ -555,16 +703,16 @@ mod tests {
 
     #[test]
     fn expanding_a_whole_chain_reveals_the_deepest_entry() {
-        let entries = vec![
+        let entries = tree(vec![
             entry("sub", 0, true),
             entry("deeper", 1, true),
             entry("deepest.txt", 2, false),
-        ];
+        ]);
         let mut expanded = HashSet::new();
         expanded.insert(PathBuf::from("sub"));
         expanded.insert(PathBuf::from("deeper"));
 
-        let visible = visible_entries(&entries, &expanded);
+        let visible = entries.visible_entries(&expanded);
         let names: Vec<&str> = visible.iter().map(|e| e.name.as_str()).collect();
         assert_eq!(names, vec!["sub", "deeper", "deepest.txt"]);
     }
@@ -573,27 +721,27 @@ mod tests {
     /// collapsed) must never punch a hole through a collapsed ancestor.
     #[test]
     fn an_expanded_directory_under_a_collapsed_ancestor_stays_hidden() {
-        let entries = vec![
+        let entries = tree(vec![
             entry("sub", 0, true),
             entry("deeper", 1, true),
             entry("deepest.txt", 2, false),
             entry("a.txt", 0, false),
-        ];
+        ]);
         let mut expanded = HashSet::new();
         expanded.insert(PathBuf::from("deeper"));
 
-        let visible = visible_entries(&entries, &expanded);
+        let visible = entries.visible_entries(&expanded);
         let names: Vec<&str> = visible.iter().map(|e| e.name.as_str()).collect();
         assert_eq!(names, vec!["sub", "a.txt"]);
     }
 
     #[test]
     fn expanding_a_directory_with_no_children_reveals_nothing_extra() {
-        let entries = vec![entry("empty-dir", 0, true), entry("a.txt", 0, false)];
+        let entries = tree(vec![entry("empty-dir", 0, true), entry("a.txt", 0, false)]);
         let mut expanded = HashSet::new();
         expanded.insert(PathBuf::from("empty-dir"));
 
-        let visible = visible_entries(&entries, &expanded);
+        let visible = entries.visible_entries(&expanded);
         assert_eq!(visible.len(), 2);
     }
 
@@ -608,7 +756,7 @@ mod tests {
         let mut expanded = HashSet::new();
         expanded.insert(dir.path().join("sub"));
 
-        let visible = visible_entries(&entries, &expanded);
+        let visible = entries.visible_entries(&expanded);
         let names: Vec<&str> = visible.iter().map(|e| e.name.as_str()).collect();
         assert_eq!(names, vec!["sub", "nested.txt", "a.txt"]);
     }

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -218,44 +218,6 @@ impl AdeApp {
         }
     }
 
-    /// Whether the current walk budget is already at [`file_tree::MAX_LOAD_MORE_ENTRIES`], so
-    /// [`Self::load_more_file_tree_entries`] has nothing left to raise - the condition that turns
-    /// the sidebar's action row into a plain disclosure rather than a button that re-walks a
-    /// ceiling's worth of entries to no effect.
-    pub(crate) fn file_tree_limit_is_at_ceiling(&self) -> bool {
-        self.file_tree_limit_override
-            .unwrap_or(self.settings.file_tree.max_entries)
-            >= file_tree::MAX_LOAD_MORE_ENTRIES
-    }
-
-    /// The "load more" action's real handler - re-walks the current tree with a tenfold larger
-    /// entry budget. Genuinely reloads rather than revealing something already loaded: the
-    /// capped walk never collected those entries. Still bounded, deliberately - see
-    /// [`AdeApp::file_tree_limit_override`] for why this raises the cap instead of removing it.
-    pub(crate) fn load_more_file_tree_entries(&mut self, cx: &mut Context<Self>) {
-        let current = self
-            .file_tree_limit_override
-            .unwrap_or(self.settings.file_tree.max_entries);
-        // Ceilinged *and* monotonic. The ceiling is why this can't escalate into the unbounded
-        // walk again (see `file_tree::MAX_LOAD_MORE_ENTRIES`); the `.max(current)` is a real bug
-        // fix rather than defensive padding - a `max_entries` above the ceiling would otherwise
-        // make one click *shrink* the budget, so "load more" would visibly remove rows from the
-        // tree. A limit this action produces can never be smaller than the one it replaced.
-        let next = current
-            .saturating_mul(10)
-            .min(file_tree::MAX_LOAD_MORE_ENTRIES)
-            .max(current);
-        if next == current {
-            // Already at the ceiling: re-walking would burn a whole budget's worth of work to
-            // produce byte-identical rows. `render_file_tree` doesn't offer the action at all in
-            // this state (it renders a plain disclosure instead); this is the same fact enforced
-            // at the handler, so no other caller can reintroduce the dead-but-expensive click.
-            return;
-        }
-        self.file_tree_limit_override = Some(next);
-        self.load_file_tree(self.file_tree_root.clone(), cx);
-    }
-
     /// Toggles a file's staged state (Revision R12 §5: the checkbox **is** staging) - the
     /// Changes row checkbox's click handler. `Self::render_change_row` stops propagation at the
     /// call site so checking a box never also opens that file's diff.
@@ -548,7 +510,7 @@ impl AdeApp {
         // indices are valid for exactly as long as they need to be, since nothing can mutate
         // `file_tree` between this line and the closure's last call within one frame. They are
         // still bounds-checked below rather than indexed blindly.
-        let visible_indices = file_tree::visible_indices(&self.file_tree, &self.expanded_dirs);
+        let visible_indices = self.file_tree.visible_indices(&self.expanded_dirs);
         // The in-progress inline name editor is woven into that same row list as a real row
         // (issue #19 §2: "an inline name editor at the right spot in the tree"), rather than
         // floating over it - so it scrolls with the tree, is indented like its neighbours, and
@@ -581,9 +543,10 @@ impl AdeApp {
         //
         // The former `MAX_RENDERED_FILE_ENTRIES` (500) cap is gone: virtualization already
         // removed the per-frame cost it was originally guarding, and hiding real entries behind
-        // a "... and N more" row was the dishonesty issue #18 §4 set out to remove. The one
-        // surviving cap is a *load*-time one (`Settings.file_tree.max_entries`), and it announces
-        // itself with the real "load more" action below rather than a silent cut-off.
+        // a "... and N more" row was the dishonesty issue #18 §4 set out to remove. The
+        // *load*-time cap that used to survive alongside it (`Settings.file_tree.max_entries`,
+        // plus its "load more" action) is gone too, as of GitHub issue #160 - there is no cap of
+        // any kind on this tree now.
         let list = uniform_list(
             "file-tree-list",
             rendered_count,
@@ -662,52 +625,9 @@ impl AdeApp {
             .min_h_0()
             .py(px(4.0))
             .child(list);
-        // The explicit replacement for the old truncation row: not a message saying entries were
-        // silently dropped, but a real action that goes and loads more of them
-        // (`Self::load_more_file_tree_entries`). Only ever shown when the walk genuinely stopped
-        // early, and it names the exact count it stopped at rather than implying a total it
-        // cannot know without walking the rest.
-        if self.file_tree_truncated && self.file_tree_limit_is_at_ceiling() {
-            // The honest end of the escalation: still truncated, but no larger budget is
-            // available, so an action here would be a button that re-walks a whole ceiling's
-            // worth of entries to produce exactly the same rows. A plain, non-interactive
-            // disclosure instead - it still names the count, so the listing is never *silently*
-            // cut off, which is the actual requirement.
-            column = column.child(render_sidebar_message(
-                format!(
-                    "Showing the first {} entries (the most this tree can load)",
-                    self.file_tree.len()
-                ),
-                theme::text::FAINT.into(),
-            ));
-        } else if self.file_tree_truncated {
-            let loaded = self.file_tree.len();
-            column = column.child(
-                div()
-                    .id("file-tree-show-all")
-                    .debug_selector(|| "file-tree-show-all".to_string())
-                    .flex_none()
-                    .w_full()
-                    .cursor_pointer()
-                    .px(px(10.0))
-                    .py(px(5.0))
-                    .font(font(theme::font::MONO))
-                    .text_size(self.ui_text_size(10.5))
-                    .text_color(theme::text::DIM)
-                    .hover(|el| {
-                        el.bg(theme::surface::ROW_HOVER)
-                            .text_color(theme::text::PRIMARY)
-                    })
-                    .tooltip(text_tooltip(
-                        "Re-read this worktree with a 10x larger entry limit. Set \
-                         `file_tree.max_entries` in settings.toml to raise it permanently.",
-                    ))
-                    .child(format!("Stopped at {loaded} entries \u{2013} load more"))
-                    .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
-                        this.load_more_file_tree_entries(cx);
-                    })),
-            );
-        }
+        // No truncation row and no "load more" action live here any more: GitHub issue #160
+        // removed the walk's entry cap, so there is no "stopped early" state left to disclose.
+        // The tree below `list` is the whole tree.
 
         // The real, honest surface for a failed file operation (a refused rename, a trash
         // command that didn't run) - next to the tree it happened in, not buried in the log.
@@ -3297,25 +3217,11 @@ mod fold_state_tests {
         repo_path: PathBuf,
         settings_path: PathBuf,
     ) -> (gpui::Entity<AdeApp>, &mut gpui::VisualTestContext) {
-        open_app_with_state_dir_and_settings(
-            cx,
-            repo_path,
-            settings_path,
-            settings_store::Settings::default(),
-        )
-    }
-
-    fn open_app_with_state_dir_and_settings(
-        cx: &mut TestAppContext,
-        repo_path: PathBuf,
-        settings_path: PathBuf,
-        settings: settings_store::Settings,
-    ) -> (gpui::Entity<AdeApp>, &mut gpui::VisualTestContext) {
         cx.add_window_view(|window, cx| {
             AdeApp::new_with_settings(
                 Some(repo_path),
                 true,
-                settings,
+                settings_store::Settings::default(),
                 Some(settings_path),
                 window,
                 cx,
@@ -3360,7 +3266,8 @@ mod fold_state_tests {
 
         assert!(app.read_with(cx, |app, _| app.expanded_dirs.is_empty()));
         let visible = app.read_with(cx, |app, _| {
-            file_tree::visible_entries(&app.file_tree, &app.expanded_dirs)
+            app.file_tree
+                .visible_entries(&app.expanded_dirs)
                 .iter()
                 .map(|entry| entry.name.clone())
                 .collect::<Vec<_>>()
@@ -3756,7 +3663,7 @@ mod fold_state_tests {
         cx.run_until_parked();
 
         let visible = app.read_with(cx, |app, _| {
-            file_tree::visible_entries(&app.file_tree, &app.expanded_dirs).len()
+            app.file_tree.visible_entries(&app.expanded_dirs).len()
         });
         assert_eq!(
             visible, 801,
@@ -3764,12 +3671,13 @@ mod fold_state_tests {
              would have silently hidden 301 of them"
         );
         assert!(
-            !app.read_with(cx, |app, _| app.file_tree_truncated),
-            "800 entries is far below the configured load cap, so nothing was truncated"
+            app.read_with(cx, |app, _| app.file_tree_complete),
+            "the walk reached everything, so the listing is a complete inventory"
         );
         assert!(
             cx.debug_bounds("file-tree-show-all").is_none(),
-            "and no 'Show all entries' action may appear for a complete listing"
+            "the 'load more' action was removed outright (GitHub issue #160) and must never \
+             render again"
         );
 
         assert!(cx.debug_bounds("file-tree-row-f-000.txt").is_some());
@@ -3798,105 +3706,30 @@ mod fold_state_tests {
         );
     }
 
-    /// §4's surviving load cap, and its honest replacement for the old silent cut-off: when the
-    /// walk really does stop early, a real action appears that goes and loads more - and the cap
-    /// it re-walks with is still a real cap, so a pathological tree can't be pulled into memory
-    /// wholesale by one click.
+    /// GitHub issue #160, end to end through the real app: a tree with more entries than the
+    /// removed 20,000-entry cap loads *completely* into the sidebar, and the "Stopped at N
+    /// entries - load more" row it used to grow instead is gone.
+    ///
+    /// This is the expensive fixture (21,200 real files and folders on disk) but it is the only
+    /// honest way to test the thing the issue asks for: a smaller tree would pass identically
+    /// before and after the change.
     #[gpui::test]
-    fn hitting_the_load_cap_offers_a_load_more_action_that_really_loads_more(
+    fn a_tree_past_the_removed_cap_loads_every_entry_with_no_load_more_row(
         cx: &mut TestAppContext,
     ) {
+        const DIRS: usize = 200;
+        const FILES_PER_DIR: usize = 105;
+        const EXPECTED: usize = DIRS + DIRS * FILES_PER_DIR;
+
         let repo = TempDir::new().expect("tempdir");
         let state_dir = TempDir::new().expect("tempdir");
-        for index in 0..40 {
-            fs::write(repo.path().join(format!("f-{index:02}.txt")), "x\n").expect("write");
+        for d in 0..DIRS {
+            let sub = repo.path().join(format!("d-{d:03}"));
+            fs::create_dir(&sub).expect("mkdir");
+            for f in 0..FILES_PER_DIR {
+                fs::write(sub.join(format!("f-{f:03}.txt")), "x\n").expect("write");
+            }
         }
-        let mut settings = settings_store::Settings::default();
-        settings.file_tree.max_entries = 10;
-
-        let (app, cx) = open_app_with_state_dir_and_settings(
-            cx,
-            repo.path().to_path_buf(),
-            state_dir.path().join("settings.toml"),
-            settings,
-        );
-        cx.run_until_parked();
-
-        assert_eq!(app.read_with(cx, |app, _| app.file_tree.len()), 10);
-        assert!(app.read_with(cx, |app, _| app.file_tree_truncated));
-        assert!(
-            cx.debug_bounds("file-tree-show-all").is_some(),
-            "a walk that stopped early must say so with a real action, never silently"
-        );
-
-        app.update(cx, |app, cx| app.load_more_file_tree_entries(cx));
-        cx.run_until_parked();
-
-        assert_eq!(
-            app.read_with(cx, |app, _| app.file_tree.len()),
-            40,
-            "the action must genuinely re-walk with a bigger budget - the capped walk never \
-             collected these entries, so nothing else could have produced them"
-        );
-        assert!(!app.read_with(cx, |app, _| app.file_tree_truncated));
-        assert!(cx.debug_bounds("file-tree-show-all").is_none());
-        assert_eq!(
-            app.read_with(cx, |app, _| app.file_tree_limit_override),
-            Some(100),
-            "the escape hatch raises the bound tenfold - it never removes it, or one click on a \
-             pathological tree would pull the whole thing into memory"
-        );
-    }
-
-    /// CRITICAL 1: "load more" must never *shrink* the budget. With a `max_entries` above the
-    /// escalation ceiling, the old `saturating_mul(10).min(ceiling)` computed a smaller limit
-    /// than the one already in force, so clicking "load more" would visibly remove rows from the
-    /// tree.
-    #[gpui::test]
-    fn load_more_can_never_shrink_the_walk_budget(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
-        let state_dir = TempDir::new().expect("tempdir");
-        seed_tree(&repo);
-        // Deliberately above `MAX_LOAD_MORE_ENTRIES`. `sanitize` clamps this on load from a real
-        // file, so this is constructed directly - the handler must still be correct for it.
-        let mut settings = settings_store::Settings::default();
-        settings.file_tree.max_entries = file_tree::MAX_LOAD_MORE_ENTRIES * 5;
-
-        let (app, cx) = open_app_with_state_dir_and_settings(
-            cx,
-            repo.path().to_path_buf(),
-            state_dir.path().join("settings.toml"),
-            settings,
-        );
-        cx.run_until_parked();
-
-        app.update(cx, |app, cx| app.load_more_file_tree_entries(cx));
-        cx.run_until_parked();
-
-        let effective = app.read_with(cx, |app, _| {
-            app.file_tree_limit_override
-                .unwrap_or(app.settings.file_tree.max_entries)
-        });
-        assert!(
-            effective >= file_tree::MAX_LOAD_MORE_ENTRIES * 5,
-            "the effective walk budget went *down* from {} to {effective} - one click on \
-             `load more` would remove rows from the tree",
-            file_tree::MAX_LOAD_MORE_ENTRIES * 5
-        );
-    }
-
-    /// CRITICAL 1, other half: once the budget is at the ceiling and the walk is *still*
-    /// truncated, the row must stop being an action. Clicking it would re-walk a whole ceiling's
-    /// worth of entries to produce byte-identical rows.
-    ///
-    /// The at-the-ceiling state is set directly rather than reached by walking: producing it
-    /// honestly needs `MAX_LOAD_MORE_ENTRIES` real files on disk. Everything asserted *from* that
-    /// precondition is real behaviour - what renders, and what the handler does.
-    #[gpui::test]
-    fn at_the_ceiling_the_row_stops_being_a_button(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
-        let state_dir = TempDir::new().expect("tempdir");
-        seed_tree(&repo);
 
         let (app, cx) = open_app_with_state_dir(
             cx,
@@ -3905,27 +3738,43 @@ mod fold_state_tests {
         );
         cx.run_until_parked();
 
-        app.update(cx, |app, cx| {
-            app.file_tree_truncated = true;
-            app.file_tree_limit_override = Some(file_tree::MAX_LOAD_MORE_ENTRIES);
-            cx.notify();
-        });
-        cx.run_until_parked();
-
+        assert_eq!(
+            app.read_with(cx, |app, _| app.file_tree.len()),
+            EXPECTED,
+            "the walk used to stop at 20,000 entries - every folder and file must now load"
+        );
+        assert!(
+            app.read_with(cx, |app, _| app.file_tree_complete),
+            "and a walk that reached everything is a complete inventory, so fold-state pruning \
+             may trust it"
+        );
         assert!(
             cx.debug_bounds("file-tree-show-all").is_none(),
-            "at the ceiling there is nothing left to load, so the clickable row must be gone - \
-             a button that re-walks a ceiling's worth of entries for identical results is worse \
-             than no button"
+            "the 'Stopped at N entries - load more' row must not exist any more"
         );
 
-        let before = app.read_with(cx, |app, _| app.file_tree_limit_override);
-        app.update(cx, |app, cx| app.load_more_file_tree_entries(cx));
-        cx.run_until_parked();
+        // The palette's own candidate list is derived from the same walk, on the background
+        // executor now that it is unbounded - it must cover the whole tree, not the first 20,000.
         assert_eq!(
-            app.read_with(cx, |app, _| app.file_tree_limit_override),
-            before,
-            "and the handler itself must be a no-op at the ceiling, not just unreachable"
+            app.read_with(cx, |app, _| app.palette_file_candidates.len()),
+            DIRS * FILES_PER_DIR,
+            "one candidate per file (directories are not candidates), across the whole tree"
+        );
+
+        // A folder well past the old cut-off must expand and render for real, not just be
+        // counted: `d-199` starts at entry ~21,000.
+        let last_dir = repo.path().join(format!("d-{:03}", DIRS - 1));
+        app.update(cx, |app, cx| app.toggle_dir_expanded(last_dir.clone(), cx));
+        cx.run_until_parked();
+        assert!(
+            app.read_with(cx, |app, _| {
+                app.file_tree
+                    .visible_entries(&app.expanded_dirs)
+                    .iter()
+                    .any(|entry| entry.path == last_dir.join("f-104.txt"))
+            }),
+            "the last file of the last directory is ~1,200 entries past the removed cap and must \
+             be a real, visible row"
         );
     }
 
@@ -4018,18 +3867,25 @@ mod fold_state_tests {
         );
     }
 
-    /// A truncated walk must never be used as evidence that the directories it never reached are
-    /// gone - pruning against it would silently, and permanently, destroy good state. Driven
-    /// through a walk that genuinely truncates, not by hand-setting the flag.
+    /// An incomplete walk must never be used as evidence that the directories it never reached
+    /// are gone - pruning against it would silently, and permanently, destroy good state.
+    ///
+    /// GitHub issue #160 removed the entry cap this used to be driven through, so it is now
+    /// driven through the incompleteness that genuinely remains: a directory the walk cannot
+    /// read. The expanded folder lives *inside* that directory, so it really is absent from the
+    /// listing while the listing really is `partial` - the exact combination that would delete
+    /// its fold state if `prune_stale_fold_state` trusted an incomplete inventory.
+    #[cfg(unix)]
     #[gpui::test]
-    fn a_truncated_walk_never_prunes_fold_state(cx: &mut TestAppContext) {
+    fn an_incomplete_walk_never_prunes_fold_state(cx: &mut TestAppContext) {
+        use std::os::unix::fs::PermissionsExt;
+
         let repo = TempDir::new().expect("tempdir");
         let state_dir = TempDir::new().expect("tempdir");
-        // Directories sort first and then alphabetically, so a 1-entry budget reaches `aaa` and
-        // stops - `zzz`, the one whose expansion is recorded, is never seen by the capped walk.
-        fs::create_dir(repo.path().join("aaa")).expect("mkdir");
-        fs::create_dir(repo.path().join("zzz")).expect("mkdir");
-        fs::write(repo.path().join("zzz/inside.txt"), "x\n").expect("write");
+        let outer = repo.path().join("outer");
+        fs::create_dir(&outer).expect("mkdir");
+        fs::create_dir(outer.join("zzz")).expect("mkdir");
+        fs::write(outer.join("zzz/inside.txt"), "x\n").expect("write");
         let settings_path = state_dir.path().join("settings.toml");
         let fold_path = state_dir.path().join("file-tree-state.toml");
 
@@ -4037,7 +3893,7 @@ mod fold_state_tests {
             open_app_with_state_dir(cx, repo.path().to_path_buf(), settings_path.clone());
         cx.run_until_parked();
         app.update(cx, |app, cx| {
-            app.toggle_dir_expanded(repo.path().join("zzz"), cx);
+            app.toggle_dir_expanded(outer.join("zzz"), cx);
         });
         cx.run_until_parked();
         assert_eq!(
@@ -4047,27 +3903,32 @@ mod fold_state_tests {
             1
         );
 
-        let mut capped = settings_store::Settings::default();
-        capped.file_tree.max_entries = 1;
-        let (reloaded, cx) = open_app_with_state_dir_and_settings(
-            cx,
-            repo.path().to_path_buf(),
-            settings_path,
-            capped,
-        );
+        fs::set_permissions(&outer, fs::Permissions::from_mode(0o000)).expect("chmod");
+        if fs::read_dir(&outer).is_ok() {
+            // Running as root (or on a filesystem that ignores the mode) - the premise doesn't
+            // hold, so this would pass for the wrong reason.
+            fs::set_permissions(&outer, fs::Permissions::from_mode(0o755)).expect("chmod back");
+            return;
+        }
+
+        let (reloaded, cx) = open_app_with_state_dir(cx, repo.path().to_path_buf(), settings_path);
         cx.run_until_parked();
 
+        let complete = reloaded.read_with(cx, |app, _| app.file_tree_complete);
+        let saw_zzz = reloaded.read_with(cx, |app, _| {
+            app.file_tree.iter().any(|entry| entry.name == "zzz")
+        });
+        // Restore before any assertion can fail, or `TempDir`'s own cleanup fails too.
+        fs::set_permissions(&outer, fs::Permissions::from_mode(0o755)).expect("chmod back");
+
         assert!(
-            reloaded.read_with(cx, |app, _| app.file_tree_truncated),
-            "precondition: the walk really must have stopped early, from the real cap - not \
-             from a flag this test set itself"
+            !complete,
+            "precondition: the walk really must have come back incomplete, from a real \
+             unreadable directory - not from a flag this test set itself"
         );
         assert!(
-            reloaded.read_with(cx, |app, _| !app
-                .file_tree
-                .iter()
-                .any(|entry| entry.name == "zzz")),
-            "precondition: the expanded directory really must be absent from the capped listing"
+            !saw_zzz,
+            "precondition: the expanded directory really must be absent from that listing"
         );
 
         assert_eq!(

--- a/crates/app/src/sidebar/tree_ops.rs
+++ b/crates/app/src/sidebar/tree_ops.rs
@@ -250,7 +250,7 @@ impl AdeApp {
     }
 
     /// The tree's whole real selection - the anchor plus every additionally-selected path -
-    /// ordered the way the tree itself displays them (via [`file_tree::visible_indices`]) rather
+    /// ordered the way the tree itself displays them (via [`file_tree::FileTree::visible_indices`]) rather
     /// than insertion order, so a bulk action's own visible order (a "delete these 3 files" log,
     /// say) reads the same way the rows did. A selected path currently hidden inside a collapsed
     /// ancestor (reachable via Shift+click through an ancestor that was later re-collapsed) sorts
@@ -260,7 +260,7 @@ impl AdeApp {
         if self.additional_tree_selection.is_empty() {
             return self.selected_tree_path.iter().cloned().collect();
         }
-        let visible = file_tree::visible_indices(&self.file_tree, &self.expanded_dirs);
+        let visible = self.file_tree.visible_indices(&self.expanded_dirs);
         let mut ordered: Vec<PathBuf> = Vec::with_capacity(self.tree_selection_len());
         let mut remaining = self.additional_tree_selection.clone();
         if let Some(anchor) = &self.selected_tree_path {
@@ -337,7 +337,7 @@ impl AdeApp {
             self.additional_tree_selection.clear();
             return;
         };
-        let visible = file_tree::visible_indices(&self.file_tree, &self.expanded_dirs);
+        let visible = self.file_tree.visible_indices(&self.expanded_dirs);
         let anchor_index = visible
             .iter()
             .position(|&index| self.file_tree[index].path == anchor);


### PR DESCRIPTION
Fixes #160.

> Remove the "Stopped at 20000 entries - load more" button at the bottom of file tree. File tree should load all folders and files.

## What the cap actually was

`file_tree::build_file_tree` took a `limit: Option<usize>` and stopped mid-walk when it ran out, setting `FileTreeListing::truncated`. `AdeApp::load_file_tree` always passed a real bound (`Settings.file_tree.max_entries`, 20,000 by default, clamped to 100,000). `render_file_tree` grew a footer off `file_tree_truncated`: a clickable "Stopped at N entries – load more" row that raised `file_tree_limit_override` tenfold and re-walked, degrading to a plain non-interactive disclosure at the ceiling.

## Why this isn't just deleting the check

The walk itself has always run on `cx.background_executor()`, so it was never what could hang a frame. The cap's real job — documented on `FILE_TREE_MAX_ENTRIES_MAX` — was to bound two pieces of **foreground** work that scale with the loaded entry count. Deleting the cap without touching either would have traded a visible-but-honest "load more" row for an invisible per-frame regression on exactly the trees this issue is about. Both are fixed here:

**1. Palette candidates now build on the background executor.** `rebuild_palette_file_candidates` allocates a `FileCandidate` (a cloned `PathBuf` plus two `String`s) per file, and it ran in `load_file_tree`'s completion handler on the foreground thread. `load_file_tree` is now a three-step task:

walk (background) → snapshot the diff marks (foreground, bounded by the *diff's* size, tens of files) → build the candidates (background) → apply tree + candidates in one `update`.

The identity guard (`this.file_tree_root != root`) is re-applied at every point the task touches the app, since there are now three of them. A `load_diff` that lands during the background hop is detected by comparing the marks and repaired. `rebuild_palette_file_candidates` survives for the cheap "same tree, new diff marks" case (`load_diff`, `open_file_tab`) and shares one `build_file_candidates` with the background path, so the two can't disagree.

**2. Visibility resolution is now O(visible rows), not O(loaded entries).** `visible_indices` — called once per frame by `render_file_tree` — used to touch *every* loaded entry, including every entry inside a collapsed folder. New `file_tree::FileTree` owns the entries plus a derived per-entry subtree span, so a collapsed directory is stepped over in one addition. The spans are private and derived in `FileTree::new`, the only constructor: a stale span wouldn't error, it would silently show a collapsed folder's children. `FileTree` derefs to `[FileTreeEntry]`, so every read site (indexing, `iter`, `len`) is unchanged.

## Removed

`FileTreeListing::truncated`, `MAX_LOAD_MORE_ENTRIES`, `AdeApp::file_tree_truncated`, `AdeApp::file_tree_limit_override`, `load_more_file_tree_entries`, `file_tree_limit_is_at_ceiling`, both footer branches in `render_file_tree`, and the whole `FileTreeSettings` section (`file_tree.max_entries` and its three constants) — a persisted setting with nothing left to configure would be exactly the "looks wired up but isn't" this project forbids. `Settings` has no `deny_unknown_fields`, so an older `settings.toml` still carrying `[file_tree]` loads as a no-op rather than falling back to defaults; there's a test for that.

`FileTreeListing::partial` and `MAX_DEPTH` stay — the depth bound is a stack-overflow guard on a recursive walk, not an entry budget, and `partial` is still what stops `prune_stale_fold_state` from reading an incomplete listing as "these folders were deleted".

## Tests

Two new ones prove the actual ask, at both levels:

- `file_tree::tests::a_tree_larger_than_the_removed_twenty_thousand_entry_cap_loads_completely` — a real 21,200-entry tempdir (200 dirs × 105 files, so it exercises recursive descent rather than one flat folder), asserting the count, `is_complete()`, and that the *last* file of the *last* directory (~1,200 entries past the old cut-off) is present by path.
- `sidebar::render::fold_state_tests::a_tree_past_the_removed_cap_loads_every_entry_with_no_load_more_row` — the same fixture through a real window: full entry count, no `file-tree-show-all` element, the palette's candidate list covering the whole tree, and a folder past the cut-off expanding into real visible rows.

`span_based_visibility_matches_the_depth_scan_for_every_expansion` pins the new span-based skip against the depth scan it replaced (kept as a `#[cfg(test)]` oracle) across all 32 expansion combinations of a real 5-directory tree.

The three tests that asserted the old capped behaviour are gone. `a_truncated_walk_never_prunes_fold_state` became `an_incomplete_walk_never_prunes_fold_state`, driven through the incompleteness that genuinely remains — a `chmod 000` directory with the expanded folder inside it — rather than a cap that no longer exists.

## Verification

`cargo fmt --all -- --check`, `cargo build --workspace`, `cargo clippy --workspace --all-targets -- -D warnings` — all clean.

`cargo test --workspace --lib -- --test-threads=1`: **1592 passed, 1 failed** — `code_surface::diff_view::diff_render_tests::opening_a_real_diff_renders_real_syntax_highlighted_rows`, the already-known flake, which passes in isolation.

An earlier run of the same suite also showed 15 `spawn_*_watcher` failures. Those were the host running out of inotify instances (measured at 124/128, with three other worktrees' suites running concurrently), not this change: no watcher file is touched by it, and all 18 watcher tests pass once the host has headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)