### PR TITLE
feat(app): let the user choose which shell a terminal tab runs

### DIFF
--- a/crates/app/src/keymap_overrides.rs
+++ b/crates/app/src/keymap_overrides.rs
@@ -156,18 +156,19 @@ pub fn effective_key_bindings(overrides: &[KeybindingOverride]) -> Vec<KeyBindin
 ///
 /// This is the single source of truth for "what contexts really exist", shared by
 /// [`contexts_could_overlap`] and by `crate::undo_scoping_matrix_tests`, so the two can never
-/// disagree about the app they are both reasoning over. Derived by hand from the ten
+/// disagree about the app they are both reasoning over. Derived by hand from the twelve
 /// `.key_context(..)` call sites in the crate - `crate::root::AdeApp::render`'s baseline `"app"`,
 /// `crate::terminal::pane`, `crate::code_surface::render` (one call site, three literals from a
-/// `match`), `crate::merge::editing`, the five single-line inputs (the rail's agent filter,
+/// `match`), `crate::merge::editing`, the seven single-line inputs (the rail's agent filter,
 /// Settings' keymap filter, the palette's own query field, `root::new_file`'s inline name editor,
-/// and `crate::graph_view::render`'s Branches filter box), which all emit the same bare
-/// `"text-input"`, and `crate::sidebar::render::AdeApp::file_tree_shell` (one call site, four
-/// literals from a `match`) - and guarded against drift by this module's own
-/// `every_real_key_context_call_site_is_covered` test, which fails the moment an eleventh call
+/// `crate::graph_view::render`'s Branches filter box, the Themes page's "Generate from colour"
+/// seed field, and - newest, GitHub issue #213 - the General page's "Shell" field), which all
+/// emit the same bare `"text-input"`, and `crate::sidebar::render::AdeApp::file_tree_shell` (one
+/// call site, four literals from a `match`) - and guarded against drift by this module's own
+/// `every_real_key_context_call_site_is_covered` test, which fails the moment a thirteenth call
 /// site appears. (That test earned its keep immediately: this comment originally said "six",
 /// counting distinct emitted literals rather than real call sites, and the test caught it on its
-/// first run.)
+/// first run; it has since caught this comment drifting behind two more real inputs.)
 ///
 /// The four `file-tree*` stacks arrived with a merge, not with an edit to this file, which is
 /// exactly why they are called out here. GitHub issue #19's file tree and issue #17's text-undo
@@ -716,13 +717,13 @@ mod tests {
         let sites = key_context_call_sites();
         let call_sites: usize = sites.iter().map(|(_, count)| count).sum();
         assert_eq!(
-            call_sites, 11,
-            "real_context_stacks() is hand-derived from exactly eleven .key_context(..) call \
-             sites (six of which emit the same bare \"text-input\": the palette, the rail filter, \
-             the new-file prompt, the Branches filter, the Keybindings filter and - newest, \
-             GitHub issue #141 - the Themes page's \"Generate from colour\" seed input) - a new \
-             one means that list, and every disjointness answer built on it, needs updating. Real \
-             sites found: {sites:?}"
+            call_sites, 12,
+            "real_context_stacks() is hand-derived from exactly twelve .key_context(..) call \
+             sites (seven of which emit the same bare \"text-input\": the palette, the rail \
+             filter, the new-file prompt, the Branches filter, the Keybindings filter, the \
+             Themes page's \"Generate from colour\" seed input and - newest, GitHub issue #213 - \
+             the General page's \"Shell\" field) - a new one means that list, and every \
+             disjointness answer built on it, needs updating. Real sites found: {sites:?}"
         );
 
         // The file tree's own site is named explicitly: it is the one a merge added while this

--- a/crates/app/src/merge/flow.rs
+++ b/crates/app/src/merge/flow.rs
@@ -1017,6 +1017,7 @@ mod merge_regression_tests {
                 AgentKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
+                app.settings.terminal.shell_override(),
                 window,
                 cx,
             )
@@ -1095,6 +1096,7 @@ mod merge_regression_tests {
                 AgentKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
+                app.settings.terminal.shell_override(),
                 window,
                 cx,
             )
@@ -1119,6 +1121,7 @@ mod merge_regression_tests {
                 AgentKind::Shell,
                 second_feature.clone(),
                 app.settings.appearance.terminal_font_size,
+                app.settings.terminal.shell_override(),
                 window,
                 cx,
             )
@@ -1178,6 +1181,7 @@ mod merge_regression_tests {
                 AgentKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
+                app.settings.terminal.shell_override(),
                 window,
                 cx,
             )
@@ -1289,6 +1293,7 @@ mod merge_regression_tests {
                 AgentKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
+                app.settings.terminal.shell_override(),
                 window,
                 cx,
             )
@@ -1392,6 +1397,7 @@ mod merge_regression_tests {
                 AgentKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
+                app.settings.terminal.shell_override(),
                 window,
                 cx,
             )
@@ -1459,6 +1465,7 @@ mod merge_regression_tests {
                 AgentKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
+                app.settings.terminal.shell_override(),
                 window,
                 cx,
             )
@@ -1544,6 +1551,7 @@ mod merge_regression_tests {
                 AgentKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
+                app.settings.terminal.shell_override(),
                 window,
                 cx,
             )
@@ -1662,6 +1670,7 @@ mod merge_regression_tests {
                 AgentKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
+                app.settings.terminal.shell_override(),
                 window,
                 cx,
             )
@@ -1794,6 +1803,7 @@ mod merge_regression_tests {
                 AgentKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
+                app.settings.terminal.shell_override(),
                 window,
                 cx,
             )
@@ -1898,6 +1908,7 @@ mod merge_regression_tests {
                 AgentKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
+                app.settings.terminal.shell_override(),
                 window,
                 cx,
             )
@@ -1997,6 +2008,7 @@ mod merge_regression_tests {
                 AgentKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
+                app.settings.terminal.shell_override(),
                 window,
                 cx,
             )
@@ -2161,6 +2173,7 @@ mod merge_regression_tests {
                 AgentKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
+                app.settings.terminal.shell_override(),
                 window,
                 cx,
             )
@@ -2214,6 +2227,7 @@ mod merge_regression_tests {
                 AgentKind::Shell,
                 second_feature.clone(),
                 app.settings.appearance.terminal_font_size,
+                app.settings.terminal.shell_override(),
                 window,
                 cx,
             )
@@ -2322,6 +2336,7 @@ mod merge_regression_tests {
                 AgentKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
+                app.settings.terminal.shell_override(),
                 window,
                 cx,
             )
@@ -2418,6 +2433,7 @@ mod merge_regression_tests {
                 AgentKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
+                app.settings.terminal.shell_override(),
                 window,
                 cx,
             )
@@ -2533,6 +2549,7 @@ mod merge_regression_tests {
                 AgentKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
+                app.settings.terminal.shell_override(),
                 window,
                 cx,
             )

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -1764,8 +1764,14 @@ mod rail_row_tests {
             // real not-currently-selected case, or the new selected-worktree exemption would
             // make this test vacuous.
             app.select_worktree(1, window, cx);
-            app.agents
-                .spawn(AgentKind::Shell, wt.path().to_path_buf(), 12.0, window, cx);
+            app.agents.spawn(
+                AgentKind::Shell,
+                wt.path().to_path_buf(),
+                12.0,
+                None,
+                window,
+                cx,
+            );
         });
         // The pty spawn itself is async (`TerminalPane::spawn_process`), so the process isn't
         // observably running yet the instant `spawn` returns - let it actually start before
@@ -1824,8 +1830,14 @@ mod rail_row_tests {
         });
         app.update_in(cx, |app, window, cx| {
             app.select_worktree(0, window, cx);
-            app.agents
-                .spawn(AgentKind::Shell, wt.path().to_path_buf(), 12.0, window, cx);
+            app.agents.spawn(
+                AgentKind::Shell,
+                wt.path().to_path_buf(),
+                12.0,
+                None,
+                window,
+                cx,
+            );
         });
         cx.run_until_parked();
 
@@ -1877,8 +1889,14 @@ mod rail_row_tests {
         });
         app.update_in(cx, |app, window, cx| {
             app.select_worktree(0, window, cx);
-            app.agents
-                .spawn(AgentKind::Shell, wt.path().to_path_buf(), 12.0, window, cx);
+            app.agents.spawn(
+                AgentKind::Shell,
+                wt.path().to_path_buf(),
+                12.0,
+                None,
+                window,
+                cx,
+            );
         });
         // See the identical `run_until_parked` call/comment in
         // `worktree_is_expanded_defaults_to_the_real_idle_rooted_rule` just above.
@@ -1938,6 +1956,7 @@ mod rail_row_tests {
                 AgentKind::Shell,
                 wt_a.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             );
@@ -1946,6 +1965,7 @@ mod rail_row_tests {
                 AgentKind::Shell,
                 wt_b.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             )
@@ -2000,6 +2020,7 @@ mod rail_row_tests {
                 AgentKind::Claude,
                 busy_wt.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             );
@@ -2007,6 +2028,7 @@ mod rail_row_tests {
                 AgentKind::Codex,
                 busy_wt.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             );
@@ -2472,8 +2494,14 @@ mod agent_chip_icon_pack_tests {
         });
         app.update_in(cx, |app, window, cx| {
             app.select_worktree(0, window, cx);
-            app.agents
-                .spawn(AgentKind::Shell, wt.path().to_path_buf(), 12.0, window, cx);
+            app.agents.spawn(
+                AgentKind::Shell,
+                wt.path().to_path_buf(),
+                12.0,
+                None,
+                window,
+                cx,
+            );
         });
         cx.run_until_parked();
         (repo, wt, app, cx)

--- a/crates/app/src/root/focus.rs
+++ b/crates/app/src/root/focus.rs
@@ -168,6 +168,11 @@ impl AdeApp {
         // and `$PATH` (or the file it names) can have changed since the last time Settings was
         // open - re-probe once here, on open, rather than per render.
         self.refresh_shell_status();
+        // Same reasoning for that field's suggestion list (issue #213's follow-up): detected here,
+        // on a real gesture, so the dropdown has real entries the instant it is opened rather than
+        // needing a frame of detection. Its own open flag is left alone - opening Settings does
+        // not open a dropdown.
+        self.refresh_shell_suggestions();
         cx.notify();
     }
 
