### PR TITLE
feat(app): collapse code blocks from the File view gutter

### DIFF
--- a/crates/app/src/code_surface/edit_buffer.rs
+++ b/crates/app/src/code_surface/edit_buffer.rs
@@ -182,6 +182,7 @@ use std::time::{Instant, SystemTime};
 use unicode_segmentation::UnicodeSegmentation;
 
 use crate::code_surface::code_view;
+use crate::code_surface::fold;
 use crate::code_surface::indent;
 use crate::code_surface::symbols;
 use crate::language::HighlighterFn;
@@ -384,6 +385,12 @@ pub struct EditBuffer {
     /// revisions of the text. Empty - never fabricated - for a language with no symbol support;
     /// see `crate::code_surface::symbols` for which those are and why.
     pub symbols: Vec<symbols::SymbolSpan>,
+    /// GitHub issue #202: this buffer's collapsible regions as of [`Self::lines`], memoized.
+    /// `None` means "owed a recompute" - see [`Self::fold_ranges`].
+    ///
+    /// Private, and only ever read through that accessor, so no call site can look at a list
+    /// that describes a revision of the text this buffer has already moved past.
+    fold_ranges: Option<Vec<fold::FoldRange>>,
 }
 
 /// One additional cursor/selection beyond the primary `EditBuffer::selected_range`/
@@ -495,7 +502,24 @@ impl EditBuffer {
             replaying: false,
             secondary_cursors: Vec::new(),
             symbols,
+            fold_ranges: None,
         }
+    }
+
+    /// GitHub issue #202: this buffer's real collapsible regions
+    /// (`crate::code_surface::fold::foldable_ranges` over [`Self::lines`]), computed at most once
+    /// per revision of the text rather than on every repaint.
+    ///
+    /// `&mut self` purely because of that memoization. The scan is a linear pass over the whole
+    /// buffer's runs, which is fine once per keystroke but genuinely not fine at 60fps on a large
+    /// file - and the File view's row builder needs to ask "is this line a fold start" for every
+    /// visible row, every frame. Every site that assigns or splices [`Self::lines`] clears the
+    /// cache; `folding_ranges_track_real_edits` (this module's own tests) drives a real edit
+    /// through `replace_range` and asserts the answer really moved, so a missed invalidation
+    /// would fail rather than silently serve a stale chevron.
+    pub fn fold_ranges(&mut self) -> &[fold::FoldRange] {
+        self.fold_ranges
+            .get_or_insert_with(|| fold::foldable_ranges(&self.lines))
     }
 
     /// The real, local (i.e. relative to `source`'s own start, not any wider buffer)
@@ -571,6 +595,7 @@ impl EditBuffer {
         self.utf16_line_starts =
             Self::cumulative_utf16_line_starts(&self.content, &self.line_ranges);
         self.highlight_dirty = true;
+        self.fold_ranges = None;
     }
 
     /// Splices `new_text` into `self.content` at `range` (byte offsets into the *old* content,
@@ -727,6 +752,9 @@ impl EditBuffer {
         }
 
         self.highlight_dirty = true;
+        // GitHub issue #202: `lines` just changed, so the memoized fold ranges describe text this
+        // buffer has moved past - see `Self::fold_ranges`.
+        self.fold_ranges = None;
     }
 
     /// Best-effort real highlight spans, in `region_source`-local byte coordinates, carried over
@@ -832,6 +860,10 @@ impl EditBuffer {
             return false;
         }
         self.lines = lines;
+        // A fresh highlight can genuinely change which brackets are foldable - a `{` the plain
+        // fallback runs counted may now sit in a real string/comment run (see
+        // `crate::code_surface::fold`'s own docs), so this must be invalidated with `lines`.
+        self.fold_ranges = None;
         // Installed under the exact same content-snapshot guard as `lines`, and only together
         // with them: a symbol outline whose byte ranges describe text this buffer has already
         // moved past would put the breadcrumb inside a function the caret isn't in. Rejecting
@@ -1419,6 +1451,7 @@ impl EditBuffer {
         self.utf16_line_starts =
             Self::cumulative_utf16_line_starts(&self.content, &self.line_ranges);
         self.lines = lines;
+        self.fold_ranges = None;
         // The reloaded text is genuinely different bytes at genuinely different offsets, so the
         // outline this buffer was holding describes content that no longer exists - replaced
         // here, from the same background parse that produced `lines`, rather than left stale
@@ -2741,6 +2774,40 @@ impl QueryBuilder {
     }
 }
 ";
+
+    /// GitHub issue #202: the memoized fold-range cache must be invalidated by a real edit, or
+    /// the File view would keep drawing a chevron on a line that no longer opens a block (and,
+    /// worse, hide the wrong lines when it is clicked). Driven through `replace_range` - the same
+    /// real mutation a keystroke takes, which reaches the cache only via `splice_lines`' own
+    /// invalidation - rather than by poking the field.
+    #[test]
+    fn fold_ranges_track_real_edits() {
+        let mut buf = buffer("fn alpha() {\n    let x = 1;\n}\n");
+        assert_eq!(
+            buf.fold_ranges(),
+            [fold::FoldRange {
+                start_line: 0,
+                end_line: 2
+            }]
+        );
+
+        // Insert a whole new line at the very top; every region shifts down by one.
+        buf.move_to(0);
+        buf.replace_range(Some(0..0), "// header\n");
+        assert_eq!(
+            buf.fold_ranges(),
+            [fold::FoldRange {
+                start_line: 1,
+                end_line: 3
+            }],
+            "a stale cache would still claim line 0 opens the block"
+        );
+
+        // Delete the opening brace: nothing is foldable any more.
+        let brace = buf.content.find('{').expect("brace present");
+        buf.replace_range(Some(brace..brace + 1), "");
+        assert!(buf.fold_ranges().is_empty());
+    }
 
     #[test]
     fn a_freshly_constructed_buffer_already_holds_a_real_symbol_outline() {

--- a/crates/app/src/code_surface/editing.rs
+++ b/crates/app/src/code_surface/editing.rs
@@ -5418,10 +5418,11 @@ let last = 5;
             cx.debug_bounds("file-view-fold-marker-1").is_none(),
             "an expanded row must not keep claiming lines are hidden"
         );
-        assert!(app.read_with(cx, |app, _| app
-            .file_view_folds
-            .get(&path)
-            .is_none_or(|folded| folded.is_empty())));
+        assert!(
+            app.read_with(cx, |app, _| !app.file_view_folds.contains_key(&path)),
+            "expanding the last fold in a file must drop its now-empty entry entirely, not just \
+             empty it - the same unbounded-growth discipline the popup-anchor map follows"
+        );
     }
 
     /// Regression guard for the one real hazard `render_fold_chevron`'s `cx.stop_propagation()`
@@ -5570,6 +5571,133 @@ let last = 5;
         assert!(
             cx.debug_bounds("file-view-text-row-3").is_none(),
             "coming back to the folded file must find it still folded"
+        );
+    }
+
+    /// Lines (1-based): 1 is an ordinary statement, 2 opens a block that closes on 4 - the file's
+    /// own last line. Built specifically so folding line 2 leaves the collapsed region's closer
+    /// sitting on the buffer's real end, which is exactly the case a click in the blank space
+    /// below the content has to reveal correctly.
+    ///
+    /// Deliberately **no** trailing newline: `EditBuffer::lines` treats content ending in `\n` as
+    /// carrying one further, real, empty trailing line (`"a\n".split('\n')` is `["a", ""]`) - and
+    /// that phantom-looking-but-real line always sits *outside* any fold's own `hidden_lines()`,
+    /// so a source ending in `\n` cannot exercise this bug at all: the click's target line would
+    /// be the empty line after the fold, never the folded line itself.
+    const LAST_LINE_FOLD_SOURCE: &str = "let a = 1;\nfn main() {\n    let b = 2;\n}";
+
+    /// Real regression test for a bug a review caught before this ever shipped: clicking the
+    /// blank space below a short file's content places the caret at the real end of the buffer
+    /// (`file_view.rs`'s own "click past the end of the buffer" fallback), but that fallback only
+    /// moved the caret - it never called [`AdeApp::scroll_file_view_to_line`]. Whenever the
+    /// collapsed region closest to the end of the file is still folded, the caret's own line
+    /// never gets expanded back into view, its row never paints, and
+    /// [`AdeApp::render_editable_file_view_line`]'s own `window.handle_input` registration (which
+    /// only exists on the caret's painted row) never fires - so typing after that click would
+    /// silently do nothing at all.
+    #[gpui::test]
+    fn clicking_below_a_folded_files_content_still_reveals_the_caret_row(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let file_path = write_file(repo.path(), "sample.rs", LAST_LINE_FOLD_SOURCE);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        open_file_for_editing(&app, cx, file_path.clone());
+
+        click_fold_chevron(cx, 2);
+        assert!(
+            cx.debug_bounds("file-view-text-row-4").is_none(),
+            "line 4 (the block's own closing brace, and the file's real last line) must be \
+             hidden once line 2 is folded, or this test cannot tell a real reveal from a line \
+             that was never hidden"
+        );
+
+        let marker_row_bounds = cx
+            .debug_bounds("file-view-text-row-2")
+            .expect("the fold's own start line stays visible and carries the marker");
+        let list_bounds = cx
+            .debug_bounds("file-view-code-list")
+            .expect("the real code list container should have painted real bounds");
+        let click_point = gpui::point(
+            marker_row_bounds.center().x,
+            (marker_row_bounds.bottom() + gpui::px(20.0)).min(list_bounds.bottom() - gpui::px(1.0)),
+        );
+        cx.simulate_click(click_point, gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        assert!(
+            cx.debug_bounds("file-view-text-row-4").is_some(),
+            "a click below the content must reveal the caret's own line - the real last line of \
+             the buffer - not leave it hidden inside the fold it landed in"
+        );
+        let relative = PathBuf::from("sample.rs");
+        let (cursor_offset, expected_end) = app.read_with(cx, |app, _| {
+            let buffer = app.edit_buffer(&relative).expect("buffer");
+            (buffer.cursor_offset(), buffer.content.len())
+        });
+        assert_eq!(
+            cursor_offset, expected_end,
+            "the caret itself must still land at the real end of the buffer, exactly as it does \
+             in an unfolded file"
+        );
+    }
+
+    /// Real regression test for a second bug the same review caught: fold state is a plain line
+    /// index, and a real external rewrite of the open file (an agent CLI or formatter, not the
+    /// user's own edit) replaces `lines` wholesale without touching `AdeApp::file_view_folds` at
+    /// all. A stale index can end up naming a *different*, larger region than the one the user
+    /// actually folded - silently swallowing whatever line the caret is on, with nothing left to
+    /// expand it back into view.
+    #[gpui::test]
+    fn a_real_external_rewrite_clears_stale_fold_state_for_that_file(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let file_path = write_file(repo.path(), "sample.rs", FOLDABLE_SOURCE);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        open_file_for_editing(&app, cx, file_path.clone());
+
+        click_fold_chevron(cx, 1);
+        assert!(
+            cx.debug_bounds("file-view-text-row-3").is_none(),
+            "line 1 must be folded"
+        );
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.file_view_folds
+                    .get(&file_path)
+                    .is_some_and(|folded| !folded.is_empty()),
+                "the fold must be really recorded before the rewrite, or this test proves nothing"
+            );
+        });
+
+        // A real external rewrite of the file the user has open and has made no edits to - the
+        // same real content-change path `a_real_on_disk_change_to_the_open_file_invalidates_the_
+        // cache` (this module's own `tabs.rs` precedent) drives, past the same real throttle.
+        std::fs::write(
+            &file_path,
+            "fn alpha() {\n    let a = 1;\n    let b = 2;\n    let c = 3;\n}\n",
+        )
+        .expect("rewrite sample.rs");
+        std::thread::sleep(
+            crate::root::FILE_FRESHNESS_CHECK_INTERVAL + std::time::Duration::from_millis(50),
+        );
+        app.update(cx, |app, cx| {
+            app.render_center_pane(cx);
+        });
+        cx.run_until_parked();
+        app.update(cx, |app, cx| {
+            app.render_center_pane(cx);
+        });
+
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.file_view_folds
+                    .get(&file_path)
+                    .is_none_or(|folded| folded.is_empty()),
+                "a real external rewrite must drop this file's fold state rather than leave a \
+                 stale line index that could silently swallow a line nobody chose to hide"
+            );
+        });
+        assert!(
+            cx.debug_bounds("file-view-text-row-5").is_some(),
+            "with the fold cleared, every real line of the rewritten file must paint"
         );
     }
 

