### PR TITLE
refactor(app): make the shell/agent split a type-level distinction

### DIFF
--- a/crates/app/src/icon_pack.rs
+++ b/crates/app/src/icon_pack.rs
@@ -6,7 +6,7 @@
 //!
 //! ## Scope
 //!
-//! Only `crate::work_surface::state::agent_tint`/`agent_initial`'s three agent-kind chips
+//! Only `crate::work_surface::state::agent_tint`/`agent_initial`'s three process-kind chips
 //! (Claude/Codex/Shell - `crate::work_surface::render::render_agent_icon`'s own real call
 //! sites) are wired to check a pack today. The other ~25 distinct icon concepts cataloged across
 //! this app (file-type chips, folder icons, chevrons, status dots, ...) are a real, stated

--- a/crates/app/src/merge/flow.rs
+++ b/crates/app/src/merge/flow.rs
@@ -1014,7 +1014,7 @@ mod merge_regression_tests {
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
         let feature_agent_id = app.update_in(cx, |app, window, cx| {
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
@@ -1093,7 +1093,7 @@ mod merge_regression_tests {
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
         let feature_agent_id = app.update_in(cx, |app, window, cx| {
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
@@ -1118,7 +1118,7 @@ mod merge_regression_tests {
 
         let second_agent_id = app.update_in(cx, |app, window, cx| {
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 second_feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
@@ -1178,7 +1178,7 @@ mod merge_regression_tests {
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
         let feature_agent_id = app.update_in(cx, |app, window, cx| {
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
@@ -1290,7 +1290,7 @@ mod merge_regression_tests {
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
         let feature_agent_id = app.update_in(cx, |app, window, cx| {
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
@@ -1394,7 +1394,7 @@ mod merge_regression_tests {
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
         let feature_agent_id = app.update_in(cx, |app, window, cx| {
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
@@ -1462,7 +1462,7 @@ mod merge_regression_tests {
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
         let feature_agent_id = app.update_in(cx, |app, window, cx| {
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
@@ -1548,7 +1548,7 @@ mod merge_regression_tests {
         bind_real_keys(cx);
         let feature_agent_id = app.update_in(cx, |app, window, cx| {
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
@@ -1667,7 +1667,7 @@ mod merge_regression_tests {
         bind_real_keys(cx);
         let feature_agent_id = app.update_in(cx, |app, window, cx| {
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
@@ -1800,7 +1800,7 @@ mod merge_regression_tests {
         bind_real_keys(cx);
         let feature_agent_id = app.update_in(cx, |app, window, cx| {
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
@@ -1905,7 +1905,7 @@ mod merge_regression_tests {
         bind_real_keys(cx);
         let feature_agent_id = app.update_in(cx, |app, window, cx| {
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
@@ -2005,7 +2005,7 @@ mod merge_regression_tests {
         let notes_path = repo.path().join("notes.txt");
         let feature_agent_id = app.update_in(cx, |app, window, cx| {
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
@@ -2170,7 +2170,7 @@ mod merge_regression_tests {
         bind_real_keys(cx);
         let feature_agent_id = app.update_in(cx, |app, window, cx| {
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
@@ -2224,7 +2224,7 @@ mod merge_regression_tests {
         );
         let second_agent_id = app.update_in(cx, |app, window, cx| {
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 second_feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
@@ -2333,7 +2333,7 @@ mod merge_regression_tests {
         bind_real_keys(cx);
         let feature_agent_id = app.update_in(cx, |app, window, cx| {
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
@@ -2430,7 +2430,7 @@ mod merge_regression_tests {
         bind_real_keys(cx);
         let feature_agent_id = app.update_in(cx, |app, window, cx| {
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
@@ -2546,7 +2546,7 @@ mod merge_regression_tests {
         bind_real_keys(cx);
         let feature_agent_id = app.update_in(cx, |app, window, cx| {
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),

--- a/crates/app/src/merge/mod.rs
+++ b/crates/app/src/merge/mod.rs
@@ -23,7 +23,7 @@ use crate::merge::state as merge;
 use crate::root::*;
 use crate::theme;
 #[cfg(test)]
-use crate::work_surface::agents::AgentKind;
+use crate::work_surface::agents::ProcessKind;
 use crate::work_surface::agents::{Agent, AgentId};
 use crate::work_surface::state as work_surface;
 use gpui::{

--- a/crates/app/src/palette/mod.rs
+++ b/crates/app/src/palette/mod.rs
@@ -26,7 +26,7 @@ use crate::root::*;
 use crate::sidebar::changes;
 use crate::sidebar::file_tree::{self, LangChip};
 use crate::theme;
-use crate::work_surface::agents::AgentKind;
+use crate::work_surface::agents::ProcessKind;
 use crate::work_surface::state as work_surface;
 
 pub mod state;

--- a/crates/app/src/palette/render.rs
+++ b/crates/app/src/palette/render.rs
@@ -420,11 +420,13 @@ impl AdeApp {
         cx: &mut Context<Self>,
     ) {
         match command {
-            palette::PaletteCommand::NewShell => self.new_agent(AgentKind::Shell, window, cx),
+            palette::PaletteCommand::NewShell => self.new_agent(ProcessKind::Shell, window, cx),
             palette::PaletteCommand::NewClaudeAgent => {
-                self.new_agent(AgentKind::Claude, window, cx)
+                self.new_agent(ProcessKind::claude(), window, cx)
             }
-            palette::PaletteCommand::NewCodexAgent => self.new_agent(AgentKind::Codex, window, cx),
+            palette::PaletteCommand::NewCodexAgent => {
+                self.new_agent(ProcessKind::codex(), window, cx)
+            }
             palette::PaletteCommand::ToggleFilesChanges => {
                 // Any palette gesture must disarm a pending prune confirmation (see
                 // `Self::open_palette`'s docs); the other branches already do this via the
@@ -1028,7 +1030,7 @@ impl AdeApp {
         let chip = match &entry.target {
             palette::EntryTarget::Command(_) => render_palette_command_chip().into_any_element(),
             palette::EntryTarget::Agent(_) => {
-                let kind = entry.agent_kind.unwrap_or(AgentKind::Shell);
+                let kind = entry.agent_kind.unwrap_or(ProcessKind::Shell);
                 render_palette_agent_chip(kind).into_any_element()
             }
             palette::EntryTarget::File(path) => {
@@ -1193,7 +1195,7 @@ pub(in crate::palette) fn render_palette_command_chip() -> impl IntoElement {
 /// The palette row's 15×15 agent chip - the same agent badge/tint
 /// (`crate::work_surface::state::agent_tint`/`agent_initial`) the rail's agent rows use, reused
 /// verbatim rather than a second, independently-drifting colour mapping.
-pub(in crate::palette) fn render_palette_agent_chip(kind: AgentKind) -> impl IntoElement {
+pub(in crate::palette) fn render_palette_agent_chip(kind: ProcessKind) -> impl IntoElement {
     let (fg, bg) = work_surface::agent_tint(kind);
     div()
         .flex_none()

--- a/crates/app/src/palette/render.rs
+++ b/crates/app/src/palette/render.rs
@@ -1030,7 +1030,7 @@ impl AdeApp {
         let chip = match &entry.target {
             palette::EntryTarget::Command(_) => render_palette_command_chip().into_any_element(),
             palette::EntryTarget::Agent(_) => {
-                let kind = entry.agent_kind.unwrap_or(ProcessKind::Shell);
+                let kind = entry.process_kind.unwrap_or(ProcessKind::Shell);
                 render_palette_agent_chip(kind).into_any_element()
             }
             palette::EntryTarget::File(path) => {

--- a/crates/app/src/palette/state.rs
+++ b/crates/app/src/palette/state.rs
@@ -15,7 +15,7 @@
 use std::path::PathBuf;
 
 use crate::rail::status::Status;
-use crate::work_surface::agents::{AgentId, AgentKind};
+use crate::work_surface::agents::{AgentId, ProcessKind};
 
 /// Cap on how many rows a single group ([`PaletteGroup`]) contributes, independent of how many
 /// candidates matched - a palette meant to answer "which of these am I looking for" at a glance
@@ -109,7 +109,7 @@ pub enum PaletteStep {
 #[derive(Debug, Clone, PartialEq)]
 pub struct AgentCandidate {
     pub id: AgentId,
-    pub kind: AgentKind,
+    pub kind: ProcessKind,
     pub title: String,
     pub branch: Option<String>,
     pub status: Status,
@@ -120,11 +120,11 @@ pub struct AgentCandidate {
 /// never a stub.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PaletteCommand {
-    /// `crate::root::AdeApp::new_agent(AgentKind::Shell, ..)`, same as the rail's `+`/⌘N.
+    /// `crate::root::AdeApp::new_agent(ProcessKind::Shell, ..)`, same as the rail's `+`/⌘N.
     NewShell,
-    /// `crate::root::AdeApp::new_agent(AgentKind::Claude, ..)`.
+    /// `crate::root::AdeApp::new_agent(ProcessKind::claude(), ..)`.
     NewClaudeAgent,
-    /// `crate::root::AdeApp::new_agent(AgentKind::Codex, ..)`.
+    /// `crate::root::AdeApp::new_agent(ProcessKind::codex(), ..)`.
     NewCodexAgent,
     /// `crate::root::AdeApp::set_right_sidebar_view`, same as the `Files | Changes` control.
     ToggleFilesChanges,
@@ -390,7 +390,7 @@ pub struct PaletteEntry {
     /// Only set for an [`EntryTarget::File`] row that is an add/delete in the loaded diff.
     pub file_change: Option<FileChangeKind>,
     /// Only set for an [`EntryTarget::Agent`] row - which agent badge/tint to draw.
-    pub agent_kind: Option<AgentKind>,
+    pub agent_kind: Option<ProcessKind>,
     pub target: EntryTarget,
 }
 
@@ -806,7 +806,7 @@ mod tests {
     fn agent(id: AgentId, title: &str, branch: Option<&str>, status: Status) -> AgentCandidate {
         AgentCandidate {
             id,
-            kind: AgentKind::Claude,
+            kind: ProcessKind::claude(),
             title: title.to_string(),
             branch: branch.map(str::to_string),
             status,

--- a/crates/app/src/palette/state.rs
+++ b/crates/app/src/palette/state.rs
@@ -390,7 +390,7 @@ pub struct PaletteEntry {
     /// Only set for an [`EntryTarget::File`] row that is an add/delete in the loaded diff.
     pub file_change: Option<FileChangeKind>,
     /// Only set for an [`EntryTarget::Agent`] row - which agent badge/tint to draw.
-    pub agent_kind: Option<ProcessKind>,
+    pub process_kind: Option<ProcessKind>,
     pub target: EntryTarget,
 }
 
@@ -494,7 +494,7 @@ fn filter_agents(agents: &[AgentCandidate], query: &str) -> Vec<PaletteEntry> {
                 shortcut: None,
                 status: Some(candidate.status),
                 file_change: None,
-                agent_kind: Some(candidate.kind),
+                process_kind: Some(candidate.kind),
                 target: EntryTarget::Agent(candidate.id),
             },
         ));
@@ -518,7 +518,7 @@ fn filter_commands(commands: &[CommandCandidate], query: &str) -> Vec<PaletteEnt
                 shortcut: candidate.command.shortcut(),
                 status: None,
                 file_change: None,
-                agent_kind: None,
+                process_kind: None,
                 target: EntryTarget::Command(candidate.command),
             },
         ));
@@ -559,7 +559,7 @@ fn filter_files(files: &[FileCandidate], query: &str) -> Vec<PaletteEntry> {
                 shortcut: None,
                 status: None,
                 file_change: candidate.changed,
-                agent_kind: None,
+                process_kind: None,
                 target: EntryTarget::File(candidate.path.clone()),
             },
         ));
@@ -592,7 +592,7 @@ pub fn build_language_server_groups(
                 shortcut: None,
                 status: Some(candidate.status),
                 file_change: None,
-                agent_kind: None,
+                process_kind: None,
                 target: EntryTarget::LanguageServer(candidate.client_key),
             },
         ));
@@ -1125,7 +1125,7 @@ mod tests {
                     shortcut: None,
                     status: None,
                     file_change: None,
-                    agent_kind: None,
+                    process_kind: None,
                     target: EntryTarget::Agent(1),
                 }],
             },
@@ -1137,7 +1137,7 @@ mod tests {
                     shortcut: None,
                     status: None,
                     file_change: None,
-                    agent_kind: None,
+                    process_kind: None,
                     target: EntryTarget::Command(PaletteCommand::NewShell),
                 }],
             },

--- a/crates/app/src/rail/mod.rs
+++ b/crates/app/src/rail/mod.rs
@@ -34,7 +34,7 @@ use crate::rail::worktrees::WorktreeItem;
 use crate::root::*;
 use crate::status_bar::process_stats;
 use crate::theme;
-use crate::work_surface::agents::AgentKind;
+use crate::work_surface::agents::ProcessKind;
 use gpui::{div, font, prelude::*, px, App, ClickEvent, Context, KeyDownEvent, Window};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -629,7 +629,7 @@ impl AdeApp {
                 KeycapSize::Standard,
             ))
             .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
-                this.new_agent(AgentKind::Shell, window, cx);
+                this.new_agent(ProcessKind::Shell, window, cx);
             }))
     }
 
@@ -1765,7 +1765,7 @@ mod rail_row_tests {
             // make this test vacuous.
             app.select_worktree(1, window, cx);
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 wt.path().to_path_buf(),
                 12.0,
                 None,
@@ -1831,7 +1831,7 @@ mod rail_row_tests {
         app.update_in(cx, |app, window, cx| {
             app.select_worktree(0, window, cx);
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 wt.path().to_path_buf(),
                 12.0,
                 None,
@@ -1890,7 +1890,7 @@ mod rail_row_tests {
         app.update_in(cx, |app, window, cx| {
             app.select_worktree(0, window, cx);
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 wt.path().to_path_buf(),
                 12.0,
                 None,
@@ -1953,7 +1953,7 @@ mod rail_row_tests {
         let agent_in_b = app.update_in(cx, |app, window, cx| {
             app.select_worktree(0, window, cx);
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 wt_a.path().to_path_buf(),
                 12.0,
                 None,
@@ -1962,7 +1962,7 @@ mod rail_row_tests {
             );
             app.select_worktree(0, window, cx);
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 wt_b.path().to_path_buf(),
                 12.0,
                 None,
@@ -2017,7 +2017,7 @@ mod rail_row_tests {
         app.update_in(cx, |app, window, cx| {
             app.select_worktree(1, window, cx);
             app.agents.spawn(
-                AgentKind::Claude,
+                ProcessKind::claude(),
                 busy_wt.path().to_path_buf(),
                 12.0,
                 None,
@@ -2025,7 +2025,7 @@ mod rail_row_tests {
                 cx,
             );
             app.agents.spawn(
-                AgentKind::Codex,
+                ProcessKind::codex(),
                 busy_wt.path().to_path_buf(),
                 12.0,
                 None,
@@ -2453,7 +2453,7 @@ mod rail_filter_caret_tests {
 mod agent_chip_icon_pack_tests {
     use crate::rail::worktrees::WorktreeItem;
     use crate::root::focus::palette_focus_tests;
-    use crate::work_surface::agents::AgentKind;
+    use crate::work_surface::agents::ProcessKind;
     use gpui::TestAppContext;
 
     fn worktree_item(path: std::path::PathBuf, label: &str) -> WorktreeItem {
@@ -2495,7 +2495,7 @@ mod agent_chip_icon_pack_tests {
         app.update_in(cx, |app, window, cx| {
             app.select_worktree(0, window, cx);
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 wt.path().to_path_buf(),
                 12.0,
                 None,
@@ -2526,7 +2526,7 @@ mod agent_chip_icon_pack_tests {
         cx: &mut TestAppContext,
     ) {
         let pack_dir = tempfile::tempdir().expect("tempdir");
-        // The seeded agent is a real `AgentKind::Shell` (`work_surface::agent_icon_name`'s own
+        // The seeded agent is a real `ProcessKind::Shell` (`work_surface::agent_icon_name`'s own
         // mapping), so `shell.svg` is the real file this specific row's chip looks for.
         std::fs::write(pack_dir.path().join("shell.svg"), "<svg></svg>").expect("write");
 

--- a/crates/app/src/rail/state.rs
+++ b/crates/app/src/rail/state.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 
 use crate::rail::repo::RepoId;
 use crate::rail::status::Status;
-use crate::work_surface::agents::AgentKind;
+use crate::work_surface::agents::ProcessKind;
 use wt_core::diff::{AheadBehind, DiffLineKind, WorktreeDiff, WorktreeMergeStatus};
 
 /// One agent, reduced to exactly what the rail row needs to render - built in `crate::root`
@@ -25,7 +25,7 @@ use wt_core::diff::{AheadBehind, DiffLineKind, WorktreeDiff, WorktreeMergeStatus
 #[derive(Debug, Clone, PartialEq)]
 pub struct AgentRow {
     pub id: crate::work_surface::agents::AgentId,
-    pub kind: AgentKind,
+    pub kind: ProcessKind,
     pub title: String,
     pub cwd: PathBuf,
     pub status: Status,
@@ -740,7 +740,7 @@ mod tests {
     fn row(id: u64, status: Status, title: &str, cwd: &str) -> AgentRow {
         AgentRow {
             id,
-            kind: AgentKind::Claude,
+            kind: ProcessKind::claude(),
             title: title.to_string(),
             cwd: PathBuf::from(cwd),
             status,

--- a/crates/app/src/rail/status.rs
+++ b/crates/app/src/rail/status.rs
@@ -2,10 +2,10 @@
 //! calls the whole point of the agent rail.
 //!
 //! GPUI-free and pty/process-free: takes small, already-read signals ([`ProcessSignal`], a
-//! `has_reviewable_diff` bool, a [`crate::work_surface::agents::AgentKind`]) and returns a [`Status`], so
-//! the decision logic is unit testable without a window or a child process. Gathering those
-//! signals from a live [`crate::terminal::pane::TerminalPane`] and `wt_core::diff::diff_against_base`
-//! lives in `crate::rail::state`/`crate::root`.
+//! `has_reviewable_diff` bool, a [`crate::work_surface::agents::ProcessKind`]) and returns a
+//! [`Status`], so the decision logic is unit testable without a window or a child process.
+//! Gathering those signals from a live [`crate::terminal::pane::TerminalPane`] and
+//! `wt_core::diff::diff_against_base` lives in `crate::rail::state`/`crate::root`.
 //!
 //! ## The heuristic, precisely
 //!
@@ -13,9 +13,9 @@
 //! non-zero/was killed by a signal, or exited 0. Whether a "review ready" exit has anything to
 //! review is likewise exact - `wt_core::diff::diff_against_base` reporting at least one changed
 //! file. [`Status::Review`] is further gated on
-//! [`crate::work_surface::agents::AgentKind::is_agent_session`]: a plain
-//! [`crate::work_surface::agents::AgentKind::Shell`] exiting next to an unrelated worktree diff
-//! didn't do reviewable work - it's a terminal that closed, not a session that finished a turn -
+//! [`crate::work_surface::agents::ProcessKind::is_agent_session`]: a plain
+//! [`crate::work_surface::agents::ProcessKind::Shell`] exiting next to an unrelated worktree
+//! diff didn't do reviewable work - it's a terminal that closed, not a session that finished a turn -
 //! so it reports [`Status::Idle`] instead, same as an agent session's clean exit with nothing to
 //! review.
 //!
@@ -29,7 +29,7 @@
 //! certainty.
 //!
 //! Two thresholds, because a plain shell and a real agent session
-//! ([`crate::work_surface::agents::AgentKind::is_agent_session`]) mean something different by
+//! ([`crate::work_surface::agents::ProcessKind::is_agent_session`]) mean something different by
 //! "gone quiet":
 //! - [`RUN_RECENT_OUTPUT_WINDOW`] (2s) is the boundary between "actively streaming" and "merely
 //!   paused" for any live process.
@@ -38,21 +38,22 @@
 //!   and its result, so treating every pause past 2s as "needs input" would flicker the rail on
 //!   normal agent latency. Only past the longer window is an agent flagged [`Status::Ask`].
 //!
-//! A plain [`crate::work_surface::agents::AgentKind::Shell`] has no such grace window: a shell sitting at
-//! its prompt isn't "asking a question", it's just idle - so it falls straight to
+//! A plain [`crate::work_surface::agents::ProcessKind::Shell`] has no such grace window: a shell
+//! sitting at its prompt isn't "asking a question", it's just idle - so it falls straight to
 //! [`Status::Idle`] once [`RUN_RECENT_OUTPUT_WINDOW`] elapses, never [`Status::Ask`].
 
 use std::time::Duration;
 
-use crate::work_surface::agents::AgentKind;
+use crate::work_surface::agents::ProcessKind;
 
 /// How long a live process must have produced output within to count as "recently active" - the
 /// short end of the Run/Ask heuristic (see the module docs).
 pub const RUN_RECENT_OUTPUT_WINDOW: Duration = Duration::from_secs(2);
 
-/// How long an agent-CLI agent ([`AgentKind::Claude`]/[`AgentKind::Codex`]) must have
-/// been quiet before it's flagged [`Status::Ask`] - see the module docs for why this is longer
-/// than [`RUN_RECENT_OUTPUT_WINDOW`].
+/// How long a real agent session ([`ProcessKind::Agent`] - i.e. any
+/// [`crate::work_surface::agents::AgentKind`] CLI, never a shell) must have been quiet before
+/// it's flagged [`Status::Ask`] - see the module docs for why this is longer than
+/// [`RUN_RECENT_OUTPUT_WINDOW`].
 pub const AGENT_ASK_IDLE_THRESHOLD: Duration = Duration::from_secs(15);
 
 /// The status vocabulary from `design_handoff_jerry_ade/README.md`'s "Status vocabulary" table,
@@ -148,7 +149,11 @@ pub enum ProcessSignal {
 
 /// Derives the [`Status`] for one agent from its process signal and whether it has a
 /// non-empty diff against its worktree's base - see the module docs for the Run/Ask split.
-pub fn derive_status(kind: AgentKind, signal: ProcessSignal, has_reviewable_diff: bool) -> Status {
+pub fn derive_status(
+    kind: ProcessKind,
+    signal: ProcessSignal,
+    has_reviewable_diff: bool,
+) -> Status {
     match signal {
         ProcessSignal::NoProcess => Status::Idle,
         ProcessSignal::Running { idle } => {
@@ -169,7 +174,7 @@ pub fn derive_status(kind: AgentKind, signal: ProcessSignal, has_reviewable_diff
                 // A worktree diff sitting around when a plain shell happens to exit isn't
                 // this shell's doing - it's not a session that did reviewable work, it's a
                 // terminal that closed. Only a real agent session's successful exit means
-                // "review ready" (see `AgentKind::is_agent_session`'s docs).
+                // "review ready" (see `ProcessKind::is_agent_session`'s docs).
                 if kind.is_agent_session() && has_reviewable_diff {
                     Status::Review
                 } else {
@@ -189,11 +194,11 @@ mod tests {
     #[test]
     fn no_process_is_idle_regardless_of_kind_or_diff() {
         assert_eq!(
-            derive_status(AgentKind::Shell, ProcessSignal::NoProcess, true),
+            derive_status(ProcessKind::Shell, ProcessSignal::NoProcess, true),
             Status::Idle
         );
         assert_eq!(
-            derive_status(AgentKind::Claude, ProcessSignal::NoProcess, true),
+            derive_status(ProcessKind::claude(), ProcessSignal::NoProcess, true),
             Status::Idle
         );
     }
@@ -203,9 +208,18 @@ mod tests {
         let signal = ProcessSignal::Running {
             idle: Duration::from_millis(500),
         };
-        assert_eq!(derive_status(AgentKind::Shell, signal, false), Status::Run);
-        assert_eq!(derive_status(AgentKind::Claude, signal, false), Status::Run);
-        assert_eq!(derive_status(AgentKind::Codex, signal, false), Status::Run);
+        assert_eq!(
+            derive_status(ProcessKind::Shell, signal, false),
+            Status::Run
+        );
+        assert_eq!(
+            derive_status(ProcessKind::claude(), signal, false),
+            Status::Run
+        );
+        assert_eq!(
+            derive_status(ProcessKind::codex(), signal, false),
+            Status::Run
+        );
     }
 
     #[test]
@@ -214,7 +228,7 @@ mod tests {
             idle: RUN_RECENT_OUTPUT_WINDOW + Duration::from_secs(1),
         };
         assert_eq!(
-            derive_status(AgentKind::Shell, signal, false),
+            derive_status(ProcessKind::Shell, signal, false),
             Status::Idle,
             "a shell sitting at its prompt is idle, not \"needs input\" - it isn't asking anything"
         );
@@ -228,8 +242,14 @@ mod tests {
         let signal = ProcessSignal::Running {
             idle: RUN_RECENT_OUTPUT_WINDOW + Duration::from_secs(1),
         };
-        assert_eq!(derive_status(AgentKind::Claude, signal, false), Status::Run);
-        assert_eq!(derive_status(AgentKind::Codex, signal, false), Status::Run);
+        assert_eq!(
+            derive_status(ProcessKind::claude(), signal, false),
+            Status::Run
+        );
+        assert_eq!(
+            derive_status(ProcessKind::codex(), signal, false),
+            Status::Run
+        );
     }
 
     #[test]
@@ -237,16 +257,25 @@ mod tests {
         let signal = ProcessSignal::Running {
             idle: AGENT_ASK_IDLE_THRESHOLD + Duration::from_secs(1),
         };
-        assert_eq!(derive_status(AgentKind::Claude, signal, false), Status::Ask);
-        assert_eq!(derive_status(AgentKind::Codex, signal, false), Status::Ask);
+        assert_eq!(
+            derive_status(ProcessKind::claude(), signal, false),
+            Status::Ask
+        );
+        assert_eq!(
+            derive_status(ProcessKind::codex(), signal, false),
+            Status::Ask
+        );
     }
 
     #[test]
     fn nonzero_exit_is_fail_regardless_of_diff() {
         let signal = ProcessSignal::Exited { success: false };
-        assert_eq!(derive_status(AgentKind::Shell, signal, true), Status::Fail);
         assert_eq!(
-            derive_status(AgentKind::Claude, signal, false),
+            derive_status(ProcessKind::Shell, signal, true),
+            Status::Fail
+        );
+        assert_eq!(
+            derive_status(ProcessKind::claude(), signal, false),
             Status::Fail
         );
     }
@@ -255,7 +284,7 @@ mod tests {
     fn zero_exit_with_a_real_diff_is_review() {
         let signal = ProcessSignal::Exited { success: true };
         assert_eq!(
-            derive_status(AgentKind::Claude, signal, true),
+            derive_status(ProcessKind::claude(), signal, true),
             Status::Review
         );
     }
@@ -264,10 +293,10 @@ mod tests {
     fn a_shell_zero_exit_with_a_real_diff_is_idle_not_review() {
         // A plain shell exiting next to an unrelated worktree diff isn't a session that
         // finished reviewable work - it's a terminal that closed. Only a real agent session's
-        // clean exit means "review ready" (see `AgentKind::is_agent_session`'s docs).
+        // clean exit means "review ready" (see `ProcessKind::is_agent_session`'s docs).
         let signal = ProcessSignal::Exited { success: true };
         assert_eq!(
-            derive_status(AgentKind::Shell, signal, true),
+            derive_status(ProcessKind::Shell, signal, true),
             Status::Idle,
             "a shell isn't an agent session - its exit can't be \"review ready\""
         );
@@ -277,7 +306,7 @@ mod tests {
     fn zero_exit_with_no_diff_is_idle_not_review() {
         let signal = ProcessSignal::Exited { success: true };
         assert_eq!(
-            derive_status(AgentKind::Claude, signal, false),
+            derive_status(ProcessKind::claude(), signal, false),
             Status::Idle
         );
     }

--- a/crates/app/src/root/focus.rs
+++ b/crates/app/src/root/focus.rs
@@ -460,7 +460,7 @@ mod tab_strip_keybinding_tests {
         );
         assert_eq!(
             active_kind,
-            Some(AgentKind::Shell),
+            Some(ProcessKind::Shell),
             "New terminal always spawns a real Shell agent"
         );
     }
@@ -600,7 +600,7 @@ mod tab_strip_keybinding_tests {
         });
         app.update_in(cx, |app, window, cx| {
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 repo.path().to_path_buf(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
@@ -645,7 +645,7 @@ mod tab_strip_keybinding_tests {
         });
         app.update_in(cx, |app, window, cx| {
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 repo.path().to_path_buf(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
@@ -802,7 +802,7 @@ mod tab_strip_keybinding_tests {
 
         for _ in 0..4 {
             app.update_in(cx, |app, window, cx| {
-                app.new_agent(AgentKind::Shell, window, cx);
+                app.new_agent(ProcessKind::Shell, window, cx);
             });
         }
         let third_id = app.read_with(cx, |app, _| {
@@ -848,7 +848,7 @@ mod tab_strip_keybinding_tests {
         for _ in 0..3 {
             let id = app.update_in(cx, |app, window, cx| {
                 app.agents.spawn(
-                    AgentKind::Shell,
+                    ProcessKind::Shell,
                     repo.path().to_path_buf(),
                     app.settings.appearance.terminal_font_size,
                     app.settings.terminal.shell_override(),

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -86,7 +86,7 @@ use crate::text_history;
 use crate::theme;
 use crate::title_bar::menu as title_bar;
 use crate::updater;
-use crate::work_surface::agents::{AgentId, AgentKind, Agents};
+use crate::work_surface::agents::{AgentId, Agents, ProcessKind};
 use crate::work_surface::state as work_surface;
 use crate::worktree_history::flow as worktree_history;
 
@@ -2270,7 +2270,7 @@ impl AdeApp {
 
         if self.agents.iter_for_cwd(path.clone()).next().is_none() {
             self.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 path.clone(),
                 self.settings.appearance.terminal_font_size,
                 self.settings.terminal.shell_override(),
@@ -3738,7 +3738,7 @@ mod repo_list_tests {
 
         app.update_in(cx, |app, window, cx| {
             app.agents.spawn(
-                AgentKind::Claude,
+                ProcessKind::claude(),
                 repo_a.path().to_path_buf(),
                 12.0,
                 None,
@@ -3884,7 +3884,7 @@ mod repo_list_tests {
         });
 
         app.update_in(cx, |app, window, cx| {
-            app.new_agent(AgentKind::Shell, window, cx);
+            app.new_agent(ProcessKind::Shell, window, cx);
         });
         app.update_in(cx, |app, window, cx| {
             app.handle_new_agent_pane_action(&NewAgentPane, window, cx);

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -574,7 +574,7 @@ impl AdeApp {
                 // `Agents::focus_active`'s docs and this crate's `OverlayFocus`/`restore_focus`
                 // docs for why a *focused* window must never start with `Window::focus == None`.
                 this.agents.spawn(
-                    AgentKind::Shell,
+                    ProcessKind::Shell,
                     path.clone(),
                     this.settings.appearance.terminal_font_size,
                     this.settings.terminal.shell_override(),

--- a/crates/app/src/root/widgets.rs
+++ b/crates/app/src/root/widgets.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::icon_pack;
-use crate::work_surface::agents::AgentKind;
+use crate::work_surface::agents::ProcessKind;
 
 /// The two keycap sizes: `Standard` (primary shortcuts - the rail's `+`/⌘N, the status bar's
 /// `⌘P`) and `Hint` (smaller, for hint-row contexts like footers and empty-state hint lists).
@@ -432,7 +432,7 @@ impl AdeApp {
     /// of this helper's real call sites, rather than needing per-call-site size plumbing.
     pub(crate) fn render_agent_chip_icon(
         &self,
-        kind: AgentKind,
+        kind: ProcessKind,
         size: Pixels,
         font_size: Pixels,
     ) -> gpui::AnyElement {

--- a/crates/app/src/settings/mod.rs
+++ b/crates/app/src/settings/mod.rs
@@ -35,8 +35,7 @@ use crate::settings::state::{self as settings, SettingsPage};
 use crate::settings::store as settings_store;
 use crate::sidebar::file_tree;
 use crate::theme;
-#[cfg(test)]
-use crate::work_surface::agents::AgentKind;
+use crate::work_surface::agents::ProcessKind;
 use crate::work_surface::state as work_surface;
 
 pub mod builtin_themes;

--- a/crates/app/src/settings/render.rs
+++ b/crates/app/src/settings/render.rs
@@ -527,7 +527,11 @@ impl AdeApp {
         is_last: bool,
         _cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        let (badge_fg, badge_bg) = work_surface::agent_tint(row.kind);
+        // `row.kind` is an `AgentKind` (this card only ever lists real agent CLIs); the badge
+        // helpers are shared with the tab strip/rail, which also have to draw shells, so they
+        // take the wider `ProcessKind`.
+        let badge_kind = ProcessKind::from(row.kind);
+        let (badge_fg, badge_bg) = work_surface::agent_tint(badge_kind);
         let path_text = match &row.resolved_path {
             Some(path) => path.display().to_string(),
             // The exact reason a "ready" dot isn't shown, not just "unknown"/blank.
@@ -564,7 +568,7 @@ impl AdeApp {
                     .font_weight(gpui::FontWeight::MEDIUM)
                     .text_size(px(9.5))
                     .text_color(badge_fg)
-                    .child(work_surface::agent_initial(row.kind)),
+                    .child(work_surface::agent_initial(badge_kind)),
             )
             .child(
                 div()
@@ -608,8 +612,8 @@ impl AdeApp {
 
     /// The Installed card's footer - `design_handoff_jerry_ade/README.md`: "Card footer ...
     /// '+ Add an agent — any binary that speaks a resumable agent on stdin'." Rendered dimmed
-    /// and inert (no `on_click`) - `crate::work_surface::agents::AgentKind` is a fixed Rust enum, so there
-    /// is no runtime "register a new agent binary" flow to wire this to yet.
+    /// and inert (no `on_click`) - `crate::work_surface::agents::AgentKind` is a fixed Rust enum,
+    /// so there is no runtime "register a new agent binary" flow to wire this to yet.
     pub(in crate::settings) fn render_settings_agents_footer(&self) -> impl IntoElement {
         div()
             .flex_none()
@@ -4431,7 +4435,7 @@ mod terminal_font_size_tests {
 
         // A second real agent, spawned at whatever the default font size already was.
         app.update_in(cx, |app, window, cx| {
-            app.new_agent(AgentKind::Shell, window, cx);
+            app.new_agent(ProcessKind::Shell, window, cx);
         });
         cx.run_until_parked();
 
@@ -4701,7 +4705,7 @@ mod shell_setting_tests {
         // The next real Shell tab runs it - and really starts.
         app.update_in(cx, |app, window, cx| {
             app.close_settings(window, cx);
-            app.new_agent(AgentKind::Shell, window, cx);
+            app.new_agent(ProcessKind::Shell, window, cx);
         });
         cx.run_until_parked();
         let pane = app
@@ -4938,7 +4942,7 @@ mod shell_suggestion_dropdown_tests {
         // The real proof it was a usable choice and not just a string: the next Shell tab spawns it.
         app.update_in(cx, |app, window, cx| {
             app.close_settings(window, cx);
-            app.new_agent(AgentKind::Shell, window, cx);
+            app.new_agent(ProcessKind::Shell, window, cx);
         });
         cx.run_until_parked();
         let pane = app

--- a/crates/app/src/settings/state.rs
+++ b/crates/app/src/settings/state.rs
@@ -192,15 +192,17 @@ pub fn nav_groups() -> Vec<NavGroup> {
     ]
 }
 
-/// Agent kinds this app can spawn as an "agent" - `AgentKind::Shell` is deliberately excluded,
-/// since the Settings › Agents card lists agent CLIs, not shells.
+/// Every agent CLI this app can spawn. A shell isn't spawnable *as an agent* here at all, and
+/// that's now structural rather than a documented exclusion: [`AgentKind`] has no `Shell`
+/// variant, so nothing can put one in this array (a shell is a
+/// `crate::work_surface::agents::ProcessKind::Shell`, a different type).
 pub const AGENT_KINDS: [AgentKind; 2] = [AgentKind::Claude, AgentKind::Codex];
 
 /// One row for the Agents page's Installed card - see [`detect_agent_rows`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentRow {
     pub kind: AgentKind,
-    /// The exact command name `AgentKind::agent_binary_name` hands to `TerminalSpec::command`
+    /// The exact command name `AgentKind::binary_name` hands to `TerminalSpec::command`
     /// at spawn time - the same name [`Self::resolved_path`] was searched for.
     pub binary_name: &'static str,
     /// `Some(path)` if a real `$PATH` search found the binary, `None` if it genuinely isn't
@@ -234,12 +236,13 @@ impl AgentRow {
 pub fn detect_agent_rows(resolve: impl Fn(&str) -> Option<PathBuf>) -> Vec<AgentRow> {
     AGENT_KINDS
         .into_iter()
-        .filter_map(|kind| {
-            kind.agent_binary_name().map(|binary_name| AgentRow {
+        .map(|kind| {
+            let binary_name = kind.binary_name();
+            AgentRow {
                 kind,
                 binary_name,
                 resolved_path: resolve(binary_name),
-            })
+            }
         })
         .collect()
 }

--- a/crates/app/src/settings/store.rs
+++ b/crates/app/src/settings/store.rs
@@ -112,7 +112,7 @@ pub struct Settings {
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct TerminalSettings {
-    /// The program a plain Shell tab (`crate::work_surface::agents::AgentKind::Shell`) spawns,
+    /// The program a plain Shell tab (`crate::work_surface::agents::ProcessKind::Shell`) spawns,
     /// or `None` for "whatever the OS says" - `$SHELL` on unix, `%COMSPEC%` on Windows, exactly
     /// the behaviour every install had before this setting existed (see
     /// `crate::terminal::pane::TerminalSpec::shell`). `None` is the zero-config default, so a

--- a/crates/app/src/sidebar/mod.rs
+++ b/crates/app/src/sidebar/mod.rs
@@ -31,7 +31,7 @@
 use crate::root::*;
 use crate::sidebar::file_tree::{FileTreeEntry, LangChip};
 use crate::theme;
-use crate::work_surface::agents::{AgentId, AgentKind};
+use crate::work_surface::agents::{AgentId, ProcessKind};
 use crate::work_surface::state as work_surface;
 use gpui::{div, font, prelude::*, px, uniform_list, ClickEvent, Context, Pixels, Window};
 use std::collections::{HashMap, HashSet};

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -1917,11 +1917,11 @@ impl AdeApp {
         Some(group)
     }
 
-    /// Resolves a recorded author's [`AgentKind`] for chip tinting - `None` if that agent has
+    /// Resolves a recorded author's [`ProcessKind`] for chip tinting - `None` if that agent has
     /// since closed (its process exited, its tab closed), in which case
     /// [`Self::render_change_author_chips`] simply omits the chip rather than guessing a kind for
     /// an agent that no longer exists.
-    fn agent_kind_for(&self, id: AgentId) -> Option<AgentKind> {
+    fn agent_kind_for(&self, id: AgentId) -> Option<ProcessKind> {
         self.agents
             .iter()
             .find(|agent| agent.id == id)
@@ -1934,7 +1934,7 @@ impl AdeApp {
     /// strip can never disagree about which agents belong to the selected worktree.
     pub(in crate::sidebar) fn current_worktree_agent_count(&self) -> usize {
         self.current_worktree_agents()
-            .filter(|agent| agent.kind != AgentKind::Shell)
+            .filter(|agent| agent.kind.is_agent_session())
             .count()
     }
 
@@ -2050,18 +2050,18 @@ impl AdeApp {
         // The agent whose tint/initial the message box's chip shows - the current worktree's
         // first real agent, if any. There is no per-message "which agent drafted this"
         // fact to read (`changes::draft_commit_message`'s own docs cover why the message itself
-        // is a deterministic placeholder, not real agent output) - `AgentKind::Shell`'s
+        // is a deterministic placeholder, not real agent output) - `ProcessKind::Shell`'s
         // existing neutral chip (`work_surface::agent_tint`'s own docs: "isn't an agent, so it
         // gets a neutral chip instead of an invented tint") is the honest fallback with none.
         let drafting_kind = self
             .current_worktree_agents()
-            .find(|agent| agent.kind != AgentKind::Shell)
+            .find(|agent| agent.kind.is_agent_session())
             .map(|agent| agent.kind);
         let drafted_by = match drafting_kind {
             Some(kind) => format!("drafted by {}", kind.label()),
             None => "drafted by no agent".to_string(),
         };
-        let chip_kind = drafting_kind.unwrap_or(AgentKind::Shell);
+        let chip_kind = drafting_kind.unwrap_or(ProcessKind::Shell);
         let (chip_fg, chip_bg) = work_surface::agent_tint(chip_kind);
         let chip_initial = work_surface::agent_initial(chip_kind);
 
@@ -2559,7 +2559,7 @@ fn render_commit_menu_row(label: &'static str, sub: String) -> impl IntoElement 
 /// `work_surface::agent_tint`/`work_surface::agent_initial` (`work_surface::state`'s existing
 /// per-agent colour convention, already the tab strip's own source of truth) rather than a
 /// second, independently-tinted chip style.
-pub(in crate::sidebar) fn render_change_author_chip(kind: AgentKind) -> impl IntoElement {
+pub(in crate::sidebar) fn render_change_author_chip(kind: ProcessKind) -> impl IntoElement {
     let (fg, bg) = work_surface::agent_tint(kind);
     let initial = work_surface::agent_initial(kind);
     div()

--- a/crates/app/src/status_bar/mod.rs
+++ b/crates/app/src/status_bar/mod.rs
@@ -22,11 +22,11 @@ use crate::rail::state as rail;
 use crate::root::*;
 use crate::theme;
 // `Agent` itself is only named inside `render::render_status_agents_cluster`'s real
-// `#[cfg(target_os = "linux")]` variant (`Vec<&Agent>`) - the non-Linux twin only needs
-// `AgentKind`, so a Windows/macOS build genuinely never references `Agent` here.
+// `#[cfg(target_os = "linux")]` variant (`Vec<&Agent>`); the non-Linux twin reaches the same
+// agents through `AdeApp` and only calls `ProcessKind::is_agent_session` on them, so a
+// Windows/macOS build genuinely never references `Agent` here.
 #[cfg(target_os = "linux")]
 use crate::work_surface::agents::Agent;
-use crate::work_surface::agents::AgentKind;
 use gpui::{div, font, prelude::*, px, ClickEvent, Context};
 #[cfg(test)]
 use std::path::PathBuf;

--- a/crates/app/src/status_bar/render.rs
+++ b/crates/app/src/status_bar/render.rs
@@ -206,9 +206,10 @@ impl AdeApp {
     }
 
     /// `N agents · X% cpu · Y GB` - agent count is a real count of currently open
-    /// [`AgentKind::Claude`]/[`AgentKind::Codex`] agents; cpu/mem are the real,
-    /// periodically-sampled [`Self::process_stats`] aggregated across those agents' real pids
-    /// via [`process_stats::aggregate_process_stats`]. A field with no real sample known yet for
+    /// [`crate::work_surface::agents::ProcessKind::Agent`] agents - never a plain
+    /// `ProcessKind::Shell`, which has no agent work to attribute cpu/memory to. cpu/mem are the
+    /// real, periodically-sampled [`Self::process_stats`] aggregated across those agents' real
+    /// pids via [`process_stats::aggregate_process_stats`]. A field with no real sample yet for
     /// *any* agent shows `...` for that one piece rather than a fabricated `0%`/`0 B` - see that
     /// function's own docs for exactly when that is: a single un-sampleable pid (e.g. a real
     /// zombie mid-EOF-poll) no longer blanks every other agent's genuinely known value.
@@ -237,7 +238,7 @@ impl AdeApp {
         let agents: Vec<&Agent> = self
             .agents
             .iter()
-            .filter(|agent| matches!(agent.kind, AgentKind::Claude | AgentKind::Codex))
+            .filter(|agent| agent.kind.is_agent_session())
             .collect();
         let agent_count = agents.len();
         let agent_pids: Vec<u32> = agents
@@ -276,7 +277,7 @@ impl AdeApp {
         let agent_count = self
             .agents
             .iter()
-            .filter(|agent| matches!(agent.kind, AgentKind::Claude | AgentKind::Codex))
+            .filter(|agent| agent.kind.is_agent_session())
             .count();
         self.render_status_text(format!("{agent_count} agents"))
     }

--- a/crates/app/src/title_bar/menu.rs
+++ b/crates/app/src/title_bar/menu.rs
@@ -504,10 +504,11 @@ impl AdeApp {
     /// swap to "confirm discard?" for a real second click); every other row closes the menu on
     /// click, matching the `+` menu's own convention.
     fn agent_menu_rows(&self, macos: bool, cx: &mut Context<Self>) -> Vec<gpui::AnyElement> {
-        let resolved_kind = self.resolved_new_agent_kind();
+        let resolved_agent = self.resolved_new_agent_kind();
+        let resolved_kind = ProcessKind::from(resolved_agent);
         let (agent_fg, agent_bg) = work_surface::agent_tint(resolved_kind);
         let agent_initial = work_surface::agent_initial(resolved_kind);
-        let agent_label = resolved_kind.label();
+        let agent_label = resolved_agent.label();
         // Scoped to the *currently selected worktree*'s own agents, matching
         // `AdeApp::select_relative_agent`'s own real cycling scope (see that method's docs) -
         // otherwise this row could show "enabled" while the real cycle it drives is a genuine
@@ -1292,7 +1293,7 @@ mod title_menu_tests {
         });
         let id = app.update_in(cx, |app, window, cx| {
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 worktree_path.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
@@ -1393,7 +1394,7 @@ mod title_menu_tests {
         });
         let id = app.update_in(cx, |app, window, cx| {
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 worktree_path.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
@@ -1525,7 +1526,7 @@ mod title_menu_tests {
         // more real agents there so there are three to cycle through.
         app.update_in(cx, |app, window, cx| {
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 repo.path().to_path_buf(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
@@ -1533,7 +1534,7 @@ mod title_menu_tests {
                 cx,
             );
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 repo.path().to_path_buf(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
@@ -1545,7 +1546,7 @@ mod title_menu_tests {
         // selected worktree rather than this flat list.
         app.update_in(cx, |app, window, cx| {
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 other_wt.path().to_path_buf(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),

--- a/crates/app/src/title_bar/mod.rs
+++ b/crates/app/src/title_bar/mod.rs
@@ -29,7 +29,8 @@ use crate::settings::state as settings;
 use crate::theme;
 use crate::title_bar::menu::TitleMenu;
 #[cfg(test)]
-use crate::work_surface::agents::{AgentId, AgentKind};
+use crate::work_surface::agents::AgentId;
+use crate::work_surface::agents::ProcessKind;
 use crate::work_surface::state as work_surface;
 use crate::worktree_history::flow as worktree_history;
 #[cfg(test)]

--- a/crates/app/src/title_bar/render.rs
+++ b/crates/app/src/title_bar/render.rs
@@ -629,7 +629,7 @@ mod agent_state_chip_text_tests {
     fn row(id: u64, status: Status) -> AgentRow {
         AgentRow {
             id,
-            kind: AgentKind::Claude,
+            kind: ProcessKind::claude(),
             title: format!("agent-{id}"),
             cwd: PathBuf::from(format!("/wt-{id}")),
             status,
@@ -769,7 +769,7 @@ mod agent_state_chip_text_tests {
     }
 }
 
-/// Genuinely-live coverage: real spawned [`AgentKind::Shell`] agents in a real
+/// Genuinely-live coverage: real spawned [`ProcessKind::Shell`] agents in a real
 /// [`gpui::TestAppContext`] window, read back through the real
 /// [`crate::rail::render::AdeApp::build_agent_rows`]/[`Self::render_title_bar_agent_state_chips`]/
 /// [`Self::render_title_bar`] path - proves the wiring itself, not just the pure formatting
@@ -782,7 +782,7 @@ mod agent_state_chip_text_tests {
 /// environment state (`$SHELL`/`$PATH`, which this workspace's own established discipline
 /// forbids in a test - see `pty_core::resolve_in_path_var`'s and `lsp_core::client::
 /// resolve_server_binary_with`'s docs for the exact same call) isn't practical through
-/// [`crate::work_surface::agents::Agents::spawn`]'s real `AgentKind`-only spec. Those two states'
+/// [`crate::work_surface::agents::Agents::spawn`]'s real `ProcessKind`-only spec. Those two states'
 /// text/visibility rules are instead covered - just as really, over the identical `Status`/
 /// `AgentRow` types - by the pure tests above.
 #[cfg(test)]
@@ -810,7 +810,7 @@ mod agent_state_chip_live_tests {
 
     /// `AdeApp::new_with_settings` (`crate::root::state`, see its own "a fresh window starts
     /// with one shell in the repo root" comment) always auto-spawns exactly one real
-    /// `AgentKind::Shell` agent at startup, so `open_test_app` never actually starts at zero
+    /// `ProcessKind::Shell` agent at startup, so `open_test_app` never actually starts at zero
     /// agents - there is no real "empty app" state to observe live. This closes that one real
     /// startup agent via the real `Self::close_agent` path (the same one the tab strip's `×`
     /// and `Self::archive_agent` use) to reach a genuine, live zero-agents state, and proves
@@ -898,7 +898,7 @@ mod agent_state_chip_live_tests {
         app.update_in(cx, |app, window, cx| {
             app.select_worktree(0, window, cx);
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 wt_b.path().to_path_buf(),
                 12.0,
                 None,

--- a/crates/app/src/work_surface/agents.rs
+++ b/crates/app/src/work_surface/agents.rs
@@ -24,12 +24,18 @@ use gpui::{App, AppContext as _, Context, Entity, Focusable as _, Subscription, 
 use crate::root::AdeApp;
 use crate::terminal::pane::{TerminalPane, TerminalPaneEvent, TerminalSpec};
 
-/// What kind of process an agent runs. Purely descriptive - drives the tab label and which
-/// "New ... Agent" button created it; `TerminalPane` itself has no branching for
-/// "shell" vs. "agent CLI".
+/// Which agent CLI a real agent runs. Never a bare shell - see [`ProcessKind`] for the type that
+/// also covers a plain interactive terminal.
+///
+/// This type existing *without* a `Shell` variant is the point: anything that only makes sense
+/// for a real agent (the Settings › Agents "installed on `$PATH`?" card, the `$PATH` name to
+/// search for, which tint/initial an agent badge wears) can take an `AgentKind` and be
+/// structurally impossible to call with a shell, rather than having to remember a runtime
+/// "is this Shell?" check it could silently forget - which is exactly the bug class this shape
+/// replaced (`crate::rail::status::derive_status`'s [`crate::rail::status::Status::Review`] arm
+/// genuinely forgot it, back when one flat enum held all three cases as equal peers).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AgentKind {
-    Shell,
     /// The `claude` CLI (Claude Code), spawned with no arguments in the chosen worktree.
     /// Resolved via `PATH`; if not installed, spawning fails and the pane shows
     /// `TerminalPane::spawn_error`.
@@ -41,51 +47,92 @@ pub enum AgentKind {
 impl AgentKind {
     pub fn label(self) -> &'static str {
         match self {
-            AgentKind::Shell => "Shell",
             AgentKind::Claude => "Claude",
             AgentKind::Codex => "Codex",
         }
     }
 
-    /// `shell_override` is the user's configured shell
-    /// (`crate::settings::store::TerminalSettings::shell_override`, GitHub issue #213) and only
-    /// reaches [`AgentKind::Shell`]: an agent CLI spawns its own fixed binary directly, never
-    /// through a shell, so which shell the user prefers genuinely cannot affect it.
-    fn spec(self, cwd: PathBuf, shell_override: Option<&str>) -> TerminalSpec {
-        // Reads through `agent_binary_name` rather than matching `Claude`/`Codex` again here,
-        // so it stays the single source of truth for "what binary does this kind spawn".
-        match self.agent_binary_name() {
-            Some(binary) => TerminalSpec::command(binary, Vec::new(), cwd),
-            None => TerminalSpec::shell(cwd, shell_override),
-        }
-    }
-
-    /// The literal command name this kind spawns as - `None` for [`AgentKind::Shell`],
-    /// which resolves the configured shell (or `$SHELL`) rather than a fixed binary name.
+    /// The literal command name this agent's CLI spawns as. Infallible - there is no
+    /// "this kind has no fixed binary" case to model, precisely because an `AgentKind` is never
+    /// a shell (before the shell/agent split this was an `Option<&'static str>` every caller had
+    /// to unwrap or `filter_map` away).
     ///
     /// Public so `crate::settings::state`'s Agents page can look up the same `$PATH` name this
-    /// method hands `TerminalSpec::command` at spawn time, instead of a second hardcoded
-    /// list that could drift from what's actually spawned.
-    pub fn agent_binary_name(self) -> Option<&'static str> {
+    /// eventually hands `TerminalSpec::command` at spawn time (see [`ProcessKind::spec`]),
+    /// instead of a second hardcoded list that could drift from what's actually spawned.
+    pub fn binary_name(self) -> &'static str {
         match self {
-            AgentKind::Shell => None,
-            AgentKind::Claude => Some("claude"),
-            AgentKind::Codex => Some("codex"),
+            AgentKind::Claude => "claude",
+            AgentKind::Codex => "codex",
+        }
+    }
+}
+
+/// What's actually running in an agent slot/tab: a bare interactive terminal, or a real agent
+/// session. Purely descriptive - drives the tab label and which "New ..." button created it;
+/// `TerminalPane` itself has no branching for "shell" vs. "agent CLI", and the PTY/tab/spawn/
+/// close/focus machinery below is deliberately identical for both.
+///
+/// The shell/agent split is a *type-level* distinction, not a convention: a [`Self::Shell`] is a
+/// bare terminal with no turns and nothing to review, so every `match` on this enum is forced by
+/// the compiler to say what it does about that case. Cases that only ever cared about "is this a
+/// shell or not" collapse to two arms (`Shell` / `Agent(_)`); the rarer cases that genuinely
+/// differ per CLI destructure the inner [`AgentKind`]. And code that can only ever mean a real
+/// agent doesn't take this type at all - it takes [`AgentKind`], which has no shell to handle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessKind {
+    Shell,
+    Agent(AgentKind),
+}
+
+impl ProcessKind {
+    /// Construction-only shorthand for `ProcessKind::Agent(AgentKind::Claude)`. Deliberately
+    /// *not* usable to dodge exhaustiveness: it's a constructor, so a `match` still has to name
+    /// the real variants and still breaks if a fourth distinguishing case is ever added.
+    pub const fn claude() -> Self {
+        ProcessKind::Agent(AgentKind::Claude)
+    }
+
+    /// Construction-only shorthand for `ProcessKind::Agent(AgentKind::Codex)` - see
+    /// [`Self::claude`].
+    pub const fn codex() -> Self {
+        ProcessKind::Agent(AgentKind::Codex)
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            ProcessKind::Shell => "Shell",
+            ProcessKind::Agent(agent) => agent.label(),
         }
     }
 
-    /// Whether this kind is a real agent session (has turns, can be asked something, can
-    /// finish a unit of work worth reviewing) as opposed to [`AgentKind::Shell`], which is just
-    /// an interactive terminal that happens to live in the same rail/tab UI. The single place
-    /// that distinction lives - `crate::rail::status::derive_status` reads it instead of
-    /// re-deriving "is this Shell or not" per status, and any future per-session machinery
-    /// (structured hook/ACP signal, review-eligibility) should gate on this rather than adding
-    /// another ad-hoc kind match.
-    pub fn is_agent_session(self) -> bool {
+    /// `shell_override` is the user's configured shell
+    /// (`crate::settings::store::TerminalSettings::shell_override`, GitHub issue #213) and only
+    /// reaches [`ProcessKind::Shell`]: an agent CLI spawns its own fixed binary directly, never
+    /// through a shell, so which shell the user prefers genuinely cannot affect it.
+    fn spec(self, cwd: PathBuf, shell_override: Option<&str>) -> TerminalSpec {
         match self {
-            AgentKind::Shell => false,
-            AgentKind::Claude | AgentKind::Codex => true,
+            ProcessKind::Shell => TerminalSpec::shell(cwd, shell_override),
+            ProcessKind::Agent(agent) => {
+                TerminalSpec::command(agent.binary_name(), Vec::new(), cwd)
+            }
         }
+    }
+
+    /// Whether this slot holds a real agent session ([`ProcessKind::Agent`]) as opposed to
+    /// [`ProcessKind::Shell`], which is just an interactive terminal that happens to live in the
+    /// same rail/tab UI. The boolean form of that distinction, for filter/predicate call sites
+    /// that don't need the inner [`AgentKind`]; anything that *does* need it should
+    /// `if let ProcessKind::Agent(agent) = kind` (or match) rather than calling this and then
+    /// re-deriving the CLI.
+    pub fn is_agent_session(self) -> bool {
+        matches!(self, ProcessKind::Agent(_))
+    }
+}
+
+impl From<AgentKind> for ProcessKind {
+    fn from(agent: AgentKind) -> Self {
+        ProcessKind::Agent(agent)
     }
 }
 
@@ -96,7 +143,7 @@ pub type AgentId = u64;
 
 pub struct Agent {
     pub id: AgentId,
-    pub kind: AgentKind,
+    pub kind: ProcessKind,
     /// The worktree (or repo root) this agent's process was started in. Kept for the tab
     /// label/title; `TerminalPane` doesn't expose its own `cwd` back out.
     pub cwd: PathBuf,
@@ -180,11 +227,11 @@ impl Agents {
     /// threading pattern, for the same reason): a freshly spawned pane never starts out
     /// mismatched from what Settings shows. `shell_override` is GitHub issue #213's configured
     /// shell (`crate::settings::store::TerminalSettings::shell_override`) - `None` means "the
-    /// real OS default", and it only affects [`AgentKind::Shell`] tabs (see
-    /// [`AgentKind::spec`]).
+    /// real OS default", and it only affects [`ProcessKind::Shell`] tabs (see
+    /// [`ProcessKind::spec`]).
     pub fn spawn(
         &mut self,
-        kind: AgentKind,
+        kind: ProcessKind,
         cwd: PathBuf,
         terminal_font_size_px: f32,
         shell_override: Option<&str>,
@@ -395,5 +442,87 @@ mod tests {
         let agents = Agents::new();
         assert_eq!(agents.active_id(), None);
         assert!(agents.is_empty());
+    }
+
+    #[test]
+    fn every_agent_kind_is_a_session_and_a_shell_never_is() {
+        // The whole point of the two-type split: `is_agent_session` can only ever be `false`
+        // for the one variant that isn't an agent, and there is no `AgentKind` value at all
+        // that could make it `false` - `ProcessKind::from` can't produce a shell.
+        for agent in [AgentKind::Claude, AgentKind::Codex] {
+            assert!(
+                ProcessKind::from(agent).is_agent_session(),
+                "{agent:?} wrapped as a ProcessKind must be a real agent session"
+            );
+        }
+        assert!(
+            !ProcessKind::Shell.is_agent_session(),
+            "a bare shell has no turns and nothing to review - it is never a session"
+        );
+    }
+
+    #[test]
+    fn the_construction_shorthands_are_exactly_their_long_forms() {
+        // `claude()`/`codex()` exist only to keep call sites short; if they ever drifted from
+        // the explicit construction, spawn sites would quietly disagree with match arms.
+        assert_eq!(ProcessKind::claude(), ProcessKind::Agent(AgentKind::Claude));
+        assert_eq!(ProcessKind::codex(), ProcessKind::Agent(AgentKind::Codex));
+        assert_eq!(ProcessKind::claude(), AgentKind::Claude.into());
+        assert_eq!(ProcessKind::codex(), AgentKind::Codex.into());
+    }
+
+    #[test]
+    fn a_process_kinds_label_delegates_to_its_agents_own_label() {
+        assert_eq!(ProcessKind::Shell.label(), "Shell");
+        assert_eq!(ProcessKind::claude().label(), AgentKind::Claude.label());
+        assert_eq!(ProcessKind::codex().label(), AgentKind::Codex.label());
+        assert_eq!(AgentKind::Claude.label(), "Claude");
+        assert_eq!(AgentKind::Codex.label(), "Codex");
+    }
+
+    #[test]
+    fn each_agent_kind_spawns_its_own_distinct_path_binary() {
+        assert_eq!(AgentKind::Claude.binary_name(), "claude");
+        assert_eq!(AgentKind::Codex.binary_name(), "codex");
+        assert_ne!(
+            AgentKind::Claude.binary_name(),
+            AgentKind::Codex.binary_name(),
+            "a copy-pasted arm sharing one binary name would spawn the wrong CLI silently"
+        );
+    }
+
+    /// `spec` is private, but the fact it reads through `AgentKind::binary_name` (rather than a
+    /// second hardcoded list) is what keeps the Settings › Agents `$PATH` search honest: the name
+    /// that card searches for must be the name actually spawned. This asserts the shared source,
+    /// which is the part that could drift.
+    #[test]
+    fn the_settings_path_search_and_the_real_spawn_read_the_same_binary_name() {
+        for agent in [AgentKind::Claude, AgentKind::Codex] {
+            let spec = ProcessKind::Agent(agent).spec(PathBuf::from("/tmp"), None);
+            assert_eq!(
+                spec.program,
+                PathBuf::from(agent.binary_name()),
+                "{agent:?} must spawn exactly the binary the Agents page searches $PATH for"
+            );
+            assert!(
+                spec.args.is_empty(),
+                "{agent:?} is spawned bare, with no arguments"
+            );
+        }
+        // `shell_override` reaches only the shell arm - an agent CLI is spawned directly, never
+        // through a shell, so the user's preferred shell genuinely cannot affect it.
+        let shell = ProcessKind::Shell.spec(PathBuf::from("/tmp"), Some("/bin/dash"));
+        assert_eq!(
+            shell.program,
+            PathBuf::from("/bin/dash"),
+            "a shell resolves the user's configured shell, not a fixed agent binary"
+        );
+        let agent_ignoring_override =
+            ProcessKind::claude().spec(PathBuf::from("/tmp"), Some("/bin/dash"));
+        assert_eq!(
+            agent_ignoring_override.program,
+            PathBuf::from("claude"),
+            "a configured shell must not be substituted for an agent CLI's own binary"
+        );
     }
 }

--- a/crates/app/src/work_surface/mod.rs
+++ b/crates/app/src/work_surface/mod.rs
@@ -3,7 +3,7 @@
 //! Split the way every feature folder in this crate is split - pure, GPUI-window-free
 //! logic separate from the `gpui::Div`-building code that draws it:
 //!
-//! - [`state`] - the pure mapping from already-known facts (an `AgentKind`, a `Status`, a
+//! - [`state`] - the pure mapping from already-known facts (a `ProcessKind`, a `Status`, a
 //!   bool) onto which colours/labels/actions a Zone 2 element shows. No `gpui::Window`.
 //! - [`agents`] - agent/tab bookkeeping: which agents are open, which worktree each
 //!   belongs to, and which one is active for the centre pane.
@@ -24,7 +24,7 @@ use crate::root::*;
 use crate::settings::state as settings;
 use crate::sidebar::file_tree::{self};
 use crate::theme;
-use crate::work_surface::agents::{Agent, AgentId, AgentKind};
+use crate::work_surface::agents::{Agent, AgentId, AgentKind, ProcessKind};
 use crate::work_surface::state as work_surface;
 use crate::worktree_history::flow as worktree_history;
 use gpui::{div, font, prelude::*, px, App, ClickEvent, Context, Window};

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -69,7 +69,7 @@ impl AdeApp {
     /// this app can offer to spawn an agent into until a real repo is opened.
     pub(crate) fn new_agent(
         &mut self,
-        kind: AgentKind,
+        kind: ProcessKind,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -116,7 +116,7 @@ impl AdeApp {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.new_agent(AgentKind::Shell, window, cx);
+        self.new_agent(ProcessKind::Shell, window, cx);
     }
 
     /// `Ctrl+W` (GitHub issue #26) - closes whichever tab the centre pane is genuinely showing
@@ -440,13 +440,13 @@ impl AdeApp {
         let existing = self
             .agents
             .iter()
-            .find(|agent| agent.kind == AgentKind::Shell && agent.cwd == cwd)
+            .find(|agent| agent.kind == ProcessKind::Shell && agent.cwd == cwd)
             .map(|agent| agent.id);
         match existing {
             Some(id) => self.select_agent(id, window, cx),
             None => {
                 self.agents.spawn(
-                    AgentKind::Shell,
+                    ProcessKind::Shell,
                     cwd,
                     self.settings.appearance.terminal_font_size,
                     self.settings.terminal.shell_override(),
@@ -688,7 +688,7 @@ impl AdeApp {
     pub(crate) fn current_worktree_is_bare(&self) -> bool {
         !self
             .current_worktree_agents()
-            .any(|agent| agent.kind != AgentKind::Shell)
+            .any(|agent| agent.kind.is_agent_session())
     }
 
     /// The branch label for the currently selected worktree, if any is recorded for it - shared
@@ -1180,7 +1180,7 @@ impl AdeApp {
     /// [`Self::plus_button_bounds`].
     ///
     /// Five rows, in the exact order and wording Revision R12 §3 specifies: *New terminal*
-    /// ([`Self::new_agent`] with [`AgentKind::Shell`]), *New agent* (`runs in <branch>` -
+    /// ([`Self::new_agent`] with [`ProcessKind::Shell`]), *New agent* (`runs in <branch>` -
     /// [`Self::new_agent_pane`]), *Git graph* ([`Self::open_git_graph`]), *Open file…*
     /// ([`Self::open_palette`], scoped to [`palette::PaletteScope::Files`]), and *Next changed
     /// file* ([`Self::next_changed_file`]). *New terminal*, *New agent*, *Git graph*, and *Next
@@ -1211,7 +1211,7 @@ impl AdeApp {
             None => self.plus_button_bounds,
         };
 
-        let resolved_kind = self.resolved_new_agent_kind();
+        let resolved_kind = ProcessKind::from(self.resolved_new_agent_kind());
         let (agent_fg, agent_bg) = work_surface::agent_tint(resolved_kind);
         let agent_initial = work_surface::agent_initial(resolved_kind);
         let branch = self.current_worktree_branch();
@@ -1259,7 +1259,7 @@ impl AdeApp {
                     )
                     .on_click(cx.listener(
                         |this, _event: &ClickEvent, window, cx| {
-                            this.new_agent(AgentKind::Shell, window, cx);
+                            this.new_agent(ProcessKind::Shell, window, cx);
                             this.plus_menu_open = false;
                             cx.notify();
                         },
@@ -1349,6 +1349,10 @@ impl AdeApp {
     /// installed, or `AGENT_KINDS[0]` if none are (or `agent_rows` hasn't been populated yet).
     /// Display-only - [`Self::new_agent_pane`] runs its own detection independently, off the
     /// foreground thread, at the moment it actually spawns.
+    ///
+    /// Returns the narrow [`AgentKind`], not [`ProcessKind`]: the "New agent" row can only ever
+    /// resolve to a real agent CLI, so "could this be a shell?" isn't a question a caller has to
+    /// answer - the type says it can't be.
     pub(crate) fn resolved_new_agent_kind(&self) -> AgentKind {
         settings::AGENT_KINDS
             .into_iter()
@@ -1380,11 +1384,9 @@ impl AdeApp {
             let installed = cx
                 .background_executor()
                 .spawn(async move {
-                    settings::AGENT_KINDS.into_iter().find(|kind| {
-                        kind.agent_binary_name()
-                            .and_then(pty_core::resolve_on_path)
-                            .is_some()
-                    })
+                    settings::AGENT_KINDS
+                        .into_iter()
+                        .find(|kind| pty_core::resolve_on_path(kind.binary_name()).is_some())
                 })
                 .await;
             // Needs `Window` access to move focus onto the newly spawned agent's pane
@@ -1392,7 +1394,7 @@ impl AdeApp {
             let _ = this.update_in(cx, |this, window, cx| {
                 let kind = installed.unwrap_or(settings::AGENT_KINDS[0]);
                 this.agents.spawn(
-                    kind,
+                    ProcessKind::Agent(kind),
                     cwd,
                     this.settings.appearance.terminal_font_size,
                     this.settings.terminal.shell_override(),
@@ -1496,14 +1498,14 @@ impl AdeApp {
     }
 
     /// [`NewTerminal`]'s `ctrl-shift-T` action handler - the `+` menu's "New terminal" row's own
-    /// keybinding, spawning a [`AgentKind::Shell`] agent like the row's click handler does.
+    /// keybinding, spawning a [`ProcessKind::Shell`] agent like the row's click handler does.
     pub(crate) fn handle_new_terminal_action(
         &mut self,
         _action: &NewTerminal,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.new_agent(AgentKind::Shell, window, cx);
+        self.new_agent(ProcessKind::Shell, window, cx);
     }
 
     /// [`NewAgentPane`]'s `secondary-shift-n` action handler - see [`Self::new_agent_pane`].
@@ -1641,7 +1643,7 @@ impl AdeApp {
         let (agent_fg, agent_bg) = work_surface::agent_tint(agent.kind);
         let agent_initial = work_surface::agent_initial(agent.kind);
         let is_bare = self.current_worktree_is_bare();
-        // `AgentKind` only tracks which CLI binary is running, not which model it's
+        // `ProcessKind` only tracks which CLI binary is running, not which model it's
         // configured to use, so `agent.kind.label()` ("Claude"/"Codex"/"Shell") is the
         // closest honest substitute for a model name this app never actually observes. A bare
         // worktree (no real agent at all - `is_bare` is only ever true while `agent.kind`
@@ -1885,7 +1887,7 @@ impl AdeApp {
         let exit_code = pane.exit_status().map(|status| status.exit_code());
         let status_value = self.agent_status(agent, cx);
         let state_label = work_surface::pty_state_label(is_running, status_value, exit_code);
-        let is_wsl_shell = agent.kind == AgentKind::Shell && env_info::is_wsl();
+        let is_wsl_shell = agent.kind == ProcessKind::Shell && env_info::is_wsl();
         let label_text = if is_wsl_shell {
             format!("{program_label} \u{b7} wsl")
         } else {
@@ -1913,7 +1915,7 @@ impl AdeApp {
             );
 
         let header = match agent.kind {
-            AgentKind::Shell => header.child(
+            ProcessKind::Shell => header.child(
                 div()
                     .flex_none()
                     .max_w(px(280.0))
@@ -1926,7 +1928,7 @@ impl AdeApp {
             ),
             // No per-kind header content for an agent - pid is shown once, in the info
             // footer below.
-            AgentKind::Claude | AgentKind::Codex => header,
+            ProcessKind::Agent(_) => header,
         };
 
         let macos = self.window_controls_style().is_macos();
@@ -2413,7 +2415,10 @@ pub(crate) fn render_dropdown_menu_row(
 /// agent CLI tabs, or a pane glyph (a bar plus a prompt mark) for terminal tabs. Turns
 /// `work_surface::tab_chip_kind`/`tab_chip_colors`'s mapping into GPUI elements; no
 /// chip-selection logic lives here.
-pub(in crate::work_surface) fn render_tab_chip(kind: AgentKind, active: bool) -> gpui::AnyElement {
+pub(in crate::work_surface) fn render_tab_chip(
+    kind: ProcessKind,
+    active: bool,
+) -> gpui::AnyElement {
     let colors = work_surface::tab_chip_colors(kind, active);
     let base = div()
         .flex_none()
@@ -2647,7 +2652,7 @@ mod tab_scoping_tests {
         app.update_in(cx, |app, window, cx| {
             app.select_worktree(0, window, cx);
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 wt_a.path().to_path_buf(),
                 12.0,
                 None,
@@ -2655,7 +2660,7 @@ mod tab_scoping_tests {
                 cx,
             );
             app.agents.spawn(
-                AgentKind::Claude,
+                ProcessKind::claude(),
                 wt_a.path().to_path_buf(),
                 12.0,
                 None,
@@ -2736,7 +2741,7 @@ mod tab_scoping_tests {
         let (id_a, id_b) = app.update_in(cx, |app, window, cx| {
             app.select_worktree(0, window, cx);
             let id_a = app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 wt_a.path().to_path_buf(),
                 12.0,
                 None,
@@ -2745,7 +2750,7 @@ mod tab_scoping_tests {
             );
             app.select_worktree(1, window, cx);
             let id_b = app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 wt_b.path().to_path_buf(),
                 12.0,
                 None,
@@ -2798,7 +2803,7 @@ mod tab_scoping_tests {
         let (id1, id2) = app.update_in(cx, |app, window, cx| {
             app.select_worktree(0, window, cx);
             let id1 = app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 wt_a.path().to_path_buf(),
                 12.0,
                 None,
@@ -2806,7 +2811,7 @@ mod tab_scoping_tests {
                 cx,
             );
             let id2 = app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 wt_a.path().to_path_buf(),
                 12.0,
                 None,
@@ -2861,7 +2866,7 @@ mod tab_scoping_tests {
         let id_a = app.update_in(cx, |app, window, cx| {
             app.select_worktree(0, window, cx);
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 wt_a.path().to_path_buf(),
                 12.0,
                 None,
@@ -2872,7 +2877,7 @@ mod tab_scoping_tests {
         app.update_in(cx, |app, window, cx| {
             app.select_worktree(1, window, cx);
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 wt_b.path().to_path_buf(),
                 12.0,
                 None,
@@ -2919,7 +2924,7 @@ mod tab_scoping_tests {
         let (initial_id, id2, id3) = app.update_in(cx, |app, window, cx| {
             let initial_id = app.agents.active_id().expect("initial shell agent");
             let id2 = app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 repo.path().to_path_buf(),
                 12.0,
                 None,
@@ -2927,7 +2932,7 @@ mod tab_scoping_tests {
                 cx,
             );
             let id3 = app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 repo.path().to_path_buf(),
                 12.0,
                 None,
@@ -3033,7 +3038,7 @@ mod tab_scoping_tests {
         let (first_id, second_id) = app.update_in(cx, |app, window, cx| {
             let first_id = app.agents.active_id().expect("initial shell agent");
             let second_id = app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 repo.path().to_path_buf(),
                 12.0,
                 None,
@@ -3108,7 +3113,7 @@ mod tab_scoping_tests {
         let (initial_id, second_id) = app.update_in(cx, |app, window, cx| {
             let initial_id = app.agents.active_id().expect("initial shell agent");
             let second_id = app.agents.spawn(
-                AgentKind::Claude,
+                ProcessKind::claude(),
                 repo.path().to_path_buf(),
                 12.0,
                 None,
@@ -3167,7 +3172,7 @@ mod tab_scoping_tests {
         let (initial_id, second_id) = app.update_in(cx, |app, window, cx| {
             let initial_id = app.agents.active_id().expect("initial shell agent");
             let second_id = app.agents.spawn(
-                AgentKind::Claude,
+                ProcessKind::claude(),
                 repo.path().to_path_buf(),
                 12.0,
                 None,
@@ -3271,7 +3276,7 @@ mod tab_scoping_tests {
         let (initial_id, second_id) = app.update_in(cx, |app, window, cx| {
             let initial_id = app.agents.active_id().expect("initial shell agent");
             let second_id = app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 repo.path().to_path_buf(),
                 12.0,
                 None,
@@ -3349,7 +3354,7 @@ mod tab_scoping_tests {
         let (initial_id, second_id) = app.update_in(cx, |app, window, cx| {
             let initial_id = app.agents.active_id().expect("initial shell agent");
             let second_id = app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 repo.path().to_path_buf(),
                 12.0,
                 None,
@@ -3452,7 +3457,7 @@ mod tab_scoping_tests {
         let (initial_id, second_id) = app.update_in(cx, |app, window, cx| {
             let initial_id = app.agents.active_id().expect("initial shell agent");
             let second_id = app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 repo.path().to_path_buf(),
                 12.0,
                 None,
@@ -3510,7 +3515,7 @@ mod tab_scoping_tests {
         let (first_id, second_id) = app.update_in(cx, |app, window, cx| {
             app.select_worktree(0, window, cx);
             let first_id = app.agents.spawn(
-                AgentKind::Claude,
+                ProcessKind::claude(),
                 wt_a.path().to_path_buf(),
                 12.0,
                 None,
@@ -3518,7 +3523,7 @@ mod tab_scoping_tests {
                 cx,
             );
             let second_id = app.agents.spawn(
-                AgentKind::Claude,
+                ProcessKind::claude(),
                 wt_a.path().to_path_buf(),
                 12.0,
                 None,
@@ -3541,7 +3546,7 @@ mod tab_scoping_tests {
     /// Revision R12 §3: a worktree with only its default `Shell` agent is "bare" -
     /// `current_worktree_is_bare` must say so - and stops being bare the moment a real agent
     /// spawns into it, proven through the same live `Agents`/`AdeApp` plumbing every other test
-    /// in this module uses (not just the pure `AgentKind` match this reads off of).
+    /// in this module uses (not just the pure `ProcessKind` match this reads off of).
     #[gpui::test]
     fn a_worktree_with_only_its_default_shell_is_bare_until_a_real_agent_spawns(
         cx: &mut TestAppContext,
@@ -3556,7 +3561,7 @@ mod tab_scoping_tests {
         app.update_in(cx, |app, window, cx| {
             app.select_worktree(0, window, cx);
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 wt_a.path().to_path_buf(),
                 12.0,
                 None,
@@ -3572,7 +3577,7 @@ mod tab_scoping_tests {
 
         app.update_in(cx, |app, window, cx| {
             app.agents.spawn(
-                AgentKind::Claude,
+                ProcessKind::claude(),
                 wt_a.path().to_path_buf(),
                 12.0,
                 None,
@@ -3606,7 +3611,7 @@ mod tab_scoping_tests {
         let shell_id = app.update_in(cx, |app, window, cx| {
             app.select_worktree(0, window, cx);
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 wt_a.path().to_path_buf(),
                 12.0,
                 None,
@@ -3799,7 +3804,7 @@ mod tab_scoping_tests {
         let claude_id = app.update_in(cx, |app, window, cx| {
             app.select_worktree(0, window, cx);
             let shell_id = app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 wt_a.path().to_path_buf(),
                 12.0,
                 None,
@@ -3807,7 +3812,7 @@ mod tab_scoping_tests {
                 cx,
             );
             let claude_id = app.agents.spawn(
-                AgentKind::Claude,
+                ProcessKind::claude(),
                 wt_a.path().to_path_buf(),
                 12.0,
                 None,
@@ -3882,7 +3887,7 @@ mod tab_scoping_tests {
         });
         let second_id = app.update_in(cx, |app, window, cx| {
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 repo.path().to_path_buf(),
                 12.0,
                 None,
@@ -3947,7 +3952,7 @@ mod tab_scoping_tests {
         app.update_in(cx, |app, window, cx| {
             app.select_worktree(0, window, cx);
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 wt_a.path().to_path_buf(),
                 12.0,
                 None,
@@ -4000,7 +4005,7 @@ mod tab_scoping_tests {
         app.update_in(cx, |app, window, cx| {
             app.select_worktree(0, window, cx);
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 wt_a.path().to_path_buf(),
                 12.0,
                 None,
@@ -4116,7 +4121,7 @@ mod terminal_clear_action_tests {
 
         let (first_id, second_id) = app.update_in(cx, |app, window, cx| {
             let first = app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 repo.path().to_path_buf(),
                 12.0,
                 None,
@@ -4124,7 +4129,7 @@ mod terminal_clear_action_tests {
                 cx,
             );
             let second = app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 repo.path().to_path_buf(),
                 12.0,
                 None,
@@ -4237,7 +4242,7 @@ mod tab_order_persistence_tests {
         );
         app.update_in(cx, |app, window, cx| {
             app.agents.spawn(
-                AgentKind::Claude,
+                ProcessKind::claude(),
                 repo.path().to_path_buf(),
                 12.0,
                 None,
@@ -4277,7 +4282,7 @@ mod tab_order_persistence_tests {
             open_test_app_with_real_persistence(cx, repo.path().to_path_buf(), settings_path);
         app.update_in(cx, |app, window, cx| {
             app.agents.spawn(
-                AgentKind::Claude,
+                ProcessKind::claude(),
                 repo.path().to_path_buf(),
                 12.0,
                 None,
@@ -4387,7 +4392,7 @@ mod terminal_clipboard_action_tests {
         seed_active_pane(&app, cx, "background-agent-text");
         app.update_in(cx, |app, window, cx| {
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 repo.path().to_path_buf(),
                 12.0,
                 None,

--- a/crates/app/src/work_surface/state.rs
+++ b/crates/app/src/work_surface/state.rs
@@ -2,7 +2,7 @@
 //! CLI/terminal pane header/footer.
 //!
 //! Deliberately GPUI-free, mirroring `crate::rail::status`'s own split: this module only maps
-//! already-known facts (a [`AgentKind`], a [`Status`], a `bool`) onto *which*
+//! already-known facts (a [`ProcessKind`], a [`Status`], a `bool`) onto *which*
 //! colours/labels/actions a Zone 2 element should show, so that mapping is directly
 //! unit-testable without a live GPUI window. Turning these into actual `gpui::Div` trees (and
 //! wiring click handlers) happens one layer up, in `crate::root`, which has the
@@ -15,7 +15,7 @@ use gpui::Rgba;
 use crate::rail::status::Status;
 use crate::sidebar::file_tree::LangChip;
 use crate::theme;
-use crate::work_surface::agents::{AgentId, AgentKind};
+use crate::work_surface::agents::{AgentId, AgentKind, ProcessKind};
 
 /// One entry in a worktree's combined tab-strip order (GitHub issue #16, extended by issue #93
 /// to also cover the git graph tab) - an agent tab, a file tab, or the one real git graph tab.
@@ -130,22 +130,26 @@ pub const TRANSPARENT: Rgba = Rgba {
     a: 0.0,
 };
 
-/// The agent tint `(fg, bg)` for an agent's badge/chip. [`AgentKind::Shell`] isn't an agent,
+/// The agent tint `(fg, bg)` for an agent's badge/chip. [`ProcessKind::Shell`] isn't an agent,
 /// so it gets a neutral chip instead of an invented tint.
-pub fn agent_tint(kind: AgentKind) -> (Rgba, Rgba) {
+pub fn agent_tint(kind: ProcessKind) -> (Rgba, Rgba) {
     match kind {
-        AgentKind::Claude => (theme::agent::SONNET.0.into(), theme::agent::SONNET.1.into()),
-        AgentKind::Codex => (theme::agent::CODEX.0.into(), theme::agent::CODEX.1.into()),
-        AgentKind::Shell => (theme::text::DIM.into(), theme::surface::CHIP_NEUTRAL.into()),
+        ProcessKind::Agent(AgentKind::Claude) => {
+            (theme::agent::SONNET.0.into(), theme::agent::SONNET.1.into())
+        }
+        ProcessKind::Agent(AgentKind::Codex) => {
+            (theme::agent::CODEX.0.into(), theme::agent::CODEX.1.into())
+        }
+        ProcessKind::Shell => (theme::text::DIM.into(), theme::surface::CHIP_NEUTRAL.into()),
     }
 }
 
 /// The agent badge's single-character initial.
-pub fn agent_initial(kind: AgentKind) -> &'static str {
+pub fn agent_initial(kind: ProcessKind) -> &'static str {
     match kind {
-        AgentKind::Claude => "C",
-        AgentKind::Codex => "X",
-        AgentKind::Shell => "$",
+        ProcessKind::Agent(AgentKind::Claude) => "C",
+        ProcessKind::Agent(AgentKind::Codex) => "X",
+        ProcessKind::Shell => "$",
     }
 }
 
@@ -154,11 +158,11 @@ pub fn agent_initial(kind: AgentKind) -> &'static str {
 /// single-letter glyph rather than reusing that string directly: a pack author names files by
 /// what the icon *depicts* (`"claude.svg"`), not by this app's own internal one-letter fallback
 /// convention.
-pub fn agent_icon_name(kind: AgentKind) -> &'static str {
+pub fn agent_icon_name(kind: ProcessKind) -> &'static str {
     match kind {
-        AgentKind::Claude => "claude",
-        AgentKind::Codex => "codex",
-        AgentKind::Shell => "shell",
+        ProcessKind::Agent(AgentKind::Claude) => "claude",
+        ProcessKind::Agent(AgentKind::Codex) => "codex",
+        ProcessKind::Shell => "shell",
     }
 }
 
@@ -170,10 +174,10 @@ pub enum TabChipKind {
     Term,
 }
 
-pub fn tab_chip_kind(kind: AgentKind) -> TabChipKind {
+pub fn tab_chip_kind(kind: ProcessKind) -> TabChipKind {
     match kind {
-        AgentKind::Claude | AgentKind::Codex => TabChipKind::Cli,
-        AgentKind::Shell => TabChipKind::Term,
+        ProcessKind::Agent(_) => TabChipKind::Cli,
+        ProcessKind::Shell => TabChipKind::Term,
     }
 }
 
@@ -185,7 +189,7 @@ pub struct ChipColors {
     pub fg: Rgba,
 }
 
-pub fn tab_chip_colors(kind: AgentKind, active: bool) -> ChipColors {
+pub fn tab_chip_colors(kind: ProcessKind, active: bool) -> ChipColors {
     if active {
         let (fg, bg) = agent_tint(kind);
         ChipColors { bg, fg }
@@ -529,9 +533,9 @@ mod tests {
 
     #[test]
     fn agent_kinds_get_the_cli_chip_and_shell_gets_the_terminal_chip() {
-        assert_eq!(tab_chip_kind(AgentKind::Claude), TabChipKind::Cli);
-        assert_eq!(tab_chip_kind(AgentKind::Codex), TabChipKind::Cli);
-        assert_eq!(tab_chip_kind(AgentKind::Shell), TabChipKind::Term);
+        assert_eq!(tab_chip_kind(ProcessKind::claude()), TabChipKind::Cli);
+        assert_eq!(tab_chip_kind(ProcessKind::codex()), TabChipKind::Cli);
+        assert_eq!(tab_chip_kind(ProcessKind::Shell), TabChipKind::Term);
     }
 
     fn same(a: Rgba, b: Rgba) -> bool {
@@ -540,8 +544,8 @@ mod tests {
 
     #[test]
     fn an_active_cli_chip_is_tinted_with_its_own_agent_colour_not_a_shared_default() {
-        let claude = tab_chip_colors(AgentKind::Claude, true);
-        let codex = tab_chip_colors(AgentKind::Codex, true);
+        let claude = tab_chip_colors(ProcessKind::claude(), true);
+        let codex = tab_chip_colors(ProcessKind::codex(), true);
         assert!(
             !same(claude.bg, codex.bg),
             "two different agents must not share a tab chip colour"
@@ -571,15 +575,15 @@ mod tests {
             bg: theme::lang::RS.1.into(),
         };
         let file_colors = file_tab_chip_colors(rs, false);
-        let agent_colors = tab_chip_colors(AgentKind::Shell, false);
+        let agent_colors = tab_chip_colors(ProcessKind::Shell, false);
         assert!(same(file_colors.bg, agent_colors.bg));
         assert!(same(file_colors.fg, agent_colors.fg));
     }
 
     #[test]
     fn an_inactive_chip_is_always_dimmed_to_the_same_neutral_regardless_of_kind() {
-        let claude = tab_chip_colors(AgentKind::Claude, false);
-        let shell = tab_chip_colors(AgentKind::Shell, false);
+        let claude = tab_chip_colors(ProcessKind::claude(), false);
+        let shell = tab_chip_colors(ProcessKind::Shell, false);
         assert!(same(claude.bg, shell.bg));
         assert!(same(claude.fg, shell.fg));
         assert!(same(claude.bg, theme::border::ZONE.into()));

--- a/crates/app/src/worktree_history/flow.rs
+++ b/crates/app/src/worktree_history/flow.rs
@@ -266,7 +266,7 @@ mod worktree_history_regression_tests {
     ) -> AgentId {
         app.update_in(cx, |app, window, cx| {
             app.agents.spawn(
-                AgentKind::Shell,
+                ProcessKind::Shell,
                 cwd,
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),

--- a/crates/app/src/worktree_history/mod.rs
+++ b/crates/app/src/worktree_history/mod.rs
@@ -9,7 +9,7 @@
 use crate::root::*;
 use crate::work_surface::agents::AgentId;
 #[cfg(test)]
-use crate::work_surface::agents::AgentKind;
+use crate::work_surface::agents::ProcessKind;
 use gpui::{Context, Window};
 use std::path::Path;
 #[cfg(test)]

--- a/crates/pty-core/src/lib.rs
+++ b/crates/pty-core/src/lib.rs
@@ -330,7 +330,7 @@ impl SpawnOptions {
 ///   uid/gid. Judged an acceptable simplification for a status dot over adding a dependency.
 /// - This never checks a cwd-relative candidate (`portable-pty`'s `is_cwd_relative_path`
 ///   branch, e.g. `./claude`) - every caller here passes a bare name
-///   (`SessionKind::agent_binary_name` in the `app` crate only returns plain names like
+///   (`AgentKind::binary_name` in the `app` crate only returns plain names like
 ///   `"claude"`/`"codex"`), so that branch is dead code for this crate's actual callers.
 ///
 /// Because this is a second, independent implementation of the same algorithm rather than a


### PR DESCRIPTION
## Summary

Closes #231 (in addition to what #232 already fixed - this is a stacked follow-up building on that branch).

`AgentKind` used to be a flat 3-variant enum (`Shell`, `Claude`, `Codex`) that everything in the rail/tab/settings/palette machinery matched on. That shape is exactly how #232's bug happened: a type named "AgentKind" containing a non-agent variant means every `match` has to *remember* to give Shell separate treatment, and one place forgot.

This splits it for real, at the type level:

```rust
/// A real agent CLI kind. Never a bare shell.
pub enum AgentKind { Claude, Codex }

/// What's actually running in an agent slot/tab.
pub enum ProcessKind { Shell, Agent(AgentKind) }
```

- `AgentKind` now means only "a real agent" - nothing can construct a `AgentKind::Shell` because it doesn't exist. Anywhere that only ever makes sense for a real agent (the Settings › Agents installed-CLI card, `$PATH` binary resolution, `resolved_new_agent_kind`) now takes `AgentKind` directly, so passing a shell there is a compile error, not a runtime bug waiting to happen.
- `ProcessKind` is the new wrapper for the ~25 call sites that genuinely need to handle "shell or agent" (tab chips, spawn, status derivation, badges). Cases that only cared about "is this a shell or not" collapse to a clean 2-arm match; cases that need to tell Claude from Codex destructure the inner `AgentKind`.
- `ProcessKind::claude()`/`::codex()` are `const fn` construction shorthands only - never usable to dodge an exhaustive match.
- `AgentKind::binary_name()` is now infallible (was `Option<&'static str>` on the old flat enum, since `Shell` had no binary) - deletes a `filter_map`/`and_then` at both call sites.
- `PaletteEntry::agent_kind` renamed to `process_kind` - it held a `ProcessKind` (can be `Shell`) under a name that implied it was always a real agent, the same trap one level down.

Touches 32 files, all mechanical propagation plus real judgment in the handful of places that generate per-CLI content (icon/tint/label lookups). No `_ =>` wildcards were introduced anywhere - every match stays exhaustive.

## Test plan

- [x] `cargo build --workspace` - clean
- [x] `cargo clippy -p app --all-targets -- -D warnings` - clean
- [x] `cargo fmt --check -p app` - clean
- [x] `cargo test -p app --lib` - 2078 passed, 0 failed
- [x] Self-reviewed the full diff file-by-file (type def, status.rs, settings, palette, status_bar's non-Linux cfg path, pty-core doc fix) before pushing
- [x] Grepped the final diff for leftover flat `AgentKind::Shell` references and `_ =>` wildcards - none found

🤖 Generated with [Claude Code](https://claude.com/claude-code)