### PR TITLE
feat(app): git graph row-menu actions - checkout, create branch, reset (issue #241)

### DIFF
--- a/crates/app/src/graph_view/mod.rs
+++ b/crates/app/src/graph_view/mod.rs
@@ -14,20 +14,24 @@
 //! ## Scope
 //!
 //! Phase (a) shipped read-only. Phase (c) (GitHub issue #1's own "push (force with lease,
-//! force, no force)"/"pull") has since wired the toolbar's Fetch/Pull and the Push `▾` menu's
+//! force, no force)"/"pull") wired the toolbar's Fetch/Pull and the Push `▾` menu's
 //! Push/Force-with-lease/Force rows to real `wt_core::remote` calls
 //! (`AdeApp::request_graph_fetch`/`request_graph_pull`/`request_graph_push`) - see that
 //! module's own docs for the fetch/pull/push implementations and
 //! [`state::GraphTabState::push_force_confirm_armed`] for the real two-click confirmation the
-//! two force variants require. The row `⋯` menu's Branch/Apply/Reset groups remain real,
-//! visible menu rows (per the design spec) but every entry that would perform a *different*
-//! destructive git operation (check out, cherry-pick, revert, rebase, reset, "start an agent
-//! from this commit") is still rendered **disabled** -
-//! `crate::work_surface::render::render_dropdown_menu_row`'s existing `enabled: false`
-//! treatment, with no `.on_click` attached - because none of those specific operations exist in
-//! `wt_core` yet (real, separate follow-up work, not yet started). Only the Copy group's
-//! entries (real clipboard writes of already-loaded data), the toolbar's read-only scope
-//! segment, and now Fetch/Pull/Push are actually wired. Agent-to-commit correlation (which agent
+//! two force variants require. A later pass wired the row `⋯` menu's Apply group (Cherry-pick/
+//! Revert/Rebase onto this commit, `wt_core::rewrite`) and GitHub issue #241 wired its
+//! Branch/Reset groups too (`Check out`/`Create branch here`/Soft-Mixed-Hard reset,
+//! `wt_core::checkout`) - see [`state::GraphTabState::hard_reset_confirm_armed`] for Hard
+//! reset's own two-click confirmation, the same discipline `push_force_confirm_armed` already
+//! established, and [`state::GraphCreateBranchPrompt`] for "Create branch here"'s small,
+//! hand-rolled branch-name input. Only "Interactive rebase from here" (a separate, later issue -
+//! it needs its own commit-selection UI, not just a click) and "Start agent from this commit"
+//! (needs a new-worktree-creation entry point this app deliberately has none of yet - every
+//! "add worktree"/"add repo" entry point stays out until a real design lands, per Revision R12)
+//! are still rendered **disabled** - `crate::work_surface::render::render_dropdown_menu_row`'s
+//! existing `enabled: false` treatment, with no `.on_click` attached. Agent-to-commit correlation
+//! (which agent
 //! authored a commit) is a
 //! separate, later feature too; a first draft carried an always-empty per-commit agent column
 //! for it, but `design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §6.2 removed that

--- a/crates/app/src/graph_view/render.rs
+++ b/crates/app/src/graph_view/render.rs
@@ -3,9 +3,12 @@
 //! AdeApp` glue that opens/closes/loads it. See `super`'s module docs for scope.
 
 use super::*;
-use crate::root::widgets::{menu_popover_chrome, render_sidebar_message, render_tag_pill};
+use crate::root::widgets::{
+    menu_popover_chrome, modal_scrim_bg, render_sidebar_message, render_tag_pill,
+};
 use crate::settings::widgets;
 use crate::sidebar::changes;
+use crate::text_history::TextField;
 use crate::work_surface::render::{render_dropdown_menu_row, DraggedTab, TabChromeArgs};
 use gpui::{uniform_list, KeyDownEvent, Pixels};
 use std::ops::Range;
@@ -222,6 +225,12 @@ impl AdeApp {
         // for an outright close, closes the gap for the "switch tabs and back" path too.
         self.graph_state.row_menu_open = None;
         self.graph_state.push_menu_open = false;
+        // GitHub issue #241: the same "switch tabs and back reveals a stale overlay with no
+        // click at all" gap the comment above fixes for the row/push menus applies identically
+        // to the "Create branch here" prompt (also gated on `graph_tab_active` in
+        // `crate::root::AdeApp::render`) and to a stale armed Hard-reset confirmation.
+        self.graph_state.create_branch_prompt = None;
+        self.graph_state.hard_reset_confirm_armed = None;
     }
 
     /// Loads (or reloads) the graph and its upstream ahead/behind counts, off the UI thread -
@@ -460,6 +469,10 @@ impl AdeApp {
         );
         if already_open_here {
             self.graph_state.row_menu_open = None;
+            // GitHub issue #241: closing the menu (rather than acting on one of its rows) is
+            // itself "some other action" - see `GraphTabState::hard_reset_confirm_armed`'s own
+            // docs.
+            self.graph_state.hard_reset_confirm_armed = None;
             cx.notify();
             return;
         }
@@ -522,6 +535,10 @@ impl AdeApp {
         // call replaces the single `push_menu_open = false` that used to live here, and runs
         // *before* the assignment below so the sweep can't clear what it just set.
         let _ = self.close_menu_surfaces_except(Some(menus::MenuSurface::GraphRow));
+        // GitHub issue #241: a freshly (re)opened menu instance never inherits an armed Hard
+        // reset confirmation from a previous one - see
+        // `GraphTabState::hard_reset_confirm_armed`'s own docs.
+        self.graph_state.hard_reset_confirm_armed = None;
         self.graph_state.row_menu_open = Some(GraphRowMenu {
             row_index: index,
             origin_x: px(clamped_x),
@@ -547,6 +564,8 @@ impl AdeApp {
     pub(crate) fn copy_graph_text(&mut self, text: String, cx: &mut Context<Self>) {
         cx.write_to_clipboard(gpui::ClipboardItem::new_string(text));
         self.graph_state.row_menu_open = None;
+        // GitHub issue #241: see `GraphTabState::hard_reset_confirm_armed`'s own docs.
+        self.graph_state.hard_reset_confirm_armed = None;
         cx.notify();
     }
 
@@ -611,6 +630,9 @@ impl AdeApp {
     /// [`Self::request_graph_pull`] does: the worktree is left in the real conflicted state for
     /// the user to resolve, not silently rolled back.
     pub(crate) fn request_graph_cherry_pick(&mut self, sha: String, cx: &mut Context<Self>) {
+        // GitHub issue #241: any other row-menu action disarms a previously-armed Hard reset
+        // confirmation - see [`GraphTabState::hard_reset_confirm_armed`]'s own docs.
+        self.graph_state.hard_reset_confirm_armed = None;
         self.run_graph_remote_op("Cherry-pick", cx, move |root| {
             wt_core::rewrite::cherry_pick(&root, &sha)
         });
@@ -621,6 +643,8 @@ impl AdeApp {
     /// [`Self::request_graph_cherry_pick`]'s own docs on real-conflict handling, which applies
     /// identically here.
     pub(crate) fn request_graph_revert(&mut self, sha: String, cx: &mut Context<Self>) {
+        // GitHub issue #241: see [`Self::request_graph_cherry_pick`]'s own comment above.
+        self.graph_state.hard_reset_confirm_armed = None;
         self.run_graph_remote_op("Revert", cx, move |root| {
             wt_core::rewrite::revert(&root, &sha)
         });
@@ -633,8 +657,154 @@ impl AdeApp {
     /// identically here. Interactive rebase (commit reordering/squash/edit) is a real, stated
     /// follow-up - it needs its own commit-selection UI, not just a single click.
     pub(crate) fn request_graph_rebase_onto(&mut self, sha: String, cx: &mut Context<Self>) {
+        // GitHub issue #241: see [`Self::request_graph_cherry_pick`]'s own comment above.
+        self.graph_state.hard_reset_confirm_armed = None;
         self.run_graph_remote_op("Rebase", cx, move |root| {
             wt_core::rewrite::rebase_onto(&root, &sha)
+        });
+    }
+
+    /// The row menu's "Check out" action (GitHub issue #241). Moves `HEAD` (detached) onto `sha`
+    /// in the focused worktree (`wt_core::checkout::checkout`) - never the repository's main
+    /// checkout, the same "current worktree" resolution [`Self::request_graph_cherry_pick`] and
+    /// friends already use via `Self::diff_root`. A genuinely conflicting checkout (uncommitted
+    /// changes that would be overwritten) surfaces through [`Self::run_graph_remote_op`]'s own
+    /// status-message path with git's own real refusal text - this makes no attempt to pre-check
+    /// or second-guess a dirty worktree itself; see `wt_core::checkout::checkout`'s own docs.
+    pub(crate) fn request_graph_checkout(&mut self, sha: String, cx: &mut Context<Self>) {
+        self.graph_state.hard_reset_confirm_armed = None;
+        self.run_graph_remote_op("Check out", cx, move |root| {
+            wt_core::checkout::checkout(&root, &sha)
+        });
+    }
+
+    /// Opens the row menu's "Create branch here" prompt (GitHub issue #241) - a small, hand-
+    /// rolled inline text input (mirrors `crate::root::new_file::AdeApp::start_new_file`'s own
+    /// shape; see [`state::GraphCreateBranchPrompt`]'s own docs for why there's no separate
+    /// modal-dialog subsystem behind it). Closes the row `⋯` menu it was clicked from - the
+    /// prompt replaces it as a focus-owning overlay, the same relationship the "New file" prompt
+    /// has with whatever it was opened from.
+    pub(crate) fn start_graph_create_branch(
+        &mut self,
+        sha: String,
+        short_sha: String,
+        subject: String,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.graph_state.hard_reset_confirm_armed = None;
+        self.graph_state.row_menu_open = None;
+        self.graph_state.create_branch_prompt = Some(state::GraphCreateBranchPrompt {
+            sha,
+            short_sha,
+            subject,
+            error: None,
+        });
+        self.graph_state.create_branch_name = TextField::new();
+        window.focus(&self.graph_state.create_branch_focus_handle, cx);
+        cx.notify();
+    }
+
+    /// Closes the "Create branch here" prompt without creating anything - Escape, or a click on
+    /// its own scrim. Mirrors `crate::root::new_file::AdeApp::cancel_new_file`'s own shape,
+    /// simpler here since the prompt only ever opens while the graph tab is focused: focus always
+    /// returns to [`AdeApp::graph_focus_handle`].
+    pub(crate) fn cancel_graph_create_branch(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.graph_state.create_branch_prompt.take().is_some() {
+            window.focus(&self.graph_focus_handle, cx);
+            cx.notify();
+        }
+    }
+
+    /// Enter on the "Create branch here" prompt. The only hand-rolled validation here is "not
+    /// empty" - just enough to avoid a clearly-broken `git checkout -b '' <sha>` invocation; a
+    /// name colliding with an existing branch is deliberately *not* pre-checked here and instead
+    /// surfaces as git's own real error through [`Self::run_graph_remote_op`]'s status-message
+    /// path, exactly like every other row-menu mutation's real-conflict handling.
+    pub(crate) fn commit_graph_create_branch(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(prompt) = self.graph_state.create_branch_prompt.clone() else {
+            return;
+        };
+        let name = self
+            .graph_state
+            .create_branch_name
+            .as_str()
+            .trim()
+            .to_string();
+        if name.is_empty() {
+            if let Some(open) = self.graph_state.create_branch_prompt.as_mut() {
+                open.error = Some("branch name can't be empty".to_string());
+            }
+            cx.notify();
+            return;
+        }
+        self.graph_state.create_branch_prompt = None;
+        window.focus(&self.graph_focus_handle, cx);
+        self.request_graph_create_branch(prompt.sha, name, cx);
+    }
+
+    /// The real `wt_core::checkout::create_branch_at` call behind
+    /// [`Self::commit_graph_create_branch`] - split out so tests can drive it directly without
+    /// going through the prompt's own focus/window plumbing, matching
+    /// [`Self::request_graph_cherry_pick`] and friends.
+    pub(crate) fn request_graph_create_branch(
+        &mut self,
+        sha: String,
+        name: String,
+        cx: &mut Context<Self>,
+    ) {
+        self.graph_state.hard_reset_confirm_armed = None;
+        self.run_graph_remote_op("Create branch", cx, move |root| {
+            wt_core::checkout::create_branch_at(&root, &name, &sha)
+        });
+    }
+
+    /// The row menu's "Soft"/"Mixed"/"Hard" reset actions (GitHub issue #241) - real `git reset`
+    /// against the focused worktree's current branch (`wt_core::checkout::reset`).
+    ///
+    /// `Soft`/`Mixed` run immediately on a single click - neither ever discards uncommitted work
+    /// (see `wt_core::checkout::ResetMode`'s own docs on what each really does), so like the Push
+    /// menu's plain "Push" row they need no confirmation. `Hard` genuinely discards uncommitted
+    /// changes and detaches whatever commits sat after `sha`, so it follows the exact two-click
+    /// discipline [`Self::request_graph_push`] already established for its own Force rows: the
+    /// first click on a given commit's "Hard" row only arms
+    /// [`GraphTabState::hard_reset_confirm_armed`] and re-labels the row, without resetting
+    /// anything; a second click on that *same* commit's "Hard" row is what actually runs the
+    /// reset. Any other mode, or "Hard" on a *different* commit, disarms rather than carrying a
+    /// stale confirmation over onto a reset the user never confirmed for that commit.
+    pub(crate) fn request_graph_reset(
+        &mut self,
+        mode: wt_core::checkout::ResetMode,
+        sha: String,
+        cx: &mut Context<Self>,
+    ) {
+        use wt_core::checkout::ResetMode;
+
+        if mode == ResetMode::Hard
+            && self.graph_state.hard_reset_confirm_armed.as_deref() != Some(sha.as_str())
+        {
+            self.graph_state.hard_reset_confirm_armed = Some(sha);
+            self.graph_state.status_message = Some("click Hard again to really reset".to_string());
+            cx.notify();
+            return;
+        }
+        self.graph_state.hard_reset_confirm_armed = None;
+
+        let action = match mode {
+            ResetMode::Soft => "Soft reset",
+            ResetMode::Mixed => "Mixed reset",
+            ResetMode::Hard => "Hard reset",
+        };
+        self.run_graph_remote_op(action, cx, move |root| {
+            wt_core::checkout::reset(&root, mode, &sha)
         });
     }
 
@@ -729,6 +899,211 @@ impl AdeApp {
         if self.graph_state.branches_filter.redo() {
             cx.notify();
         }
+    }
+
+    /// The "Create branch here" prompt's key handler - append/backspace/Enter (create)/Escape
+    /// (cancel), mirroring `crate::root::new_file::AdeApp::handle_new_file_key_down`'s own
+    /// minimal shape (GitHub issue #241).
+    pub(in crate::graph_view) fn handle_graph_create_branch_key_down(
+        &mut self,
+        event: &KeyDownEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let keystroke = &event.keystroke;
+        if keystroke.modifiers.platform || keystroke.modifiers.control || keystroke.modifiers.alt {
+            return;
+        }
+        match keystroke.key.as_str() {
+            "escape" => {
+                self.cancel_graph_create_branch(window, cx);
+                cx.stop_propagation();
+            }
+            "enter" => {
+                self.commit_graph_create_branch(window, cx);
+                cx.stop_propagation();
+            }
+            "backspace" => {
+                if self.graph_state.create_branch_prompt.is_some() {
+                    self.graph_state.create_branch_name.pop(Instant::now());
+                    if let Some(open) = self.graph_state.create_branch_prompt.as_mut() {
+                        open.error = None;
+                    }
+                    self.reset_caret_blink(cx);
+                    cx.notify();
+                    cx.stop_propagation();
+                }
+            }
+            _ => {
+                if let Some(text) = keystroke
+                    .key_char
+                    .as_deref()
+                    .filter(|text| !text.is_empty())
+                {
+                    if self.graph_state.create_branch_prompt.is_some() {
+                        self.graph_state
+                            .create_branch_name
+                            .push_str(text, Instant::now());
+                        if let Some(open) = self.graph_state.create_branch_prompt.as_mut() {
+                            open.error = None;
+                        }
+                        self.reset_caret_blink(cx);
+                        cx.notify();
+                        cx.stop_propagation();
+                    }
+                }
+            }
+        }
+    }
+
+    /// `Ctrl/Cmd+Z` inside the "Create branch here" prompt (GitHub issue #17's per-widget text
+    /// undo, GitHub issue #241).
+    pub(in crate::graph_view) fn handle_graph_create_branch_text_undo(
+        &mut self,
+        _: &crate::root::TextUndo,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.graph_state.create_branch_name.undo() {
+            if let Some(open) = self.graph_state.create_branch_prompt.as_mut() {
+                open.error = None;
+            }
+            cx.notify();
+        }
+    }
+
+    /// `Ctrl/Cmd+Shift+Z` / `Ctrl+Y` inside the "Create branch here" prompt - the mirror of
+    /// [`Self::handle_graph_create_branch_text_undo`].
+    pub(in crate::graph_view) fn handle_graph_create_branch_text_redo(
+        &mut self,
+        _: &crate::root::TextRedo,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.graph_state.create_branch_name.redo() {
+            if let Some(open) = self.graph_state.create_branch_prompt.as_mut() {
+                open.error = None;
+            }
+            cx.notify();
+        }
+    }
+
+    /// The "Create branch here" prompt: a scrim + small centered panel (GitHub issue #241),
+    /// exactly the shape `crate::root::new_file::AdeApp::render_new_file_prompt` already
+    /// established for this app's one other hand-rolled "prompt for a name" - transparent-to-
+    /// nothing modal scrim, `.occlude()`d panel that stops its own click from bubbling up and
+    /// dismissing it. Assumes `Self::graph_state.create_branch_prompt` is `Some` - the caller
+    /// (`crate::root::AdeApp::render`) only renders this when it is.
+    pub(crate) fn render_graph_create_branch_prompt(
+        &self,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let prompt = self.graph_state.create_branch_prompt.clone();
+        let name = self.graph_state.create_branch_name.as_str().to_string();
+        let has_name = !name.is_empty();
+
+        div()
+            .id("graph-create-branch-scrim")
+            .absolute()
+            .top(theme::band::TITLE_BAR)
+            .left(px(0.0))
+            .right(px(0.0))
+            .bottom(px(0.0))
+            .flex()
+            .items_center()
+            .justify_center()
+            .occlude()
+            .bg(modal_scrim_bg())
+            .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
+                this.cancel_graph_create_branch(window, cx);
+            }))
+            .child(
+                div()
+                    .id("graph-create-branch-panel")
+                    .track_focus(&self.graph_state.create_branch_focus_handle)
+                    .key_context("text-input")
+                    .on_action(cx.listener(Self::handle_graph_create_branch_text_undo))
+                    .on_action(cx.listener(Self::handle_graph_create_branch_text_redo))
+                    .on_key_down(cx.listener(Self::handle_graph_create_branch_key_down))
+                    .on_click(cx.listener(|_this, _event: &ClickEvent, _window, cx| {
+                        cx.stop_propagation();
+                    }))
+                    .flex()
+                    .flex_col()
+                    .gap(px(6.0))
+                    .w(px(320.0))
+                    .p(px(12.0))
+                    .bg(theme::surface::PALETTE)
+                    .border_1()
+                    .border_color(theme::border::POPOVER)
+                    .rounded(theme::radius::CARD)
+                    .child(
+                        div()
+                            .font(font(theme::font::SANS))
+                            .font_weight(gpui::FontWeight::MEDIUM)
+                            .text_size(px(11.5))
+                            .text_color(theme::text::HEADING)
+                            .child("Create branch here"),
+                    )
+                    .child(
+                        div()
+                            .font(font(theme::font::MONO))
+                            .text_size(px(9.5))
+                            .text_color(theme::text::FAINTER)
+                            .child(match &prompt {
+                                Some(prompt) => {
+                                    format!("{} \u{b7} {}", prompt.short_sha, prompt.subject)
+                                }
+                                None => String::new(),
+                            }),
+                    )
+                    .child(
+                        div()
+                            .px(px(8.0))
+                            .py(px(5.0))
+                            .rounded(theme::radius::CHIP)
+                            .bg(theme::surface::SEGMENT_TRACK)
+                            .flex()
+                            .items_center()
+                            .gap(px(2.0))
+                            .font(font(theme::font::MONO))
+                            .text_size(px(11.5))
+                            .text_color(theme::text::BODY)
+                            .when(!has_name, |el| {
+                                el.child(self.render_simple_input_caret(
+                                    "graph-create-branch-caret",
+                                    &self.graph_state.create_branch_focus_handle,
+                                ))
+                            })
+                            .child(if has_name {
+                                name
+                            } else {
+                                "branch-name".to_string()
+                            })
+                            .when(has_name, |el| {
+                                el.child(self.render_simple_input_caret(
+                                    "graph-create-branch-caret",
+                                    &self.graph_state.create_branch_focus_handle,
+                                ))
+                            }),
+                    )
+                    .when_some(prompt.and_then(|prompt| prompt.error), |el, error| {
+                        el.child(
+                            div()
+                                .font(font(theme::font::SANS))
+                                .text_size(px(10.5))
+                                .text_color(theme::status::FAIL)
+                                .child(error),
+                        )
+                    })
+                    .child(
+                        div()
+                            .font(font(theme::font::SANS))
+                            .text_size(px(10.0))
+                            .text_color(theme::text::GHOST)
+                            .child("enter to create \u{b7} esc to cancel"),
+                    ),
+            )
     }
 }
 
@@ -1498,6 +1873,8 @@ impl AdeApp {
             .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
                 cx.stop_propagation();
                 this.graph_state.row_menu_open = None;
+                // GitHub issue #241: see `GraphTabState::hard_reset_confirm_armed`'s own docs.
+                this.graph_state.hard_reset_confirm_armed = None;
                 cx.notify();
             }))
             // A right-click elsewhere must dismiss too (mirrors `crate::sidebar::render::AdeApp::
@@ -1513,6 +1890,11 @@ impl AdeApp {
                 gpui::MouseButton::Right,
                 cx.listener(|this, _event: &gpui::MouseDownEvent, _window, cx| {
                     this.graph_state.row_menu_open = None;
+                    // GitHub issue #241: see `GraphTabState::hard_reset_confirm_armed`'s own
+                    // docs - `Self::open_graph_row_menu_at` would disarm too if this lands on
+                    // another row and reopens fresh right after, but a right-click on empty
+                    // space only ever reaches this dismiss.
+                    this.graph_state.hard_reset_confirm_armed = None;
                     cx.notify();
                 }),
             )
@@ -1543,24 +1925,48 @@ impl AdeApp {
                     cx.stop_propagation();
                 }))
                 .child(render_graph_row_menu_header("Branch"))
-                .child(render_dropdown_menu_row(
-                    "\u{2713}",
-                    theme::text::GHOST.into(),
-                    theme::surface::CHIP_NEUTRAL.into(),
-                    "Check out",
-                    "not implemented yet".to_string(),
-                    Vec::new(),
-                    false,
-                ))
-                .child(render_dropdown_menu_row(
-                    "+",
-                    theme::text::GHOST.into(),
-                    theme::surface::CHIP_NEUTRAL.into(),
-                    "Create branch here",
-                    "not implemented yet".to_string(),
-                    Vec::new(),
-                    false,
-                ))
+                .child(
+                    render_dropdown_menu_row(
+                        "\u{2713}",
+                        theme::button::BLUE_FG.into(),
+                        theme::surface::CHIP_NEUTRAL.into(),
+                        "Check out",
+                        String::new(),
+                        Vec::new(),
+                        true,
+                    )
+                    .on_click(cx.listener({
+                        let sha = sha.clone();
+                        move |this, _event: &ClickEvent, _window, cx| {
+                            this.request_graph_checkout(sha.clone(), cx);
+                        }
+                    })),
+                )
+                .child(
+                    render_dropdown_menu_row(
+                        "+",
+                        theme::button::BLUE_FG.into(),
+                        theme::surface::CHIP_NEUTRAL.into(),
+                        "Create branch here",
+                        String::new(),
+                        Vec::new(),
+                        true,
+                    )
+                    .on_click(cx.listener({
+                        let sha = sha.clone();
+                        let short_sha = short_sha.clone();
+                        let subject = subject.clone();
+                        move |this, _event: &ClickEvent, window, cx| {
+                            this.start_graph_create_branch(
+                                sha.clone(),
+                                short_sha.clone(),
+                                subject.clone(),
+                                window,
+                                cx,
+                            );
+                        }
+                    })),
+                )
                 .child(render_dropdown_menu_row(
                     "\u{25b8}",
                     theme::button::BLUE_FG.into(),
@@ -1632,33 +2038,75 @@ impl AdeApp {
                     false,
                 ))
                 .child(render_graph_row_menu_header("Reset"))
-                .child(render_dropdown_menu_row(
-                    "\u{21ba}",
-                    theme::text::GHOST.into(),
-                    theme::surface::CHIP_NEUTRAL.into(),
-                    "Soft",
-                    "not implemented yet".to_string(),
-                    Vec::new(),
-                    false,
-                ))
-                .child(render_dropdown_menu_row(
-                    "\u{21ba}",
-                    theme::text::GHOST.into(),
-                    theme::surface::CHIP_NEUTRAL.into(),
-                    "Mixed",
-                    "not implemented yet".to_string(),
-                    Vec::new(),
-                    false,
-                ))
-                .child(render_dropdown_menu_row(
-                    "\u{21ba}",
-                    theme::button::DANGER_FG.into(),
-                    theme::surface::CHIP_NEUTRAL.into(),
-                    "Hard",
-                    "not implemented yet".to_string(),
-                    Vec::new(),
-                    false,
-                ))
+                .child(
+                    render_dropdown_menu_row(
+                        "\u{21ba}",
+                        theme::button::BLUE_FG.into(),
+                        theme::surface::CHIP_NEUTRAL.into(),
+                        "Soft",
+                        "keeps changes staged".to_string(),
+                        Vec::new(),
+                        true,
+                    )
+                    .on_click(cx.listener({
+                        let sha = sha.clone();
+                        move |this, _event: &ClickEvent, _window, cx| {
+                            this.request_graph_reset(
+                                wt_core::checkout::ResetMode::Soft,
+                                sha.clone(),
+                                cx,
+                            );
+                        }
+                    })),
+                )
+                .child(
+                    render_dropdown_menu_row(
+                        "\u{21ba}",
+                        theme::button::BLUE_FG.into(),
+                        theme::surface::CHIP_NEUTRAL.into(),
+                        "Mixed",
+                        "keeps changes unstaged".to_string(),
+                        Vec::new(),
+                        true,
+                    )
+                    .on_click(cx.listener({
+                        let sha = sha.clone();
+                        move |this, _event: &ClickEvent, _window, cx| {
+                            this.request_graph_reset(
+                                wt_core::checkout::ResetMode::Mixed,
+                                sha.clone(),
+                                cx,
+                            );
+                        }
+                    })),
+                )
+                .child(
+                    render_dropdown_menu_row(
+                        "\u{21ba}",
+                        theme::button::DANGER_FG.into(),
+                        theme::surface::CHIP_NEUTRAL.into(),
+                        "Hard",
+                        if self.graph_state.hard_reset_confirm_armed.as_deref()
+                            == Some(sha.as_str())
+                        {
+                            "click again to really reset".to_string()
+                        } else {
+                            "discards uncommitted changes".to_string()
+                        },
+                        Vec::new(),
+                        true,
+                    )
+                    .on_click(cx.listener({
+                        let sha = sha.clone();
+                        move |this, _event: &ClickEvent, _window, cx| {
+                            this.request_graph_reset(
+                                wt_core::checkout::ResetMode::Hard,
+                                sha.clone(),
+                                cx,
+                            );
+                        }
+                    })),
+                )
                 .child(render_graph_row_menu_header("Copy"))
                 .child(
                     render_dropdown_menu_row(
@@ -1700,7 +2148,8 @@ impl AdeApp {
                         .text_size(px(9.5))
                         .text_color(theme::text::GHOSTER)
                         .child(
-                            "rebase and reset run in the focused worktree, never the main checkout",
+                            "check out, branch, rebase, and reset all run in the focused \
+                             worktree, never the main checkout",
                         ),
                 ),
             )
@@ -6066,6 +6515,358 @@ mod graph_remote_action_tests {
                 .is_some_and(|text| text.starts_with("Rebase failed:")),
             "a real conflicting rebase must surface as a real, visible failure message, not a \
              silent success or a panic - got {status:?}"
+        );
+    }
+
+    // GitHub issue #241: "Check out" / "Create branch here" / Soft-Mixed-Hard reset.
+
+    #[gpui::test]
+    async fn checkout_really_moves_head_and_reports_success(cx: &mut TestAppContext) {
+        let (local, app, cx) = open_seeded_local_repo(cx);
+        let base_sha = git_output(local.path(), &["rev-parse", "HEAD"]);
+        commit(local.path(), "b.txt", "second", "second commit");
+
+        app.update_in(cx, |app, _window, cx| {
+            app.request_graph_checkout(base_sha.clone(), cx);
+        });
+        cx.run_until_parked();
+
+        assert_eq!(
+            git_output(local.path(), &["rev-parse", "HEAD"]),
+            base_sha,
+            "the real click must have run a real git checkout onto the target commit"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.graph_state.status_message.clone()),
+            Some("Check out".to_string()),
+            "a successful checkout must report real success, not the old 'not implemented yet' \
+             stub text"
+        );
+        assert!(
+            !app.read_with(cx, |app, _| app.graph_state.remote_op_in_flight),
+            "the in-flight guard must clear once the real checkout completes"
+        );
+    }
+
+    #[gpui::test]
+    async fn checkout_on_a_dirty_worktree_with_a_real_conflict_surfaces_gits_own_refusal(
+        cx: &mut TestAppContext,
+    ) {
+        let (local, app, cx) = open_seeded_local_repo(cx);
+        git(local.path(), &["checkout", "-b", "other"]);
+        commit(
+            local.path(),
+            "a.txt",
+            "other branch content",
+            "other change",
+        );
+        git(local.path(), &["checkout", "main"]);
+        // An uncommitted change that genuinely conflicts with what "other" holds - real git
+        // refuses to silently clobber it, and this makes no attempt to pre-check that itself.
+        std::fs::write(local.path().join("a.txt"), "uncommitted dirty content")
+            .expect("write a.txt");
+
+        app.update_in(cx, |app, _window, cx| {
+            app.request_graph_checkout("other".to_string(), cx);
+        });
+        cx.run_until_parked();
+
+        let status = app.read_with(cx, |app, _| app.graph_state.status_message.clone());
+        assert!(
+            status
+                .as_deref()
+                .is_some_and(|text| text.starts_with("Check out failed:")),
+            "a real conflicting checkout must surface as a real, visible failure message, not a \
+             silent success or a panic - got {status:?}"
+        );
+        assert_eq!(
+            git_output(local.path(), &["rev-parse", "--abbrev-ref", "HEAD"]),
+            "main",
+            "a refused checkout must leave the worktree exactly where it was"
+        );
+        assert_eq!(
+            std::fs::read_to_string(local.path().join("a.txt")).expect("read a.txt"),
+            "uncommitted dirty content",
+            "the refused checkout must not have touched the dirty file"
+        );
+    }
+
+    #[gpui::test]
+    async fn create_branch_here_really_creates_and_switches_and_reports_success(
+        cx: &mut TestAppContext,
+    ) {
+        let (local, app, cx) = open_seeded_local_repo(cx);
+        let base_sha = git_output(local.path(), &["rev-parse", "HEAD"]);
+        commit(local.path(), "b.txt", "second", "second commit");
+
+        app.update_in(cx, |app, window, cx| {
+            app.start_graph_create_branch(
+                base_sha.clone(),
+                base_sha[..7].to_string(),
+                "base".to_string(),
+                window,
+                cx,
+            );
+            app.graph_state.create_branch_name =
+                crate::text_history::TextField::seeded("feature-x");
+            app.commit_graph_create_branch(window, cx);
+        });
+        cx.run_until_parked();
+
+        assert_eq!(
+            git_output(local.path(), &["rev-parse", "--abbrev-ref", "HEAD"]),
+            "feature-x",
+            "must really switch onto the newly created branch"
+        );
+        assert_eq!(
+            git_output(local.path(), &["rev-parse", "HEAD"]),
+            base_sha,
+            "the new branch must really be rooted at the commit the prompt was opened on"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.graph_state.status_message.clone()),
+            Some("Create branch".to_string()),
+            "a successful create-branch must report real success, not the old 'not implemented \
+             yet' stub text"
+        );
+        assert!(
+            app.read_with(cx, |app, _| app.graph_state.create_branch_prompt.is_none()),
+            "the prompt must close once the branch has really been created"
+        );
+    }
+
+    #[gpui::test]
+    async fn create_branch_prompt_rejects_an_empty_name_without_touching_git(
+        cx: &mut TestAppContext,
+    ) {
+        let (local, app, cx) = open_seeded_local_repo(cx);
+        let base_sha = git_output(local.path(), &["rev-parse", "HEAD"]);
+
+        app.update_in(cx, |app, window, cx| {
+            app.start_graph_create_branch(
+                base_sha.clone(),
+                base_sha[..7].to_string(),
+                "base".to_string(),
+                window,
+                cx,
+            );
+            // The field starts genuinely empty - commit without typing anything, the same real
+            // "just hit enter" case a hand-rolled empty-name guard exists for.
+            app.commit_graph_create_branch(window, cx);
+        });
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app
+                .graph_state
+                .create_branch_prompt
+                .as_ref()
+                .and_then(|prompt| prompt.error.clone())),
+            Some("branch name can't be empty".to_string()),
+            "an empty name must leave the prompt open with a real, visible rejection, not \
+             silently close it or invoke git at all"
+        );
+        assert_eq!(
+            git_output(local.path(), &["branch", "--list"]),
+            "* main",
+            "no branch must have been created for an empty name - this is exactly the \
+             'clearly-broken invocation' the empty-name guard exists to avoid, not a real git \
+             error"
+        );
+    }
+
+    #[gpui::test]
+    async fn create_branch_with_a_colliding_name_surfaces_gits_own_real_error(
+        cx: &mut TestAppContext,
+    ) {
+        let (local, app, cx) = open_seeded_local_repo(cx);
+        let base_sha = git_output(local.path(), &["rev-parse", "HEAD"]);
+        git(local.path(), &["branch", "existing-branch"]);
+
+        app.update_in(cx, |app, window, cx| {
+            app.start_graph_create_branch(
+                base_sha.clone(),
+                base_sha[..7].to_string(),
+                "base".to_string(),
+                window,
+                cx,
+            );
+            app.graph_state.create_branch_name =
+                crate::text_history::TextField::seeded("existing-branch");
+            app.commit_graph_create_branch(window, cx);
+        });
+        cx.run_until_parked();
+
+        let status = app.read_with(cx, |app, _| app.graph_state.status_message.clone());
+        assert!(
+            status
+                .as_deref()
+                .is_some_and(|text| text.starts_with("Create branch failed:")
+                    && text.contains("already exists")),
+            "a real branch-name collision must surface git's own real error, not hand-rolled \
+             validation - got {status:?}"
+        );
+        assert_eq!(
+            git_output(local.path(), &["rev-parse", "--abbrev-ref", "HEAD"]),
+            "main",
+            "a failed create-branch must not have switched anything"
+        );
+    }
+
+    #[gpui::test]
+    async fn soft_reset_moves_the_branch_tip_and_keeps_the_change_staged(cx: &mut TestAppContext) {
+        let (local, app, cx) = open_seeded_local_repo(cx);
+        let base_sha = git_output(local.path(), &["rev-parse", "HEAD"]);
+        commit(local.path(), "a.txt", "changed", "second commit");
+
+        app.update_in(cx, |app, _window, cx| {
+            app.request_graph_reset(wt_core::checkout::ResetMode::Soft, base_sha.clone(), cx);
+        });
+        cx.run_until_parked();
+
+        assert_eq!(git_output(local.path(), &["rev-parse", "HEAD"]), base_sha);
+        assert_eq!(
+            git_output(local.path(), &["diff", "--cached", "--name-only"]),
+            "a.txt",
+            "a soft reset must leave the undone commit's own change staged"
+        );
+        assert_eq!(
+            std::fs::read_to_string(local.path().join("a.txt")).expect("read a.txt"),
+            "changed",
+            "the working tree content must be untouched by a soft reset"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.graph_state.status_message.clone()),
+            Some("Soft reset".to_string())
+        );
+    }
+
+    #[gpui::test]
+    async fn mixed_reset_moves_the_branch_tip_and_unstages_the_change(cx: &mut TestAppContext) {
+        let (local, app, cx) = open_seeded_local_repo(cx);
+        let base_sha = git_output(local.path(), &["rev-parse", "HEAD"]);
+        commit(local.path(), "a.txt", "changed", "second commit");
+
+        app.update_in(cx, |app, _window, cx| {
+            app.request_graph_reset(wt_core::checkout::ResetMode::Mixed, base_sha.clone(), cx);
+        });
+        cx.run_until_parked();
+
+        assert_eq!(git_output(local.path(), &["rev-parse", "HEAD"]), base_sha);
+        assert!(
+            git_output(local.path(), &["diff", "--cached", "--name-only"]).is_empty(),
+            "a mixed reset must leave nothing staged"
+        );
+        assert_eq!(
+            git_output(local.path(), &["diff", "--name-only"]),
+            "a.txt",
+            "the undone commit's own change must land unstaged instead"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.graph_state.status_message.clone()),
+            Some("Mixed reset".to_string())
+        );
+    }
+
+    #[gpui::test]
+    async fn hard_reset_requires_a_real_second_click_before_it_runs(cx: &mut TestAppContext) {
+        let (local, app, cx) = open_seeded_local_repo(cx);
+        let base_sha = git_output(local.path(), &["rev-parse", "HEAD"]);
+        commit(local.path(), "a.txt", "changed", "second commit");
+        let tip_sha = git_output(local.path(), &["rev-parse", "HEAD"]);
+
+        app.update_in(cx, |app, _window, cx| {
+            app.request_graph_reset(wt_core::checkout::ResetMode::Hard, base_sha.clone(), cx);
+        });
+        cx.run_until_parked();
+
+        assert_eq!(
+            git_output(local.path(), &["rev-parse", "HEAD"]),
+            tip_sha,
+            "the first click on Hard must only arm the confirmation, never touch real git state"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app
+                .graph_state
+                .hard_reset_confirm_armed
+                .clone()),
+            Some(base_sha.clone()),
+            "the first click must arm exactly the commit that was clicked"
+        );
+
+        app.update_in(cx, |app, _window, cx| {
+            app.request_graph_reset(wt_core::checkout::ResetMode::Hard, base_sha.clone(), cx);
+        });
+        cx.run_until_parked();
+
+        assert_eq!(
+            git_output(local.path(), &["rev-parse", "HEAD"]),
+            base_sha,
+            "the second click on the same armed commit must really run the hard reset"
+        );
+        assert_eq!(
+            std::fs::read_to_string(local.path().join("a.txt")).expect("read a.txt"),
+            "base",
+            "a hard reset must really restore the working tree to the target commit's content"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app
+                .graph_state
+                .hard_reset_confirm_armed
+                .clone()),
+            None,
+            "the confirmation must disarm once the real reset has actually run"
+        );
+    }
+
+    #[gpui::test]
+    async fn a_different_row_action_disarms_a_previously_armed_hard_reset(cx: &mut TestAppContext) {
+        let (local, app, cx) = open_seeded_local_repo(cx);
+        let base_sha = git_output(local.path(), &["rev-parse", "HEAD"]);
+        commit(local.path(), "a.txt", "changed", "second commit");
+        let tip_sha = git_output(local.path(), &["rev-parse", "HEAD"]);
+
+        app.update_in(cx, |app, _window, cx| {
+            app.request_graph_reset(wt_core::checkout::ResetMode::Hard, base_sha.clone(), cx);
+        });
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app
+                .graph_state
+                .hard_reset_confirm_armed
+                .clone()),
+            Some(base_sha.clone()),
+            "premise: Hard is armed by its own first click"
+        );
+
+        // A click on a *different* row-menu action (here, a harmless clipboard copy - no git
+        // mutation at all) must disarm rather than let a later, unrelated second click on Hard
+        // silently ride on this stale confirmation. Mirrors
+        // `clicking_a_different_row_disarms_the_previous_confirmation`'s identical premise for
+        // the Push menu's own force-confirmation.
+        app.update_in(cx, |app, _window, cx| {
+            app.copy_graph_text("unrelated".to_string(), cx);
+        });
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app
+                .graph_state
+                .hard_reset_confirm_armed
+                .clone()),
+            None,
+            "a different action must disarm the previous Hard confirmation"
+        );
+
+        // With the arm cleared, a further click on Hard must arm again from scratch rather than
+        // execute immediately.
+        app.update_in(cx, |app, _window, cx| {
+            app.request_graph_reset(wt_core::checkout::ResetMode::Hard, base_sha.clone(), cx);
+        });
+        cx.run_until_parked();
+        assert_eq!(
+            git_output(local.path(), &["rev-parse", "HEAD"]),
+            tip_sha,
+            "the disarmed confirmation must require a fresh first click before Hard can run again"
         );
     }
 }