@@ -175,6 +180,11 @@ impl AdeApp {
     /// [`Self::handle_settings_key_down`]) and restores focus via [`restore_focus`].
     pub(crate) fn close_settings(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.settings_open = false;
+        // The Shell field's suggestion dropdown belongs to the page being left (GitHub issue
+        // #213's follow-up). `AdeApp::render` already gates it on `settings_open`, so this is not
+        // what keeps it off the workspace - it is what stops it from silently reappearing the next
+        // time Settings is opened, still holding the state a user walked away from.
+        self.shell_suggestions_open = false;
         // A live keybinding-recording intercept (`Self::_keymap_intercept`) is a real, global
         // `App::intercept_keystrokes` subscription - it must never survive leaving the Settings
         // surface, or every keystroke in the whole app would keep being silently swallowed.

--- a/crates/app/src/root/focus.rs
+++ b/crates/app/src/root/focus.rs
@@ -164,6 +164,10 @@ impl AdeApp {
         window.focus(&self.settings_focus_handle, cx);
         self.load_agent_rows(cx);
         self.load_lsp_rows(cx);
+        // GitHub issue #213: the General page's shell field shows a real found/not-found hint,
+        // and `$PATH` (or the file it names) can have changed since the last time Settings was
+        // open - re-probe once here, on open, rather than per render.
+        self.refresh_shell_status();
         cx.notify();
     }
 
@@ -589,6 +593,7 @@ mod tab_strip_keybinding_tests {
                 AgentKind::Shell,
                 repo.path().to_path_buf(),
                 app.settings.appearance.terminal_font_size,
+                app.settings.terminal.shell_override(),
                 window,
                 cx,
             )
@@ -633,6 +638,7 @@ mod tab_strip_keybinding_tests {
                 AgentKind::Shell,
                 repo.path().to_path_buf(),
                 app.settings.appearance.terminal_font_size,
+                app.settings.terminal.shell_override(),
                 window,
                 cx,
             )
@@ -835,6 +841,7 @@ mod tab_strip_keybinding_tests {
                     AgentKind::Shell,
                     repo.path().to_path_buf(),
                     app.settings.appearance.terminal_font_size,
+                    app.settings.terminal.shell_override(),
                     window,
                     cx,
                 )

--- a/crates/app/src/root/menus.rs
+++ b/crates/app/src/root/menus.rs
@@ -23,7 +23,7 @@
 
 use super::*;
 
-/// Every real floating menu/dropdown surface in the app - the six built on
+/// Every real floating menu/dropdown surface in the app - the seven built on
 /// [`crate::root::widgets::menu_popover_chrome`].
 ///
 /// Deliberately *not* including the command palette, the "New file" prompt, or the Settings
@@ -50,6 +50,12 @@ pub(crate) enum MenuSurface {
     GraphPush,
     /// A git graph row's `⋯`/right-click menu - `graph_state.row_menu_open`.
     GraphRow,
+    /// Settings › General's "Shell" field suggestion dropdown (GitHub issue #213's follow-up) -
+    /// [`AdeApp::shell_suggestions_open`]. The seventh surface, and the first one that lives on
+    /// the Settings page rather than the workspace; it is a click-away dropdown built on
+    /// [`crate::root::widgets::menu_popover_chrome`] like the other six, so it belongs to the
+    /// same one-at-a-time invariant rather than owning a second dismissal rule of its own.
+    ShellSuggestions,
 }
 
 impl MenuSurface {
@@ -57,13 +63,14 @@ impl MenuSurface {
     /// [`AdeApp::close_menu_surface`] are exhaustive, so a new variant added here cannot compile
     /// until it is really wired to real state - that pairing is what stops a seventh menu from
     /// quietly opting out of the invariant.
-    pub(crate) const ALL: [MenuSurface; 6] = [
+    pub(crate) const ALL: [MenuSurface; 7] = [
         MenuSurface::Plus,
         MenuSurface::Title,
         MenuSurface::TreeContext,
         MenuSurface::Commit,
         MenuSurface::GraphPush,
         MenuSurface::GraphRow,
+        MenuSurface::ShellSuggestions,
     ];
 }
 
@@ -78,6 +85,7 @@ impl AdeApp {
             MenuSurface::Commit => self.commit_menu_open,
             MenuSurface::GraphPush => self.graph_state.push_menu_open,
             MenuSurface::GraphRow => self.graph_state.row_menu_open.is_some(),
+            MenuSurface::ShellSuggestions => self.shell_suggestions_open,
         }
     }
 
@@ -98,6 +106,7 @@ impl AdeApp {
             MenuSurface::Commit => self.commit_menu_open = false,
             MenuSurface::GraphPush => self.graph_state.push_menu_open = false,
             MenuSurface::GraphRow => self.graph_state.row_menu_open = None,
+            MenuSurface::ShellSuggestions => self.shell_suggestions_open = false,
         }
     }
 
@@ -106,7 +115,7 @@ impl AdeApp {
     /// `cx.notify()`.
     ///
     /// This is the whole "opening a second menu closes the first" rule. Every real path that
-    /// *opens* one of the six calls it with its own surface as `keep` immediately before setting
+    /// *opens* one of them calls it with its own surface as `keep` immediately before setting
     /// its own state - so the invariant holds no matter which of the (many) entry points was used:
     /// a click on the tab strip `+`, a click on a rail repo header's `+`, a title bar label, a
     /// right-click in the file tree, the commit composer's `▾`, the graph's `Push ▾`, a graph
@@ -148,7 +157,7 @@ mod menu_surface_tests {
     use crate::root::focus::palette_focus_tests::open_test_app;
     use gpui::TestAppContext;
 
-    /// Opens every one of the six at once by writing their real state fields directly - the state
+    /// Opens every one of them at once by writing their real state fields directly - the state
     /// this test then proves cannot survive a single `close_menu_surfaces_except`.
     fn open_every_menu(app: &mut AdeApp) {
         app.plus_menu_open = true;
@@ -165,10 +174,11 @@ mod menu_surface_tests {
             origin_x: px(4.0),
             origin_y: px(4.0),
         });
+        app.shell_suggestions_open = true;
     }
 
     #[gpui::test]
-    fn closing_all_menu_surfaces_really_closes_every_one_of_the_six(cx: &mut TestAppContext) {
+    fn closing_all_menu_surfaces_really_closes_every_one_of_them(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
         let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
@@ -203,7 +213,7 @@ mod menu_surface_tests {
     /// The exact "2 context menus open at the same time" shape from GitHub issue #176, at the
     /// level of the shared primitive: whichever surface is being opened is the only survivor.
     #[gpui::test]
-    fn opening_any_one_surface_closes_all_five_others(cx: &mut TestAppContext) {
+    fn opening_any_one_surface_closes_all_the_others(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
         let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -1579,6 +1579,19 @@ pub struct AdeApp {
     /// #17). Its value is what `crate::theme::shift_from_seed` derives a whole theme from.
     pub(crate) theme_seed_input: text_history::TextField,
     pub(crate) theme_seed_focus_handle: FocusHandle,
+    /// GitHub issue #213: the General page's "Shell" field - the same minimal focusable
+    /// text-input shape as [`Self::theme_seed_input`] (real `FocusHandle`, real caret,
+    /// append/backspace/`Esc`-clears, real per-widget undo history). Seeded at startup from the
+    /// persisted `settings.terminal.shell` and written straight back to it on every edit, so the
+    /// field and the file never disagree.
+    pub(crate) shell_input: text_history::TextField,
+    pub(crate) shell_focus_handle: FocusHandle,
+    /// The advisory found/not-found state of whatever [`Self::shell_input`] currently holds
+    /// (`crate::settings::state::detect_shell_status`) - recomputed on each edit and when
+    /// Settings opens, never inside `render` (it does real filesystem work). Advisory only: a
+    /// `NotFound` never stops the app from trying to spawn the configured program - see
+    /// `crate::terminal::pane::configured_shell_program`'s docs.
+    pub(crate) shell_status: settings::ShellStatus,
     /// The real background-executor task behind "Generate from colour" - same one-at-a-time
     /// shape as [`Self::_custom_theme_import_task`].
     pub(crate) _theme_generate_task: Option<Task<()>>,
@@ -2216,6 +2229,7 @@ impl AdeApp {
                 AgentKind::Shell,
                 path.clone(),
                 self.settings.appearance.terminal_font_size,
+                self.settings.terminal.shell_override(),
                 window,
                 cx,
             );
@@ -3670,6 +3684,7 @@ mod repo_list_tests {
                 AgentKind::Claude,
                 repo_a.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             );

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -1592,6 +1592,26 @@ pub struct AdeApp {
     /// `NotFound` never stops the app from trying to spawn the configured program - see
     /// `crate::terminal::pane::configured_shell_program`'s docs.
     pub(crate) shell_status: settings::ShellStatus,
+    /// Every shell this machine genuinely has, offered as clickable suggestions under the Shell
+    /// field (GitHub issue #213's follow-up - "a select + auto-detect installed shells", built as
+    /// a hybrid so the field itself stays unrestricted free text).
+    ///
+    /// Detected by real I/O - `/etc/shells` plus a real `PATH` search, `%COMSPEC%` plus a real
+    /// `PATH` search on Windows (`crate::settings::state::detect_installed_shells`) - so like
+    /// [`Self::shell_status`] it is refreshed on a real user gesture (opening Settings, opening
+    /// the dropdown) and held here, never recomputed from `render`.
+    pub(crate) shell_suggestions: Vec<settings::ShellSuggestion>,
+    /// Whether that suggestion dropdown is currently painted. A real
+    /// [`crate::root::menus::MenuSurface`] like every other floating dropdown in the app, so the
+    /// one-at-a-time/close-on-window-deactivation invariant covers it too and it cannot get stuck
+    /// open behind another surface.
+    pub(crate) shell_suggestions_open: bool,
+    /// The Shell field's real painted, window-space bounds, captured through the same
+    /// `gpui::canvas` idiom [`Self::plus_button_bounds`] uses, so the dropdown can be positioned
+    /// directly under the field while still being a top-level sibling in [`Self::render`] - a
+    /// child of the settings row itself would be clipped by the settings page's own scroll
+    /// column. `Bounds::default()` until the field has really painted once.
+    pub(crate) shell_field_bounds: gpui::Bounds<Pixels>,
     /// The real background-executor task behind "Generate from colour" - same one-at-a-time
     /// shape as [`Self::_custom_theme_import_task`].
     pub(crate) _theme_generate_task: Option<Task<()>>,
@@ -2596,6 +2616,19 @@ impl Render for AdeApp {
                     && self.right_sidebar_view == RightSidebarView::Files
                     && self.tree_context_menu.is_some(),
                 |el| el.child(self.render_tree_context_menu(cx)),
+            )
+            // Settings › General's Shell field suggestion dropdown (GitHub issue #213's
+            // follow-up) - a window-positioned overlay for the same reason the `+` menu is one,
+            // and more sharply so: the settings page is a scrolling column that clips its own
+            // children, so this popover can only paint in full as a top-level sibling positioned
+            // off `Self::shell_field_bounds`. Gated on Settings really being open on the page that
+            // paints the field, so a stale anchor from an earlier frame can never float a dropdown
+            // over the workspace.
+            .when(
+                self.settings_open
+                    && self.settings_page == settings::SettingsPage::General
+                    && self.shell_suggestions_open,
+                |el| el.child(self.render_shell_suggestions(cx)),
             )
             .when(self.palette_open, |el| el.child(self.render_palette(cx)))
     }

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -157,6 +157,7 @@ impl AdeApp {
         let filter_focus_handle = cx.focus_handle();
         let settings_keymap_filter_focus_handle = cx.focus_handle();
         let theme_seed_focus_handle = cx.focus_handle();
+        let shell_focus_handle = cx.focus_handle();
         let caret_blink_subscriptions = AdeApp::wire_caret_blink(
             &[
                 &code_focus_handle,
@@ -166,10 +167,18 @@ impl AdeApp {
                 &filter_focus_handle,
                 &settings_keymap_filter_focus_handle,
                 &theme_seed_focus_handle,
+                &shell_focus_handle,
             ],
             window,
             cx,
         );
+
+        // GitHub issue #213: the Settings field starts out holding whatever the real file says,
+        // so opening Settings shows the shell that is actually in force rather than a blank
+        // field next to a running `fish`. Built here, before `settings` is moved into the
+        // literal below.
+        let shell_input =
+            text_history::TextField::seeded(settings.terminal.shell_override().unwrap_or(""));
 
         // GitHub issue #5: real, additional themes loaded from disk, before `apply_theme_selection`
         // (below) needs to resolve `settings.theme.name` against them. Derived from
@@ -428,6 +437,12 @@ impl AdeApp {
             settings_keymap_filter_focus_handle,
             theme_seed_input: text_history::TextField::new(),
             theme_seed_focus_handle,
+            shell_input,
+            shell_focus_handle,
+            // Left un-probed at construction: resolving it walks `$PATH` (or stats a file), and
+            // nothing shows it until Settings is opened, which recomputes it - see
+            // `AdeApp::refresh_shell_status`.
+            shell_status: settings::ShellStatus::SystemDefault,
             _theme_generate_task: None,
             keymap_recording: None,
             _keymap_intercept: None,
@@ -555,6 +570,7 @@ impl AdeApp {
                     AgentKind::Shell,
                     path.clone(),
                     this.settings.appearance.terminal_font_size,
+                    this.settings.terminal.shell_override(),
                     window,
                     cx,
                 );

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -443,6 +443,12 @@ impl AdeApp {
             // nothing shows it until Settings is opened, which recomputes it - see
             // `AdeApp::refresh_shell_status`.
             shell_status: settings::ShellStatus::SystemDefault,
+            // Same reasoning, and more so: detecting the installed shells reads `/etc/shells` and
+            // walks `$PATH` several times over. Left genuinely empty until a real gesture asks
+            // for it (`AdeApp::refresh_shell_suggestions`), never guessed at startup.
+            shell_suggestions: Vec::new(),
+            shell_suggestions_open: false,
+            shell_field_bounds: gpui::Bounds::default(),
             _theme_generate_task: None,
             keymap_recording: None,
             _keymap_intercept: None,

--- a/crates/app/src/settings/render.rs
+++ b/crates/app/src/settings/render.rs
@@ -1,6 +1,27 @@
 use super::*;
-use crate::root::widgets::{hover_keycap_row, render_env_chip, render_keycap_row, KeycapSize};
+use crate::root::widgets::{
+    hover_keycap_row, menu_popover_chrome, render_env_chip, render_keycap_row, KeycapSize,
+};
 use crate::settings::widgets::ChoiceOption;
+
+/// The Shell suggestion dropdown's width (GitHub issue #213's follow-up). Wider than the 168px
+/// field it hangs under, because a row carries a shell's name *and* its real absolute path
+/// (`/usr/local/bin/fish`) and truncating that away would defeat the point of showing the path at
+/// all. Sized between the git graph's own two menus (`theme::graph::PUSH_MENU_WIDTH` 268,
+/// `ROW_MENU_WIDTH` 330) rather than picked freehand.
+const SHELL_SUGGESTIONS_WIDTH: gpui::Pixels = px(288.0);
+
+/// How tall the row list may grow before it scrolls. Nine 29px rows plus the panel's own padding,
+/// which comfortably clears what a real machine lists (this one's `/etc/shells` yields seven after
+/// deduplication) while keeping the dropdown from ever covering the whole Settings page on a host
+/// with an unusually long list. Anything beyond it is genuinely reachable by scrolling, not
+/// silently dropped from the detection results.
+const SHELL_SUGGESTIONS_MAX_HEIGHT: gpui::Pixels = px(269.0);
+
+/// The smallest left offset the dropdown will accept, for a window narrow enough that
+/// right-aligning it against the field would push it off the left edge. Mirrors
+/// `crate::sidebar::context_menu::MENU_EDGE_MARGIN`, whose job is exactly this.
+const SHELL_SUGGESTIONS_EDGE_MARGIN: f32 = 4.0;
 
 impl AdeApp {
     pub(crate) fn handle_toggle_settings_action(
@@ -928,8 +949,9 @@ impl AdeApp {
         );
         let shell_row = self.render_settings_row(
             "Shell",
-            "What a new Shell tab runs - a name on PATH (bash, fish, pwsh) or an absolute path. \
-             Leave it empty to use the system default. Agent tabs are unaffected.",
+            "What a new Shell tab runs - click the field for the shells detected on this machine, \
+             or type any name on PATH or absolute path. Leave it empty to use the system default. \
+             Agent tabs are unaffected.",
             self.render_settings_shell_control(cx),
         );
         let inline_blame_row = self.render_settings_row(
@@ -1023,7 +1045,26 @@ impl AdeApp {
                     .on_key_down(cx.listener(Self::handle_settings_shell_key_down))
                     .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
                         window.focus(&this.shell_focus_handle, cx);
+                        this.open_shell_suggestions(cx);
                     }))
+                    // The field's real, window-space painted bounds, for positioning the
+                    // suggestion dropdown - the same `gpui::canvas` idiom
+                    // `Self::plus_button_bounds` uses, and for the same reason: the dropdown is a
+                    // top-level sibling in `AdeApp::render`, so it needs the field's position in
+                    // window space, not in this row's own coordinate system.
+                    .child({
+                        let this = cx.entity();
+                        gpui::canvas(
+                            move |bounds, _window, cx| {
+                                this.update(cx, |this, _cx| {
+                                    this.shell_field_bounds = bounds;
+                                });
+                            },
+                            |_, _, _, _| {},
+                        )
+                        .absolute()
+                        .size_full()
+                    })
                     .cursor_pointer()
                     .flex_none()
                     .flex()
@@ -1074,6 +1115,14 @@ impl AdeApp {
     /// deliberate scope cut (no cursor positioning, no selection, no IME). Every real change
     /// goes straight to the persisted setting through [`Self::apply_shell_input`], so there is
     /// no separate "save" step that could be forgotten.
+    ///
+    /// The suggestion dropdown deliberately consumes **no** keystroke this handler needs. It has
+    /// no keyboard selection of its own (no up/down/enter capture), so every key still means
+    /// exactly what it meant before the dropdown existed - the field is the only thing typing can
+    /// reach. `Esc` in particular keeps its existing, tested meaning (clear the field, undoably),
+    /// rather than being stolen as a "close the dropdown" key; it just closes the dropdown as
+    /// well, since a cleared field is the user saying they want out of the way, and every other
+    /// edit re-opens it so the filtered list keeps up with what is being typed.
     pub(in crate::settings) fn handle_settings_shell_key_down(
         &mut self,
         event: &KeyDownEvent,
@@ -1085,6 +1134,7 @@ impl AdeApp {
             return;
         }
         self.reset_caret_blink(cx);
+        let escaped = keystroke.key.as_str() == "escape";
         let changed = match keystroke.key.as_str() {
             "backspace" => self.shell_input.pop(Instant::now()),
             // Clearing the field is itself a real, meaningful edit here (it means "go back to the
@@ -1100,6 +1150,58 @@ impl AdeApp {
             self.apply_shell_input(cx);
             cx.stop_propagation();
         }
+        if escaped {
+            self.shell_suggestions_open = false;
+            cx.notify();
+        } else if changed {
+            self.open_shell_suggestions(cx);
+        }
+    }
+
+    /// Opens (or re-opens) the Shell field's suggestion dropdown, re-detecting the machine's real
+    /// shells first (GitHub issue #213's follow-up).
+    ///
+    /// The detection runs here, on a real user gesture - a click on the field, a keystroke that
+    /// changed it - and never from `render`: [`crate::settings::state::detect_installed_shells`]
+    /// reads `/etc/shells` and walks `$PATH`, which is exactly the class of work
+    /// [`Self::refresh_shell_status`] and [`Self::load_agent_rows`] already keep off the frame
+    /// path. Re-running it per gesture rather than once at startup is what makes a shell the user
+    /// installed *while* the app was running actually show up.
+    ///
+    /// Goes through [`Self::close_menu_surfaces_except`] like every other menu-opening path
+    /// (GitHub issue #176), so this dropdown and some other popover can never be painted at once.
+    pub(in crate::settings) fn open_shell_suggestions(&mut self, cx: &mut Context<Self>) {
+        let _ = self.close_menu_surfaces_except(Some(menus::MenuSurface::ShellSuggestions));
+        self.refresh_shell_suggestions();
+        self.shell_suggestions_open = true;
+        cx.notify();
+    }
+
+    /// Re-detects the shells this machine genuinely has ([`Self::shell_suggestions`]). Separate
+    /// from [`Self::open_shell_suggestions`] so opening Settings can warm it without also opening
+    /// the dropdown.
+    pub(crate) fn refresh_shell_suggestions(&mut self) {
+        self.shell_suggestions = settings::detect_installed_shells();
+    }
+
+    /// Puts a clicked suggestion's real path into the field, exactly as if it had been typed:
+    /// same [`text_history::TextField`] (so it is a single undoable edit, and the field's existing
+    /// caret/undo behaviour is untouched), same [`Self::apply_shell_input`] persistence path, same
+    /// advisory status hint recomputed afterwards. Nothing about a suggested value is special once
+    /// it is in the field - which is the whole point of the field staying free text.
+    pub(in crate::settings) fn select_shell_suggestion(
+        &mut self,
+        value: String,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.shell_input.set(&value, Instant::now());
+        self.apply_shell_input(cx);
+        self.shell_suggestions_open = false;
+        // Focus goes back to the field, not the dropdown that just vanished, so the very next
+        // keystroke edits the value the user just picked.
+        window.focus(&self.shell_focus_handle, cx);
+        cx.notify();
     }
 
     /// `TextUndo`/`TextRedo` for the Shell field (GitHub issue #17's per-widget undo) - see
@@ -1158,6 +1260,169 @@ impl AdeApp {
             self.settings.terminal.shell_override(),
             pty_core::resolve_on_path,
         );
+    }
+
+    /// The Shell field's suggestion dropdown (GitHub issue #213's follow-up): one clickable row
+    /// per shell this machine genuinely has ([`Self::shell_suggestions`]), filtered by whatever is
+    /// currently typed, positioned directly under the field.
+    ///
+    /// **Why it is a top-level sibling in [`AdeApp::render`]** rather than a child of the settings
+    /// row: the row lives inside the settings page's own scrolling column, which clips its
+    /// children, so a popover nested there would be cut off at the column's edge. The established
+    /// answer in this app is the `+` menu's: capture the trigger's window-space bounds with a real
+    /// `gpui::canvas` ([`Self::shell_field_bounds`]) and position an `.absolute()` root-level
+    /// sibling off them.
+    ///
+    /// **Chrome is not invented here.** The panel is
+    /// [`crate::root::widgets::menu_popover_chrome`] with `theme::shadow::MENU` - the one real
+    /// dropdown/context-menu surface every other popover in the app is built from - and the rows
+    /// mirror `crate::work_surface::render::render_dropdown_menu_row`'s exact tokens (see
+    /// [`Self::render_shell_suggestion_row`] for the one reason they can't literally call it).
+    /// The click-away scrim is the file tree context menu's: full-window below the title bar
+    /// (never over it - a full-window occluding scrim swallows the caption buttons) and
+    /// `.occlude()`d, with the panel calling `cx.stop_propagation()` so a click on a row is not
+    /// also a click on the scrim.
+    ///
+    /// Dismissal is therefore the same as every other menu's, not a new rule: the scrim's click,
+    /// opening any other menu surface, the window losing focus
+    /// (`crate::root::menus::MenuSurface::ShellSuggestions`), leaving Settings, and picking a row.
+    pub(crate) fn render_shell_suggestions(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let bounds = self.shell_field_bounds;
+        // Right-aligned with the field (which sits at the right edge of its settings row) so the
+        // panel, wider than the 168px field, grows inwards over the page rather than off it -
+        // the same right-alignment the git graph's row menu uses against its own trigger. Clamped
+        // to a small left margin for a genuinely narrow window, mirroring
+        // `crate::sidebar::context_menu::MENU_EDGE_MARGIN`'s own job.
+        let left = px(f32::max(
+            (bounds.origin.x + bounds.size.width - SHELL_SUGGESTIONS_WIDTH).as_f32(),
+            SHELL_SUGGESTIONS_EDGE_MARGIN,
+        ));
+        // The scrim starts below the title bar, so positions measured in window space have to be
+        // rebased into it - exactly what `render_tree_context_menu` does.
+        let top = bounds.origin.y + bounds.size.height + px(4.0) - theme::band::TITLE_BAR;
+        let matches =
+            settings::filter_shell_suggestions(&self.shell_suggestions, self.shell_input.as_str());
+
+        div()
+            .id("settings-shell-suggestions-scrim")
+            .absolute()
+            .top(theme::band::TITLE_BAR)
+            .left(px(0.0))
+            .right(px(0.0))
+            .bottom(px(0.0))
+            .occlude()
+            .bg(work_surface::TRANSPARENT)
+            .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
+                this.shell_suggestions_open = false;
+                cx.notify();
+            }))
+            .child(
+                menu_popover_chrome(
+                    div()
+                        .id("settings-shell-suggestions-popover")
+                        .debug_selector(|| "settings-shell-suggestions-popover".to_string())
+                        .absolute()
+                        .left(left)
+                        .top(top)
+                        .w(SHELL_SUGGESTIONS_WIDTH)
+                        .py(px(4.0)),
+                    theme::shadow::MENU,
+                )
+                .occlude()
+                .on_click(cx.listener(|_this, _event: &ClickEvent, _window, cx| {
+                    cx.stop_propagation();
+                }))
+                .child(
+                    div()
+                        .px(px(10.0))
+                        .pb(px(3.0))
+                        .font(font(theme::font::MONO))
+                        .text_size(self.ui_text_size(9.0))
+                        .text_color(theme::text::GHOST)
+                        .child("detected on this machine"),
+                )
+                .child(
+                    div()
+                        .id("settings-shell-suggestions-list")
+                        .flex()
+                        .flex_col()
+                        .max_h(SHELL_SUGGESTIONS_MAX_HEIGHT)
+                        .overflow_y_scroll()
+                        .children(matches.iter().enumerate().map(|(index, suggestion)| {
+                            self.render_shell_suggestion_row(index, suggestion, cx)
+                        })),
+                ),
+            )
+    }
+
+    /// One suggestion row - a `❯` chip (the same glyph the `+` menu's own "New terminal" row
+    /// uses), the shell's real name, and the real absolute path it was found at, so the user can
+    /// tell `/bin/bash` from `/usr/local/bin/bash` before clicking. Clicking types that path into
+    /// the field ([`Self::select_shell_suggestion`]).
+    ///
+    /// Visually this is `crate::work_surface::render::render_dropdown_menu_row` - same 29px band,
+    /// same 10px padding and 9px gap, same 14×14 chip, same label/sub type ramp, same
+    /// `theme::surface::MENU_ROW_HOVER` hover. It cannot literally call that function for one real
+    /// reason: that helper keys its GPUI element id off a `&'static str` label, and a shell's name
+    /// is neither `'static` nor guaranteed unique (a machine can genuinely have two different
+    /// `bash` binaries at two different paths), so the ids would collide. The row's identity is
+    /// its position in the filtered list instead.
+    fn render_shell_suggestion_row(
+        &self,
+        index: usize,
+        suggestion: &settings::ShellSuggestion,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let value = suggestion.value();
+        div()
+            .id(("settings-shell-suggestion", index))
+            .debug_selector(move || format!("settings-shell-suggestion-{index}"))
+            .flex()
+            .items_center()
+            .gap(px(9.0))
+            .h(theme::band::PLUS_MENU_ROW)
+            .px(px(10.0))
+            .cursor_pointer()
+            .hover(|el| el.bg(theme::surface::MENU_ROW_HOVER))
+            .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
+                this.select_shell_suggestion(value.clone(), window, cx);
+            }))
+            .child(
+                div()
+                    .flex_none()
+                    .w(px(14.0))
+                    .h(px(14.0))
+                    .rounded(theme::radius::CHIP)
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .bg(theme::surface::CHIP_NEUTRAL)
+                    .font(font(theme::font::MONO))
+                    .font_weight(gpui::FontWeight::MEDIUM)
+                    .text_size(px(8.0))
+                    .text_color(theme::text::DIM)
+                    .child("\u{276f}"),
+            )
+            .child(
+                div()
+                    .flex_none()
+                    .font(font(theme::font::SANS))
+                    .font_weight(gpui::FontWeight::MEDIUM)
+                    .text_size(self.ui_text_size(11.5))
+                    .text_color(theme::text::HEADING)
+                    .child(suggestion.name.clone()),
+            )
+            .child(
+                div()
+                    .flex_1()
+                    .min_w_0()
+                    .overflow_hidden()
+                    .truncate()
+                    .font(font(theme::font::MONO))
+                    .text_size(self.ui_text_size(10.0))
+                    .text_color(theme::text::FAINTER)
+                    .child(suggestion.value()),
+            )
     }
 
     /// *Appearance & scaling* - every row here is persisted and round-trips through
@@ -4381,6 +4646,384 @@ mod shell_setting_tests {
         assert!(
             cx.debug_bounds("settings-shell-status").is_some(),
             "the row's live found/not-found hint must really paint"
+        );
+    }
+}
+
+/// GitHub issue #213's follow-up ("would a select + auto-detect installed shells be better?" -
+/// answered as a hybrid): real detected shells offered as clickable suggestions under a field that
+/// stays unrestricted free text.
+///
+/// Every test here drives the real thing end to end - a real window, real painted bounds, a real
+/// mouse click on a real suggestion row, the real `/etc/shells`/`PATH` detection of the machine
+/// running the suite - rather than asserting on the pure detector alone (which
+/// `crate::settings::state`'s own tests already cover against real tempdir fixtures).
+///
+/// unix-only, like its sibling module: the final assertions spawn a real shell.
+#[cfg(all(test, unix))]
+mod shell_suggestion_dropdown_tests {
+    use super::*;
+    use crate::root::menus::MenuSurface;
+    use gpui::TestAppContext;
+
+    /// Opens Settings on the General page, with a real isolated `settings.toml`, and returns the
+    /// app plus that path.
+    fn open_general_settings(
+        cx: &mut TestAppContext,
+        settings_path: PathBuf,
+        repo_path: PathBuf,
+    ) -> (gpui::Entity<AdeApp>, &mut gpui::VisualTestContext) {
+        let (app, cx) = cx.add_window_view(|window, cx| {
+            AdeApp::new_with_settings(
+                Some(repo_path),
+                true,
+                settings_store::Settings::default(),
+                Some(settings_path),
+                window,
+                cx,
+            )
+        });
+        cx.dispatch_action(ToggleSettings);
+        app.update_in(cx, |app, window, cx| {
+            app.select_settings_page(SettingsPage::General, window, cx);
+        });
+        cx.run_until_parked();
+        (app, cx)
+    }
+
+    /// `VisualTestContext::debug_bounds` takes a `&'static str`, and a suggestion row's selector
+    /// is built from its runtime position in the filtered list - so a test that wants to click
+    /// row *n* has to hand out a genuinely `'static` selector for it. Leaking a per-lookup
+    /// `String` is the honest way to do that in a test binary: bounded (a handful of rows per
+    /// test), and it keeps the row selectors index-based, which is what makes them unique even on
+    /// a machine with two shells of the same name.
+    fn row_selector(index: usize) -> &'static str {
+        Box::leak(format!("settings-shell-suggestion-{index}").into_boxed_str())
+    }
+
+    /// Clicks the real painted Shell field, which is what opens the dropdown.
+    fn click_the_shell_field(cx: &mut gpui::VisualTestContext) {
+        let field = cx
+            .debug_bounds("settings-shell-input")
+            .expect("the Shell field must really paint on the General page");
+        cx.simulate_click(field.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+    }
+
+    /// The core of the feature: clicking the field really paints a dropdown, and every row in it
+    /// is a shell that genuinely exists on this machine - detected, not hardcoded.
+    #[gpui::test]
+    fn clicking_the_field_opens_a_dropdown_of_genuinely_detected_shells(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = open_general_settings(
+            cx,
+            settings_dir.path().join("settings.toml"),
+            repo.path().to_path_buf(),
+        );
+
+        assert!(
+            cx.debug_bounds("settings-shell-suggestions-popover")
+                .is_none(),
+            "the dropdown must not be painted before anything has been clicked"
+        );
+
+        click_the_shell_field(cx);
+
+        assert!(
+            app.read_with(cx, |app, _| app.shell_suggestions_open),
+            "clicking the field must really open the suggestion surface"
+        );
+        assert!(
+            cx.debug_bounds("settings-shell-suggestions-popover")
+                .is_some(),
+            "the dropdown must really paint, with real bounds, under the field"
+        );
+
+        let suggestions = app.read_with(cx, |app, _| app.shell_suggestions.clone());
+        assert!(
+            !suggestions.is_empty(),
+            "detection must find real shells on a machine that genuinely has /etc/shells"
+        );
+        for (index, suggestion) in suggestions.iter().enumerate() {
+            assert!(
+                suggestion.path.is_file(),
+                "the dropdown offered {}, which is not a real file on this machine",
+                suggestion.path.display()
+            );
+            assert!(
+                cx.debug_bounds(row_selector(index)).is_some(),
+                "every detected shell must really paint as a clickable row: {}",
+                suggestion.name
+            );
+        }
+    }
+
+    /// The whole user journey the follow-up asked for, with no typing at all: click the field,
+    /// click a real detected shell, and that shell's real path is in the field, in the real
+    /// `settings.toml`, and running as the real child process of the next Shell tab.
+    #[gpui::test]
+    fn clicking_a_suggestion_configures_it_and_the_next_tab_really_runs_it(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+        let (app, cx) = open_general_settings(cx, settings_path.clone(), repo.path().to_path_buf());
+        click_the_shell_field(cx);
+
+        // Pick a real detected shell this test can then really spawn. `sh` is the one every Unix
+        // host running this suite genuinely has.
+        let (index, chosen) = app
+            .read_with(cx, |app, _| {
+                app.shell_suggestions
+                    .iter()
+                    .enumerate()
+                    .find(|(_, suggestion)| suggestion.name == "sh")
+                    .map(|(index, suggestion)| (index, suggestion.clone()))
+            })
+            .expect("every Unix host running this suite has a real sh in /etc/shells");
+
+        let row = cx
+            .debug_bounds(row_selector(index))
+            .expect("the chosen suggestion must really paint");
+        cx.simulate_click(row.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.shell_input.as_str().to_string()),
+            chosen.value(),
+            "clicking a suggestion must put its real path in the field, exactly as typing would"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.settings.terminal.shell.clone()),
+            Some(chosen.value()),
+            "and it must reach the real setting through the same path a typed value does"
+        );
+        let written = std::fs::read_to_string(&settings_path).expect("the file must exist");
+        assert!(
+            written.contains(&format!("shell = \"{}\"", chosen.value())),
+            "a clicked suggestion must really be persisted to settings.toml, got: {written}"
+        );
+        assert!(
+            !app.read_with(cx, |app, _| app.shell_suggestions_open),
+            "picking a suggestion must close the dropdown, not leave it stuck open"
+        );
+        assert!(
+            cx.debug_bounds("settings-shell-suggestions-popover")
+                .is_none(),
+            "and it must really stop painting"
+        );
+
+        // The real proof it was a usable choice and not just a string: the next Shell tab spawns it.
+        app.update_in(cx, |app, window, cx| {
+            app.close_settings(window, cx);
+            app.new_agent(AgentKind::Shell, window, cx);
+        });
+        cx.run_until_parked();
+        let pane = app
+            .read_with(cx, |app, _| app.agents.active().map(|a| a.pane.clone()))
+            .expect("the newly spawned tab");
+        pane.read_with(cx, |pane, _| {
+            assert_eq!(
+                pane.spawn_error(),
+                None,
+                "a shell picked from the detected list must always start - that is what makes \
+                 detection worth trusting"
+            );
+            assert_eq!(pane.program_label(), "sh");
+            assert!(pane.is_running(), "the picked shell must really be running");
+        });
+    }
+
+    /// The field must stay genuinely free text: a path this machine has never heard of is still
+    /// typeable and still persists, and the dropdown - which has nothing to suggest for it -
+    /// simply shows no rows rather than restricting or overriding anything.
+    #[gpui::test]
+    fn a_custom_value_the_machine_has_never_heard_of_still_works(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = open_general_settings(
+            cx,
+            settings_dir.path().join("settings.toml"),
+            repo.path().to_path_buf(),
+        );
+        click_the_shell_field(cx);
+        cx.simulate_keystrokes("q q q");
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.settings.terminal.shell.clone()),
+            Some("qqq".to_string()),
+            "typing must reach the setting exactly as it did before the dropdown existed"
+        );
+        assert!(
+            app.read_with(cx, |app, _| settings::filter_shell_suggestions(
+                &app.shell_suggestions,
+                app.shell_input.as_str()
+            )
+            .is_empty()),
+            "nothing detected matches a custom value, so nothing may be suggested for it"
+        );
+        assert!(
+            cx.debug_bounds("settings-shell-suggestion-0").is_none(),
+            "no suggestion row may paint when nothing matches - the dropdown never restricts what \
+             can be typed, it just has nothing to add"
+        );
+
+        // And typing something the machine *does* have narrows the list to it rather than
+        // replacing what was typed.
+        cx.simulate_keystrokes("escape");
+        cx.simulate_keystrokes("z s h");
+        cx.run_until_parked();
+        let matched = app.read_with(cx, |app, _| {
+            settings::filter_shell_suggestions(&app.shell_suggestions, app.shell_input.as_str())
+                .into_iter()
+                .map(|suggestion| suggestion.name.clone())
+                .collect::<Vec<_>>()
+        });
+        assert_eq!(
+            app.read_with(cx, |app, _| app.shell_input.as_str().to_string()),
+            "zsh",
+            "the field still holds exactly what was typed - a suggestion never rewrites it"
+        );
+        if app.read_with(cx, |app, _| {
+            app.shell_suggestions
+                .iter()
+                .any(|suggestion| suggestion.name == "zsh")
+        }) {
+            assert_eq!(
+                matched,
+                vec!["zsh".to_string()],
+                "typing a real shell's name must narrow the list to it"
+            );
+        }
+    }
+
+    /// A clicked suggestion is an ordinary edit of the same [`crate::text_history::TextField`] the
+    /// field already used, so the field's existing undo history really covers it - a real
+    /// regression guard against the dropdown growing a second, parallel way to change the value
+    /// that undo would not know about.
+    #[gpui::test]
+    fn a_clicked_suggestion_is_a_single_undoable_edit_of_the_real_field(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = open_general_settings(
+            cx,
+            settings_dir.path().join("settings.toml"),
+            repo.path().to_path_buf(),
+        );
+        click_the_shell_field(cx);
+        // A real typed value first, so undo has something distinct to come back to.
+        cx.simulate_keystrokes("s");
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.shell_input.as_str().to_string()),
+            "s"
+        );
+
+        let row = cx
+            .debug_bounds("settings-shell-suggestion-0")
+            .expect("'s' matches real detected shells, so a row must paint");
+        cx.simulate_click(row.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+        let picked = app.read_with(cx, |app, _| app.shell_input.as_str().to_string());
+        assert!(
+            picked.starts_with('/'),
+            "the click must have replaced the typed text with a real absolute path, got {picked}"
+        );
+
+        let undo = if cfg!(target_os = "macos") {
+            "cmd-z"
+        } else {
+            "ctrl-z"
+        };
+        cx.simulate_keystrokes(undo);
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.shell_input.as_str().to_string()),
+            "s",
+            "the field's own existing undo must reverse a clicked suggestion in one step - the \
+             dropdown writes through the same TextField, not around it"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.settings.terminal.shell.clone()),
+            Some("s".to_string()),
+            "and the undone value must be re-applied to the real setting, so the field and the \
+             file can never disagree"
+        );
+    }
+
+    /// The dropdown obeys the app's one shared dismissal rule
+    /// (`crate::root::menus::MenuSurface`), rather than owning a second one: a click away closes
+    /// it, the window losing focus closes it, and leaving Settings closes it.
+    #[gpui::test]
+    fn the_dropdown_dismisses_the_same_way_every_other_menu_does(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = open_general_settings(
+            cx,
+            settings_dir.path().join("settings.toml"),
+            repo.path().to_path_buf(),
+        );
+
+        // It is a real member of the shared menu-surface set, not a private bool.
+        click_the_shell_field(cx);
+        assert!(
+            app.read_with(cx, |app, _| app
+                .menu_surface_is_open(MenuSurface::ShellSuggestions)),
+            "the dropdown must answer the shared 'is a menu open' question"
+        );
+
+        // A click away from the panel hits the scrim and closes it.
+        let popover = cx
+            .debug_bounds("settings-shell-suggestions-popover")
+            .expect("the dropdown must be painted");
+        cx.simulate_click(
+            gpui::Point::new(popover.origin.x - px(80.0), popover.origin.y + px(200.0)),
+            gpui::Modifiers::none(),
+        );
+        cx.run_until_parked();
+        assert!(
+            !app.read_with(cx, |app, _| app.shell_suggestions_open),
+            "clicking away from the dropdown must close it"
+        );
+
+        // Leaving Settings entirely never leaves it armed for the next visit.
+        click_the_shell_field(cx);
+        assert!(app.read_with(cx, |app, _| app.shell_suggestions_open));
+        app.update_in(cx, |app, window, cx| app.close_settings(window, cx));
+        cx.run_until_parked();
+        assert!(
+            !app.read_with(cx, |app, _| app.shell_suggestions_open),
+            "closing Settings must close the dropdown that belonged to it"
+        );
+        app.update_in(cx, |app, window, cx| {
+            app.open_settings(window, cx);
+            app.select_settings_page(SettingsPage::General, window, cx);
+        });
+        cx.run_until_parked();
+        assert!(
+            cx.debug_bounds("settings-shell-suggestions-popover")
+                .is_none(),
+            "reopening Settings must not resurrect a dropdown nobody asked for"
+        );
+
+        // And the window losing OS focus closes it, exactly like every other menu surface - last,
+        // since `VisualTestContext` has no way to re-activate a window afterwards.
+        //
+        // `deactivate_window` is a no-op unless this window really is the platform's active one,
+        // and `TestWindow` does not start active - the same premise
+        // `crate::root::menus`'s own window-activation test sets up.
+        cx.update(|window, _cx| window.activate_window());
+        cx.run_until_parked();
+        click_the_shell_field(cx);
+        assert!(app.read_with(cx, |app, _| app.shell_suggestions_open));
+        cx.deactivate_window();
+        cx.run_until_parked();
+        assert!(
+            !app.read_with(cx, |app, _| app.shell_suggestions_open),
+            "a deactivated window must not leave a dropdown floating over the app"
         );
     }
 }

