### PR TITLE
Close dropdowns and context menus when focus or interaction moves away

### DIFF
--- a/crates/app/src/graph_view/render.rs
+++ b/crates/app/src/graph_view/render.rs
@@ -372,19 +372,21 @@ impl AdeApp {
             f32::from(viewport.width),
             f32::from(viewport.height),
         );
-        self.graph_state.row_menu_open = Some(GraphRowMenu {
-            row_index: index,
-            origin_x: px(clamped_x),
-            origin_y: px(clamped_y),
-        });
         // An adversarial audit's own finding: this menu and the Push `▾` menu
         // (`Self::toggle_graph_push_menu`) are independent booleans/options with no shared
         // "only one overlay open" invariant, so without this a right-click while the Push menu
         // was open left both painted at once (and this menu's own scrim, which *does*
         // `stop_propagation` on a left-click, then ate the next click meant to dismiss the Push
-        // menu). Pre-existing gap, not introduced by this change - fixed here since it's the same
-        // "which overlay owns the next click" property this change is already about.
-        self.graph_state.push_menu_open = false;
+        // menu). GitHub issue #176 generalised that one hand-added pair into the real shared
+        // invariant `AdeApp::close_menu_surfaces_except` now enforces across all six menus - this
+        // call replaces the single `push_menu_open = false` that used to live here, and runs
+        // *before* the assignment below so the sweep can't clear what it just set.
+        let _ = self.close_menu_surfaces_except(Some(menus::MenuSurface::GraphRow));
+        self.graph_state.row_menu_open = Some(GraphRowMenu {
+            row_index: index,
+            origin_x: px(clamped_x),
+            origin_y: px(clamped_y),
+        });
         window.focus(&self.graph_focus_handle, cx);
         // GitHub issue #127 - see `Self::open_git_graph`'s own matching comment.
         self.graph_view_focused = true;
@@ -392,10 +394,11 @@ impl AdeApp {
     }
 
     pub(crate) fn toggle_graph_push_menu(&mut self, cx: &mut Context<Self>) {
-        self.graph_state.push_menu_open = !self.graph_state.push_menu_open;
-        if self.graph_state.push_menu_open {
-            self.graph_state.row_menu_open = None;
-        }
+        let opening = !self.graph_state.push_menu_open;
+        // GitHub issue #176 - replaces this method's own hand-added "also close the row menu"
+        // rule with the shared invariant across all six menu surfaces.
+        let _ = self.close_menu_surfaces_except(Some(menus::MenuSurface::GraphPush));
+        self.graph_state.push_menu_open = opening;
         cx.notify();
     }
 
@@ -3267,6 +3270,44 @@ mod graph_row_menu_tests {
                 "opening the Push menu must close the row menu, not paint both at once"
             );
         });
