### PR TITLE
fix(app): exclude Shell from the rail's agent rows

### DIFF
--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -107,9 +107,18 @@ impl AdeApp {
     /// summary from [`Self::diff_cache`] (refreshed by the periodic task started in
     /// `Self::new`). An agent with no diff data yet simply shows `0`/`0` until the next
     /// status-poll tick fills it in.
+    ///
+    /// A plain [`crate::work_surface::agents::ProcessKind::Shell`] never gets a row here - the
+    /// rail answers "who needs me", and a shell has no turn to finish and nothing to ask. It
+    /// still shows up in the tab strip (`crate::work_surface::render`, which lists everything
+    /// open in the selected worktree, agents and shells alike) - this is specifically the rail's
+    /// own, narrower list. A worktree whose only open pane is a shell therefore renders as an
+    /// empty/idle row here, identically to a worktree with nothing open at all
+    /// (`rail::build_worktree_rows` already handles that case).
     pub(crate) fn build_agent_rows(&self, cx: &App) -> Vec<AgentRow> {
         self.agents
             .iter()
+            .filter(|agent| agent.kind.is_agent_session())
             .map(|agent| {
                 let status_value = self.agent_status(agent, cx);
                 let pane = agent.pane.read(cx);
@@ -1732,8 +1741,15 @@ mod rail_row_tests {
     }
 
     /// §2.2: "Worktrees whose most urgent agent is idle start collapsed" - proven here against
-    /// a real running agent (never collapsed by default) and a real idle one (collapsed by
-    /// default), through `Self::worktree_is_expanded`, the single real place that default lives.
+    /// a running agent (never collapsed by default) and a real idle one (collapsed by default),
+    /// through `Self::worktree_is_expanded`, the single real place that default lives.
+    ///
+    /// The running case is a synthetic `AgentRow` rather than a real spawned agent: a plain
+    /// shell no longer produces any rail row at all (see `Self::build_agent_rows`'s own docs),
+    /// so it can't stand in for "a running agent" here any more, and reaching for a real
+    /// `claude`/`codex` spawn just to get one `Status::Run` row would trade a fast, deterministic
+    /// test for a slow one that also depends on those CLIs being installed - this test is about
+    /// `worktree_is_expanded`'s idle-rooted default, not about spawning.
     ///
     /// Selects a *second*, unrelated worktree rather than `wt` itself (GitHub issue #112 live
     /// follow-up: the currently selected worktree is now exempt from this default - see
@@ -1758,30 +1774,37 @@ mod rail_row_tests {
             // real not-currently-selected case, or the new selected-worktree exemption would
             // make this test vacuous.
             app.select_worktree(1, window, cx);
-            app.agents.spawn(
-                ProcessKind::Shell,
-                wt.path().to_path_buf(),
-                12.0,
-                None,
-                window,
-                cx,
-            );
         });
-        // The pty spawn itself is async (`TerminalPane::spawn_process`), so the process isn't
-        // observably running yet the instant `spawn` returns - let it actually start before
-        // reading a live `Status` off it.
-        cx.run_until_parked();
 
-        let running_row = app.read_with(cx, |app, cx| {
+        let empty_row = app.read_with(cx, |app, cx| {
             app.build_worktree_rows(cx)
                 .into_iter()
                 .find(|row| row.path == wt.path())
                 .expect("the seeded worktree must produce a row")
         });
+        let running_agent = rail::AgentRow {
+            id: 1,
+            kind: ProcessKind::claude(),
+            title: "wt".to_string(),
+            cwd: wt.path().to_path_buf(),
+            status: Status::Run,
+            branch: Some("wt".to_string()),
+            add: 0,
+            del: 0,
+            question_preview: None,
+            exit_code: None,
+            activity: None,
+            elapsed: std::time::Duration::from_secs(1),
+            review_file_count: None,
+        };
+        let running_row = rail::WorktreeRow {
+            agents: vec![running_agent],
+            ..empty_row
+        };
         assert_eq!(
             running_row.aggregate_status(),
             Status::Run,
-            "sanity check: a just-spawned shell is Run, not Idle, within the recent-output window"
+            "sanity check: a running agent's row aggregates to Run"
         );
         assert!(
             app.read_with(cx, |app, _| app.worktree_is_expanded(&running_row)),
@@ -1800,6 +1823,71 @@ mod rail_row_tests {
         assert!(
             !app.read_with(cx, |app, _| app.worktree_is_expanded(&idle_row)),
             "an idle-rooted worktree must default to collapsed"
+        );
+    }
+
+    /// **The regression test for this fix.** The rail answers "who needs me", and a plain shell
+    /// never needs anyone - so a worktree whose only open pane is a shell must produce zero rail
+    /// rows, the same as a worktree with nothing open at all. The tab strip
+    /// (`crate::work_surface::render`) is the real place a shell tab shows up; this test proves
+    /// the rail and the tab strip are allowed to disagree about that on purpose.
+    #[gpui::test]
+    fn a_worktree_with_only_a_shell_open_produces_no_agent_row(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        app.update(cx, |app, _cx| {
+            app.worktrees = vec![worktree_item(repo.path().to_path_buf(), "repo")];
+        });
+        cx.run_until_parked();
+
+        // The startup shell (`root::state`) already occupies this worktree - assert the
+        // precondition rather than assuming it, then add a second shell explicitly so this test
+        // doesn't depend on exactly how many the app happens to start with.
+        app.update_in(cx, |app, window, cx| {
+            app.agents.spawn(
+                ProcessKind::Shell,
+                repo.path().to_path_buf(),
+                12.0,
+                None,
+                window,
+                cx,
+            );
+        });
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.agents
+                    .iter()
+                    .all(|agent| !agent.kind.is_agent_session()),
+                "precondition: every open agent in this test is a shell"
+            );
+            assert!(
+                app.agents.iter().count() >= 2,
+                "precondition: at least two shells are genuinely open"
+            );
+        });
+
+        let rows = app.read_with(cx, |app, cx| app.build_agent_rows(cx));
+        assert!(
+            rows.is_empty(),
+            "a worktree with only shells open must produce zero agent rows - got {rows:?}"
+        );
+
+        let worktree_row = app.read_with(cx, |app, cx| {
+            app.build_worktree_rows(cx)
+                .into_iter()
+                .find(|row| row.path == repo.path())
+                .expect("the repo's own worktree must still produce a row")
+        });
+        assert!(
+            worktree_row.agents.is_empty(),
+            "and the worktree row itself must fold in none of them"
+        );
+        assert_eq!(
+            worktree_row.aggregate_status(),
+            Status::Idle,
+            "a shell-only worktree aggregates exactly like an empty one"
         );
     }
 
@@ -2467,11 +2555,17 @@ mod agent_chip_icon_pack_tests {
         }
     }
 
-    /// A real, running shell agent in a real seeded worktree - a just-spawned shell is `Status::
-    /// Run`, which defaults its worktree row to expanded (`AdeApp::worktree_is_expanded`'s own
+    /// A real, running agent in a real seeded worktree - a just-spawned agent is `Status::Run`,
+    /// which defaults its worktree row to expanded (`AdeApp::worktree_is_expanded`'s own
     /// "idle-rooted" rule), so the agent row (and this chip) actually renders without needing a
     /// separate collapse-override hack.
-    fn open_with_a_running_shell_agent(
+    ///
+    /// Real `AgentKind::Claude`, not `ProcessKind::Shell`: the rail never renders a row for a
+    /// plain shell at all (`AdeApp::build_agent_rows`'s own docs - a shell has nothing for the
+    /// rail to triage), so it can no longer stand in for "an agent row" here. The icon-chip
+    /// logic under test (`AdeApp::render_agent_chip_icon`) doesn't care which real kind it's
+    /// given - it's exercised identically either way.
+    fn open_with_a_running_agent(
         cx: &mut TestAppContext,
     ) -> (
         tempfile::TempDir,
@@ -2489,7 +2583,7 @@ mod agent_chip_icon_pack_tests {
         app.update_in(cx, |app, window, cx| {
             app.select_worktree(0, window, cx);
             app.agents.spawn(
-                ProcessKind::Shell,
+                ProcessKind::claude(),
                 wt.path().to_path_buf(),
                 12.0,
                 None,
@@ -2503,7 +2597,7 @@ mod agent_chip_icon_pack_tests {
 
     #[gpui::test]
     fn the_rail_agent_row_shows_the_default_chip_with_no_pack_configured(cx: &mut TestAppContext) {
-        let (_repo, _wt, _app, cx) = open_with_a_running_shell_agent(cx);
+        let (_repo, _wt, _app, cx) = open_with_a_running_agent(cx);
 
         assert!(
             cx.debug_bounds("agent-chip-icon-default").is_some(),
@@ -2520,11 +2614,11 @@ mod agent_chip_icon_pack_tests {
         cx: &mut TestAppContext,
     ) {
         let pack_dir = tempfile::tempdir().expect("tempdir");
-        // The seeded agent is a real `ProcessKind::Shell` (`work_surface::agent_icon_name`'s own
-        // mapping), so `shell.svg` is the real file this specific row's chip looks for.
-        std::fs::write(pack_dir.path().join("shell.svg"), "<svg></svg>").expect("write");
+        // The seeded agent is a real `AgentKind::Claude` (`work_surface::agent_icon_name`'s own
+        // mapping), so `claude.svg` is the real file this specific row's chip looks for.
+        std::fs::write(pack_dir.path().join("claude.svg"), "<svg></svg>").expect("write");
 
-        let (_repo, _wt, app, cx) = open_with_a_running_shell_agent(cx);
+        let (_repo, _wt, app, cx) = open_with_a_running_agent(cx);
         app.update(cx, |app, cx| {
             app.settings.icon_pack.directory = Some(pack_dir.path().to_path_buf());
             cx.notify();

--- a/crates/app/src/title_bar/render.rs
+++ b/crates/app/src/title_bar/render.rs
@@ -817,6 +817,13 @@ mod agent_state_chip_live_tests {
     /// the title bar's chip row really disappears in response - not just that it starts out
     /// `None` before anything has run. `Self::render_title_bar` itself is also exercised at
     /// both ends, unmodified, to prove the real production method doesn't panic either way.
+    ///
+    /// The startup shell is retagged to a real `AgentKind` via `Agents::set_kind_for_test`
+    /// immediately after spawn: the rail (and so the title bar chip it drives) never produces a
+    /// row for a plain shell at all (`AdeApp::build_agent_rows`'s own docs), so this test's real
+    /// subject - "the chip row disappears once the one open real agent closes" - needs a real
+    /// agent kind to have anything to observe in the first place. The retag doesn't touch the
+    /// real spawned process, only the bookkeeping `kind` the rail/chip logic reads.
     #[gpui::test]
     fn closing_the_only_real_agent_makes_the_chip_row_disappear(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
@@ -826,12 +833,16 @@ mod agent_state_chip_live_tests {
         let startup_agent_id = app
             .read_with(cx, |app, _| app.agents.active_id())
             .expect("the real startup shell must be the active agent");
+        app.update(cx, |app, _cx| {
+            app.agents
+                .set_kind_for_test(startup_agent_id, ProcessKind::claude());
+        });
 
         let chips_at_startup = app.update(cx, |app, cx| app.render_title_bar_agent_state_chips(cx));
         assert!(
             chips_at_startup.is_some(),
-            "the real, freshly spawned startup shell is a genuine Status::Run agent and must \
-             produce a real, visible chip"
+            "the retagged startup process is a genuine Status::Run agent and must produce a \
+             real, visible chip"
         );
         app.update(cx, |app, cx| {
             let _ = app.render_title_bar(cx);
@@ -864,6 +875,14 @@ mod agent_state_chip_live_tests {
     /// Spawning a real second agent on top of the real startup shell is a genuine state change
     /// over live process data - not a hand-built row - and the chip text must track it,
     /// including the exact singular → plural flip at 1 → 2.
+    ///
+    /// Both the startup shell and the second spawned process are retagged to a real `AgentKind`
+    /// via `Agents::set_kind_for_test` (see the sibling test's own docs for why): the rail no
+    /// longer produces any row at all for a plain shell, but this test is specifically about the
+    /// chip's real PTY-activity/idle-duration tracking, which is genuinely cheaper and more
+    /// deterministic to exercise against real shell processes than against real `claude`/`codex`
+    /// CLI spawns - the retag keeps that real PTY behavior while making the two agents count as
+    /// real agents for the chip logic under test.
     #[gpui::test]
     fn a_second_real_spawned_agent_flips_the_live_chip_from_singular_to_plural(
         cx: &mut TestAppContext,
@@ -872,6 +891,14 @@ mod agent_state_chip_live_tests {
         let wt_b = tempfile::tempdir().expect("tempdir wt-b");
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
+
+        let startup_agent_id = app
+            .read_with(cx, |app, _| app.agents.active_id())
+            .expect("the real startup shell must be the active agent");
+        app.update(cx, |app, _cx| {
+            app.agents
+                .set_kind_for_test(startup_agent_id, ProcessKind::claude());
+        });
 
         let rows_at_startup = app.update(cx, |app, cx| app.build_agent_rows(cx));
         assert_eq!(
@@ -888,14 +915,12 @@ mod agent_state_chip_live_tests {
             vec![(Status::Run, "1 agent running".to_string())],
             "one real running agent must read as the singular form"
         );
-        let first_agent_id = app
-            .read_with(cx, |app, _| app.agents.active_id())
-            .expect("the real startup shell is the sole, active agent");
+        let first_agent_id = startup_agent_id;
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![worktree_item(wt_b.path().to_path_buf(), "wt-b")];
         });
-        app.update_in(cx, |app, window, cx| {
+        let second_agent_id = app.update_in(cx, |app, window, cx| {
             app.select_worktree(0, window, cx);
             app.agents.spawn(
                 ProcessKind::Shell,
@@ -904,7 +929,11 @@ mod agent_state_chip_live_tests {
                 None,
                 window,
                 cx,
-            );
+            )
+        });
+        app.update(cx, |app, _cx| {
+            app.agents
+                .set_kind_for_test(second_agent_id, ProcessKind::codex());
         });
         // The pty spawn is async (`TerminalPane::spawn_process`) - let it actually start
         // before reading a live `Status` off it, the same real seam


### PR DESCRIPTION
## Summary

The rail (`design_handoff_jerry_ade/README.md`'s "session rail") answers "who needs me" - a plain shell has no turn to finish and nothing to ask, so it never belonged in that list at all. `build_agent_rows` folded in every open agent unconditionally, so a shell tab got a rail row, inflated the title bar's "N agents running" chip text, and inflated the status bar's urgency-counter squares - all three readings incorrectly treated a running shell as a running agent.

- `AdeApp::build_agent_rows` now filters to `agent.kind.is_agent_session()`.
- Shell tabs remain fully visible and usable in the tab strip (`crate::work_surface::render`, which lists everything open in a worktree) - this is specifically the rail's own, narrower list.
- A worktree whose only open pane is a shell now renders as an empty/idle row, identically to a worktree with nothing open at all - already-tested, unchanged behavior (`build_worktree_rows_includes_worktrees_with_no_agent_as_empty_rows`).
- New regression test: `a_worktree_with_only_a_shell_open_produces_no_agent_row`.
- Two existing tests assumed a shell counts as an agent row and needed updating:
  - `worktree_is_expanded_defaults_to_the_real_idle_rooted_rule` - repurposed to build a synthetic `AgentRow` directly, which also removes a real-CLI-spawn timing dependency it didn't actually need.
  - `the_rail_agent_row_shows_the_default_chip_with_no_pack_configured` / `..._switches_to_a_real_pack_icon_once_one_is_configured` - switched their seeded agent from `ProcessKind::Shell` to a real `AgentKind::Claude`.
  - `closing_the_only_real_agent_makes_the_chip_row_disappear` / `a_second_real_spawned_agent_flips_the_live_chip_from_singular_to_plural` - retagged their shell-spawned test subjects to a real `AgentKind` via `Agents::set_kind_for_test` (added this session) so their real PTY-timing mechanics (Ctrl-L echo / `idle_duration` refresh) stay intact while correctly counting for the chip logic under test, without needing a real `claude`/`codex` CLI spawn.

## Test plan

- [x] `cargo test -p app --lib rail::` / `title_bar::` - all green, including the new/updated tests
- [x] `cargo clippy -p app --all-targets -- -D warnings` - clean
- [x] `cargo fmt --check -p app` - clean (one pre-existing, unrelated fmt diff in `review/render.rs` confirmed present on master before this branch - not touched here)
- [x] `cargo test -p app --lib` - full suite, 2109 passed; the usual 9 known-flaky file-tree-watch/repo-list tests under heavy parallel load, confirmed passing standalone with reduced parallelism

🤖 Generated with [Claude Code](https://claude.com/claude-code)