### PR TITLE
fix(app): let X11 users force GPUI's display scale factor

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -625,6 +625,50 @@ pub(crate) fn default_window_options(cx: &App) -> WindowOptions {
     }
 }
 
+/// The environment variable GPUI's X11 client reads a forced scale factor from - the literal
+/// name from its own `get_scale_factor`
+/// (`gpui_linux/src/linux/x11/client.rs`, this workspace's pinned `zed` rev). Named here rather
+/// than spelled out at the one call site in `crate::main` so the string and the code that
+/// explains it stay together.
+pub const GPUI_X11_SCALE_FACTOR_ENV: &str = "GPUI_X11_SCALE_FACTOR";
+
+/// GitHub issue #216. Decides what, if anything, `crate::main` should put in
+/// [`GPUI_X11_SCALE_FACTOR_ENV`] before GPUI starts - the whole decision, factored out of `main`
+/// so it can be tested without a process to mutate. `existing_env` is whatever that variable
+/// already holds in the real process environment (`std::env::var` at the call site).
+///
+/// Why an environment variable at all: GPUI resolves the X11 scale factor exactly once, while its
+/// X11 client initialises inside `gpui_platform::application()`, and this variable is the only
+/// override it offers - there is no runtime API, and `gpui` is a pinned git dependency with no
+/// `[patch]` section, so it cannot be changed from here. That is also why the Appearance page's
+/// hint says a restart is required.
+///
+/// Two decisions worth stating, both visible in the tests below:
+///
+/// - An override already present in the environment wins. A user who exported
+///   `GPUI_X11_SCALE_FACTOR` in their shell profile or launcher meant it for this launch
+///   specifically; silently overwriting it from a persisted setting would make that export
+///   look broken. An empty or whitespace-only value is not an override - GPUI itself treats the
+///   empty string as "not set" (`DpiMode::NotSet`) - so it is passed over.
+/// - The value is re-clamped through
+///   [`settings::store::sanitize_display_scale_override`] rather than trusted. Loading normally
+///   sanitizes it already, but GPUI *panics* (not falls back) on a non-positive or non-normal
+///   float, so the last step before handing it over does not assume anything about how the
+///   `Settings` value was obtained.
+pub fn x11_scale_factor_env_value(
+    settings: &settings::store::Settings,
+    existing_env: Option<&str>,
+) -> Option<String> {
+    if existing_env.is_some_and(|value| !value.trim().is_empty()) {
+        return None;
+    }
+    settings
+        .appearance
+        .display_scale_override
+        .map(settings::store::sanitize_display_scale_override)
+        .map(|factor| factor.to_string())
+}
+
 /// Opens the ADE window against `repo_path` and runs the GPUI event loop until the window is
 /// closed. Blocks the calling thread for the application's lifetime, mirroring
 /// `gpui::Application::run`'s own contract (`vendor/zed/crates/gpui/examples/hello_world.rs`).
@@ -679,6 +723,91 @@ pub fn run(repo_path: Option<PathBuf>) {
                 }
             }
         });