--- a/crates/app/src/settings/render.rs
+++ b/crates/app/src/settings/render.rs
@@ -926,6 +926,12 @@ impl AdeApp {
              elsewhere. The same chip shown in the status bar and terminal footer.",
             render_env_chip(),
         );
+        let shell_row = self.render_settings_row(
+            "Shell",
+            "What a new Shell tab runs - a name on PATH (bash, fish, pwsh) or an absolute path. \
+             Leave it empty to use the system default. Agent tabs are unaffected.",
+            self.render_settings_shell_control(cx),
+        );
         let inline_blame_row = self.render_settings_row(
             "Inline git blame",
             "Show who last changed the current line, and when, dimmed at the end of it. Off \
@@ -954,6 +960,7 @@ impl AdeApp {
             )
             .child(window_controls_row)
             .child(environment_row)
+            .child(shell_row)
             .child(
                 div()
                     .pt(px(20.0))
@@ -966,6 +973,191 @@ impl AdeApp {
             )
             .child(inline_blame_row)
             .child(self.render_snippet_block(settings_store::ConfigPage::General))
+    }
+
+    /// GitHub issue #213's "Shell" control: a real, focusable free-text field naming the program
+    /// a Shell tab launches, plus a live, advisory hint saying what that name really resolves to
+    /// right now ([`Self::shell_status`]).
+    ///
+    /// The field is the same minimal hand-rolled input shape as the Themes page's seed field
+    /// ([`Self::render_theme_seed_row`]) and the Keybindings filter - a real `FocusHandle`, a
+    /// real caret ([`Self::render_simple_input_caret`]), append/backspace/`Esc`-clears, real
+    /// per-widget undo - deliberately reusing that established pattern rather than introducing a
+    /// second, richer text-input mechanism this app doesn't otherwise have.
+    ///
+    /// The placeholder is the real answer to "what happens if I leave this blank": whichever
+    /// program the OS itself names, not a blank field with no consequence stated.
+    fn render_settings_shell_control(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let shell = self.shell_input.as_str().to_string();
+        let has_shell = !shell.is_empty();
+        // The real program an empty field means on *this* machine, read live rather than
+        // described as a generic "$SHELL" - see `TerminalSpec::default_shell_program_display`.
+        let placeholder = crate::terminal::pane::TerminalSpec::default_shell_program_display();
+
+        div()
+            .flex()
+            .items_center()
+            .gap(px(9.0))
+            .child(
+                div()
+                    .font(font(theme::font::MONO))
+                    .text_size(self.ui_text_size(10.0))
+                    .text_color(if self.shell_status.is_not_found() {
+                        theme::status::FAIL
+                    } else {
+                        theme::text::FAINTER
+                    })
+                    .child(self.shell_status.hint())
+                    .debug_selector(|| "settings-shell-status".to_string()),
+            )
+            .child(
+                div()
+                    .id("settings-shell-input")
+                    .debug_selector(|| "settings-shell-input".to_string())
+                    .track_focus(&self.shell_focus_handle)
+                    // See `crate::default_key_bindings`' `TextUndo`/`TextRedo` docs for why the
+                    // tag and the listeners both live on this exact node.
+                    .key_context("text-input")
+                    .on_action(cx.listener(Self::handle_settings_shell_text_undo))
+                    .on_action(cx.listener(Self::handle_settings_shell_text_redo))
+                    .on_key_down(cx.listener(Self::handle_settings_shell_key_down))
+                    .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
+                        window.focus(&this.shell_focus_handle, cx);
+                    }))
+                    .cursor_pointer()
+                    .flex_none()
+                    .flex()
+                    .items_center()
+                    .gap(px(2.0))
+                    .h(px(20.0))
+                    .w(px(168.0))
+                    .px(px(7.0))
+                    .rounded(theme::radius::BUTTON)
+                    .border_1()
+                    .border_color(theme::border::CARD_FIELD)
+                    .bg(theme::surface::CARD_SUNK)
+                    // The caret sits before the placeholder (real cursor position 0) while the
+                    // field is empty, never appended after it - same fix as every other simple
+                    // input in this app (GitHub issue #45).
+                    .when(!has_shell, |el| {
+                        el.child(self.render_simple_input_caret(
+                            "settings-shell-caret",
+                            &self.shell_focus_handle,
+                        ))
+                    })
+                    .child(
+                        div()
+                            .flex_1()
+                            .min_w_0()
+                            .truncate()
+                            .font(font(theme::font::MONO))
+                            .text_size(self.ui_text_size(10.5))
+                            .text_color(if has_shell {
+                                theme::text::BODY
+                            } else {
+                                theme::text::GHOST
+                            })
+                            .child(if has_shell { shell } else { placeholder })
+                            .debug_selector(|| "settings-shell-text".to_string()),
+                    )
+                    .when(has_shell, |el| {
+                        el.child(self.render_simple_input_caret(
+                            "settings-shell-caret",
+                            &self.shell_focus_handle,
+                        ))
+                    }),
+            )
+    }
+
+    /// Same minimal append/backspace/`Esc`-clears shape as
+    /// [`Self::handle_settings_keymap_filter_key_down`] - see that method's docs for the
+    /// deliberate scope cut (no cursor positioning, no selection, no IME). Every real change
+    /// goes straight to the persisted setting through [`Self::apply_shell_input`], so there is
+    /// no separate "save" step that could be forgotten.
+    pub(in crate::settings) fn handle_settings_shell_key_down(
+        &mut self,
+        event: &KeyDownEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let keystroke = &event.keystroke;
+        if keystroke.modifiers.platform || keystroke.modifiers.control || keystroke.modifiers.alt {
+            return;
+        }
+        self.reset_caret_blink(cx);
+        let changed = match keystroke.key.as_str() {
+            "backspace" => self.shell_input.pop(Instant::now()),
+            // Clearing the field is itself a real, meaningful edit here (it means "go back to the
+            // system default"), so it persists like any other - and is undoable, like every other
+            // simple input's `Esc`.
+            "escape" => self.shell_input.clear(Instant::now()),
+            _ => match keystroke.key_char.as_deref() {
+                Some(text) if !text.is_empty() => self.shell_input.push_str(text, Instant::now()),
+                _ => false,
+            },
+        };
+        if changed {
+            self.apply_shell_input(cx);
+            cx.stop_propagation();
+        }
+    }
+
+    /// `TextUndo`/`TextRedo` for the Shell field (GitHub issue #17's per-widget undo) - see
+    /// `crate::default_key_bindings`' own docs for the scoping. Both re-apply the resulting text
+    /// to the real setting, so an undo can't leave the field and the file disagreeing.
+    pub(in crate::settings) fn handle_settings_shell_text_undo(
+        &mut self,
+        _: &TextUndo,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.shell_input.undo() {
+            self.apply_shell_input(cx);
+        }
+    }
+
+    pub(in crate::settings) fn handle_settings_shell_text_redo(
+        &mut self,
+        _: &TextRedo,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.shell_input.redo() {
+            self.apply_shell_input(cx);
+        }
+    }
+
+    /// Copies the Shell field's current text into the real, persisted setting and saves it
+    /// (GitHub issue #213). An empty/whitespace-only field is stored as a real `None` - "use the
+    /// system default" - never as `Some("")`.
+    ///
+    /// Deliberately does **not** touch already-open tabs: which program a terminal runs is fixed
+    /// when its process is spawned, and this app has no way to swap a live pty's program out from
+    /// under a running shell. The next Shell tab picks it up (`Agents::spawn` reads live
+    /// settings on every spawn), which is the honest scope - unlike the terminal *font size*,
+    /// which really can be applied to a live pane and therefore is
+    /// ([`Self::adjust_terminal_font_size`]).
+    pub(in crate::settings) fn apply_shell_input(&mut self, cx: &mut Context<Self>) {
+        let typed = self.shell_input.as_str().trim();
+        self.settings.terminal.shell = (!typed.is_empty()).then(|| typed.to_string());
+        self.refresh_shell_status();
+        self.persist_settings(cx);
+        cx.notify();
+    }
+
+    /// Re-probes what the configured shell resolves to right now
+    /// ([`crate::settings::state::detect_shell_status`], with the real
+    /// `pty_core::resolve_on_path`). Called on every edit and when Settings opens - never from
+    /// `render`, which would put a real `$PATH` walk on the frame path.
+    ///
+    /// A single `$PATH` walk for one name, unlike [`Self::load_agent_rows`]'s walk *per agent
+    /// binary*, so this stays on the foreground thread rather than growing a background task and
+    /// a stale-result race for a keystroke-frequency operation.
+    pub(crate) fn refresh_shell_status(&mut self) {
+        self.shell_status = settings::detect_shell_status(
+            self.settings.terminal.shell_override(),
+            pty_core::resolve_on_path,
+        );
     }
 
     /// *Appearance & scaling* - every row here is persisted and round-trips through
