### PR TITLE
feat(app): real structural agent status from terminal title and OSC signal (issue #239, phase 1)

### DIFF
--- a/crates/app/src/rail/mod.rs
+++ b/crates/app/src/rail/mod.rs
@@ -17,6 +17,9 @@
 //! - [`status`] - derives an agent's `Status` ("who needs me") from already-read process
 //!   signals; the rail's whole reason for existing, and shared with the tab strip and
 //!   status bar that surface the same answer.
+//! - [`title_signal`] - the pure classifier turning an agent CLI's own terminal title into the
+//!   coarse busy/idle/needs-you signal [`status`] refines its quiescence heuristic with
+//!   (GitHub issue #239). No `gpui`, and no terminal types either.
 //! - [`render`] - the real GPUI rail, its rows, hover affordances and click handlers, as
 //!   `impl AdeApp` methods.
 //!
@@ -43,6 +46,7 @@ use std::time::Instant;
 pub mod repo;
 pub mod state;
 pub mod status;
+pub mod title_signal;
 pub mod worktree_watch;
 pub mod worktrees;
 

--- a/crates/app/src/rail/status.rs
+++ b/crates/app/src/rail/status.rs
@@ -2,10 +2,11 @@
 //! calls the whole point of the agent rail.
 //!
 //! GPUI-free and pty/process-free: takes small, already-read signals ([`ProcessSignal`], a
-//! `has_reviewable_diff` bool, a [`crate::work_surface::agents::ProcessKind`]) and returns a
-//! [`Status`], so the decision logic is unit testable without a window or a child process.
-//! Gathering those signals from a live [`crate::terminal::pane::TerminalPane`] and
-//! `wt_core::diff::diff_against_base` lives in `crate::rail::state`/`crate::root`.
+//! [`TerminalSignal`], a `has_reviewable_diff` bool, a
+//! [`crate::work_surface::agents::ProcessKind`]) and returns a [`Status`], so the decision logic
+//! is unit testable without a window or a child process. Gathering those signals from a live
+//! [`crate::terminal::pane::TerminalPane`] and `wt_core::diff::diff_against_base` lives in
+//! `crate::rail::state`/`crate::root`.
 //!
 //! ## The heuristic, precisely
 //!
@@ -41,9 +42,49 @@
 //! A plain [`crate::work_surface::agents::ProcessKind::Shell`] has no such grace window: a shell
 //! sitting at its prompt isn't "asking a question", it's just idle - so it falls straight to
 //! [`Status::Idle`] once [`RUN_RECENT_OUTPUT_WINDOW`] elapses, never [`Status::Ask`].
+//!
+//! ## The second signal: what the agent says about itself (GitHub issue #239)
+//!
+//! Idle time is a substitute for a signal the process never sent. But real agent CLIs *do* send
+//! one, into the same pty, and Jerry used to throw it away: they write a live status glyph into
+//! the terminal title (OSC 0/2), and some fire real desktop notifications (OSC 9, OSC 777) and
+//! progress reports (OSC 9;4). [`TerminalSignal`] carries all three, already parsed
+//! (`crate::terminal::osc`) and already classified (`crate::rail::title_signal`), and it
+//! *refines* the quiescence heuristic above rather than replacing it - a CLI that says nothing
+//! lands on exactly the behaviour described above, unchanged.
+//!
+//! Two refinements, both only for a real agent session, and both narrowly scoped to the
+//! [`ProcessSignal::Running`] branch (an exit is an exact fact; no title can argue with it):
+//!
+//! - **Attention beats the clock.** [`TitleSignal::NeedsAttention`], or an unanswered OSC 9 /
+//!   OSC 777 notification, reports [`Status::Ask`] immediately. The 15s
+//!   [`AGENT_ASK_IDLE_THRESHOLD`] exists *only* to compensate for not having this signal; when
+//!   the agent says outright that it's blocked on the human, making the human wait out a timer
+//!   built to guess at that same fact is pure added latency.
+//! - **Busy beats the clock too, the other way.** [`TitleSignal::Busy`], or an active
+//!   [`crate::terminal::osc::ProgressState`], holds [`Status::Run`] even past
+//!   [`AGENT_ASK_IDLE_THRESHOLD`]. This fixes a real false-positive class the idle heuristic
+//!   cannot fix on its own: a long tool call that produces no terminal output - a slow compile,
+//!   a big download - goes quiet for minutes and gets read as "needs input" purely because of
+//!   the silence, while the agent's own title glyph is still spinning.
+//!
+//! Everything else about a terminal signal is deliberately *not* acted on.
+//! [`TitleSignal::Idle`] does not shortcut anything: an agent that finished its turn and is
+//! sitting at its prompt is waiting on the human, which is what the existing threshold already
+//! concludes on its own - so there is no decision left for it to improve, only a chance to be
+//! wrong faster. And [`TitleSignal::Unknown`] means exactly what it says, "no information", not
+//! "idle".
+//!
+//! A [`crate::work_surface::agents::ProcessKind::Shell`] never consults [`TerminalSignal`] at
+//! all - not even to stay [`Status::Run`]. Titles are attacker-adjacent input in the mundane
+//! sense: a shell prompt, a `vim` session, or a `printf '\e]0;...\a'` in someone's `.bashrc` can
+//! put any glyph or word in a shell's title, and none of that makes a shell an agent session
+//! that can need input. That gate is pinned by its own test below.
 
 use std::time::Duration;
 
+use crate::rail::title_signal::TitleSignal;
+use crate::terminal::osc::Progress;
 use crate::work_surface::agents::ProcessKind;
 
 /// How long a live process must have produced output within to count as "recently active" - the
@@ -147,18 +188,61 @@ pub enum ProcessSignal {
     NoProcess,
 }
 
-/// Derives the [`Status`] for one agent from its process signal and whether it has a
-/// non-empty diff against its worktree's base - see the module docs for the Run/Ask split.
+/// What the process said about itself through its own terminal, as opposed to what its silence
+/// implies - see the module docs' "second signal" section (GitHub issue #239).
+///
+/// Built by the caller (`crate::work_surface::render::AdeApp::agent_status`) from a live
+/// [`crate::terminal::pane::TerminalPane`]. [`Default`] is "the process said nothing", which is
+/// both the honest starting state and what every non-agent process is handed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct TerminalSignal {
+    /// The classification of the process's own window title, or `None` if it never set one.
+    pub title: Option<TitleSignal>,
+    /// Whether an OSC 9 / OSC 777 desktop notification is outstanding - fired by the process and
+    /// not yet answered by the human. See
+    /// [`crate::terminal::pane::TerminalPane::has_pending_attention_ping`].
+    pub attention_pinged: bool,
+    /// The process's most recent OSC 9;4 progress report, if it speaks that protocol.
+    pub progress: Option<Progress>,
+}
+
+impl TerminalSignal {
+    /// Whether the process is explicitly asking for the human - see the module docs.
+    fn wants_attention(self) -> bool {
+        self.attention_pinged || self.title == Some(TitleSignal::NeedsAttention)
+    }
+
+    /// Whether the process is explicitly claiming to be working right now - see the module docs.
+    ///
+    /// A progress report only counts while it describes work that is actually advancing;
+    /// [`crate::terminal::osc::ProgressState::is_active`] is where that line is drawn, and it
+    /// deliberately excludes the error and paused states, which are exactly when a stalled
+    /// agent would otherwise get to claim it's still busy forever.
+    fn is_busy(self) -> bool {
+        self.title == Some(TitleSignal::Busy) || self.progress.is_some_and(|p| p.state.is_active())
+    }
+}
+
+/// Derives the [`Status`] for one agent from its process signal, what its own terminal claims
+/// about it ([`TerminalSignal`]), and whether it has a non-empty diff against its worktree's
+/// base - see the module docs for the Run/Ask split and how the two signals combine.
 pub fn derive_status(
     kind: ProcessKind,
     signal: ProcessSignal,
+    terminal: TerminalSignal,
     has_reviewable_diff: bool,
 ) -> Status {
     match signal {
         ProcessSignal::NoProcess => Status::Idle,
         ProcessSignal::Running { idle } => {
             if kind.is_agent_session() {
-                if idle < AGENT_ASK_IDLE_THRESHOLD {
+                // Both of these deliberately outrank the idle clock in both directions - see the
+                // module docs' "second signal" section. `wants_attention` is checked first: an
+                // agent that is both spinning a busy glyph and has an unanswered notification
+                // out is one that needs the human *now* and happens to still be rendering.
+                if terminal.wants_attention() {
+                    Status::Ask
+                } else if terminal.is_busy() || idle < AGENT_ASK_IDLE_THRESHOLD {
                     Status::Run
                 } else {
                     Status::Ask
@@ -190,15 +274,36 @@ pub fn derive_status(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::terminal::osc::ProgressState;
+
+    /// The "this process said nothing through its terminal" signal - what every pre-existing
+    /// test below means, and exactly what a CLI that sets no title and sends no OSC produces.
+    fn quiet() -> TerminalSignal {
+        TerminalSignal::default()
+    }
+
+    /// A [`TerminalSignal`] carrying only a classified title - the common real case, since
+    /// every agent CLI observed sets a title and none of them sent an OSC 9 notification.
+    fn titled(title: TitleSignal) -> TerminalSignal {
+        TerminalSignal {
+            title: Some(title),
+            ..TerminalSignal::default()
+        }
+    }
 
     #[test]
     fn no_process_is_idle_regardless_of_kind_or_diff() {
         assert_eq!(
-            derive_status(ProcessKind::Shell, ProcessSignal::NoProcess, true),
+            derive_status(ProcessKind::Shell, ProcessSignal::NoProcess, quiet(), true),
             Status::Idle
         );
         assert_eq!(
-            derive_status(ProcessKind::claude(), ProcessSignal::NoProcess, true),
+            derive_status(
+                ProcessKind::claude(),
+                ProcessSignal::NoProcess,
+                quiet(),
+                true
+            ),
             Status::Idle
         );
     }
@@ -209,15 +314,15 @@ mod tests {
             idle: Duration::from_millis(500),
         };
         assert_eq!(
-            derive_status(ProcessKind::Shell, signal, false),
+            derive_status(ProcessKind::Shell, signal, quiet(), false),
             Status::Run
         );
         assert_eq!(
-            derive_status(ProcessKind::claude(), signal, false),
+            derive_status(ProcessKind::claude(), signal, quiet(), false),
             Status::Run
         );
         assert_eq!(
-            derive_status(ProcessKind::codex(), signal, false),
+            derive_status(ProcessKind::codex(), signal, quiet(), false),
             Status::Run
         );
     }
@@ -228,7 +333,7 @@ mod tests {
             idle: RUN_RECENT_OUTPUT_WINDOW + Duration::from_secs(1),
         };
         assert_eq!(
-            derive_status(ProcessKind::Shell, signal, false),
+            derive_status(ProcessKind::Shell, signal, quiet(), false),
             Status::Idle,
             "a shell sitting at its prompt is idle, not \"needs input\" - it isn't asking anything"
         );
@@ -243,12 +348,247 @@ mod tests {
             idle: RUN_RECENT_OUTPUT_WINDOW + Duration::from_secs(1),
         };
         assert_eq!(
-            derive_status(ProcessKind::claude(), signal, false),
+            derive_status(ProcessKind::claude(), signal, quiet(), false),
             Status::Run
         );
         assert_eq!(
-            derive_status(ProcessKind::codex(), signal, false),
+            derive_status(ProcessKind::codex(), signal, quiet(), false),
             Status::Run
+        );
+    }
+
+    #[test]
+    fn a_busy_title_keeps_a_long_quiet_agent_on_run_instead_of_ask() {
+        // The real false-positive class this signal exists to fix (GitHub issue #239), and one
+        // observed live: Claude Code kept its `\u{25d0}`/`\u{25d1}` spinner animating through a
+        // 9-second run of `sleep 3` tool calls that wrote nothing at all to the terminal. Purely
+        // by idle time that agent is "needs input"; by its own title it is plainly still working.
+        let long_quiet = ProcessSignal::Running {
+            idle: AGENT_ASK_IDLE_THRESHOLD * 20,
+        };
+        assert_eq!(
+            derive_status(ProcessKind::claude(), long_quiet, quiet(), false),
+            Status::Ask,
+            "baseline: with no terminal signal, silence alone still means Ask"
+        );
+        assert_eq!(
+            derive_status(
+                ProcessKind::claude(),
+                long_quiet,
+                titled(TitleSignal::Busy),
+                false
+            ),
+            Status::Run,
+            "an agent whose own title says it is working must not be reported as needing input"
+        );
+    }
+
+    #[test]
+    fn an_active_progress_report_also_keeps_a_long_quiet_agent_on_run() {
+        let long_quiet = ProcessSignal::Running {
+            idle: AGENT_ASK_IDLE_THRESHOLD * 20,
+        };
+        for state in [ProgressState::Normal, ProgressState::Indeterminate] {
+            let terminal = TerminalSignal {
+                progress: Some(Progress {
+                    state,
+                    percent: Some(40),
+                }),
+                ..TerminalSignal::default()
+            };
+            assert_eq!(
+                derive_status(ProcessKind::claude(), long_quiet, terminal, false),
+                Status::Run,
+                "{state:?} is work actually advancing"
+            );
+        }
+        // A stalled or paused report is exactly when the human may be wanted, so it must not buy
+        // the process an indefinite "still running" - the idle clock takes over again.
+        for state in [ProgressState::Error, ProgressState::Paused] {
+            let terminal = TerminalSignal {
+                progress: Some(Progress {
+                    state,
+                    percent: Some(40),
+                }),
+                ..TerminalSignal::default()
+            };
+            assert_eq!(
+                derive_status(ProcessKind::claude(), long_quiet, terminal, false),
+                Status::Ask,
+                "{state:?} must not be able to claim the agent is still working"
+            );
+        }
+    }
+
+    #[test]
+    fn a_needs_attention_title_reaches_ask_long_before_the_idle_threshold() {
+        // The 15s threshold exists only because Jerry used to have no better signal. When the
+        // agent says outright that it's blocked on the human, waiting the timer out is pure
+        // added latency.
+        let barely_quiet = ProcessSignal::Running {
+            idle: Duration::from_millis(100),
+        };
+        assert_eq!(
+            derive_status(ProcessKind::claude(), barely_quiet, quiet(), false),
+            Status::Run,
+            "baseline: this agent is nowhere near the ask threshold"
+        );
+        assert_eq!(
+            derive_status(
+                ProcessKind::claude(),
+                barely_quiet,
+                titled(TitleSignal::NeedsAttention),
+                false
+            ),
+            Status::Ask
+        );
+    }
+
+    #[test]
+    fn an_unanswered_osc_notification_reaches_ask_long_before_the_idle_threshold() {
+        let barely_quiet = ProcessSignal::Running {
+            idle: Duration::from_millis(100),
+        };
+        let terminal = TerminalSignal {
+            attention_pinged: true,
+            ..TerminalSignal::default()
+        };
+        assert_eq!(
+            derive_status(ProcessKind::claude(), barely_quiet, terminal, false),
+            Status::Ask
+        );
+    }
+
+    #[test]
+    fn attention_outranks_busy_when_an_agent_claims_both() {
+        // An agent that is both spinning a busy glyph and has an unanswered notification out is
+        // one that needs the human now and happens to still be rendering - see the module docs.
+        let terminal = TerminalSignal {
+            title: Some(TitleSignal::Busy),
+            attention_pinged: true,
+            progress: Some(Progress {
+                state: ProgressState::Normal,
+                percent: Some(10),
+            }),
+        };
+        let signal = ProcessSignal::Running {
+            idle: Duration::from_millis(100),
+        };
+        assert_eq!(
+            derive_status(ProcessKind::claude(), signal, terminal, false),
+            Status::Ask
+        );
+    }
+
+    #[test]
+    fn an_idle_or_unknown_title_changes_nothing_at_all() {
+        // Neither is allowed to shortcut a decision: `Idle` reaches the same answer the existing
+        // threshold already reaches on its own, and `Unknown` means "no information", never
+        // "idle". Checked on both sides of the ask threshold so a wrong shortcut in either
+        // direction would show up.
+        for idle in [Duration::from_millis(100), AGENT_ASK_IDLE_THRESHOLD * 2] {
+            let signal = ProcessSignal::Running { idle };
+            let baseline = derive_status(ProcessKind::claude(), signal, quiet(), false);
+            for title in [TitleSignal::Idle, TitleSignal::Unknown] {
+                assert_eq!(
+                    derive_status(ProcessKind::claude(), signal, titled(title), false),
+                    baseline,
+                    "{title:?} at idle={idle:?} must not change the answer"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_shell_never_reaches_ask_no_matter_how_agent_like_its_title_looks() {
+        // A shell prompt, a `vim` session, or a stray `printf '\e]0;...\a'` in someone's
+        // `.bashrc` can put any glyph or word in a shell's title. None of that makes a shell an
+        // agent session that can need input - see the module docs. This also covers the reverse
+        // direction: a busy-looking title must not hold a shell on `Run` either.
+        let every_signal = [
+            titled(TitleSignal::NeedsAttention),
+            titled(TitleSignal::Busy),
+            titled(TitleSignal::Idle),
+            titled(TitleSignal::Unknown),
+            TerminalSignal {
+                attention_pinged: true,
+                ..TerminalSignal::default()
+            },
+            TerminalSignal {
+                title: Some(TitleSignal::NeedsAttention),
+                attention_pinged: true,
+                progress: Some(Progress {
+                    state: ProgressState::Normal,
+                    percent: Some(50),
+                }),
+            },
+        ];
+        for terminal in every_signal {
+            assert_eq!(
+                derive_status(
+                    ProcessKind::Shell,
+                    ProcessSignal::Running {
+                        idle: AGENT_ASK_IDLE_THRESHOLD * 2
+                    },
+                    terminal,
+                    false
+                ),
+                Status::Idle,
+                "a quiet shell stays Idle regardless of {terminal:?}"
+            );
+            assert_eq!(
+                derive_status(
+                    ProcessKind::Shell,
+                    ProcessSignal::Running {
+                        idle: Duration::from_millis(100)
+                    },
+                    terminal,
+                    false
+                ),
+                Status::Run,
+                "a freshly-active shell stays Run regardless of {terminal:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_terminal_signal_never_overrides_an_exit_or_a_missing_process() {
+        // An exit is an exact fact - a stale title glyph from just before the process died must
+        // not be able to argue with it.
+        let shouting = TerminalSignal {
+            title: Some(TitleSignal::Busy),
+            attention_pinged: true,
+            progress: Some(Progress {
+                state: ProgressState::Normal,
+                percent: Some(50),
+            }),
+        };
+        assert_eq!(
+            derive_status(
+                ProcessKind::claude(),
+                ProcessSignal::Exited { success: false },
+                shouting,
+                false
+            ),
+            Status::Fail
+        );
+        assert_eq!(
+            derive_status(
+                ProcessKind::claude(),
+                ProcessSignal::Exited { success: true },
+                shouting,
+                true
+            ),
+            Status::Review
+        );
+        assert_eq!(
+            derive_status(
+                ProcessKind::claude(),
+                ProcessSignal::NoProcess,
+                shouting,
+                true
+            ),
+            Status::Idle
         );
     }
 
@@ -258,11 +598,11 @@ mod tests {
             idle: AGENT_ASK_IDLE_THRESHOLD + Duration::from_secs(1),
         };
         assert_eq!(
-            derive_status(ProcessKind::claude(), signal, false),
+            derive_status(ProcessKind::claude(), signal, quiet(), false),
             Status::Ask
         );
         assert_eq!(
-            derive_status(ProcessKind::codex(), signal, false),
+            derive_status(ProcessKind::codex(), signal, quiet(), false),
             Status::Ask
         );
     }
@@ -271,11 +611,11 @@ mod tests {
     fn nonzero_exit_is_fail_regardless_of_diff() {
         let signal = ProcessSignal::Exited { success: false };
         assert_eq!(
-            derive_status(ProcessKind::Shell, signal, true),
+            derive_status(ProcessKind::Shell, signal, quiet(), true),
             Status::Fail
         );
         assert_eq!(
-            derive_status(ProcessKind::claude(), signal, false),
+            derive_status(ProcessKind::claude(), signal, quiet(), false),
             Status::Fail
         );
     }
@@ -284,7 +624,7 @@ mod tests {
     fn zero_exit_with_a_real_diff_is_review() {
         let signal = ProcessSignal::Exited { success: true };
         assert_eq!(
-            derive_status(ProcessKind::claude(), signal, true),
+            derive_status(ProcessKind::claude(), signal, quiet(), true),
             Status::Review
         );
     }
@@ -296,7 +636,7 @@ mod tests {
         // clean exit means "review ready" (see `ProcessKind::is_agent_session`'s docs).
         let signal = ProcessSignal::Exited { success: true };
         assert_eq!(
-            derive_status(ProcessKind::Shell, signal, true),
+            derive_status(ProcessKind::Shell, signal, quiet(), true),
             Status::Idle,
             "a shell isn't an agent session - its exit can't be \"review ready\""
         );
@@ -306,7 +646,7 @@ mod tests {
     fn zero_exit_with_no_diff_is_idle_not_review() {
         let signal = ProcessSignal::Exited { success: true };
         assert_eq!(
-            derive_status(ProcessKind::claude(), signal, false),
+            derive_status(ProcessKind::claude(), signal, quiet(), false),
             Status::Idle
         );
     }

--- a/crates/app/src/rail/title_signal.rs
+++ b/crates/app/src/rail/title_signal.rs
@@ -1,0 +1,335 @@
+//! Reading an agent CLI's own window title as a coarse status signal (GitHub issue #239).
+//!
+//! GPUI-free and terminal-free: takes the plain title string
+//! `crate::terminal::pane::TerminalPane::title` captured off the pty and returns a
+//! [`TitleSignal`], so every classification rule below is directly `#[test]`-able without a
+//! window or a child process - the same contract [`crate::rail::status`] holds.
+//!
+//! ## Why a terminal title is a real signal
+//!
+//! TUI programs have set their status into the terminal title since long before agent CLIs
+//! existed - it is how `vim` shows the open file, how `ssh` shows the host, and the mechanism
+//! tmux's `set-titles`/`automatic-rename` and every terminal multiplexer's window list is built
+//! on. Agent CLIs reuse it the same way, so a terminal that reads the title learns what the
+//! agent is doing *the moment the agent decides it*, instead of inferring it from how long the
+//! pty has been quiet.
+//!
+//! ## What was verified on real CLIs, and what was not
+//!
+//! Observed directly on this machine, by driving each CLI under a real pty and logging every OSC
+//! sequence it wrote:
+//!
+//! - **Claude Code 2.1.228** - verified across three independent sessions. It rests on
+//!   `OSC 0 ; "\u{2733} <task>"` and, while actually working, alternates a two-frame half-circle
+//!   spinner between `\u{25d0}` and `\u{25d1}` at roughly 1Hz. A representative capture:
+//!   `\u{2733} Claude Code` at startup, `\u{25d0} Claude Code` 0.1s after the prompt was
+//!   submitted, then `\u{25d0}`/`\u{25d1}` alternating for the next 16 seconds *including a
+//!   9-second stretch where three `sleep 3` tool calls produced no terminal output at all*, then
+//!   back to `\u{2733}` the moment it finished. That silent stretch is precisely the
+//!   false-positive class `crate::rail::status`'s new busy refinement exists to fix, caught live.
+//!   (The issue's research called `\u{2733}` the idle glyph and did not name the busy one; the
+//!   idle half is confirmed, and `\u{25d0}`/`\u{25d1}` is the missing half.)
+//! - **Gemini CLI** - emits `OSC 0 ; "\u{25c7}  Ready (<dir>)"` when idle, confirming the
+//!   `\u{25c7}` idle glyph from the research. Its other three documented glyphs (`\u{2726}`
+//!   working, `\u{23f2}` silently working, `\u{270b}` needs permission) were **not** reproduced:
+//!   the captured sessions only ever reached the idle state. Those three are implemented from
+//!   the documented set and are **unverified by observation here**.
+//! - **OSC 9 / OSC 777 notifications** - neither CLI emitted one in any captured session, not
+//!   even Claude Code at a live permission prompt (its notification channel is configurable and
+//!   was evidently not set to a terminal-escape one). `crate::terminal::osc`'s handling of those
+//!   is therefore verified against the protocol specs and its own tests, not against a live CLI.
+//!
+//! Everything below is therefore an explicitly heuristic layer, ordered most-specific first, and
+//! it always answers [`TitleSignal::Unknown`] rather than guessing when nothing matches -
+//! `crate::rail::status` treats `Unknown` as "no opinion" and falls back entirely to its own
+//! quiescence heuristic.
+
+/// A coarse read of what an agent CLI's window title is claiming about itself.
+///
+/// Deliberately four states and no free text: a title glyph can honestly support "busy / idle /
+/// wants you", and nothing finer. Anything textual about *what* the agent is doing (tool name,
+/// the actual question) needs a real structured payload, not a title scrape - see the parent
+/// issue's Phase 2.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TitleSignal {
+    /// The agent says it is actively working.
+    Busy,
+    /// The agent says it is sitting idle, done with its turn.
+    Idle,
+    /// The agent says it is blocked on the human - a permission prompt, a question.
+    NeedsAttention,
+    /// The title matched nothing recognizable (including the common case of a title that is
+    /// just a shell's `user@host:path`). Callers must treat this as "no information", never as
+    /// evidence of any state.
+    Unknown,
+}
+
+/// Claude Code's at-rest glyph, `\u{2733}` - observed live, see the module docs.
+const CLAUDE_IDLE: char = '\u{2733}'; // ✳
+
+/// Claude Code's busy spinner. `\u{25d0}` and `\u{25d1}` were both observed alternating live;
+/// `\u{25d2}` and `\u{25d3}` are the other two frames of the same contiguous half-circle set
+/// (the `circleHalves` spinner in `cli-spinners`, the de-facto source for these), included so a
+/// version that animates all four frames doesn't read as idle on half of them.
+const CLAUDE_SPINNER_FIRST: char = '\u{25d0}'; // ◐
+const CLAUDE_SPINNER_LAST: char = '\u{25d3}'; // ◓
+
+/// Gemini CLI's four documented status glyphs. Only `\u{25c7}` (idle) was reproduced live on
+/// this machine - see the module docs.
+const GEMINI_WORKING: char = '\u{2726}'; // ✦
+const GEMINI_SILENTLY_WORKING: char = '\u{23f2}'; // ⏲
+const GEMINI_IDLE: char = '\u{25c7}'; // ◇
+const GEMINI_NEEDS_PERMISSION: char = '\u{270b}'; // ✋
+
+/// The Braille Patterns block, the near-universal spinner alphabet for CLI progress indicators
+/// (the `braille` family in `cli-spinners`, which `ora`, `yaspin`, `indicatif` and effectively
+/// every modern CLI spinner draw from). A title carrying one of these is animating a spinner in
+/// the title bar, which only ever means "work in progress".
+const BRAILLE_FIRST: char = '\u{2800}';
+const BRAILLE_LAST: char = '\u{28ff}';
+
+/// Keywords checked only after every glyph rule has missed, and only on whole words - see
+/// [`has_word`].
+const BUSY_WORDS: [&str; 3] = ["working", "thinking", "running"];
+const IDLE_WORDS: [&str; 3] = ["ready", "idle", "done"];
+const ATTENTION_WORDS: [&str; 4] = ["waiting", "permission", "approve", "confirm"];
+
+/// Classifies a terminal title into a coarse [`TitleSignal`].
+///
+/// Rule order is most-specific first, and it matters: a Gemini title reads
+/// `"\u{270b}  Waiting for permission (jerry)"`, where the glyph and the keywords agree, but a
+/// title like `"\u{2726} finishing up, almost done"` has a working glyph and an idle *word* -
+/// the glyph is the deliberate signal and the prose is incidental, so glyphs win.
+///
+/// 1. A recognized per-CLI status glyph anywhere in the title.
+/// 2. A Braille spinner frame anywhere in the title (busy).
+/// 3. Whole-word keyword match, attention first, then busy, then idle.
+/// 4. [`TitleSignal::Unknown`].
+pub fn classify_title(title: &str) -> TitleSignal {
+    for c in title.chars() {
+        match c {
+            GEMINI_NEEDS_PERMISSION => return TitleSignal::NeedsAttention,
+            GEMINI_WORKING | GEMINI_SILENTLY_WORKING => return TitleSignal::Busy,
+            GEMINI_IDLE | CLAUDE_IDLE => return TitleSignal::Idle,
+            CLAUDE_SPINNER_FIRST..=CLAUDE_SPINNER_LAST => return TitleSignal::Busy,
+            BRAILLE_FIRST..=BRAILLE_LAST => return TitleSignal::Busy,
+            _ => {}
+        }
+    }
+
+    let lowered = title.to_lowercase();
+    if ATTENTION_WORDS.iter().any(|word| has_word(&lowered, word)) {
+        return TitleSignal::NeedsAttention;
+    }
+    if BUSY_WORDS.iter().any(|word| has_word(&lowered, word)) {
+        return TitleSignal::Busy;
+    }
+    if IDLE_WORDS.iter().any(|word| has_word(&lowered, word)) {
+        return TitleSignal::Idle;
+    }
+    TitleSignal::Unknown
+}
+
+/// Whether `haystack` (already lowercased) contains `word` as a whole word.
+///
+/// A plain `contains` is wrong here and would misfire constantly in practice: terminal titles
+/// are overwhelmingly *paths*, and `~/src/already/threading.rs` contains "ready" and "reading"
+/// contains neither of the words anyone meant. A word boundary is any non-alphanumeric byte -
+/// so `"ready."`, `"[ready]"` and `"working…"` all match, while `"already"`, `"readyish"` and
+/// `"networking"` do not.
+fn has_word(haystack: &str, word: &str) -> bool {
+    let mut from = 0;
+    while let Some(offset) = haystack[from..].find(word) {
+        let start = from + offset;
+        let end = start + word.len();
+        let before_ok = haystack[..start]
+            .chars()
+            .next_back()
+            .is_none_or(|c| !c.is_alphanumeric());
+        let after_ok = haystack[end..]
+            .chars()
+            .next()
+            .is_none_or(|c| !c.is_alphanumeric());
+        if before_ok && after_ok {
+            return true;
+        }
+        // Advance past this occurrence's first char, not past the whole match: overlapping
+        // occurrences are possible and skipping the whole match could step over a real one.
+        from = start + haystack[start..].chars().next().map_or(1, char::len_utf8);
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_exact_gemini_idle_title_captured_from_a_real_session_reads_as_idle() {
+        // Byte-for-byte what Gemini CLI wrote to a real pty on this machine (OSC 0 payload,
+        // trailing padding included) - see the module docs.
+        assert_eq!(
+            classify_title(
+                "\u{25c7}  Ready (scratchpad)                                                    "
+            ),
+            TitleSignal::Idle
+        );
+    }
+
+    #[test]
+    fn the_real_claude_code_session_transcript_classifies_end_to_end() {
+        // The exact titles Claude Code 2.1.228 wrote to a real pty, in order, over one session:
+        // at rest, then a spinner alternating across a 9-second stretch of silent `sleep 3` tool
+        // calls, then back to rest. Nothing here is invented - see the module docs for the
+        // capture. This is the whole signal, pinned as one sequence.
+        let transcript = [
+            ("\u{2733} Claude Code", TitleSignal::Idle),
+            ("\u{25d0} Claude Code", TitleSignal::Busy),
+            (
+                "\u{25d0} Run sequential shell commands with delays",
+                TitleSignal::Busy,
+            ),
+            (
+                "\u{25d1} Run sequential shell commands with delays",
+                TitleSignal::Busy,
+            ),
+            (
+                "\u{2733} Run sequential shell commands with delays",
+                TitleSignal::Idle,
+            ),
+        ];
+        for (title, expected) in transcript {
+            assert_eq!(classify_title(title), expected, "{title:?}");
+        }
+    }
+
+    #[test]
+    fn every_frame_of_claude_codes_half_circle_spinner_reads_as_busy() {
+        // `\u{25d0}`/`\u{25d1}` were observed live; the other two are the rest of the same
+        // contiguous set (see the constants' docs) and must not read as anything else.
+        for frame in ['\u{25d0}', '\u{25d1}', '\u{25d2}', '\u{25d3}'] {
+            assert_eq!(
+                classify_title(&format!("{frame} doing something")),
+                TitleSignal::Busy,
+                "{frame:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn geminis_documented_glyph_set_maps_to_its_four_states() {
+        assert_eq!(
+            classify_title("\u{2726} Working (jerry)"),
+            TitleSignal::Busy
+        );
+        assert_eq!(classify_title("\u{23f2} (jerry)"), TitleSignal::Busy);
+        assert_eq!(classify_title("\u{25c7} Ready"), TitleSignal::Idle);
+        assert_eq!(
+            classify_title("\u{270b} Waiting for permission"),
+            TitleSignal::NeedsAttention
+        );
+    }
+
+    #[test]
+    fn a_braille_spinner_frame_anywhere_means_busy() {
+        for frame in [
+            '\u{280b}', '\u{2819}', '\u{2839}', '\u{2807}', '\u{2800}', '\u{28ff}',
+        ] {
+            assert_eq!(
+                classify_title(&format!("{frame} some-cli")),
+                TitleSignal::Busy,
+                "{frame:?} is a Braille spinner frame"
+            );
+        }
+    }
+
+    #[test]
+    fn a_glyph_beats_a_contradicting_keyword() {
+        assert_eq!(
+            classify_title("\u{2726} almost done"),
+            TitleSignal::Busy,
+            "the glyph is the deliberate signal; the prose is incidental"
+        );
+        assert_eq!(
+            classify_title("\u{270b} working on it"),
+            TitleSignal::NeedsAttention
+        );
+    }
+
+    #[test]
+    fn keywords_match_only_on_whole_words() {
+        assert_eq!(classify_title("agent: thinking"), TitleSignal::Busy);
+        assert_eq!(classify_title("[Ready]"), TitleSignal::Idle);
+        assert_eq!(classify_title("build done."), TitleSignal::Idle);
+        assert_eq!(
+            classify_title("waiting for approval"),
+            TitleSignal::NeedsAttention
+        );
+    }
+
+    #[test]
+    fn a_path_that_merely_contains_a_keyword_as_a_substring_does_not_match() {
+        // The exact false-positive class the word-boundary guard exists for: terminal titles
+        // are mostly paths, and plenty of ordinary ones embed these letters.
+        for title in [
+            "~/src/already/main.rs",
+            "vim ~/notes/readyish.md",
+            "npm run networking-tests",
+            "~/code/rethinking/mod.rs",
+            "~/work/idleness.txt",
+        ] {
+            assert_eq!(
+                classify_title(title),
+                TitleSignal::Unknown,
+                "{title:?} must not be read as a status claim"
+            );
+        }
+    }
+
+    #[test]
+    fn an_ordinary_shell_title_is_unknown() {
+        for title in [
+            "colin@jerry: ~/spike/ade",
+            "bash",
+            "",
+            "make -j8",
+            "\u{2713} tests passed",
+        ] {
+            assert_eq!(classify_title(title), TitleSignal::Unknown, "{title:?}");
+        }
+    }
+
+    #[test]
+    fn classification_is_case_insensitive_for_keywords() {
+        assert_eq!(classify_title("WORKING"), TitleSignal::Busy);
+        assert_eq!(classify_title("Idle"), TitleSignal::Idle);
+        assert_eq!(
+            classify_title("PERMISSION needed"),
+            TitleSignal::NeedsAttention
+        );
+    }
+
+    #[test]
+    fn a_word_at_either_end_of_the_title_still_matches() {
+        // The boundary check has to treat "start of string" and "end of string" as boundaries,
+        // not as missing characters that fail the test.
+        assert_eq!(classify_title("ready"), TitleSignal::Idle);
+        assert_eq!(classify_title("ready to go"), TitleSignal::Idle);
+        assert_eq!(classify_title("all ready"), TitleSignal::Idle);
+    }
+
+    #[test]
+    fn a_real_word_after_a_non_matching_occurrence_is_still_found() {
+        // Exercises `has_word`'s scan-onward loop: the first "ready" is inside "already" and
+        // must be rejected without ending the search.
+        assert_eq!(classify_title("already ready"), TitleSignal::Idle);
+    }
+
+    #[test]
+    fn multibyte_titles_do_not_panic_and_classify_by_their_glyph() {
+        // `has_word`'s byte-offset arithmetic must never split a UTF-8 character.
+        assert_eq!(classify_title("日本語のタイトル"), TitleSignal::Unknown);
+        assert_eq!(classify_title("\u{25c7} 準備完了"), TitleSignal::Idle);
+        assert_eq!(classify_title("……ready……"), TitleSignal::Idle);
+    }
+}

--- a/crates/app/src/review/render.rs
+++ b/crates/app/src/review/render.rs
@@ -1232,6 +1232,9 @@ mod review_flow_tests {
         let status_on_exit = crate::rail::status::derive_status(
             ProcessKind::claude(),
             crate::rail::status::ProcessSignal::Exited { success: true },
+            // An exit is an exact fact; no terminal-title/OSC signal takes part in it (see
+            // `crate::rail::status`'s module docs), so the default "said nothing" is right here.
+            crate::rail::status::TerminalSignal::default(),
             has_unreviewed,
         );
         assert_eq!(

--- a/crates/app/src/terminal/grid.rs
+++ b/crates/app/src/terminal/grid.rs
@@ -21,9 +21,9 @@
 //!   `screen_lines`/`columns` - see [`GridSize`].
 //! - `Term<T>` only requires `T: EventListener` for `renderable_content`/the `Handler` impl.
 //!   This pane polls the grid directly every tick (see `crate::terminal::pane`'s poll loop)
-//!   rather than reacting to most events (title changes, bell, clipboard, ...), which
-//!   [`PtyWriteQueue`] does still drop. `Event::PtyWrite` is the one real exception - see that
-//!   type's own docs for why dropping it is a genuine correctness bug, not a scope cut.
+//!   rather than reacting to most events (bell, clipboard, ...), which [`TermEventSink`] does
+//!   still drop. `Event::PtyWrite` and `Event::Title`/`Event::ResetTitle` are the real
+//!   exceptions - see that type's own docs for why each is captured.
 //! - Feeding bytes: `Processor::<StdSyncHandler>::advance(&mut self, handler: &mut H, bytes:
 //!   &[u8]) where H: Handler` (`vte-0.15.0/src/ansi.rs:298`); `Term<T: EventListener>`
 //!   implements `Handler`. `alacritty_terminal` re-exports its exact `vte` dependency as
@@ -106,6 +106,7 @@
 //! an alt-screen swap (`Term::swap_alt`, `:733`) - which is why [`TerminalGrid::clear`], itself
 //! just an `ESC[2J` through the same parser, needs no selection handling of its own.
 
+use crate::terminal::osc::{OscWatcher, Progress};
 use alacritty_terminal::event::{Event as AlacEvent, EventListener};
 use alacritty_terminal::grid::Dimensions;
 use alacritty_terminal::index::{Column, Line, Point as AlacPoint, Side};
@@ -137,11 +138,13 @@ impl Dimensions for GridSize {
     }
 }
 
-/// Captures [`AlacEvent::PtyWrite`] and drops every other [`AlacEvent`] (title changes, bell,
-/// clipboard, ...) - see the module docs' API surface section for why those others are a
-/// deliberate scope cut.
+/// Captures the two [`AlacEvent`]s this app actually acts on - [`AlacEvent::PtyWrite`] and the
+/// window-title pair [`AlacEvent::Title`]/[`AlacEvent::ResetTitle`] - and drops every other one
+/// (bell, clipboard, cursor-blink requests, ...): see the module docs' API surface section for
+/// why those others are a deliberate scope cut.
 ///
-/// `PtyWrite` is different: `alacritty_terminal`'s own `Handler` impl for `Term` emits it
+/// `PtyWrite` is the original reason this type exists at all: `alacritty_terminal`'s own
+/// `Handler` impl for `Term` emits it
 /// whenever the VT parser sees a query the *terminal* (not the running program) is supposed to
 /// answer back into the pty's stdin - e.g. `ESC[6n` (Device Status Report / cursor position
 /// report), already correctly formatted as `ESC[<row>;<col>R` by `Term::device_status`
@@ -156,19 +159,52 @@ impl Dimensions for GridSize {
 /// then never read another byte, because ConPTY was sitting there waiting on the CPR reply this
 /// listener used to throw away.
 ///
+/// `Title`/`ResetTitle` are the second capture (GitHub issue #239). `alacritty_terminal` emits
+/// `Event::Title(String)` for OSC 0 (icon name + window title) and OSC 2 (window title only),
+/// and `Event::ResetTitle` for OSC 0/2 with no argument - confirmed against the pinned rev's
+/// own `Term::set_title`/`reset_title` (`term/mod.rs`) and `vte::ansi`'s `b"0" | b"2"`
+/// `osc_dispatch` arm. Real agent CLIs put a live status glyph in that title (Claude Code and
+/// Gemini CLI both do - observed directly, see `crate::rail::title_signal`), which is a far
+/// faster and more honest "is this agent busy or waiting on me" signal than the pty-quiescence
+/// timer `crate::rail::status` otherwise has to fall back on.
+///
 /// `Rc<RefCell<..>>`, not a channel: [`EventListener::send_event`] takes `&self`
 /// (`Term<T>` only ever holds a `T`, no `&mut` access once constructed), and this needs to be
 /// cheaply `Clone`d so [`TerminalGrid`] can hand `Term::new` its own copy while keeping one to
 /// drain from - a `Rc`'d interior-mutable buffer is the direct way to satisfy both without a
 /// background thread/channel this is far too small to warrant.
 #[derive(Debug, Clone, Default)]
-struct PtyWriteQueue(std::rc::Rc<std::cell::RefCell<Vec<u8>>>);
+struct TermEventSink {
+    /// Bytes the VT parser generated as a reply owed back to the pty, appended in arrival order.
+    pty_writes: std::rc::Rc<std::cell::RefCell<Vec<u8>>>,
+    /// The pending window-title change, if one arrived since [`Self::take_title_update`] last
+    /// looked. Two levels of `Option` on purpose, and they mean different things: the outer one
+    /// is "did a title event happen at all", the inner one is "what it set the title to" -
+    /// `Some(None)` is a real [`AlacEvent::ResetTitle`] clearing the title, which a single
+    /// `Option<String>` could not tell apart from "nothing happened".
+    title: std::rc::Rc<std::cell::RefCell<Option<Option<String>>>>,
+}
 
-impl EventListener for PtyWriteQueue {
+impl EventListener for TermEventSink {
     fn send_event(&self, event: AlacEvent) {
-        if let AlacEvent::PtyWrite(text) = event {
-            self.0.borrow_mut().extend_from_slice(text.as_bytes());
+        match event {
+            AlacEvent::PtyWrite(text) => {
+                self.pty_writes
+                    .borrow_mut()
+                    .extend_from_slice(text.as_bytes());
+            }
+            AlacEvent::Title(title) => *self.title.borrow_mut() = Some(Some(title)),
+            AlacEvent::ResetTitle => *self.title.borrow_mut() = Some(None),
+            _ => {}
         }
+    }
+}
+
+impl TermEventSink {
+    /// Takes the pending title change, if any - see [`Self::title`]'s docs for what each layer
+    /// of the returned `Option` means.
+    fn take_title_update(&self) -> Option<Option<String>> {
+        self.title.borrow_mut().take()
     }
 }
 
@@ -450,12 +486,20 @@ fn grid_cell_from_alacritty(
 /// `pty-core`, fed in through [`TerminalGrid::append_bytes`]) are parsed as real ANSI/VT100 and
 /// land in a real cursor-addressed grid.
 pub struct TerminalGrid {
-    term: Term<PtyWriteQueue>,
+    term: Term<TermEventSink>,
     processor: Processor<StdSyncHandler>,
     size: GridSize,
-    /// The other half of the `Term`'s own [`PtyWriteQueue`] - see that type's docs for why this
+    /// The other half of the `Term`'s own [`TermEventSink`] - see that type's docs for why this
     /// is an `Rc`'d clone rather than reading straight off `term`.
-    pending_pty_writes: PtyWriteQueue,
+    events: TermEventSink,
+    /// The window title the child process last set via OSC 0/2, drained out of [`Self::events`]
+    /// at the end of every [`Self::append_bytes`] so [`Self::title`] can hand out a plain
+    /// borrow instead of forcing every reader through the sink's `RefCell`.
+    title: Option<String>,
+    /// The tee'd OSC 9 / 9;4 / 777 parser - see [`crate::terminal::osc`]'s module docs for why
+    /// this is a second, independent parser over the same bytes rather than an extension of
+    /// [`Self::processor`].
+    osc: OscWatcher,
     /// `true` once the backing process has exited; the grid stops changing after this but
     /// keeps whatever it last rendered, mirroring step 3's `TerminalBuffer::ended`.
     pub ended: bool,
@@ -467,23 +511,53 @@ impl TerminalGrid {
             rows: rows.max(1) as usize,
             cols: cols.max(1) as usize,
         };
-        let pending_pty_writes = PtyWriteQueue::default();
-        let term = Term::new(Config::default(), &size, pending_pty_writes.clone());
+        let events = TermEventSink::default();
+        let term = Term::new(Config::default(), &size, events.clone());
         Self {
             term,
             processor: Processor::new(),
             size,
-            pending_pty_writes,
+            events,
+            title: None,
+            osc: OscWatcher::default(),
             ended: false,
         }
     }
 
     /// Feeds a chunk of raw pty bytes into the VT100 parser (`Processor::advance`), which
     /// drives the real `Term` grid state (cursor movement, SGR colors, screen clears, etc.) and
-    /// may also queue bytes into [`Self::pending_pty_writes`] for [`Self::take_pending_pty_writes`]
-    /// to hand back to the pty - see [`PtyWriteQueue`]'s own docs.
+    /// may also queue bytes into [`Self::events`] for [`Self::take_pending_pty_writes`]
+    /// to hand back to the pty, and update [`Self::title`] - see [`TermEventSink`]'s own docs.
+    ///
+    /// The same slice is also tee'd into [`Self::osc`], the independent parser that recovers the
+    /// OSC 9 / 9;4 / 777 sequences `Processor` drops on the floor (see
+    /// [`crate::terminal::osc`]). Both parsers must see identical bytes in identical order:
+    /// either one's state machine can be mid-sequence at a chunk boundary.
     pub fn append_bytes(&mut self, bytes: &[u8]) {
         self.processor.advance(&mut self.term, bytes);
+        self.osc.feed(bytes);
+        if let Some(update) = self.events.take_title_update() {
+            self.title = update;
+        }
+    }
+
+    /// The window title the child process last set via OSC 0/2, or `None` if it has never set
+    /// one or last sent a title reset. See [`TermEventSink`]'s docs; classified into a coarse
+    /// status signal by `crate::rail::title_signal`.
+    pub fn title(&self) -> Option<&str> {
+        self.title.as_deref()
+    }
+
+    /// Consumes the "an OSC 9 / OSC 777 desktop notification fired" flag - see
+    /// [`crate::terminal::osc::OscWatcher::take_attention_ping`] for why it is consumed rather
+    /// than latched here.
+    pub fn take_attention_ping(&mut self) -> bool {
+        self.osc.take_attention_ping()
+    }
+
+    /// The most recent OSC 9;4 progress report, if the child process is speaking that protocol.
+    pub fn progress(&self) -> Option<Progress> {
+        self.osc.progress()
     }
 
     /// Drains and returns any bytes the VT parser generated in response to a terminal query
@@ -494,7 +568,7 @@ impl TerminalGrid {
     /// case - a plain `Vec` (not an `Option`) so the caller can check emptiness without an extra
     /// match arm.
     pub fn take_pending_pty_writes(&mut self) -> Vec<u8> {
-        std::mem::take(&mut *self.pending_pty_writes.0.borrow_mut())
+        std::mem::take(&mut *self.events.pty_writes.borrow_mut())
     }
 
     /// Resizes the grid to match a new pty size. Must be called alongside `PtySession::resize`
@@ -634,10 +708,10 @@ mod tests {
         assert!(row_text(&rows[0]).starts_with("hello"));
     }
 
-    /// [`PtyWriteQueue`]'s real regression coverage: a Device Status Report query (`ESC[6n`,
+    /// [`TermEventSink`]'s real regression coverage: a Device Status Report query (`ESC[6n`,
     /// "where's the cursor?") must produce a real, correctly formatted `ESC[<row>;<col>R` reply
     /// queued for the pty - not silently dropped, which is exactly what real Windows ConPTY
-    /// hangs on during its own startup handshake (see [`PtyWriteQueue`]'s own docs for the live
+    /// hangs on during its own startup handshake (see [`TermEventSink`]'s own docs for the live
     /// Windows repro this fixes). Uses `\x1b[3;5H` first (the same cursor-positioning sequence
     /// [`cursor_positioning_places_text_at_the_addressed_cell`] already proves lands the cursor
     /// correctly) so the expected reply has a real, non-default row/col to check against - a
@@ -671,6 +745,78 @@ mod tests {
             "the queue must be genuinely drained by the previous take_pending_pty_writes call, \
              not left with the same reply queued forever"
         );
+    }
+
+    /// [`TermEventSink`]'s title half (GitHub issue #239): a real OSC 0 / OSC 2 sequence through
+    /// the real parser must land in [`TerminalGrid::title`], and must not print anything into
+    /// the grid - a title is metadata about the window, not screen content.
+    #[test]
+    fn a_real_osc_title_sequence_is_captured_and_prints_nothing() {
+        let mut grid = TerminalGrid::new(5, 40);
+        assert_eq!(
+            grid.title(),
+            None,
+            "sanity check: no title before any is set"
+        );
+
+        // Exactly what Claude Code writes while working, byte for byte (OSC 0, BEL-terminated).
+        grid.append_bytes("\x1b]0;\u{25d0} Claude Code\x07".as_bytes());
+        assert_eq!(grid.title(), Some("\u{25d0} Claude Code"));
+
+        let rows = grid.visible_rows(&TerminalPalette::default());
+        assert_eq!(
+            row_text(&rows[0]).trim(),
+            "",
+            "an OSC title must be consumed by the parser, never painted into the grid"
+        );
+
+        // OSC 2 (title only) and ST termination are the other real spellings.
+        grid.append_bytes(b"\x1b]2;second title\x1b\\");
+        assert_eq!(grid.title(), Some("second title"));
+    }
+
+    /// The [`AlacEvent::ResetTitle`] half of the same capture. `alacritty_terminal` only ever
+    /// emits it from `Term::pop_title` (`term/mod.rs:2249`) restoring a `None` that was pushed
+    /// before any title existed - the XTPUSHTITLE/XTPOPTITLE pair `ESC[22t`/`ESC[23t`
+    /// (`vte-0.15.0/src/ansi.rs:1742`) - so that is what this drives, rather than a synthetic
+    /// event a real process could never produce.
+    #[test]
+    fn a_real_title_reset_clears_the_captured_title() {
+        let mut grid = TerminalGrid::new(5, 40);
+        grid.append_bytes(b"\x1b[22t"); // push the current (absent) title
+        grid.append_bytes(b"\x1b]0;working\x07");
+        assert_eq!(grid.title(), Some("working"));
+
+        grid.append_bytes(b"\x1b[23t"); // pop it back to "no title"
+        assert_eq!(
+            grid.title(),
+            None,
+            "a title reset must clear the stored title, not leave the stale one standing"
+        );
+    }
+
+    /// The tee'd OSC parser reached through the same `append_bytes` the renderer uses - proof
+    /// that both parsers really see the same bytes (see [`crate::terminal::osc`]'s module docs).
+    #[test]
+    fn osc_9_family_sequences_reach_the_teed_parser_through_append_bytes() {
+        let mut grid = TerminalGrid::new(5, 40);
+        assert!(!grid.take_attention_ping());
+        assert_eq!(grid.progress(), None);
+
+        grid.append_bytes(b"hello\x1b]9;Agent needs you\x07 world\x1b]9;4;1;60\x07");
+
+        assert!(grid.take_attention_ping());
+        assert_eq!(
+            grid.progress(),
+            Some(Progress {
+                state: crate::terminal::osc::ProgressState::Normal,
+                percent: Some(60)
+            })
+        );
+        // The surrounding plain text still rendered normally: the tee must not consume bytes
+        // from, or otherwise disturb, the primary pipeline.
+        let rows = grid.visible_rows(&TerminalPalette::default());
+        assert_eq!(row_text(&rows[0]).trim_end(), "hello world");
     }
 
     /// The key proof that this is real cursor-addressed grid emulation rather than a plain-text

--- a/crates/app/src/terminal/mod.rs
+++ b/crates/app/src/terminal/mod.rs
@@ -7,6 +7,8 @@
 //! - [`grid`] - the ANSI/VT100 grid emulation itself, over `alacritty_terminal::Term`.
 //! - [`links`] - the pure `path:line[:col]` scanner over already-rendered row text, GPUI-free
 //!   so its matching rules stay directly `#[test]`-able.
+//! - [`osc`] - the tee'd second VT parser recovering the OSC 9 / 9;4 / 777 notification and
+//!   progress sequences `alacritty_terminal` drops (GitHub issue #239). GPUI-free.
 //!
 //! Unlike the other feature folders, these three files were already self-contained top-level
 //! modules with their own imports (never `use super::*`), so this module deliberately carries
@@ -14,4 +16,5 @@
 
 pub mod grid;
 pub mod links;
+pub mod osc;
 pub mod pane;

--- a/crates/app/src/terminal/osc.rs
+++ b/crates/app/src/terminal/osc.rs
@@ -1,0 +1,373 @@
+//! The OSC 9 / OSC 9;4 / OSC 777 side-channel: desktop notifications and progress reports that
+//! real agent CLIs already emit into their pty and that `alacritty_terminal` throws away.
+//!
+//! ## Why this is a second, independent parser
+//!
+//! The primary rendering pipeline (`crate::terminal::grid`) drives
+//! `alacritty_terminal::vte::ansi::Processor` over a `Term`, and `Processor`'s own
+//! `vte::Perform::osc_dispatch` impl (`vte-0.15.0/src/ansi.rs:1329`, read from the vendored
+//! source this workspace actually compiles) has match arms for exactly OSC
+//! `0`/`2`/`4`/`8`/`10`/`11`/`12`/`22`/`50`/`52`/`104`/`110`/`111`/`112`. Everything else -
+//! including the whole OSC 9 family and OSC 777 - falls into its catch-all `_ => unhandled(params)`
+//! arm, which formats the params into a `debug!` log line and drops them. There is no
+//! `alacritty_terminal::event::Event` variant for them either, so no amount of widening
+//! `crate::terminal::grid`'s `EventListener` can recover them: the data is gone before any
+//! listener could see it.
+//!
+//! So this module tees: [`OscWatcher::feed`] is handed the *same* byte slice
+//! `crate::terminal::grid::TerminalGrid::append_bytes` hands `Processor::advance`, and runs its
+//! own [`vte::Parser`] over it with a [`vte::Perform`] impl that implements *only*
+//! `osc_dispatch` (every other `Perform` method keeps its no-op default, so printing, CSI
+//! dispatch, DCS, etc. cost nothing here beyond the state machine's own transitions).
+//!
+//! Teeing rather than extending is deliberate and load-bearing: the primary pipeline has a
+//! documented history of subtle real bugs (see `crate::terminal::grid`'s `TermEventSink` docs
+//! for the ConPTY handshake hang), so it is treated as untouchable - a bug in this module's OSC
+//! handling can make Jerry's rail guess wrong, but it can never corrupt what the user sees on
+//! screen.
+//!
+//! ## What is parsed
+//!
+//! - **OSC 9** (`ESC ] 9 ; <message> BEL`) - iTerm2's "post a desktop notification", also emitted
+//!   by Claude Code and Gemini CLI. A point-in-time "the human's attention is wanted" event; the
+//!   message text is deliberately *not* kept (see the parent issue: coarse status only, no
+//!   free-text activity in this phase).
+//! - **OSC 9;4** (`ESC ] 9 ; 4 ; <state> ; <progress> BEL`) - ConEmu's taskbar-progress protocol,
+//!   also spoken by Windows Terminal, WezTerm and others. `state` is `0` clear / `1` normal /
+//!   `2` error / `3` indeterminate / `4` paused; `progress` is a percentage `0..=100`, and is
+//!   meaningless for `0` and `3`. See [`ProgressState`].
+//! - **OSC 777** (`ESC ] 777 ; notify ; <title> ; <body> BEL`) - urxvt's `notify` module, the
+//!   other notification convention agent CLIs emit. Only the `notify` sub-command counts;
+//!   OSC 777 has other sub-commands (e.g. `precmd`) that are not attention requests.
+//!
+//! Everything else is ignored, including OSC 0/2 - the window title arrives through
+//! `alacritty_terminal`'s own `Event::Title` on the primary pipeline (see
+//! `crate::terminal::grid::TermEventSink`), and parsing it twice would just create a second copy
+//! to drift.
+
+use alacritty_terminal::vte::{Parser, Perform};
+
+/// The ConEmu OSC 9;4 progress states, exactly as that protocol defines them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProgressState {
+    /// `1` - a normal, determinate progress report; [`Progress::percent`] is meaningful.
+    Normal,
+    /// `2` - an error state, still carrying a percentage.
+    Error,
+    /// `3` - work is happening but its extent is unknown; [`Progress::percent`] is `None`.
+    Indeterminate,
+    /// `4` - the reported work is paused.
+    Paused,
+}
+
+impl ProgressState {
+    /// Whether this state means "work is actively happening right now".
+    ///
+    /// [`ProgressState::Error`] and [`ProgressState::Paused`] are deliberately *not* busy: both
+    /// describe work that has stopped advancing, which is exactly when a human's attention may
+    /// be wanted, so claiming "still running" for them would be the false-positive this whole
+    /// signal exists to remove.
+    pub fn is_active(self) -> bool {
+        matches!(self, ProgressState::Normal | ProgressState::Indeterminate)
+    }
+}
+
+/// One OSC 9;4 progress report. State `0` (clear) has no [`Progress`] - it clears the stored
+/// report to `None` instead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Progress {
+    pub state: ProgressState,
+    /// The reported percentage, clamped to `0..=100`. `None` for
+    /// [`ProgressState::Indeterminate`], where the protocol defines no meaningful value, and for
+    /// a report whose percentage field was absent or unparseable.
+    pub percent: Option<u8>,
+}
+
+/// The mutable signal state [`OscWatcher`] accumulates - separate from [`OscWatcher`] itself
+/// because `vte::Parser::advance` needs `&mut P` for the `Perform` impl while it also holds
+/// `&mut self`, so the parser and the thing it writes into cannot be the same value.
+#[derive(Debug, Clone, Copy, Default)]
+struct OscSignals {
+    /// Set by any OSC 9 notification or OSC 777 `notify`; cleared by
+    /// [`OscWatcher::take_attention_ping`].
+    attention_pinged: bool,
+    progress: Option<Progress>,
+}
+
+impl Perform for OscSignals {
+    fn osc_dispatch(&mut self, params: &[&[u8]], _bell_terminated: bool) {
+        let Some(&kind) = params.first() else {
+            return;
+        };
+        match kind {
+            // OSC 9;4;<state>;<progress> is ConEmu progress; any *other* OSC 9 is an iTerm2
+            // desktop notification. The `params.len() >= 2` guard matters: a bare `ESC]9BEL`
+            // with no message is not a notification anyone meant to send.
+            b"9" if params.get(1) == Some(&b"4".as_slice()) => {
+                self.progress = parse_progress(params.get(2).copied(), params.get(3).copied());
+            }
+            b"9" if params.len() >= 2 => self.attention_pinged = true,
+            b"777" if params.get(1) == Some(&b"notify".as_slice()) => {
+                self.attention_pinged = true;
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Parses the `<state>` and `<progress>` fields of an OSC 9;4 payload. Returns `None` for
+/// state `0` (explicitly "clear the progress indicator") and for any state outside `0..=4`,
+/// which no sender should emit and which would otherwise be silently rounded into a real state.
+fn parse_progress(state: Option<&[u8]>, percent: Option<&[u8]>) -> Option<Progress> {
+    let state = match parse_u8(state?)? {
+        0 => return None,
+        1 => ProgressState::Normal,
+        2 => ProgressState::Error,
+        3 => ProgressState::Indeterminate,
+        4 => ProgressState::Paused,
+        _ => return None,
+    };
+    let percent = match state {
+        // The protocol defines no percentage for an indeterminate report; senders commonly put
+        // a `0` there, and reporting that as "0% done" would be inventing a fact.
+        ProgressState::Indeterminate => None,
+        _ => percent.and_then(parse_u8).map(|percent| percent.min(100)),
+    };
+    Some(Progress { state, percent })
+}
+
+/// Parses an ASCII decimal parameter. Deliberately strict - a param with any non-digit byte is
+/// not a number, rather than a number with the trailing junk ignored.
+fn parse_u8(bytes: &[u8]) -> Option<u8> {
+    if bytes.is_empty() || !bytes.iter().all(u8::is_ascii_digit) {
+        return None;
+    }
+    // Saturating rather than `Option`: a sender writing `9;4;1;999` meant "a big percentage",
+    // and every consumer here clamps to `0..=100` anyway.
+    let mut value: u32 = 0;
+    for byte in bytes {
+        value = value
+            .saturating_mul(10)
+            .saturating_add(u32::from(byte - b'0'));
+        if value > u32::from(u8::MAX) {
+            return Some(u8::MAX);
+        }
+    }
+    Some(value as u8)
+}
+
+/// A `vte::Parser` fed the same raw pty bytes as the rendering pipeline, watching only for the
+/// OSC sequences that pipeline drops - see the module docs.
+pub struct OscWatcher {
+    parser: Parser,
+    signals: OscSignals,
+}
+
+impl Default for OscWatcher {
+    fn default() -> Self {
+        Self {
+            parser: Parser::new(),
+            signals: OscSignals::default(),
+        }
+    }
+}
+
+impl std::fmt::Debug for OscWatcher {
+    /// `vte::Parser` is not `Debug`, and the parser's internal state machine position isn't
+    /// something a caller could act on anyway - only the accumulated signals are.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OscWatcher")
+            .field("signals", &self.signals)
+            .finish_non_exhaustive()
+    }
+}
+
+impl OscWatcher {
+    /// Feeds a chunk of raw pty bytes. Must be handed exactly the same slices, in the same
+    /// order, as the primary parser: OSC sequences can straddle a chunk boundary, and the
+    /// `vte::Parser` state machine is what carries the partial sequence across.
+    pub fn feed(&mut self, bytes: &[u8]) {
+        self.parser.advance(&mut self.signals, bytes);
+    }
+
+    /// Consumes the "a notification fired" flag: `true` if at least one OSC 9 notification or
+    /// OSC 777 `notify` arrived since the last call, and clears it.
+    ///
+    /// Consume-on-read because these are point-in-time events, not state - the sender says "now",
+    /// never "still". The caller (`crate::terminal::pane::TerminalPane`'s poll loop) is
+    /// responsible for turning that instant into whatever durable state it needs; leaving the
+    /// flag latched here instead would make it stick forever, since nothing in the protocol ever
+    /// un-fires a notification.
+    pub fn take_attention_ping(&mut self) -> bool {
+        std::mem::take(&mut self.signals.attention_pinged)
+    }
+
+    /// The most recent OSC 9;4 progress report, or `None` if none has arrived or the last one
+    /// was state `0` (clear). Unlike [`Self::take_attention_ping`] this is real state - the
+    /// protocol's whole point is that a progress report stands until superseded or cleared - so
+    /// it is not consumed on read.
+    pub fn progress(&self) -> Option<Progress> {
+        self.signals.progress
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn watch(bytes: &[u8]) -> OscWatcher {
+        let mut watcher = OscWatcher::default();
+        watcher.feed(bytes);
+        watcher
+    }
+
+    #[test]
+    fn a_bare_osc_9_notification_pings_for_attention_once() {
+        let mut watcher = watch(b"\x1b]9;Claude needs your permission\x07");
+        assert!(watcher.take_attention_ping());
+        assert!(
+            !watcher.take_attention_ping(),
+            "the ping is a point-in-time event and must not re-fire on a second read"
+        );
+    }
+
+    #[test]
+    fn an_st_terminated_osc_9_also_pings() {
+        // OSC can be terminated by BEL *or* by ST (`ESC \`); real senders use both.
+        let mut watcher = watch(b"\x1b]9;done\x1b\\");
+        assert!(watcher.take_attention_ping());
+    }
+
+    #[test]
+    fn osc_777_notify_pings_but_other_777_subcommands_do_not() {
+        let mut watcher = watch(b"\x1b]777;notify;Gemini;waiting on you\x07");
+        assert!(watcher.take_attention_ping());
+
+        let mut watcher = watch(b"\x1b]777;precmd;0\x07");
+        assert!(
+            !watcher.take_attention_ping(),
+            "OSC 777 has non-notification sub-commands; only `notify` is an attention request"
+        );
+    }
+
+    #[test]
+    fn osc_9_4_is_progress_not_a_notification() {
+        let mut watcher = watch(b"\x1b]9;4;1;42\x07");
+        assert_eq!(
+            watcher.progress(),
+            Some(Progress {
+                state: ProgressState::Normal,
+                percent: Some(42)
+            })
+        );
+        assert!(
+            !watcher.take_attention_ping(),
+            "a progress report is not a request for the human's attention"
+        );
+    }
+
+    #[test]
+    fn every_progress_state_parses_to_its_documented_meaning() {
+        assert_eq!(watch(b"\x1b]9;4;0;0\x07").progress(), None);
+        assert_eq!(
+            watch(b"\x1b]9;4;2;80\x07").progress(),
+            Some(Progress {
+                state: ProgressState::Error,
+                percent: Some(80)
+            })
+        );
+        assert_eq!(
+            watch(b"\x1b]9;4;3;0\x07").progress(),
+            Some(Progress {
+                state: ProgressState::Indeterminate,
+                percent: None
+            }),
+            "indeterminate defines no percentage - reporting the sender's filler 0 as \"0% done\" \
+             would be inventing a fact"
+        );
+        assert_eq!(
+            watch(b"\x1b]9;4;4;33\x07").progress(),
+            Some(Progress {
+                state: ProgressState::Paused,
+                percent: Some(33)
+            })
+        );
+    }
+
+    #[test]
+    fn only_normal_and_indeterminate_progress_count_as_active_work() {
+        assert!(ProgressState::Normal.is_active());
+        assert!(ProgressState::Indeterminate.is_active());
+        assert!(!ProgressState::Error.is_active());
+        assert!(!ProgressState::Paused.is_active());
+    }
+
+    #[test]
+    fn a_clear_report_clears_an_earlier_progress() {
+        let mut watcher = OscWatcher::default();
+        watcher.feed(b"\x1b]9;4;1;50\x07");
+        assert!(watcher.progress().is_some());
+        watcher.feed(b"\x1b]9;4;0\x07");
+        assert_eq!(watcher.progress(), None);
+    }
+
+    #[test]
+    fn a_later_progress_report_supersedes_an_earlier_one() {
+        let mut watcher = OscWatcher::default();
+        watcher.feed(b"\x1b]9;4;1;10\x07");
+        watcher.feed(b"\x1b]9;4;1;90\x07");
+        assert_eq!(watcher.progress().and_then(|p| p.percent), Some(90));
+    }
+
+    #[test]
+    fn a_percentage_above_100_is_clamped_and_a_junk_one_is_dropped() {
+        assert_eq!(
+            watch(b"\x1b]9;4;1;999\x07").progress().unwrap().percent,
+            Some(100)
+        );
+        assert_eq!(
+            watch(b"\x1b]9;4;1;abc\x07").progress().unwrap().percent,
+            None,
+            "an unparseable percentage is absent, not zero"
+        );
+    }
+
+    #[test]
+    fn an_out_of_range_progress_state_is_ignored_entirely() {
+        assert_eq!(watch(b"\x1b]9;4;7;50\x07").progress(), None);
+        assert_eq!(watch(b"\x1b]9;4\x07").progress(), None);
+    }
+
+    #[test]
+    fn unrelated_osc_sequences_and_plain_text_produce_no_signal() {
+        let mut watcher = watch(
+            b"hello \x1b]0;some window title\x07 world\x1b]8;;https://example.com\x07link\
+              \x1b]52;c;Zm9v\x07\x1b]4;1;#ff0000\x07",
+        );
+        assert!(!watcher.take_attention_ping());
+        assert_eq!(watcher.progress(), None);
+    }
+
+    #[test]
+    fn a_sequence_split_across_chunk_boundaries_still_parses() {
+        // The pty hands over arbitrary chunk boundaries; the `vte::Parser` state machine is what
+        // carries a half-read sequence across one, which is why the watcher owns a persistent
+        // parser rather than parsing each chunk standalone.
+        let mut watcher = OscWatcher::default();
+        for chunk in [
+            b"\x1b]9".as_slice(),
+            b";4;1".as_slice(),
+            b";7".as_slice(),
+            b"7\x07".as_slice(),
+        ] {
+            watcher.feed(chunk);
+        }
+        assert_eq!(watcher.progress().and_then(|p| p.percent), Some(77));
+    }
+
+    #[test]
+    fn a_bare_osc_9_with_no_message_is_not_a_notification() {
+        let mut watcher = watch(b"\x1b]9\x07");
+        assert!(!watcher.take_attention_ping());
+    }
+}

--- a/crates/app/src/terminal/pane.rs
+++ b/crates/app/src/terminal/pane.rs
@@ -93,6 +93,7 @@ use crate::terminal::grid::{
     CellPosition, CellSide, CellWidth, GridCell, TerminalGrid, TerminalPalette,
 };
 use crate::terminal::links::{self as terminal_links, LinkMatch};
+use crate::terminal::osc::Progress;
 use crate::theme;
 
 /// How often the poll task of the *globally active* agent's pane (see
@@ -573,6 +574,20 @@ pub struct TerminalPane {
     /// from; intentionally not itself a `Status` - this pane only knows "when did I last see
     /// this process do something".
     activity_at: Option<Instant>,
+    /// When this pane's process last fired an OSC 9 / OSC 777 desktop notification that the
+    /// human has not yet answered, or `None` if it never has or the human has since answered
+    /// (GitHub issue #239).
+    ///
+    /// This is the latch that turns the *event* the pty carries into the *state* the rail needs.
+    /// [`crate::terminal::osc::OscWatcher::take_attention_ping`] is deliberately consume-on-read,
+    /// because a notification is a point-in-time "now" that nothing in the protocol ever
+    /// un-fires; but `crate::rail::status` is read from the render path many times a second, so
+    /// consuming it *there* would make an agent's "needs input" status blink out one frame after
+    /// it appeared. So the poll loop consumes the one-shot flag exactly once, here, and holds it
+    /// until something real answers it: the human typing into this pane
+    /// ([`Self::handle_key_down`]), or a new process starting ([`Self::spawn_process`]). It
+    /// cannot leak across either boundary, and it never outlives the session that raised it.
+    attention_ping_at: Option<Instant>,
     /// `true` from the moment pty EOF is observed until the child's exit status is either
     /// confirmed or given up on - see [`eof_poll_decision`]'s docs for the bug this state
     /// exists to fix. While `true`, [`Self::session`] is deliberately not yet cleared: the
@@ -655,6 +670,7 @@ impl TerminalPane {
             spawn_error: None,
             exit_status: None,
             activity_at: None,
+            attention_ping_at: None,
             eof_pending: false,
             eof_poll_ticks: 0,
             focus_handle: cx.focus_handle(),
@@ -746,6 +762,36 @@ impl TerminalPane {
     /// field docs for exactly when this becomes `Some`.
     pub fn exit_status(&self) -> Option<&ExitStatus> {
         self.exit_status.as_ref()
+    }
+
+    /// The window title this pane's process last set via OSC 0/2, if any (GitHub issue #239).
+    ///
+    /// Real agent CLIs put a live status glyph here - Claude Code alternates a `\u{25d0}`-family
+    /// spinner while working and rests on `\u{2733}`; Gemini CLI writes `\u{25c7}  Ready (...)`
+    /// when idle (both observed directly against real CLIs; see
+    /// `crate::rail::title_signal`, which is what turns this raw string into a status signal).
+    pub fn title(&self) -> Option<&str> {
+        self.grid.title()
+    }
+
+    /// Whether this pane's process has fired an OSC 9 / OSC 777 desktop notification that the
+    /// human hasn't answered yet - see [`Self::attention_ping_at`]'s field docs for the exact
+    /// lifecycle, and `crate::terminal::osc` for the sequences involved.
+    pub fn has_pending_attention_ping(&self) -> bool {
+        self.attention_ping_at.is_some()
+    }
+
+    /// The most recent OSC 9;4 progress report from this pane's process, if it speaks that
+    /// protocol - see [`crate::terminal::osc::Progress`].
+    pub fn progress(&self) -> Option<Progress> {
+        self.grid.progress()
+    }
+
+    /// Marks this pane's outstanding attention ping as answered - called when the human
+    /// actually responds to it, which is when they type into this pane, and when a new process
+    /// takes the pane over. See [`Self::attention_ping_at`]'s field docs.
+    fn clear_attention_ping(&mut self) {
+        self.attention_ping_at = None;
     }
 
     /// Tells this pane whether its agent is the globally active tab - see
@@ -1107,6 +1153,9 @@ impl TerminalPane {
                     // a still-spawning agent from being immediately misread as long-idle by
                     // `crate::rail::status::derive_status`.
                     this.activity_at = Some(std::time::Instant::now());
+                    // A previous process's unanswered attention ping is not this one's - see
+                    // `attention_ping_at`'s field docs.
+                    this.clear_attention_ping();
                     // The pane may already have rendered (and computed a target grid size)
                     // before this task's background spawn finished - there was no live
                     // session yet for that call to reach, so retry it now that one exists,
@@ -1177,6 +1226,13 @@ impl TerminalPane {
                                     drained_bytes += chunk.len().max(1);
                                     this.grid.append_bytes(&chunk);
                                     this.activity_at = Some(Instant::now());
+                                    // Consume the grid's one-shot OSC 9 / 777 notification flag
+                                    // right where the bytes that could have set it were parsed,
+                                    // and latch it - see `attention_ping_at`'s field docs for
+                                    // why this must not be consumed from the render path.
+                                    if this.grid.take_attention_ping() {
+                                        this.attention_ping_at = Some(Instant::now());
+                                    }
                                     appended = true;
                                 }
                                 Err(TryRecvError::Empty) => break,
@@ -1201,7 +1257,7 @@ impl TerminalPane {
                         // `this.grid`. This is never a no-op-safe skip: real Windows ConPTY
                         // sends exactly this query as part of its own startup handshake and
                         // blocks its entire output stream on a real answer (confirmed live -
-                        // see `PtyWriteQueue`'s own docs), so a dropped reply here doesn't just
+                        // see `TermEventSink`'s own docs), so a dropped reply here doesn't just
                         // misrender a query response, it silently hangs the whole pane forever.
                         if appended {
                             let pending_writes = this.grid.take_pending_pty_writes();
@@ -1291,7 +1347,15 @@ impl TerminalPane {
         let Some(bytes) = keystroke_to_bytes(&event.keystroke) else {
             return;
         };
-        if let Err(err) = session.write_input(&bytes) {
+        // Bound rather than matched inline so the `&self.session` borrow ends before
+        // `clear_attention_ping` takes `&mut self` below.
+        let write_result = session.write_input(&bytes);
+        // The human is typing at this pane: whatever the agent pinged for attention about, this
+        // is them answering it. Placed after `keystroke_to_bytes` so a keystroke that isn't real
+        // terminal input (a bare modifier, an unmapped key) doesn't count as an answer. See
+        // `attention_ping_at`'s field docs.
+        self.clear_attention_ping();
+        if let Err(err) = write_result {
             self.spawn_error = Some(format!("failed to write input: {err}"));
             cx.notify();
         }
@@ -2885,6 +2949,167 @@ mod clear_pty_signal_tests {
              appear in the grid - this is what actually proves the byte reached the pty, not \
              just that write_input() was called"
         );
+    }
+}
+
+/// GitHub issue #239's structural status signal, end to end through a **real pty**: a real child
+/// process writes real escape sequences into a real pty, this pane's real poll loop reads them,
+/// and the pane's accessors report what was parsed. Nothing here is injected or simulated - the
+/// escape bytes are produced by a real `printf`, exactly as a real agent CLI produces them.
+#[cfg(test)]
+mod terminal_signal_tests {
+    use super::*;
+    use crate::rail::title_signal::{classify_title, TitleSignal};
+    use crate::terminal::osc::{Progress, ProgressState};
+    use gpui::TestAppContext;
+
+    /// Spawns a real `sh` that writes `script`'s escape sequences and then blocks, so the
+    /// process is still alive (and the pane still `is_running`) while the assertions run - the
+    /// same real-pty pattern this module's other tests use, and `sh` rather than bare `printf`
+    /// so the sequences and the sleep are one child process.
+    fn pane_emitting(cx: &mut TestAppContext, script: &str) -> gpui::Entity<TerminalPane> {
+        cx.new(|cx| {
+            TerminalPane::new(
+                TerminalSpec::command(
+                    "sh",
+                    vec!["-c".to_string(), format!("{script}; sleep 60")],
+                    std::env::temp_dir(),
+                ),
+                ROW_FONT_SIZE_PX,
+                cx,
+            )
+        })
+    }
+
+    /// Drives the pane's real poll loop until `done` reports true, or gives up. The pty write
+    /// itself takes real wall time (a real process, real fd) while the *drain* only happens on
+    /// poll ticks, which the test executor's clock drives - hence both a real sleep and the
+    /// virtual-clock loop, matching `cadence_tests`' own approach.
+    fn poll_until(
+        cx: &mut TestAppContext,
+        pane: &gpui::Entity<TerminalPane>,
+        done: impl Fn(&TerminalPane) -> bool,
+    ) -> bool {
+        cx.run_until_parked();
+        for _ in 0..60 {
+            std::thread::sleep(Duration::from_millis(50));
+            cx.background_executor.advance_clock(POLL_INTERVAL);
+            cx.run_until_parked();
+            if pane.read_with(cx, |pane, _| done(pane)) {
+                return true;
+            }
+        }
+        false
+    }
+
+    #[gpui::test]
+    fn a_real_pty_process_setting_its_title_is_captured_and_classified(cx: &mut TestAppContext) {
+        // Byte for byte what Claude Code writes while it is working - see
+        // `crate::rail::title_signal`'s module docs for the live capture this came from.
+        // The glyph goes in as a literal UTF-8 character rather than a `printf` escape: `\033`
+        // and `\007` are POSIX octal escapes every `printf` supports, but `\u` is not portable.
+        let pane = pane_emitting(cx, "printf '\\033]0;\u{25d0} Claude Code\\007'");
+        assert!(
+            poll_until(cx, &pane, |pane| pane.title().is_some()),
+            "the pane never captured a title from a real pty"
+        );
+
+        let title = pane.read_with(cx, |pane, _| pane.title().map(str::to_string));
+        assert_eq!(title.as_deref(), Some("\u{25d0} Claude Code"));
+        assert_eq!(
+            classify_title(title.as_deref().unwrap()),
+            TitleSignal::Busy,
+            "a real agent CLI's real working title must classify as Busy end to end"
+        );
+
+        pane.update(cx, |pane, cx| pane.shutdown(cx));
+        cx.run_until_parked();
+    }
+
+    #[gpui::test]
+    fn a_real_osc_9_notification_from_a_pty_process_latches_an_attention_ping(
+        cx: &mut TestAppContext,
+    ) {
+        let pane = pane_emitting(cx, "printf '\\033]9;Agent needs your input\\007'");
+        assert!(
+            !pane.read_with(cx, |pane, _| pane.has_pending_attention_ping()),
+            "sanity check: nothing pinged before the process wrote anything"
+        );
+        assert!(
+            poll_until(cx, &pane, |pane| pane.has_pending_attention_ping()),
+            "a real OSC 9 notification off a real pty never reached the pane"
+        );
+        // The latch is state, not a one-shot: reading it twice must not consume it, or the
+        // render path would see "needs input" for exactly one frame. See
+        // `TerminalPane::attention_ping_at`'s field docs.
+        assert!(
+            pane.read_with(cx, |pane, _| pane.has_pending_attention_ping()),
+            "the pane's ping must survive being read"
+        );
+
+        pane.update(cx, |pane, cx| pane.shutdown(cx));
+        cx.run_until_parked();
+    }
+
+    #[gpui::test]
+    fn a_real_osc_777_notify_from_a_pty_process_also_pings(cx: &mut TestAppContext) {
+        let pane = pane_emitting(cx, "printf '\\033]777;notify;Gemini;your turn\\007'");
+        assert!(
+            poll_until(cx, &pane, |pane| pane.has_pending_attention_ping()),
+            "a real OSC 777 notify off a real pty never reached the pane"
+        );
+
+        pane.update(cx, |pane, cx| pane.shutdown(cx));
+        cx.run_until_parked();
+    }
+
+    #[gpui::test]
+    fn a_real_osc_9_4_progress_report_from_a_pty_process_is_parsed(cx: &mut TestAppContext) {
+        let pane = pane_emitting(cx, "printf '\\033]9;4;1;73\\007'");
+        assert!(
+            poll_until(cx, &pane, |pane| pane.progress().is_some()),
+            "a real OSC 9;4 progress report off a real pty never reached the pane"
+        );
+        assert_eq!(
+            pane.read_with(cx, |pane, _| pane.progress()),
+            Some(Progress {
+                state: ProgressState::Normal,
+                percent: Some(73)
+            })
+        );
+        assert!(
+            !pane.read_with(cx, |pane, _| pane.has_pending_attention_ping()),
+            "a progress report is not a notification - OSC 9;4 must not ping for attention"
+        );
+
+        pane.update(cx, |pane, cx| pane.shutdown(cx));
+        cx.run_until_parked();
+    }
+
+    #[gpui::test]
+    fn a_pty_process_that_says_nothing_reports_no_signal_at_all(cx: &mut TestAppContext) {
+        // The honest default, and the one every non-agent process hits: a `cat` sitting on a
+        // real pty has no title, no ping and no progress - not an invented one.
+        let pane = cx.new(|cx| {
+            TerminalPane::new(
+                TerminalSpec::command("cat", Vec::new(), std::env::temp_dir()),
+                ROW_FONT_SIZE_PX,
+                cx,
+            )
+        });
+        cx.run_until_parked();
+        for _ in 0..5 {
+            cx.background_executor.advance_clock(POLL_INTERVAL);
+            cx.run_until_parked();
+        }
+        pane.read_with(cx, |pane, _| {
+            assert_eq!(pane.title(), None);
+            assert!(!pane.has_pending_attention_ping());
+            assert_eq!(pane.progress(), None);
+        });
+
+        pane.update(cx, |pane, cx| pane.shutdown(cx));
+        cx.run_until_parked();
     }
 }
 

--- a/crates/app/src/work_surface/mod.rs
+++ b/crates/app/src/work_surface/mod.rs
@@ -20,6 +20,7 @@ use crate::keymap::{self};
 use crate::merge::state as merge;
 use crate::palette::state as palette;
 use crate::rail::status::{self, Status};
+use crate::rail::title_signal;
 use crate::root::*;
 use crate::settings::state as settings;
 use crate::sidebar::file_tree::{self};

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -332,6 +332,16 @@ impl AdeApp {
         } else {
             status::ProcessSignal::NoProcess
         };
+        // GitHub issue #239: the second, structural signal - what the process said about itself
+        // through its own terminal (title glyph, OSC 9/777 notification, OSC 9;4 progress),
+        // rather than what its silence implies. Gathered for every kind and gated inside
+        // `derive_status`, which consults it only for a real agent session: a shell's title can
+        // say anything and must never be able to fake agent-ness (see that module's docs).
+        let terminal = status::TerminalSignal {
+            title: pane.title().map(title_signal::classify_title),
+            attention_pinged: pane.has_pending_attention_ping(),
+            progress: pane.progress(),
+        };
         // GitHub issue #225: what makes an exited agent "review ready" is now whether *it* has a
         // real, unreviewed diff against *its own* baseline - not whether its worktree's branch
         // differs from the default branch, which is a different question and was producing a
@@ -344,7 +354,7 @@ impl AdeApp {
         // readiness it can't honestly substantiate. Such an agent lands on `Idle` instead, which
         // is the same state it would show with an empty review.
         let has_unreviewed_changes = self.agent_has_unreviewed_changes(agent.id);
-        status::derive_status(agent.kind, signal, has_unreviewed_changes)
+        status::derive_status(agent.kind, signal, terminal, has_unreviewed_changes)
     }
 
     /// The context bar's and idle-status footer's `Archive` action - closes the tab via


### PR DESCRIPTION
## Summary

Phase 1 of #239 - full research and design: https://claude.ai/code/artifact/e1d221d0-44b7-4da0-a94b-ed5ded943b05

Jerry's rail currently derives an agent's status purely from PTY output *quiescence* (15s of silence → "needs input"). Real agent CLIs already emit richer signal into the terminal that Jerry discarded entirely: a live status glyph in the window title, and (per the protocol spec, not observed live from either CLI tested) OSC 9/777 desktop notifications and OSC 9;4 progress reports. This wires all three up as a second, faster, more accurate signal layered on top of - never replacing - the existing quiescence floor.

- **Title capture**: widened the terminal's event listener (`PtyWriteQueue` → `TermEventSink`) to also capture `Event::Title`/`Event::ResetTitle`, alongside the existing `PtyWrite` capture (untouched - that one exists to answer ConPTY's real Windows handshake query and stays exactly as sensitive as before).
- **OSC 9/9;4/777 capture**: these are silently dropped by the vendored `alacritty_terminal`'s own ANSI processor (confirmed against the real vendored source - no `Event` variant exists for them). Added a second, independent `vte::Parser` (`terminal/osc.rs`) teed onto the same raw PTY byte stream - deliberately never touching the primary rendering pipeline, which has a documented history of subtle real bugs (the ConPTY hang).
- **Classification** (`rail/title_signal.rs`): a small, pure, GPUI-free function reading a title into `Busy`/`Idle`/`NeedsAttention`/`Unknown`. **Empirically verified against real, live CLIs, not just the prior research**: driving both Claude Code and Gemini CLI under a real pty surfaced a real gap in the original research - it named Claude's idle glyph (`✳`) but never identified the busy one, which turned out to be a `◐`/`◑` half-circle spinner. Also caught, live, the exact false-positive class this exists to fix: a 9-second stretch of silent `sleep` tool calls that the spinner correctly kept showing as busy. Gemini's other three documented glyphs, and the whole OSC 9/777 path, were not reproduced live and are explicitly marked unverified-by-observation in the module docs rather than asserted.
- **Status derivation** (`rail/status.rs`): `derive_status` gained a `TerminalSignal` parameter. Two refinements, both agent-only: an explicit "needs attention" signal reaches `Ask` before the 15s clock would; an explicit "busy" signal holds `Run` past it. A `ProcessKind::Shell` never consults this signal at all - not even to stay `Run` - enforced structurally (the check lives inside the `is_agent_session()` branch), so a shell prompt or a stray escape sequence in someone's `.bashrc` can never fake agent-ness.

Deliberately out of scope for this PR: hooks, any new network listener, and `AgentRow.activity`/`question_preview` - those need real textual content only Phase 2's hook payloads can honestly provide.

## Test plan

- [x] Real-pty tests: actual OSC title/OSC-9/OSC-9;4/OSC-777 byte sequences written via `printf` into a real spawned shell, read back through the real poll loop
- [x] The exact real Claude Code title transcript captured live, pinned as a test
- [x] Pure unit tests for title classification (word-boundary false-positives against real paths, multibyte safety, glyph-vs-keyword precedence)
- [x] Regression test: `ProcessKind::Shell` never reaches `Ask` and is never held on `Run` by any terminal signal, however agent-like
- [x] Regression test: an exited/no-process signal is never overridden by a stale terminal signal
- [x] `cargo build --workspace` - clean
- [x] `cargo clippy -p app --all-targets -- -D warnings` - clean
- [x] `cargo fmt --check -p app` - clean (one pre-existing, unrelated violation in `review/render.rs:1506`, confirmed present on master itself before this branch)
- [x] `cargo test -p app --lib` - 2152 passed; the usual known-flaky file-tree-watch/LSP tests under heavy parallel load, confirmed passing standalone

🤖 Generated with [Claude Code](https://claude.com/claude-code)