### PR TITLE
fix(app): markdown links are real links, in the preview and in hovers

### DIFF
--- a/crates/app/src/code_surface/lsp_ui.rs
+++ b/crates/app/src/code_surface/lsp_ui.rs
@@ -1329,13 +1329,54 @@ fn highlighted_signature_lines(
     .collect()
 }
 
+/// One run of [`render_doc_prose`]' output that is not ordinary prose.
+enum DocSpan {
+    /// A JSDoc tag (`@param`, `{@link ...}`) - painted in its own accent colour.
+    Tag(std::ops::Range<usize>),
+    /// A real Markdown inline link - painted as just its visible text, underlined, and genuinely
+    /// clickable (GitHub issue #201).
+    Link(markdown_preview::InlineLinkSpan),
+}
+
+impl DocSpan {
+    fn range(&self) -> std::ops::Range<usize> {
+        match self {
+            DocSpan::Tag(range) => range.clone(),
+            DocSpan::Link(span) => span.markup.clone(),
+        }
+    }
+}
+
+/// GitHub issue #201's hover/completion half: every real Markdown inline link in `doc`, plus every
+/// real JSDoc tag range that doesn't sit inside one, sorted into a single ordered span list.
+///
+/// Links win over tags on overlap, because a link's markup is what actually has to be *replaced*
+/// on screen (its `[...](...)` syntax must stop rendering literally), whereas a tag is only ever
+/// recoloured in place. A real overlap is possible: `[{@link Foo}](https://example.com)`.
+fn doc_spans(doc: &str) -> Vec<DocSpan> {
+    let links = markdown_preview::inline_link_spans(doc);
+    let mut spans: Vec<DocSpan> = code_view::doc_tag_ranges(doc)
+        .into_iter()
+        .filter(|tag| {
+            !links
+                .iter()
+                .any(|link| tag.start < link.markup.end && link.markup.start < tag.end)
+        })
+        .map(DocSpan::Tag)
+        .collect();
+    spans.extend(links.into_iter().map(DocSpan::Link));
+    spans.sort_by_key(|span| span.range().start);
+    spans
+}
+
 /// A doc paragraph's own plain-text body (`HoverRenderModel::doc`/`completion_documentation_text`,
 /// see either's own docs for why this is plain text, not real Markdown, in the first place), with
 /// every real `code_view::doc_tag_ranges` span (`@param`, `{@link ...}`, ...) painted in
 /// `HighlightKind::CommentDocTag`'s own accent colour and a heavier weight - GitHub issue #200's
-/// rendered-side half. `base_color` is every non-tag run's own colour, so the Hover card
-/// (`theme::text::DIM`) and the Completions detail pane (`theme::text::DIMMER`) each keep their own
-/// already-designed doc-paragraph colour for ordinary prose.
+/// rendered-side half - and every real Markdown inline link painted as a real, clickable link
+/// (GitHub issue #201, see [`render_doc_link`]). `base_color` is every ordinary-prose run's own
+/// colour, so the Hover card (`theme::text::DIM`) and the Completions detail pane
+/// (`theme::text::DIMMER`) each keep their own already-designed doc-paragraph colour.
 ///
 /// Shared between the two real places LSP doc prose is rendered as free text, rather than
 /// duplicated - `crate::lsp::completion_popup` calls this directly instead of growing its own