@@ -3927,6 +4119,268 @@ mod settings_lsp_install_action_tests {
             cx.debug_bounds("settings-lsp-install-ready-binary")
                 .is_none(),
             "a ready row has already live-found its binary and should show no Install action"
+        );
+    }
+}
+
+/// GitHub issue #213 ("Allow to select shell") end-to-end: the persisted `terminal.shell` isn't
+/// just a string in a file, it decides which real program a real Shell tab's real child process
+/// is. Every test here drives the same path a user does - a real window, a real settings value or
+/// real keystrokes into the real field, a real spawned pty - rather than asserting on the pure
+/// helper alone (which `terminal::pane::shell_program_tests` already covers).
+///
+/// unix-only: these spawn `sh`, matching this project's own convention of only running the test
+/// suite on Linux (`pty-core`'s "Platform scope" docs).
+#[cfg(all(test, unix))]
+mod shell_setting_tests {
+    use super::*;
+    use crate::rail::status::Status;
+    use crate::root::focus::palette_focus_tests;
+    use crate::terminal::pane::TerminalSpec;
+    use gpui::TestAppContext;
+
+    /// Same shape as the sibling test modules' own helper (`keybinding_rebind_tests`,
+    /// `custom_theme_settings_tests`) - a real window with a real, isolated `settings.toml` path,
+    /// so `persist_settings` actually writes a file these tests can read back.
+    fn open_test_app_with_real_settings_path(
+        cx: &mut TestAppContext,
+        repo_path: PathBuf,
+        settings: settings_store::Settings,
+        settings_path: PathBuf,
+    ) -> (gpui::Entity<AdeApp>, &mut gpui::VisualTestContext) {
+        cx.add_window_view(|window, cx| {
+            AdeApp::new_with_settings(
+                Some(repo_path),
+                true,
+                settings,
+                Some(settings_path),
+                window,
+                cx,
+            )
+        })
+    }
+
+    fn settings_with_shell(shell: Option<&str>) -> settings_store::Settings {
+        let mut settings = settings_store::Settings::default();
+        settings.terminal.shell = shell.map(str::to_string);
+        settings
+    }
+
+    /// The whole point of the issue: a configured shell is what a real Shell tab really runs.
+    /// `sh` rather than the machine's own `$SHELL` so the assertion means something on any host
+    /// (a developer already using `sh` as their login shell would make a `$SHELL` comparison
+    /// vacuous).
+    #[gpui::test]
+    fn a_configured_shell_is_what_a_real_shell_tab_really_spawns(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = open_test_app_with_real_settings_path(
+            cx,
+            repo.path().to_path_buf(),
+            settings_with_shell(Some("sh")),
+            settings_dir.path().join("settings.toml"),
+        );
+        cx.run_until_parked();
+
+        let pane = app
+            .read_with(cx, |app, _| app.agents.active().map(|a| a.pane.clone()))
+            .expect("a fresh window starts one real shell tab");
+
+        pane.read_with(cx, |pane, _| {
+            assert_eq!(
+                pane.program_label(),
+                "sh",
+                "the configured shell - not $SHELL - must be the program this tab spawned"
+            );
+            assert_eq!(
+                pane.spawn_error(),
+                None,
+                "a real, installed shell must start cleanly"
+            );
+            assert!(
+                pane.is_running(),
+                "the configured shell must be a genuinely live child process, not just a spec"
+            );
+        });
+    }
+
+    /// The zero-config guarantee: an install that never touches this setting keeps spawning
+    /// exactly what it spawned before the setting existed.
+    #[gpui::test]
+    fn an_unconfigured_shell_still_spawns_the_real_os_default(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        let expected = PathBuf::from(TerminalSpec::default_shell_program_display())
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .expect("the OS default shell must have a real file name");
+
+        let pane = app
+            .read_with(cx, |app, _| app.agents.active().map(|a| a.pane.clone()))
+            .expect("a fresh window starts one real shell tab");
+        pane.read_with(cx, |pane, _| {
+            assert_eq!(pane.program_label(), expected);
+            assert!(pane.is_running(), "the OS default shell must really run");
+        });
+    }
+
+    /// GitHub issue #213's honest-failure question: a typo'd shell name must fail the way any
+    /// other missing program already does - a real, typed spawn error, named on the tab itself
+    /// and reflected in the tab's real status - not a blank pane, and not a silently substituted
+    /// fallback that would hide the user's mistake.
+    #[gpui::test]
+    fn a_misconfigured_shell_fails_visibly_on_the_tab_itself(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = open_test_app_with_real_settings_path(
+            cx,
+            repo.path().to_path_buf(),
+            settings_with_shell(Some("definitely-not-a-real-shell-xyz")),
+            settings_dir.path().join("settings.toml"),
+        );
+        cx.run_until_parked();
+
+        let pane = app
+            .read_with(cx, |app, _| app.agents.active().map(|a| a.pane.clone()))
+            .expect("the tab is still created - it is the *process* that failed");
+        let error = pane
+            .read_with(cx, |pane, _| pane.spawn_error().map(str::to_string))
+            .expect("a shell that doesn't exist must record a real spawn error");
+        assert!(
+            error.contains("definitely-not-a-real-shell-xyz"),
+            "the error must name the program the user actually configured, so the typo is \
+             diagnosable: {error}"
+        );
+
+        let status = app.read_with(cx, |app, cx| {
+            let agent = app.agents.active().expect("the failed tab");
+            app.agent_status(agent, cx)
+        });
+        assert_eq!(
+            status,
+            Status::Fail,
+            "a tab whose shell never started must read as a real failure everywhere the app \
+             shows status, not as idle"
+        );
+
+        // And the Settings row says so up front, before the user has to read a terminal.
+        app.update(cx, |app, _| app.refresh_shell_status());
+        assert!(
+            app.read_with(cx, |app, _| app.shell_status.is_not_found()),
+            "the Settings row must flag a shell that genuinely isn't there"
+        );
+    }
+
+    /// The real user journey, driven through the real UI: focus the real painted field, type a
+    /// real shell name, and it lands in the real `settings.toml` *and* in the next real tab's
+    /// real child process.
+    #[gpui::test]
+    fn typing_a_shell_into_the_settings_row_persists_it_and_the_next_tab_uses_it(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+        let (app, cx) = open_test_app_with_real_settings_path(
+            cx,
+            repo.path().to_path_buf(),
+            settings_store::Settings::default(),
+            settings_path.clone(),
+        );
+        cx.dispatch_action(ToggleSettings);
+        app.update_in(cx, |app, window, cx| {
+            app.select_settings_page(SettingsPage::General, window, cx);
+        });
+        cx.run_until_parked();
+
+        let field = cx
+            .debug_bounds("settings-shell-input")
+            .expect("the Shell field must really paint on the General page");
+        cx.simulate_click(field.center(), gpui::Modifiers::none());
+        cx.simulate_keystrokes("s h");
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.settings.terminal.shell.clone()),
+            Some("sh".to_string()),
+            "real keystrokes in the real field must reach the real setting"
+        );
+        let written = std::fs::read_to_string(&settings_path).expect("the file must exist");
+        assert!(
+            written.contains("shell = \"sh\""),
+            "the edit must really be persisted to settings.toml, got: {written}"
+        );
+
+        // The next real Shell tab runs it - and really starts.
+        app.update_in(cx, |app, window, cx| {
+            app.close_settings(window, cx);
+            app.new_agent(AgentKind::Shell, window, cx);
+        });
+        cx.run_until_parked();
+        let pane = app
+            .read_with(cx, |app, _| app.agents.active().map(|a| a.pane.clone()))
+            .expect("the newly spawned tab");
+        pane.read_with(cx, |pane, _| {
+            assert_eq!(pane.program_label(), "sh");
+            assert_eq!(pane.spawn_error(), None);
+            assert!(pane.is_running(), "the typed shell must really be running");
+        });
+
+        // Clearing the field again is a real edit back to the system default, not a stuck value.
+        app.update_in(cx, |app, window, cx| {
+            app.open_settings(window, cx);
+            app.select_settings_page(SettingsPage::General, window, cx);
+        });
+        cx.run_until_parked();
+        let field = cx
+            .debug_bounds("settings-shell-input")
+            .expect("the Shell field must paint again on reopening Settings");
+        cx.simulate_click(field.center(), gpui::Modifiers::none());
+        cx.simulate_keystrokes("escape");
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.settings.terminal.shell.clone()),
+            None,
+            "emptying the field must mean 'use the system default', not an empty program name"
+        );
+    }
+
+    /// A shell configured in the file shows up in the field the moment Settings is opened -
+    /// otherwise a user with a hand-edited `settings.toml` would see a blank field and assume
+    /// nothing was set.
+    #[gpui::test]
+    fn an_already_persisted_shell_is_shown_in_the_field_at_startup(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = open_test_app_with_real_settings_path(
+            cx,
+            repo.path().to_path_buf(),
+            settings_with_shell(Some("sh")),
+            settings_dir.path().join("settings.toml"),
+        );
+        cx.dispatch_action(ToggleSettings);
+        app.update_in(cx, |app, window, cx| {
+            app.select_settings_page(SettingsPage::General, window, cx);
+        });
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.shell_input.as_str().to_string()),
+            "sh",
+            "the field must start out holding the real persisted value"
+        );
+        assert!(
+            app.read_with(cx, |app, _| matches!(
+                app.shell_status,
+                settings::ShellStatus::Resolved(_)
+            )),
+            "opening Settings must re-probe the configured shell against the real PATH"
+        );
+        assert!(
+            cx.debug_bounds("settings-shell-status").is_some(),
+            "the row's live found/not-found hint must really paint"
         );
     }
 }