+    }
+
+    /// GitHub issue #176 generalised the pairwise rule above into one shared invariant across all
+    /// six menu surfaces (`crate::root::menus`). This is the part that pair could never cover: a
+    /// real right-click on a graph row must also close a menu that has nothing to do with the
+    /// graph - here the tab strip's `+`, whose own scrim ignores right-clicks entirely and so used
+    /// to stay painted right alongside the row menu.
+    #[gpui::test]
+    fn opening_the_row_menu_closes_an_open_plus_menu(cx: &mut TestAppContext) {
+        let (_repo, app, cx) = open_seeded_graph(cx);
+
+        app.update(cx, |app, cx| {
+            app.plus_menu_open = true;
+            cx.notify();
+        });
+        cx.run_until_parked();
+        assert!(
+            cx.debug_bounds("dropdown-menu-row-Git graph").is_some(),
+            "premise: the + menu must really be painted before the right-click"
+        );
+
+        let row0 = cx.debug_bounds("graph-row-0").expect("row 0 painted");
+        right_click(cx, row0.center());
+
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.graph_state.row_menu_open.is_some(),
+                "premise: the right-click must really open the graph row menu"
+            );
+            assert!(
+                !app.plus_menu_open,
+                "and must close the + menu - two popovers open at once is GitHub issue #176"
+            );
+        });
+        assert!(
+            cx.debug_bounds("dropdown-menu-row-Git graph").is_none(),
+            "the + menu must really stop painting, not merely have its flag cleared"
+        );
     }
 
     /// Real, reachable-without-Settings bug an adversarial audit found: `open_git_graph` only

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -998,6 +998,9 @@ impl AdeApp {
             .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
                 cx.stop_propagation();
                 this.checkout_repo_from_rail(repo_id, window, cx);
+                // GitHub issue #176 - see `AdeApp::close_menu_surfaces_except`. Runs before the
+                // two assignments below, since the sweep clears `plus_menu_repo_anchor`.
+                let _ = this.close_menu_surfaces_except(Some(menus::MenuSurface::Plus));
                 this.plus_menu_open = true;
                 this.plus_menu_repo_anchor = Some(repo_id);
                 this.load_agent_rows(cx);

--- a/crates/app/src/root/focus.rs
+++ b/crates/app/src/root/focus.rs
@@ -56,11 +56,13 @@ impl AdeApp {
     /// something else".
     pub(crate) fn open_palette(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.palette_open = true;
-        // The tab strip's `+` menu, the title bar's File/Edit/View/Agent/Help dropdown, and
-        // the "New file" prompt are all unconditional siblings of the palette - see
-        // `Self::plus_menu_open`'s/`Self::title_menu_open`'s/`Self::new_file_input`'s own docs.
-        self.plus_menu_open = false;
-        self.title_menu_open = None;
+        // Every floating menu is an unconditional sibling of the palette - see
+        // `crate::root::menus`. This used to close only the `+` menu and the title bar's
+        // dropdown by hand, which meant opening the palette on top of an open commit-composer or
+        // git-graph menu left that popover painted over it (GitHub issue #176).
+        let _ = self.close_menu_surfaces_except(None);
+        // Not a `MenuSurface`: the "New file" prompt is a focus-owning modal, closed here for the
+        // separate reason `Self::new_file_input`'s own docs give.
         self.new_file_input = None;
         self.palette_focus.capture(window, &self.agents, cx);
         self.palette_scope = palette::PaletteScope::default();
@@ -134,27 +136,21 @@ impl AdeApp {
         if self.palette_open {
             self.close_palette(window, cx);
         }
-        self.plus_menu_open = false;
-        self.title_menu_open = None;
+        // Settings *replaces* the workspace body, so any floating menu left open would either
+        // float over the Settings page or keep painting its own full-window scrim over it,
+        // swallowing the first click a user aimed at it (an adversarial audit's own finding, for
+        // the git graph's two menus in particular: unlike opening a *different* tab, opening
+        // Settings does not clear `graph_tab_active`, so `leave_graph_tab` never runs). One sweep
+        // now, across all six - see `crate::root::menus`; this used to be three separate hand-kept
+        // lists that each covered a different subset (GitHub issue #176).
+        let _ = self.close_menu_surfaces_except(None);
         self.new_file_input = None;
-        // Same reason as the three above: Settings *replaces* the workspace body, so a file-tree
-        // context menu or a half-typed inline name left open would either float over the
-        // Settings page or - worse for the editor - keep the tree's `"tree-editing"` key context
-        // alive on a node that is no longer rendered (GitHub issue #19). The armed *delete
-        // confirmation* is deliberately left alone: it is a real, window-level modal the user is
-        // mid-way through answering, and `crate::root::AdeApp::render` keeps it hidden while
-        // Settings is up rather than silently disarming it.
-        self.tree_context_menu = None;
+        // Not a `MenuSurface`: a half-typed inline name would keep the tree's `"tree-editing"` key
+        // context alive on a node that is no longer rendered (GitHub issue #19). The armed
+        // *delete confirmation* is deliberately left alone: it is a real, window-level modal the
+        // user is mid-way through answering, and `crate::root::AdeApp::render` keeps it hidden
+        // while Settings is up rather than silently disarming it.
         self.tree_inline_edit = None;
-        // Same reason, for the git graph tab's own two window-positioned overlays (GitHub issue
-        // #1's row `⋯`/right-click menu and Push `▾` menu): unlike opening a *different* tab,
-        // opening Settings does not clear `graph_tab_active` (the graph tab, if it was showing,
-        // is still "active" underneath Settings - `crate::graph_view::render::AdeApp::
-        // leave_graph_tab` is not called here), so without this an open row or Push menu kept
-        // painting its full-window scrim over the Settings surface, swallowing the first click a
-        // user aimed at it (an adversarial audit's own finding).
-        self.graph_state.row_menu_open = None;
-        self.graph_state.push_menu_open = false;
         self.settings_open = true;
         self.settings_focus.capture(window, &self.agents, cx);
         self.prune_confirm_armed = false;

--- a/crates/app/src/root/menus.rs
+++ b/crates/app/src/root/menus.rs
@@ -1,0 +1,296 @@
+//! The one real "only one menu is open at a time, and it closes when interaction moves away"
+//! mechanism, shared by every floating dropdown/context-menu surface in the app (GitHub issue
+//! #176).
+//!
+//! Before this module each of the six menu surfaces owned an independent `Option`/`bool` with no
+//! knowledge of its siblings, and only two hand-added pairwise rules existed (graph row ↔ graph
+//! push, and title bar → `+`). Everything else could genuinely stack: opening the tab strip's `+`
+//! menu and then right-clicking a file tree row left *both* popovers painted at once, because the
+//! `+` menu's scrim only listens for a *left* click and the file tree's own right-click handler
+//! never looked at `plus_menu_open`. That is exactly the "2 context menus open at the same time"
+//! the issue reports.
+//!
+//! [`MenuSurface`] is the fix's shape: a payload-free name for each surface, an `ALL` array, and
+//! two exhaustive `match`es ([`AdeApp::menu_surface_is_open`]/[`AdeApp::close_menu_surface`]).
+//! Adding a seventh popover without teaching it the invariant is a compile error, not a silent
+//! drift - the same reason `crate::root::widgets::menu_popover_chrome` is a shared *function*
+//! rather than a shared set of style constants.
+//!
+//! The state each surface owns stays where it is (it carries per-surface payload - which title
+//! menu, which tree row, which graph commit - that a common field could not hold), so callers
+//! that open a payload-carrying menu run [`AdeApp::close_menu_surfaces_except`] and then assign
+//! their own field, rather than this module trying to own all six shapes.
+
+use super::*;
+
+/// Every real floating menu/dropdown surface in the app - the six built on
+/// [`crate::root::widgets::menu_popover_chrome`].
+///
+/// Deliberately *not* including the command palette, the "New file" prompt, or the Settings
+/// surface: those are focus-owning modal overlays with their own capture/restore contract
+/// (`crate::root::mod`'s [`OverlayFocus`]), not click-away menus, and they already close each
+/// other explicitly. They do, however, close *these* - see
+/// [`crate::root::focus::AdeApp::open_palette`]/`open_settings`.
+///
+/// Payload-free on purpose: which title menu is open, which tree row a context menu targets, and
+/// which graph commit a row menu names all stay in the surfaces' own fields. This enum only
+/// answers "is it open" and "close it", which is all the shared invariant needs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MenuSurface {
+    /// The tab strip's (and rail repo header's) `+` menu - [`AdeApp::plus_menu_open`].
+    Plus,
+    /// The Windows/Linux title bar's File/Edit/View/Agent/Help dropdowns -
+    /// [`AdeApp::title_menu_open`].
+    Title,
+    /// The file tree's right-click context menu - [`AdeApp::tree_context_menu`].
+    TreeContext,
+    /// The commit composer's `▾` split-button menu - [`AdeApp::commit_menu_open`].
+    Commit,
+    /// The git graph toolbar's `Push ▾` menu - `graph_state.push_menu_open`.
+    GraphPush,
+    /// A git graph row's `⋯`/right-click menu - `graph_state.row_menu_open`.
+    GraphRow,
+}
+
+impl MenuSurface {
+    /// Every variant. The `match`es in [`AdeApp::menu_surface_is_open`] and
+    /// [`AdeApp::close_menu_surface`] are exhaustive, so a new variant added here cannot compile
+    /// until it is really wired to real state - that pairing is what stops a seventh menu from
+    /// quietly opting out of the invariant.
+    pub(crate) const ALL: [MenuSurface; 6] = [
+        MenuSurface::Plus,
+        MenuSurface::Title,
+        MenuSurface::TreeContext,
+        MenuSurface::Commit,
+        MenuSurface::GraphPush,
+        MenuSurface::GraphRow,
+    ];
+}
+
+impl AdeApp {
+    /// Whether `surface`'s popover is currently open, read from that surface's own real state
+    /// field (never a duplicate "which menu is open" mirror that could disagree with it).
+    pub(crate) fn menu_surface_is_open(&self, surface: MenuSurface) -> bool {
+        match surface {
+            MenuSurface::Plus => self.plus_menu_open,
+            MenuSurface::Title => self.title_menu_open.is_some(),
+            MenuSurface::TreeContext => self.tree_context_menu.is_some(),
+            MenuSurface::Commit => self.commit_menu_open,
+            MenuSurface::GraphPush => self.graph_state.push_menu_open,
+            MenuSurface::GraphRow => self.graph_state.row_menu_open.is_some(),
+        }
+    }
+
+    /// Closes `surface`, leaving every other one alone. Does **not** `cx.notify()` - the callers
+    /// below batch a single notify for the whole sweep.
+    ///
+    /// The tree context menu goes through [`Self::close_tree_context_menu`]'s own plain field
+    /// clear rather than that method (which takes a `Context` and notifies); the extra work that
+    /// method does is exactly the notify this one deliberately defers.
+    pub(crate) fn close_menu_surface(&mut self, surface: MenuSurface) {
+        match surface {
+            MenuSurface::Plus => {
+                self.plus_menu_open = false;
+                self.plus_menu_repo_anchor = None;
+            }
+            MenuSurface::Title => self.title_menu_open = None,
+            MenuSurface::TreeContext => self.tree_context_menu = None,
+            MenuSurface::Commit => self.commit_menu_open = false,
+            MenuSurface::GraphPush => self.graph_state.push_menu_open = false,
+            MenuSurface::GraphRow => self.graph_state.row_menu_open = None,
+        }
+    }
+
+    /// Closes every open menu surface except `keep` (pass `None` to close all of them). Returns
+    /// whether anything was actually open and got closed, so callers can skip a pointless
+    /// `cx.notify()`.
+    ///
+    /// This is the whole "opening a second menu closes the first" rule. Every real path that
+    /// *opens* one of the six calls it with its own surface as `keep` immediately before setting
+    /// its own state - so the invariant holds no matter which of the (many) entry points was used:
+    /// a click on the tab strip `+`, a click on a rail repo header's `+`, a title bar label, a
+    /// right-click in the file tree, the commit composer's `▾`, the graph's `Push ▾`, a graph
+    /// row's `⋯`, or a right-click on a graph row.
+    #[must_use]
+    pub(crate) fn close_menu_surfaces_except(&mut self, keep: Option<MenuSurface>) -> bool {
+        let mut closed_any = false;
+        for surface in MenuSurface::ALL {
+            if Some(surface) == keep || !self.menu_surface_is_open(surface) {
+                continue;
+            }
+            self.close_menu_surface(surface);
+            closed_any = true;
+        }
+        closed_any
+    }
+
+    /// Closes every open menu surface and notifies if that changed anything. The "interaction
+    /// moved somewhere a menu has no business staying open over" entry point: the window itself
+    /// losing OS focus ([`Self::_window_activation_subscription`]), and opening one of the
+    /// focus-owning overlays (the palette, Settings).
+    pub(crate) fn close_all_menu_surfaces(&mut self, cx: &mut Context<Self>) -> bool {
+        let closed_any = self.close_menu_surfaces_except(None);
+        if closed_any {
+            cx.notify();
+        }
+        closed_any
+    }
+}
+
+/// Real coverage for the shared invariant itself. The per-surface interaction tests (a real
+/// simulated click on one menu's real trigger while another is really open) live beside each
+/// surface's own tests - see `crate::work_surface::render`'s `plus_menu_tests`,
+/// `crate::sidebar::render`'s `commit_composer_tests`, and `crate::sidebar::tree_ops`'s
+/// `context_menu_tests`.
+#[cfg(test)]
+mod menu_surface_tests {
+    use super::*;
+    use crate::root::focus::palette_focus_tests::open_test_app;
+    use gpui::TestAppContext;
+
+    /// Opens every one of the six at once by writing their real state fields directly - the state
+    /// this test then proves cannot survive a single `close_menu_surfaces_except`.
+    fn open_every_menu(app: &mut AdeApp) {
+        app.plus_menu_open = true;
+        app.title_menu_open = Some(crate::title_bar::menu::TitleMenu::File);
+        app.tree_context_menu = Some(crate::sidebar::tree_ops::TreeContextMenu {
+            target: crate::sidebar::context_menu::ContextTarget::Empty,
+            origin_x: 4.0,
+            origin_y: 4.0,
+        });
+        app.commit_menu_open = true;
+        app.graph_state.push_menu_open = true;
+        app.graph_state.row_menu_open = Some(crate::graph_view::state::GraphRowMenu {
+            row_index: 0,
+            origin_x: px(4.0),
+            origin_y: px(4.0),
+        });
+    }
+
+    #[gpui::test]
+    fn closing_all_menu_surfaces_really_closes_every_one_of_the_six(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
+
+        app.update(cx, |app, cx| {
+            open_every_menu(app);
+            for surface in MenuSurface::ALL {
+                assert!(
+                    app.menu_surface_is_open(surface),
+                    "premise: {surface:?} must really be open before the sweep - otherwise this \
+                     test would pass without closing anything"
+                );
+            }
+            assert!(
+                app.close_all_menu_surfaces(cx),
+                "the sweep must report that it really closed something"
+            );
+            for surface in MenuSurface::ALL {
+                assert!(
+                    !app.menu_surface_is_open(surface),
+                    "{surface:?} must really be closed by close_all_menu_surfaces - a surface \
+                     missing from the sweep is exactly the drift MenuSurface::ALL exists to stop"
+                );
+            }
+            assert!(
+                !app.close_all_menu_surfaces(cx),
+                "a second sweep with nothing open must report no change, so callers can skip a \
+                 pointless notify"
+            );
+        });
+    }
+
+    /// The exact "2 context menus open at the same time" shape from GitHub issue #176, at the
+    /// level of the shared primitive: whichever surface is being opened is the only survivor.
+    #[gpui::test]
+    fn opening_any_one_surface_closes_all_five_others(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
+
+        for keep in MenuSurface::ALL {
+            app.update(cx, |app, _cx| {
+                open_every_menu(app);
+                assert!(
+                    app.close_menu_surfaces_except(Some(keep)),
+                    "with all six open, keeping {keep:?} must really close the other five"
+                );
+                assert!(
+                    app.menu_surface_is_open(keep),
+                    "{keep:?} is the surface being opened - the sweep must leave it alone"
+                );
+                for other in MenuSurface::ALL {
+                    if other == keep {
+                        continue;
+                    }
+                    assert!(
+                        !app.menu_surface_is_open(other),
+                        "{other:?} must not still be open next to {keep:?} - two menus painted \
+                         at once is the reported bug"
+                    );
+                }
+                let _ = app.close_menu_surfaces_except(None);
+            });
+        }
+    }
+
+    /// The issue's headline requirement - "when a dropdown loses focus it should be closed" - at
+    /// its coarsest real granularity: the whole window losing OS focus. Driven through GPUI's own
+    /// `VisualTestContext::deactivate_window`, which really runs the platform active-status
+    /// callback and so really fires [`AdeApp::_window_activation_subscription`]; nothing here
+    /// calls the close path directly.
+    #[gpui::test]
+    fn the_window_losing_focus_really_closes_every_open_menu(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
+
+        // `deactivate_window` is a no-op unless this window really is the platform's active one,
+        // and `TestWindow` does not start active.
+        cx.update(|window, _cx| window.activate_window());
+        cx.run_until_parked();
+
+        app.update(cx, |app, cx| {
+            open_every_menu(app);
+            cx.notify();
+        });
+        cx.run_until_parked();
+        assert!(
+            app.read_with(cx, |app, _| app.plus_menu_open && app.commit_menu_open),
+            "premise: menus must really be open before the window is deactivated"
+        );
+
+        cx.deactivate_window();
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            for surface in MenuSurface::ALL {
+                assert!(
+                    !app.menu_surface_is_open(surface),
+                    "{surface:?} must be closed once the window itself loses focus - a menu is \
+                     anchored to a control in *this* window, and coming back from another app to \
+                     a still-open popover positioned off possibly-moved bounds is the bug"
+                );
+            }
+        });
+    }
+
+    /// The `+` menu's repo anchor is part of "which `+` menu is open", not a separate fact: a
+    /// stale anchor left behind by a rail repo header's `+` would position the *next* tab-strip
+    /// `+` menu off that repo row instead of off the `+` button.
+    #[gpui::test]
+    fn closing_the_plus_menu_also_clears_its_repo_anchor(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
+
+        app.update(cx, |app, cx| {
+            let repo_id = crate::rail::repo::RepoId(7);
+            app.plus_menu_open = true;
+            app.plus_menu_repo_anchor = Some(repo_id);
+            assert!(app.close_all_menu_surfaces(cx));
+            assert_eq!(
+                app.plus_menu_repo_anchor, None,
+                "the anchor must be cleared with the menu it belongs to, or the next tab-strip \
+                 + menu would paint off a rail repo header's bounds"
+            );
+        });
+    }
+}

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -532,8 +532,22 @@ pub struct AdeApp {
     /// Whether the commit composer's `▾` split-button popover (Revision R12 §5: *Commit and
     /// push* / *Commit all N files* / *Amend last commit* / *Stash staged files*) is open. Closed
     /// on every worktree switch (`Self::select_worktree`) since it targets that worktree's own
-    /// staged set.
+    /// staged set, whenever any other [`menus::MenuSurface`] opens, when the right sidebar leaves
+    /// the Changes view (the composer stops being rendered, and a latched-open flag would pop the
+    /// popover back up on return), and when the window loses focus.
     pub(crate) commit_menu_open: bool,
+    /// The commit composer's own painted bounds, captured every render by a `gpui::canvas` child
+    /// (the same pattern [`Self::plus_button_bounds`] uses). `Bounds::default()` until the
+    /// composer has really painted once.
+    ///
+    /// GitHub issue #176: the popover used to be a *child* of the composer, which made its
+    /// "click-away dismisses" scrim - `absolute()` with inset 0 - resolve against the composer's
+    /// own ~135px box instead of the window, so clicking the Changes list, the file tree, the
+    /// rail, the tab strip or the editor did not close it ("the commit one is particularly bugged
+    /// and hard to close"). It is now a sibling of `Self::render_plus_menu` in [`Render::render`]
+    /// with a genuinely full-window scrim, which means it has to carry its anchor in window space
+    /// like every other popover here does.
+    pub(crate) commit_composer_bounds: gpui::Bounds<Pixels>,
     /// Ordered list of currently-open file tabs, rendered after every agent's own tab by
     /// `Self::render_tab_strip` - **per worktree**, keyed by [`Self::file_tree_root`]
     /// (`design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §3: "Switching worktrees
@@ -1431,8 +1445,22 @@ pub struct AdeApp {
     /// once at construction regardless of whether `Settings.theme.follow_system` starts on (see
     /// that method's own docs for why).
     pub(crate) _window_appearance_subscription: Subscription,
+    /// The live `Window::observe_window_activation` subscription that closes every open
+    /// dropdown/context menu when the window itself loses OS focus (GitHub issue #176: "when a
+    /// dropdown loses focus it should be closed"). Held for the entity's whole lifetime, like
+    /// [`Self::_window_appearance_subscription`] beside it - a dropped `Subscription` stops
+    /// firing.
+    ///
+    /// A menu is a transient, click-away surface anchored to a control in *this* window; leaving
+    /// one painted while the user is working in another window means coming back to a stale
+    /// popover positioned off bounds that may since have moved. Only the six
+    /// [`menus::MenuSurface`]s are swept - the palette/Settings/"New file" overlays own real
+    /// keyboard focus and half-typed input, and closing those out from under an alt-tab would
+    /// destroy real work.
+    pub(crate) _window_activation_subscription: Subscription,
     /// Whether the tab strip's `+` menu popover is open - see [`Self::render_plus_menu`].
-    /// Closed by its own scrim click, by picking a row, and defensively by
+    /// Closed by its own scrim click, by picking a row, by opening any other
+    /// [`menus::MenuSurface`], by the window losing focus, and defensively by
     /// [`Self::open_palette`]/[`Self::open_settings`] (it's rendered as an unconditional sibling
     /// of both, so it would otherwise paint over a surface it no longer makes sense above).
     pub(crate) plus_menu_open: bool,
@@ -2186,7 +2214,7 @@ impl AdeApp {
 }
 
 impl Render for AdeApp {
-    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         div()
             .flex()
             .flex_col()
@@ -2279,6 +2307,25 @@ impl Render for AdeApp {
             .when_some(self.title_menu_open, |el, menu| {
                 el.child(self.render_title_menu(menu, cx))
             })
+            // The commit composer's `▾` menu (GitHub issue #176) - a window-positioned overlay for
+            // the same reason `render_plus_menu` is one: it is anchored off a `gpui::canvas`-
+            // captured, window-space `Self::commit_composer_bounds`, and its click-away scrim has
+            // to cover the whole window rather than the composer's own 135px box. See
+            // `crate::sidebar::render::AdeApp::render_commit_menu`'s own docs.
+            //
+            // Gated on the composer really being rendered underneath: Settings replaces the
+            // workspace body, the right sidebar may be showing Files instead of Changes, and the
+            // Changes view itself falls back to an error message when there is no real diff - in
+            // all three cases `commit_composer_bounds` is a stale anchor from an earlier frame.
+            // `Self::close_right_sidebar_view`'s own clear keeps `commit_menu_open` from latching
+            // across a view switch; this guard is the belt to that braces.
+            .when(
+                self.commit_menu_open
+                    && !self.settings_open
+                    && self.right_sidebar_view == RightSidebarView::Changes
+                    && self.current_diff().is_some(),
+                |el| el.child(self.render_commit_menu(window, cx)),
+            )
             .children(self.render_hover_card(cx))
             .children(self.render_completions_popover(cx))
             .when(self.new_file_input.is_some(), |el| {
@@ -3552,6 +3599,7 @@ mod repo_list_tests {
 pub(crate) mod caret_blink;
 pub(crate) mod focus;
 pub mod layout;
+pub(crate) mod menus;
 pub(crate) mod new_file;
 pub(crate) mod rem_scope;
 pub(crate) mod resize;

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -250,6 +250,7 @@ impl AdeApp {
             staging_error: None,
             _stage_tasks: TaskPool::new(),
             commit_menu_open: false,
+            commit_composer_bounds: gpui::Bounds::default(),
             open_files_by_worktree: HashMap::new(),
             open_change: None,
             close_tab_confirm_armed: None,
@@ -422,6 +423,18 @@ impl AdeApp {
                 window,
                 |this, window, cx| {
                     this.sync_theme_to_system_appearance(window, cx);
+                },
+            ),
+            // GitHub issue #176. Fires on both edges (activate *and* deactivate), so the callback
+            // has to ask `Window::is_window_active` which one it is rather than assuming - the
+            // same shape `vendor/zed/crates/workspace/src/workspace.rs`'s own
+            // `on_window_activation_changed` uses.
+            _window_activation_subscription: cx.observe_window_activation(
+                window,
+                |this, window, cx| {
+                    if !window.is_window_active() {
+                        this.close_all_menu_surfaces(cx);
+                    }
                 },
             ),
             plus_menu_open: false,
@@ -946,10 +959,14 @@ impl AdeApp {
         // Browsing away disarms a pending prune confirmation - see `Self::request_prune`'s docs.
         self.prune_confirm_armed = false;
         self.discard_confirm_armed = None;
-        // Same reasoning for the commit composer's own split-button popover (Revision R12 §5) -
-        // it targets whatever was previously selected's staged set, so it must not stay open
-        // pointed at the wrong one.
-        self.commit_menu_open = false;
+        // Same reasoning for every floating menu (`crate::root::menus`): the commit composer's
+        // split-button popover (Revision R12 §5) names the previously selected worktree's staged
+        // set, the file tree's context menu targets a row that is about to stop existing, and the
+        // git graph's row menu names a commit in the repo being left - none may stay open pointed
+        // at the wrong one. This used to clear only `commit_menu_open` here and
+        // `tree_context_menu` further down, leaving the graph's two menus behind (GitHub issue
+        // #176's own audit of who closes what).
+        let _ = self.close_menu_surfaces_except(None);
         // Reset per-worktree UI state (see `reset_per_worktree_ui_state`'s docs) so switching
         // never leaks a staged checkbox, open diff, or collapsed-dir entry from whatever was open
         // before. Deliberately runs *before* the focus-fallback block below: both
@@ -983,13 +1000,13 @@ impl AdeApp {
         self.file_tree = file_tree::FileTree::default();
         self.reload_expanded_dirs_from_fold_state();
         // Every one of these holds an absolute path in whatever was just left (GitHub issue #19):
-        // an open context menu targeting a row that is about to stop existing, a half-typed name
-        // for a folder in the old tree, a cut/copied entry a paste here would move across
-        // worktrees/repos, and an armed delete for a path in the old tree. Cleared together, in
-        // the same step as `file_tree`/`expanded_dirs` above and for the same reason - the window
-        // between here and the new walk landing must not leave a control pointing at the old
-        // worktree/repo.
-        self.tree_context_menu = None;
+        // a half-typed name for a folder in the old tree, a cut/copied entry a paste here would
+        // move across worktrees/repos, and an armed delete for a path in the old tree. Cleared
+        // together, in the same step as `file_tree`/`expanded_dirs` above and for the same reason
+        // - the window between here and the new walk landing must not leave a control pointing at
+        // the old worktree/repo. The tree's *context menu* belongs to that same list but is closed
+        // by the `close_menu_surfaces_except` sweep at the top of this method instead, so there is
+        // exactly one place that closes it.
         self.tree_inline_edit = None;
         self.tree_clipboard = None;
         // Every entry names an absolute path in whatever was just left, same reasoning as the

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -56,6 +56,12 @@ impl AdeApp {
             self.settings_focus.forget_target(&self.tree_focus_handle);
             self.code_focus.forget_target(&self.tree_focus_handle);
         }
+        if view != RightSidebarView::Changes {
+            // GitHub issue #176, the mirror image of the block above: leaving Changes unrenders
+            // the commit composer, but `commit_menu_open` used to stay latched `true` - so coming
+            // back to Changes popped the `▾` popover open again on its own, with no click.
+            self.commit_menu_open = false;
+        }
         self.right_sidebar_view = view;
         if view == RightSidebarView::Changes {
             self.load_diff(self.diff_root.clone(), cx);
@@ -2021,7 +2027,6 @@ impl AdeApp {
         // rendering after a promotion to "real" with no binding behind it - "a real keycap must
         // never render for a keystroke that does nothing" - so this composer never grows one in
         // the first place.
-        let menu_open = self.commit_menu_open;
 
         // Test-only (no-op outside `cfg(test)`/`test-support`, matching every other
         // `debug_selector` in this file - see e.g. `Self::render_status_zoom_value`'s own
@@ -2038,8 +2043,9 @@ impl AdeApp {
             format!("commit-composer-message-{message}")
         };
 
-        let mut composer = div()
+        let composer = div()
             .id("commit-composer")
+            .debug_selector(|| "commit-composer".to_string())
             .relative()
             .flex_none()
             .flex()
@@ -2050,6 +2056,33 @@ impl AdeApp {
             .border_t_1()
             .border_color(theme::border::INNER)
             .bg(theme::surface::FOOTER)
+            .child({
+                // GitHub issue #176: the `▾` popover is no longer a child of this composer (see
+                // `AdeApp::commit_composer_bounds`' own docs), so it needs this composer's real
+                // window-space bounds to anchor off - the same `gpui::canvas` capture
+                // `crate::work_surface::render::AdeApp::render_tab_strip_plus` uses for the `+`
+                // button.
+                let this = cx.entity();
+                gpui::canvas(
+                    move |bounds, _window, cx| {
+                        this.update(cx, |this, _cx| {
+                            this.commit_composer_bounds = bounds;
+                        });
+                    },
+                    |_, _, _, _| {},
+                )
+                .absolute()
+                // Explicit insets rather than `.size_full()`: an absolutely-positioned child with
+                // no insets takes its *static* position, which here is the composer's content box
+                // (inside the 12px horizontal padding) while `size_full` still resolves against
+                // the padding box - so the captured origin and size would describe two different
+                // rectangles. Pinning all four edges makes this exactly the composer's own box,
+                // which is what `render_commit_menu` then insets by the design's 12px.
+                .top(px(0.0))
+                .left(px(0.0))
+                .right(px(0.0))
+                .bottom(px(0.0))
+            })
             .child(
                 // Header row: `COMMIT` · `N of M staged` · staged diffstat, right-aligned.
                 div()
@@ -2228,7 +2261,11 @@ impl AdeApp {
                             .text_color(theme::text::DIMMER)
                             .child("\u{25be}")
                             .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
-                                this.commit_menu_open = !this.commit_menu_open;
+                                let opening = !this.commit_menu_open;
+                                // GitHub issue #176 - see `AdeApp::close_menu_surfaces_except`.
+                                let _ = this
+                                    .close_menu_surfaces_except(Some(menus::MenuSurface::Commit));
+                                this.commit_menu_open = opening;
                                 cx.notify();
                             })),
                     )
@@ -2247,23 +2284,30 @@ impl AdeApp {
                     ),
             );
 
-        if menu_open {
-            composer = composer.child(self.render_commit_menu(cx));
-        }
-
         composer
     }
 
     /// The commit composer's `▾` split-button popover (Revision R12 §5): *Commit and push* /
     /// *Commit all N files* / *Amend last commit* / *Stash staged files*. Opens **upward** -
     /// `bottom`-anchored, not `top` - since the button it hangs off sits near the bottom of the
-    /// Changes panel. A transparent, `.occlude()`d scrim confined to the composer's own bounds
-    /// (matching [`crate::work_surface::render::AdeApp::render_plus_menu`]'s click-away-
-    /// dismisses shape, scoped smaller here since the composer itself is the only positioned
-    /// ancestor available) closes the menu on a click anywhere else *within the composer* -
-    /// this is not a window-wide click-away like `render_plus_menu`'s own scrim, only the
-    /// composer's own footprint; the popover panel itself also `.occlude()`s and stops that
-    /// click from bubbling further.
+    /// Changes panel.
+    ///
+    /// ## Why this is rendered from `AdeApp::render`, not from the composer (GitHub issue #176)
+    ///
+    /// This popover used to be a *child* of [`Self::render_commit_composer`], which made its
+    /// click-away scrim - `absolute()` with inset 0 - resolve against the composer's own
+    /// `.relative()` box (~135px tall, at the foot of the Changes panel) rather than the window.
+    /// Clicking the Changes list, the file tree, the rail, the tab strip, the editor or the title
+    /// bar therefore did *not* dismiss it, and none of its four rows is clickable either, so the
+    /// only gesture that reliably closed it was a second click on the `▾` toggle itself. That is
+    /// the issue's "the commit one is particularly bugged and hard to close".
+    ///
+    /// It is now a sibling of [`crate::work_surface::render::AdeApp::render_plus_menu`] and the
+    /// file tree's context menu in `AdeApp::render`, with the same genuinely full-window
+    /// `.occlude()`d scrim they use - the established shape in this app for a popover whose anchor
+    /// is a `gpui::canvas`-captured, window-space bounds ([`AdeApp::commit_composer_bounds`]).
+    /// `crate::graph_view::render::AdeApp::render_graph_view`'s own docs record the same move for
+    /// the graph's two menus, made for the same reason.
     ///
     /// Every row is real, visible, and **honestly non-interactive**: only the primary `Commit N
     /// files` button (`Self::commit_staged_files`, backed by a real `wt_core::undo::commit_paths`)
@@ -2271,7 +2315,21 @@ impl AdeApp {
     /// phase doesn't add - each row is dimmed and un-clickable, the same
     /// `work_surface::state::ActionKind::Unimplemented` convention this codebase already uses for
     /// "visible, real, but not wired up yet" (never a clickable-looking no-op).
-    fn render_commit_menu(&self, cx: &mut Context<Self>) -> impl IntoElement {
+    pub(crate) fn render_commit_menu(
+        &self,
+        window: &Window,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        // The composer's own painted box, in window space. The popover keeps its R12 §5 geometry
+        // relative to that box - inset 12px on both sides, 44px of clearance above the composer's
+        // bottom edge so it clears the primary button row - just expressed against the window now
+        // that this is a root-level child.
+        let composer = self.commit_composer_bounds;
+        let window_height = window.bounds().size.height;
+        let popover_left = composer.origin.x + px(12.0);
+        let popover_width = (composer.size.width - px(24.0)).max(px(0.0));
+        let popover_bottom = window_height - (composer.origin.y + composer.size.height) + px(44.0);
+
         let branch = self
             .worktrees
             .iter()
@@ -2287,7 +2345,12 @@ impl AdeApp {
             .id("commit-menu-scrim")
             .debug_selector(|| "commit-menu-scrim".to_string())
             .absolute()
-            .top(px(0.0))
+            // Starts *below* the title bar, exactly like the file tree's own context-menu scrim
+            // (`Self::render_tree_context_menu`) and for the same real reason it documents: a
+            // full-window `.occlude()`ing layer swallows the window's own close/minimise/maximise
+            // caption buttons and the title bar's drag region, so the window could not be closed
+            // or moved while the menu was up.
+            .top(theme::band::TITLE_BAR)
             .left(px(0.0))
             .right(px(0.0))
             .bottom(px(0.0))
@@ -2309,29 +2372,32 @@ impl AdeApp {
                 this.commit_menu_open = false;
                 cx.notify();
             }))
+            // A right-click anywhere else must dismiss too - the same rule the file tree's and the
+            // graph row's own scrims already follow, so the next right-click doesn't land on an
+            // invisible layer and appear to do nothing at all.
+            .on_mouse_down(
+                gpui::MouseButton::Right,
+                cx.listener(|this, _event: &gpui::MouseDownEvent, _window, cx| {
+                    this.commit_menu_open = false;
+                    cx.notify();
+                }),
+            )
             .child(
                 menu_popover_chrome(
                     div()
                         .id("commit-menu-popover")
                         .debug_selector(|| "commit-menu-popover".to_string())
                         .absolute()
-                        .left(px(12.0))
-                        .right(px(12.0))
-                        .bottom(px(44.0))
-                        // The composer itself is short (~135px of header/message-box/button-row),
-                        // shorter than this four-row popover (`bottom(px(44.0))` plus its own
-                        // real painted height) - so the popover's *top* genuinely paints above
-                        // the composer's own top edge, over the Changes rows behind it, which is
-                        // outside the scrim's own bounds (`top(0)/bottom(0)` relative to the
-                        // composer, not the whole sidebar - see this fn's own docs on the scrim
-                        // being "confined to the composer's own bounds"). Without its own
-                        // `.occlude()` here, a click in that overflow region only avoids reaching
-                        // a real Changes row underneath by relying on `Window::
-                        // dispatch_mouse_event`'s bubble-phase registration order happening to
-                        // run this popover's own `stop_propagation` listener first - a
-                        // coincidence of paint order, not a structural guarantee. This makes the
-                        // block real regardless of ordering, the same reasoning as the scrim's
-                        // own `.occlude()` above.
+                        .left(popover_left)
+                        .w(popover_width)
+                        // The scrim starts at `theme::band::TITLE_BAR`, not at the window top, so
+                        // a distance measured from the *window's* bottom edge still lands right -
+                        // `bottom` is unaffected by where the top edge was clipped.
+                        .bottom(popover_bottom)
+                        // Kept from when this popover lived inside the composer: it paints over
+                        // real Changes rows and the primary commit button, and blocking the mouse
+                        // structurally (rather than relying on bubble-phase listener ordering)
+                        // is what stops a click on the panel reaching them.
                         .occlude()
                         .py(px(4.0)),
                     // `COMMIT_MENU`, not `MENU`: same blur/alpha as every other menu (GitHub
@@ -4672,6 +4738,194 @@ mod commit_composer_tests {
                 "a real click on {selector} must never change the real staged set"
             );
         }
+    }
+
+    /// GitHub issue #176's "the commit one is particularly bugged and hard to close". Before this
+    /// fix the popover's dismiss scrim was a child of the composer, so it only covered the
+    /// composer's own ~130px box: a real click anywhere else in the window - the Changes list, the
+    /// file tree, the centre pane - went straight past it and the menu stayed open. This clicks a
+    /// point that is genuinely outside the composer and genuinely inside the window.
+    #[gpui::test]
+    fn a_real_click_far_outside_the_composer_closes_the_commit_menu(cx: &mut TestAppContext) {
+        let repo = changes_test_repo();
+        let (app, cx) = open_changes_view(cx, &repo);
+
+        let composer = cx
+            .debug_bounds("commit-composer")
+            .expect("the composer must really paint");
+        let toggle = cx
+            .debug_bounds("commit-composer-menu-toggle")
+            .expect("the ▾ toggle must really paint");
+        cx.simulate_click(toggle.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+        assert!(
+            app.read_with(cx, |app, _| app.commit_menu_open),
+            "premise: the menu must really be open before the click-away below"
+        );
+
+        let popover = cx
+            .debug_bounds("commit-menu-popover")
+            .expect("the popover must really paint while the menu is open");
+
+        // Well up and to the left of both the composer and the popover: the centre pane, hundreds
+        // of pixels from anything the old composer-scoped scrim covered.
+        let away = gpui::Point {
+            x: composer.origin.x / 2.0,
+            y: popover.origin.y / 2.0,
+        };
+        assert!(
+            !composer.contains(&away) && !popover.contains(&away),
+            "premise: {away:?} must really be outside both the composer {composer:?} and the \
+             popover {popover:?}, or this test would be clicking the menu itself"
+        );
+        cx.simulate_click(away, gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        assert!(
+            !app.read_with(cx, |app, _| app.commit_menu_open),
+            "a real click far outside the composer must close the commit menu - the popover's \
+             scrim is window-wide now, not confined to the composer that used to own it"
+        );
+        assert!(
+            cx.debug_bounds("commit-menu-popover").is_none(),
+            "closing must really unpaint the popover, not just flip a flag"
+        );
+    }
+
+    /// The popover moved out of the composer and into `AdeApp::render` (GitHub issue #176), so its
+    /// position is now derived from a `gpui::canvas`-captured window-space anchor rather than from
+    /// its parent's own box. This pins the geometry that move had to preserve: Revision R12 §5's
+    /// 12px inset on both sides of the composer, and an upward-opening panel that clears the
+    /// primary commit button row.
+    #[gpui::test]
+    fn the_commit_menu_popover_really_paints_anchored_to_the_composer(cx: &mut TestAppContext) {
+        let repo = changes_test_repo();
+        let (app, cx) = open_changes_view(cx, &repo);
+
+        let toggle = cx
+            .debug_bounds("commit-composer-menu-toggle")
+            .expect("the ▾ toggle must really paint");
+        cx.simulate_click(toggle.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        let composer = cx
+            .debug_bounds("commit-composer")
+            .expect("the composer must really paint");
+        let popover = cx
+            .debug_bounds("commit-menu-popover")
+            .expect("the popover must really paint while the menu is open");
+
+        assert_eq!(
+            popover.origin.x,
+            composer.origin.x + px(12.0),
+            "the popover must be inset 12px from the composer's own left edge - a popover \
+             anchored off stale or wrongly-scoped bounds would land somewhere else entirely"
+        );
+        assert_eq!(
+            popover.size.width,
+            composer.size.width - px(24.0),
+            "and inset the same 12px on the right"
+        );
+        assert!(
+            popover.origin.y + popover.size.height < composer.origin.y + composer.size.height,
+            "the popover opens *upward*: its bottom edge {:?} must sit above the composer's own \
+             bottom edge {:?}, clearing the primary commit button row",
+            popover.origin.y + popover.size.height,
+            composer.origin.y + composer.size.height
+        );
+        assert!(
+            popover.origin.y < composer.origin.y,
+            "the four-row popover is taller than the composer, so its top must genuinely paint \
+             above the composer - the exact overflow that made a composer-scoped scrim wrong"
+        );
+        assert!(
+            app.read_with(cx, |app, _| app.commit_menu_open),
+            "sanity check: none of the geometry above may be read from a closed menu"
+        );
+    }
+
+    /// Leaving the Changes view unrenders the composer. `commit_menu_open` used to stay latched
+    /// `true` through that, so coming back to Changes popped the popover open again with no click
+    /// (GitHub issue #176).
+    #[gpui::test]
+    fn leaving_the_changes_view_really_closes_the_commit_menu(cx: &mut TestAppContext) {
+        let repo = changes_test_repo();
+        let (app, cx) = open_changes_view(cx, &repo);
+
+        let toggle = cx
+            .debug_bounds("commit-composer-menu-toggle")
+            .expect("the ▾ toggle must really paint");
+        cx.simulate_click(toggle.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+        assert!(
+            app.read_with(cx, |app, _| app.commit_menu_open),
+            "premise: the menu must really be open before the view switch"
+        );
+
+        app.update_in(cx, |app, window, cx| {
+            app.set_right_sidebar_view(RightSidebarView::Files, window, cx);
+        });
+        cx.run_until_parked();
+        assert!(
+            !app.read_with(cx, |app, _| app.commit_menu_open),
+            "switching away from Changes must close the menu, not latch it"
+        );
+
+        app.update_in(cx, |app, window, cx| {
+            app.set_right_sidebar_view(RightSidebarView::Changes, window, cx);
+        });
+        cx.run_until_parked();
+        assert!(
+            cx.debug_bounds("commit-menu-popover").is_none(),
+            "returning to Changes must not resurrect a popover the user never reopened"
+        );
+    }
+
+    /// The reported "2 context menus open at the same time", for this pair, end to end through a
+    /// real click on the real `▾` trigger.
+    ///
+    /// Honest about what it discriminates: the `+` menu's own scrim is full-window and
+    /// non-occluding, so that click would incidentally dismiss it even without
+    /// `close_menu_surfaces_except`. What this pins is the *outcome* - one menu open, never two -
+    /// through a real interaction; the sweep itself is what makes that outcome structural rather
+    /// than a coincidence of which scrim happens to be painted where, and
+    /// `crate::root::menus::menu_surface_tests::opening_any_one_surface_closes_all_five_others`
+    /// is the test that fails the moment the sweep stops covering a surface.
+    #[gpui::test]
+    fn opening_the_commit_menu_closes_an_already_open_plus_menu(cx: &mut TestAppContext) {
+        let repo = changes_test_repo();
+        let (app, cx) = open_changes_view(cx, &repo);
+
+        app.update(cx, |app, cx| {
+            app.plus_menu_open = true;
+            cx.notify();
+        });
+        cx.run_until_parked();
+        assert!(
+            cx.debug_bounds("dropdown-menu-row-Git graph").is_some(),
+            "premise: the + menu must really be painted before the commit menu opens"
+        );
+
+        let toggle = cx
+            .debug_bounds("commit-composer-menu-toggle")
+            .expect("the ▾ toggle must really paint");
+        cx.simulate_click(toggle.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.commit_menu_open,
+                "the click must really open the commit menu"
+            );
+            assert!(
+                !app.plus_menu_open,
+                "and must close the + menu - two popovers painted at once is the reported bug"
+            );
+        });
+        assert!(
+            cx.debug_bounds("dropdown-menu-row-Git graph").is_none(),
+            "the + menu must really stop painting, not merely have its flag cleared"
+        );
     }
 
     #[gpui::test]

--- a/crates/app/src/sidebar/tree_ops.rs
+++ b/crates/app/src/sidebar/tree_ops.rs
@@ -383,6 +383,11 @@ impl AdeApp {
         if self.tree_inline_edit.is_some() {
             self.cancel_tree_inline_edit(window, cx);
         }
+        // GitHub issue #176 - the reported "2 context menus open at the same time" is most easily
+        // reproduced right here: the `+` menu's own scrim only listens for a *left* click, so a
+        // right-click in the file tree went straight past it to this method and left both
+        // popovers painted. See `AdeApp::close_menu_surfaces_except`.
+        let _ = self.close_menu_surfaces_except(Some(menus::MenuSurface::TreeContext));
         // GitHub issue #145: a right-click on a row that's already part of a real multi-selection
         // (more than just the anchor) must act on the *whole* selection, not collapse it down to
         // just the row under the cursor - the same "right-click within a selection" convention
@@ -3419,6 +3424,124 @@ mod tree_ops_regression_tests {
             assert!(
                 app.tree_context_menu.is_none(),
                 "and it must still have dismissed the menu"
+            );
+        });
+    }
+
+    /// GitHub issue #176's literal report - "2 context menus open at the same time" - through the
+    /// two real surfaces that used to reach it most easily. The tab strip's `+` menu paints a
+    /// full-window scrim, but that scrim only listens for a *left* click, so a right-click in the
+    /// file tree sailed past it, opened this menu, and left both popovers painted. Driven by a
+    /// genuine `MouseButton::Right` platform event, not by calling `open_tree_context_menu`.
+    #[gpui::test]
+    fn a_real_right_click_in_the_file_tree_closes_an_open_plus_menu(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        seed(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        app.update(cx, |app, cx| {
+            app.plus_menu_open = true;
+            cx.notify();
+        });
+        cx.run_until_parked();
+        assert!(
+            cx.debug_bounds("dropdown-menu-row-Git graph").is_some(),
+            "premise: the + menu must really be painted before the right-click"
+        );
+
+        let row = cx
+            .debug_bounds("file-tree-row-README.md")
+            .expect("the file row must really paint");
+        cx.simulate_event(gpui::MouseDownEvent {
+            position: row.center(),
+            modifiers: gpui::Modifiers::none(),
+            button: gpui::MouseButton::Right,
+            click_count: 1,
+            first_mouse: false,
+        });
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.tree_context_menu.is_some(),
+                "premise: the right-click must really open the tree's own context menu - \
+                 otherwise this test proves nothing about two menus coexisting"
+            );
+            assert!(
+                !app.plus_menu_open,
+                "opening the tree's context menu must close the + menu: two popovers open at \
+                 once is exactly what GitHub issue #176 reports"
+            );
+        });
+        assert!(
+            cx.debug_bounds("dropdown-menu-row-Git graph").is_none(),
+            "the + menu must really stop painting, not merely have its flag cleared"
+        );
+        assert!(
+            cx.debug_bounds("tree-context-menu").is_some(),
+            "and the context menu the right-click opened must really be painted"
+        );
+    }
+
+    /// The other direction, so the rule above can't pass by making the `+` menu permanently
+    /// unopenable. This one lands on the tree menu's own **occluding** scrim, which deliberately
+    /// absorbs the click that dismisses it (see `crate::sidebar::render::AdeApp::
+    /// render_tree_context_menu`'s docs - a dismiss must not also run whatever was underneath) -
+    /// so the first click closes the tree menu *without* opening the `+` menu, and a second click
+    /// on the now-uncovered `+` opens it. Two menus are never open at the same time in either
+    /// step, which is the property GitHub issue #176 is actually about.
+    #[gpui::test]
+    fn clicking_the_tab_strip_plus_under_an_open_tree_context_menu_never_leaves_both_open(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = TempDir::new().expect("tempdir");
+        seed(&repo);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_tree_context_menu(ContextTarget::Empty, 4.0, 4.0, window, cx);
+        });
+        cx.run_until_parked();
+        assert!(
+            cx.debug_bounds("tree-context-menu").is_some(),
+            "premise: the context menu must really be painted"
+        );
+
+        let plus = app.read_with(cx, |app, _| app.plus_button_bounds);
+        assert_ne!(
+            plus,
+            gpui::Bounds::default(),
+            "premise: the + button must really have painted by now"
+        );
+        cx.simulate_click(plus.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.tree_context_menu.is_none(),
+                "the first click must dismiss the tree's context menu"
+            );
+            assert!(
+                !app.plus_menu_open,
+                "and must be absorbed by that menu's own occluding scrim rather than also \
+                 opening the + menu underneath it"
+            );
+        });
+
+        cx.simulate_click(plus.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.plus_menu_open,
+                "with the scrim gone, the very same click must really open the + menu - proof \
+                 the step above absorbed a click rather than breaking the button"
+            );
+            assert!(
+                app.tree_context_menu.is_none(),
+                "and the tree's context menu must not have come back"
             );
         });
     }

--- a/crates/app/src/title_bar/menu.rs
+++ b/crates/app/src/title_bar/menu.rs
@@ -1191,6 +1191,57 @@ mod title_menu_tests {
         );
     }
 
+    /// GitHub issue #176 for this surface: clicking a real title-bar label while another menu is
+    /// open must close that one rather than stack on top of it. The file tree's context menu is
+    /// the interesting partner - its scrim `.occlude()`s, but deliberately starts *below* the
+    /// title bar (so the window's caption buttons stay reachable), which is exactly why this click
+    /// really does reach the "File" label and really can leave two menus open.
+    #[gpui::test]
+    fn clicking_a_title_label_closes_an_open_tree_context_menu(cx: &mut TestAppContext) {
+        let (app, cx) = open_windows_variant(cx);
+        app.update(cx, |app, cx| {
+            // `open_tree_context_menu` is `pub(in crate::sidebar)`; its own module's tests drive
+            // it through a real right-click. What matters here is only that a context menu is
+            // really open and really painted when the title label is clicked.
+            app.tree_context_menu = Some(crate::sidebar::tree_ops::TreeContextMenu {
+                target: crate::sidebar::context_menu::ContextTarget::Empty,
+                // Well clear of the title bar's own labels: this popover paints *over* whatever
+                // is beneath it, and a menu opened at the window's top-left corner would sit on
+                // top of the very "File" label this test needs to click.
+                origin_x: 600.0,
+                origin_y: 400.0,
+            });
+            cx.notify();
+        });
+        cx.run_until_parked();
+        assert!(
+            cx.debug_bounds("tree-context-menu").is_some(),
+            "premise: the tree's context menu must really be painted"
+        );
+
+        let bounds = app.read_with(cx, |app, _| {
+            app.title_menu_button_bounds[TitleMenu::File.index()]
+        });
+        cx.simulate_click(center_of(bounds), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.title_menu_open,
+                Some(TitleMenu::File),
+                "the click must really open the File dropdown"
+            );
+            assert!(
+                app.tree_context_menu.is_none(),
+                "and must close the tree's context menu - two menus painted at once is the bug"
+            );
+        });
+        assert!(
+            cx.debug_bounds("tree-context-menu").is_none(),
+            "the context menu must really stop painting, not merely have its state cleared"
+        );
+    }
+
     /// The Agent menu's "Discard worktree" row's real two-step confirm - mirrors the agent
     /// footer's own identical two-click button
     /// (`crate::work_surface::render::AdeApp::render_footer_action_button`), reusing the

--- a/crates/app/src/title_bar/render.rs
+++ b/crates/app/src/title_bar/render.rs
@@ -119,12 +119,18 @@ impl AdeApp {
                         .size_full(),
                     )
                     .on_click(cx.listener(move |this, _event: &ClickEvent, _window, cx| {
-                        this.title_menu_open = if this.title_menu_open == Some(menu) {
+                        let next = if this.title_menu_open == Some(menu) {
                             None
                         } else {
-                            this.plus_menu_open = false;
                             Some(menu)
                         };
+                        // GitHub issue #176. This used to close only the `+` menu by hand - the
+                        // shared sweep covers the file tree's context menu, the commit composer's
+                        // menu and the graph's two menus as well, none of which this label knew
+                        // about. `Title` is kept so switching File → Edit stays one open menu
+                        // rather than briefly none.
+                        let _ = this.close_menu_surfaces_except(Some(menus::MenuSurface::Title));
+                        this.title_menu_open = next;
                         cx.notify();
                     }))
             }))

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -1153,7 +1153,12 @@ impl AdeApp {
                 .size_full()
             })
             .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