+}
+
+/// GitHub issue #216's real decision, tested without a process environment to mutate - see
+/// [`x11_scale_factor_env_value`]'s own docs.
+///
+/// What these tests deliberately do **not** claim: that GPUI then renders at the forced scale.
+/// That happens inside a pinned dependency, at X11-client init, against a real display - there is
+/// no headless way to assert it from here. What is proven is the whole of this app's side of the
+/// contract: which string, if any, reaches the variable GPUI reads.
+#[cfg(test)]
+mod x11_scale_factor_env_tests {
+    use super::x11_scale_factor_env_value;
+    use crate::settings::store::{
+        Settings, DISPLAY_SCALE_OVERRIDE_MAX, DISPLAY_SCALE_OVERRIDE_MIN,
+    };
+
+    #[test]
+    fn no_override_configured_leaves_the_environment_untouched() {
+        assert_eq!(x11_scale_factor_env_value(&Settings::default(), None), None);
+    }
+
+    #[test]
+    fn a_configured_override_becomes_the_bare_float_gpui_parses() {
+        let mut settings = Settings::default();
+
+        settings.appearance.display_scale_override = Some(1.25);
+        assert_eq!(
+            x11_scale_factor_env_value(&settings, None).as_deref(),
+            Some("1.25")
+        );
+
+        // A whole number must not pick up any decoration GPUI's `var.parse::<f32>()` would
+        // choke on (no `%`, no `x`) - "1" is what the reporter's own case needs to produce.
+        settings.appearance.display_scale_override = Some(1.0);
+        assert_eq!(
+            x11_scale_factor_env_value(&settings, None).as_deref(),
+            Some("1")
+        );
+    }
+
+    /// GPUI panics rather than falling back on a value outside its `valid_scale_factor`, so this
+    /// last step re-clamps instead of trusting that the `Settings` came from a sanitizing load.
+    #[test]
+    fn an_unsanitized_settings_value_is_still_clamped_before_it_reaches_gpui() {
+        let mut settings = Settings::default();
+
+        settings.appearance.display_scale_override = Some(90.0);
+        assert_eq!(
+            x11_scale_factor_env_value(&settings, None).as_deref(),
+            Some(DISPLAY_SCALE_OVERRIDE_MAX.to_string().as_str())
+        );
+
+        settings.appearance.display_scale_override = Some(0.0);
+        assert_eq!(
+            x11_scale_factor_env_value(&settings, None).as_deref(),
+            Some(DISPLAY_SCALE_OVERRIDE_MIN.to_string().as_str())
+        );
+    }
+
+    #[test]
+    fn a_real_override_already_in_the_environment_is_never_overwritten() {
+        let mut settings = Settings::default();
+        settings.appearance.display_scale_override = Some(1.25);
+
+        assert_eq!(
+            x11_scale_factor_env_value(&settings, Some("2")),
+            None,
+            "an exported GPUI_X11_SCALE_FACTOR is this launch's explicit choice and wins"
+        );
+        assert_eq!(
+            x11_scale_factor_env_value(&settings, Some("randr")),
+            None,
+            "including GPUI's own literal `randr` mode, which is not a number"
+        );
+
+        // GPUI itself reads an empty value as `DpiMode::NotSet`, so neither of these is a real
+        // override to defer to.
+        for empty in ["", "   "] {
+            assert_eq!(
+                x11_scale_factor_env_value(&settings, Some(empty)).as_deref(),
+                Some("1.25"),
+                "an empty GPUI_X11_SCALE_FACTOR={empty:?} is not an override"
+            );
+        }
+    }
 }
 
 /// GitHub issue #17's scoping matrix, proven as predicate logic against every real key-context

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -6,6 +6,12 @@
 //! beneath it, `root::AdeApp::new_with_settings`) resolves what to do with `None` itself: reopen
 //! the last-remembered folder if one was persisted, or a genuinely empty window if not - see
 //! those functions' own docs.
+//!
+//! GitHub issue #216 adds the one other thing that genuinely has to happen out here rather than
+//! inside `app::run`: exporting the persisted X11 scale-factor override, which GPUI only reads
+//! from the environment, once, as its X11 client starts. The decision itself lives in
+//! `app::x11_scale_factor_env_value` (which is unit-tested); this file stays the thin glue it has
+//! always been.
 
 use std::env;
 use std::path::PathBuf;
@@ -14,8 +20,47 @@ use std::process::ExitCode;
 fn main() -> ExitCode {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    apply_display_scale_override();
+
     let repo_path = env::args_os().nth(1).map(PathBuf::from);
 
     app::run(repo_path);
     ExitCode::SUCCESS
+}
+
+/// GitHub issue #216 ("Scaling issues on Linux"): hands GPUI's X11 client the user's forced scale
+/// factor, if they configured one on the Appearance page
+/// (`app::settings::store::AppearanceSettings::display_scale_override`).
+///
+/// Scoped to the two targets that actually build a GPUI backend able to read this - see
+/// `crates/app/Cargo.toml`, where `gpui_platform`'s `x11` feature is requested under
+/// `cfg(any(target_os = "linux", target_os = "freebsd"))`. On a Wayland session the variable is
+/// simply never read, which is what the settings row's own hint says.
+///
+/// `Settings::load_or_init` is a plain synchronous file read with no GPUI dependency, so calling
+/// it here - before any `App` exists - is not a layering violation; the same load happens again
+/// inside `app::run` for the window itself.
+#[cfg(any(target_os = "linux", target_os = "freebsd"))]
+fn apply_display_scale_override() {
+    let settings = app::settings::store::Settings::load_or_init();
+    let existing = env::var(app::GPUI_X11_SCALE_FACTOR_ENV).ok();
+    let Some(value) = app::x11_scale_factor_env_value(&settings, existing.as_deref()) else {
+        return;
+    };
+
+    log::info!(
+        "forcing {}={value} from appearance.display_scale_override (X11 sessions only; \
+         restart-scoped)",
+        app::GPUI_X11_SCALE_FACTOR_ENV
+    );
+    // SAFETY: `std::env::set_var` is `unsafe` as of this workspace's edition because the process
+    // environment is global mutable state that a concurrent `getenv` in another thread can read
+    // (or a concurrent `setenv` can reallocate under). Neither hazard exists here: this runs at
+    // the very top of `main`, before `app::run` starts GPUI and before this process has spawned
+    // any thread of its own - so there is no other thread in existence to race. It is also the
+    // only `set_var` call in this workspace; every other place that needed a custom environment
+    // (see `pty_core::resolve_in_path_var` and `lsp_core::client`'s injected resolvers) passes
+    // the value as an argument specifically to avoid mutating the real one.
+    unsafe { env::set_var(app::GPUI_X11_SCALE_FACTOR_ENV, value) };
 }