--- a/crates/app/src/code_surface/editing.rs
+++ b/crates/app/src/code_surface/editing.rs
@@ -1549,15 +1549,18 @@ fn render_fold_chevron(
         // builds, matching every other `debug_selector` in this crate.
         .debug_selector(move || format!("file-view-fold-chevron-{line_number}"))
         .absolute()
-        .left(gpui::px(3.0))
+        .left(gpui::px(2.0))
         .top_0()
         .h_full()
-        .w(gpui::px(12.0))
+        .w(gpui::px(16.0))
         .flex()
         .items_center()
         .justify_center()
         .cursor_pointer()
-        .text_size(gpui::px(9.0))
+        // Live-reported: too small to notice at the original 9px/12px box - bumped to match the
+        // line number's own 11px (`text_size(gpui::px(11.0))` on the gutter container above) so
+        // the chevron reads at a glance rather than disappearing next to it.
+        .text_size(gpui::px(11.0))
         .text_color(if folded {
             theme::editor::GUTTER_TEXT_ACTIVE
         } else {
@@ -5341,6 +5344,44 @@ let last = 5;
         assert!(
             cx.debug_bounds("file-view-fold-marker-1").is_none(),
             "nothing is folded yet, so no `⋯ N lines` marker may be drawn"
+        );
+    }
+
+    /// Live-reported: the chevron was too small to notice, sized up in response
+    /// (`render_fold_chevron`: 9px/12px box -> 11px/16px box, `left` 3px -> 2px). A real
+    /// regression guard that the bigger box still sits where it's coded to, inside the gutter's
+    /// own real measured bounds - not a claim about the line number's own glyph bounds, which
+    /// nothing paints a separately-measurable box for, but the arithmetic the comment below
+    /// gives is real: the gutter is a fixed 52px box with 12px of right padding
+    /// (`render_editable_file_view_line`), so real text has 40px to paint in; the chevron's own
+    /// right edge at 2+16=18px inside that box leaves 22px clear before it, comfortably more
+    /// than a real 3-digit line number needs at the gutter's 11px mono font.
+    #[gpui::test]
+    fn the_bigger_fold_chevron_still_sits_inside_the_gutters_own_left_margin(
+        cx: &mut TestAppContext,
+    ) {
+        let (_app, cx, _path) = open_foldable_file(cx);
+
+        let gutter = cx
+            .debug_bounds("file-view-gutter-1")
+            .expect("line 1's real gutter box must be painted");
+        let chevron = cx
+            .debug_bounds("file-view-fold-chevron-1")
+            .expect("line 1 opens a block, so it must offer a chevron");
+
+        assert_eq!(
+            chevron.left() - gutter.left(),
+            gpui::px(2.0),
+            "the chevron's real left offset inside its real gutter parent must match what \
+             `render_fold_chevron` is coded to paint"
+        );
+        assert_eq!(
+            chevron.right() - gutter.left(),
+            gpui::px(18.0),
+            "the chevron's real right edge (2px left + 16px wide) must land inside the \
+             documented 22px of clearance before the gutter's own 40px text region \
+             (52px box - 12px right padding), not creep into where a real 3-digit line number \
+             paints"
         );
     }
 

--- a/crates/app/src/code_surface/editing.rs
+++ b/crates/app/src/code_surface/editing.rs
@@ -173,8 +173,13 @@ impl AdeApp {
                 };
                 let (line, _) = buffer.line_col_for_offset(buffer.cursor_offset());
                 self.code_cursor = Some(line + 1);
-                self.file_view_scroll_handle
-                    .scroll_to_item(line, gpui::ScrollStrategy::Nearest);
+                // GitHub issue #202: `scroll_to_item` indexes *visual rows*, which stop being
+                // line indices once anything is collapsed - and a caret that ended up inside a
+                // collapsed region is expanded back into view here, since only the caret's own
+                // painted row registers the real `window.handle_input` wiring. See
+                // `AdeApp::scroll_file_view_to_line`.
+                let absolute_path = self.file_tree_root.join(&path);
+                self.scroll_file_view_to_line(&absolute_path, line, gpui::ScrollStrategy::Nearest);
             }
             Some(EditTarget::Merge) => {
                 let Some(edit) = self.merge_edit.as_ref() else {
@@ -1492,6 +1497,115 @@ pub(in crate::code_surface) struct EditableLineContext<'a> {
     /// text origin (the same origin `cursor_local`'s `x_for_index` measurements below use), of
     /// one real indent level's own guide line.
     pub indent_guide_xs: Vec<Pixels>,
+    /// GitHub issue #202: `Some` only on a row whose line really opens a collapsible region -
+    /// that row grows a gutter chevron, and a `⋯ N lines` marker while collapsed. Every other
+    /// row is `None` and paints exactly as it always did.
+    pub fold_state: Option<RowFoldState>,
+}
+
+/// One row's fold affordance - see [`EditableLineContext::fold_state`].
+///
+/// Carries the *absolute* path rather than reusing [`EditableLineContext::path`] (which is
+/// worktree-relative) because `AdeApp::file_view_folds` is keyed absolutely; both are needed at
+/// the click, so the chevron's handler gets one of each.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::code_surface) struct RowFoldState {
+    pub path: PathBuf,
+    /// 0-based start line of the region this row opens - the key the fold set stores.
+    pub start_line: usize,
+    /// How many real lines the region hides while collapsed; reported verbatim by the marker, so
+    /// the number on screen is never an estimate.
+    pub hidden_count: usize,
+    /// Whether the region is collapsed right now, which decides both the chevron's direction and
+    /// whether the marker is drawn at all.
+    pub folded: bool,
+}
+
+/// The `▾`/`▸` fold chevron in a foldable row's line-number gutter (GitHub issue #202).
+///
+/// Absolutely positioned inside the gutter's own fixed 52px box rather than added as a flex
+/// sibling of the line number: the gutter's exact width is test-locked
+/// (`crate::code_surface::zoom::code_zoom_tests::zoom_scales_text_but_not_the_gutter_width`) and
+/// widening it would shift every row's code column. An absolute child contributes nothing to its
+/// parent's layout, so the number keeps its existing right-aligned position and the chevron sits
+/// in the empty space to its left.
+///
+/// Uses the same `▾`/`▸` glyph pair the file tree's own expand caret uses
+/// (`crate::sidebar::render::render_tree_caret`) so "this thing collapses" reads the same way in
+/// both surfaces, and the same `editor::GUTTER_TEXT`/`GUTTER_TEXT_ACTIVE` pair the line numbers
+/// beside it already use, so a collapsed region reads as active without a new colour token.
+fn render_fold_chevron(
+    fold: &RowFoldState,
+    relative_path: PathBuf,
+    line_number: usize,
+    cx: &mut Context<AdeApp>,
+) -> impl IntoElement {
+    let absolute_path = fold.path.clone();
+    let start_line = fold.start_line;
+    let folded = fold.folded;
+    gpui::div()
+        .id(("file-view-fold-chevron", line_number))
+        // Lets a real GPUI test find and click this exact affordance - a no-op outside test
+        // builds, matching every other `debug_selector` in this crate.
+        .debug_selector(move || format!("file-view-fold-chevron-{line_number}"))
+        .absolute()
+        .left(gpui::px(3.0))
+        .top_0()
+        .h_full()
+        .w(gpui::px(12.0))
+        .flex()
+        .items_center()
+        .justify_center()
+        .cursor_pointer()
+        .text_size(gpui::px(9.0))
+        .text_color(if folded {
+            theme::editor::GUTTER_TEXT_ACTIVE
+        } else {
+            theme::editor::GUTTER_TEXT
+        })
+        .hover(|style| style.text_color(theme::editor::GUTTER_TEXT_ACTIVE))
+        .child(if folded { "\u{25b8}" } else { "\u{25be}" })
+        .on_mouse_down(
+            gpui::MouseButton::Left,
+            cx.listener(move |this, _event: &gpui::MouseDownEvent, _window, cx| {
+                this.toggle_code_fold(&absolute_path, &relative_path, start_line);
+                // Mandatory, not defensive. Nothing else in the gutter handles a click, so
+                // without this the event bubbles all the way to the `uniform_list`
+                // container's own "clicked below the last line" fallback
+                // (`crate::code_surface::file_view::AdeApp::render_file_view`), which would
+                // fling the caret to the end of the buffer on every fold.
+                cx.stop_propagation();
+                cx.notify();
+            }),
+        )
+}
+
+/// The `⋯ N lines` marker a collapsed row grows at the end of its own text (GitHub issue #202) -
+/// the visible evidence that content is hidden here rather than simply absent.
+///
+/// Reuses the Diff view's own `theme::diff::FOLD_BG`/`FOLD_FG` pair
+/// (`crate::code_surface::diff_view::render_fold_marker`, the `⋯ N unchanged lines` band between
+/// hunks), so the app's two "content is collapsed here" affordances read identically.
+///
+/// `N` is the region's real hidden line count, straight from
+/// `crate::code_surface::fold::FoldRange::hidden_count` - never an estimate.
+fn render_fold_marker(hidden_count: usize, line_number: usize) -> impl IntoElement {
+    gpui::div()
+        .debug_selector(move || format!("file-view-fold-marker-{line_number}"))
+        .flex_none()
+        .ml(gpui::px(8.0))
+        .px(gpui::px(6.0))
+        .rounded(gpui::px(3.0))
+        .bg(theme::diff::FOLD_BG)
+        .text_color(theme::diff::FOLD_FG)
+        // `rems()`, matching the code text beside it, so the marker scales with editor zoom
+        // instead of becoming a fixed-size sliver - the same reasoning the Diff view's own
+        // marker documents.
+        .text_size(gpui::rems(0.85))
+        .child(format!(
+            "\u{22ef} {hidden_count} line{}",
+            if hidden_count == 1 { "" } else { "s" }
+        ))
 }
 
 /// The real quad(s) to paint for a caret at pixel range `[start_x, end_x)` on a row spanning
@@ -1599,7 +1713,11 @@ pub(in crate::code_surface) fn render_editable_file_view_line(
         caret_style,
         caret_blink_visible,
         indent_guide_xs,
+        fold_state,
     } = context;
+    // A third independent owned copy of this row's relative path, for the fold chevron's own
+    // `move` click closure - the same reason `row_path`/`drag_row_path` below are separate clones.
+    let fold_relative_path = path.clone();
 
     let gutter_color = if is_current {
         theme::editor::GUTTER_TEXT_ACTIVE
@@ -1861,6 +1979,13 @@ pub(in crate::code_surface) fn render_editable_file_view_line(
     // own, overflowed and painted over the glyphs on a narrow pane. Here the code text is the
     // `flex_none` child and this is the shrinkable one, so it takes exactly whatever width is
     // left after the code and ellipsizes - see `render_inline_diagnostic_message`'s own docs.
+    // GitHub issue #202: the `⋯ N lines` marker for a row whose region is collapsed, placed
+    // immediately after the `flex_none` code text - so it reads as a continuation of the line the
+    // way VS Code's own collapsed-region badge does - and before the shrinkable diagnostic
+    // message below, which must stay the element that yields on a narrow pane.
+    if let Some(fold) = fold_state.as_ref().filter(|fold| fold.folded) {
+        text_row = text_row.child(render_fold_marker(fold.hidden_count, line_number));
+    }
     if let Some(first) = diagnostics.first() {
         let first_line = first.message.lines().next().unwrap_or_default();
         text_row = text_row.child(render_inline_diagnostic_message(
@@ -2062,6 +2187,10 @@ pub(in crate::code_surface) fn render_editable_file_view_line(
                 .flex_none()
                 .w(gpui::px(52.0))
                 .pr(gpui::px(12.0))
+                // GitHub issue #202: the positioning context the fold chevron below anchors to.
+                // The gutter's own fixed width and right-aligned number are untouched - see
+                // `render_fold_chevron`'s own docs for why it must not become a flex sibling.
+                .relative()
                 .text_right()
                 .text_color(gutter_color)
                 .text_size(gpui::px(11.0))
@@ -2069,7 +2198,12 @@ pub(in crate::code_surface) fn render_editable_file_view_line(
                 // that function's docs (`code_zoom_tests::zoom_scales_text_but_not_the_gutter_
                 // width` measures this exact id against both rendering paths).
                 .debug_selector(move || format!("file-view-gutter-{line_number}"))
-                .child(line_number.to_string()),
+                .child(line_number.to_string())
+                .children(
+                    fold_state
+                        .as_ref()
+                        .map(|fold| render_fold_chevron(fold, fold_relative_path, line_number, cx)),
+                ),
         )
         .child(
             gpui::div()
@@ -5120,6 +5254,350 @@ mod editing_tests {
         assert!(
             ring_runs(&app, cx) > 0,
             "turning it back on must restore the ring on the same already-open buffer"
+        );
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // GitHub issue #202 ("Collapse code blocks")
+    //
+    // Every one of these drives the real File view: a real file on disk, opened through
+    // `open_file_view`, rendered through the real `uniform_list` row builder, and folded by a
+    // real `simulate_click` on the real painted bounds of the real gutter chevron. Nothing here
+    // calls `AdeApp::toggle_code_fold` directly - a test that did could not tell a working
+    // chevron from one bound to nothing.
+    // ---------------------------------------------------------------------------------------
+
+    /// Lines (1-based): 1 opens a block that closes on 4, so folding it hides 2, 3 and 4.
+    /// Line 5 is a complete `{}` pair on one line - deliberately present, because it must *not*
+    /// offer a chevron. Lines 6-8 are the tail that has to shift up when the block collapses.
+    const FOLDABLE_SOURCE: &str = "\
+fn alpha() {
+    let a = 1;
+    let b = 2;
+}
+fn beta() {}
+let tail = 3;
+let more = 4;
+let last = 5;
+";
+
+    /// `VisualTestContext::debug_bounds` takes a `&'static str`, but these tests build selector
+    /// names per line number. Leaking the handful of short strings a test produces is the
+    /// simplest honest way to satisfy that, and the test binary exits moments later.
+    fn selector(name: String) -> &'static str {
+        Box::leak(name.into_boxed_str())
+    }
+
+    fn open_foldable_file(
+        cx: &mut TestAppContext,
+    ) -> (Entity<AdeApp>, &mut gpui::VisualTestContext, PathBuf) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let repo_path = repo.path().to_path_buf();
+        // The tempdir must outlive the test body; every other test in this module keeps it in a
+        // local, but these need the app *and* the context back, so it is leaked deliberately -
+        // the process exits at the end of the test binary anyway.
+        std::mem::forget(repo);
+        let file_path = write_file(&repo_path, "sample.rs", FOLDABLE_SOURCE);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_path);
+        open_file_for_editing(&app, cx, file_path.clone());
+        (app, cx, file_path)
+    }
+
+    /// Clicks the middle of whatever the fold chevron on `line_number` actually painted, failing
+    /// loudly if no such element was painted at all - so a chevron that silently stopped
+    /// rendering can never be mistaken for a fold that did nothing.
+    fn click_fold_chevron(cx: &mut gpui::VisualTestContext, line_number: usize) {
+        let bounds = cx
+            .debug_bounds(selector(format!("file-view-fold-chevron-{line_number}")))
+            .unwrap_or_else(|| {
+                panic!("line {line_number} should have painted a real fold chevron")
+            });
+        assert!(
+            bounds.size.width > gpui::px(0.0) && bounds.size.height > gpui::px(0.0),
+            "the chevron must have real clickable area, measured {:?}",
+            bounds.size
+        );
+        cx.simulate_click(bounds.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+    }
+
+    #[gpui::test]
+    fn only_a_line_that_really_opens_a_block_draws_a_fold_chevron(cx: &mut TestAppContext) {
+        let (_app, cx, _path) = open_foldable_file(cx);
+
+        assert!(
+            cx.debug_bounds("file-view-fold-chevron-1").is_some(),
+            "line 1 opens a block that closes on line 4, so it must offer a chevron"
+        );
+        assert!(
+            cx.debug_bounds("file-view-fold-chevron-2").is_none(),
+            "line 2 is an ordinary statement - no chevron"
+        );
+        assert!(
+            cx.debug_bounds("file-view-fold-chevron-5").is_none(),
+            "`fn beta() {{}}` opens and closes on one line, so there is nothing to hide and it \
+             must not offer a chevron that would do nothing"
+        );
+        assert!(
+            cx.debug_bounds("file-view-fold-marker-1").is_none(),
+            "nothing is folded yet, so no `⋯ N lines` marker may be drawn"
+        );
+    }
+
+    /// The core of the feature: a real click on the real chevron makes the block's rows stop
+    /// existing on screen, leaves the block's own first line in place with a marker reporting the
+    /// real hidden count, and keeps everything after the block rendering.
+    #[gpui::test]
+    fn clicking_the_chevron_really_collapses_the_block(cx: &mut TestAppContext) {
+        let (app, cx, path) = open_foldable_file(cx);
+
+        for line_number in 1..=8 {
+            assert!(
+                cx.debug_bounds(selector(format!("file-view-text-row-{line_number}")))
+                    .is_some(),
+                "line {line_number} must be on screen before the fold, or this test cannot tell \
+                 a real collapse from a row that was never rendered"
+            );
+        }
+
+        click_fold_chevron(cx, 1);
+
+        assert!(
+            cx.debug_bounds("file-view-text-row-1").is_some(),
+            "the block's own first line stays visible - it is what carries the marker"
+        );
+        for hidden in 2..=4 {
+            assert!(
+                cx.debug_bounds(selector(format!("file-view-text-row-{hidden}")))
+                    .is_none(),
+                "line {hidden} is inside the collapsed block and must no longer paint"
+            );
+        }
+        for still_visible in 5..=8 {
+            assert!(
+                cx.debug_bounds(selector(format!("file-view-text-row-{still_visible}")))
+                    .is_some(),
+                "line {still_visible} is past the collapsed block and must still paint"
+            );
+        }
+        assert!(
+            cx.debug_bounds("file-view-fold-marker-1").is_some(),
+            "a collapsed row must show the `⋯ N lines` marker - the only on-screen evidence that \
+             content is hidden rather than absent"
+        );
+
+        // And the real state behind it, so a marker drawn without a real fold would still fail.
+        let folded = app.read_with(cx, |app, _| {
+            app.file_view_folds.get(&path).cloned().unwrap_or_default()
+        });
+        assert_eq!(
+            folded,
+            std::collections::HashSet::from([0]),
+            "the 0-based start line of the collapsed region"
+        );
+    }
+
+    #[gpui::test]
+    fn clicking_the_chevron_again_brings_every_hidden_row_back(cx: &mut TestAppContext) {
+        let (app, cx, path) = open_foldable_file(cx);
+
+        click_fold_chevron(cx, 1);
+        assert!(cx.debug_bounds("file-view-text-row-3").is_none());
+
+        // The chevron is still there (now pointing right) on the collapsed row.
+        click_fold_chevron(cx, 1);
+
+        for line_number in 1..=8 {
+            assert!(
+                cx.debug_bounds(selector(format!("file-view-text-row-{line_number}")))
+                    .is_some(),
+                "line {line_number} must be back after expanding"
+            );
+        }
+        assert!(
+            cx.debug_bounds("file-view-fold-marker-1").is_none(),
+            "an expanded row must not keep claiming lines are hidden"
+        );
+        assert!(app.read_with(cx, |app, _| app
+            .file_view_folds
+            .get(&path)
+            .is_none_or(|folded| folded.is_empty())));
+    }
+
+    /// Regression guard for the one real hazard `render_fold_chevron`'s `cx.stop_propagation()`
+    /// exists for: nothing else in the gutter handles a click, so without it the event reaches
+    /// the `uniform_list` container's own "clicked below the last line" fallback and slams the
+    /// caret to the end of the buffer.
+    #[gpui::test]
+    fn folding_does_not_fling_the_caret_to_the_end_of_the_buffer(cx: &mut TestAppContext) {
+        let (app, cx, _path) = open_foldable_file(cx);
+        let relative = PathBuf::from("sample.rs");
+
+        let before = app.read_with(cx, |app, _| {
+            app.edit_buffer(&relative).expect("buffer").cursor_offset()
+        });
+        assert_eq!(
+            before, 0,
+            "a freshly opened file starts with the caret at 0"
+        );
+
+        click_fold_chevron(cx, 1);
+
+        let after = app.read_with(cx, |app, _| {
+            app.edit_buffer(&relative).expect("buffer").cursor_offset()
+        });
+        assert_eq!(
+            after, before,
+            "the caret was outside the collapsed block, so folding must leave it exactly where \
+             it was - not at the end of the buffer"
+        );
+    }
+
+    /// Collapsing the block the caret is sitting in is not merely a cosmetic problem: only the
+    /// caret's *own* painted row registers the real `window.handle_input` wiring, so a caret left
+    /// on a row that no longer paints would make typing silently stop working. The caret must be
+    /// lifted onto the collapsed region's own still-visible line.
+    #[gpui::test]
+    fn folding_the_block_the_caret_is_inside_lifts_the_caret_onto_the_visible_row(
+        cx: &mut TestAppContext,
+    ) {
+        let (app, cx, _path) = open_foldable_file(cx);
+        let relative = PathBuf::from("sample.rs");
+
+        // Click a real row inside the block to put the caret there, the way a user would.
+        let row_bounds = cx
+            .debug_bounds("file-view-text-row-3")
+            .expect("line 3 should paint");
+        cx.simulate_click(row_bounds.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| {
+                app.edit_buffer(&relative)
+                    .expect("buffer")
+                    .line_col_for_offset(app.edit_buffer(&relative).unwrap().cursor_offset())
+                    .0
+            }),
+            2,
+            "the caret must really be on 0-based line 2 before folding"
+        );
+
+        click_fold_chevron(cx, 1);
+
+        let caret_line = app.read_with(cx, |app, _| {
+            let buffer = app.edit_buffer(&relative).expect("buffer");
+            buffer.line_col_for_offset(buffer.cursor_offset()).0
+        });
+        assert_eq!(
+            caret_line, 0,
+            "the caret must move onto the collapsed region's own visible start line"
+        );
+        assert_eq!(app.read_with(cx, |app, _| app.code_cursor), Some(1));
+        assert!(
+            cx.debug_bounds("file-view-text-row-1").is_some(),
+            "and that row really is on screen, so it can still register input handling"
+        );
+    }
+
+    /// Folding must not break where the hover/diagnostic cards anchor. Those read
+    /// `AdeApp::file_view_row_layout`, which is keyed by *buffer line number* and written by each
+    /// row's own paint - so this measures a real line's real painted row before and after a fold
+    /// and asserts it is still filed under its own line number, at the row it actually moved to.
+    #[gpui::test]
+    fn a_row_below_a_fold_keeps_its_own_line_number_in_the_popup_anchor_map(
+        cx: &mut TestAppContext,
+    ) {
+        let (app, cx, _path) = open_foldable_file(cx);
+
+        let row_top = |app: &Entity<AdeApp>, cx: &mut gpui::VisualTestContext, line: usize| {
+            app.read_with(cx, |app, _| {
+                app.file_view_row_layout
+                    .get(&line)
+                    .map(|(bounds, _)| bounds.top())
+            })
+        };
+
+        let line_5_before = row_top(&app, cx, 5).expect("line 5 painted before the fold");
+        let line_6_before = row_top(&app, cx, 6).expect("line 6 painted before the fold");
+        let row_height = line_6_before - line_5_before;
+        assert!(
+            row_height > gpui::px(0.0),
+            "two adjacent rows must be a real row height apart, measured {row_height:?}"
+        );
+
+        click_fold_chevron(cx, 1);
+
+        // Lines 2..=4 are hidden, so line 5 must have climbed exactly three rows - and must
+        // still be filed under 5, not under its new row index of 1.
+        let line_5_after = row_top(&app, cx, 5).expect("line 5 must still be anchored, under 5");
+        let climbed = line_5_before - line_5_after;
+        assert!(
+            (climbed - row_height * 3.0).abs() < gpui::px(1.0),
+            "line 5 should have moved up exactly three rows ({:?}), moved {climbed:?}",
+            row_height * 3.0
+        );
+
+        for hidden in 2..=4 {
+            assert!(
+                row_top(&app, cx, hidden).is_none(),
+                "line {hidden} no longer paints, so its stale anchor entry must have been pruned \
+                 - a popup anchored to it would otherwise point at a row that isn't there"
+            );
+        }
+    }
+
+    /// Folding is per file, and reopening a file keeps whatever was collapsed in it (the fold set
+    /// is keyed by absolute path, like `edit_buffers` is keyed per worktree) - while a *different*
+    /// file opened in between is entirely unaffected.
+    #[gpui::test]
+    fn fold_state_is_per_file(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let folded_file = write_file(repo.path(), "sample.rs", FOLDABLE_SOURCE);
+        let other_file = write_file(repo.path(), "other.rs", FOLDABLE_SOURCE);
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+
+        open_file_for_editing(&app, cx, folded_file.clone());
+        click_fold_chevron(cx, 1);
+        assert!(cx.debug_bounds("file-view-text-row-3").is_none());
+
+        open_file_for_editing(&app, cx, other_file);
+        assert!(
+            cx.debug_bounds("file-view-text-row-3").is_some(),
+            "a different file with identical content must open fully expanded"
+        );
+        assert!(cx.debug_bounds("file-view-fold-marker-1").is_none());
+
+        open_file_for_editing(&app, cx, folded_file);
+        assert!(
+            cx.debug_bounds("file-view-text-row-3").is_none(),
+            "coming back to the folded file must find it still folded"
+        );
+    }
+
+    /// The rows the list actually builds come from the fold map, so a collapsed file really is a
+    /// shorter list - not the same rows with some of them painted invisibly.
+    #[gpui::test]
+    fn a_collapsed_file_really_has_fewer_visual_rows(cx: &mut TestAppContext) {
+        let (app, cx, path) = open_foldable_file(cx);
+        let relative = PathBuf::from("sample.rs");
+
+        let row_count = |app: &Entity<AdeApp>, cx: &mut gpui::VisualTestContext| {
+            app.update(cx, |app, _| {
+                let line_count = app.edit_buffer(&relative).expect("buffer").lines.len();
+                app.file_view_fold_map(&path, &relative, line_count)
+                    .visible_row_count()
+            })
+        };
+
+        assert_eq!(
+            row_count(&app, cx),
+            9,
+            "8 real lines plus the trailing empty"
+        );
+        click_fold_chevron(cx, 1);
+        assert_eq!(
+            row_count(&app, cx),
+            6,
+            "three lines collapsed away, and nothing else changed"
         );
     }
 }

--- a/crates/app/src/code_surface/file_view.rs
+++ b/crates/app/src/code_surface/file_view.rs
@@ -63,6 +63,12 @@ impl AdeApp {
             .or_default();
         if folded.remove(&start_line) {
             // Expanding can never hide anything, so there is nothing to protect the caret from.
+            // An empty set left behind is pure bookkeeping debt - nothing reads it as
+            // "this file is still folded" - so it goes with the last fold it held, the same
+            // "don't grow this map forever" discipline `Self::file_view_row_layout` follows.
+            if folded.is_empty() {
+                self.file_view_folds.remove(absolute_path);
+            }
             return;
         }
         folded.insert(start_line);
@@ -799,7 +805,28 @@ impl AdeApp {
                     } else {
                         buffer.move_to(end);
                     }
+                    // The buffer's own real last line, 0-based - not
+                    // `line_col_for_offset(cursor_offset())`, whose documented boundary
+                    // convention rounds an offset sitting exactly on a line break up to the
+                    // *start of the next line*. For content ending in a trailing newline (the
+                    // ordinary case) `end` is exactly such a boundary, so that call would resolve
+                    // to one line past the buffer's real content - never a folded line, so the
+                    // reveal below would silently do nothing.
+                    let line = buffer.lines.len().saturating_sub(1);
                     this.code_cursor = Some(click_line_count.max(1));
+                    // GitHub issue #202: the caret can land on a line hidden inside a collapsed
+                    // fold whenever that region's closer sits on (or near) the buffer's own last
+                    // line - real, reachable content this app edits every day (`fn main() { ... }`
+                    // as the last block in a short file). A row that never paints never registers
+                    // `window.handle_input`, so without this the click would silently strand
+                    // typing - the same class of bug `Self::sync_cursor_and_scroll` exists to
+                    // prevent for every other caret-moving action.
+                    let absolute_path = this.file_tree_root.join(&click_path);
+                    this.scroll_file_view_to_line(
+                        &absolute_path,
+                        line,
+                        gpui::ScrollStrategy::Nearest,
+                    );
                     cx.stop_propagation();
                     cx.notify();
                 }),

--- a/crates/app/src/code_surface/file_view.rs
+++ b/crates/app/src/code_surface/file_view.rs
@@ -14,6 +14,144 @@ use crate::root::widgets::render_sidebar_message;
 use std::collections::HashSet;
 
 impl AdeApp {
+    /// GitHub issue #202: the visual-row <-> buffer-line translation this file needs *right now*,
+    /// given whichever of its blocks the user has collapsed (`AdeApp::file_view_folds`).
+    ///
+    /// [`fold::FoldMap::unfolded`] - the identity, and the fast path every method on it
+    /// short-circuits on - whenever nothing is folded here, or whenever there is no live edit
+    /// buffer at all. That second case is deliberate rather than a gap: the read-only fallback
+    /// view (a truncated or non-UTF-8 file, which `EditBuffer` refuses to open at all) carries no
+    /// fold affordances, so it can never have a non-empty fold set to honour.
+    ///
+    /// `&mut self` because the fold ranges themselves are memoized on the buffer - see
+    /// [`edit_buffer::EditBuffer::fold_ranges`] for why they must not be recomputed per frame.
+    pub(in crate::code_surface) fn file_view_fold_map(
+        &mut self,
+        absolute_path: &Path,
+        relative_path: &Path,
+        line_count: usize,
+    ) -> fold::FoldMap {
+        let folded = match self.file_view_folds.get(absolute_path) {
+            Some(folded) if !folded.is_empty() => folded.clone(),
+            _ => return fold::FoldMap::unfolded(line_count),
+        };
+        let Some(buffer) = self.edit_buffer_mut(relative_path) else {
+            return fold::FoldMap::unfolded(line_count);
+        };
+        let total_lines = buffer.lines.len();
+        fold::FoldMap::new(total_lines, buffer.fold_ranges(), &folded)
+    }
+
+    /// Collapses the region starting at 0-based `start_line`, or expands it if it is already
+    /// collapsed - the whole behavior behind one click on a gutter chevron
+    /// (`crate::code_surface::editing::render_fold_chevron`).
+    ///
+    /// Collapsing can swallow the row the caret is sitting on, which is not merely cosmetic: only
+    /// the caret's *own* row registers the real `window.handle_input` wiring
+    /// (`render_editable_file_view_line`'s paint callback), so a caret on a row that no longer
+    /// paints would leave typing silently doing nothing. [`Self::lift_caret_out_of_folds`] is what
+    /// makes that unreachable.
+    pub(in crate::code_surface) fn toggle_code_fold(
+        &mut self,
+        absolute_path: &Path,
+        relative_path: &Path,
+        start_line: usize,
+    ) {
+        let folded = self
+            .file_view_folds
+            .entry(absolute_path.to_path_buf())
+            .or_default();
+        if folded.remove(&start_line) {
+            // Expanding can never hide anything, so there is nothing to protect the caret from.
+            return;
+        }
+        folded.insert(start_line);
+        self.lift_caret_out_of_folds(absolute_path, relative_path);
+    }
+
+    /// Moves the caret to the end of the collapsed region's own (still visible) start line if it
+    /// currently sits on a line some collapsed region hides. A no-op in every other case.
+    fn lift_caret_out_of_folds(&mut self, absolute_path: &Path, relative_path: &Path) {
+        let Some(folded) = self.file_view_folds.get(absolute_path).cloned() else {
+            return;
+        };
+        if folded.is_empty() {
+            return;
+        }
+        let Some(buffer) = self.edit_buffer_mut(relative_path) else {
+            return;
+        };
+        let total_lines = buffer.lines.len();
+        let (caret_line, _) = buffer.line_col_for_offset(buffer.cursor_offset());
+        let map = fold::FoldMap::new(total_lines, buffer.fold_ranges(), &folded);
+        if !map.is_hidden(caret_line) {
+            return;
+        }
+        // `row_for_line` resolves a hidden line to the row of the region that swallowed it, and
+        // `line_for_row` back to that region's own start line - the line that stays on screen.
+        let visible_line = map.line_for_row(map.row_for_line(caret_line));
+        let offset = buffer.offset_for_line_col(visible_line, buffer.line_len(visible_line));
+        buffer.move_to(offset);
+        self.code_cursor = Some(visible_line + 1);
+    }
+
+    /// Scrolls the File view so 0-based buffer line `line` is in view, first *expanding* any
+    /// collapsed region currently hiding it.
+    ///
+    /// Every caller used to hand `line` straight to `UniformListScrollHandle::scroll_to_item`,
+    /// which indexes *visual rows*; with a fold active those two numbers differ and the list
+    /// would scroll somewhere unrelated. Routing all of them through here is what keeps go-to-
+    /// definition, caret-follow and file-open landing on the right row.
+    ///
+    /// Expanding rather than merely scrolling to the collapsed row is deliberate: every caller is
+    /// putting the caret on `line`, and a caret on a row that does not paint has no
+    /// `window.handle_input` registration, so typing would silently stop working. See this
+    /// module's own fold tests for the coverage that pins this down.
+    pub(crate) fn scroll_file_view_to_line(
+        &mut self,
+        absolute_path: &Path,
+        line: usize,
+        strategy: ScrollStrategy,
+    ) {
+        let row = self.reveal_folded_line(absolute_path, line);
+        self.file_view_scroll_handle.scroll_to_item(row, strategy);
+    }
+
+    /// Expands every collapsed region hiding 0-based `line`, and returns the visual row that
+    /// line then occupies. Returns `line` unchanged - the identity every call site had before
+    /// folding existed - whenever this file has nothing folded.
+    fn reveal_folded_line(&mut self, absolute_path: &Path, line: usize) -> usize {
+        let folded = match self.file_view_folds.get(absolute_path) {
+            Some(folded) if !folded.is_empty() => folded.clone(),
+            _ => return line,
+        };
+        let Ok(relative_path) = absolute_path.strip_prefix(&self.file_tree_root) else {
+            return line;
+        };
+        let relative_path = relative_path.to_path_buf();
+        let Some(buffer) = self.edit_buffer_mut(&relative_path) else {
+            return line;
+        };
+        let total_lines = buffer.lines.len();
+        let ranges = buffer.fold_ranges().to_vec();
+
+        let mut folded = folded;
+        let expanded: Vec<usize> = ranges
+            .iter()
+            .filter(|range| {
+                folded.contains(&range.start_line) && range.hidden_lines().contains(&line)
+            })
+            .map(|range| range.start_line)
+            .collect();
+        for start_line in expanded {
+            folded.remove(&start_line);
+        }
+        let row = fold::FoldMap::new(total_lines, &ranges, &folded).row_for_line(line);
+        self.file_view_folds
+            .insert(absolute_path.to_path_buf(), folded);
+        row
+    }
+
     /// Surface C's File view: a breadcrumb, line-numbered/syntax-highlighted code
     /// (`crate::code_surface::code_view`), and a status bar for whichever file `relative_path` (resolved
     /// against [`Self::file_tree_root`]) names on disk.
@@ -162,8 +300,13 @@ impl AdeApp {
             if let Some(line) = target_line {
                 self.pending_cursor_line = None;
                 self.code_cursor = Some(line);
-                self.file_view_scroll_handle
-                    .scroll_to_item(line.saturating_sub(1), ScrollStrategy::Center);
+                // GitHub issue #202: a visual row, not a line index, and the target is expanded
+                // first if a collapsed region is hiding it - see `Self::scroll_file_view_to_line`.
+                self.scroll_file_view_to_line(
+                    &absolute_path,
+                    line.saturating_sub(1),
+                    ScrollStrategy::Center,
+                );
             }
         }
 
@@ -377,29 +520,69 @@ impl AdeApp {
         let show_indent_guides = self.settings.appearance.show_indent_guides;
         let indent_settings = self.resolved_indent_settings_for_target();
         let code_font_size_px = self.effective_code_rem_px();
+        // GitHub issue #202: resolved once per frame, here, and then used both for
+        // `uniform_list`'s own item count and inside its row builder, so the count the list is
+        // sized by and the mapping its rows are built from can never describe different fold
+        // states. `fold::FoldMap::unfolded` (a cheap, allocation-free identity that every method
+        // on it short-circuits on) whenever this file has nothing collapsed, which is the
+        // overwhelmingly common case.
+        let fold_map = self.file_view_fold_map(&absolute_path, &relative_path_buf, line_count);
+        let row_count = fold_map.visible_row_count();
+        let row_fold_map = fold_map.clone();
+        // The path the gutter chevrons' own click handlers toggle folds against - a separate
+        // owned clone, since `absolute_path` itself is borrowed further down this function.
+        let fold_absolute_path = absolute_path.clone();
+        // Which regions are collapsed right now, read directly rather than re-derived from
+        // `row_fold_map`, so a chevron's own direction says exactly what the fold set says.
+        let folded_starts: HashSet<usize> = self
+            .file_view_folds
+            .get(&absolute_path)
+            .cloned()
+            .unwrap_or_default();
 
         let mut code = uniform_list(
             "file-view-code",
-            line_count,
+            row_count,
             cx.processor(move |this: &mut Self, range: Range<usize>, window, cx| {
                 let relative_path = relative_path_buf.clone();
                 let has_buffer = this.edit_buffer_contains(&relative_path);
                 if has_buffer {
-                    let total = this
-                        .edit_buffer(&relative_path)
-                        .map(|buffer| buffer.lines.len())
-                        .unwrap_or(0);
-                    let start = range.start.min(total);
-                    let end = range.end.min(total);
+                    let start = range.start.min(row_count);
+                    let end = range.end.min(row_count);
+                    // GitHub issue #202: `uniform_list` hands out *visual row* indices, which stop
+                    // being buffer line indices the moment anything is collapsed. This is the one
+                    // place that translation happens for the row list; everything below works in
+                    // real buffer line indices exactly as it always did.
+                    let visible_lines: Vec<usize> = (start..end)
+                        .map(|row| row_fold_map.line_for_row(row))
+                        .collect();
+                    // Each visible line's own collapsible region, if it starts one - what decides
+                    // whether that row grows a gutter chevron, and (when collapsed) how many lines
+                    // its `⋯ N lines` marker reports. Looked up only for the handful of rows
+                    // actually on screen, against the buffer's own memoized range list.
+                    let visible_folds: Vec<Option<fold::FoldRange>> = {
+                        let ranges = this
+                            .edit_buffer_mut(&relative_path)
+                            .map(|buffer| buffer.fold_ranges())
+                            .unwrap_or(&[]);
+                        visible_lines
+                            .iter()
+                            .map(|&line| fold::range_starting_at(ranges, line))
+                            .collect()
+                    };
                     // `AdeApp::file_view_row_layout` is transient/best-effort (see its own docs)
                     // but was never pruned per-frame, only cleared wholesale on a worktree
                     // switch - a real, measured unbounded-growth risk (one `(Bounds, ShapedLine)`
                     // retained per line ever scrolled past, for the life of the worktree
-                    // agent). Pruned here to just this frame's own visible range (1-based, to
+                    // agent). Pruned here to just this frame's own visible rows (1-based, to
                     // match the map's own key convention): any entry this drops for a row that's
                     // about to be rebuilt below is harmless - that row's own real paint, moments
-                    // later this same pass, reinserts it fresh anyway.
-                    let visible_line_numbers = (start + 1)..=end;
+                    // later this same pass, reinserts it fresh anyway. Built from
+                    // `visible_lines`, not from the row range: with a fold active those are
+                    // different sets, and pruning by row index would evict the layout entries the
+                    // hover/diagnostic cards anchor to.
+                    let visible_line_numbers: HashSet<usize> =
+                        visible_lines.iter().map(|line| line + 1).collect();
                     this.file_view_row_layout
                         .retain(|line_number, _| visible_line_numbers.contains(line_number));
                     let cursor_line = this.code_cursor;
@@ -427,7 +610,7 @@ impl AdeApp {
                         None
                     };
                     let mut rows = Vec::with_capacity(end.saturating_sub(start));
-                    for index in start..end {
+                    for (visible_index, &index) in visible_lines.iter().enumerate() {
                         let Some(buffer) = this.edit_buffer(&relative_path) else {
                             break;
                         };
@@ -435,6 +618,17 @@ impl AdeApp {
                             break;
                         };
                         let line_number = index + 1;
+                        // GitHub issue #202: `Some` only on a line that really opens a
+                        // collapsible region - that row draws a chevron; every other row draws
+                        // the same blank gutter it always did.
+                        let fold_range = visible_folds[visible_index];
+                        let fold_state =
+                            fold_range.map(|range| crate::code_surface::editing::RowFoldState {
+                                path: fold_absolute_path.clone(),
+                                start_line: range.start_line,
+                                hidden_count: range.hidden_count(),
+                                folded: folded_starts.contains(&range.start_line),
+                            });
                         let is_current = cursor_line == Some(line_number);
                         // Still suppressed while dirty - see `buffer_dirty`'s own docs, above,
                         // for why this one (the git-gutter changed-line stripe, sourced from a
@@ -505,6 +699,7 @@ impl AdeApp {
                             caret_style: this.settings.appearance.caret_style,
                             caret_blink_visible: this.caret_blink_visible,
                             indent_guide_xs,
+                            fold_state,
                         };
                         rows.push(
                             crate::code_surface::editing::render_editable_file_view_line(
@@ -635,7 +830,7 @@ impl AdeApp {
             &self.file_view_diagnostics,
             &self.file_view_changed_lines,
             self.code_cursor,
-            line_count,
+            &fold_map,
         );
         let code_with_scrollbar = div()
             .relative()
@@ -670,6 +865,7 @@ impl AdeApp {
                 lines,
                 &self.file_view_changed_lines,
                 row_line_height.as_f32(),
+                &fold_map,
                 cx,
             ),
             None => None,
@@ -728,13 +924,20 @@ pub(in crate::code_surface) fn editor_scrollbar_marks(
     diagnostics: &HashMap<usize, Vec<diagnostics_view::LineDiagnostic>>,
     changed_lines: &HashSet<usize>,
     cursor_line: Option<usize>,
-    line_count: usize,
+    fold_map: &fold::FoldMap,
 ) -> Vec<scrollbar::ScrollbarMark> {
-    if line_count == 0 {
+    // GitHub issue #202: fractions are of the *scrollable* extent, which is the visual row count,
+    // not the line count - the two diverge the moment a region is collapsed, and a mark placed at
+    // a line fraction would then point somewhere the scrollbar can't scroll to. With nothing
+    // folded `row_for_line` is the identity and `visible_row_count` is the line count, so this
+    // computes exactly what it always did.
+    let row_count = fold_map.visible_row_count();
+    if row_count == 0 {
         return Vec::new();
     }
-    let fraction_for_line =
-        |line_number: usize| -> f32 { line_number.saturating_sub(1) as f32 / line_count as f32 };
+    let fraction_for_line = |line_number: usize| -> f32 {
+        fold_map.row_for_line(line_number.saturating_sub(1)) as f32 / row_count as f32
+    };
 
     let mut marks = Vec::new();
     for (&line_number, line_diagnostics) in diagnostics {
@@ -781,7 +984,12 @@ mod editor_scrollbar_mark_tests {
 
     #[test]
     fn an_empty_file_produces_no_marks_rather_than_a_divide_by_zero() {
-        let marks = editor_scrollbar_marks(&HashMap::new(), &HashSet::new(), Some(1), 0);
+        let marks = editor_scrollbar_marks(
+            &HashMap::new(),
+            &HashSet::new(),
+            Some(1),
+            &fold::FoldMap::unfolded(0),
+        );
         assert!(marks.is_empty());
     }
 
@@ -795,7 +1003,12 @@ mod editor_scrollbar_mark_tests {
                 diagnostic(diagnostics_view::Severity::Information),
             ],
         );
-        let marks = editor_scrollbar_marks(&diagnostics, &HashSet::new(), None, 100);
+        let marks = editor_scrollbar_marks(
+            &diagnostics,
+            &HashSet::new(),
+            None,
+            &fold::FoldMap::unfolded(100),
+        );
         assert!(marks.is_empty());
     }
 
@@ -803,7 +1016,12 @@ mod editor_scrollbar_mark_tests {
     fn an_error_diagnostic_produces_a_real_mark_at_the_lines_fraction() {
         let mut diagnostics = HashMap::new();
         diagnostics.insert(51, vec![diagnostic(diagnostics_view::Severity::Error)]);
-        let marks = editor_scrollbar_marks(&diagnostics, &HashSet::new(), None, 100);
+        let marks = editor_scrollbar_marks(
+            &diagnostics,
+            &HashSet::new(),
+            None,
+            &fold::FoldMap::unfolded(100),
+        );
         assert_eq!(marks.len(), 1);
         // Line 51 of 100, 1-based -> fraction 0.50.
         assert!((marks[0].fraction - 0.50).abs() < 0.001);
@@ -811,7 +1029,12 @@ mod editor_scrollbar_mark_tests {
 
     #[test]
     fn the_cursor_line_produces_its_own_mark_independent_of_diagnostics_and_git_changes() {
-        let marks = editor_scrollbar_marks(&HashMap::new(), &HashSet::new(), Some(1), 100);
+        let marks = editor_scrollbar_marks(
+            &HashMap::new(),
+            &HashSet::new(),
+            Some(1),
+            &fold::FoldMap::unfolded(100),
+        );
         assert_eq!(marks.len(), 1);
         assert!((marks[0].fraction - 0.0).abs() < 0.001);
     }
@@ -820,7 +1043,12 @@ mod editor_scrollbar_mark_tests {
     fn a_changed_line_produces_its_own_mark() {
         let mut changed = HashSet::new();
         changed.insert(100);
-        let marks = editor_scrollbar_marks(&HashMap::new(), &changed, None, 100);
+        let marks = editor_scrollbar_marks(
+            &HashMap::new(),
+            &changed,
+            None,
+            &fold::FoldMap::unfolded(100),
+        );
         assert_eq!(marks.len(), 1);
         // Line 100 of 100, 1-based -> fraction 0.99.
         assert!((marks[0].fraction - 0.99).abs() < 0.001);
@@ -832,7 +1060,12 @@ mod editor_scrollbar_mark_tests {
         diagnostics.insert(1, vec![diagnostic(diagnostics_view::Severity::Error)]);
         let mut changed = HashSet::new();
         changed.insert(2);
-        let marks = editor_scrollbar_marks(&diagnostics, &changed, Some(3), 100);
+        let marks = editor_scrollbar_marks(
+            &diagnostics,
+            &changed,
+            Some(3),
+            &fold::FoldMap::unfolded(100),
+        );
         assert_eq!(marks.len(), 3);
     }
 }

--- a/crates/app/src/code_surface/fold.rs
+++ b/crates/app/src/code_surface/fold.rs
@@ -1,0 +1,649 @@
+//! GitHub issue #202 ("Collapse code blocks"): which regions of one open file *can* be
+//! collapsed, and what the File view's row list looks like once some of them are.
+//!
+//! Deliberately pure - no `gpui::Window`, no `AdeApp` - so "which lines does folding line 3
+//! actually hide, and which buffer line does visual row 7 show" is a real `#[test]` assertion
+//! rather than something only reachable through a live window. The GPUI half (the gutter
+//! chevron, the `⋯ N lines` marker, the click handler) lives in
+//! `crate::code_surface::editing`; the wiring that turns a [`FoldMap`] into `uniform_list`'s own
+//! item count lives in `crate::code_surface::file_view`.
+//!
+//! ## Where fold ranges come from
+//!
+//! There is no `textDocument/foldingRange` in this app's language-server client (see
+//! `crate::lsp::client` - the declared `ClientCapabilities` cover hover/diagnostics/completion
+//! only), so [`foldable_ranges`] derives them itself, from real bracket matching over the exact
+//! same `code_view::RenderedLine` runs the File view already renders.
+//!
+//! Working off the *already-classified* runs rather than the raw text is the whole point: a
+//! `{` inside a string literal or a comment lands in a [`HighlightKind::String`]/
+//! [`HighlightKind::Comment`] run, and [`kind_can_hold_brackets`] skips those - so this gets
+//! real string/comment awareness for free from the tree-sitter pass that already ran, with no
+//! second, independently-drifting lexer of its own. For a file whose language has no grammar at
+//! all every run is plain [`HighlightKind::Text`], so brackets there still pair up (a `.txt`
+//! file with braces really is foldable) - the honest fallback, not a special case.
+//!
+//! Deliberately *not* keyed off [`HighlightKind::BRACKET_DEPTH_RING`] (the rainbow-bracket
+//! classification `code_view::colorize_bracket_pairs` assigns, which already knows which
+//! brackets found a real partner): that pass only runs when the user's own
+//! `appearance.bracket_pair_colorization` setting is on, and folding must not silently
+//! disappear when someone turns rainbow brackets off.
+//!
+//! ## What is not covered
+//!
+//! Only bracket-delimited regions. Indentation-only blocks (Python's `def f():`, YAML) produce
+//! no fold range, and neither do `#region` comment markers or Markdown headings - all real
+//! VS Code behaviors, all left as follow-ups rather than guessed at here.
+
+use super::code_view::{HighlightKind, RenderedLine};
+use std::collections::HashSet;
+use std::ops::Range;
+
+/// The three bracket shapes folding tracks, mirroring `code_view::TRACKED_BRACKET_PAIRS` (which
+/// is private to that module) so a foldable region and a rainbow-coloured bracket pair always
+/// mean the same three shapes. Angle brackets are deliberately absent for the same reason that
+/// pass gives: `<`/`>` are far more often comparison operators than a real pair.
+const TRACKED_BRACKET_PAIRS: [(u8, u8); 3] = [(b'(', b')'), (b'[', b']'), (b'{', b'}')];
+
+fn closer_for(opener: u8) -> Option<u8> {
+    TRACKED_BRACKET_PAIRS
+        .iter()
+        .find_map(|&(open, close)| (open == opener).then_some(close))
+}
+
+fn is_tracked_closer(byte: u8) -> bool {
+    TRACKED_BRACKET_PAIRS
+        .iter()
+        .any(|&(_, close)| close == byte)
+}
+
+/// Whether a run of this classification can contain a bracket that really opens or closes a
+/// block. String and comment bodies cannot - a `{` in `"a { b"` or in `// close the { here` is
+/// literal text, and pairing it up would produce fold regions that span nonsense.
+///
+/// Everything else is included, which matters for two real cases beyond ordinary code: a file
+/// whose language has no grammar (every run is [`HighlightKind::Text`]) still folds, and a
+/// bracket the rainbow pass reclassified into the depth ring still counts.
+fn kind_can_hold_brackets(kind: HighlightKind) -> bool {
+    !matches!(
+        kind,
+        HighlightKind::String
+            | HighlightKind::StringEscape
+            | HighlightKind::Comment
+            | HighlightKind::CommentDoc
+            | HighlightKind::CommentDocTag
+    )
+}
+
+/// One region the user can collapse: the line carrying an opening bracket, and the line carrying
+/// its real matching closer.
+///
+/// Both are 0-based indices into the buffer's own `lines`. [`Self::start_line`] always stays
+/// visible when folded (it is the row that grows the `⋯ N lines` marker); everything from
+/// `start_line + 1` through `end_line` inclusive is what disappears - including the closing
+/// bracket's own line, matching VS Code, which collapses `fn f() {` ... `}` down to a single
+/// visible row rather than leaving a stranded `}` behind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct FoldRange {
+    pub start_line: usize,
+    pub end_line: usize,
+}
+
+impl FoldRange {
+    /// The half-open range of 0-based line indices this region hides when it is folded.
+    pub fn hidden_lines(&self) -> Range<usize> {
+        self.start_line + 1..self.end_line + 1
+    }
+
+    /// How many real lines disappear when this region is folded - what the `⋯ N lines` marker
+    /// reports, so the number on screen is always the real count rather than an estimate.
+    pub fn hidden_count(&self) -> usize {
+        self.end_line.saturating_sub(self.start_line)
+    }
+}
+
+/// Every collapsible region in `lines`, sorted by [`FoldRange::start_line`], at most one per
+/// start line.
+///
+/// The matcher is a single stack that only pops when the top of the stack expects exactly the
+/// closer it just saw - the same rule `code_view::colorize_bracket_pairs` uses, so a file the
+/// rainbow pass considers mismatched doesn't fold in some third, different way. An unmatched
+/// opener simply never yields a region.
+///
+/// **One fold per start line, and it is the widest one.** `foo({` opens two regions on the same
+/// line; VS Code offers a single chevron there, collapsing the outer one. Keeping the largest
+/// `end_line` is exactly that.
+///
+/// A pair that opens and closes on the *same* line (`fn f() {}`) is not a region at all - there
+/// is nothing to hide - and is dropped rather than offered as a chevron that does nothing.
+pub fn foldable_ranges(lines: &[RenderedLine]) -> Vec<FoldRange> {
+    // (expected closer, 0-based index of the line the opener is on).
+    let mut stack: Vec<(u8, usize)> = Vec::new();
+    let mut pairs: Vec<(usize, usize)> = Vec::new();
+
+    for (line_index, line) in lines.iter().enumerate() {
+        for (text, kind) in &line.runs {
+            if !kind_can_hold_brackets(*kind) {
+                continue;
+            }
+            // Byte-wise, not `chars()`: every tracked bracket is ASCII, and an ASCII byte can
+            // never occur inside a multi-byte UTF-8 sequence, so this is exactly as correct as
+            // decoding and materially cheaper on the whole-file scan this does.
+            for &byte in text.as_bytes() {
+                if let Some(closer) = closer_for(byte) {
+                    stack.push((closer, line_index));
+                } else if is_tracked_closer(byte) {
+                    if let Some(&(expected, opener_line)) = stack.last() {
+                        if expected == byte {
+                            stack.pop();
+                            if line_index > opener_line {
+                                pairs.push((opener_line, line_index));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pairs.sort_unstable();
+    let mut ranges: Vec<FoldRange> = Vec::new();
+    for (start_line, end_line) in pairs {
+        match ranges.last_mut() {
+            Some(last) if last.start_line == start_line => {
+                last.end_line = last.end_line.max(end_line);
+            }
+            _ => ranges.push(FoldRange {
+                start_line,
+                end_line,
+            }),
+        }
+    }
+    ranges
+}
+
+/// The region starting exactly at `line`, if `line` carries a fold chevron at all - a binary
+/// search over [`foldable_ranges`]' own already-sorted output, so the per-row lookup the File
+/// view does for every visible row costs `O(log n)` rather than a scan.
+pub fn range_starting_at(ranges: &[FoldRange], line: usize) -> Option<FoldRange> {
+    ranges
+        .binary_search_by_key(&line, |range| range.start_line)
+        .ok()
+        .map(|index| ranges[index])
+}
+
+/// The translation between the File view `uniform_list`'s own **visual row** indices and the
+/// buffer's **line** indices, for one file, as of one frame.
+///
+/// `uniform_list` (`vendor/zed/crates/gpui/src/elements/uniform_list.rs`) is a fixed-row-height
+/// virtualized list: it is told an item *count* and hands its row builder a `Range<usize>` of
+/// item indices. Until folding, that index was the buffer line index directly. With a fold
+/// active those two diverge, and this type is the single place that divergence is expressed -
+/// rather than each of the several call sites that currently do `scroll_to_item(line)` growing
+/// its own ad-hoc arithmetic.
+///
+/// ## Why the popups don't need to know about any of this
+///
+/// `AdeApp::file_view_row_layout` is keyed by *1-based buffer line number* and written by each
+/// row's own paint callback, and the hover/diagnostic cards (`crate::code_surface::lsp_ui`)
+/// position themselves off the real painted `Bounds` they find there. A folded-away line simply
+/// never paints, so it has no entry, and both cards already treat a missing entry as "nothing to
+/// anchor to" and render nothing. Folding therefore cannot misplace a popup - the one thing it
+/// must not do is start keying that map by row index instead.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FoldMap {
+    total_lines: usize,
+    /// Merged, sorted, disjoint, non-adjacent half-open ranges of hidden 0-based line indices.
+    hidden: Vec<Range<usize>>,
+    /// The first visible line of each contiguous run of visible lines; `hidden.len() + 1` entries,
+    /// strictly increasing.
+    segment_start_line: Vec<usize>,
+    /// The visual row that same segment starts at; index-aligned with `segment_start_line`.
+    segment_start_row: Vec<usize>,
+    visible_rows: usize,
+}
+
+impl FoldMap {
+    /// The identity map: nothing folded, so visual row `n` is buffer line `n`. This is the
+    /// overwhelmingly common case and every method below short-circuits on it, so an unfolded
+    /// file pays no measurable cost for folding existing.
+    pub fn unfolded(total_lines: usize) -> Self {
+        Self::from_hidden(total_lines, Vec::new())
+    }
+
+    /// The map for `folded_starts` (0-based [`FoldRange::start_line`]s the user has actually
+    /// collapsed) against `ranges`, this buffer's currently-detected regions.
+    ///
+    /// A `folded_starts` entry with no matching current range contributes nothing. That is the
+    /// deliberate self-healing behavior for the one real way fold state can go stale: fold
+    /// indices are plain line numbers and are *not* shifted by an edit above them, so an edit
+    /// that moves or destroys a region leaves an entry pointing at a line that no longer opens
+    /// one. Silently ignoring it is what makes that harmless rather than a crash or a region
+    /// that hides the wrong lines.
+    pub fn new(total_lines: usize, ranges: &[FoldRange], folded_starts: &HashSet<usize>) -> Self {
+        if folded_starts.is_empty() {
+            return Self::unfolded(total_lines);
+        }
+        let mut hidden: Vec<Range<usize>> = ranges
+            .iter()
+            .filter(|range| folded_starts.contains(&range.start_line))
+            .filter_map(|range| {
+                let hidden = range.hidden_lines();
+                let end = hidden.end.min(total_lines);
+                (hidden.start < end).then_some(hidden.start..end)
+            })
+            .collect();
+        hidden.sort_unstable_by_key(|range| range.start);
+
+        // Merge overlapping *and* touching ranges (nested folds always overlap; two sibling
+        // folds can end up exactly adjacent). Merging the touching case too is what guarantees
+        // every segment below is non-empty, which `segment_start_line` being strictly increasing
+        // - and therefore the binary searches - relies on.
+        let mut merged: Vec<Range<usize>> = Vec::with_capacity(hidden.len());
+        for range in hidden {
+            match merged.last_mut() {
+                Some(last) if range.start <= last.end => last.end = last.end.max(range.end),
+                _ => merged.push(range),
+            }
+        }
+        Self::from_hidden(total_lines, merged)
+    }
+
+    fn from_hidden(total_lines: usize, hidden: Vec<Range<usize>>) -> Self {
+        let mut segment_start_line = Vec::with_capacity(hidden.len() + 1);
+        let mut segment_start_row = Vec::with_capacity(hidden.len() + 1);
+        segment_start_line.push(0);
+        segment_start_row.push(0);
+        let mut hidden_so_far = 0usize;
+        for range in &hidden {
+            hidden_so_far += range.end - range.start;
+            segment_start_line.push(range.end);
+            segment_start_row.push(range.end - hidden_so_far);
+        }
+        let visible_rows = total_lines.saturating_sub(hidden_so_far);
+        Self {
+            total_lines,
+            hidden,
+            segment_start_line,
+            segment_start_row,
+            visible_rows,
+        }
+    }
+
+    /// What `uniform_list` must be told its item count is.
+    pub fn visible_row_count(&self) -> usize {
+        self.visible_rows
+    }
+
+    /// `true` when nothing at all is folded - the fast path the File view's row builder takes to
+    /// skip every conversion below.
+    pub fn is_identity(&self) -> bool {
+        self.hidden.is_empty()
+    }
+
+    /// Whether `line` (0-based) is currently hidden inside some collapsed region.
+    pub fn is_hidden(&self, line: usize) -> bool {
+        self.enclosing_hidden(line).is_some()
+    }
+
+    /// The 0-based buffer line visual row `row` shows.
+    ///
+    /// Clamped to the last real line: `uniform_list` is never asked for a row past
+    /// [`Self::visible_row_count`], but clamping rather than panicking keeps a stale frame
+    /// (a row range computed against a count from before an edit) rendering the wrong line
+    /// instead of taking the whole window down.
+    pub fn line_for_row(&self, row: usize) -> usize {
+        let last_line = self.total_lines.saturating_sub(1);
+        if self.hidden.is_empty() {
+            return row.min(last_line);
+        }
+        let segment = self
+            .segment_start_row
+            .partition_point(|&start| start <= row)
+            .saturating_sub(1);
+        let line = self.segment_start_line[segment] + (row - self.segment_start_row[segment]);
+        line.min(last_line)
+    }
+
+    /// The visual row showing 0-based buffer line `line`.
+    ///
+    /// A hidden line resolves to the row of the collapsed region that swallowed it - the fold's
+    /// own start line, which is exactly where a `scroll_to_item` for that line should land and
+    /// where the user would look for it.
+    pub fn row_for_line(&self, line: usize) -> usize {
+        if self.hidden.is_empty() {
+            return line.min(self.visible_rows.saturating_sub(1));
+        }
+        let line = match self.enclosing_hidden(line) {
+            Some(hidden) => hidden.start.saturating_sub(1),
+            None => line,
+        };
+        let segment = self
+            .segment_start_line
+            .partition_point(|&start| start <= line)
+            .saturating_sub(1);
+        let row = self.segment_start_row[segment] + (line - self.segment_start_line[segment]);
+        row.min(self.visible_rows.saturating_sub(1))
+    }
+
+    fn enclosing_hidden(&self, line: usize) -> Option<Range<usize>> {
+        let index = self
+            .hidden
+            .partition_point(|range| range.start <= line)
+            .checked_sub(1)?;
+        let candidate = self.hidden[index].clone();
+        (line < candidate.end).then_some(candidate)
+    }
+}
+
+#[cfg(test)]
+mod fold_range_tests {
+    use super::*;
+    use crate::code_surface::code_view;
+
+    /// Real `RenderedLine`s, built by the same real highlighter + line splitter the File view
+    /// itself renders from - not hand-assembled runs, so these tests exercise the actual runs
+    /// `foldable_ranges` will see in the app (including tree-sitter's own string/comment
+    /// classification, which is the whole basis for this module's string-awareness).
+    fn lines_of(source: &str, extension: Option<&str>) -> Vec<code_view::RenderedLine> {
+        let spans = code_view::HighlightOptions::default()
+            .highlight(source, code_view::highlighter_for_extension(extension));
+        code_view::build_lines(source, &spans)
+    }
+
+    #[test]
+    fn a_real_rust_function_body_is_one_foldable_region() {
+        let source = "fn alpha() {\n    let x = 1;\n    let y = 2;\n}\n";
+        let ranges = foldable_ranges(&lines_of(source, Some("rs")));
+        assert_eq!(
+            ranges,
+            vec![FoldRange {
+                start_line: 0,
+                end_line: 3
+            }],
+            "the `{{` on line 0 closes on line 3, so folding line 0 must hide lines 1..=3"
+        );
+        assert_eq!(ranges[0].hidden_lines(), 1..4);
+        assert_eq!(ranges[0].hidden_count(), 3);
+    }
+
+    #[test]
+    fn nested_blocks_each_get_their_own_region() {
+        let source = "fn alpha() {\n    if x {\n        y();\n    }\n}\n";
+        let ranges = foldable_ranges(&lines_of(source, Some("rs")));
+        assert_eq!(
+            ranges,
+            vec![
+                FoldRange {
+                    start_line: 0,
+                    end_line: 4
+                },
+                FoldRange {
+                    start_line: 1,
+                    end_line: 3
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn a_pair_that_opens_and_closes_on_one_line_is_not_foldable() {
+        let source = "fn alpha() {}\nfn beta() {}\n";
+        assert!(
+            foldable_ranges(&lines_of(source, Some("rs"))).is_empty(),
+            "there is nothing to hide, so offering a chevron would be a lie"
+        );
+    }
+
+    /// The reason this module reads already-classified runs instead of raw text: tree-sitter has
+    /// already decided these braces are inside a string literal, so they must not pair up.
+    #[test]
+    fn braces_inside_a_string_literal_never_open_a_region() {
+        let source = "fn alpha() {\n    let s = \"{\";\n    let t = 1;\n}\n";
+        let ranges = foldable_ranges(&lines_of(source, Some("rs")));
+        assert_eq!(
+            ranges,
+            vec![FoldRange {
+                start_line: 0,
+                end_line: 3
+            }],
+            "the `{{` inside the string must not become a second, unbalanced region"
+        );
+    }
+
+    #[test]
+    fn braces_inside_a_comment_never_open_a_region() {
+        let source = "fn alpha() {\n    // opens a { here\n    let t = 1;\n}\n";
+        let ranges = foldable_ranges(&lines_of(source, Some("rs")));
+        assert_eq!(
+            ranges,
+            vec![FoldRange {
+                start_line: 0,
+                end_line: 3
+            }]
+        );
+    }
+
+    /// `foo({` opens two regions on one line. VS Code shows a single chevron there; keeping the
+    /// widest is what makes that one chevron collapse the whole call rather than only its inner
+    /// object literal.
+    #[test]
+    fn one_line_opening_two_brackets_yields_a_single_widest_region() {
+        let source = "call({\n    a: 1,\n}\n);\n";
+        let ranges = foldable_ranges(&lines_of(source, Some("ts")));
+        assert_eq!(
+            ranges,
+            vec![FoldRange {
+                start_line: 0,
+                end_line: 3
+            }],
+            "the `(` closing on line 3 must win over the `{{` closing on line 2: {ranges:?}"
+        );
+    }
+
+    #[test]
+    fn an_unmatched_opener_yields_no_region_at_all() {
+        let source = "fn alpha() {\n    let x = 1;\n";
+        assert!(foldable_ranges(&lines_of(source, Some("rs"))).is_empty());
+    }
+
+    /// A file with no grammar at all: every run is plain `Text`, and brackets in it still pair
+    /// up. This is the honest fallback, and it is what makes the JSON/plain-text case work.
+    #[test]
+    fn a_file_with_no_grammar_still_folds_on_real_brackets() {
+        let source = "outer [\n  inner\n]\n";
+        let ranges = foldable_ranges(&lines_of(source, None));
+        assert_eq!(
+            ranges,
+            vec![FoldRange {
+                start_line: 0,
+                end_line: 2
+            }]
+        );
+    }
+
+    #[test]
+    fn range_starting_at_finds_only_a_real_start_line() {
+        let ranges = foldable_ranges(&lines_of(
+            "fn alpha() {\n    if x {\n        y();\n    }\n}\n",
+            Some("rs"),
+        ));
+        assert_eq!(
+            range_starting_at(&ranges, 1),
+            Some(FoldRange {
+                start_line: 1,
+                end_line: 3
+            })
+        );
+        assert_eq!(range_starting_at(&ranges, 2), None);
+    }
+}
+
+#[cfg(test)]
+mod fold_map_tests {
+    use super::*;
+
+    fn folded(starts: &[usize]) -> HashSet<usize> {
+        starts.iter().copied().collect()
+    }
+
+    const RANGES: [FoldRange; 2] = [
+        // lines 1..=3 hidden when folded
+        FoldRange {
+            start_line: 0,
+            end_line: 3,
+        },
+        // lines 6..=8 hidden when folded
+        FoldRange {
+            start_line: 5,
+            end_line: 8,
+        },
+    ];
+
+    #[test]
+    fn an_unfolded_map_is_the_identity_it_always_was() {
+        let map = FoldMap::new(10, &RANGES, &folded(&[]));
+        assert!(map.is_identity());
+        assert_eq!(map.visible_row_count(), 10);
+        for line in 0..10 {
+            assert_eq!(map.line_for_row(line), line);
+            assert_eq!(map.row_for_line(line), line);
+        }
+    }
+
+    #[test]
+    fn folding_one_region_removes_exactly_its_hidden_lines_from_the_row_count() {
+        let map = FoldMap::new(10, &RANGES, &folded(&[0]));
+        assert_eq!(
+            map.visible_row_count(),
+            7,
+            "10 lines minus lines 1, 2 and 3"
+        );
+        // Row 0 is still line 0 (the fold's own start line stays visible).
+        assert_eq!(map.line_for_row(0), 0);
+        // Row 1 skips straight past the hidden 1..=3 to line 4.
+        assert_eq!(map.line_for_row(1), 4);
+        assert_eq!(map.line_for_row(2), 5);
+        assert_eq!(map.line_for_row(6), 9);
+    }
+
+    #[test]
+    fn a_hidden_line_maps_back_to_the_row_of_the_region_that_swallowed_it() {
+        let map = FoldMap::new(10, &RANGES, &folded(&[0]));
+        assert!(map.is_hidden(1) && map.is_hidden(2) && map.is_hidden(3));
+        assert!(!map.is_hidden(0) && !map.is_hidden(4));
+        for hidden_line in 1..=3 {
+            assert_eq!(
+                map.row_for_line(hidden_line),
+                0,
+                "a scroll request for a folded-away line must land on the collapsed row"
+            );
+        }
+        assert_eq!(map.row_for_line(4), 1);
+        assert_eq!(map.row_for_line(9), 6);
+    }
+
+    #[test]
+    fn two_separate_folded_regions_compose() {
+        let map = FoldMap::new(10, &RANGES, &folded(&[0, 5]));
+        assert_eq!(map.visible_row_count(), 4, "lines 0, 4, 5 and 9 remain");
+        assert_eq!(map.line_for_row(0), 0);
+        assert_eq!(map.line_for_row(1), 4);
+        assert_eq!(map.line_for_row(2), 5);
+        assert_eq!(map.line_for_row(3), 9);
+        assert_eq!(map.row_for_line(9), 3);
+    }
+
+    /// Nested regions overlap, so folding both must not double-count the shared lines.
+    #[test]
+    fn folding_a_region_and_a_region_nested_inside_it_does_not_double_count() {
+        let ranges = [
+            FoldRange {
+                start_line: 0,
+                end_line: 6,
+            },
+            FoldRange {
+                start_line: 1,
+                end_line: 4,
+            },
+        ];
+        let map = FoldMap::new(8, &ranges, &folded(&[0, 1]));
+        assert_eq!(
+            map.visible_row_count(),
+            2,
+            "lines 1..=6 are hidden once, not twice: line 0 and line 7 remain"
+        );
+        assert_eq!(map.line_for_row(0), 0);
+        assert_eq!(map.line_for_row(1), 7);
+    }
+
+    /// Two regions whose hidden spans are exactly adjacent must merge, or the segment between
+    /// them would be empty and the row arithmetic would step through a zero-width segment.
+    #[test]
+    fn exactly_adjacent_hidden_regions_merge_cleanly() {
+        let ranges = [
+            FoldRange {
+                start_line: 0,
+                end_line: 2,
+            },
+            FoldRange {
+                start_line: 2,
+                end_line: 4,
+            },
+        ];
+        let map = FoldMap::new(6, &ranges, &folded(&[0, 2]));
+        // Hidden: 1..=2 and 3..=4 -> 1..=4. Lines 0 and 5 remain.
+        assert_eq!(map.visible_row_count(), 2);
+        assert_eq!(map.line_for_row(0), 0);
+        assert_eq!(map.line_for_row(1), 5);
+        assert_eq!(map.row_for_line(3), 0);
+    }
+
+    /// The real staleness case this design accepts (see [`FoldMap::new`]'s own docs): an edit
+    /// moved the block, so the remembered start line no longer opens a region. It must simply
+    /// not fold, rather than hiding some unrelated span.
+    #[test]
+    fn a_folded_start_line_that_is_no_longer_a_region_hides_nothing() {
+        let map = FoldMap::new(10, &RANGES, &folded(&[7]));
+        assert_eq!(map.visible_row_count(), 10);
+        assert!(map.is_identity());
+    }
+
+    #[test]
+    fn a_region_running_past_the_end_of_the_buffer_is_clamped_not_panicked_on() {
+        let ranges = [FoldRange {
+            start_line: 0,
+            end_line: 99,
+        }];
+        let map = FoldMap::new(4, &ranges, &folded(&[0]));
+        assert_eq!(map.visible_row_count(), 1);
+        assert_eq!(map.line_for_row(0), 0);
+        // Clamped rather than panicking, per `line_for_row`'s own docs.
+        assert_eq!(map.line_for_row(5), 3);
+    }
+
+    #[test]
+    fn an_empty_buffer_produces_no_rows_and_no_panics() {
+        let map = FoldMap::new(0, &[], &folded(&[]));
+        assert_eq!(map.visible_row_count(), 0);
+        assert_eq!(map.line_for_row(0), 0);
+        assert_eq!(map.row_for_line(0), 0);
+    }
+
+    /// Exhaustive round-trip over every visible row: `line_for_row` and `row_for_line` must be
+    /// real inverses on the visible half, or a click, a scroll and a popup anchor would each
+    /// disagree about which line they are talking about.
+    #[test]
+    fn line_for_row_and_row_for_line_round_trip_across_every_visible_row() {
+        let map = FoldMap::new(10, &RANGES, &folded(&[0, 5]));
+        for row in 0..map.visible_row_count() {
+            let line = map.line_for_row(row);
+            assert!(!map.is_hidden(line), "row {row} resolved to a hidden line");
+            assert_eq!(
+                map.row_for_line(line),
+                row,
+                "round trip failed for row {row}"
+            );
+        }
+    }
+}

--- a/crates/app/src/code_surface/lsp_ui.rs
+++ b/crates/app/src/code_surface/lsp_ui.rs
@@ -496,8 +496,13 @@ impl AdeApp {
             // Already cached (e.g. navigating within the open file), so render_file_view won't
             // reload and there's no completion handler to consume `pending_cursor_line`.
             self.code_cursor = Some(one_based_line);
-            self.file_view_scroll_handle
-                .scroll_to_item(one_based_line.saturating_sub(1), ScrollStrategy::Center);
+            // GitHub issue #202: a visual row, not a line index, and the destination is expanded
+            // first if a collapsed region is hiding it - see `AdeApp::scroll_file_view_to_line`.
+            self.scroll_file_view_to_line(
+                &absolute_target_path,
+                one_based_line.saturating_sub(1),
+                ScrollStrategy::Center,
+            );
         } else {
             self.pending_cursor_line = Some((absolute_target_path, one_based_line));
         }

--- a/crates/app/src/code_surface/minimap.rs
+++ b/crates/app/src/code_surface/minimap.rs
@@ -175,6 +175,34 @@ fn visible_line_range(
     (first, count)
 }
 
+/// [`visible_line_range`]'s answer translated out of *visual row* space into the *buffer line*
+/// space every other helper in this module works in (GitHub issue #202).
+///
+/// [`visible_line_range`] divides a real scroll offset by the real row height, so what it really
+/// returns is which `uniform_list` rows are on screen. This panel draws one bar per real line of
+/// the file - collapsed or not, see this module's own "compress the whole file to fit" docs - so
+/// the viewport slider has to be placed over the *lines* those rows show. With nothing folded
+/// `FoldMap::line_for_row` is the identity and this returns exactly what
+/// [`visible_line_range`] did.
+///
+/// Returns `(first_visible_line, visible_line_count)`, `0`-indexed/counted, matching
+/// [`visible_line_range`]'s own convention so [`slider_geometry`]/[`line_for_pointer`] take it
+/// unchanged.
+fn visible_line_range_through_folds(
+    viewport_height: f32,
+    scrolled_px: f32,
+    row_line_height: f32,
+    fold_map: &fold::FoldMap,
+) -> (usize, usize) {
+    let (first_row, row_count) = visible_line_range(viewport_height, scrolled_px, row_line_height);
+    if row_count == 0 {
+        return (0, 0);
+    }
+    let first_line = fold_map.line_for_row(first_row);
+    let last_line = fold_map.line_for_row(first_row + row_count - 1);
+    (first_line, (last_line + 1).saturating_sub(first_line))
+}
+
 /// The viewport slider's own `(top, height)` in the minimap panel's local coordinates, given the
 /// real, effective per-line height (`effective_line_height`) and the code column's real visible
 /// range (`visible_line_range`). Floored at `MINIMAP_MIN_SLIDER_HEIGHT_PX` and clamped so the
@@ -326,11 +354,23 @@ impl gpui::Render for MinimapSliderDrag {
 }
 
 impl AdeApp {
+    /// GitHub issue #202: `fold_map` is what keeps this panel honest once a block is collapsed.
+    ///
+    /// Every helper in this module works in *buffer line* space (it draws one bar per real line
+    /// of the file, collapsed or not - see this module's own "compress the whole file to fit"
+    /// docs), while `file_view_scroll_handle` works in *visual row* space. Those were the same
+    /// number until folding existed, and this method is the only boundary where they meet: the
+    /// viewport slider is derived from a scroll offset (rows -> lines), and both the drag and the
+    /// track click produce a line the code column must scroll to (lines -> rows). Left
+    /// unconverted, a fold would put the slider over the wrong band and send a click to the wrong
+    /// place. With nothing folded both conversions are the identity, so an unfolded file's
+    /// minimap behaves exactly as it did.
     pub(in crate::code_surface) fn render_minimap(
         &self,
         lines: &[code_view::RenderedLine],
         changed_lines: &HashSet<usize>,
         row_line_height: f32,
+        fold_map: &fold::FoldMap,
         cx: &mut Context<Self>,
     ) -> Option<AnyElement> {
         let total_lines = lines.len();
@@ -346,8 +386,12 @@ impl AdeApp {
         let base = self.file_view_scroll_handle.base_handle();
         let scrolled_px = (-base.offset().y.as_f32()).max(0.0);
         let viewport_height_px = base.bounds().size.height.as_f32();
-        let (first_visible_line, visible_line_count) =
-            visible_line_range(viewport_height_px, scrolled_px, row_line_height);
+        let (first_visible_line, visible_line_count) = visible_line_range_through_folds(
+            viewport_height_px,
+            scrolled_px,
+            row_line_height,
+            fold_map,
+        );
 
         let line_rects = build_line_rects(lines, line_height, char_width(scale_percent), width);
         let git_rects = build_git_overlay_rects(changed_lines, total_lines, line_height);
@@ -367,6 +411,10 @@ impl AdeApp {
         let drag_total_lines = total_lines;
         let drag_line_height = line_height;
         let drag_visible_line_count = visible_line_count;
+        // Both handlers below resolve a real *buffer line* and must hand `scroll_to_item` a
+        // *visual row*; each closure needs its own owned map.
+        let click_fold_map = fold_map.clone();
+        let drag_fold_map = fold_map.clone();
 
         let bounds_entity = cx.entity();
 
@@ -443,7 +491,10 @@ impl AdeApp {
                             drag_visible_line_count,
                             local_y,
                         );
-                        drag_scroll_handle.scroll_to_item_strict(target_line, ScrollStrategy::Top);
+                        drag_scroll_handle.scroll_to_item_strict(
+                            drag_fold_map.row_for_line(target_line),
+                            ScrollStrategy::Top,
+                        );
                         cx.notify();
                     },
                 ))
@@ -467,7 +518,10 @@ impl AdeApp {
                             event.position.y.as_f32() - this.minimap_panel_bounds.origin.y.as_f32();
                         let target_line =
                             line_for_click(click_total_lines, click_line_height, local_y);
-                        click_scroll_handle.scroll_to_item(target_line, ScrollStrategy::Center);
+                        click_scroll_handle.scroll_to_item(
+                            click_fold_map.row_for_line(target_line),
+                            ScrollStrategy::Center,
+                        );
                         cx.notify();
                     }),
                 )
@@ -492,6 +546,50 @@ mod geometry_tests {
     #[test]
     fn a_disabled_setting_hides_the_minimap_even_for_a_tiny_file() {
         assert!(!should_render_minimap(false, 10));
+    }
+
+    /// GitHub issue #202. With nothing collapsed the row->line translation must be a no-op, or
+    /// this fix would have silently moved every existing minimap's slider.
+    #[test]
+    fn with_nothing_folded_the_slider_range_is_exactly_what_it_always_was() {
+        let unfolded = fold::FoldMap::unfolded(100);
+        // 10 rows of 20px scrolled 200px: rows 10..=19, i.e. lines 10..=19.
+        assert_eq!(
+            visible_line_range_through_folds(200.0, 200.0, 20.0, &unfolded),
+            (10, 10)
+        );
+        assert_eq!(visible_line_range(200.0, 200.0, 20.0), (10, 10));
+    }
+
+    /// The real point of the translation: the ten rows on screen span a much wider band of the
+    /// *file* when a collapsed region sits inside them, and the minimap draws the whole file - so
+    /// the slider must cover that wider band, not ten lines' worth of it.
+    #[test]
+    fn a_collapsed_region_inside_the_viewport_widens_the_slider_to_the_lines_it_spans() {
+        let ranges = [fold::FoldRange {
+            start_line: 12,
+            end_line: 41,
+        }];
+        let folded: std::collections::HashSet<usize> = [12].into_iter().collect();
+        let map = fold::FoldMap::new(100, &ranges, &folded);
+
+        // Same scroll and viewport as above: rows 10..=19. Rows 10, 11 and 12 are lines 10, 11
+        // and 12; row 13 is line 42 (lines 13..=41 are collapsed away), so row 19 is line 48.
+        assert_eq!(map.line_for_row(10), 10);
+        assert_eq!(map.line_for_row(13), 42);
+        assert_eq!(
+            visible_line_range_through_folds(200.0, 200.0, 20.0, &map),
+            (10, 39),
+            "ten rows on screen really do span lines 10 through 48 of the file"
+        );
+    }
+
+    #[test]
+    fn an_unmeasured_row_height_still_produces_no_range_through_the_fold_translation() {
+        assert_eq!(
+            visible_line_range_through_folds(200.0, 200.0, 0.0, &fold::FoldMap::unfolded(100)),
+            (0, 0)
+        );
     }
 
     #[test]

--- a/crates/app/src/code_surface/mod.rs
+++ b/crates/app/src/code_surface/mod.rs
@@ -13,6 +13,9 @@
 //!   shown for the current line (GitHub issue #29).
 //! - [`indent`] - Tab/Shift+Tab indentation resolution (tabs vs. spaces, width), including a
 //!   real, minimal `.editorconfig` reader (GitHub issue #26).
+//! - [`fold`] - which bracket-delimited regions of one file can be collapsed, and the
+//!   visual-row <-> buffer-line translation the File view's `uniform_list` needs once some of
+//!   them are (GitHub issue #202).
 //!
 //! GPUI-facing:
 //! - [`state`] - the load-state enums the surface's own fields are typed with.
@@ -68,6 +71,7 @@ use wt_core::diff::{DiffBase, DiffFile, DiffLineKind, WorktreeDiff};
 pub mod blame;
 pub mod code_view;
 pub mod edit_buffer;
+pub mod fold;
 pub mod indent;
 pub mod symbols;
 

--- a/crates/app/src/code_surface/tabs.rs
+++ b/crates/app/src/code_surface/tabs.rs
@@ -715,14 +715,25 @@ impl AdeApp {
                             });
                         let cursor_line =
                             target_line.or(reloaded_cursor_line).or(buffer_cursor_line);
+                        // GitHub issue #202: both of these now scroll to a *visual row*, not a
+                        // line index (the two differ once anything in this file is collapsed -
+                        // fold state is keyed by absolute path, so it survives a tab close and is
+                        // still here when the file is reopened), expanding the destination first.
+                        // See `AdeApp::scroll_file_view_to_line`.
                         if let Some(line) = target_line {
                             this.pending_cursor_line = None;
-                            this.file_view_scroll_handle
-                                .scroll_to_item(line.saturating_sub(1), ScrollStrategy::Center);
+                            this.scroll_file_view_to_line(
+                                &path,
+                                line.saturating_sub(1),
+                                ScrollStrategy::Center,
+                            );
                         } else if newly_in_view {
                             if let Some(line) = buffer_cursor_line {
-                                this.file_view_scroll_handle
-                                    .scroll_to_item(line.saturating_sub(1), ScrollStrategy::Center);
+                                this.scroll_file_view_to_line(
+                                    &path,
+                                    line.saturating_sub(1),
+                                    ScrollStrategy::Center,
+                                );
                             }
                         }
                         this.code_cursor = Some(cursor_line.unwrap_or(1));

--- a/crates/app/src/code_surface/tabs.rs
+++ b/crates/app/src/code_surface/tabs.rs
@@ -678,6 +678,18 @@ impl AdeApp {
                             }
                         }
                         if reloaded {
+                            // GitHub issue #202: fold state is plain line indices into content
+                            // this reload just replaced wholesale (an agent CLI or formatter
+                            // rewriting the file the user has open - this app's own core domain,
+                            // not an edge case). A stale index can point at a *different*, larger
+                            // region than the one the user actually folded, silently swallowing
+                            // the caret's line with nothing left to expand it - the same
+                            // `window.handle_input` breakage `Self::scroll_file_view_to_line`
+                            // exists to prevent for every other caret-moving action. Dropping the
+                            // folds here is the same "not persisted, self-healing" posture
+                            // `AdeApp::file_view_folds` already documents for a restart; a real
+                            // external rewrite is exactly as much a break in continuity as one.
+                            this.file_view_folds.remove(&path);
                             this.schedule_lsp_sync(cwd.clone(), relative_path.clone(), cx);
                         }
                         // Whether this load is a *different* file arriving in the view, as

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -799,6 +799,22 @@ pub struct AdeApp {
     /// only ever read for a row-click hit test, and a scrolled-away row can't be clicked), so this
     /// is cleared wholesale only on a worktree switch, not pruned every frame.
     pub(crate) file_view_row_layout: HashMap<usize, (gpui::Bounds<Pixels>, gpui::ShapedLine)>,
+    /// GitHub issue #202: which code blocks the user has currently collapsed, keyed by absolute
+    /// path, each value a set of 0-based [`code_surface::fold::FoldRange::start_line`]s.
+    ///
+    /// **Deliberately ephemeral** - in memory only, never written to disk. This app does persist
+    /// comparable per-worktree view state elsewhere (`crate::sidebar::fold_state` for the *file
+    /// tree*'s expanded directories, `crate::work_surface::tab_order_state` for tab order), but
+    /// neither of those precedents applies cleanly here: both key off a stable identity (a
+    /// directory path, a tab), while a code fold is a plain line index that a single edit made
+    /// outside the app invalidates. Restoring one across a restart would just as often collapse
+    /// the wrong block as the right one. Not even scroll position is persisted per file (see
+    /// `crate::code_surface::tabs`' own note), so this matches the surrounding discipline.
+    ///
+    /// Keyed by *absolute* path rather than by the `(worktree cwd, relative path)` pair
+    /// [`Self::edit_buffers`] uses, since an absolute path is already unambiguous across
+    /// worktrees - so unlike `edit_buffers` this needs no worktree-switch reset to stay honest.
+    pub(crate) file_view_folds: HashMap<PathBuf, std::collections::HashSet<usize>>,
     /// The real shaped line, bounds, and 0-indexed buffer line that painted the *caret's own* row
     /// most recently - `crate::code_surface::editing`'s `EntityInputHandler::bounds_for_range`/
     /// `character_index_for_point` read these three together (never `file_view_row_layout`, which

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -295,6 +295,7 @@ impl AdeApp {
             _blame_message_tasks: HashMap::new(),
             edit_buffers: HashMap::new(),
             file_view_row_layout: HashMap::new(),
+            file_view_folds: HashMap::new(),
             file_view_last_layout: None,
             file_view_last_bounds: None,
             file_view_last_layout_for: None,


### PR DESCRIPTION
## Summary
- Closes #202. Code folding for the File view's editor, built from scratch (no `textDocument/foldingRange` in this app's LSP client).
- **Fold-range detection**: bracket-matching over the already-classified `RenderedLine` runs, so string/comment awareness comes free from the tree-sitter pass that already ran. One region per start line, widest wins (`foo({` gets one chevron); same-line pairs (`fn f() {}`) yield nothing.
- **Row layout**: a new `FoldMap` owns the translation between buffer line indices and the `uniform_list`'s visual row indices - identity fast-path when nothing is folded, so an unfolded file pays no measurable cost.
- Popup anchoring (hover/diagnostic cards, fixed for positioning in #197) is unaffected: `file_view_row_layout` stays keyed by line number, and the per-frame prune now uses the real set of lines rendered rather than an assumed row range.
- Only the caret's own row registers `window.handle_input`; folding a region containing the caret lifts it onto the visible start line rather than leaving typing silently broken.
- **Follow-up commit, found by review before this ever shipped**: two further real ways the caret could still end up stranded on a hidden line - clicking the blank space below a folded file's content, and a real external file rewrite (agent CLI/formatter) while a fold was active. Both fixed with dedicated regression tests.
- Deliberate v1 scope: only bracket-delimited regions (no indentation-only blocks, `#region` markers, or Markdown headings); arrow-keying into a collapsed region expands it rather than skipping over it; fold state is per-path, in-memory only, and self-heals if a remembered fold index no longer opens a real region.

## Test plan
- [x] 19 pure unit tests on `FoldMap`/`foldable_ranges` (string/comment exclusion via the real highlighter, nesting, adjacency merge, exhaustive row↔line round-trip)
- [x] Real GPUI tests clicking the actual painted chevron via `simulate_click` - fold/unfold, caret-lift, popup-anchor-map pruning, per-file fold isolation
- [x] Two new regression tests for the review-caught bugs: a real click below folded content, and a real `std::fs::write` past the real freshness throttle
- [x] `cargo build`, `cargo clippy -p app --lib --tests` clean
- [x] `cargo fmt` diffed against a backup - zero drift on pre-existing code
- [x] `cargo test -p app --lib` full suite: 1935 passed, 0 failed
- [x] Real screenshots of the running app: chevrons on exactly the multi-line block openers, click-to-collapse/expand, nested folds

🤖 Generated with [Claude Code](https://claude.com/claude-code)