@@ -1348,9 +1389,10 @@ fn highlighted_signature_lines(
 pub(crate) fn render_doc_prose(
     doc: &str,
     base_color: impl Into<gpui::Hsla> + Copy,
+    next_id: &mut usize,
 ) -> gpui::AnyElement {
-    let tag_ranges = code_view::doc_tag_ranges(doc);
-    if tag_ranges.is_empty() {
+    let spans = doc_spans(doc);
+    if spans.is_empty() {
         return div()
             .text_color(base_color)
             .child(doc.to_string())
@@ -1358,28 +1400,34 @@ pub(crate) fn render_doc_prose(
     }
     let mut wrapper = div().flex().flex_wrap();
     let mut cursor = 0;
-    for (index, tag_range) in tag_ranges.into_iter().enumerate() {
-        if tag_range.start > cursor {
+    for span in spans {
+        let range = span.range();
+        if range.start > cursor {
             wrapper = wrapper.child(
                 div()
                     .text_color(base_color)
-                    .child(doc[cursor..tag_range.start].to_string()),
+                    .child(doc[cursor..range.start].to_string()),
             );
         }
-        wrapper = wrapper.child(
-            div()
-                .id(("doc-prose-tag", index))
-                // Lets a real test measure this real tag run's own painted bounds
-                // (`debug_bounds` reads this, not `.id(..)`) - a no-op outside test builds,
-                // matching every other `debug_selector` in this crate.
-                .debug_selector(move || format!("doc-prose-tag-{index}"))
-                .text_color(code_view::color_for_kind(
-                    code_view::HighlightKind::CommentDocTag,
-                ))
-                .font_weight(gpui::FontWeight::MEDIUM)
-                .child(doc[tag_range.clone()].to_string()),
-        );
-        cursor = tag_range.end;
+        wrapper = wrapper.child(match span {
+            DocSpan::Tag(_) => {
+                let index = take_doc_span_id(next_id);
+                div()
+                    .id(("doc-prose-tag", index))
+                    // Lets a real test measure this real tag run's own painted bounds
+                    // (`debug_bounds` reads this, not `.id(..)`) - a no-op outside test builds,
+                    // matching every other `debug_selector` in this crate.
+                    .debug_selector(move || format!("doc-prose-tag-{index}"))
+                    .text_color(code_view::color_for_kind(
+                        code_view::HighlightKind::CommentDocTag,
+                    ))
+                    .font_weight(gpui::FontWeight::MEDIUM)
+                    .child(doc[range.clone()].to_string())
+                    .into_any_element()
+            }
+            DocSpan::Link(link) => render_doc_link(&link, base_color, next_id),
+        });
+        cursor = range.end;
     }
     if cursor < doc.len() {
         wrapper = wrapper.child(
@@ -1389,6 +1437,65 @@ pub(crate) fn render_doc_prose(
         );
     }
     wrapper.into_any_element()
+}
+
+/// Hands out the next card-unique doc-span id - see [`render_doc_link`]'s own docs for why these
+/// have to be unique across the *whole* card rather than per `render_doc_prose` call.
+fn take_doc_span_id(next_id: &mut usize) -> usize {
+    let id = *next_id;
+    *next_id += 1;
+    id
+}
+
+/// One real Markdown link inside an LSP doc body (GitHub issue #201: "In markdown preview but also
+/// other places where we render it"). Before this, a link in a real docstring - `[MDN](https://
+/// developer.mozilla.org/...)`, which is exactly how TypeScript's own lib docs and countless
+/// rustdoc comments cite references - reached the hover card as *literal* `[...](...)` bracket and
+/// paren syntax: `crate::lsp::hover::degrade_markdown_to_plain_text` strips `**`, backticks,
+/// headings and bullets, but has never touched link markup. It now renders as just its visible
+/// text, underlined in the link colour, and really opens.
+///
+/// A plain `div` with `.on_click`, not the [`gpui::InteractiveText`] the Markdown *preview* uses,
+/// because this render site was already built as a `flex_wrap` row of separate `div` runs (see
+/// [`render_doc_prose`]'s own docs) - so a link is just one more run in that row, and no
+/// sub-range hit testing is needed.
+///
+/// `next_id` is threaded from the card's own single counter rather than restarting per call: one
+/// hover card really does call [`render_doc_prose`] many times (description, each `@param` row,
+/// `@returns`, each other tag), and a stateful `.id(..)` element's own state is keyed by its id
+/// path - two links sharing one would be a real, not cosmetic, collision.
+fn render_doc_link(
+    link: &markdown_preview::InlineLinkSpan,
+    base_color: impl Into<gpui::Hsla> + Copy,
+    next_id: &mut usize,
+) -> gpui::AnyElement {
+    let index = take_doc_span_id(next_id);
+    // A destination this app cannot honestly open (a relative path, a bare fragment - see
+    // `markdown_preview::openable_url`) still sheds its literal `[...](...)` syntax, which was the
+    // visible half of the bug, but is painted as ordinary prose rather than advertised as a link.
+    let Some(url) = markdown_preview::openable_url(&link.destination) else {
+        return div()
+            .text_color(base_color)
+            .child(link.text.clone())
+            .into_any_element();
+    };
+    let url = url.to_string();
+    div()
+        .id(("doc-prose-link", index))
+        // Lets a real test measure this real link run's own painted bounds and click it
+        // (`debug_bounds` reads this, not `.id(..)`) - a no-op outside test builds.
+        .debug_selector(move || format!("doc-prose-link-{index}"))
+        .cursor_pointer()
+        .text_color(theme::syntax::LINK)
+        .border_b_1()
+        .border_color(theme::syntax::LINK)
+        .child(link.text.clone())
+        .on_click(move |_event, _window, cx| {
+            // The same real `gpui::App::open_url` the Markdown preview and
+            // `crate::title_bar::menu` open URLs with - one mechanism, not a third copy.
+            cx.open_url(&url);
+        })
+        .into_any_element()
 }
 
 /// A doc body's own real, structured JSDoc rendering (GitHub issue #200: "params/returns/example
@@ -1408,26 +1515,32 @@ pub(crate) fn render_doc_sections(
 ) -> gpui::AnyElement {
     let sections = hover_view::parse_doc_sections(doc);
     let mut column = div().flex().flex_col().gap(px(10.0));
+    // One counter for the whole card - see `render_doc_link`'s own docs for why every interactive
+    // doc span across every section below has to draw its id from the same sequence.
+    let next_id = &mut 0usize;
 
     if let Some(description) = &sections.description {
-        column = column.child(render_doc_prose(description, base_color));
+        column = column.child(render_doc_prose(description, base_color, next_id));
     }
     if !sections.params.is_empty() {
-        column = column.child(render_doc_params_section(&sections.params, base_color));
+        column = column.child(render_doc_params_section(
+            &sections.params,
+            base_color,
+            next_id,
+        ));
     }
     if let Some(returns) = &sections.returns {
-        column = column.child(render_doc_labeled_section(
-            "Returns",
-            render_doc_prose(returns, base_color),
-        ));
+        let body = render_doc_prose(returns, base_color, next_id);
+        column = column.child(render_doc_labeled_section("Returns", body));
     }
     for example in &sections.examples {
         column = column.child(render_doc_example_section(example, extension));
     }
     for (tag, body) in &sections.other {
+        let body = render_doc_prose(body, base_color, next_id);
         column = column.child(render_doc_labeled_section(
             &doc_tag_section_label(tag),
-            render_doc_prose(body, base_color),
+            body,
         ));
     }
 
@@ -1475,6 +1588,7 @@ fn doc_tag_section_label(tag: &str) -> String {
 fn render_doc_params_section(
     params: &[(String, String)],
     base_color: impl Into<gpui::Hsla> + Copy,
+    next_id: &mut usize,
 ) -> gpui::AnyElement {
     let label = if params.len() > 1 {
         "Parameters"
@@ -1502,7 +1616,7 @@ fn render_doc_params_section(
                     .child(name.clone()),
             );
         if !description.is_empty() {
-            row = row.child(render_doc_prose(description, base_color));
+            row = row.child(render_doc_prose(description, base_color, next_id));
         }
         rows = rows.child(row);
     }
@@ -4344,6 +4458,96 @@ mod hover_card_footer_layout_tests {
             "a real click over the hover card must never also reach a real File view row \
              underneath it - the same real hitbox-blocking mechanism a scroll wheel event relies \
              on to avoid also scrolling the content behind the card"
+        );
+    }
+
+    /// Mounts a real hover card carrying `doc` as its real doc body, exactly as
+    /// `a_real_jsdoc_tag_in_the_hover_doc_body_paints_its_own_tag_run` does - shared so the link
+    /// tests below differ only in the doc text they exercise.
+    fn show_hover_with_doc<'a>(
+        cx: &'a mut TestAppContext,
+        doc: &str,
+    ) -> (
+        gpui::Entity<AdeApp>,
+        &'a mut gpui::VisualTestContext,
+        tempfile::TempDir,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let file_path = repo.path().join("sample.rs");
+        std::fs::write(&file_path, "fn add_one(x: i32) -> i32 { x + 1 }\n").expect("write");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        app.update_in(cx, |app, window, cx| {
+            app.open_file_view(file_path.clone(), window, cx);
+        });
+        cx.run_until_parked();
+        app.update(cx, |app, cx| {
+            app.render_center_pane(cx);
+        });
+        cx.run_until_parked();
+
+        let doc = doc.to_string();
+        app.update(cx, |app, cx| {
+            app.hover = Some(HoverEntry {
+                path: file_path,
+                line_number: 1,
+                byte_range: 0..2,
+                position: lsp_core::lsp_types::Position {
+                    line: 0,
+                    character: 0,
+                },
+                status: HoverStatus::Ready(Some(hover_view::HoverRenderModel {
+                    module_path: None,
+                    signature: "fn add_one(x: i32) -> i32".to_string(),
+                    doc: Some(doc),
+                })),
+            });
+            cx.notify();
+        });
+        cx.run_until_parked();
+        (app, cx, repo)
+    }
+
+    /// GitHub issue #201's second render site - "In markdown preview but also other places where
+    /// we render it". A real Markdown link in an LSP docstring (exactly how TypeScript's own lib
+    /// docs and countless rustdoc comments cite references) used to reach this card as *literal*
+    /// `[MDN](https://...)` bracket-and-paren syntax: `hover::degrade_markdown_to_plain_text`
+    /// strips `**`, backticks, headings and bullets, but never touched link markup, and nothing
+    /// downstream parsed it either. It must now paint as its own real link run and really open.
+    #[gpui::test]
+    fn a_real_markdown_link_in_a_hover_doc_body_really_opens(cx: &mut TestAppContext) {
+        let (_app, cx, _repo) = show_hover_with_doc(
+            cx,
+            "Fetches a resource. See [MDN](https://developer.mozilla.org/fetch) for details.",
+        );
+
+        let link = cx
+            .debug_bounds("doc-prose-link-0")
+            .expect("a real Markdown link in the hover doc body must paint its own real link run");
+        assert_eq!(
+            cx.opened_url(),
+            None,
+            "sanity: nothing has been opened before the click"
+        );
+
+        cx.simulate_click(link.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+        assert_eq!(
+            cx.opened_url().as_deref(),
+            Some("https://developer.mozilla.org/fetch"),
+            "clicking a real link in a real hover card must really open its real destination"
+        );
+    }
+
+    /// The same deliberate limit the preview honours: a destination this app cannot resolve still
+    /// sheds its literal `[...](...)` syntax (the visible half of the bug), but is painted as
+    /// ordinary prose rather than advertised as a clickable link it could not actually follow.
+    #[gpui::test]
+    fn a_relative_link_in_a_hover_doc_body_is_not_painted_as_clickable(cx: &mut TestAppContext) {
+        let (_app, cx, _repo) = show_hover_with_doc(cx, "See [the guide](./guide.md) for details.");
+
+        assert!(
+            cx.debug_bounds("doc-prose-link-0").is_none(),
+            "a relative destination must not be advertised as a clickable link"
         );
     }
 

--- a/crates/app/src/code_surface/markdown_preview.rs
+++ b/crates/app/src/code_surface/markdown_preview.rs
@@ -14,6 +14,14 @@
 //!   links. A reference/shortcut link's visible text still renders (as plain text via the generic
 //!   gap-capture in [`build_inline_run`]), just without link styling or a destination - not
 //!   dropped, just not specially recognized.
+//! - An inline link with an absolute `http`/`https`/`mailto` destination is really clickable and
+//!   really opens in the OS default browser (GitHub issue #201, see [`openable_url`] and
+//!   [`render_prose_font`]). A *relative* destination (`./CONTRIBUTING.md`, `#a-heading`) is
+//!   deliberately **not** clickable: resolving it needs the previewed file's own directory as a
+//!   base, and handing a bare relative path to the OS handler would silently open the wrong
+//!   thing. Those still render as styled link text, exactly as before - the app just never
+//!   advertises a click it cannot honour. Opening a relative link *inside this editor* would be a
+//!   real feature, but it is a navigation feature, not this bug fix.
 //! - Table cells render as plain trimmed text, not further inline-parsed - a cell containing
 //!   `**bold**` shows the literal asterisks rather than real bold text.
 //! - Images render as a small `[image: alt]` placeholder, not the fetched picture - this is a
@@ -383,13 +391,130 @@ fn build_image(image: Node, text: &str) -> MdInline {
 }
 
 // ---------------------------------------------------------------------------------------------
+// Link destinations: which ones this app can genuinely open, and finding them in loose prose.
+// ---------------------------------------------------------------------------------------------
+
+/// GitHub issue #201 ("Markdown links do not work"): whether `destination` is a real absolute URL
+/// this app can honestly hand to the OS default browser (`gpui::App::open_url`, the same real
+/// mechanism `crate::title_bar::menu` already opens this project's own GitHub links with).
+///
+/// Deliberately scheme-gated rather than "open whatever the link says". A relative destination
+/// (`./CONTRIBUTING.md`, `#a-heading`) is a real and common thing to find in a README, but it is
+/// *not* something a browser can resolve on its own: the resolution base is the previewed file's
+/// own directory, which this function doesn't have, and handing a bare relative path to
+/// `xdg-open` would resolve it against the app's working directory instead - silently opening the
+/// wrong file, or nothing. Those destinations keep rendering as styled link text (exactly as
+/// before this fix) but are not painted as clickable, so the app never advertises a click it
+/// can't honour. See this module's own "Scope" docs.
+///
+/// `mailto:` is included because it is the one non-`http` scheme that genuinely appears in real
+/// prose docs and that every desktop's default-handler chain really does route (to a mail
+/// client). Every other scheme is rejected rather than passed through, so a `javascript:` or
+/// `file:` destination embedded in a downloaded/untrusted Markdown file can never be handed to
+/// the OS handler by a single click in this app.
+pub(crate) fn openable_url(destination: &str) -> Option<&str> {
+    let trimmed = destination.trim();
+    // Angle-bracket destinations (`[x](<https://example.com/a b>)`) are real CommonMark - the
+    // brackets are the destination's own delimiters, never part of the URL.
+    let trimmed = trimmed
+        .strip_prefix('<')
+        .and_then(|rest| rest.strip_suffix('>'))
+        .unwrap_or(trimmed);
+    let is_openable = ["http://", "https://", "mailto:"].iter().any(|scheme| {
+        trimmed.len() > scheme.len() && trimmed.to_ascii_lowercase().starts_with(scheme)
+    });
+    is_openable.then_some(trimmed)
+}
+
+/// One real inline link found in a run of loose prose - the byte range its whole `[text](url)`
+/// markup covers, the visible text it should render as, and where it points.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct InlineLinkSpan {
+    /// Byte range of the entire `[text](destination)` markup within the scanned string.
+    pub(crate) markup: std::ops::Range<usize>,
+    pub(crate) text: String,
+    pub(crate) destination: String,
+}
+
+/// Every real inline link in `text`, in source order - the other half of GitHub issue #201, for
+/// the render sites that only ever see already-flattened prose rather than a parsed block tree
+/// (`crate::code_surface::lsp_ui::render_doc_prose`'s LSP hover/completion doc bodies, which
+/// arrive as one plain `String` from `crate::lsp::hover::degrade_markdown_to_plain_text`).
+///
+/// Runs the *same* real `tree-sitter-md` inline grammar [`parse_inline_node`] uses rather than a
+/// hand-rolled bracket/paren scanner, so exactly the constructs CommonMark calls a link are
+/// recognized here and in the preview - one grammar, one answer. A hand-rolled scan would have to
+/// re-derive nesting, escaping (`\[not a link\](x)`) and code-span exclusion for itself and would
+/// inevitably disagree with the preview about some real document.
+///
+/// Returns an empty `Vec` (never panics) if the inline grammar fails to load, matching
+/// [`parse_markdown`]'s own posture for the same should-never-happen case.
+pub(crate) fn inline_link_spans(text: &str) -> Vec<InlineLinkSpan> {
+    let mut parser = Parser::new();
+    if parser
+        .set_language(&tree_sitter_md::INLINE_LANGUAGE.into())
+        .is_err()
+    {
+        return Vec::new();
+    }
+    let Some(tree) = parser.parse(text, None) else {
+        return Vec::new();
+    };
+    let mut spans = Vec::new();
+    collect_inline_links(tree.root_node(), text, &mut spans);
+    spans.sort_by_key(|span| span.markup.start);
+    spans
+}
+
+fn collect_inline_links(node: Node, text: &str, out: &mut Vec<InlineLinkSpan>) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "inline_link" {
+            let MdInline::Link {
+                text: link_text,
+                destination,
+            } = build_link(child, text)
+            else {
+                continue;
+            };
+            out.push(InlineLinkSpan {
+                markup: child.byte_range(),
+                text: flatten_inline_text(&link_text),
+                destination,
+            });
+            continue;
+        }
+        collect_inline_links(child, text, out);
+    }
+}
+
+/// Every real visible character of `inlines`, emphasis/strong nesting flattened away - unlike
+/// [`flatten_text`], which only reads the top level and so would silently return an empty string
+/// for a link whose text is entirely `**bold**`.
+fn flatten_inline_text(inlines: &[MdInline]) -> String {
+    inlines
+        .iter()
+        .map(|inline| match inline {
+            MdInline::Text(text) | MdInline::Code(text) => text.clone(),
+            MdInline::Strong(children) | MdInline::Emphasis(children) => {
+                flatten_inline_text(children)
+            }
+            MdInline::Image { alt } => alt.clone(),
+            MdInline::Link { text, .. } => flatten_inline_text(text),
+            MdInline::LineBreak => " ".to_string(),
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------------------------
 // Rendering: `Vec<MdBlock>` -> nested styled GPUI elements.
 // ---------------------------------------------------------------------------------------------
 
 use gpui::prelude::FluentBuilder;
 use gpui::{
-    div, font, px, rems, AnyElement, Context, FontWeight, Hsla, InteractiveElement, IntoElement,
-    ParentElement, SharedString, StatefulInteractiveElement, Styled, StyledText, TextRun,
+    div, font, px, rems, AnyElement, Context, FontWeight, Hsla, InteractiveElement,
+    InteractiveText, IntoElement, ParentElement, SharedString, StatefulInteractiveElement, Styled,
+    StyledText, TextRun, UnderlineStyle,
 };
 
 use super::code_view;
@@ -434,6 +559,11 @@ impl AdeApp {
     ) -> AnyElement {
         let blocks = parse_markdown(source);
         let options = self.highlight_options();
+        let mut next_id = 0usize;
+        let block_elements: Vec<AnyElement> = blocks
+            .iter()
+            .map(|block| render_block(block, options, &mut next_id))
+            .collect();
         let content = div()
             .id("markdown-preview-content")
             // Test-only lookup key for `VisualTestContext::debug_bounds` - matches
@@ -450,7 +580,7 @@ impl AdeApp {
             .px(px(28.0))
             .py(px(20.0))
             .gap(px(10.0))
-            .children(blocks.iter().map(|block| render_block(block, options)));
+            .children(block_elements);
         let scrolled = div()
             .relative()
             .flex()
@@ -472,10 +602,22 @@ impl AdeApp {
 /// `options` is threaded down from [`AdeApp::render_markdown_preview`]'s own `&self` rather than
 /// read from ambient state, so a fenced code block honours `appearance.bracket_pair_colorization`
 /// exactly like the source view does - see `code_view::HighlightOptions`' own docs.
-fn render_block(block: &MdBlock, options: code_view::HighlightOptions) -> AnyElement {
+///
+/// `next_id` is a document-wide running counter handing every prose run its own unique
+/// [`InteractiveText`] element id - see [`render_prose_font`]'s own docs for why sharing one
+/// would be a real bug rather than a cosmetic one. A counter, rather than hashing each block's
+/// text, because two identical paragraphs in one document are perfectly legal and must still get
+/// distinct ids.
+fn render_block(
+    block: &MdBlock,
+    options: code_view::HighlightOptions,
+    next_id: &mut usize,
+) -> AnyElement {
     match block {
-        MdBlock::Heading { level, inline } => render_heading(*level, inline),
-        MdBlock::Paragraph(inline) => render_prose(inline, theme::text::BODY, prose_font()),
+        MdBlock::Heading { level, inline } => render_heading(*level, inline, next_id),
+        MdBlock::Paragraph(inline) => {
+            render_prose(inline, theme::text::BODY, prose_font(), next_id)
+        }
         MdBlock::CodeBlock { language, text } => {
             render_code_block(language.as_deref(), text, options)
         }
@@ -483,11 +625,18 @@ fn render_block(block: &MdBlock, options: code_view::HighlightOptions) -> AnyEle
             ordered,
             start,
             items,
-        } => render_list(*ordered, *start, items, options),
-        MdBlock::BlockQuote(blocks) => render_block_quote(blocks, options),
+        } => render_list(*ordered, *start, items, options, next_id),
+        MdBlock::BlockQuote(blocks) => render_block_quote(blocks, options, next_id),
         MdBlock::ThematicBreak => render_thematic_break(),
         MdBlock::Table { header, rows } => render_table(header, rows),
     }
+}
+
+/// Hands out the next document-unique prose-run id.
+fn take_id(next_id: &mut usize) -> usize {
+    let id = *next_id;
+    *next_id += 1;
+    id
 }
 
 fn heading_size_rems(level: u8) -> f32 {
@@ -501,7 +650,7 @@ fn heading_size_rems(level: u8) -> f32 {
     }
 }
 
-fn render_heading(level: u8, inline: &[MdInline]) -> AnyElement {
+fn render_heading(level: u8, inline: &[MdInline], next_id: &mut usize) -> AnyElement {
     let mut el = div()
         .flex()
         .flex_col()
@@ -511,6 +660,7 @@ fn render_heading(level: u8, inline: &[MdInline]) -> AnyElement {
             inline,
             theme::text::HEADING,
             prose_font().bold(),
+            take_id(next_id),
         ));
     if level <= 2 {
         el = el
@@ -522,11 +672,21 @@ fn render_heading(level: u8, inline: &[MdInline]) -> AnyElement {
 }
 
 /// A plain prose block (paragraph body, list item text) at the ambient body text size.
-fn render_prose(inline: &[MdInline], color: theme::ColorToken, font: gpui::Font) -> AnyElement {
+fn render_prose(
+    inline: &[MdInline],
+    color: theme::ColorToken,
+    font: gpui::Font,
+    next_id: &mut usize,
+) -> AnyElement {
+    let id = take_id(next_id);
     div()
         .text_size(rems(0.95))
         .line_height(rems(1.55))
-        .child(render_prose_font(inline, color, font))
+        // Lets a real test measure this real paragraph's own painted bounds and click inside it
+        // (`debug_bounds` reads this, not `.id(..)`) - a no-op outside test builds, matching every
+        // other `debug_selector` in this crate.
+        .debug_selector(move || format!("markdown-prose-{id}"))
+        .child(render_prose_font(inline, color, font, id))
         .into_any_element()
 }
 
@@ -534,18 +694,56 @@ fn render_prose(inline: &[MdInline], color: theme::ColorToken, font: gpui::Font)
 /// (bold/italic/code/link spans flowing together on the same line), not a `flex()` row of
 /// separate divs, which GPUI does not word-wrap the way inline HTML does. `base_color`/`base_font`
 /// are this run's own default styling before any nested emphasis/strong/link/code override.
+///
+/// GitHub issue #201 ("Markdown links do not work"): when this run contains at least one link
+/// with a genuinely openable destination, the `StyledText` is wrapped in a real
+/// [`InteractiveText`], whose `on_click` fires only for a press *and* release inside the same
+/// registered byte range (`vendor/zed/crates/gpui/src/elements/text.rs:1022`) - so clicking the
+/// link text opens it, and clicking the prose around it does nothing. `InteractiveText` is the
+/// only GPUI element that can make a sub-range of one wrapped text element clickable; splitting
+/// the paragraph into per-span `div`s to hang an `on_click` on instead would have destroyed the
+/// word wrapping this single-`StyledText` shape exists to preserve.
+///
+/// `id` must be unique across the whole rendered document - [`InteractiveText`] is a *stateful*
+/// element that stores its in-progress mouse-down byte index under this id
+/// (`InteractiveTextState`), so two paragraphs sharing an id would share that state and misreport
+/// which range a click landed in.
 fn render_prose_font(
     inline: &[MdInline],
     base_color: theme::ColorToken,
     base_font: gpui::Font,
+    id: usize,
 ) -> AnyElement {
-    let mut text = String::new();
-    let mut runs = Vec::new();
-    build_text_runs(inline, hsla(base_color), &base_font, &mut text, &mut runs);
-    if text.is_empty() {
+    let mut out = ProseRuns::default();
+    build_text_runs(
+        inline,
+        &RunStyle {
+            color: hsla(base_color),
+            font: base_font,
+            underline: None,
+        },
+        &mut out,
+    );
+    if out.text.is_empty() {
         return div().into_any_element();
     }
-    StyledText::new(text).with_runs(runs).into_any_element()
+    let styled = StyledText::new(out.text).with_runs(out.runs);
+    if out.link_ranges.is_empty() {
+        return styled.into_any_element();
+    }
+    let destinations = out.link_destinations;
+    InteractiveText::new(("markdown-prose", id), styled)
+        .on_click(out.link_ranges, move |index, _window, cx| {
+            let Some(url) = destinations.get(index) else {
+                return;
+            };
+            // The same real "hand this URL to the platform's default browser" call
+            // `crate::title_bar::menu` already opens this project's own GitHub links with
+            // (`gpui::App::open_url` -> `vendor/zed/crates/gpui_linux/src/linux/platform.rs:387`'s
+            // real `open_uri`), not a second, independent implementation of it.
+            cx.open_url(url);
+        })
+        .into_any_element()
 }
 
 fn push_run(
@@ -555,6 +753,7 @@ fn push_run(
     font: &gpui::Font,
     color: Hsla,
     background: Option<Hsla>,
+    underline: Option<UnderlineStyle>,
 ) {
     if run_text.is_empty() {
         return;
@@ -565,56 +764,128 @@ fn push_run(
         font: font.clone(),
         color,
         background_color: background,
-        underline: None,
+        underline,
         strikethrough: None,
     });
 }
 
-fn build_text_runs(
-    inlines: &[MdInline],
+/// One prose block's accumulated text and styling runs, plus the real clickable link spans found
+/// inside it - byte ranges into `text`, paired positionally with the destination each one opens
+/// (GitHub issue #201). Collected during the same single walk that builds the runs, because a
+/// link's range is only knowable as the text is appended: it is exactly the stretch of `text`
+/// that its own nested inlines contributed.
+#[derive(Default)]
+struct ProseRuns {
+    text: String,
+    runs: Vec<TextRun>,
+    link_ranges: Vec<std::ops::Range<usize>>,
+    link_destinations: Vec<String>,
+}
+
+/// The styling in force at one nesting level of [`build_text_runs`]' walk.
+#[derive(Clone)]
+struct RunStyle {
     color: Hsla,
-    font: &gpui::Font,
-    text: &mut String,
-    runs: &mut Vec<TextRun>,
-) {
+    font: gpui::Font,
+    underline: Option<UnderlineStyle>,
+}
+
+/// A real link's own underline, in the link colour - the standard, unmissable "this is a link"
+/// affordance, and the only visual cue distinguishing a *clickable* link from the merely
+/// colour-shifted text this app painted before issue #201. Applied per [`TextRun`] rather than as
+/// a container border, because a link is an inline span inside a wrapping paragraph, not a box.
+fn link_underline() -> UnderlineStyle {
+    UnderlineStyle {
+        thickness: px(1.0),
+        color: Some(hsla(theme::syntax::LINK)),
+        wavy: false,
+    }
+}
+
+fn build_text_runs(inlines: &[MdInline], style: &RunStyle, out: &mut ProseRuns) {
     for inline in inlines {
         match inline {
-            MdInline::Text(run_text) => push_run(text, runs, run_text, font, color, None),
+            MdInline::Text(run_text) => push_run(
+                &mut out.text,
+                &mut out.runs,
+                run_text,
+                &style.font,
+                style.color,
+                None,
+                style.underline,
+            ),
             MdInline::Strong(children) => build_text_runs(
                 children,
-                hsla(theme::syntax::STRONG),
-                &font.clone().bold(),
-                text,
-                runs,
+                &RunStyle {
+                    color: hsla(theme::syntax::STRONG),
+                    font: style.font.clone().bold(),
+                    underline: style.underline,
+                },
+                out,
             ),
             MdInline::Emphasis(children) => build_text_runs(
                 children,
-                hsla(theme::syntax::EMPHASIS),
-                &font.clone().italic(),
-                text,
-                runs,
+                &RunStyle {
+                    color: hsla(theme::syntax::EMPHASIS),
+                    font: style.font.clone().italic(),
+                    underline: style.underline,
+                },
+                out,
             ),
             MdInline::Code(code_text) => push_run(
-                text,
-                runs,
+                &mut out.text,
+                &mut out.runs,
                 code_text,
                 &mono_font(),
                 hsla(theme::text::PATH),
                 Some(hsla(theme::surface::ROW_HOVER_ALT)),
+                style.underline,
             ),
             MdInline::Link {
                 text: link_text,
-                destination: _,
-            } => build_text_runs(link_text, hsla(theme::syntax::LINK), font, text, runs),
+                destination,
+            } => {
+                // Only a destination this app can genuinely open gets the underline and a
+                // clickable range - see [`openable_url`] for why a relative destination is
+                // deliberately left as inert styled text rather than advertised as clickable.
+                let url = openable_url(destination);
+                let start = out.text.len();
+                build_text_runs(
+                    link_text,
+                    &RunStyle {
+                        color: hsla(theme::syntax::LINK),
+                        font: style.font.clone(),
+                        underline: url.map(|_| link_underline()),
+                    },
+                    out,
+                );
+                if let Some(url) = url {
+                    let url = url.to_string();
+                    let end = out.text.len();
+                    if end > start {
+                        out.link_ranges.push(start..end);
+                        out.link_destinations.push(url);
+                    }
+                }
+            }
             MdInline::Image { alt } => push_run(
-                text,
-                runs,
+                &mut out.text,
+                &mut out.runs,
                 &format!("[image: {alt}]"),
-                font,
+                &style.font,
                 hsla(theme::text::GHOST),
                 None,
+                style.underline,
             ),
-            MdInline::LineBreak => push_run(text, runs, "\n", font, color, None),
+            MdInline::LineBreak => push_run(
+                &mut out.text,
+                &mut out.runs,
+                "\n",
+                &style.font,
+                style.color,
+                None,
+                style.underline,
+            ),
         }
     }
 }
@@ -672,6 +943,7 @@ fn render_code_line(line: &code_view::RenderedLine) -> AnyElement {
             &mono_font(),
             code_view::color_for_kind(*kind).into(),
             None,
+            None,
         );
     }
     if text.is_empty() {
@@ -694,6 +966,7 @@ fn render_list(
     start: u64,
     items: &[Vec<MdBlock>],
     options: code_view::HighlightOptions,
+    next_id: &mut usize,
 ) -> AnyElement {
     let mut list = div().flex().flex_col().gap(px(4.0));
     for (index, item_blocks) in items.iter().enumerate() {
@@ -721,14 +994,23 @@ fn render_list(
                     .flex_1()
                     .min_w_0()
                     .gap(px(6.0))
-                    .children(item_blocks.iter().map(|block| render_block(block, options))),
+                    .children(
+                        item_blocks
+                            .iter()
+                            .map(|block| render_block(block, options, next_id))
+                            .collect::<Vec<_>>(),
+                    ),
             );
         list = list.child(row);
     }
     div().pl(px(INDENT_PX * 0.0)).child(list).into_any_element()
 }
 
-fn render_block_quote(blocks: &[MdBlock], options: code_view::HighlightOptions) -> AnyElement {
+fn render_block_quote(
+    blocks: &[MdBlock],
+    options: code_view::HighlightOptions,
+    next_id: &mut usize,
+) -> AnyElement {
     div()
         .flex()
         .flex_col()
@@ -738,7 +1020,12 @@ fn render_block_quote(blocks: &[MdBlock], options: code_view::HighlightOptions) 
         .border_l_2()
         .border_color(theme::border::DIVIDER)
         .text_color(theme::text::SECONDARY)
-        .children(blocks.iter().map(|block| render_block(block, options)))
+        .children(
+            blocks
+                .iter()
+                .map(|block| render_block(block, options, next_id))
+                .collect::<Vec<_>>(),
+        )
         .into_any_element()
 }
 
@@ -1115,5 +1402,146 @@ mod parse_tests {
     #[test]
     fn an_empty_document_parses_to_no_blocks() {
         assert_eq!(parse_markdown(""), Vec::new());
+    }
+}
+
+/// GitHub issue #201, "Markdown links do not work". The parse side already produced a real
+/// [`MdInline::Link`] carrying a real destination (`an_inline_link_carries_its_real_text_and_
+/// destination`, above) - what was missing was everything after it: the destination was dropped
+/// on the floor at render time (`build_text_runs` matched `destination: _`), so a link painted as
+/// inert coloured text with no click target at all. These cover the two new pieces that fix
+/// closes: which destinations this app will really open, and finding links in loose prose for the
+/// LSP hover/completion render sites.
+#[cfg(test)]
+mod link_tests {
+    use super::*;
+
+    #[test]
+    fn a_real_web_url_is_openable_and_keeps_its_exact_text() {
+        for url in [
+            "https://example.com/x",
+            "http://example.com",
+            "https://developer.mozilla.org/en-US/docs/Web/API/fetch#options",
+            "mailto:someone@example.com",
+        ] {
+            assert_eq!(openable_url(url), Some(url), "{url}");
+        }
+    }
+
+    /// Scheme matching is case-insensitive (`HTTPS://` is a real, legal URL), but the returned
+    /// destination is never normalized - it is handed to the OS handler byte-for-byte as written.
+    #[test]
+    fn scheme_matching_ignores_case_without_rewriting_the_url() {
+        assert_eq!(
+            openable_url("HTTPS://Example.COM/Path"),
+            Some("HTTPS://Example.COM/Path")
+        );
+    }
+
+    /// CommonMark's own angle-bracket destination form: the brackets delimit the destination and
+    /// are never part of the URL handed to the browser.
+    #[test]
+    fn an_angle_bracketed_destination_sheds_its_delimiters() {
+        assert_eq!(
+            openable_url("<https://example.com/a>"),
+            Some("https://example.com/a")
+        );
+    }
+
+    /// The deliberate limit, stated honestly rather than silently: a destination this app cannot
+    /// resolve on its own is *not* openable, so it never gets painted as a clickable link. See
+    /// [`openable_url`]'s own docs.
+    #[test]
+    fn a_destination_this_app_cannot_honestly_resolve_is_not_openable() {
+        for destination in [
+            "./CONTRIBUTING.md",
+            "../other/file.md",
+            "#a-heading",
+            "docs/guide.md",
+            "",
+            // Not a navigation at all - never handed to the OS default handler on one click.
+            "javascript:alert(1)",
+            "file:///etc/passwd",
+            "data:text/html,<script>alert(1)</script>",
+            // Scheme present but nothing after it.
+            "https://",
+        ] {
+            assert_eq!(openable_url(destination), None, "{destination:?}");
+        }
+    }
+
+    #[test]
+    fn a_link_in_loose_prose_reports_its_real_markup_range_text_and_destination() {
+        let doc = "see [the docs](https://example.com/x) now";
+        let spans = inline_link_spans(doc);
+        assert_eq!(
+            spans,
+            vec![InlineLinkSpan {
+                markup: 4..37,
+                text: "the docs".to_string(),
+                destination: "https://example.com/x".to_string(),
+            }]
+        );
+        // The reported range must really cover the whole `[text](url)` markup - this is exactly
+        // the slice `lsp_ui::render_doc_prose` replaces, so an off-by-one here would leave a
+        // stray bracket or paren visible on the hover card.
+        assert_eq!(
+            &doc[spans[0].markup.clone()],
+            "[the docs](https://example.com/x)"
+        );
+    }
+
+    /// A real LSP hover body is multi-line plain text with several sections, not one tidy line -
+    /// every link in it must still be found, in source order.
+    #[test]
+    fn every_link_across_a_real_multi_line_doc_body_is_found_in_order() {
+        let doc = "Fetches a resource.\n\nSee [MDN](https://developer.mozilla.org/x) for \
+                   details.\n\n@returns a [Response](https://example.com/response)";
+        let spans = inline_link_spans(doc);
+        assert_eq!(
+            spans
+                .iter()
+                .map(|span| (span.text.as_str(), span.destination.as_str()))
+                .collect::<Vec<_>>(),
+            vec![
+                ("MDN", "https://developer.mozilla.org/x"),
+                ("Response", "https://example.com/response"),
+            ]
+        );
+        for span in &spans {
+            assert_eq!(&doc[span.markup.clone()][..1], "[");
+            assert_eq!(&doc[span.markup.clone()][span.markup.len() - 1..], ")");
+        }
+    }
+
+    /// A link whose visible text is itself emphasized must report the real *visible* text, not an
+    /// empty string - `flatten_text` only ever read the top level, which is exactly the shape
+    /// (`[**bold link**](url)`) that would have silently rendered as a blank clickable gap.
+    #[test]
+    fn a_link_whose_text_is_emphasized_still_reports_its_real_visible_text() {
+        let spans = inline_link_spans("[**bold link**](https://example.com)");
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].text, "bold link");
+    }
+
+    #[test]
+    fn prose_with_no_links_reports_none() {
+        assert!(inline_link_spans("just some ordinary prose, 3 * 4 = 12").is_empty());
+        assert!(inline_link_spans("").is_empty());
+    }
+
+    /// The real reason this scans with `tree-sitter-md`'s own inline grammar rather than a
+    /// hand-rolled bracket/paren scan: a bracketed span that is *not* a CommonMark inline link
+    /// must not be mistaken for one. A hand-rolled `[`-then-`](` scan would happily match inside
+    /// a code span.
+    #[test]
+    fn a_bracketed_span_that_is_not_a_real_link_is_not_reported() {
+        assert!(
+            inline_link_spans("an array index like list[0] and a footnote [1] stay put").is_empty()
+        );
+        assert!(
+            inline_link_spans("`[not a link](https://example.com)` inside a code span").is_empty(),
+            "a code span's contents are not links - the real grammar knows this, a regex would not"
+        );
     }
 }

--- a/crates/app/src/code_surface/render.rs
+++ b/crates/app/src/code_surface/render.rs
@@ -585,4 +585,112 @@ mod markdown_preview_toggle_tests {
             "a newly opened file must never inherit a different file's stray Preview selection"
         );
     }
+
+    /// Opens `contents` as a real `.md` file already switched to Preview, by really clicking the
+    /// real toggle - the same path a user takes, not a direct field poke.
+    fn open_markdown_preview<'a>(
+        cx: &'a mut TestAppContext,
+        contents: &str,
+    ) -> (
+        gpui::Entity<AdeApp>,
+        &'a mut gpui::VisualTestContext,
+        tempfile::TempDir,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        std::fs::write(repo.path().join("readme.md"), contents).expect("write readme.md");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        app.update_in(cx, |app, window, cx| {
+            app.open_file_view(repo.path().join("readme.md"), window, cx);
+        });
+        cx.run_until_parked();
+        let preview_bounds = cx
+            .debug_bounds("choice-markdown-view-toggle-1")
+            .expect("the Preview segment must have painted");
+        cx.simulate_click(preview_bounds.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+        (app, cx, repo)
+    }
+
+    /// A real click a few pixels into the first rendered paragraph - i.e. on its own first word,
+    /// which every test below arranges to be the link text (or deliberately not). Deliberately not
+    /// `bounds.center()`: a prose paragraph's `div` stretches the full content width, so its
+    /// centre lands in empty space well past the end of a short line, where
+    /// `TextLayout::index_for_position` (`vendor/zed/crates/gpui/src/elements/text.rs:829`)
+    /// genuinely returns `Err` and no click range can match.
+    fn click_first_paragraph_start(cx: &mut gpui::VisualTestContext) {
+        let bounds = cx
+            .debug_bounds("markdown-prose-0")
+            .expect("the first preview paragraph must have painted");
+        let point = bounds.origin + gpui::point(gpui::px(6.0), bounds.size.height / 2.0);
+        cx.simulate_click(point, gpui::Modifiers::none());
+        cx.run_until_parked();
+    }
+
+    /// GitHub issue #201, "Markdown links do not work" - the real, reported bug, end to end.
+    ///
+    /// The parse side already produced a real destination; the render side threw it away
+    /// (`build_text_runs` matched `destination: _`), so a link painted as coloured text that did
+    /// nothing at all when clicked. This clicks a real rendered link in a real Preview tab and
+    /// asserts the app really asked the platform to open that exact URL - `cx.opened_url()` reads
+    /// what `gpui::App::open_url` actually handed the platform layer
+    /// (`vendor/zed/crates/gpui/src/platform/test/platform.rs:418`), so nothing here is stubbed on
+    /// this app's side of the call.
+    #[gpui::test]
+    fn clicking_a_real_preview_link_really_opens_its_url(cx: &mut TestAppContext) {
+        let (_app, cx, _repo) = open_markdown_preview(
+            cx,
+            "[the real documentation](https://example.com/real-target)\n",
+        );
+
+        assert_eq!(
+            cx.opened_url(),
+            None,
+            "sanity: nothing has been opened before the click"
+        );
+        click_first_paragraph_start(cx);
+        assert_eq!(
+            cx.opened_url().as_deref(),
+            Some("https://example.com/real-target"),
+            "clicking a real rendered Markdown link must really open its real destination"
+        );
+    }
+
+    /// The other half of "clickable": clicking the ordinary prose *around* a link must not open
+    /// anything. Without this, a test that only ever clicks a link cannot tell a real per-range
+    /// hit test apart from a paragraph-wide "any click opens the first URL" handler - which would
+    /// be exactly the kind of fake this fix must not be.
+    #[gpui::test]
+    fn clicking_ordinary_prose_next_to_a_link_opens_nothing(cx: &mut TestAppContext) {
+        let (_app, cx, _repo) = open_markdown_preview(
+            cx,
+            "ordinary words first, then [a link](https://example.com/should-not-open)\n",
+        );
+
+        click_first_paragraph_start(cx);
+        assert_eq!(
+            cx.opened_url(),
+            None,
+            "a click on the plain prose at the start of the paragraph must not open the link \
+             that happens to sit later in the same paragraph"
+        );
+    }
+
+    /// The deliberate, documented limit (`markdown_preview::openable_url`), pinned as real
+    /// behaviour rather than left to drift: a relative destination is not something this app can
+    /// resolve, so clicking it must do *nothing* rather than hand a bare relative path to the OS
+    /// default handler, which would resolve it against the app's working directory and open the
+    /// wrong thing.
+    #[gpui::test]
+    fn clicking_a_relative_link_opens_nothing_rather_than_the_wrong_thing(cx: &mut TestAppContext) {
+        let (_app, cx, _repo) =
+            open_markdown_preview(cx, "[the contributing guide](./CONTRIBUTING.md)\n");
+
+        click_first_paragraph_start(cx);
+        assert_eq!(
+            cx.opened_url(),
+            None,
+            "a relative destination must never reach the OS default-open handler"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Closes #201. Two render sites, two different real root causes - the parse side was never the problem in either.
- **Markdown preview**: `parse_markdown` already produced a real `MdInline::Link` with a real destination, but `build_text_runs` destructured it as `destination: _` and dropped it - links painted in link colour with no click target and no underline. Fixed by collecting link byte-ranges during the run walk and wrapping the paragraph in a real `InteractiveText`, whose `on_click` fires only for a press+release inside one registered range.
- **LSP hover cards + completion detail pane**: nothing ever parsed links at all - `degrade_markdown_to_plain_text` never touched link markup, so `[MDN](https://...)` in a real docstring reached the card as literal bracket-and-paren syntax. Both share `render_doc_prose`, so one fix covers both.
- Both sites find links with the same real `tree-sitter-md` inline grammar the preview already parses with, not a hand-rolled scanner that would disagree with it inside a code span.
- Only `http`/`https`/`mailto` destinations open (via the same `gpui::App::open_url` the Help menu already uses); a relative destination (`./CONTRIBUTING.md`) sheds its literal syntax but is deliberately left inert - resolving it needs the previewed file's own directory, which isn't available here.

## Test plan
- [x] New GPUI tests click a rendered link and read back what `open_url` actually received - confirmed to fail against the pre-fix code
- [x] Negative controls: clicking ordinary prose next to a link, and a relative link, open nothing
- [x] Driven in the running app with a logging `xdg-open` on PATH - real click reaches it with the exact URL, including two links on one line resolving to separate destinations
- [x] `cargo build`, `cargo clippy -p app -p lsp-core --lib --tests` clean
- [x] `cargo fmt` diffed against a backup - only new lines touched, zero drift on pre-existing code
- [x] `cargo test -p app --lib` full suite: 1916 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)