-                this.plus_menu_open = !this.plus_menu_open;
+                let opening = !this.plus_menu_open;
+                // GitHub issue #176: opening this menu closes whatever other menu was open, so
+                // two popovers can never be painted at once. Read *before* the sweep and applied
+                // after it, because the sweep clears `plus_menu_repo_anchor` too.
+                let _ = this.close_menu_surfaces_except(Some(menus::MenuSurface::Plus));
+                this.plus_menu_open = opening;
                 // This is the tab strip's own `+`, not a rail repo header's - see
                 // `Self::plus_menu_repo_anchor`'s own docs for why `Self::render_plus_menu` needs
                 // to know which one opened it.


### PR DESCRIPTION
Fixes #176

## What was wrong

Each of the app's six floating menu surfaces owned an independent `Option`/`bool` with no knowledge of its siblings. Only two hand-added pairwise rules existed (graph row ↔ graph push, and title bar → `+`), so most pairs could genuinely stack — the reported "2 context menus open at the same time".

Per surface:

| Surface | State | What was actually wrong |
| --- | --- | --- |
| Tab strip / rail `+` | `plus_menu_open` | Closed nothing else. Its scrim is full-window but left-click only, so a right-click in the file tree sailed past it. |
| Title bar File/Edit/View/Agent/Help | `title_menu_open` | Closed only the `+` menu by hand. |
| File tree context menu | `tree_context_menu` | Closed nothing else. Most complete dismissal otherwise (occluding scrim, right-click dismiss, Escape). |
| Commit composer `▾` | `commit_menu_open` | **The bad one.** Scrim was a child of the composer, so `absolute` inset-0 resolved against the composer's ~130px box, not the window — clicking the Changes list, file tree, rail, tab strip, editor or title bar did not close it. Its four rows are all inert, so a second click on the toggle was the only reliable gesture. Also latched open across a switch away from the Changes view. |
| Graph `Push ▾` | `graph_state.push_menu_open` | Closed only the row menu. |
| Graph row `⋯` | `graph_state.row_menu_open` | Closed only the push menu. |

