### PR TITLE
fix(app): Restart Language Servers and Check for Updates were never listed

### DIFF
--- a/crates/app/src/palette/render.rs
+++ b/crates/app/src/palette/render.rs
@@ -201,6 +201,21 @@ impl AdeApp {
                     WindowControlsStyle::WindowsLinuxStyle,
                 ),
             },
+            // Real, previously-reported bug: `PaletteCommand::RestartLanguageServers` and
+            // `PaletteCommand::CheckForUpdates` have carried a real label, real search keywords,
+            // and a real click handler (see the `handle_palette_command` match below) since the
+            // commits that introduced them - but neither was ever pushed into this hand-built
+            // list, so the palette never actually listed either one. `PaletteCommand::ALL`
+            // (used by this module's own exhaustive-listing test) didn't catch the gap because
+            // it enumerates the enum, not what actually reaches a user.
+            palette::CommandCandidate {
+                command: palette::PaletteCommand::RestartLanguageServers,
+                secondary: "recover a language server that stopped responding".to_string(),
+            },
+            palette::CommandCandidate {
+                command: palette::PaletteCommand::CheckForUpdates,
+                secondary: "check GitHub for a newer release".to_string(),
+            },
         ];
         // GitHub issue #90: a genuinely empty window has no real repo to graph -
         // `crate::graph_view::render::AdeApp::open_git_graph`'s own guard now refuses outright

--- a/crates/app/src/root/focus.rs
+++ b/crates/app/src/root/focus.rs
@@ -2059,4 +2059,58 @@ mod palette_result_focus_tests {
              non-opening palette command would silently strand the next keystroke"
         );
     }
+
+    /// Live-reported: "restart lsp server" wasn't findable in the palette at all. Real root
+    /// cause, found by reading the actual list `AdeApp::build_palette_groups` hands the palette
+    /// rather than `PaletteCommand::ALL` (which only enumerates the enum, not what a user can
+    /// actually reach): `RestartLanguageServers` and `CheckForUpdates` had a real label, real
+    /// search keywords, and a real click handler in `handle_palette_command` since the commits
+    /// that introduced them, but neither was ever pushed into the hand-built `commands` vec in
+    /// `render.rs` - so the palette never listed either one, under any query.
+    ///
+    /// Searches by each command's own label rather than checking an unfiltered, empty-query
+    /// listing: `MAX_ENTRIES_PER_GROUP` (8) caps the plain "Commands" group, and this app now
+    /// defines 11 non-git commands - more than that cap - so an empty-query browse can never show
+    /// all of them at once even in a fully working palette. That's real, pre-existing, unrelated
+    /// behavior, not the bug; typing a command's own name to find it is how a user actually
+    /// reaches one they don't see in the unfiltered top-8, and is what this test drives instead.
+    ///
+    /// One deliberate, documented exception: `OpenGitGraph` only appears with a focused repo
+    /// (GitHub issue #90 - see `build_palette_groups`'s own comment on why that entry is dropped
+    /// rather than shown disabled). This drives a real, empty window, so that guard is the one
+    /// gap this test itself expects and excludes.
+    #[gpui::test]
+    fn every_palette_command_is_findable_by_its_own_label(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+
+        for command in palette::PaletteCommand::ALL {
+            if command == palette::PaletteCommand::OpenGitGraph {
+                continue;
+            }
+            app.update_in(cx, |app, window, cx| app.open_palette(window, cx));
+            app.update(cx, |app, _| {
+                app.palette_query
+                    .push_str(command.label(), std::time::Instant::now());
+            });
+            cx.run_until_parked();
+
+            let found = app.update(cx, |app, cx| {
+                let groups = app.build_palette_groups(cx);
+                palette::flatten(&groups)
+                    .iter()
+                    .any(|entry| entry.target == palette::EntryTarget::Command(command))
+            });
+            assert!(
+                found,
+                "{:?} has a real handler but searching its own label {:?} finds nothing in the \
+                 palette - the exact shape of the live-reported bug",
+                command,
+                command.label()
+            );
+
+            app.update_in(cx, |app, window, cx| app.close_palette(window, cx));
+            cx.run_until_parked();
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Closes #203. Real bug, not user error: `RestartLanguageServers` and `CheckForUpdates` have carried a real label, real search keywords, and a real click handler since the commits that introduced them - but neither was ever pushed into the hand-built `commands` vec in `AdeApp::build_palette_groups` (`palette/render.rs`), which is the actual list the palette searches. `PaletteCommand::ALL` (used elsewhere for enum-level tests) enumerates the enum, not what a user can reach, so this gap went unnoticed.
- Added both entries. `RestartLanguageServers`' secondary text names what it recovers, matching the convention other plain-action rows already use.

## Test plan
- [x] New regression test searches by each command's own label (not an unfiltered empty-query listing, which this app's real `MAX_ENTRIES_PER_GROUP` cap of 8 would legitimately truncate now that there are 11 non-git commands) - fails against the pre-fix code for both missing commands, passes for everything already wired correctly
- [x] `cargo test -p app --lib -- palette`: 76 passed
- [x] `cargo build`, `cargo clippy -p app --lib --tests` clean
- [x] `cargo fmt` diffed against a backup - zero drift on pre-existing code
- [x] `cargo test -p app --lib` full suite: 1903 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)