### PR TITLE
feat(app): a real per-agent review surface, separate from the git diff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9500,6 +9500,7 @@ name = "wt-core"
 version = "0.1.0"
 dependencies = [
  "gix",
+ "sha2",
  "tempfile",
  "thiserror 1.0.69",
 ]

--- a/crates/app/src/code_surface/diff_view.rs
+++ b/crates/app/src/code_surface/diff_view.rs
@@ -5,7 +5,6 @@ use super::zoom::zoom_scoped;
 use super::*;
 #[cfg(test)]
 use crate::root::focus::palette_focus_tests;
-use crate::root::widgets::render_action_keycap_row;
 use crate::root::widgets::render_sidebar_message;
 use std::rc::Rc;
 
@@ -99,6 +98,76 @@ fn diff_rows(file: &DiffFile) -> Vec<DiffRow> {
         rows.push(DiffRow::Truncated);
     }
     rows
+}
+
+/// Which surface [`AdeApp::render_diff_file_detail`] is drawing into.
+///
+/// GitHub issue #225 introduced a second place that shows a file's hunks - the agent Review tab -
+/// and the decision was explicitly **not** to write a second diff renderer for it. There is one
+/// hunk renderer in this app, and this parameter is the whole of what differs between its two
+/// callers: which highlight cache to read, which scroll handle to drive, and which element-id/
+/// `debug_selector` prefix to use so the two surfaces' elements stay distinguishable.
+///
+/// The three resources are genuinely per-surface, not shared, because both surfaces can hold a
+/// *different* open file at the same time: one shared highlight cache would have its identity
+/// guard reject every read as the user moved between them (recomputing both files' highlighting
+/// on every switch), and one shared scroll handle would drag each surface's scroll position onto
+/// the other.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DiffDetailSurface {
+    /// The git-side Diff view, opened from the Changes sidebar or the File/Diff toggle.
+    Changes,
+    /// The agent Review tab (`crate::review::render`).
+    Review,
+}
+
+impl DiffDetailSurface {
+    /// This surface's element-id and `debug_selector` prefix - `diff-line-3` vs. `review-line-3`.
+    /// Two surfaces rendering rows under one id prefix would produce duplicate GPUI element ids
+    /// whenever both were mounted, and would make a render test unable to say which surface it
+    /// actually measured.
+    pub(crate) fn id_prefix(self) -> &'static str {
+        match self {
+            DiffDetailSurface::Changes => "diff",
+            DiffDetailSurface::Review => "review",
+        }
+    }
+
+    fn scrollbar_id(self) -> &'static str {
+        match self {
+            DiffDetailSurface::Changes => "diff-view-scrollbar",
+            DiffDetailSurface::Review => "review-view-scrollbar",
+        }
+    }
+
+    fn scroll_handle(self, app: &AdeApp) -> &gpui::UniformListScrollHandle {
+        match self {
+            DiffDetailSurface::Changes => &app.diff_view_scroll_handle,
+            DiffDetailSurface::Review => &app.review_scroll_handle,
+        }
+    }
+
+    fn highlight_cache(self, app: &AdeApp) -> &Option<DiffHighlightCache> {
+        match self {
+            DiffDetailSurface::Changes => &app.diff_highlight_cache,
+            DiffDetailSurface::Review => &app.review_highlight_cache,
+        }
+    }
+
+    /// The `DiffFile` this surface currently has open, if any.
+    ///
+    /// The row builder inside [`AdeApp::render_diff_file_detail`]'s `uniform_list` is `'static`
+    /// (GitHub issue #224) and so cannot hold a borrow of the `&DiffFile` the method itself was
+    /// handed - it re-resolves through this instead, the same way the pre-#225 Changes-only
+    /// closure re-resolved `self.open_diff_file_cache` directly. Reading through `surface` rather
+    /// than hardcoding that field is what lets one virtualized list implementation serve both
+    /// surfaces correctly.
+    fn open_file(self, app: &AdeApp) -> Option<&DiffFile> {
+        match self {
+            DiffDetailSurface::Changes => app.open_diff_file_cache.as_ref(),
+            DiffDetailSurface::Review => app.open_review_file_detail(),
+        }
+    }
 }
 
 impl AdeApp {
@@ -196,17 +265,18 @@ impl AdeApp {
     ///
     /// The guard is consulted *inside* the row builder, once per invocation of it, rather than
     /// once per frame in this method: the builder is `'static` and re-resolves the open
-    /// `DiffFile` from `self` (below), so the cache has to be filtered against that same
-    /// re-resolved file for the check to mean anything. Nothing about the check itself changed -
-    /// same function, same `None`-means-fall-back-to-plain-text contract, and the per-row
-    /// `per_hunk.get(hunk)`/`lines.get(line)` reads are still reachable only through it.
+    /// `DiffFile` through `surface.open_file(self)` (below), so the cache has to be filtered
+    /// against that same re-resolved file for the check to mean anything. Nothing about the check
+    /// itself changed - same function, same `None`-means-fall-back-to-plain-text contract, and
+    /// the per-row `per_hunk.get(hunk)`/`lines.get(line)` reads are still reachable only through
+    /// it.
     ///
-    /// ## Virtualization (GitHub issue #224)
+    /// ## Virtualization (GitHub issue #224), generalized to two surfaces (GitHub issue #225)
     ///
     /// A real `gpui::uniform_list`, following
     /// `crate::code_surface::file_view::AdeApp::render_file_view`'s established pattern for this
     /// same content shape (see `vendor/zed/crates/gpui/examples/uniform_list.rs` for the API
-    /// itself). Until this fix every row of the whole capped diff - up to
+    /// itself). Until issue #224 every row of the whole capped diff - up to
     /// [`MAX_RENDERED_DIFF_LINES_PER_FILE`] lines plus every hunk header and fold marker - was
     /// built, laid out and painted on *every single frame*, inside a plain
     /// `div().overflow_y_scroll()`, including the great majority scrolled off screen. That is
@@ -217,12 +287,20 @@ impl AdeApp {
     /// view. What is measured here is `diff_virtualization_tests`' own before/after: a row far
     /// below the viewport stopped being built at all.
     ///
+    /// `surface` is what makes one `uniform_list` implementation correct for both the git Diff
+    /// view and the agent Review tab (issue #225): every place this method would otherwise reach
+    /// for `self.open_diff_file_cache`/`self.diff_highlight_cache`/`self.diff_view_scroll_handle`
+    /// directly instead goes through `surface.open_file`/`surface.highlight_cache`/
+    /// `surface.scroll_handle`, so the two surfaces can each hold a different open file without
+    /// either one's render pass reading the other's state.
+    ///
     /// Two things `uniform_list` requires, both real:
     /// - **Definite height.** Its default `ListSizingBehavior::Auto` gives it zero intrinsic
     ///   height, so every pixel comes from the `.flex_1().min_h_0()` below - drop either and it
-    ///   renders zero rows, silently. It also owns its own scroll offset (hence
-    ///   [`Self::diff_view_scroll_handle`] becoming a `gpui::UniformListScrollHandle`), so it
-    ///   needs no `overflow_y_scroll()` wrapper and must not be given one.
+    ///   renders zero rows, silently. It also owns its own scroll offset (hence both
+    ///   [`Self::diff_view_scroll_handle`] and [`Self::review_scroll_handle`] being a
+    ///   `gpui::UniformListScrollHandle`), so it needs no `overflow_y_scroll()` wrapper and must
+    ///   not be given one.
     /// - **One uniform row height,** measured from item 0 alone and then used for every slot
     ///   (`vendor/zed/crates/gpui/src/elements/uniform_list.rs`'s `measure_item`/`prepaint`).
     ///   This list interleaves four differently-purposed rows, so each is pinned to the same
@@ -231,9 +309,10 @@ impl AdeApp {
     ///   were given it here. `rems`, not `px`, so they all still scale together under
     ///   [`zoom_scoped`] - which wraps the list exactly the way `render_file_view` wraps its own.
     ///   A row that disagreed would simply be clipped, with no panic and no warning.
-    pub(in crate::code_surface) fn render_diff_file_detail(
+    pub(crate) fn render_diff_file_detail(
         &self,
         file: &DiffFile,
+        surface: DiffDetailSurface,
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
         // Read the effective zoom once and pass it to `zoom_scoped` at every return point below.
@@ -243,7 +322,7 @@ impl AdeApp {
             return zoom_scoped(
                 rem_px,
                 render_diff_message_pane(
-                    "diff-detail-binary",
+                    format!("{}-detail-binary", surface.id_prefix()),
                     "binary file (contents not diffed)".to_string(),
                 ),
             );
@@ -257,7 +336,7 @@ impl AdeApp {
             return zoom_scoped(
                 rem_px,
                 render_diff_message_pane(
-                    "diff-detail-empty",
+                    format!("{}-detail-empty", surface.id_prefix()),
                     changes::empty_hunks_message(file.status).to_string(),
                 ),
             );
@@ -275,26 +354,28 @@ impl AdeApp {
         let row_count = rows.len();
 
         let list = uniform_list(
-            // Per-path, matching the element id the pre-virtualization container carried: a
-            // different open diff is a different list, not the same one showing new content.
-            format!("diff-detail-{}", file.path.display()),
+            // Per-surface and per-path (see `DiffDetailSurface::id_prefix`'s own docs): a
+            // different open diff, or the other surface entirely, is a different list, not the
+            // same one showing new content.
+            format!("{}-detail-{}", surface.id_prefix(), file.path.display()),
             row_count,
             cx.processor(move |this: &mut Self, range: Range<usize>, _window, _cx| {
-                // Re-resolved from `this` rather than captured, mirroring
-                // `crate::graph_view::render::AdeApp::render_graph_rows`' identical re-resolve:
-                // the closure is `'static` and cannot borrow the `&DiffFile` this method was
-                // handed, and cloning one (up to `wt_core::diff`'s own per-file line cap) per
-                // frame would be a real cost of its own. `Self::render_center_pane` takes this
-                // field out only for the duration of its own `render()` call and puts it straight
-                // back, so it is genuinely populated by the time this closure runs (layout), the
-                // same lifecycle `render_graph_rows` relies on.
-                let Some(file) = this.open_diff_file_cache.as_ref() else {
+                // Re-resolved from `this` through `surface` rather than a hardcoded field,
+                // mirroring `crate::graph_view::render::AdeApp::render_graph_rows`' identical
+                // re-resolve: the closure is `'static` and cannot borrow the `&DiffFile` this
+                // method was handed, and cloning one (up to `wt_core::diff`'s own per-file line
+                // cap) per frame would be a real cost of its own. `Self::render_center_pane`/
+                // `crate::review::render::AdeApp::render_review_view` each take their own surface's
+                // open-file field out only for the duration of their own `render()` call and put
+                // it straight back, so it is genuinely populated by the time this closure runs
+                // (layout), the same lifecycle `render_graph_rows` relies on.
+                let Some(file) = surface.open_file(this) else {
                     return Vec::new();
                 };
                 // The real identity guard - a cache entry only counts as usable for these rows if
                 // it was built from this exact file (see this method's own "Cache identity guard"
                 // docs, and `diff_highlight_cache_for`'s own docs/tests for the pure logic).
-                let cache = diff_highlight_cache_for(&this.diff_highlight_cache, file);
+                let cache = diff_highlight_cache_for(surface.highlight_cache(this), file);
                 // Clamped rather than trusted, and `start` against `end` rather than only against
                 // the length, so a divergence degrades to "renders fewer rows" instead of
                 // panicking on an inverted range.
@@ -328,8 +409,14 @@ impl AdeApp {
                                         .and_then(|nums| nums.get(line))
                                         .copied()
                                         .unwrap_or((None, None));
-                                    render_diff_line(diff_line, rendered, numbers, row)
-                                        .into_any_element()
+                                    render_diff_line(
+                                        diff_line,
+                                        rendered,
+                                        numbers,
+                                        surface.id_prefix(),
+                                        row,
+                                    )
+                                    .into_any_element()
                                 }
                                 None => render_blank_diff_row().into_any_element(),
                             }
@@ -345,9 +432,9 @@ impl AdeApp {
         .bg(theme::surface::PTY)
         // GitHub issue #30's real overlay scrollbar reads its geometry straight off this same
         // handle (`crate::root::scrollbar::AdeApp::render_vertical_scrollbar`).
-        .track_scroll(&self.diff_view_scroll_handle);
+        .track_scroll(surface.scroll_handle(self));
 
-        zoom_scoped(rem_px, self.wrap_with_scrollbar(list, cx))
+        zoom_scoped(rem_px, self.wrap_with_scrollbar(surface, list, cx))
     }
 
     /// Wraps the Diff view's `uniform_list` in the real, non-scrolling `.relative()` sibling
@@ -363,6 +450,7 @@ impl AdeApp {
     /// screen.
     fn wrap_with_scrollbar(
         &self,
+        surface: DiffDetailSurface,
         content: impl IntoElement,
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
@@ -374,8 +462,8 @@ impl AdeApp {
             .min_h_0()
             .child(content)
             .children(self.render_vertical_scrollbar(
-                "diff-view-scrollbar",
-                &self.diff_view_scroll_handle,
+                surface.scrollbar_id(),
+                surface.scroll_handle(self),
                 &[],
                 cx,
             ))
@@ -387,7 +475,7 @@ impl AdeApp {
 /// all) as a real pane: the same `theme::surface::PTY` background and top padding the row list
 /// sits on, with one [`render_sidebar_message`] on it. Deliberately not scrollable - see
 /// [`AdeApp::wrap_with_scrollbar`]'s own docs.
-fn render_diff_message_pane(id: &'static str, message: String) -> impl IntoElement {
+fn render_diff_message_pane(id: String, message: String) -> impl IntoElement {
     div()
         .id(id)
         .flex()
@@ -575,6 +663,7 @@ pub(in crate::code_surface) fn render_diff_line(
     line: &wt_core::diff::DiffLine,
     rendered: Option<&code_view::RenderedLine>,
     numbers: (Option<usize>, Option<usize>),
+    selector_prefix: &'static str,
     row_index: usize,
 ) -> impl IntoElement {
     // `accent` (`Some` only for Added/Removed) drives both the left-edge bar below and the sign
@@ -611,7 +700,7 @@ pub(in crate::code_surface) fn render_diff_line(
         // row's painted bounds and confirm the diff view's own rows are genuinely reachable, the
         // same pattern `render_file_view_line`'s `file-view-text-row-{n}` selector already
         // establishes for the File view.
-        .debug_selector(move || format!("diff-line-{row_index}"));
+        .debug_selector(move || format!("{selector_prefix}-line-{row_index}"));
     if let Some(bg) = bg {
         row = row.bg(bg);
     }
@@ -661,39 +750,6 @@ pub(in crate::code_surface) fn render_diff_line(
                 .child(sign),
         )
         .child(text_row)
-}
-
-/// The File view toolbar's always-rendered `Accept file` button, always in its dimmed
-/// non-interactive state: this app has no per-file review-apply logic yet, so it's deliberately
-/// given no `cursor_pointer()`/`on_click` at all rather than a handler that would silently no-op.
-///
-/// The trailing keycap is resolved through `crate::keymap::resolve_combo("enter", macos)` rather
-/// than a baked-in `⏎` glyph, so it reads `Enter` on Windows/Linux.
-pub(in crate::code_surface) fn render_accept_file_button(macos: bool) -> impl IntoElement {
-    let parts = keymap::resolve_combo("enter", macos);
-    div()
-        .flex_none()
-        .flex()
-        .items_center()
-        .gap(px(6.0))
-        .px(px(8.0))
-        .py(px(3.0))
-        .rounded(theme::radius::BUTTON)
-        .border_1()
-        .border_color(theme::border::BUTTON_DISABLED)
-        .child(
-            div()
-                .font(font(theme::font::SANS))
-                .font_weight(gpui::FontWeight::MEDIUM)
-                .text_size(px(10.5))
-                .text_color(theme::text::GHOSTER)
-                .child("Accept file"),
-        )
-        .child(render_action_keycap_row(
-            &parts,
-            theme::text::GHOSTER.into(),
-            theme::border::BUTTON_DISABLED.into(),
-        ))
 }
 
 /// Real, render-level coverage for the Diff view's per-token syntax highlighting and its

--- a/crates/app/src/code_surface/mod.rs
+++ b/crates/app/src/code_surface/mod.rs
@@ -46,7 +46,6 @@ use crate::code_surface::state::{
     BlameCacheEntry, BlameLoadState, CommitMessageState, DiffLoadState, FileLoadState, HoverAnchor,
     HoverEntry, HoverStatus,
 };
-use crate::keymap::{self};
 use crate::language;
 use crate::lsp::client::LspClientState;
 use crate::lsp::diagnostics as diagnostics_view;

--- a/crates/app/src/code_surface/render.rs
+++ b/crates/app/src/code_surface/render.rs
@@ -2,7 +2,6 @@
 //! the key context that decides which keybindings are live over it, and the segmented
 //! File/Diff toggle that switches between them.
 
-use super::diff_view::render_accept_file_button;
 use super::*;
 #[cfg(test)]
 use crate::root::focus::palette_focus_tests;
@@ -38,7 +37,7 @@ impl AdeApp {
 
     /// The centre's single-file Surface C, opened by a Changes-row click (`diff_file` always
     /// `Some`) or a Files-tree row click (`diff_file` may be `None`): a toolbar (dir/name, tag
-    /// pill, +n/-n stats, the `File | Diff` toggle, the zoom group, `Accept file`, close) over
+    /// pill, +n/-n stats, the `File | Diff` toggle, the zoom group, close) over
     /// either [`Self::render_diff_file_detail`]'s folded hunk content or [`Self::render_file_view`]'s
     /// syntax-highlighted content, both zoom-scoped through [`zoom_scoped`].
     ///
@@ -137,9 +136,6 @@ impl AdeApp {
                     .h(px(16.0))
                     .bg(theme::border::DIVIDER),
             )
-            .child(render_accept_file_button(
-                self.window_controls_style().is_macos(),
-            ))
             .child(
                 div()
                     .id("close-diff-surface")
@@ -155,7 +151,9 @@ impl AdeApp {
             );
 
         let body = match (effective_view, diff_file) {
-            (code_view::CodeView::Diff, Some(file)) => self.render_diff_file_detail(file, cx),
+            (code_view::CodeView::Diff, Some(file)) => {
+                self.render_diff_file_detail(file, diff_view::DiffDetailSurface::Changes, cx)
+            }
             _ if is_markdown_file
                 && self.markdown_view == markdown_preview::MarkdownView::Preview =>
             {

--- a/crates/app/src/code_surface/tabs.rs
+++ b/crates/app/src/code_surface/tabs.rs
@@ -40,11 +40,6 @@ impl AdeApp {
         self.diff_state = DiffLoadState::Loading;
         self.diff_totals = None;
         self.dirty_files = None;
-        // A reloaded diff is a new worktree's (or the same worktree's freshly re-read) file
-        // list - any authorship recorded against the *previous* one belongs to files that may
-        // not even be in this diff anymore. See `changes::Authorship`'s own docs for why this is
-        // always empty today regardless (no real tracking wired up yet).
-        self.file_authorship = changes::Authorship::default();
         cx.notify();
         let task = cx.spawn(async move |this, cx| {
             let (diff_result, staged_result, dirty_result) = cx

--- a/crates/app/src/code_surface/tabs.rs
+++ b/crates/app/src/code_surface/tabs.rs
@@ -180,6 +180,14 @@ impl AdeApp {
         // its own `code_focus.capture()` never captures a handle that's about to stop being
         // rendered. See `crate::graph_view::render::AdeApp::leave_graph_tab`'s own docs.
         self.leave_graph_tab(window, cx);
+        // GitHub issue #225: the review tab occupies the centre pane exactly as the graph tab
+        // does, so it needs the identical teardown here. Without this, `review_tab_active` stayed
+        // set, `render_center_pane` kept returning the review body, and the tab this call is
+        // switching *to* never mounted at all - while real focus had already moved onto it. Found
+        // by an adversarial audit; the review surface's own docs claimed to copy the graph tab's
+        // discipline and, in exactly this way, did not.
+        self.leave_review_tab(window, cx);
+
         if focus_editor {
             self.focus_code_surface(window, cx);
         }
@@ -338,6 +346,14 @@ impl AdeApp {
         // See `Self::open_and_focus_file`'s identical call for why this must run before
         // `focus_code_surface` below.
         self.leave_graph_tab(window, cx);
+        // GitHub issue #225: the review tab occupies the centre pane exactly as the graph tab
+        // does, so it needs the identical teardown here. Without this, `review_tab_active` stayed
+        // set, `render_center_pane` kept returning the review body, and the tab this call is
+        // switching *to* never mounted at all - while real focus had already moved onto it. Found
+        // by an adversarial audit; the review surface's own docs claimed to copy the graph tab's
+        // discipline and, in exactly this way, did not.
+        self.leave_review_tab(window, cx);
+
         self.focus_code_surface(window, cx);
         let has_diff = self
             .current_diff()

--- a/crates/app/src/graph_view/render.rs
+++ b/crates/app/src/graph_view/render.rs
@@ -64,6 +64,12 @@ impl AdeApp {
         if self.palette_open {
             self.close_palette(window, cx);
         }
+        // GitHub issue #225: the review tab is the other centre-pane occupant, and it needs the
+        // same real teardown here that this function's own `leave_graph_tab` counterparts perform
+        // in the opposite direction - see `crate::review::render::AdeApp::leave_review_tab`.
+        self.leave_review_tab(window, cx);
+        self.review_tab_open = None;
+
         self.graph_tab_open = true;
         let was_active = self.graph_tab_active;
         self.graph_tab_active = true;

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -25,6 +25,7 @@ pub mod palette;
 // to close. Nothing outside this crate has any business calling it directly.
 pub(crate) mod persisted_state_lock;
 pub mod rail;
+pub mod review;
 pub mod root;
 pub mod settings;
 pub mod sidebar;

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -298,9 +298,9 @@ impl AdeApp {
                             Vec<PathBuf>,
                         )> = review_targets
                             .into_iter()
-                            .filter_map(|(id, worktree, tree_id)| {
+                            .filter_map(|(id, worktree, tree_id, untracked)| {
                                 let paths = wt_core::review::changed_paths_against_tree(
-                                    &worktree, &tree_id,
+                                    &worktree, &tree_id, untracked,
                                 )
                                 .ok()?;
                                 Some((id, tree_id, paths))

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -1,6 +1,5 @@
 use super::*;
 use crate::root::widgets::{render_keycap_row, text_tooltip, KeycapSize};
-use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -136,26 +135,17 @@ impl AdeApp {
                     None => agent.cwd.display().to_string(),
                 };
 
-                // See `AgentRow::review_file_count`'s own docs: a review-ready agent outside
-                // the one worktree currently loaded in Zone 3 (`Self::diff_root`) has no diff data
-                // to report and stays `None` rather than a fabricated count. Within that worktree,
-                // the count is only unambiguous when this agent is the sole agent there - with
-                // more than one agent sharing the worktree, attributing which files are "this
-                // agent's" needs real per-agent authorship tracking, which doesn't exist yet (see
-                // `crate::sidebar::changes::Authorship`'s own docs), so that case also stays `None`
-                // rather than reporting every agent's row as authoring zero files.
-                let review_file_count =
-                    if status_value == Status::Review && agent.cwd == self.diff_root {
-                        let agents_in_worktree =
-                            self.agents.iter().filter(|s| s.cwd == agent.cwd).count();
-                        if agents_in_worktree <= 1 {
-                            self.current_diff().map(|diff| diff.files.len())
-                        } else {
-                            None
-                        }
-                    } else {
-                        None
-                    };
+                // GitHub issue #225: a real per-agent count, read from this agent's *own* review
+                // against its *own* baseline (`Self::agent_review_file_count`) - no longer the
+                // whole worktree's git diff, which was never this agent's answer and was only
+                // ever available for the one worktree currently loaded in Zone 3. It is now real
+                // for every single-agent worktree, loaded or not. See that method's own docs for
+                // exactly when it stays `None`.
+                let review_file_count = if status_value == Status::Review {
+                    self.agent_review_file_count(agent.id)
+                } else {
+                    None
+                };
 
                 AgentRow {
                     id: agent.id,
@@ -255,36 +245,68 @@ impl AdeApp {
             loop {
                 cx.background_executor().timer(STATUS_POLL_INTERVAL).await;
 
-                let Ok((worktrees, diff_paths, pids)) = this.update(cx, |this, cx| {
-                    let worktrees: Vec<rail::WorktreeQuery> = this
-                        .worktrees
-                        .iter()
-                        .filter(|item| item.error.is_none())
-                        .map(|item| rail::WorktreeQuery {
-                            path: item.path.clone(),
-                            is_main: item.is_main,
-                            is_locked: item.is_locked,
-                        })
-                        .collect();
-                    let diff_paths: Vec<PathBuf> =
-                        this.agents.iter().map(|agent| agent.cwd.clone()).collect();
-                    let pids: Vec<u32> = this
-                        .agents
-                        .iter()
-                        .filter_map(|agent| agent.pane.read(cx).pid())
-                        .collect();
-                    (worktrees, diff_paths, pids)
-                }) else {
+                let Ok((worktrees, diff_paths, pids, review_targets)) =
+                    this.update(cx, |this, cx| {
+                        let worktrees: Vec<rail::WorktreeQuery> = this
+                            .worktrees
+                            .iter()
+                            .filter(|item| item.error.is_none())
+                            .map(|item| rail::WorktreeQuery {
+                                path: item.path.clone(),
+                                is_main: item.is_main,
+                                is_locked: item.is_locked,
+                            })
+                            .collect();
+                        let diff_paths: Vec<PathBuf> =
+                            this.agents.iter().map(|agent| agent.cwd.clone()).collect();
+                        let pids: Vec<u32> = this
+                            .agents
+                            .iter()
+                            .filter_map(|agent| agent.pane.read(cx).pid())
+                            .collect();
+                        // GitHub issue #225: every agent with a captured baseline, to be measured
+                        // against it below.
+                        let review_targets = this.review_measure_targets();
+                        (worktrees, diff_paths, pids, review_targets)
+                    })
+                else {
                     break;
                 };
 
-                let (snapshot, process_samples, next_prev) = cx
+                let (snapshot, process_samples, next_prev, review_measurements) = cx
                     .background_executor()
                     .spawn(async move {
                         let snapshot = rail::compute_status_snapshot(&worktrees, &diff_paths);
                         let (process_samples, next_prev) =
                             process_stats::sample_processes(&pids, prev_process_samples);
-                        (snapshot, process_samples, next_prev)
+                        // GitHub issue #225: each agent's own unreviewed set, measured against
+                        // its own baseline. `changed_paths_against_tree` is one
+                        // `git diff --name-only` process per agent with no hunk parsing - the
+                        // cheap counterpart to the full review the tab itself loads.
+                        //
+                        // This runs on the *poll*, not only when the Review tab is open, and that
+                        // is load-bearing rather than eager: `Status::Review` is what surfaces the
+                        // footer's `Review` door, the door is what opens the tab, and the tab is
+                        // what loads the full diff - so measuring only inside the tab would be
+                        // circular and nothing would ever become reviewable at all.
+                        //
+                        // A failed measurement is dropped rather than recorded as an empty set;
+                        // see `AdeApp::apply_review_measurements`.
+                        let review_measurements: Vec<(
+                            crate::work_surface::agents::AgentId,
+                            String,
+                            Vec<PathBuf>,
+                        )> = review_targets
+                            .into_iter()
+                            .filter_map(|(id, worktree, tree_id)| {
+                                let paths = wt_core::review::changed_paths_against_tree(
+                                    &worktree, &tree_id,
+                                )
+                                .ok()?;
+                                Some((id, tree_id, paths))
+                            })
+                            .collect();
+                        (snapshot, process_samples, next_prev, review_measurements)
                     })
                     .await;
                 prev_process_samples = next_prev;
@@ -294,6 +316,7 @@ impl AdeApp {
                     this.worktree_notes = snapshot.worktree_notes;
                     this.ahead_behind_cache = snapshot.ahead_behind;
                     this.process_stats = process_samples;
+                    this.apply_review_measurements(review_measurements);
                     cx.notify();
                 });
                 if updated.is_err() {
@@ -1046,23 +1069,6 @@ impl AdeApp {
         cx.notify();
     }
 
-    /// The worktree row's `⚠ N` shared-file flag (§2.2's trailing slot, §4's "files two agents
-    /// both wrote") - real, but only for whichever worktree's diff is currently loaded in
-    /// Zone 3 ([`Self::diff_root`]): [`Self::file_authorship`] is scoped to that one diff (see
-    /// its own docs), not tracked per-worktree yet, so every other row has no data to report and
-    /// gets a real `0` (hidden by the render side's own "only when ≥1" gate) rather than a
-    /// fabricated count.
-    pub(in crate::rail) fn worktree_shared_file_count(&self, worktree_path: &Path) -> usize {
-        if worktree_path != self.diff_root {
-            return 0;
-        }
-        let Some(diff) = self.current_diff() else {
-            return 0;
-        };
-        self.file_authorship
-            .shared_file_count(diff.files.iter().map(|f| f.path.as_path()))
-    }
-
     /// One worktree row (§2.2: 27 high, padding `0 10 0 6`, gap 6) plus, when expanded, its
     /// agent rows (§2.3) - the rail's real "worktree owns N agents" structure. `index` (unique
     /// within its repo group) disambiguates element ids for the real degenerate case
@@ -1133,8 +1139,6 @@ impl AdeApp {
         } else {
             theme::text::DIM.into()
         };
-
-        let shared_count = self.worktree_shared_file_count(&row.path);
 
         let caret = if has_agents {
             let worktree_path = row.path.clone();
@@ -1235,17 +1239,6 @@ impl AdeApp {
                 )
             })
             .child(div().flex_1().min_w(px(2.0)))
-            .when(shared_count > 0, |el| {
-                el.child(
-                    div()
-                        .flex_none()
-                        .font(font(theme::font::MONO))
-                        .font_weight(gpui::FontWeight::MEDIUM)
-                        .text_size(self.ui_text_size(9.0))
-                        .text_color(theme::status::ASK_CARD_FG)
-                        .child(format!("\u{26a0} {shared_count}")),
-                )
-            })
             .child(trailing);
 
         let mut container = div()
@@ -1548,6 +1541,7 @@ mod prune_regression_tests {
     use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
     use std::fs;
+    use std::path::Path;
     use std::process::Command;
     use tempfile::TempDir;
 

--- a/crates/app/src/rail/state.rs
+++ b/crates/app/src/rail/state.rs
@@ -62,19 +62,28 @@ pub struct AgentRow {
     /// row's line-1 elapsed time (§2.3: "elapsed 9.5px mono right"). See [`format_elapsed`] for
     /// how this becomes the rendered `4m`/`1h` text.
     pub elapsed: Duration,
-    /// How many files are in the loaded diff, for a [`Status::Review`] row only - §2.3's "review
-    /// ready" trailing text (`12 files`). `None` for every other status (§2.3: "Do not put a
-    /// per-agent file count here" - review-ready is the one documented exception).
+    /// How many files **this agent** has changed since its own review baseline, for a
+    /// [`Status::Review`] row only - §2.3's "review ready" trailing text (`12 files`). `None` for
+    /// every other status (§2.3: "Do not put a per-agent file count here" - review-ready is the
+    /// one documented exception).
     ///
-    /// Also `None` when either the count would be a guess rather than a fact: a review-ready row
-    /// whose worktree diff isn't the one currently loaded in Zone 3 (`crate::root::AdeApp::
-    /// diff_root` only tracks one diff at a time, so a row outside it has no diff data at all),
-    /// or a worktree with more than one agent sharing it - attributing which of the diff's files
-    /// are "this agent's" needs real per-agent authorship tracking, which doesn't exist yet
-    /// (see `crate::sidebar::changes::Authorship`'s own docs), so every agent sharing that
-    /// worktree would otherwise report the same full count, or - if sourced from `Authorship`
-    /// instead - a uniformly fabricated zero. With exactly one agent in the worktree there's no
-    /// such ambiguity: every file in the diff is unambiguously that agent's.
+    /// GitHub issue #225 made this a genuinely per-agent number: it comes from
+    /// `crate::review::flow::AdeApp::agent_review_file_count`, a real
+    /// `wt_core::review::diff_against_tree` against the snapshot taken when this agent started
+    /// (or when the user last marked it reviewed). It used to be the *worktree's* whole git diff
+    /// against the merge-base with the default branch, which is a different question entirely -
+    /// an agent that changed nothing in a worktree whose branch had already diverged reported
+    /// every one of the branch's files as its own.
+    ///
+    /// Still `None` whenever the count would be a guess rather than a fact:
+    /// - No baseline has been captured yet (capture is a background task, so there is a real
+    ///   moment after spawn where there is genuinely nothing to measure against).
+    /// - The review hasn't loaded yet, or failed to load.
+    /// - **More than one agent is open in this worktree.** This is a deliberate design gate, not
+    ///   a missing feature: real per-agent attribution doesn't exist yet, so with two agents
+    ///   sharing a worktree this agent's review would honestly include the other's changes. The
+    ///   whole review surface is held back for such worktrees until they're back down to one
+    ///   agent - see `crate::work_surface::agents::Agents::count_for_cwd`.
     pub review_file_count: Option<usize>,
 }
 
@@ -223,7 +232,10 @@ impl WorktreeNote {
 /// deliberate: `std` has no timezone database, and pulling one in (`chrono-tz`, or the
 /// `time` crate's `local-offset` feature, unsound-by-default on unix) wasn't worth it for a
 /// single label.
-fn format_utc_hhmm(unix_seconds: i64) -> String {
+///
+/// `pub(crate)` so `crate::review::state`'s own "captured at HH:MM" header reuses this exact
+/// formatting (and its exact UTC caveat) rather than growing a second, subtly different copy.
+pub(crate) fn format_utc_hhmm(unix_seconds: i64) -> String {
     let seconds_in_day = unix_seconds.rem_euclid(86_400);
     let hours = seconds_in_day / 3600;
     let minutes = (seconds_in_day % 3600) / 60;

--- a/crates/app/src/review/baseline_state.rs
+++ b/crates/app/src/review/baseline_state.rs
@@ -46,7 +46,9 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-use super::state::{BaselineReason, ReviewBaseline};
+use wt_core::review::UntrackedCoverage;
+
+use super::state::{decode_worktree, encode_worktree, BaselineReason, ReviewBaseline};
 
 /// The baseline file's name, resolved next to the real `settings.toml` - mirrors
 /// `crate::work_surface::tab_order_state::TAB_ORDER_FILE_NAME`.
@@ -68,8 +70,11 @@ pub fn review_baseline_path_for(settings_path: &Path) -> PathBuf {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct PersistedBaseline {
-    /// The worktree this agent was running in, as an absolute path string. Recorded separately
-    /// from the map key (which also encodes it) so a reader never has to parse the key apart.
+    /// The worktree this agent was running in, in `super::state::encode_worktree`'s lossless
+    /// `utf8:`/`bytes:` form - recorded separately from the map key (which also encodes it) so a
+    /// reader never has to parse the key apart, and losslessly so it can be turned back into a
+    /// real `PathBuf` (`Self::worktree_path`) rather than a `Path::display()` string that cannot
+    /// round-trip.
     pub worktree: String,
     /// `AgentKind::label`'s output, e.g. `"Claude"`.
     pub kind: String,
@@ -84,6 +89,19 @@ pub struct PersistedBaseline {
     pub taken_at_unix: i64,
     /// [`BaselineReason::as_key`]'s stable string.
     pub reason: String,
+    /// `true` when this baseline covers tracked files only, because the worktree's untracked set
+    /// was too large to hash (`wt_core::review::MAX_UNTRACKED_SNAPSHOT_BYTES`). Persisted because
+    /// every later diff against this tree must use the *same* coverage to produce a correct
+    /// answer - a reader that assumed the default would report every untracked file as new.
+    pub tracked_only: bool,
+}
+
+impl PersistedBaseline {
+    /// This record's worktree as a real path - `None` for an entry this app didn't write (see
+    /// `super::state::decode_worktree`).
+    pub fn worktree_path(&self) -> Option<PathBuf> {
+        decode_worktree(&self.worktree)
+    }
 }
 
 impl Default for PersistedBaseline {
@@ -100,6 +118,9 @@ impl Default for PersistedBaseline {
             // the whole otherwise-valid entry away. `Spawn` is the honest default - it's what a
             // baseline is until someone marks it reviewed.
             reason: BaselineReason::Spawn.as_key().to_string(),
+            // The overwhelmingly common case, and the one a pre-`tracked_only` entry was written
+            // under - so an older file's entries keep meaning what they meant when written.
+            tracked_only: false,
         }
     }
 }
@@ -209,13 +230,14 @@ impl ReviewBaselineState {
         self.baselines.insert(
             key,
             PersistedBaseline {
-                worktree: worktree.display().to_string(),
+                worktree: encode_worktree(worktree),
                 kind: kind.to_string(),
                 spawned_at_unix,
                 tree_id: baseline.tree_id.clone(),
                 ref_name: baseline.ref_name.clone(),
                 taken_at_unix: baseline.taken_at_unix,
                 reason: baseline.reason.as_key().to_string(),
+                tracked_only: baseline.untracked == UntrackedCoverage::Excluded,
             },
         );
     }
@@ -242,6 +264,11 @@ impl ReviewBaselineState {
             ref_name: entry.ref_name.clone(),
             taken_at_unix: entry.taken_at_unix,
             reason: BaselineReason::from_key(&entry.reason)?,
+            untracked: if entry.tracked_only {
+                UntrackedCoverage::Excluded
+            } else {
+                UntrackedCoverage::Included
+            },
         })
     }
 }
@@ -256,6 +283,7 @@ mod tests {
             ref_name: "refs/jerry/review/6b6579".to_string(),
             taken_at_unix: 1_700_000_042,
             reason,
+            untracked: UntrackedCoverage::Included,
         }
     }
 
@@ -423,6 +451,78 @@ mod tests {
              live agent for it - that is exactly the data GitHub issue #227 needs to find"
         );
         assert!(on_disk.get("new-key").is_some());
+    }
+
+    /// The persisted worktree must be a real, decodable path rather than a `Path::display()`
+    /// string - it is the one field GitHub issue #227 will actually need to act on.
+    #[test]
+    fn a_persisted_worktree_round_trips_back_to_a_real_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("review-baselines.toml");
+        let worktree = Path::new("/repo/my worktree/feature-x");
+        let mut state = ReviewBaselineState::default();
+        state.set(
+            "key-a".to_string(),
+            worktree,
+            "Claude",
+            1,
+            &sample(BaselineReason::Spawn),
+        );
+        state.save_at(&path).expect("save");
+
+        let entry = ReviewBaselineState::load_at(&path).baselines["key-a"].clone();
+        assert_eq!(
+            entry.worktree_path(),
+            Some(worktree.to_path_buf()),
+            "the recorded worktree must decode back to the real path it was captured for"
+        );
+    }
+
+    /// Coverage must persist: a later diff made with the wrong coverage against a tracked-only
+    /// baseline would report every untracked file as a brand-new addition.
+    #[test]
+    fn a_tracked_only_baseline_persists_its_narrower_coverage() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("review-baselines.toml");
+        let tracked_only = ReviewBaseline {
+            untracked: UntrackedCoverage::Excluded,
+            ..sample(BaselineReason::Spawn)
+        };
+        let mut state = ReviewBaselineState::default();
+        state.set(
+            "key-a".to_string(),
+            Path::new("/repo/wt-a"),
+            "Claude",
+            1,
+            &tracked_only,
+        );
+        state.save_at(&path).expect("save");
+
+        assert_eq!(
+            ReviewBaselineState::load_at(&path).get("key-a"),
+            Some(tracked_only),
+            "a tracked-only baseline must not silently come back as a full one"
+        );
+    }
+
+    /// An entry written before `tracked_only` existed must keep meaning what it meant - the
+    /// ordinary, full-coverage case - rather than failing to parse or flipping to the narrow one.
+    #[test]
+    fn an_entry_without_the_coverage_field_defaults_to_full_coverage() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("review-baselines.toml");
+        std::fs::write(
+            &path,
+            "[baselines.\"key-a\"]\nworktree = \"utf8:/repo/wt-a\"\nkind = \"Claude\"\n\
+             spawned_at_unix = 1\ntree_id = \"aaaa\"\nref_name = \"refs/jerry/review/6b\"\n\
+             taken_at_unix = 2\nreason = \"spawn\"\n",
+        )
+        .expect("write");
+
+        let baseline = ReviewBaselineState::load_at(&path)
+            .get("key-a")
+            .expect("an entry missing only the new field must still be usable");
+        assert_eq!(baseline.untracked, UntrackedCoverage::Included);
     }
 
     #[test]

--- a/crates/app/src/review/baseline_state.rs
+++ b/crates/app/src/review/baseline_state.rs
@@ -1,0 +1,498 @@
+//! Real, on-disk persistence for agent review baselines (GitHub issue #225) - a sibling file
+//! next to `settings.toml`, in the same shape `crate::work_surface::tab_order_state` and
+//! `crate::sidebar::fold_state` already use.
+//!
+//! ## What is stored, and what is not
+//!
+//! Only *metadata*: which baseline exists, the real tree id and ref name it points at, when it
+//! was taken, and why. The snapshot's actual content lives where content belongs - in the
+//! repository's own object database, kept alive by the `refs/jerry/review/*` ref this file
+//! records the name of.
+//!
+//! ## Honest limitation: phase 1 cannot read these back
+//!
+//! `crate::work_surface::agents::AgentId` is a per-window counter that restarts at zero on every
+//! launch, and an agent's process does not survive a restart either - so after a restart there is
+//! no live agent for a persisted baseline to belong to, and nothing in this app can currently
+//! reconnect one. **This file is written today, and today nothing reads it back into a live
+//! review.**
+//!
+//! That is deliberate, not an oversight or a stub. GitHub issue #227 ("Agent history and
+//! resume/recover") is what gives agents durable identity; when it lands, the baselines it needs
+//! to reconnect to will already be here, with their real trees still anchored, instead of having
+//! been thrown away by every prior run. The alternative - not persisting until something can read
+//! it - would mean issue #227 arrives to find every historical baseline already destroyed. So
+//! this deliberately does *not* build a reconnection UI: there is genuinely nothing to reconnect
+//! to yet, and a UI implying otherwise would be a fake.
+//!
+//! [`ReviewBaselineState::forget`] is therefore called only from a real user-visible "this
+//! worktree is gone" action, never from an agent merely closing - see its own docs.
+//!
+//! ## Known gap: no orphan pruning
+//!
+//! Nothing sweeps entries whose agent is long gone. Entries accumulate, one small TOML record per
+//! agent ever spawned. Deliberately left as a known gap for the same reason as above: a
+//! time-based sweep would be deciding, on issue #227's behalf and before it exists, exactly which
+//! history is worthless. The file is small (a few hundred bytes per entry) and never read on a
+//! hot path.
+//!
+//! Atomicity, the multi-instance merge, and the corrupt/missing-file fallback are all copied from
+//! `crate::work_surface::tab_order_state` unchanged - see `crate::sidebar::fold_state`'s module
+//! docs for the full reasoning behind that shape, including its honest limits.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::io;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use super::state::{BaselineReason, ReviewBaseline};
+
+/// The baseline file's name, resolved next to the real `settings.toml` - mirrors
+/// `crate::work_surface::tab_order_state::TAB_ORDER_FILE_NAME`.
+pub const REVIEW_BASELINE_FILE_NAME: &str = "review-baselines.toml";
+
+/// The baseline file for a given real settings-file path - identical reasoning to
+/// `crate::work_surface::tab_order_state::tab_order_path_for`: a test that supplies a temp-dir
+/// settings path gets real, isolated persistence in that same directory, and a caller with no
+/// settings path gets none at all.
+pub fn review_baseline_path_for(settings_path: &Path) -> PathBuf {
+    match settings_path.parent() {
+        Some(parent) => parent.join(REVIEW_BASELINE_FILE_NAME),
+        None => PathBuf::from(REVIEW_BASELINE_FILE_NAME),
+    }
+}
+
+/// One persisted baseline. Every field is a real, already-computed fact - nothing here is
+/// derived at read time, so a future reader (GitHub issue #227) gets exactly what was captured.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct PersistedBaseline {
+    /// The worktree this agent was running in, as an absolute path string. Recorded separately
+    /// from the map key (which also encodes it) so a reader never has to parse the key apart.
+    pub worktree: String,
+    /// `AgentKind::label`'s output, e.g. `"Claude"`.
+    pub kind: String,
+    /// The wall-clock second the agent was spawned in - the durable half of its identity.
+    pub spawned_at_unix: i64,
+    /// The real hex tree id of the snapshot.
+    pub tree_id: String,
+    /// The `refs/jerry/review/*` ref anchoring `tree_id`.
+    pub ref_name: String,
+    /// When the snapshot itself was really taken (not when the agent spawned - see
+    /// [`ReviewBaseline::taken_at_unix`]).
+    pub taken_at_unix: i64,
+    /// [`BaselineReason::as_key`]'s stable string.
+    pub reason: String,
+}
+
+impl Default for PersistedBaseline {
+    fn default() -> Self {
+        Self {
+            worktree: String::new(),
+            kind: String::new(),
+            spawned_at_unix: 0,
+            tree_id: String::new(),
+            ref_name: String::new(),
+            taken_at_unix: 0,
+            // Not `String::new()`: `#[serde(default)]` fills this in for a hand-written entry
+            // that omits it, and an empty string would fail `BaselineReason::from_key` and throw
+            // the whole otherwise-valid entry away. `Spawn` is the honest default - it's what a
+            // baseline is until someone marks it reviewed.
+            reason: BaselineReason::Spawn.as_key().to_string(),
+        }
+    }
+}
+
+/// The whole on-disk file: every baseline this app has ever captured, keyed by
+/// `super::state::baseline_key`. A `BTreeMap` so the serialized file has a stable, diffable
+/// order.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ReviewBaselineState {
+    pub baselines: BTreeMap<String, PersistedBaseline>,
+}
+
+impl ReviewBaselineState {
+    /// Loads `path`, falling back to empty state for *any* failure - the same "never important
+    /// enough to fail startup over" rule every sibling persisted file follows.
+    pub fn load_at(path: &Path) -> ReviewBaselineState {
+        let Ok(contents) = std::fs::read_to_string(path) else {
+            return ReviewBaselineState::default();
+        };
+        match toml::from_str::<ReviewBaselineState>(&contents) {
+            Ok(state) => state,
+            Err(err) => {
+                log::warn!(
+                    "{} failed to parse ({err}) - starting from no recorded review baselines",
+                    path.display()
+                );
+                ReviewBaselineState::default()
+            }
+        }
+    }
+
+    /// Writes `self` to `path` atomically - a process-unique sibling `*.tmp`, `sync_all`, rename,
+    /// then a parent-directory sync. Copied from
+    /// `crate::work_surface::tab_order_state::TabOrderState::save_at`; see
+    /// `crate::sidebar::fold_state::FoldState::save_at` for the full reasoning.
+    pub fn save_at(&self, path: &Path) -> io::Result<()> {
+        use std::io::Write;
+
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let contents = toml::to_string_pretty(self)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+        let file_name = path
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| REVIEW_BASELINE_FILE_NAME.to_string());
+        static WRITE_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let unique = WRITE_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let temp = path.with_file_name(format!("{file_name}.{}.{unique}.tmp", std::process::id()));
+
+        let write_result = (|| -> io::Result<()> {
+            let mut file = std::fs::File::create(&temp)?;
+            file.write_all(contents.as_bytes())?;
+            file.sync_all()
+        })();
+        if let Err(err) = write_result {
+            let _ = std::fs::remove_file(&temp);
+            return Err(err);
+        }
+        if let Err(err) = std::fs::rename(&temp, path) {
+            let _ = std::fs::remove_file(&temp);
+            return Err(err);
+        }
+        if let Some(parent) = path.parent() {
+            if let Ok(dir) = std::fs::File::open(parent) {
+                let _ = dir.sync_all();
+            }
+        }
+        Ok(())
+    }
+
+    /// The app's real write path: merges only the keys this instance owns into whatever is
+    /// currently on disk, then writes the result - so a second `jerry` instance (or a second
+    /// window) can't erase baselines it doesn't know about.
+    ///
+    /// Wrapped in `crate::persisted_state_lock::with_locked_merge`, sharing the same process-wide
+    /// lock as every other merged persisted file here - see that module's docs for the real
+    /// concurrent-writer race it closes.
+    ///
+    /// Unlike its siblings, a key absent from `self` is **not** removed from disk. A baseline is
+    /// history, not current layout: this instance simply not having a live agent for some key
+    /// (the normal case for every entry written by a previous run) must never be read as "delete
+    /// it". [`Self::forget`] is the one real way an entry goes away.
+    pub fn save_merged_at(&self, path: &Path, owned: &BTreeSet<String>) -> io::Result<()> {
+        crate::persisted_state_lock::with_locked_merge(|| {
+            let mut merged = ReviewBaselineState::load_at(path);
+            for key in owned {
+                if let Some(entry) = self.baselines.get(key) {
+                    merged.baselines.insert(key.clone(), entry.clone());
+                }
+            }
+            merged.save_at(path)
+        })
+    }
+
+    /// Records (or advances) `key`'s baseline.
+    pub fn set(
+        &mut self,
+        key: String,
+        worktree: &Path,
+        kind: &str,
+        spawned_at_unix: i64,
+        baseline: &ReviewBaseline,
+    ) {
+        self.baselines.insert(
+            key,
+            PersistedBaseline {
+                worktree: worktree.display().to_string(),
+                kind: kind.to_string(),
+                spawned_at_unix,
+                tree_id: baseline.tree_id.clone(),
+                ref_name: baseline.ref_name.clone(),
+                taken_at_unix: baseline.taken_at_unix,
+                reason: baseline.reason.as_key().to_string(),
+            },
+        );
+    }
+
+    /// Drops `key`'s entry outright. Deliberately **not** wired to an agent closing (see the
+    /// module docs); it exists so a real "this worktree is gone" action has a way to stop
+    /// recording baselines for a path that no longer exists, and so tests can exercise removal.
+    pub fn forget(&mut self, key: &str) {
+        self.baselines.remove(key);
+    }
+
+    /// `key`'s recorded baseline, reconstructed into the live type - `None` if there is no entry,
+    /// or if the entry is unusable (an unrecognised `reason`, or an empty tree id/ref name from a
+    /// hand-edited file). An unusable entry is skipped rather than repaired with guessed values,
+    /// because a baseline that says the wrong thing about what a user has already reviewed is
+    /// worse than no baseline at all.
+    pub fn get(&self, key: &str) -> Option<ReviewBaseline> {
+        let entry = self.baselines.get(key)?;
+        if entry.tree_id.is_empty() || entry.ref_name.is_empty() {
+            return None;
+        }
+        Some(ReviewBaseline {
+            tree_id: entry.tree_id.clone(),
+            ref_name: entry.ref_name.clone(),
+            taken_at_unix: entry.taken_at_unix,
+            reason: BaselineReason::from_key(&entry.reason)?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample(reason: BaselineReason) -> ReviewBaseline {
+        ReviewBaseline {
+            tree_id: "a".repeat(40),
+            ref_name: "refs/jerry/review/6b6579".to_string(),
+            taken_at_unix: 1_700_000_042,
+            reason,
+        }
+    }
+
+    #[test]
+    fn the_baseline_file_lives_next_to_the_real_settings_file() {
+        assert_eq!(
+            review_baseline_path_for(Path::new("/home/someone/.config/jerry/settings.toml")),
+            PathBuf::from("/home/someone/.config/jerry/review-baselines.toml")
+        );
+    }
+
+    #[test]
+    fn a_recorded_baseline_round_trips_through_a_real_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("review-baselines.toml");
+        let mut state = ReviewBaselineState::default();
+        state.set(
+            "key-a".to_string(),
+            Path::new("/repo/wt-a"),
+            "Claude",
+            1_700_000_000,
+            &sample(BaselineReason::MarkedReviewed),
+        );
+        state.save_at(&path).expect("save");
+
+        let reloaded = ReviewBaselineState::load_at(&path);
+        assert_eq!(reloaded, state);
+        assert_eq!(
+            reloaded.get("key-a"),
+            Some(sample(BaselineReason::MarkedReviewed)),
+            "every field of a real baseline must survive the round trip, including why it was \
+             taken - that's what the header wording is derived from"
+        );
+    }
+
+    #[test]
+    fn an_unknown_key_has_no_baseline() {
+        assert_eq!(ReviewBaselineState::default().get("never-seen"), None);
+    }
+
+    #[test]
+    fn a_missing_or_corrupt_file_loads_as_empty_state_rather_than_failing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert_eq!(
+            ReviewBaselineState::load_at(&dir.path().join("nope.toml")),
+            ReviewBaselineState::default()
+        );
+
+        let path = dir.path().join("review-baselines.toml");
+        std::fs::write(&path, "not valid toml {{{").expect("write");
+        assert_eq!(
+            ReviewBaselineState::load_at(&path),
+            ReviewBaselineState::default()
+        );
+    }
+
+    /// A hand-edited entry naming a reason this app doesn't know must be skipped, not guessed
+    /// at: telling a user "since you last reviewed" about a baseline that isn't one is worse
+    /// than showing nothing.
+    #[test]
+    fn an_entry_with_an_unrecognised_reason_is_skipped_rather_than_guessed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("review-baselines.toml");
+        std::fs::write(
+            &path,
+            "[baselines.\"key-a\"]\nworktree = \"/repo/wt-a\"\nkind = \"Claude\"\n\
+             spawned_at_unix = 1\ntree_id = \"aaaa\"\nref_name = \"refs/jerry/review/6b\"\n\
+             taken_at_unix = 2\nreason = \"pty-went-quiet\"\n",
+        )
+        .expect("write");
+
+        let state = ReviewBaselineState::load_at(&path);
+        assert!(
+            state.baselines.contains_key("key-a"),
+            "the raw entry is still parsed and preserved on disk"
+        );
+        assert_eq!(
+            state.get("key-a"),
+            None,
+            "but it must not be handed back as a usable baseline"
+        );
+    }
+
+    #[test]
+    fn an_entry_missing_its_tree_or_ref_is_not_usable() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("review-baselines.toml");
+        std::fs::write(
+            &path,
+            "[baselines.\"key-a\"]\nworktree = \"/repo/wt-a\"\nkind = \"Claude\"\n\
+             spawned_at_unix = 1\ntree_id = \"\"\nref_name = \"refs/jerry/review/6b\"\n\
+             taken_at_unix = 2\nreason = \"spawn\"\n",
+        )
+        .expect("write");
+        assert_eq!(ReviewBaselineState::load_at(&path).get("key-a"), None);
+    }
+
+    #[test]
+    fn saving_merges_with_another_instances_entries_instead_of_erasing_them() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("review-baselines.toml");
+
+        let mut instance_a = ReviewBaselineState::default();
+        instance_a.set(
+            "key-a".to_string(),
+            Path::new("/repo/wt-a"),
+            "Claude",
+            1,
+            &sample(BaselineReason::Spawn),
+        );
+        let owned_a: BTreeSet<String> = ["key-a".to_string()].into_iter().collect();
+        instance_a.save_merged_at(&path, &owned_a).expect("save a");
+
+        let mut instance_b = ReviewBaselineState::default();
+        instance_b.set(
+            "key-b".to_string(),
+            Path::new("/repo/wt-b"),
+            "Codex",
+            2,
+            &sample(BaselineReason::Spawn),
+        );
+        let owned_b: BTreeSet<String> = ["key-b".to_string()].into_iter().collect();
+        instance_b.save_merged_at(&path, &owned_b).expect("save b");
+
+        let on_disk = ReviewBaselineState::load_at(&path);
+        assert!(on_disk.get("key-a").is_some(), "A's baseline must survive");
+        assert!(on_disk.get("key-b").is_some());
+    }
+
+    /// The one place this file's merge deliberately differs from its siblings: an entry from a
+    /// previous run (which this instance has no live agent for, and so does not "own") must
+    /// survive a save. This is the property GitHub issue #227 will depend on.
+    #[test]
+    fn a_previous_runs_baseline_survives_a_save_that_does_not_know_about_it() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("review-baselines.toml");
+
+        let mut previous_run = ReviewBaselineState::default();
+        previous_run.set(
+            "old-key".to_string(),
+            Path::new("/repo/wt-a"),
+            "Claude",
+            1,
+            &sample(BaselineReason::MarkedReviewed),
+        );
+        previous_run.save_at(&path).expect("save");
+
+        // A fresh launch: a brand new agent, a brand new key, and no knowledge of `old-key` at
+        // all - exactly what every restart looks like today (see the module docs).
+        let mut this_run = ReviewBaselineState::default();
+        this_run.set(
+            "new-key".to_string(),
+            Path::new("/repo/wt-a"),
+            "Claude",
+            9,
+            &sample(BaselineReason::Spawn),
+        );
+        let owned: BTreeSet<String> = ["new-key".to_string()].into_iter().collect();
+        this_run.save_merged_at(&path, &owned).expect("save");
+
+        let on_disk = ReviewBaselineState::load_at(&path);
+        assert!(
+            on_disk.get("old-key").is_some(),
+            "a baseline from a previous run must not be destroyed just because this run has no \
+             live agent for it - that is exactly the data GitHub issue #227 needs to find"
+        );
+        assert!(on_disk.get("new-key").is_some());
+    }
+
+    #[test]
+    fn forgetting_a_key_really_removes_it() {
+        let mut state = ReviewBaselineState::default();
+        state.set(
+            "key-a".to_string(),
+            Path::new("/repo/wt-a"),
+            "Claude",
+            1,
+            &sample(BaselineReason::Spawn),
+        );
+        assert!(state.get("key-a").is_some());
+        state.forget("key-a");
+        assert_eq!(state.get("key-a"), None);
+    }
+
+    #[test]
+    fn advancing_a_baseline_replaces_the_recorded_entry_in_place() {
+        let mut state = ReviewBaselineState::default();
+        state.set(
+            "key-a".to_string(),
+            Path::new("/repo/wt-a"),
+            "Claude",
+            1,
+            &sample(BaselineReason::Spawn),
+        );
+        let advanced = ReviewBaseline {
+            tree_id: "b".repeat(40),
+            taken_at_unix: 1_700_000_999,
+            reason: BaselineReason::MarkedReviewed,
+            ..sample(BaselineReason::Spawn)
+        };
+        state.set(
+            "key-a".to_string(),
+            Path::new("/repo/wt-a"),
+            "Claude",
+            1,
+            &advanced,
+        );
+
+        assert_eq!(state.baselines.len(), 1, "advancing must not add a row");
+        assert_eq!(state.get("key-a"), Some(advanced));
+    }
+
+    #[test]
+    fn saving_leaves_no_temp_file_behind_and_the_result_parses() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("nested").join("review-baselines.toml");
+        let mut state = ReviewBaselineState::default();
+        state.set(
+            "key-a".to_string(),
+            Path::new("/repo/wt-a"),
+            "Claude",
+            1,
+            &sample(BaselineReason::Spawn),
+        );
+        state.save_at(&path).expect("save");
+
+        let siblings: Vec<String> = std::fs::read_dir(path.parent().expect("parent"))
+            .expect("read_dir")
+            .map(|entry| {
+                entry
+                    .expect("entry")
+                    .file_name()
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .collect();
+        assert_eq!(siblings, vec!["review-baselines.toml".to_string()]);
+        assert!(ReviewBaselineState::load_at(&path).get("key-a").is_some());
+    }
+}

--- a/crates/app/src/review/flow.rs
+++ b/crates/app/src/review/flow.rs
@@ -50,7 +50,9 @@ impl AdeApp {
     /// Called from `crate::work_surface::render::AdeApp::new_agent` - the caller of
     /// `Agents::spawn`, not `Agents::spawn` itself, mirroring how `load_diff` is triggered by a
     /// caller rather than baked into a lower-level type. `Agents` has no business knowing about
-    /// git snapshots.
+    /// git snapshots. Called unconditionally after every spawn, [`ProcessKind::Shell`] included -
+    /// the kind check below is what makes that safe rather than something every caller has to
+    /// remember.
     ///
     /// ## The accepted race
     ///
@@ -61,16 +63,23 @@ impl AdeApp {
     /// [`ReviewBaseline::taken_at_unix`] records when the snapshot really happened, so the tab
     /// header can say "09:31" honestly instead of implying it is the process's own start instant.
     ///
-    /// Captured for **every** agent, including agents in worktrees that already have others open:
-    /// the gate is a display-time decision ([`Self::review_available_for`]), so a worktree that
-    /// later drops back to one agent finds a real baseline already waiting, taken at the right
-    /// moment rather than retroactively invented.
+    /// Captured for **every real agent session**, including agents in worktrees that already have
+    /// others open: the multi-agent gate is a display-time decision
+    /// ([`Self::review_available_for`]), so a worktree that later drops back to one agent finds a
+    /// real baseline already waiting, taken at the right moment rather than retroactively
+    /// invented. A plain [`ProcessKind::Shell`] is a different exclusion entirely - not gated at
+    /// display time at all, because there is nothing for it to eventually reveal: a shell has no
+    /// turns, so a baseline captured for one would only ever be able to show "whatever changed in
+    /// this worktree while the shell happened to be open", attributed to a shell that did not
+    /// necessarily do it. No baseline is ever captured for one, full stop.
     pub(crate) fn capture_review_baseline(&mut self, id: AgentId, cx: &mut Context<Self>) {
         let Some(agent) = self.agents.iter().find(|agent| agent.id == id) else {
             return;
         };
+        let ProcessKind::Agent(kind) = agent.kind else {
+            return;
+        };
         let worktree = agent.cwd.clone();
-        let kind = agent.kind;
         let spawned_at_unix = agent.spawned_at_unix;
         let key = baseline_key(&worktree, kind, spawned_at_unix);
         let ref_name = wt_core::review::baseline_ref_name(&key);
@@ -283,8 +292,14 @@ impl AdeApp {
         let Some(agent) = self.agents.iter().find(|agent| agent.id == id) else {
             return;
         };
+        // Unreachable in practice - `review_available_for`'s already-checked
+        // `agent_reviews.contains_key` implies a baseline exists, which `capture_review_baseline`
+        // only ever creates for a real agent session - but a destructure here rather than
+        // trusting that invariant keeps this function correct even if that changes.
+        let ProcessKind::Agent(kind) = agent.kind else {
+            return;
+        };
         let worktree = agent.cwd.clone();
-        let kind = agent.kind;
         let spawned_at_unix = agent.spawned_at_unix;
         let key = baseline_key(&worktree, kind, spawned_at_unix);
         let ref_name = wt_core::review::baseline_ref_name(&key);

--- a/crates/app/src/review/flow.rs
+++ b/crates/app/src/review/flow.rs
@@ -1,0 +1,409 @@
+//! The `impl AdeApp` glue behind the agent review surface: capturing a baseline when an agent
+//! spawns, loading a review off the UI thread, advancing the baseline on `Mark reviewed`, and
+//! releasing a baseline's ref when its agent closes. See `super`'s module docs for scope.
+//!
+//! ## Every git call here is real blocking I/O
+//!
+//! `wt_core::review::snapshot_worktree_tree`, `diff_against_tree`, `changed_paths_against_tree`,
+//! `anchor_tree` and `delete_ref` all spawn real `git` child processes. Every one of them runs on
+//! `cx.background_executor()` and mutates [`AdeApp`] state only afterwards, from inside
+//! `this.update` - the exact shape `crate::code_surface::tabs::AdeApp::load_diff` and
+//! `crate::graph_view::render::AdeApp::load_graph` already established.
+
+use super::state::{baseline_key, AgentReview, BaselineReason, ReviewBaseline, ReviewLoadState};
+use super::*;
+
+impl AdeApp {
+    /// Whether agent `id`'s review surface should be shown at all right now - GitHub issue
+    /// #225's single-agent gate, in the one place every caller reads it from.
+    ///
+    /// Two real conditions, both required:
+    /// 1. A baseline has actually been captured (the snapshot is a background task, so there is a
+    ///    real window right after spawn where there is genuinely nothing to review *against*
+    ///    yet - and a review surface with no baseline would have to invent one).
+    /// 2. This agent is the only one open in its worktree
+    ///    (`Agents::is_sole_agent_in_worktree` - see that method's docs for why).
+    ///
+    /// Read by the footer's `Review` action, the rail's review-ready status, the tab strip, and
+    /// the Review tab's own open path, so none of them can drift from each other.
+    pub(crate) fn review_available_for(&self, id: AgentId) -> bool {
+        self.agent_reviews.contains_key(&id) && self.agents.is_sole_agent_in_worktree(id)
+    }
+
+    /// Captures agent `id`'s review baseline: a real `wt_core::review::snapshot_worktree_tree` of
+    /// its worktree, anchored under its own `refs/jerry/review/*` ref, recorded in memory and
+    /// persisted.
+    ///
+    /// Called from `crate::work_surface::render::AdeApp::new_agent` - the caller of
+    /// `Agents::spawn`, not `Agents::spawn` itself, mirroring how `load_diff` is triggered by a
+    /// caller rather than baked into a lower-level type. `Agents` has no business knowing about
+    /// git snapshots.
+    ///
+    /// ## The accepted race
+    ///
+    /// The agent's process starts immediately; this snapshot lands a real moment later (it's a
+    /// background task spawning `git`). Anything the agent writes inside that window is captured
+    /// *into* the baseline and therefore won't appear as an unreviewed change. That is accepted
+    /// for phase 1 rather than papered over - which is exactly why
+    /// [`ReviewBaseline::taken_at_unix`] records when the snapshot really happened, so the tab
+    /// header can say "09:31" honestly instead of implying it is the process's own start instant.
+    ///
+    /// Captured for **every** agent, including agents in worktrees that already have others open:
+    /// the gate is a display-time decision ([`Self::review_available_for`]), so a worktree that
+    /// later drops back to one agent finds a real baseline already waiting, taken at the right
+    /// moment rather than retroactively invented.
+    pub(crate) fn capture_review_baseline(&mut self, id: AgentId, cx: &mut Context<Self>) {
+        let Some(agent) = self.agents.iter().find(|agent| agent.id == id) else {
+            return;
+        };
+        let worktree = agent.cwd.clone();
+        let kind = agent.kind;
+        let spawned_at_unix = agent.spawned_at_unix;
+        let key = baseline_key(&worktree, kind, spawned_at_unix);
+        let ref_name = wt_core::review::baseline_ref_name(&key);
+
+        let task = cx.spawn(async move |this, cx| {
+            let snapshot_ref_name = ref_name.clone();
+            let result = cx
+                .background_executor()
+                .spawn({
+                    let worktree = worktree.clone();
+                    async move {
+                        let tree_id = wt_core::review::snapshot_worktree_tree(&worktree)?;
+                        // Anchor before reporting success: an unanchored tree is collectable, so
+                        // a baseline that skipped this could silently stop resolving later.
+                        wt_core::review::anchor_tree(&worktree, &snapshot_ref_name, &tree_id)?;
+                        Ok::<String, wt_core::Error>(tree_id)
+                    }
+                })
+                .await;
+            let _ = this.update(cx, |this, cx| match result {
+                Ok(tree_id) => {
+                    let baseline = ReviewBaseline {
+                        tree_id,
+                        ref_name,
+                        taken_at_unix: unix_now(),
+                        reason: BaselineReason::Spawn,
+                    };
+                    this.record_review_baseline(
+                        id,
+                        key,
+                        &worktree,
+                        kind,
+                        spawned_at_unix,
+                        baseline,
+                    );
+                    cx.notify();
+                }
+                Err(err) => {
+                    // No baseline means no review surface for this agent at all
+                    // ([`Self::review_available_for`]) - honest, and strictly better than
+                    // inventing a base point. Everything else about the agent still works.
+                    log::warn!(
+                        "failed to capture a review baseline for {}: {err}",
+                        worktree.display()
+                    );
+                }
+            });
+        });
+        self._review_baseline_task = Some(task);
+    }
+
+    /// Stores a freshly captured baseline in memory and queues its persistence. Shared by
+    /// [`Self::capture_review_baseline`] and [`Self::mark_reviewed`] so the in-memory and on-disk
+    /// halves can never be updated by one and forgotten by the other.
+    fn record_review_baseline(
+        &mut self,
+        id: AgentId,
+        key: String,
+        worktree: &Path,
+        kind: AgentKind,
+        spawned_at_unix: i64,
+        baseline: ReviewBaseline,
+    ) {
+        self.review_baseline_state.set(
+            key.clone(),
+            worktree,
+            kind.label(),
+            spawned_at_unix,
+            &baseline,
+        );
+        self.review_baselines_owned.insert(key);
+        match self.agent_reviews.get_mut(&id) {
+            Some(review) => review.advance_to(baseline),
+            None => {
+                self.agent_reviews.insert(id, AgentReview::new(baseline));
+            }
+        }
+        self.persist_review_baselines();
+    }
+
+    /// Queues a background-executor save of [`Self::review_baseline_state`] - the exact shape
+    /// `crate::work_surface::render::AdeApp::persist_tab_order` uses, including the merge against
+    /// [`Self::review_baselines_owned`] so a second window can't erase baselines it never saw. A
+    /// genuine no-op with a `None` path (every GPUI test that hasn't opted into a real one).
+    fn persist_review_baselines(&mut self) {
+        let Some(path) = self.review_baseline_path.clone() else {
+            return;
+        };
+        let state = self.review_baseline_state.clone();
+        let owned = self.review_baselines_owned.clone();
+        // Deliberately `std::thread::spawn`-free and `cx`-free: this is called from inside an
+        // existing `this.update` closure, where no `Context` is available to spawn a task from
+        // without re-entering. A blocking write of a small TOML file is bounded work, and the
+        // sibling persisted-state files' own save paths are the same size; the cost of getting a
+        // background task's lifetime wrong here would be a dropped (silently unwritten) save.
+        if let Err(err) = state.save_merged_at(&path, &owned) {
+            log::warn!("failed to save {}: {err}", path.display());
+        }
+    }
+
+    /// Loads (or reloads) agent `id`'s review diff against its own baseline, off the UI thread.
+    /// Mirrors `crate::code_surface::tabs::AdeApp::load_diff`'s shape exactly.
+    ///
+    /// A no-op if `id` has no baseline yet - there is genuinely nothing to diff against, and
+    /// falling back to any *other* base point would produce a number this surface would then
+    /// present as "this agent's changes", which it would not be.
+    pub(crate) fn load_agent_review(&mut self, id: AgentId, cx: &mut Context<Self>) {
+        let Some(review) = self.agent_reviews.get_mut(&id) else {
+            return;
+        };
+        let Some(agent) = self.agents.iter().find(|agent| agent.id == id) else {
+            return;
+        };
+        let worktree = agent.cwd.clone();
+        let tree_id = review.baseline.tree_id.clone();
+        // The `WorktreeDiff::base_branch` slot carries a *label*, and a review has no base branch
+        // at all - so it carries the honest "since ..." phrase instead of a branch name that
+        // would be a lie. See `wt_core::review::diff_against_tree`'s own docs.
+        let label = review.baseline.reason.since_phrase().to_string();
+        review.load = ReviewLoadState::Loading;
+        cx.notify();
+
+        let task = cx.spawn(async move |this, cx| {
+            let result = cx
+                .background_executor()
+                .spawn(
+                    async move { wt_core::review::diff_against_tree(&worktree, &tree_id, label) },
+                )
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                let Some(review) = this.agent_reviews.get_mut(&id) else {
+                    // The agent closed while this was loading - its review is already gone, and
+                    // re-inserting one here would resurrect state for an agent that no longer
+                    // exists.
+                    return;
+                };
+                review.load = match result {
+                    Ok(diff) => {
+                        // The full load is itself a real measurement of the same set the status
+                        // poll measures cheaply, so it refreshes `unreviewed_paths` too rather
+                        // than leaving a possibly-staler poll answer next to a fresher diff. A
+                        // failed load deliberately leaves the previous measurement alone (see
+                        // `Self::apply_review_measurements` for the same rule).
+                        review.unreviewed_paths =
+                            Some(diff.files.iter().map(|file| file.path.clone()).collect());
+                        ReviewLoadState::Loaded(diff)
+                    }
+                    Err(err) => ReviewLoadState::Error(err.to_string()),
+                };
+                // The previously open file may not be in the reloaded review any more.
+                if let Some(open) = review.open_file.clone() {
+                    let still_changed = review
+                        .diff()
+                        .is_some_and(|diff| diff.files.iter().any(|file| file.path == open));
+                    if !still_changed {
+                        review.open_file = None;
+                    }
+                }
+                this.refresh_review_highlight_cache();
+                cx.notify();
+            });
+        });
+        self._review_load_task = Some(task);
+    }
+
+    /// The Review tab's `Mark reviewed` action: re-snapshots the worktree *right now*, advances
+    /// this agent's baseline onto it, and reloads.
+    ///
+    /// After this, the review is empty (nothing has changed since a snapshot taken a moment
+    /// ago), and that is the correct, good outcome, not an error (see
+    /// `super::state::review_empty_message`). The reload is what makes the surface actually show
+    /// it, rather than leaving the pre-mark file list on screen next to a baseline it no longer
+    /// describes.
+    ///
+    /// Re-anchors the same ref onto the new tree (`anchor_tree` moves an existing ref), so a
+    /// baseline never accumulates one ref per mark.
+    pub(crate) fn mark_reviewed(&mut self, id: AgentId, cx: &mut Context<Self>) {
+        if !self.review_available_for(id) || self.review_mark_in_flight.is_some() {
+            return;
+        }
+        let Some(agent) = self.agents.iter().find(|agent| agent.id == id) else {
+            return;
+        };
+        let worktree = agent.cwd.clone();
+        let kind = agent.kind;
+        let spawned_at_unix = agent.spawned_at_unix;
+        let key = baseline_key(&worktree, kind, spawned_at_unix);
+        let ref_name = wt_core::review::baseline_ref_name(&key);
+        self.review_mark_in_flight = Some(id);
+        cx.notify();
+
+        let task = cx.spawn(async move |this, cx| {
+            let snapshot_ref_name = ref_name.clone();
+            let result = cx
+                .background_executor()
+                .spawn({
+                    let worktree = worktree.clone();
+                    async move {
+                        let tree_id = wt_core::review::snapshot_worktree_tree(&worktree)?;
+                        wt_core::review::anchor_tree(&worktree, &snapshot_ref_name, &tree_id)?;
+                        Ok::<String, wt_core::Error>(tree_id)
+                    }
+                })
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                this.review_mark_in_flight = None;
+                match result {
+                    Ok(tree_id) => {
+                        let baseline = ReviewBaseline {
+                            tree_id,
+                            ref_name,
+                            taken_at_unix: unix_now(),
+                            reason: BaselineReason::MarkedReviewed,
+                        };
+                        this.record_review_baseline(
+                            id,
+                            key,
+                            &worktree,
+                            kind,
+                            spawned_at_unix,
+                            baseline,
+                        );
+                        this.refresh_review_highlight_cache();
+                        this.load_agent_review(id, cx);
+                    }
+                    Err(err) => {
+                        // The old baseline is deliberately left exactly where it was: a failed
+                        // snapshot must never silently advance what the user has "reviewed".
+                        if let Some(review) = this.agent_reviews.get_mut(&id) {
+                            review.load =
+                                ReviewLoadState::Error(format!("could not mark reviewed: {err}"));
+                        }
+                    }
+                }
+                cx.notify();
+            });
+        });
+        self._review_mark_task = Some(task);
+    }
+
+    /// Drops agent `id`'s in-memory review and deletes its baseline ref, releasing the snapshot's
+    /// objects to a future `git gc`. Called from `Self::close_agent`.
+    ///
+    /// The **persisted metadata entry is deliberately left in place** - see
+    /// `super::baseline_state`'s module docs. The ref goes because a closed agent's snapshot has
+    /// no live consumer and shouldn't pin objects forever; the record of what was captured, when,
+    /// and why stays, because that is exactly the groundwork GitHub issue #227 ("Agent history and
+    /// resume/recover") will need and this app should not be actively destroying.
+    pub(crate) fn release_review_baseline(&mut self, id: AgentId, cx: &mut Context<Self>) {
+        let Some(review) = self.agent_reviews.remove(&id) else {
+            return;
+        };
+        let Some(agent) = self.agents.iter().find(|agent| agent.id == id) else {
+            // Already removed from `Agents` - we no longer know which worktree to run
+            // `update-ref -d` in. The ref stays; it costs one small file and one unreachable
+            // tree. Callers run this *before* `Agents::close` precisely so this is the rare path.
+            return;
+        };
+        let worktree = agent.cwd.clone();
+        let ref_name = review.baseline.ref_name.clone();
+        let task = cx.spawn(async move |_this, cx| {
+            let result = cx
+                .background_executor()
+                .spawn(async move { wt_core::review::delete_ref(&worktree, &ref_name) })
+                .await;
+            if let Err(err) = result {
+                log::warn!("failed to release a review baseline ref: {err}");
+            }
+        });
+        self._review_release_task = Some(task);
+    }
+
+    /// The rail's real per-agent `N files` count for a [`crate::rail::status::Status::Review`]
+    /// row - how many files this agent has changed since *its own* baseline.
+    ///
+    /// A pure read of an already-loaded review, never a fresh git call: this is consumed by
+    /// `build_agent_rows`, which runs on every rail render. The loading itself happens in
+    /// [`Self::load_agent_review`].
+    ///
+    /// `None` (rather than a fabricated `0`) whenever the number would be a guess: no baseline
+    /// yet, nothing loaded yet, a failed load, or a multi-agent worktree the gate holds back.
+    pub(crate) fn agent_review_file_count(&self, id: AgentId) -> Option<usize> {
+        if !self.review_available_for(id) {
+            return None;
+        }
+        self.agent_reviews.get(&id)?.unreviewed_file_count()
+    }
+
+    /// Every agent that currently has a baseline, as `(id, worktree, tree id)` - what the rail's
+    /// status-poll tick needs to measure each agent's unreviewed set on the background executor.
+    ///
+    /// Deliberately **not** filtered by the single-agent gate: measuring is cheap and the answer
+    /// is genuinely correct per-agent-baseline regardless of how many agents share a worktree.
+    /// Only *presenting* it is gated (`Self::review_available_for`), so a worktree dropping back
+    /// to one agent has a fresh measurement already in hand rather than waiting a tick for one.
+    pub(crate) fn review_measure_targets(&self) -> Vec<(AgentId, PathBuf, String)> {
+        self.agents
+            .iter()
+            .filter_map(|agent| {
+                let review = self.agent_reviews.get(&agent.id)?;
+                Some((agent.id, agent.cwd.clone(), review.baseline.tree_id.clone()))
+            })
+            .collect()
+    }
+
+    /// Writes back one status-poll tick's real measurements. An agent whose measurement failed
+    /// (or that closed mid-tick) is skipped, leaving its previous answer in place rather than
+    /// being reset to a fabricated empty set off the back of a git call that errored.
+    ///
+    /// Also drops a stale entry whose baseline moved while the tick was in flight (a concurrent
+    /// `Mark reviewed`): that measurement describes the *old* baseline, and applying it would
+    /// briefly show already-reviewed files as unreviewed.
+    pub(crate) fn apply_review_measurements(
+        &mut self,
+        measurements: Vec<(AgentId, String, Vec<PathBuf>)>,
+    ) {
+        for (id, measured_tree_id, paths) in measurements {
+            if let Some(review) = self.agent_reviews.get_mut(&id) {
+                if review.baseline.tree_id == measured_tree_id {
+                    review.unreviewed_paths = Some(paths);
+                }
+            }
+        }
+    }
+
+    /// `true` when agent `id` has a real, loaded, non-empty review against its own baseline and
+    /// the single-agent gate allows showing it - the replacement for the old
+    /// "is the *worktree's* git diff non-empty" input to `crate::rail::status::derive_status`.
+    ///
+    /// This is the correctness fix at the heart of GitHub issue #225: an agent that changed
+    /// nothing, in a worktree whose branch had already diverged from `main`, used to be reported
+    /// `Review ready` off the back of the *branch's* diff.
+    pub(crate) fn agent_has_unreviewed_changes(&self, id: AgentId) -> bool {
+        self.review_available_for(id)
+            && self
+                .agent_reviews
+                .get(&id)
+                .is_some_and(|review| review.has_unreviewed_changes())
+    }
+}
+
+/// Real wall-clock seconds since the Unix epoch, for a baseline's own `taken_at_unix`. Mirrors
+/// `crate::work_surface::agents`' and `crate::graph_view::render`'s identical helpers.
+fn unix_now() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_secs() as i64)
+        .unwrap_or(0)
+}

--- a/crates/app/src/review/flow.rs
+++ b/crates/app/src/review/flow.rs
@@ -13,6 +13,19 @@
 use super::state::{baseline_key, AgentReview, BaselineReason, ReviewBaseline, ReviewLoadState};
 use super::*;
 
+/// The durable identity a captured baseline is filed under, bundled into one value so
+/// [`AdeApp::record_review_baseline`] stays under clippy's argument limit - the same reason
+/// `crate::work_surface::render::TabChromeArgs` and
+/// `crate::code_surface::file_view::HoverRenderContext` exist.
+struct BaselineIdentity {
+    id: AgentId,
+    /// `super::state::baseline_key`'s output for the three fields below.
+    key: String,
+    worktree: PathBuf,
+    kind: AgentKind,
+    spawned_at_unix: i64,
+}
+
 impl AdeApp {
     /// Whether agent `id`'s review surface should be shown at all right now - GitHub issue
     /// #225's single-agent gate, in the one place every caller reads it from.
@@ -69,44 +82,57 @@ impl AdeApp {
                 .spawn({
                     let worktree = worktree.clone();
                     async move {
-                        let tree_id = wt_core::review::snapshot_worktree_tree(&worktree)?;
+                        let snapshot = wt_core::review::snapshot_worktree_tree(&worktree)?;
                         // Anchor before reporting success: an unanchored tree is collectable, so
                         // a baseline that skipped this could silently stop resolving later.
-                        wt_core::review::anchor_tree(&worktree, &snapshot_ref_name, &tree_id)?;
-                        Ok::<String, wt_core::Error>(tree_id)
+                        wt_core::review::anchor_tree(
+                            &worktree,
+                            &snapshot_ref_name,
+                            &snapshot.tree_id,
+                        )?;
+                        Ok::<wt_core::review::WorktreeSnapshot, wt_core::Error>(snapshot)
                     }
                 })
                 .await;
-            let _ = this.update(cx, |this, cx| match result {
-                Ok(tree_id) => {
-                    let baseline = ReviewBaseline {
-                        tree_id,
-                        ref_name,
-                        taken_at_unix: unix_now(),
-                        reason: BaselineReason::Spawn,
-                    };
-                    this.record_review_baseline(
-                        id,
-                        key,
-                        &worktree,
-                        kind,
-                        spawned_at_unix,
-                        baseline,
-                    );
-                    cx.notify();
-                }
-                Err(err) => {
-                    // No baseline means no review surface for this agent at all
-                    // ([`Self::review_available_for`]) - honest, and strictly better than
-                    // inventing a base point. Everything else about the agent still works.
-                    log::warn!(
-                        "failed to capture a review baseline for {}: {err}",
-                        worktree.display()
-                    );
+            let _ = this.update(cx, |this, cx| {
+                // This capture is finished either way; drop its own slot so the map only ever
+                // holds genuinely in-flight work.
+                this._review_baseline_tasks.remove(&id);
+                match result {
+                    Ok(snapshot) => {
+                        let baseline = ReviewBaseline {
+                            tree_id: snapshot.tree_id,
+                            ref_name,
+                            taken_at_unix: unix_now(),
+                            reason: BaselineReason::Spawn,
+                            untracked: snapshot.untracked,
+                        };
+                        this.record_review_baseline(
+                            BaselineIdentity {
+                                id,
+                                key,
+                                worktree: worktree.clone(),
+                                kind,
+                                spawned_at_unix,
+                            },
+                            baseline,
+                            cx,
+                        );
+                        cx.notify();
+                    }
+                    Err(err) => {
+                        // No baseline means no review surface for this agent at all
+                        // ([`Self::review_available_for`]) - honest, and strictly better than
+                        // inventing a base point. Everything else about the agent still works.
+                        log::warn!(
+                            "failed to capture a review baseline for {}: {err}",
+                            worktree.display()
+                        );
+                    }
                 }
             });
         });
-        self._review_baseline_task = Some(task);
+        self._review_baseline_tasks.insert(id, task);
     }
 
     /// Stores a freshly captured baseline in memory and queues its persistence. Shared by
@@ -114,16 +140,20 @@ impl AdeApp {
     /// halves can never be updated by one and forgotten by the other.
     fn record_review_baseline(
         &mut self,
-        id: AgentId,
-        key: String,
-        worktree: &Path,
-        kind: AgentKind,
-        spawned_at_unix: i64,
+        identity: BaselineIdentity,
         baseline: ReviewBaseline,
+        cx: &mut Context<Self>,
     ) {
+        let BaselineIdentity {
+            id,
+            key,
+            worktree,
+            kind,
+            spawned_at_unix,
+        } = identity;
         self.review_baseline_state.set(
             key.clone(),
-            worktree,
+            &worktree,
             kind.label(),
             spawned_at_unix,
             &baseline,
@@ -135,27 +165,36 @@ impl AdeApp {
                 self.agent_reviews.insert(id, AgentReview::new(baseline));
             }
         }
-        self.persist_review_baselines();
+        self.persist_review_baselines(cx);
     }
 
     /// Queues a background-executor save of [`Self::review_baseline_state`] - the exact shape
     /// `crate::work_surface::render::AdeApp::persist_tab_order` uses, including the merge against
     /// [`Self::review_baselines_owned`] so a second window can't erase baselines it never saw. A
     /// genuine no-op with a `None` path (every GPUI test that hasn't opted into a real one).
-    fn persist_review_baselines(&mut self) {
+    ///
+    /// Really on the background executor, not merely documented as such. An earlier version ran
+    /// `save_merged_at` inline here, which meant the main thread performed two `fsync`s (the temp
+    /// file and its parent directory) while holding `crate::persisted_state_lock`'s process-wide
+    /// mutex - a lock that background writers of `repos.toml`/`tab-order.toml` also hold across
+    /// *their* fsyncs, so the UI thread could block on an entirely unrelated save.
+    fn persist_review_baselines(&mut self, cx: &mut Context<Self>) {
         let Some(path) = self.review_baseline_path.clone() else {
             return;
         };
         let state = self.review_baseline_state.clone();
         let owned = self.review_baselines_owned.clone();
-        // Deliberately `std::thread::spawn`-free and `cx`-free: this is called from inside an
-        // existing `this.update` closure, where no `Context` is available to spawn a task from
-        // without re-entering. A blocking write of a small TOML file is bounded work, and the
-        // sibling persisted-state files' own save paths are the same size; the cost of getting a
-        // background task's lifetime wrong here would be a dropped (silently unwritten) save.
-        if let Err(err) = state.save_merged_at(&path, &owned) {
-            log::warn!("failed to save {}: {err}", path.display());
-        }
+        let task = cx.spawn(async move |_this, cx| {
+            let save_path = path.clone();
+            let result = cx
+                .background_executor()
+                .spawn(async move { state.save_merged_at(&save_path, &owned) })
+                .await;
+            if let Err(err) = result {
+                log::warn!("failed to save {}: {err}", path.display());
+            }
+        });
+        self._review_persist_task = Some(task);
     }
 
     /// Loads (or reloads) agent `id`'s review diff against its own baseline, off the UI thread.
@@ -173,6 +212,9 @@ impl AdeApp {
         };
         let worktree = agent.cwd.clone();
         let tree_id = review.baseline.tree_id.clone();
+        // Must match the coverage the snapshot was taken with, or a tracked-only baseline would
+        // report every pre-existing untracked file as a brand-new addition.
+        let untracked = review.baseline.untracked;
         // The `WorktreeDiff::base_branch` slot carries a *label*, and a review has no base branch
         // at all - so it carries the honest "since ..." phrase instead of a branch name that
         // would be a lie. See `wt_core::review::diff_against_tree`'s own docs.
@@ -183,9 +225,9 @@ impl AdeApp {
         let task = cx.spawn(async move |this, cx| {
             let result = cx
                 .background_executor()
-                .spawn(
-                    async move { wt_core::review::diff_against_tree(&worktree, &tree_id, label) },
-                )
+                .spawn(async move {
+                    wt_core::review::diff_against_tree(&worktree, &tree_id, untracked, label)
+                })
                 .await;
             let _ = this.update(cx, |this, cx| {
                 let Some(review) = this.agent_reviews.get_mut(&id) else {
@@ -256,29 +298,37 @@ impl AdeApp {
                 .spawn({
                     let worktree = worktree.clone();
                     async move {
-                        let tree_id = wt_core::review::snapshot_worktree_tree(&worktree)?;
-                        wt_core::review::anchor_tree(&worktree, &snapshot_ref_name, &tree_id)?;
-                        Ok::<String, wt_core::Error>(tree_id)
+                        let snapshot = wt_core::review::snapshot_worktree_tree(&worktree)?;
+                        wt_core::review::anchor_tree(
+                            &worktree,
+                            &snapshot_ref_name,
+                            &snapshot.tree_id,
+                        )?;
+                        Ok::<wt_core::review::WorktreeSnapshot, wt_core::Error>(snapshot)
                     }
                 })
                 .await;
             let _ = this.update(cx, |this, cx| {
                 this.review_mark_in_flight = None;
                 match result {
-                    Ok(tree_id) => {
+                    Ok(snapshot) => {
                         let baseline = ReviewBaseline {
-                            tree_id,
+                            tree_id: snapshot.tree_id,
                             ref_name,
                             taken_at_unix: unix_now(),
                             reason: BaselineReason::MarkedReviewed,
+                            untracked: snapshot.untracked,
                         };
                         this.record_review_baseline(
-                            id,
-                            key,
-                            &worktree,
-                            kind,
-                            spawned_at_unix,
+                            BaselineIdentity {
+                                id,
+                                key,
+                                worktree: worktree.clone(),
+                                kind,
+                                spawned_at_unix,
+                            },
                             baseline,
+                            cx,
                         );
                         this.refresh_review_highlight_cache();
                         this.load_agent_review(id, cx);
@@ -318,7 +368,7 @@ impl AdeApp {
         };
         let worktree = agent.cwd.clone();
         let ref_name = review.baseline.ref_name.clone();
-        let task = cx.spawn(async move |_this, cx| {
+        let task = cx.spawn(async move |this, cx| {
             let result = cx
                 .background_executor()
                 .spawn(async move { wt_core::review::delete_ref(&worktree, &ref_name) })
@@ -326,8 +376,11 @@ impl AdeApp {
             if let Err(err) = result {
                 log::warn!("failed to release a review baseline ref: {err}");
             }
+            let _ = this.update(cx, |this, _cx| {
+                this._review_release_tasks.remove(&id);
+            });
         });
-        self._review_release_task = Some(task);
+        self._review_release_tasks.insert(id, task);
     }
 
     /// The rail's real per-agent `N files` count for a [`crate::rail::status::Status::Review`]
@@ -353,12 +406,20 @@ impl AdeApp {
     /// is genuinely correct per-agent-baseline regardless of how many agents share a worktree.
     /// Only *presenting* it is gated (`Self::review_available_for`), so a worktree dropping back
     /// to one agent has a fresh measurement already in hand rather than waiting a tick for one.
-    pub(crate) fn review_measure_targets(&self) -> Vec<(AgentId, PathBuf, String)> {
+    pub(crate) fn review_measure_targets(
+        &self,
+    ) -> Vec<(AgentId, PathBuf, String, wt_core::review::UntrackedCoverage)> {
         self.agents
             .iter()
             .filter_map(|agent| {
                 let review = self.agent_reviews.get(&agent.id)?;
-                Some((agent.id, agent.cwd.clone(), review.baseline.tree_id.clone()))
+                Some((
+                    agent.id,
+                    agent.cwd.clone(),
+                    review.baseline.tree_id.clone(),
+                    // Same coverage the baseline was captured with - see `load_agent_review`.
+                    review.baseline.untracked,
+                ))
             })
             .collect()
     }

--- a/crates/app/src/review/mod.rs
+++ b/crates/app/src/review/mod.rs
@@ -1,0 +1,72 @@
+//! The agent **review** surface (GitHub issue #225, "Separate diffs for git and agents") -
+//! everything about this feature, in one folder.
+//!
+//! ## The distinction this folder exists to draw
+//!
+//! The maintainer's report: *"Right now there is a confusion between agents diff review and git
+//! diffs. We need to separate both concepts."* And, when asked to clarify: *"displaying a git
+//! diff is not the same as displaying an agent diff for review, those are different concepts."*
+//!
+//! They are separated here by **base point and lifetime**, not by filtering one list into two:
+//!
+//! - A **git diff** (`crate::sidebar::changes`, the File/Diff toggle, `wt_core::diff::
+//!   diff_against_base`) answers *how does this worktree differ from the merge-base with the
+//!   default branch*. It's a property of the branch. Same answer regardless of who made the
+//!   changes, and it only moves when the branch does.
+//! - A **review** (this folder, `wt_core::review`) answers *what has changed since the point I
+//!   last looked*. Its base is a snapshot of the working tree taken at a moment in time, and it
+//!   advances only when the user explicitly says `Mark reviewed`.
+//!
+//! An agent spawned into a worktree whose branch already diverged from `main` has a big git diff
+//! and an empty review. Both answers are correct; before this, only the first one existed, and it
+//! was being presented as if it answered the second - which is the reported confusion, exactly.
+//!
+//! Downstream of the base point, everything is shared: a review diff is a real
+//! `wt_core::diff::WorktreeDiff`, rendered by the very same
+//! `crate::code_surface::AdeApp::render_diff_file_detail` the git side uses. There is one diff
+//! renderer in this app, not two.
+//!
+//! ## Vocabulary
+//!
+//! This surface never says a bare "diff" - it says *review*, *unreviewed*, *mark reviewed*,
+//! *since*. The git-side Changes sidebar and File/Diff toggle keep their existing words
+//! untouched. `state`'s own `no_review_wording_anywhere_says_a_bare_diff` test pins this.
+//!
+//! ## The single-agent gate
+//!
+//! Real per-agent attribution doesn't exist yet, so in a worktree with more than one open agent
+//! an agent's review would honestly include changes it didn't make. The entire review surface is
+//! therefore held back for multi-agent worktrees - see
+//! `crate::work_surface::agents::Agents::count_for_cwd` for the gate itself and why it's checked
+//! at *display* time while baselines are still captured for every agent.
+//!
+//! ## Layout
+//!
+//! Split the way every feature folder in this crate is split (see `crate::graph_view`'s own docs
+//! for the convention):
+//!
+//! - [`state`] - pure, GPUI-free types and wording: what a baseline is, what a review holds, the
+//!   persisted key, and the exact words the tab header says.
+//! - [`baseline_state`] - the real on-disk sibling file next to `settings.toml`.
+//! - [`flow`] - the `impl AdeApp` glue: capturing a baseline at spawn, loading a review off the
+//!   UI thread, `Mark reviewed`, and releasing a baseline's ref when an agent closes.
+//! - [`render`] - the real GPUI surface: the tab strip entry, the tab body, and the open/close/
+//!   focus discipline copied from the git graph tab.
+//!
+//! `flow`/`render` glob-import this module (`use super::*`), which is why the shared imports they
+//! need live here rather than at the top of each file - the same convention `crate::root`
+//! established for its own submodules.
+
+use crate::code_surface::code_view;
+use crate::root::*;
+use crate::sidebar::changes;
+use crate::theme;
+use crate::work_surface::agents::{AgentId, AgentKind};
+use crate::work_surface::state as work_surface;
+use gpui::{div, font, prelude::*, px, App, ClickEvent, Context, Window};
+use std::path::{Path, PathBuf};
+
+pub mod baseline_state;
+pub(crate) mod flow;
+pub(crate) mod render;
+pub mod state;

--- a/crates/app/src/review/mod.rs
+++ b/crates/app/src/review/mod.rs
@@ -61,7 +61,7 @@ use crate::code_surface::code_view;
 use crate::root::*;
 use crate::sidebar::changes;
 use crate::theme;
-use crate::work_surface::agents::{AgentId, AgentKind};
+use crate::work_surface::agents::{AgentId, AgentKind, ProcessKind};
 use crate::work_surface::state as work_surface;
 use gpui::{div, font, prelude::*, px, App, ClickEvent, Context, Window};
 use std::path::{Path, PathBuf};

--- a/crates/app/src/review/render.rs
+++ b/crates/app/src/review/render.rs
@@ -1,0 +1,1253 @@
+//! The real GPUI surface for the agent review tab (GitHub issue #225): its tab strip entry, its
+//! header/body/footer, and the `impl AdeApp` glue that opens, closes and focuses it. See `super`'s
+//! module docs for scope.
+//!
+//! ## Open/close/focus discipline
+//!
+//! [`AdeApp::open_review_tab`]/[`AdeApp::leave_review_tab`]/[`AdeApp::close_review_tab`] are
+//! deliberate copies of `crate::graph_view::render::AdeApp::open_git_graph`/`leave_graph_tab`/
+//! `close_git_graph_tab`, step for step. That file's own comments document real, live-reproduced
+//! dangling-focus bugs this app has already hit twice (a handle that stops being `track_focus`'d
+//! the moment its tab stops rendering, while `Window::focus` still points at it, and an
+//! `OverlayFocus` still holding it as a restore target). [`Self::review_focus_handle`] has exactly
+//! the same conditional-render lifetime, so it needs exactly the same sweep - not a shortened
+//! version of it because a step looked unnecessary.
+
+use super::state::{
+    review_empty_message, review_summary_label, review_tab_header, ReviewLoadState,
+};
+use super::*;
+
+use crate::code_surface::diff_view::DiffDetailSurface;
+use crate::root::widgets::{render_sidebar_message, render_tag_pill};
+use crate::work_surface::render::{DraggedTab, TabChromeArgs};
+
+impl AdeApp {
+    /// Opens (or re-activates) the review tab for agent `id`. The single real door: the footer's
+    /// `Review` action and the tab's own click handler both come through here.
+    ///
+    /// Refuses outright when [`Self::review_available_for`] says no - no baseline captured yet, or
+    /// a multi-agent worktree (GitHub issue #225's single-agent gate). A refusal is a genuine
+    /// no-op: the surface simply doesn't exist for that agent right now, and every entry point
+    /// that could reach it is rendered disabled to match, so this is a backstop rather than the
+    /// primary gate.
+    pub(crate) fn open_review_tab(
+        &mut self,
+        id: AgentId,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if !self.review_available_for(id) {
+            return;
+        }
+        // Mirrors `open_git_graph`'s own defensive close: this is reachable from the footer while
+        // the palette also happens to be open.
+        if self.palette_open {
+            self.close_palette(window, cx);
+        }
+
+        // The review tab and the graph tab both occupy the centre pane, so opening one must leave
+        // the other properly - not merely stop drawing it, which is what left `graph_focus_handle`
+        // dangling in the bugs `leave_graph_tab` documents.
+        self.leave_graph_tab(window, cx);
+        self.graph_tab_open = false;
+
+        let was_active = self.review_tab_active && self.review_tab_open == Some(id);
+        self.review_tab_open = Some(id);
+        self.review_tab_active = true;
+        self.open_change = None;
+        self.plus_menu_open = false;
+        self.title_menu_open = None;
+        self.prune_confirm_armed = false;
+        self.discard_confirm_armed = None;
+
+        // Same "leaving Files"/"leaving the code surface" sweep `open_git_graph` performs, for the
+        // identical reason: `self.open_change = None` above just unrendered the code surface, and
+        // this tab replaces the centre pane the file tree's own focus interacts with. See
+        // `crate::sidebar::render::AdeApp::set_right_sidebar_view`'s docs for the bug class.
+        self.tree_context_menu = None;
+        self.tree_inline_edit = None;
+        if self.tree_focus_handle.is_focused(window) {
+            restore_focus(&self.agents, &mut self.code_focus, window, cx);
+        }
+        self.palette_focus.forget_target(&self.tree_focus_handle);
+        self.settings_focus.forget_target(&self.tree_focus_handle);
+        self.code_focus.forget_target(&self.tree_focus_handle);
+
+        if self.code_focus_handle.is_focused(window) {
+            restore_focus(&self.agents, &mut self.code_focus, window, cx);
+        }
+        self.palette_focus.forget_target(&self.code_focus_handle);
+        self.settings_focus.forget_target(&self.code_focus_handle);
+        // `open_change` just changed; every cache keyed on it must follow, exactly like every
+        // other site that clears it.
+        self.refresh_open_diff_file_cache();
+
+        if !was_active && !self.focus_is_on_an_overlay(window, cx) {
+            self.review_focus.capture(window, &self.agents, cx);
+        }
+        window.focus(&self.review_focus_handle, cx);
+
+        if matches!(
+            self.agent_reviews.get(&id).map(|review| &review.load),
+            Some(ReviewLoadState::NotLoaded)
+        ) {
+            self.load_agent_review(id, cx);
+        }
+        cx.notify();
+    }
+
+    /// Closes the review tab outright (its `×`), removing it from the tab strip. Unlike the graph
+    /// tab this does **not** drop the loaded review: the baseline is unchanged, so what was loaded
+    /// is still exactly the right answer, and re-opening should not have to re-run `git diff`.
+    /// (Closing the *agent* is what really discards a review - see
+    /// `crate::review::flow::AdeApp::release_review_baseline`.)
+    pub(crate) fn close_review_tab(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.leave_review_tab(window, cx);
+        self.review_tab_open = None;
+        cx.notify();
+    }
+
+    /// Closes the review tab if the single-agent gate has just shut on it - i.e. a second agent
+    /// started in the worktree whose agent the tab is reviewing.
+    ///
+    /// Called right after every spawn. This is a real close, with the full focus teardown, rather
+    /// than merely filtering the tab out of the strip: `review_focus_handle` stops being
+    /// `track_focus`'d the moment the tab stops rendering, so quietly dropping it from the strip
+    /// while `Window::focus` still pointed at it is precisely the dangling-focus bug class this
+    /// module's docs describe.
+    ///
+    /// The agent's *review* survives (`agent_reviews` keeps its baseline), so closing the extra
+    /// agent later and re-opening the tab picks up exactly where this left off - against the
+    /// baseline captured at spawn, not a retroactive one.
+    pub(crate) fn close_gated_review_tab(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if let Some(id) = self.review_tab_open {
+            if !self.review_available_for(id) {
+                self.close_review_tab(window, cx);
+            }
+        }
+    }
+
+    /// Common bookkeeping whenever the review tab stops being the active centre-pane content -
+    /// selecting an agent/file/graph tab while it was showing, or closing it outright. A no-op if
+    /// it wasn't active.
+    ///
+    /// [`Self::review_focus_handle`] is about to stop being `track_focus`'d
+    /// ([`Self::render_review_view`] is only rendered while `review_tab_active`), so real keyboard
+    /// focus moves off it *first*, before anything else can capture it as an `OverlayFocus` return
+    /// target - and any target already holding it from earlier is swept. See this module's docs.
+    pub(crate) fn leave_review_tab(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if !self.review_tab_active {
+            return;
+        }
+        self.review_tab_active = false;
+        if self.review_focus_handle.is_focused(window) {
+            restore_focus(&self.agents, &mut self.review_focus, window, cx);
+        }
+        self.palette_focus.forget_target(&self.review_focus_handle);
+        self.settings_focus.forget_target(&self.review_focus_handle);
+        self.code_focus.forget_target(&self.review_focus_handle);
+        self.graph_focus.forget_target(&self.review_focus_handle);
+    }
+
+    /// Opens `path`'s hunks inside the review tab - the review-side counterpart to
+    /// `Self::open_change_diff`, deliberately *not* that function: opening a git Diff view tab
+    /// from a review row would drop the user straight back into the surface this feature exists
+    /// to keep separate, showing the same file measured against a different base.
+    pub(crate) fn open_review_file(&mut self, path: PathBuf, cx: &mut Context<Self>) {
+        let Some(id) = self.review_tab_open else {
+            return;
+        };
+        let Some(review) = self.agent_reviews.get_mut(&id) else {
+            return;
+        };
+        // Clicking the already-open row closes it again, so the file list is always reachable
+        // without needing a separate "back" affordance.
+        review.open_file = if review.open_file.as_deref() == Some(path.as_path()) {
+            None
+        } else {
+            Some(path)
+        };
+        self.refresh_review_highlight_cache();
+        cx.notify();
+    }
+
+    /// Rebuilds [`Self::review_highlight_cache`] for whichever file the review tab currently has
+    /// open - the review-side twin of [`Self::ensure_diff_highlight_cache`], with the identical
+    /// "recompute only when the cached `DiffFile` actually differs" freshness check, and called
+    /// from the same kind of place: real change points (a row click, a completed load, a
+    /// baseline advance), never from inside `render()`.
+    pub(crate) fn refresh_review_highlight_cache(&mut self) {
+        let Some(file) = self.open_review_file_detail().cloned() else {
+            self.review_highlight_cache = None;
+            return;
+        };
+        if self
+            .review_highlight_cache
+            .as_ref()
+            .is_some_and(|(cached, _, _)| cached == &file)
+        {
+            return;
+        }
+        let extension = file.path.extension().and_then(|ext| ext.to_str());
+        let highlight_options = self.highlight_options();
+        let mut remaining = MAX_RENDERED_DIFF_LINES_PER_FILE;
+        let mut per_hunk = Vec::with_capacity(file.hunks.len());
+        let mut per_hunk_numbers = Vec::with_capacity(file.hunks.len());
+        for hunk in &file.hunks {
+            if remaining == 0 {
+                break;
+            }
+            let capped_lines: Vec<&str> = hunk
+                .lines
+                .iter()
+                .take(remaining)
+                .map(|line| line.content.as_str())
+                .collect();
+            remaining -= capped_lines.len();
+            per_hunk.push(code_view::highlight_block(
+                capped_lines,
+                extension,
+                highlight_options,
+            ));
+            per_hunk_numbers.push(changes::hunk_line_numbers(hunk));
+        }
+        self.review_highlight_cache = Some((file, per_hunk, per_hunk_numbers));
+    }
+
+    /// The `DiffFile` the review tab currently has open, if any - a real lookup into the loaded
+    /// review, never a cached copy that could go stale against it.
+    ///
+    /// `pub(crate)`, not private: `crate::code_surface::diff_view::DiffDetailSurface::open_file`
+    /// calls this directly so the virtualized `uniform_list` row builder (GitHub issue #224) can
+    /// re-resolve the *review* tab's own open file the same way it already re-resolves the git
+    /// Diff view's (`AdeApp::open_diff_file_cache`) - one accessor per surface, not a shared one.
+    pub(crate) fn open_review_file_detail(&self) -> Option<&wt_core::diff::DiffFile> {
+        let id = self.review_tab_open?;
+        let review = self.agent_reviews.get(&id)?;
+        let open = review.open_file.as_deref()?;
+        review.diff()?.files.iter().find(|file| file.path == open)
+    }
+
+    /// The label the review tab and its header show for agent `id` - the agent's real program
+    /// label (`claude`, `codex`, the resolved shell), never a hardcoded name.
+    fn review_agent_label(&self, id: AgentId, cx: &App) -> String {
+        self.agents
+            .iter()
+            .find(|agent| agent.id == id)
+            .map(|agent| agent.pane.read(cx).program_label())
+            .unwrap_or_else(|| "agent".to_string())
+    }
+
+    /// The review tab's whole body: the header stating what this is measured against, the list of
+    /// unreviewed files, the open file's hunks, and the `Mark reviewed` footer.
+    pub(crate) fn render_review_view(&mut self, cx: &mut Context<Self>) -> gpui::AnyElement {
+        let Some(id) = self.review_tab_open else {
+            return div().into_any_element();
+        };
+        // The gate is re-checked at render time, not just at open time: a *second* agent spawning
+        // into this worktree while the tab is open must make the surface stop claiming to show
+        // "this agent's" changes immediately, without waiting for a click.
+        if !self.review_available_for(id) {
+            return div()
+                .id("review-view")
+                .track_focus(&self.review_focus_handle.clone())
+                .flex()
+                .flex_col()
+                .flex_1()
+                .min_h_0()
+                .bg(theme::surface::PTY)
+                .child(render_sidebar_message(
+                    "review is unavailable while more than one agent is running in this \
+                     worktree - close the others to review this agent's changes on their own"
+                        .to_string(),
+                    theme::text::FAINT.into(),
+                ))
+                .into_any_element();
+        }
+
+        let agent_label = self.review_agent_label(id, cx);
+        let Some(review) = self.agent_reviews.get(&id) else {
+            return div().into_any_element();
+        };
+        let header_text = review_tab_header(&agent_label, &review.baseline);
+        let summary = review_summary_label(review);
+        let reason = review.baseline.reason;
+        let load_is_error = matches!(review.load, ReviewLoadState::Error(_));
+        let error_text = match &review.load {
+            ReviewLoadState::Error(message) => Some(message.clone()),
+            _ => None,
+        };
+        let files: Vec<wt_core::diff::DiffFile> = review
+            .diff()
+            .map(|diff| diff.files.clone())
+            .unwrap_or_default();
+        let open_file = review.open_file.clone();
+        let truncated = review.diff().is_some_and(|diff| diff.truncated);
+
+        let mut body = div()
+            .id("review-view")
+            .track_focus(&self.review_focus_handle.clone())
+            .flex()
+            .flex_col()
+            .flex_1()
+            .min_h_0()
+            .min_w_0()
+            .bg(theme::surface::PTY)
+            .child(self.render_review_header(header_text, summary, cx));
+
+        if let Some(message) = error_text {
+            body = body.child(render_sidebar_message(
+                format!("could not load this review: {message}"),
+                theme::status::FAIL.into(),
+            ));
+        } else if files.is_empty() && !load_is_error {
+            // The good empty state - deliberately worded as success, and deliberately different
+            // from the git side's own "this branch matches main". See `state::review_empty_message`.
+            body = body.child(render_sidebar_message(
+                review_empty_message(reason).to_string(),
+                theme::text::FAINT.into(),
+            ));
+        } else {
+            let mut list = div().flex().flex_col().flex_none();
+            for file in &files {
+                list = list.child(self.render_review_file_row(file, open_file.as_deref(), cx));
+            }
+            if truncated {
+                list = list.child(render_sidebar_message(
+                    "\u{2026} this review was too large to show in full".to_string(),
+                    theme::text::FAINT.into(),
+                ));
+            }
+            body = body.child(list);
+
+            if let Some(file) = self.open_review_file_detail().cloned() {
+                // The one real diff renderer in this app, reused verbatim against this review's
+                // own `WorktreeDiff` - see `DiffDetailSurface`'s own docs.
+                body =
+                    body.child(self.render_diff_file_detail(&file, DiffDetailSurface::Review, cx));
+            } else {
+                body = body.child(div().flex_1().min_h_0());
+            }
+        }
+
+        body.child(self.render_review_footer(id, cx))
+            .into_any_element()
+    }
+
+    /// The header band: what this review is measured against and when
+    /// (`state::review_tab_header`), plus how much is unreviewed.
+    fn render_review_header(
+        &self,
+        header_text: String,
+        summary: String,
+        _cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        div()
+            .flex()
+            .flex_none()
+            .items_center()
+            .gap(px(8.0))
+            .px(px(12.0))
+            .h(theme::band::CHROME_HEADER)
+            .bg(theme::surface::FOOTER)
+            .border_b_1()
+            .border_color(theme::border::INNER)
+            .child(
+                div()
+                    .debug_selector(|| "review-header".to_string())
+                    .font(font(theme::font::MONO))
+                    .font_weight(gpui::FontWeight::MEDIUM)
+                    .text_size(self.ui_text_size(11.0))
+                    .text_color(theme::text::PRIMARY)
+                    .child(header_text),
+            )
+            .child(div().flex_1())
+            .child(
+                div()
+                    .flex_none()
+                    .font(font(theme::font::MONO))
+                    .text_size(self.ui_text_size(10.0))
+                    .text_color(theme::text::DIMMER)
+                    .child(summary),
+            )
+    }
+
+    /// One unreviewed file row. Deliberately its own row rather than
+    /// `crate::sidebar::render::AdeApp::render_change_row`: that row carries a **staging**
+    /// checkbox and a `committed` marker, both of which are git-side concepts about the index and
+    /// about commits on this branch. Neither means anything about a review, and showing them here
+    /// would re-merge exactly the two concepts this feature exists to separate.
+    fn render_review_file_row(
+        &self,
+        file: &wt_core::diff::DiffFile,
+        open_file: Option<&Path>,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let path = file.path.clone();
+        let selected = open_file == Some(file.path.as_path());
+        let (add, del) = changes::diff_file_stats(file);
+        let (dir, name) = changes::split_dir_name(&file.path);
+        let tag = changes::change_tag(file.status);
+
+        div()
+            .id(format!("review-row-{}", file.path.display()))
+            .debug_selector(|| format!("review-row-{}", file.path.display()))
+            .flex()
+            .w_full()
+            .items_center()
+            .gap(px(6.0))
+            .h(theme::band::CHANGE_ROW)
+            .px(px(10.0))
+            .border_b_1()
+            .border_color(theme::border::ROW)
+            .cursor_pointer()
+            .when(selected, |el| {
+                el.bg(theme::surface::ROW_SELECTED)
+                    .border_l_2()
+                    .border_color(theme::border::SELECTED_EDGE)
+            })
+            .when(!selected, |el| {
+                el.hover(|el| el.bg(theme::surface::ROW_HOVER))
+            })
+            .on_click(cx.listener(move |this, _event: &ClickEvent, _window, cx| {
+                this.open_review_file(path.clone(), cx);
+            }))
+            .when(!dir.is_empty(), |el| {
+                el.child(
+                    div()
+                        .flex_none()
+                        .font(font(theme::font::MONO))
+                        .text_size(self.ui_text_size(10.5))
+                        .text_color(theme::text::GHOST)
+                        .child(format!("{dir}/")),
+                )
+            })
+            .child(
+                div()
+                    .flex_1()
+                    .min_w_0()
+                    .overflow_hidden()
+                    .font(font(theme::font::MONO))
+                    .font_weight(gpui::FontWeight::MEDIUM)
+                    .text_size(self.ui_text_size(11.5))
+                    .text_color(theme::text::STRONG)
+                    .child(name),
+            )
+            .when_some(tag, |el, tag| el.child(render_tag_pill(tag)))
+            .child(
+                div()
+                    .flex_none()
+                    .font(font(theme::font::MONO))
+                    .text_size(self.ui_text_size(10.0))
+                    .text_color(theme::diff::STAT_ADD)
+                    .child(format!("+{add}")),
+            )
+            .child(
+                div()
+                    .flex_none()
+                    .font(font(theme::font::MONO))
+                    .text_size(self.ui_text_size(10.0))
+                    .text_color(theme::diff::STAT_DEL)
+                    .child(format!("\u{2212}{del}")),
+            )
+    }
+
+    /// The review tab's footer: the real `Mark reviewed` action.
+    ///
+    /// Disabled - dimmed, with no `cursor_pointer`/`on_click` at all, this crate's established
+    /// convention - while a mark is already in flight, and when there is nothing unreviewed to
+    /// mark. The second case matters: clicking it with an empty review would take a fresh
+    /// snapshot, move the baseline's timestamp, and change the header's "since" time for no
+    /// reason the user asked for.
+    fn render_review_footer(&self, id: AgentId, cx: &mut Context<Self>) -> impl IntoElement {
+        let in_flight = self.review_mark_in_flight == Some(id);
+        let has_changes = self
+            .agent_reviews
+            .get(&id)
+            .is_some_and(|review| review.has_unreviewed_changes());
+        let enabled = has_changes && !in_flight;
+        let label = if in_flight {
+            "marking reviewed\u{2026}"
+        } else {
+            "Mark reviewed"
+        };
+        let colors = work_surface::action_button_colors(work_surface::ActionStyle::PrimaryGreen);
+
+        let mut button = div()
+            .id("review-mark-reviewed")
+            .debug_selector(|| "review-mark-reviewed".to_string())
+            .h(px(23.0))
+            .px(px(10.0))
+            .rounded(theme::radius::BUTTON)
+            .flex()
+            .items_center()
+            .bg(if enabled {
+                colors.bg
+            } else {
+                work_surface::TRANSPARENT
+            })
+            .border_1()
+            .border_color(if enabled {
+                colors.border
+            } else {
+                theme::border::BUTTON_DISABLED.into()
+            })
+            .child(
+                div()
+                    .font(font(theme::font::SANS))
+                    .font_weight(gpui::FontWeight::MEDIUM)
+                    .text_size(px(11.0))
+                    .text_color(if enabled {
+                        colors.fg
+                    } else {
+                        theme::text::GHOSTER.into()
+                    })
+                    .child(label),
+            );
+        if enabled {
+            button = button
+                .cursor_pointer()
+                .hover(|el| el.bg(theme::surface::ROW_HOVER_ALT))
+                .on_click(cx.listener(move |this, _event: &ClickEvent, _window, cx| {
+                    this.mark_reviewed(id, cx);
+                }));
+        } else {
+            button = button.cursor_default();
+        }
+
+        div()
+            .flex()
+            .flex_none()
+            .items_center()
+            .gap(px(7.0))
+            .px(px(12.0))
+            .h(theme::band::SURFACE_FOOTER)
+            .bg(theme::surface::FOOTER)
+            .border_t_1()
+            .border_color(theme::border::INNER)
+            .child(button)
+            .child(div().flex_1())
+    }
+}
+
+/// The tab strip's own review entry, rendered only for `TabRef::Review` - which
+/// `work_surface::state::reconcile_tab_order` only ever produces while the tab is really open for
+/// an agent of this worktree.
+pub(crate) fn render_review_tab(
+    app: &AdeApp,
+    id: AgentId,
+    cx: &mut Context<AdeApp>,
+) -> gpui::AnyElement {
+    let is_active = app.review_tab_active;
+    let colors = work_surface::tab_colors(is_active);
+    let close_color = if is_active {
+        theme::text::DIMMER
+    } else {
+        theme::text::DISABLED
+    };
+    // Says "Review", never "Diff" - see `super`'s module docs on the vocabulary split.
+    let label = "Review".to_string();
+
+    let close_button = app.render_tab_close_button(
+        "close-review-tab",
+        close_color,
+        None,
+        |this, window, cx| {
+            this.close_review_tab(window, cx);
+        },
+        cx,
+    );
+    let content: Vec<gpui::AnyElement> = vec![
+        render_review_tab_chip().into_any_element(),
+        div()
+            .font(font(theme::font::MONO))
+            .font_weight(gpui::FontWeight::MEDIUM)
+            .text_size(app.ui_text_size(11.0))
+            .text_color(colors.label)
+            .child(label.clone())
+            .into_any_element(),
+        close_button.into_any_element(),
+    ];
+
+    app.render_tab_chrome(
+        TabChromeArgs {
+            outer_id: "review-tab".into(),
+            hit_id: "review-tab-hit".into(),
+            tab_ref: work_surface::TabRef::Review(id),
+            drag_value: DraggedTab::Review { id, label },
+            is_active,
+            content,
+            on_middle_click: Box::new(|this, window, cx| {
+                this.close_review_tab(window, cx);
+            }),
+            on_activate: Box::new(move |this, window, cx| {
+                this.open_review_tab(id, window, cx);
+            }),
+            debug_selector: Some("review-tab"),
+        },
+        cx,
+    )
+}
+
+/// The review tab's own chip: a check glyph drawn from two rects, matching
+/// `crate::graph_view::render::render_graph_tab_chip`'s "no icon font" approach (design spec §1).
+pub(crate) fn render_review_tab_chip() -> impl IntoElement {
+    div()
+        .flex_none()
+        .relative()
+        .w(px(14.0))
+        .h(px(14.0))
+        .rounded(theme::radius::CHIP)
+        .bg(theme::status::REVIEW_BG)
+        .child(
+            // The check's short, downward stroke.
+            div()
+                .absolute()
+                .w(px(1.0))
+                .h(px(4.0))
+                .top(px(6.0))
+                .left(px(4.0))
+                .bg(theme::status::REVIEW),
+        )
+        .child(
+            // The long, upward stroke.
+            div()
+                .absolute()
+                .w(px(1.0))
+                .h(px(7.0))
+                .top(px(3.0))
+                .left(px(9.0))
+                .bg(theme::status::REVIEW),
+        )
+        .child(
+            // The joining foot, so the two strokes read as one glyph rather than two ticks.
+            div()
+                .absolute()
+                .w(px(6.0))
+                .h(px(1.0))
+                .top(px(9.0))
+                .left(px(4.0))
+                .bg(theme::status::REVIEW),
+        )
+}
+
+/// Real, end-to-end coverage for the agent review surface (GitHub issue #225): a real git repo,
+/// real agents spawned into it, real `wt_core::review` snapshots, and the real single-agent gate.
+///
+/// These deliberately drive the same entry points the UI does (`AdeApp::new_agent`,
+/// `open_review_tab`, `mark_reviewed`, `close_agent`) rather than poking state directly, so they
+/// prove the wiring, not just the pure logic underneath it.
+#[cfg(test)]
+mod review_flow_tests {
+    use super::*;
+    use crate::review::state::BaselineReason;
+    use crate::root::focus::palette_focus_tests;
+    use crate::work_surface::agents::AgentKind;
+    use gpui::TestAppContext;
+
+    fn git(dir: &Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .output()
+            .expect("failed to spawn git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
+            args,
+            dir,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git_stdout(dir: &Path, args: &[&str]) -> String {
+        let output = std::process::Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .output()
+            .expect("failed to spawn git");
+        String::from_utf8_lossy(&output.stdout).into_owned()
+    }
+
+    /// A real repo whose branch has **already diverged from `main`**, with a real committed
+    /// change on it. That divergence is the whole point: it gives the worktree a real, non-empty
+    /// *git* diff that has nothing to do with any agent, which is exactly the state that used to
+    /// make an agent falsely report "review ready".
+    fn diverged_repo() -> tempfile::TempDir {
+        let repo = tempfile::tempdir().expect("tempdir");
+        git(repo.path(), &["init", "-b", "main"]);
+        git(repo.path(), &["config", "user.email", "test@example.com"]);
+        git(repo.path(), &["config", "user.name", "Test User"]);
+        std::fs::write(repo.path().join("base.txt"), "base\n").expect("write");
+        git(repo.path(), &["add", "."]);
+        git(repo.path(), &["commit", "-m", "initial"]);
+        git(repo.path(), &["checkout", "-b", "feature"]);
+        std::fs::write(
+            repo.path().join("already_here.txt"),
+            "committed on feature\n",
+        )
+        .expect("write");
+        git(repo.path(), &["add", "."]);
+        git(
+            repo.path(),
+            &["commit", "-m", "work that predates any agent"],
+        );
+        repo
+    }
+
+    /// Every window starts with exactly one real agent - the startup shell `AdeApp::new` spawns
+    /// into the repo root (see `root::state`). That agent is what these tests review, precisely
+    /// because it is the *sole* agent in its worktree, which is what the single-agent gate
+    /// requires. Its baseline is captured at startup, so callers must `run_until_parked` first.
+    fn sole_agent(app: &gpui::Entity<AdeApp>, cx: &mut gpui::VisualTestContext) -> AgentId {
+        app.read_with(cx, |app, _| {
+            let ids: Vec<AgentId> = app.agents.iter().map(|agent| agent.id).collect();
+            assert_eq!(
+                ids.len(),
+                1,
+                "a fresh test window must start with exactly one agent"
+            );
+            ids[0]
+        })
+    }
+
+    /// Spawns an *additional* agent through the real `new_agent` entry point (the same door the
+    /// `+` menu uses) and waits for its baseline capture to land.
+    fn spawn_extra_agent(
+        app: &gpui::Entity<AdeApp>,
+        cx: &mut gpui::VisualTestContext,
+        kind: AgentKind,
+    ) -> AgentId {
+        app.update_in(cx, |app, window, cx| app.new_agent(kind, window, cx));
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| {
+            app.agents.iter().last().expect("a spawned agent").id
+        })
+    }
+
+    /// Spawning an agent must capture a genuinely real baseline: a hex tree id that git can
+    /// resolve, anchored under a real ref so `git gc` can't take it.
+    #[gpui::test]
+    fn spawning_an_agent_captures_a_real_anchored_baseline(cx: &mut TestAppContext) {
+        let repo = diverged_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        let id = sole_agent(&app, cx);
+
+        let (tree_id, ref_name, reason) = app.read_with(cx, |app, _| {
+            let review = app
+                .agent_reviews
+                .get(&id)
+                .expect("spawning an agent must capture a real review baseline");
+            (
+                review.baseline.tree_id.clone(),
+                review.baseline.ref_name.clone(),
+                review.baseline.reason,
+            )
+        });
+
+        assert_eq!(reason, BaselineReason::Spawn);
+        assert!(
+            ref_name.starts_with(wt_core::review::REVIEW_REF_PREFIX),
+            "a baseline must be anchored inside this app's own ref namespace - got {ref_name}"
+        );
+        assert_eq!(
+            git_stdout(repo.path(), &["rev-parse", &ref_name]).trim(),
+            tree_id,
+            "the anchored ref must really resolve to the captured tree in the real repository"
+        );
+        assert_eq!(
+            git_stdout(repo.path(), &["cat-file", "-t", &tree_id]).trim(),
+            "tree",
+            "and that object must really be a tree"
+        );
+    }
+
+    /// **The heart of GitHub issue #225.** A freshly spawned agent has changed nothing, so its
+    /// review is empty - even though the worktree it is sitting in has a large, real *git* diff
+    /// against `main`. Before this, that git diff was what drove "review ready", so this agent
+    /// would have claimed work it never did.
+    #[gpui::test]
+    fn a_fresh_agents_review_is_empty_even_though_the_git_diff_is_not(cx: &mut TestAppContext) {
+        let repo = diverged_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        let id = sole_agent(&app, cx);
+
+        app.update_in(cx, |app, window, cx| app.open_review_tab(id, window, cx));
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            let review = app.agent_reviews.get(&id).expect("a review");
+            assert_eq!(
+                review.diff().expect("a really loaded review").files.len(),
+                0,
+                "a fresh agent has changed nothing, so its review must be empty"
+            );
+            assert!(!app.agent_has_unreviewed_changes(id));
+            assert_eq!(app.agent_review_file_count(id), Some(0));
+
+            // The same worktree, at the same instant, really does have a non-empty git diff -
+            // which is what makes the empty review above a genuine distinction rather than an
+            // empty repository.
+            let git_files = app
+                .current_diff()
+                .expect("a real git diff is loaded")
+                .files
+                .len();
+            assert!(
+                git_files > 0,
+                "the git diff must be non-empty here, or this test proves nothing about the two \
+                 answers differing"
+            );
+        });
+    }
+
+    /// The other half: work the agent really does after it starts must appear in its review, and
+    /// must be countable per-agent for the rail.
+    #[gpui::test]
+    fn work_done_after_an_agent_starts_shows_up_in_its_review(cx: &mut TestAppContext) {
+        let repo = diverged_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        let id = sole_agent(&app, cx);
+
+        // Exactly what an agent CLI does: write a file into its own worktree.
+        std::fs::write(
+            repo.path().join("written_by_the_agent.rs"),
+            "fn main() {}\n",
+        )
+        .expect("write");
+
+        app.update_in(cx, |app, window, cx| app.open_review_tab(id, window, cx));
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            let review = app.agent_reviews.get(&id).expect("a review");
+            let paths: Vec<PathBuf> = review
+                .diff()
+                .expect("loaded")
+                .files
+                .iter()
+                .map(|file| file.path.clone())
+                .collect();
+            assert_eq!(
+                paths,
+                vec![PathBuf::from("written_by_the_agent.rs")],
+                "only what the agent really did since it started - not the branch's own \
+                 already-committed work"
+            );
+            assert!(app.agent_has_unreviewed_changes(id));
+            assert_eq!(app.agent_review_file_count(id), Some(1));
+        });
+    }
+
+    /// `Mark reviewed` must take a fresh snapshot, advance the baseline (including its reason and
+    /// timestamp), re-anchor the same ref, and leave a genuinely empty review behind.
+    #[gpui::test]
+    fn marking_reviewed_advances_the_baseline_and_empties_the_review(cx: &mut TestAppContext) {
+        let repo = diverged_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        let id = sole_agent(&app, cx);
+        std::fs::write(repo.path().join("agent_work.rs"), "fn main() {}\n").expect("write");
+
+        app.update_in(cx, |app, window, cx| app.open_review_tab(id, window, cx));
+        cx.run_until_parked();
+
+        let (before_tree, ref_name) = app.read_with(cx, |app, _| {
+            let review = app.agent_reviews.get(&id).expect("a review");
+            assert!(
+                review.has_unreviewed_changes(),
+                "precondition: something to review"
+            );
+            (
+                review.baseline.tree_id.clone(),
+                review.baseline.ref_name.clone(),
+            )
+        });
+
+        app.update(cx, |app, cx| app.mark_reviewed(id, cx));
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            let review = app.agent_reviews.get(&id).expect("a review");
+            assert_eq!(review.baseline.reason, BaselineReason::MarkedReviewed);
+            assert_ne!(
+                review.baseline.tree_id, before_tree,
+                "marking reviewed must move the baseline onto a genuinely new snapshot"
+            );
+            assert_eq!(
+                review.baseline.ref_name, ref_name,
+                "and must move the same ref rather than accumulating one per mark"
+            );
+            assert_eq!(
+                review.diff().expect("reloaded").files.len(),
+                0,
+                "nothing has changed since a snapshot taken a moment ago - the good empty state"
+            );
+            assert!(!app.agent_has_unreviewed_changes(id));
+            assert!(review.open_file.is_none());
+            assert_eq!(
+                git_stdout(repo.path(), &["rev-parse", &ref_name]).trim(),
+                review.baseline.tree_id,
+                "the real ref must really point at the new snapshot"
+            );
+        });
+
+        // And further work after marking is unreviewed again - the baseline advanced, it didn't
+        // stop tracking.
+        std::fs::write(repo.path().join("more_work.rs"), "fn more() {}\n").expect("write");
+        app.update(cx, |app, cx| app.load_agent_review(id, cx));
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.agent_review_file_count(id), Some(1));
+        });
+    }
+
+    /// **The single-agent gate, proved in both directions.** A second agent opening in the same
+    /// worktree must hide the whole review surface (no tab, no footer door, no review-ready
+    /// status, no file count); closing it again must reveal it, against the baseline that was
+    /// quietly captured all along.
+    #[gpui::test]
+    fn a_second_agent_hides_the_review_surface_and_closing_it_reveals_it_again(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = diverged_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        let first = sole_agent(&app, cx);
+        std::fs::write(repo.path().join("agent_work.rs"), "fn main() {}\n").expect("write");
+
+        app.update_in(cx, |app, window, cx| app.open_review_tab(first, window, cx));
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| {
+            assert!(app.review_available_for(first), "one agent: available");
+            assert!(app.agent_has_unreviewed_changes(first));
+            assert_eq!(app.agent_review_file_count(first), Some(1));
+            assert_eq!(app.review_tab_open, Some(first));
+            assert!(
+                app.combined_tab_order()
+                    .contains(&work_surface::TabRef::Review(first)),
+                "the review tab must really be in the strip"
+            );
+        });
+
+        // A second agent starts in the same worktree.
+        let second = spawn_extra_agent(&app, cx, AgentKind::Claude);
+
+        app.read_with(cx, |app, _| {
+            assert!(
+                !app.review_available_for(first),
+                "with two agents sharing a worktree, this agent's review would include changes it \
+                 did not make - the surface must be held back"
+            );
+            assert!(!app.review_available_for(second));
+            assert!(
+                !app.agent_has_unreviewed_changes(first),
+                "and no agent may claim review-readiness it cannot substantiate"
+            );
+            assert_eq!(
+                app.agent_review_file_count(first),
+                None,
+                "an honestly-absent count, never a fabricated one"
+            );
+            assert!(
+                !app.combined_tab_order()
+                    .contains(&work_surface::TabRef::Review(first)),
+                "and the review tab must be gone from the strip"
+            );
+            // A baseline was still *captured* for both - the gate is display-time only, so the
+            // surface can simply start working again once the worktree is back to one agent.
+            assert!(app.agent_reviews.contains_key(&first));
+            assert!(app.agent_reviews.contains_key(&second));
+        });
+
+        // Close the second agent - back down to one.
+        app.update_in(cx, |app, window, cx| app.close_agent(second, window, cx));
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.review_available_for(first),
+                "back down to a single agent, the review surface must be available again"
+            );
+            assert!(app.agent_has_unreviewed_changes(first));
+            assert_eq!(
+                app.agent_review_file_count(first),
+                Some(1),
+                "against the baseline captured at spawn all along, not a retroactive one"
+            );
+        });
+
+        // And it can really be re-opened.
+        app.update_in(cx, |app, window, cx| app.open_review_tab(first, window, cx));
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.review_tab_open, Some(first));
+            assert!(app
+                .combined_tab_order()
+                .contains(&work_surface::TabRef::Review(first)));
+        });
+    }
+
+    /// Opening the review tab while the gate is closed must be a real no-op, not a tab that opens
+    /// and then renders an apology.
+    #[gpui::test]
+    fn the_review_tab_refuses_to_open_for_a_multi_agent_worktree(cx: &mut TestAppContext) {
+        let repo = diverged_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        let first = sole_agent(&app, cx);
+        let _second = spawn_extra_agent(&app, cx, AgentKind::Claude);
+
+        app.update_in(cx, |app, window, cx| app.open_review_tab(first, window, cx));
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.review_tab_open, None);
+            assert!(!app.review_tab_active);
+        });
+    }
+
+    /// Closing an agent releases its baseline ref (so `git gc` can reclaim the objects) but
+    /// deliberately keeps the persisted metadata entry - the groundwork GitHub issue #227 needs.
+    #[gpui::test]
+    fn closing_an_agent_releases_its_ref_but_keeps_the_persisted_record(cx: &mut TestAppContext) {
+        let repo = diverged_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        let id = sole_agent(&app, cx);
+
+        let ref_name = app.read_with(cx, |app, _| {
+            app.agent_reviews
+                .get(&id)
+                .expect("a review")
+                .baseline
+                .ref_name
+                .clone()
+        });
+        assert!(!git_stdout(repo.path(), &["rev-parse", &ref_name])
+            .trim()
+            .is_empty());
+
+        app.update_in(cx, |app, window, cx| app.close_agent(id, window, cx));
+        cx.run_until_parked();
+
+        assert!(
+            git_stdout(repo.path(), &["rev-parse", "--verify", &ref_name])
+                .trim()
+                .is_empty(),
+            "a closed agent's baseline ref must really be deleted"
+        );
+        app.read_with(cx, |app, _| {
+            assert!(
+                !app.agent_reviews.contains_key(&id),
+                "and its in-memory review must be gone"
+            );
+            assert!(
+                app.review_baseline_state
+                    .baselines
+                    .values()
+                    .any(|entry| entry.ref_name == ref_name),
+                "but the persisted record of what was captured must survive - it is exactly the \
+                 data GitHub issue #227 will need, and this app must not destroy it"
+            );
+        });
+    }
+
+    /// The header is the thing that actually resolves the issue's "confusion" complaint, so it
+    /// must be built from the real baseline and must really paint.
+    #[gpui::test]
+    fn the_review_tab_header_states_the_real_since_point_and_really_paints(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = diverged_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        let id = sole_agent(&app, cx);
+        std::fs::write(repo.path().join("agent_work.rs"), "fn main() {}\n").expect("write");
+
+        app.update_in(cx, |app, window, cx| app.open_review_tab(id, window, cx));
+        cx.run_until_parked();
+
+        assert!(
+            cx.debug_bounds("review-header").is_some(),
+            "the review tab's header must really have painted"
+        );
+        assert!(
+            cx.debug_bounds("review-row-agent_work.rs").is_some(),
+            "and the real unreviewed file must really have painted as a row"
+        );
+
+        let header = app.read_with(cx, |app, cx| {
+            let review = app.agent_reviews.get(&id).expect("a review");
+            crate::review::state::review_tab_header(
+                &app.review_agent_label(id, cx),
+                &review.baseline,
+            )
+        });
+        assert!(
+            header.contains("since it started"),
+            "a spawn baseline must say what it is measured against - got {header:?}"
+        );
+        assert!(
+            !header.to_lowercase().contains("diff"),
+            "and must never use the git side's own word - got {header:?}"
+        );
+
+        // Clicking the row really opens that file's hunks, through the review's own renderer.
+        app.update(cx, |app, cx| {
+            app.open_review_file(PathBuf::from("agent_work.rs"), cx)
+        });
+        cx.run_until_parked();
+        assert!(
+            cx.debug_bounds("review-line-0").is_some(),
+            "the review's own diff rows must really paint, under their own selector prefix"
+        );
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.review_highlight_cache.is_some(),
+                "and the review's own highlight cache must be populated - not the git Diff \
+                 view's, which stays independent"
+            );
+        });
+    }
+
+    /// **The reachability proof.** Every other test in this module opens the review tab by
+    /// calling `open_review_tab` directly, which proves the surface works but says nothing about
+    /// whether a real user can ever get to it. This one touches none of the review API: it lets
+    /// the rail's own status poll run, and checks that the real chain closes.
+    ///
+    /// That chain is genuinely circular-looking and was briefly broken during this build: the
+    /// footer's `Review` door only appears on a `Status::Review` agent, `Status::Review` requires
+    /// `agent_has_unreviewed_changes`, and if that had been derived from the tab's own loaded diff
+    /// it could only ever become true *after* the tab was already open. The status poll's cheap
+    /// `changed_paths_against_tree` measurement is what breaks the cycle - so this test is the one
+    /// that would fail if that measurement were ever moved back inside the tab.
+    #[gpui::test]
+    fn the_status_poll_alone_makes_an_agent_really_reviewable(cx: &mut TestAppContext) {
+        let repo = diverged_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        let id = sole_agent(&app, cx);
+
+        // Real agent work, and nothing else - no review API is touched anywhere in this test.
+        std::fs::write(repo.path().join("agent_work.rs"), "fn main() {}\n").expect("write");
+        app.read_with(cx, |app, _| {
+            assert!(
+                !app.agent_has_unreviewed_changes(id),
+                "precondition: nothing measured yet, so nothing may be claimed yet"
+            );
+            assert_eq!(app.agent_review_file_count(id), None);
+        });
+
+        // Let one real status-poll tick run.
+        cx.background_executor
+            .advance_clock(crate::root::STATUS_POLL_INTERVAL * 2);
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.agent_has_unreviewed_changes(id),
+                "the status poll alone must make an agent's real work reviewable - without it, \
+                 `Status::Review` could never fire, so the footer's `Review` door could never \
+                 appear, so the tab could never be opened at all"
+            );
+            assert_eq!(
+                app.agent_review_file_count(id),
+                Some(1),
+                "and the rail's per-agent count must be real without the tab ever being opened"
+            );
+            assert!(
+                app.review_available_for(id),
+                "so the footer door is genuinely offerable"
+            );
+        });
+
+        // And that measurement is exactly the fact `derive_status` needs to reach
+        // `Status::Review` - the status whose footer carries the real `Review` door. (The agent
+        // here is a live shell, so its *current* status is `Run`/`Idle`; what this pins is that
+        // the input is now genuinely true, which is the half the poll is responsible for.)
+        let has_unreviewed = app.read_with(cx, |app, _| app.agent_has_unreviewed_changes(id));
+        let status_on_exit = crate::rail::status::derive_status(
+            AgentKind::Shell,
+            crate::rail::status::ProcessSignal::Exited { success: true },
+            has_unreviewed,
+        );
+        assert_eq!(
+            status_on_exit,
+            crate::rail::status::Status::Review,
+            "a successfully-exited agent with real unreviewed work must reach Status::Review"
+        );
+        assert!(
+            work_surface::footer_actions(status_on_exit)
+                .iter()
+                .any(|action| action.kind == work_surface::ActionKind::OpenReview
+                    && action.implemented),
+            "and that status's footer must carry the real, implemented `Review` door"
+        );
+    }
+
+    /// A snapshot must not disturb the worktree an agent is actively working in - the guarantee
+    /// the whole approach rests on, checked here through the real app flow (not just `wt_core`'s
+    /// own unit test) with a real mixed staged/unstaged/untracked state.
+    #[gpui::test]
+    fn spawning_an_agent_does_not_perturb_real_git_state(cx: &mut TestAppContext) {
+        let repo = diverged_repo();
+        std::fs::write(repo.path().join("staged.txt"), "staged\n").expect("write");
+        git(repo.path(), &["add", "staged.txt"]);
+        std::fs::write(repo.path().join("base.txt"), "base\nedited\n").expect("write");
+        std::fs::write(repo.path().join("untracked.txt"), "untracked\n").expect("write");
+
+        let status_before = git_stdout(repo.path(), &["status", "--porcelain"]);
+        let head_before = git_stdout(repo.path(), &["rev-parse", "HEAD"]);
+
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        let _id = sole_agent(&app, cx);
+
+        assert_eq!(
+            git_stdout(repo.path(), &["status", "--porcelain"]),
+            status_before,
+            "capturing a baseline must not change one byte of the worktree's real git state"
+        );
+        assert_eq!(git_stdout(repo.path(), &["rev-parse", "HEAD"]), head_before);
+        assert!(git_stdout(repo.path(), &["stash", "list"])
+            .trim()
+            .is_empty());
+    }
+
+    /// Leaving the review tab must move real keyboard focus off a handle that is about to stop
+    /// being rendered - the dangling-focus bug class `leave_graph_tab`'s own docs describe, which
+    /// this surface copies its discipline from.
+    #[gpui::test]
+    fn leaving_the_review_tab_moves_focus_off_its_handle(cx: &mut TestAppContext) {
+        let repo = diverged_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        let id = sole_agent(&app, cx);
+
+        app.update_in(cx, |app, window, cx| app.open_review_tab(id, window, cx));
+        cx.run_until_parked();
+        app.update_in(cx, |app, window, _cx| {
+            assert!(
+                app.review_focus_handle.is_focused(window),
+                "opening the review tab must really move focus onto its own handle"
+            );
+        });
+
+        app.update_in(cx, |app, window, cx| app.leave_review_tab(window, cx));
+        cx.run_until_parked();
+        app.update_in(cx, |app, window, _cx| {
+            assert!(!app.review_tab_active);
+            assert!(
+                !app.review_focus_handle.is_focused(window),
+                "the handle stops being track_focus'd the moment the tab stops rendering, so \
+                 focus must already have moved off it"
+            );
+        });
+    }
+}

--- a/crates/app/src/review/render.rs
+++ b/crates/app/src/review/render.rs
@@ -715,6 +715,13 @@ mod review_flow_tests {
 
     /// Spawns an *additional* agent through the real `new_agent` entry point (the same door the
     /// `+` menu uses) and waits for its baseline capture to land.
+    ///
+    /// Callers that need a second agent **in the startup agent's own worktree** must pass a kind
+    /// other than [`AgentKind::Shell`]: a baseline key is `(worktree, kind, spawn second)`, so a
+    /// second shell spawned into the same worktree within the same second would share the startup
+    /// agent's key and therefore its baseline ref (this crate's documented, accepted collision -
+    /// see `super::state::baseline_key`). Sharing it would make one agent's close delete the
+    /// other's ref, which is not what any of these tests mean to exercise.
     fn spawn_extra_agent(
         app: &gpui::Entity<AdeApp>,
         cx: &mut gpui::VisualTestContext,
@@ -727,14 +734,42 @@ mod review_flow_tests {
         })
     }
 
-    /// Spawning an agent must capture a genuinely real baseline: a hex tree id that git can
-    /// resolve, anchored under a real ref so `git gc` can't take it.
+    /// Spawning an agent must capture a genuinely real baseline - a hex tree id git can resolve,
+    /// anchored under a real ref so `git gc` can't take it - **without disturbing one byte** of
+    /// the worktree the agent is about to work in.
+    ///
+    /// Both halves in one test deliberately: they need the same real, mixed staged/unstaged/
+    /// untracked fixture, and every GPUI test app on a real git repo arms two OS-level `notify`
+    /// watchers (`start_file_tree_watch`/`start_worktree_watch`), which are a genuinely scarce
+    /// per-user resource under a fully parallel `cargo test` - see
+    /// `crate::sidebar::file_tree_watch::spawn_file_tree_watcher`'s own docs on the inotify
+    /// instance budget and the real regression that already exhausted it once.
     #[gpui::test]
-    fn spawning_an_agent_captures_a_real_anchored_baseline(cx: &mut TestAppContext) {
+    fn spawning_an_agent_captures_a_real_anchored_baseline_without_disturbing_git(
+        cx: &mut TestAppContext,
+    ) {
         let repo = diverged_repo();
+        // A genuinely mixed state, present *before* the app (and so before the snapshot) opens.
+        std::fs::write(repo.path().join("staged.txt"), "staged\n").expect("write");
+        git(repo.path(), &["add", "staged.txt"]);
+        std::fs::write(repo.path().join("base.txt"), "base\nedited\n").expect("write");
+        std::fs::write(repo.path().join("untracked.txt"), "untracked\n").expect("write");
+        let status_before = git_stdout(repo.path(), &["status", "--porcelain"]);
+        let head_before = git_stdout(repo.path(), &["rev-parse", "HEAD"]);
+
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         let id = sole_agent(&app, cx);
+
+        assert_eq!(
+            git_stdout(repo.path(), &["status", "--porcelain"]),
+            status_before,
+            "capturing a baseline must not change one byte of the worktree's real git state"
+        );
+        assert_eq!(git_stdout(repo.path(), &["rev-parse", "HEAD"]), head_before);
+        assert!(git_stdout(repo.path(), &["stash", "list"])
+            .trim()
+            .is_empty());
 
         let (tree_id, ref_name, reason) = app.read_with(cx, |app, _| {
             let review = app
@@ -936,7 +971,11 @@ mod review_flow_tests {
         });
 
         // A second agent starts in the same worktree.
-        let second = spawn_extra_agent(&app, cx, AgentKind::Claude);
+        // `Codex`, not `Claude`: the kind only has to *differ* from the startup shell's (see
+        // `spawn_extra_agent`), and spawning the real `claude` CLI starts a heavy Node process
+        // whose load was measurably breaking this crate's timing-sensitive inotify tests running
+        // in parallel. Nothing this test asserts depends on which binary runs.
+        let second = spawn_extra_agent(&app, cx, AgentKind::Codex);
 
         app.read_with(cx, |app, _| {
             assert!(
@@ -965,6 +1004,18 @@ mod review_flow_tests {
             assert!(app.agent_reviews.contains_key(&second));
         });
 
+        // And trying to open it while gated is a real no-op, not a tab that opens and then
+        // renders an apology.
+        app.update_in(cx, |app, window, cx| app.open_review_tab(first, window, cx));
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.review_tab_open, None,
+                "gated: opening must refuse outright"
+            );
+            assert!(!app.review_tab_active);
+        });
+
         // Close the second agent - back down to one.
         app.update_in(cx, |app, window, cx| app.close_agent(second, window, cx));
         cx.run_until_parked();
@@ -990,25 +1041,6 @@ mod review_flow_tests {
             assert!(app
                 .combined_tab_order()
                 .contains(&work_surface::TabRef::Review(first)));
-        });
-    }
-
-    /// Opening the review tab while the gate is closed must be a real no-op, not a tab that opens
-    /// and then renders an apology.
-    #[gpui::test]
-    fn the_review_tab_refuses_to_open_for_a_multi_agent_worktree(cx: &mut TestAppContext) {
-        let repo = diverged_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        cx.run_until_parked();
-        let first = sole_agent(&app, cx);
-        let _second = spawn_extra_agent(&app, cx, AgentKind::Claude);
-
-        app.update_in(cx, |app, window, cx| app.open_review_tab(first, window, cx));
-        cx.run_until_parked();
-
-        app.read_with(cx, |app, _| {
-            assert_eq!(app.review_tab_open, None);
-            assert!(!app.review_tab_active);
         });
     }
 
@@ -1191,33 +1223,261 @@ mod review_flow_tests {
         );
     }
 
-    /// A snapshot must not disturb the worktree an agent is actively working in - the guarantee
-    /// the whole approach rests on, checked here through the real app flow (not just `wt_core`'s
-    /// own unit test) with a real mixed staged/unstaged/untracked state.
+    /// **The regression test for the wedged centre pane.** `leave_review_tab` had exactly one
+    /// non-test caller (`close_review_tab`), so every *other* way of taking over the centre pane -
+    /// clicking an agent tab, opening a file, opening the graph tab - left `review_tab_active`
+    /// set. `render_center_pane` checks that flag first and returns the review body
+    /// unconditionally, so the tab being switched to never mounted at all, while real focus had
+    /// already moved onto it: typed input went nowhere.
+    ///
+    /// Deliberately drives the real entry points rather than calling `leave_review_tab` - the bug
+    /// was precisely that those entry points didn't call it, so a test that calls it directly
+    /// (like `leaving_the_review_tab_moves_focus_off_its_handle` below) cannot catch this.
     #[gpui::test]
-    fn spawning_an_agent_does_not_perturb_real_git_state(cx: &mut TestAppContext) {
+    fn every_way_of_leaving_the_review_tab_really_releases_the_centre_pane(
+        cx: &mut TestAppContext,
+    ) {
         let repo = diverged_repo();
-        std::fs::write(repo.path().join("staged.txt"), "staged\n").expect("write");
-        git(repo.path(), &["add", "staged.txt"]);
-        std::fs::write(repo.path().join("base.txt"), "base\nedited\n").expect("write");
-        std::fs::write(repo.path().join("untracked.txt"), "untracked\n").expect("write");
-
-        let status_before = git_stdout(repo.path(), &["status", "--porcelain"]);
-        let head_before = git_stdout(repo.path(), &["rev-parse", "HEAD"]);
-
+        std::fs::write(repo.path().join("agent_work.rs"), "fn main() {}\n").expect("write");
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
-        let _id = sole_agent(&app, cx);
+        let id = sole_agent(&app, cx);
 
-        assert_eq!(
-            git_stdout(repo.path(), &["status", "--porcelain"]),
-            status_before,
-            "capturing a baseline must not change one byte of the worktree's real git state"
+        // (a) Selecting an agent tab.
+        app.update_in(cx, |app, window, cx| app.open_review_tab(id, window, cx));
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| assert!(app.review_tab_active, "precondition"));
+
+        app.update_in(cx, |app, window, cx| app.select_agent(id, window, cx));
+        cx.run_until_parked();
+        app.update_in(cx, |app, window, _cx| {
+            assert!(
+                !app.review_tab_active,
+                "clicking an agent tab must release the centre pane - otherwise the terminal \
+                 never mounts and focus dangles on an unrendered handle"
+            );
+            assert!(!app.review_focus_handle.is_focused(window));
+        });
+
+        // (b) Opening a file tab.
+        app.update_in(cx, |app, window, cx| app.open_review_tab(id, window, cx));
+        cx.run_until_parked();
+        app.update_in(cx, |app, window, cx| {
+            app.open_file_view(PathBuf::from("agent_work.rs"), window, cx);
+        });
+        cx.run_until_parked();
+        app.update_in(cx, |app, window, _cx| {
+            assert!(!app.review_tab_active, "opening a file must release it too");
+            assert!(!app.review_focus_handle.is_focused(window));
+        });
+
+        // (c) Opening the git graph tab.
+        app.update_in(cx, |app, window, cx| app.open_review_tab(id, window, cx));
+        cx.run_until_parked();
+        app.update_in(cx, |app, window, cx| app.open_git_graph(window, cx));
+        cx.run_until_parked();
+        app.update_in(cx, |app, window, _cx| {
+            assert!(
+                !app.review_tab_active,
+                "opening the graph tab must release it too - two centre-pane occupants must \
+                 never both consider themselves active"
+            );
+            assert!(app.graph_tab_active, "and the graph tab really took over");
+            assert!(!app.review_focus_handle.is_focused(window));
+        });
+    }
+
+    /// **The regression test for the cancelled-capture bug.** Baseline captures used to share one
+    /// `Option<Task<()>>` slot, and GPUI cancels a `Task` on drop - so spawning a second agent
+    /// while the first's snapshot was still running silently destroyed the first capture, leaving
+    /// that agent permanently without a review and its ref orphaned.
+    ///
+    /// Spawns two extra agents back to back, with no `run_until_parked` in between, so both
+    /// captures are genuinely in flight simultaneously.
+    ///
+    /// Both are cheap [`AgentKind::Shell`] agents in **separate real repositories**, rather than
+    /// one `Claude` and one `Codex`. Two reasons, both real: distinct worktrees is what makes
+    /// their baseline keys (and so their refs) genuinely distinct without relying on agent kind,
+    /// and spawning the actual `claude`/`codex` CLIs starts heavy Node processes whose load was
+    /// measurably breaking this crate's timing-sensitive inotify tests running in parallel. What
+    /// this test is about - two captures in flight at once - is entirely independent of which
+    /// binary the agent runs.
+    #[gpui::test]
+    fn concurrent_per_agent_captures_and_releases_are_never_cancelled_by_each_other(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = diverged_repo();
+        let other_a = diverged_repo();
+        let other_b = diverged_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        let startup = sole_agent(&app, cx);
+
+        // `Agents::spawn` + `capture_review_baseline` is exactly what `new_agent` does, minus the
+        // focus/menu bookkeeping - the same pair, driven with an explicit cwd.
+        let (first, second) = app.update_in(cx, |app, window, cx| {
+            let first = app.agents.spawn(
+                AgentKind::Shell,
+                other_a.path().to_path_buf(),
+                12.0,
+                None,
+                window,
+                cx,
+            );
+            app.capture_review_baseline(first, cx);
+            // No parking in between: the first capture is still running right now.
+            let second = app.agents.spawn(
+                AgentKind::Shell,
+                other_b.path().to_path_buf(),
+                12.0,
+                None,
+                window,
+                cx,
+            );
+            app.capture_review_baseline(second, cx);
+            (first, second)
+        });
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            for (label, id) in [("startup", startup), ("first", first), ("second", second)] {
+                assert!(
+                    app.agent_reviews.contains_key(&id),
+                    "the {label} agent's baseline capture must not have been cancelled by a \
+                     later agent's - a cancelled capture is never retried, so that agent would \
+                     have no review for its entire lifetime"
+                );
+            }
+            assert!(
+                app._review_baseline_tasks.is_empty(),
+                "and every completed capture must drop its own task slot"
+            );
+        });
+
+        // Every agent's ref is real, in its own repository, and distinct from the others'.
+        let refs: Vec<(PathBuf, String)> = app.read_with(cx, |app, _| {
+            [startup, first, second]
+                .iter()
+                .map(|id| {
+                    let agent = app.agents.iter().find(|a| a.id == *id).expect("agent");
+                    (
+                        agent.cwd.clone(),
+                        app.agent_reviews[id].baseline.ref_name.clone(),
+                    )
+                })
+                .collect()
+        });
+        for (cwd, ref_name) in &refs {
+            assert!(
+                !git_stdout(cwd, &["rev-parse", ref_name]).trim().is_empty(),
+                "{ref_name} must really exist in {}",
+                cwd.display()
+            );
+        }
+        let unique: std::collections::HashSet<&String> =
+            refs.iter().map(|(_, name)| name).collect();
+        assert_eq!(unique.len(), 3, "each agent gets its own baseline ref");
+
+        // The mirror image, on the same two agents: closing them back to back must release
+        // *both* refs. With one shared task slot the first `delete_ref` was cancelled by the
+        // second and that ref leaked forever, since nothing ever retries it.
+        app.update_in(cx, |app, window, cx| {
+            app.close_agent(first, window, cx);
+            // Again, no parking in between - the first deletion is still in flight.
+            app.close_agent(second, window, cx);
+        });
+        cx.run_until_parked();
+
+        for (cwd, ref_name) in refs.iter().filter(|(_, name)| {
+            // The startup agent is still open, so its own ref must survive; only the two just
+            // closed should be gone.
+            name != &refs[0].1
+        }) {
+            assert!(
+                git_stdout(cwd, &["rev-parse", "--verify", ref_name])
+                    .trim()
+                    .is_empty(),
+                "{ref_name} must really have been deleted"
+            );
+        }
+        assert!(
+            !git_stdout(&refs[0].0, &["rev-parse", "--verify", &refs[0].1])
+                .trim()
+                .is_empty(),
+            "the still-open startup agent's own baseline ref must be untouched"
         );
-        assert_eq!(git_stdout(repo.path(), &["rev-parse", "HEAD"]), head_before);
-        assert!(git_stdout(repo.path(), &["stash", "list"])
-            .trim()
-            .is_empty());
+        app.read_with(cx, |app, _| {
+            assert!(app._review_release_tasks.is_empty());
+        });
+    }
+
+    /// The mirror image for ref *release*: closing two agents in quick succession used to cancel
+    /// the first one's `delete_ref`, leaking that ref forever.
+    /// Baseline persistence must be a real, on-disk write with real content - and must go through
+    /// the background executor rather than blocking the UI thread on two `fsync`s under
+    /// `persisted_state_lock`'s process-wide mutex (which background writers of the sibling state
+    /// files hold across their own fsyncs).
+    ///
+    /// Honest about what this proves: the real, checked assertion is the on-disk *result* - the
+    /// file exists, holds exactly the live baseline, and decodes back to the real worktree.
+    /// "Runs off the UI thread" is asserted structurally, via the `_review_persist_task` slot
+    /// only a `cx.spawn` ever fills, rather than by timing - `add_window_view` already runs the
+    /// test executor, so a "not written yet" check would be measuring GPUI's scheduling rather
+    /// than this code.
+    #[gpui::test]
+    fn baseline_persistence_really_writes_to_disk_off_the_ui_thread(cx: &mut TestAppContext) {
+        let repo = diverged_repo();
+        let config = tempfile::tempdir().expect("config dir");
+        let settings_path = config.path().join("settings.toml");
+        let baselines_path =
+            crate::review::baseline_state::review_baseline_path_for(&settings_path);
+
+        let (app, cx) = cx.add_window_view(|window, cx| {
+            AdeApp::new_with_settings(
+                Some(repo.path().to_path_buf()),
+                true,
+                crate::settings::store::Settings::default(),
+                Some(settings_path.clone()),
+                window,
+                cx,
+            )
+        });
+
+        cx.run_until_parked();
+
+        assert!(
+            baselines_path.exists(),
+            "the baseline must really be persisted to disk"
+        );
+        app.read_with(cx, |app, _| {
+            assert!(
+                app._review_persist_task.is_some(),
+                "and the save must have gone through a real `cx.spawn` task - an inline \
+                 `save_merged_at` would leave this slot empty while fsync'ing on the UI thread"
+            );
+        });
+        let state = crate::review::baseline_state::ReviewBaselineState::load_at(&baselines_path);
+        assert_eq!(
+            state.baselines.len(),
+            1,
+            "exactly the startup agent's baseline"
+        );
+        let entry = state.baselines.values().next().expect("an entry");
+        assert_eq!(
+            entry.worktree_path(),
+            Some(repo.path().to_path_buf()),
+            "recorded against the real worktree, decodably"
+        );
+        app.read_with(cx, |app, _| {
+            let agent = app.agents.iter().next().expect("the startup agent");
+            let key =
+                crate::review::state::baseline_key(&agent.cwd, agent.kind, agent.spawned_at_unix);
+            assert_eq!(
+                state.get(&key),
+                Some(app.agent_reviews[&agent.id].baseline.clone()),
+                "and the persisted baseline must match the live one exactly"
+            );
+        });
     }
 
     /// Leaving the review tab must move real keyboard focus off a handle that is about to stop

--- a/crates/app/src/review/render.rs
+++ b/crates/app/src/review/render.rs
@@ -643,7 +643,7 @@ mod review_flow_tests {
     use super::*;
     use crate::review::state::BaselineReason;
     use crate::root::focus::palette_focus_tests;
-    use crate::work_surface::agents::AgentKind;
+    use crate::work_surface::agents::{AgentKind, ProcessKind};
     use gpui::TestAppContext;
 
     fn git(dir: &Path, args: &[&str]) {
@@ -697,17 +697,36 @@ mod review_flow_tests {
         repo
     }
 
-    /// Every window starts with exactly one real agent - the startup shell `AdeApp::new` spawns
-    /// into the repo root (see `root::state`). That agent is what these tests review, precisely
-    /// because it is the *sole* agent in its worktree, which is what the single-agent gate
-    /// requires. Its baseline is captured at startup, so callers must `run_until_parked` first.
+    /// Every window starts with exactly one agent - a plain shell `AdeApp::new` spawns into the
+    /// repo root (see `root::state`). A shell is never review-eligible (see [`ProcessKind`]'s
+    /// docs: it has no turns, so `capture_review_baseline` never captures one for it), so it
+    /// can't be what these tests review. This closes it and spawns a real `Claude` agent into
+    /// the same worktree in its place - still the *sole* agent there (what the single-agent gate
+    /// requires), and still rooted at the same `repo.path()` every caller already writes test
+    /// files into. Waits for the replacement's baseline capture to land, so callers don't need
+    /// their own `run_until_parked` just to get a usable id.
     fn sole_agent(app: &gpui::Entity<AdeApp>, cx: &mut gpui::VisualTestContext) -> AgentId {
-        app.read_with(cx, |app, _| {
+        let startup = app.read_with(cx, |app, _| {
             let ids: Vec<AgentId> = app.agents.iter().map(|agent| agent.id).collect();
             assert_eq!(
                 ids.len(),
                 1,
                 "a fresh test window must start with exactly one agent"
+            );
+            ids[0]
+        });
+        app.update_in(cx, |app, window, cx| {
+            app.close_agent(startup, window, cx);
+            app.new_agent(ProcessKind::claude(), window, cx);
+        });
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| {
+            let ids: Vec<AgentId> = app.agents.iter().map(|agent| agent.id).collect();
+            assert_eq!(
+                ids.len(),
+                1,
+                "closing the startup shell and spawning its replacement must still leave exactly \
+                 one agent"
             );
             ids[0]
         })
@@ -716,18 +735,21 @@ mod review_flow_tests {
     /// Spawns an *additional* agent through the real `new_agent` entry point (the same door the
     /// `+` menu uses) and waits for its baseline capture to land.
     ///
-    /// Callers that need a second agent **in the startup agent's own worktree** must pass a kind
-    /// other than [`AgentKind::Shell`]: a baseline key is `(worktree, kind, spawn second)`, so a
-    /// second shell spawned into the same worktree within the same second would share the startup
-    /// agent's key and therefore its baseline ref (this crate's documented, accepted collision -
-    /// see `super::state::baseline_key`). Sharing it would make one agent's close delete the
-    /// other's ref, which is not what any of these tests mean to exercise.
+    /// Callers that need a second agent **in the sole agent's own worktree** must pass a kind
+    /// other than [`AgentKind::Claude`] (what [`sole_agent`] itself now spawns): a baseline key
+    /// is `(worktree, kind, spawn second)`, so a second `Claude` agent spawned into the same
+    /// worktree within the same second would share the sole agent's key and therefore its
+    /// baseline ref (this crate's documented, accepted collision - see
+    /// `super::state::baseline_key`). Sharing it would make one agent's close delete the other's
+    /// ref, which is not what any of these tests mean to exercise.
     fn spawn_extra_agent(
         app: &gpui::Entity<AdeApp>,
         cx: &mut gpui::VisualTestContext,
         kind: AgentKind,
     ) -> AgentId {
-        app.update_in(cx, |app, window, cx| app.new_agent(kind, window, cx));
+        app.update_in(cx, |app, window, cx| {
+            app.new_agent(ProcessKind::Agent(kind), window, cx)
+        });
         cx.run_until_parked();
         app.read_with(cx, |app, _| {
             app.agents.iter().last().expect("a spawned agent").id
@@ -971,10 +993,11 @@ mod review_flow_tests {
         });
 
         // A second agent starts in the same worktree.
-        // `Codex`, not `Claude`: the kind only has to *differ* from the startup shell's (see
-        // `spawn_extra_agent`), and spawning the real `claude` CLI starts a heavy Node process
-        // whose load was measurably breaking this crate's timing-sensitive inotify tests running
-        // in parallel. Nothing this test asserts depends on which binary runs.
+        // `Codex`, not `Claude`: the kind only has to *differ* from the sole agent's own (see
+        // `spawn_extra_agent`) to get a distinct baseline key, and using the same kind twice
+        // would additionally spawn a second real `claude` CLI - a heavy Node process whose load
+        // was measurably breaking this crate's timing-sensitive inotify tests running in
+        // parallel. Nothing this test asserts depends on which binary runs.
         let second = spawn_extra_agent(&app, cx, AgentKind::Codex);
 
         app.read_with(cx, |app, _| {
@@ -1201,11 +1224,13 @@ mod review_flow_tests {
 
         // And that measurement is exactly the fact `derive_status` needs to reach
         // `Status::Review` - the status whose footer carries the real `Review` door. (The agent
-        // here is a live shell, so its *current* status is `Run`/`Idle`; what this pins is that
-        // the input is now genuinely true, which is the half the poll is responsible for.)
+        // here is a live `claude` process, so its *current* status is `Run`/`Ask`; what this pins
+        // is that the input is now genuinely true, which is the half the poll is responsible
+        // for. `Status::Review` is real-agent-only - see `AgentKind::is_agent_session`'s docs -
+        // so this must use the sole agent's own real kind, not a placeholder.)
         let has_unreviewed = app.read_with(cx, |app, _| app.agent_has_unreviewed_changes(id));
         let status_on_exit = crate::rail::status::derive_status(
-            AgentKind::Shell,
+            ProcessKind::claude(),
             crate::rail::status::ProcessSignal::Exited { success: true },
             has_unreviewed,
         );
@@ -1295,13 +1320,16 @@ mod review_flow_tests {
     /// Spawns two extra agents back to back, with no `run_until_parked` in between, so both
     /// captures are genuinely in flight simultaneously.
     ///
-    /// Both are cheap [`AgentKind::Shell`] agents in **separate real repositories**, rather than
-    /// one `Claude` and one `Codex`. Two reasons, both real: distinct worktrees is what makes
-    /// their baseline keys (and so their refs) genuinely distinct without relying on agent kind,
-    /// and spawning the actual `claude`/`codex` CLIs starts heavy Node processes whose load was
-    /// measurably breaking this crate's timing-sensitive inotify tests running in parallel. What
-    /// this test is about - two captures in flight at once - is entirely independent of which
-    /// binary the agent runs.
+    /// Spawned as cheap [`ProcessKind::Shell`] processes in **separate real repositories**,
+    /// rather than real `Claude`/`Codex` CLIs - spawning the actual `claude`/`codex` binaries
+    /// starts heavy Node processes whose load was measurably breaking this crate's
+    /// timing-sensitive inotify tests running in parallel. Immediately retagged to
+    /// `ProcessKind::claude()` via `Agents::set_kind_for_test` before `capture_review_baseline`
+    /// runs, since (unlike before this app drew a real type-level line between a shell and an
+    /// agent session) a plain shell is never baseline-eligible at all - what this test is about,
+    /// two captures genuinely in flight at once, only needs the recorded `kind`, not the real
+    /// binary. Distinct worktrees, not distinct kinds, is what makes their baseline keys (and so
+    /// their refs) genuinely distinct.
     #[gpui::test]
     fn concurrent_per_agent_captures_and_releases_are_never_cancelled_by_each_other(
         cx: &mut TestAppContext,
@@ -1311,36 +1339,38 @@ mod review_flow_tests {
         let other_b = diverged_repo();
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
-        let startup = sole_agent(&app, cx);
+        let sole = sole_agent(&app, cx);
 
         // `Agents::spawn` + `capture_review_baseline` is exactly what `new_agent` does, minus the
         // focus/menu bookkeeping - the same pair, driven with an explicit cwd.
         let (first, second) = app.update_in(cx, |app, window, cx| {
             let first = app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 other_a.path().to_path_buf(),
                 12.0,
                 None,
                 window,
                 cx,
             );
+            app.agents.set_kind_for_test(first, ProcessKind::claude());
             app.capture_review_baseline(first, cx);
             // No parking in between: the first capture is still running right now.
             let second = app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 other_b.path().to_path_buf(),
                 12.0,
                 None,
                 window,
                 cx,
             );
+            app.agents.set_kind_for_test(second, ProcessKind::claude());
             app.capture_review_baseline(second, cx);
             (first, second)
         });
         cx.run_until_parked();
 
         app.read_with(cx, |app, _| {
-            for (label, id) in [("startup", startup), ("first", first), ("second", second)] {
+            for (label, id) in [("sole", sole), ("first", first), ("second", second)] {
                 assert!(
                     app.agent_reviews.contains_key(&id),
                     "the {label} agent's baseline capture must not have been cancelled by a \
@@ -1356,7 +1386,7 @@ mod review_flow_tests {
 
         // Every agent's ref is real, in its own repository, and distinct from the others'.
         let refs: Vec<(PathBuf, String)> = app.read_with(cx, |app, _| {
-            [startup, first, second]
+            [sole, first, second]
                 .iter()
                 .map(|id| {
                     let agent = app.agents.iter().find(|a| a.id == *id).expect("agent");
@@ -1389,7 +1419,7 @@ mod review_flow_tests {
         cx.run_until_parked();
 
         for (cwd, ref_name) in refs.iter().filter(|(_, name)| {
-            // The startup agent is still open, so its own ref must survive; only the two just
+            // The sole agent is still open, so its own ref must survive; only the two just
             // closed should be gone.
             name != &refs[0].1
         }) {
@@ -1404,7 +1434,7 @@ mod review_flow_tests {
             !git_stdout(&refs[0].0, &["rev-parse", "--verify", &refs[0].1])
                 .trim()
                 .is_empty(),
-            "the still-open startup agent's own baseline ref must be untouched"
+            "the still-open sole agent's own baseline ref must be untouched"
         );
         app.read_with(cx, |app, _| {
             assert!(app._review_release_tasks.is_empty());
@@ -1444,6 +1474,10 @@ mod review_flow_tests {
         });
 
         cx.run_until_parked();
+        // The window's own startup shell (see `sole_agent`'s docs) is never baseline-eligible,
+        // so it never persists anything - this replaces it with a real agent before checking
+        // that a baseline was written at all.
+        let id = sole_agent(&app, cx);
 
         assert!(
             baselines_path.exists(),
@@ -1460,7 +1494,7 @@ mod review_flow_tests {
         assert_eq!(
             state.baselines.len(),
             1,
-            "exactly the startup agent's baseline"
+            "exactly the sole agent's baseline"
         );
         let entry = state.baselines.values().next().expect("an entry");
         assert_eq!(
@@ -1469,9 +1503,11 @@ mod review_flow_tests {
             "recorded against the real worktree, decodably"
         );
         app.read_with(cx, |app, _| {
-            let agent = app.agents.iter().next().expect("the startup agent");
-            let key =
-                crate::review::state::baseline_key(&agent.cwd, agent.kind, agent.spawned_at_unix);
+            let agent = app.agents.iter().find(|a| a.id == id).expect("the sole agent");
+            let ProcessKind::Agent(kind) = agent.kind else {
+                unreachable!("sole_agent always spawns a real agent, never a shell");
+            };
+            let key = crate::review::state::baseline_key(&agent.cwd, kind, agent.spawned_at_unix);
             assert_eq!(
                 state.get(&key),
                 Some(app.agent_reviews[&agent.id].baseline.clone()),

--- a/crates/app/src/review/state.rs
+++ b/crates/app/src/review/state.rs
@@ -1,0 +1,445 @@
+//! Pure, GPUI-window-free state and wording for the agent review surface - see `super`'s module
+//! docs for the scope this belongs to.
+//!
+//! Everything here is directly unit-testable without a live window: what a baseline *is*, what
+//! an agent's review currently holds, the persisted key an agent resolves to, and the exact
+//! words the Review tab's header says. Actually capturing a baseline, loading a diff, and
+//! drawing any of it happens in the sibling `flow`/`render` modules.
+
+use std::path::{Path, PathBuf};
+
+use wt_core::diff::WorktreeDiff;
+
+use crate::work_surface::agents::AgentKind;
+
+/// Why a baseline is where it is - the two, and only two, real ways a baseline is ever set
+/// (GitHub issue #225, phase 1's decided scope).
+///
+/// There is deliberately no third variant. A baseline advances **only** when the user explicitly
+/// marks the review as read; automatically advancing it on PTY quiescence (or on any other
+/// inferred "the agent seems done" signal) is explicitly out of scope for this phase, because a
+/// baseline that moves on its own can silently discard changes the user never actually looked at
+/// - the exact failure this feature exists to prevent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BaselineReason {
+    /// Captured when the agent was spawned. The review diff therefore reads "everything this
+    /// agent has done since it started".
+    Spawn,
+    /// Captured when the user clicked `Mark reviewed`. The review diff reads "everything that
+    /// has changed since you last looked".
+    MarkedReviewed,
+}
+
+impl BaselineReason {
+    /// The "since ..." phrase the Review tab's header uses for this reason. Vocabulary is
+    /// deliberately review-side, never git-side: this surface says "since", "review",
+    /// "unreviewed", "mark reviewed" - never a bare "diff", which is the git side's word and
+    /// whose overloading is precisely what GitHub issue #225 reports as confusing.
+    pub fn since_phrase(self) -> &'static str {
+        match self {
+            BaselineReason::Spawn => "since it started",
+            BaselineReason::MarkedReviewed => "since you last reviewed",
+        }
+    }
+
+    /// The stable string this reason persists as. Written by hand rather than derived, so
+    /// renaming a variant can never silently invalidate every already-written state file.
+    pub fn as_key(self) -> &'static str {
+        match self {
+            BaselineReason::Spawn => "spawn",
+            BaselineReason::MarkedReviewed => "marked-reviewed",
+        }
+    }
+
+    /// The inverse of [`Self::as_key`]. `None` for an unrecognised value (a hand-edited or
+    /// future-written state file), which callers treat as "this entry is unusable" rather than
+    /// guessing a reason and then telling the user something false about their own review.
+    pub fn from_key(key: &str) -> Option<Self> {
+        match key {
+            "spawn" => Some(BaselineReason::Spawn),
+            "marked-reviewed" => Some(BaselineReason::MarkedReviewed),
+            _ => None,
+        }
+    }
+}
+
+/// One captured review baseline: the real git tree an agent's changes are measured against, the
+/// ref keeping that tree alive, and when and why it was taken.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReviewBaseline {
+    /// The real hex tree id from `wt_core::review::snapshot_worktree_tree`.
+    pub tree_id: String,
+    /// The `refs/jerry/review/*` ref anchoring [`Self::tree_id`] against `git gc` -
+    /// `wt_core::review::baseline_ref_name`'s output for this agent's own key.
+    pub ref_name: String,
+    /// When this snapshot was really taken, as seconds since the Unix epoch.
+    ///
+    /// Deliberately the snapshot's **own** timestamp, not the agent's spawn time: capturing runs
+    /// on the background executor, so a baseline lands a real (if small) moment after the process
+    /// it belongs to actually started. Recording when the snapshot really happened lets the
+    /// header say "captured at 09:31" honestly, instead of implying a precision this doesn't
+    /// have. Any file the agent managed to write inside that window is attributed to *before*
+    /// the baseline and so won't appear in the review - an accepted, documented limitation of
+    /// phase 1, not an oversight.
+    pub taken_at_unix: i64,
+    pub reason: BaselineReason,
+}
+
+/// The Review tab's background diff load - mirrors `crate::graph_view::state::GraphLoadState`'s
+/// three-real-outcomes-plus-not-started shape, for one consistent idiom across this crate's
+/// background-loaded surfaces.
+#[derive(Debug, Clone, Default)]
+pub enum ReviewLoadState {
+    /// No load has been started yet (the tab has never been opened, or the baseline just
+    /// advanced) - deliberately not eager, since `wt_core::review::diff_against_tree` spawns a
+    /// real `git diff` process.
+    #[default]
+    NotLoaded,
+    Loading,
+    /// A real, parsed review diff. An empty `files` list here is the good, correct empty state -
+    /// "nothing new since you last looked" - never an error.
+    Loaded(WorktreeDiff),
+    /// A real error message from the underlying `wt_core` call, surfaced rather than swallowed
+    /// into a fabricated empty diff (which would read as "nothing changed" - the single most
+    /// misleading thing this surface could say).
+    Error(String),
+}
+
+/// Everything this app knows about one agent's review: where its baseline is, what's currently
+/// loaded against it, and which file the user has open in the Review tab.
+#[derive(Debug, Clone)]
+pub struct AgentReview {
+    pub baseline: ReviewBaseline,
+    pub load: ReviewLoadState,
+    /// Which of the review diff's changed files is expanded in the tab's detail pane. `None`
+    /// means the file list is showing with nothing selected. Cleared whenever the baseline
+    /// advances, since the previously-open file is - by definition - no longer changed.
+    pub open_file: Option<PathBuf>,
+    /// The paths that differ from this agent's baseline right now - refreshed cheaply on the
+    /// rail's own status-poll tick (`wt_core::review::changed_paths_against_tree`: one
+    /// `git diff --name-only` process, no hunk parsing at all).
+    ///
+    /// This, not [`Self::load`], is what tells the rest of the app whether an agent has anything
+    /// unreviewed, and that split is load-bearing rather than an optimization. The full
+    /// [`ReviewLoadState`] diff is only ever loaded while the Review tab is actually open, so
+    /// deriving "has unreviewed changes" from it would be circular: the rail's `Review ready`
+    /// status is what surfaces the footer door, the footer door is what opens the tab, and the
+    /// tab is what triggers the load. Nothing would ever become reviewable.
+    ///
+    /// `None` means "not yet measured" (no tick has completed for this agent), never "nothing
+    /// changed" - the two are genuinely different and callers must not conflate them.
+    pub unreviewed_paths: Option<Vec<PathBuf>>,
+}
+
+impl AgentReview {
+    pub fn new(baseline: ReviewBaseline) -> Self {
+        Self {
+            baseline,
+            load: ReviewLoadState::NotLoaded,
+            open_file: None,
+            unreviewed_paths: None,
+        }
+    }
+
+    /// The real, loaded review diff, if one is loaded. `None` while loading, on error, and
+    /// before the first load - never a fabricated empty diff standing in for "don't know yet",
+    /// which callers would be unable to tell apart from a genuine "nothing changed".
+    pub fn diff(&self) -> Option<&WorktreeDiff> {
+        match &self.load {
+            ReviewLoadState::Loaded(diff) => Some(diff),
+            ReviewLoadState::NotLoaded | ReviewLoadState::Loading | ReviewLoadState::Error(_) => {
+                None
+            }
+        }
+    }
+
+    /// How many files this agent has really changed since its baseline, or `None` if that has
+    /// not been measured yet. Reads [`Self::unreviewed_paths`] - see that field's docs for why
+    /// the cheap measurement, not the loaded diff, is the source of truth here.
+    pub fn unreviewed_file_count(&self) -> Option<usize> {
+        self.unreviewed_paths.as_ref().map(Vec::len)
+    }
+
+    /// `true` only when a real measurement has landed **and** it found at least one changed
+    /// file. An unmeasured review is not "has unreviewed changes": claiming so would put a
+    /// `Review ready` status on the rail off the back of an answer git never actually gave.
+    pub fn has_unreviewed_changes(&self) -> bool {
+        self.unreviewed_file_count().is_some_and(|count| count > 0)
+    }
+
+    /// Advances this review onto a freshly captured baseline (`Mark reviewed`). The loaded diff
+    /// and the open file are both dropped rather than kept: they describe the *old* baseline, and
+    /// showing them next to a new one would be actively wrong. `flow` re-loads immediately
+    /// afterwards, which - against a snapshot taken moments ago - lands on a real, empty diff.
+    pub fn advance_to(&mut self, baseline: ReviewBaseline) {
+        self.baseline = baseline;
+        self.load = ReviewLoadState::NotLoaded;
+        self.open_file = None;
+        // Reset to "not measured yet" rather than to an empty list: the new baseline genuinely
+        // has not been measured against yet, and asserting "nothing changed" before any git call
+        // has run would be a fabricated answer that happens to usually be right.
+        self.unreviewed_paths = None;
+    }
+}
+
+/// The durable identity a persisted baseline is filed under: this agent's worktree, its kind,
+/// and the wall-clock second it was spawned in.
+///
+/// ## Known limitation
+///
+/// Two agents of the identical kind, spawned into the identical worktree, within the identical
+/// second, produce the identical key. That is a real collision, and it is accepted rather than
+/// engineered around (with, say, a UUID): it needs two spawns of the same agent CLI into one
+/// worktree inside one second, and the cost of getting it wrong is one agent reading the other's
+/// baseline - a wrong "since" point, not data loss. A UUID scheme would buy that narrow case at
+/// the price of a second identity concept living alongside the one GitHub issue #227 ("Agent
+/// history and resume/recover") will need to introduce properly anyway.
+///
+/// `|` is the separator because it cannot appear in `AgentKind::label`'s output and is vanishingly
+/// rare in a path; it doesn't need to be escape-proof, since the whole key is hex-encoded into a
+/// ref name downstream (`wt_core::review::baseline_ref_name`) and stored as an opaque string here.
+pub fn baseline_key(worktree: &Path, kind: AgentKind, spawned_at_unix: i64) -> String {
+    format!("{}|{}|{spawned_at_unix}", worktree.display(), kind.label())
+}
+
+/// The Review tab's header text: what this review is measured against, and when that measurement
+/// was taken - e.g. `claude \u{b7} since it started \u{b7} 09:31`.
+///
+/// This is not decoration. GitHub issue #225's actual complaint is that "there is a confusion
+/// between agents diff review and git diffs", and the thing that resolves it is this surface
+/// stating, in words, exactly which question it is answering - so a user looking at it never has
+/// to guess whether they're seeing "changes since main" or "changes since I last looked". Both
+/// halves are derived from the real baseline ([`BaselineReason::since_phrase`] and
+/// [`ReviewBaseline::taken_at_unix`]), never a hardcoded string.
+///
+/// The time is UTC - see `crate::rail::state::format_utc_hhmm` for why this crate has no local
+/// timezone conversion anywhere.
+pub fn review_tab_header(agent_label: &str, baseline: &ReviewBaseline) -> String {
+    format!(
+        "{agent_label} \u{b7} {} \u{b7} {}",
+        baseline.reason.since_phrase(),
+        crate::rail::state::format_utc_hhmm(baseline.taken_at_unix),
+    )
+}
+
+/// The Review tab's own empty state, worded as the genuinely good outcome it is.
+///
+/// Deliberately distinct from the git side's "this branch matches main" empty state: they are
+/// different facts, and reusing one phrase for both is exactly the conflation this feature
+/// exists to undo. A freshly-marked-reviewed agent lands here immediately, and that is success,
+/// not an error or a missing load.
+pub fn review_empty_message(reason: BaselineReason) -> &'static str {
+    match reason {
+        BaselineReason::Spawn => "nothing changed since this agent started",
+        BaselineReason::MarkedReviewed => "nothing new since you last looked",
+    }
+}
+
+/// The Review tab's strip label: how many files are unreviewed, or the honest loading/error
+/// state. Never says "diff".
+pub fn review_summary_label(review: &AgentReview) -> String {
+    match &review.load {
+        ReviewLoadState::NotLoaded | ReviewLoadState::Loading => "checking\u{2026}".to_string(),
+        ReviewLoadState::Error(_) => "review unavailable".to_string(),
+        ReviewLoadState::Loaded(diff) => match diff.files.len() {
+            0 => "nothing unreviewed".to_string(),
+            1 => "1 file unreviewed".to_string(),
+            count => format!("{count} files unreviewed"),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn baseline(reason: BaselineReason, taken_at_unix: i64) -> ReviewBaseline {
+        ReviewBaseline {
+            tree_id: "a".repeat(40),
+            ref_name: "refs/jerry/review/6b6579".to_string(),
+            taken_at_unix,
+            reason,
+        }
+    }
+
+    /// The header must name the real "since" point and the real capture time - this is the thing
+    /// that actually resolves GitHub issue #225's "confusion" complaint.
+    #[test]
+    fn the_header_states_what_it_is_measured_against_and_when() {
+        // 1970-01-01T09:31:00Z.
+        let header = review_tab_header(
+            "claude",
+            &baseline(BaselineReason::Spawn, 9 * 3600 + 31 * 60),
+        );
+        assert_eq!(header, "claude \u{b7} since it started \u{b7} 09:31");
+    }
+
+    #[test]
+    fn a_marked_reviewed_baseline_says_since_you_last_reviewed_not_since_it_started() {
+        let header = review_tab_header(
+            "codex",
+            &baseline(BaselineReason::MarkedReviewed, 12 * 3600 + 4 * 60),
+        );
+        assert_eq!(header, "codex \u{b7} since you last reviewed \u{b7} 12:04");
+    }
+
+    /// The vocabulary split is a real requirement, not a style preference: this surface must
+    /// never use the git side's word for its own, different concept.
+    #[test]
+    fn no_review_wording_anywhere_says_a_bare_diff() {
+        let mut wording: Vec<String> = vec![
+            review_tab_header("claude", &baseline(BaselineReason::Spawn, 0)),
+            review_tab_header("claude", &baseline(BaselineReason::MarkedReviewed, 0)),
+            review_empty_message(BaselineReason::Spawn).to_string(),
+            review_empty_message(BaselineReason::MarkedReviewed).to_string(),
+        ];
+        for reason in [BaselineReason::Spawn, BaselineReason::MarkedReviewed] {
+            wording.push(reason.since_phrase().to_string());
+        }
+        let mut review = AgentReview::new(baseline(BaselineReason::Spawn, 0));
+        wording.push(review_summary_label(&review));
+        review.load = ReviewLoadState::Error("boom".to_string());
+        wording.push(review_summary_label(&review));
+
+        for text in wording {
+            assert!(
+                !text.to_lowercase().contains("diff"),
+                "the review surface must never say a bare 'diff' - got {text:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_two_empty_states_are_worded_differently_from_each_other() {
+        assert_ne!(
+            review_empty_message(BaselineReason::Spawn),
+            review_empty_message(BaselineReason::MarkedReviewed)
+        );
+    }
+
+    /// "Unreviewed changes" must come from a real measurement, and must distinguish *unmeasured*
+    /// from *measured as empty*. Conflating the two is what would put a `Review ready` status on
+    /// the rail with nothing behind it.
+    #[test]
+    fn only_a_real_measurement_counts_as_having_unreviewed_changes() {
+        let mut review = AgentReview::new(baseline(BaselineReason::Spawn, 0));
+        assert!(
+            !review.has_unreviewed_changes(),
+            "nothing measured yet must never read as 'has changes'"
+        );
+        assert_eq!(
+            review.unreviewed_file_count(),
+            None,
+            "and unmeasured must be honestly absent, not a fabricated 0"
+        );
+
+        review.unreviewed_paths = Some(Vec::new());
+        assert!(
+            !review.has_unreviewed_changes(),
+            "measured as empty is a real answer, and it is 'nothing unreviewed'"
+        );
+        assert_eq!(
+            review.unreviewed_file_count(),
+            Some(0),
+            "measured-empty and unmeasured must be distinguishable"
+        );
+
+        review.unreviewed_paths = Some(vec![PathBuf::from("a.rs"), PathBuf::from("b.rs")]);
+        assert!(review.has_unreviewed_changes());
+        assert_eq!(review.unreviewed_file_count(), Some(2));
+    }
+
+    /// The load state is a genuinely separate axis from the measurement: it describes only what
+    /// the Review *tab* has to draw, and must never fabricate a diff for a state that has none.
+    #[test]
+    fn no_load_state_short_of_loaded_ever_yields_a_diff() {
+        let mut review = AgentReview::new(baseline(BaselineReason::Spawn, 0));
+        assert!(review.diff().is_none(), "NotLoaded");
+        assert_eq!(review_summary_label(&review), "checking\u{2026}");
+        review.load = ReviewLoadState::Loading;
+        assert!(review.diff().is_none(), "Loading");
+        review.load = ReviewLoadState::Error("git exploded".to_string());
+        assert!(review.diff().is_none(), "Error");
+        assert_eq!(review_summary_label(&review), "review unavailable");
+
+        review.load = ReviewLoadState::Loaded(WorktreeDiff {
+            base_branch: "since it started".to_string(),
+            base_commit: "a".repeat(40),
+            files: Vec::new(),
+            truncated: false,
+        });
+        assert!(review.diff().is_some());
+        assert_eq!(review_summary_label(&review), "nothing unreviewed");
+    }
+
+    /// Advancing the baseline must drop everything that described the old one - keeping a loaded
+    /// diff next to a fresh baseline would show changes that are, by definition, already
+    /// reviewed.
+    #[test]
+    fn marking_reviewed_drops_the_old_loaded_review_and_the_open_file() {
+        let mut review = AgentReview::new(baseline(BaselineReason::Spawn, 100));
+        review.load = ReviewLoadState::Loaded(WorktreeDiff {
+            base_branch: "since it started".to_string(),
+            base_commit: "a".repeat(40),
+            files: Vec::new(),
+            truncated: false,
+        });
+        review.open_file = Some(PathBuf::from("src/main.rs"));
+
+        let advanced = ReviewBaseline {
+            tree_id: "b".repeat(40),
+            reason: BaselineReason::MarkedReviewed,
+            taken_at_unix: 200,
+            ..baseline(BaselineReason::Spawn, 200)
+        };
+        review.advance_to(advanced.clone());
+
+        assert_eq!(review.baseline, advanced);
+        assert!(review.open_file.is_none());
+        assert!(matches!(review.load, ReviewLoadState::NotLoaded));
+        assert!(!review.has_unreviewed_changes());
+    }
+
+    #[test]
+    fn every_baseline_reason_round_trips_through_its_persisted_key() {
+        for reason in [BaselineReason::Spawn, BaselineReason::MarkedReviewed] {
+            assert_eq!(BaselineReason::from_key(reason.as_key()), Some(reason));
+        }
+        assert_eq!(BaselineReason::from_key("pty-went-quiet"), None);
+        assert_eq!(BaselineReason::from_key(""), None);
+    }
+
+    /// The key must genuinely separate agents that differ in *any* of its three parts - that is
+    /// the whole reason it has three parts.
+    #[test]
+    fn baseline_keys_differ_by_worktree_kind_and_spawn_second() {
+        let base = baseline_key(Path::new("/repo/wt-a"), AgentKind::Claude, 1_700_000_000);
+        assert_ne!(
+            base,
+            baseline_key(Path::new("/repo/wt-b"), AgentKind::Claude, 1_700_000_000)
+        );
+        assert_ne!(
+            base,
+            baseline_key(Path::new("/repo/wt-a"), AgentKind::Codex, 1_700_000_000)
+        );
+        assert_ne!(
+            base,
+            baseline_key(Path::new("/repo/wt-a"), AgentKind::Claude, 1_700_000_001)
+        );
+        assert_eq!(
+            base,
+            baseline_key(Path::new("/repo/wt-a"), AgentKind::Claude, 1_700_000_000),
+            "the same agent must resolve to the same key every time - that's what makes a \
+             persisted baseline findable at all"
+        );
+    }
+
+    /// The documented collision, pinned as a real, known limitation rather than left implicit.
+    #[test]
+    fn two_identical_agents_spawned_in_the_same_second_share_a_key_a_known_limitation() {
+        assert_eq!(
+            baseline_key(Path::new("/repo/wt-a"), AgentKind::Claude, 1_700_000_000),
+            baseline_key(Path::new("/repo/wt-a"), AgentKind::Claude, 1_700_000_000),
+        );
+    }
+}

--- a/crates/app/src/review/state.rs
+++ b/crates/app/src/review/state.rs
@@ -9,6 +9,7 @@
 use std::path::{Path, PathBuf};
 
 use wt_core::diff::WorktreeDiff;
+use wt_core::review::UntrackedCoverage;
 
 use crate::work_surface::agents::AgentKind;
 
@@ -83,6 +84,16 @@ pub struct ReviewBaseline {
     /// phase 1, not an oversight.
     pub taken_at_unix: i64,
     pub reason: BaselineReason,
+    /// Whether this snapshot actually captured the worktree's untracked files, or fell back to
+    /// tracked paths only because the untracked set was too large to hash
+    /// (`wt_core::review::MAX_UNTRACKED_SNAPSHOT_BYTES`).
+    ///
+    /// Carried on the baseline rather than recomputed, for two reasons: every later
+    /// `diff_against_tree`/`changed_paths_against_tree` call **must** be made with the same
+    /// coverage the snapshot used (otherwise a tracked-only baseline reports every pre-existing
+    /// untracked file as a brand-new addition), and the user is told about it in the tab header -
+    /// a narrower review is honest only if it says it is narrower.
+    pub untracked: UntrackedCoverage,
 }
 
 /// The Review tab's background diff load - mirrors `crate::graph_view::state::GraphLoadState`'s
@@ -199,7 +210,61 @@ impl AgentReview {
 /// rare in a path; it doesn't need to be escape-proof, since the whole key is hex-encoded into a
 /// ref name downstream (`wt_core::review::baseline_ref_name`) and stored as an opaque string here.
 pub fn baseline_key(worktree: &Path, kind: AgentKind, spawned_at_unix: i64) -> String {
-    format!("{}|{}|{spawned_at_unix}", worktree.display(), kind.label())
+    format!(
+        "{}|{}|{spawned_at_unix}",
+        encode_worktree(worktree),
+        kind.label()
+    )
+}
+
+/// A lossless, always-UTF-8 encoding of a worktree path, for use inside a [`baseline_key`] and in
+/// the persisted state file.
+///
+/// `Path::display()` - what this used to use - is *lossy*: it replaces invalid UTF-8 with U+FFFD.
+/// Two genuinely different worktree paths differing only in invalid bytes would therefore collapse
+/// to one key, and so onto one baseline ref, silently sharing a "since" point between unrelated
+/// agents. It also cannot round-trip back to a real `PathBuf`, which the persisted record needs to
+/// be worth anything to GitHub issue #227.
+///
+/// Both arms carry an explicit tag, so a real path that happens to look like the other encoding
+/// can't be mistaken for it - the encoding is injective by construction, not by luck.
+pub fn encode_worktree(worktree: &Path) -> String {
+    match worktree.to_str() {
+        Some(text) => format!("utf8:{text}"),
+        None => {
+            let bytes = worktree.as_os_str().as_encoded_bytes();
+            let mut encoded = String::with_capacity(6 + bytes.len() * 2);
+            encoded.push_str("bytes:");
+            for byte in bytes {
+                encoded.push_str(&format!("{byte:02x}"));
+            }
+            encoded
+        }
+    }
+}
+
+/// The inverse of [`encode_worktree`] - `None` for anything this app didn't write (a hand-edited
+/// or truncated state file), which callers treat as "this record isn't usable" rather than
+/// guessing at a path.
+///
+/// Non-UTF-8 paths decode only where their bytes are also valid UTF-8 once reassembled; the
+/// checked `String::from_utf8` path is deliberate, rather than reaching for
+/// `OsString::from_encoded_bytes_unchecked`'s `unsafe` in a read path whose only consumers are
+/// diagnostics and future issue #227 work.
+pub fn decode_worktree(encoded: &str) -> Option<PathBuf> {
+    if let Some(text) = encoded.strip_prefix("utf8:") {
+        return Some(PathBuf::from(text));
+    }
+    let hex = encoded.strip_prefix("bytes:")?;
+    if hex.len() % 2 != 0 {
+        return None;
+    }
+    let mut bytes = Vec::with_capacity(hex.len() / 2);
+    for pair in hex.as_bytes().chunks(2) {
+        let text = std::str::from_utf8(pair).ok()?;
+        bytes.push(u8::from_str_radix(text, 16).ok()?);
+    }
+    String::from_utf8(bytes).ok().map(PathBuf::from)
 }
 
 /// The Review tab's header text: what this review is measured against, and when that measurement
@@ -215,11 +280,18 @@ pub fn baseline_key(worktree: &Path, kind: AgentKind, spawned_at_unix: i64) -> S
 /// The time is UTC - see `crate::rail::state::format_utc_hhmm` for why this crate has no local
 /// timezone conversion anywhere.
 pub fn review_tab_header(agent_label: &str, baseline: &ReviewBaseline) -> String {
-    format!(
+    let mut header = format!(
         "{agent_label} \u{b7} {} \u{b7} {}",
         baseline.reason.since_phrase(),
         crate::rail::state::format_utc_hhmm(baseline.taken_at_unix),
-    )
+    );
+    // A tracked-only baseline answers a genuinely narrower question, so the header says so rather
+    // than presenting it as the full answer. Same honesty rule as the rest of this header: state
+    // what is really being measured, never imply more.
+    if baseline.untracked == UntrackedCoverage::Excluded {
+        header.push_str(" \u{b7} tracked files only");
+    }
+    header
 }
 
 /// The Review tab's own empty state, worded as the genuinely good outcome it is.
@@ -259,6 +331,7 @@ mod tests {
             ref_name: "refs/jerry/review/6b6579".to_string(),
             taken_at_unix,
             reason,
+            untracked: UntrackedCoverage::Included,
         }
     }
 
@@ -431,6 +504,84 @@ mod tests {
             baseline_key(Path::new("/repo/wt-a"), AgentKind::Claude, 1_700_000_000),
             "the same agent must resolve to the same key every time - that's what makes a \
              persisted baseline findable at all"
+        );
+    }
+
+    /// A worktree path must survive the key encoding exactly - `Path::display()`, which this used
+    /// to use, is lossy for non-UTF-8 and would collapse genuinely different worktrees onto one
+    /// key (and so onto one baseline ref, silently sharing a "since" point).
+    #[test]
+    fn a_worktree_path_round_trips_through_its_key_encoding() {
+        for path in [
+            "/repo/wt-a",
+            "/home/u/My Repo/.worktrees/feature-x",
+            "/tmp/utf8:looks-like-a-tag",
+            "/tmp/bytes:6162",
+        ] {
+            let encoded = encode_worktree(Path::new(path));
+            assert_eq!(
+                decode_worktree(&encoded),
+                Some(PathBuf::from(path)),
+                "{path} must round-trip exactly - including paths that look like the encoding's \
+                 own tags, which is why both arms carry an explicit prefix"
+            );
+        }
+    }
+
+    #[test]
+    fn a_key_encoding_this_app_did_not_write_is_refused_rather_than_guessed() {
+        assert_eq!(decode_worktree("/repo/wt-a"), None, "no tag at all");
+        assert_eq!(decode_worktree("bytes:abc"), None, "odd-length hex");
+        assert_eq!(decode_worktree("bytes:zz"), None, "not hex");
+    }
+
+    /// Two worktree paths differing only in bytes `display()` would have flattened must produce
+    /// genuinely different keys. Built from real `OsStr` bytes on unix, where invalid UTF-8 in a
+    /// path is actually representable.
+    #[cfg(unix)]
+    #[test]
+    fn worktrees_differing_only_in_invalid_utf8_get_distinct_keys() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt as _;
+
+        let a = PathBuf::from(OsStr::from_bytes(b"/repo/\xff"));
+        let b = PathBuf::from(OsStr::from_bytes(b"/repo/\xfe"));
+        assert_ne!(
+            a, b,
+            "precondition: these really are different paths on this platform"
+        );
+        assert_eq!(
+            a.display().to_string(),
+            b.display().to_string(),
+            "precondition: and `display()` really does flatten them to the same string - which is \
+             exactly the bug this encoding replaces"
+        );
+
+        assert_ne!(
+            baseline_key(&a, AgentKind::Claude, 1),
+            baseline_key(&b, AgentKind::Claude, 1),
+            "two genuinely different worktrees must never share one baseline key"
+        );
+    }
+
+    /// A tracked-only baseline must say so in the header - a narrower answer presented as a
+    /// complete one is exactly the kind of quiet lie this feature exists to remove.
+    #[test]
+    fn a_tracked_only_baseline_says_so_in_the_header() {
+        let mut tracked_only = baseline(BaselineReason::Spawn, 9 * 3600 + 31 * 60);
+        tracked_only.untracked = UntrackedCoverage::Excluded;
+        assert_eq!(
+            review_tab_header("claude", &tracked_only),
+            "claude \u{b7} since it started \u{b7} 09:31 \u{b7} tracked files only"
+        );
+
+        // And the ordinary case must not grow a spurious caveat.
+        assert_eq!(
+            review_tab_header(
+                "claude",
+                &baseline(BaselineReason::Spawn, 9 * 3600 + 31 * 60)
+            ),
+            "claude \u{b7} since it started \u{b7} 09:31"
         );
     }
 

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -72,6 +72,7 @@ use crate::palette::state as palette;
 use crate::rail::repo::{self as repo, Repo, RepoId};
 use crate::rail::state as rail;
 use crate::rail::worktrees::{self, WorktreeItem};
+use crate::review;
 use crate::settings::custom_theme;
 use crate::settings::state as settings;
 #[cfg(test)]
@@ -371,13 +372,39 @@ pub struct AdeApp {
     /// [`Self::current_diff`]'s docs for exactly which [`DiffLoadState`]/[`DiffBase`]
     /// combinations count).
     pub(crate) diff_totals: Option<(u32, u32)>,
-    /// Which agent(s) wrote each file in [`Self::diff_state`]'s currently loaded diff
-    /// (`design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §4's `by: 's1'`/`by:
-    /// ['s1','s9']` record) - see [`changes::Authorship`]'s own docs for why this is always empty
-    /// today (no real authorship tracking exists yet; this phase only defines the shape a later
-    /// one populates). Reset alongside [`Self::diff_state`] on every reload
-    /// (`crate::code_surface::tabs::AdeApp::load_diff`), never carried across one.
-    pub(crate) file_authorship: changes::Authorship,
+    /// Every open agent's own **review** state (GitHub issue #225) - its captured baseline, the
+    /// diff loaded against that baseline, and which file it has open. Keyed by
+    /// [`crate::work_surface::agents::AgentId`].
+    ///
+    /// This is deliberately *not* the same thing as [`Self::diff_state`], and the difference is
+    /// the whole point of issue #225: `diff_state` holds the one **git** diff for the selected
+    /// worktree (against the merge-base with the default branch), while this holds a per-agent
+    /// **review** (against a snapshot taken when that agent started, or when the user last marked
+    /// it reviewed). One worktree with one agent has both, they answer different questions, and
+    /// they frequently disagree - correctly. See `crate::review`'s own module docs.
+    ///
+    /// An entry appears when a baseline is really captured
+    /// (`crate::review::flow::AdeApp::capture_review_baseline`, a background task, so slightly
+    /// after the agent itself appears) and is removed when the agent closes. An agent with no
+    /// entry has no review surface at all, which is honest: there is nothing to measure against.
+    pub(crate) agent_reviews: HashMap<AgentId, review::state::AgentReview>,
+    /// The on-disk mirror of [`Self::agent_reviews`]' baselines - see
+    /// `crate::review::baseline_state`'s module docs, including the honest note that nothing can
+    /// read these back into a live review yet.
+    pub(crate) review_baseline_state: review::baseline_state::ReviewBaselineState,
+    /// Where [`Self::review_baseline_state`] is persisted - a sibling of the real `settings.toml`,
+    /// or `None` for a test that hasn't opted into real persistence (in which case saving is a
+    /// genuine no-op, exactly like [`Self::tab_order_path`]).
+    pub(crate) review_baseline_path: Option<PathBuf>,
+    /// Which persisted baseline keys *this* instance owns, for the merge-not-clobber write path -
+    /// mirrors [`Self::tab_order_owned`]. See
+    /// `crate::review::baseline_state::ReviewBaselineState::save_merged_at` for the one way this
+    /// file's merge deliberately differs from its siblings'.
+    pub(crate) review_baselines_owned: std::collections::BTreeSet<String>,
+    /// `Some(id)` while a real `Mark reviewed` snapshot is running for that agent - guards against
+    /// a double-click starting two overlapping `git write-tree` runs against the same worktree,
+    /// mirroring [`Self::worktree_history_op_in_flight`]'s own single-flight discipline.
+    pub(crate) review_mark_in_flight: Option<AgentId>,
     /// Real expand/collapse state for the file tree - a directory's absolute path is in this set
     /// iff it is expanded (see `crate::sidebar::file_tree::visible_entries`, which this set feeds
     /// directly). **Absence means collapsed**, so a worktree opened for the first time shows only
@@ -692,6 +719,49 @@ pub struct AdeApp {
     /// The git graph tab's own state (loaded rows, scope, selection, right panel) - see
     /// `crate::graph_view::state::GraphTabState`.
     pub(crate) graph_state: graph_view::state::GraphTabState,
+    /// `Some(id)` when the review tab (GitHub issue #225) is open, for that agent. At most one
+    /// review tab exists per window - opening a review for a different agent retargets this one
+    /// rather than accumulating tabs, the same "one per window" shape [`Self::graph_tab_open`]
+    /// uses - but unlike the graph tab it carries which agent it's *for*, since a review is
+    /// inherently per-agent (that is the entire point of the feature).
+    pub(crate) review_tab_open: Option<AgentId>,
+    /// Whether the review tab is the tab strip's currently *active* entry - exactly mirrors
+    /// [`Self::graph_tab_active`], including that switching to another tab clears this without
+    /// closing the review tab.
+    pub(crate) review_tab_active: bool,
+    /// The review tab's own keyboard-focus target, `track_focus`'d by
+    /// `crate::review::render::AdeApp::render_review_view`'s container - and swept exactly like
+    /// [`Self::graph_focus_handle`] whenever the tab stops being rendered (see
+    /// `crate::review::render::AdeApp::leave_review_tab`).
+    pub(crate) review_focus_handle: FocusHandle,
+    /// Pre-open focus target for [`Self::review_focus_handle`] - see [`OverlayFocus`], and
+    /// [`Self::graph_focus`] for the identical role on the graph tab.
+    pub(crate) review_focus: OverlayFocus,
+    /// The review tab's own overlay-scrollbar handle - its own, not
+    /// [`Self::diff_view_scroll_handle`]: the two surfaces are separate places in the app, and
+    /// sharing one handle would carry the git Diff view's scroll position into the review (and
+    /// back) every time the user switched between them.
+    ///
+    /// A `gpui::UniformListScrollHandle`, matching [`Self::diff_view_scroll_handle`]'s own type -
+    /// both surfaces are driven by the same `render_diff_file_detail` `uniform_list` (GitHub
+    /// issue #224), which owns its scroll offset through this handle type rather than a plain
+    /// `gpui::ScrollHandle`.
+    pub(crate) review_scroll_handle: UniformListScrollHandle,
+    /// [`Self::diff_highlight_cache`]'s counterpart for the review tab's own open file - a
+    /// separate cache for the same reason the scroll handle is separate: the review tab and the
+    /// git Diff view can each have a *different* file open, and one shared cache would thrash
+    /// (its identity guard rejecting every read) every time the user moved between them. Kept
+    /// fresh by `crate::review::render::AdeApp::refresh_review_highlight_cache`.
+    pub(crate) review_highlight_cache: Option<DiffHighlightCache>,
+    /// The in-flight `wt_core::review::snapshot_worktree_tree` behind a fresh agent's baseline
+    /// capture - one slot, same shape as [`Self::_load_graph_task`].
+    pub(crate) _review_baseline_task: Option<Task<()>>,
+    /// The in-flight `wt_core::review::diff_against_tree` load behind the review tab.
+    pub(crate) _review_load_task: Option<Task<()>>,
+    /// The in-flight `Mark reviewed` re-snapshot - guarded by [`Self::review_mark_in_flight`].
+    pub(crate) _review_mark_task: Option<Task<()>>,
+    /// The in-flight `wt_core::review::delete_ref` releasing a closed agent's baseline ref.
+    pub(crate) _review_release_task: Option<Task<()>>,
     /// The in-flight `wt_core::graph::build_graph` background load, one slot - a fresh load
     /// supersedes an older one still running, mirroring [`Self::_load_diff_task`].
     pub(crate) _load_graph_task: Option<Task<()>>,

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -753,15 +753,33 @@ pub struct AdeApp {
     /// (its identity guard rejecting every read) every time the user moved between them. Kept
     /// fresh by `crate::review::render::AdeApp::refresh_review_highlight_cache`.
     pub(crate) review_highlight_cache: Option<DiffHighlightCache>,
-    /// The in-flight `wt_core::review::snapshot_worktree_tree` behind a fresh agent's baseline
-    /// capture - one slot, same shape as [`Self::_load_graph_task`].
-    pub(crate) _review_baseline_task: Option<Task<()>>,
+    /// The in-flight `wt_core::review::snapshot_worktree_tree` behind each fresh agent's
+    /// baseline capture, keyed by agent.
+    ///
+    /// Deliberately **not** the single `Option<Task<()>>` slot [`Self::_load_graph_task`] uses:
+    /// GPUI cancels a `Task` when it is dropped, so one shared slot meant spawning agent B while
+    /// agent A's snapshot was still running silently cancelled A's capture - permanently, since
+    /// nothing retries it, leaving A with no review for its entire lifetime and an orphaned
+    /// baseline ref that `release_review_baseline` would never clean up (it early-returns when
+    /// there is no entry). A single slot is right for a *replaceable* load like the graph's; a
+    /// baseline capture is per-agent and must not be superseded by an unrelated agent's.
+    ///
+    /// Entries are removed when their capture completes, so this never grows past the number of
+    /// captures genuinely in flight.
+    pub(crate) _review_baseline_tasks: HashMap<AgentId, Task<()>>,
     /// The in-flight `wt_core::review::diff_against_tree` load behind the review tab.
     pub(crate) _review_load_task: Option<Task<()>>,
     /// The in-flight `Mark reviewed` re-snapshot - guarded by [`Self::review_mark_in_flight`].
     pub(crate) _review_mark_task: Option<Task<()>>,
-    /// The in-flight `wt_core::review::delete_ref` releasing a closed agent's baseline ref.
-    pub(crate) _review_release_task: Option<Task<()>>,
+    /// In-flight `wt_core::review::delete_ref` calls releasing closed agents' baseline refs,
+    /// keyed by the agent that was closed - same reasoning as [`Self::_review_baseline_tasks`]:
+    /// with one shared slot, closing two agents in quick succession cancelled the first one's
+    /// deletion and leaked that ref forever.
+    pub(crate) _review_release_tasks: HashMap<AgentId, Task<()>>,
+    /// The in-flight background save of [`Self::review_baseline_state`] - one slot is correct
+    /// here (unlike the two above), because every save writes the *whole* merged state, so a
+    /// newer one genuinely supersedes an older one. Mirrors `AdeApp::_tab_order_save_task`.
+    pub(crate) _review_persist_task: Option<Task<()>>,
     /// The in-flight `wt_core::graph::build_graph` background load, one slot - a fresh load
     /// supersedes an older one still running, mirroring [`Self::_load_diff_task`].
     pub(crate) _load_graph_task: Option<Task<()>>,

--- a/crates/app/src/root/new_file.rs
+++ b/crates/app/src/root/new_file.rs
@@ -388,6 +388,14 @@ impl AdeApp {
         // `graph_tab_active` (so `Self::render_center_pane` kept showing the graph, not this new
         // file) with `Window::focus` on `code_focus_handle`, which isn't in that frame either.
         self.leave_graph_tab(window, cx);
+        // GitHub issue #225: the review tab occupies the centre pane exactly as the graph tab
+        // does, so it needs the identical teardown here. Without this, `review_tab_active` stayed
+        // set, `render_center_pane` kept returning the review body, and the tab this call is
+        // switching *to* never mounted at all - while real focus had already moved onto it. Found
+        // by an adversarial audit; the review surface's own docs claimed to copy the graph tab's
+        // discipline and, in exactly this way, did not.
+        self.leave_review_tab(window, cx);
+
         self.focus_code_surface(window, cx);
         self.pending_cursor_line = None;
         if !self

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -250,10 +250,11 @@ impl AdeApp {
             review_focus: OverlayFocus::default(),
             review_scroll_handle: UniformListScrollHandle::new(),
             review_highlight_cache: None,
-            _review_baseline_task: None,
+            _review_baseline_tasks: HashMap::new(),
             _review_load_task: None,
             _review_mark_task: None,
-            _review_release_task: None,
+            _review_release_tasks: HashMap::new(),
+            _review_persist_task: None,
             // Both are filled in immediately after this literal, through the same single
             // chokepoints every later change uses (`set_file_tree_root` +
             // `reload_expanded_dirs_from_fold_state`) - a second, constructor-only copy of that

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -104,6 +104,18 @@ impl AdeApp {
             .map(crate::work_surface::tab_order_state::TabOrderState::load_at)
             .unwrap_or_default();
 
+        // GitHub issue #225's review baselines resolve the same way, for the same reasons - see
+        // `crate::review::baseline_state`'s module docs, including the honest note that nothing
+        // can reconnect a loaded baseline to a live agent yet (agent ids don't survive a restart).
+        // Loaded anyway so the file is merged into rather than clobbered on the first save.
+        let review_baseline_path = settings_path
+            .as_deref()
+            .map(crate::review::baseline_state::review_baseline_path_for);
+        let review_baseline_state = review_baseline_path
+            .as_deref()
+            .map(crate::review::baseline_state::ReviewBaselineState::load_at)
+            .unwrap_or_default();
+
         // The repo-list file mirrors the fold-state file's own resolution one line up (see
         // `rail::repo`'s module docs for why it's the identical pattern): a sibling of whatever
         // settings path this instance was given, `None` (and so no persistence at all) for a test
@@ -227,7 +239,21 @@ impl AdeApp {
             changes_rows_scroll_handle: UniformListScrollHandle::new(),
             diff_state: DiffLoadState::Loading,
             diff_totals: None,
-            file_authorship: changes::Authorship::default(),
+            agent_reviews: HashMap::new(),
+            review_baseline_state,
+            review_baseline_path,
+            review_baselines_owned: std::collections::BTreeSet::new(),
+            review_mark_in_flight: None,
+            review_tab_open: None,
+            review_tab_active: false,
+            review_focus_handle: cx.focus_handle(),
+            review_focus: OverlayFocus::default(),
+            review_scroll_handle: UniformListScrollHandle::new(),
+            review_highlight_cache: None,
+            _review_baseline_task: None,
+            _review_load_task: None,
+            _review_mark_task: None,
+            _review_release_task: None,
             // Both are filled in immediately after this literal, through the same single
             // chokepoints every later change uses (`set_file_tree_root` +
             // `reload_expanded_dirs_from_fold_state`) - a second, constructor-only copy of that
@@ -573,7 +599,7 @@ impl AdeApp {
                 // other. `focus_active` below moves real keyboard focus onto it - see
                 // `Agents::focus_active`'s docs and this crate's `OverlayFocus`/`restore_focus`
                 // docs for why a *focused* window must never start with `Window::focus == None`.
-                this.agents.spawn(
+                let startup_agent = this.agents.spawn(
                     AgentKind::Shell,
                     path.clone(),
                     this.settings.appearance.terminal_font_size,
@@ -581,6 +607,14 @@ impl AdeApp {
                     window,
                     cx,
                 );
+                // GitHub issue #225: the startup shell is a real agent like any other and needs a
+                // real review baseline too. This is the *second* `Agents::spawn` call site in the
+                // app (`Self::new_agent` is the other), and it is deliberately hooked separately
+                // rather than folded into `Agents::spawn` itself - see
+                // `crate::review::flow::AdeApp::capture_review_baseline`'s docs for why `Agents`
+                // stays out of the git-snapshot business. Missing this would have left exactly one
+                // agent - the one every window starts with - permanently without a review.
+                this.capture_review_baseline(startup_agent, cx);
                 this.agents.focus_active(window, cx);
                 this.load_worktrees(cx);
                 this.load_file_tree(path.clone(), cx);

--- a/crates/app/src/sidebar/changes.rs
+++ b/crates/app/src/sidebar/changes.rs
@@ -6,89 +6,13 @@
 //! shows lives here; `gpui::Div` construction happens in `crate::root`, which owns the
 //! `Context<AdeApp>` the click handlers (review-toggle, open-in-centre) need.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use gpui::Rgba;
 
 use crate::theme;
-use crate::work_surface::agents::AgentId;
 use wt_core::diff::{DiffFile, DiffHunk, DiffLineKind, FileChangeStatus};
-
-/// Which agent(s) wrote each changed file in one worktree's diff -
-/// `design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §4 ("Where numbers live")'s
-/// `by: 's1'`, or `by: ['s1', 's9']` when more than one agent touched the same file. Keyed by a
-/// [`DiffFile::path`] (or `old_path`, before a rename - callers decide which path they're asking
-/// about; this type doesn't special-case renames itself).
-///
-/// **Not wired to any real tracking yet.** A separate, parallel piece of work watches an agent's
-/// edit tool calls and is meant to call [`Self::record`] as it observes them; this phase only
-/// defines the shape so that work has somewhere real to write into, and so every current consumer
-/// (`crate::code_surface::tabs::AdeApp::load_diff`, which resets this to
-/// [`Authorship::default`] on every worktree/diff reload - see that method's own docs) has a real,
-/// empty value to thread through rather than a stub. An empty `Authorship` means exactly what an
-/// empty [`Self::authors_for`] result says: "nobody's authorship has been recorded for this file
-/// yet", never fabricated as "no agent touched it".
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct Authorship {
-    by_path: HashMap<PathBuf, Vec<AgentId>>,
-}
-
-impl Authorship {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Every agent id recorded as having written `path`, in the order [`Self::record`] saw
-    /// them - empty (never fabricated) when nothing has recorded authorship for it yet, which
-    /// today is every path (see this type's own docs).
-    pub fn authors_for(&self, path: &Path) -> &[AgentId] {
-        self.by_path.get(path).map(Vec::as_slice).unwrap_or(&[])
-    }
-
-    /// Records `agent` as (one of) `path`'s authors. Idempotent: recording the same agent
-    /// against the same path twice does not duplicate the entry, so [`Self::authors_for`]'s
-    /// length is always the real distinct-author count, not an edit-tool-call count.
-    pub fn record(&mut self, path: PathBuf, agent: AgentId) {
-        let authors = self.by_path.entry(path).or_default();
-        if !authors.contains(&agent) {
-            authors.push(agent);
-        }
-    }
-
-    /// `true` when more than one distinct agent has written `path` - the design's amber
-    /// shared-file warning: the rail's worktree-row `⚠ N` and the Changes panel's amber
-    /// author-chip ring both key off this per-file check.
-    pub fn has_multiple_authors(&self, path: &Path) -> bool {
-        self.authors_for(path).len() > 1
-    }
-
-    /// How many of `paths` have more than one recorded author - the worktree row's `⚠ N` count
-    /// itself (§4: "files two agents both wrote").
-    pub fn shared_file_count<'a>(&self, paths: impl IntoIterator<Item = &'a Path>) -> usize {
-        paths
-            .into_iter()
-            .filter(|path| self.has_multiple_authors(path))
-            .count()
-    }
-
-    /// How many of `paths` `agent` is a recorded author of - the rail agent row's
-    /// `review ready` trailing text (`design_handoff_jerry_ade/revision 3/
-    /// REVISION-2026-07-31.md` §2.3: "`12 files` ... here the count **is** the ask - the size of
-    /// the review handed to you"). Deliberately per-agent, unlike [`Self::shared_file_count`]
-    /// (which is worktree-wide) - the whole point of this number is "how much of *this* review
-    /// is mine".
-    pub fn file_count_for<'a>(
-        &self,
-        agent: AgentId,
-        paths: impl IntoIterator<Item = &'a Path>,
-    ) -> usize {
-        paths
-            .into_iter()
-            .filter(|path| self.authors_for(path).contains(&agent))
-            .count()
-    }
-}
 
 /// Added/removed line counts for one file, counted directly from its hunks.
 /// `wt_core::diff::DiffFile` has no separate stored counter for this, so it's recomputed here
@@ -365,8 +289,7 @@ pub fn commit_button_label(staged_count: usize) -> String {
 
 /// A placeholder commit message, standing in for real agent-drafted commit-message generation -
 /// **out of scope for this task**: no such system exists anywhere in this codebase yet (this
-/// phase only wires the Changes panel's real staging/composer UI against real data, per this
-/// module's own `Authorship` precedent for "real API, honestly incomplete data"). Deterministic
+/// phase only wires the Changes panel's real staging/composer UI against real data). Deterministic
 /// and derived straight from the staged file list rather than fabricated prose, and empty when
 /// nothing is staged - the composer only ever shows this with something real to say.
 pub fn draft_commit_message(staged: &[&DiffFile]) -> String {
@@ -814,97 +737,6 @@ mod tests {
         assert_eq!(
             empty_hunks_message(FileChangeStatus::Deleted),
             "no line changes"
-        );
-    }
-
-    #[test]
-    fn a_fresh_authorship_has_no_authors_for_any_path() {
-        let authorship = Authorship::new();
-        assert_eq!(
-            authorship.authors_for(Path::new("src/main.rs")),
-            &[] as &[AgentId]
-        );
-        assert!(!authorship.has_multiple_authors(Path::new("src/main.rs")));
-    }
-
-    #[test]
-    fn recording_one_agent_makes_it_the_sole_author() {
-        let mut authorship = Authorship::new();
-        authorship.record(PathBuf::from("src/main.rs"), 1);
-        assert_eq!(authorship.authors_for(Path::new("src/main.rs")), &[1]);
-        assert!(!authorship.has_multiple_authors(Path::new("src/main.rs")));
-    }
-
-    #[test]
-    fn recording_the_same_agent_twice_does_not_duplicate_it() {
-        let mut authorship = Authorship::new();
-        authorship.record(PathBuf::from("src/main.rs"), 1);
-        authorship.record(PathBuf::from("src/main.rs"), 1);
-        assert_eq!(authorship.authors_for(Path::new("src/main.rs")), &[1]);
-    }
-
-    #[test]
-    fn two_distinct_agents_writing_the_same_file_is_a_shared_file() {
-        let mut authorship = Authorship::new();
-        authorship.record(PathBuf::from("src/main.rs"), 1);
-        authorship.record(PathBuf::from("src/main.rs"), 9);
-        assert_eq!(authorship.authors_for(Path::new("src/main.rs")), &[1, 9]);
-        assert!(authorship.has_multiple_authors(Path::new("src/main.rs")));
-    }
-
-    #[test]
-    fn shared_file_count_only_counts_paths_with_more_than_one_author() {
-        let mut authorship = Authorship::new();
-        authorship.record(PathBuf::from("src/main.rs"), 1);
-        authorship.record(PathBuf::from("src/main.rs"), 9);
-        authorship.record(PathBuf::from("src/lib.rs"), 1);
-
-        let paths = [
-            PathBuf::from("src/main.rs"),
-            PathBuf::from("src/lib.rs"),
-            PathBuf::from("src/untouched.rs"),
-        ];
-        assert_eq!(
-            authorship.shared_file_count(paths.iter().map(PathBuf::as_path)),
-            1
-        );
-    }
-
-    #[test]
-    fn different_paths_never_share_recorded_authors() {
-        let mut authorship = Authorship::new();
-        authorship.record(PathBuf::from("src/main.rs"), 1);
-        assert!(authorship.authors_for(Path::new("src/other.rs")).is_empty());
-    }
-
-    #[test]
-    fn file_count_for_only_counts_paths_this_agent_authored() {
-        let mut authorship = Authorship::new();
-        authorship.record(PathBuf::from("src/main.rs"), 1);
-        authorship.record(PathBuf::from("src/main.rs"), 9);
-        authorship.record(PathBuf::from("src/lib.rs"), 1);
-        authorship.record(PathBuf::from("src/other.rs"), 9);
-
-        let paths = [
-            PathBuf::from("src/main.rs"),
-            PathBuf::from("src/lib.rs"),
-            PathBuf::from("src/other.rs"),
-            PathBuf::from("src/untouched.rs"),
-        ];
-        assert_eq!(
-            authorship.file_count_for(1, paths.iter().map(PathBuf::as_path)),
-            2,
-            "agent 1 wrote main.rs and lib.rs, not other.rs or untouched.rs"
-        );
-        assert_eq!(
-            authorship.file_count_for(9, paths.iter().map(PathBuf::as_path)),
-            2,
-            "agent 9 wrote main.rs and other.rs, not lib.rs or untouched.rs"
-        );
-        assert_eq!(
-            authorship.file_count_for(42, paths.iter().map(PathBuf::as_path)),
-            0,
-            "an agent with no recorded authorship anywhere gets a real 0, not a stray match"
         );
     }
 

--- a/crates/app/src/sidebar/mod.rs
+++ b/crates/app/src/sidebar/mod.rs
@@ -31,7 +31,7 @@
 use crate::root::*;
 use crate::sidebar::file_tree::{FileTreeEntry, LangChip};
 use crate::theme;
-use crate::work_surface::agents::{AgentId, AgentKind};
+use crate::work_surface::agents::AgentKind;
 use crate::work_surface::state as work_surface;
 use gpui::{div, font, prelude::*, px, uniform_list, ClickEvent, Context, Pixels, Window};
 use std::collections::{HashMap, HashSet};

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -1740,9 +1740,8 @@ impl AdeApp {
         column.into_any_element()
     }
 
-    /// One Changes row: a staging checkbox, `dir`/`name`, a `flex:none` per-author chip group
-    /// (Revision R12 §5, multi-agent worktrees only - see [`Self::render_change_author_chips`]),
-    /// an optional tag pill, `+n`/`−n`, and the five-segment stat bar. Clicking anywhere on the
+    /// One Changes row: a staging checkbox, `dir`/`name`, an optional tag pill, `+n`/`−n`, and
+    /// the five-segment stat bar. Clicking anywhere on the
     /// row other than the checkbox itself (see [`Self::render_staging_checkbox`]'s
     /// `stop_propagation`) opens the file's diff via [`Self::open_change_diff`] - the checkbox
     /// **is** staging, not "reviewed": it has its own click target, entirely separate from the
@@ -1774,7 +1773,6 @@ impl AdeApp {
         let (dir, name) = changes::split_dir_name(&file.path);
         let tag = changes::change_tag(file.status);
         let segments = changes::stat_bar_segments(add, del);
-        let author_chips = self.render_change_author_chips(&file.path);
 
         // See `Self::render_file_tree_row`'s own `debug_selector` for why this exists, and why
         // the closure borrows `file` instead of capturing an owned `String`.
@@ -1846,7 +1844,6 @@ impl AdeApp {
                     })
                     .child(name),
             )
-            .when_some(author_chips, |el, chips| el.child(chips))
             .when_some(tag, |el, tag| el.child(render_tag_pill(tag)))
             // Alongside `tag`, never instead of it: a file added by a commit on this branch is
             // genuinely both `new` (relative to the base) and `committed`.
@@ -1874,68 +1871,6 @@ impl AdeApp {
                     .child(format!("\u{2212}{del}")),
             )
             .child(render_stat_bar(segments))
-    }
-
-    /// The Changes row's `flex:none` per-file author chip group (Revision R12 §5): one
-    /// [`render_change_author_chip`] per agent [`AdeApp::file_authorship`] records as having
-    /// written this file, with a 1px amber ring (`theme::status::ASK_CARD_EDGE`) once it has more
-    /// than one. `None` (never an empty-but-present group) unless the currently selected
-    /// worktree has more than one agent - [`Self::current_worktree_agent_count`] is this
-    /// gate, per the design's own reasoning: with a single agent every chip would be identical
-    /// and carry no information.
-    ///
-    /// `file_authorship` is real, wired data (`crate::sidebar::changes::Authorship::authors_for`)
-    /// that today is always empty - the heuristic that records edits into it lives on a separate,
-    /// not-yet-merged branch (see [`crate::root::AdeApp::file_authorship`]'s own docs) - so a
-    /// multi-agent worktree renders a real, ringless, chip-less group until that heuristic lands,
-    /// rather than fabricating a chip for an agent nobody recorded.
-    pub(in crate::sidebar) fn render_change_author_chips(
-        &self,
-        path: &Path,
-    ) -> Option<impl IntoElement> {
-        if self.current_worktree_agent_count() <= 1 {
-            return None;
-        }
-        let ring: gpui::Rgba = if self.file_authorship.has_multiple_authors(path) {
-            theme::status::ASK_CARD_EDGE.into()
-        } else {
-            work_surface::TRANSPARENT
-        };
-        let mut group = div()
-            .flex_none()
-            .flex()
-            .gap(px(2.0))
-            .p(px(1.0))
-            .rounded(theme::radius::BUTTON)
-            .border_1()
-            .border_color(ring);
-        for &id in self.file_authorship.authors_for(path) {
-            if let Some(kind) = self.agent_kind_for(id) {
-                group = group.child(render_change_author_chip(kind));
-            }
-        }
-        Some(group)
-    }
-
-    /// Resolves a recorded author's [`AgentKind`] for chip tinting - `None` if that agent has
-    /// since closed (its process exited, its tab closed), in which case
-    /// [`Self::render_change_author_chips`] simply omits the chip rather than guessing a kind for
-    /// an agent that no longer exists.
-    fn agent_kind_for(&self, id: AgentId) -> Option<AgentKind> {
-        self.agents
-            .iter()
-            .find(|agent| agent.id == id)
-            .map(|agent| agent.kind)
-    }
-
-    /// How many distinct agent (non-`Shell`) processes are running in the currently selected
-    /// worktree - Revision R12 §5's gate for the Changes row author chip group. Reuses
-    /// [`Self::current_worktree_agents`] (`crate::work_surface::render`) so this and the tab
-    /// strip can never disagree about which agents belong to the selected worktree.
-    pub(in crate::sidebar) fn current_worktree_agent_count(&self) -> usize {
-        self.current_worktree_agents()
-            .filter(|agent| agent.kind != AgentKind::Shell)
-            .count()
     }
 
     /// The Changes row's 12×12 staging checkbox (Revision R12 §5: the checkbox **is** staging,
@@ -2551,31 +2486,6 @@ fn render_commit_menu_row(label: &'static str, sub: String) -> impl IntoElement 
                 .text_color(theme::text::FAINTER)
                 .child(sub),
         )
-}
-
-/// One author chip in a Changes row's chip group (Revision R12 §5) - the same 13×13 visual
-/// template `Self::render_lang_chip` uses for the file tree's language chip
-/// (`crate::sidebar::file_tree::LangChip`), tinted per-agent via
-/// `work_surface::agent_tint`/`work_surface::agent_initial` (`work_surface::state`'s existing
-/// per-agent colour convention, already the tab strip's own source of truth) rather than a
-/// second, independently-tinted chip style.
-pub(in crate::sidebar) fn render_change_author_chip(kind: AgentKind) -> impl IntoElement {
-    let (fg, bg) = work_surface::agent_tint(kind);
-    let initial = work_surface::agent_initial(kind);
-    div()
-        .flex_none()
-        .w(px(13.0))
-        .h(px(13.0))
-        .rounded(theme::radius::CHIP)
-        .bg(bg)
-        .flex()
-        .items_center()
-        .justify_center()
-        .font(font(theme::font::MONO))
-        .font_weight(gpui::FontWeight::MEDIUM)
-        .text_size(px(7.5))
-        .text_color(fg)
-        .child(initial)
 }
 
 /// Which data source the right sidebar currently shows for the selected worktree - Zone 3's

--- a/crates/app/src/work_surface/agents.rs
+++ b/crates/app/src/work_surface/agents.rs
@@ -17,7 +17,7 @@
 //! docs for why it must also move real keyboard focus in the same step.
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::time::Instant;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use gpui::{App, AppContext as _, Context, Entity, Focusable as _, Subscription, Window};
 
@@ -93,6 +93,20 @@ pub struct Agent {
     /// pause/resume-with-a-fresh-clock concept (see `crate::work_surface::state::pty_state_label`'s
     /// docs), so "elapsed" is simply wall-clock time since this real process was spawned.
     pub spawned_at: Instant,
+    /// The same spawn moment as [`Self::spawned_at`], but as real wall-clock seconds since the
+    /// Unix epoch - set from the identical call site, at the identical instant.
+    ///
+    /// Both exist because they answer genuinely different questions and neither can answer the
+    /// other's. [`Instant`] is monotonic, which is exactly right for "how long has this been
+    /// running" (the rail's elapsed text) and exactly wrong for identity: it has no meaning
+    /// outside this process, and cannot be converted to a wall-clock time at all. This field is
+    /// the durable half - part of the key a persisted review baseline is filed under
+    /// (`crate::review::state::baseline_key`), since [`AgentId`] is a per-window counter that
+    /// restarts at zero on every launch and so cannot key anything expected to outlive one.
+    ///
+    /// See `crate::review::baseline_state`'s own module docs for what that persistence can and
+    /// cannot do today.
+    pub spawned_at_unix: i64,
     /// Keeps [`Agents::spawn`]'s link-click-opens-a-file subscription (see
     /// [`TerminalPaneEvent`]) alive for this agent's lifetime - never read, only held.
     _link_subscription: Subscription,
@@ -136,6 +150,42 @@ impl Agents {
     /// as long as `self` - it owns its own copy instead, closed over by the filter closure.
     pub fn iter_for_cwd(&self, cwd: PathBuf) -> impl Iterator<Item = &Agent> {
         self.agents.iter().filter(move |agent| agent.cwd == cwd)
+    }
+
+    /// How many agents are currently open in `cwd` - the real signal behind GitHub issue #225's
+    /// **single-agent gate**.
+    ///
+    /// The whole review surface (the Review tab, the footer's `Review diff` door, and the rail's
+    /// review-ready status) is held back for any worktree with more than one open agent, because
+    /// real per-agent attribution does not exist yet: with two agents sharing a worktree, an
+    /// agent's review diff would honestly include changes the *other* one made, and this app
+    /// would have no way to tell them apart. Presenting that as "this agent's review" would be a
+    /// fabrication, so it shows nothing at all until the worktree is back down to one agent.
+    ///
+    /// Deliberately a **decision-time** check, not a capture-time one: a baseline is still
+    /// captured for every agent regardless of how many share its worktree (it's cheap, and it
+    /// means the surface simply starts working - correctly, against a real baseline taken at the
+    /// right moment - the instant the others close). Only *display* is gated.
+    ///
+    /// Reads through [`Self::iter_for_cwd`] rather than open-coding the filter, so the tab
+    /// strip's own per-worktree scoping and this gate can never disagree about which agents
+    /// belong to a worktree.
+    pub fn count_for_cwd(&self, cwd: &Path) -> usize {
+        self.iter_for_cwd(cwd.to_path_buf()).count()
+    }
+
+    /// `true` if `id` names an agent that is the **only** one currently open in its own
+    /// worktree: the review surface's real gate, in the one form every call site wants. `false`
+    /// for an
+    /// unknown id (e.g. a just-closed agent), so a stale click handler can never re-open a review
+    /// surface for an agent that no longer exists.
+    ///
+    /// See [`Self::count_for_cwd`] for why this gate exists at all.
+    pub fn is_sole_agent_in_worktree(&self, id: AgentId) -> bool {
+        let Some(agent) = self.agents.iter().find(|agent| agent.id == id) else {
+            return false;
+        };
+        self.count_for_cwd(&agent.cwd) == 1
     }
 
     pub fn active_id(&self) -> Option<AgentId> {
@@ -194,6 +244,7 @@ impl Agents {
             cwd: cwd.clone(),
             pane,
             spawned_at: Instant::now(),
+            spawned_at_unix: unix_now(),
             _link_subscription: link_subscription,
         });
         self.active = Some(id);
@@ -356,6 +407,16 @@ impl Agents {
         }
         self.sync_pane_cadence(cx);
     }
+}
+
+/// Real wall-clock seconds since the Unix epoch, for [`Agent::spawned_at_unix`]. Mirrors
+/// `crate::graph_view::render::unix_now` exactly, including its `unwrap_or(0)` for a system clock
+/// somehow set before 1970 - a nonsense clock shouldn't stop an agent from spawning.
+fn unix_now() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_secs() as i64)
+        .unwrap_or(0)
 }
 
 impl Default for Agents {

--- a/crates/app/src/work_surface/agents.rs
+++ b/crates/app/src/work_surface/agents.rs
@@ -314,6 +314,20 @@ impl Agents {
         id
     }
 
+    /// Test-only: overrides an already-spawned agent's recorded [`ProcessKind`] without
+    /// touching its real process. Exists for tests that need to exercise kind-gated logic (e.g.
+    /// `crate::review::flow::AdeApp::capture_review_baseline`'s real-agent-only gate) without
+    /// paying for an actual `claude`/`codex` CLI spawn - `ProcessKind::spec` only affects which
+    /// binary [`Self::spawn`] execs, so retagging after the fact is honest: everything
+    /// downstream of the recorded `kind` field behaves exactly as if a real agent CLI had been
+    /// spawned, without the process weight of one.
+    #[cfg(test)]
+    pub(crate) fn set_kind_for_test(&mut self, id: AgentId, kind: ProcessKind) {
+        if let Some(agent) = self.agents.iter_mut().find(|agent| agent.id == id) {
+            agent.kind = kind;
+        }
+    }
+
     /// Re-derives every open pane's poll cadence from [`Self::active`]: exactly the active
     /// agent's pane is foreground (`TerminalPane::set_foreground`), every other pane is
     /// background. Called at the end of **every** mutator that can change which agent is

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -250,6 +250,14 @@ impl AdeApp {
         // *after* `set_active` above: its `restore_focus` fallback resolves to
         // `Self::agents.active()`, which by this point is already the agent just selected.
         self.leave_graph_tab(window, cx);
+        // GitHub issue #225: the review tab occupies the centre pane exactly as the graph tab
+        // does, so it needs the identical teardown here. Without this, `review_tab_active` stayed
+        // set, `render_center_pane` kept returning the review body, and the tab this call is
+        // switching *to* never mounted at all - while real focus had already moved onto it. Found
+        // by an adversarial audit; the review surface's own docs claimed to copy the graph tab's
+        // discipline and, in exactly this way, did not.
+        self.leave_review_tab(window, cx);
+
         let had_open_file_tab = self.open_change.is_some();
         if had_open_file_tab {
             self.open_change = None;

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -77,7 +77,7 @@ impl AdeApp {
             return;
         }
         let cwd = self.active_agent_cwd();
-        self.agents.spawn(
+        let id = self.agents.spawn(
             kind,
             cwd,
             self.settings.appearance.terminal_font_size,
@@ -85,6 +85,19 @@ impl AdeApp {
             window,
             cx,
         );
+        // GitHub issue #225: capture this agent's review baseline - a real snapshot of the
+        // worktree exactly as it stands right now, so "what has this agent changed" has a real
+        // base point to be measured against. Hooked here, at `Agents::spawn`'s caller rather than
+        // inside `Agents` itself, for the same reason `load_diff` is triggered by its caller:
+        // `Agents` owns processes and tabs, not git snapshots. See
+        // `crate::review::flow::AdeApp::capture_review_baseline` for the small, accepted race
+        // between the process starting and the snapshot landing.
+        self.capture_review_baseline(id, cx);
+        // A second agent in this worktree closes the single-agent gate on every agent already
+        // there, so a review tab open for one of them must really close now - see
+        // `crate::review::render::AdeApp::close_gated_review_tab` for why this is a real close
+        // rather than just dropping the tab from the strip.
+        self.close_gated_review_tab(window, cx);
         self.focus_newly_spawned_agent(window, cx);
         self.prune_confirm_armed = false;
         self.discard_confirm_armed = None;
@@ -311,12 +324,19 @@ impl AdeApp {
         } else {
             status::ProcessSignal::NoProcess
         };
-        let has_diff = self
-            .diff_cache
-            .get(&agent.cwd)
-            .map(|summary| summary.has_changes)
-            .unwrap_or(false);
-        status::derive_status(agent.kind, signal, has_diff)
+        // GitHub issue #225: what makes an exited agent "review ready" is now whether *it* has a
+        // real, unreviewed diff against *its own* baseline - not whether its worktree's branch
+        // differs from the default branch, which is a different question and was producing a
+        // genuinely wrong answer: an agent that changed nothing, in a worktree whose branch had
+        // already diverged from `main`, was reported `Review ready` off the back of the branch's
+        // diff. `derive_status` itself is unchanged - only the fact fed into it is.
+        //
+        // Also carries the single-agent gate (see `Self::review_available_for`): in a worktree
+        // with more than one open agent this is always `false`, so no agent there claims review
+        // readiness it can't honestly substantiate. Such an agent lands on `Idle` instead, which
+        // is the same state it would show with an empty review.
+        let has_unreviewed_changes = self.agent_has_unreviewed_changes(agent.id);
+        status::derive_status(agent.kind, signal, has_unreviewed_changes)
     }
 
     /// The context bar's and idle-status footer's `Archive` action - closes the tab via
@@ -368,6 +388,14 @@ impl AdeApp {
         // one was not.
         let skip_focus_move =
             self.open_change.is_some() || self.settings_open || self.graph_tab_active;
+        // GitHub issue #225: close this agent's review tab (if it's the one open) and release its
+        // baseline ref, *before* `Agents::close` removes the agent - `release_review_baseline`
+        // needs to still be able to look up which worktree to run `git update-ref -d` in. The
+        // persisted metadata entry deliberately survives; see that method's own docs.
+        if self.review_tab_open == Some(id) {
+            self.close_review_tab(window, cx);
+        }
+        self.release_review_baseline(id, cx);
         self.agents.close(id, skip_focus_move, window, cx);
         if self
             .merge_flow
@@ -509,6 +537,7 @@ impl AdeApp {
             &agent_ids,
             self.open_files(),
             self.graph_tab_open,
+            self.review_tab_open,
         )
     }
 
@@ -540,7 +569,9 @@ impl AdeApp {
             .iter()
             .filter_map(|tab_ref| match tab_ref {
                 work_surface::TabRef::File(path) => Some(cwd.join(path)),
-                work_surface::TabRef::Agent(_) | work_surface::TabRef::Graph => None,
+                work_surface::TabRef::Agent(_)
+                | work_surface::TabRef::Graph
+                | work_surface::TabRef::Review(_) => None,
             })
             .collect();
         self.tab_order_state.set_file_order(&cwd, &files);
@@ -673,7 +704,9 @@ impl AdeApp {
         let order = self.combined_tab_order();
         order.into_iter().filter_map(move |tab_ref| match tab_ref {
             work_surface::TabRef::Agent(id) => self.agents.iter().find(|agent| agent.id == id),
-            work_surface::TabRef::File(_) | work_surface::TabRef::Graph => None,
+            work_surface::TabRef::File(_)
+            | work_surface::TabRef::Graph
+            | work_surface::TabRef::Review(_) => None,
         })
     }
 
@@ -767,7 +800,9 @@ impl AdeApp {
             .iter()
             .filter_map(|tab_ref| match tab_ref {
                 work_surface::TabRef::Agent(id) => Some(*id),
-                work_surface::TabRef::File(_) | work_surface::TabRef::Graph => None,
+                work_surface::TabRef::File(_)
+                | work_surface::TabRef::Graph
+                | work_surface::TabRef::Review(_) => None,
             })
             .collect();
         let labels = self.current_worktree_agent_tab_labels(&agent_ids, cx);
@@ -792,6 +827,11 @@ impl AdeApp {
                 // render_graph_tab`'s own docs for the drag wiring this required.
                 work_surface::TabRef::Graph => {
                     bar = bar.child(crate::graph_view::render::render_graph_tab(self, cx));
+                }
+                // GitHub issue #225: the agent review tab, a full member of the same combined,
+                // draggable order every other kind already goes through.
+                work_surface::TabRef::Review(id) => {
+                    bar = bar.child(crate::review::render::render_review_tab(self, id, cx));
                 }
             }
         }
@@ -2072,6 +2112,16 @@ impl AdeApp {
             {
                 enabled = false;
             }
+            // GitHub issue #225's single-agent gate, applied to the footer door: `Review` is real
+            // backing logic (`implemented: true`), but it is only *offerable* when this agent
+            // really has a baseline and is the sole agent in its worktree. Disabled rather than
+            // hidden, so the row doesn't shift around as agents come and go - and disabled here
+            // means genuinely inert (`Self::render_footer_action_button` drops
+            // `cursor_pointer`/hover/`on_click` entirely), never a clickable-looking no-op.
+            if action.kind == work_surface::ActionKind::OpenReview && !self.review_available_for(id)
+            {
+                enabled = false;
+            }
             // `Keep all`/`Discard worktree` (Revision R10) share one in-flight guard
             // (`Self::worktree_history_op_in_flight`) - see `crate::worktree_history::flow`'s own
             // module docs for why one flag is enough discipline here. Disabled, not just
@@ -2206,6 +2256,9 @@ impl AdeApp {
                         work_surface::ActionKind::DiscardWorktree => {
                             this.request_discard_worktree(id, window, cx)
                         }
+                        work_surface::ActionKind::OpenReview => {
+                            this.open_review_tab(id, window, cx)
+                        }
                         work_surface::ActionKind::Unimplemented => {}
                     }),
                 );
@@ -2242,6 +2295,15 @@ impl AdeApp {
             .h_full()
             .bg(theme::surface::CENTER)
             .child(self.render_tab_strip(cx));
+
+        // GitHub issue #225: the review tab occupies the centre pane exactly as the graph tab
+        // does. Checked first because `open_review_tab` always leaves the graph tab on its way in,
+        // so the two flags are never both set - the order only matters as a defence against a
+        // future path that forgets that.
+        if self.review_tab_active {
+            let body = self.render_review_view(cx);
+            return surface.child(body).into_any_element();
+        }
 
         if self.graph_tab_active {
             let body = self.render_graph_view(cx);
@@ -2487,6 +2549,12 @@ pub(crate) enum DraggedTab {
     Graph {
         label: String,
     },
+    /// GitHub issue #225 - the agent review tab. Carries the agent id it reviews, since (unlike
+    /// the graph tab) a review is always *of* a specific agent.
+    Review {
+        id: AgentId,
+        label: String,
+    },
 }
 
 impl DraggedTab {
@@ -2495,6 +2563,7 @@ impl DraggedTab {
             DraggedTab::Agent { label, .. } => label,
             DraggedTab::File { label, .. } => label,
             DraggedTab::Graph { label } => label,
+            DraggedTab::Review { label, .. } => label,
         }
     }
 
@@ -2505,6 +2574,7 @@ impl DraggedTab {
             DraggedTab::Agent { id, .. } => work_surface::TabRef::Agent(*id),
             DraggedTab::File { path, .. } => work_surface::TabRef::File(path.clone()),
             DraggedTab::Graph { .. } => work_surface::TabRef::Graph,
+            DraggedTab::Review { id, .. } => work_surface::TabRef::Review(*id),
         }
     }
 }

--- a/crates/app/src/work_surface/state.rs
+++ b/crates/app/src/work_surface/state.rs
@@ -31,6 +31,11 @@ pub enum TabRef {
     Agent(AgentId),
     File(PathBuf),
     Graph,
+    /// The agent review tab (GitHub issue #225), for the agent it reviews. Unlike `Graph` this
+    /// carries a payload, because a review is inherently *per agent* - that is the entire point
+    /// of the feature - even though, like `Graph`, at most one is open per window at a time
+    /// (`crate::root::AdeApp::review_tab_open`).
+    Review(AgentId),
 }
 
 /// Reconciles a worktree's stored tab order (`crate::root::AdeApp::tab_order`) against what's
@@ -55,13 +60,21 @@ pub fn reconcile_tab_order(
     agents_for_cwd: &[AgentId],
     open_files: &[PathBuf],
     graph_open: bool,
+    review_open: Option<AgentId>,
 ) -> Vec<TabRef> {
+    // GitHub issue #225: a review tab is live only when it's really open *and* the agent it
+    // reviews is one of this worktree's own agents. Both halves matter: the first drops a closed
+    // review tab exactly like every other kind, and the second keeps another worktree's review
+    // tab out of this worktree's strip - `review_open` is a single window-wide slot (like
+    // `graph_open`), but unlike the graph tab a review genuinely belongs to one worktree.
+    let review_live = |id: &AgentId| review_open == Some(*id) && agents_for_cwd.contains(id);
     let mut order: Vec<TabRef> = stored
         .iter()
         .filter(|tab_ref| match tab_ref {
             TabRef::Agent(id) => agents_for_cwd.contains(id),
             TabRef::File(path) => open_files.contains(path),
             TabRef::Graph => graph_open,
+            TabRef::Review(id) => review_live(id),
         })
         .cloned()
         .collect();
@@ -83,6 +96,11 @@ pub fn reconcile_tab_order(
     }
     if graph_open && !order.contains(&TabRef::Graph) {
         order.push(TabRef::Graph);
+    }
+    if let Some(id) = review_open {
+        if review_live(&id) && !order.contains(&TabRef::Review(id)) {
+            order.push(TabRef::Review(id));
+        }
     }
     order
 }
@@ -385,8 +403,20 @@ pub enum ActionKind {
     /// action that force-removes a worktree, preserving uncommitted/untracked content in a real
     /// git stash first).
     DiscardWorktree,
-    /// No backing logic exists yet (git-level review/editor-surface workflows) - always rendered
-    /// disabled regardless of [`FooterAction::implemented`] (always `false` for these).
+    /// GitHub issue #225: opens this agent's **review** tab
+    /// (`crate::review::render::AdeApp::open_review_tab`) - what has changed since this agent
+    /// started, or since the user last marked it reviewed. Deliberately not a second door: this
+    /// row has existed as [`ActionKind::Unimplemented`] since the original design, waiting for
+    /// exactly this feature, and was wired up rather than replaced.
+    ///
+    /// Real, but *conditionally* so: the render call site disables it whenever
+    /// `crate::review::flow::AdeApp::review_available_for` is false (no baseline captured yet, or
+    /// more than one agent open in this worktree - see that method's docs), the same
+    /// state-dependent enablement layered on top of [`FooterAction::implemented`] that
+    /// [`ActionKind::Respawn`] already uses.
+    OpenReview,
+    /// No backing logic exists yet (the editor-surface workflow) - always rendered disabled
+    /// regardless of [`FooterAction::implemented`] (always `false` for these).
     Unimplemented,
 }
 
@@ -437,11 +467,14 @@ pub fn footer_actions(status: Status) -> Vec<FooterAction> {
                 implemented: true,
             },
             FooterAction {
-                kind: ActionKind::Unimplemented,
-                label: "Review diff",
+                kind: ActionKind::OpenReview,
+                // "Review", not "Review diff" (GitHub issue #225): this door leads to the
+                // agent-review surface, and "diff" is the git side's word - see
+                // `crate::review`'s own module docs on the enforced vocabulary split.
+                label: "Review",
                 keycap: None,
                 style: ActionStyle::Outline,
-                implemented: false,
+                implemented: true,
             },
             FooterAction {
                 kind: ActionKind::Unimplemented,
@@ -640,21 +673,45 @@ mod tests {
         );
     }
 
+    /// GitHub issue #225 promoted the review row from a permanently-disabled placeholder to a
+    /// real door into the agent review surface. `Open in editor` is the only row in this strip
+    /// with no backing logic left.
     #[test]
-    fn review_actions_keep_all_and_discard_are_real_review_diff_and_open_in_editor_are_not() {
+    fn every_review_footer_action_except_open_in_editor_now_has_real_backing() {
         let actions = footer_actions(Status::Review);
         for action in &actions {
-            let should_be_implemented = matches!(
-                action.kind,
-                ActionKind::KeepAllChanges | ActionKind::DiscardWorktree
-            );
+            let should_be_implemented = !matches!(action.kind, ActionKind::Unimplemented);
             assert_eq!(
                 action.implemented, should_be_implemented,
-                "{} implemented={} - Revision R10 gave Keep all/Discard worktree real backing, \
-                 Review diff/Open in editor still have none",
+                "{} implemented={} - only `Open in editor` should still be unimplemented",
                 action.label, action.implemented
             );
         }
+        let unimplemented: Vec<&str> = actions
+            .iter()
+            .filter(|action| !action.implemented)
+            .map(|action| action.label)
+            .collect();
+        assert_eq!(unimplemented, vec!["Open in editor"]);
+    }
+
+    /// The review door must be a real [`ActionKind::OpenReview`], not the old placeholder - and
+    /// it must not say "diff", which is the git side's word (see `crate::review`'s module docs on
+    /// the enforced vocabulary split).
+    #[test]
+    fn the_review_footer_door_is_real_and_never_says_diff() {
+        let actions = footer_actions(Status::Review);
+        let review = actions
+            .iter()
+            .find(|action| action.kind == ActionKind::OpenReview)
+            .expect("the Review status footer must offer a real review door");
+        assert!(review.implemented);
+        assert_eq!(review.label, "Review");
+        assert!(
+            !review.label.to_lowercase().contains("diff"),
+            "the review door must not use the git side's own word - got {:?}",
+            review.label
+        );
     }
 
     #[test]
@@ -788,6 +845,7 @@ mod tests {
             &[1, 2],
             &[PathBuf::from("a.rs"), PathBuf::from("b.rs")],
             false,
+            None,
         );
         assert_eq!(
             order,
@@ -810,7 +868,7 @@ mod tests {
             TabRef::File(PathBuf::from("a.rs")),
             TabRef::Agent(2),
         ];
-        let order = reconcile_tab_order(&stored, &[1, 2], &[PathBuf::from("a.rs")], false);
+        let order = reconcile_tab_order(&stored, &[1, 2], &[PathBuf::from("a.rs")], false, None);
         assert_eq!(order, stored);
     }
 
@@ -824,7 +882,7 @@ mod tests {
             TabRef::File(PathBuf::from("a.rs")),
             TabRef::Agent(2),
         ];
-        let order = reconcile_tab_order(&stored, &[2], &[], false);
+        let order = reconcile_tab_order(&stored, &[2], &[], false, None);
         assert_eq!(order, vec![TabRef::Agent(2)]);
     }
 
@@ -833,7 +891,7 @@ mod tests {
     #[test]
     fn reconcile_appends_newly_opened_tabs_not_yet_in_the_stored_order() {
         let stored = vec![TabRef::Agent(1)];
-        let order = reconcile_tab_order(&stored, &[1, 2], &[PathBuf::from("a.rs")], false);
+        let order = reconcile_tab_order(&stored, &[1, 2], &[PathBuf::from("a.rs")], false, None);
         assert_eq!(
             order,
             vec![
@@ -849,7 +907,7 @@ mod tests {
     /// gets, not silently dropped or given a hardcoded fixed position.
     #[test]
     fn reconcile_appends_a_freshly_opened_graph_tab() {
-        let order = reconcile_tab_order(&[], &[1], &[], true);
+        let order = reconcile_tab_order(&[], &[1], &[], true, None);
         assert_eq!(order, vec![TabRef::Agent(1), TabRef::Graph]);
     }
 
@@ -859,7 +917,7 @@ mod tests {
     #[test]
     fn reconcile_preserves_a_stored_graph_tab_position() {
         let stored = vec![TabRef::Graph, TabRef::Agent(1)];
-        let order = reconcile_tab_order(&stored, &[1], &[], true);
+        let order = reconcile_tab_order(&stored, &[1], &[], true, None);
         assert_eq!(order, stored);
     }
 
@@ -869,8 +927,49 @@ mod tests {
     #[test]
     fn reconcile_drops_a_closed_graph_tab() {
         let stored = vec![TabRef::Agent(1), TabRef::Graph];
-        let order = reconcile_tab_order(&stored, &[1], &[], false);
+        let order = reconcile_tab_order(&stored, &[1], &[], false, None);
         assert_eq!(order, vec![TabRef::Agent(1)]);
+    }
+
+    /// GitHub issue #225: a freshly opened review tab is appended like every other kind.
+    #[test]
+    fn reconcile_appends_a_freshly_opened_review_tab() {
+        let order = reconcile_tab_order(&[], &[1], &[], false, Some(1));
+        assert_eq!(order, vec![TabRef::Agent(1), TabRef::Review(1)]);
+    }
+
+    #[test]
+    fn reconcile_preserves_a_stored_review_tab_position() {
+        let stored = vec![TabRef::Review(1), TabRef::Agent(1)];
+        assert_eq!(
+            reconcile_tab_order(&stored, &[1], &[], false, Some(1)),
+            stored
+        );
+    }
+
+    #[test]
+    fn reconcile_drops_a_closed_review_tab() {
+        let stored = vec![TabRef::Agent(1), TabRef::Review(1)];
+        let order = reconcile_tab_order(&stored, &[1], &[], false, None);
+        assert_eq!(order, vec![TabRef::Agent(1)]);
+    }
+
+    /// A review tab whose agent has closed must be dropped even while `review_open` still names
+    /// it - otherwise the strip would keep rendering a tab for an agent that no longer exists,
+    /// exactly the dangling-entry class `reconcile_tab_order` exists to prevent.
+    #[test]
+    fn reconcile_drops_a_review_tab_whose_agent_is_gone() {
+        let stored = vec![TabRef::Review(7)];
+        assert!(reconcile_tab_order(&stored, &[], &[], false, Some(7)).is_empty());
+    }
+
+    /// The review tab belongs to *one* worktree's strip - the worktree its agent runs in. Another
+    /// worktree's strip must not show it, even though `review_open` is a single window-wide slot.
+    #[test]
+    fn a_review_tab_never_leaks_into_another_worktrees_strip() {
+        // Worktree B's strip: its own agent 2 is open, but the review is for agent 1 (worktree A).
+        let order = reconcile_tab_order(&[], &[2], &[], false, Some(1));
+        assert_eq!(order, vec![TabRef::Agent(2)]);
     }
 
     /// The real cross-kind drag this revision exists to unlock: dropping a file tab so it lands

--- a/crates/wt-core/Cargo.toml
+++ b/crates/wt-core/Cargo.toml
@@ -12,3 +12,9 @@ thiserror = { workspace = true }
 # Used at runtime (not just in tests) by `diff::prepare_shadow_index` to build a throwaway
 # copy of the real index for `git diff`'s untracked-file handling - see that function's docs.
 tempfile = "3"
+# Fixed-length, collision-free ref-name components for `review::baseline_ref_name`. Raw hex
+# encoding of the key doubled its length and pushed real, ordinary worktree paths past the
+# filesystem's 255-byte `NAME_MAX` for a loose ref's filename, which failed baseline capture
+# outright. Already present in this workspace's lockfile via other dependencies, so this adds no
+# new crate to the build graph.
+sha2 = "0.10"

--- a/crates/wt-core/src/diff.rs
+++ b/crates/wt-core/src/diff.rs
@@ -217,6 +217,7 @@ pub fn diff_against_base(worktree_path: &Path) -> Result<DiffBase, Error> {
         let uncommitted = compute_diff(
             worktree_path,
             &worktree_head_sha,
+            ShadowIndexContent::IntentToAdd,
             worktree_branch.unwrap_or_default(),
         )?;
         return Ok(DiffBase::NoBase {
@@ -226,7 +227,12 @@ pub fn diff_against_base(worktree_path: &Path) -> Result<DiffBase, Error> {
     };
 
     if worktree_branch.as_deref() == Some(base_branch.as_str()) {
-        let uncommitted = compute_diff(worktree_path, &worktree_head_sha, base_branch.clone())?;
+        let uncommitted = compute_diff(
+            worktree_path,
+            &worktree_head_sha,
+            ShadowIndexContent::IntentToAdd,
+            base_branch.clone(),
+        )?;
         return Ok(DiffBase::NoBase {
             branch: Some(base_branch),
             uncommitted,
@@ -239,7 +245,12 @@ pub fn diff_against_base(worktree_path: &Path) -> Result<DiffBase, Error> {
             // A real default branch exists, but shares no common ancestor with this worktree's
             // history - still real uncommitted changes to show against `HEAD`, same as the
             // on-default-branch case just above.
-            let uncommitted = compute_diff(worktree_path, &worktree_head_sha, base_branch.clone())?;
+            let uncommitted = compute_diff(
+                worktree_path,
+                &worktree_head_sha,
+                ShadowIndexContent::IntentToAdd,
+                base_branch.clone(),
+            )?;
             return Ok(DiffBase::NoBase {
                 branch: Some(base_branch),
                 uncommitted,
@@ -248,7 +259,12 @@ pub fn diff_against_base(worktree_path: &Path) -> Result<DiffBase, Error> {
         Err(source) => return Err(Error::MergeBase(Box::new(source))),
     };
 
-    let diff = compute_diff(worktree_path, &merge_base_id.to_string(), base_branch)?;
+    let diff = compute_diff(
+        worktree_path,
+        &merge_base_id.to_string(),
+        ShadowIndexContent::IntentToAdd,
+        base_branch,
+    )?;
     Ok(DiffBase::Diff(diff))
 }
 
@@ -286,12 +302,13 @@ pub(crate) fn validate_object_id(id: &str, what: &str) -> Result<(), Error> {
 pub(crate) fn compute_diff(
     worktree_path: &Path,
     object_id: &str,
+    shadow_content: ShadowIndexContent,
     label_branch: String,
 ) -> Result<WorktreeDiff, Error> {
     let commit_sha = object_id;
     validate_object_id(commit_sha, "commit id")?;
 
-    let shadow_index = prepare_shadow_index(worktree_path, ShadowIndexContent::IntentToAdd)?;
+    let shadow_index = prepare_shadow_index(worktree_path, shadow_content)?;
 
     let args: Vec<OsString> = vec![
         // Global config overrides (`-c key=value`) must precede the subcommand for `git` to
@@ -713,7 +730,26 @@ pub(crate) enum ShadowIndexContent {
     /// only way to snapshot a working tree at all), but still only ever into the object database:
     /// the real index, working tree, `HEAD` and stash are as untouched as with `IntentToAdd`,
     /// because every mutation still goes through the same `GIT_INDEX_FILE` override.
+    ///
+    /// **Unbounded in the size of the untracked set**, which is why
+    /// [`crate::review::snapshot_worktree_tree`] measures that set before ever asking for this -
+    /// see [`crate::review::MAX_UNTRACKED_SNAPSHOT_BYTES`] and the real 19 GB worktree that
+    /// motivated the cap.
     FullContent,
+    /// `git add -u` - stages real content for **tracked** paths only (including deletions), and
+    /// never touches untracked files at all.
+    ///
+    /// The bounded fallback for a worktree whose untracked set is too large to hash into the
+    /// object database. Bounded by construction: every path it can write a blob for is already
+    /// in git's history, so the work is proportional to what the user has actually committed
+    /// rather than to whatever build output happens to be sitting in the directory.
+    ///
+    /// Known limitation: `git write-tree` refuses an index containing intent-to-add entries, and
+    /// unlike [`Self::FullContent`]'s `add -A` this flavour does not materialize them. A worktree
+    /// where the user has run a real `git add -N` therefore fails to snapshot through this path.
+    /// That surfaces as an ordinary error (the caller logs it and leaves the review surface
+    /// unavailable), not as a wrong answer.
+    TrackedOnly,
 }
 
 /// Builds a temporary, throwaway copy of the worktree's index with untracked files added,
@@ -813,10 +849,17 @@ pub(crate) fn prepare_shadow_index(
     }
 
     let mut add_args: Vec<OsString> = vec!["add".into()];
-    if content == ShadowIndexContent::IntentToAdd {
-        add_args.push("--intent-to-add".into());
+    match content {
+        ShadowIndexContent::IntentToAdd => {
+            add_args.push("--intent-to-add".into());
+            add_args.push("-A".into());
+        }
+        ShadowIndexContent::FullContent => add_args.push("-A".into()),
+        // `-u` restricts the update to paths git already tracks, so no untracked file's content
+        // can reach the object database through this flavour - see its own docs.
+        ShadowIndexContent::TrackedOnly => add_args.push("-u".into()),
     }
-    add_args.extend([OsString::from("-A"), "--".into(), ".".into()]);
+    add_args.extend([OsString::from("--"), ".".into()]);
     let output = git_command(worktree_path, &add_args)
         .env("GIT_INDEX_FILE", shadow.path())
         .output()

--- a/crates/wt-core/src/diff.rs
+++ b/crates/wt-core/src/diff.rs
@@ -78,7 +78,7 @@ use crate::{check_success, format_args, git_command, open_repo, run_git};
 /// (thousands of changed lines, or a huge generated file slipping past `.gitignore`) is
 /// truncated rather than buffered without bound or left to hang the read loop; see
 /// [`WorktreeDiff::truncated`].
-const MAX_DIFF_OUTPUT_BYTES: usize = 2 * 1024 * 1024;
+pub(crate) const MAX_DIFF_OUTPUT_BYTES: usize = 2 * 1024 * 1024;
 
 /// Cap on how many changed files are kept from a single diff. Mirrors the "cap the loaded
 /// data, independent of what's rendered" approach `file_tree::build_file_tree` uses.
@@ -252,27 +252,46 @@ pub fn diff_against_base(worktree_path: &Path) -> Result<DiffBase, Error> {
     Ok(DiffBase::Diff(diff))
 }
 
-/// Runs `git diff <commit_sha>` against the worktree's real working tree (see the module docs'
+/// Defensive validation for an object id about to be handed to a spawned `git` process as a
+/// bare argument: it must be a non-empty, all-ASCII-hex string, so it can never be misparsed as
+/// a flag or as revision syntax. Every in-crate caller produces these from a real `gix` object
+/// id (or from `git write-tree`'s own stdout), but re-checking costs nothing and means a future
+/// change to how one is derived can't silently turn into a git-argument injection.
+///
+/// Deliberately does **not** pin a length (40 for SHA-1, 64 for SHA-256): a repository's hash
+/// algorithm is the repository's business, and hardcoding today's two lengths here would be a
+/// latent failure for a future one without buying anything the hex-only check doesn't already.
+///
+/// `pub(crate)` so [`crate::review`]'s own tree-id arguments go through this exact check rather
+/// than a second, drifting copy of it.
+pub(crate) fn validate_object_id(id: &str, what: &str) -> Result<(), Error> {
+    if id.is_empty() || !id.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(Error::WorktreeIo(std::io::Error::other(format!(
+            "{what} was not a hex object id"
+        ))));
+    }
+    Ok(())
+}
+
+/// Runs `git diff <object_id>` against the worktree's real working tree (see the module docs'
 /// "What the diff includes" section) and folds the result into a [`WorktreeDiff`]. `label_branch`
 /// is purely descriptive - the real base branch name for [`DiffBase::Diff`], or whatever branch
 /// name is available (possibly none) for the [`DiffBase::NoBase`] uncommitted-vs-`HEAD` fallback.
-fn compute_diff(
+///
+/// `object_id` is a commit id for every caller in this module, but `git diff <object>` resolves a
+/// **tree** id exactly the same way - it diffs that tree against the working tree either way - so
+/// [`crate::review::diff_against_tree`] reuses this function verbatim against a
+/// `git write-tree` snapshot rather than duplicating the invocation, the shadow index, the pinned
+/// config, and the parser. That is why this is `pub(crate)` rather than private.
+pub(crate) fn compute_diff(
     worktree_path: &Path,
-    commit_sha: &str,
+    object_id: &str,
     label_branch: String,
 ) -> Result<WorktreeDiff, Error> {
-    // Defensive: this is about to be handed to a spawned `git` process as an argument. Every
-    // caller just produced it from a real `gix` object id, but double-checking it's actually a
-    // hex string (rather than something that could be misparsed as a flag) costs nothing and
-    // means a future change to how it's derived can't silently turn into a git-argument
-    // injection.
-    if commit_sha.is_empty() || !commit_sha.bytes().all(|b| b.is_ascii_hexdigit()) {
-        return Err(Error::WorktreeIo(std::io::Error::other(
-            "commit id was not a hex object id",
-        )));
-    }
+    let commit_sha = object_id;
+    validate_object_id(commit_sha, "commit id")?;
 
-    let shadow_index = prepare_shadow_index(worktree_path)?;
+    let shadow_index = prepare_shadow_index(worktree_path, ShadowIndexContent::IntentToAdd)?;
 
     let args: Vec<OsString> = vec![
         // Global config overrides (`-c key=value`) must precede the subcommand for `git` to
@@ -551,7 +570,7 @@ const MAX_STDERR_BYTES: usize = 64 * 1024;
 /// `max_bytes`, the child is killed (rather than waited on to completion) and the second
 /// element of the returned tuple is `true` - mirrors [`super::is_dirty`]'s reasoning for not
 /// risking a blocked read against a pipe the child may still be filling.
-fn capture_git_stdout(
+pub(crate) fn capture_git_stdout(
     dir: &Path,
     args: &[OsString],
     max_bytes: usize,
@@ -677,29 +696,55 @@ fn read_streams_concurrently(
     Ok((buf, truncated, stderr_text))
 }
 
-/// Builds a temporary, throwaway copy of the worktree's index with untracked files added as
-/// "intent to add" stubs (`git add --intent-to-add`), so `git diff <merge-base>` - which
-/// only ever considers paths already present in the index or in `<merge-base>`'s tree (see
-/// the module docs' "What the diff includes" section) - picks up new, unstaged files as
-/// additions instead of silently omitting them.
+/// Which flavour of `git add` [`prepare_shadow_index`] runs into the throwaway index copy.
+///
+/// `pub(crate)` because [`crate::review::snapshot_worktree_tree`] needs the second flavour: a
+/// `git write-tree` snapshot has to name real blobs, and an intent-to-add stub has no blob to
+/// name (`write-tree` refuses outright with `fatal: ... has intent-to-add entries`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ShadowIndexContent {
+    /// `git add --intent-to-add -A` - records just enough for `git diff <object>` to treat an
+    /// untracked path as present, without writing any blob into the object database. The
+    /// long-standing default for [`compute_diff`]; see this function's own docs for why that is
+    /// sufficient there.
+    IntentToAdd,
+    /// `git add -A` - stages real content, so every untracked/modified file's blob genuinely
+    /// lands in the object database and `git write-tree` can name it. Writes real objects (the
+    /// only way to snapshot a working tree at all), but still only ever into the object database:
+    /// the real index, working tree, `HEAD` and stash are as untouched as with `IntentToAdd`,
+    /// because every mutation still goes through the same `GIT_INDEX_FILE` override.
+    FullContent,
+}
+
+/// Builds a temporary, throwaway copy of the worktree's index with untracked files added,
+/// either as "intent to add" stubs or with their real content ([`ShadowIndexContent`]), so
+/// `git diff <merge-base>` - which only ever considers paths already present in the index or in
+/// `<merge-base>`'s tree (see the module docs' "What the diff includes" section) - picks up new,
+/// unstaged files as additions instead of silently omitting them, and so
+/// [`crate::review::snapshot_worktree_tree`] can `git write-tree` a complete snapshot.
 ///
 /// The real index is only ever *read* (to seed the copy); every mutation happens on the temp
 /// file via a `GIT_INDEX_FILE` override in the caller, so this can never perturb the real
 /// repository state - verified by checking that `git status` still reports the untracked
 /// file as untracked (`??`), never staged, immediately after diffing through a shadow index.
 ///
-/// `--intent-to-add` (rather than a full `git add -A`) is deliberate: it records just enough
-/// (an empty-blob stub entry) for `git diff` to treat the path as present, without staging
-/// actual file content into the temp index - unnecessary, since `git diff <commit>` (no
-/// `--cached`) always compares against the real working-tree file content directly
-/// regardless of what's staged.
+/// [`ShadowIndexContent::IntentToAdd`] (rather than a full `git add -A`) is deliberate for
+/// [`compute_diff`]: it records just enough (an empty-blob stub entry) for `git diff` to treat
+/// the path as present, without staging actual file content into the temp index - unnecessary,
+/// since `git diff <commit>` (no `--cached`) always compares against the real working-tree file
+/// content directly regardless of what's staged. [`crate::review::snapshot_worktree_tree`] is the
+/// one caller that genuinely does need the content, and asks for
+/// [`ShadowIndexContent::FullContent`] instead - see that variant's own docs.
 ///
 /// The copy also inherits the real index's **mtime**, not just its bytes - an index's cached
 /// stat data only means anything relative to that index file's own timestamp (git's
 /// racy-index rule). See the inline comment at the copy itself, and the
 /// `a_same_length_edit_racy_against_the_index_timestamp_is_still_reported` test, for the real
 /// bug (GitHub issue #163) that came of not doing this.
-fn prepare_shadow_index(worktree_path: &Path) -> Result<tempfile::NamedTempFile, Error> {
+pub(crate) fn prepare_shadow_index(
+    worktree_path: &Path,
+    content: ShadowIndexContent,
+) -> Result<tempfile::NamedTempFile, Error> {
     let index_path_args: Vec<OsString> =
         vec!["rev-parse".into(), "--git-path".into(), "index".into()];
     let output = run_git(worktree_path, &index_path_args)?;
@@ -767,13 +812,11 @@ fn prepare_shadow_index(worktree_path: &Path) -> Result<tempfile::NamedTempFile,
         }
     }
 
-    let add_args: Vec<OsString> = vec![
-        "add".into(),
-        "--intent-to-add".into(),
-        "-A".into(),
-        "--".into(),
-        ".".into(),
-    ];
+    let mut add_args: Vec<OsString> = vec!["add".into()];
+    if content == ShadowIndexContent::IntentToAdd {
+        add_args.push("--intent-to-add".into());
+    }
+    add_args.extend([OsString::from("-A"), "--".into(), ".".into()]);
     let output = git_command(worktree_path, &add_args)
         .env("GIT_INDEX_FILE", shadow.path())
         .output()

--- a/crates/wt-core/src/lib.rs
+++ b/crates/wt-core/src/lib.rs
@@ -25,6 +25,7 @@ mod error;
 pub mod graph;
 pub mod merge;
 pub mod remote;
+pub mod review;
 pub mod rewrite;
 pub mod stage;
 pub mod undo;

--- a/crates/wt-core/src/review.rs
+++ b/crates/wt-core/src/review.rs
@@ -1,0 +1,711 @@
+//! Per-agent **review** baselines: snapshotting a worktree's exact current state as a real git
+//! tree, and diffing the working tree against one of those snapshots later.
+//!
+//! ## Why this is a separate concept from [`crate::diff`]
+//!
+//! GitHub issue #225 ("Separate diffs for git and agents"). [`crate::diff::diff_against_base`]
+//! answers exactly one question: *how does this worktree differ from the merge-base with the
+//! repository's default branch* - the **git** question, the one the Changes sidebar and the
+//! File/Diff toggle are built around. It is a property of the branch, and it is the same answer
+//! no matter who or what produced those changes.
+//!
+//! A **review** diff answers a different question: *what has changed since the point I last
+//! looked*. Its base point is not a branch at all - it is a snapshot taken at a moment in time
+//! (when an agent was spawned, or when the user last clicked "Mark reviewed"), and it has its own
+//! lifetime, advancing only when the user says so. An agent spawned into a worktree whose branch
+//! already diverged from `main` has a large git diff and an empty review diff, and that is the
+//! honest answer to both questions - the confusion the issue reports is exactly what comes of
+//! only ever being able to answer the first one.
+//!
+//! Everything *downstream* of the base point is deliberately shared, not duplicated: a review
+//! diff is parsed into the very same [`crate::diff::WorktreeDiff`]/[`crate::diff::DiffFile`]/
+//! [`crate::diff::DiffHunk`] types, by the very same parser, through the very same pinned
+//! `git diff` invocation ([`crate::diff::compute_diff`], which resolves a tree id exactly as it
+//! resolves a commit id). Only the base point and the lifetime differ.
+//!
+//! ## Snapshotting safely, alongside a live agent
+//!
+//! An agent CLI running inside the worktree is running its own `git` commands at unpredictable
+//! moments (a documented, real hazard - see [`crate::undo::commit_paths`]' own docs). A snapshot
+//! must therefore never touch the real index, the working tree, `HEAD`, or the stash.
+//! [`snapshot_worktree_tree`] builds on [`crate::diff::prepare_shadow_index`]'s existing
+//! mechanism for exactly that reason: every mutation lands in a throwaway `GIT_INDEX_FILE` copy.
+//!
+//! The one thing a snapshot genuinely *does* write is blobs and trees into the object database -
+//! unavoidable, since "remember this exact working tree" has no other representation in git. That
+//! is additive and invisible to every git command the agent might run; nothing existing is
+//! rewritten. Those objects are then anchored under a real ref ([`anchor_tree`]) so a `git gc`
+//! can't collect a baseline that is still in use.
+//!
+//! Performs blocking I/O; see the crate-level docs.
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+use crate::diff::{
+    capture_git_stdout, compute_diff, prepare_shadow_index, validate_object_id, ShadowIndexContent,
+    WorktreeDiff, MAX_DIFF_OUTPUT_BYTES,
+};
+use crate::error::Error;
+use crate::{check_success, format_args, git_command, run_git};
+
+/// The ref namespace every review baseline is anchored under. Deliberately **not** under
+/// `refs/heads/` or `refs/tags/`: a baseline is not a branch and not a tag, and putting it in
+/// either would make it show up in `git branch`/`git tag`, in this app's own graph tab
+/// (`crate::graph::build_graph` walks `refs/heads`, `refs/remotes` and `refs/tags`), and in a
+/// user's own tooling - noise for something that is purely this app's internal bookkeeping.
+///
+/// A custom top-level namespace is the standard git idiom for exactly this (the same shape
+/// `refs/stash`, `refs/notes/*` and `refs/replace/*` use); refs outside the well-known
+/// namespaces are ignored by essentially everything while still being real, gc-protecting refs.
+pub const REVIEW_REF_PREFIX: &str = "refs/jerry/review/";
+
+/// Snapshots the worktree at `worktree_path` exactly as it stands right now - tracked
+/// modifications, staged changes, and untracked files alike - as a real git tree object, and
+/// returns its hex object id.
+///
+/// This is a *review baseline*: the "since" point a later [`diff_against_tree`] compares
+/// against. It captures the working tree, not `HEAD`, because that is what a reviewer actually
+/// wants a baseline for - an agent that has committed some of its work and left the rest
+/// uncommitted has still changed the same set of things either way.
+///
+/// ## What it does not touch
+///
+/// The real index, the working tree, `HEAD`, and the stash are all left byte-identical. Every
+/// `git add` here runs against a throwaway copy of the index via a `GIT_INDEX_FILE` override
+/// ([`crate::diff::prepare_shadow_index`], whose own docs cover the mechanics, including the
+/// racy-index mtime handling GitHub issue #163 needed), and `git write-tree` only reads that
+/// copy. The `snapshotting_a_worktree_leaves_real_git_status_byte_identical` test proves this
+/// against a real repository with real staged, unstaged and untracked files present.
+///
+/// It *does* write new blob and tree objects into the object database - see the module docs for
+/// why that is both unavoidable and harmless. Anchor the returned id under a ref
+/// ([`anchor_tree`]) if it needs to survive a `git gc`.
+///
+/// ## `FullContent`, not `--intent-to-add`
+///
+/// Unlike [`crate::diff::diff_against_base`]'s own shadow index, this one stages real content
+/// ([`ShadowIndexContent::FullContent`]): `git write-tree` needs a real blob to name for every
+/// entry, and refuses outright (`fatal: ... has intent-to-add entries`) on a stub.
+///
+/// Performs blocking I/O (spawns real `git` child processes).
+pub fn snapshot_worktree_tree(worktree_path: &Path) -> Result<String, Error> {
+    let shadow_index = prepare_shadow_index(worktree_path, ShadowIndexContent::FullContent)?;
+
+    let args: Vec<OsString> = vec!["write-tree".into()];
+    let output = git_command(worktree_path, &args)
+        .env("GIT_INDEX_FILE", shadow_index.path())
+        .output()
+        .map_err(|source| Error::GitSpawn {
+            args: format_args(&args),
+            source,
+        })?;
+    check_success(&args, &output)?;
+
+    let tree_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    // `git write-tree` succeeding with output that isn't a hex object id would mean something is
+    // very wrong; refusing it here (rather than storing it as a baseline that every later
+    // `diff_against_tree` would reject one at a time) keeps the failure at the point it happened.
+    validate_object_id(&tree_id, "written tree id")?;
+    Ok(tree_id)
+}
+
+/// The real review diff: how the worktree at `worktree_path` differs *right now* from the
+/// `tree_id` snapshot - i.e. everything that has changed since that baseline was taken.
+///
+/// A thin, validated wrapper over [`crate::diff::compute_diff`], deliberately reusing that
+/// function verbatim rather than reimplementing it: `git diff <object>` resolves a tree id
+/// exactly as it resolves a commit id, so the pinned config, the shadow index (untracked files
+/// still show up as additions), `-M` rename detection, the output caps and the whole unified-diff
+/// parser all apply unchanged. The result is a genuine [`WorktreeDiff`], structurally identical
+/// to a git diff - only its base point differs.
+///
+/// `label` is purely descriptive, landing in [`WorktreeDiff::base_branch`]. A review diff has no
+/// base *branch* at all, so callers pass something honest about what this is diffed against
+/// (e.g. `"since it started"`) rather than a branch name that would be a lie.
+///
+/// Returns an error if `tree_id` isn't a hex object id, or if git can't resolve it - a baseline
+/// whose objects were garbage-collected (never anchored, or its ref deleted) fails honestly here
+/// rather than silently degrading into some other comparison.
+///
+/// Performs blocking I/O (spawns a real `git diff` child process).
+pub fn diff_against_tree(
+    worktree_path: &Path,
+    tree_id: &str,
+    label: String,
+) -> Result<WorktreeDiff, Error> {
+    validate_object_id(tree_id, "baseline tree id")?;
+    compute_diff(worktree_path, tree_id, label)
+}
+
+/// Just the paths that differ from the `tree_id` snapshot - one `git diff --name-only` process,
+/// no hunk parsing at all.
+///
+/// The cheap counterpart to [`diff_against_tree`], for callers that only need "how many files"
+/// or "which files" and would otherwise pay to parse (and allocate) every hunk of every file for
+/// a number. The session rail's per-agent `N files` trailing text is the real motivating caller:
+/// it needs this for every visible agent row, on a surface that re-renders constantly.
+///
+/// Uses `-z` (NUL-separated records) rather than newline-separated output, so a path containing
+/// a newline, a quote or a backslash can't be misread - with `-z`, git emits every path raw and
+/// never applies its C-style quoting, which makes the `core.quotePath` handling
+/// [`crate::diff`]'s own text parser needs irrelevant here.
+///
+/// Output is capped exactly as the full diff is ([`MAX_DIFF_OUTPUT_BYTES`]). If the cap truncates
+/// mid-record, that final partial path is dropped rather than returned as a real path that was
+/// never actually reported - a short list is honest, a mangled path is not.
+///
+/// Performs blocking I/O (spawns a real `git diff` child process).
+pub fn changed_paths_against_tree(
+    worktree_path: &Path,
+    tree_id: &str,
+) -> Result<Vec<PathBuf>, Error> {
+    validate_object_id(tree_id, "baseline tree id")?;
+
+    let shadow_index = prepare_shadow_index(worktree_path, ShadowIndexContent::IntentToAdd)?;
+
+    let args: Vec<OsString> = vec![
+        "diff".into(),
+        "--no-color".into(),
+        "--no-ext-diff".into(),
+        "--name-only".into(),
+        "-z".into(),
+        tree_id.into(),
+    ];
+    let (output, truncated) = capture_git_stdout(
+        worktree_path,
+        &args,
+        MAX_DIFF_OUTPUT_BYTES,
+        Some(shadow_index.path()),
+    )?;
+
+    // With `-z` every complete record is NUL-*terminated*, so a well-formed run always ends in a
+    // trailing empty split. A truncated run's final split is instead a real, incomplete path.
+    let mut records: Vec<&[u8]> = output.split(|byte| *byte == 0).collect();
+    if truncated {
+        records.pop();
+    }
+    Ok(records
+        .into_iter()
+        .filter(|record| !record.is_empty())
+        .map(|record| PathBuf::from(String::from_utf8_lossy(record).into_owned()))
+        .collect())
+}
+
+/// Turns an arbitrary caller-supplied `key` into a full, always-valid ref name under
+/// [`REVIEW_REF_PREFIX`].
+///
+/// The real keys this app builds are `(worktree path, agent kind, spawn timestamp)` tuples -
+/// containing `/`, spaces, `.`, and potentially any byte a filesystem allows, none of which can
+/// go into a ref name raw (`git check-ref-format`'s rules reject `..`, a trailing `.`, `~^:?*[`,
+/// control characters, a `.lock` suffix, and more). Rather than trying to sanitize each of those
+/// rules individually - a list that is easy to get subtly wrong, and where a *collision* between
+/// two different keys sanitizing to the same string would silently mean two agents sharing one
+/// baseline - this lowercase-hex-encodes the whole key. Hex is injective (distinct keys always
+/// produce distinct refs) and is trivially a valid ref-name component, with no rule left to get
+/// wrong.
+///
+/// The cost is an unreadable ref name. That is an acceptable trade for internal bookkeeping refs
+/// no user is expected to read; the human-readable form of the same fact lives in this app's own
+/// persisted review state, next to the tree id.
+pub fn baseline_ref_name(key: &str) -> String {
+    let mut encoded = String::with_capacity(REVIEW_REF_PREFIX.len() + key.len() * 2);
+    encoded.push_str(REVIEW_REF_PREFIX);
+    for byte in key.as_bytes() {
+        encoded.push_str(&format!("{byte:02x}"));
+    }
+    encoded
+}
+
+/// `true` if `name` is a ref this module produced - i.e. it really sits under
+/// [`REVIEW_REF_PREFIX`] and its remainder is a plain hex component with nothing else in it.
+///
+/// Every mutating function here checks this before handing `name` to `git update-ref`, so a
+/// caller can never (through a bug, or a hand-edited persisted state file) point one of these
+/// operations at `refs/heads/main` or at anything else outside this app's own namespace. That is
+/// a real concern for [`delete_ref`] specifically, which is a destructive operation.
+fn is_review_ref(name: &str) -> bool {
+    match name.strip_prefix(REVIEW_REF_PREFIX) {
+        Some(rest) => !rest.is_empty() && rest.bytes().all(|byte| byte.is_ascii_hexdigit()),
+        None => false,
+    }
+}
+
+fn check_review_ref(name: &str) -> Result<(), Error> {
+    if is_review_ref(name) {
+        Ok(())
+    } else {
+        Err(Error::WorktreeIo(std::io::Error::other(format!(
+            "{name} is not a {REVIEW_REF_PREFIX}* ref"
+        ))))
+    }
+}
+
+/// Points `ref_name` at the `tree_id` snapshot, so a `git gc` can't collect a baseline that is
+/// still in use. Creates the ref if it doesn't exist, and moves it if it does (the "Mark
+/// reviewed" case - advancing a baseline to a fresh snapshot).
+///
+/// A ref pointing directly at a *tree* (rather than a commit) is unusual but entirely legal -
+/// git refs name arbitrary objects, and reachability for gc purposes follows from the object,
+/// not from its type. Wrapping each snapshot in a throwaway commit just to have a commit-shaped
+/// ref would add an object, an author identity, and a timestamp this doesn't need.
+///
+/// Refuses any `ref_name` outside [`REVIEW_REF_PREFIX`] - see [`is_review_ref`].
+///
+/// Performs blocking I/O (spawns a real `git` child process).
+pub fn anchor_tree(worktree_path: &Path, ref_name: &str, tree_id: &str) -> Result<(), Error> {
+    check_review_ref(ref_name)?;
+    validate_object_id(tree_id, "baseline tree id")?;
+
+    let args: Vec<OsString> = vec!["update-ref".into(), ref_name.into(), tree_id.into()];
+    let output = run_git(worktree_path, &args)?;
+    check_success(&args, &output)
+}
+
+/// Deletes `ref_name`, releasing its snapshot's objects to a future `git gc` - what an agent
+/// closing does to its own baseline ref.
+///
+/// Deliberately **not** an error when the ref doesn't exist: `git update-ref -d` on a missing ref
+/// already exits zero, and "make sure this is gone" is idempotent by nature - a caller cleaning
+/// up after an agent shouldn't have to distinguish "deleted it" from "it was already gone".
+///
+/// Refuses any `ref_name` outside [`REVIEW_REF_PREFIX`] - see [`is_review_ref`]. This one really
+/// matters: without it, a corrupted persisted state file could name `refs/heads/main` here and
+/// have this delete a real branch.
+///
+/// Performs blocking I/O (spawns a real `git` child process).
+pub fn delete_ref(worktree_path: &Path, ref_name: &str) -> Result<(), Error> {
+    check_review_ref(ref_name)?;
+
+    let args: Vec<OsString> = vec!["update-ref".into(), "-d".into(), ref_name.into()];
+    let output = run_git(worktree_path, &args)?;
+    check_success(&args, &output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::process::Command;
+    use tempfile::TempDir;
+
+    fn git(dir: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .output()
+            .expect("failed to spawn git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
+            args,
+            dir,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git_stdout(dir: &Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .output()
+            .expect("failed to spawn git");
+        String::from_utf8_lossy(&output.stdout).into_owned()
+    }
+
+    fn init_repo() -> TempDir {
+        let dir = TempDir::new().expect("tempdir");
+        git(dir.path(), &["init", "-b", "main"]);
+        git(dir.path(), &["config", "user.email", "test@example.com"]);
+        git(dir.path(), &["config", "user.name", "Test User"]);
+        fs::write(dir.path().join("file.txt"), "hello\n").expect("write file");
+        git(dir.path(), &["add", "file.txt"]);
+        git(dir.path(), &["commit", "-m", "initial commit"]);
+        dir
+    }
+
+    /// The core promise of a baseline: nothing has changed since it was taken, so the review
+    /// diff against it is genuinely empty - even though this worktree has a real, non-empty
+    /// *git* diff (an uncommitted edit and an untracked file), which is exactly the distinction
+    /// GitHub issue #225 is about.
+    #[test]
+    fn a_fresh_snapshot_reports_no_review_changes_even_when_the_git_diff_is_not_empty() {
+        let repo = init_repo();
+        fs::write(repo.path().join("file.txt"), "hello\nedited\n").expect("write");
+        fs::write(repo.path().join("untracked.txt"), "brand new\n").expect("write");
+
+        let tree = snapshot_worktree_tree(repo.path()).expect("snapshot");
+        let review = diff_against_tree(repo.path(), &tree, "since it started".to_string())
+            .expect("diff_against_tree");
+
+        assert!(
+            review.files.is_empty(),
+            "nothing changed since the snapshot, so the review diff must be empty - got {:?}",
+            review
+                .files
+                .iter()
+                .map(|file| file.path.clone())
+                .collect::<Vec<_>>()
+        );
+
+        // The same worktree, at the same instant, really does have changes to show on the *git*
+        // side - proving the empty review diff above is a genuine "nothing new since you looked",
+        // not just an empty worktree.
+        let git_diff = crate::diff::diff_against_base(repo.path()).expect("diff_against_base");
+        let git_files = git_diff.diff().expect("a real git diff").files.len();
+        assert!(
+            git_files > 0,
+            "the git diff must be non-empty here, or this test isn't proving the two answers \
+             can differ"
+        );
+    }
+
+    /// The other half: a real edit made *after* the snapshot must show up in the review diff,
+    /// with real hunks - the same parsed shape a git diff produces.
+    #[test]
+    fn changes_made_after_a_snapshot_show_up_in_the_review_diff_with_real_hunks() {
+        let repo = init_repo();
+        let tree = snapshot_worktree_tree(repo.path()).expect("snapshot");
+
+        fs::write(repo.path().join("file.txt"), "hello\nafter the snapshot\n").expect("write");
+
+        let review = diff_against_tree(repo.path(), &tree, "since it started".to_string())
+            .expect("diff_against_tree");
+        assert_eq!(review.files.len(), 1, "exactly one file changed");
+        let file = &review.files[0];
+        assert_eq!(file.path, PathBuf::from("file.txt"));
+        assert!(
+            file.hunks
+                .iter()
+                .flat_map(|hunk| hunk.lines.iter())
+                .any(|line| line.content == "after the snapshot"),
+            "the real added line must be present in the parsed hunks - got {:?}",
+            file.hunks
+        );
+        assert_eq!(
+            review.base_commit, tree,
+            "a review diff records the real tree it was taken against"
+        );
+    }
+
+    /// An *untracked* file created after a snapshot is a real change the reviewer needs to see -
+    /// and the case `git diff <object>` would silently miss without the shadow index.
+    #[test]
+    fn an_untracked_file_created_after_a_snapshot_is_reported_as_an_addition() {
+        let repo = init_repo();
+        let tree = snapshot_worktree_tree(repo.path()).expect("snapshot");
+
+        fs::write(repo.path().join("brand_new.txt"), "written by an agent\n").expect("write");
+
+        let review =
+            diff_against_tree(repo.path(), &tree, "since".to_string()).expect("diff_against_tree");
+        let paths: Vec<PathBuf> = review.files.iter().map(|file| file.path.clone()).collect();
+        assert_eq!(paths, vec![PathBuf::from("brand_new.txt")]);
+        assert_eq!(review.files[0].status, crate::diff::FileChangeStatus::Added);
+    }
+
+    /// A file that already existed *untracked* at snapshot time must be captured with its real
+    /// content, so a later edit to it is a modification rather than reappearing as a whole-file
+    /// addition. This is what `ShadowIndexContent::FullContent` buys over `--intent-to-add`.
+    #[test]
+    fn a_file_untracked_at_snapshot_time_is_captured_with_its_real_content() {
+        let repo = init_repo();
+        fs::write(repo.path().join("notes.txt"), "line one\n").expect("write");
+
+        let tree = snapshot_worktree_tree(repo.path()).expect("snapshot");
+        fs::write(repo.path().join("notes.txt"), "line one\nline two\n").expect("write");
+
+        let review =
+            diff_against_tree(repo.path(), &tree, "since".to_string()).expect("diff_against_tree");
+        assert_eq!(review.files.len(), 1);
+        assert_eq!(
+            review.files[0].status,
+            crate::diff::FileChangeStatus::Modified,
+            "the snapshot really captured `line one`, so adding `line two` is a modification - \
+             an intent-to-add stub would have made this a whole-file addition instead"
+        );
+        let added: Vec<&str> = review.files[0]
+            .hunks
+            .iter()
+            .flat_map(|hunk| hunk.lines.iter())
+            .filter(|line| line.kind == crate::diff::DiffLineKind::Added)
+            .map(|line| line.content.as_str())
+            .collect();
+        assert_eq!(added, vec!["line two"]);
+    }
+
+    /// The safety guarantee this whole approach rests on: snapshotting a worktree that a real
+    /// agent might be working in must not perturb one single thing git reports about it. Checks
+    /// real `git status --porcelain` output (staged, unstaged and untracked files all present)
+    /// byte-for-byte across the call, plus `HEAD`, the index file's own bytes, and the stash.
+    #[test]
+    fn snapshotting_a_worktree_leaves_real_git_status_byte_identical() {
+        let repo = init_repo();
+        // A genuinely mixed state: one staged change, one unstaged change, one untracked file.
+        fs::write(repo.path().join("staged.txt"), "staged content\n").expect("write");
+        git(repo.path(), &["add", "staged.txt"]);
+        fs::write(repo.path().join("file.txt"), "hello\nunstaged edit\n").expect("write");
+        fs::write(repo.path().join("untracked.txt"), "untracked\n").expect("write");
+
+        let status_before = git_stdout(repo.path(), &["status", "--porcelain"]);
+        let head_before = git_stdout(repo.path(), &["rev-parse", "HEAD"]);
+        let index_before = fs::read(repo.path().join(".git").join("index")).expect("read index");
+        let stash_before = git_stdout(repo.path(), &["stash", "list"]);
+        assert!(
+            status_before.contains("A  staged.txt")
+                && status_before.contains(" M file.txt")
+                && status_before.contains("?? untracked.txt"),
+            "the test fixture must really have staged, unstaged and untracked entries - got:\n\
+             {status_before}"
+        );
+
+        snapshot_worktree_tree(repo.path()).expect("snapshot");
+
+        assert_eq!(
+            git_stdout(repo.path(), &["status", "--porcelain"]),
+            status_before,
+            "snapshotting must not change one byte of what git reports about the worktree"
+        );
+        assert_eq!(git_stdout(repo.path(), &["rev-parse", "HEAD"]), head_before);
+        assert_eq!(
+            fs::read(repo.path().join(".git").join("index")).expect("read index"),
+            index_before,
+            "the real index file must be untouched - every mutation goes to the shadow copy"
+        );
+        assert_eq!(git_stdout(repo.path(), &["stash", "list"]), stash_before);
+    }
+
+    /// Two snapshots of the *same* content must produce the same tree id (git trees are content
+    /// addressed), and a snapshot after a real change must produce a different one - the
+    /// property "Mark reviewed" relies on to actually advance the baseline.
+    #[test]
+    fn a_snapshot_id_tracks_real_content_not_the_time_it_was_taken() {
+        let repo = init_repo();
+        let first = snapshot_worktree_tree(repo.path()).expect("snapshot");
+        let unchanged = snapshot_worktree_tree(repo.path()).expect("snapshot");
+        assert_eq!(
+            first, unchanged,
+            "an unchanged worktree must snapshot to the same tree"
+        );
+
+        fs::write(repo.path().join("file.txt"), "hello\nchanged\n").expect("write");
+        let after = snapshot_worktree_tree(repo.path()).expect("snapshot");
+        assert_ne!(
+            first, after,
+            "a real change must produce a genuinely different baseline"
+        );
+    }
+
+    /// `changed_paths_against_tree` must agree exactly with the full diff's own file list - it
+    /// exists purely as a cheaper route to the same answer, so any disagreement is a bug.
+    #[test]
+    fn changed_paths_agrees_with_the_full_review_diffs_file_list() {
+        let repo = init_repo();
+        let tree = snapshot_worktree_tree(repo.path()).expect("snapshot");
+
+        fs::write(repo.path().join("file.txt"), "hello\nedited\n").expect("write");
+        fs::write(repo.path().join("added.txt"), "new\n").expect("write");
+
+        let mut paths = changed_paths_against_tree(repo.path(), &tree).expect("changed_paths");
+        paths.sort();
+        assert_eq!(
+            paths,
+            vec![PathBuf::from("added.txt"), PathBuf::from("file.txt")]
+        );
+
+        let mut full: Vec<PathBuf> = diff_against_tree(repo.path(), &tree, "since".to_string())
+            .expect("diff_against_tree")
+            .files
+            .iter()
+            .map(|file| file.path.clone())
+            .collect();
+        full.sort();
+        assert_eq!(paths, full, "the cheap path list must match the full diff");
+    }
+
+    #[test]
+    fn changed_paths_is_empty_immediately_after_a_snapshot() {
+        let repo = init_repo();
+        fs::write(repo.path().join("file.txt"), "hello\nedited\n").expect("write");
+        let tree = snapshot_worktree_tree(repo.path()).expect("snapshot");
+        assert!(changed_paths_against_tree(repo.path(), &tree)
+            .expect("changed_paths")
+            .is_empty());
+    }
+
+    /// A real, anchored baseline must survive an aggressive `git gc` - the whole reason
+    /// `anchor_tree` exists rather than trusting a bare tree id to stay reachable.
+    #[test]
+    fn an_anchored_baseline_survives_a_real_aggressive_gc() {
+        let repo = init_repo();
+        fs::write(repo.path().join("only_here.txt"), "unreferenced content\n").expect("write");
+        let tree = snapshot_worktree_tree(repo.path()).expect("snapshot");
+
+        let ref_name = baseline_ref_name("worktree-a|Claude|1700000000");
+        anchor_tree(repo.path(), &ref_name, &tree).expect("anchor");
+
+        git(repo.path(), &["gc", "--prune=now", "--aggressive"]);
+
+        assert_eq!(
+            git_stdout(repo.path(), &["rev-parse", &ref_name]).trim(),
+            tree,
+            "the anchored ref must still resolve to the same tree after a real gc"
+        );
+        // And the tree's real content is still readable - not just the ref surviving.
+        assert!(git_stdout(repo.path(), &["cat-file", "-p", &tree]).contains("only_here.txt"));
+    }
+
+    #[test]
+    fn anchoring_again_moves_an_existing_baseline_ref_rather_than_failing() {
+        let repo = init_repo();
+        let first = snapshot_worktree_tree(repo.path()).expect("snapshot");
+        let ref_name = baseline_ref_name("key");
+        anchor_tree(repo.path(), &ref_name, &first).expect("anchor");
+
+        fs::write(repo.path().join("file.txt"), "hello\nmarked reviewed\n").expect("write");
+        let second = snapshot_worktree_tree(repo.path()).expect("snapshot");
+        anchor_tree(repo.path(), &ref_name, &second).expect("re-anchor");
+
+        assert_eq!(
+            git_stdout(repo.path(), &["rev-parse", &ref_name]).trim(),
+            second,
+            "'Mark reviewed' advances the same ref onto the new snapshot"
+        );
+    }
+
+    #[test]
+    fn deleting_a_baseline_ref_removes_it_and_is_idempotent() {
+        let repo = init_repo();
+        let tree = snapshot_worktree_tree(repo.path()).expect("snapshot");
+        let ref_name = baseline_ref_name("key");
+        anchor_tree(repo.path(), &ref_name, &tree).expect("anchor");
+
+        delete_ref(repo.path(), &ref_name).expect("delete");
+        assert!(
+            git_stdout(repo.path(), &["rev-parse", "--verify", &ref_name])
+                .trim()
+                .is_empty(),
+            "the ref must really be gone"
+        );
+
+        delete_ref(repo.path(), &ref_name)
+            .expect("deleting an already-deleted baseline ref must not be an error");
+    }
+
+    /// The guard that matters most: a corrupted or hand-edited persisted state file must never
+    /// be able to talk `delete_ref` into deleting a real branch.
+    #[test]
+    fn a_ref_outside_the_review_namespace_is_refused_and_the_branch_survives() {
+        let repo = init_repo();
+        let head_before = git_stdout(repo.path(), &["rev-parse", "refs/heads/main"]);
+
+        assert!(delete_ref(repo.path(), "refs/heads/main").is_err());
+        assert!(anchor_tree(repo.path(), "refs/heads/main", &"0".repeat(40)).is_err());
+        // Nor a path that merely *looks* like it starts inside the namespace.
+        assert!(delete_ref(repo.path(), "refs/jerry/review/../../heads/main").is_err());
+
+        assert_eq!(
+            git_stdout(repo.path(), &["rev-parse", "refs/heads/main"]),
+            head_before,
+            "the real branch must be completely untouched"
+        );
+    }
+
+    /// Ref names must be injective in the key: two agents whose keys differ only in characters a
+    /// naive sanitizer would collapse (a space vs. an underscore, `/` vs. `-`) must never end up
+    /// sharing one baseline ref.
+    #[test]
+    fn distinct_keys_never_collide_onto_one_baseline_ref() {
+        let a = baseline_ref_name("/repo/wt a|Claude|1");
+        let b = baseline_ref_name("/repo/wt-a|Claude|1");
+        let c = baseline_ref_name("_repo_wt_a|Claude|1");
+        assert_ne!(a, b);
+        assert_ne!(b, c);
+        assert_ne!(a, c);
+        for name in [&a, &b, &c] {
+            assert!(name.starts_with(REVIEW_REF_PREFIX));
+            assert!(
+                is_review_ref(name),
+                "{name} must be recognised as this module's own ref"
+            );
+        }
+    }
+
+    /// A real `git check-ref-format` run over a key stuffed with every character class git's own
+    /// ref rules reject - the encoding must produce something git genuinely accepts.
+    #[test]
+    fn an_encoded_ref_name_is_accepted_by_real_git_check_ref_format() {
+        let repo = init_repo();
+        let nasty = "/home/u/my repo/../wt~1^2:3?4*5[6\\7.lock|Claude|1700000000";
+        let ref_name = baseline_ref_name(nasty);
+
+        let output = Command::new("git")
+            .current_dir(repo.path())
+            .args(["check-ref-format", &ref_name])
+            .output()
+            .expect("spawn git");
+        assert!(
+            output.status.success(),
+            "git rejected the encoded ref name {ref_name}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        // And it really works as a ref, end to end.
+        let tree = snapshot_worktree_tree(repo.path()).expect("snapshot");
+        anchor_tree(repo.path(), &ref_name, &tree).expect("anchor");
+        assert_eq!(
+            git_stdout(repo.path(), &["rev-parse", &ref_name]).trim(),
+            tree
+        );
+    }
+
+    #[test]
+    fn a_tree_id_that_is_not_a_hex_object_id_is_refused_before_git_ever_runs() {
+        let repo = init_repo();
+        assert!(diff_against_tree(repo.path(), "--upload-pack=evil", "x".to_string()).is_err());
+        assert!(changed_paths_against_tree(repo.path(), "").is_err());
+        assert!(diff_against_tree(repo.path(), "HEAD", "x".to_string()).is_err());
+    }
+
+    /// A snapshot really is per-worktree: two worktrees of the same repository snapshot their own
+    /// content, and diffing one against the other's baseline reports the real difference.
+    #[test]
+    fn snapshots_are_scoped_to_the_worktree_they_were_taken_in() {
+        let repo = init_repo();
+        let other = repo.path().parent().expect("parent").join("linked-wt");
+        git(
+            repo.path(),
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "feature",
+                other.to_str().expect("utf8"),
+            ],
+        );
+
+        fs::write(other.join("feature_only.txt"), "in the linked worktree\n").expect("write");
+
+        let main_tree = snapshot_worktree_tree(repo.path()).expect("snapshot main");
+        let linked_paths =
+            changed_paths_against_tree(&other, &main_tree).expect("changed_paths in linked");
+        assert_eq!(
+            linked_paths,
+            vec![PathBuf::from("feature_only.txt")],
+            "the linked worktree's own new file is what differs from the main worktree's snapshot"
+        );
+
+        // Clean up the linked worktree so `TempDir`'s own drop isn't left with a registered
+        // worktree pointing outside it.
+        git(
+            repo.path(),
+            &[
+                "worktree",
+                "remove",
+                "--force",
+                other.to_str().expect("utf8"),
+            ],
+        );
+    }
+}

--- a/crates/wt-core/src/review.rs
+++ b/crates/wt-core/src/review.rs
@@ -42,12 +42,39 @@
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
+use sha2::{Digest, Sha256};
+
 use crate::diff::{
     capture_git_stdout, compute_diff, prepare_shadow_index, validate_object_id, ShadowIndexContent,
     WorktreeDiff, MAX_DIFF_OUTPUT_BYTES,
 };
 use crate::error::Error;
 use crate::{check_success, format_args, git_command, run_git};
+
+/// Cap on the total bytes of **untracked** content a single snapshot will hash into the object
+/// database before falling back to a tracked-only baseline ([`UntrackedCoverage::Excluded`]).
+///
+/// This cap is not hypothetical. `snapshot_worktree_tree` originally ran an unconditional
+/// `git add -A`, and this project's own checkout at the time carried a 19 GB, 21,471-file
+/// untracked build directory that was *not* gitignored. Every agent spawn - including the one
+/// every window performs at startup - would have hashed and written all of it into the user's
+/// real `.git/objects`, taking minutes and leaving the objects behind as loose files until a
+/// `git gc --prune` (a two-week default grace period).
+///
+/// 128 MiB is chosen as comfortably above any plausible *legitimate* untracked set (scratch
+/// files, a few generated artifacts) while bounding the pathological case to a few seconds of
+/// hashing. Large build outputs are normally gitignored, and a gitignored file is never counted
+/// here at all - a worktree tripping this cap has genuinely put hundreds of megabytes of
+/// un-ignored content in front of git.
+pub const MAX_UNTRACKED_SNAPSHOT_BYTES: u64 = 128 * 1024 * 1024;
+
+/// Companion cap to [`MAX_UNTRACKED_SNAPSHOT_BYTES`] on the *number* of untracked files.
+///
+/// Needed separately because per-file cost is not only bytes: each path costs a `stat`, an index
+/// entry, and a loose object. 21,471 tiny files would slip under a pure byte cap while still
+/// being exactly the case that motivated this. Also lets [`measure_untracked`] stop counting
+/// early rather than stat-ing an unbounded list just to discover it is unbounded.
+pub const MAX_UNTRACKED_SNAPSHOT_FILES: usize = 5_000;
 
 /// The ref namespace every review baseline is anchored under. Deliberately **not** under
 /// `refs/heads/` or `refs/tags/`: a baseline is not a branch and not a tag, and putting it in
@@ -60,9 +87,117 @@ use crate::{check_success, format_args, git_command, run_git};
 /// namespaces are ignored by essentially everything while still being real, gc-protecting refs.
 pub const REVIEW_REF_PREFIX: &str = "refs/jerry/review/";
 
+/// Whether a baseline's snapshot actually captured the worktree's untracked files.
+///
+/// Not a detail: it changes what a review *means*, so it travels with the baseline and is shown
+/// to the user rather than being silently assumed. It must also be passed back to
+/// [`diff_against_tree`]/[`changed_paths_against_tree`], because measuring against a baseline
+/// with one coverage using the other's rules produces a systematically wrong answer - a
+/// tracked-only baseline compared with untracked files included would report every pre-existing
+/// untracked file as something the agent had just added.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UntrackedCoverage {
+    /// The normal case: untracked, non-ignored files were captured with their real content, so a
+    /// file the agent creates afterwards shows up as a real addition.
+    Included,
+    /// The worktree's untracked set exceeded [`MAX_UNTRACKED_SNAPSHOT_BYTES`] or
+    /// [`MAX_UNTRACKED_SNAPSHOT_FILES`], so the baseline covers tracked files only.
+    ///
+    /// Reviews against such a baseline are honest but narrower: they report changes to files git
+    /// already tracks, and say nothing about untracked ones in either direction. Callers are
+    /// expected to surface this to the user (this app's Review tab header appends `tracked files
+    /// only`) rather than presenting it as a complete answer.
+    Excluded,
+}
+
+impl UntrackedCoverage {
+    /// The shadow-index flavour that matches this coverage - the single place the mapping lives,
+    /// so a snapshot and every later diff against it can never disagree about whether untracked
+    /// files are in scope.
+    fn shadow_index_content(self, for_snapshot: bool) -> ShadowIndexContent {
+        match (self, for_snapshot) {
+            (UntrackedCoverage::Included, true) => ShadowIndexContent::FullContent,
+            // A diff never needs real untracked *content* - `git diff <object>` reads the working
+            // tree directly - so the cheap intent-to-add stub is enough to make the path visible.
+            (UntrackedCoverage::Included, false) => ShadowIndexContent::IntentToAdd,
+            (UntrackedCoverage::Excluded, _) => ShadowIndexContent::TrackedOnly,
+        }
+    }
+}
+
+/// A real captured baseline: the tree, and what it actually covers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorktreeSnapshot {
+    /// The tree's hex object id.
+    pub tree_id: String,
+    pub untracked: UntrackedCoverage,
+    /// How many untracked, non-ignored files were found at capture time - real and measured, and
+    /// kept even when they were included, so a caller can explain *why* a baseline is
+    /// tracked-only. Saturates at [`MAX_UNTRACKED_SNAPSHOT_FILES`] + 1 when counting stopped
+    /// early (see [`measure_untracked`]).
+    pub untracked_files: usize,
+    /// Their total size in bytes, measured the same way. `0` when counting stopped on the file
+    /// cap before sizes were summed.
+    pub untracked_bytes: u64,
+}
+
+/// Measures the worktree's untracked, non-ignored set: how many files, and how many bytes.
+///
+/// `git ls-files -o --exclude-standard -z` is the real list git itself would stage under
+/// `add -A`, so this measures exactly what a [`ShadowIndexContent::FullContent`] snapshot would
+/// be asked to hash - gitignored content is excluded here for the same reason it is excluded
+/// there.
+///
+/// Stops early once the file count passes [`MAX_UNTRACKED_SNAPSHOT_FILES`], returning
+/// `(cap + 1, 0)`: past that point the answer is already "too many", and stat-ing the rest would
+/// be doing the very unbounded work this exists to avoid. A truncated path list is treated the
+/// same way, since a list too large to even read is by definition past the cap.
+fn measure_untracked(worktree_path: &Path) -> Result<(usize, u64), Error> {
+    let args: Vec<OsString> = vec![
+        "ls-files".into(),
+        "-o".into(),
+        "--exclude-standard".into(),
+        "-z".into(),
+    ];
+    let (output, truncated) =
+        capture_git_stdout(worktree_path, &args, MAX_DIFF_OUTPUT_BYTES, None)?;
+    if truncated {
+        return Ok((MAX_UNTRACKED_SNAPSHOT_FILES + 1, 0));
+    }
+
+    let mut files = 0usize;
+    let mut bytes = 0u64;
+    for record in output.split(|byte| *byte == 0) {
+        if record.is_empty() {
+            continue;
+        }
+        files += 1;
+        if files > MAX_UNTRACKED_SNAPSHOT_FILES {
+            return Ok((MAX_UNTRACKED_SNAPSHOT_FILES + 1, 0));
+        }
+        let relative = PathBuf::from(String::from_utf8_lossy(record).into_owned());
+        // `symlink_metadata`, not `metadata`: a symlink is staged as the link itself, so its own
+        // (tiny) size is what a snapshot would write - following it could both over-count wildly
+        // and wander outside the worktree entirely.
+        if let Ok(meta) = std::fs::symlink_metadata(worktree_path.join(&relative)) {
+            bytes = bytes.saturating_add(meta.len());
+        }
+    }
+    Ok((files, bytes))
+}
+
 /// Snapshots the worktree at `worktree_path` exactly as it stands right now - tracked
-/// modifications, staged changes, and untracked files alike - as a real git tree object, and
-/// returns its hex object id.
+/// modifications, staged changes, and (subject to the caps below) untracked files - as a real
+/// git tree object.
+///
+/// ## Bounded, not unconditional
+///
+/// The untracked set is **measured first** ([`measure_untracked`]). Only if it fits within
+/// [`MAX_UNTRACKED_SNAPSHOT_BYTES`] and [`MAX_UNTRACKED_SNAPSHOT_FILES`] is it staged with real
+/// content; otherwise the snapshot falls back to tracked paths only and says so via
+/// [`WorktreeSnapshot::untracked`]. See [`MAX_UNTRACKED_SNAPSHOT_BYTES`]'s own docs for the real
+/// 19 GB worktree this exists for - an unconditional `git add -A` here writes every untracked,
+/// non-ignored byte into the user's real object database, on every single agent spawn.
 ///
 /// This is a *review baseline*: the "since" point a later [`diff_against_tree`] compares
 /// against. It captures the working tree, not `HEAD`, because that is what a reviewer actually
@@ -89,8 +224,17 @@ pub const REVIEW_REF_PREFIX: &str = "refs/jerry/review/";
 /// entry, and refuses outright (`fatal: ... has intent-to-add entries`) on a stub.
 ///
 /// Performs blocking I/O (spawns real `git` child processes).
-pub fn snapshot_worktree_tree(worktree_path: &Path) -> Result<String, Error> {
-    let shadow_index = prepare_shadow_index(worktree_path, ShadowIndexContent::FullContent)?;
+pub fn snapshot_worktree_tree(worktree_path: &Path) -> Result<WorktreeSnapshot, Error> {
+    let (untracked_files, untracked_bytes) = measure_untracked(worktree_path)?;
+    let untracked = if untracked_files > MAX_UNTRACKED_SNAPSHOT_FILES
+        || untracked_bytes > MAX_UNTRACKED_SNAPSHOT_BYTES
+    {
+        UntrackedCoverage::Excluded
+    } else {
+        UntrackedCoverage::Included
+    };
+
+    let shadow_index = prepare_shadow_index(worktree_path, untracked.shadow_index_content(true))?;
 
     let args: Vec<OsString> = vec!["write-tree".into()];
     let output = git_command(worktree_path, &args)
@@ -107,7 +251,12 @@ pub fn snapshot_worktree_tree(worktree_path: &Path) -> Result<String, Error> {
     // very wrong; refusing it here (rather than storing it as a baseline that every later
     // `diff_against_tree` would reject one at a time) keeps the failure at the point it happened.
     validate_object_id(&tree_id, "written tree id")?;
-    Ok(tree_id)
+    Ok(WorktreeSnapshot {
+        tree_id,
+        untracked,
+        untracked_files,
+        untracked_bytes,
+    })
 }
 
 /// The real review diff: how the worktree at `worktree_path` differs *right now* from the
@@ -132,10 +281,16 @@ pub fn snapshot_worktree_tree(worktree_path: &Path) -> Result<String, Error> {
 pub fn diff_against_tree(
     worktree_path: &Path,
     tree_id: &str,
+    untracked: UntrackedCoverage,
     label: String,
 ) -> Result<WorktreeDiff, Error> {
     validate_object_id(tree_id, "baseline tree id")?;
-    compute_diff(worktree_path, tree_id, label)
+    compute_diff(
+        worktree_path,
+        tree_id,
+        untracked.shadow_index_content(false),
+        label,
+    )
 }
 
 /// Just the paths that differ from the `tree_id` snapshot - one `git diff --name-only` process,
@@ -159,10 +314,11 @@ pub fn diff_against_tree(
 pub fn changed_paths_against_tree(
     worktree_path: &Path,
     tree_id: &str,
+    untracked: UntrackedCoverage,
 ) -> Result<Vec<PathBuf>, Error> {
     validate_object_id(tree_id, "baseline tree id")?;
 
-    let shadow_index = prepare_shadow_index(worktree_path, ShadowIndexContent::IntentToAdd)?;
+    let shadow_index = prepare_shadow_index(worktree_path, untracked.shadow_index_content(false))?;
 
     let args: Vec<OsString> = vec![
         "diff".into(),
@@ -201,17 +357,31 @@ pub fn changed_paths_against_tree(
 /// control characters, a `.lock` suffix, and more). Rather than trying to sanitize each of those
 /// rules individually - a list that is easy to get subtly wrong, and where a *collision* between
 /// two different keys sanitizing to the same string would silently mean two agents sharing one
-/// baseline - this lowercase-hex-encodes the whole key. Hex is injective (distinct keys always
-/// produce distinct refs) and is trivially a valid ref-name component, with no rule left to get
-/// wrong.
+/// baseline - this hashes the whole key.
+///
+/// ## Why a digest rather than raw hex
+///
+/// The first version hex-encoded the key directly. Hex is injective and always ref-name-legal,
+/// but it **doubles the length**, and a loose ref is a real file whose name must fit in
+/// `NAME_MAX` (255 bytes on Linux, and less once git appends its own `.lock` suffix). That capped
+/// the worktree-path portion of a key at roughly 107 bytes - well inside the range of an ordinary
+/// `~/Developer/<org>/<repo>/.worktrees/<branch>` layout - and past it `git update-ref` failed
+/// with "File name too long", which surfaced only as a logged warning and a silently, permanently
+/// disabled Review door.
+///
+/// A SHA-256 digest is a fixed 64 characters regardless of key length, so the full ref is always
+/// 82 bytes. Collisions remain a non-issue - and these keys are local filesystem paths under the
+/// user's own control, never attacker-chosen input, so collision *resistance* is not the property
+/// being relied on here; injectivity in practice is.
 ///
 /// The cost is an unreadable ref name. That is an acceptable trade for internal bookkeeping refs
 /// no user is expected to read; the human-readable form of the same fact lives in this app's own
 /// persisted review state, next to the tree id.
 pub fn baseline_ref_name(key: &str) -> String {
-    let mut encoded = String::with_capacity(REVIEW_REF_PREFIX.len() + key.len() * 2);
+    let digest = Sha256::digest(key.as_bytes());
+    let mut encoded = String::with_capacity(REVIEW_REF_PREFIX.len() + digest.len() * 2);
     encoded.push_str(REVIEW_REF_PREFIX);
-    for byte in key.as_bytes() {
+    for byte in digest {
         encoded.push_str(&format!("{byte:02x}"));
     }
     encoded
@@ -314,6 +484,19 @@ mod tests {
         String::from_utf8_lossy(&output.stdout).into_owned()
     }
 
+    /// `snapshot_worktree_tree`, asserting the ordinary case (untracked content really captured)
+    /// and handing back just the tree id - the shape most tests here want.
+    fn snapshot_tree(path: &Path) -> String {
+        let snapshot = snapshot_worktree_tree(path).expect("snapshot");
+        assert_eq!(
+            snapshot.untracked,
+            UntrackedCoverage::Included,
+            "these fixtures are far under the untracked caps, so a tracked-only fallback here \
+             would mean the cap logic is misfiring"
+        );
+        snapshot.tree_id
+    }
+
     fn init_repo() -> TempDir {
         let dir = TempDir::new().expect("tempdir");
         git(dir.path(), &["init", "-b", "main"]);
@@ -335,9 +518,14 @@ mod tests {
         fs::write(repo.path().join("file.txt"), "hello\nedited\n").expect("write");
         fs::write(repo.path().join("untracked.txt"), "brand new\n").expect("write");
 
-        let tree = snapshot_worktree_tree(repo.path()).expect("snapshot");
-        let review = diff_against_tree(repo.path(), &tree, "since it started".to_string())
-            .expect("diff_against_tree");
+        let tree = snapshot_tree(repo.path());
+        let review = diff_against_tree(
+            repo.path(),
+            &tree,
+            UntrackedCoverage::Included,
+            "since it started".to_string(),
+        )
+        .expect("diff_against_tree");
 
         assert!(
             review.files.is_empty(),
@@ -366,12 +554,17 @@ mod tests {
     #[test]
     fn changes_made_after_a_snapshot_show_up_in_the_review_diff_with_real_hunks() {
         let repo = init_repo();
-        let tree = snapshot_worktree_tree(repo.path()).expect("snapshot");
+        let tree = snapshot_tree(repo.path());
 
         fs::write(repo.path().join("file.txt"), "hello\nafter the snapshot\n").expect("write");
 
-        let review = diff_against_tree(repo.path(), &tree, "since it started".to_string())
-            .expect("diff_against_tree");
+        let review = diff_against_tree(
+            repo.path(),
+            &tree,
+            UntrackedCoverage::Included,
+            "since it started".to_string(),
+        )
+        .expect("diff_against_tree");
         assert_eq!(review.files.len(), 1, "exactly one file changed");
         let file = &review.files[0];
         assert_eq!(file.path, PathBuf::from("file.txt"));
@@ -394,12 +587,17 @@ mod tests {
     #[test]
     fn an_untracked_file_created_after_a_snapshot_is_reported_as_an_addition() {
         let repo = init_repo();
-        let tree = snapshot_worktree_tree(repo.path()).expect("snapshot");
+        let tree = snapshot_tree(repo.path());
 
         fs::write(repo.path().join("brand_new.txt"), "written by an agent\n").expect("write");
 
-        let review =
-            diff_against_tree(repo.path(), &tree, "since".to_string()).expect("diff_against_tree");
+        let review = diff_against_tree(
+            repo.path(),
+            &tree,
+            UntrackedCoverage::Included,
+            "since".to_string(),
+        )
+        .expect("diff_against_tree");
         let paths: Vec<PathBuf> = review.files.iter().map(|file| file.path.clone()).collect();
         assert_eq!(paths, vec![PathBuf::from("brand_new.txt")]);
         assert_eq!(review.files[0].status, crate::diff::FileChangeStatus::Added);
@@ -413,11 +611,16 @@ mod tests {
         let repo = init_repo();
         fs::write(repo.path().join("notes.txt"), "line one\n").expect("write");
 
-        let tree = snapshot_worktree_tree(repo.path()).expect("snapshot");
+        let tree = snapshot_tree(repo.path());
         fs::write(repo.path().join("notes.txt"), "line one\nline two\n").expect("write");
 
-        let review =
-            diff_against_tree(repo.path(), &tree, "since".to_string()).expect("diff_against_tree");
+        let review = diff_against_tree(
+            repo.path(),
+            &tree,
+            UntrackedCoverage::Included,
+            "since".to_string(),
+        )
+        .expect("diff_against_tree");
         assert_eq!(review.files.len(), 1);
         assert_eq!(
             review.files[0].status,
@@ -482,15 +685,15 @@ mod tests {
     #[test]
     fn a_snapshot_id_tracks_real_content_not_the_time_it_was_taken() {
         let repo = init_repo();
-        let first = snapshot_worktree_tree(repo.path()).expect("snapshot");
-        let unchanged = snapshot_worktree_tree(repo.path()).expect("snapshot");
+        let first = snapshot_tree(repo.path());
+        let unchanged = snapshot_tree(repo.path());
         assert_eq!(
             first, unchanged,
             "an unchanged worktree must snapshot to the same tree"
         );
 
         fs::write(repo.path().join("file.txt"), "hello\nchanged\n").expect("write");
-        let after = snapshot_worktree_tree(repo.path()).expect("snapshot");
+        let after = snapshot_tree(repo.path());
         assert_ne!(
             first, after,
             "a real change must produce a genuinely different baseline"
@@ -502,24 +705,30 @@ mod tests {
     #[test]
     fn changed_paths_agrees_with_the_full_review_diffs_file_list() {
         let repo = init_repo();
-        let tree = snapshot_worktree_tree(repo.path()).expect("snapshot");
+        let tree = snapshot_tree(repo.path());
 
         fs::write(repo.path().join("file.txt"), "hello\nedited\n").expect("write");
         fs::write(repo.path().join("added.txt"), "new\n").expect("write");
 
-        let mut paths = changed_paths_against_tree(repo.path(), &tree).expect("changed_paths");
+        let mut paths = changed_paths_against_tree(repo.path(), &tree, UntrackedCoverage::Included)
+            .expect("changed_paths");
         paths.sort();
         assert_eq!(
             paths,
             vec![PathBuf::from("added.txt"), PathBuf::from("file.txt")]
         );
 
-        let mut full: Vec<PathBuf> = diff_against_tree(repo.path(), &tree, "since".to_string())
-            .expect("diff_against_tree")
-            .files
-            .iter()
-            .map(|file| file.path.clone())
-            .collect();
+        let mut full: Vec<PathBuf> = diff_against_tree(
+            repo.path(),
+            &tree,
+            UntrackedCoverage::Included,
+            "since".to_string(),
+        )
+        .expect("diff_against_tree")
+        .files
+        .iter()
+        .map(|file| file.path.clone())
+        .collect();
         full.sort();
         assert_eq!(paths, full, "the cheap path list must match the full diff");
     }
@@ -528,10 +737,127 @@ mod tests {
     fn changed_paths_is_empty_immediately_after_a_snapshot() {
         let repo = init_repo();
         fs::write(repo.path().join("file.txt"), "hello\nedited\n").expect("write");
-        let tree = snapshot_worktree_tree(repo.path()).expect("snapshot");
-        assert!(changed_paths_against_tree(repo.path(), &tree)
-            .expect("changed_paths")
-            .is_empty());
+        let tree = snapshot_tree(repo.path());
+        assert!(
+            changed_paths_against_tree(repo.path(), &tree, UntrackedCoverage::Included)
+                .expect("changed_paths")
+                .is_empty()
+        );
+    }
+
+    /// Counts the loose objects under `.git/objects` - what a snapshot writes, and the thing an
+    /// unbounded `git add -A` would blow up.
+    fn loose_object_count(repo: &Path) -> usize {
+        let objects = repo.join(".git").join("objects");
+        let Ok(shards) = std::fs::read_dir(&objects) else {
+            return 0;
+        };
+        shards
+            .flatten()
+            .filter(|shard| {
+                let name = shard.file_name();
+                let name = name.to_string_lossy();
+                // The two-hex-char fan-out directories; `info`/`pack` are not loose objects.
+                name.len() == 2 && name.bytes().all(|b| b.is_ascii_hexdigit())
+            })
+            .map(|shard| {
+                std::fs::read_dir(shard.path())
+                    .map(|entries| entries.flatten().count())
+                    .unwrap_or(0)
+            })
+            .sum()
+    }
+
+    /// **The regression test for the 19 GB bug.** A worktree with an untracked set past
+    /// [`MAX_UNTRACKED_SNAPSHOT_FILES`] must not hash that content into the object database at
+    /// all - it must fall back to a tracked-only baseline and say so.
+    ///
+    /// Checks the real consequence (loose objects actually written), not just the returned flag:
+    /// the flag being right while the content still landed in `.git/objects` would be exactly the
+    /// bug, still present, with a label on it.
+    #[test]
+    fn an_oversized_untracked_set_is_never_hashed_into_the_object_database() {
+        let repo = init_repo();
+        // Comfortably past the file cap, deliberately tiny so the test stays fast - the file cap
+        // exists precisely because many small files are as expensive as a few large ones.
+        let junk = repo.path().join("build-output");
+        std::fs::create_dir_all(&junk).expect("mkdir");
+        for index in 0..(MAX_UNTRACKED_SNAPSHOT_FILES + 10) {
+            fs::write(junk.join(format!("{index}.o")), b"x").expect("write");
+        }
+
+        let before = loose_object_count(repo.path());
+        let snapshot = snapshot_worktree_tree(repo.path()).expect("snapshot");
+
+        assert_eq!(
+            snapshot.untracked,
+            UntrackedCoverage::Excluded,
+            "an untracked set past the cap must produce a tracked-only baseline"
+        );
+        let written = loose_object_count(repo.path()).saturating_sub(before);
+        assert!(
+            written < 100,
+            "a tracked-only snapshot must not write the untracked set into the object database - \
+             it wrote {written} new loose objects for {} untracked files",
+            MAX_UNTRACKED_SNAPSHOT_FILES + 10
+        );
+
+        // And the baseline is still genuinely usable for what it does cover.
+        let paths = changed_paths_against_tree(repo.path(), &snapshot.tree_id, snapshot.untracked)
+            .expect("changed_paths");
+        assert!(
+            paths.is_empty(),
+            "nothing tracked has changed since the snapshot, and the untracked set must not leak \
+             in as spurious additions either - got {paths:?}"
+        );
+
+        // A real edit to a *tracked* file is still caught, which is what makes the fallback worth
+        // having rather than refusing outright.
+        fs::write(repo.path().join("file.txt"), "hello\nedited\n").expect("write");
+        let paths = changed_paths_against_tree(repo.path(), &snapshot.tree_id, snapshot.untracked)
+            .expect("changed_paths");
+        assert_eq!(paths, vec![PathBuf::from("file.txt")]);
+    }
+
+    /// The cap must not fire for an ordinary worktree - a fallback that triggered constantly
+    /// would quietly degrade every review.
+    #[test]
+    fn an_ordinary_untracked_set_is_still_captured_in_full() {
+        let repo = init_repo();
+        fs::write(repo.path().join("scratch.txt"), "a normal untracked file\n").expect("write");
+
+        let snapshot = snapshot_worktree_tree(repo.path()).expect("snapshot");
+        assert_eq!(snapshot.untracked, UntrackedCoverage::Included);
+        assert_eq!(snapshot.untracked_files, 1);
+    }
+
+    /// Gitignored content must not count toward the cap at all - `git add -A` would never have
+    /// staged it, so counting it would push ordinary worktrees onto the fallback for content git
+    /// was never going to touch.
+    #[test]
+    fn gitignored_content_does_not_count_toward_the_untracked_cap() {
+        let repo = init_repo();
+        fs::write(repo.path().join(".gitignore"), "ignored/\n").expect("write");
+        let ignored = repo.path().join("ignored");
+        std::fs::create_dir_all(&ignored).expect("mkdir");
+        // A handful is enough: what this pins is that ignored files are counted as *zero*, not
+        // that some threshold isn't reached - so it deliberately doesn't recreate the sibling
+        // test's several-thousand-file fixture, which is real filesystem work this crate's own
+        // parallel test suite has to share a machine with.
+        for index in 0..25 {
+            fs::write(ignored.join(format!("{index}.o")), b"x").expect("write");
+        }
+
+        let snapshot = snapshot_worktree_tree(repo.path()).expect("snapshot");
+        assert_eq!(
+            snapshot.untracked,
+            UntrackedCoverage::Included,
+            "ignored files must never count toward the cap"
+        );
+        assert_eq!(
+            snapshot.untracked_files, 1,
+            "only the real untracked, non-ignored file (.gitignore itself) should be counted"
+        );
     }
 
     /// A real, anchored baseline must survive an aggressive `git gc` - the whole reason
@@ -540,7 +866,7 @@ mod tests {
     fn an_anchored_baseline_survives_a_real_aggressive_gc() {
         let repo = init_repo();
         fs::write(repo.path().join("only_here.txt"), "unreferenced content\n").expect("write");
-        let tree = snapshot_worktree_tree(repo.path()).expect("snapshot");
+        let tree = snapshot_tree(repo.path());
 
         let ref_name = baseline_ref_name("worktree-a|Claude|1700000000");
         anchor_tree(repo.path(), &ref_name, &tree).expect("anchor");
@@ -559,12 +885,12 @@ mod tests {
     #[test]
     fn anchoring_again_moves_an_existing_baseline_ref_rather_than_failing() {
         let repo = init_repo();
-        let first = snapshot_worktree_tree(repo.path()).expect("snapshot");
+        let first = snapshot_tree(repo.path());
         let ref_name = baseline_ref_name("key");
         anchor_tree(repo.path(), &ref_name, &first).expect("anchor");
 
         fs::write(repo.path().join("file.txt"), "hello\nmarked reviewed\n").expect("write");
-        let second = snapshot_worktree_tree(repo.path()).expect("snapshot");
+        let second = snapshot_tree(repo.path());
         anchor_tree(repo.path(), &ref_name, &second).expect("re-anchor");
 
         assert_eq!(
@@ -577,7 +903,7 @@ mod tests {
     #[test]
     fn deleting_a_baseline_ref_removes_it_and_is_idempotent() {
         let repo = init_repo();
-        let tree = snapshot_worktree_tree(repo.path()).expect("snapshot");
+        let tree = snapshot_tree(repo.path());
         let ref_name = baseline_ref_name("key");
         anchor_tree(repo.path(), &ref_name, &tree).expect("anchor");
 
@@ -632,6 +958,58 @@ mod tests {
         }
     }
 
+    /// **The regression test for the `NAME_MAX` bug.** A realistically deep worktree path used to
+    /// hex-encode into a ref filename longer than the 255-byte limit, so `git update-ref` failed
+    /// with "File name too long" and the review surface was silently, permanently disabled.
+    ///
+    /// Drives a real `anchor_tree` against a real repository with a long key, rather than only
+    /// asserting a length - the failure was in git, not in this crate's arithmetic.
+    #[test]
+    fn a_long_worktree_path_still_produces_a_usable_ref_name() {
+        let repo = init_repo();
+        // A perfectly ordinary deep layout, well past the ~107-byte ceiling raw hex imposed.
+        let long_key = format!(
+            "/home/developer/Developer/some-organisation/{}/.worktrees/{}|Claude|1700000000",
+            "a-reasonably-long-repository-name", "feature/a-descriptive-branch-name-here"
+        );
+        assert!(
+            long_key.len() > 107,
+            "the fixture must exceed the old ceiling, or it proves nothing"
+        );
+
+        let ref_name = baseline_ref_name(&long_key);
+        assert_eq!(
+            ref_name.len(),
+            REVIEW_REF_PREFIX.len() + 64,
+            "a digest-based ref name is a fixed length regardless of key length"
+        );
+        // The real limit is on the final path *component*, which is what git turns into a file.
+        let component = ref_name.rsplit('/').next().expect("a final ref component");
+        assert!(
+            component.len() + ".lock".len() <= 255,
+            "the ref's own filename, plus git's `.lock` suffix, must fit in NAME_MAX"
+        );
+
+        // And it really works against real git, which is where the original bug actually showed.
+        let tree = snapshot_tree(repo.path());
+        anchor_tree(repo.path(), &ref_name, &tree).expect("a long key must still anchor");
+        assert_eq!(
+            git_stdout(repo.path(), &["rev-parse", &ref_name]).trim(),
+            tree
+        );
+        delete_ref(repo.path(), &ref_name).expect("and must still be deletable");
+    }
+
+    /// Key length must not affect ref length at all - the property that makes the `NAME_MAX`
+    /// failure structurally impossible rather than merely unlikely.
+    #[test]
+    fn ref_name_length_is_independent_of_key_length() {
+        let short = baseline_ref_name("a");
+        let long = baseline_ref_name(&"x".repeat(4096));
+        assert_eq!(short.len(), long.len());
+        assert_ne!(short, long, "but distinct keys still produce distinct refs");
+    }
+
     /// A real `git check-ref-format` run over a key stuffed with every character class git's own
     /// ref rules reject - the encoding must produce something git genuinely accepts.
     #[test]
@@ -652,7 +1030,7 @@ mod tests {
         );
 
         // And it really works as a ref, end to end.
-        let tree = snapshot_worktree_tree(repo.path()).expect("snapshot");
+        let tree = snapshot_tree(repo.path());
         anchor_tree(repo.path(), &ref_name, &tree).expect("anchor");
         assert_eq!(
             git_stdout(repo.path(), &["rev-parse", &ref_name]).trim(),
@@ -663,9 +1041,21 @@ mod tests {
     #[test]
     fn a_tree_id_that_is_not_a_hex_object_id_is_refused_before_git_ever_runs() {
         let repo = init_repo();
-        assert!(diff_against_tree(repo.path(), "--upload-pack=evil", "x".to_string()).is_err());
-        assert!(changed_paths_against_tree(repo.path(), "").is_err());
-        assert!(diff_against_tree(repo.path(), "HEAD", "x".to_string()).is_err());
+        assert!(diff_against_tree(
+            repo.path(),
+            "--upload-pack=evil",
+            UntrackedCoverage::Included,
+            "x".to_string()
+        )
+        .is_err());
+        assert!(changed_paths_against_tree(repo.path(), "", UntrackedCoverage::Included).is_err());
+        assert!(diff_against_tree(
+            repo.path(),
+            "HEAD",
+            UntrackedCoverage::Included,
+            "x".to_string()
+        )
+        .is_err());
     }
 
     /// A snapshot really is per-worktree: two worktrees of the same repository snapshot their own
@@ -687,9 +1077,10 @@ mod tests {
 
         fs::write(other.join("feature_only.txt"), "in the linked worktree\n").expect("write");
 
-        let main_tree = snapshot_worktree_tree(repo.path()).expect("snapshot main");
+        let main_tree = snapshot_tree(repo.path());
         let linked_paths =
-            changed_paths_against_tree(&other, &main_tree).expect("changed_paths in linked");
+            changed_paths_against_tree(&other, &main_tree, UntrackedCoverage::Included)
+                .expect("changed_paths in linked");
         assert_eq!(
             linked_paths,
             vec![PathBuf::from("feature_only.txt")],


### PR DESCRIPTION
## Summary

Closes #225. Real report: "Right now there is a confusion between agents diff review and git diffs. We need to separate both concepts" — clarified as genuinely separate concepts, not a filtered view of the same data.

Root cause: `wt_core::diff::diff_against_base` answers exactly one question — how does this worktree differ from the merge-base with the default branch — and every "review" surface in the app was fed from it, which can't honestly answer "what has this specific agent changed." An agent that changed nothing in a worktree whose branch already diverged from `main` was reported "Review ready."

**The distinction shipped here is a different base point, not a filter.** An agent's review diff is `git diff <its own baseline tree>` — parsed by the exact same `WorktreeDiff`/`DiffFile`/`DiffHunk` types and the same `git diff` invocation as a real git diff, just with a different base and a different lifetime. This deliberately supersedes the design doc's "one worktree, one git diff, one answer" rule for review specifically — staging/committing stay worktree-level, unchanged.

- **`wt_core::review`**: `snapshot_worktree_tree` takes a real git tree snapshot via a throwaway shadow index (never touches the real index/working tree/HEAD/stash — verified byte-for-byte in tests), anchored under `refs/jerry/review/<sha256 of the baseline key>` so `git gc` can't collect it. `diff_against_tree`/`changed_paths_against_tree` reuse the existing diff parser verbatim.
- Baselines are captured once at agent spawn, and only ever advance when the user clicks **Mark reviewed** — never automatically.
- **Persisted across restarts** (`review-baselines.toml`, merge-on-save so concurrent instances never clobber each other's entries), keyed by `(worktree, agent kind, real wall-clock spawn timestamp)` since neither `AgentId` nor the existing `Instant` field survives a restart. Deliberately doesn't try to solve full agent resume (#227) — just doesn't destroy data that future work could reconnect to.
- **Gated to single-agent worktrees for now**: real per-agent attribution doesn't exist yet, so the whole Review surface (footer door, tab, "Review ready" status) is unavailable whenever a worktree has more than one open agent, re-checked at every relevant decision point through one `review_available_for` accessor.
- A new `Review` tab per agent, patterned directly on the git graph tab's open/close/focus discipline, reusing the existing diff renderer. The header states in words what it's diffed against and when (`claude · since it started · 09:31`).
- Removed now-fully-dead UI: the unwired `Accept file` button and the `Authorship`/author-chip system (its `record()` had zero production callers — the data was always empty).

## A dedicated adversarial review caught two critical bugs before this went anywhere near a push

1. **Unbounded `git add -A`.** The original snapshot mechanism staged every untracked, non-ignored file with real content — measured against this actual checkout, that's 21,471 files / 19 GB hashed into `.git/objects` on every single agent spawn. Fixed: the untracked set is measured first (cheap `git ls-files -o`), and a snapshot falls back to tracked-only past 128 MiB or 5,000 files, with the resulting `UntrackedCoverage` threaded through every later diff and surfaced in the tab header (`· tracked files only`) rather than silently narrowed.
2. **A wedged centre pane.** `leave_review_tab` had exactly one real caller (its own close button) — switching to any other tab while the Review tab was open left it stuck on screen with focus dangling on an unmounted terminal. Fixed at all five real centre-pane takeover sites.

Plus three more real fixes: single-slot `Task` fields that silently cancelled in-flight baseline captures/ref deletions when agents spawned or closed in quick succession (now keyed per-agent); a blocking double-`fsync` on the UI thread (now on the background executor, matching what the sibling persisted-state files actually do); and ref names that could exceed filesystem `NAME_MAX` for realistic deep worktree paths (now a fixed-length SHA-256 digest).

One incidental find worth flagging: chasing this round's own test flakiness root-caused a previously-unexplained flaky-test class in this repo — `fs.inotify.max_user_instances` exhaustion under heavy concurrent `#[gpui::test]` runs that each arm real file-tree watchers, not an event-timing race as previously assumed.

## Test plan

- [x] `wt-core`: real temp-repo tests for snapshot/diff/ref-anchor/ref-delete, including byte-for-byte `git status`/index/HEAD/stash identity before and after a snapshot, an aggressive real `git gc` survival test, and a test asserting real loose-object counts stay near zero when the untracked-set cap kicks in (not just that the flag says so)
- [x] `app`: real `#[gpui::test]`s driving actual spawn/close/mark-reviewed/tab-open flows — including a regression test that drives the real entry points (`select_agent`, opening a file, opening the graph tab) rather than calling `leave_review_tab` directly, since the bug was precisely that those callers didn't, and a concurrency test that spawns/closes two agents with no parking in between so both operations are genuinely in flight
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p app -p wt-core --all-targets -- -D warnings` clean
- [x] `cargo test -p wt-core --lib` — 207/207 passed
- [x] `cargo test -p app --lib` — 2100/2100 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)