--- a/crates/app/src/settings/state.rs
+++ b/crates/app/src/settings/state.rs
@@ -658,11 +658,152 @@ pub fn filter_keybinding_rows<'a>(
         .collect()
 }
 
+/// What the General page's "Shell" row can honestly say about the configured shell program
+/// (GitHub issue #213) - see [`detect_shell_status`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ShellStatus {
+    /// Nothing configured: a shell tab launches the real OS default (`$SHELL`/`%COMSPEC%`).
+    SystemDefault,
+    /// A real program was found - the resolved absolute path, exactly as it would be run.
+    Resolved(PathBuf),
+    /// Nothing by that name exists. Advisory only: this never stops the app from trying to spawn
+    /// it (see `crate::terminal::pane::configured_shell_program`'s docs for why the real spawn
+    /// stays the authority), it just makes a typo visible before a tab fails.
+    NotFound,
+}
+
+impl ShellStatus {
+    /// The trailing hint text the row shows next to the field - a real resolved path, an honest
+    /// "not found", or the name of what will actually run when nothing is configured.
+    pub fn hint(&self) -> String {
+        match self {
+            ShellStatus::SystemDefault => "empty - using the system default".to_string(),
+            ShellStatus::Resolved(path) => path.display().to_string(),
+            ShellStatus::NotFound => "not found - this tab will fail to start".to_string(),
+        }
+    }
+
+    pub fn is_not_found(&self) -> bool {
+        matches!(self, ShellStatus::NotFound)
+    }
+}
+
+/// Resolves the configured shell the same two ways `pty_core::spawn` itself will (GitHub issue
+/// #213): a name with no path separator is searched for on `PATH` via `resolve`, anything that
+/// looks like a path is checked as a real file on disk. Whitespace-only (or absent) is
+/// [`ShellStatus::SystemDefault`], matching
+/// `crate::settings::store::TerminalSettings::shell_override`.
+///
+/// Takes `resolve` as a parameter - in production `pty_core::resolve_on_path` - for the same
+/// reason [`detect_agent_rows`] does: so this is unit-testable independently of which shells
+/// happen to be installed on the machine running the suite. The on-disk check for a path-shaped
+/// value is a real `Path::is_file` call rather than a second injected closure; a test can point
+/// it at a real temp file, which is a truer check than a fake.
+///
+/// This is deliberately *advisory*. It cannot be a guarantee - `resolve_on_path` is a second
+/// implementation of `portable-pty`'s own search (see its docs for the disclosed divergences) -
+/// so it is used to inform the settings row, never to gate the spawn.
+pub fn detect_shell_status(
+    configured: Option<&str>,
+    resolve: impl Fn(&str) -> Option<PathBuf>,
+) -> ShellStatus {
+    let Some(program) = configured
+        .map(str::trim)
+        .filter(|program| !program.is_empty())
+    else {
+        return ShellStatus::SystemDefault;
+    };
+
+    let path = std::path::Path::new(program);
+    if path.components().count() > 1 {
+        // A path, not a name to search for - `CommandBuilder` runs it as given, so the only
+        // real question is whether that file exists.
+        return match path.is_file() {
+            true => ShellStatus::Resolved(path.to_path_buf()),
+            false => ShellStatus::NotFound,
+        };
+    }
+
+    match resolve(program) {
+        Some(resolved) => ShellStatus::Resolved(resolved),
+        None => ShellStatus::NotFound,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::rail::state::WorktreeNote;
     use wt_core::diff::WorktreeMergeStatus;
+
+    /// GitHub issue #213's advisory found/not-found hint: both real forms a user can type, plus
+    /// the "nothing configured" case that must never be reported as an error.
+    #[test]
+    fn shell_status_reports_each_real_configured_form_honestly() {
+        let fake_path_search =
+            |program: &str| (program == "fish").then(|| PathBuf::from("/usr/bin/fish"));
+
+        assert_eq!(
+            detect_shell_status(None, fake_path_search),
+            ShellStatus::SystemDefault,
+            "no override at all is the normal, healthy state - never a 'not found'"
+        );
+        assert_eq!(
+            detect_shell_status(Some("   "), fake_path_search),
+            ShellStatus::SystemDefault,
+            "a blank field means the system default, exactly like an absent value"
+        );
+        assert_eq!(
+            detect_shell_status(Some("fish"), fake_path_search),
+            ShellStatus::Resolved(PathBuf::from("/usr/bin/fish")),
+            "a bare name must be reported as the real path PATH resolution finds"
+        );
+        assert_eq!(
+            detect_shell_status(Some("fsih"), fake_path_search),
+            ShellStatus::NotFound,
+            "a typo'd name must be called out, not silently accepted"
+        );
+    }
+
+    /// A path-shaped value is checked against the real filesystem, not searched for on `PATH` -
+    /// exercised against a genuinely existing temp file and a genuinely missing one.
+    #[test]
+    fn a_path_shaped_shell_is_checked_on_disk_not_on_path() {
+        let never_resolves = |_: &str| -> Option<PathBuf> {
+            panic!("a path-shaped value must never be searched for on PATH")
+        };
+        let dir = tempfile::tempdir().expect("tempdir");
+        let real_file = dir.path().join("my-shell");
+        std::fs::write(&real_file, "#!/bin/sh\n").expect("write");
+
+        assert_eq!(
+            detect_shell_status(Some(real_file.to_str().expect("utf-8")), never_resolves),
+            ShellStatus::Resolved(real_file.clone())
+        );
+        assert_eq!(
+            detect_shell_status(
+                Some(dir.path().join("no-such-shell").to_str().expect("utf-8")),
+                never_resolves
+            ),
+            ShellStatus::NotFound
+        );
+    }
+
+    /// The real production resolver, on a real binary this test environment genuinely has -
+    /// proof the injected-resolver tests above aren't only true of the fake.
+    #[cfg(unix)]
+    #[test]
+    fn the_real_path_resolver_finds_a_real_shell() {
+        let status = detect_shell_status(Some("sh"), pty_core::resolve_on_path);
+        match status {
+            ShellStatus::Resolved(path) => assert!(
+                path.is_file(),
+                "the reported path must be a real file on this machine, got {}",
+                path.display()
+            ),
+            other => panic!("expected a real resolved sh, got {other:?}"),
+        }
+    }
 
     #[test]
     fn all_eleven_pages_are_covered_by_the_four_nav_groups_exactly_once() {

--- a/crates/app/src/settings/state.rs
+++ b/crates/app/src/settings/state.rs
@@ -730,11 +730,520 @@ pub fn detect_shell_status(
     }
 }
 
+/// One genuinely-present shell offered under the General page's free-text "Shell" field (GitHub
+/// issue #213's follow-up: "would a select + auto-detect installed shells be better?" - a hybrid,
+/// so the common case needs no typing while the field itself stays unrestricted).
+///
+/// Every one of these was found by real I/O - a line of `/etc/shells` whose file is on disk right
+/// now, or a real `$PATH`/`%PATH%` hit - never a hardcoded "shells people usually have". A name
+/// that isn't genuinely resolvable is never offered, because clicking it would configure a shell
+/// that cannot spawn.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShellSuggestion {
+    /// The program's own file name (`bash`, `pwsh.exe`) - what a user recognizes at a glance.
+    pub name: String,
+    /// The real, absolute path it was found at, which is also the value clicking the row types
+    /// into the field ([`Self::value`]). Absolute rather than the bare name so the suggestion
+    /// means exactly one program: `pty_core::spawn` runs an absolute path verbatim, with no
+    /// second `PATH` search that could resolve to a different `bash` than the one listed here.
+    pub path: PathBuf,
+}
+
+impl ShellSuggestion {
+    /// The text this suggestion puts in the field when clicked - identical to what the user could
+    /// have typed by hand, so it flows through the exact same
+    /// `crate::settings::store::TerminalSettings::shell` path with nothing special about it.
+    pub fn value(&self) -> String {
+        self.path.display().to_string()
+    }
+}
+
+/// The real, standard file listing a Unix system's valid login shells - one absolute path per
+/// line, `#` comments and blank lines allowed. Read (never written) by [`detect_installed_shells`].
+#[cfg(unix)]
+pub const ETC_SHELLS: &str = "/etc/shells";
+
+/// Well-known shells that are genuinely, routinely *absent* from `/etc/shells` even when
+/// installed, so [`unix_shell_suggestions`] probes `PATH` for them as a supplement - not as the
+/// primary mechanism, and never as an answer of its own: a name here is only ever offered when a
+/// real `PATH` search actually finds it.
+///
+/// The list is short and evidence-driven rather than a general "common shells" guess. Registering
+/// a shell in `/etc/shells` is the *distribution packager's* job, and each of these is
+/// predominantly installed by a route that has no packager: fish's and PowerShell's own install
+/// instructions tell the user to append the path to `/etc/shells` by hand afterwards (which is
+/// only necessary because the install genuinely doesn't), Nushell ships mainly through
+/// `cargo install` and release tarballs, Xonsh through `pip`, and Elvish through `go install` and
+/// tarballs. None of those routes touch `/etc/shells` at all.
+#[cfg(unix)]
+const UNIX_SUPPLEMENTARY_SHELLS: [&str; 5] = ["fish", "nu", "pwsh", "elvish", "xonsh"];
+
+/// Shell programs a Windows install may genuinely have on `%PATH%`, probed one by one - see
+/// [`windows_shell_suggestions`], which only offers the ones a real search actually finds.
+///
+/// There is no `/etc/shells` equivalent on Windows, so this is a probe list rather than a source
+/// of truth, and it is deliberately confined to names that are real, well-known program names -
+/// not a catalogue of everything that might be a shell. `bash.exe` is a real example of why the
+/// *probe* matters more than the name: on a given machine it could be WSL's bash shim, Git Bash,
+/// or Cygwin's, and this makes no claim about which - only that the file the search found really
+/// exists and would really run.
+const WINDOWS_PROBED_SHELLS: [&str; 3] = ["powershell.exe", "pwsh.exe", "bash.exe"];
+
+/// Every shell this machine genuinely has, for the field's suggestion list - the production
+/// entry point, wired to the real `/etc/shells`, the real `%COMSPEC%`, and the real
+/// `pty_core::resolve_on_path`.
+///
+/// Does real filesystem and `PATH` I/O, so like [`detect_agent_rows`] and [`detect_shell_status`]
+/// it is called when Settings opens (`AdeApp::refresh_shell_suggestions`) and the result is held
+/// in state - never from `render`, which would put a directory walk on the frame path.
+pub fn detect_installed_shells() -> Vec<ShellSuggestion> {
+    #[cfg(unix)]
+    {
+        unix_shell_suggestions(std::path::Path::new(ETC_SHELLS), pty_core::resolve_on_path)
+    }
+    #[cfg(windows)]
+    {
+        windows_shell_suggestions(std::env::var_os("COMSPEC"), pty_core::resolve_on_path)
+    }
+}
+
+/// The Unix half of [`detect_installed_shells`]: parse `shells_file` (the real `/etc/shells`
+/// format - one absolute path per line, `#` comments and blank lines skipped) and keep the
+/// entries that are *actually a file on disk right now*. A listed shell can have been
+/// uninstalled without the line being removed, and offering a path that isn't there would be
+/// offering a shell that cannot spawn.
+///
+/// Then, and only then, [`UNIX_SUPPLEMENTARY_SHELLS`] are looked for on `PATH` via `resolve` and
+/// appended if genuinely found - see that constant's docs for why a supplement is warranted and
+/// why it is not the primary source.
+///
+/// `shells_file`/`resolve` are parameters, not constants read inside, for the same reason
+/// [`detect_agent_rows`] takes its resolver: a test can point this at a real, hand-written
+/// `/etc/shells` in a real tempdir and get a deterministic answer, instead of asserting on
+/// whatever the machine running the suite happens to have installed.
+#[cfg(unix)]
+pub fn unix_shell_suggestions(
+    shells_file: &std::path::Path,
+    resolve: impl Fn(&str) -> Option<PathBuf>,
+) -> Vec<ShellSuggestion> {
+    let mut found = Vec::new();
+    let mut seen = Vec::new();
+
+    if let Ok(contents) = std::fs::read_to_string(shells_file) {
+        for line in contents.lines() {
+            let entry = line.trim();
+            if entry.is_empty() || entry.starts_with('#') {
+                continue;
+            }
+            let path = PathBuf::from(entry);
+            if path.is_file() {
+                push_unique_shell(&mut found, &mut seen, path);
+            }
+        }
+    }
+
+    for name in UNIX_SUPPLEMENTARY_SHELLS {
+        if let Some(path) = resolve(name) {
+            push_unique_shell(&mut found, &mut seen, path);
+        }
+    }
+
+    found
+}
+
+/// The Windows half of [`detect_installed_shells`]. Windows has no `/etc/shells`, so there are
+/// exactly two real sources and this uses both: `%COMSPEC%` - already this app's own default-shell
+/// mechanism (`crate::terminal::pane::TerminalSpec::default_shell_program`), so the first
+/// suggestion is literally the program an empty field already runs - and a real `PATH` search for
+/// each of [`WINDOWS_PROBED_SHELLS`].
+///
+/// Both sources are verified before anything is offered: `%COMSPEC%` must name a file that
+/// genuinely exists, and a probed name must be genuinely found by `resolve`. A name that is
+/// merely plausible on Windows is never listed.
+///
+/// Takes `comspec`/`resolve` as parameters rather than reading the environment itself so this is
+/// exercisable as a real unit test (with a real temp file standing in for a real `%COMSPEC%`
+/// target) on any host, including the Linux machines this project's suite runs on - the
+/// alternative being a Windows code path with no test coverage whatsoever. It is compiled on
+/// every platform for exactly that reason (it is only *called* under `#[cfg(windows)]`), so the
+/// Linux suite really runs it rather than only type-checking it.
+pub fn windows_shell_suggestions(
+    comspec: Option<std::ffi::OsString>,
+    resolve: impl Fn(&str) -> Option<PathBuf>,
+) -> Vec<ShellSuggestion> {
+    let mut found = Vec::new();
+    let mut seen = Vec::new();
+
+    if let Some(comspec) = comspec {
+        let path = PathBuf::from(comspec);
+        if path.is_file() {
+            push_unique_shell(&mut found, &mut seen, path);
+        }
+    }
+
+    for name in WINDOWS_PROBED_SHELLS {
+        if let Some(path) = resolve(name) {
+            push_unique_shell(&mut found, &mut seen, path);
+        }
+    }
+
+    found
+}
+
+/// Appends `path` as a suggestion unless an equivalent one is already listed, keyed on
+/// `(file name, real canonicalized target)`.
+///
+/// Both halves of that key are load-bearing against real, live `/etc/shells` content. On any
+/// usr-merged distribution the file lists `/bin/bash` *and* `/usr/bin/bash`, which are the same
+/// binary reached through a symlinked directory - two rows that would offer a user the same
+/// choice twice, so the canonical target dedupes them. But `/bin/sh` and `/bin/dash` also
+/// canonicalize to the same target on Debian, and those are genuinely different choices a user
+/// means differently (POSIX `sh` semantics vs. dash by name), so the file name keeps them apart.
+///
+/// Symlink resolution failure falls back to the path itself rather than dropping the entry: the
+/// entry has already been proven to be a real file, and a failure to canonicalize is a reason to
+/// keep it, not to hide it.
+fn push_unique_shell(
+    found: &mut Vec<ShellSuggestion>,
+    seen: &mut Vec<(String, PathBuf)>,
+    path: PathBuf,
+) {
+    let Some(name) = path
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+    else {
+        return;
+    };
+    let target = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+    let key = (name.clone(), target);
+    if seen.contains(&key) {
+        return;
+    }
+    seen.push(key);
+    found.push(ShellSuggestion { name, path });
+}
+
+/// The suggestions worth showing under a field currently holding `query` - a case-insensitive
+/// substring match against both the shell's name and its full path, mirroring
+/// [`filter_keybinding_rows`]'s own established "one lowercase substring test per searchable
+/// field" shape rather than inventing a second matching rule.
+///
+/// An empty (or whitespace-only) field matches everything: with nothing typed yet, every real
+/// shell on the machine is a legitimate suggestion. A query nothing matches yields nothing, which
+/// is exactly what should happen when a user is typing a custom path the machine has never heard
+/// of - the field stays entirely usable, the dropdown simply has nothing to add.
+pub fn filter_shell_suggestions<'a>(
+    suggestions: &'a [ShellSuggestion],
+    query: &str,
+) -> Vec<&'a ShellSuggestion> {
+    let query = query.trim().to_lowercase();
+    suggestions
+        .iter()
+        .filter(|suggestion| {
+            query.is_empty()
+                || suggestion.name.to_lowercase().contains(&query)
+                || suggestion
+                    .path
+                    .to_string_lossy()
+                    .to_lowercase()
+                    .contains(&query)
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::rail::state::WorktreeNote;
     use wt_core::diff::WorktreeMergeStatus;
+
+    /// Writes a real, executable file and returns its path - the suggestion detector's entire
+    /// contract is "only offer things that genuinely exist on disk", so its tests need real files,
+    /// not paths that merely look plausible.
+    #[cfg(unix)]
+    fn write_real_program(dir: &std::path::Path, name: &str) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let path = dir.join(name);
+        std::fs::write(&path, "#!/bin/sh\n").expect("write");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        path
+    }
+
+    /// The heart of the Unix detection (GitHub issue #213's follow-up): a real `/etc/shells`-format
+    /// file is parsed for real, and a line whose program is genuinely not on disk is never
+    /// offered, because a listed shell can have been uninstalled and suggesting it would be
+    /// suggesting a tab that cannot start.
+    #[cfg(unix)]
+    #[test]
+    fn only_shells_that_really_exist_on_disk_are_suggested() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let real_bash = write_real_program(dir.path(), "bash");
+        let real_zsh = write_real_program(dir.path(), "zsh");
+        let uninstalled = dir.path().join("ksh");
+
+        let shells_file = dir.path().join("shells");
+        std::fs::write(
+            &shells_file,
+            format!(
+                "# /etc/shells: valid login shells\n\
+                 \n\
+                 {}\n\
+                 {}\n\
+                    {}   \n\
+                 #{}\n",
+                real_bash.display(),
+                uninstalled.display(),
+                real_zsh.display(),
+                real_bash.display(),
+            ),
+        )
+        .expect("write");
+
+        let found = unix_shell_suggestions(&shells_file, |_| None);
+        let paths: Vec<PathBuf> = found.iter().map(|s| s.path.clone()).collect();
+
+        assert_eq!(
+            paths,
+            vec![real_bash.clone(), real_zsh.clone()],
+            "only the two lines naming files that genuinely exist may be offered, in file order, \
+             with the blank line, the comment header, and the commented-out duplicate all skipped"
+        );
+        assert!(
+            !paths.contains(&uninstalled),
+            "a shell listed in /etc/shells but not actually installed must never be offered"
+        );
+        assert_eq!(
+            found[0].name, "bash",
+            "the row's label is the program's own real file name"
+        );
+        assert_eq!(
+            found[1].value(),
+            real_zsh.display().to_string(),
+            "clicking a row types the real absolute path it was found at, nothing invented"
+        );
+    }
+
+    /// A missing `/etc/shells` (a system that genuinely has none) is not an error and not a
+    /// fabricated fallback list - it just means the supplementary `PATH` probe is all there is.
+    #[cfg(unix)]
+    #[test]
+    fn a_missing_shells_file_yields_only_what_path_really_has() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let real_fish = write_real_program(dir.path(), "fish");
+        let resolve = |program: &str| (program == "fish").then(|| real_fish.clone());
+
+        let found = unix_shell_suggestions(&dir.path().join("no-such-shells-file"), resolve);
+
+        assert_eq!(
+            found,
+            vec![ShellSuggestion {
+                name: "fish".to_string(),
+                path: real_fish
+            }],
+            "with no /etc/shells at all, the only honest answer is what a real PATH search found"
+        );
+    }
+
+    /// The supplementary probe's whole reason to exist: fish/nu/pwsh & co. are routinely installed
+    /// by routes that never register them in `/etc/shells`, so they must still be offered - and a
+    /// probed name that `PATH` genuinely doesn't have must not be.
+    #[cfg(unix)]
+    #[test]
+    fn a_shell_missing_from_etc_shells_is_still_found_on_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let real_bash = write_real_program(dir.path(), "bash");
+        let real_nu = write_real_program(dir.path(), "nu");
+        let shells_file = dir.path().join("shells");
+        std::fs::write(&shells_file, format!("{}\n", real_bash.display())).expect("write");
+
+        let found = unix_shell_suggestions(&shells_file, |program| {
+            (program == "nu").then(|| real_nu.clone())
+        });
+        let names: Vec<&str> = found.iter().map(|s| s.name.as_str()).collect();
+
+        assert_eq!(
+            names,
+            vec!["bash", "nu"],
+            "the /etc/shells entries come first, then the genuinely-resolvable supplements"
+        );
+        assert!(
+            !names.contains(&"xonsh"),
+            "a probed name PATH does not have must never be offered - the probe list is a list of \
+             things to *look for*, never a list of things to claim"
+        );
+    }
+
+    /// Real usr-merge duplication (`/bin/bash` and `/usr/bin/bash` are one binary on every modern
+    /// distribution, and this machine's own `/etc/shells` lists both) collapses to one row, while
+    /// two genuinely different *names* for the same binary - `sh` and `dash` on Debian - stay two
+    /// rows, because a user choosing "sh" means something different by it.
+    #[cfg(unix)]
+    #[test]
+    fn the_same_binary_listed_twice_is_offered_once_but_two_names_are_not_merged() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let usr_bin = dir.path().join("usr").join("bin");
+        std::fs::create_dir_all(&usr_bin).expect("mkdir");
+        let real_dash = write_real_program(&usr_bin, "dash");
+        // The real usr-merge shape: /bin is a symlink to /usr/bin, so /bin/dash and /usr/bin/dash
+        // are the same file reached two ways.
+        std::os::unix::fs::symlink("usr/bin", dir.path().join("bin")).expect("symlink");
+        // And the real Debian shape for `sh`: a differently-named symlink to that same binary.
+        std::os::unix::fs::symlink("dash", usr_bin.join("sh")).expect("symlink");
+
+        let shells_file = dir.path().join("shells");
+        std::fs::write(
+            &shells_file,
+            format!(
+                "{}\n{}\n{}\n",
+                dir.path().join("bin").join("dash").display(),
+                real_dash.display(),
+                usr_bin.join("sh").display(),
+            ),
+        )
+        .expect("write");
+
+        let found = unix_shell_suggestions(&shells_file, |_| None);
+        let names: Vec<&str> = found.iter().map(|s| s.name.as_str()).collect();
+
+        assert_eq!(
+            names,
+            vec!["dash", "sh"],
+            "one row for the one dash binary listed under two directories, and a separate row for \
+             the sh name that resolves to it"
+        );
+        assert_eq!(
+            found[0].path,
+            dir.path().join("bin").join("dash"),
+            "the first-listed spelling is the one kept, not the canonicalized target"
+        );
+    }
+
+    /// Windows has no `/etc/shells`, so the two real sources are `%COMSPEC%` (this app's own
+    /// existing default-shell mechanism) and a real `PATH` search - both verified before anything
+    /// is offered. Runs on every platform, deliberately: the alternative is a Windows-only code
+    /// path this project's Linux-only suite could never execute.
+    #[test]
+    fn windows_offers_comspec_and_real_path_hits_and_nothing_else() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let real_cmd = dir.path().join("cmd.exe");
+        std::fs::write(&real_cmd, "").expect("write");
+        let real_pwsh = dir.path().join("pwsh.exe");
+        std::fs::write(&real_pwsh, "").expect("write");
+        let resolve = |program: &str| (program == "pwsh.exe").then(|| real_pwsh.clone());
+
+        let found = windows_shell_suggestions(Some(real_cmd.clone().into_os_string()), resolve);
+
+        assert_eq!(
+            found,
+            vec![
+                ShellSuggestion {
+                    name: "cmd.exe".to_string(),
+                    path: real_cmd
+                },
+                ShellSuggestion {
+                    name: "pwsh.exe".to_string(),
+                    path: real_pwsh
+                },
+            ],
+            "%COMSPEC% first (it is what an empty field already runs), then only the probed names \
+             a real PATH search actually found - never powershell.exe or bash.exe on faith"
+        );
+
+        assert!(
+            windows_shell_suggestions(Some(dir.path().join("gone.exe").into_os_string()), |_| None)
+                .is_empty(),
+            "a %COMSPEC% pointing at a file that isn't there must produce no suggestion at all"
+        );
+        assert!(
+            windows_shell_suggestions(None, |_| None).is_empty(),
+            "no %COMSPEC% and nothing on PATH is an honest empty list, not a guessed one"
+        );
+    }
+
+    /// The filter is a convenience over real data, never a gate: it narrows on both the name and
+    /// the path, and a query matching nothing yields nothing rather than falling back to
+    /// everything (which would offer suggestions for a custom path the machine has never heard of).
+    #[test]
+    fn the_suggestion_filter_matches_name_and_path_case_insensitively() {
+        let suggestions = vec![
+            ShellSuggestion {
+                name: "bash".to_string(),
+                path: PathBuf::from("/bin/bash"),
+            },
+            ShellSuggestion {
+                name: "fish".to_string(),
+                path: PathBuf::from("/usr/local/bin/fish"),
+            },
+        ];
+        let names = |query: &str| -> Vec<String> {
+            filter_shell_suggestions(&suggestions, query)
+                .into_iter()
+                .map(|s| s.name.clone())
+                .collect()
+        };
+
+        assert_eq!(names(""), vec!["bash", "fish"], "an empty field offers all");
+        assert_eq!(names("   "), vec!["bash", "fish"]);
+        assert_eq!(names("FI"), vec!["fish"], "matching is case-insensitive");
+        assert_eq!(
+            names("/usr/local"),
+            vec!["fish"],
+            "a partial path must match too - a user typing an absolute path is exactly who the \
+             suggestions can still help"
+        );
+        assert!(
+            names("/opt/my-own-shell").is_empty(),
+            "a custom path nothing matches must produce an empty list, never the whole list back"
+        );
+    }
+
+    /// The real production detector on the real machine running this suite: whatever it returns,
+    /// every single entry must be a file that genuinely exists right now. This is the honesty
+    /// claim the whole feature rests on, checked against reality rather than a fixture.
+    #[test]
+    fn every_really_detected_shell_is_a_file_that_really_exists() {
+        for suggestion in detect_installed_shells() {
+            assert!(
+                suggestion.path.is_file(),
+                "detection offered {}, which is not a real file - a suggestion that cannot spawn \
+                 must never be shown",
+                suggestion.path.display()
+            );
+            assert!(
+                suggestion.path.is_absolute(),
+                "a suggestion's value is used verbatim as the program to spawn, so it must be an \
+                 absolute path: {}",
+                suggestion.path.display()
+            );
+            assert_eq!(
+                suggestion.value(),
+                suggestion.path.display().to_string(),
+                "the value typed into the field is the real detected path, nothing else"
+            );
+        }
+    }
+
+    /// This project's own CI hosts really do have `/etc/shells` with real shells in it, so the
+    /// production detector must genuinely find some - a detector that always returned an empty
+    /// list would pass every test above without doing anything at all.
+    #[cfg(unix)]
+    #[test]
+    fn real_detection_finds_at_least_one_real_shell_on_this_machine() {
+        if !std::path::Path::new(ETC_SHELLS).exists() {
+            // Honest skip rather than a false pass: a Unix host genuinely without /etc/shells has
+            // nothing for this assertion to be about. The sibling test above still holds there.
+            return;
+        }
+        let found = detect_installed_shells();
+        assert!(
+            !found.is_empty(),
+            "a machine with a real /etc/shells must yield real suggestions"
+        );
+        assert!(
+            found.iter().any(|s| s.name == "sh" || s.name == "bash"),
+            "every Unix host running this suite has a real sh or bash; got {found:?}"
+        );
+    }
 
     /// GitHub issue #213's advisory found/not-found hint: both real forms a user can type, plus
     /// the "nothing configured" case that must never be reported as an error.