--- a/crates/app/src/graph_view/state.rs
+++ b/crates/app/src/graph_view/state.rs
@@ -43,6 +43,28 @@ pub(crate) struct GraphRowMenu {
     pub origin_y: Pixels,
 }
 
+/// GitHub issue #241: the row menu's "Create branch here" prompt - `Some` only while the small,
+/// hand-rolled branch-name modal (`crate::graph_view::render::AdeApp::
+/// render_graph_create_branch_prompt`) is open. Mirrors `crate::root::new_file::
+/// NewFileInputState`'s own shape - this app's one established "prompt for a name" idiom
+/// (append/backspace-only [`TextField`], Enter to confirm, Escape to cancel) - rather than a
+/// second, competing one.
+///
+/// `sha`/`short_sha`/`subject` are captured once, at open time, from the row that was
+/// right-clicked/`⋯`'d - not re-looked-up from the graph on every render, which a background
+/// reload racing with the still-open prompt could otherwise change out from under it.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct GraphCreateBranchPrompt {
+    pub sha: String,
+    pub short_sha: String,
+    pub subject: String,
+    /// A real rejection message from the last attempt - only this prompt's own "branch name
+    /// can't be empty" guard (a real collision with an existing branch surfaces through
+    /// [`GraphTabState::status_message`] instead, git's own real error text, exactly like every
+    /// other row-menu mutation) - cleared on the very next keystroke.
+    pub error: Option<String>,
+}
+
 /// The graph tab's own UI state: what's loaded, which scope/panel is selected, and the row `⋯`/
 /// Push `▾` menu popovers' anchors. One instance, owned by [`AdeApp::graph_state`].
 pub(crate) struct GraphTabState {
@@ -108,6 +130,29 @@ pub(crate) struct GraphTabState {
     /// disarms this rather than carrying the arm over onto an operation the user never
     /// confirmed.
     pub push_force_confirm_armed: Option<PushForce>,
+    /// GitHub issue #241: `Some(sha)` for exactly one real click past the two-click confirmation
+    /// on the row menu's "Hard" reset row, naming the commit that click targeted - `None` for
+    /// "Soft"/"Mixed", which never discard uncommitted work and so need no confirmation at all.
+    /// Mirrors [`Self::push_force_confirm_armed`]'s own discipline (see that field's docs): the
+    /// *first* click on a given commit's "Hard" row only arms this field and re-labels the row,
+    /// without resetting anything; only a second click on that *same* commit's "Hard" row - with
+    /// nothing else clicked in between - actually runs [`wt_core::checkout::reset`]. Keyed by
+    /// sha rather than a bare `bool` for the same reason `push_force_confirm_armed` is keyed by
+    /// variant: a "Hard" click on a *different* commit must arm its own confirmation, not
+    /// silently ride on a stale arm left over from a different row. Every other row-menu action
+    /// (Check out, Create branch here, Cherry-pick, Revert, Rebase onto this commit, Soft/Mixed
+    /// reset, Copy) disarms this rather than let it carry over onto an operation the user never
+    /// confirmed - see `crate::graph_view::render::AdeApp::request_graph_reset`'s own docs.
+    pub hard_reset_confirm_armed: Option<String>,
+    /// GitHub issue #241: the row menu's "Create branch here" prompt - see
+    /// [`GraphCreateBranchPrompt`]'s own docs.
+    pub create_branch_prompt: Option<GraphCreateBranchPrompt>,
+    /// The prompt's own real text input - a real undo history (GitHub issue #17), the same shape
+    /// as [`Self::branches_filter`]. Lives independently of [`Self::create_branch_prompt`]
+    /// (rather than nested inside it) only so it can be reset to empty with `TextField::new()`
+    /// each time the prompt opens without reconstructing the whole prompt struct around it.
+    pub create_branch_name: TextField,
+    pub create_branch_focus_handle: FocusHandle,
     /// The currently in-flight remote operation's own real task - held so it isn't dropped (and
     /// therefore cancelled) the instant this function returns, matching
     /// `AdeApp::_worktree_history_task`'s identical one-slot-per-feature pattern. `None` when
@@ -174,6 +219,10 @@ impl GraphTabState {
             status_message: None,
             remote_op_in_flight: false,
             push_force_confirm_armed: None,
+            hard_reset_confirm_armed: None,
+            create_branch_prompt: None,
+            create_branch_name: TextField::new(),
+            create_branch_focus_handle: cx.focus_handle(),
             _remote_op_task: None,
             loaded_cap: wt_core::graph::DEFAULT_MAX_COMMITS,
             load_more_in_flight: false,

--- a/crates/app/src/keymap_overrides.rs
+++ b/crates/app/src/keymap_overrides.rs
@@ -156,19 +156,20 @@ pub fn effective_key_bindings(overrides: &[KeybindingOverride]) -> Vec<KeyBindin
 ///
 /// This is the single source of truth for "what contexts really exist", shared by
 /// [`contexts_could_overlap`] and by `crate::undo_scoping_matrix_tests`, so the two can never
-/// disagree about the app they are both reasoning over. Derived by hand from the twelve
+/// disagree about the app they are both reasoning over. Derived by hand from the thirteen
 /// `.key_context(..)` call sites in the crate - `crate::root::AdeApp::render`'s baseline `"app"`,
 /// `crate::terminal::pane`, `crate::code_surface::render` (one call site, three literals from a
-/// `match`), `crate::merge::editing`, the seven single-line inputs (the rail's agent filter,
+/// `match`), `crate::merge::editing`, the eight single-line inputs (the rail's agent filter,
 /// Settings' keymap filter, the palette's own query field, `root::new_file`'s inline name editor,
 /// `crate::graph_view::render`'s Branches filter box, the Themes page's "Generate from colour"
-/// seed field, and - newest, GitHub issue #213 - the General page's "Shell" field), which all
-/// emit the same bare `"text-input"`, and `crate::sidebar::render::AdeApp::file_tree_shell` (one
-/// call site, four literals from a `match`) - and guarded against drift by this module's own
-/// `every_real_key_context_call_site_is_covered` test, which fails the moment a thirteenth call
+/// seed field, the General page's "Shell" field (GitHub issue #213), and - newest, GitHub issue
+/// #241 - the git graph row menu's "Create branch here" prompt), which all emit the same bare
+/// `"text-input"`, and `crate::sidebar::render::AdeApp::file_tree_shell` (one call site, four
+/// literals from a `match`) - and guarded against drift by this module's own
+/// `every_real_key_context_call_site_is_covered` test, which fails the moment a fourteenth call
 /// site appears. (That test earned its keep immediately: this comment originally said "six",
 /// counting distinct emitted literals rather than real call sites, and the test caught it on its
-/// first run; it has since caught this comment drifting behind two more real inputs.)
+/// first run; it has since caught this comment drifting behind three more real inputs.)
 ///
 /// The four `file-tree*` stacks arrived with a merge, not with an edit to this file, which is
 /// exactly why they are called out here. GitHub issue #19's file tree and issue #17's text-undo
@@ -717,12 +718,13 @@ mod tests {
         let sites = key_context_call_sites();
         let call_sites: usize = sites.iter().map(|(_, count)| count).sum();
         assert_eq!(
-            call_sites, 12,
-            "real_context_stacks() is hand-derived from exactly twelve .key_context(..) call \
-             sites (seven of which emit the same bare \"text-input\": the palette, the rail \
+            call_sites, 13,
+            "real_context_stacks() is hand-derived from exactly thirteen .key_context(..) call \
+             sites (eight of which emit the same bare \"text-input\": the palette, the rail \
              filter, the new-file prompt, the Branches filter, the Keybindings filter, the \
-             Themes page's \"Generate from colour\" seed input and - newest, GitHub issue #213 - \
-             the General page's \"Shell\" field) - a new one means that list, and every \
+             Themes page's \"Generate from colour\" seed input, the General page's \"Shell\" \
+             field (GitHub issue #213), and - newest, GitHub issue #241 - the git graph row \
+             menu's \"Create branch here\" prompt) - a new one means that list, and every \
              disjointness answer built on it, needs updating. Real sites found: {sites:?}"
         );
 

--- a/crates/app/src/root/focus.rs
+++ b/crates/app/src/root/focus.rs
@@ -150,6 +150,10 @@ impl AdeApp {
         // lists that each covered a different subset (GitHub issue #176).
         let _ = self.close_menu_surfaces_except(None);
         self.new_file_input = None;
+        // GitHub issue #241: the row menu's "Create branch here" prompt is the same kind of
+        // focus-owning modal overlay `new_file_input` is (not a `MenuSurface`, for the identical
+        // reason documented on that enum), so it needs the same explicit clear here.
+        self.graph_state.create_branch_prompt = None;
         // Not a `MenuSurface`: a half-typed inline name would keep the tree's `"tree-editing"` key
         // context alive on a node that is no longer rendered (GitHub issue #19). The armed
         // *delete confirmation* is deliberately left alone: it is a real, window-level modal the

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -2677,6 +2677,17 @@ impl Render for AdeApp {
                     && self.graph_state.row_menu_open.is_some(),
                 |el| el.child(self.render_graph_row_menu(cx)),
             )
+            // The row menu's "Create branch here" prompt (GitHub issue #241) - a focus-owning
+            // modal overlay, not a click-away menu (`crate::graph_view::state::
+            // GraphCreateBranchPrompt`'s own docs), so it lives beside the "New file" prompt
+            // below rather than inside `crate::root::menus::MenuSurface` - mirrors that enum's
+            // own doc comment on why "New file" is excluded from it too.
+            .when(
+                self.graph_tab_active
+                    && !self.settings_open
+                    && self.graph_state.create_branch_prompt.is_some(),
+                |el| el.child(self.render_graph_create_branch_prompt(cx)),
+            )
             .when_some(self.title_menu_open, |el, menu| {
                 el.child(self.render_title_menu(menu, cx))
             })

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -537,18 +537,24 @@ impl AdeApp {
         };
         // GitHub issue #45 ("Input blink only on focused input or file") / a live follow-up
         // report of missing carets: `graph_state.branches_filter_focus_handle` (added later, in
-        // Revision R12's git graph tab) and `new_file_focus_handle` are two more genuine
-        // caret-bearing `FocusHandle`s - real, hand-rolled `text_history::TextField` inputs, the
-        // same shape as the six wired above - that never got threaded through
-        // `Self::wire_caret_blink`. They can't join that earlier call: it runs before `this`
-        // exists, and both handles live *inside* `this` (one nested in `graph_state`, built by
-        // this same literal). Wired here instead, appending onto the very same
-        // `_caret_blink_subscriptions` vec so there's still exactly one place holding every real
-        // caret subscription this app has, not two.
+        // Revision R12's git graph tab), `new_file_focus_handle`, and (GitHub issue #241)
+        // `graph_state.create_branch_focus_handle` are three more genuine caret-bearing
+        // `FocusHandle`s - real, hand-rolled `text_history::TextField` inputs, the same shape as
+        // the six wired above - that never got threaded through `Self::wire_caret_blink`. They
+        // can't join that earlier call: it runs before `this` exists, and every one of these
+        // handles lives *inside* `this` (two nested in `graph_state`, built by this same
+        // literal). Wired here instead, appending onto the very same `_caret_blink_subscriptions`
+        // vec so there's still exactly one place holding every real caret subscription this app
+        // has, not two.
         let extra_caret_blink_subscriptions = AdeApp::wire_caret_blink(
             &[
                 &this.graph_state.branches_filter_focus_handle,
                 &this.new_file_focus_handle,
+                // GitHub issue #241: the row menu's "Create branch here" prompt is a third real
+                // hand-rolled `TextField` input built after this same `graph_state` literal, so
+                // it joins this later call for the same reason `branches_filter_focus_handle`
+                // does - see this call's own docs just above.
+                &this.graph_state.create_branch_focus_handle,
             ],
             window,
             cx,

--- a/crates/wt-core/src/checkout.rs
+++ b/crates/wt-core/src/checkout.rs
@@ -1,0 +1,333 @@
+//! Real git `HEAD`/branch-pointer operations that are *not* history-rewrites: checking out a
+//! commit, creating a branch at a commit, and resetting the current branch's tip - the git graph
+//! row menu's "Check out" / "Create branch here" / Soft-Mixed-Hard reset (GitHub issue #241).
+//!
+//! Kept in a module of its own rather than folded into [`crate::rewrite`]: every one of
+//! `rewrite`'s cherry-pick/revert/rebase-onto creates or replays a real commit, changing what
+//! some commit *contains*; none of the three functions here ever do that - they only ever move
+//! `HEAD` or a branch ref to point somewhere else. Same real-git-invocation discipline as
+//! `rewrite` throughout: every mutation shells out to a real `git` subprocess and surfaces git's
+//! own real stderr on failure ([`Error::GitCommand`]), nothing simulated or pre-validated beyond
+//! what's needed to avoid a clearly-broken invocation.
+
+use std::ffi::OsString;
+use std::path::Path;
+
+use crate::error::Error;
+use crate::{check_success, run_git};
+
+/// Real `git checkout <commit>` for `worktree_path`: moves `HEAD` (detached) onto `commit`,
+/// leaving the current branch pointer untouched - the row menu's "Check out".
+///
+/// `commit` is always a real object id resolved from this app's own graph, never user-typed -
+/// exactly like [`crate::rewrite::cherry_pick`]/[`crate::rewrite::revert`]/
+/// [`crate::rewrite::rebase_onto`]'s own commit arguments - so no `--` terminator is needed to
+/// guard against a flag-shaped value.
+///
+/// Plain `git checkout` already refuses on its own, with its own real, unmodified error, if
+/// switching would silently overwrite modified tracked files; this makes no attempt to pre-check
+/// or second-guess that itself - the worktree is left exactly where the equivalent command-line
+/// invocation would leave it, for the user to resolve.
+///
+/// Performs blocking I/O.
+pub fn checkout(worktree_path: &Path, commit: &str) -> Result<(), Error> {
+    let args: Vec<OsString> = vec!["checkout".into(), commit.into()];
+    let output = run_git(worktree_path, &args)?;
+    check_success(&args, &output)
+}
+
+/// Real `git checkout -b <name> <commit>` for `worktree_path`: creates a new branch named `name`
+/// at `commit` and switches to it in one atomic step - the row menu's "Create branch here".
+///
+/// `name` is genuinely user-typed (the row menu's own inline branch-name prompt), unlike almost
+/// every other string this crate shells out with. It still needs no `--` terminator, unlike
+/// `crate::add_worktree`'s own positional `worktree_path`: `-b`'s argument is always consumed as
+/// `-b`'s own option-value by git's argument parser, never re-parsed as a flag regardless of its
+/// content - confirmed empirically (`git checkout -b --evil <commit>` reports `fatal: '--evil'
+/// is not a valid branch name`, not an unknown-option error) - so there is no positional slot
+/// here for a `--` terminator to protect. A name colliding with an existing branch surfaces as
+/// git's own real [`Error::GitCommand`] (`fatal: a branch named '<name>' already exists`), not
+/// hand-rolled collision detection.
+///
+/// Performs blocking I/O.
+pub fn create_branch_at(worktree_path: &Path, name: &str, commit: &str) -> Result<(), Error> {
+    let args: Vec<OsString> = vec!["checkout".into(), "-b".into(), name.into(), commit.into()];
+    let output = run_git(worktree_path, &args)?;
+    check_success(&args, &output)
+}
+
+/// The three real `git reset` modes the row menu's "Reset" section offers - see [`reset`]'s own
+/// docs for what each really does to the working tree/index/branch tip.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResetMode {
+    Soft,
+    Mixed,
+    Hard,
+}
+
+impl ResetMode {
+    fn flag(self) -> &'static str {
+        match self {
+            ResetMode::Soft => "--soft",
+            ResetMode::Mixed => "--mixed",
+            ResetMode::Hard => "--hard",
+        }
+    }
+}
+
+/// Real `git reset --soft|--mixed|--hard <commit>` for `worktree_path`: moves the current
+/// branch's tip to `commit` - the row menu's "Reset" section.
+///
+/// - [`ResetMode::Soft`] leaves the index and working tree exactly as they were: every
+///   difference between the old tip and `commit` ends up staged.
+/// - [`ResetMode::Mixed`] (git's own default) resets the index to match `commit` but leaves the
+///   working tree untouched: those differences end up unstaged instead.
+/// - [`ResetMode::Hard`] resets both the index *and* the working tree to `commit`, discarding any
+///   uncommitted changes outright - genuinely destructive, which is why the row menu only ever
+///   reaches this for `Hard` after its own two-click confirmation
+///   (`GraphTabState::hard_reset_confirm_armed`), never on a first click.
+///
+/// `commit` is always a real object id resolved from this app's own graph, never user-typed -
+/// exactly like [`checkout`] above - so no `--` terminator is needed.
+///
+/// Performs blocking I/O.
+pub fn reset(worktree_path: &Path, mode: ResetMode, commit: &str) -> Result<(), Error> {
+    let args: Vec<OsString> = vec!["reset".into(), mode.flag().into(), commit.into()];
+    let output = run_git(worktree_path, &args)?;
+    check_success(&args, &output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::process::Command;
+    use tempfile::TempDir;
+
+    fn git(dir: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .output()
+            .expect("failed to spawn git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
+            args,
+            dir,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git_output(dir: &Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .output()
+            .expect("failed to spawn git");
+        assert!(output.status.success(), "git {args:?} failed in {dir:?}");
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    fn init_repo() -> TempDir {
+        let dir = TempDir::new().expect("tempdir");
+        git(dir.path(), &["init", "-b", "main"]);
+        git(dir.path(), &["config", "user.email", "test@example.com"]);
+        git(dir.path(), &["config", "user.name", "Test User"]);
+        dir
+    }
+
+    fn commit(dir: &Path, file: &str, contents: &str, message: &str) -> String {
+        fs::write(dir.join(file), contents).expect("write file");
+        git(dir, &["add", file]);
+        git(dir, &["commit", "-m", message]);
+        git_output(dir, &["rev-parse", "HEAD"])
+    }
+
+    fn head_sha(dir: &Path) -> String {
+        git_output(dir, &["rev-parse", "HEAD"])
+    }
+
+    fn current_branch(dir: &Path) -> String {
+        git_output(dir, &["rev-parse", "--abbrev-ref", "HEAD"])
+    }
+
+    #[test]
+    fn checkout_really_moves_head_to_the_target_commit_detached() {
+        let repo = init_repo();
+        let base = commit(repo.path(), "a.txt", "base", "base");
+        let tip = commit(repo.path(), "a.txt", "changed", "second commit");
+        assert_eq!(head_sha(repo.path()), tip);
+
+        checkout(repo.path(), &base).expect("checkout should succeed");
+
+        assert_eq!(
+            head_sha(repo.path()),
+            base,
+            "HEAD must really point at the target commit"
+        );
+        assert_eq!(
+            current_branch(repo.path()),
+            "HEAD",
+            "checking out a bare commit must really detach HEAD, not stay on the branch"
+        );
+    }
+
+    #[test]
+    fn checkout_on_a_dirty_worktree_with_a_real_conflict_surfaces_gits_own_refusal() {
+        let repo = init_repo();
+        commit(repo.path(), "a.txt", "base", "base");
+        git(repo.path(), &["checkout", "-b", "other"]);
+        commit(repo.path(), "a.txt", "other branch content", "other change");
+        git(repo.path(), &["checkout", "main"]);
+        // An uncommitted change to the same file that genuinely conflicts with what "other"
+        // holds - real git refuses to silently clobber it.
+        fs::write(repo.path().join("a.txt"), "uncommitted dirty content").expect("write");
+
+        let result = checkout(repo.path(), "other");
+        assert!(
+            result.is_err(),
+            "a genuinely conflicting checkout over dirty tracked files must fail"
+        );
+        match result.unwrap_err() {
+            Error::GitCommand { stderr, .. } => {
+                assert!(
+                    stderr.to_lowercase().contains("overwritten")
+                        || stderr.to_lowercase().contains("checkout"),
+                    "git's own real refusal reason must be preserved: {stderr}"
+                );
+            }
+            other => panic!("expected Error::GitCommand, got {other:?}"),
+        }
+        assert_eq!(
+            current_branch(repo.path()),
+            "main",
+            "a refused checkout must leave the worktree exactly where it was"
+        );
+        assert_eq!(
+            fs::read_to_string(repo.path().join("a.txt")).expect("read a.txt"),
+            "uncommitted dirty content",
+            "the refused checkout must not have touched the dirty file"
+        );
+    }
+
+    #[test]
+    fn create_branch_at_really_creates_the_branch_at_the_commit_and_switches_to_it() {
+        let repo = init_repo();
+        let base = commit(repo.path(), "a.txt", "base", "base");
+        commit(repo.path(), "a.txt", "changed again", "second commit");
+
+        create_branch_at(repo.path(), "feature-x", &base).expect("create_branch_at should succeed");
+
+        assert_eq!(
+            current_branch(repo.path()),
+            "feature-x",
+            "must really switch onto the newly created branch"
+        );
+        assert_eq!(
+            head_sha(repo.path()),
+            base,
+            "the new branch must really be rooted at the given commit"
+        );
+        let branches = git_output(repo.path(), &["branch", "--list", "feature-x"]);
+        assert!(
+            branches.contains("feature-x"),
+            "the branch must really exist in the repository's refs"
+        );
+    }
+
+    #[test]
+    fn create_branch_at_with_a_colliding_name_surfaces_gits_own_real_error() {
+        let repo = init_repo();
+        let base = commit(repo.path(), "a.txt", "base", "base");
+        git(repo.path(), &["branch", "existing-branch"]);
+
+        let result = create_branch_at(repo.path(), "existing-branch", &base);
+        assert!(
+            result.is_err(),
+            "creating a branch with a name that already exists must fail"
+        );
+        match result.unwrap_err() {
+            Error::GitCommand { stderr, .. } => {
+                assert!(
+                    stderr.contains("already exists"),
+                    "git's own real collision error must be preserved: {stderr}"
+                );
+            }
+            other => panic!("expected Error::GitCommand, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reset_soft_keeps_the_index_and_working_tree_and_only_moves_the_branch_tip() {
+        let repo = init_repo();
+        let base = commit(repo.path(), "a.txt", "base", "base");
+        commit(repo.path(), "a.txt", "changed", "second commit");
+
+        reset(repo.path(), ResetMode::Soft, &base).expect("soft reset should succeed");
+
+        assert_eq!(
+            head_sha(repo.path()),
+            base,
+            "the branch tip must really move to the target commit"
+        );
+        let staged = git_output(repo.path(), &["diff", "--cached", "--name-only"]);
+        assert_eq!(
+            staged, "a.txt",
+            "the undone commit's own change must land staged in the index"
+        );
+        assert_eq!(
+            fs::read_to_string(repo.path().join("a.txt")).expect("read a.txt"),
+            "changed",
+            "the working tree content must be untouched by a soft reset"
+        );
+    }
+
+    #[test]
+    fn reset_mixed_unstages_but_keeps_the_working_tree_content() {
+        let repo = init_repo();
+        let base = commit(repo.path(), "a.txt", "base", "base");
+        commit(repo.path(), "a.txt", "changed", "second commit");
+
+        reset(repo.path(), ResetMode::Mixed, &base).expect("mixed reset should succeed");
+
+        assert_eq!(head_sha(repo.path()), base);
+        let staged = git_output(repo.path(), &["diff", "--cached", "--name-only"]);
+        assert!(
+            staged.is_empty(),
+            "a mixed reset must leave nothing staged, got: {staged:?}"
+        );
+        let unstaged = git_output(repo.path(), &["diff", "--name-only"]);
+        assert_eq!(
+            unstaged, "a.txt",
+            "the undone commit's own change must land unstaged instead"
+        );
+        assert_eq!(
+            fs::read_to_string(repo.path().join("a.txt")).expect("read a.txt"),
+            "changed",
+            "the working tree content must be untouched by a mixed reset"
+        );
+    }
+
+    #[test]
+    fn reset_hard_discards_the_working_tree_change_entirely() {
+        let repo = init_repo();
+        let base = commit(repo.path(), "a.txt", "base", "base");
+        commit(repo.path(), "a.txt", "changed", "second commit");
+
+        reset(repo.path(), ResetMode::Hard, &base).expect("hard reset should succeed");
+
+        assert_eq!(head_sha(repo.path()), base);
+        assert_eq!(
+            fs::read_to_string(repo.path().join("a.txt")).expect("read a.txt"),
+            "base",
+            "a hard reset must really restore the working tree to the target commit's content"
+        );
+        let status = git_output(repo.path(), &["status", "--porcelain"]);
+        assert!(
+            status.is_empty(),
+            "a hard reset must leave a genuinely clean worktree, got: {status:?}"
+        );
+    }
+}

--- a/crates/wt-core/src/lib.rs
+++ b/crates/wt-core/src/lib.rs
@@ -20,6 +20,7 @@
 //! invoking them from a UI main thread.
 
 pub mod blame;
+pub mod checkout;
 pub mod diff;
 mod error;
 pub mod graph;


### PR DESCRIPTION
## Summary
- Wires up three of the git graph row context menu's stubbed actions: **Check out**, **Create branch here**, and **Soft/Mixed/Hard reset**.
- New `wt_core::checkout` module (`checkout`, `create_branch_at`, `reset`) — kept separate from `wt_core::rewrite` since none of these three rewrite commit contents, they only move `HEAD`/a branch ref.
- "Create branch here" opens a small inline text prompt, following the same idiom already established by `crate::root::new_file`'s "New file" prompt (scrim + centered panel), not a new modal subsystem.
- Hard reset gets the same two-click confirmation discipline already used for force-push: first click arms and relabels the row, only a second click on the *same* commit executes; any other action (including Hard on a different commit) disarms.

## Explicitly out of scope
- **"Start agent from this commit"** stays stubbed — it would require the "add worktree" UI entry point that's been explicitly deferred until its design lands.
- **"Interactive rebase from here"** stays stubbed — that's issue #242, tracked separately (design spec already in hand).

## Real git behavior verified empirically
- `git checkout -b <name> <commit>`: `-b`'s argument is always consumed as the flag's own value by git's parser regardless of content (confirmed: `git checkout -b --evil <sha>` reports an invalid-branch-name error, never an unknown-option error) — no `--` terminator needed there, unlike `add_worktree`'s positional path.
- A genuinely conflicting checkout (dirty file that would be overwritten) refuses on its own with real git stderr, worktree untouched.
- Branch-name collision surfaces git's own real `fatal: a branch named '<name>' already exists`.
- Soft/Mixed/Hard reset's index/working-tree/branch-tip effects are asserted directly in both wt-core and app-level tests.

## Test plan
- [x] `wt_core::checkout`: 7 new tests, real git repos — checkout move + dirty refusal, create-branch success + collision, soft/mixed/hard reset state (214/214 wt-core tests pass)
- [x] `graph_view` app tests: 9 new tests — checkout, create-branch (success/empty/collision), soft/mixed reset, hard-reset two-click arm/confirm, cross-action disarm (85/85 graph_view tests pass)
- [x] Fixed a real regression: a hard-asserted key-context-count test needed updating for the new branch-name prompt's context
- [x] `cargo build --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check` all clean (only the pre-existing, unrelated violation at `review/render.rs:1503` remains, untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)