### PR TITLE
feat(app): make the integrated terminal's colours follow the theme

### DIFF
--- a/assets/themes/ember.toml
+++ b/assets/themes/ember.toml
@@ -288,6 +288,30 @@ link_underline       = "#0a556e"
 link_hover           = "#6599ae"
 link_underline_hover = "#3f8099"
 
+# The integrated terminal's own rendered-content palette - the colours a program running inside
+# a terminal pane actually paints its characters with.
+[terminal]
+background = "#0e1112"  # The terminal pane's own fill
+foreground = "#777f84"  # Unstyled output
+cursor     = "#00789d"  # What NamedColor::Cursor resolves to
+selection  = "#16323e"  # The fill painted behind a selected cell
+"ansi.0"   = "#000000"
+"ansi.1"   = "#cd3131"
+"ansi.2"   = "#0dbc79"
+"ansi.3"   = "#e5e510"
+"ansi.4"   = "#2472c8"
+"ansi.5"   = "#bc3fbc"
+"ansi.6"   = "#11a8cd"
+"ansi.7"   = "#e5e5e5"
+"ansi.8"   = "#666666"
+"ansi.9"   = "#f14c4c"
+"ansi.10"  = "#23d18b"
+"ansi.11"  = "#f5f543"
+"ansi.12"  = "#3b8eea"
+"ansi.13"  = "#d670d6"
+"ansi.14"  = "#29b8db"
+"ansi.15"  = "#ffffff"
+
 # Exact colours for Surface C's real Completions popup item rows - read directly from
 # design_handoff_jerry_ade/revision/Jerry.dc.html's own completions/KBG/KFG data (the sel ? ...
 [completions_popup]

--- a/assets/themes/jerry-dim.toml
+++ b/assets/themes/jerry-dim.toml
@@ -288,6 +288,30 @@ link_underline       = "#43658a"
 link_hover           = "#99b8d9"
 link_underline_hover = "#7499bf"
 
+# The integrated terminal's own rendered-content palette - the colours a program running inside
+# a terminal pane actually paints its characters with.
+[terminal]
+background = "#16181a"  # The terminal pane's own fill
+foreground = "#9a9ea5"  # Unstyled output
+cursor     = "#5e8dc4"  # What NamedColor::Cursor resolves to
+selection  = "#2e3d4f"  # The fill painted behind a selected cell
+"ansi.0"   = "#000000"
+"ansi.1"   = "#cd3131"
+"ansi.2"   = "#0dbc79"
+"ansi.3"   = "#e5e510"
+"ansi.4"   = "#2472c8"
+"ansi.5"   = "#bc3fbc"
+"ansi.6"   = "#11a8cd"
+"ansi.7"   = "#e5e5e5"
+"ansi.8"   = "#666666"
+"ansi.9"   = "#f14c4c"
+"ansi.10"  = "#23d18b"
+"ansi.11"  = "#f5f543"
+"ansi.12"  = "#3b8eea"
+"ansi.13"  = "#d670d6"
+"ansi.14"  = "#29b8db"
+"ansi.15"  = "#ffffff"
+
 # Exact colours for Surface C's real Completions popup item rows - read directly from
 # design_handoff_jerry_ade/revision/Jerry.dc.html's own completions/KBG/KFG data (the sel ? ...
 [completions_popup]

--- a/assets/themes/moss.toml
+++ b/assets/themes/moss.toml
@@ -288,6 +288,30 @@ link_underline       = "#415e7b"
 link_hover           = "#95b0c9"
 link_underline_hover = "#7191ae"
 
+# The integrated terminal's own rendered-content palette - the colours a program running inside
+# a terminal pane actually paints its characters with.
+[terminal]
+background = "#101213"  # The terminal pane's own fill
+foreground = "#92969b"  # Unstyled output
+cursor     = "#5c86b0"  # What NamedColor::Cursor resolves to
+selection  = "#293644"  # The fill painted behind a selected cell
+"ansi.0"   = "#000000"
+"ansi.1"   = "#cd3131"
+"ansi.2"   = "#0dbc79"
+"ansi.3"   = "#e5e510"
+"ansi.4"   = "#2472c8"
+"ansi.5"   = "#bc3fbc"
+"ansi.6"   = "#11a8cd"
+"ansi.7"   = "#e5e5e5"
+"ansi.8"   = "#666666"
+"ansi.9"   = "#f14c4c"
+"ansi.10"  = "#23d18b"
+"ansi.11"  = "#f5f543"
+"ansi.12"  = "#3b8eea"
+"ansi.13"  = "#d670d6"
+"ansi.14"  = "#29b8db"
+"ansi.15"  = "#ffffff"
+
 # Exact colours for Surface C's real Completions popup item rows - read directly from
 # design_handoff_jerry_ade/revision/Jerry.dc.html's own completions/KBG/KFG data (the sel ? ...
 [completions_popup]

--- a/assets/themes/paper.toml
+++ b/assets/themes/paper.toml
@@ -288,6 +288,30 @@ link_underline       = "#789ebf"
 link_hover           = "#355269"
 link_underline_hover = "#486e8a"
 
+# The integrated terminal's own rendered-content palette - the colours a program running inside
+# a terminal pane actually paints its characters with.
+[terminal]
+background = "#eff2f4"  # The terminal pane's own fill
+foreground = "#5e6267"  # Unstyled output
+cursor     = "#4678a3"  # What NamedColor::Cursor resolves to
+selection  = "#b4c7d9"  # The fill painted behind a selected cell
+"ansi.0"   = "#000000"
+"ansi.1"   = "#cd3131"
+"ansi.2"   = "#00bc00"
+"ansi.3"   = "#949800"
+"ansi.4"   = "#0451a5"
+"ansi.5"   = "#bc05bc"
+"ansi.6"   = "#0598bc"
+"ansi.7"   = "#555555"
+"ansi.8"   = "#666666"
+"ansi.9"   = "#cd3131"
+"ansi.10"  = "#14ce14"
+"ansi.11"  = "#b5ba00"
+"ansi.12"  = "#0451a5"
+"ansi.13"  = "#bc05bc"
+"ansi.14"  = "#0598bc"
+"ansi.15"  = "#a5a5a5"
+
 # Exact colours for Surface C's real Completions popup item rows - read directly from
 # design_handoff_jerry_ade/revision/Jerry.dc.html's own completions/KBG/KFG data (the sel ? ...
 [completions_popup]

--- a/assets/themes/slate.toml
+++ b/assets/themes/slate.toml
@@ -288,6 +288,30 @@ link_underline       = "#294d72"
 link_hover           = "#6e8dae"
 link_underline_hover = "#4f759b"
 
+# The integrated terminal's own rendered-content palette - the colours a program running inside
+# a terminal pane actually paints its characters with.
+[terminal]
+background = "#0f1113"  # The terminal pane's own fill
+foreground = "#787d83"  # Unstyled output
+cursor     = "#396ba2"  # What NamedColor::Cursor resolves to
+selection  = "#1f2e40"  # The fill painted behind a selected cell
+"ansi.0"   = "#000000"
+"ansi.1"   = "#cd3131"
+"ansi.2"   = "#0dbc79"
+"ansi.3"   = "#e5e510"
+"ansi.4"   = "#2472c8"
+"ansi.5"   = "#bc3fbc"
+"ansi.6"   = "#11a8cd"
+"ansi.7"   = "#e5e5e5"
+"ansi.8"   = "#666666"
+"ansi.9"   = "#f14c4c"
+"ansi.10"  = "#23d18b"
+"ansi.11"  = "#f5f543"
+"ansi.12"  = "#3b8eea"
+"ansi.13"  = "#d670d6"
+"ansi.14"  = "#29b8db"
+"ansi.15"  = "#ffffff"
+
 # Exact colours for Surface C's real Completions popup item rows - read directly from
 # design_handoff_jerry_ade/revision/Jerry.dc.html's own completions/KBG/KFG data (the sel ? ...
 [completions_popup]

--- a/crates/app/src/settings/builtin_themes.rs
+++ b/crates/app/src/settings/builtin_themes.rs
@@ -384,6 +384,60 @@ mod tests {
         );
     }
 
+    /// GitHub issue #208, at the layer where a stale checked-in file (rather than a bad default)
+    /// would break it: every bundled theme's terminal must really be its *own* terminal, and must
+    /// really be readable.
+    ///
+    /// The readability floor is WCAG's own 4.5:1 "normal text" number, which is the right bar here
+    /// (unlike `crate::settings::custom_theme::MIN_CONTRAST_PER_HUNDRED`, a deliberately far lower
+    /// *validity* floor for arbitrary user-authored themes): these six files are this project's own
+    /// generated output, so anything below the real bar is a generator bug to fix, not a theme to
+    /// tolerate.
+    #[test]
+    fn every_bundled_theme_paints_its_own_readable_terminal() {
+        use crate::settings::custom_theme::compile_palette_by_name;
+
+        let mut backgrounds: Vec<u32> = Vec::new();
+        for source in BUILTIN_THEME_SOURCES.iter() {
+            let palette = compile_palette_by_name(source.name, &[])
+                .expect("a bundled theme must compile")
+                .unwrap_or_default();
+            let resolve =
+                |token: theme::ColorToken| palette.get(token.key).copied().unwrap_or(token.default);
+            let background = resolve(theme::terminal::BACKGROUND);
+            let foreground = resolve(theme::terminal::FOREGROUND);
+
+            let ratio = theme::contrast_ratio(foreground, background);
+            assert!(
+                ratio >= 4.5,
+                "{}: terminal.foreground is {ratio:.2}:1 against terminal.background - unstyled \
+                 terminal output would be hard to read",
+                source.name
+            );
+
+            // The pane is painted *into* `surface.pty`; a terminal fill that drifted away from it
+            // would put the exact lighter-rectangle-inside-the-app back that issue #208 is about.
+            assert_eq!(
+                crate::settings::custom_theme::rgba_to_hex(background),
+                crate::settings::custom_theme::rgba_to_hex(resolve(theme::surface::PTY)),
+                "{}: the terminal fill has drifted off the surface it is painted into",
+                source.name
+            );
+
+            backgrounds.push(crate::settings::custom_theme::rgba_to_hex(background));
+        }
+
+        let mut unique = backgrounds.clone();
+        unique.sort_unstable();
+        unique.dedup();
+        assert_eq!(
+            unique.len(),
+            backgrounds.len(),
+            "two bundled themes paint the terminal the same colour, so switching between them \
+             would not visibly change it: {backgrounds:06x?}"
+        );
+    }
+
     /// "Paper" is the one real light bundled theme - its generated `surface.window` must really be
     /// light, the same property the old derivation's lightness fit produced live.
     #[test]

--- a/crates/app/src/settings/custom_theme.rs
+++ b/crates/app/src/settings/custom_theme.rs
@@ -1436,6 +1436,55 @@ keyword = "#ff79c6"
         );
     }
 