--- a/crates/app/src/settings/store.rs
+++ b/crates/app/src/settings/store.rs
@@ -99,8 +99,55 @@ pub struct Settings {
     pub keymap: KeymapSettings,
     pub blame: BlameSettings,
     pub editor: EditorSettings,
+    pub terminal: TerminalSettings,
     pub icon_pack: IconPackSettings,
     pub lsp: BTreeMap<String, LspServerSettings>,
+}
+
+/// The integrated terminal's own behavioural settings (GitHub issue #213: "Allow to select
+/// shell") - deliberately its own section rather than another key under [`AppearanceSettings`],
+/// which is exclusively about text sizes and painted shapes (`terminal_font_size` lives there
+/// because it *is* a font size). What program a shell tab launches is a spawn-time behaviour,
+/// not an appearance.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct TerminalSettings {
+    /// The program a plain Shell tab (`crate::work_surface::agents::AgentKind::Shell`) spawns,
+    /// or `None` for "whatever the OS says" - `$SHELL` on unix, `%COMSPEC%` on Windows, exactly
+    /// the behaviour every install had before this setting existed (see
+    /// `crate::terminal::pane::TerminalSpec::shell`). `None` is the zero-config default, so a
+    /// user who never touches this keeps their real login shell.
+    ///
+    /// Either a bare program name to resolve against `PATH` (`"bash"`, `"fish"`, `"pwsh"`) or an
+    /// absolute path (`"/usr/local/bin/fish"`) - the same two forms `TerminalSpec::command`
+    /// already documents, resolved by the same real mechanism (`portable_pty::CommandBuilder`
+    /// inside `pty_core::spawn`), never by a second path search of this app's own.
+    ///
+    /// Agent CLI tabs (`claude`, `codex`) are unaffected: those spawn their own binary directly
+    /// rather than through a shell.
+    pub shell: Option<String>,
+}
+
+impl TerminalSettings {
+    /// The configured shell as a real, usable program name, or `None` when the user hasn't
+    /// chosen one. Whitespace-only is `None`, not a program named `" "`: the settings row's own
+    /// field is a free-text input, and an accidental space must mean the same thing an empty
+    /// field means (use the OS default), never a guaranteed-to-fail spawn.
+    pub fn shell_override(&self) -> Option<&str> {
+        self.shell
+            .as_deref()
+            .map(str::trim)
+            .filter(|shell| !shell.is_empty())
+    }
+
+    /// Normalizes a hand-edited `shell = "  "` (or `shell = ""`) down to a real `None`, so the
+    /// in-memory value a freshly loaded file produces is the same one the UI would have written.
+    /// Same "a hand-edit gets normalized, not rejected" discipline as
+    /// [`AppearanceSettings::sanitize`]/[`EditorSettings::sanitize`]; called from the same place
+    /// (see [`Settings::load_or_init_at`]).
+    pub fn sanitize(&mut self) {
+        self.shell = self.shell_override().map(str::to_string);
+    }
 }
 
 /// Per-language-server overrides, keyed by the server's own name as this app knows it -