--- a/crates/app/src/settings/render.rs
+++ b/crates/app/src/settings/render.rs
@@ -1588,6 +1588,7 @@ impl AdeApp {
             .child(editor_font_row)
             .child(terminal_font_row)
             .child(follow_system_row)
+            .child(self.render_display_scale_override_rows(cx))
             .child(
                 div()
                     .pt(px(20.0))
@@ -1603,6 +1604,76 @@ impl AdeApp {
             .child(indent_guides_row)
             .child(bracket_pair_row)
             .child(self.render_snippet_block(settings_store::ConfigPage::Appearance))
+    }
+
+    /// GitHub issue #216's rows: a toggle that turns
+    /// [`settings_store::AppearanceSettings::display_scale_override`] from `None` (GPUI detects
+    /// the scale, as it always has) into a real forced factor, plus - only while it is on - a
+    /// stepper for that factor.
+    ///
+    /// Two rows rather than one control, because the setting is genuinely two states: "leave
+    /// detection alone" is not the same as "force 1.0", and a bare stepper could not express the
+    /// first. The stepper is hidden rather than disabled while the override is off, so the page
+    /// never shows a number that isn't being used.
+    ///
+    /// Built as a `#[cfg]` pair of same-named methods - the idiom
+    /// `crate::status_bar::render::AdeApp::render_status_agents_cluster` already established for a
+    /// platform-conditional *rendered* element - scoped to the two targets whose `gpui_platform`
+    /// dependency requests the `x11` feature (`crates/app/Cargo.toml`). Everywhere else the
+    /// variable this writes is never read by anything, so the row would be a control bound to
+    /// nothing.
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    fn render_display_scale_override_rows(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let override_factor = self.settings.appearance.display_scale_override;
+
+        let toggle_row = self.render_settings_row(
+            "Override display scale",
+            "Ignore the scale GPUI detects for this display. X11 sessions only, not Wayland - \
+             takes effect the next time Jerry starts.",
+            self.render_toggle_control(
+                "settings-display-scale-override",
+                override_factor.is_some(),
+                cx,
+                |this, cx| this.toggle_display_scale_override(cx),
+            ),
+        );
+        let factor_row = override_factor.map(|factor| {
+            self.render_settings_row(
+                "Forced scale factor",
+                "1.00\u{d7} is unscaled - what a display that reports no scaling should look like.",
+                self.render_stepper_control(
+                    "settings-display-scale-factor",
+                    format!("{factor:.2}\u{d7}"),
+                    cx,
+                    |this, cx| {
+                        this.adjust_display_scale_override(
+                            -settings_store::DISPLAY_SCALE_OVERRIDE_STEP,
+                            cx,
+                        )
+                    },
+                    |this, cx| {
+                        this.adjust_display_scale_override(
+                            settings_store::DISPLAY_SCALE_OVERRIDE_STEP,
+                            cx,
+                        )
+                    },
+                ),
+            )
+        });
+
+        div()
+            .flex()
+            .flex_col()
+            .child(toggle_row)
+            .children(factor_row)
+    }
+
+    /// Non-X11 build: this setting's only real effect is `GPUI_X11_SCALE_FACTOR`, which nothing on
+    /// this platform reads (see the `#[cfg]` twin above), so the Appearance page shows no row at
+    /// all rather than a switch that would persist a value and change nothing.
+    #[cfg(not(any(target_os = "linux", target_os = "freebsd")))]
+    fn render_display_scale_override_rows(&self, _cx: &mut Context<Self>) -> impl IntoElement {
+        div()
     }
 
     /// One Appearance page preview card - a static approximation of `percent`'s scale on a fixed
@@ -3301,6 +3372,55 @@ impl AdeApp {
     fn toggle_follow_system_text_size(&mut self, cx: &mut Context<Self>) {
         self.settings.appearance.follow_system_text_size =
             !self.settings.appearance.follow_system_text_size;
+        self.persist_settings(cx);
+        cx.notify();
+    }
+
+    /// GitHub issue #216's toggle: flips
+    /// [`settings_store::AppearanceSettings::display_scale_override`] between `None` (GPUI's own
+    /// detection) and a real forced factor, starting at
+    /// [`settings_store::DISPLAY_SCALE_OVERRIDE_DEFAULT`] - `1.0`, the unscaled value the reported
+    /// bug is asking for, so turning the switch on is already the fix in the common case.
+    ///
+    /// Persist-and-notify only, with no live application, and that is the whole honest story:
+    /// GPUI reads `GPUI_X11_SCALE_FACTOR` once while its X11 client initialises, so the new value
+    /// is picked up by `crate::main` at the *next* launch. The row's hint says so.
+    ///
+    /// `#[cfg]`-scoped to match [`Self::render_display_scale_override_rows`], its only caller -
+    /// an ungated mutator would be dead code on every other platform.
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    pub(in crate::settings) fn toggle_display_scale_override(&mut self, cx: &mut Context<Self>) {
+        self.settings.appearance.display_scale_override =
+            match self.settings.appearance.display_scale_override {
+                Some(_) => None,
+                None => Some(settings_store::DISPLAY_SCALE_OVERRIDE_DEFAULT),
+            };
+        self.persist_settings(cx);
+        cx.notify();
+    }
+
+    /// GitHub issue #216's stepper. A no-op while the override is off - there is no factor to
+    /// step, and inventing one would silently turn the override on from a button the page isn't
+    /// even showing then.
+    ///
+    /// Each result is snapped back to the two decimal places the row displays, rather than left as
+    /// whatever repeatedly adding [`settings_store::DISPLAY_SCALE_OVERRIDE_STEP`] to an `f32`
+    /// accumulates. Twenty clicks then land on a real `2.00`, not on a `1.9999998` that would look
+    /// like `2.00` in the row while being written to `settings.toml` - and exported to GPUI -
+    /// verbatim. Two decimals is exactly the step's own precision (`0.05`), so no reachable value
+    /// is lost to the snap.
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    pub(in crate::settings) fn adjust_display_scale_override(
+        &mut self,
+        delta: f32,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(current) = self.settings.appearance.display_scale_override else {
+            return;
+        };
+        let stepped = ((current + delta) * 100.0).round() / 100.0;
+        self.settings.appearance.display_scale_override =
+            Some(settings_store::sanitize_display_scale_override(stepped));
         self.persist_settings(cx);
         cx.notify();
     }
@@ -6870,6 +6990,18 @@ mod bracket_pair_colorization_settings_tests {
         });
         cx.run_until_parked();
 
+        // This row now sits past the bottom of the page's own scroll viewport (GitHub issue #216
+        // added a row above it), so it has to be scrolled to before it can be clicked - exactly
+        // what a real user does. Without this the click lands on a clipped position and silently
+        // hits nothing, which is a real hazard for a test that would otherwise still "pass" its
+        // `debug_bounds` lookup: painted bounds are recorded even for content scrolled out of
+        // view.
+        app.update(cx, |app, cx| {
+            app.settings_content_scroll_handle.scroll_to_bottom();
+            cx.notify();
+        });
+        cx.run_until_parked();
+
         let bounds = cx
             .debug_bounds("settings-bracket-pair-colorization")
             .expect("the Bracket pair colors toggle must really paint on the Appearance page");
@@ -6900,6 +7032,193 @@ mod bracket_pair_colorization_settings_tests {
                 .appearance
                 .bracket_pair_colorization),
             "and clicking it again must flip it back"
+        );
+    }
+}
+
+/// GitHub issue #216's Appearance rows, driven through the same real mutators a click invokes.
+///
+/// Scoped to the platforms that render the rows at all - see
+/// [`AdeApp::render_display_scale_override_rows`]'s `#[cfg]` pair.
+///
+/// The honest limit of this coverage: it proves the setting is a real, persisted, correctly
+/// clamped tri-state that survives a reload, and `crate::x11_scale_factor_env_tests` proves which
+/// string that turns into for `GPUI_X11_SCALE_FACTOR`. Neither proves GPUI then paints at that
+/// scale - that happens inside a pinned dependency during X11 client init, against a real display
+/// this test harness does not have.
+#[cfg(test)]
+#[cfg(any(target_os = "linux", target_os = "freebsd"))]
+mod display_scale_override_settings_tests {
+    use crate::root::AdeApp;
+    use crate::settings::state::SettingsPage;
+    use crate::settings::store as settings_store;
+    use gpui::TestAppContext;
+    use std::path::PathBuf;
+
+    /// Same real-load-before-construct helper the neighbouring settings tests use.
+    fn open_app_with_state_dir(
+        cx: &mut TestAppContext,
+        repo_path: PathBuf,
+        settings_path: PathBuf,
+    ) -> (gpui::Entity<AdeApp>, &mut gpui::VisualTestContext) {
+        let settings = settings_store::Settings::load_or_init_at(&settings_path);
+        cx.add_window_view(|window, cx| {
+            AdeApp::new_with_settings(
+                Some(repo_path),
+                true,
+                settings,
+                Some(settings_path),
+                window,
+                cx,
+            )
+        })
+    }
+
+    #[gpui::test]
+    fn the_toggle_turns_detection_into_a_real_forced_factor_and_persists_it(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let state_dir = tempfile::tempdir().expect("tempdir");
+        let settings_path = state_dir.path().join("settings.toml");
+        let (app, cx) =
+            open_app_with_state_dir(cx, repo.path().to_path_buf(), settings_path.clone());
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.settings.appearance.display_scale_override),
+            None,
+            "sanity check: an install that never touched this keeps GPUI's own detection"
+        );
+
+        app.update(cx, |app, cx| app.toggle_display_scale_override(cx));
+        assert_eq!(
+            app.read_with(cx, |app, _| app.settings.appearance.display_scale_override),
+            Some(settings_store::DISPLAY_SCALE_OVERRIDE_DEFAULT),
+            "turning it on must produce a real unscaled 1.0, which is the reported bug's own fix"
+        );
+        cx.run_until_parked();
+
+        let (reloaded, cx) =
+            open_app_with_state_dir(cx, repo.path().to_path_buf(), settings_path.clone());
+        assert_eq!(
+            reloaded.read_with(cx, |app, _| app.settings.appearance.display_scale_override),
+            Some(settings_store::DISPLAY_SCALE_OVERRIDE_DEFAULT),
+            "it must have really reached disk - `main` reads the file, not this process's memory"
+        );
+
+        app.update(cx, |app, cx| app.toggle_display_scale_override(cx));
+        assert_eq!(
+            app.read_with(cx, |app, _| app.settings.appearance.display_scale_override),
+            None,
+            "turning it back off must restore detection, not leave a forced 1.0 behind"
+        );
+        cx.run_until_parked();
+
+        let (reloaded_off, cx) =
+            open_app_with_state_dir(cx, repo.path().to_path_buf(), settings_path);
+        assert_eq!(
+            reloaded_off.read_with(cx, |app, _| app.settings.appearance.display_scale_override),
+            None
+        );
+    }
+
+    #[gpui::test]
+    fn the_stepper_moves_in_whole_steps_and_stops_at_the_real_bounds(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let state_dir = tempfile::tempdir().expect("tempdir");
+        let settings_path = state_dir.path().join("settings.toml");
+        let (app, cx) = open_app_with_state_dir(cx, repo.path().to_path_buf(), settings_path);
+        let step = settings_store::DISPLAY_SCALE_OVERRIDE_STEP;
+
+        app.update(cx, |app, cx| {
+            // While the override is off there is nothing to step, and stepping must not switch it
+            // on behind a control the page isn't showing.
+            app.adjust_display_scale_override(step, cx);
+        });
+        assert_eq!(
+            app.read_with(cx, |app, _| app.settings.appearance.display_scale_override),
+            None
+        );
+
+        app.update(cx, |app, cx| {
+            app.toggle_display_scale_override(cx);
+            app.adjust_display_scale_override(step, cx);
+        });
+        assert_eq!(
+            app.read_with(cx, |app, _| app.settings.appearance.display_scale_override),
+            Some(1.05)
+        );
+
+        // Twenty more increments must land exactly on 2.05, not on an accumulated float drift -
+        // the value is written to `settings.toml` and exported to GPUI as-is.
+        app.update(cx, |app, cx| {
+            for _ in 0..20 {
+                app.adjust_display_scale_override(step, cx);
+            }
+        });
+        assert_eq!(
+            app.read_with(cx, |app, _| app.settings.appearance.display_scale_override),
+            Some(2.05)
+        );
+
+        app.update(cx, |app, cx| {
+            for _ in 0..200 {
+                app.adjust_display_scale_override(step, cx);
+            }
+        });
+        assert_eq!(
+            app.read_with(cx, |app, _| app.settings.appearance.display_scale_override),
+            Some(settings_store::DISPLAY_SCALE_OVERRIDE_MAX),
+            "the stepper must clamp to the same bound a hand-edited file is clamped to"
+        );
+
+        app.update(cx, |app, cx| {
+            for _ in 0..200 {
+                app.adjust_display_scale_override(-step, cx);
+            }
+        });
+        assert_eq!(
+            app.read_with(cx, |app, _| app.settings.appearance.display_scale_override),
+            Some(settings_store::DISPLAY_SCALE_OVERRIDE_MIN),
+            "and must never reach the zero or negative that would panic GPUI outright"
+        );
+    }
+
+    /// The real Appearance page row: it paints, and a real click on it flips the real persisted
+    /// value - what would catch a row wired to nothing or wired to the wrong handler.
+    #[gpui::test]
+    fn the_appearance_page_row_paints_and_clicking_it_flips_the_real_setting(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let state_dir = tempfile::tempdir().expect("tempdir");
+        let settings_path = state_dir.path().join("settings.toml");
+        let (app, cx) = open_app_with_state_dir(cx, repo.path().to_path_buf(), settings_path);
+
+        cx.dispatch_action(crate::settings::ToggleSettings);
+        app.update_in(cx, |app, window, cx| {
+            app.select_settings_page(SettingsPage::Appearance, window, cx);
+        });
+        cx.run_until_parked();
+
+        let bounds = cx
+            .debug_bounds("settings-display-scale-override")
+            .expect("the Override display scale toggle must really paint on the Appearance page");
+
+        cx.simulate_click(bounds.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.settings.appearance.display_scale_override),
+            Some(settings_store::DISPLAY_SCALE_OVERRIDE_DEFAULT),
+            "clicking the real row must set a real forced factor"
+        );
+
+        cx.simulate_click(bounds.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.settings.appearance.display_scale_override),
+            None,
+            "and clicking it again must hand detection back to GPUI"
         );
     }
 }