Nothing anywhere reacted to focus, and the three "close menus" cleanup blocks (`open_palette`, `open_settings`, `reset_repo_scoped_state`) each covered a different subset.

## The fix

**One shared mechanism, not six copies.** New `crate::root::menus` defines a payload-free `MenuSurface` with an `ALL` array plus two exhaustive `match`es (`menu_surface_is_open` / `close_menu_surface`), behind `close_menu_surfaces_except(keep)`. Every real path that opens one of the six runs the sweep first, so a seventh popover cannot opt out without a compile error — the same anti-drift reasoning `menu_popover_chrome` already uses. Per-surface state stays where it is, since it carries payload a common field could not hold.

**The commit menu moved out of the composer** into `AdeApp::render`, beside the `+` menu, with a genuinely full-window `.occlude()`d scrim (starting below the title bar so caption buttons stay reachable) and a right-click dismiss. It anchors off a new `gpui::canvas`-captured `commit_composer_bounds` — the same move the graph's two menus already made, for the same reason. Painted geometry is unchanged (12px inset both sides, upward-opening, clearing the button row); a test pins it. It also closes when the sidebar leaves the Changes view.

**Window focus loss** closes all six, via a real `cx.observe_window_activation` subscription. The palette / Settings / "New file" overlays are deliberately not swept — they own real keyboard focus and half-typed input.

`open_palette`, `open_settings` and `reset_repo_scoped_state` now route through the same sweep. Escape for the tree menu is untouched and still works.

## Tests

- `root::menus::menu_surface_tests` — all six closed by one sweep; opening any one closes the other five (every pair); the `+` menu's repo anchor is cleared with it; **window deactivation** through GPUI's real `VisualTestContext::deactivate_window` (verified to fail without the subscription).
- `sidebar::render::commit_composer_tests` — real click far outside the composer closes the menu; popover geometry is really anchored to the composer; leaving Changes closes it and returning does not resurrect it; opening it closes the `+` menu.
- `sidebar::tree_ops::tree_ops_regression_tests` — real `MouseButton::Right` in the file tree closes an open `+` menu (verified to fail without the fix); clicking the `+` under an open tree menu never leaves both open.
- `title_bar::menu::title_menu_tests` — real click on the File label closes an open tree context menu (verified to fail without the fix).
- `graph_view::render::graph_row_menu_tests` — a real right-click on a graph row closes an open `+` menu.

## Gates

`cargo fmt --all -- --check`, `cargo build --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --lib` — all green (1881 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)