### PR TITLE
Complete the File view breadcrumb: live symbol path + real diagnostic counts

### DIFF
--- a/crates/app/src/code_surface/code_view.rs
+++ b/crates/app/src/code_surface/code_view.rs
@@ -393,7 +393,7 @@ pub struct HighlightSpan {
 /// two genuinely different grammars in `tree-sitter-typescript` (not one grammar with a flag), and
 /// they need two different composed query strings - see [`highlight_query_for`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Grammar {
+pub(in crate::code_surface) enum Grammar {
     Rust,
     TypeScript,
     Tsx,
@@ -470,7 +470,7 @@ impl Grammar {
         }
     }
 
-    fn language(self) -> tree_sitter::Language {
+    pub(in crate::code_surface) fn language(self) -> tree_sitter::Language {
         match self {
             Grammar::Rust => tree_sitter_rust::LANGUAGE.into(),
             Grammar::TypeScript => tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
@@ -550,7 +550,7 @@ impl Grammar {
     /// (identical monomorphisations may be merged), so a table that looked derived would in fact
     /// be relying on unspecified behaviour. An explicit match plus a real drift test is the honest
     /// version of the same guarantee.
-    fn for_extension(extension: &str) -> Option<Grammar> {
+    pub(in crate::code_surface) fn for_extension(extension: &str) -> Option<Grammar> {
         Some(match extension {
             "rs" => Grammar::Rust,
             // `.js` reuses the plain TypeScript grammar, `.jsx` the TSX one - see

--- a/crates/app/src/code_surface/edit_buffer.rs
+++ b/crates/app/src/code_surface/edit_buffer.rs
@@ -183,6 +183,7 @@ use unicode_segmentation::UnicodeSegmentation;
 
 use crate::code_surface::code_view;
 use crate::code_surface::indent;
+use crate::code_surface::symbols;
 use crate::language::HighlighterFn;
 use crate::text_history::{self, EditKind, SelectionSnapshot, TextEdit, TextHistory};
 
@@ -368,6 +369,15 @@ pub struct EditBuffer {
     /// in). See this module's own "Multi-cursor" docs for the overall design and every method that
     /// populates/consumes this.
     pub secondary_cursors: Vec<SecondaryCursor>,
+    /// GitHub issue #178: the real enclosing-declaration outline of [`Self::content`], as of the
+    /// last parse - what the File view breadcrumb turns into `› impl QueryBuilder › build` for
+    /// wherever [`Self::cursor_offset`] currently is. Refreshed on exactly the same schedule as
+    /// [`Self::lines`] (seeded at construction, then recomputed by
+    /// `crate::code_surface::editing::AdeApp::schedule_rehighlight`'s debounced background parse
+    /// and installed by [`Self::apply_highlight`]), so the two can never describe different
+    /// revisions of the text. Empty - never fabricated - for a language with no symbol support;
+    /// see `crate::code_surface::symbols` for which those are and why.
+    pub symbols: Vec<symbols::SymbolSpan>,
 }
 
 /// One additional cursor/selection beyond the primary `EditBuffer::selected_range`/
@@ -403,22 +413,28 @@ impl EditBuffer {
             None => Vec::new(),
         };
         let lines = code_view::build_lines(&content, &spans);
-        Self::assemble(path, content, extension, lines, mtime, len)
+        // Same "fine for a directly-built buffer, too slow for the production path" trade the
+        // highlight above already makes - `from_highlighted` takes both off a caller that
+        // computed them on the background executor instead.
+        let symbols = symbols::symbol_outline(&content, extension.as_deref());
+        Self::assemble(path, content, extension, lines, symbols, mtime, len)
     }
 
-    /// Production constructor: takes already-highlighted `lines` (computed off the foreground
-    /// thread by whichever background load also read `content`) rather than re-running the real
-    /// highlighter here - see this module's own "Re-highlighting cost" docs for the measured
-    /// reason a synchronous foreground `tree-sitter` parse of a large file must be avoided.
+    /// Production constructor: takes already-highlighted `lines` and an already-computed
+    /// `symbols` outline (both computed off the foreground thread by whichever background load
+    /// also read `content`) rather than re-running the real highlighter/parser here - see this
+    /// module's own "Re-highlighting cost" docs for the measured reason a synchronous foreground
+    /// `tree-sitter` parse of a large file must be avoided.
     pub fn from_highlighted(
         path: PathBuf,
         content: String,
         extension: Option<String>,
         lines: Vec<code_view::RenderedLine>,
+        symbols: Vec<symbols::SymbolSpan>,
         mtime: Option<SystemTime>,
         len: u64,
     ) -> Self {
-        Self::assemble(path, content, extension, lines, mtime, len)
+        Self::assemble(path, content, extension, lines, symbols, mtime, len)
     }
 
     fn assemble(
@@ -426,6 +442,7 @@ impl EditBuffer {
         content: String,
         extension: Option<String>,
         lines: Vec<code_view::RenderedLine>,
+        symbols: Vec<symbols::SymbolSpan>,
         mtime: Option<SystemTime>,
         len: u64,
     ) -> Self {
@@ -449,6 +466,7 @@ impl EditBuffer {
             history: TextHistory::new(),
             replaying: false,
             secondary_cursors: Vec::new(),
+            symbols,
         }
     }
 
@@ -780,11 +798,18 @@ impl EditBuffer {
         &mut self,
         content_snapshot: &str,
         lines: Vec<code_view::RenderedLine>,
+        symbols: Vec<symbols::SymbolSpan>,
     ) -> bool {
         if self.content != content_snapshot {
             return false;
         }
         self.lines = lines;
+        // Installed under the exact same content-snapshot guard as `lines`, and only together
+        // with them: a symbol outline whose byte ranges describe text this buffer has already
+        // moved past would put the breadcrumb inside a function the caret isn't in. Rejecting
+        // both as one unit is what keeps `Self::symbols` and `Self::lines` describing the same
+        // revision (see `Self::symbols`' own docs).
+        self.symbols = symbols;
         self.highlight_dirty = false;
         true
     }
@@ -1336,6 +1361,7 @@ impl EditBuffer {
         &mut self,
         new_content: String,
         lines: Vec<code_view::RenderedLine>,
+        symbols: Vec<symbols::SymbolSpan>,
         mtime: Option<SystemTime>,
         len: u64,
     ) -> bool {
@@ -1365,6 +1391,11 @@ impl EditBuffer {
         self.utf16_line_starts =
             Self::cumulative_utf16_line_starts(&self.content, &self.line_ranges);
         self.lines = lines;
+        // The reloaded text is genuinely different bytes at genuinely different offsets, so the
+        // outline this buffer was holding describes content that no longer exists - replaced
+        // here, from the same background parse that produced `lines`, rather than left stale
+        // (which would point the breadcrumb at symbol boundaries from the pre-reload revision).
+        self.symbols = symbols;
         self.highlight_dirty = false;
         self.saved_content = self.content.clone();
         self.saved_mtime = mtime;
@@ -2660,6 +2691,112 @@ mod tests {
         )
     }
 
+    /// GitHub issue #178: the File view breadcrumb's enclosing-symbol chain is read, live, out of
+    /// `EditBuffer::symbols` at `EditBuffer::cursor_offset` - this is that exact expression, as
+    /// `crate::code_surface::file_view::AdeApp::render_file_view` evaluates it, so these tests
+    /// exercise the real production path rather than a parallel reimplementation of it.
+    fn breadcrumb_symbol_path(buffer: &EditBuffer) -> Vec<String> {
+        symbols::symbol_path_at(&buffer.symbols, buffer.cursor_offset())
+            .into_iter()
+            .map(str::to_string)
+            .collect()
+    }
+
+    const OUTLINE_SOURCE: &str = "\
+impl QueryBuilder {
+    pub fn select(&self) {
+        let a = 1;
+    }
+
+    pub fn build(&self) {
+        let b = 2;
+    }
+}
+";
+
+    #[test]
+    fn a_freshly_constructed_buffer_already_holds_a_real_symbol_outline() {
+        let buf = buffer(OUTLINE_SOURCE);
+        let labels: Vec<&str> = buf.symbols.iter().map(|s| s.label.as_str()).collect();
+        assert_eq!(labels, vec!["impl QueryBuilder", "select", "build"]);
+    }
+
+    #[test]
+    fn moving_the_real_caret_really_changes_the_breadcrumbs_symbol_path() {
+        let mut buf = buffer(OUTLINE_SOURCE);
+        // Caret at the very end of the file - past the `impl` block's own closing brace, so
+        // genuinely inside nothing. (Offset 0 is *not* such a position here: `impl QueryBuilder`
+        // starts at byte 0, so the caret really is inside it there.)
+        buf.move_to(buf.content.len());
+        assert!(breadcrumb_symbol_path(&buf).is_empty());
+
+        buf.move_to(OUTLINE_SOURCE.find("let a = 1;").expect("marker") + 3);
+        assert_eq!(
+            breadcrumb_symbol_path(&buf),
+            vec!["impl QueryBuilder", "select"]
+        );
+
+        buf.move_to(OUTLINE_SOURCE.find("let b = 2;").expect("marker") + 3);
+        assert_eq!(
+            breadcrumb_symbol_path(&buf),
+            vec!["impl QueryBuilder", "build"],
+            "arrowing from one method into another must really move the last crumb with it"
+        );
+    }
+
+    #[test]
+    fn a_file_whose_language_has_no_symbol_concept_holds_an_honestly_empty_outline() {
+        let buf = EditBuffer::new(
+            PathBuf::from("/tmp/Cargo.toml"),
+            "[package]\nname = \"ade\"\n".to_string(),
+            Some("toml".to_string()),
+            None,
+            0,
+        );
+        assert!(buf.symbols.is_empty());
+    }
+
+    #[test]
+    fn a_rejected_stale_highlight_also_leaves_the_previous_symbol_outline_untouched() {
+        let mut buf = buffer(OUTLINE_SOURCE);
+        let good_outline = buf.symbols.clone();
+        assert!(!good_outline.is_empty());
+
+        // Content moves on, so the background result computed against the old snapshot is stale.
+        let stale_snapshot = buf.content.clone();
+        buf.move_to(0);
+        buf.replace_range(None, "// edited\n");
+        assert_ne!(buf.content, stale_snapshot);
+
+        let stale_lines = code_view::build_lines(&stale_snapshot, &[]);
+        let stale_outline = symbols::symbol_outline("fn totally_different() {}\n", Some("rs"));
+        assert!(!buf.apply_highlight(&stale_snapshot, stale_lines, stale_outline));
+        assert_eq!(
+            buf.symbols, good_outline,
+            "a rejected highlight result must not smuggle its symbol outline in either"
+        );
+    }
+
+    #[test]
+    fn an_external_reload_replaces_the_symbol_outline_rather_than_keeping_a_stale_one() {
+        let mut buffer = buffer(OUTLINE_SOURCE);
+        assert!(!buffer.symbols.is_empty());
+        let rewritten = "fn only_this_one() {\n    let c = 3;\n}\n".to_string();
+        let lines = code_view::build_lines(&rewritten, &[]);
+        let outline = symbols::symbol_outline(&rewritten, Some("rs"));
+        assert!(buffer.reload_from_disk(
+            rewritten.clone(),
+            lines,
+            outline,
+            None,
+            rewritten.len() as u64
+        ));
+        let labels: Vec<&str> = buffer.symbols.iter().map(|s| s.label.as_str()).collect();
+        assert_eq!(labels, vec!["only_this_one"]);
+        buffer.move_to(rewritten.find("let c = 3;").expect("marker") + 3);
+        assert_eq!(breadcrumb_symbol_path(&buffer), vec!["only_this_one"]);
+    }
+
     /// Same as [`buffer`], but with a real `.py` extension - GitHub issue #121/PR #136's Python
     /// colon-block auto-indent tests need a real `Some("py")` `EditBuffer::extension` (the same
     /// lowercase, no-leading-dot convention `crate::language::EXTENSIONS` uses), not the `.rs`
@@ -2944,7 +3081,8 @@ mod tests {
         let spans = code_view::highlight_rust(&buf.content);
         let lines = code_view::build_lines(&buf.content, &spans);
         let content_snapshot = buf.content.clone();
-        assert!(buf.apply_highlight(&content_snapshot, lines));
+        let outline = symbols::symbol_outline(&content_snapshot, Some("rs"));
+        assert!(buf.apply_highlight(&content_snapshot, lines, outline));
         assert!(!buf.highlight_dirty);
         let kinds: Vec<code_view::HighlightKind> =
             buf.lines[0].runs.iter().map(|(_, kind)| *kind).collect();
@@ -3013,7 +3151,8 @@ mod tests {
         let spans = code_view::highlight_rust(&buf.content);
         let lines = code_view::build_lines(&buf.content, &spans);
         let content_snapshot = buf.content.clone();
-        assert!(buf.apply_highlight(&content_snapshot, lines));
+        let outline = symbols::symbol_outline(&content_snapshot, Some("rs"));
+        assert!(buf.apply_highlight(&content_snapshot, lines, outline));
         assert!(!buf.highlight_dirty);
         assert_eq!(
             find_kind(&buf, "fn"),
@@ -3036,7 +3175,8 @@ mod tests {
         buf.replace_range(None, "bar");
         assert_ne!(buf.content, stale_snapshot);
 
-        assert!(!buf.apply_highlight(&stale_snapshot, stale_lines));
+        let stale_outline = symbols::symbol_outline(&stale_snapshot, Some("rs"));
+        assert!(!buf.apply_highlight(&stale_snapshot, stale_lines, stale_outline));
         assert!(
             buf.highlight_dirty,
             "a stale highlight result must not clear the dirty flag"
@@ -3747,7 +3887,13 @@ mod tests {
         // ...and now a real external writer (an agent CLI running in this worktree) rewrites it.
         let rewritten = "rewritten by an agent\n".to_string();
         let lines = code_view::build_lines(&rewritten, &[]);
-        assert!(buffer.reload_from_disk(rewritten.clone(), lines, None, rewritten.len() as u64));
+        assert!(buffer.reload_from_disk(
+            rewritten.clone(),
+            lines,
+            Vec::new(),
+            None,
+            rewritten.len() as u64
+        ));
         assert_eq!(buffer.content, rewritten);
         assert!(!buffer.is_dirty(), "the reloaded buffer matches disk");
 
@@ -3776,7 +3922,7 @@ mod tests {
     fn a_reload_whose_content_is_identical_records_no_step_at_all() {
         let mut buffer = buffer("same\n");
         let lines = code_view::build_lines("same\n", &[]);
-        assert!(!buffer.reload_from_disk("same\n".to_string(), lines, None, 5));
+        assert!(!buffer.reload_from_disk("same\n".to_string(), lines, Vec::new(), None, 5));
         assert!(
             !buffer.can_undo(),
             "a reload that changes nothing must not push an empty step the user has to press \
@@ -3794,7 +3940,13 @@ mod tests {
         buffer.move_to(20);
         let short = "hi\n".to_string();
         let lines = code_view::build_lines(&short, &[]);
-        assert!(buffer.reload_from_disk(short.clone(), lines, None, short.len() as u64));
+        assert!(buffer.reload_from_disk(
+            short.clone(),
+            lines,
+            Vec::new(),
+            None,
+            short.len() as u64
+        ));
         assert!(
             buffer.cursor_offset() <= buffer.content.len(),
             "the caret must be clamped into the new content, never left dangling past its end"

--- a/crates/app/src/code_surface/editing.rs
+++ b/crates/app/src/code_surface/editing.rs
@@ -57,6 +57,7 @@ use crate::code_surface::indent;
 use crate::code_surface::lsp_ui::{
     diagnostic_inline_message_color, diagnostic_row_bg, diagnostic_underline_color,
 };
+use crate::code_surface::symbols;
 use crate::lsp::diagnostics as diagnostics_view;
 use crate::lsp::hover as hover_view;
 use crate::root::{
@@ -191,6 +192,13 @@ impl AdeApp {
     /// A single slot per path in [`AdeApp::_rehighlight_tasks`]: assigning a fresh task here drops
     /// (cancels) whatever earlier debounce timer for the same path was still waiting, so only the
     /// most recent keystroke's timer ever actually fires - real debounce, not a queue.
+    ///
+    /// GitHub issue #178: the same background task also rebuilds the File view breadcrumb's
+    /// enclosing-symbol outline (`crate::code_surface::symbols::symbol_outline`), and
+    /// [`EditBuffer::apply_highlight`] installs the two together under one content-snapshot
+    /// guard. Riding along here rather than getting its own timer is deliberate: the outline is
+    /// stale for exactly as long as the highlighting is, so the breadcrumb can never claim a
+    /// symbol structure that disagrees with the colours on screen.
     pub(crate) fn schedule_rehighlight(&mut self, path: PathBuf, cx: &mut Context<Self>) {
         let Some(buffer) = self.edit_buffer(&path) else {
             return;
@@ -209,6 +217,10 @@ impl AdeApp {
             return;
         };
         let content_snapshot = buffer.content.clone();
+        // Cloned now (not read back off the buffer once this task resumes) for exactly the same
+        // reason `cwd` below is - this buffer may be gone or replaced by the time the debounce
+        // fires, and the parse must describe the snapshot it was actually handed.
+        let extension = buffer.extension.clone();
         // Captured now (synchronously, before the real debounce timer below) rather than
         // re-read from `self.file_tree_root` once this task resumes - see `AdeApp::
         // edit_buffers`'s own docs for the stale-worktree bug class this prevents.
@@ -218,19 +230,22 @@ impl AdeApp {
             let content_snapshot = content_snapshot.clone();
             async move |this, cx| {
                 cx.background_executor().timer(REHIGHLIGHT_DEBOUNCE).await;
-                let lines = cx
+                let (lines, symbols) = cx
                     .background_executor()
                     .spawn({
                         let content_snapshot = content_snapshot.clone();
                         async move {
                             let spans = highlighter(&content_snapshot);
-                            code_view::build_lines(&content_snapshot, &spans)
+                            let lines = code_view::build_lines(&content_snapshot, &spans);
+                            let symbols =
+                                symbols::symbol_outline(&content_snapshot, extension.as_deref());
+                            (lines, symbols)
                         }
                     })
                     .await;
                 let _ = this.update(cx, |this, cx| {
                     if let Some(buffer) = this.edit_buffer_at_mut(&cwd, &path) {
-                        if buffer.apply_highlight(&content_snapshot, lines) {
+                        if buffer.apply_highlight(&content_snapshot, lines, symbols) {
                             cx.notify();
                         }
                     }

--- a/crates/app/src/code_surface/file_view.rs
+++ b/crates/app/src/code_surface/file_view.rs
@@ -285,6 +285,29 @@ impl AdeApp {
             Some(LspFileStatus::Analyzed { errors, .. }) => Some(*errors),
             _ => None,
         };
+        // GitHub issue #178: the breadcrumb's right-hand counts, read off the exact same
+        // `LspFileStatus` this frame's footer label is built from rather than re-derived, so the
+        // two can never disagree about how many problems this file has. `None` for every
+        // non-`Analyzed` status (no server, still spawning/indexing, or a failed one) - the band
+        // then draws no dots at all instead of an unearned `0`.
+        let breadcrumb_diagnostic_counts = match &lsp_status {
+            Some(LspFileStatus::Analyzed { errors, warnings }) => Some((*errors, *warnings)),
+            _ => None,
+        };
+        // The live enclosing-declaration chain at the caret, from the outline the buffer's own
+        // last parse produced (`crate::code_surface::symbols`). Read here, before the `parsed`
+        // borrow below, and materialized as owned `String`s so the breadcrumb can be built
+        // further down without holding a borrow of `self` across it. Empty - and the breadcrumb
+        // then honestly shows the path alone - whenever there's no live edit buffer for this file
+        // (still loading, or truncated/non-UTF-8 and therefore permanently read-only), which is
+        // also the only state where there is no real caret offset to look anything up by.
+        let breadcrumb_symbol_path: Vec<String> = match self.edit_buffer(&relative_path_buf) {
+            Some(buffer) => symbols::symbol_path_at(&buffer.symbols, buffer.cursor_offset())
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
+            None => Vec::new(),
+        };
 
         let Some(parsed) = self.file_view_cache.as_ref() else {
             return render_sidebar_message("no file loaded".to_string(), theme::text::FAINT.into());
@@ -595,7 +618,11 @@ impl AdeApp {
             .flex_col()
             .flex_1()
             .min_h_0()
-            .child(render_file_breadcrumb(relative_path));
+            .child(render_file_breadcrumb(
+                relative_path,
+                &breadcrumb_symbol_path,
+                breadcrumb_diagnostic_counts,
+            ));
 
         // GitHub issue #30's real editor scrollbar decoration marks - see `Self::render_file_tree`'s
         // own docs (`crate::sidebar::render`) on why the scrollbar must be a sibling of the
@@ -810,14 +837,64 @@ mod editor_scrollbar_mark_tests {
     }
 }
 
-/// The File view's breadcrumb, built from `relative_path`'s segments
-/// (`code_view::breadcrumb_segments`). The design's deeper symbol-path suffix (`› impl
-/// QueryBuilder › build`) is out of scope: it needs symbol/AST-position tracking this read-only
-/// viewer doesn't build. The last (file name) segment is the active crumb; earlier segments are
-/// dimmer ancestor directories.
-pub(in crate::code_surface) fn render_file_breadcrumb(relative_path: &Path) -> impl IntoElement {
+/// One rendered breadcrumb crumb - see [`breadcrumb_crumbs`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::code_surface) struct Crumb {
+    pub text: String,
+    /// `true` for exactly one crumb: the file's own name. The design (`design_handoff_jerry_ade/
+    /// revision/Jerry.dc.html`, the File view breadcrumb band) renders that one at `#a9b0b7` and
+    /// every other crumb - ancestor directories *and* enclosing symbols alike - at `#5e646a`.
+    pub active: bool,
+}
+
+/// The File view breadcrumb's real crumb list: `relative_path`'s own directory/file segments
+/// (`code_view::breadcrumb_segments`) followed by `symbol_path`, the chain of declarations
+/// enclosing wherever the caret currently is (`crate::code_surface::symbols::symbol_path_at`).
+///
+/// GitHub issue #178: the path half alone is what this band used to render, which the Surface C
+/// toolbar directly above it already shows - the literal duplicate the issue is about. The symbol
+/// half is what makes it the design's `src › db › query_builder.rs › impl QueryBuilder › build`
+/// instead. `symbol_path` is legitimately empty in real, reachable states (caret at a file's top
+/// level, a language with no enclosing-declaration concept, or no live edit buffer for this file
+/// yet), and the band then honestly renders the path alone rather than padding it out.
+///
+/// Pure and separately tested, so "what does the breadcrumb actually say for this caret" is a
+/// real assertion rather than something only reachable through a GPUI window.
+pub(in crate::code_surface) fn breadcrumb_crumbs(
+    relative_path: &Path,
+    symbol_path: &[String],
+) -> Vec<Crumb> {
     let segments = code_view::breadcrumb_segments(relative_path);
-    let last_index = segments.len().saturating_sub(1);
+    let last_path_index = segments.len().saturating_sub(1);
+    let mut crumbs: Vec<Crumb> = segments
+        .into_iter()
+        .enumerate()
+        .map(|(index, text)| Crumb {
+            text,
+            active: index == last_path_index,
+        })
+        .collect();
+    crumbs.extend(symbol_path.iter().map(|text| Crumb {
+        text: text.clone(),
+        active: false,
+    }));
+    crumbs
+}
+
+/// The File view's breadcrumb (`design_handoff_jerry_ade/README.md`: "Breadcrumb 26 (`src › db ›
+/// query_builder.rs › impl QueryBuilder › build`, 10.5px mono, separators `#3d4248`, active crumb
+/// `#a9b0b7`) with error/warning counts right").
+///
+/// `symbol_path` is the live enclosing-symbol chain at the caret and `diagnostic_counts` the real
+/// `(errors, warnings)` pair from this same frame's `LspFileStatus::Analyzed` - `None` whenever
+/// this file has no analyzed language-server result at all, in which case no count dots are drawn
+/// rather than a fabricated `0 0`.
+pub(in crate::code_surface) fn render_file_breadcrumb(
+    relative_path: &Path,
+    symbol_path: &[String],
+    diagnostic_counts: Option<(usize, usize)>,
+) -> impl IntoElement {
+    let crumbs = breadcrumb_crumbs(relative_path, symbol_path);
 
     let mut row = div()
         .flex_none()
@@ -832,19 +909,224 @@ pub(in crate::code_surface) fn render_file_breadcrumb(relative_path: &Path) -> i
         .font(font(theme::font::MONO))
         .text_size(px(10.5));
 
-    for (index, segment) in segments.into_iter().enumerate() {
+    for (index, crumb) in crumbs.into_iter().enumerate() {
         if index > 0 {
             row = row.child(div().text_color(theme::text::DISABLED).child("\u{203A}"));
         }
-        let color = if index == last_index {
+        let color = if crumb.active {
             theme::text::SECONDARY
         } else {
-            theme::text::GHOST
+            // `#5e646a`, the inactive-crumb colour the design mockup uses for both ancestor
+            // directories and symbol crumbs.
+            theme::text::FAINTER
         };
-        row = row.child(div().text_color(color).child(segment));
+        row = row.child(div().text_color(color).child(crumb.text));
+    }
+
+    if let Some((errors, warnings)) = diagnostic_counts {
+        row = row.child(div().flex_1());
+        row = row.child(
+            div()
+                .flex()
+                .items_center()
+                .gap(px(9.0))
+                .children(diagnostic_count_dot(
+                    diagnostics_view::Severity::Error,
+                    errors,
+                ))
+                .children(diagnostic_count_dot(
+                    diagnostics_view::Severity::Warning,
+                    warnings,
+                )),
+        );
     }
 
     row
+}
+
+/// One `● N` group on the breadcrumb's right edge - a 5px severity-coloured dot plus the count,
+/// per the design mockup's File view breadcrumb band.
+///
+/// `None` when `count` is 0: a clean file shows nothing at all rather than a `0`, which is both
+/// the mockup's own shape (it only ever draws groups for non-zero counts) and the honest reading -
+/// the absence of a dot is unambiguous where a grey `0` next to a red dot is not. The dot colour
+/// comes from [`diagnostic_underline_color`], the same severity->colour map the in-code dotted
+/// underlines use, so the breadcrumb can never disagree with the markers it is counting.
+fn diagnostic_count_dot(
+    severity: diagnostics_view::Severity,
+    count: usize,
+) -> Option<impl IntoElement> {
+    if count == 0 {
+        return None;
+    }
+    Some(
+        div()
+            .flex()
+            .items_center()
+            .gap(px(4.0))
+            .child(
+                div()
+                    .w(px(5.0))
+                    .h(px(5.0))
+                    .rounded_full()
+                    .bg(diagnostic_underline_color(severity)),
+            )
+            .child(
+                div()
+                    .text_size(px(10.0))
+                    .text_color(theme::text::DIM)
+                    .child(count.to_string()),
+            ),
+    )
+}
+
+/// GitHub issue #178's real regression coverage: the breadcrumb band used to render only the file
+/// path, which the Surface C toolbar directly above it already shows - a literal duplicate. These
+/// assert the band now genuinely carries the design's symbol suffix and its error/warning counts,
+/// against the same pure builders [`render_file_breadcrumb`] itself calls.
+#[cfg(test)]
+mod breadcrumb_tests {
+    use super::*;
+    use crate::code_surface::symbols;
+
+    const SOURCE: &str = "\
+mod db {
+    impl QueryBuilder {
+        pub fn build(&self) {
+            let marker = 1;
+        }
+    }
+}
+";
+
+    /// The exact expression `AdeApp::render_file_view` evaluates for a live edit buffer, driven
+    /// here off a real parse of `SOURCE` rather than a hand-written crumb list.
+    fn symbol_path_at_marker(needle: &str) -> Vec<String> {
+        let outline = symbols::symbol_outline(SOURCE, Some("rs"));
+        let offset = SOURCE.find(needle).expect("needle present") + needle.len();
+        symbols::symbol_path_at(&outline, offset)
+            .into_iter()
+            .map(str::to_string)
+            .collect()
+    }
+
+    #[test]
+    fn the_breadcrumb_really_carries_the_designs_own_path_plus_symbol_chain() {
+        let crumbs = breadcrumb_crumbs(
+            Path::new("src/db/query_builder.rs"),
+            &symbol_path_at_marker("let marker = 1;"),
+        );
+        let texts: Vec<&str> = crumbs.iter().map(|crumb| crumb.text.as_str()).collect();
+        assert_eq!(
+            texts,
+            vec![
+                "src",
+                "db",
+                "query_builder.rs",
+                "mod db",
+                "impl QueryBuilder",
+                "build",
+            ],
+            "design_handoff_jerry_ade/README.md's own breadcrumb example, minus the mockup's \
+             elided `mod db`"
+        );
+    }
+
+    #[test]
+    fn exactly_one_crumb_is_active_and_it_is_the_file_name() {
+        let crumbs = breadcrumb_crumbs(
+            Path::new("src/db/query_builder.rs"),
+            &symbol_path_at_marker("let marker = 1;"),
+        );
+        let active: Vec<&str> = crumbs
+            .iter()
+            .filter(|crumb| crumb.active)
+            .map(|crumb| crumb.text.as_str())
+            .collect();
+        assert_eq!(active, vec!["query_builder.rs"]);
+    }
+
+    #[test]
+    fn moving_the_caret_really_changes_the_rendered_crumb_list() {
+        let inside = breadcrumb_crumbs(
+            Path::new("src/db/query_builder.rs"),
+            &symbol_path_at_marker("let marker = 1;"),
+        );
+        // Between `mod db {` and the `impl` that follows it: inside the module, inside nothing
+        // else - so the breadcrumb genuinely sheds two crumbs.
+        let outside = breadcrumb_crumbs(
+            Path::new("src/db/query_builder.rs"),
+            &symbol_path_at_marker("mod db {"),
+        );
+        let texts = |crumbs: &[Crumb]| -> Vec<String> {
+            crumbs.iter().map(|crumb| crumb.text.clone()).collect()
+        };
+        assert_eq!(
+            texts(&outside),
+            vec!["src", "db", "query_builder.rs", "mod db"]
+        );
+        assert_ne!(texts(&inside), texts(&outside));
+    }
+
+    #[test]
+    fn with_no_symbol_path_the_breadcrumb_is_exactly_the_path_it_always_was() {
+        let crumbs = breadcrumb_crumbs(Path::new("Cargo.toml"), &[]);
+        let texts: Vec<&str> = crumbs.iter().map(|crumb| crumb.text.as_str()).collect();
+        assert_eq!(texts, vec!["Cargo.toml"]);
+        assert!(crumbs[0].active);
+    }
+
+    #[test]
+    fn a_clean_file_draws_no_count_dots_at_all() {
+        assert!(diagnostic_count_dot(diagnostics_view::Severity::Error, 0).is_none());
+        assert!(diagnostic_count_dot(diagnostics_view::Severity::Warning, 0).is_none());
+        assert!(diagnostic_count_dot(diagnostics_view::Severity::Error, 1).is_some());
+    }
+
+    /// The counts the band draws come straight off `LspFileStatus::Analyzed`, which
+    /// `crate::lsp::client::lsp_file_status` builds with
+    /// `diagnostics_view::count_errors_and_warnings` - so this drives real `lsp_types::
+    /// Diagnostic` values through that same real counting function and checks the pair the
+    /// breadcrumb would be handed.
+    #[test]
+    fn the_breadcrumb_counts_come_from_a_real_diagnostics_list() {
+        let diagnostics = vec![
+            severity_diagnostic(lsp_core::lsp_types::DiagnosticSeverity::ERROR),
+            severity_diagnostic(lsp_core::lsp_types::DiagnosticSeverity::WARNING),
+            severity_diagnostic(lsp_core::lsp_types::DiagnosticSeverity::WARNING),
+            severity_diagnostic(lsp_core::lsp_types::DiagnosticSeverity::HINT),
+        ];
+        let (errors, warnings) = diagnostics_view::count_errors_and_warnings(&diagnostics);
+        let status = LspFileStatus::Analyzed { errors, warnings };
+        let counts = match &status {
+            LspFileStatus::Analyzed { errors, warnings } => Some((*errors, *warnings)),
+            _ => None,
+        };
+        assert_eq!(
+            counts,
+            Some((1, 2)),
+            "one error and two warnings, with the hint counted as neither"
+        );
+    }
+
+    fn severity_diagnostic(
+        severity: lsp_core::lsp_types::DiagnosticSeverity,
+    ) -> lsp_core::lsp_types::Diagnostic {
+        lsp_core::lsp_types::Diagnostic {
+            range: lsp_core::lsp_types::Range {
+                start: lsp_core::lsp_types::Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: lsp_core::lsp_types::Position {
+                    line: 0,
+                    character: 4,
+                },
+            },
+            severity: Some(severity),
+            ..Default::default()
+        }
+    }
 }
 
 /// Bundles [`render_file_view_line`]'s two hover-state parameters to keep that function's

--- a/crates/app/src/code_surface/mod.rs
+++ b/crates/app/src/code_surface/mod.rs
@@ -69,6 +69,7 @@ pub mod blame;
 pub mod code_view;
 pub mod edit_buffer;
 pub mod indent;
+pub mod symbols;
 
 pub(crate) mod blame_view;
 pub(crate) mod diff_view;

--- a/crates/app/src/code_surface/symbols.rs
+++ b/crates/app/src/code_surface/symbols.rs
@@ -1,0 +1,625 @@
+//! The File view breadcrumb's **symbol path** - the real chain of enclosing declarations around
+//! wherever the caret currently sits (`design_handoff_jerry_ade/README.md`: "Breadcrumb 26
+//! (`src › db › query_builder.rs › impl QueryBuilder › build`, ...)").
+//!
+//! GitHub issue #178: the breadcrumb band used to render only `code_view::breadcrumb_segments`'
+//! path components, which the Surface C toolbar directly above it already shows - a literal
+//! duplicate. This module supplies the half that was missing.
+//!
+//! ## Why a flat span list rather than a retained `tree_sitter::Tree`
+//!
+//! The obvious implementation is to keep the parsed tree alive and, on every caret move, call
+//! `Node::descendant_for_byte_range(offset, offset)` and walk `parent()` upwards. That is
+//! genuinely cheaper per lookup, and it is deliberately not what this does. A retained tree is
+//! only valid against the exact source text it was parsed from, so it would have to be kept in
+//! lockstep with `crate::code_surface::edit_buffer::EditBuffer::content` through every splice -
+//! and `EditBuffer` is cloned, snapshotted and compared in several places that have no business
+//! knowing about grammar lifetimes.
+//!
+//! [`symbol_outline`] instead flattens the tree **once per parse**, on the same background
+//! executor that already re-highlights the file, into plain owned data: a preorder list of
+//! `(byte range, label)`. Looking a caret up in it ([`symbol_path_at`]) is a linear scan over a
+//! few hundred entries - far below a frame budget, measured against nothing more exotic than the
+//! fact that this file's own outline has 40-odd entries. Plain data also means the outline can be
+//! unit-tested against real parses with no GPUI window and no `EditBuffer` at all, which is what
+//! this module's own tests do.
+//!
+//! ## Staleness while typing
+//!
+//! The outline is recomputed by `crate::code_surface::editing::AdeApp::schedule_rehighlight`,
+//! i.e. 150ms after the last keystroke, exactly like the syntax highlighting it rides along with.
+//! Between an edit and that refresh, the stored byte ranges describe the *pre-edit* text: spans
+//! that start after the caret are shifted by the edit's own delta. This is deliberate and is not
+//! hidden - the enclosing chain at the caret is built from spans whose `start` is *before* the
+//! edit (so still correct) and whose `end` may be off by the edit's length, which can only matter
+//! in the narrow window where the caret sits within that many bytes of a symbol's closing
+//! boundary. The alternative - clearing the outline on every keystroke - would make the
+//! breadcrumb blink empty while typing, which is a worse lie than being 150ms behind.
+//!
+//! ## Which languages are covered, and why not all of them
+//!
+//! Rust, TypeScript/TSX (and therefore `.js`/`.jsx`, which this app parses with the TypeScript
+//! grammars - see `code_view::Grammar::for_extension`), Python and Go. Those are the languages
+//! whose "what is an enclosing declaration" node kinds were each read out of the grammar's own
+//! bundled `src/node-types.json` in the pinned crate on disk, field names included, and are
+//! asserted by real parses in this module's tests.
+//!
+//! C is deliberately absent despite being a supported highlight grammar: `tree-sitter-c`'s
+//! `function_definition` has no `name` field at all (its fields are `declarator`/`type`, checked
+//! in `tree-sitter-c-0.24.2/src/node-types.json`), so producing `foo` from `static int *foo(void)`
+//! means walking down through `pointer_declarator`/`function_declarator` by hand - real work with
+//! its own failure modes, and no shared abstraction with the four languages here. TOML, JSON,
+//! YAML, Markdown, HTML and CSS have no enclosing *symbol* concept worth a breadcrumb crumb at
+//! all. For any of those, [`symbol_outline`] returns an empty outline and the breadcrumb honestly
+//! shows the path alone.
+
+use std::ops::Range;
+
+use tree_sitter::{Node, Parser};
+
+use crate::code_surface::code_view::Grammar;
+
+/// One enclosing declaration found in a real parse: the byte range it spans in the source it was
+/// parsed from, and the crumb text the breadcrumb renders for it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SymbolSpan {
+    /// Half-open, exactly `tree_sitter::Node::byte_range()` - see [`symbol_path_at`] for why the
+    /// half-open end matters for a caret parked on a closing brace.
+    pub byte_range: Range<usize>,
+    /// What the breadcrumb shows: `build`, `impl QueryBuilder`, `class Foo`, `mod db`, ...
+    pub label: String,
+}
+
+/// Which of the four languages with real enclosing-declaration support a [`Grammar`] maps to.
+/// Separate from [`Grammar`] itself so the "is there a symbol outline for this file" answer is a
+/// single exhaustive `match` that a newly added grammar cannot silently fall through.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SymbolLanguage {
+    Rust,
+    /// Both `tree-sitter-typescript` grammars (`typescript` and `tsx`). Their declaration node
+    /// kinds are the same set - the TSX grammar is the TypeScript one plus JSX expressions - so
+    /// one label extractor serves both, which is why `Grammar::TypeScript` and `Grammar::Tsx`
+    /// both land here.
+    TypeScript,
+    Python,
+    Go,
+}
+
+impl SymbolLanguage {
+    /// `None` for every grammar this module deliberately does not cover - see this module's own
+    /// docs for the per-language reasoning. Exhaustive on purpose (no `_` arm): adding a grammar
+    /// to [`Grammar`] must force a decision here rather than silently defaulting to "no symbols".
+    fn for_grammar(grammar: Grammar) -> Option<Self> {
+        match grammar {
+            Grammar::Rust => Some(SymbolLanguage::Rust),
+            Grammar::TypeScript | Grammar::Tsx => Some(SymbolLanguage::TypeScript),
+            Grammar::Python => Some(SymbolLanguage::Python),
+            Grammar::Go => Some(SymbolLanguage::Go),
+            Grammar::C
+            | Grammar::Toml
+            | Grammar::Json
+            | Grammar::Yaml
+            | Grammar::Markdown
+            | Grammar::MarkdownInline
+            | Grammar::Html
+            | Grammar::Css => None,
+        }
+    }
+}
+
+/// Parses `source` with the grammar `extension` maps to and flattens every enclosing declaration
+/// in it into a preorder (outermost first) [`SymbolSpan`] list.
+///
+/// Empty - never a fabricated placeholder - when `extension` has no grammar at all, has a grammar
+/// this module doesn't cover, or the parse itself fails. The empty case is what the breadcrumb
+/// renders as "path segments only", which is the honest rendering for a file whose language has
+/// no symbol nesting to report.
+///
+/// Runs a real `tree_sitter::Parser::parse` (~16ms on this repository's largest file, measured in
+/// `code_view`'s own module docs), so every production caller runs it on
+/// `cx.background_executor()`, never in a render pass.
+pub fn symbol_outline(source: &str, extension: Option<&str>) -> Vec<SymbolSpan> {
+    let Some(grammar) = extension.and_then(Grammar::for_extension) else {
+        return Vec::new();
+    };
+    let Some(language) = SymbolLanguage::for_grammar(grammar) else {
+        return Vec::new();
+    };
+
+    let mut parser = Parser::new();
+    if parser.set_language(&grammar.language()).is_err() {
+        return Vec::new();
+    }
+    let Some(tree) = parser.parse(source, None) else {
+        return Vec::new();
+    };
+
+    let mut spans = Vec::new();
+    collect(tree.root_node(), source, language, &mut spans);
+    spans
+}
+
+/// Preorder walk: a node's own crumb (if it has one) is pushed before its children's, so the
+/// resulting list is already outermost-first for any nested chain - which is exactly the order
+/// [`symbol_path_at`] hands to the breadcrumb, with no sorting pass.
+fn collect(node: Node, source: &str, language: SymbolLanguage, spans: &mut Vec<SymbolSpan>) {
+    if let Some(label) = label_for(node, source, language) {
+        spans.push(SymbolSpan {
+            byte_range: node.byte_range(),
+            label,
+        });
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect(child, source, language, spans);
+    }
+}
+
+/// The real crumb chain enclosing `offset`, outermost first - `["impl QueryBuilder", "build"]` for
+/// a caret inside `QueryBuilder::build`.
+///
+/// Containment is **half-open** (`start <= offset < end`), matching `tree_sitter`'s own
+/// `descendant_for_byte_range` convention: a caret parked immediately *after* a function's closing
+/// brace is genuinely outside that function, and reporting it as still inside would be a visible
+/// lie the moment the user arrows past the brace.
+pub fn symbol_path_at(spans: &[SymbolSpan], offset: usize) -> Vec<&str> {
+    spans
+        .iter()
+        .filter(|span| span.byte_range.start <= offset && offset < span.byte_range.end)
+        .map(|span| span.label.as_str())
+        .collect()
+}
+
+/// The crumb for `node`, or `None` if it isn't an enclosing declaration in `language`.
+fn label_for(node: Node, source: &str, language: SymbolLanguage) -> Option<String> {
+    if !node.is_named() {
+        return None;
+    }
+    match language {
+        SymbolLanguage::Rust => rust_label(node, source),
+        SymbolLanguage::TypeScript => typescript_label(node, source),
+        SymbolLanguage::Python => python_label(node, source),
+        SymbolLanguage::Go => go_label(node, source),
+    }
+}
+
+/// `node`'s `field`-named child rendered as source text, or `None` when the field is absent (every
+/// one of these fields is optional in at least one real shape - `impl_item` has no `trait` for an
+/// inherent impl, `function_expression` has no `name` for an anonymous one).
+fn field_text<'a>(node: Node, source: &'a str, field: &str) -> Option<&'a str> {
+    node.child_by_field_name(field)?
+        .utf8_text(source.as_bytes())
+        .ok()
+}
+
+/// Node kinds and field names read from `tree-sitter-rust-0.24.2/src/node-types.json`:
+/// `function_item`/`function_signature_item`/`mod_item`/`struct_item`/`enum_item`/`union_item`/
+/// `trait_item`/`macro_definition` all carry a `name` field; `impl_item` carries `type` and an
+/// optional `trait` (and no `name` at all), which is why it is the one kind assembled by hand.
+fn rust_label(node: Node, source: &str) -> Option<String> {
+    match node.kind() {
+        "function_item" | "function_signature_item" => {
+            field_text(node, source, "name").map(str::to_string)
+        }
+        "impl_item" => {
+            let type_name = field_text(node, source, "type")?;
+            Some(match field_text(node, source, "trait") {
+                Some(trait_name) => format!("impl {trait_name} for {type_name}"),
+                None => format!("impl {type_name}"),
+            })
+        }
+        "trait_item" => field_text(node, source, "name").map(|name| format!("trait {name}")),
+        "mod_item" => field_text(node, source, "name").map(|name| format!("mod {name}")),
+        "struct_item" => field_text(node, source, "name").map(|name| format!("struct {name}")),
+        "enum_item" => field_text(node, source, "name").map(|name| format!("enum {name}")),
+        "union_item" => field_text(node, source, "name").map(|name| format!("union {name}")),
+        "macro_definition" => field_text(node, source, "name").map(|name| format!("{name}!")),
+        _ => None,
+    }
+}
+
+/// Node kinds and field names read from `tree-sitter-typescript-0.23.2/typescript/src/
+/// node-types.json`. Note `class` and `class_declaration` are two genuinely different kinds there
+/// (a class *expression* versus a statement), both with a `name` field, and both are covered.
+///
+/// `arrow_function` has no `name` field at all, so `const handler = () => {}` and a class's
+/// `handler = () => {}` field are resolved through the parent that *does* name them -
+/// `variable_declarator` (fields `name`/`type`/`value`) and `public_field_definition` (fields
+/// `decorator`/`name`/`type`/`value`) respectively. An arrow function with neither parent (an
+/// inline callback) genuinely has no name and contributes no crumb, rather than an invented one.
+fn typescript_label(node: Node, source: &str) -> Option<String> {
+    match node.kind() {
+        "class_declaration" | "abstract_class_declaration" | "class" => {
+            field_text(node, source, "name").map(|name| format!("class {name}"))
+        }
+        "interface_declaration" => {
+            field_text(node, source, "name").map(|name| format!("interface {name}"))
+        }
+        "enum_declaration" => field_text(node, source, "name").map(|name| format!("enum {name}")),
+        "internal_module" => {
+            field_text(node, source, "name").map(|name| format!("namespace {name}"))
+        }
+        "module" => field_text(node, source, "name").map(|name| format!("module {name}")),
+        "function_declaration" | "generator_function_declaration" | "method_definition" => {
+            field_text(node, source, "name").map(str::to_string)
+        }
+        "function_expression" | "arrow_function" => field_text(node, source, "name")
+            .map(str::to_string)
+            .or_else(|| named_by_enclosing_binding(node, source)),
+        _ => None,
+    }
+}
+
+/// The name a `variable_declarator`/`public_field_definition` parent gives an otherwise-anonymous
+/// function value. Only the *direct* parent is consulted: `const a = foo(() => {})` must not
+/// borrow `a`'s name for the inner callback, and it doesn't, because that callback's parent is an
+/// `arguments` node, not a declarator.
+fn named_by_enclosing_binding(node: Node, source: &str) -> Option<String> {
+    let parent = node.parent()?;
+    match parent.kind() {
+        "variable_declarator" | "public_field_definition" => {
+            field_text(parent, source, "name").map(str::to_string)
+        }
+        _ => None,
+    }
+}
+
+/// Node kinds and field names read from `tree-sitter-python-0.25.0/src/node-types.json`:
+/// `function_definition` and `class_definition` both carry a `name` field. `decorated_definition`
+/// wraps them rather than replacing them, so a decorated function is still reached as its own
+/// `function_definition` child by the walk in [`collect`] and needs no special case.
+fn python_label(node: Node, source: &str) -> Option<String> {
+    match node.kind() {
+        "function_definition" => field_text(node, source, "name").map(str::to_string),
+        "class_definition" => field_text(node, source, "name").map(|name| format!("class {name}")),
+        _ => None,
+    }
+}
+
+/// Node kinds and field names read from `tree-sitter-go-0.25.0/src/node-types.json`:
+/// `function_declaration` (fields include `name`), `method_declaration` (also `receiver`) and
+/// `type_spec` (field `name`; it is the child of `type_declaration`, which carries no fields of
+/// its own, so the crumb hangs off the spec).
+///
+/// A method's crumb is its bare name, not `(*T) Name`: the receiver field's own source text is
+/// the whole parameter list (`(b *QueryBuilder)`), and picking the type out of it means parsing a
+/// second declarator shape for one cosmetic gain. Go has no lexical nesting of declarations
+/// anyway, so a method crumb never appears beside a type crumb the way Rust's `impl` does.
+fn go_label(node: Node, source: &str) -> Option<String> {
+    match node.kind() {
+        "function_declaration" | "method_declaration" => {
+            field_text(node, source, "name").map(str::to_string)
+        }
+        "type_spec" => field_text(node, source, "name").map(|name| format!("type {name}")),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod symbol_outline_tests {
+    use super::*;
+
+    /// The byte offset just after the first occurrence of `needle` in `source` - how every test
+    /// below places a caret at a real position in real source text rather than a magic number.
+    fn offset_after(source: &str, needle: &str) -> usize {
+        source.find(needle).expect("needle present in source") + needle.len()
+    }
+
+    fn path_at(source: &str, extension: &str, needle: &str) -> Vec<String> {
+        let spans = symbol_outline(source, Some(extension));
+        let offset = offset_after(source, needle);
+        symbol_path_at(&spans, offset)
+            .into_iter()
+            .map(str::to_string)
+            .collect()
+    }
+
+    const RUST_SOURCE: &str = r#"
+mod db {
+    pub struct QueryBuilder {
+        projection: Vec<String>,
+    }
+
+    impl QueryBuilder {
+        pub fn select(mut self, cols: &[&str]) -> Self {
+            self.projection.extend(cols.iter().map(|c| c.to_string()));
+            self
+        }
+
+        pub fn build(&self) -> String {
+            let marker_inside_build = 1;
+            String::new()
+        }
+    }
+
+    impl Default for QueryBuilder {
+        fn default() -> Self {
+            Self { projection: Vec::new() }
+        }
+    }
+}
+
+fn free_standing() {
+    let marker_inside_free = 2;
+}
+"#;
+
+    #[test]
+    fn a_caret_inside_a_real_rust_method_reports_the_designs_own_mod_impl_fn_chain() {
+        assert_eq!(
+            path_at(RUST_SOURCE, "rs", "marker_inside_build"),
+            vec!["mod db", "impl QueryBuilder", "build"],
+        );
+    }
+
+    #[test]
+    fn moving_the_caret_to_a_sibling_method_really_changes_the_last_crumb() {
+        let spans = symbol_outline(RUST_SOURCE, Some("rs"));
+        let in_build = offset_after(RUST_SOURCE, "marker_inside_build");
+        let in_select = offset_after(RUST_SOURCE, "self.projection.extend");
+        assert_eq!(
+            symbol_path_at(&spans, in_build),
+            vec!["mod db", "impl QueryBuilder", "build"],
+        );
+        assert_eq!(
+            symbol_path_at(&spans, in_select),
+            vec!["mod db", "impl QueryBuilder", "select"],
+        );
+    }
+
+    #[test]
+    fn moving_the_caret_out_of_every_declaration_really_empties_the_symbol_path() {
+        let spans = symbol_outline(RUST_SOURCE, Some("rs"));
+        // The very first byte of the file: before `mod db` starts, so genuinely inside nothing.
+        assert!(symbol_path_at(&spans, 0).is_empty());
+        // Inside a free function at the file's top level: exactly one crumb, no `mod`.
+        assert_eq!(
+            symbol_path_at(&spans, offset_after(RUST_SOURCE, "marker_inside_free")),
+            vec!["free_standing"],
+        );
+    }
+
+    #[test]
+    fn a_rust_trait_impl_names_both_the_trait_and_the_type() {
+        assert_eq!(
+            path_at(RUST_SOURCE, "rs", "Self { projection"),
+            vec!["mod db", "impl Default for QueryBuilder", "default"],
+        );
+    }
+
+    #[test]
+    fn a_caret_inside_a_rust_struct_body_reports_the_struct_crumb() {
+        assert_eq!(
+            path_at(RUST_SOURCE, "rs", "projection: Vec<String>"),
+            vec!["mod db", "struct QueryBuilder"],
+        );
+    }
+
+    #[test]
+    fn a_caret_immediately_after_a_functions_closing_brace_is_outside_it() {
+        let source = "fn a() {\n    let x = 1;\n}\nfn b() {}\n";
+        let spans = symbol_outline(source, Some("rs"));
+        let inside = offset_after(source, "let x = 1;");
+        assert_eq!(symbol_path_at(&spans, inside), vec!["a"]);
+        // `fn a`'s node ends exactly at its closing brace; one byte past it is the newline
+        // between the two functions, which belongs to neither.
+        let after_brace = source.find("}\nfn b").expect("closing brace") + 1;
+        assert!(
+            symbol_path_at(&spans, after_brace).is_empty(),
+            "a caret past the closing brace must report no enclosing symbol"
+        );
+    }
+
+    #[test]
+    fn a_rust_trait_and_its_default_method_both_appear() {
+        let source = "trait Query {\n    fn run(&self) -> usize {\n        7\n    }\n}\n";
+        assert_eq!(
+            path_at(source, "rs", "        7"),
+            vec!["trait Query", "run"]
+        );
+    }
+
+    const TYPESCRIPT_SOURCE: &str = r#"
+namespace db {
+  export class QueryBuilder {
+    private projection: string[] = [];
+
+    build(): string {
+      const markerInsideBuild = 1;
+      return "";
+    }
+
+    reset = () => {
+      const markerInsideReset = 2;
+    };
+  }
+
+  export interface Query {
+    run(): number;
+  }
+}
+
+const handler = (event: string) => {
+  const markerInsideHandler = 3;
+};
+
+function freeStanding() {
+  const markerInsideFree = 4;
+}
+"#;
+
+    #[test]
+    fn a_caret_inside_a_real_typescript_method_reports_namespace_class_and_method() {
+        assert_eq!(
+            path_at(TYPESCRIPT_SOURCE, "ts", "markerInsideBuild"),
+            vec!["namespace db", "class QueryBuilder", "build"],
+        );
+    }
+
+    #[test]
+    fn a_typescript_arrow_function_borrows_the_name_of_whatever_binds_it() {
+        assert_eq!(
+            path_at(TYPESCRIPT_SOURCE, "ts", "markerInsideHandler"),
+            vec!["handler"],
+        );
+        assert_eq!(
+            path_at(TYPESCRIPT_SOURCE, "ts", "markerInsideReset"),
+            vec!["namespace db", "class QueryBuilder", "reset"],
+        );
+    }
+
+    #[test]
+    fn a_typescript_interface_is_a_real_crumb() {
+        assert_eq!(
+            path_at(TYPESCRIPT_SOURCE, "ts", "run(): number;"),
+            vec!["namespace db", "interface Query"],
+        );
+    }
+
+    #[test]
+    fn an_anonymous_inline_callback_contributes_no_invented_crumb() {
+        // `rows` binds a *call expression*, not a function, so it is not a declaration at all -
+        // and the arrow function's own parent is the call's `arguments` node, not a declarator.
+        // Both halves must stay silent: borrowing `rows` for this callback would put a caret
+        // inside an inline lambda under a crumb that names something it isn't.
+        let source = "const rows = items.map((item) => {\n  return item.id;\n});\n";
+        assert!(path_at(source, "ts", "return item.id;").is_empty());
+        // The contrast case, proving the silence above is about *this* shape and not about arrow
+        // functions generally: bind the same arrow directly and it does get its binding's name.
+        let bound = "const pick = (item) => {\n  return item.id;\n};\n";
+        assert_eq!(path_at(bound, "ts", "return item.id;"), vec!["pick"]);
+    }
+
+    #[test]
+    fn tsx_uses_the_same_declaration_kinds_as_plain_typescript() {
+        let source = "export function Panel() {\n  const label = 1;\n  return <div />;\n}\n";
+        assert_eq!(path_at(source, "tsx", "const label = 1;"), vec!["Panel"]);
+    }
+
+    #[test]
+    fn a_javascript_file_is_parsed_with_the_typescript_grammar_and_still_gets_crumbs() {
+        let source = "class Widget {\n  render() {\n    const inner = 1;\n  }\n}\n";
+        assert_eq!(
+            path_at(source, "js", "const inner = 1;"),
+            vec!["class Widget", "render"],
+        );
+    }
+
+    const PYTHON_SOURCE: &str = r#"
+class QueryBuilder:
+    def build(self):
+        marker_inside_build = 1
+        return ""
+
+    @staticmethod
+    def decorated():
+        marker_inside_decorated = 2
+
+
+def free_standing():
+    def nested():
+        marker_inside_nested = 3
+    return nested
+"#;
+
+    #[test]
+    fn a_caret_inside_a_real_python_method_reports_class_and_method() {
+        assert_eq!(
+            path_at(PYTHON_SOURCE, "py", "marker_inside_build"),
+            vec!["class QueryBuilder", "build"],
+        );
+    }
+
+    #[test]
+    fn a_decorated_python_method_is_still_reached_through_its_own_definition_node() {
+        assert_eq!(
+            path_at(PYTHON_SOURCE, "py", "marker_inside_decorated"),
+            vec!["class QueryBuilder", "decorated"],
+        );
+    }
+
+    #[test]
+    fn a_python_function_nested_in_another_function_reports_both() {
+        assert_eq!(
+            path_at(PYTHON_SOURCE, "py", "marker_inside_nested"),
+            vec!["free_standing", "nested"],
+        );
+    }
+
+    const GO_SOURCE: &str = r#"
+package db
+
+type QueryBuilder struct {
+	projection []string
+}
+
+func (b *QueryBuilder) Build() string {
+	markerInsideBuild := 1
+	return ""
+}
+
+func FreeStanding() {
+	markerInsideFree := 2
+}
+"#;
+
+    #[test]
+    fn a_caret_inside_a_real_go_method_reports_the_method_name() {
+        assert_eq!(path_at(GO_SOURCE, "go", "markerInsideBuild"), vec!["Build"]);
+        assert_eq!(
+            path_at(GO_SOURCE, "go", "markerInsideFree"),
+            vec!["FreeStanding"],
+        );
+    }
+
+    #[test]
+    fn a_go_struct_type_is_a_real_crumb() {
+        assert_eq!(
+            path_at(GO_SOURCE, "go", "projection []string"),
+            vec!["type QueryBuilder"],
+        );
+    }
+
+    #[test]
+    fn a_language_without_symbol_support_yields_an_empty_outline_rather_than_a_guess() {
+        // Real TOML/JSON/Markdown sources, all of which this app really does highlight - they
+        // just have no enclosing-declaration concept, so the breadcrumb shows the path alone.
+        assert!(symbol_outline("[package]\nname = \"ade\"\n", Some("toml")).is_empty());
+        assert!(symbol_outline("{\"a\": 1}\n", Some("json")).is_empty());
+        assert!(symbol_outline("# Heading\n\ntext\n", Some("md")).is_empty());
+    }
+
+    #[test]
+    fn an_unknown_or_absent_extension_yields_an_empty_outline() {
+        assert!(symbol_outline("SELECT 1;\n", Some("sql")).is_empty());
+        assert!(symbol_outline("fn main() {}\n", None).is_empty());
+    }
+
+    #[test]
+    fn malformed_source_still_produces_whatever_really_parsed_rather_than_panicking() {
+        // Tree-sitter always yields a best-effort tree; the complete function before the broken
+        // tail is genuinely there, so it is genuinely reported.
+        let source = "fn good() {\n    let x = 1;\n}\n\nfn bad( {{{\n";
+        let spans = symbol_outline(source, Some("rs"));
+        assert_eq!(
+            symbol_path_at(&spans, offset_after(source, "let x = 1;")),
+            vec!["good"],
+        );
+    }
+
+    #[test]
+    fn the_outline_is_preorder_so_the_reported_chain_is_outermost_first() {
+        let spans = symbol_outline(RUST_SOURCE, Some("rs"));
+        let labels: Vec<&str> = spans.iter().map(|span| span.label.as_str()).collect();
+        let mod_index = labels.iter().position(|l| *l == "mod db").expect("mod db");
+        let impl_index = labels
+            .iter()
+            .position(|l| *l == "impl QueryBuilder")
+            .expect("impl QueryBuilder");
+        let fn_index = labels.iter().position(|l| *l == "build").expect("build");
+        assert!(
+            mod_index < impl_index && impl_index < fn_index,
+            "preorder walk must emit enclosing declarations before enclosed ones, got {labels:?}"
+        );
+    }
+}

--- a/crates/app/src/code_surface/tabs.rs
+++ b/crates/app/src/code_surface/tabs.rs
@@ -531,12 +531,24 @@ impl AdeApp {
                 .background_executor()
                 .spawn({
                     let path = path.clone();
-                    async move { code_view::load_file_with_source(&path) }
+                    let extension = extension.clone();
+                    // GitHub issue #178: the File view breadcrumb's enclosing-symbol outline is a
+                    // second real `tree_sitter::Parser::parse` of the same source, so it runs
+                    // here - on the same background executor, off the back of the same decode -
+                    // rather than on the foreground thread once this task resumes. See
+                    // `code_surface::symbols`' own docs for why the outline is flattened to plain
+                    // data at this point instead of a tree being carried across the await.
+                    async move {
+                        code_view::load_file_with_source(&path).map(|(parsed, source)| {
+                            let symbols = symbols::symbol_outline(&source, extension.as_deref());
+                            (parsed, source, symbols)
+                        })
+                    }
                 })
                 .await;
             let _ = this.update(cx, |this, cx| {
                 match result {
-                    Ok((parsed, source)) => {
+                    Ok((parsed, source, symbols)) => {
                         // Lazily seed a real edit buffer the first time this file is opened in
                         // File view - never overwrite an existing entry (which may hold real
                         // unsaved edits and a live cursor/selection); see `Self::edit_buffers`'
@@ -604,6 +616,7 @@ impl AdeApp {
                                     buffer.reload_from_disk(
                                         source,
                                         parsed.lines.clone(),
+                                        symbols,
                                         parsed.mtime,
                                         parsed.len,
                                     );
@@ -644,6 +657,7 @@ impl AdeApp {
                                             source,
                                             extension.clone(),
                                             parsed.lines.clone(),
+                                            symbols,
                                             parsed.mtime,
                                             parsed.len,
                                         ),

--- a/crates/app/src/lsp/client.rs
+++ b/crates/app/src/lsp/client.rs
@@ -1944,20 +1944,10 @@ pub(crate) fn lsp_file_status(
         return LspFileStatus::Indexing;
     }
     let diagnostics = connection.diagnostics_for_uri(uri).unwrap_or_default();
-    let errors = diagnostics
-        .iter()
-        .filter(|diagnostic| {
-            diagnostics_view::Severity::from_lsp(diagnostic.severity)
-                == diagnostics_view::Severity::Error
-        })
-        .count();
-    let warnings = diagnostics
-        .iter()
-        .filter(|diagnostic| {
-            diagnostics_view::Severity::from_lsp(diagnostic.severity)
-                == diagnostics_view::Severity::Warning
-        })
-        .count();
+    // One shared implementation with the breadcrumb's own counts (GitHub issue #178) - see
+    // `diagnostics_view::count_errors_and_warnings`' docs for why counting must not go through
+    // the per-line index.
+    let (errors, warnings) = diagnostics_view::count_errors_and_warnings(&diagnostics);
     LspFileStatus::Analyzed { errors, warnings }
 }
 

--- a/crates/app/src/lsp/diagnostics.rs
+++ b/crates/app/src/lsp/diagnostics.rs
@@ -102,6 +102,33 @@ fn number_or_string_to_string(code: &lsp_types::NumberOrString) -> String {
     }
 }
 
+/// The real error and warning counts (in that order) over a raw published diagnostics list.
+///
+/// Counted **per diagnostic**, straight off `lsp_types::Diagnostic::severity`, which is why this
+/// exists as its own function rather than being derived from [`index_diagnostics_by_line`]'s
+/// output: that index deliberately records a multi-line diagnostic on *every* line it touches, so
+/// counting it would report one three-line error as three. `crate::root::AdeApp::
+/// file_view_error_count`'s own docs already flag that trap; this is the single implementation
+/// both the File view footer's `N errors, M warnings` label and (GitHub issue #178) the
+/// breadcrumb's right-hand error/warning counts ultimately read, through
+/// `crate::lsp::client::lsp_file_status`.
+///
+/// `Information`/`Hint` are counted as neither - they are real diagnostics, but the design's
+/// breadcrumb and status-bar treatments only define an error and a warning slot, and folding a
+/// hint into either would overstate how bad the file is.
+pub fn count_errors_and_warnings(diagnostics: &[lsp_types::Diagnostic]) -> (usize, usize) {
+    let mut errors = 0;
+    let mut warnings = 0;
+    for diagnostic in diagnostics {
+        match Severity::from_lsp(diagnostic.severity) {
+            Severity::Error => errors += 1,
+            Severity::Warning => warnings += 1,
+            Severity::Information | Severity::Hint => {}
+        }
+    }
+    (errors, warnings)
+}
+
 /// Builds a per-line (1-based, matching `code_view`/`crate::root`'s convention) index of every
 /// diagnostic that touches at least one line of `lines`. A diagnostic whose range spans multiple
 /// lines is recorded on *every* line it touches, clipped to each line's own bounds (from the
@@ -273,6 +300,66 @@ mod tests {
             tags: None,
             data: None,
         }
+    }
+
+    /// Same shape as [`diagnostic`], but with a caller-chosen severity - the counting tests below
+    /// need real `WARNING`/`HINT` values, not the `ERROR` that helper hardcodes.
+    fn diagnostic_with_severity(
+        severity: lsp_types::DiagnosticSeverity,
+        start_line: u32,
+        end_line: u32,
+    ) -> lsp_types::Diagnostic {
+        let mut diagnostic = diagnostic(start_line, 0, end_line, 4, "boom");
+        diagnostic.severity = Some(severity);
+        diagnostic
+    }
+
+    #[test]
+    fn count_errors_and_warnings_counts_a_real_mixed_severity_list() {
+        let diagnostics = vec![
+            diagnostic_with_severity(lsp_types::DiagnosticSeverity::ERROR, 0, 0),
+            diagnostic_with_severity(lsp_types::DiagnosticSeverity::WARNING, 1, 1),
+            diagnostic_with_severity(lsp_types::DiagnosticSeverity::WARNING, 2, 2),
+            diagnostic_with_severity(lsp_types::DiagnosticSeverity::HINT, 3, 3),
+            diagnostic_with_severity(lsp_types::DiagnosticSeverity::INFORMATION, 4, 4),
+        ];
+        assert_eq!(count_errors_and_warnings(&diagnostics), (1, 2));
+    }
+
+    #[test]
+    fn count_errors_and_warnings_is_empty_for_an_empty_list() {
+        assert_eq!(count_errors_and_warnings(&[]), (0, 0));
+    }
+
+    #[test]
+    fn a_diagnostic_with_no_severity_at_all_counts_as_a_real_error() {
+        // `Severity::from_lsp` already treats a missing severity as `Error` (rust-analyzer does
+        // send some); the count must agree with that rather than silently dropping it.
+        let mut diagnostic = diagnostic(0, 0, 0, 4, "boom");
+        diagnostic.severity = None;
+        assert_eq!(
+            count_errors_and_warnings(std::slice::from_ref(&diagnostic)),
+            (1, 0)
+        );
+    }
+
+    #[test]
+    fn a_multi_line_diagnostic_is_counted_once_not_once_per_line_it_touches() {
+        // The exact trap `count_errors_and_warnings` exists to avoid: one error spanning four
+        // lines lands on four keys in `index_diagnostics_by_line`, and a count taken from that
+        // index would report four errors for one.
+        let spanning = diagnostic_with_severity(lsp_types::DiagnosticSeverity::ERROR, 0, 3);
+        let lines = ["one", "two", "three", "four"].map(line);
+        let by_line = index_diagnostics_by_line(std::slice::from_ref(&spanning), &lines);
+        assert_eq!(
+            by_line.len(),
+            4,
+            "sanity check: the per-line index really does record this one diagnostic four times"
+        );
+        assert_eq!(
+            count_errors_and_warnings(std::slice::from_ref(&spanning)),
+            (1, 0)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #178

## The duplicate, and why completing it was the right call

The File view stacked two header bands: the Surface C toolbar (directory, file name, change tag, +n/-n, toggles) and, directly below it, a 26px breadcrumb band that rendered `code_view::breadcrumb_segments(relative_path)` and nothing else - i.e. the same directory and file name the toolbar above it already showed. A real, literal duplicate.

The design specifies what the second band is actually for (`design_handoff_jerry_ade/README.md`, and the File view band at `design_handoff_jerry_ade/revision/Jerry.dc.html:405-418`):

> Breadcrumb 26 (`src › db › query_builder.rs › impl QueryBuilder › build`, 10.5px mono, separators `#3d4248`, active crumb `#a9b0b7`) with error/warning counts right.

Both missing halves turned out to be reachable from infrastructure that already exists rather than needing new machinery, so this completes the feature instead of deleting the band:

- the app already parses every open file with tree-sitter and already has a debounced background re-highlight task to hang a second parse off;
- `EditBuffer` already tracks a real caret byte offset, and every caret move already calls `cx.notify()`, so live tracking needed no new data flow;
- the real per-file error/warning counts were already computed by `lsp_file_status` and already displayed in the footer - they just needed reading, not inventing.

## Symbol path

New `crates/app/src/code_surface/symbols.rs`. `symbol_outline(source, extension)` parses with the same grammar the highlighter uses and flattens every enclosing declaration into a preorder `(byte range, label)` list; `symbol_path_at(spans, offset)` returns the enclosing chain for a caret. The breadcrumb evaluates `symbol_path_at(&buffer.symbols, buffer.cursor_offset())` each render, so the suffix really follows the caret.

A flat span list rather than a retained `tree_sitter::Tree`: a tree is only valid against the exact text it was parsed from and would have to be kept in lockstep with `EditBuffer::content` through every splice, whereas plain owned data is trivially unit-testable with no GPUI window at all. Lookup is a linear scan over a few hundred entries.

**Languages covered**, every node kind and field name read out of the pinned grammar crate's own `src/node-types.json` on disk rather than guessed:

| Language | Crumbs |
|---|---|
| Rust | `fn`, `impl T` / `impl Tr for T`, `trait`, `mod`, `struct`, `enum`, `union`, `macro!` |
| TypeScript / TSX (so also `.js`/`.jsx`) | `class`, `interface`, `enum`, `namespace`, `module`, function/method declarations, arrow functions named through the `variable_declarator` / `public_field_definition` that binds them |
| Python | `def`, `class` (decorated definitions included) |
| Go | `func`, methods, `type` |

`tree-sitter-c` is deliberately excluded: its `function_definition` has no `name` field at all (fields are `declarator`/`type`), so a name means walking down through `pointer_declarator`/`function_declarator` by hand, with no shared abstraction with the four above. TOML/JSON/YAML/Markdown/HTML/CSS have no enclosing-symbol concept. All of them return an empty outline and the band honestly shows the path alone - as does a file with no live edit buffer yet.

**Freshness.** The outline rides on the existing 150ms debounced background re-highlight and is installed by `EditBuffer::apply_highlight` under the same content-snapshot guard as the highlighted lines, so the two can never describe different revisions. Fresh loads and external reloads compute it on the same background executor that already decodes and highlights the file - never in a render pass. The staleness window that leaves (identical to the highlighting's) is documented in the module docs rather than papered over.

## Diagnostic counts

The band's right edge draws `● N` groups for errors and warnings, read off the same `LspFileStatus::Analyzed` this frame's footer label is built from, so the two can never disagree. Dot colours come from `diagnostic_underline_color`, the same severity→colour map the in-code dotted underlines use.

The counting moved into `lsp::diagnostics::count_errors_and_warnings` - one implementation shared with `lsp_file_status` - which keeps a multi-line diagnostic from being counted once per line it touches (the trap `AdeApp::file_view_error_count`'s docs already flag). A clean file draws no dots rather than a `0`; a file with no analyzed result draws none at all rather than a fabricated zero.

## Tests

- `code_surface::symbols::symbol_outline_tests` (22): real parses of real Rust/TypeScript/TSX/JS/Python/Go sources asserting the exact crumb chain at a real caret position, that moving the caret to a sibling method really changes the last crumb, that a caret past a closing brace is genuinely outside, `impl Trait for Type`, decorated Python definitions, arrow functions named by their binding, an inline callback contributing no invented crumb, unsupported/unknown languages yielding empty outlines, and malformed source degrading rather than panicking.
- `code_surface::edit_buffer::tests` (5 new): a freshly constructed buffer already holds a real outline; moving the real caret through the exact production expression really changes the reported path; a language with no symbol concept holds an honestly empty outline; a rejected stale highlight leaves the previous outline untouched; an external reload replaces it rather than keeping a stale one.
- `code_surface::file_view::breadcrumb_tests` (6): the band really carries path + symbol chain, exactly one crumb (the file name) is active, moving the caret really changes the rendered crumb list, an empty symbol path degrades to exactly the old path-only band, a clean file draws no dots, and the counts come from a real `lsp_types::Diagnostic` list through the real counting function.
- `lsp::diagnostics::tests` (4 new): mixed-severity counting, empty list, a missing severity counting as an error, and a multi-line diagnostic counted once rather than once per line it touches (with a sanity check that the per-line index really does record it four times).

## Gates

`cargo fmt --all -- --check`, `cargo build --workspace`, `cargo clippy --workspace --all-targets -- -D warnings` and `cargo test --workspace --lib -- --test-threads=1` (1906 passed, 0 failed) are all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)