### PR TITLE
fix(app): stop already-committed files reading as unstaged in Changes

### DIFF
--- a/crates/app/src/code_surface/tabs.rs
+++ b/crates/app/src/code_surface/tabs.rs
@@ -26,10 +26,20 @@ impl AdeApp {
     /// call per reload. This is also what makes a worktree with something already staged in real
     /// git *before* Jerry ever opened it read as staged the moment it's loaded, rather than
     /// starting at an empty, UI-only set the way it used to.
+    ///
+    /// The same background task also re-derives [`Self::dirty_files`]
+    /// (`wt_core::stage::dirty_paths`, a real `git status --porcelain` read) for exactly the same
+    /// reasons, plus one specific to it: `diff_against_base` diffs against the **merge-base with
+    /// the default branch**, so the file list it produces mixes already-committed changes with
+    /// live uncommitted ones, and only this second query can tell them apart (GitHub issue #220 -
+    /// see [`Self::dirty_files`]' own docs). It is reset to `None` ("not known yet") synchronously
+    /// here rather than left holding the outgoing diff's answer, so a stale set can never outlive
+    /// the diff it described.
     pub(crate) fn load_diff(&mut self, root: PathBuf, cx: &mut Context<Self>) {
         self.diff_root = root.clone();
         self.diff_state = DiffLoadState::Loading;
         self.diff_totals = None;
+        self.dirty_files = None;
         // A reloaded diff is a new worktree's (or the same worktree's freshly re-read) file
         // list - any authorship recorded against the *previous* one belongs to files that may
         // not even be in this diff anymore. See `changes::Authorship`'s own docs for why this is
@@ -37,7 +47,7 @@ impl AdeApp {
         self.file_authorship = changes::Authorship::default();
         cx.notify();
         let task = cx.spawn(async move |this, cx| {
-            let (diff_result, staged_result) = cx
+            let (diff_result, staged_result, dirty_result) = cx
                 .background_executor()
                 .spawn({
                     let root = root.clone();
@@ -54,7 +64,8 @@ impl AdeApp {
                             (base, totals)
                         });
                         let staged_result = wt_core::stage::staged_paths(&root);
-                        (diff_result, staged_result)
+                        let dirty_result = wt_core::stage::dirty_paths(&root);
+                        (diff_result, staged_result, dirty_result)
                     }
                 })
                 .await;
@@ -76,6 +87,13 @@ impl AdeApp {
                 // problem honestly.
                 if let Ok(staged) = staged_result {
                     this.staged_files = staged;
+                }
+                // A failed `dirty_paths` query leaves `dirty_files` at the `None` this method
+                // already set synchronously - "not known", so every Changes row falls back to the
+                // ordinary stageable presentation rather than silently declaring every file
+                // committed-clean off the back of an answer git never actually gave.
+                if let Ok(dirty) = dirty_result {
+                    this.dirty_files = Some(dirty);
                 }
                 // The reloaded diff may have changed whether `open_change`'s path has a
                 // `DiffFile`, so refresh the cache immediately rather than leaving it stale.

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -515,6 +515,27 @@ pub struct AdeApp {
     /// than a per-worktree cache, and why that means a worktree with something already staged in
     /// real git before Jerry ever opened it still reads as staged once loaded.
     pub(crate) staged_files: HashSet<PathBuf>,
+    /// Every path in the currently-loaded worktree with a *live* uncommitted delta - staged,
+    /// unstaged, or untracked (`wt_core::stage::dirty_paths`, a real `git status --porcelain`
+    /// read), or `None` while that answer isn't known yet.
+    ///
+    /// GitHub issue #220 ("Changes are displayed as unstaged but are commited"): the Changes list
+    /// is `wt_core::diff::diff_against_base`'s diff against the **merge-base with the default
+    /// branch**, so it deliberately lists files whose difference from that base is already latched
+    /// into a real commit on this branch alongside files with genuinely uncommitted edits, and
+    /// `wt_core::diff::DiffFile` carries nothing to tell the two apart. Without this set, every
+    /// file not in [`Self::staged_files`] rendered an actionable, unchecked "stage me" checkbox -
+    /// including already-committed files, for which `git add` would be a no-op, so the row falsely
+    /// implied the work wasn't committed yet. `crate::sidebar::changes::is_committed_clean` is the
+    /// read side.
+    ///
+    /// `None` means **unknown**, never "nothing is dirty": it is set synchronously at the top of
+    /// [`Self::load_diff`] (so it can never outlive the diff it describes, which is also why -
+    /// unlike [`Self::staged_files`] - nothing in `crate::sidebar::tree_ops` has to remap or prune
+    /// it across a rename or delete) and only filled in once the real query lands. Every consumer
+    /// falls back to the ordinary stageable presentation while it is `None`, rather than claiming
+    /// files are committed on the strength of an answer that hasn't arrived.
+    pub(crate) dirty_files: Option<HashSet<PathBuf>>,
     /// The most recent real staging/unstaging failure from [`Self::toggle_staged`] - `(path,
     /// message)`. Surfaced next to the commit composer (`Self::render_staging_error`) the same
     /// honest way [`Self::tree_op_error`] surfaces a failed tree operation, rather than silently

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -256,6 +256,7 @@ impl AdeApp {
             _tree_delete_tasks: Vec::new(),
             _tree_copy_task: None,
             staged_files: HashSet::new(),
+            dirty_files: None,
             staging_error: None,
             _stage_tasks: TaskPool::new(),
             commit_menu_open: false,

--- a/crates/app/src/root/widgets.rs
+++ b/crates/app/src/root/widgets.rs
@@ -160,6 +160,29 @@ pub(crate) fn render_tag_pill(tag: ChangeTag) -> impl IntoElement {
         .child(style.label)
 }
 
+/// The Changes row's `committed` tag - a file that differs from the base branch only because a
+/// real commit on this branch already holds that difference (`crate::sidebar::changes::
+/// is_committed_clean`, GitHub issue #220).
+///
+/// Deliberately **not** a [`ChangeTag`] variant: `ChangeTag` is documented as derived from the
+/// file's `FileChangeStatus`, and this is orthogonal to it - a committed-clean file can perfectly
+/// well also be an addition, and would then need both this and the `new` pill. That is the same
+/// reason `crate::sidebar::render::render_moved_tag` is its own neutral chip rather than a
+/// `ChangeTag`, and this matches its look exactly so the row's two status-independent pills read
+/// as one family.
+pub(crate) fn render_committed_tag() -> impl IntoElement {
+    div()
+        .flex_none()
+        .px(px(5.0))
+        .py(px(1.0))
+        .rounded(theme::radius::CHIP)
+        .bg(theme::surface::CHIP_NEUTRAL)
+        .font(font(theme::font::MONO))
+        .text_size(px(9.5))
+        .text_color(theme::text::GHOST)
+        .child("committed")
+}
+
 /// One always-neutral, single-literal keyboard-shortcut keycap. For a platform-resolved combo
 /// (anything that could contain a `mod`/`alt`/`ctrl`/`shift`/`enter`/`esc`/`tab`/`bksp` token),
 /// use [`render_keycap_row`] with `crate::keymap::resolve_combo`'s output instead - this helper

--- a/crates/app/src/sidebar/changes.rs
+++ b/crates/app/src/sidebar/changes.rs
@@ -222,10 +222,47 @@ pub fn stat_bar_segments(add: u32, del: u32) -> [StatSegment; STAT_BAR_LEN] {
     segments
 }
 
+/// Whether `path` is a change that is **already committed and clean** - it differs from the base
+/// branch (that is why `wt_core::diff::diff_against_base` listed it at all), but a real commit on
+/// this branch already holds that difference and nothing about it is uncommitted right now.
+///
+/// GitHub issue #220: `diff_against_base` diffs the working tree against the *merge-base with the
+/// default branch*, so its file list deliberately mixes committed and uncommitted changes and
+/// `DiffFile` itself carries no signal to tell them apart. `dirty` is that signal -
+/// `wt_core::stage::dirty_paths`' real `git status --porcelain` result, as cached in
+/// [`crate::root::AdeApp::dirty_files`].
+///
+/// `dirty` is an `Option` and `None` means **not known yet** (the query hasn't landed, or it
+/// failed), never "nothing is dirty": with no evidence this returns `false`, so a row falls back
+/// to the ordinary stageable presentation rather than claiming a file is committed on the strength
+/// of an absent answer.
+pub fn is_committed_clean(path: &Path, dirty: Option<&HashSet<PathBuf>>) -> bool {
+    match dirty {
+        Some(dirty) => !dirty.contains(path),
+        None => false,
+    }
+}
+
+/// How many of `files` actually have something to stage - i.e. everything
+/// [`is_committed_clean`] doesn't rule out. The real denominator for the Changes header's staged
+/// progress: counting a committed-clean file in it would make `1 staged` out of a 3-file list read
+/// as two-thirds of the work outstanding when in truth there is nothing left to stage.
+pub fn stageable_count(files: &[DiffFile], dirty: Option<&HashSet<PathBuf>>) -> usize {
+    files
+        .iter()
+        .filter(|file| !is_committed_clean(&file.path, dirty))
+        .count()
+}
+
 /// Staged progress for the Changes header's `N of M staged` label and progress bar (Revision R12
 /// §5: the checkbox **is** staging, not "reviewed") - `staged`/`total` are counted by the caller
-/// from real state (how many files are in [`crate::root::AdeApp::staged_files`]), never tracked
-/// as an independent counter that could drift.
+/// from real state (how many files are in [`crate::root::AdeApp::staged_files`], out of
+/// [`stageable_count`]'s genuinely stageable files), never tracked as an independent counter that
+/// could drift.
+///
+/// `total` is the *stageable* count, not the diff's whole file list: a committed-clean file
+/// (GitHub issue #220) has nothing to stage, so including it would permanently pin the fraction
+/// below 1.0 for a worktree where everything stageable really is staged.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct StagedProgress {
     pub staged: usize,
@@ -536,6 +573,65 @@ mod tests {
         // to 1" rule this function documents - confirm the bump actually applies.
         let segments = stat_bar_segments(1, 399);
         assert!(segments.contains(&StatSegment::Add));
+    }
+
+    #[test]
+    fn a_path_missing_from_a_known_dirty_set_is_committed_clean() {
+        let dirty: HashSet<PathBuf> = [PathBuf::from("src/edited.rs")].into_iter().collect();
+        assert!(is_committed_clean(
+            Path::new("src/committed.rs"),
+            Some(&dirty)
+        ));
+        assert!(!is_committed_clean(
+            Path::new("src/edited.rs"),
+            Some(&dirty)
+        ));
+    }
+
+    #[test]
+    fn nothing_is_committed_clean_while_the_dirty_set_is_still_unknown() {
+        // `None` is "the `git status` answer hasn't landed", not "nothing is dirty" - claiming a
+        // file is committed on the strength of an absent answer is exactly the mislabelling
+        // GitHub issue #220 is about, in the other direction.
+        assert!(!is_committed_clean(Path::new("src/anything.rs"), None));
+    }
+
+    #[test]
+    fn stageable_count_excludes_committed_clean_files() {
+        let files = vec![
+            changed_file("src/committed.rs", 4, 0),
+            changed_file("src/edited.rs", 1, 1),
+        ];
+        let dirty: HashSet<PathBuf> = [PathBuf::from("src/edited.rs")].into_iter().collect();
+        assert_eq!(stageable_count(&files, Some(&dirty)), 1);
+    }
+
+    #[test]
+    fn stageable_count_falls_back_to_every_file_when_the_dirty_set_is_unknown() {
+        let files = vec![
+            changed_file("src/a.rs", 1, 0),
+            changed_file("src/b.rs", 0, 1),
+        ];
+        assert_eq!(stageable_count(&files, None), 2);
+    }
+
+    #[test]
+    fn a_fully_committed_branch_has_nothing_stageable_and_so_a_zero_fraction_not_a_partial_one() {
+        let files = vec![
+            changed_file("src/one.rs", 3, 0),
+            changed_file("src/two.rs", 2, 0),
+        ];
+        let stageable = stageable_count(&files, Some(&HashSet::new()));
+        assert_eq!(stageable, 0);
+        let progress = StagedProgress {
+            staged: 0,
+            total: stageable,
+        };
+        assert_eq!(
+            progress.fraction(),
+            0.0,
+            "with nothing left to stage the bar must not read as `0 of 2` outstanding work"
+        );
     }
 
     #[test]

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -2,8 +2,8 @@ use super::*;
 use crate::keymap;
 use crate::root::scrollbar;
 use crate::root::widgets::{
-    hover_bg, menu_popover_chrome, render_keycap_row, render_menu_group_divider,
-    render_sidebar_message, render_tag_pill, text_tooltip, KeycapSize,
+    hover_bg, menu_popover_chrome, render_committed_tag, render_keycap_row,
+    render_menu_group_divider, render_sidebar_message, render_tag_pill, text_tooltip, KeycapSize,
 };
 use crate::settings::widgets::ChoiceOption;
 use crate::worktree_history::flow as worktree_history;
@@ -1553,19 +1553,35 @@ impl AdeApp {
     /// answers "how many of the worktree's changed files are staged", the composer's answers
     /// "how many of those staged files is the next commit about to include" (today the same set,
     /// but a distinct question).
+    ///
+    /// The `N file(s)` label counts every row the list really paints, but the progress bar's
+    /// denominator is the *stageable* subset (`changes::stageable_count`): a committed-clean file
+    /// (GitHub issue #220) is a real row with genuinely nothing left to stage, so counting it
+    /// against the bar would pin a fully-staged worktree short of full forever.
     pub(in crate::sidebar) fn render_changes_header(
         &self,
         diff: &WorktreeDiff,
     ) -> impl IntoElement {
         let total = diff.files.len();
+        let stageable = changes::stageable_count(&diff.files, self.dirty_files.as_ref());
         let staged = diff
             .files
             .iter()
             .filter(|file| self.staged_files.contains(&file.path))
             .count();
-        let progress = changes::StagedProgress { staged, total };
+        let progress = changes::StagedProgress {
+            staged,
+            total: stageable,
+        };
         let fraction = progress.fraction();
         const BAR_WIDTH: f32 = 56.0;
+
+        // Test-only outside `cfg(test)`/`test-support`, exactly like the commit composer's own
+        // `commit-composer-progress-{n}-of-{m}` selector: the real counts baked into the string so
+        // an interaction test can prove this header moved with real git state instead of a
+        // hardcoded number.
+        let files_selector = format!("changes-header-{total}-files");
+        let staged_selector = format!("changes-header-{staged}-of-{stageable}-staged");
 
         div()
             .flex_none()
@@ -1579,6 +1595,7 @@ impl AdeApp {
             .border_color(theme::border::INNER)
             .child(
                 div()
+                    .debug_selector(move || files_selector)
                     .font(font(theme::font::MONO))
                     .text_size(self.ui_text_size(10.0))
                     .text_color(theme::text::DIM)
@@ -1605,6 +1622,7 @@ impl AdeApp {
             )
             .child(
                 div()
+                    .debug_selector(move || staged_selector)
                     .font(font(theme::font::MONO))
                     .text_size(self.ui_text_size(10.0))
                     .text_color(theme::text::DIM)
@@ -1729,6 +1747,19 @@ impl AdeApp {
     /// `stop_propagation`) opens the file's diff via [`Self::open_change_diff`] - the checkbox
     /// **is** staging, not "reviewed": it has its own click target, entirely separate from the
     /// row body's.
+    ///
+    /// **A committed-clean file gets no checkbox at all** (GitHub issue #220). The Changes list is
+    /// a diff against the merge-base with the default branch, so it legitimately shows files whose
+    /// difference from that base is already inside a real commit on this branch - and until this
+    /// fix every one of them painted an unchecked, actionable "stage me" box, which is what made
+    /// committed work read as unstaged. Such a row keeps its place in the list (reviewing the
+    /// whole branch against main is the entire point of this panel) and stays clickable to open
+    /// its diff; what changes is that the checkbox is replaced by
+    /// [`Self::render_committed_marker`]'s inert check plus a `committed` pill
+    /// (`crate::root::widgets::render_committed_tag`). A checked-but-disabled checkbox was the
+    /// alternative and was rejected: in this panel a checked box means "staged, and the next
+    /// commit will include it", and reusing that exact mark for "this is already *in* a commit"
+    /// would trade one wrong reading for another.
     pub(in crate::sidebar) fn render_change_row(
         &self,
         file: &DiffFile,
@@ -1737,6 +1768,7 @@ impl AdeApp {
         let path = file.path.clone();
         let open_path = path.clone();
         let staged = self.staged_files.contains(&file.path);
+        let committed = changes::is_committed_clean(&file.path, self.dirty_files.as_ref());
         let selected = self.open_change.as_deref() == Some(file.path.as_path());
         let (add, del) = changes::diff_file_stats(file);
         let (dir, name) = changes::split_dir_name(&file.path);
@@ -1776,7 +1808,12 @@ impl AdeApp {
             .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
                 this.open_change_diff(open_path.clone(), window, cx);
             }))
-            .child(self.render_staging_checkbox(path, staged, cx))
+            .child(if committed {
+                self.render_committed_marker(&path).into_any_element()
+            } else {
+                self.render_staging_checkbox(path, staged, cx)
+                    .into_any_element()
+            })
             .when(!dir.is_empty(), |el| {
                 el.child(
                     div()
@@ -1797,7 +1834,11 @@ impl AdeApp {
                     .text_size(self.ui_text_size(11.5))
                     // Staged rows read at full strength; unstaged drop to `theme::text::DIM` -
                     // the exact inverse of the old "reviewed" dimming this replaces (Revision R12
-                    // §5), never both conventions at once.
+                    // §5), never both conventions at once. A committed-clean row lands on `DIM`
+                    // too, and correctly so under that same rule: this dimming means "not part of
+                    // the commit being composed", which is true of a file already sitting in an
+                    // earlier commit. Its `committed` pill and marker, not its text weight, are
+                    // what say *why*.
                     .text_color(if staged {
                         theme::text::STRONG
                     } else {
@@ -1807,6 +1848,9 @@ impl AdeApp {
             )
             .when_some(author_chips, |el, chips| el.child(chips))
             .when_some(tag, |el, tag| el.child(render_tag_pill(tag)))
+            // Alongside `tag`, never instead of it: a file added by a commit on this branch is
+            // genuinely both `new` (relative to the base) and `committed`.
+            .when(committed, |el| el.child(render_committed_tag()))
             // A rename-only file gets no `tag` from `changes::change_tag` (a plain rename
             // isn't `new`/`del`), so without this it looked identical to an unchanged file.
             // `changes::is_real_rename` only fires when `old_path` differs from the current path.
@@ -1898,14 +1942,20 @@ impl AdeApp {
     /// not "reviewed") - toggled via [`Self::toggle_staged`]. Stops propagation on click so
     /// checking a box never also opens the row's diff, mirroring `Self::render_agent_tab`'s
     /// nested-clickable-child pattern (its tab-close `×`).
+    ///
+    /// Only rendered for a file with a real, live uncommitted delta - see
+    /// [`Self::render_change_row`] for why a committed-clean file gets
+    /// [`Self::render_committed_marker`] instead.
     pub(in crate::sidebar) fn render_staging_checkbox(
         &self,
         path: PathBuf,
         checked: bool,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
+        let selector = format!("stage-checkbox-{}", path.display());
         div()
             .id(format!("stage-checkbox-{}", path.display()))
+            .debug_selector(move || selector)
             .flex_none()
             .w(px(12.0))
             .h(px(12.0))
@@ -1931,6 +1981,38 @@ impl AdeApp {
             }))
     }
 
+    /// What sits in the checkbox slot for a committed-clean Changes row (GitHub issue #220): the
+    /// same 12×12 footprint so the list's text column stays aligned, holding an inert `✓` in
+    /// [`theme::text::GHOST`] - no border, no fill, no hover, no `cursor_pointer`, and above all
+    /// no click handler, because there is no real git operation for it to run. Staging an
+    /// already-committed, clean file is a `git add` that changes nothing, so a checkbox here would
+    /// be a control bound to a no-op - exactly the kind of thing that must not be drawn.
+    ///
+    /// The `✓` is deliberately grey rather than the checkbox's `theme::button::GREEN_FG`: green
+    /// means "staged for the next commit" everywhere else in this panel, and this state is the
+    /// different, quieter fact that the change is already in history. The row's `committed` pill
+    /// (`crate::root::widgets::render_committed_tag`) carries the word itself; a
+    /// [`text_tooltip`] spells it out on hover.
+    pub(in crate::sidebar) fn render_committed_marker(&self, path: &Path) -> impl IntoElement {
+        let selector = format!("committed-marker-{}", path.display());
+        div()
+            .id(format!("committed-marker-{}", path.display()))
+            .debug_selector(move || selector)
+            .flex_none()
+            .w(px(12.0))
+            .h(px(12.0))
+            .flex()
+            .items_center()
+            .justify_center()
+            .font(font(theme::font::MONO))
+            .text_size(self.ui_text_size(9.0))
+            .text_color(theme::text::GHOST)
+            .child("\u{2713}")
+            .tooltip(text_tooltip(
+                "Already committed on this branch - nothing to stage",
+            ))
+    }
+
     /// The commit composer at the foot of the Changes panel (Revision R12 §5): header row
     /// (`COMMIT` · `N of M staged` · staged diffstat), a pre-drafted message box, and the primary
     /// commit action with its `▾` split-button menu. The staged set is derived once, early
@@ -1946,7 +2028,11 @@ impl AdeApp {
     ) -> impl IntoElement {
         let staged = changes::staged_subset(&diff.files, &self.staged_files);
         let staged_count = staged.len();
-        let total = diff.files.len();
+        // The stageable count, not `diff.files.len()` - same reasoning as
+        // `Self::render_changes_header`'s own denominator (GitHub issue #220): a committed-clean
+        // file can never join this commit, so counting it here would make `N of M staged` claim
+        // outstanding work that doesn't exist.
+        let total = changes::stageable_count(&diff.files, self.dirty_files.as_ref());
         let (add, del) = changes::staged_diff_stats(&staged);
         let stat_text = if staged_count > 0 {
             format!("+{add} \u{2212}{del}")
@@ -4463,6 +4549,34 @@ mod commit_composer_tests {
         repo
     }
 
+    /// GitHub issue #220's exact shape: a feature branch carrying **one real commit** since its
+    /// merge-base with `main` (`committed.txt`, clean on disk - nothing left to stage) plus **one
+    /// genuinely uncommitted edit** (`dirty.txt`). `wt_core::diff::diff_against_base` diffs
+    /// against that merge-base, so it lists *both* files and `DiffFile` alone cannot tell them
+    /// apart - which is precisely what used to make the committed one render an actionable,
+    /// unchecked "stage me" checkbox.
+    fn repo_with_a_committed_and_a_dirty_file() -> TempDir {
+        let repo = TempDir::new().expect("tempdir");
+        git(repo.path(), &["init", "-b", "main"]);
+        git(repo.path(), &["config", "user.email", "test@example.com"]);
+        git(repo.path(), &["config", "user.name", "Test User"]);
+        std::fs::write(repo.path().join("dirty.txt"), "one\ntwo\n").expect("write dirty.txt");
+        git(repo.path(), &["add", "."]);
+        git(repo.path(), &["commit", "-m", "initial"]);
+        git(repo.path(), &["checkout", "-b", "feature"]);
+        std::fs::write(repo.path().join("committed.txt"), "committed\n")
+            .expect("write committed.txt");
+        git(repo.path(), &["add", "committed.txt"]);
+        git(
+            repo.path(),
+            &["commit", "-m", "a real commit on the feature branch"],
+        );
+        // ...and only now a real, still-uncommitted edit to the other file.
+        std::fs::write(repo.path().join("dirty.txt"), "one\ntwo\nthree\n")
+            .expect("modify dirty.txt");
+        repo
+    }
+
     fn open_changes_view<'a>(
         cx: &'a mut TestAppContext,
         repo: &TempDir,
@@ -5159,6 +5273,186 @@ mod commit_composer_tests {
             "switching into the second worktree must re-derive staged_files from *its* real \
              index (c.txt, staged before this switch ever happened), not carry over the first \
              worktree's empty set or silently stay empty"
+        );
+    }
+
+    /// GitHub issue #220, "Changes are displayed as unstaged but are commited". The Changes list
+    /// diffs against the merge-base with the default branch, so a file whose difference from that
+    /// base is already inside a real commit sits in the same list as a genuinely uncommitted one.
+    /// It must still be *visible* there (reviewing the whole branch is the point of the panel),
+    /// but it must not present an actionable staging checkbox - `git add` on an already-committed,
+    /// clean file does nothing at all.
+    #[gpui::test]
+    fn a_committed_clean_file_shows_no_staging_checkbox_but_a_really_edited_one_does(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = repo_with_a_committed_and_a_dirty_file();
+        let (app, cx) = open_changes_view(cx, &repo);
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.current_diff().map(|d| d.files.len())),
+            Some(2),
+            "sanity check: the merge-base diff really does list both files - if it listed only \
+             the dirty one, everything below would pass for the wrong reason"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.dirty_files.clone()),
+            Some([PathBuf::from("dirty.txt")].into_iter().collect()),
+            "the real `git status --porcelain` read must name exactly the uncommitted file"
+        );
+
+        assert!(
+            cx.debug_bounds("change-row-committed.txt").is_some(),
+            "the committed file must stay in the Changes list - reviewing the branch against \
+             main is exactly what this panel is for, so it must not be filtered out"
+        );
+        assert!(
+            cx.debug_bounds("stage-checkbox-committed.txt").is_none(),
+            "the committed-clean file must NOT paint a staging checkbox - that unchecked box is \
+             the whole bug: it claimed committed work was still unstaged"
+        );
+        assert!(
+            cx.debug_bounds("committed-marker-committed.txt").is_some(),
+            "it must paint the inert committed marker in the checkbox's place instead, so the \
+             row still says something true about its state rather than going blank"
+        );
+
+        assert!(
+            cx.debug_bounds("stage-checkbox-dirty.txt").is_some(),
+            "the genuinely uncommitted file must keep its real, actionable staging checkbox"
+        );
+        assert!(
+            cx.debug_bounds("committed-marker-dirty.txt").is_none(),
+            "and must never be marked committed"
+        );
+    }
+
+    /// The header's denominator is the *stageable* count, not the raw file count: with one of the
+    /// two listed files already committed there is exactly one thing left to stage, and staging it
+    /// must fill the bar rather than stalling at a permanent one-of-two.
+    #[gpui::test]
+    fn the_changes_header_counts_only_really_stageable_files_in_its_denominator(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = repo_with_a_committed_and_a_dirty_file();
+        let (app, cx) = open_changes_view(cx, &repo);
+
+        assert!(
+            cx.debug_bounds("changes-header-2-files").is_some(),
+            "both files are really in the list, so the file count says 2"
+        );
+        assert!(
+            cx.debug_bounds("changes-header-0-of-1-staged").is_some(),
+            "but only one of them can be staged at all, so that is the real denominator"
+        );
+        assert!(
+            cx.debug_bounds("changes-header-0-of-2-staged").is_none(),
+            "counting the committed file as outstanding work is exactly the misleading fraction \
+             this fix removes"
+        );
+        assert!(
+            cx.debug_bounds("commit-composer-progress-0-of-1").is_some(),
+            "the composer's own `N of M staged` must agree - two counters in one panel may not \
+             disagree about how much is left to stage"
+        );
+
+        app.update(cx, |app, cx| {
+            app.toggle_staged(PathBuf::from("dirty.txt"), cx);
+        });
+        cx.run_until_parked();
+
+        assert_eq!(
+            git_output(repo.path(), &["status", "--porcelain", "dirty.txt"]),
+            "M  dirty.txt",
+            "sanity check: that really staged it in the real git index"
+        );
+        assert!(
+            cx.debug_bounds("changes-header-1-of-1-staged").is_some(),
+            "with the only stageable file staged, the header must read fully staged - not `1 of \
+             2`, which would imply a second file still needs attention when none does"
+        );
+    }
+
+    /// The committed row's marker is inert by construction (no click handler at all), so a click
+    /// at its exact painted position must reach the row underneath and open the file's diff -
+    /// never run a meaningless `git add` on an already-clean file.
+    #[gpui::test]
+    fn clicking_a_committed_files_marker_stages_nothing_in_real_git(cx: &mut TestAppContext) {
+        let repo = repo_with_a_committed_and_a_dirty_file();
+        let (app, cx) = open_changes_view(cx, &repo);
+
+        let marker = cx
+            .debug_bounds("committed-marker-committed.txt")
+            .expect("the committed marker must really paint");
+        cx.simulate_click(marker.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        assert_eq!(
+            git_output(repo.path(), &["status", "--porcelain"]),
+            "M dirty.txt",
+            "the real index must be untouched: only dirty.txt's own unstaged modification, no \
+             newly staged committed.txt"
+        );
+        assert!(
+            app.read_with(cx, |app, _| !app
+                .staged_files
+                .contains(Path::new("committed.txt"))),
+            "and nothing may claim it got staged in memory either"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.open_change.clone()),
+            Some(PathBuf::from("committed.txt")),
+            "with no click handler of its own the marker lets the click through to the row, \
+             which opens the file's diff - the committed file stays fully reviewable"
+        );
+    }
+
+    /// Before the fix, committing from the composer left the just-committed files in the Changes
+    /// list (correctly - they still differ from `main`) but *still* showing unchecked staging
+    /// checkboxes, which is the exact user-visible report in issue #220. After a real commit the
+    /// reloaded diff must reclassify them.
+    #[gpui::test]
+    fn committing_a_staged_file_flips_its_row_from_stageable_to_committed(cx: &mut TestAppContext) {
+        let repo = repo_with_a_committed_and_a_dirty_file();
+        let (app, cx) = open_changes_view(cx, &repo);
+
+        app.update(cx, |app, cx| {
+            app.toggle_staged(PathBuf::from("dirty.txt"), cx);
+        });
+        cx.run_until_parked();
+        assert!(
+            cx.debug_bounds("stage-checkbox-dirty.txt").is_some(),
+            "sanity check: it is stageable (and now staged) before the commit"
+        );
+
+        let commits_before = commit_count(repo.path());
+        app.update(cx, |app, cx| {
+            app.commit_staged_files(cx);
+        });
+        cx.run_until_parked();
+        assert_eq!(
+            commit_count(repo.path()),
+            commits_before + 1,
+            "sanity check: a real commit must actually have happened"
+        );
+
+        assert!(
+            cx.debug_bounds("change-row-dirty.txt").is_some(),
+            "it still differs from `main`, so it stays in the list - `commit_staged_files`' own \
+             docs are explicit about that"
+        );
+        assert!(
+            cx.debug_bounds("stage-checkbox-dirty.txt").is_none(),
+            "but it must no longer offer to stage anything: this is the reported bug, a file the \
+             user just committed still rendering an unchecked staging checkbox"
+        );
+        assert!(
+            cx.debug_bounds("committed-marker-dirty.txt").is_some(),
+            "it must read as committed now"
+        );
+        assert!(
+            cx.debug_bounds("changes-header-0-of-0-staged").is_some(),
+            "with everything committed there is nothing stageable left at all"
         );
     }
 }

--- a/crates/wt-core/src/stage.rs
+++ b/crates/wt-core/src/stage.rs
@@ -66,6 +66,89 @@ pub fn staged_paths(worktree_path: &Path) -> Result<HashSet<PathBuf>, Error> {
         .collect())
 }
 
+/// Every worktree-relative path in `worktree_path` that has *any* live, uncommitted delta right
+/// now - staged in the index, modified (or deleted) in the working tree, or untracked. The
+/// per-path counterpart to [`crate::is_dirty`]'s whole-worktree boolean, and the signal that
+/// tells a **committed** change apart from an **uncommitted** one.
+///
+/// That distinction is not derivable from a [`crate::diff::WorktreeDiff`] alone, which is what
+/// made GitHub issue #220 ("Changes are displayed as unstaged but are commited") possible:
+/// `diff_against_base` deliberately diffs the working tree against the *merge-base with the
+/// default branch* (see that module's docs), so its file list mixes files whose only difference
+/// from the base branch is already latched into a real commit on this branch with files that
+/// really do have live, uncommitted edits. A path absent from this set is in the first group:
+/// there is genuinely nothing to `git add`, so presenting it as a stageable "unstaged" file is a
+/// lie. A path present in it is in the second group - and [`staged_paths`] says which *half* of
+/// the index/working-tree split it sits on.
+///
+/// One `git status --porcelain -z --untracked-files=all` call reports both status columns for
+/// every path at once, so this needs no second round trip to cover the unstaged half; `-z`
+/// additionally makes git emit raw, never-quoted paths regardless of the caller's `core.quotePath`
+/// setting (the same class of caller-config hazard [`crate::diff`] pins `-c core.quotePath=false`
+/// for). A rename or copy contributes **both** of its paths, since a live rename is a real
+/// uncommitted delta at the old path as much as the new one.
+///
+/// `--untracked-files=all`, not the `normal` [`crate::is_dirty`] uses: `normal` collapses a
+/// wholly-untracked directory into a single `?? src/` entry, which is enough for a
+/// whole-worktree yes/no but would leave `src/db/query.rs` *absent* from this set - and absent
+/// means "committed and clean" to every caller here, the precise opposite of the truth for a
+/// brand-new file. [`crate::diff`]'s shadow index lists those files individually, so this has to
+/// as well.
+///
+/// Shells out to `git` rather than using `gix`, per this crate's split: `gix` for object-graph
+/// reads, the real `git` CLI for anything that has to reproduce git's own porcelain status/diff
+/// text exactly (see [`crate::diff`]'s "gix vs. the `git` CLI" docs).
+///
+/// Performs blocking I/O.
+pub fn dirty_paths(worktree_path: &Path) -> Result<HashSet<PathBuf>, Error> {
+    let args: Vec<OsString> = vec![
+        "status".into(),
+        "--porcelain".into(),
+        "-z".into(),
+        "--untracked-files=all".into(),
+    ];
+    let output = run_git(worktree_path, &args)?;
+    check_success(&args, &output)?;
+    Ok(parse_status_porcelain_z(&output.stdout))
+}
+
+/// Parses `git status --porcelain -z` output into the set of paths it reports.
+///
+/// Each record is `XY<space><path>` terminated by a NUL, where `X` is the index (staged) column
+/// and `Y` the working-tree column - the exact convention this module's own
+/// [`unstage_path`] tests already document (`" M file.txt"` is unstaged-only, `"M  file.txt"` is
+/// staged). Any record at all means that path has a live delta, so the columns' *values* don't
+/// need interpreting here; only `R` (rename) and `C` (copy) do, because those records are followed
+/// by a second NUL-terminated field holding the original path.
+///
+/// Paths are decoded with [`String::from_utf8_lossy`], matching [`staged_paths`]'s own decoding,
+/// so a path that isn't valid UTF-8 lands in the set under its lossy form. That is a real
+/// limitation, not a silent one: such a path simply won't match the equally-lossy path a
+/// [`crate::diff::DiffFile`] carries either, so it falls back to being treated as "not known to be
+/// clean" rather than being wrongly reported as committed.
+fn parse_status_porcelain_z(stdout: &[u8]) -> HashSet<PathBuf> {
+    let mut paths = HashSet::new();
+    let mut records = stdout.split(|byte| *byte == 0).filter(|r| !r.is_empty());
+    while let Some(record) = records.next() {
+        // `XY` + a space + at least one path byte.
+        if record.len() < 4 {
+            continue;
+        }
+        let (x, y) = (record[0], record[1]);
+        paths.insert(path_from_bytes(&record[3..]));
+        if matches!(x, b'R' | b'C') || matches!(y, b'R' | b'C') {
+            if let Some(original) = records.next() {
+                paths.insert(path_from_bytes(original));
+            }
+        }
+    }
+    paths
+}
+
+fn path_from_bytes(bytes: &[u8]) -> PathBuf {
+    PathBuf::from(String::from_utf8_lossy(bytes).into_owned())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -212,6 +295,181 @@ mod tests {
             staged.is_empty(),
             "a real, unstaged modification must never appear in staged_paths"
         );
+    }
+
+    /// A real feature branch with one commit since its merge-base with `main` - the exact shape
+    /// GitHub issue #220 is about. `committed.txt` is genuinely part of a commit and clean on
+    /// disk; the caller then dirties whatever else it wants to contrast against it.
+    fn repo_with_a_committed_clean_file() -> TempDir {
+        let dir = init_repo();
+        git(dir.path(), &["checkout", "-b", "feature"]);
+        fs::write(dir.path().join("committed.txt"), "committed\n").expect("write");
+        git(dir.path(), &["add", "committed.txt"]);
+        git(
+            dir.path(),
+            &["commit", "-m", "a real commit on the feature branch"],
+        );
+        dir
+    }
+
+    #[test]
+    fn dirty_paths_is_empty_on_a_genuinely_clean_worktree() {
+        let repo = repo_with_a_committed_clean_file();
+        assert!(
+            dirty_paths(repo.path()).expect("dirty_paths").is_empty(),
+            "a worktree whose only difference from main is a real, clean commit has no live \
+             uncommitted delta at all"
+        );
+    }
+
+    /// The regression this function exists for: a file changed by a real commit on this branch,
+    /// with no further edits, must not be reported as dirty, while a file with a real live edit
+    /// must be - even though `wt_core::diff::diff_against_base` lists both.
+    #[test]
+    fn dirty_paths_tells_a_committed_clean_file_apart_from_a_really_edited_one() {
+        let repo = repo_with_a_committed_clean_file();
+        fs::write(repo.path().join("file.txt"), "really edited\n").expect("modify");
+
+        let dirty = dirty_paths(repo.path()).expect("dirty_paths");
+
+        assert_eq!(
+            dirty,
+            [PathBuf::from("file.txt")]
+                .into_iter()
+                .collect::<HashSet<_>>(),
+            "only the really-edited file has a live delta; committed.txt is committed and clean"
+        );
+    }
+
+    #[test]
+    fn dirty_paths_includes_a_staged_file() {
+        let repo = init_repo();
+        fs::write(repo.path().join("file.txt"), "changed\n").expect("modify");
+        git(repo.path(), &["add", "file.txt"]);
+
+        assert!(
+            dirty_paths(repo.path())
+                .expect("dirty_paths")
+                .contains(Path::new("file.txt")),
+            "a staged-only change (`M  file.txt`: index column set, working-tree column blank) \
+             is still a live uncommitted delta"
+        );
+    }
+
+    #[test]
+    fn dirty_paths_includes_an_unstaged_file() {
+        let repo = init_repo();
+        fs::write(repo.path().join("file.txt"), "changed\n").expect("modify");
+
+        assert!(
+            dirty_paths(repo.path())
+                .expect("dirty_paths")
+                .contains(Path::new("file.txt")),
+            "an unstaged-only change (` M file.txt`) is a live uncommitted delta"
+        );
+    }
+
+    #[test]
+    fn dirty_paths_includes_an_untracked_file() {
+        let repo = init_repo();
+        fs::write(repo.path().join("brand-new.txt"), "new\n").expect("write");
+
+        assert!(
+            dirty_paths(repo.path())
+                .expect("dirty_paths")
+                .contains(Path::new("brand-new.txt")),
+            "an untracked file (`?? brand-new.txt`) has never been committed, so it is a live \
+             uncommitted delta - `git diff --cached` would never have reported it"
+        );
+    }
+
+    #[test]
+    fn dirty_paths_includes_a_deleted_tracked_file() {
+        let repo = init_repo();
+        fs::remove_file(repo.path().join("file.txt")).expect("remove");
+
+        assert!(
+            dirty_paths(repo.path())
+                .expect("dirty_paths")
+                .contains(Path::new("file.txt")),
+            "a deletion (` D file.txt`) is a live uncommitted delta too"
+        );
+    }
+
+    #[test]
+    fn dirty_paths_includes_both_halves_of_a_live_rename() {
+        let repo = init_repo();
+        git(repo.path(), &["mv", "file.txt", "renamed.txt"]);
+
+        let dirty = dirty_paths(repo.path()).expect("dirty_paths");
+
+        // `git mv` stages the rename, so real porcelain -z output here is a single
+        // `R  renamed.txt\0file.txt\0` record: the new path in the record itself, the original
+        // path in the *following* NUL-terminated field.
+        assert!(
+            dirty.contains(Path::new("renamed.txt")),
+            "the rename's destination must be dirty; got {dirty:?}"
+        );
+        assert!(
+            dirty.contains(Path::new("file.txt")),
+            "the rename's source must be dirty too - a live rename is an uncommitted delta at \
+             the old path as much as the new one; got {dirty:?}"
+        );
+    }
+
+    #[test]
+    fn dirty_paths_reports_a_nested_path_relative_to_the_worktree_root() {
+        let repo = init_repo();
+        fs::create_dir_all(repo.path().join("src/db")).expect("mkdir");
+        fs::write(repo.path().join("src/db/query.rs"), "fn q() {}\n").expect("write");
+
+        assert!(
+            dirty_paths(repo.path())
+                .expect("dirty_paths")
+                .contains(Path::new("src/db/query.rs")),
+            "a brand-new file inside a brand-new directory must be listed individually and \
+             worktree-relative - `--untracked-files=normal` would have collapsed the whole thing \
+             into a single `?? src/` entry, leaving this path looking committed and clean"
+        );
+    }
+
+    /// A path with a space in it is exactly what `core.quotePath`/quoting would mangle in
+    /// non-`-z` porcelain output (`"my file.txt"`, with real quotes). `-z` emits it raw.
+    #[test]
+    fn dirty_paths_handles_a_path_with_a_space_without_quoting_it() {
+        let repo = init_repo();
+        fs::write(repo.path().join("my file.txt"), "spaces\n").expect("write");
+
+        assert!(
+            dirty_paths(repo.path())
+                .expect("dirty_paths")
+                .contains(Path::new("my file.txt")),
+            "the path must come back raw, not wrapped in the quotes non-`-z` porcelain adds"
+        );
+    }
+
+    #[test]
+    fn dirty_paths_and_staged_paths_agree_on_which_half_a_change_sits_in() {
+        let repo = repo_with_a_committed_clean_file();
+        fs::write(repo.path().join("file.txt"), "staged edit\n").expect("modify");
+        stage_path(repo.path(), Path::new("file.txt")).expect("stage_path");
+        fs::write(repo.path().join("also.txt"), "unstaged new file\n").expect("write");
+
+        let dirty = dirty_paths(repo.path()).expect("dirty_paths");
+        let staged = staged_paths(repo.path()).expect("staged_paths");
+
+        assert_eq!(
+            dirty,
+            [PathBuf::from("file.txt"), PathBuf::from("also.txt")]
+                .into_iter()
+                .collect::<HashSet<_>>()
+        );
+        assert_eq!(staged, [PathBuf::from("file.txt")].into_iter().collect());
+        assert!(
+            !dirty.contains(Path::new("committed.txt")),
+            "neither query may claim the committed-clean file has anything left to stage"
+        );
+        assert!(!staged.contains(Path::new("committed.txt")));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #220. Real user report: "When opening a branch with jerry, changes that are commited appear like they are unstaged. When files are commited they should not appear in unstaged changes anymore."

Root cause: the Changes sidebar's diff (`wt_core::diff::diff_against_base`) is deliberately computed against the **merge-base with the default branch**, not against `HEAD` — this is intentional (an agent may not have committed anything yet, and the panel exists to review the whole branch against `main`), but it means the file list mixes files whose only difference from the base is already latched into a real commit on this branch with files that have a genuinely live uncommitted delta. `DiffFile` itself carries nothing to distinguish the two, and the row renderer only ever asked "is this path in the staged set" — so every already-committed, clean file painted an unchecked, actionable "stage me" checkbox. Staging it would have been a `git add` on an already-clean tracked file: a no-op that falsely implied the work wasn't committed yet.

- `wt_core::stage::dirty_paths`: a real `git status --porcelain -z --untracked-files=all` read returning every path with a live uncommitted delta (staged, unstaged, or untracked; both halves of a live rename). `--untracked-files=all` rather than `is_dirty`'s `normal`, since `normal` collapses an untracked directory into one `?? src/` entry, which would leave a brand-new nested file looking committed.
- `AdeApp::dirty_files` caches it with the same lifecycle as `staged_files`, reset to `None` ("not known yet", never "nothing is dirty") synchronously at the top of `load_diff`, filled in once the query lands.
- A committed-clean row **stays in the Changes list** — reviewing the whole branch against main is the entire point of this panel — and stays clickable to open its diff. What changes: the checkbox is replaced by an inert grey `✓` marker plus a `committed` pill. A checked-but-disabled checkbox was considered and rejected: in this panel a check means "staged, and the next commit will include it," so reusing that mark for "already in a commit" would trade one wrong reading for another.
- The header's `N of M staged` and the commit composer's own count now both use `changes::stageable_count` — a committed-clean file has nothing to stage, so counting it in the denominator would pin a fully-staged worktree short of 100% forever.

## Test plan

- [x] `wt-core`: `dirty_paths` against real temp repos — committed-clean vs. genuinely edited, staged-only, unstaged-only, untracked, deleted, both halves of a live rename, a nested untracked file (the `-uall` regression), a path with a space, and agreement with `staged_paths` on which half a change sits in
- [x] `app`: a real feature branch with one clean commit plus one live edit — only the dirty file paints a staging checkbox; clicking the committed marker changes nothing in the real git index and falls through to open the diff; the header's denominator counts only stageable files; committing a staged file flips its row from checkbox to committed marker on reload
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p app -p wt-core --all-targets -- -D warnings` clean
- [x] `cargo test -p wt-core --lib` — 185/185 passed
- [x] `cargo test -p app --lib` — 2057/2057 passed in isolation; two separate full-suite runs each hit a different pre-existing flake unrelated to this diff (`title_bar::render::agent_state_chip_live_tests`, and `rail::worktree_watch` — both real-process/fs-watcher tests known to be sensitive to heavy concurrent test-suite load), each confirmed passing standalone

🤖 Generated with [Claude Code](https://claude.com/claude-code)