--- a/crates/app/src/settings/store.rs
+++ b/crates/app/src/settings/store.rs
@@ -203,6 +203,26 @@ pub struct WindowSettings {
 #[serde(default)]
 pub struct AppearanceSettings {
     pub interface_scale_percent: u16,
+    /// GitHub issue #216 ("Scaling issues on Linux"): a forced display scale factor for GPUI's
+    /// X11 backend, or `None` - the default - to leave GPUI's own detection alone.
+    ///
+    /// Not covered by [`Self::interface_scale_percent`], which is text-size-only by deliberate
+    /// design (see `crate::theme::ui_scale`'s own docs) and so cannot undo an over-detected
+    /// *window* scale: GPUI multiplies every painted pixel - padding, icons, fixed chrome - by
+    /// the factor its X11 client resolves once at startup, so when that number is wrong the whole
+    /// UI is oversized, not just its text.
+    ///
+    /// The reported case is the real one this exists for: a KDE/X11 session with
+    /// `ScreenScaleFactors=eDP-1=1;HDMI-1=1` (explicitly *no* scaling) still came up zoomed,
+    /// because GPUI's `get_scale_factor` never reads KScreen's config. Its real resolution order
+    /// is `GPUI_X11_SCALE_FACTOR`, then the `Xft.dpi` X resource, then a physical-millimetres-vs-
+    /// pixels RandR heuristic that over-scales on small laptop panels, then `1.0`.
+    ///
+    /// Applied by [`crate::x11_scale_factor_env_value`], read in `main` before GPUI starts: that
+    /// environment variable is the only override GPUI offers, and it is read once while the X11
+    /// client initialises, so a change here needs a restart and does nothing on Wayland or on a
+    /// non-X11 platform.
+    pub display_scale_override: Option<f32>,
     pub editor_font_size: f32,
     pub terminal_font_size: f32,
     pub follow_system_text_size: bool,
@@ -249,6 +269,7 @@ impl Default for AppearanceSettings {
     fn default() -> Self {
         Self {
             interface_scale_percent: 100,
+            display_scale_override: None,
             editor_font_size: 13.0,
             terminal_font_size: 12.5,
             follow_system_text_size: false,
@@ -305,6 +326,41 @@ pub const FONT_SIZE_MAX: f32 = 32.0;
 pub const INTERFACE_SCALE_PERCENT_MIN: u16 = 50;
 pub const INTERFACE_SCALE_PERCENT_MAX: u16 = 300;
 
+/// Bounds, step and "just switched on" starting value for
+/// [`AppearanceSettings::display_scale_override`]. A raw `f32` multiplier rather than a `u16`
+/// percentage like [`INTERFACE_SCALE_PERCENT_MIN`]/[`INTERFACE_SCALE_PERCENT_MAX`], because the
+/// value is handed to GPUI's `GPUI_X11_SCALE_FACTOR` verbatim and GPUI parses it as a bare
+/// `f32`; keeping the stored form identical to the transmitted form means there is no
+/// percentage-to-factor conversion to get wrong in either direction.
+///
+/// The range spans every real arrangement (0.5 for a panel GPUI detects at 2x that the user
+/// wants unscaled, 4.0 beyond any shipping display) and, more importantly, excludes the values
+/// GPUI refuses: its own `valid_scale_factor` requires a positive, normal float and *panics* the
+/// process on anything else, so a `0`, a negative, or a subnormal from a bad hand-edit must never
+/// reach it - see [`sanitize_display_scale_override`].
+///
+/// The default is `1.0` because that is precisely what issue #216's reporter is asking for: their
+/// KScreen config already says "no scaling", and this is the switch that makes GPUI agree.
+pub const DISPLAY_SCALE_OVERRIDE_MIN: f32 = 0.5;
+pub const DISPLAY_SCALE_OVERRIDE_MAX: f32 = 4.0;
+pub const DISPLAY_SCALE_OVERRIDE_STEP: f32 = 0.05;
+pub const DISPLAY_SCALE_OVERRIDE_DEFAULT: f32 = 1.0;
+
+/// The one real clamp for [`AppearanceSettings::display_scale_override`], shared by
+/// [`AppearanceSettings::sanitize`] (hand-edited file), `crate::settings::render`'s stepper (UI
+/// edit) and [`crate::x11_scale_factor_env_value`] (the value actually handed to GPUI), so those
+/// three can never disagree about what is in range.
+///
+/// NaN is handled explicitly rather than left to `f32::clamp`, which propagates it: `nan` is a
+/// real, spellable TOML float literal, and a NaN reaching `GPUI_X11_SCALE_FACTOR` would panic
+/// GPUI's X11 client at startup instead of merely looking wrong.
+pub fn sanitize_display_scale_override(factor: f32) -> f32 {
+    if factor.is_nan() {
+        return DISPLAY_SCALE_OVERRIDE_DEFAULT;
+    }
+    factor.clamp(DISPLAY_SCALE_OVERRIDE_MIN, DISPLAY_SCALE_OVERRIDE_MAX)
+}
+
 /// Editor-zoom range (70-200%, in steps of 10) and default (100%) - the single real source for
 /// these bounds. `crate::code_surface` re-exports these as `AdeApp::ZOOM_*` associated
 /// consts (unchanged names, so its own call sites and doc comments didn't need to move) rather
@@ -324,6 +380,11 @@ impl AppearanceSettings {
         self.interface_scale_percent = self
             .interface_scale_percent
             .clamp(INTERFACE_SCALE_PERCENT_MIN, INTERFACE_SCALE_PERCENT_MAX);
+        // `map`, not a blanket clamp: `None` is a real, distinct state ("leave GPUI's own
+        // detection alone"), not a zero to be pulled up into range.
+        self.display_scale_override = self
+            .display_scale_override
+            .map(sanitize_display_scale_override);
         self.editor_font_size = self.editor_font_size.clamp(FONT_SIZE_MIN, FONT_SIZE_MAX);
         self.terminal_font_size = self.terminal_font_size.clamp(FONT_SIZE_MIN, FONT_SIZE_MAX);
         self.editor_zoom_percent = self
@@ -644,8 +705,9 @@ pub fn config_keys_line(page: ConfigPage) -> &'static str {
     match page {
         ConfigPage::General => "window.controls \u{b7} terminal.shell",
         ConfigPage::Appearance => {
-            "appearance.interface_scale_percent \u{b7} appearance.editor_font_size \u{b7} \
-             appearance.terminal_font_size \u{b7} appearance.follow_system_text_size \u{b7} \
+            "appearance.interface_scale_percent \u{b7} appearance.display_scale_override \u{b7} \
+             appearance.editor_font_size \u{b7} appearance.terminal_font_size \u{b7} \
+             appearance.follow_system_text_size \u{b7} \
              appearance.editor_zoom_percent \u{b7} appearance.caret_style \u{b7} \
              appearance.caret_blink \u{b7} appearance.show_indent_guides \u{b7} \
              appearance.bracket_pair_colorization"
@@ -1153,6 +1215,71 @@ mod tests {
         );
     }
 
+    /// GitHub issue #216. The forced X11 scale factor is the one appearance value a bad hand-edit
+    /// can do more than misrender with: it is handed to `GPUI_X11_SCALE_FACTOR`, and GPUI's own
+    /// `valid_scale_factor` panics the process on anything that isn't a positive, normal float.
+    /// `nan` is checked alongside the out-of-range numbers because it is a real TOML float
+    /// literal, and it is the one value `f32::clamp` would have propagated straight through.
+    #[test]
+    fn a_hand_edited_out_of_range_display_scale_override_is_clamped_on_load() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("settings.toml");
+
+        for (written, expected) in [
+            ("12.0", DISPLAY_SCALE_OVERRIDE_MAX),
+            ("-3.0", DISPLAY_SCALE_OVERRIDE_MIN),
+            ("0.0", DISPLAY_SCALE_OVERRIDE_MIN),
+            ("nan", DISPLAY_SCALE_OVERRIDE_DEFAULT),
+        ] {
+            std::fs::write(
+                &path,
+                format!("[appearance]\ndisplay_scale_override = {written}\n"),
+            )
+            .expect("write out-of-range file");
+
+            assert_eq!(
+                Settings::load_or_init_at(&path)
+                    .appearance
+                    .display_scale_override,
+                Some(expected),
+                "a hand-edited `display_scale_override = {written}` must be clamped into range, \
+                 not handed to GPUI verbatim"
+            );
+        }
+    }
+
+    /// The default has to stay a real `None` - "let GPUI detect the scale, as it always has" - and
+    /// must be omitted from the written file entirely rather than materializing as some number,
+    /// which would silently pin every existing install to a scale its user never chose.
+    #[test]
+    fn the_display_scale_override_defaults_to_none_and_round_trips_through_a_real_file() {
+        assert_eq!(
+            Settings::default().appearance.display_scale_override,
+            None,
+            "auto-detection is the default; an override is opt-in"
+        );
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("settings.toml");
+
+        Settings::default().save_at(&path).expect("write defaults");
+        let written = std::fs::read_to_string(&path).expect("read back");
+        assert!(
+            !written.contains("display_scale_override"),
+            "an unset override must not appear in the file at all: {written}"
+        );
+
+        let mut configured = Settings::default();
+        configured.appearance.display_scale_override = Some(1.25);
+        configured.save_at(&path).expect("write configured");
+        assert_eq!(
+            Settings::load_or_init_at(&path)
+                .appearance
+                .display_scale_override,
+            Some(1.25)
+        );
+    }
+
     /// The real regression guard for removing `per_tab_zoom`/`AdeApp::file_zoom_percent`: an old
     /// `settings.toml` written before this consolidation has a real `per_tab_zoom` key under
     /// `[appearance]` that no longer maps to any field. `serde`'s default (non-`deny_unknown_
@@ -1189,6 +1316,7 @@ mod tests {
     fn appearance_settings_sanitize_leaves_in_range_values_untouched() {
         let mut appearance = AppearanceSettings {
             interface_scale_percent: 110,
+            display_scale_override: Some(1.25),
             editor_font_size: 15.0,
             terminal_font_size: 13.5,
             follow_system_text_size: true,


### PR DESCRIPTION
## Summary

Closes #216. A KDE/X11 user reported the whole UI coming up oversized despite a KScreen config that explicitly asks for no scaling (`ScreenScaleFactors=eDP-1=1;HDMI-1=1`).

Root cause, verified directly against the real pinned `gpui` dependency source (`gpui_linux/src/linux/x11/client.rs`, `get_scale_factor`, this workspace's pinned rev): GPUI's X11 backend never reads KScreen's config at all. It resolves the scale factor in this order: the `GPUI_X11_SCALE_FACTOR` env var, then the `Xft.dpi` X resource, then a physical-millimetres-vs-pixels RandR heuristic (which over-scales small laptop panels), then a `1.0` default. None of these consult KDE's own per-output scale setting.

The app's existing `appearance.interface_scale_percent` setting doesn't help either — it's deliberately text-size-only (see its own doc comment), and the reported symptom is every painted pixel, not just text.

`gpui` is a pinned git dependency with no `[patch]` section, so it can't be fixed at the source. The only override it offers is that environment variable, read once as its X11 client initializes — which has to happen before `app::run`, i.e. in `main()`.

- `appearance.display_scale_override: Option<f32>` — `None` (default) leaves GPUI's own detection alone; `Some(factor)` forces one. Clamped to 0.5–4.0 (GPUI panics, rather than falling back, on a non-positive/non-normal float — including `nan`, a real TOML literal).
- New Appearance page rows: an "Override display scale" toggle, plus — only while it's on — a "Forced scale factor" stepper (0.05 steps). Scoped to Linux/FreeBSD (matching the targets whose `gpui_platform` dependency requests the `x11` feature). The hint is explicit that it's X11-only and needs a restart to take effect.
- `main()` reads the settings file and exports `GPUI_X11_SCALE_FACTOR` before GPUI starts, via the pure, unit-tested `x11_scale_factor_env_value`. An override already present in the real environment wins over the persisted setting.

**Honest limitation:** I cannot prove from this sandbox that GPUI actually paints at the forced scale — that resolution happens inside the pinned dependency during X11 client init, against a real display with a controllable `Xft.dpi`/monitor geometry, which no automated test here can assert. What's tested is the entirety of this app's own side of the contract: the persisted tri-state and its clamping, the real settings row (paints + a real click flips the real value), and exactly which string reaches the environment variable GPUI reads.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p app --all-targets -- -D warnings` clean
- [x] `cargo test -p app --lib` — 2044 passed, 0 failed
- [ ] Manual: on a real KDE/X11 session reproducing the report, toggle "Override display scale" on, set it to `1.0`, restart Jerry, and confirm the UI now renders unscaled

🤖 Generated with [Claude Code](https://claude.com/claude-code)