+    /// GitHub issue #208's custom-theme half. A user's own theme file almost never mentions the
+    /// terminal at all, so what it renders the terminal with is entirely a question of inheritance
+    /// - and it must resolve to something real and coherent either way:
+    ///
+    /// - a theme based on a bundled one gets *that theme's* terminal, so a custom theme built on
+    ///   Paper gets Paper's light terminal rather than Jerry Dark's dark one;
+    /// - a theme based on nothing gets Jerry Dark's own compiled defaults, the same as every other
+    ///   key it doesn't name.
+    ///
+    /// Nothing terminal-specific makes this true - it is the same generic `base`-chain layering
+    /// every other token already gets - which is exactly the point of asserting it: these tokens
+    /// really are ordinary registry entries, not a second mechanism.
+    #[test]
+    fn a_custom_theme_that_names_no_terminal_colours_inherits_its_bases() {
+        let builtins: Vec<&CustomTheme> = THEME_DEFS.iter().map(|def| def.theme).collect();
+        let paper = *builtins
+            .iter()
+            .find(|def| def.name == "Paper")
+            .expect("Paper is a bundled theme");
+
+        let child = theme_named("Mine", Some("Paper"), &[("surface.window", 0x333333)]);
+        let mut known = builtins.clone();
+        known.push(&child);
+        let palette = compile_palette(&child, &known).expect("should compile");
+
+        for key in [
+            "terminal.background",
+            "terminal.foreground",
+            "terminal.ansi.2",
+        ] {
+            assert_eq!(
+                palette.get(key).copied(),
+                paper.overrides.get(key).copied(),
+                "{key} must be inherited from the named base, not silently dropped"
+            );
+        }
+        assert!(
+            theme::theme_is_light(palette["terminal.background"]),
+            "a custom theme based on the light bundled theme must get a light terminal"
+        );
+
+        // And a theme with no base at all falls through to the compiled defaults, the real Jerry
+        // Dark case - absent from the palette is exactly how this app expresses that.
+        let rootless = theme_named("Rootless", None, &[("surface.window", 0x333333)]);
+        let palette = compile_palette(&rootless, &[&rootless]).expect("should compile");
+        assert!(!palette.contains_key("terminal.background"));
+        assert!(!palette.contains_key("terminal.ansi.2"));
+    }
+
     #[test]
     fn a_multi_level_base_chain_layers_root_first() {
         let root = theme_named("Root", None, &[("text.body", 0x111111)]);

--- a/crates/app/src/settings/theme_file_format.rs
+++ b/crates/app/src/settings/theme_file_format.rs
@@ -53,7 +53,7 @@ const SECTIONS: &[(&str, &[&str])] = &[
     ),
     (
         "The code surface",
-        &["syntax", "editor", "term", "completions_popup"],
+        &["syntax", "editor", "term", "terminal", "completions_popup"],
     ),
     (
         "Chrome and widgets",

--- a/crates/app/src/settings/vscode_theme.rs
+++ b/crates/app/src/settings/vscode_theme.rs
@@ -477,6 +477,51 @@ const COLOR_KEY_MAP: &[(&str, &[&str])] = &[
         "term.menu_sel_fg",
         &["terminal.ansiBrightYellow", "terminal.ansiYellow"],
     ),
+    // ---- the integrated terminal's own rendered palette (GitHub issue #208) ------------------
+    //
+    // The *other* genuinely one-to-one block, and a more literal one than the `term.*` rows above:
+    // `crate::theme::terminal`'s twenty tokens are modelled on exactly the keys VSCode's own
+    // terminal contributes, so each of these is the same colour under a different name rather than
+    // a mapping that had to pick a plausible stand-in. Worth having precisely because
+    // `crate::theme::terminal::LIGHT_ANSI`'s two pinned palettes are only the *default* a theme
+    // that says nothing inherits - an imported theme that really authors its own sixteen gets them
+    // rendered verbatim instead.
+    (
+        "terminal.background",
+        &[
+            "terminal.background",
+            "panel.background",
+            "editor.background",
+        ],
+    ),
+    (
+        "terminal.foreground",
+        &["terminal.foreground", "editor.foreground"],
+    ),
+    (
+        "terminal.cursor",
+        &["terminalCursor.foreground", "editorCursor.foreground"],
+    ),
+    (
+        "terminal.selection",
+        &["terminal.selectionBackground", "editor.selectionBackground"],
+    ),
+    ("terminal.ansi.0", &["terminal.ansiBlack"]),
+    ("terminal.ansi.1", &["terminal.ansiRed"]),
+    ("terminal.ansi.2", &["terminal.ansiGreen"]),
+    ("terminal.ansi.3", &["terminal.ansiYellow"]),
+    ("terminal.ansi.4", &["terminal.ansiBlue"]),
+    ("terminal.ansi.5", &["terminal.ansiMagenta"]),
+    ("terminal.ansi.6", &["terminal.ansiCyan"]),
+    ("terminal.ansi.7", &["terminal.ansiWhite"]),
+    ("terminal.ansi.8", &["terminal.ansiBrightBlack"]),
+    ("terminal.ansi.9", &["terminal.ansiBrightRed"]),
+    ("terminal.ansi.10", &["terminal.ansiBrightGreen"]),
+    ("terminal.ansi.11", &["terminal.ansiBrightYellow"]),
+    ("terminal.ansi.12", &["terminal.ansiBrightBlue"]),
+    ("terminal.ansi.13", &["terminal.ansiBrightMagenta"]),
+    ("terminal.ansi.14", &["terminal.ansiBrightCyan"]),
+    ("terminal.ansi.15", &["terminal.ansiBrightWhite"]),
     // ---- diff -------------------------------------------------------------------------------
     (
         "diff.add_bg",

--- a/crates/app/src/terminal/grid.rs
+++ b/crates/app/src/terminal/grid.rs
@@ -42,14 +42,27 @@
 //! `Term::scroll_display` (mouse-wheel/PageUp scrolling into history) isn't wired up here. Not
 //! an oversight - a natural following step.
 //!
-//! ## Scope cut: fixed 16-color palette, no OSC 4/10/11 customization
+//! ## Scope cut: no OSC 4/10/11 customization
 //!
 //! `Term::colors` (a palette OSC 4/10/11 sequences can override) starts out entirely `None` and
-//! this module never populates or consults it; named/indexed colors resolve against a fixed,
-//! hardcoded ANSI-16 palette plus the standard xterm 256-color cube/grayscale formulas for
-//! `Color::Indexed` (matching `vendor/zed/crates/terminal/src/terminal.rs`'s
-//! `get_color_at_index`/`rgb_for_index`, a public xterm convention). A program that repalettes
-//! its own colors via OSC renders with the default palette instead.
+//! this module never populates or consults it. A program that repalettes its own colors via OSC
+//! renders with the theme's palette instead.
+//!
+//! ## The palette is the caller's, not this module's (GitHub issue #208)
+//!
+//! Named/indexed colors resolve against a [`TerminalPalette`] the caller passes into
+//! [`TerminalGrid::visible_rows`], plus the standard xterm 256-color cube/grayscale formulas for
+//! `Color::Indexed(16..=255)` (matching `vendor/zed/crates/terminal/src/terminal.rs`'s
+//! `get_color_at_index`/`rgb_for_index`, a public xterm convention).
+//!
+//! Those sixteen-plus-four colors used to be hardcoded module constants, which is why the terminal
+//! rendered as one fixed set of VS Code default values regardless of which of this app's six themes
+//! was selected. They are now real, registered `crate::theme::terminal` tokens - but this module
+//! deliberately does not read them itself. It stays entirely free of `gpui::Window`/theme access
+//! (the same pure-module discipline `crate::code_surface::fold` keeps, and for the same reason:
+//! grid state and color resolution have to stay unit-testable with no real GPUI window), so
+//! resolving the live theme is `crate::terminal::pane`'s job - it has the theme at paint time -
+//! and this module only consumes the already-resolved RGB it hands over.
 //!
 //! ## Text selection (GitHub issue #158)
 //!
@@ -190,40 +203,66 @@ impl CellPosition {
     }
 }
 
-/// Default foreground/background, used both for `NamedColor::Foreground`/`Background` and this
-/// pane's own rendering background - matches step 3's `TerminalPane` colors (`rgb(0xd4d4d4)` on
-/// `rgb(0x1e1e1e)`).
-pub const DEFAULT_FOREGROUND: (u8, u8, u8) = (0xd4, 0xd4, 0xd4);
-pub const DEFAULT_BACKGROUND: (u8, u8, u8) = (0x1e, 0x1e, 0x1e);
+/// Every real colour a terminal grid resolves against, already reduced to concrete RGB - the whole
+/// interface between the live theme and this pure module (GitHub issue #208).
+///
+/// Built from `crate::theme::terminal`'s real registered tokens by
+/// `crate::terminal::pane::theme_terminal_palette`, which runs at paint time where the live theme
+/// is actually reachable. This module never resolves a token itself; see the module docs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TerminalPalette {
+    /// The pane's own fill, and what `NamedColor::Background` resolves to.
+    pub background: (u8, u8, u8),
+    /// Unstyled output, and what `NamedColor::Foreground`/`BrightForeground` resolve to.
+    pub foreground: (u8, u8, u8),
+    /// What `NamedColor::Cursor` resolves to. The block cursor itself is an inverse-video swap
+    /// (see [`grid_cell_from_alacritty`]), not a fill painted in this colour.
+    pub cursor: (u8, u8, u8),
+    /// The fill painted behind a selected cell (GitHub issue #158).
+    pub selection: (u8, u8, u8),
+    /// The ANSI 16, indexed `0..=15` by `NamedColor`'s own discriminants / `Color::Indexed(0..=15)`.
+    pub ansi: [(u8, u8, u8); 16],
+}
 
-/// The fill painted behind a selected cell (GitHub issue #158). `#264f78` - VS Code's own
-/// `terminal.selectionBackground`, the same source [`NAMED_COLOR_PALETTE`] below already takes
-/// its 16 ANSI values from, rather than `crate::theme::editor::SELECTION`: this module's colors
-/// are deliberately a fixed palette independent of the live theme (see the module docs' palette
-/// scope cut), and a selection fill that tracked the theme while the 16 colors behind it did not
-/// would be the only thing in the terminal that did.
-pub const SELECTION_BACKGROUND: (u8, u8, u8) = (0x26, 0x4f, 0x78);
-
-/// The standard ANSI 16-color palette (VS Code's default terminal theme values), indexed
-/// `0..=15` by `NamedColor`'s own discriminants / `Color::Indexed(0..=15)`.
-const NAMED_COLOR_PALETTE: [(u8, u8, u8); 16] = [
-    (0x00, 0x00, 0x00), // 0 black
-    (0xcd, 0x31, 0x31), // 1 red
-    (0x0d, 0xbc, 0x79), // 2 green
-    (0xe5, 0xe5, 0x10), // 3 yellow
-    (0x24, 0x72, 0xc8), // 4 blue
-    (0xbc, 0x3f, 0xbc), // 5 magenta
-    (0x11, 0xa8, 0xcd), // 6 cyan
-    (0xe5, 0xe5, 0xe5), // 7 white
-    (0x66, 0x66, 0x66), // 8 bright black
-    (0xf1, 0x4c, 0x4c), // 9 bright red
-    (0x23, 0xd1, 0x8b), // 10 bright green
-    (0xf5, 0xf5, 0x43), // 11 bright yellow
-    (0x3b, 0x8e, 0xea), // 12 bright blue
-    (0xd6, 0x70, 0xd6), // 13 bright magenta
-    (0x29, 0xb8, 0xdb), // 14 bright cyan
-    (0xff, 0xff, 0xff), // 15 bright white
-];
+/// Jerry Dark's own terminal palette, transcribed - the exact literal values
+/// `crate::theme::terminal`'s tokens carry as their compiled defaults.
+///
+/// Duplicated here rather than resolved from `crate::theme` so this module stays theme-free (see
+/// the module docs), and kept honest about it by
+/// `crate::terminal::pane::terminal_theme_tests::the_pure_grid_default_palette_is_exactly_jerry_darks_own`,
+/// which resolves the real tokens and asserts they equal this value - so a retuned token can't
+/// leave this stale.
+///
+/// This is what the module's own tests render against, and what a caller that has no theme to offer
+/// gets. The app itself always passes the live theme's palette.
+impl Default for TerminalPalette {
+    fn default() -> Self {
+        Self {
+            background: (0x0d, 0x0f, 0x11),
+            foreground: (0xa7, 0xad, 0xb4),
+            cursor: (0x5a, 0x9a, 0xd4),
+            selection: (0x27, 0x3a, 0x4d),
+            ansi: [
+                (0x00, 0x00, 0x00), // 0 black
+                (0xcd, 0x31, 0x31), // 1 red
+                (0x0d, 0xbc, 0x79), // 2 green
+                (0xe5, 0xe5, 0x10), // 3 yellow
+                (0x24, 0x72, 0xc8), // 4 blue
+                (0xbc, 0x3f, 0xbc), // 5 magenta
+                (0x11, 0xa8, 0xcd), // 6 cyan
+                (0xe5, 0xe5, 0xe5), // 7 white
+                (0x66, 0x66, 0x66), // 8 bright black
+                (0xf1, 0x4c, 0x4c), // 9 bright red
+                (0x23, 0xd1, 0x8b), // 10 bright green
+                (0xf5, 0xf5, 0x43), // 11 bright yellow
+                (0x3b, 0x8e, 0xea), // 12 bright blue
+                (0xd6, 0x70, 0xd6), // 13 bright magenta
+                (0x29, 0xb8, 0xdb), // 14 bright cyan
+                (0xff, 0xff, 0xff), // 15 bright white
+            ],
+        }
+    }
+}
 
 /// Halves each channel - used for `NamedColor`'s `Dim*` variants, which have no fixed standard
 /// RGB value the way the base 16 colors do.
@@ -231,45 +270,49 @@ fn dim(color: (u8, u8, u8)) -> (u8, u8, u8) {
     (color.0 / 2, color.1 / 2, color.2 / 2)
 }
 
-fn named_color_rgb(name: NamedColor) -> (u8, u8, u8) {
+fn named_color_rgb(name: NamedColor, palette: &TerminalPalette) -> (u8, u8, u8) {
     match name {
-        NamedColor::Black => NAMED_COLOR_PALETTE[0],
-        NamedColor::Red => NAMED_COLOR_PALETTE[1],
-        NamedColor::Green => NAMED_COLOR_PALETTE[2],
-        NamedColor::Yellow => NAMED_COLOR_PALETTE[3],
-        NamedColor::Blue => NAMED_COLOR_PALETTE[4],
-        NamedColor::Magenta => NAMED_COLOR_PALETTE[5],
-        NamedColor::Cyan => NAMED_COLOR_PALETTE[6],
-        NamedColor::White => NAMED_COLOR_PALETTE[7],
-        NamedColor::BrightBlack => NAMED_COLOR_PALETTE[8],
-        NamedColor::BrightRed => NAMED_COLOR_PALETTE[9],
-        NamedColor::BrightGreen => NAMED_COLOR_PALETTE[10],
-        NamedColor::BrightYellow => NAMED_COLOR_PALETTE[11],
-        NamedColor::BrightBlue => NAMED_COLOR_PALETTE[12],
-        NamedColor::BrightMagenta => NAMED_COLOR_PALETTE[13],
-        NamedColor::BrightCyan => NAMED_COLOR_PALETTE[14],
-        NamedColor::BrightWhite => NAMED_COLOR_PALETTE[15],
-        NamedColor::Foreground | NamedColor::BrightForeground => DEFAULT_FOREGROUND,
-        NamedColor::Background => DEFAULT_BACKGROUND,
-        NamedColor::Cursor => DEFAULT_FOREGROUND,
-        NamedColor::DimForeground => dim(DEFAULT_FOREGROUND),
-        NamedColor::DimBlack => dim(NAMED_COLOR_PALETTE[0]),
-        NamedColor::DimRed => dim(NAMED_COLOR_PALETTE[1]),
-        NamedColor::DimGreen => dim(NAMED_COLOR_PALETTE[2]),
-        NamedColor::DimYellow => dim(NAMED_COLOR_PALETTE[3]),
-        NamedColor::DimBlue => dim(NAMED_COLOR_PALETTE[4]),
-        NamedColor::DimMagenta => dim(NAMED_COLOR_PALETTE[5]),
-        NamedColor::DimCyan => dim(NAMED_COLOR_PALETTE[6]),
-        NamedColor::DimWhite => dim(NAMED_COLOR_PALETTE[7]),
+        NamedColor::Black => palette.ansi[0],
+        NamedColor::Red => palette.ansi[1],
+        NamedColor::Green => palette.ansi[2],
+        NamedColor::Yellow => palette.ansi[3],
+        NamedColor::Blue => palette.ansi[4],
+        NamedColor::Magenta => palette.ansi[5],
+        NamedColor::Cyan => palette.ansi[6],
+        NamedColor::White => palette.ansi[7],
+        NamedColor::BrightBlack => palette.ansi[8],
+        NamedColor::BrightRed => palette.ansi[9],
+        NamedColor::BrightGreen => palette.ansi[10],
+        NamedColor::BrightYellow => palette.ansi[11],
+        NamedColor::BrightBlue => palette.ansi[12],
+        NamedColor::BrightMagenta => palette.ansi[13],
+        NamedColor::BrightCyan => palette.ansi[14],
+        NamedColor::BrightWhite => palette.ansi[15],
+        NamedColor::Foreground | NamedColor::BrightForeground => palette.foreground,
+        NamedColor::Background => palette.background,
+        NamedColor::Cursor => palette.cursor,
+        NamedColor::DimForeground => dim(palette.foreground),
+        NamedColor::DimBlack => dim(palette.ansi[0]),
+        NamedColor::DimRed => dim(palette.ansi[1]),
+        NamedColor::DimGreen => dim(palette.ansi[2]),
+        NamedColor::DimYellow => dim(palette.ansi[3]),
+        NamedColor::DimBlue => dim(palette.ansi[4]),
+        NamedColor::DimMagenta => dim(palette.ansi[5]),
+        NamedColor::DimCyan => dim(palette.ansi[6]),
+        NamedColor::DimWhite => dim(palette.ansi[7]),
     }
 }
 
 /// The standard xterm 256-color cube (indices `16..=231`) and grayscale ramp (`232..=255`)
 /// formulas - matches `vendor/zed/crates/terminal/src/terminal.rs`'s `get_color_at_index`/
 /// `rgb_for_index` (a public xterm convention, cited from the same source there).
-fn indexed_color_rgb(index: u8) -> (u8, u8, u8) {
+///
+/// Only `0..=15` is themeable: the cube and the ramp are fixed arithmetic on the index itself, the
+/// same in every real terminal, and a program asking for `Color::Indexed(196)` is asking for that
+/// exact well-known RGB rather than for "the theme's red".
+fn indexed_color_rgb(index: u8, palette: &TerminalPalette) -> (u8, u8, u8) {
     match index {
-        0..=15 => NAMED_COLOR_PALETTE[index as usize],
+        0..=15 => palette.ansi[index as usize],
         16..=231 => {
             let i = index - 16;
             let r = i / 36;
@@ -285,17 +328,22 @@ fn indexed_color_rgb(index: u8) -> (u8, u8, u8) {
     }
 }
 
-fn resolve_color(color: Color) -> (u8, u8, u8) {
+fn resolve_color(color: Color, palette: &TerminalPalette) -> (u8, u8, u8) {
     match color {
-        Color::Named(name) => named_color_rgb(name),
+        Color::Named(name) => named_color_rgb(name, palette),
         Color::Spec(rgb) => (rgb.r, rgb.g, rgb.b),
-        Color::Indexed(index) => indexed_color_rgb(index),
+        Color::Indexed(index) => indexed_color_rgb(index, palette),
     }
 }
 
-fn grid_cell_from_alacritty(cell: &AlacCell, is_cursor: bool, selected: bool) -> GridCell {
-    let mut fg = resolve_color(cell.fg);
-    let mut bg = resolve_color(cell.bg);
+fn grid_cell_from_alacritty(
+    cell: &AlacCell,
+    is_cursor: bool,
+    selected: bool,
+    palette: &TerminalPalette,
+) -> GridCell {
+    let mut fg = resolve_color(cell.fg, palette);
+    let mut bg = resolve_color(cell.bg, palette);
     if cell.flags.contains(Flags::INVERSE) {
         std::mem::swap(&mut fg, &mut bg);
     }
@@ -404,7 +452,11 @@ impl TerminalGrid {
     /// exactly `columns` cells). The cell at the cursor's current position (if visible) has its
     /// fg/bg swapped, so the renderer doesn't need to separately overlay a cursor glyph, and
     /// every cell inside the live selection is flagged [`GridCell::selected`].
-    pub fn visible_rows(&self) -> Vec<Vec<GridCell>> {
+    ///
+    /// `palette` is what every `NamedColor`/`Color::Indexed(0..=15)` the running program asked for
+    /// resolves against (GitHub issue #208) - passed in per call rather than stored, so a theme
+    /// switch is picked up by the very next repaint with no invalidation step that could go stale.
+    pub fn visible_rows(&self, palette: &TerminalPalette) -> Vec<Vec<GridCell>> {
         let content = self.term.renderable_content();
         let cursor_point =
             (content.cursor.shape != CursorShape::Hidden).then_some(content.cursor.point);
@@ -425,7 +477,12 @@ impl TerminalGrid {
             };
             let is_cursor = cursor_point == Some(indexed.point);
             let selected = selection.is_some_and(|range| range.contains(indexed.point));
-            row.push(grid_cell_from_alacritty(indexed.cell, is_cursor, selected));
+            row.push(grid_cell_from_alacritty(
+                indexed.cell,
+                is_cursor,
+                selected,
+                palette,
+            ));
         }
 
         rows
@@ -491,7 +548,7 @@ mod tests {
     fn plain_text_lands_on_the_first_row() {
         let mut grid = TerminalGrid::new(5, 20);
         grid.append_bytes(b"hello");
-        let rows = grid.visible_rows();
+        let rows = grid.visible_rows(&TerminalPalette::default());
         assert_eq!(rows.len(), 5);
         assert!(row_text(&rows[0]).starts_with("hello"));
     }
@@ -543,7 +600,7 @@ mod tests {
         let mut grid = TerminalGrid::new(5, 20);
         // Move to row 3, column 5 (1-indexed, per CSI CUP), then write "X".
         grid.append_bytes(b"\x1b[3;5HX");
-        let rows = grid.visible_rows();
+        let rows = grid.visible_rows(&TerminalPalette::default());
         // Row index 2 (0-indexed), column index 4.
         assert_eq!(rows[2][4].c, 'X');
         // Everywhere else on that row is still blank.
@@ -558,7 +615,7 @@ mod tests {
         let mut grid = TerminalGrid::new(5, 20);
         grid.append_bytes(b"\x1b[1;1Hfirst");
         grid.append_bytes(b"\x1b[1;1HSECOND");
-        let rows = grid.visible_rows();
+        let rows = grid.visible_rows(&TerminalPalette::default());
         assert!(row_text(&rows[0]).starts_with("SECOND"));
     }
 
@@ -566,16 +623,92 @@ mod tests {
     fn sgr_red_foreground_resolves_to_the_named_palette_color() {
         let mut grid = TerminalGrid::new(2, 10);
         grid.append_bytes(b"\x1b[31mR\x1b[0m");
-        let rows = grid.visible_rows();
+        let rows = grid.visible_rows(&TerminalPalette::default());
         assert_eq!(rows[0][0].c, 'R');
-        assert_eq!(rows[0][0].fg, NAMED_COLOR_PALETTE[1]);
+        assert_eq!(rows[0][0].fg, TerminalPalette::default().ansi[1]);
+    }
+
+    /// GitHub issue #208's pure half. Two renders of the *same* grid state under two different
+    /// palettes must produce two different sets of colours - which is only true because every
+    /// resolution path (unstyled default fg/bg, a named ANSI colour, and `Color::Indexed(0..=15)`)
+    /// reads the passed-in palette rather than a module constant.
+    #[test]
+    fn every_themeable_colour_comes_from_the_supplied_palette_not_a_hardcoded_one() {
+        let mut grid = TerminalGrid::new(2, 10);
+        // "P" unstyled, "R" in named red (SGR 31), "B" in indexed blue (SGR 38;5;4).
+        grid.append_bytes(b"P\x1b[31mR\x1b[0m\x1b[38;5;4mB\x1b[0m");
+
+        let mut ansi = TerminalPalette::default().ansi;
+        ansi[1] = (0x77, 0x88, 0x99);
+        ansi[4] = (0xaa, 0xbb, 0xcc);
+        let themed = TerminalPalette {
+            foreground: (0x11, 0x22, 0x33),
+            background: (0x44, 0x55, 0x66),
+            ansi,
+            ..Default::default()
+        };
+
+        let default_rows = grid.visible_rows(&TerminalPalette::default());
+        let themed_rows = grid.visible_rows(&themed);
+
+        assert_eq!(themed_rows[0][0].c, 'P');
+        assert_eq!(themed_rows[0][0].fg, (0x11, 0x22, 0x33));
+        assert_eq!(themed_rows[0][0].bg, (0x44, 0x55, 0x66));
+        assert_eq!(themed_rows[0][1].c, 'R');
+        assert_eq!(themed_rows[0][1].fg, (0x77, 0x88, 0x99));
+        assert_eq!(themed_rows[0][2].c, 'B');
+        assert_eq!(themed_rows[0][2].fg, (0xaa, 0xbb, 0xcc));
+
+        for column in 0..3 {
+            assert_ne!(
+                default_rows[0][column].fg, themed_rows[0][column].fg,
+                "column {column} rendered the same foreground under two different palettes - it \
+                 is still resolving against something hardcoded"
+            );
+        }
+    }
+
+    /// A cell the running program gave a real 24-bit colour (`SGR 38;2;r;g;b`) is *not* themeable -
+    /// the program asked for that exact colour, and a terminal that repainted it in a theme colour
+    /// would be corrupting output, not theming it.
+    #[test]
+    fn a_program_specified_truecolor_is_left_exactly_alone_by_the_palette() {
+        let mut grid = TerminalGrid::new(2, 10);
+        grid.append_bytes(b"\x1b[38;2;1;2;3mX");
+
+        let themed = TerminalPalette {
+            foreground: (0x11, 0x22, 0x33),
+            ansi: [(0x11, 0x22, 0x33); 16],
+            ..Default::default()
+        };
+
+        assert_eq!(grid.visible_rows(&themed)[0][0].fg, (1, 2, 3));
+    }
+
+    /// The xterm 256-colour cube and grayscale ramp (`16..=255`) are fixed arithmetic, not palette
+    /// entries - see [`indexed_color_rgb`]'s own docs.
+    #[test]
+    fn the_xterm_256_cube_stays_fixed_while_the_first_sixteen_follow_the_palette() {
+        let mut grid = TerminalGrid::new(2, 10);
+        grid.append_bytes(b"\x1b[38;5;196mC\x1b[0m");
+
+        let themed = TerminalPalette {
+            ansi: [(0x11, 0x22, 0x33); 16],
+            ..Default::default()
+        };
+
+        assert_eq!(
+            grid.visible_rows(&themed)[0][0].fg,
+            (0xff, 0x00, 0x00),
+            "index 196 is the cube's own pure red, the same in every real terminal"
+        );
     }
 
     #[test]
     fn sgr_bold_sets_the_bold_flag() {
         let mut grid = TerminalGrid::new(2, 10);
         grid.append_bytes(b"\x1b[1mB");
-        let rows = grid.visible_rows();
+        let rows = grid.visible_rows(&TerminalPalette::default());
         assert!(rows[0][0].bold);
     }
 
@@ -583,7 +716,7 @@ mod tests {
     fn resize_changes_the_visible_row_and_column_count() {
         let mut grid = TerminalGrid::new(5, 20);
         grid.resize(10, 40);
-        let rows = grid.visible_rows();
+        let rows = grid.visible_rows(&TerminalPalette::default());
         assert_eq!(rows.len(), 10);
         assert_eq!(rows[0].len(), 40);
     }
@@ -593,7 +726,7 @@ mod tests {
         let mut grid = TerminalGrid::new(5, 20);
         grid.append_bytes(b"hello");
         grid.append_bytes(b"\x1b[2J\x1b[1;1H");
-        let rows = grid.visible_rows();
+        let rows = grid.visible_rows(&TerminalPalette::default());
         assert_eq!(row_text(&rows[0]).trim(), "");
     }
 
@@ -609,10 +742,13 @@ mod tests {
     fn clear_erases_visible_text_and_homes_the_cursor() {
         let mut grid = TerminalGrid::new(5, 20);
         grid.append_bytes(b"\x1b[3;5Hhello");
-        assert_eq!(row_text(&grid.visible_rows()[2]).trim(), "hello");
+        assert_eq!(
+            row_text(&grid.visible_rows(&TerminalPalette::default())[2]).trim(),
+            "hello"
+        );
 
         grid.clear();
-        for row in grid.visible_rows() {
+        for row in grid.visible_rows(&TerminalPalette::default()) {
             assert_eq!(
                 row_text(&row).trim(),
                 "",
@@ -623,7 +759,7 @@ mod tests {
         // The cursor is homed to (1,1) - writing right after `clear()` lands at the top-left,
         // not wherever the cursor happened to be before.
         grid.append_bytes(b"X");
-        assert_eq!(grid.visible_rows()[0][0].c, 'X');
+        assert_eq!(grid.visible_rows(&TerminalPalette::default())[0][0].c, 'X');
     }
 
     #[test]
@@ -652,7 +788,7 @@ mod tests {
             grid.append_bytes(&chunk);
         }
 
-        let rows = grid.visible_rows();
+        let rows = grid.visible_rows(&TerminalPalette::default());
         assert_eq!(
             rows[1][2].c, 'O',
             "expected 'O' at row 2 col 3, got rows: {rows:?}"
@@ -796,7 +932,7 @@ mod selection_tests {
         grid.start_selection(left(0, 6));
         grid.update_selection(right(0, 10));
 
-        let rows = grid.visible_rows();
+        let rows = grid.visible_rows(&TerminalPalette::default());
         let flagged: String = rows[0]
             .iter()
             .filter(|cell| cell.selected)
@@ -813,7 +949,7 @@ mod selection_tests {
     fn no_selection_means_no_cell_is_flagged() {
         let mut grid = TerminalGrid::new(5, 20);
         grid.append_bytes(b"hello world");
-        let rows = grid.visible_rows();
+        let rows = grid.visible_rows(&TerminalPalette::default());
         assert!(rows.iter().flatten().all(|cell| !cell.selected));
     }
 

--- a/crates/app/src/terminal/pane.rs
+++ b/crates/app/src/terminal/pane.rs
@@ -72,10 +72,7 @@ use gpui::{
 };
 use pty_core::{ExitStatus, PtyError, PtySession, SpawnOptions};
 
-use crate::terminal::grid::{
-    CellPosition, CellSide, GridCell, TerminalGrid, DEFAULT_BACKGROUND, DEFAULT_FOREGROUND,
-    SELECTION_BACKGROUND,
-};
+use crate::terminal::grid::{CellPosition, CellSide, GridCell, TerminalGrid, TerminalPalette};
 use crate::terminal::links::{self as terminal_links, LinkMatch};
 use crate::theme;
 
@@ -467,6 +464,15 @@ pub struct TerminalPane {
     /// selection *itself* lives in `alacritty_terminal`'s own `Term::selection` (see
     /// `crate::terminal::grid`'s selection docs), not here.
     selecting: bool,
+    /// Test-only seam: the exact [`TerminalPalette`] the most recent real `Render::render` call
+    /// painted with (GitHub issue #208). Written by `render` itself and by nothing else, so a test
+    /// asserting on it is asserting on what the pane genuinely painted rather than re-deriving the
+    /// palette a second way and hoping the two agree.
+    ///
+    /// `#[cfg(test)]` because production has no use for it - the palette is resolved fresh every
+    /// frame and consumed within that frame (see [`theme_terminal_palette`]).
+    #[cfg(test)]
+    last_painted_palette: Option<TerminalPalette>,
 }
 
 impl TerminalPane {
@@ -495,6 +501,8 @@ impl TerminalPane {
             _task: None,
             is_foreground: true,
             selecting: false,
+            #[cfg(test)]
+            last_painted_palette: None,
         };
         this.spawn_process(cx);
         this
@@ -858,12 +866,32 @@ impl TerminalPane {
         self.font_size_px
     }
 
+    /// Test-only seam: the palette the most recent real paint used - see
+    /// [`Self::last_painted_palette`].
+    #[cfg(test)]
+    pub(crate) fn last_painted_palette_for_test(&self) -> Option<TerminalPalette> {
+        self.last_painted_palette
+    }
+
+    /// Test-only seam: the visible grid resolved against the palette the most recent real paint
+    /// used, i.e. exactly the cells that paint turned into styled spans.
+    #[cfg(test)]
+    pub(crate) fn painted_rows_for_test(&self) -> Vec<Vec<GridCell>> {
+        let palette = self
+            .last_painted_palette
+            .expect("the pane must have painted at least once");
+        self.grid.visible_rows(&palette)
+    }
+
     /// The visible grid as trimmed-right text lines (leading whitespace, e.g. an agent CLI's
     /// indented menu, is preserved) - used by `crate::rail::state` to build the "question preview"
     /// (the design's "Jerry reading the tail of the agent's pty").
     pub fn visible_text_lines(&self) -> Vec<String> {
         self.grid
-            .visible_rows()
+            // Text only - this reads nothing but `GridCell::c`, so which palette the cells were
+            // resolved against genuinely cannot affect the result, and this caller (`crate::rail::
+            // state`'s question preview) has no live theme access of its own to offer.
+            .visible_rows(&TerminalPalette::default())
             .iter()
             .map(|row| {
                 row.iter()
@@ -1442,6 +1470,38 @@ fn pack_rgb((r, g, b): (u8, u8, u8)) -> u32 {
     ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
 }
 
+/// One [`theme::ColorToken`], resolved against whichever theme is really live right now and
+/// reduced to the 8-bit-per-channel RGB triple [`TerminalPalette`] carries.
+///
+/// 8-bit is the terminal's real precision on both ends - `alacritty_terminal` hands back `u8`
+/// channels for a program-specified colour, and a theme file stores `#rrggbb` - so nothing is lost
+/// here that the grid could have represented anyway.
+fn token_rgb(token: theme::ColorToken) -> (u8, u8, u8) {
+    let color = token.resolve();
+    let channel = |component: f32| (component.clamp(0.0, 1.0) * 255.0).round() as u8;
+    (channel(color.r), channel(color.g), channel(color.b))
+}
+
+/// The live theme's real terminal palette (GitHub issue #208) - `crate::theme::terminal`'s twenty
+/// registered tokens resolved against whichever theme is installed right now.
+///
+/// This is the one place the terminal's colours cross from the theme system into
+/// `crate::terminal::grid`, which is deliberately theme-free (see that module's own docs). Called
+/// fresh inside [`Render::render`] rather than cached on the pane: `crate::theme`'s resolution is a
+/// single hash lookup per token, and `AdeApp::apply_theme_selection` already forces a repaint of
+/// every window when the selection changes (`App::refresh_windows`), so reading it at paint time
+/// means a theme switch lands on the very next frame with no invalidation hook of its own to
+/// forget.
+fn theme_terminal_palette() -> TerminalPalette {
+    TerminalPalette {
+        background: token_rgb(theme::terminal::BACKGROUND),
+        foreground: token_rgb(theme::terminal::FOREGROUND),
+        cursor: token_rgb(theme::terminal::CURSOR),
+        selection: token_rgb(theme::terminal::SELECTION),
+        ansi: std::array::from_fn(|index| token_rgb(theme::terminal::ANSI[index])),
+    }
+}
+
 /// Whether two cells share every attribute a rendered run cares about (everything but the
 /// character itself) - used to group a grid row into as few styled spans as possible.
 fn same_run_style(a: &GridCell, b: &GridCell) -> bool {
@@ -1507,13 +1567,13 @@ fn split_segments(row_char_count: usize, links: &[LinkMatch]) -> Vec<RowSegment>
     segments
 }
 
-fn plain_span(style: &GridCell, text: String) -> impl IntoElement {
+fn plain_span(style: &GridCell, text: String, palette: &TerminalPalette) -> impl IntoElement {
     let mut span = div().text_color(rgb(pack_rgb(style.fg)));
     // The selection fill wins over the cell's own ANSI background, so a selection is visible
     // across text a program has coloured - which is most of what an agent CLI prints.
     if style.selected {
-        span = span.bg(rgb(pack_rgb(SELECTION_BACKGROUND)));
-    } else if style.bg != DEFAULT_BACKGROUND {
+        span = span.bg(rgb(pack_rgb(palette.selection)));
+    } else if style.bg != palette.background {
         span = span.bg(rgb(pack_rgb(style.bg)));
     }
     if style.bold {
@@ -1557,7 +1617,10 @@ fn render_link_span(
     cwd: &Path,
     row_index: usize,
     link_ordinal: usize,
-    selected: bool,
+    // `selection_fill` is the live theme's selection fill when this span falls inside the
+    // selection and `None` when it doesn't - one parameter rather than a `selected: bool` plus
+    // the whole palette, since the fill is the only thing this function ever wants out of it.
+    selection_fill: Option<(u8, u8, u8)>,
     cx: &mut Context<TerminalPane>,
 ) -> impl IntoElement {
     let target = terminal_links::resolve(cwd, &link.path);
@@ -1570,8 +1633,8 @@ fn render_link_span(
         .border_b_1()
         .border_color(theme::term::LINK_UNDERLINE)
         .child(text);
-    if selected {
-        span = span.bg(rgb(pack_rgb(SELECTION_BACKGROUND)));
+    if let Some(fill) = selection_fill {
+        span = span.bg(rgb(pack_rgb(fill)));
     }
     span.style().border_style = Some(BorderStyle::Dashed);
 
@@ -1621,6 +1684,7 @@ fn render_row(
     row: &[GridCell],
     row_index: usize,
     cwd: &Path,
+    palette: &TerminalPalette,
     cx: &mut Context<TerminalPane>,
 ) -> impl IntoElement {
     let row_text: String = row.iter().map(|cell| cell.c).collect();
@@ -1641,7 +1705,7 @@ fn render_row(
                         run_end += 1;
                     }
                     let text: String = row[inner..run_end].iter().map(|cell| cell.c).collect();
-                    line = line.child(plain_span(style, text));
+                    line = line.child(plain_span(style, text, palette));
                     inner = run_end;
                 }
             }
@@ -1665,7 +1729,7 @@ fn render_row(
                         cwd,
                         row_index,
                         link_ordinal,
-                        selected,
+                        selected.then_some(palette.selection),
                         cx,
                     ));
                     link_ordinal += 1;
@@ -1715,7 +1779,7 @@ fn render_plain_line_with_links(
                     link_ordinal,
                     // The spawn-error line is not part of the grid, so it is never part of a
                     // grid selection.
-                    false,
+                    None,
                     cx,
                 ));
                 link_ordinal += 1;
@@ -1729,6 +1793,15 @@ fn render_plain_line_with_links(
 impl Render for TerminalPane {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         self.maybe_resize_pty(window);
+
+        // GitHub issue #208: resolved once per frame and threaded through every span this paints,
+        // so the whole pane (its own fill, unstyled text, every ANSI colour a program asked for,
+        // and the selection fill) tracks whichever theme is live - see `theme_terminal_palette`.
+        let palette = theme_terminal_palette();
+        #[cfg(test)]
+        {
+            self.last_painted_palette = Some(palette);
+        }
 
         // Measures this pane's rendered content-area bounds every frame, so
         // `Self::maybe_resize_pty` can size the terminal grid from the pane's actual
@@ -1787,7 +1860,7 @@ impl Render for TerminalPane {
             .size_full()
             .min_w_0()
             .overflow_hidden()
-            .bg(rgb(pack_rgb(DEFAULT_BACKGROUND)))
+            .bg(rgb(pack_rgb(palette.background)))
             // Not the equivalent `.p_2()` shorthand - see `PANE_PADDING_PX`'s docs for why
             // this needs to be the same value `Self::maybe_resize_pty` subtracts.
             .p(px(PANE_PADDING_PX))
@@ -1796,7 +1869,7 @@ impl Render for TerminalPane {
             // for why leaving either implicit was a measured bug.
             .text_size(px(self.font_size_px))
             .line_height(px(self.line_height_px()))
-            .text_color(rgb(pack_rgb(DEFAULT_FOREGROUND)))
+            .text_color(rgb(pack_rgb(palette.foreground)))
             .child(measure_bounds);
 
         let cwd = self.spec.cwd.clone();
@@ -1811,8 +1884,8 @@ impl Render for TerminalPane {
             ));
         }
 
-        for (row_index, row) in self.grid.visible_rows().into_iter().enumerate() {
-            pane = pane.child(render_row(&row, row_index, &cwd, cx));
+        for (row_index, row) in self.grid.visible_rows(&palette).into_iter().enumerate() {
+            pane = pane.child(render_row(&row, row_index, &cwd, &palette, cx));
         }
 
         if self.grid.ended {
@@ -2927,12 +3000,222 @@ mod mouse_selection_tests {
         cx.run_until_parked();
 
         let flagged = pane.read_with(cx, |pane, _| {
-            pane.grid.visible_rows()[0]
+            pane.grid.visible_rows(&TerminalPalette::default())[0]
                 .iter()
                 .filter(|cell| cell.selected)
                 .map(|cell| cell.c)
                 .collect::<String>()
         });
         assert_eq!(flagged, "hello");
+    }
+}
+
+/// GitHub issue #208, end to end through a real painted GPUI window: the integrated terminal's own
+/// rendered colours must follow the selected theme.
+///
+/// Before this, `crate::terminal::grid` held them as module constants (VS Code's own default
+/// terminal palette), so every one of this app's six themes rendered the terminal identically - a
+/// `#1e1e1e` rectangle sitting inside a `#0d0f11` app, unchanged by switching to the light theme.
+///
+/// These assert on [`TerminalPane::last_painted_palette_for_test`], which `Render::render` itself
+/// writes - so what is checked is the palette a real paint genuinely used, not one this test
+/// re-derived a second way.
+#[cfg(test)]
+mod terminal_theme_tests {
+    use super::*;
+    use gpui::{Entity, TestAppContext, VisualTestContext};
+    use std::rc::Rc;
+
+    /// Restores the Jerry Dark identity (no palette installed) on drop, so a test that installs a
+    /// theme - or panics half way through one - can't leak it into any other test on this thread.
+    struct ResetThemeOnDrop;
+
+    impl Drop for ResetThemeOnDrop {
+        fn drop(&mut self) {
+            theme::set_current_theme(None);
+        }
+    }
+
+    /// Installs a real bundled theme exactly the way selecting its card does: compiled from its own
+    /// checked-in `assets/themes/*.toml` file through the real `base` chain
+    /// (`crate::settings::custom_theme::compile_palette_by_name`, which is what
+    /// `AdeApp::apply_theme_selection` calls), not a palette synthesized for the test.
+    fn with_bundled_theme(name: &str) -> ResetThemeOnDrop {
+        let palette = crate::settings::custom_theme::compile_palette_by_name(name, &[])
+            .expect("a bundled theme must compile")
+            .expect("a bundled non-Jerry-Dark theme has real overrides");
+        theme::set_current_theme(Some(Rc::new(palette)));
+        ResetThemeOnDrop
+    }
+
+    /// That bundled theme's own value for one key, straight out of its compiled palette.
+    fn bundled_rgb(name: &str, key: &str) -> (u8, u8, u8) {
+        let palette = crate::settings::custom_theme::compile_palette_by_name(name, &[])
+            .expect("a bundled theme must compile")
+            .expect("a bundled non-Jerry-Dark theme has real overrides");
+        let color = *palette.get(key).expect("a real registered key");
+        let channel = |component: f32| (component.clamp(0.0, 1.0) * 255.0).round() as u8;
+        (channel(color.r), channel(color.g), channel(color.b))
+    }
+
+    /// Opens a real window on a `cat`-backed pane (`cat` writes nothing of its own, so the grid
+    /// holds exactly the injected bytes) and paints it at least once.
+    fn painted_pane<'a>(
+        cx: &'a mut TestAppContext,
+        bytes: &[u8],
+    ) -> (Entity<TerminalPane>, &'a mut VisualTestContext) {
+        let (pane, cx) = cx.add_window_view(|_window, cx| {
+            TerminalPane::new(
+                TerminalSpec::command("cat", Vec::new(), std::env::temp_dir()),
+                ROW_FONT_SIZE_PX,
+                cx,
+            )
+        });
+        cx.run_until_parked();
+        pane.update(cx, |pane, cx| pane.inject_bytes_for_test(bytes, cx));
+        cx.run_until_parked();
+        (pane, cx)
+    }
+
+    /// `crate::terminal::grid` stays theme-free, so it carries its own transcription of Jerry
+    /// Dark's terminal palette. This is what stops that copy from going stale: with no theme
+    /// installed (the real Jerry Dark identity case), resolving the real tokens must produce
+    /// exactly it.
+    #[test]
+    fn the_pure_grid_default_palette_is_exactly_jerry_darks_own() {
+        assert!(
+            theme::current_theme_palette().is_none(),
+            "the real Jerry Dark identity case - no palette installed"
+        );
+        assert_eq!(
+            theme_terminal_palette(),
+            TerminalPalette::default(),
+            "crate::terminal::grid's TerminalPalette::default() has drifted from \
+             crate::theme::terminal's own compiled defaults - retune one and you must retune both"
+        );
+    }
+
+    /// The headline behaviour. The *same* pane, painted twice, must genuinely change colour when
+    /// the theme changes - and land on the light theme's own real values, not merely on something
+    /// different.
+    #[gpui::test]
+    fn switching_to_the_light_theme_really_repaints_the_terminal_light(cx: &mut TestAppContext) {
+        let (pane, cx) = painted_pane(cx, b"hello world");
+
+        let dark = pane
+            .read_with(cx, |pane, _| pane.last_painted_palette_for_test())
+            .expect("the pane must have painted at least once");
+        assert_eq!(
+            dark,
+            TerminalPalette::default(),
+            "with no theme installed the pane must paint Jerry Dark's own palette"
+        );
+
+        let _theme = with_bundled_theme("Paper");
+        pane.update(cx, |_pane, cx| cx.notify());
+        cx.run_until_parked();
+
+        let light = pane
+            .read_with(cx, |pane, _| pane.last_painted_palette_for_test())
+            .expect("the repaint must have happened");
+
+        assert_eq!(
+            light.background,
+            bundled_rgb("Paper", "terminal.background")
+        );
+        assert_eq!(
+            light.foreground,
+            bundled_rgb("Paper", "terminal.foreground")
+        );
+        assert_ne!(
+            light.background, dark.background,
+            "the terminal background must genuinely change when the theme does - this is the \
+             whole of GitHub issue #208"
+        );
+        assert_ne!(light.foreground, dark.foreground);
+
+        let luminance =
+            |(r, g, b): (u8, u8, u8)| 0.299 * r as f32 + 0.587 * g as f32 + 0.114 * b as f32;
+        assert!(
+            luminance(light.background) > luminance(light.foreground),
+            "Paper is a light theme, so its terminal must be dark text on a light fill, not the \
+             other way round - got fg {:?} on bg {:?}",
+            light.foreground,
+            light.background
+        );
+    }
+
+    /// Two visually distinct *dark* themes must differ too - a guard against a fix that only
+    /// happened to work because one bundled theme inverts lightness.
+    #[gpui::test]
+    fn two_different_dark_themes_paint_two_different_terminals(cx: &mut TestAppContext) {
+        let (pane, cx) = painted_pane(cx, b"hello world");
+
+        let ember = {
+            let _theme = with_bundled_theme("Ember");
+            pane.update(cx, |_pane, cx| cx.notify());
+            cx.run_until_parked();
+            pane.read_with(cx, |pane, _| pane.last_painted_palette_for_test())
+                .expect("painted")
+        };
+        let moss = {
+            let _theme = with_bundled_theme("Moss");
+            pane.update(cx, |_pane, cx| cx.notify());
+            cx.run_until_parked();
+            pane.read_with(cx, |pane, _| pane.last_painted_palette_for_test())
+                .expect("painted")
+        };
+
+        assert_eq!(
+            ember.background,
+            bundled_rgb("Ember", "terminal.background")
+        );
+        assert_eq!(moss.background, bundled_rgb("Moss", "terminal.background"));
+        assert_ne!(
+            ember, moss,
+            "two bundled dark themes must not paint the terminal identically"
+        );
+    }
+
+    /// A colour the *running program* asked for by name (`SGR 32`, "green") has to come out of the
+    /// theme's own palette too, not only the pane's default fill and text - that is the half a fix
+    /// that only retinted the background would miss entirely.
+    #[gpui::test]
+    fn a_named_ansi_colour_is_painted_from_the_themes_own_palette(cx: &mut TestAppContext) {
+        let (pane, cx) = painted_pane(cx, b"\x1b[32mOK\x1b[0m");
+
+        let dark_green = pane.read_with(cx, |pane, _| pane.painted_rows_for_test()[0][0].fg);
+        assert_eq!(dark_green, TerminalPalette::default().ansi[2]);
+
+        let _theme = with_bundled_theme("Paper");
+        pane.update(cx, |_pane, cx| cx.notify());
+        cx.run_until_parked();
+
+        let light_green = pane.read_with(cx, |pane, _| pane.painted_rows_for_test()[0][0].fg);
+        assert_eq!(
+            light_green,
+            bundled_rgb("Paper", "terminal.ansi.2"),
+            "the cell the program printed in ANSI green must resolve against the live theme's own \
+             ansi.2, not a module constant"
+        );
+        assert_ne!(
+            light_green, dark_green,
+            "Paper ships the light ANSI palette, so its green is genuinely a different colour"
+        );
+    }
+
+    /// Unstyled text - the overwhelming majority of what a terminal paints - must take the theme's
+    /// foreground, and an unstyled cell's background must be the theme's terminal background.
+    #[gpui::test]
+    fn unstyled_output_takes_the_themes_own_foreground_and_background(cx: &mut TestAppContext) {
+        let (pane, cx) = painted_pane(cx, b"plain");
+        let _theme = with_bundled_theme("Slate");
+        pane.update(cx, |_pane, cx| cx.notify());
+        cx.run_until_parked();
+
+        let cell = pane.read_with(cx, |pane, _| pane.painted_rows_for_test()[0][0]);
+        assert_eq!(cell.c, 'p');
+        assert_eq!(cell.fg, bundled_rgb("Slate", "terminal.foreground"));
+        assert_eq!(cell.bg, bundled_rgb("Slate", "terminal.background"));
     }
 }

--- a/crates/app/src/theme.rs
+++ b/crates/app/src/theme.rs
@@ -271,6 +271,7 @@ pub const TOKEN_GROUPS: &[(&str, &[(&str, ColorToken)])] = &[
     ("syntax", syntax::TOKENS),
     ("editor", editor::TOKENS),
     ("term", term::TOKENS),
+    ("terminal", terminal::TOKENS),
     ("env", env::TOKENS),
     ("agent", agent::TOKENS),
     ("lang", lang::TOKENS),
@@ -715,55 +716,93 @@ fn enforce_syntax_contrast_floors(palette: &mut [(&'static str, Rgba)]) {
         let Some(floor) = syntax_contrast_floor(key) else {
             continue;
         };
-        let quantized_now = Rgba {
-            r: (color.r * 255.0).round() / 255.0,
-            g: (color.g * 255.0).round() / 255.0,
-            b: (color.b * 255.0).round() / 255.0,
-            a: color.a,
-        };
-        if contrast_ratio(quantized_now, background) >= floor * 1.005 {
-            continue;
+        *color = pushed_to_clear_floor(*color, background, floor, lighten);
+    }
+}
+
+/// The one real "move this colour away from that background until it clears `floor`" step both
+/// contrast guards share - [`enforce_syntax_contrast_floors`] and
+/// [`enforce_terminal_foreground_contrast`].
+///
+/// Holds hue and chroma and moves lightness only, so the colour keeps its identity; `lighten` is
+/// the direction its own guard already decided from the background (up on a dark theme, down on a
+/// light one). Returns `color` completely unchanged when it already clears, so this is strictly
+/// one-directional - it can only ever increase contrast.
+fn pushed_to_clear_floor(color: Rgba, background: Rgba, floor: f32, lighten: bool) -> Rgba {
+    // Measured on the **quantized** colour, not the float one. A theme file stores `#rrggbb`, so an
+    // 8-bit rounding step is applied to whatever this produces; searching in float space and
+    // ignoring that lands colours a hundredth of a ratio point under the floor, which is a real
+    // failure of a real assertion rather than a rounding nicety.
+    let quantize = |candidate: Rgba| -> Rgba {
+        Rgba {
+            r: (candidate.r * 255.0).round() / 255.0,
+            g: (candidate.g * 255.0).round() / 255.0,
+            b: (candidate.b * 255.0).round() / 255.0,
+            a: candidate.a,
         }
-        let (lightness, chroma, hue) = oklch::of(*color);
-        let limit = if lighten { 1.0 } else { 0.0 };
-        // Measured on the **quantized** colour, not the float one. A theme file stores `#rrggbb`,
-        // so an 8-bit rounding step is applied to whatever this produces; searching in float space
-        // and ignoring that lands colours a hundredth of a ratio point under the floor, which is a
-        // real failure of a real assertion rather than a rounding nicety.
-        let quantize = |candidate: Rgba| -> Rgba {
-            Rgba {
-                r: (candidate.r * 255.0).round() / 255.0,
-                g: (candidate.g * 255.0).round() / 255.0,
-                b: (candidate.b * 255.0).round() / 255.0,
-                a: candidate.a,
-            }
-        };
-        // A hair above the floor, not exactly on it. Landing a colour on 4.4999 is a real
-        // assertion failure, and the difference between an f32 ratio computed here and an f64 one
-        // computed by any external checker is comfortably inside that margin.
-        let target = floor * 1.005;
-        let clears = |candidate: Rgba| contrast_ratio(quantize(candidate), background) >= target;
-        // Binary-search the smallest move that clears the floor: contrast is monotonic in
-        // lightness once we are moving away from the background, so this converges.
-        let (mut low, mut high) = (lightness, limit);
-        let mut best = oklch::to_rgba(limit, chroma, hue, color.a);
-        if !clears(best) {
-            // Even pure white/black cannot clear it - take the extreme and let the theme's own
-            // validation report the palette as unreadable rather than silently pretending.
-            *color = best;
-            continue;
+    };
+    // A hair above the floor, not exactly on it. Landing a colour on 4.4999 is a real assertion
+    // failure, and the difference between an f32 ratio computed here and an f64 one computed by any
+    // external checker is comfortably inside that margin.
+    let target = floor * 1.005;
+    let clears = |candidate: Rgba| contrast_ratio(quantize(candidate), background) >= target;
+    if clears(color) {
+        return color;
+    }
+
+    let (lightness, chroma, hue) = oklch::of(color);
+    let limit = if lighten { 1.0 } else { 0.0 };
+    let mut best = oklch::to_rgba(limit, chroma, hue, color.a);
+    if !clears(best) {
+        // Even pure white/black cannot clear it - take the extreme and let the theme's own
+        // validation report the palette as unreadable rather than silently pretending.
+        return best;
+    }
+    // Binary-search the smallest move that clears the floor: contrast is monotonic in lightness
+    // once we are moving away from the background, so this converges.
+    let (mut low, mut high) = (lightness, limit);
+    for _ in 0..24 {
+        let mid = 0.5 * (low + high);
+        let candidate = oklch::to_rgba(mid, chroma, hue, color.a);
+        if clears(candidate) {
+            best = candidate;
+            high = mid;
+        } else {
+            low = mid;
         }
-        for _ in 0..24 {
-            let mid = 0.5 * (low + high);
-            let candidate = oklch::to_rgba(mid, chroma, hue, color.a);
-            if clears(candidate) {
-                best = candidate;
-                high = mid;
-            } else {
-                low = mid;
-            }
+    }
+    best
+}
+
+/// The same guard [`enforce_syntax_contrast_floors`] applies to code, applied to unstyled terminal
+/// output - `terminal.foreground` against `terminal.background` rather than against
+/// `surface.center`, because that is the surface it is actually painted on.
+///
+/// Needed for the same reason and measured the same way: [`derive_shift`]'s lightness fit is solved
+/// from a theme's two *background* swatches and carries no foreground-contrast guarantee at all. On
+/// this app's own bundled themes it lands `Slate`'s terminal foreground at a measured 4.27:1 -
+/// readable-ish, but under WCAG's 4.5:1 body-text bar for what is, by volume, most of what a
+/// terminal ever paints.
+///
+/// Deliberately only the foreground. The ANSI sixteen are pinned rather than derived (see
+/// [`pin_terminal_ansi_palette`]), and pinned values are authored to be legible; forcing a floor on
+/// them would also be wrong on its own terms, since ANSI black on a dark background is *supposed*
+/// to be near-invisible - that is what a program asking for colour 0 is asking for.
+fn enforce_terminal_foreground_contrast(palette: &mut [(&'static str, Rgba)]) {
+    let Some(background) = palette
+        .iter()
+        .find(|(key, _)| *key == terminal::BACKGROUND.key)
+        .map(|(_, color)| *color)
+    else {
+        return;
+    };
+    let (background_lightness, _, _) = oklch::of(background);
+    let lighten = background_lightness < 0.5;
+
+    for (key, color) in palette.iter_mut() {
+        if *key == terminal::FOREGROUND.key {
+            *color = pushed_to_clear_floor(*color, background, 4.5, lighten);
         }
-        *color = best;
     }
 }
 
@@ -780,7 +819,47 @@ pub fn derived_palette(shift: OklchShift) -> Vec<(&'static str, Rgba)> {
         .map(|token| (token.key, apply_shift(token.default, shift)))
         .collect();
     enforce_syntax_contrast_floors(&mut palette);
+    pin_terminal_ansi_palette(&mut palette);
+    enforce_terminal_foreground_contrast(&mut palette);
     palette
+}
+
+/// Replaces the sixteen derived `terminal.ansi.*` entries with a real, *authored* ANSI palette -
+/// [`terminal::ANSI`]'s own defaults for a dark derived theme, [`terminal::LIGHT_ANSI`] for a light
+/// one, decided from the palette's own derived `surface.window` via [`theme_is_light`].
+///
+/// See [`terminal::LIGHT_ANSI`]'s docs for the whole reasoning. The short version: every other
+/// colour in this app is a free design choice, so shifting it is right; the ANSI sixteen carry
+/// fixed conventional meanings that a systematic hue/lightness shift destroys - most sharply on
+/// `Paper`, whose genuinely negative lightness slope would derive ANSI *black* to near-white, i.e.
+/// invisible on Paper's own light terminal background.
+///
+/// Deliberately shaped like [`enforce_syntax_contrast_floors`] - a narrow, documented pass over the
+/// already-derived palette rather than a special case threaded through [`apply_shift`] - so
+/// everything that consumes a derived palette (the bundled theme generator, "generate from colour",
+/// and the VSCode importer's base layer) gets it identically and for free.
+fn pin_terminal_ansi_palette(palette: &mut [(&'static str, Rgba)]) {
+    let Some(window) = palette
+        .iter()
+        .find(|(key, _)| *key == "surface.window")
+        .map(|(_, color)| *color)
+    else {
+        return;
+    };
+    let light = theme_is_light(window);
+    for (key, color) in palette.iter_mut() {
+        let Some(index) = key
+            .strip_prefix("terminal.ansi.")
+            .and_then(|digits| digits.parse::<usize>().ok())
+        else {
+            continue;
+        };
+        *color = if light {
+            hex_rgba(terminal::LIGHT_ANSI[index])
+        } else {
+            terminal::ANSI[index].default
+        };
+    }
 }
 /// Backgrounds - every solid fill in the app, from the window itself down to popovers,
 /// hover states and keycaps.
@@ -1745,6 +1824,146 @@ pub mod term {
         ("LINK_UNDERLINE", LINK_UNDERLINE),
         ("LINK_HOVER", LINK_HOVER),
         ("LINK_UNDERLINE_HOVER", LINK_UNDERLINE_HOVER),
+    ];
+}
+
+/// The integrated terminal's own rendered-content palette - the colours a program running inside a
+/// terminal pane actually paints its characters with.
+///
+/// GitHub issue #208, "the integrated terminal theme should follow the editor theme".
+///
+/// ## Why this is not `term`, despite the name
+///
+/// `theme::term` is chrome *around and over* terminal output - the caret this app paints in its
+/// own text fields (`term::CURSOR`), the command palette's prompt tint (`term::PROMPT`), the
+/// diagnostic warning tone (`term::WARN`), and the clickable `path:line` link styling the terminal
+/// pane overlays on rows it has scanned (`term::LINK` and friends). None of it is what a pty's own
+/// bytes resolve to. This module is: `crate::terminal::grid`'s `TerminalPalette` is built from
+/// exactly these tokens, and every character cell `crate::terminal::pane` paints takes its
+/// foreground, background and selection fill from it.
+///
+/// Before this existed the whole set was hardcoded in `crate::terminal::grid` - VS Code's own
+/// default terminal colours, identical in every one of this app's six themes, so the terminal
+/// stayed a `#1e1e1e` rectangle inside a `#0d0f11` app no matter which theme was selected.
+///
+/// ## What "follow the editor theme" means for each of these
+///
+/// [`BACKGROUND`], [`FOREGROUND`], [`CURSOR`] and [`SELECTION`] are ordinary chrome: they default
+/// to the values this palette already had for exactly these jobs (`surface::PTY` is literally
+/// documented as "agent CLI + terminal", `term::TEXT` as terminal output text), and they go
+/// through `super::derived_palette`'s real OKLCH shift like every other token, so switching themes
+/// visibly moves them.
+///
+/// [`ANSI`] is deliberately different - see [`LIGHT_ANSI`]'s docs for the whole reasoning.
+pub mod terminal {
+    use super::{token, ColorToken};
+
+    /// The terminal pane's own fill - and what `NamedColor::Background` resolves to. Defaults to
+    /// [`super::surface::PTY`]'s value, the token this palette already documents as "agent CLI +
+    /// terminal", and the exact colour of the surface this pane is painted *into*
+    /// (`crate::work_surface::render`'s `pty-surface`), so out of the box the terminal stops being
+    /// a lighter rectangle floating inside the app's own chrome.
+    pub const BACKGROUND: ColorToken = token("terminal.background", 0x0d0f11);
+    /// Unstyled output - and what `NamedColor::Foreground`/`BrightForeground` resolve to. Defaults
+    /// to [`super::term::TEXT`]'s value, this palette's own designed "terminal output text" tone,
+    /// which until this module existed no renderer had ever actually painted.
+    pub const FOREGROUND: ColorToken = token("terminal.foreground", 0xa7adb4);
+    /// What `NamedColor::Cursor` resolves to - the colour a program gets when it explicitly asks
+    /// for "the cursor colour" rather than a concrete one. Defaults to [`super::term::CURSOR`]'s
+    /// value, the caret colour this app already paints elsewhere.
+    ///
+    /// The block cursor itself is *not* painted from this: `crate::terminal::grid` renders it the
+    /// way a real terminal does, by swapping the cursor cell's own foreground and background, so
+    /// it tracks [`BACKGROUND`]/[`FOREGROUND`] (or whatever colours that cell already had) for
+    /// free.
+    pub const CURSOR: ColorToken = token("terminal.cursor", 0x5a9ad4);
+    /// The fill painted behind a selected cell - GitHub issue #158's real mouse selection.
+    ///
+    /// Its default is exactly what the *editor's* own selection composites to:
+    /// [`super::editor::SELECTION`] at [`super::editor::SELECTION_OPACITY`] over
+    /// [`super::surface::CENTER`], flattened to an opaque value because the terminal paints a span
+    /// background rather than a translucent overlay quad. Pinned by
+    /// `super::terminal_palette_tests::the_terminal_selection_default_is_the_editor_selection_flattened`,
+    /// so the two can't drift into looking like unrelated features.
+    pub const SELECTION: ColorToken = token("terminal.selection", 0x273a4d);
+
+    /// The standard ANSI 16-colour palette, indexed `0..=15` by `NamedColor`'s own discriminants
+    /// and by `Color::Indexed(0..=15)`, in the conventional order: black, red, green, yellow, blue,
+    /// magenta, cyan, white, then the eight bright variants in the same order.
+    ///
+    /// These values are VS Code's own default *dark* terminal palette, which is where
+    /// `crate::terminal::grid`'s hardcoded array took them from before they became real tokens.
+    pub const ANSI: [ColorToken; 16] = [
+        token("terminal.ansi.0", 0x000000),
+        token("terminal.ansi.1", 0xcd3131),
+        token("terminal.ansi.2", 0x0dbc79),
+        token("terminal.ansi.3", 0xe5e510),
+        token("terminal.ansi.4", 0x2472c8),
+        token("terminal.ansi.5", 0xbc3fbc),
+        token("terminal.ansi.6", 0x11a8cd),
+        token("terminal.ansi.7", 0xe5e5e5),
+        token("terminal.ansi.8", 0x666666),
+        token("terminal.ansi.9", 0xf14c4c),
+        token("terminal.ansi.10", 0x23d18b),
+        token("terminal.ansi.11", 0xf5f543),
+        token("terminal.ansi.12", 0x3b8eea),
+        token("terminal.ansi.13", 0xd670d6),
+        token("terminal.ansi.14", 0x29b8db),
+        token("terminal.ansi.15", 0xffffff),
+    ];
+
+    /// [`ANSI`]'s light-theme counterpart - VS Code's own default *light* terminal palette, same
+    /// provenance and same `0..=15` ordering.
+    ///
+    /// ## Why the ANSI sixteen are not run through the OKLCH derivation
+    ///
+    /// Every other colour in this app is a free design choice, so [`super::derived_palette`]'s
+    /// systematic hue/chroma/lightness shift is exactly the right way to carry it into another
+    /// theme. The ANSI sixteen are not free: their *meaning* is fixed by forty years of convention
+    /// (index 1 is red because programs print errors in it; index 0 is the darkest colour a
+    /// program can ask for), and a shifted palette stops answering to that name. Measured on this
+    /// app's own themes, the derivation would have rotated every one of them off-hue on `Ember`
+    /// and `Moss`, and - far worse - inverted them wholesale on `Paper`, whose fit has a genuinely
+    /// negative lightness slope: ANSI *black* would have come out near-white, i.e. invisible on
+    /// Paper's own light terminal background, for every program that prints black-on-default.
+    ///
+    /// So the sixteen are pinned rather than derived, and pinned in the two variants a real
+    /// terminal palette needs. [`super::derived_palette`] picks between them from the derived
+    /// theme's own [`super::theme_is_light`] verdict, which is exactly what VS Code itself does
+    /// (its Dark+ and Light+ themes ship two separately authored `terminal.ansi*` blocks; these
+    /// are those two blocks). Every one of them is still a real, registered, independently
+    /// themeable token, so a hand-written theme file or an imported VSCode theme that *does* author
+    /// its own sixteen gets them honoured verbatim - the pinning is only the default a theme that
+    /// says nothing inherits.
+    pub const LIGHT_ANSI: [u32; 16] = [
+        0x000000, 0xcd3131, 0x00bc00, 0x949800, 0x0451a5, 0xbc05bc, 0x0598bc, 0x555555, 0x666666,
+        0xcd3131, 0x14ce14, 0xb5ba00, 0x0451a5, 0xbc05bc, 0x0598bc, 0xa5a5a5,
+    ];
+
+    /// Every real [`ColorToken`] this module declares, paired with its own Rust `const` name -
+    /// the module's slice of [`super::TOKEN_GROUPS`]'s whole-app registry. See that constant's
+    /// own docs for what walks this and why every token has to appear here.
+    pub const TOKENS: &[(&str, ColorToken)] = &[
+        ("BACKGROUND", BACKGROUND),
+        ("FOREGROUND", FOREGROUND),
+        ("CURSOR", CURSOR),
+        ("SELECTION", SELECTION),
+        ("ANSI.0", ANSI[0]),
+        ("ANSI.1", ANSI[1]),
+        ("ANSI.2", ANSI[2]),
+        ("ANSI.3", ANSI[3]),
+        ("ANSI.4", ANSI[4]),
+        ("ANSI.5", ANSI[5]),
+        ("ANSI.6", ANSI[6]),
+        ("ANSI.7", ANSI[7]),
+        ("ANSI.8", ANSI[8]),
+        ("ANSI.9", ANSI[9]),
+        ("ANSI.10", ANSI[10]),
+        ("ANSI.11", ANSI[11]),
+        ("ANSI.12", ANSI[12]),
+        ("ANSI.13", ANSI[13]),
+        ("ANSI.14", ANSI[14]),
+        ("ANSI.15", ANSI[15]),
     ];
 }
 
@@ -2740,6 +2959,155 @@ mod token_registry_tests {
             all_tokens().count() >= 250,
             "only {} registered tokens - this app's palette is ~270",
             all_tokens().count()
+        );
+    }
+}
+
+/// GitHub issue #208's own coverage inside this module: the shape of the new [`terminal`] group,
+/// and the one real special case it adds to [`derived_palette`].
+///
+/// The end-to-end half - a real painted pane whose colours genuinely change with the selected
+/// theme - lives in `crate::terminal::pane::terminal_theme_tests`.
+#[cfg(test)]
+mod terminal_palette_tests {
+    use super::*;
+
+    /// [`terminal`] must be a genuinely separate group from [`term`], not a rename of it: the two
+    /// name completely different things (see [`terminal`]'s own docs) and a theme has to be able to
+    /// move one without touching the other.
+    #[test]
+    fn the_terminal_group_is_distinct_from_term_and_fully_registered() {
+        let terminal_keys: Vec<&str> = terminal::TOKENS.iter().map(|(_, t)| t.key).collect();
+        assert_eq!(
+            terminal_keys.len(),
+            20,
+            "background, foreground, cursor, selection and the ANSI sixteen"
+        );
+        for key in &terminal_keys {
+            assert!(
+                token_for_key(key).is_some(),
+                "{key} is declared but not reachable through the registry"
+            );
+        }
+        for (_, token) in term::TOKENS {
+            assert!(
+                !terminal_keys.contains(&token.key),
+                "{} is registered in both groups - one would shadow the other",
+                token.key
+            );
+        }
+        // The specific confusion this guards: `term.cursor` (the app's own caret colour, painted
+        // in the command palette and the File view) and `terminal.cursor` (what a pty's own
+        // `NamedColor::Cursor` resolves to) are two real, separately themeable colours.
+        assert_ne!(term::CURSOR.key, terminal::CURSOR.key);
+    }
+
+    /// [`terminal::SELECTION`]'s default is not a hand-picked blue: it is exactly what the
+    /// *editor's* own selection composites to over the code surface, flattened. Recomputed here
+    /// rather than restated, so retuning [`editor::SELECTION`] or [`editor::SELECTION_OPACITY`]
+    /// without retuning this fails loudly instead of quietly leaving two selections that no longer
+    /// look like the same feature.
+    #[test]
+    fn the_terminal_selection_default_is_the_editor_selection_flattened() {
+        let over = surface::CENTER.default;
+        let fill = editor::SELECTION.default;
+        let alpha = editor::SELECTION_OPACITY;
+        let flatten =
+            |top: f32, bottom: f32| ((alpha * top + (1.0 - alpha) * bottom) * 255.0).round();
+
+        let expected = (
+            flatten(fill.r, over.r) as u8,
+            flatten(fill.g, over.g) as u8,
+            flatten(fill.b, over.b) as u8,
+        );
+        let actual = terminal::SELECTION.default;
+        assert_eq!(
+            (
+                (actual.r * 255.0).round() as u8,
+                (actual.g * 255.0).round() as u8,
+                (actual.b * 255.0).round() as u8
+            ),
+            expected
+        );
+    }
+
+    /// The ANSI sixteen are pinned, not derived - see [`terminal::LIGHT_ANSI`]'s docs. A *dark*
+    /// derived theme gets [`terminal::ANSI`]'s own defaults back verbatim, no matter how far the
+    /// shift moves everything else.
+    #[test]
+    fn a_dark_derived_theme_keeps_the_standard_ansi_sixteen_exactly() {
+        let shift = derive_shift(
+            crate::settings::builtin_themes::jerry_dark_swatches(),
+            [0x12100e, 0x1e1a16, 0x8fae6b, 0xd98b3a, 0xc4713f], // Ember's own swatches
+        );
+        let derived: HashMap<&str, Rgba> = derived_palette(shift).into_iter().collect();
+
+        for index in 0..16 {
+            let key = terminal::ANSI[index].key;
+            assert_eq!(
+                crate::settings::custom_theme::rgba_to_hex(derived[key]),
+                crate::settings::custom_theme::rgba_to_hex(terminal::ANSI[index].default),
+                "{key} was shifted - the ANSI sixteen carry fixed conventional meanings and are \
+                 deliberately not derived"
+            );
+        }
+        // ...while the chrome around them genuinely *is* derived, or this test would pass just as
+        // well against a shift that did nothing at all.
+        assert_ne!(
+            crate::settings::custom_theme::rgba_to_hex(derived["terminal.background"]),
+            crate::settings::custom_theme::rgba_to_hex(terminal::BACKGROUND.default),
+        );
+    }
+
+    /// A *light* derived theme gets [`terminal::LIGHT_ANSI`] instead. The value that matters most:
+    /// ANSI black must still be black. Derived, it would have come out near-white - i.e. invisible
+    /// on a light terminal - for every program that prints black-on-default.
+    #[test]
+    fn a_light_derived_theme_gets_the_light_ansi_palette_with_black_still_black() {
+        let shift = derive_shift(
+            crate::settings::builtin_themes::jerry_dark_swatches(),
+            [0xf4f1ea, 0xe4e0d6, 0x3f7a52, 0xa8752a, 0x3d6c9c], // Paper's own swatches
+        );
+        let derived: HashMap<&str, Rgba> = derived_palette(shift).into_iter().collect();
+
+        assert!(
+            theme_is_light(derived["surface.window"]),
+            "sanity check: these swatches really do derive a light theme"
+        );
+        for index in 0..16 {
+            let key = terminal::ANSI[index].key;
+            assert_eq!(
+                crate::settings::custom_theme::rgba_to_hex(derived[key]),
+                terminal::LIGHT_ANSI[index],
+                "{key} must come from the light palette"
+            );
+        }
+        assert_eq!(
+            crate::settings::custom_theme::rgba_to_hex(derived["terminal.ansi.0"]),
+            0x000000,
+            "ANSI black must survive a light theme as black - deriving it would have inverted it \
+             to near-white, invisible on the light background this same theme derives"
+        );
+        assert!(
+            theme_is_light(derived["terminal.background"]),
+            "and the terminal itself must genuinely go light, or the palette above is being used \
+             against the wrong background"
+        );
+    }
+
+    /// The two pinned palettes are really two palettes - a guard against one of them being an
+    /// accidental copy of the other, which would make the light case above vacuous.
+    #[test]
+    fn the_dark_and_light_ansi_palettes_are_genuinely_different() {
+        let differing = (0..16)
+            .filter(|index| {
+                crate::settings::custom_theme::rgba_to_hex(terminal::ANSI[*index].default)
+                    != terminal::LIGHT_ANSI[*index]
+            })
+            .count();
+        assert!(
+            differing >= 8,
+            "only {differing} of the sixteen differ between the dark and light palettes"
         );
     }
 }


### PR DESCRIPTION
## Summary
- Closes #208. The terminal's real rendered content (background, foreground, the 16-color ANSI palette, cursor, selection) was a hardcoded VS Code default palette, completely independent of the app's theme system - a documented, deliberate scope cut in `crates/app/src/terminal/grid.rs`'s own module docs. (Note: this app already has a `theme::term::*` token category, but it's used elsewhere - caret color, palette prompt tint, diagnostic warnings, terminal link hover - not the pty grid's actual character colors. Confirmed by grepping real call sites before adding anything new.)
- New `theme::terminal` token group (background/foreground/cursor/selection + 16 ANSI colors), registered like every other token module. `grid.rs` stays a pure module (no GPUI/theme access) - it now takes a `TerminalPalette` struct as a parameter instead of reading hardcoded constants; `pane.rs` resolves the live theme's tokens at paint time and passes the palette in.
- All 6 built-in themes regenerated through the real `JERRY_REGENERATE_THEMES=1` path - confirmed no existing token value changed in any file, only new `[terminal]` blocks were added.
- **ANSI-16 decision**: pinned (VS Code's own dark palette on dark themes, Light+ palette on light ones - chosen by the derived theme's own light/dark verdict), not run through the systematic OKLCH shift the rest of the palette uses. Measured why: the shift would rotate hues off on Ember/Moss and, on Paper (whose lightness fit has a genuinely negative slope), invert the sixteen wholesale - ANSI black would derive to near-white, invisible on Paper's own light terminal background. Still ordinary registered tokens, so a theme file or imported VSCode theme that authors its own sixteen gets them honored verbatim.
- A new foreground-contrast guard (`enforce_terminal_foreground_contrast`, sharing its core `pushed_to_clear_floor` step with the existing syntax-contrast guard rather than duplicating it) - `Slate`'s derived terminal foreground measured 4.27:1 against its background, under the 4.5:1 body-text bar.
- Custom themes need no new mechanism: the existing base-chain layering (`compile_palette`) already makes a theme that names no terminal colors inherit its base's.

## Test plan
- [x] Real GPUI tests reading `last_painted_palette_for_test()` (a test-only field `Render::render` itself writes, so these check what a real paint used) - theme switch genuinely repaints the terminal, two different dark themes paint two different terminals, a named ANSI color resolves from the theme's own palette, Paper's terminal reads as light text on light fill (not inverted)
- [x] Mutation-checked: swapping the live-resolved palette for `TerminalPalette::default()` in `render` fails 4 of 5 new tests
- [x] `builtin_themes`/`custom_theme` tests: every bundled theme paints a readable terminal; a theme naming no terminal colors inherits its base's
- [x] I independently re-verified this review pass rather than taking the original screenshots at face value: reproduced the **dark-theme** background change precisely at the pixel level (`(30,30,30)` = `0x1e1e1e` old vs. `(13,15,17)` = `0x0d0f11` new, exact match). I could not get a trustworthy screenshot of the **Paper** case myself (this sandbox instance's keyboard input isn't reaching the app reliably, and a pre-seeded settings.toml theme selection didn't visibly take effect on a fresh launch for a reason I didn't chase down) - but the real, mutation-tested `switching_to_the_light_theme_really_repaints_the_terminal_light` test covers exactly that case through the actual paint path, and I ran it myself
- [x] `cargo build`, `cargo clippy -p app -p lsp-core --lib --tests` clean
- [x] `cargo fmt` diffed against a backup across all 7 touched Rust files - zero drift on pre-existing code
- [x] `cargo test -p app --lib` full suite: 1985 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)