### PR TITLE
perf(app): virtualize the diff view's row list

### DIFF
--- a/crates/app/src/code_surface/diff_view.rs
+++ b/crates/app/src/code_surface/diff_view.rs
@@ -7,6 +7,99 @@ use super::*;
 use crate::root::focus::palette_focus_tests;
 use crate::root::widgets::render_action_keycap_row;
 use crate::root::widgets::render_sidebar_message;
+use std::rc::Rc;
+
+/// Every row of the Diff view's virtualized list, in the flat order it scrolls in - built once
+/// per frame by [`diff_rows`] and then indexed by `uniform_list`'s row builder.
+///
+/// The same shape (and the same reason) as `crate::sidebar::render`'s own `TreeRow`: the row
+/// builder closure is `'static` and cannot hold a borrow of `self` or of the `&DiffFile` being
+/// rendered, so a row names *where* its content lives rather than carrying the content itself.
+/// It is `Copy` for the same reason - nothing here owns a `String`.
+///
+/// The three real row kinds this list interleaves (hunk header, fold marker, diff line) all
+/// render at the same `rems(1.6)` height, which is `uniform_list`'s one real requirement - see
+/// [`AdeApp::render_diff_file_detail`]'s own docs on how that is enforced.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DiffRow {
+    /// `⋯ N unchanged lines` between two hunks - `gap` from `changes::fold_gap_between`, never
+    /// an estimate (see [`render_fold_marker`]). `before_hunk` is the index of the hunk this
+    /// marker sits directly above; it names nothing about the content, only this row's own
+    /// `diff-fold-marker-{before_hunk}` debug selector, which needs to be stable and unique
+    /// across a file with several gaps for a real render test to measure one specific marker.
+    FoldMarker { gap: usize, before_hunk: usize },
+    /// One hunk's own `@@ ... @@` header, by index into `DiffFile::hunks`.
+    HunkHeader(usize),
+    /// One real diff line. `hunk`/`line` index `DiffFile::hunks` (and, through the identity
+    /// guard, the index-aligned [`AdeApp::diff_highlight_cache`]); `row` is the flat
+    /// rendered-line counter that names this row's `diff-line-{row}` debug selector and that
+    /// [`MAX_RENDERED_DIFF_LINES_PER_FILE`] caps - all three are kept because the cache is
+    /// per-hunk while the cap and the selector are per-file.
+    Line {
+        hunk: usize,
+        line: usize,
+        row: usize,
+    },
+    /// The trailing `... diff truncated for this file` notice - a genuine final *item* of the
+    /// list, not a sibling below it (see [`render_diff_truncated_row`]).
+    Truncated,
+}
+
+/// The Diff view's whole row plan for `file`, in scroll order: fold markers between hunks that
+/// have a real unchanged gap, each hunk's header, that hunk's lines up to
+/// [`MAX_RENDERED_DIFF_LINES_PER_FILE`], and a trailing truncation notice when this file's diff
+/// really was cut short (either by that cap here or by `wt_core::diff`'s own load-time cap,
+/// `DiffFile::truncated`).
+///
+/// Pure, and separate from [`AdeApp::render_diff_file_detail`], for two reasons: `uniform_list`
+/// needs a real item *count* before it ever calls its row builder, and both numbers have to come
+/// from the same plan or the list would be sized by one shape and drawn from another. Being pure
+/// also makes the interleaving directly `#[test]`-able without a GPUI window - see
+/// `diff_row_plan_tests`.
+///
+/// The cap is applied exactly where the pre-virtualization render loop applied it, including its
+/// one subtlety: the cap is only checked *inside* a hunk's line loop, so a hunk whose first line
+/// would exceed it still contributes its header (and fold marker) before the plan stops. That is
+/// deliberately preserved rather than "cleaned up" - it is what makes the truncation notice read
+/// as sitting under a real hunk boundary instead of mid-hunk.
+fn diff_rows(file: &DiffFile) -> Vec<DiffRow> {
+    // At most one header + one fold marker per hunk, the capped line count, and the notice.
+    let mut rows: Vec<DiffRow> =
+        Vec::with_capacity(file.hunks.len() * 2 + MAX_RENDERED_DIFF_LINES_PER_FILE + 1);
+    let mut rendered_lines = 0usize;
+    let mut hunks_truncated = false;
+    let mut previous_header: Option<&str> = None;
+    'hunks: for (hunk_index, hunk) in file.hunks.iter().enumerate() {
+        if let Some(previous) = previous_header {
+            if let Some(gap) = changes::fold_gap_between(previous, &hunk.header) {
+                rows.push(DiffRow::FoldMarker {
+                    gap,
+                    before_hunk: hunk_index,
+                });
+            }
+        }
+        previous_header = Some(hunk.header.as_str());
+        rows.push(DiffRow::HunkHeader(hunk_index));
+
+        for line_index in 0..hunk.lines.len() {
+            if rendered_lines >= MAX_RENDERED_DIFF_LINES_PER_FILE {
+                hunks_truncated = true;
+                break 'hunks;
+            }
+            rows.push(DiffRow::Line {
+                hunk: hunk_index,
+                line: line_index,
+                row: rendered_lines,
+            });
+            rendered_lines += 1;
+        }
+    }
+
+    if file.truncated || hunks_truncated {
+        rows.push(DiffRow::Truncated);
+    }
+    rows
+}
 
 impl AdeApp {
     /// Ensures [`Self::diff_highlight_cache`] holds real per-hunk syntax highlighting for
@@ -100,6 +193,44 @@ impl AdeApp {
     /// blank-gutter path - real, honestly-blank output, never another file's real content. The
     /// guard itself is [`diff_highlight_cache_for`], factored out as its own pure, directly
     /// unit-tested function - see its own docs and tests for the constructed-mismatch proof.
+    ///
+    /// The guard is consulted *inside* the row builder, once per invocation of it, rather than
+    /// once per frame in this method: the builder is `'static` and re-resolves the open
+    /// `DiffFile` from `self` (below), so the cache has to be filtered against that same
+    /// re-resolved file for the check to mean anything. Nothing about the check itself changed -
+    /// same function, same `None`-means-fall-back-to-plain-text contract, and the per-row
+    /// `per_hunk.get(hunk)`/`lines.get(line)` reads are still reachable only through it.
+    ///
+    /// ## Virtualization (GitHub issue #224)
+    ///
+    /// A real `gpui::uniform_list`, following
+    /// `crate::code_surface::file_view::AdeApp::render_file_view`'s established pattern for this
+    /// same content shape (see `vendor/zed/crates/gpui/examples/uniform_list.rs` for the API
+    /// itself). Until this fix every row of the whole capped diff - up to
+    /// [`MAX_RENDERED_DIFF_LINES_PER_FILE`] lines plus every hunk header and fold marker - was
+    /// built, laid out and painted on *every single frame*, inside a plain
+    /// `div().overflow_y_scroll()`, including the great majority scrolled off screen. That is
+    /// structurally the same per-frame cost `crate::sidebar::render::AdeApp::render_file_tree`
+    /// and `crate::graph_view::render::AdeApp::render_graph_rows` (GitHub issue #218) were
+    /// carrying before they were virtualized; the file tree's own measurement of it (~72% of a
+    /// whole `Window::draw`) is *the file tree's*, on its row shape, not a measurement of this
+    /// view. What is measured here is `diff_virtualization_tests`' own before/after: a row far
+    /// below the viewport stopped being built at all.
+    ///
+    /// Two things `uniform_list` requires, both real:
+    /// - **Definite height.** Its default `ListSizingBehavior::Auto` gives it zero intrinsic
+    ///   height, so every pixel comes from the `.flex_1().min_h_0()` below - drop either and it
+    ///   renders zero rows, silently. It also owns its own scroll offset (hence
+    ///   [`Self::diff_view_scroll_handle`] becoming a `gpui::UniformListScrollHandle`), so it
+    ///   needs no `overflow_y_scroll()` wrapper and must not be given one.
+    /// - **One uniform row height,** measured from item 0 alone and then used for every slot
+    ///   (`vendor/zed/crates/gpui/src/elements/uniform_list.rs`'s `measure_item`/`prepaint`).
+    ///   This list interleaves four differently-purposed rows, so each is pinned to the same
+    ///   `rems(1.6)` a diff line's own `line_height` already gives it: [`render_fold_marker`]
+    ///   already had `.h(rems(1.6))`, [`render_hunk_header`] and [`render_diff_truncated_row`]
+    ///   were given it here. `rems`, not `px`, so they all still scale together under
+    ///   [`zoom_scoped`] - which wraps the list exactly the way `render_file_view` wraps its own.
+    ///   A row that disagreed would simply be clipped, with no panic and no warning.
     pub(in crate::code_surface) fn render_diff_file_detail(
         &self,
         file: &DiffFile,
@@ -107,112 +238,129 @@ impl AdeApp {
     ) -> gpui::AnyElement {
         // Read the effective zoom once and pass it to `zoom_scoped` at every return point below.
         let rem_px = self.effective_code_rem_px();
-        let mut container = div()
-            .id(format!("diff-detail-{}", file.path.display()))
-            .flex()
-            .flex_col()
-            .flex_1()
-            .min_h_0()
-            .overflow_y_scroll()
-            .bg(theme::surface::PTY)
-            .py(px(4.0))
-            // GitHub issue #30's real overlay scrollbar reads its geometry straight off this
-            // same handle (`crate::root::scrollbar::AdeApp::render_vertical_scrollbar`).
-            .track_scroll(&self.diff_view_scroll_handle);
 
         if file.is_binary {
             return zoom_scoped(
                 rem_px,
-                self.wrap_with_scrollbar(
-                    container.child(render_sidebar_message(
-                        "binary file (contents not diffed)".to_string(),
-                        theme::text::FAINT.into(),
-                    )),
-                    cx,
+                render_diff_message_pane(
+                    "diff-detail-binary",
+                    "binary file (contents not diffed)".to_string(),
                 ),
             );
         }
 
-        // A rename-only file produces zero `@@` hunks, so falling through the loop below would
-        // leave `container` with no children - a blank pane that looks like a rendering bug
-        // rather than "nothing to show". `changes::empty_hunks_message` picks honest wording,
-        // naming the rename specifically when that's the cause.
+        // A rename-only file produces zero `@@` hunks, so falling through to the list below would
+        // leave it with no items at all - a blank pane that looks like a rendering bug rather
+        // than "nothing to show". `changes::empty_hunks_message` picks honest wording, naming the
+        // rename specifically when that's the cause.
         if file.hunks.is_empty() {
             return zoom_scoped(
                 rem_px,
-                self.wrap_with_scrollbar(
-                    container.child(render_sidebar_message(
-                        changes::empty_hunks_message(file.status).to_string(),
-                        theme::text::FAINT.into(),
-                    )),
-                    cx,
+                render_diff_message_pane(
+                    "diff-detail-empty",
+                    changes::empty_hunks_message(file.status).to_string(),
                 ),
             );
         }
 
-        // The real identity guard: a cache entry only counts as usable for this render pass if
-        // it was built from this exact `file` (see this method's own docs, "Cache identity
-        // guard", and `diff_highlight_cache_for`'s own docs/tests for the pure logic below).
-        let cache = diff_highlight_cache_for(&self.diff_highlight_cache, file);
+        // Resolved once per frame, here, and shared with the row builder through an `Rc` - the
+        // same indirection (and the same reason) as `crate::sidebar::render::AdeApp::
+        // render_file_tree`'s own row list: `uniform_list` invokes its closure several times per
+        // frame (once at `0..1` to measure the row height, again during prepaint, then for the
+        // real visible range), so re-deriving this plan inside it would walk every hunk of the
+        // file that many times per frame - most of the cost this change exists to remove.
+        // It also has to exist before the list does, since `uniform_list` needs a real item count
+        // up front, and both must come from the same plan.
+        let rows: Rc<Vec<DiffRow>> = Rc::new(diff_rows(file));
+        let row_count = rows.len();
 
-        let mut rendered_lines = 0usize;
-        let mut hunks_truncated = false;
-        let mut previous_header: Option<&str> = None;
-        'hunks: for (hunk_index, hunk) in file.hunks.iter().enumerate() {
-            if let Some(previous) = previous_header {
-                if let Some(gap) = changes::fold_gap_between(previous, &hunk.header) {
-                    container = container.child(render_fold_marker(gap));
-                }
-            }
-            previous_header = Some(hunk.header.as_str());
+        let list = uniform_list(
+            // Per-path, matching the element id the pre-virtualization container carried: a
+            // different open diff is a different list, not the same one showing new content.
+            format!("diff-detail-{}", file.path.display()),
+            row_count,
+            cx.processor(move |this: &mut Self, range: Range<usize>, _window, _cx| {
+                // Re-resolved from `this` rather than captured, mirroring
+                // `crate::graph_view::render::AdeApp::render_graph_rows`' identical re-resolve:
+                // the closure is `'static` and cannot borrow the `&DiffFile` this method was
+                // handed, and cloning one (up to `wt_core::diff`'s own per-file line cap) per
+                // frame would be a real cost of its own. `Self::render_center_pane` takes this
+                // field out only for the duration of its own `render()` call and puts it straight
+                // back, so it is genuinely populated by the time this closure runs (layout), the
+                // same lifecycle `render_graph_rows` relies on.
+                let Some(file) = this.open_diff_file_cache.as_ref() else {
+                    return Vec::new();
+                };
+                // The real identity guard - a cache entry only counts as usable for these rows if
+                // it was built from this exact file (see this method's own "Cache identity guard"
+                // docs, and `diff_highlight_cache_for`'s own docs/tests for the pure logic).
+                let cache = diff_highlight_cache_for(&this.diff_highlight_cache, file);
+                // Clamped rather than trusted, and `start` against `end` rather than only against
+                // the length, so a divergence degrades to "renders fewer rows" instead of
+                // panicking on an inverted range.
+                let end = range.end.min(rows.len());
+                let start = range.start.min(end);
+                rows[start..end]
+                    .iter()
+                    .map(|row| match *row {
+                        DiffRow::FoldMarker { gap, before_hunk } => {
+                            render_fold_marker(gap, before_hunk).into_any_element()
+                        }
+                        DiffRow::HunkHeader(index) => match file.hunks.get(index) {
+                            Some(hunk) => {
+                                render_hunk_header(&hunk.header, index).into_any_element()
+                            }
+                            // Only reachable if the open file changed shape between this frame's
+                            // row plan and this call; an empty row of the shared height keeps the
+                            // list's geometry honest instead of panicking.
+                            None => render_blank_diff_row().into_any_element(),
+                        },
+                        DiffRow::Line { hunk, line, row } => {
+                            match file.hunks.get(hunk).and_then(|h| h.lines.get(line)) {
+                                Some(diff_line) => {
+                                    let rendered = cache
+                                        .and_then(|(per_hunk, _)| per_hunk.get(hunk))
+                                        .and_then(|lines| lines.get(line));
+                                    let numbers = cache
+                                        .and_then(|(_, per_hunk_numbers)| {
+                                            per_hunk_numbers.get(hunk)
+                                        })
+                                        .and_then(|nums| nums.get(line))
+                                        .copied()
+                                        .unwrap_or((None, None));
+                                    render_diff_line(diff_line, rendered, numbers, row)
+                                        .into_any_element()
+                                }
+                                None => render_blank_diff_row().into_any_element(),
+                            }
+                        }
+                        DiffRow::Truncated => render_diff_truncated_row().into_any_element(),
+                    })
+                    .collect::<Vec<_>>()
+            }),
+        )
+        // Load-bearing, and it fails silently if removed - see this method's own docs.
+        .flex_1()
+        .min_h_0()
+        .bg(theme::surface::PTY)
+        // GitHub issue #30's real overlay scrollbar reads its geometry straight off this same
+        // handle (`crate::root::scrollbar::AdeApp::render_vertical_scrollbar`).
+        .track_scroll(&self.diff_view_scroll_handle);
 
-            container = container.child(
-                div()
-                    .font(font(theme::font::MONO))
-                    .text_size(rems(1.0))
-                    .line_height(rems(1.6))
-                    .px(px(8.0))
-                    .bg(theme::diff::HUNK_BG)
-                    .text_color(theme::diff::HUNK_FG)
-                    .child(hunk.header.clone()),
-            );
-
-            for (line_index, line) in hunk.lines.iter().enumerate() {
-                if rendered_lines >= MAX_RENDERED_DIFF_LINES_PER_FILE {
-                    hunks_truncated = true;
-                    break 'hunks;
-                }
-                let row_index = rendered_lines;
-                rendered_lines += 1;
-                let rendered = cache
-                    .and_then(|(per_hunk, _)| per_hunk.get(hunk_index))
-                    .and_then(|lines| lines.get(line_index));
-                let numbers = cache
-                    .and_then(|(_, per_hunk_numbers)| per_hunk_numbers.get(hunk_index))
-                    .and_then(|nums| nums.get(line_index))
-                    .copied()
-                    .unwrap_or((None, None));
-                container = container.child(render_diff_line(line, rendered, numbers, row_index));
-            }
-        }
-
-        if file.truncated || hunks_truncated {
-            container = container.child(render_sidebar_message(
-                "... diff truncated for this file".to_string(),
-                theme::text::FAINT.into(),
-            ));
-        }
-
-        zoom_scoped(rem_px, self.wrap_with_scrollbar(container, cx))
+        zoom_scoped(rem_px, self.wrap_with_scrollbar(list, cx))
     }
 
-    /// Wraps `content` (the Diff view's own scrollable `container`, already `track_scroll`'d with
-    /// [`Self::diff_view_scroll_handle`]) in the real, non-scrolling `.relative()` sibling wrapper
-    /// GitHub issue #30's overlay scrollbar needs - see `crate::sidebar::render::AdeApp::
+    /// Wraps the Diff view's `uniform_list` in the real, non-scrolling `.relative()` sibling
+    /// wrapper GitHub issue #30's overlay scrollbar needs - see `crate::sidebar::render::AdeApp::
     /// render_file_tree`'s own docs on why the scrollbar must never be a child of the scrolling
-    /// element itself. Factored out because [`Self::render_diff_file_detail`] has three real
-    /// return points (binary, no-hunks, and the real hunk-rendering path), and each needs the
-    /// exact same wrap.
+    /// element itself.
+    ///
+    /// Only the real hunk-rendering path uses this now. The two message return points (binary,
+    /// no-hunks) render through [`render_diff_message_pane`] instead, with no scrollbar at all:
+    /// a one-line message can never overflow the pane, and now that this handle's geometry is
+    /// written by the `uniform_list` alone, a message frame that still consulted it would be
+    /// reading whatever the last *diff* left there - a scrollbar for content that isn't on
+    /// screen.
     fn wrap_with_scrollbar(
         &self,
         content: impl IntoElement,
@@ -235,6 +383,86 @@ impl AdeApp {
     }
 }
 
+/// One of the Diff view's two non-diff return points (a binary file, or a file with no hunks at
+/// all) as a real pane: the same `theme::surface::PTY` background and top padding the row list
+/// sits on, with one [`render_sidebar_message`] on it. Deliberately not scrollable - see
+/// [`AdeApp::wrap_with_scrollbar`]'s own docs.
+fn render_diff_message_pane(id: &'static str, message: String) -> impl IntoElement {
+    div()
+        .id(id)
+        .flex()
+        .flex_col()
+        .flex_1()
+        .min_h_0()
+        .bg(theme::surface::PTY)
+        .py(px(4.0))
+        .child(render_sidebar_message(message, theme::text::FAINT.into()))
+}
+
+/// One hunk's `@@ ... @@` header row.
+///
+/// `.h(rems(1.6))` (with `.flex().items_center()`) rather than relying on its own line height:
+/// this is item 0 of [`AdeApp::render_diff_file_detail`]'s `uniform_list` for every real diff -
+/// the single row every other slot's height is measured from - so its height is stated outright
+/// rather than left to emerge from the text style, and it is the same `rems(1.6)` a diff line's
+/// `line_height` gives it. `rems`, not `px`, so it scales with zoom like the rows around it.
+pub(in crate::code_surface) fn render_hunk_header(
+    header: &str,
+    hunk_index: usize,
+) -> impl IntoElement {
+    div()
+        .flex()
+        .items_center()
+        .h(rems(1.6))
+        .font(font(theme::font::MONO))
+        .text_size(rems(1.0))
+        .line_height(rems(1.6))
+        .px(px(8.0))
+        .bg(theme::diff::HUNK_BG)
+        .text_color(theme::diff::HUNK_FG)
+        .whitespace_nowrap()
+        .overflow_hidden()
+        .child(header.to_string())
+        // A no-op outside test builds, like every other `debug_selector` in this crate - lets a
+        // real render test measure one specific hunk header's painted bounds.
+        .debug_selector(move || format!("diff-hunk-header-{hunk_index}"))
+}
+
+/// The `... diff truncated for this file` notice, shown when this file's diff really was cut
+/// short - by [`MAX_RENDERED_DIFF_LINES_PER_FILE`] here, or by `wt_core::diff`'s own load-time
+/// cap (`DiffFile::truncated`).
+///
+/// The final *item* of the row list rather than a sibling below it, which is what keeps it
+/// scrolling with the rows it is talking about - the same treatment
+/// `crate::graph_view::render::render_graph_load_more_row` gives the graph's own trailing notice
+/// (GitHub issue #218/#221), and for the same reason it carries the shared `rems(1.6)` row
+/// height: `uniform_list` sizes every slot from item 0 alone, so a taller row (which is exactly
+/// what the `render_sidebar_message` this replaces was, at `p(px(10.0))` around 10.5px text)
+/// would simply be clipped, with no panic and no warning. Same wording as before, in the same
+/// faint monospace as the fold markers it sits below.
+fn render_diff_truncated_row() -> impl IntoElement {
+    div()
+        .flex()
+        .items_center()
+        .h(rems(1.6))
+        .px(px(8.0))
+        .font(font(theme::font::MONO))
+        .text_size(rems(0.85))
+        .text_color(theme::text::FAINT)
+        .whitespace_nowrap()
+        .overflow_hidden()
+        .child("... diff truncated for this file")
+        .debug_selector(|| "diff-truncated-row".to_string())
+}
+
+/// An empty row at the shared height, for the one case the row builder can't resolve: a row plan
+/// index that no longer names real content because the open `DiffFile` changed between this
+/// frame's plan and the builder's call. Real, honest blank space - never a guess at what the row
+/// used to hold, and never a panic.
+fn render_blank_diff_row() -> impl IntoElement {
+    div().h(rems(1.6))
+}
+
 /// The diff view's `⋯ N unchanged lines` fold marker. `N` is derived from the hunks' `@@ ... @@`
 /// headers (`crate::sidebar::changes::fold_gap_between`), never an estimate.
 ///
@@ -242,13 +470,22 @@ impl AdeApp {
 /// marker isn't exempt from zoom, so it must scale with the surrounding diff rows rather than
 /// staying a fixed-size sliver once zoom moves off 100%. `0.85` keeps it proportionally smaller
 /// than a diff line's own text, matching the 11px-vs-13px ratio at the 100% baseline.
-pub(in crate::code_surface) fn render_fold_marker(gap: usize) -> impl IntoElement {
+///
+/// Its `.h(rems(1.6))` - which predates virtualization - is also exactly the shared row height
+/// [`AdeApp::render_diff_file_detail`]'s `uniform_list` lays every slot out at, so this marker
+/// needed no height change to become a real item of that list. `before_hunk` names only this
+/// row's own `diff-fold-marker-{before_hunk}` debug selector (see [`DiffRow::FoldMarker`]).
+pub(in crate::code_surface) fn render_fold_marker(
+    gap: usize,
+    before_hunk: usize,
+) -> impl IntoElement {
     div()
         .flex()
         .items_center()
         .gap(px(4.0))
         .px(px(8.0))
         .h(rems(1.6))
+        .debug_selector(move || format!("diff-fold-marker-{before_hunk}"))
         .bg(theme::diff::FOLD_BG)
         .font(font(theme::font::MONO))
         .text_size(rems(0.85))
@@ -303,9 +540,11 @@ fn render_diff_gutter_number(number: Option<usize>) -> impl IntoElement {
         // once already for the File view's own gutter (`render_file_view_line`'s docs). Real
         // width headroom, not just a wider number: `.whitespace_nowrap()`/`.overflow_hidden()`
         // below are the same real defensive backstop, so an even-longer number clips rather than
-        // wrapping and growing this row's height past its neighbours' (a real `uniform_list`-
-        // adjacent risk elsewhere in this crate, even though this Diff view isn't itself
-        // virtualized).
+        // wrapping and growing this row's height past its neighbours'. That is no longer just
+        // tidiness: since GitHub issue #224 this view *is* a `uniform_list`, which lays every row
+        // out at the height it measured from item 0 alone, so a row that grew taller would be
+        // silently clipped - the exact bug Revision R5's audit fixed for the File view's own
+        // gutter (`render_file_view_line`'s docs), reachable here too now.
         .w(px(44.0))
         .pr(px(6.0))
         .text_right()
@@ -690,6 +929,12 @@ mod diff_render_tests {
     /// with more lines than the render loop will ever show must still render every one of the
     /// lines it *does* show with real highlighting (not a `None`-cache fallback row), and must
     /// not panic at the exact truncation boundary.
+    ///
+    /// GitHub issue #224 changed *when* the last row within the cap paints, not whether it is
+    /// reachable: the list is a real `gpui::uniform_list` now, so row 299 is only built once it
+    /// is genuinely scrolled into view. The assertion below therefore scrolls first - and the
+    /// row past the cap must still not exist at any scroll position at all, which is the half of
+    /// this test that is really about the cap.
     #[gpui::test]
     fn a_diff_past_the_rendered_line_cap_still_highlights_every_line_it_actually_renders(
         cx: &mut TestAppContext,
@@ -731,13 +976,29 @@ mod diff_render_tests {
             );
         });
 
+        let first_row = cx
+            .debug_bounds("diff-line-0")
+            .expect("the first diff row must really paint");
+        // A deliberately huge delta: `uniform_list` clamps to its own real maximum scroll offset,
+        // so this lands at the true bottom without this test having to model row heights or the
+        // viewport itself (the same technique `crate::graph_view::render::
+        // graph_virtualization_tests` uses).
+        cx.simulate_event(gpui::ScrollWheelEvent {
+            position: first_row.center(),
+            delta: gpui::ScrollDelta::Pixels(gpui::point(px(0.0), px(-100_000.0))),
+            modifiers: gpui::Modifiers::default(),
+            touch_phase: gpui::TouchPhase::Moved,
+        });
+        cx.run_until_parked();
+
         assert!(
             cx.debug_bounds("diff-line-299").is_some(),
-            "the last row within the real render cap should have really painted"
+            "the last row within the real render cap must really paint once it is scrolled to"
         );
         assert!(
             cx.debug_bounds("diff-line-300").is_none(),
-            "a row past the real render cap must not exist at all"
+            "a row past the real render cap must not exist at all - not even at the very bottom \
+             of the list, which is exactly where it would be if the cap had been raised"
         );
     }
 
@@ -814,5 +1075,572 @@ mod diff_render_tests {
         let file = sample_diff_file("a.rs");
         let cache: Option<DiffHighlightCache> = None;
         assert!(diff_highlight_cache_for(&cache, &file).is_none());
+    }
+}
+
+/// The pure half of GitHub issue #224: [`diff_rows`], the flat row plan
+/// [`AdeApp::render_diff_file_detail`]'s `uniform_list` is both sized by and drawn from.
+///
+/// These need no GPUI window at all, which is the point of factoring the plan out of the render
+/// method: the interleaving of hunk headers, fold markers, diff lines and the truncation notice -
+/// and the exact place [`MAX_RENDERED_DIFF_LINES_PER_FILE`] cuts it off - is directly assertable
+/// here, while `diff_virtualization_tests` below covers what only a real render can show.
+#[cfg(test)]
+mod diff_row_plan_tests {
+    use super::*;
+
+    fn line(kind: DiffLineKind, content: &str) -> wt_core::diff::DiffLine {
+        wt_core::diff::DiffLine {
+            kind,
+            content: content.to_string(),
+        }
+    }
+
+    fn file_with(hunks: Vec<wt_core::diff::DiffHunk>, truncated: bool) -> DiffFile {
+        DiffFile {
+            path: PathBuf::from("src/main.rs"),
+            old_path: None,
+            status: wt_core::diff::FileChangeStatus::Modified,
+            is_binary: false,
+            hunks,
+            truncated,
+        }
+    }
+
+    /// The ordinary shape: header, that hunk's lines, then - only where the headers say there is
+    /// a real unchanged gap - a fold marker before the next header.
+    #[test]
+    fn the_row_plan_interleaves_headers_fold_markers_and_lines_in_scroll_order() {
+        let file = file_with(
+            vec![
+                wt_core::diff::DiffHunk {
+                    header: "@@ -1,2 +1,2 @@".to_string(),
+                    lines: vec![
+                        line(DiffLineKind::Removed, "old"),
+                        line(DiffLineKind::Added, "new"),
+                    ],
+                },
+                // New-side range starts at 40, while the first hunk covered 1..=2 - a real
+                // 37-line unchanged gap (`changes::fold_gap_between`).
+                wt_core::diff::DiffHunk {
+                    header: "@@ -40,1 +40,1 @@".to_string(),
+                    lines: vec![line(DiffLineKind::Context, "unchanged")],
+                },
+            ],
+            false,
+        );
+
+        assert_eq!(
+            diff_rows(&file),
+            vec![
+                DiffRow::HunkHeader(0),
+                DiffRow::Line {
+                    hunk: 0,
+                    line: 0,
+                    row: 0
+                },
+                DiffRow::Line {
+                    hunk: 0,
+                    line: 1,
+                    row: 1
+                },
+                DiffRow::FoldMarker {
+                    gap: 37,
+                    before_hunk: 1
+                },
+                DiffRow::HunkHeader(1),
+                DiffRow::Line {
+                    hunk: 1,
+                    line: 0,
+                    row: 2
+                },
+            ],
+            "the plan must be exactly what the pre-virtualization render loop appended, in the \
+             same order - including the flat `row` counter the `diff-line-{{n}}` selectors and \
+             the render cap are both expressed in, which keeps counting across hunk boundaries"
+        );
+    }
+
+    /// Back-to-back hunks (no real unchanged span between them) get no fold marker, so the plan
+    /// can't invent scroll extent that isn't there.
+    #[test]
+    fn back_to_back_hunks_produce_no_fold_marker() {
+        let file = file_with(
+            vec![
+                wt_core::diff::DiffHunk {
+                    header: "@@ -1,5 +1,5 @@".to_string(),
+                    lines: vec![line(DiffLineKind::Context, "a")],
+                },
+                wt_core::diff::DiffHunk {
+                    header: "@@ -6,5 +6,5 @@".to_string(),
+                    lines: vec![line(DiffLineKind::Context, "b")],
+                },
+            ],
+            false,
+        );
+        assert!(
+            !diff_rows(&file)
+                .iter()
+                .any(|row| matches!(row, DiffRow::FoldMarker { .. })),
+            "there is no unchanged span between these two hunks, so there must be no `⋯ N \
+             unchanged lines` row claiming one"
+        );
+    }
+
+    /// The cap is unchanged by virtualization (deliberately - GitHub issue #224 is about
+    /// per-frame render cost, not about how much of a diff is reachable): exactly
+    /// [`MAX_RENDERED_DIFF_LINES_PER_FILE`] line rows, then the truncation notice as the final
+    /// item of the list.
+    #[test]
+    fn the_row_plan_stops_at_the_render_cap_and_ends_with_the_truncation_notice() {
+        let lines: Vec<wt_core::diff::DiffLine> = (0..MAX_RENDERED_DIFF_LINES_PER_FILE + 50)
+            .map(|index| line(DiffLineKind::Added, &format!("line {index}")))
+            .collect();
+        let file = file_with(
+            vec![wt_core::diff::DiffHunk {
+                header: "@@ -1,1 +1,350 @@".to_string(),
+                lines,
+            }],
+            false,
+        );
+
+        let rows = diff_rows(&file);
+        let line_rows = rows
+            .iter()
+            .filter(|row| matches!(row, DiffRow::Line { .. }))
+            .count();
+        assert_eq!(
+            line_rows, MAX_RENDERED_DIFF_LINES_PER_FILE,
+            "the render cap must still be exactly what it was - a virtualized list is not a \
+             reason to raise it, and raising it would be its own separate decision"
+        );
+        assert_eq!(
+            rows.last(),
+            Some(&DiffRow::Truncated),
+            "a diff cut short by the cap must end with the truncation notice as the list's own \
+             final item"
+        );
+    }
+
+    /// The loader's own cap (`wt_core::diff`'s `DiffFile::truncated`) is a second, independent
+    /// reason for that notice - a file well under this view's own render cap still gets it.
+    #[test]
+    fn a_loader_truncated_file_under_the_cap_still_ends_with_the_notice() {
+        let file = file_with(
+            vec![wt_core::diff::DiffHunk {
+                header: "@@ -1,1 +1,1 @@".to_string(),
+                lines: vec![line(DiffLineKind::Context, "unchanged")],
+            }],
+            true,
+        );
+        assert_eq!(diff_rows(&file).last(), Some(&DiffRow::Truncated));
+    }
+
+    /// And a whole, untruncated diff must not grow a notice out of nowhere.
+    #[test]
+    fn a_complete_diff_gets_no_truncation_notice() {
+        let file = file_with(
+            vec![wt_core::diff::DiffHunk {
+                header: "@@ -1,1 +1,1 @@".to_string(),
+                lines: vec![line(DiffLineKind::Context, "unchanged")],
+            }],
+            false,
+        );
+        assert!(!diff_rows(&file).contains(&DiffRow::Truncated));
+    }
+}
+
+/// Real, live-rendered proof that the Diff view's row list is genuinely virtualized (GitHub issue
+/// #224, "Diff file view is lagging") - that a row scrolled far below the viewport is not merely
+/// *invisible* but never becomes a painted element at all.
+///
+/// None of this is observable from [`diff_rows`]' pure plan, which is identical either way: only
+/// a real render can tell "built 300 rows and clipped 250 of them" apart from "built 50". These
+/// tests therefore also assert the positive half - that the rows which should paint really do,
+/// that the absent ones are still reachable by really scrolling, and that the list's three other
+/// row kinds (hunk header, fold marker, truncation notice) survived being folded into a list that
+/// lays every slot out at one fixed height - so a future change that "virtualizes" by rendering
+/// nothing, or by silently clipping every non-line row, fails here rather than passing.
+///
+/// The first two were run against the pre-fix eager `flex_col` before being committed, and both
+/// genuinely failed against it: with 350 real changed lines open, `diff-line-250` had painted
+/// bounds with the list untouched at the top, and so had `diff-line-299`, the very last row
+/// within the render cap. Both pass against the `uniform_list`. That is what they measure and all
+/// they measure - no frame timing is claimed here, for this view.
+///
+/// Mirrors `crate::graph_view::render::graph_virtualization_tests`, the same proof for the git
+/// graph's commit rows.
+#[cfg(test)]
+mod diff_virtualization_tests {
+    use super::*;
+    use gpui::{Entity, TestAppContext};
+
+    fn git(dir: &std::path::Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .output()
+            .expect("failed to spawn git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed in {:?}: {}",
+            args,
+            dir,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn init_repo(dir: &std::path::Path) {
+        git(dir, &["init", "-b", "main"]);
+        git(dir, &["config", "user.email", "test@example.com"]);
+        git(dir, &["config", "user.name", "Test User"]);
+    }
+
+    /// A real repository whose working tree differs from its committed base by `added` brand-new
+    /// lines in one file - a single real git hunk, `added` lines long.
+    ///
+    /// 350 is deliberately more than [`MAX_RENDERED_DIFF_LINES_PER_FILE`] (300), so the same seed
+    /// exercises the cap and the truncation notice; the test viewport is 1920x1080, so at the
+    /// `rems(1.6)` row height (about 21px at the default editor font size) only on the order of
+    /// 50 rows can be on screen at once - far fewer than either number.
+    fn seed_big_diff(dir: &std::path::Path, added: usize) {
+        init_repo(dir);
+        std::fs::write(dir.join("big.rs"), "fn noop() {}\n").expect("write big.rs");
+        git(dir, &["add", "."]);
+        git(dir, &["commit", "-m", "initial"]);
+        git(dir, &["checkout", "-b", "feature"]);
+        let mut content = String::from("fn noop() {}\n");
+        for index in 0..added {
+            content.push_str(&format!("fn generated_{index}() -> i32 {{ {index} }}\n"));
+        }
+        std::fs::write(dir.join("big.rs"), &content).expect("rewrite big.rs");
+    }
+
+    /// A real repository whose working tree changes one line near the top and one near the bottom
+    /// of a 60-line file - two real git hunks with a real unchanged span between them, which is
+    /// what makes `changes::fold_gap_between` produce a genuine `⋯ N unchanged lines` row.
+    fn seed_two_hunk_diff(dir: &std::path::Path) {
+        init_repo(dir);
+        let original: String = (1..=60).map(|n| format!("fn f{n}() {{ {n} }}\n")).collect();
+        std::fs::write(dir.join("two.rs"), &original).expect("write two.rs");
+        git(dir, &["add", "."]);
+        git(dir, &["commit", "-m", "initial"]);
+        git(dir, &["checkout", "-b", "feature"]);
+        let changed: String = (1..=60)
+            .map(|n| {
+                if n == 2 || n == 58 {
+                    format!("fn f{n}() {{ {} }}\n", n * 1000)
+                } else {
+                    format!("fn f{n}() {{ {n} }}\n")
+                }
+            })
+            .collect();
+        std::fs::write(dir.join("two.rs"), &changed).expect("rewrite two.rs");
+    }
+
+    fn open_diff_on<'a>(
+        cx: &'a mut TestAppContext,
+        repo: &std::path::Path,
+        path: &str,
+    ) -> (Entity<AdeApp>, &'a mut gpui::VisualTestContext) {
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.to_path_buf());
+        cx.run_until_parked();
+        let path = PathBuf::from(path);
+        app.update_in(cx, |app, window, cx| {
+            app.open_change_diff(path, window, cx);
+        });
+        cx.run_until_parked();
+        (app, cx)
+    }
+
+    /// A deliberately huge delta: `uniform_list` clamps to its own real maximum scroll offset, so
+    /// this lands at the true bottom without modelling row heights or the viewport.
+    fn scroll_to_bottom(cx: &mut gpui::VisualTestContext, anchor: gpui::Point<Pixels>) {
+        cx.simulate_event(gpui::ScrollWheelEvent {
+            position: anchor,
+            delta: gpui::ScrollDelta::Pixels(gpui::point(px(0.0), px(-100_000.0))),
+            modifiers: gpui::Modifiers::default(),
+            touch_phase: gpui::TouchPhase::Moved,
+        });
+        cx.run_until_parked();
+    }
+
+    #[gpui::test]
+    fn a_diff_line_far_below_the_viewport_is_never_painted(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        seed_big_diff(repo.path(), 350);
+        let (_app, cx) = open_diff_on(cx, repo.path(), "big.rs");
+
+        assert!(
+            cx.debug_bounds("diff-line-0").is_some(),
+            "the first diff row must really paint - if it doesn't, this test proves nothing \
+             about virtualization, only that the diff is empty"
+        );
+        assert!(
+            cx.debug_bounds("diff-line-250").is_none(),
+            "row 250 is far below any plausible viewport, so a virtualized list must never build \
+             it as an element at all - this is exactly what the pre-fix eager `flex_col` did, and \
+             what this assertion was checked to genuinely fail against"
+        );
+    }
+
+    /// The other half of "is it really virtualized": a row that legitimately isn't painted yet
+    /// must still be reachable. This scrolls the real list with a real `gpui::ScrollWheelEvent`
+    /// and asserts the row that was absent genuinely materializes - which simultaneously proves
+    /// the list still scrolls at all now that the former `div().overflow_y_scroll()` wrapper is
+    /// gone, the one behaviour this change could plausibly have broken outright.
+    #[gpui::test]
+    fn scrolling_the_virtualized_diff_materializes_a_row_that_was_not_painted(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        seed_big_diff(repo.path(), 350);
+        let (_app, cx) = open_diff_on(cx, repo.path(), "big.rs");
+
+        let first_row = cx
+            .debug_bounds("diff-line-0")
+            .expect("the first diff row must really paint");
+        assert!(
+            cx.debug_bounds("diff-line-299").is_none(),
+            "precondition: a row far below the viewport must not be painted before scrolling"
+        );
+
+        scroll_to_bottom(cx, first_row.center());
+
+        assert!(
+            cx.debug_bounds("diff-line-299").is_some(),
+            "scrolling to the bottom must really materialize a row that was absent - if this \
+             fails the list is not scrollable any more, which is a far worse regression than the \
+             per-frame render cost this change set out to fix"
+        );
+        assert!(
+            cx.debug_bounds("diff-line-0").is_none(),
+            "and the rows scrolled off the top must stop being built, not merely move - a list \
+             that keeps painting them is not virtualizing, it is just translating"
+        );
+    }
+
+    /// The three rows that are not diff lines have to survive being items of a list that measures
+    /// item 0 and lays every other slot out at exactly that height: a hunk header (which *is*
+    /// item 0 of every real diff), the `⋯ N unchanged lines` fold marker between two hunks, and
+    /// the second hunk's own header after it. All three must paint, in that order, each exactly
+    /// as tall as a real diff line - a row that disagreed would be clipped, with no panic and no
+    /// warning.
+    #[gpui::test]
+    fn hunk_headers_and_fold_markers_paint_at_the_shared_row_height(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        seed_two_hunk_diff(repo.path());
+        let (app, cx) = open_diff_on(cx, repo.path(), "two.rs");
+
+        // Precondition, read off the real loaded diff rather than assumed: git really did produce
+        // two hunks here, with a real unchanged gap between them.
+        app.read_with(cx, |app, _| {
+            let file = app
+                .open_diff_file_cache
+                .as_ref()
+                .expect("the diff must be loaded");
+            assert_eq!(
+                file.hunks.len(),
+                2,
+                "precondition: this seed must produce exactly two real hunks, got {:?}",
+                file.hunks.iter().map(|h| &h.header).collect::<Vec<_>>()
+            );
+            assert!(
+                diff_rows(file)
+                    .iter()
+                    .any(|row| matches!(row, DiffRow::FoldMarker { .. })),
+                "precondition: the two hunks must have a real unchanged span between them"
+            );
+        });
+
+        let header = cx
+            .debug_bounds("diff-hunk-header-0")
+            .expect("the first hunk's header must really paint inside the virtualized list");
+        let first_line = cx
+            .debug_bounds("diff-line-0")
+            .expect("the first diff row must really paint");
+        let fold = cx
+            .debug_bounds("diff-fold-marker-1")
+            .expect("the fold marker between the two hunks must really paint");
+        let second_header = cx
+            .debug_bounds("diff-hunk-header-1")
+            .expect("the second hunk's header must really paint");
+
+        assert_eq!(
+            header.size.height, first_line.size.height,
+            "the hunk header is item 0, the one row every other slot's height is measured from - \
+             it must be exactly as tall as a real diff line"
+        );
+        assert_eq!(
+            fold.size.height, first_line.size.height,
+            "and so must the fold marker, which is a different element with its own `rems(0.85)` \
+             text"
+        );
+        assert_eq!(
+            first_line.origin.y,
+            header.origin.y + header.size.height,
+            "the first diff line must sit directly below its own hunk's header, with no gap - \
+             the list lays its items out contiguously"
+        );
+        assert_eq!(
+            second_header.origin.y,
+            fold.origin.y + fold.size.height,
+            "and the second hunk's header directly below the fold marker that introduces it"
+        );
+    }
+
+    /// The truncation notice is the final *item* of the list rather than a sibling below it, so
+    /// it has to sit directly under the last row within the cap and carry the same fixed height.
+    /// (As a `render_sidebar_message` - what it used to be - it would have been a ~31px element
+    /// in a ~21px slot, i.e. clipped.)
+    #[gpui::test]
+    fn the_truncation_notice_is_the_last_item_of_the_list_at_the_shared_row_height(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        seed_big_diff(repo.path(), 350);
+        let (_app, cx) = open_diff_on(cx, repo.path(), "big.rs");
+
+        let first_row = cx
+            .debug_bounds("diff-line-0")
+            .expect("the first diff row must really paint");
+        assert!(
+            cx.debug_bounds("diff-truncated-row").is_none(),
+            "precondition: the notice lives at the very bottom of a 300-row list, so it must not \
+             be painted while the list is scrolled to the top"
+        );
+
+        scroll_to_bottom(cx, first_row.center());
+
+        let last_row = cx
+            .debug_bounds("diff-line-299")
+            .expect("the last row within the render cap must paint at the bottom of the list");
+        let notice = cx
+            .debug_bounds("diff-truncated-row")
+            .expect("a diff cut short by the render cap must say so at its bottom");
+        assert_eq!(
+            notice.origin.y,
+            last_row.origin.y + last_row.size.height,
+            "the notice must be the item directly below the last rendered diff line"
+        );
+        assert_eq!(
+            notice.size.height, last_row.size.height,
+            "and exactly as tall as every other item, which is the fixed height `uniform_list` \
+             lays every slot out at"
+        );
+    }
+
+    /// GitHub issue #30's overlay scrollbar has to keep working across the handle's type change
+    /// (`gpui::ScrollHandle` -> `gpui::UniformListScrollHandle`): it reads its geometry through
+    /// `crate::root::scrollbar::ScrollableHandle`, which already covered both kinds, but the
+    /// values behind it are written by the `uniform_list` now rather than by a scrolling `div`.
+    /// A diff long enough to overflow must still get a real, painted track - and one that fits
+    /// must still get none, so this can't pass by drawing a scrollbar unconditionally.
+    #[gpui::test]
+    fn the_overlay_scrollbar_still_tracks_the_virtualized_list(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        seed_big_diff(repo.path(), 350);
+        let (app, cx) = open_diff_on(cx, repo.path(), "big.rs");
+        // The scrollbar is built from the geometry the *previous* frame's layout wrote onto the
+        // handle, so a second real frame is what makes it appear - the same one-frame lag every
+        // other overlay scrollbar in this app has.
+        app.update(cx, |_app, cx| cx.notify());
+        cx.run_until_parked();
+
+        assert!(
+            cx.debug_bounds("diff-view-scrollbar").is_some(),
+            "a 300-row diff overflows its pane, so the real overlay scrollbar must paint - if \
+             this fails the handle's geometry is no longer reaching it"
+        );
+
+        // A diff that genuinely fits must still get no scrollbar at all.
+        let small = tempfile::tempdir().expect("tempdir");
+        init_repo(small.path());
+        std::fs::write(small.path().join("small.rs"), "fn a() -> i32 {\n    1\n}\n")
+            .expect("write small.rs");
+        git(small.path(), &["add", "."]);
+        git(small.path(), &["commit", "-m", "initial"]);
+        git(small.path(), &["checkout", "-b", "feature"]);
+        std::fs::write(small.path().join("small.rs"), "fn a() -> i32 {\n    2\n}\n")
+            .expect("rewrite small.rs");
+        let (app, cx) = open_diff_on(cx, small.path(), "small.rs");
+        app.update(cx, |_app, cx| cx.notify());
+        cx.run_until_parked();
+
+        assert!(
+            cx.debug_bounds("diff-line-0").is_some(),
+            "precondition: the small diff really is open and rendering rows"
+        );
+        assert!(
+            cx.debug_bounds("diff-view-scrollbar").is_none(),
+            "a four-row diff doesn't overflow anything, so there must be no scrollbar for it"
+        );
+    }
+
+    /// The cache identity guard under virtualization. The guard itself is unchanged
+    /// ([`diff_highlight_cache_for`], still covered directly by `diff_render_tests`' own
+    /// constructed-mismatch proofs) but *where* it is consulted moved: into the row builder,
+    /// which now resolves one row at a time by `(hunk, line)` instead of walking hunks in order.
+    /// That is exactly the indexing a virtualized rewrite could plausibly get wrong - and getting
+    /// it wrong would reproduce the original CRITICAL bug's symptom, one line's real source text
+    /// under another line's diff sign and gutter number.
+    ///
+    /// So this walks the real row plan for a real two-hunk diff and resolves each line row
+    /// through the guard exactly the way the row builder does, asserting the text it lands on is
+    /// that row's own content - including for the second hunk, whose rows are the ones a
+    /// flat-counter mix-up would misroute.
+    #[gpui::test]
+    fn every_virtualized_row_resolves_its_own_line_through_the_identity_guard(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        seed_two_hunk_diff(repo.path());
+        let (app, cx) = open_diff_on(cx, repo.path(), "two.rs");
+
+        app.read_with(cx, |app, _| {
+            let file = app
+                .open_diff_file_cache
+                .as_ref()
+                .expect("the diff must be loaded");
+            let (per_hunk, per_hunk_numbers) =
+                diff_highlight_cache_for(&app.diff_highlight_cache, file)
+                    .expect("the guard must accept the cache built for this very file");
+
+            let mut checked_second_hunk = 0usize;
+            for row in diff_rows(file) {
+                let DiffRow::Line { hunk, line, .. } = row else {
+                    continue;
+                };
+                let expected = &file.hunks[hunk].lines[line].content;
+                let rendered = per_hunk
+                    .get(hunk)
+                    .and_then(|lines| lines.get(line))
+                    .unwrap_or_else(|| {
+                        panic!("row (hunk {hunk}, line {line}) must resolve real highlighting")
+                    });
+                assert_eq!(
+                    &rendered.text, expected,
+                    "the highlighted text a virtualized row resolves must be that row's own \
+                     line - anything else is the class of bug the identity guard exists to \
+                     prevent, reintroduced through per-row indexing"
+                );
+                assert!(
+                    per_hunk_numbers
+                        .get(hunk)
+                        .and_then(|nums| nums.get(line))
+                        .is_some(),
+                    "and its gutter numbers must be resolvable at the same (hunk {hunk}, line \
+                     {line}) position, from the index-aligned second half of the same cache"
+                );
+                if hunk == 1 {
+                    checked_second_hunk += 1;
+                }
+            }
+            assert!(
+                checked_second_hunk > 0,
+                "this test is only meaningful if it really checked rows of the *second* hunk - \
+                 those are the ones a per-row indexing mistake would misroute"
+            );
+        });
     }
 }

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -707,12 +707,15 @@ pub struct AdeApp {
     /// never on an ordinary click or fresh file open (no reason to fight the user's own scroll
     /// position).
     pub(crate) file_view_scroll_handle: UniformListScrollHandle,
-    /// The read-only Diff view's own real overlay scrollbar handle (GitHub issue #30) - a plain
-    /// `gpui::ScrollHandle`: `crate::code_surface::diff_view::AdeApp::render_diff_file_detail`
-    /// renders every hunk line eagerly into a plain `overflow_y_scroll()` div, not a
-    /// `uniform_list`, so it needs the base handle type directly rather than the `uniform_list`
-    /// wrapper [`Self::file_view_scroll_handle`] uses.
-    pub(crate) diff_view_scroll_handle: gpui::ScrollHandle,
+    /// The read-only Diff view's own scroll handle, and the source its real overlay scrollbar
+    /// (GitHub issue #30) reads its geometry from. A `gpui::UniformListScrollHandle`, the same
+    /// type [`Self::file_view_scroll_handle`] uses, since GitHub issue #224 turned
+    /// `crate::code_surface::diff_view::AdeApp::render_diff_file_detail`'s eager
+    /// `overflow_y_scroll()` div into a real `gpui::uniform_list`, which owns its own scroll
+    /// offset through this handle type rather than a plain `gpui::ScrollHandle`. The scrollbar
+    /// itself needed no change: `crate::root::scrollbar::ScrollableHandle` already treats both
+    /// handle kinds interchangeably.
+    pub(crate) diff_view_scroll_handle: UniformListScrollHandle,
     /// Cached parse/highlight of whichever file [`Self::render_file_view`] last loaded
     /// (`code_view::load_file`/`highlight_rust`) - reused unless `code_view::cache_is_fresh`
     /// says otherwise, always written from [`Self::spawn_file_load`]'s background task, never

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -289,7 +289,7 @@ impl AdeApp {
             _load_graph_task: None,
             _load_commit_files_task: None,
             file_view_scroll_handle: UniformListScrollHandle::new(),
-            diff_view_scroll_handle: gpui::ScrollHandle::new(),
+            diff_view_scroll_handle: UniformListScrollHandle::new(),
             file_view_cache: None,
             diff_highlight_cache: None,
             file_view_last_freshness_check: None,


### PR DESCRIPTION
## Summary

Closes #224. The Diff view built, laid out, and painted every rendered row of the open file on every single frame - up to `MAX_RENDERED_DIFF_LINES_PER_FILE` (300) diff lines plus every hunk header and fold marker, appended as children of a plain `div().overflow_y_scroll()`, with no virtualization at all. Only ~50 of those rows fit a 1080p viewport at the default editor font size; the rest were real per-frame work with nothing on screen to show for it. Structurally the same cost the file tree and the git graph (#218) were carrying before each was converted to a `gpui::uniform_list`.

`render_diff_file_detail`'s hunk path is now a real `uniform_list`, following `render_file_view`'s established pattern for this same content shape:

- `diff_rows()` resolves a flat, indexable row plan (`DiffRow`: fold marker, hunk header, diff line, truncation notice) once per frame and shares it with the row builder through an `Rc` - the same shape and reasoning as the file tree's own `TreeRow`. Pure, so the interleaving and render cap are directly unit-testable without a GPUI window.
- All four row kinds are pinned to the same `rems(1.6)` height a diff line's own line-height already gave it - `uniform_list` measures item 0 and lays every slot out at that height. The trailing "... diff truncated for this file" notice became a real final list item at that height instead of a taller sibling below it.
- The highlight cache identity guard is unchanged and still the only way the cache is read. It moved into the row builder, which re-resolves the open `DiffFile` from `self` (the closure is `'static`) and filters the cache against that same file before any per-row lookup.
- `diff_view_scroll_handle` is a `UniformListScrollHandle` now - the overlay scrollbar needed no change, `ScrollableHandle` already covers both handle kinds.

The 300-line cap and its truncation behavior are deliberately untouched - this is about per-frame render cost, not about how much of a diff is reachable, the same line #218 drew around `DEFAULT_MAX_COMMITS`.

## Test plan

- [x] `diff_row_plan_tests`: pure row-plan interleaving, no fold marker for back-to-back hunks, the render cap, both truncation sources
- [x] `diff_virtualization_tests`: a real 350-line diff, row 250 never painted while row 0 is - verified this genuinely fails against the pre-fix eager list (rows 250 and 299 had painted bounds with the list untouched at the top); scrolling materializes row 299 and drops row 0; hunk headers/fold markers paint at the shared row height in the right order; the truncation notice is the last item at that height; the overlay scrollbar appears only when the diff really overflows
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p app --all-targets -- -D warnings` clean
- [x] `cargo test -p app --lib` - 2072/2072 passed, no flakes

🤖 Generated with [Claude Code](https://claude.com/claude-code)