@@ -515,13 +562,15 @@ impl Settings {
     /// doesn't exist yet, writes a default file there (via [`Settings::save_at`]) so the config
     /// file exists on first run; a save failure there is also logged rather than propagated. A
     /// file that does parse still gets every section's own `sanitize` applied
-    /// ([`AppearanceSettings::sanitize`], [`EditorSettings::sanitize`]).
+    /// ([`AppearanceSettings::sanitize`], [`EditorSettings::sanitize`],
+    /// [`TerminalSettings::sanitize`]).
     pub fn load_or_init_at(path: &Path) -> Settings {
         match std::fs::read_to_string(path) {
             Ok(contents) => match toml::from_str::<Settings>(&contents) {
                 Ok(mut settings) => {
                     settings.appearance.sanitize();
                     settings.editor.sanitize();
+                    settings.terminal.sanitize();
                     settings
                 }
                 Err(err) => {
@@ -593,7 +642,7 @@ pub enum ConfigPage {
 /// fixture also names settings this app doesn't implement, e.g. `window.restore_sessions`).
 pub fn config_keys_line(page: ConfigPage) -> &'static str {
     match page {
-        ConfigPage::General => "window.controls",
+        ConfigPage::General => "window.controls \u{b7} terminal.shell",
         ConfigPage::Appearance => {
             "appearance.interface_scale_percent \u{b7} appearance.editor_font_size \u{b7} \
              appearance.terminal_font_size \u{b7} appearance.follow_system_text_size \u{b7} \
@@ -627,9 +676,16 @@ pub enum SnippetLineKind {
     Key,
 }
 
+/// Both sections the General page really owns rows for - `[window]` (window controls) and
+/// `[terminal]` (the shell override, GitHub issue #213). One doc rather than two so the snippet
+/// block keeps showing the whole of what that page writes, in the same order the real file has
+/// it. An unset `shell` renders as a bare `[terminal]` header with no key under it, which is
+/// exactly what the real `settings.toml` on disk contains in that state - `toml` omits a `None`
+/// value entirely rather than inventing a `shell = ""` the loader would then have to un-invent.
 #[derive(Serialize)]
-struct WindowSnippetDoc<'a> {
+struct GeneralSnippetDoc<'a> {
     window: &'a WindowSettings,
+    terminal: &'a TerminalSettings,
 }
 
 #[derive(Serialize)]
@@ -654,14 +710,18 @@ struct EditorSnippetDoc<'a> {
 /// in the output - a bare struct at the TOML document root has no name to put in brackets.
 pub fn snippet_lines(settings: &Settings, page: ConfigPage, format: CfgFormat) -> Vec<SnippetLine> {
     let text = match (page, format) {
-        (ConfigPage::General, CfgFormat::Toml) => toml::to_string_pretty(&WindowSnippetDoc {
+        (ConfigPage::General, CfgFormat::Toml) => toml::to_string_pretty(&GeneralSnippetDoc {
             window: &settings.window,
+            terminal: &settings.terminal,
         })
         .unwrap_or_default(),
-        (ConfigPage::General, CfgFormat::Json) => serde_json::to_string_pretty(&WindowSnippetDoc {
-            window: &settings.window,
-        })
-        .unwrap_or_default(),
+        (ConfigPage::General, CfgFormat::Json) => {
+            serde_json::to_string_pretty(&GeneralSnippetDoc {
+                window: &settings.window,
+                terminal: &settings.terminal,
+            })
+            .unwrap_or_default()
+        }
         (ConfigPage::Appearance, CfgFormat::Toml) => {
             toml::to_string_pretty(&AppearanceSnippetDoc {
                 appearance: &settings.appearance,
@@ -1213,9 +1273,90 @@ mod tests {
             .all(|line| line.kind == SnippetLineKind::Key));
     }
 
+    /// GitHub issue #213. The zero-config default must stay "whatever the OS says" - a `None`,
+    /// never a guessed `"bash"` - and a real hand-edited value must survive a full
+    /// write-then-load round trip through the same file the app itself writes.
+    #[test]
+    fn the_shell_override_defaults_to_none_and_round_trips_through_a_real_file() {
+        assert_eq!(
+            Settings::default().terminal.shell,
+            None,
+            "an install that has never touched this setting must keep using the real OS default"
+        );
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("settings.toml");
+
+        // The default file the app writes on first run must still be a real, complete file -
+        // `to_toml_string` swallows a serialization error into an empty string, so a `None`
+        // that `toml` refused to serialize would silently blank the whole config.
+        let defaults = Settings::default();
+        defaults.save_at(&path).expect("write defaults");
+        let written = std::fs::read_to_string(&path).expect("read back");
+        assert!(
+            written.contains("[window]") && written.contains("[terminal]"),
+            "the written file must really contain every section, got: {written}"
+        );
+        assert!(
+            !written.contains("shell ="),
+            "an unset shell must be omitted from the file entirely, not written as an empty \
+             string: {written}"
+        );
+        assert_eq!(Settings::load_or_init_at(&path), defaults);
+
+        let mut configured = Settings::default();
+        configured.terminal.shell = Some("fish".to_string());
+        configured.save_at(&path).expect("write configured");
+        assert_eq!(
+            Settings::load_or_init_at(&path).terminal.shell.as_deref(),
+            Some("fish")
+        );
+    }
+
+    /// A hand-edited `[terminal] shell` is normalized the same way every other hand-edited value
+    /// is: a blank/whitespace-only entry means "system default", not a program named `" "`.
+    #[test]
+    fn a_hand_edited_blank_shell_loads_as_the_real_system_default() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("settings.toml");
+
+        std::fs::write(&path, "[terminal]\nshell = \"  \"\n").expect("write");
+        assert_eq!(
+            Settings::load_or_init_at(&path).terminal.shell,
+            None,
+            "a whitespace-only shell must load as no override at all"
+        );
+
+        std::fs::write(&path, "[terminal]\nshell = \"  /usr/bin/fish \"\n").expect("write");
+        assert_eq!(
+            Settings::load_or_init_at(&path).terminal.shell.as_deref(),
+            Some("/usr/bin/fish"),
+            "surrounding whitespace is trimmed, the real program name is kept verbatim"
+        );
+    }
+
+    /// The General page's snippet block is a live view of the real file - the shell override has
+    /// to actually appear in it once set, or the banner would name a key the panel never shows.
+    #[test]
+    fn the_general_snippet_shows_the_real_shell_override() {
+        let mut settings = Settings::default();
+        settings.terminal.shell = Some("pwsh".to_string());
+
+        let lines = snippet_lines(&settings, ConfigPage::General, CfgFormat::Toml);
+        let joined: Vec<&str> = lines.iter().map(|l| l.text.as_str()).collect();
+        assert!(joined.contains(&"[terminal]"));
+        assert!(
+            joined.iter().any(|line| line.contains("\"pwsh\"")),
+            "the snippet must show the real configured value, got {joined:?}"
+        );
+    }
+
     #[test]
     fn config_keys_line_only_names_real_persisted_fields() {
-        assert_eq!(config_keys_line(ConfigPage::General), "window.controls");
+        assert_eq!(
+            config_keys_line(ConfigPage::General),
+            "window.controls \u{b7} terminal.shell"
+        );
         assert!(
             config_keys_line(ConfigPage::Appearance).contains("appearance.interface_scale_percent")
         );

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -4889,7 +4889,7 @@ mod commit_composer_tests {
     /// `close_menu_surfaces_except`. What this pins is the *outcome* - one menu open, never two -
     /// through a real interaction; the sweep itself is what makes that outcome structural rather
     /// than a coincidence of which scrim happens to be painted where, and
-    /// `crate::root::menus::menu_surface_tests::opening_any_one_surface_closes_all_five_others`
+    /// `crate::root::menus::menu_surface_tests::opening_any_one_surface_closes_all_the_others`
     /// is the test that fails the moment the sweep stops covering a surface.
     #[gpui::test]
     fn opening_the_commit_menu_closes_an_already_open_plus_menu(cx: &mut TestAppContext) {

--- a/crates/app/src/terminal/pane.rs
+++ b/crates/app/src/terminal/pane.rs
@@ -282,9 +282,20 @@ impl TerminalSpec {
     /// itself never sets, so the fallback needs its own real Windows equivalent rather than the
     /// same Unix path unconditionally, which is a real path (`/bin/bash`) that doesn't exist on
     /// Windows at all - every default-shell spawn there was trying, and failing, to launch it.
-    pub fn shell(cwd: PathBuf) -> Self {
+    ///
+    /// `configured` is the user's own chosen shell (GitHub issue #213 -
+    /// `crate::settings::store::TerminalSettings::shell_override`, threaded here from live
+    /// settings by `crate::work_surface::agents::Agents::spawn`, exactly like the terminal font
+    /// size already is). `None` - the zero-config default - keeps the real OS behaviour above,
+    /// byte for byte. A configured value is handed straight through as the program to spawn: a
+    /// bare name (`"fish"`) is resolved against `PATH` by `pty_core::spawn`'s own
+    /// `CommandBuilder`, the same already-relied-on mechanism [`Self::command`] documents, and an
+    /// absolute path is used as-is. Nothing here checks whether it exists - see
+    /// [`configured_shell_program`]'s docs for why that is deliberate.
+    pub fn shell(cwd: PathBuf, configured: Option<&str>) -> Self {
         Self {
-            program: Self::default_shell_program(),
+            program: configured_shell_program(configured)
+                .unwrap_or_else(Self::default_shell_program),
             args: Vec::new(),
             cwd,
         }
@@ -310,6 +321,15 @@ impl TerminalSpec {
         shell_program_from_env(std::env::var_os("COMSPEC"), "cmd.exe")
     }
 
+    /// The real program a shell tab launches when the user has configured nothing (GitHub issue
+    /// #213) - `$SHELL`'s value on this machine right now, `%COMSPEC%`'s on Windows, resolved by
+    /// exactly the same code [`Self::shell`] falls back to. Exposed so the Settings row's
+    /// placeholder can name the *actual* program an empty field means, rather than a generic
+    /// `"$SHELL"` string that would be a second, drift-prone description of this decision.
+    pub fn default_shell_program_display() -> String {
+        Self::default_shell_program().display().to_string()
+    }
+
     /// An arbitrary command. `program` may be a bare name (e.g. `"claude"`, no path
     /// separator): `pty-core`'s `spawn` resolves it via `PATH` through
     /// `portable_pty::CommandBuilder` the same way a shell would, so this doesn't need the
@@ -331,6 +351,33 @@ fn shell_program_from_env(env_value: Option<std::ffi::OsString>, fallback: &str)
     env_value
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from(fallback))
+}
+
+/// The user's configured shell (GitHub issue #213) as a real program to spawn, or `None` when
+/// there genuinely isn't one - the pure half of [`TerminalSpec::shell`]'s decision, so both
+/// branches are testable on any host without touching the process environment.
+///
+/// Whitespace-only counts as "unset": the settings row backing this is a free-text field, and an
+/// accidental space must fall back to the OS default rather than becoming a program named `" "`
+/// that could never spawn. (`crate::settings::store::TerminalSettings::sanitize` already
+/// normalizes this on load; doing it here too means a value reaching this function by any other
+/// route can't reintroduce the case.)
+///
+/// Deliberately does **not** check that the program exists. `pty_core::spawn` is the only thing
+/// that can answer that question authoritatively - it is the code that actually resolves and
+/// execs it - and it already reports a real, typed `PtyError::Spawn` for a program that isn't
+/// there, which `TerminalPane` surfaces as a real `spawn_error` on the failed tab
+/// (`pty_core`'s own `spawn_reports_typed_error_for_nonexistent_program`). Second-guessing that
+/// here could only produce a *different* answer than the real spawn (a `PATH` search of this
+/// app's own is not the one `CommandBuilder` runs), which would mean silently refusing to launch
+/// a shell that would in fact have worked. The Settings row shows a live, advisory
+/// found/not-found hint instead (`crate::settings::state::detect_shell_status`), which informs
+/// without overriding.
+fn configured_shell_program(configured: Option<&str>) -> Option<PathBuf> {
+    configured
+        .map(str::trim)
+        .filter(|program| !program.is_empty())
+        .map(PathBuf::from)
 }
 
 /// GitHub issue #50's real regression guard: the Windows fallback must be a real Windows path
@@ -362,6 +409,104 @@ mod shell_program_tests {
     /// The real regression: the Windows fallback must be `cmd.exe`, a real path that exists on
     /// Windows - never the Unix `/bin/bash` this crate used to fall back to unconditionally,
     /// which does not exist there at all.
+    /// GitHub issue #213: a configured shell wins over whatever the OS environment says, in both
+    /// of the two documented forms - a bare name (`pty_core::spawn` resolves it on `PATH`) and an
+    /// absolute path (used verbatim).
+    #[test]
+    fn a_configured_shell_replaces_the_environment_default() {
+        let cwd = std::env::temp_dir();
+
+        assert_eq!(
+            TerminalSpec::shell(cwd.clone(), Some("fish")).program,
+            PathBuf::from("fish"),
+            "a bare name must reach the spawn as-is, for pty-core's own PATH resolution"
+        );
+        assert_eq!(
+            TerminalSpec::shell(cwd.clone(), Some("/usr/local/bin/fish")).program,
+            PathBuf::from("/usr/local/bin/fish"),
+            "an absolute path must be used verbatim, not searched for on PATH"
+        );
+        assert!(
+            TerminalSpec::shell(cwd.clone(), Some("fish"))
+                .args
+                .is_empty(),
+            "a configured shell is launched exactly like the default one: no extra arguments"
+        );
+        assert_eq!(
+            TerminalSpec::shell(cwd.clone(), Some("fish")).cwd,
+            cwd,
+            "choosing a shell must not change which directory it starts in"
+        );
+    }
+
+    /// The zero-config path this setting must never disturb: no override (or a blank one, which
+    /// the settings field can genuinely produce) spawns *exactly* what this app spawned before
+    /// the setting existed.
+    #[test]
+    fn no_configured_shell_is_byte_for_byte_the_previous_os_default() {
+        let cwd = std::env::temp_dir();
+        let os_default = TerminalSpec::default_shell_program();
+
+        assert_eq!(TerminalSpec::shell(cwd.clone(), None).program, os_default);
+        assert_eq!(
+            TerminalSpec::shell(cwd.clone(), Some("")).program,
+            os_default,
+            "an empty setting means 'use the system default', not a program with no name"
+        );
+        assert_eq!(
+            TerminalSpec::shell(cwd, Some("   ")).program,
+            os_default,
+            "a whitespace-only setting must fall back too, never spawn a program named ' '"
+        );
+    }
+
+    /// The end-to-end half of the two tests above: the exact `program` a configured bare name
+    /// produces really starts a live process through the same `pty_core::spawn` a shell tab uses,
+    /// and a typo'd one really fails with the typed error `TerminalPane` turns into a visible
+    /// `spawn_error` on the tab - no silent blank pane either way.
+    ///
+    /// unix-only, like `pty-core`'s own suite: it spawns `sh`, a real binary this project's CI
+    /// only runs tests on (see that crate's "Platform scope" docs).
+    #[cfg(unix)]
+    #[test]
+    fn a_configured_shell_really_spawns_and_a_typo_really_fails() {
+        let good = TerminalSpec::shell(std::env::temp_dir(), Some("sh"));
+        let mut session = pty_core::spawn(
+            pty_core::SpawnOptions::new(good.program.clone()).cwd(good.cwd.clone()),
+        )
+        .expect("a configured shell that really exists must spawn a real process");
+        assert!(
+            session.process_id().is_some(),
+            "the configured shell must be a real, running child with a real pid"
+        );
+        session.shutdown().expect("reap the child");
+
+        let bad = TerminalSpec::shell(
+            std::env::temp_dir(),
+            Some("definitely-not-a-real-shell-xyz"),
+        );
+        match pty_core::spawn(pty_core::SpawnOptions::new(bad.program).cwd(bad.cwd)) {
+            Err(err) => assert!(
+                matches!(err, pty_core::PtyError::Spawn(_)),
+                "a misconfigured shell must fail with the same real, typed, reportable error \
+                 any other missing program does, got {err:?}"
+            ),
+            Ok(_) => panic!("a shell that doesn't exist must not spawn"),
+        }
+    }
+
+    /// Trimming happens at the edge, so `" fish "` (a real, plausible copy-paste) spawns `fish`
+    /// rather than a name with spaces in it that no `PATH` entry could ever match.
+    #[test]
+    fn a_configured_shell_is_trimmed_before_it_becomes_a_program() {
+        assert_eq!(
+            configured_shell_program(Some("  zsh  ")),
+            Some(PathBuf::from("zsh"))
+        );
+        assert_eq!(configured_shell_program(None), None);
+        assert_eq!(configured_shell_program(Some(" ")), None);
+    }
+
     #[test]
     fn the_windows_fallback_is_a_real_windows_path_not_the_unix_one() {
         let windows_fallback = shell_program_from_env(None, "cmd.exe");

--- a/crates/app/src/title_bar/menu.rs
+++ b/crates/app/src/title_bar/menu.rs
@@ -1295,6 +1295,7 @@ mod title_menu_tests {
                 AgentKind::Shell,
                 worktree_path.clone(),
                 app.settings.appearance.terminal_font_size,
+                app.settings.terminal.shell_override(),
                 window,
                 cx,
             )
@@ -1395,6 +1396,7 @@ mod title_menu_tests {
                 AgentKind::Shell,
                 worktree_path.clone(),
                 app.settings.appearance.terminal_font_size,
+                app.settings.terminal.shell_override(),
                 window,
                 cx,
             )
@@ -1526,6 +1528,7 @@ mod title_menu_tests {
                 AgentKind::Shell,
                 repo.path().to_path_buf(),
                 app.settings.appearance.terminal_font_size,
+                app.settings.terminal.shell_override(),
                 window,
                 cx,
             );
@@ -1533,6 +1536,7 @@ mod title_menu_tests {
                 AgentKind::Shell,
                 repo.path().to_path_buf(),
                 app.settings.appearance.terminal_font_size,
+                app.settings.terminal.shell_override(),
                 window,
                 cx,
             );
@@ -1544,6 +1548,7 @@ mod title_menu_tests {
                 AgentKind::Shell,
                 other_wt.path().to_path_buf(),
                 app.settings.appearance.terminal_font_size,
+                app.settings.terminal.shell_override(),
                 window,
                 cx,
             );

--- a/crates/app/src/title_bar/render.rs
+++ b/crates/app/src/title_bar/render.rs
@@ -901,6 +901,7 @@ mod agent_state_chip_live_tests {
                 AgentKind::Shell,
                 wt_b.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             );

--- a/crates/app/src/work_surface/agents.rs
+++ b/crates/app/src/work_surface/agents.rs
@@ -47,17 +47,21 @@ impl AgentKind {
         }
     }
 
-    fn spec(self, cwd: PathBuf) -> TerminalSpec {
+    /// `shell_override` is the user's configured shell
+    /// (`crate::settings::store::TerminalSettings::shell_override`, GitHub issue #213) and only
+    /// reaches [`AgentKind::Shell`]: an agent CLI spawns its own fixed binary directly, never
+    /// through a shell, so which shell the user prefers genuinely cannot affect it.
+    fn spec(self, cwd: PathBuf, shell_override: Option<&str>) -> TerminalSpec {
         // Reads through `agent_binary_name` rather than matching `Claude`/`Codex` again here,
         // so it stays the single source of truth for "what binary does this kind spawn".
         match self.agent_binary_name() {
             Some(binary) => TerminalSpec::command(binary, Vec::new(), cwd),
-            None => TerminalSpec::shell(cwd),
+            None => TerminalSpec::shell(cwd, shell_override),
         }
     }
 
     /// The literal command name this kind spawns as - `None` for [`AgentKind::Shell`],
-    /// which resolves `$SHELL` rather than a fixed binary name.
+    /// which resolves the configured shell (or `$SHELL`) rather than a fixed binary name.
     ///
     /// Public so `crate::settings::state`'s Agents page can look up the same `$PATH` name this
     /// method hands `TerminalSpec::command` at spawn time, instead of a second hardcoded
@@ -157,21 +161,26 @@ impl Agents {
     ///
     /// Subscribes to the new pane's [`TerminalPaneEvent`]s so a click on a detected
     /// path/`path:line` link in this agent's terminal output opens it as a file tab
-    /// (`crate::root::AdeApp::open_terminal_link`). `terminal_font_size_px` is read fresh
-    /// from live settings by every call site, so a freshly spawned pane never starts out
-    /// mismatched from what Settings › Appearance shows.
+    /// (`crate::root::AdeApp::open_terminal_link`). `terminal_font_size_px` and
+    /// `shell_override` are both read fresh from live settings by every call site (the same
+    /// threading pattern, for the same reason): a freshly spawned pane never starts out
+    /// mismatched from what Settings shows. `shell_override` is GitHub issue #213's configured
+    /// shell (`crate::settings::store::TerminalSettings::shell_override`) - `None` means "the
+    /// real OS default", and it only affects [`AgentKind::Shell`] tabs (see
+    /// [`AgentKind::spec`]).
     pub fn spawn(
         &mut self,
         kind: AgentKind,
         cwd: PathBuf,
         terminal_font_size_px: f32,
+        shell_override: Option<&str>,
         window: &mut Window,
         cx: &mut Context<AdeApp>,
     ) -> AgentId {
         let id = self.next_id;
         self.next_id += 1;
 
-        let spec = kind.spec(cwd.clone());
+        let spec = kind.spec(cwd.clone(), shell_override);
         let pane = cx.new(|cx| TerminalPane::new(spec, terminal_font_size_px, cx));
         let link_subscription =
             cx.subscribe_in(&pane, window, move |app, _pane, event, window, cx| {

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -81,6 +81,7 @@ impl AdeApp {
             kind,
             cwd,
             self.settings.appearance.terminal_font_size,
+            self.settings.terminal.shell_override(),
             window,
             cx,
         );
@@ -416,6 +417,7 @@ impl AdeApp {
             kind,
             cwd,
             self.settings.appearance.terminal_font_size,
+            self.settings.terminal.shell_override(),
             window,
             cx,
         );
@@ -447,6 +449,7 @@ impl AdeApp {
                     AgentKind::Shell,
                     cwd,
                     self.settings.appearance.terminal_font_size,
+                    self.settings.terminal.shell_override(),
                     window,
                     cx,
                 );
@@ -1392,6 +1395,7 @@ impl AdeApp {
                     kind,
                     cwd,
                     this.settings.appearance.terminal_font_size,
+                    this.settings.terminal.shell_override(),
                     window,
                     cx,
                 );
@@ -2646,6 +2650,7 @@ mod tab_scoping_tests {
                 AgentKind::Shell,
                 wt_a.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             );
@@ -2653,6 +2658,7 @@ mod tab_scoping_tests {
                 AgentKind::Claude,
                 wt_a.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             );
@@ -2733,6 +2739,7 @@ mod tab_scoping_tests {
                 AgentKind::Shell,
                 wt_a.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             );
@@ -2741,6 +2748,7 @@ mod tab_scoping_tests {
                 AgentKind::Shell,
                 wt_b.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             );
@@ -2793,6 +2801,7 @@ mod tab_scoping_tests {
                 AgentKind::Shell,
                 wt_a.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             );
@@ -2800,6 +2809,7 @@ mod tab_scoping_tests {
                 AgentKind::Shell,
                 wt_a.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             );
@@ -2854,6 +2864,7 @@ mod tab_scoping_tests {
                 AgentKind::Shell,
                 wt_a.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             )
@@ -2864,6 +2875,7 @@ mod tab_scoping_tests {
                 AgentKind::Shell,
                 wt_b.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             );
@@ -2910,6 +2922,7 @@ mod tab_scoping_tests {
                 AgentKind::Shell,
                 repo.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             );
@@ -2917,6 +2930,7 @@ mod tab_scoping_tests {
                 AgentKind::Shell,
                 repo.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             );
@@ -3022,6 +3036,7 @@ mod tab_scoping_tests {
                 AgentKind::Shell,
                 repo.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             );
@@ -3096,6 +3111,7 @@ mod tab_scoping_tests {
                 AgentKind::Claude,
                 repo.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             );
@@ -3154,6 +3170,7 @@ mod tab_scoping_tests {
                 AgentKind::Claude,
                 repo.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             );
@@ -3257,6 +3274,7 @@ mod tab_scoping_tests {
                 AgentKind::Shell,
                 repo.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             );
@@ -3334,6 +3352,7 @@ mod tab_scoping_tests {
                 AgentKind::Shell,
                 repo.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             );
@@ -3436,6 +3455,7 @@ mod tab_scoping_tests {
                 AgentKind::Shell,
                 repo.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             );
@@ -3493,6 +3513,7 @@ mod tab_scoping_tests {
                 AgentKind::Claude,
                 wt_a.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             );
@@ -3500,6 +3521,7 @@ mod tab_scoping_tests {
                 AgentKind::Claude,
                 wt_a.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             );
@@ -3537,6 +3559,7 @@ mod tab_scoping_tests {
                 AgentKind::Shell,
                 wt_a.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             );
@@ -3552,6 +3575,7 @@ mod tab_scoping_tests {
                 AgentKind::Claude,
                 wt_a.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             );
@@ -3585,6 +3609,7 @@ mod tab_scoping_tests {
                 AgentKind::Shell,
                 wt_a.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             )
@@ -3777,6 +3802,7 @@ mod tab_scoping_tests {
                 AgentKind::Shell,
                 wt_a.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             );
@@ -3784,6 +3810,7 @@ mod tab_scoping_tests {
                 AgentKind::Claude,
                 wt_a.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             );
@@ -3858,6 +3885,7 @@ mod tab_scoping_tests {
                 AgentKind::Shell,
                 repo.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             )
@@ -3922,6 +3950,7 @@ mod tab_scoping_tests {
                 AgentKind::Shell,
                 wt_a.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             );
@@ -3974,6 +4003,7 @@ mod tab_scoping_tests {
                 AgentKind::Shell,
                 wt_a.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             );
@@ -4089,6 +4119,7 @@ mod terminal_clear_action_tests {
                 AgentKind::Shell,
                 repo.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             );
@@ -4096,6 +4127,7 @@ mod terminal_clear_action_tests {
                 AgentKind::Shell,
                 repo.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             );
@@ -4208,6 +4240,7 @@ mod tab_order_persistence_tests {
                 AgentKind::Claude,
                 repo.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             );
@@ -4247,6 +4280,7 @@ mod tab_order_persistence_tests {
                 AgentKind::Claude,
                 repo.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             );
@@ -4356,6 +4390,7 @@ mod terminal_clipboard_action_tests {
                 AgentKind::Shell,
                 repo.path().to_path_buf(),
                 12.0,
+                None,
                 window,
                 cx,
             );

--- a/crates/app/src/worktree_history/flow.rs
+++ b/crates/app/src/worktree_history/flow.rs
@@ -269,6 +269,7 @@ mod worktree_history_regression_tests {
                 AgentKind::Shell,
                 cwd,
                 app.settings.appearance.terminal_font_size,
+                app.settings.terminal.shell_override(),
                 window,
                 cx,
             )


### PR DESCRIPTION
## Summary
- Closes #213. `TerminalSpec::shell` always resolved `$SHELL`/`%COMSPEC%` with no override - now a real, persisted `[terminal] shell` setting, a genuinely new Settings row on the General page, **and** a real detected-shell suggestion dropdown under it (added as a follow-up in this same PR after discussing the UX with the user).
- `None`/blank is the true zero-config default - byte-for-byte the previous OS-resolved behavior, on every platform. A configured value is handed straight through as the program to spawn (bare name resolves via `PATH` through `pty_core`'s existing `CommandBuilder` mechanism, same as an agent CLI already does; absolute path used as-is).
- Threaded from live settings through `AgentKind::spec`/`Agents::spawn` (a new `shell_override: Option<&str>` parameter, following the exact precedent already established for `terminal_font_size_px`) to every real spawn site. Agent CLIs (`claude`, `codex`) are correctly unaffected.
- **No pre-flight existence check on the typed value**, deliberately: `pty_core::spawn` is the only thing that can authoritatively answer "does this program resolve", and it already reports a real, typed error that this app already surfaces on a failed tab. Instead the row shows a live, advisory found/not-found hint.

### Follow-up: real shell auto-detection + suggestion dropdown
- The field stays genuinely free-text (anything not detected still works, no gatekeeping), but now suggests shells the machine **actually has**, as a dropdown under the field:
  - **Unix**: parses the real `/etc/shells`, keeping only entries that are a real file on disk right now, plus a short, evidence-justified `PATH` supplement (`fish`, `nu`, `pwsh`, `elvish`, `xonsh` - shells whose own install docs say to hand-edit `/etc/shells`, so they're routinely missing from it even when installed) - each only offered if a real `PATH` search finds it.
  - **Windows**: no `/etc/shells` equivalent exists, so this checks `%COMSPEC%` (this app's own existing default) plus a real `PATH` search for `powershell.exe`/`pwsh.exe`/`bash.exe` - compiled on every platform (only *called* under `cfg(windows)`) specifically so the Linux CI suite actually executes and tests this logic rather than only type-checking it.
  - Dedup keyed on `(file name, canonicalized target)` - collapses usr-merge's `/bin/bash` + `/usr/bin/bash` duplicate, while keeping `/bin/sh` and `/bin/dash` (same symlink target, genuinely different shells) apart.
  - The dropdown is the seventh surface added to this app's existing one-menu-at-a-time invariant (`MenuSurface`, from issue #176) rather than a new, parallel dismissal mechanism - a compile error if it were wired incompletely.
  - Clicking a suggestion goes through the exact same `TextField::set` + persistence path as typing, so it's one ordinary undoable edit, and detection runs only on real gestures (Settings open, field click, edit) - never on `render`.

## Test plan
- [x] `settings::store`: the override defaults to `None` and round-trips through a real file; a hand-edited blank value loads as the real system default; the General page's config snippet shows the real override
- [x] `terminal::pane::shell_program_tests`: a configured shell replaces the environment default; unset is byte-for-byte the previous OS default; a configured value is trimmed; a real `pty_core::spawn` with a real typo really fails with a real typed error, and a real one really spawns with a real pid
- [x] `settings::state`: `unix_shell_suggestions`/`windows_shell_suggestions` against real temp `/etc/shells`/`%COMSPEC%` fixtures - only real files are ever offered, the usr-merge dedup case, `sh`/`dash` staying distinct, case-insensitive name/path filtering, and a real end-to-end run against whatever this machine actually has installed
- [x] `settings::render::shell_setting_tests` + `shell_suggestion_dropdown_tests` (10 real GPUI tests): a configured shell is what a real spawned tab actually runs; a typo fails visibly on the tab and the settings row; a real click + real keystrokes into the painted field persists and the next real tab uses it; clicking a real suggestion configures it and the next tab really runs it; a custom value the machine has never heard of still works; a clicked suggestion is a single undoable edit; the dropdown dismisses the same way every other menu in the app already does
- [x] Real screenshots of the running app, both rounds: the shell override visibly changing what a tab runs and its typo-failure path; and the dropdown listing this machine's real seven detected shells (usr-merge duplicates genuinely collapsed) with a click landing the resolved path in the field and the live `settings.toml` view
- [x] I independently traced every real (non-test) `Agents::spawn` call site to confirm it reads `settings.terminal.shell_override()` fresh, not a stale/hardcoded value
- [x] `cargo build`, `cargo clippy -p app -p lsp-core --lib --tests` clean across both commits
- [x] `cargo fmt` diffed against a backup across every touched file, both rounds - zero drift on pre-existing code
- [x] `cargo test -p app --lib` full suite: 2013 passed, 0 failed (latest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)