### PR TITLE
feat(app): tab strip neighbor-slide animation on drop (issue #16)

### DIFF
--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -1870,9 +1870,40 @@ pub struct AdeApp {
     /// frames for it once done (`AnimationElement::request_layout`'s own `if !done {
     /// request_animation_frame() }`).
     pub(crate) dropped_tab_settle: Option<(work_surface::TabRef, u64)>,
-    /// The next fresh id [`Self::drop_dragged_tab`] will stamp into [`Self::dropped_tab_settle`] -
-    /// see that field's own docs for why a fresh id matters every time.
+    /// The next fresh id [`Self::drop_dragged_tab`] will stamp into [`Self::dropped_tab_settle`]
+    /// (and, since Revision task #65, into [`Self::tab_slide`] too - one drop kicks off both
+    /// animations at once, so both can safely share one fresh id per drop) - see that field's own
+    /// docs for why a fresh id matters every time.
     pub(crate) next_tab_settle_id: u64,
+    /// Each currently-rendered tab's own real painted bounds, captured every render by a
+    /// `gpui::canvas` overlay in [`work_surface::render::AdeApp::render_tab_chrome`] - the same
+    /// idiom [`Self::plus_button_bounds`]/[`Self::rail_plus_button_bounds`] already use, keyed by
+    /// [`work_surface::TabRef`] since every tab paints its own each frame. This is the *only*
+    /// real source of a tab's on-screen width (GPUI's flex layout means no two tabs are the same
+    /// size), which [`Self::drop_dragged_tab`] needs to compute how far a drop's neighbouring
+    /// tabs must visually slide (see [`Self::tab_slide`]'s own docs). Never pruned when a tab
+    /// closes - a harmless, bounded leak, the same tradeoff [`Self::rail_plus_button_bounds`]
+    /// already makes.
+    pub(crate) tab_bounds: std::collections::HashMap<work_surface::TabRef, gpui::Bounds<Pixels>>,
+    /// The unified tab strip's real neighbour-slide animation - the "every tab other than the
+    /// one actually dropped just teleports to its new slot" gap GitHub issue #16 left open
+    /// (tracked internally as task #65), now closed the same way [`Self::dropped_tab_settle`]
+    /// closed the dropped tab's own "instant, no visual feedback" gap. `tab_ref -> (start_offset,
+    /// id)` for every tab whose horizontal slot moved as a side effect of the most recent drop -
+    /// never the dragged tab itself, which keeps its own settle-fade instead
+    /// (`work_surface::state::tab_slide_offsets`'s own docs on why the two are always disjoint).
+    /// `start_offset` is a real pixel distance (`work_surface::state::tab_slide_offsets`'s own
+    /// docs on why only the *dragged* tab's own last-measured [`Self::tab_bounds`] width is ever
+    /// needed to compute it, not each shifted tab's), `id` a fresh [`Self::next_tab_settle_id`]
+    /// value for the same "GPUI keys animation progress purely by id string" reason
+    /// [`Self::dropped_tab_settle`]'s own docs give - doubly so here, since *multiple* sibling
+    /// tabs can carry a slide at once, so [`work_surface::render::AdeApp::render_tab_chrome`]
+    /// mixes each tab's own [`gpui::ElementId`] into the animation id too. Replaced wholesale by
+    /// every new drop rather than merged - a stale entry left over from a finished animation is
+    /// harmless (it just keeps resolving to a `0` offset, [`Self::dropped_tab_settle`]'s own
+    /// "left set, never explicitly cleared" precedent), and a fresh drop's own set of shifted
+    /// tabs is never a superset of the previous drop's anyway.
+    pub(crate) tab_slide: std::collections::HashMap<work_surface::TabRef, (Pixels, u64)>,
     /// User-authored themes loaded from `~/.config/jerry/themes/*.toml` at construction time
     /// (GitHub issue #5) - real, additional `crate::settings::custom_theme::CustomTheme` entries
     /// layered on top of the six built-in `settings::THEME_DEFS`, not a replacement for them. See

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -522,6 +522,8 @@ impl AdeApp {
             dragging_tab: None,
             dropped_tab_settle: None,
             next_tab_settle_id: 0,
+            tab_bounds: HashMap::new(),
+            tab_slide: HashMap::new(),
             custom_themes,
             custom_theme_load_errors,
             custom_theme_status: None,

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -657,6 +657,16 @@ impl AdeApp {
     /// drop lands on a tab [`Self::update_tab_drag_insertion`] never actually recorded for - a
     /// drop can still fire on a tab the cursor technically never entered, e.g. a very fast
     /// release), then delegates to [`Self::reorder_tab`], and clears the now-stale caret state.
+    ///
+    /// Also records [`Self::tab_slide`] (task #65, GitHub issue #16's own remaining "neighbour
+    /// tabs teleport instead of sliding" gap) *before* [`Self::reorder_tab`] actually mutates the
+    /// order - `work_surface::state::tab_slide_offsets` needs the real pre-drop order to know
+    /// which tabs are about to shift, and the dragged tab's own real last-measured width
+    /// ([`Self::tab_bounds`]) to know by how much. `dragged_width` is `0px`
+    /// ([`Pixels::default`]) whenever that tab has never actually painted yet (e.g. a test that
+    /// never rendered a real window) - a real, honestly-measured `0` rather than an invented
+    /// placeholder width, so the recorded tabs are still correct even though nothing would
+    /// visibly move.
     pub(in crate::work_surface) fn drop_dragged_tab(
         &mut self,
         dragged: work_surface::TabRef,
@@ -669,6 +679,25 @@ impl AdeApp {
             .is_some_and(|(hovered, after)| *hovered == target && *after);
         self.next_tab_settle_id += 1;
         self.dropped_tab_settle = Some((dragged.clone(), self.next_tab_settle_id));
+
+        let old_order = self.combined_tab_order();
+        let dragged_width = self
+            .tab_bounds
+            .get(&dragged)
+            .map(|bounds| bounds.size.width)
+            .unwrap_or_default();
+        let slide_id = self.next_tab_settle_id;
+        self.tab_slide = work_surface::tab_slide_offsets(
+            &old_order,
+            &dragged,
+            &target,
+            insert_after,
+            dragged_width,
+        )
+        .into_iter()
+        .map(|(tab_ref, offset)| (tab_ref, (offset, slide_id)))
+        .collect();
+
         self.reorder_tab(dragged, target, insert_after, cx);
         self.tab_drag_insertion = None;
         self.dragging_tab = None;
@@ -919,12 +948,13 @@ impl AdeApp {
     /// the opacity dim while this tab's own drag ghost is the real thing following the cursor,
     /// the full `on_drag`/`on_drag_move`/`on_drop` wiring (GitHub issue #16's unified
     /// drag-to-reorder system - see [`DraggedTab`]'s own docs), the insertion caret, middle-click
-    /// close, and the drop settle-fade (GitHub issue #16 §5). Every real per-kind visual (chip,
-    /// label, dirty/status dot, the close button itself) is still supplied by the caller as
+    /// close, the drop settle-fade (GitHub issue #16 §5), and the neighbour-slide animation for
+    /// every *other* tab a drop shifted (task #65). Every real per-kind visual (chip, label,
+    /// dirty/status dot, the close button itself) is still supplied by the caller as
     /// `args.content`, in the order it should render - only the chrome around it is shared now,
     /// which is what makes the exact bug class GitHub issue #96 was structurally impossible:
-    /// there is now exactly one place that wires drag/close/settle-fade for every tab kind, not
-    /// three.
+    /// there is now exactly one place that wires drag/close/settle-fade/slide for every tab kind
+    /// (agent, file, graph, review), not four.
     pub(crate) fn render_tab_chrome(
         &self,
         args: TabChromeArgs,
@@ -948,9 +978,13 @@ impl AdeApp {
         };
         let is_dragging = self.dragging_tab.as_ref() == Some(&tab_ref);
         let settle_animation_id = tab_settle_animation_id(&self.dropped_tab_settle, &tab_ref);
+        let slide = self.tab_slide.get(&tab_ref).copied();
+        let outer_id_for_slide = outer_id.clone();
         let this_entity = cx.entity();
+        let this_entity_for_bounds = this_entity.clone();
         let tab_ref_for_drag = tab_ref.clone();
         let tab_ref_for_drag_move = tab_ref.clone();
+        let tab_ref_for_bounds = tab_ref.clone();
         let tab_ref_for_drop = tab_ref;
 
         let tab_div = div()
@@ -1012,22 +1046,67 @@ impl AdeApp {
                     }))
                     .children(content),
             )
-            .child(div().flex_none().w_full().h(px(1.0)).bg(colors.underline));
+            .child(div().flex_none().w_full().h(px(1.0)).bg(colors.underline))
+            // Captures this tab's own painted bounds into `Self::tab_bounds` every render - the
+            // same `gpui::canvas` idiom `Self::plus_button_bounds`/`Self::rail_plus_button_bounds`
+            // already use. The only real source of a tab's on-screen width (GPUI's flex layout
+            // means no two tabs are the same size), which `Self::drop_dragged_tab` reads for
+            // whichever tab is dragged next, to compute how far a drop's shifted neighbours must
+            // slide (`work_surface::state::tab_slide_offsets`'s own docs on why only the
+            // *dragged* tab's own width is ever needed).
+            .child({
+                let this = this_entity_for_bounds;
+                gpui::canvas(
+                    move |bounds, _window, cx| {
+                        this.update(cx, |this, _cx| {
+                            this.tab_bounds.insert(tab_ref_for_bounds.clone(), bounds);
+                        });
+                    },
+                    |_, _, _, _| {},
+                )
+                .absolute()
+                .size_full()
+            });
 
         // A real drop's own settle-in fade (GitHub issue #16's "dropping animates the tab
         // settling into its slot") - see `tab_settle_animation_id`'s own docs for why a fresh id
         // is required, and why this branches to `gpui::AnyElement` rather than a plain
         // `.when_some` (`gpui::AnimationExt::with_animation` returns a different wrapper type,
-        // not `Self`).
-        match settle_animation_id {
-            Some(id) => tab_div
+        // not `Self`). Mutually exclusive with the neighbour-slide branch below: the dropped tab
+        // itself is never in `Self::tab_slide` (`work_surface::state::tab_slide_offsets`'s own
+        // docs), so a tab is never asked to fade and slide at once.
+        match (settle_animation_id, slide) {
+            (Some(id), _) => tab_div
                 .with_animation(
                     id,
                     Animation::new(TAB_SETTLE_ANIMATION_DURATION),
                     |el, delta| el.opacity(0.55 + 0.45 * delta),
                 )
                 .into_any_element(),
-            None => tab_div.into_any_element(),
+            // The remaining GitHub issue #16 gap this closes (task #65): a tab whose slot shifted
+            // as a side effect of a drop slides from its own real pre-drop position (`offset`)
+            // down to `0` - its already-correct new position - rather than teleporting there.
+            // `.left()`, not `.opacity()`, and `tab_div` stays `position: relative` (never
+            // `.absolute()`): a `position: relative` element's `inset`/`left` is a pure paint-time
+            // offset from its own normal flex slot (`taffy`, this app's real flex layout engine -
+            // see `vendor/zed/crates/gpui/src/taffy.rs`'s `inset` translation, and `taffy` itself:
+            // "Offset is the relative position from the item's natural flow position ... Does not
+            // include margin/padding/border") - so every *other* tab's own flex position is
+            // completely unaffected by this tab's temporary offset, exactly like the dropped
+            // tab's own opacity dim above never shifts its neighbours. The animation id mixes in
+            // this tab's own `outer_id` (unlike the settle-fade above, more than one tab can slide
+            // from the same drop at once, so the batch id alone would collide across siblings) and
+            // `slide_id` (the same "GPUI keys animation progress purely by id string, so two
+            // different drops must never share an id" reason `tab_settle_animation_id`'s own docs
+            // give).
+            (None, Some((offset, slide_id))) => tab_div
+                .with_animation(
+                    format!("tab-slide-{outer_id_for_slide}-{slide_id}"),
+                    Animation::new(TAB_SLIDE_ANIMATION_DURATION),
+                    move |el, delta| el.left(offset * (1.0 - delta)),
+                )
+                .into_any_element(),
+            (None, None) => tab_div.into_any_element(),
         }
     }
 
@@ -2634,6 +2713,15 @@ pub(in crate::work_surface) fn render_tab_insertion_caret(insert_after: bool) ->
 pub(in crate::work_surface) const TAB_SETTLE_ANIMATION_DURATION: Duration =
     Duration::from_millis(150);
 
+/// How long a neighbour tab's own slide-into-place animation runs, when a drop shifts its slot
+/// (task #65, the remaining GitHub issue #16 gap: before this, every tab other than the one
+/// actually dropped just teleported to its new slot). Deliberately the same value as
+/// [`TAB_SETTLE_ANIMATION_DURATION`] - one drop kicks off both animations together, and having
+/// them run for different durations would read as two unrelated effects rather than one drop
+/// settling everything it touched.
+pub(in crate::work_surface) const TAB_SLIDE_ANIMATION_DURATION: Duration =
+    TAB_SETTLE_ANIMATION_DURATION;
+
 /// A fresh `gpui::AnimationExt::with_animation` id for `tab_ref`, if [`AdeApp::dropped_tab_settle`]
 /// says it's the tab a real drop most recently placed - `None` for every other tab, and for a
 /// tab that was never the target of a real drop this session. A distinct `String` per drop
@@ -3571,6 +3659,125 @@ mod tab_scoping_tests {
         assert_ne!(
             first_id, second_id_recorded,
             "a later drop must never reuse an earlier drop's own settle id"
+        );
+    }
+
+    /// The remaining GitHub issue #16 gap this closes (task #65): a drop must not just
+    /// settle-fade the tab that was dragged - every *other* tab whose slot it passed over must
+    /// slide too. Proven end to end against `Self::tab_bounds`'s own real, `gpui::canvas`-painted
+    /// width (`cx.run_until_parked()` lets that canvas actually paint, exactly like the plus
+    /// button's own bounds tests do) - not a fabricated placeholder offset. Three real agent tabs
+    /// dragging tab 1 to land after tab 3 must shift both 2 and 3 (each by tab 1's own real
+    /// width), and must never record tab 1 itself - it already has its own settle-fade
+    /// (`drop_dragged_tab_records_a_fresh_settle_id_for_the_dropped_tab`, just above).
+    #[gpui::test]
+    fn drop_dragged_tab_records_real_slide_offsets_for_every_shifted_neighbour(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+
+        let (first_id, second_id, third_id) = app.update_in(cx, |app, window, cx| {
+            let first_id = app.agents.active_id().expect("initial shell agent");
+            let second_id = app.agents.spawn(
+                ProcessKind::Shell,
+                repo.path().to_path_buf(),
+                12.0,
+                None,
+                window,
+                cx,
+            );
+            let third_id = app.agents.spawn(
+                ProcessKind::Shell,
+                repo.path().to_path_buf(),
+                12.0,
+                None,
+                window,
+                cx,
+            );
+            (first_id, second_id, third_id)
+        });
+        cx.run_until_parked();
+
+        let dragged_width = app
+            .read_with(cx, |app, _| {
+                app.tab_bounds
+                    .get(&work_surface::TabRef::Agent(first_id))
+                    .map(|bounds| bounds.size.width)
+            })
+            .expect(
+                "tab 1 must have really painted at least once (via the shared chrome's own \
+                 `gpui::canvas`) before a drag off it can be measured",
+            );
+        assert!(
+            dragged_width > px(0.0),
+            "a real, already-painted tab must have nonzero measured width"
+        );
+
+        // Simulates what a real `on_drag_move` tick over the right half of tab 3's own tab would
+        // already have recorded, just before the drop - the same precedent
+        // `dropping_a_tab_clears_dragging_tab` (just below) uses.
+        app.update(cx, |app, _cx| {
+            app.tab_drag_insertion = Some((work_surface::TabRef::Agent(third_id), true));
+        });
+        app.update(cx, |app, cx| {
+            app.drop_dragged_tab(
+                work_surface::TabRef::Agent(first_id),
+                work_surface::TabRef::Agent(third_id),
+                cx,
+            );
+        });
+
+        let slide = app.read_with(cx, |app, _| app.tab_slide.clone());
+        assert_eq!(
+            slide.len(),
+            2,
+            "tabs 2 and 3 both sat between tab 1's old slot (0) and its new one (2) - both, and \
+             only both, must slide: {slide:?}"
+        );
+        let (offset_2, _) = slide[&work_surface::TabRef::Agent(second_id)];
+        let (offset_3, _) = slide[&work_surface::TabRef::Agent(third_id)];
+        assert_eq!(
+            offset_2, dragged_width,
+            "tab 2 must slide by exactly tab 1's own real measured width"
+        );
+        assert_eq!(
+            offset_3, dragged_width,
+            "tab 3 must slide by exactly tab 1's own real measured width too - not by its own \
+             (different) width"
+        );
+        assert!(
+            !slide.contains_key(&work_surface::TabRef::Agent(first_id)),
+            "the dragged tab itself must never be recorded here - it already got its own \
+             settle-fade, never both at once"
+        );
+    }
+
+    /// A no-op drop (dragging a tab onto its own current slot) must record no slide state at all
+    /// - nothing actually changed position, so nothing may animate
+    /// (`drag_reorder_is_a_no_op_for_an_unknown_or_identical_id`'s own proof for the underlying
+    /// reorder itself; this is that same guarantee for the slide it now also kicks off).
+    #[gpui::test]
+    fn drop_dragged_tab_records_no_slide_state_for_a_no_op_drop(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let initial_id = app.read_with(cx, |app, _| {
+            app.agents.active_id().expect("initial shell agent")
+        });
+        cx.run_until_parked();
+
+        app.update(cx, |app, cx| {
+            app.drop_dragged_tab(
+                work_surface::TabRef::Agent(initial_id),
+                work_surface::TabRef::Agent(initial_id),
+                cx,
+            );
+        });
+
+        let slide = app.read_with(cx, |app, _| app.tab_slide.clone());
+        assert!(
+            slide.is_empty(),
+            "dropping the only tab onto itself changed nothing - nothing may slide: {slide:?}"
         );
     }
 

--- a/crates/app/src/work_surface/state.rs
+++ b/crates/app/src/work_surface/state.rs
@@ -10,7 +10,7 @@
 
 use std::path::PathBuf;
 
-use gpui::Rgba;
+use gpui::{Pixels, Rgba};
 
 use crate::rail::status::Status;
 use crate::sidebar::file_tree::LangChip;
@@ -26,7 +26,7 @@ use crate::work_surface::agents::{AgentId, AgentKind, ProcessKind};
 /// there is only ever at most one real graph tab per window (`crate::root::AdeApp::
 /// graph_tab_open`'s own "one per window" docs), so there is nothing to distinguish one from
 /// another the way an `AgentId`/`PathBuf` does for its own kind.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum TabRef {
     Agent(AgentId),
     File(PathBuf),
@@ -135,6 +135,74 @@ pub fn move_tab_order(
         to += 1;
     }
     order.insert(to, item);
+}
+
+/// The real starting pixel offset for every tab whose horizontal slot moves as a side effect of
+/// dragging `dragged` to land beside `target` - GitHub issue #16's own remaining gap (tracked
+/// internally as task #65): before this, every tab other than the one actually dropped just
+/// teleported to its new slot on the next render, with no visual feedback at all that a reorder
+/// had happened to *them*. `crate::root::AdeApp::render_tab_chrome` interpolates each returned
+/// tab's own `.left()` from this offset down to `0` (its already-correct new position - flexbox
+/// itself, not this offset, is what actually re-seats a tab; this only makes the *seating* look
+/// animated rather than instant) over a short, fixed duration, the same idiom
+/// `crate::root::AdeApp::dropped_tab_settle`'s own settle-fade already uses for the dropped tab
+/// itself.
+///
+/// Only `dragged`'s own width (`dragged_width`, [`crate::root::AdeApp::tab_bounds`]'s own
+/// last-measured value for it) is ever needed, not each shifted tab's own width - removing and
+/// re-inserting exactly one item always shifts every tab strictly between its old and new slot by
+/// exactly that one item's width, regardless of how wide any of *them* individually are: a tab's
+/// old on-screen position already counted `dragged`'s width once, on one side of the splice; its
+/// new position counts it on the other side, or not at all. Either way the difference is always
+/// `dragged`'s own width, never a sum of any of the other tabs' widths. Never includes `dragged`
+/// itself in the result - that tab gets its own settle-fade instead
+/// ([`crate::root::AdeApp::dropped_tab_settle`]), never both.
+///
+/// Empty whenever [`move_tab_order`] itself would be a no-op (`dragged`/`target` unknown, or
+/// dropping a tab onto its own already-correct slot) - the same real no-op cases
+/// `drag_reorder_is_a_no_op_for_an_unknown_or_identical_id` proves for the underlying reorder
+/// itself, so a no-op drop animates nothing here either.
+pub fn tab_slide_offsets(
+    old_order: &[TabRef],
+    dragged: &TabRef,
+    target: &TabRef,
+    insert_after: bool,
+    dragged_width: Pixels,
+) -> Vec<(TabRef, Pixels)> {
+    let mut new_order = old_order.to_vec();
+    move_tab_order(&mut new_order, dragged, target, insert_after);
+
+    let Some(old_index) = old_order.iter().position(|tab_ref| tab_ref == dragged) else {
+        return Vec::new();
+    };
+    let Some(new_index) = new_order.iter().position(|tab_ref| tab_ref == dragged) else {
+        return Vec::new();
+    };
+    if old_index == new_index {
+        return Vec::new();
+    }
+
+    let (span_start, span_end) = if old_index < new_index {
+        (old_index, new_index)
+    } else {
+        (new_index, old_index)
+    };
+    // Dragging rightward (`old_index < new_index`) removes `dragged` from in front of everything
+    // between the two slots, so each of them visually starts `dragged_width` to the right of
+    // (i.e. a *positive* offset from) its own already-correct new position and slides left to
+    // `0`. Dragging leftward does the reverse: `dragged` lands in front of them, so each one
+    // starts `dragged_width` to the left of its new position and slides right to `0`.
+    let offset = if old_index < new_index {
+        dragged_width
+    } else {
+        -dragged_width
+    };
+
+    old_order[span_start..=span_end]
+        .iter()
+        .filter(|tab_ref| *tab_ref != dragged)
+        .map(|tab_ref| (tab_ref.clone(), offset))
+        .collect()
 }
 
 /// Fully transparent - used for the "outline"/"ghost" button variants and an inactive tab's
@@ -563,6 +631,7 @@ pub fn footer_actions(status: Status) -> Vec<FooterAction> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use gpui::px;
 
     #[test]
     fn agent_kinds_get_the_cli_chip_and_shell_gets_the_terminal_chip() {
@@ -1025,5 +1094,103 @@ mod tests {
         move_tab_order(&mut order, &TabRef::Agent(99), &TabRef::Agent(1), false);
         move_tab_order(&mut order, &TabRef::Agent(1), &TabRef::Agent(99), false);
         assert_eq!(order, original);
+    }
+
+    /// Dragging rightward (into a later slot) must slide every tab it passed over - and only
+    /// those tabs - left by exactly the dragged tab's own width, never by any of *their* own
+    /// widths (`tab_slide_offsets`'s own docs on why only `dragged_width` is ever needed). The
+    /// dragged tab itself must never appear in the result, and a tab outside the passed-over span
+    /// (here, nothing - every other tab actually is between the two slots) must never appear
+    /// either.
+    #[test]
+    fn tab_slide_offsets_slides_every_passed_over_tab_left_by_the_dragged_tabs_own_width() {
+        let order = vec![TabRef::Agent(1), TabRef::Agent(2), TabRef::Agent(3)];
+        let width = px(40.0);
+
+        let slides = tab_slide_offsets(&order, &TabRef::Agent(1), &TabRef::Agent(3), true, width);
+
+        assert_eq!(
+            slides,
+            vec![(TabRef::Agent(2), width), (TabRef::Agent(3), width)]
+        );
+    }
+
+    /// The mirror image of the rightward case: dragging leftward must slide every passed-over tab
+    /// *right* by the dragged tab's own width (a negative starting offset, sliding back to `0`),
+    /// not left.
+    #[test]
+    fn tab_slide_offsets_slides_every_passed_over_tab_right_when_dragging_leftward() {
+        let order = vec![TabRef::Agent(1), TabRef::Agent(2), TabRef::Agent(3)];
+        let width = px(40.0);
+
+        let slides = tab_slide_offsets(&order, &TabRef::Agent(3), &TabRef::Agent(1), false, width);
+
+        assert_eq!(
+            slides,
+            vec![(TabRef::Agent(1), -width), (TabRef::Agent(2), -width)]
+        );
+    }
+
+    /// A tab outside the span the dragged tab actually passed over must never slide - only its
+    /// own real neighbours-in-transit do. Dragging tab 1 to sit immediately after tab 2 only ever
+    /// passes over tab 2 itself; tabs 3 and 4 never moved and must not appear in the result.
+    #[test]
+    fn tab_slide_offsets_never_slides_a_tab_outside_the_passed_over_span() {
+        let order = vec![
+            TabRef::Agent(1),
+            TabRef::Agent(2),
+            TabRef::Agent(3),
+            TabRef::Agent(4),
+        ];
+        let width = px(25.0);
+
+        let slides = tab_slide_offsets(&order, &TabRef::Agent(1), &TabRef::Agent(2), true, width);
+
+        assert_eq!(
+            slides,
+            vec![(TabRef::Agent(2), width)],
+            "only tab 2, the one real tab dragged-tab 1 passed over, may slide - tabs 3 and 4 \
+             never changed position"
+        );
+    }
+
+    /// Dropping a tab immediately before its own already-adjacent slot is a real no-op
+    /// (`move_tab_order`'s own docs) - nothing actually changed position, so nothing may slide.
+    #[test]
+    fn tab_slide_offsets_is_empty_when_the_drop_lands_on_the_tabs_own_already_adjacent_slot() {
+        let order = vec![
+            TabRef::Agent(1),
+            TabRef::Agent(2),
+            TabRef::Agent(3),
+            TabRef::Agent(4),
+        ];
+        let width = px(25.0);
+
+        let slides = tab_slide_offsets(&order, &TabRef::Agent(1), &TabRef::Agent(2), false, width);
+
+        assert!(slides.is_empty());
+    }
+
+    /// `move_tab_order`'s own no-op rules (unknown dragged/target entry, or dropping a tab onto
+    /// its own slot) must produce zero slide offsets too - a no-op reorder must animate nothing,
+    /// mirroring `drag_reorder_is_a_no_op_for_an_unknown_or_identical_id`'s own proof for the
+    /// underlying reorder.
+    #[test]
+    fn tab_slide_offsets_is_empty_for_every_move_tab_order_no_op() {
+        let order = vec![TabRef::Agent(1), TabRef::Agent(2)];
+        let width = px(40.0);
+
+        assert!(
+            tab_slide_offsets(&order, &TabRef::Agent(1), &TabRef::Agent(1), false, width)
+                .is_empty()
+        );
+        assert!(
+            tab_slide_offsets(&order, &TabRef::Agent(99), &TabRef::Agent(1), false, width)
+                .is_empty()
+        );
+        assert!(
+            tab_slide_offsets(&order, &TabRef::Agent(1), &TabRef::Agent(99), false, width)
+                .is_empty()
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Completes the last gap in issue #16's drag-and-drop tab strip work: dropping a tab already faded it into its own new slot, but neighboring tabs whose position shifted as a side effect still teleported instantly instead of sliding.
- Every tab strictly between the drag's start and end slot now slides from its real pre-drop pixel position to its new one over the same 150ms window the existing drop-settle fade uses.
- Works for both agent and file tabs (shared tab chrome), and a no-op reorder animates nothing.

## Implementation
- `work_surface/state.rs`: pure `tab_slide_offsets()` — only the dragged tab's own measured width is needed to compute every shifted neighbor's offset, since removing+reinserting one item always shifts everything in between by exactly that item's width.
- `root/mod.rs` / `root/state.rs`: new `tab_bounds` (real painted bounds per tab, tracked via a `gpui::canvas`) and `tab_slide` (start offset + fresh animation id per shifted tab) maps.
- `work_surface/render.rs`: `drop_dragged_tab` computes slide offsets before mutating tab order; render applies `.left(offset * (1.0 - delta))` inside `with_animation`, the same idiom already used for the drop-settle fade, just translating position instead of opacity.
- No dedicated GPUI translate primitive exists, so this uses `.left()` on a `position: relative` element — a real, already-precedented pattern, not opacity dressed up as motion.
- `gpui::AnimationExt::with_animation` already respects `cx.reduce_motion()` at the framework level for both the old fade and this new slide; no separate reduced-motion setting exists in this app.

## Test plan
- [x] 5 pure unit tests on `tab_slide_offsets` (rightward/leftward drags, tabs outside the passed-over span, every no-op case)
- [x] Real GPUI end-to-end test: drags a tab past two others in a headless window after a real paint pass, asserts the neighbors' recorded offsets equal the dragged tab's real measured width, and that the dragged tab itself is never in the slide map
- [x] A second end-to-end test confirms a no-op drop records no slide state
- [x] `cargo build`, `cargo clippy -p app --all-targets -- -D warnings`, `cargo fmt --check` all clean (only the pre-existing, unrelated violation at `review/render.rs:1503` remains, untouched)
- [x] Full `app` test suite green (2125 tests); a couple of unrelated flaky failures under heavy concurrent load in this session were isolated and reran clean (`inotify` contention / timing-sensitive undo-redo tests, not touching this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)