### PR TITLE
feat(app): real hook-based agent status for Claude Code (issue #239, phase 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,6 +273,7 @@ dependencies = [
  "env_logger",
  "gpui",
  "gpui_platform",
+ "libc",
  "log",
  "lsp-core",
  "notify",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,7 @@ dependencies = [
  "lsp-core",
  "notify",
  "pty-core",
+ "rand 0.9.5",
  "regex",
  "self_update",
  "serde",

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -247,6 +247,14 @@ gpui_platform = { git = "https://github.com/zed-industries/zed", rev = "7b030b50
 [target.'cfg(target_os = "windows")'.dependencies]
 gpui_platform = { git = "https://github.com/zed-industries/zed", rev = "7b030b500810b04cf5fb4aa5973be99a502d9f36" }
 
+# Unix only, and used for exactly one thing: `kill(pid, 0)` as the portable POSIX check for
+# whether a process still exists, so `crate::hooks::settings_file` can sweep launch directories
+# left behind by a Jerry that was SIGKILLed (where `Drop` never runs) without ever deleting a
+# live instance's working directory - an age-based sweep would eventually do exactly that to a
+# long-running window. Already in the lock file transitively, so no new build surface.
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 tempfile = "3"
 # `test-support` unlocks GPUI's real interactive test harness (`#[gpui::test]`,

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -62,6 +62,12 @@ tree-sitter-python = "0.25.0"
 serde = { workspace = true }
 toml = { workspace = true }
 serde_json = { workspace = true }
+# GitHub issue #239 phase 2: the agent-hook listener's per-launch auth token. A CSPRNG is the
+# point - this codebase's usual `std::process::id()` + `AtomicU64` uniqueness convention exists
+# for temp *filenames*, where predictability is free; for a token it is the whole vulnerability.
+# Already in the lock file transitively (via `self_update`'s stack), so this is a direct
+# dependency on a crate that was being compiled anyway rather than new build surface.
+rand = "0.9"
 # Real path/`path:line[:col]` link detection inside terminal output (`crate::terminal_links`) -
 # pinned to the same `"1.5"` requirement `vendor/zed/Cargo.toml` itself pins, matching this
 # project's established shared-dependency convention (this is a generic text-scanning utility

--- a/crates/app/src/hooks/event.rs
+++ b/crates/app/src/hooks/event.rs
@@ -1,0 +1,534 @@
+//! Turning one raw Claude Code hook payload into the small, already-decided fact Jerry's rail
+//! needs (GitHub issue #239, phase 2).
+//!
+//! GPUI-free, socket-free and process-free: takes an event name and the raw JSON bytes Claude
+//! Code wrote to the forwarder's stdin, and returns a [`HookReport`] - so every extraction rule
+//! below is directly `#[test]`-able without a window, a listener or a child process. That is the
+//! same contract [`crate::rail::status`] and `crate::rail::title_signal` already hold.
+//!
+//! ## Why this is a real signal and the pty is not
+//!
+//! Phase 1 read what an agent CLI *happened to render into its terminal* - a title glyph, an
+//! OSC 9 ping. Those are real, but they are presentation: they exist because a human was meant
+//! to look at them, they are coarse (a spinner says "busy", never "editing auth.rs"), and a CLI
+//! is free to restyle them in any release. A hook payload is the opposite kind of fact - it is a
+//! documented, structured side-channel Claude Code emits *for programs*, delivered out-of-band
+//! from the interactive TUI's stdio, carrying the actual tool name and the actual argument. It
+//! is the difference between reading a progress bar off a screenshot and being handed the event.
+//!
+//! ## The payload shapes below were captured, not guessed
+//!
+//! Every field this module reads was verified against real payloads emitted by a real
+//! `claude` 2.1.228 binary on this machine (a scratch project, hooks pointed at a capture
+//! script, a prompt that drove a real `Bash` call and a real `Write` call), cross-checked
+//! against <https://code.claude.com/docs/en/hooks>. That matters because the shapes are not
+//! uniform: the "interesting" argument lives under a *different key per tool*
+//! (`tool_input.command` for `Bash`, `tool_input.file_path` for `Edit`/`Write`/`Read`,
+//! `tool_input.pattern` for `Grep`), so a single hardcoded field name would silently produce a
+//! bare tool name for every tool but one. [`tool_input_preview`] is the real per-tool lookup,
+//! ordered most-specific first, with a documented fallback rather than a guess.
+//!
+//! ## What is deliberately *not* extracted
+//!
+//! `tool_output` (`PostToolUse`) and `last_assistant_message` (`Stop`) are real fields carrying
+//! real text, and both are ignored. They are model/command output of unbounded size and
+//! arbitrary content, and the rail has one short line to render - a truncated first line of a
+//! compiler's stderr is noise wearing the costume of a status. `Stop` is used purely as the turn
+//! boundary it is; what changed during the turn is answered by the real review diff
+//! (`crate::review::flow`), which is a fact about the worktree rather than about what the model
+//! said it did.
+
+use std::time::Duration;
+
+/// How long a hook fact keeps outranking the pty-quiescence and terminal-title heuristics before
+/// Jerry falls back to them - see [`crate::rail::status::HookSignal`] for how the fallback works.
+///
+/// 30 minutes, matching the TTL the research for GitHub issue #239 found in a competitor's
+/// hook-based implementation. The value is a statement about *staleness*, not about session
+/// length: a hook fact is a point-in-time observation, and the failure it must bound is the
+/// process that stopped emitting hooks entirely (Claude Code killed with `SIGKILL`, a crashed
+/// forwarder, a `claude` upgrade that renames an event) while its pty stays open. Left
+/// unbounded, such an agent would pin whatever status it last reported forever, which is exactly
+/// the "confidently wrong" failure the quiescence floor exists to catch.
+///
+/// Why not shorter: a real turn genuinely can run far longer than a few minutes between a
+/// `PreToolUse` and its `PostToolUse` - a long test suite, a big build - and expiring mid-turn
+/// would hand the row back to the quiescence guess precisely during the long silence that guess
+/// is worst at (the false "needs input" this whole issue exists to fix). Why not longer: past
+/// half an hour, a fact this stale is not evidence about the present, and an agent silently
+/// wedged for 30 minutes *should* fall back to being reported by its silence.
+pub const HOOK_SIGNAL_TTL: Duration = Duration::from_secs(30 * 60);
+
+/// Longest [`HookReport::activity`] Jerry will keep - the rail renders this as trailing text on
+/// one line and truncates visually anyway, so this is about not carrying an unbounded string
+/// around, not about layout. A `Bash` command or a file path is the realistic content, and both
+/// stay readable at this width.
+pub const ACTIVITY_MAX_CHARS: usize = 80;
+
+/// Longest [`HookReport::question`] Jerry will keep. Wider than [`ACTIVITY_MAX_CHARS`] because a
+/// permission reason is a real sentence a human has to act on ("Bash needs permission to run:
+/// npm test"), where an activity line is a label.
+pub const QUESTION_MAX_CHARS: usize = 200;
+
+/// The largest hook payload Jerry will parse at all. Claude Code payloads are small - the real
+/// ones captured were a few hundred bytes - but `tool_input.content` on a `Write` carries an
+/// entire file, and `tool_output` an entire command's output, so the honest upper bound is "as
+/// big as whatever the model just did". This is the parse-side guard; the listener enforces the
+/// same limit on the wire (see `crate::hooks::server`) so an oversized body is never even
+/// buffered.
+pub const MAX_PAYLOAD_BYTES: usize = 1024 * 1024;
+
+/// What one hook event tells Jerry about the agent's *state* - the whole reason the payload is
+/// parsed at all. Deliberately four coarse variants rather than one per event name: the rail
+/// renders five statuses, and several distinct events are the same fact about the agent (a
+/// `PreToolUse` and a `PostToolUse` both mean "mid-turn, working").
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HookFact {
+    /// The agent is mid-turn and doing something - `UserPromptSubmit`, `PreToolUse`,
+    /// `PostToolUse`, `SessionStart`.
+    Working,
+    /// The agent is blocked on the human - a `PermissionRequest`, or a `Notification` whose
+    /// `notification_type` really means "waiting on you" (see [`notification_wants_human`]).
+    NeedsInput,
+    /// The turn ended cleanly (`Stop`). Whether that means "review ready" or "idle" is not this
+    /// module's call - it depends on the real review diff, and is decided in
+    /// [`crate::rail::status::derive_status`].
+    TurnEnded,
+    /// The turn ended badly, or a tool call failed - `StopFailure`, `PostToolUseFailure`.
+    TurnFailed,
+}
+
+/// One parsed hook event, reduced to exactly what the rail row needs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HookReport {
+    /// The state fact - see [`HookFact`].
+    pub fact: HookFact,
+    /// Trailing "what it is doing" text for a running row, roughly `"{tool}: {argument}"`, already
+    /// truncated to [`ACTIVITY_MAX_CHARS`]. `None` for events that carry no tool context.
+    pub activity: Option<String>,
+    /// The real permission reason / notification message, already truncated to
+    /// [`QUESTION_MAX_CHARS`]. `None` unless the event actually carries human-facing text.
+    pub question: Option<String>,
+}
+
+impl HookReport {
+    /// A report carrying only a state fact - the common case for the turn-boundary events, which
+    /// have no text worth rendering (see the module docs on `last_assistant_message`).
+    fn bare(fact: HookFact) -> HookReport {
+        HookReport {
+            fact,
+            activity: None,
+            question: None,
+        }
+    }
+}
+
+/// Truncates on a real `char` boundary, appending an ellipsis only when something was actually
+/// cut. Returns `None` for text that is empty or whitespace-only, so a present-but-blank JSON
+/// field is treated as the absence of information rather than rendered as an empty row.
+fn truncated(text: &str, max_chars: usize) -> Option<String> {
+    let text = text.trim();
+    if text.is_empty() {
+        return None;
+    }
+    // Collapse real newlines/tabs: the rail renders a single line, and a multi-line permission
+    // reason would otherwise render as its first line with the rest silently invisible.
+    let flattened = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    if flattened.chars().count() <= max_chars {
+        return Some(flattened);
+    }
+    let kept: String = flattened
+        .chars()
+        .take(max_chars.saturating_sub(1))
+        .collect();
+    Some(format!("{}\u{2026}", kept.trim_end()))
+}
+
+/// The interesting argument out of a `tool_input` object, as `(value, was_found)`.
+///
+/// Ordered most-specific-first over the real per-tool keys, because there is genuinely no single
+/// field: `Bash` puts its command in `command`, the file tools put a path in `file_path`, the
+/// search tools put a needle in `pattern`/`query`, and `Task` puts a human label in
+/// `description`. Anything unrecognised - including every MCP tool, whose input schema is defined
+/// by a third-party server and cannot be enumerated here - falls through to `None`, which renders
+/// as the bare tool name rather than as a wrong-but-plausible field.
+fn tool_input_preview(tool_input: &serde_json::Value) -> Option<&str> {
+    const KEYS: [&str; 6] = [
+        "command",
+        "file_path",
+        "path",
+        "pattern",
+        "query",
+        "description",
+    ];
+    KEYS.iter()
+        .find_map(|key| tool_input.get(key).and_then(serde_json::Value::as_str))
+}
+
+/// Whether a `Notification`'s `notification_type` really means "a human is being waited on".
+///
+/// This distinction is the entire reason the field is read rather than treating every
+/// `Notification` as attention-worthy: Claude Code emits real notification types that are pure
+/// information (`auth_success`, `agent_completed`, the `elicitation_*` lifecycle echoes), and
+/// promoting those to [`crate::rail::status::Status::Ask`] would light the rail up with rows
+/// that need nothing - the exact false-positive class GitHub issue #239 exists to remove. Only
+/// the types that describe a *block* count.
+///
+/// Unknown types deliberately return `false`: a notification type this build has never heard of
+/// is not evidence a human is needed, and the quiescence floor still catches a genuinely stuck
+/// agent on its own.
+fn notification_wants_human(notification_type: &str) -> bool {
+    matches!(
+        notification_type,
+        "permission_prompt" | "idle_prompt" | "agent_needs_input" | "elicitation_dialog"
+    )
+}
+
+/// Parses one hook event into the fact Jerry acts on, or `None` if this event carries nothing
+/// worth changing a row over.
+///
+/// `None` is a real, common answer, not just an error path: Jerry declares only the events it
+/// uses, but a payload that fails to parse, an event this build doesn't act on, or a
+/// `Notification` that isn't about a block must all leave the row exactly as it was rather than
+/// force some default. Malformed JSON is likewise `None` - never a panic and never an error the
+/// listener has to handle, because a hook payload is untrusted input arriving on a socket.
+pub fn parse(event_name: &str, payload: &[u8]) -> Option<HookReport> {
+    if payload.len() > MAX_PAYLOAD_BYTES {
+        return None;
+    }
+    // A payload that isn't valid JSON at all still carries one real fact: this event fired. For
+    // the events whose meaning is the firing itself that would be enough - but trusting a body
+    // Jerry couldn't parse is how a half-written or truncated request turns into a wrong status,
+    // so every event here requires a real parse first.
+    let value: serde_json::Value = serde_json::from_slice(payload).ok()?;
+    // Every real hook payload is a JSON *object*. Requiring that (rather than only requiring
+    // "valid JSON") matters for the events whose meaning is carried by the event name alone:
+    // without it, a body of `"x"` or `[]` - valid JSON, and exactly what a confused or hostile
+    // client would send - would be enough to forge a turn boundary.
+    if !value.is_object() {
+        return None;
+    }
+
+    match event_name {
+        "SessionStart" | "UserPromptSubmit" => Some(HookReport::bare(HookFact::Working)),
+
+        "PreToolUse" | "PostToolUse" => {
+            let tool = value.get("tool_name").and_then(serde_json::Value::as_str)?;
+            let argument = value.get("tool_input").and_then(tool_input_preview);
+            let activity = match argument {
+                Some(argument) => truncated(&format!("{tool}: {argument}"), ACTIVITY_MAX_CHARS),
+                None => truncated(tool, ACTIVITY_MAX_CHARS),
+            };
+            Some(HookReport {
+                fact: HookFact::Working,
+                activity,
+                question: None,
+            })
+        }
+
+        // A failed tool call is a real failure signal, but it is *not* the end of the turn -
+        // Claude Code routinely recovers from one and keeps working. The activity text is kept so
+        // the row can say which tool broke.
+        "PostToolUseFailure" => {
+            let tool = value.get("tool_name").and_then(serde_json::Value::as_str)?;
+            Some(HookReport {
+                fact: HookFact::TurnFailed,
+                activity: truncated(tool, ACTIVITY_MAX_CHARS),
+                question: value
+                    .get("error")
+                    .and_then(serde_json::Value::as_str)
+                    .and_then(|error| truncated(error, QUESTION_MAX_CHARS)),
+            })
+        }
+
+        // A real permission prompt: the agent is blocked until a human answers. The tool and its
+        // argument are the question - "Bash: sudo reboot" is what the human is being asked about.
+        "PermissionRequest" => {
+            let tool = value.get("tool_name").and_then(serde_json::Value::as_str)?;
+            let argument = value.get("tool_input").and_then(tool_input_preview);
+            let question = match argument {
+                Some(argument) => truncated(
+                    &format!("{tool} needs permission: {argument}"),
+                    QUESTION_MAX_CHARS,
+                ),
+                None => truncated(&format!("{tool} needs permission"), QUESTION_MAX_CHARS),
+            };
+            Some(HookReport {
+                fact: HookFact::NeedsInput,
+                activity: None,
+                question,
+            })
+        }
+
+        "Notification" => {
+            let notification_type = value
+                .get("notification_type")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default();
+            if !notification_wants_human(notification_type) {
+                return None;
+            }
+            Some(HookReport {
+                fact: HookFact::NeedsInput,
+                activity: None,
+                question: value
+                    .get("message")
+                    .and_then(serde_json::Value::as_str)
+                    .and_then(|message| truncated(message, QUESTION_MAX_CHARS)),
+            })
+        }
+
+        "Stop" => Some(HookReport::bare(HookFact::TurnEnded)),
+
+        "StopFailure" => Some(HookReport {
+            fact: HookFact::TurnFailed,
+            activity: None,
+            question: value
+                .get("error_message")
+                .and_then(serde_json::Value::as_str)
+                .and_then(|message| truncated(message, QUESTION_MAX_CHARS)),
+        }),
+
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The exact `PreToolUse` body a real `claude` 2.1.228 wrote to a hook's stdin on this
+    /// machine, captured during this phase's build (only `transcript_path`/`session_id` shortened).
+    /// Pinned verbatim so a future refactor of the extraction rules is checked against a real
+    /// payload rather than against a payload written to make the parser pass.
+    const REAL_PRE_TOOL_USE_BASH: &[u8] = br#"{"session_id":"5a4bef04","transcript_path":"/home/colin/.claude/projects/x/5a4bef04.jsonl","cwd":"/tmp/capture","prompt_id":"4108775d","permission_mode":"default","effort":{"level":"high"},"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"echo hello-from-jerry","description":"Echo hello-from-jerry"},"tool_use_id":"toolu_017yNzAHSe1j6rqbwMkN7gJc"}"#;
+
+    /// The real `PreToolUse` for a `Write` from the same captured run - the payload that proves
+    /// the per-tool key lookup is necessary, since it carries no `command` at all.
+    const REAL_PRE_TOOL_USE_WRITE: &[u8] = br#"{"session_id":"5a4bef04","cwd":"/tmp/capture","hook_event_name":"PreToolUse","tool_name":"Write","tool_input":{"file_path":"/tmp/capture/done.txt","content":"done\n"},"tool_use_id":"toolu_01TLYrMch3N78LFKWbm8J4WS"}"#;
+
+    /// The real `Stop` body from the same run.
+    const REAL_STOP: &[u8] = br#"{"session_id":"5a4bef04","cwd":"/tmp/capture","permission_mode":"default","hook_event_name":"Stop","stop_hook_active":false,"last_assistant_message":"Both done:\n- `echo hello-from-jerry`","background_tasks":[],"session_crons":[]}"#;
+
+    #[test]
+    fn a_real_captured_bash_pre_tool_use_becomes_working_with_the_real_command() {
+        let report = parse("PreToolUse", REAL_PRE_TOOL_USE_BASH).expect("real payload must parse");
+        assert_eq!(report.fact, HookFact::Working);
+        assert_eq!(
+            report.activity.as_deref(),
+            Some("Bash: echo hello-from-jerry")
+        );
+        assert_eq!(report.question, None);
+    }
+
+    #[test]
+    fn a_real_captured_write_pre_tool_use_uses_file_path_not_command() {
+        // The whole reason `tool_input_preview` is a per-tool lookup: this real payload has no
+        // `command` key, and a parser hardcoded to `command` would report a bare "Write".
+        let report = parse("PreToolUse", REAL_PRE_TOOL_USE_WRITE).expect("real payload must parse");
+        assert_eq!(report.fact, HookFact::Working);
+        assert_eq!(
+            report.activity.as_deref(),
+            Some("Write: /tmp/capture/done.txt")
+        );
+    }
+
+    #[test]
+    fn a_real_captured_stop_is_the_turn_boundary_and_carries_no_text() {
+        let report = parse("Stop", REAL_STOP).expect("real payload must parse");
+        assert_eq!(report.fact, HookFact::TurnEnded);
+        // `last_assistant_message` is real and present in this payload, and deliberately dropped -
+        // see the module docs.
+        assert_eq!(report.activity, None);
+        assert_eq!(report.question, None);
+    }
+
+    #[test]
+    fn an_unknown_tool_falls_back_to_the_bare_tool_name_not_a_wrong_field() {
+        let payload = br#"{"hook_event_name":"PreToolUse","tool_name":"mcp__memory__store","tool_input":{"entity":"x","observation":"y"}}"#;
+        let report = parse("PreToolUse", payload).expect("must parse");
+        assert_eq!(report.activity.as_deref(), Some("mcp__memory__store"));
+    }
+
+    #[test]
+    fn a_permission_request_needs_input_and_names_what_it_is_asking_about() {
+        let payload = br#"{"hook_event_name":"PermissionRequest","tool_name":"Bash","tool_input":{"command":"sudo reboot","description":"Restart system"}}"#;
+        let report = parse("PermissionRequest", payload).expect("must parse");
+        assert_eq!(report.fact, HookFact::NeedsInput);
+        assert_eq!(
+            report.question.as_deref(),
+            Some("Bash needs permission: sudo reboot")
+        );
+    }
+
+    #[test]
+    fn only_notification_types_that_really_block_a_human_reach_needs_input() {
+        // The real reason `notification_type` is read at all (see `notification_wants_human`).
+        for blocking in [
+            "permission_prompt",
+            "idle_prompt",
+            "agent_needs_input",
+            "elicitation_dialog",
+        ] {
+            let payload = format!(
+                r#"{{"hook_event_name":"Notification","notification_type":"{blocking}","message":"Bash needs permission to run: npm test"}}"#
+            );
+            let report = parse("Notification", payload.as_bytes())
+                .unwrap_or_else(|| panic!("{blocking} must produce a report"));
+            assert_eq!(report.fact, HookFact::NeedsInput, "{blocking}");
+            assert_eq!(
+                report.question.as_deref(),
+                Some("Bash needs permission to run: npm test")
+            );
+        }
+        // Informational types must change nothing at all - promoting these to `Ask` would light
+        // up the rail with rows that need nothing.
+        for informational in [
+            "auth_success",
+            "agent_completed",
+            "elicitation_complete",
+            "elicitation_response",
+            "some_type_from_a_future_release",
+            "",
+        ] {
+            let payload = format!(
+                r#"{{"hook_event_name":"Notification","notification_type":"{informational}","message":"all good"}}"#
+            );
+            assert_eq!(
+                parse("Notification", payload.as_bytes()),
+                None,
+                "{informational} must not be treated as needing a human"
+            );
+        }
+    }
+
+    #[test]
+    fn a_notification_with_no_type_at_all_is_ignored_rather_than_assumed_blocking() {
+        let payload = br#"{"hook_event_name":"Notification","message":"something happened"}"#;
+        assert_eq!(parse("Notification", payload), None);
+    }
+
+    #[test]
+    fn stop_failure_and_post_tool_use_failure_are_both_failures() {
+        let stop_failure = parse(
+            "StopFailure",
+            br#"{"hook_event_name":"StopFailure","error_type":"rate_limit","error_message":"Rate limit exceeded"}"#,
+        )
+        .expect("must parse");
+        assert_eq!(stop_failure.fact, HookFact::TurnFailed);
+        assert_eq!(
+            stop_failure.question.as_deref(),
+            Some("Rate limit exceeded")
+        );
+
+        let tool_failure = parse(
+            "PostToolUseFailure",
+            br#"{"hook_event_name":"PostToolUseFailure","tool_name":"Bash","tool_input":{"command":"npm test"},"error":"Command timed out after 120 seconds"}"#,
+        )
+        .expect("must parse");
+        assert_eq!(tool_failure.fact, HookFact::TurnFailed);
+        assert_eq!(tool_failure.activity.as_deref(), Some("Bash"));
+        assert_eq!(
+            tool_failure.question.as_deref(),
+            Some("Command timed out after 120 seconds")
+        );
+    }
+
+    #[test]
+    fn session_start_and_user_prompt_submit_are_working() {
+        assert_eq!(
+            parse(
+                "SessionStart",
+                br#"{"hook_event_name":"SessionStart","source":"startup"}"#
+            )
+            .map(|report| report.fact),
+            Some(HookFact::Working)
+        );
+        assert_eq!(
+            parse(
+                "UserPromptSubmit",
+                br#"{"hook_event_name":"UserPromptSubmit","user_input":"do the thing"}"#
+            )
+            .map(|report| report.fact),
+            Some(HookFact::Working)
+        );
+    }
+
+    #[test]
+    fn malformed_oversized_and_unknown_input_is_ignored_rather_than_trusted() {
+        // Untrusted bytes off a socket: none of these may panic, and none may produce a fact.
+        assert_eq!(parse("PreToolUse", b"not json at all"), None);
+        assert_eq!(parse("PreToolUse", b""), None);
+        assert_eq!(parse("PreToolUse", b"{\"truncated\":"), None);
+        // Valid JSON of the wrong shape - a bare array, a string, a null. These matter most for
+        // the events whose meaning is the event name alone: without the object check, any of
+        // them would be enough to forge a turn boundary.
+        assert_eq!(parse("PreToolUse", b"[]"), None);
+        assert_eq!(parse("Stop", b"\"just a string\""), None);
+        assert_eq!(parse("Stop", b"[]"), None);
+        assert_eq!(parse("Stop", b"null"), None);
+        assert_eq!(parse("StopFailure", b"12345"), None);
+        // A `PreToolUse` with no `tool_name` has nothing to report on.
+        assert_eq!(
+            parse("PreToolUse", br#"{"tool_input":{"command":"x"}}"#),
+            None
+        );
+        // An event Jerry does not act on.
+        assert_eq!(
+            parse("PreCompact", br#"{"hook_event_name":"PreCompact"}"#),
+            None
+        );
+        assert_eq!(parse("", b"{}"), None);
+        // Oversized bodies are refused before the JSON parser is ever handed them.
+        let huge = vec![b'x'; MAX_PAYLOAD_BYTES + 1];
+        assert_eq!(parse("PreToolUse", &huge), None);
+    }
+
+    #[test]
+    fn long_and_multiline_text_is_truncated_on_a_char_boundary_and_flattened() {
+        // A real `Write` of a long path, and a multi-line error - both must come out as one
+        // bounded single-line string.
+        let long_path = "x".repeat(500);
+        let payload = format!(
+            r#"{{"hook_event_name":"PreToolUse","tool_name":"Write","tool_input":{{"file_path":"{long_path}"}}}}"#
+        );
+        let report = parse("PreToolUse", payload.as_bytes()).expect("must parse");
+        let activity = report.activity.expect("must have activity");
+        assert_eq!(activity.chars().count(), ACTIVITY_MAX_CHARS);
+        assert!(activity.ends_with('\u{2026}'));
+
+        let multiline = parse(
+            "StopFailure",
+            br#"{"hook_event_name":"StopFailure","error_message":"line one\nline two\tline three"}"#,
+        )
+        .expect("must parse");
+        assert_eq!(
+            multiline.question.as_deref(),
+            Some("line one line two line three"),
+            "a multi-line message must flatten, not render as its first line only"
+        );
+    }
+
+    #[test]
+    fn multibyte_text_truncates_without_panicking_or_splitting_a_char() {
+        // `truncated` slices by `char`, not by byte - a byte slice would panic mid-codepoint on
+        // exactly this input, and hook payloads are untrusted.
+        let emoji_path = "\u{1f600}".repeat(300);
+        let payload = format!(
+            r#"{{"hook_event_name":"PreToolUse","tool_name":"Read","tool_input":{{"file_path":"{emoji_path}"}}}}"#
+        );
+        let report = parse("PreToolUse", payload.as_bytes()).expect("must parse");
+        let activity = report.activity.expect("must have activity");
+        assert_eq!(activity.chars().count(), ACTIVITY_MAX_CHARS);
+    }
+
+    #[test]
+    fn a_blank_field_is_absence_of_information_not_an_empty_row() {
+        let report = parse(
+            "StopFailure",
+            br#"{"hook_event_name":"StopFailure","error_message":"   "}"#,
+        )
+        .expect("must parse");
+        assert_eq!(report.question, None);
+    }
+}

--- a/crates/app/src/hooks/flow.rs
+++ b/crates/app/src/hooks/flow.rs
@@ -1,0 +1,196 @@
+//! Recording what the hooks taught Jerry about each agent, onto disk (GitHub issue #239 phase 2).
+//!
+//! The `AdeApp`-side half of [`crate::hooks::store`]: it walks the live agents once per status
+//! poll, folds each one's real derived status and hook text into
+//! [`crate::root::AdeApp::agent_status_state`], and persists only when something genuinely
+//! changed.
+//!
+//! Nothing renders any of this. It exists so GitHub issue #227 ("Agent history and
+//! resume/recover") has real, structured, dated data to build on rather than having to invent a
+//! capture mechanism first - see [`crate::hooks::store`]'s module docs.
+
+use gpui::Context;
+
+use crate::root::AdeApp;
+
+impl AdeApp {
+    /// The hook injection for an agent about to be spawned, bringing the listener up on first use.
+    ///
+    /// `None` for anything that isn't a Claude agent, and `None` if the runtime can't start - both
+    /// of which simply mean "this agent reports no hooks", which is the pre-phase-2 behaviour.
+    ///
+    /// **Lazy rather than started at app startup**, which is a deliberate refinement of the
+    /// original design. It is still exactly one listener per `AdeApp`, shared by every Claude
+    /// agent that instance ever spawns - never one per agent. But a window that only ever holds
+    /// shells, or a Codex agent, now never opens a socket or writes a file at all. That matters
+    /// in two real places: a user who doesn't use Claude Code shouldn't have Jerry holding a
+    /// loopback port open for the whole session, and the test suite (which builds a great many
+    /// `AdeApp`s and spawns almost no Claude agents) no longer pays a listener thread and a temp
+    /// directory per app - real added contention that was measurably destabilising timing
+    /// sensitive tests elsewhere in the suite.
+    pub(crate) fn hook_injection_for(
+        &mut self,
+        kind: crate::work_surface::agents::ProcessKind,
+    ) -> Option<crate::hooks::HookInjection> {
+        use crate::work_surface::agents::{AgentKind, ProcessKind};
+        if !matches!(kind, ProcessKind::Agent(AgentKind::Claude)) {
+            return None;
+        }
+        if self.hook_runtime.is_none() {
+            self.hook_runtime = crate::hooks::HookRuntime::start(&std::env::temp_dir());
+        }
+        self.hook_runtime
+            .as_ref()
+            .map(|runtime| runtime.injection())
+    }
+
+    /// Folds every live agent's current real state into the persisted record, and writes the file
+    /// if anything changed.
+    ///
+    /// Called from the rail's existing status poll (`crate::rail::render::AdeApp::start_status_polling`)
+    /// rather than from a timer of its own, matching how the review measurement already rides
+    /// that loop. Deliberately *not* called from `build_agent_rows`: that runs on every render,
+    /// and this ends in an `fsync`.
+    ///
+    /// Only agents that have really reported a hook are recorded - never a shell, never a Codex
+    /// agent, and never a Claude agent still running on the quiescence heuristic. See the comment
+    /// on the gate itself for why that is the feature rather than a shortcut.
+    pub(crate) fn record_agent_statuses(&mut self, cx: &mut Context<Self>) {
+        if self.agent_status_path.is_none() {
+            return;
+        }
+
+        let now = unix_now();
+        let mut changed = false;
+        let mut touched: Vec<String> = Vec::new();
+
+        // Only agents that have actually reported a hook are recorded, and that restriction is
+        // the whole point rather than an optimisation. `crate::hooks::store`'s module docs say it
+        // outright: a status derived from pty silence is a guess, and a guess written to disk is
+        // still a guess an hour later - it would give GitHub issue #227 a history of things Jerry
+        // never really knew. A Codex agent, a shell, and a Claude agent whose hooks have not
+        // fired have nothing real to record, so nothing is recorded for them.
+        //
+        // It also matters for cost. This runs on the status poll, and a save is two `fsync`s held
+        // under `crate::persisted_state_lock`'s *process-wide* mutex - the same one `repos.toml`,
+        // `file-tree-state.toml` and `tab-order.toml`'s writers contend for. Recording every
+        // agent meant writing on every ordinary quiescence transition
+        // (`NoProcess` -> `Run` -> `Idle`), which measurably slowed the whole app down and, in
+        // the test suite, destabilised unrelated timing-sensitive tests.
+        let Some(runtime) = &self.hook_runtime else {
+            return;
+        };
+        let recordable: Vec<(
+            crate::work_surface::agents::AgentId,
+            String,
+            std::path::PathBuf,
+            &'static str,
+            i64,
+        )> = self
+            .agents
+            .iter()
+            .filter_map(|agent| {
+                let crate::work_surface::agents::ProcessKind::Agent(kind) = agent.kind else {
+                    return None;
+                };
+                // The gate: a real, unexpired hook fact, or this agent is not recorded at all.
+                runtime.signal_for(agent.id).fact?;
+                let key =
+                    crate::review::state::baseline_key(&agent.cwd, kind, agent.spawned_at_unix);
+                Some((
+                    agent.id,
+                    key,
+                    agent.cwd.clone(),
+                    agent.kind.label(),
+                    agent.spawned_at_unix,
+                ))
+            })
+            .collect();
+        if recordable.is_empty() {
+            return;
+        }
+
+        let entries: Vec<(String, std::path::PathBuf, &'static str, i64, _, _, _)> = recordable
+            .into_iter()
+            .filter_map(|(id, key, cwd, kind_label, spawned_at_unix)| {
+                let agent = self.agents.iter().find(|agent| agent.id == id)?;
+                let status = self.agent_status(agent, cx);
+                let (activity, question) = match &self.hook_runtime {
+                    Some(runtime) => runtime.text_for(id),
+                    None => (None, None),
+                };
+                Some((
+                    key,
+                    cwd,
+                    kind_label,
+                    spawned_at_unix,
+                    status,
+                    activity,
+                    question,
+                ))
+            })
+            .collect();
+
+        for (key, cwd, kind_label, spawned_at_unix, status, activity, question) in entries {
+            if self.agent_status_state.set(
+                key.clone(),
+                &cwd,
+                kind_label,
+                spawned_at_unix,
+                status,
+                activity,
+                question,
+                now,
+            ) {
+                changed = true;
+            }
+            touched.push(key);
+        }
+
+        // Ownership is cumulative across the session: an agent the user has since closed stays
+        // owned, so its final recorded status keeps being written through on later saves instead
+        // of being dropped the moment its pane goes away. That closed agent is precisely what
+        // issue #227 most wants to show.
+        for key in touched {
+            self.agent_status_owned.insert(key);
+        }
+
+        if changed {
+            self.persist_agent_statuses(cx);
+        }
+    }
+
+    /// Writes [`crate::root::AdeApp::agent_status_state`] to disk on the background executor.
+    ///
+    /// Off the UI thread deliberately, exactly like
+    /// `crate::review::flow::AdeApp::persist_review_baselines`: `save_merged_at` holds the
+    /// process-wide `crate::persisted_state_lock` mutex across two `fsync`s, and other persisted
+    /// files' writers contend for that same lock. Running it inline would put a disk flush on the
+    /// render thread.
+    fn persist_agent_statuses(&mut self, cx: &mut Context<Self>) {
+        let Some(path) = self.agent_status_path.clone() else {
+            return;
+        };
+        let state = self.agent_status_state.clone();
+        let owned = self.agent_status_owned.clone();
+        let task = cx.spawn(async move |_this, cx| {
+            let save_path = path.clone();
+            let result = cx
+                .background_executor()
+                .spawn(async move { state.save_merged_at(&save_path, &owned) })
+                .await;
+            if let Err(err) = result {
+                log::warn!("failed to save {}: {err}", path.display());
+            }
+        });
+        self._agent_status_persist_task = Some(task);
+    }
+}
+
+/// Seconds since the Unix epoch, mirroring `crate::work_surface::agents::unix_now`.
+fn unix_now() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_secs() as i64)
+        .unwrap_or(0)
+}

--- a/crates/app/src/hooks/flow.rs
+++ b/crates/app/src/hooks/flow.rs
@@ -36,7 +36,14 @@ impl AdeApp {
         if !matches!(kind, ProcessKind::Agent(AgentKind::Claude)) {
             return None;
         }
-        if self.hook_runtime.is_none() {
+        // Bring-up is attempted exactly once per `AdeApp`. Keyed on a `tried` flag rather than on
+        // `hook_runtime.is_none()`, because those differ precisely in the failure case: without
+        // it, an instance that cannot start a runtime re-ran the whole attempt - a `bind`, a
+        // directory sweep, a `mkdir`, two file writes - on the UI thread on *every* subsequent
+        // Claude spawn, and re-logged the same warning each time, for a condition (no usable
+        // loopback, an unwritable temp directory) that will not have changed since the last try.
+        if !self.hook_runtime_tried {
+            self.hook_runtime_tried = true;
             self.hook_runtime = crate::hooks::HookRuntime::start(&std::env::temp_dir());
         }
         self.hook_runtime
@@ -93,8 +100,10 @@ impl AdeApp {
                 let crate::work_surface::agents::ProcessKind::Agent(kind) = agent.kind else {
                     return None;
                 };
-                // The gate: a real, unexpired hook fact, or this agent is not recorded at all.
-                runtime.signal_for(agent.id).fact?;
+                // The gate: a real, *unexpired* hook fact, or this agent is not recorded at all.
+                // `fresh()` rather than `.fact`, and the difference is the whole point - see
+                // `crate::rail::status::HookSignal::fresh`'s own docs.
+                runtime.signal_for(agent.id).fresh()?;
                 let key =
                     crate::review::state::baseline_key(&agent.cwd, kind, agent.spawned_at_unix);
                 Some((

--- a/crates/app/src/hooks/integration_tests.rs
+++ b/crates/app/src/hooks/integration_tests.rs
@@ -1,0 +1,351 @@
+//! End-to-end tests for the agent hook side-channel (GitHub issue #239 phase 2).
+//!
+//! Two tiers, deliberately:
+//!
+//! 1. **Real transport, no `claude`.** [`the_real_forwarder_script_delivers_a_real_payload_end_to_end`]
+//!    runs the *actual generated* forwarder script, as a real subprocess, with a real Claude Code
+//!    payload on its stdin, against a real [`crate::hooks::server::HookListener`] on a real
+//!    loopback port - and asserts the fact comes out the far end as a real
+//!    [`crate::rail::status::Status`]. Everything except Claude Code itself is the production
+//!    object, and it runs everywhere, always.
+//!
+//! 2. **Real `claude`.** The tests below it drive the genuine binary when one is installed,
+//!    which is what pins Jerry's two real behavioural dependencies on it: that a `--settings`
+//!    file's hooks actually fire, and that they are *merged* with the user's own rather than
+//!    replacing them. Skipped (loudly) when no binary is present, and tolerant of one that is
+//!    present but unusable (no auth, no network) - a sandbox without credentials must not fail
+//!    the suite, but it also must not silently look like a pass, so each of those paths logs why.
+
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use crate::hooks::event::HookFact;
+use crate::hooks::server::HookListener;
+use crate::hooks::settings_file::{HookFiles, AGENT_ENV, PORT_ENV, TOKEN_ENV};
+use crate::rail::status::{derive_status, HookSignal, ProcessSignal, Status, TerminalSignal};
+use crate::work_surface::agents::ProcessKind;
+
+/// A real `PreToolUse` body, captured verbatim from a real `claude` 2.1.228 run on this machine.
+const REAL_PAYLOAD: &str = r#"{"session_id":"5a4bef04-9e59-4d75-874d-928b1f8c3958","cwd":"/tmp/capture","permission_mode":"default","hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"cargo test --workspace","description":"Run the test suite"},"tool_use_id":"toolu_017yNzAHSe1j6rqbwMkN7gJc"}"#;
+
+/// Blocks until `check` passes or the deadline expires - the forwarder is a real subprocess and
+/// the listener a real thread, so the handoff is genuinely asynchronous.
+fn wait_for(mut check: impl FnMut() -> bool) -> bool {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if check() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    check()
+}
+
+#[test]
+fn the_real_forwarder_script_delivers_a_real_payload_end_to_end() {
+    if !cfg!(unix) {
+        return;
+    }
+    let temp = tempfile::tempdir().expect("temp dir");
+    let listener = HookListener::start().expect("the listener must bind a real loopback port");
+    let files = HookFiles::write_in(temp.path()).expect("the generated files must be written");
+
+    // The real generated script, named by the real generated settings file - read the command out
+    // of the settings rather than reconstructing it, so this exercises the path Claude Code would
+    // actually run.
+    let settings: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(files.settings_path()).expect("read"))
+            .expect("valid JSON");
+    let command = settings["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+        .as_str()
+        .expect("a PreToolUse command")
+        .to_owned();
+
+    let agent_id = 42;
+    let mut child = std::process::Command::new("/bin/sh")
+        .arg("-c")
+        .arg(&command)
+        .env(PORT_ENV, listener.port().to_string())
+        .env(TOKEN_ENV, listener.token())
+        .env(AGENT_ENV, agent_id.to_string())
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("the generated hook command must be runnable");
+    {
+        use std::io::Write;
+        let mut stdin = child.stdin.take().expect("stdin");
+        stdin
+            .write_all(REAL_PAYLOAD.as_bytes())
+            .expect("write the payload");
+    }
+    let output = child.wait_with_output().expect("wait");
+    assert!(
+        output.status.success(),
+        "the forwarder must always exit 0, got {:?}: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        wait_for(|| listener.signal_for(agent_id).fact.is_some()),
+        "the real payload must reach the listener through the real script"
+    );
+
+    // ...and the fact must actually change what the rail would show. This is the whole chain:
+    // script -> socket -> parser -> inbox -> status derivation.
+    let signal = listener.signal_for(agent_id);
+    assert_eq!(signal.fact, Some(HookFact::Working));
+    let (activity, question) = listener.text_for(agent_id);
+    assert_eq!(activity.as_deref(), Some("Bash: cargo test --workspace"));
+    assert_eq!(question, None);
+
+    // An agent this quiet would otherwise be reported as needing input; the hook fact is what
+    // makes it Run.
+    let long_quiet = ProcessSignal::Running {
+        idle: Duration::from_secs(600),
+    };
+    assert_eq!(
+        derive_status(
+            ProcessKind::claude(),
+            long_quiet,
+            TerminalSignal::default(),
+            HookSignal::default(),
+            false
+        ),
+        Status::Ask,
+        "baseline: without the hook this agent's silence reads as needing input"
+    );
+    assert_eq!(
+        derive_status(
+            ProcessKind::claude(),
+            long_quiet,
+            TerminalSignal::default(),
+            signal,
+            false
+        ),
+        Status::Run,
+        "the real round-tripped hook fact must be what decides the status"
+    );
+}
+
+#[test]
+fn a_forwarder_run_outside_jerry_reaches_no_listener_at_all() {
+    // The safety property that makes the generated command harmless if a user ever copies it into
+    // their own settings: with no JERRY_* environment it must not post anywhere, even though a
+    // real listener is running and would happily accept a correctly-tokened request.
+    if !cfg!(unix) {
+        return;
+    }
+    let temp = tempfile::tempdir().expect("temp dir");
+    let listener = HookListener::start().expect("listener");
+    let files = HookFiles::write_in(temp.path()).expect("files");
+    let settings: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(files.settings_path()).expect("read"))
+            .expect("valid JSON");
+    let command = settings["hooks"]["Stop"][0]["hooks"][0]["command"]
+        .as_str()
+        .expect("a Stop command")
+        .to_owned();
+
+    let mut child = std::process::Command::new("/bin/sh")
+        .arg("-c")
+        .arg(&command)
+        .env_remove(PORT_ENV)
+        .env_remove(TOKEN_ENV)
+        .env_remove(AGENT_ENV)
+        .stdin(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn");
+    {
+        use std::io::Write;
+        let mut stdin = child.stdin.take().expect("stdin");
+        let _ = stdin.write_all(REAL_PAYLOAD.as_bytes());
+    }
+    assert!(child.wait().expect("wait").success());
+
+    std::thread::sleep(Duration::from_millis(300));
+    for id in 0..64 {
+        assert_eq!(
+            listener.signal_for(id).fact,
+            None,
+            "an unconfigured forwarder must not report anything for any agent id"
+        );
+    }
+}
+
+/// The real `claude` binary, if one is installed and looks usable.
+fn real_claude() -> Option<std::path::PathBuf> {
+    pty_core::resolve_on_path("claude")
+}
+
+/// Runs a real, minimal `claude` turn in `cwd` with `settings`, returning whether it succeeded.
+///
+/// A failure here is treated as "this environment can't run `claude`" (no credentials, no
+/// network) rather than as a test failure - see the module docs.
+fn run_real_claude(
+    binary: &Path,
+    cwd: &Path,
+    args: &[String],
+    env: &[(String, String)],
+    home: Option<&Path>,
+) -> bool {
+    let mut command = std::process::Command::new(binary);
+    command
+        .args(args)
+        .arg("-p")
+        .arg("reply with the single word ok")
+        .current_dir(cwd)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    for (key, value) in env {
+        command.env(key, value);
+    }
+    if let Some(home) = home {
+        command.env("HOME", home);
+    }
+    match command.output() {
+        Ok(output) => {
+            if !output.status.success() {
+                eprintln!(
+                    "skipping: the installed `claude` could not complete a turn here ({:?}): {}",
+                    output.status,
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            }
+            output.status.success()
+        }
+        Err(err) => {
+            eprintln!("skipping: could not run `claude` ({err})");
+            false
+        }
+    }
+}
+
+#[test]
+fn a_real_claude_session_reports_its_hooks_to_a_real_jerry_listener() {
+    if !cfg!(unix) {
+        return;
+    }
+    let Some(binary) = real_claude() else {
+        eprintln!("skipping: no `claude` binary on PATH - the hook transport is still covered by the non-`claude` end-to-end test above");
+        return;
+    };
+
+    let temp = tempfile::tempdir().expect("temp dir");
+    let listener = HookListener::start().expect("listener");
+    let files = HookFiles::write_in(temp.path()).expect("files");
+
+    // Exactly what Jerry itself would pass - built from the real production helper rather than
+    // hand-assembled, so a change to either the args or the env is caught here.
+    let agent_id = 7;
+    let args = vec![
+        "--settings".to_owned(),
+        files.settings_path().to_string_lossy().into_owned(),
+    ];
+    let env = vec![
+        (PORT_ENV.to_owned(), listener.port().to_string()),
+        (TOKEN_ENV.to_owned(), listener.token().to_owned()),
+        (AGENT_ENV.to_owned(), agent_id.to_string()),
+    ];
+
+    let project = temp.path().join("project");
+    std::fs::create_dir_all(&project).expect("create project");
+
+    if !run_real_claude(&binary, &project, &args, &env, None) {
+        return;
+    }
+
+    assert!(
+        wait_for(|| listener.signal_for(agent_id).fact.is_some()),
+        "a real `claude` session run with Jerry's generated --settings must report at least one hook"
+    );
+    // A completed `-p` turn ends with a real `Stop`.
+    assert_eq!(
+        listener.signal_for(agent_id).fact,
+        Some(HookFact::TurnEnded),
+        "the last event of a completed turn must be the turn boundary"
+    );
+}
+
+#[test]
+fn jerry_s_settings_file_does_not_disable_the_user_s_own_hooks() {
+    // The regression this whole feature must not cause. `--settings` merging (rather than
+    // replacing) hook arrays is a real behavioural dependency on Claude Code, verified
+    // empirically rather than inferred - see `crate::hooks::settings_file`'s module docs. If a
+    // future Claude Code release changed this to "replace", Jerry would silently switch off
+    // hooks its users configured themselves, and this test is what would catch it.
+    if !cfg!(unix) {
+        return;
+    }
+    let Some(binary) = real_claude() else {
+        eprintln!(
+            "skipping: no `claude` binary on PATH - cannot verify --settings merge behaviour"
+        );
+        return;
+    };
+
+    let temp = tempfile::tempdir().expect("temp dir");
+    let home = temp.path().join("home");
+    let project = temp.path().join("project");
+    std::fs::create_dir_all(home.join(".claude")).expect("create home");
+    std::fs::create_dir_all(project.join(".claude")).expect("create project");
+
+    let marker = temp.path().join("fired.txt");
+    let hook_settings = |label: &str| {
+        format!(
+            r#"{{"hooks":{{"SessionStart":[{{"hooks":[{{"type":"command","command":"echo {label} >> {}"}}]}}]}}}}"#,
+            marker.display()
+        )
+    };
+    std::fs::write(home.join(".claude/settings.json"), hook_settings("USER")).expect("write user");
+    std::fs::write(
+        project.join(".claude/settings.json"),
+        hook_settings("PROJECT"),
+    )
+    .expect("write project");
+
+    // Jerry's real generated file, written outside the project exactly as in production.
+    let files = HookFiles::write_in(temp.path()).expect("files");
+    let listener = HookListener::start().expect("listener");
+    let args = vec![
+        "--settings".to_owned(),
+        files.settings_path().to_string_lossy().into_owned(),
+    ];
+    let env = vec![
+        (PORT_ENV.to_owned(), listener.port().to_string()),
+        (TOKEN_ENV.to_owned(), listener.token().to_owned()),
+        (AGENT_ENV.to_owned(), "5".to_owned()),
+    ];
+
+    // A temp HOME so the real `~/.claude/settings.json` is never touched. Credentials are copied
+    // across so the session can still authenticate; without them this simply skips.
+    if let Some(real_home) = std::env::var_os("HOME") {
+        let real_home = Path::new(&real_home);
+        let _ = std::fs::copy(
+            real_home.join(".claude/.credentials.json"),
+            home.join(".claude/.credentials.json"),
+        );
+        let _ = std::fs::copy(real_home.join(".claude.json"), home.join(".claude.json"));
+    }
+
+    if !run_real_claude(&binary, &project, &args, &env, Some(&home)) {
+        return;
+    }
+
+    let fired = std::fs::read_to_string(&marker).unwrap_or_default();
+    assert!(
+        fired.contains("USER"),
+        "the user's own ~/.claude hook must still fire alongside Jerry's - got {fired:?}"
+    );
+    assert!(
+        fired.contains("PROJECT"),
+        "the project's own .claude hook must still fire alongside Jerry's - got {fired:?}"
+    );
+    assert!(
+        wait_for(|| listener.signal_for(5).fact.is_some()),
+        "and Jerry's own hooks must fire too - got {fired:?}"
+    );
+}

--- a/crates/app/src/hooks/integration_tests.rs
+++ b/crates/app/src/hooks/integration_tests.rs
@@ -175,6 +175,26 @@ fn a_forwarder_run_outside_jerry_reaches_no_listener_at_all() {
     }
 }
 
+/// Set `JERRY_REQUIRE_REAL_CLAUDE=1` to turn every "no usable `claude` here" skip below into a
+/// hard failure.
+///
+/// Without this the real-binary tests pass vacuously wherever no binary or no credentials exist,
+/// which means a green CI run says nothing at all about the two behaviours they exist to pin
+/// (that `--settings` hooks fire, and that they merge with the user's own rather than replacing
+/// them). Those are behaviours of a third-party binary that can change under Jerry without any
+/// change to Jerry, so they need a job where the skip is not an option. This is the switch that
+/// job sets; the default stays skip-friendly so a contributor without Claude Code installed can
+/// still run the suite.
+const REQUIRE_REAL_CLAUDE_ENV: &str = "JERRY_REQUIRE_REAL_CLAUDE";
+
+/// Reports a skip, or panics if [`REQUIRE_REAL_CLAUDE_ENV`] demands a real run.
+fn skip_or_fail(reason: &str) {
+    if std::env::var(REQUIRE_REAL_CLAUDE_ENV).is_ok_and(|value| value == "1") {
+        panic!("{REQUIRE_REAL_CLAUDE_ENV}=1 was set, but {reason}");
+    }
+    eprintln!("skipping: {reason}");
+}
+
 /// The real `claude` binary, if one is installed and looks usable.
 fn real_claude() -> Option<std::path::PathBuf> {
     pty_core::resolve_on_path("claude")
@@ -209,16 +229,16 @@ fn run_real_claude(
     match command.output() {
         Ok(output) => {
             if !output.status.success() {
-                eprintln!(
-                    "skipping: the installed `claude` could not complete a turn here ({:?}): {}",
+                skip_or_fail(&format!(
+                    "the installed `claude` could not complete a turn here ({:?}): {}",
                     output.status,
                     String::from_utf8_lossy(&output.stderr)
-                );
+                ));
             }
             output.status.success()
         }
         Err(err) => {
-            eprintln!("skipping: could not run `claude` ({err})");
+            skip_or_fail(&format!("could not run `claude` ({err})"));
             false
         }
     }
@@ -230,7 +250,10 @@ fn a_real_claude_session_reports_its_hooks_to_a_real_jerry_listener() {
         return;
     }
     let Some(binary) = real_claude() else {
-        eprintln!("skipping: no `claude` binary on PATH - the hook transport is still covered by the non-`claude` end-to-end test above");
+        skip_or_fail(
+            "no `claude` binary on PATH - the hook transport itself is still covered by the \
+             non-`claude` end-to-end test above",
+        );
         return;
     };
 

--- a/crates/app/src/hooks/integration_tests.rs
+++ b/crates/app/src/hooks/integration_tests.rs
@@ -304,9 +304,7 @@ fn jerry_s_settings_file_does_not_disable_the_user_s_own_hooks() {
         return;
     }
     let Some(binary) = real_claude() else {
-        eprintln!(
-            "skipping: no `claude` binary on PATH - cannot verify --settings merge behaviour"
-        );
+        skip_or_fail("no `claude` binary on PATH - cannot verify --settings merge behaviour");
         return;
     };
 

--- a/crates/app/src/hooks/mod.rs
+++ b/crates/app/src/hooks/mod.rs
@@ -54,7 +54,7 @@ pub mod store;
 #[cfg(test)]
 mod integration_tests;
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::work_surface::agents::AgentId;
 
@@ -113,7 +113,7 @@ impl HookRuntime {
     /// restructuring `AdeApp`'s field ownership around it.
     pub fn injection(&self) -> HookInjection {
         HookInjection {
-            settings_path: self.files.settings_path().to_string_lossy().into_owned(),
+            settings_path: self.files.settings_path().to_path_buf(),
             port: self.listener.port(),
             token: self.listener.token().to_owned(),
         }
@@ -138,7 +138,15 @@ impl HookRuntime {
 /// An owned, spawn-time snapshot of a [`HookRuntime`] - see [`HookRuntime::injection`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HookInjection {
-    settings_path: String,
+    /// Kept as a real [`PathBuf`], not a `String`.
+    ///
+    /// It used to be built with `to_string_lossy().into_owned()`, which is silently wrong on a
+    /// non-UTF-8 `TMPDIR`: the invalid bytes become U+FFFD, and `claude --settings` is then handed
+    /// a path that does not exist, with no error anywhere and hooks simply never firing. A
+    /// `PathBuf` survives any byte sequence the OS accepts, and the one place a conversion is
+    /// genuinely unavoidable ([`Self::spawn_extras`], because
+    /// `crate::terminal::pane::TerminalSpec::args` is `Vec<String>`) now fails loudly instead.
+    settings_path: PathBuf,
     port: u16,
     token: String,
 }
@@ -151,13 +159,26 @@ impl HookInjection {
     /// exactly why one generated file serves every agent this launch spawns: the file is
     /// identical for all of them, and `JERRY_AGENT_ID` is what tells the listener which row an
     /// event belongs to.
-    pub fn spawn_extras(&self, id: AgentId) -> (Vec<String>, Vec<(String, String)>) {
-        let args = vec!["--settings".to_owned(), self.settings_path.clone()];
+    /// `None` if the settings path is not representable as UTF-8, which is the only place the
+    /// `PathBuf` -> `String` conversion cannot be avoided (`TerminalSpec::args` is `Vec<String>`).
+    /// Refusing loudly here means such an agent spawns with no hooks and a real log line, rather
+    /// than with a mangled `--settings` path that silently points at nothing.
+    pub fn spawn_extras(&self, id: AgentId) -> Option<crate::work_surface::agents::SpawnExtras> {
+        let Some(settings_path) = self.settings_path.to_str() else {
+            log::warn!(
+                "the generated hook settings path ({}) is not valid UTF-8, so it cannot be passed \
+                 as a command-line argument - this agent will fall back to the terminal-title and \
+                 quiescence signals",
+                self.settings_path.display()
+            );
+            return None;
+        };
+        let args = vec!["--settings".to_owned(), settings_path.to_owned()];
         let env = vec![
             (settings_file::PORT_ENV.to_owned(), self.port.to_string()),
             (settings_file::TOKEN_ENV.to_owned(), self.token.clone()),
             (settings_file::AGENT_ENV.to_owned(), id.to_string()),
         ];
-        (args, env)
+        Some((args, env))
     }
 }

--- a/crates/app/src/hooks/mod.rs
+++ b/crates/app/src/hooks/mod.rs
@@ -1,0 +1,163 @@
+//! A real, structural status side-channel for Claude Code agents (GitHub issue #239, phase 2).
+//!
+//! Phase 1 made Jerry's rail read what an agent CLI *rendered* - a title glyph, an OSC ping - as
+//! a refinement on top of guessing from pty silence. Both are inferences about a process from the
+//! outside. This is the other thing: Claude Code's own hook system, a documented side-channel
+//! that fires a command at named lifecycle events and hands it a JSON payload describing what
+//! just happened. `Stop` fires when a turn ends. `PermissionRequest` fires when the agent is
+//! genuinely blocked on a human. `PreToolUse` carries the actual tool and the actual argument.
+//! None of that is inferable from silence, and all of it is exactly what a "who needs me" rail
+//! wants to know.
+//!
+//! ## How the pieces fit
+//!
+//! ```text
+//!   AdeApp::new_agent(Agent(Claude))
+//!     ├── AdeApp::hook_injection_for  ── first Claude agent only ──▶ HookRuntime::start()
+//!     │                                    ├── HookListener  (127.0.0.1:<ephemeral>, token)  [server]
+//!     │                                    └── HookFiles     (forwarder + --settings JSON)   [settings_file]
+//!     └── spawn `claude --settings <HookFiles::settings_path()>`
+//!           with JERRY_HOOK_PORT / JERRY_HOOK_TOKEN / JERRY_AGENT_ID in its environment
+//!
+//!   claude fires a hook
+//!     └── forwarder script (dumb; guards on the env vars; always exits 0)
+//!           └── POST /hook?event=<name>&agent=<id>  ──▶  HookListener
+//!                 └── hooks::event::parse  ──▶  HookInbox (latest fact per agent)
+//!
+//!   rail render
+//!     └── AdeApp::agent_status ──▶ rail::status::derive_status(.., HookSignal, ..)
+//!     └── AdeApp::build_agent_rows ──▶ AgentRow::activity / question_preview
+//!                                       └── AgentStatusState (agent-status.toml)  [store]
+//! ```
+//!
+//! ## Claude Code only, and per-launch only
+//!
+//! Hooks are a Claude Code feature, so this is installed for
+//! [`crate::work_surface::agents::AgentKind::Claude`] spawns and nothing else. Codex agents and
+//! shells are completely untouched and keep exactly the Phase 1 behaviour - which is also the
+//! fallback for a Claude agent whose hooks haven't fired yet, or have gone stale.
+//!
+//! Injection is strictly per-launch: a generated `--settings` file passed on the command line of
+//! the specific `claude` process Jerry spawned. Jerry never writes to `~/.claude/settings.json`,
+//! `.claude/settings.json`, or any other file Claude Code reads on its own, so a `claude` the
+//! user starts from their own terminal behaves exactly as if Jerry were not installed. And
+//! because Claude Code merges hook arrays across every settings layer (verified against a real
+//! binary - see [`settings_file`]'s module docs), Jerry adding its hooks never disables the
+//! user's own.
+
+pub mod event;
+pub mod flow;
+pub mod server;
+pub mod settings_file;
+pub mod store;
+
+#[cfg(test)]
+mod integration_tests;
+
+use std::path::Path;
+
+use crate::work_surface::agents::AgentId;
+
+/// Everything one Jerry launch needs to receive hooks: the live listener and the generated files
+/// on disk. Dropping it stops the listener and removes the files.
+pub struct HookRuntime {
+    listener: server::HookListener,
+    files: settings_file::HookFiles,
+}
+
+impl HookRuntime {
+    /// Starts the listener and writes this instance's forwarder script and settings file into
+    /// `parent` (the OS temp directory in production).
+    ///
+    /// Called lazily, on the first Claude agent an `AdeApp` spawns - see
+    /// [`crate::root::AdeApp::hook_injection_for`] for why, and for the guarantee that there is
+    /// still only ever one of these per `AdeApp`.
+    ///
+    /// Returns `None` rather than an error if hook support can't be brought up - an unsupported
+    /// platform ([`settings_file::is_supported`]), a loopback that won't bind, an unwritable temp
+    /// directory. Every one of those is a real state, and none of them should stop Jerry
+    /// starting: without a runtime, every agent simply falls back to the Phase 1 title/OSC and
+    /// quiescence signals, which is exactly the behaviour that shipped before this phase.
+    pub fn start(parent: &Path) -> Option<HookRuntime> {
+        if !settings_file::is_supported() {
+            log::info!(
+                "agent hooks are not supported on this platform - agent status will use the \
+                 terminal-title and quiescence signals only"
+            );
+            return None;
+        }
+        let listener = match server::HookListener::start() {
+            Ok(listener) => listener,
+            Err(err) => {
+                log::warn!("could not start the agent hook listener ({err}) - falling back to the terminal-title and quiescence signals");
+                return None;
+            }
+        };
+        let files = match settings_file::HookFiles::write_in(parent) {
+            Ok(files) => files,
+            Err(err) => {
+                log::warn!("could not write the agent hook settings ({err}) - falling back to the terminal-title and quiescence signals");
+                return None;
+            }
+        };
+        log::info!("agent hook listener ready on 127.0.0.1:{}", listener.port());
+        Some(HookRuntime { listener, files })
+    }
+
+    /// An owned handle carrying everything a spawn needs, detached from `self`.
+    ///
+    /// Owned rather than a borrow because of a real constraint at the call site:
+    /// `crate::work_surface::render::AdeApp::new_agent` calls `self.agents.spawn(..)`, which
+    /// takes `&mut self.agents`, and would therefore not also be able to hold a `&self.hooks`
+    /// borrow across the same call. Cloning three small values once per spawn is cheaper than
+    /// restructuring `AdeApp`'s field ownership around it.
+    pub fn injection(&self) -> HookInjection {
+        HookInjection {
+            settings_path: self.files.settings_path().to_string_lossy().into_owned(),
+            port: self.listener.port(),
+            token: self.listener.token().to_owned(),
+        }
+    }
+
+    /// This agent's current hook fact, for [`crate::rail::status::derive_status`].
+    pub fn signal_for(&self, id: AgentId) -> crate::rail::status::HookSignal {
+        self.listener.signal_for(id)
+    }
+
+    /// This agent's current hook-derived `(activity, question)` text, for its rail row.
+    pub fn text_for(&self, id: AgentId) -> (Option<String>, Option<String>) {
+        self.listener.text_for(id)
+    }
+
+    /// Drops an agent's recorded facts, so a future [`AgentId`] can't inherit them.
+    pub fn forget(&self, id: AgentId) {
+        self.listener.forget(id);
+    }
+}
+
+/// An owned, spawn-time snapshot of a [`HookRuntime`] - see [`HookRuntime::injection`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HookInjection {
+    settings_path: String,
+    port: u16,
+    token: String,
+}
+
+impl HookInjection {
+    /// The extra CLI arguments and environment a freshly spawned `claude` needs so its hooks
+    /// reach this Jerry - `(args, env)`, ready for `crate::terminal::pane::TerminalSpec`.
+    ///
+    /// The agent's identity travels in the environment rather than in the settings file, which is
+    /// exactly why one generated file serves every agent this launch spawns: the file is
+    /// identical for all of them, and `JERRY_AGENT_ID` is what tells the listener which row an
+    /// event belongs to.
+    pub fn spawn_extras(&self, id: AgentId) -> (Vec<String>, Vec<(String, String)>) {
+        let args = vec!["--settings".to_owned(), self.settings_path.clone()];
+        let env = vec![
+            (settings_file::PORT_ENV.to_owned(), self.port.to_string()),
+            (settings_file::TOKEN_ENV.to_owned(), self.token.clone()),
+            (settings_file::AGENT_ENV.to_owned(), id.to_string()),
+        ];
+        (args, env)
+    }
+}

--- a/crates/app/src/hooks/server.rs
+++ b/crates/app/src/hooks/server.rs
@@ -92,6 +92,24 @@ const MAX_HEADERS: usize = 100;
 
 /// How many connections are handled concurrently. Hook traffic is a trickle (a few events per
 /// agent turn), so this is purely a bound on pathological behaviour, not a throughput knob.
+///
+/// ## Known, accepted limitation: aggregate starvation by reconnect
+///
+/// [`REQUEST_DEADLINE`] bounds any *single* connection, which is what closed the original
+/// slow-drip hole. It does not bound the *aggregate*: a process that holds all `MAX_IN_FLIGHT`
+/// sockets and immediately reconnects as each one expires keeps every slot occupied
+/// indefinitely, and real hook connections are then closed on arrival. Because the forwarder
+/// always exits 0 (deliberately - see [`crate::hooks::settings_file`]), that failure is silent,
+/// and affected agents fall back to the Phase 1 title/quiescence signals.
+///
+/// Accepted rather than fixed, for now, because it sits inside the threat model this feature
+/// already documents: it requires a sustained same-user, same-machine reconnect loop, and such a
+/// process can already read the token straight out of `/proc/<pid>/environ`, which buys it
+/// strictly more than degrading a status glyph. It is also strictly weaker than the bug it
+/// replaced - a one-shot drip is no longer enough.
+///
+/// A future pass should reserve some slots for connections that have already authenticated, so
+/// unauthenticated churn cannot crowd out real hooks.
 const MAX_IN_FLIGHT: usize = 16;
 
 /// The header the forwarder puts the token in.
@@ -106,6 +124,10 @@ const MAX_TRACKED_AGENTS: usize = 512;
 
 /// How long [`HookListener::drop`]'s self-connect may block the dropping thread - see that impl.
 const SHUTDOWN_WAKE_TIMEOUT: Duration = Duration::from_millis(250);
+
+/// Smallest write budget allowed for the reply, used when the read phase already consumed the
+/// whole [`REQUEST_DEADLINE`] - see [`handle_connection`].
+const REPLY_WRITE_FLOOR: Duration = Duration::from_millis(500);
 
 /// One agent's most recent hook fact, as stored for the rail to read.
 #[derive(Debug, Clone)]
@@ -459,10 +481,20 @@ fn handle_connection(mut stream: TcpStream, token: &str, inbox: &Arc<Mutex<HookI
     // `REQUEST_DEADLINE`.
     let deadline = Instant::now() + REQUEST_DEADLINE;
     let _ = stream.set_read_timeout(Some(READ_TIMEOUT));
-    let _ = stream.set_write_timeout(Some(READ_TIMEOUT));
 
     let response =
         read_and_record(&mut stream, token, inbox, deadline).unwrap_or(Response::BadRequest);
+
+    // The reply is written *after* the read phase, which may already have consumed the whole
+    // deadline - so a fixed write timeout here simply adds to the worst-case hold rather than
+    // bounding it (5s of reading plus 2s of writing is a 7s hold, not the 5s the deadline
+    // advertises). Bound the write by whatever is actually left instead.
+    //
+    // `REPLY_WRITE_FLOOR` rather than zero for the already-expired case, for two reasons: a
+    // client that timed out still deserves its 400 rather than a bare RST, and
+    // `set_write_timeout(Some(Duration::ZERO))` is an error on Unix, not "don't wait".
+    let write_budget = time_left(deadline).unwrap_or(REPLY_WRITE_FLOOR);
+    let _ = stream.set_write_timeout(Some(write_budget.max(REPLY_WRITE_FLOOR)));
 
     // Always `Connection: close` and always a `Content-Length: 0` body, so a client that speaks
     // HTTP/1.1 keep-alive doesn't sit waiting for a body that isn't coming.

--- a/crates/app/src/hooks/server.rs
+++ b/crates/app/src/hooks/server.rs
@@ -1,0 +1,764 @@
+//! The loopback listener Claude Code's hooks report into (GitHub issue #239, phase 2).
+//!
+//! One listener per Jerry process, started once at app startup and serving every Claude agent
+//! this instance ever spawns - not one per agent. The port is OS-assigned (bind to `:0`, read the
+//! real port back) so Jerry never fights another program, another Jerry instance, or a stale
+//! socket for a hardcoded number.
+//!
+//! ## Why a socket rather than a file or a pipe
+//!
+//! A hook is a *detached subprocess*: Claude Code spawns it without the interactive TUI's stdio,
+//! so there is no existing channel back to Jerry to reuse. The forwarder needs a destination it
+//! can address knowing nothing but two environment variables, from a shell one-liner, with no
+//! Jerry code running inside it. A loopback TCP port is the one such destination that needs no
+//! filesystem coordination, no cleanup if Jerry dies, and no per-agent setup.
+//!
+//! ## Threat model, and what is actually defended
+//!
+//! This listener accepts unauthenticated TCP connect attempts from anything running as this user
+//! - that is unavoidable for any loopback port. So the real defences are, in order:
+//!
+//! - **Loopback only.** Bound to `127.0.0.1`, never `0.0.0.0`, so nothing off-host can reach it
+//!   at all. [`HookListener::start`] also re-checks `peer_addr()` per connection and drops
+//!   anything non-loopback - belt and braces against a future refactor changing the bind address.
+//! - **A real token.** A 256-bit CSPRNG token generated fresh per app launch, required in an
+//!   `Authorization` header, compared in constant time ([`constant_time_eq`]). A request without
+//!   it is refused before its body is read, let alone parsed. There is deliberately no "no token
+//!   configured" fallback path: the token is generated in [`HookListener::start`] and is not
+//!   optional, so there is no configuration under which the check silently becomes a no-op.
+//! - **Hard bounds on everything read.** A 2-second read timeout, an 8 KiB cap on the request
+//!   line plus headers, a 100-header cap, and [`crate::hooks::event::MAX_PAYLOAD_BYTES`] on the
+//!   body - refused by `Content-Length` *before* a single body byte is buffered, and enforced
+//!   again while reading in case the header lied. A connection that stalls mid-request dies on
+//!   the read timeout rather than pinning a thread.
+//! - **A cap on concurrent handlers.** [`MAX_IN_FLIGHT`] connections are handled at once; past
+//!   that, new connections are closed immediately rather than spawning unbounded threads.
+//!
+//! What this deliberately does *not* defend against: another process running as this same user
+//! reading Jerry's generated settings file to learn the token. That is not a boundary this can
+//! hold - a process running as you can already read `~/.claude`, attach a debugger to Jerry, or
+//! read the pty directly. The token defends against *unauthenticated* local processes (a browser
+//! page's fetch to `127.0.0.1:<port>`, another user's process, a stray port scanner), which is
+//! the real exposure a loopback port creates.
+//!
+//! The worst a forged, correctly-tokened request can do is set a wrong status glyph on one rail
+//! row until the next real event or the TTL expires. No hook payload is executed, none is
+//! rendered as markup, and none can reach a `ProcessKind::Shell` row (see
+//! [`crate::rail::status::derive_status`]).
+
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{IpAddr, Shutdown, SocketAddr, TcpListener, TcpStream};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use crate::hooks::event::{self, HookReport, MAX_PAYLOAD_BYTES};
+use crate::work_surface::agents::AgentId;
+
+/// How long a single connection may take to deliver its request before it is dropped.
+const READ_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Cap on the request line plus all headers. Real Claude Code hook requests carry a handful of
+/// short headers; anything approaching this is either broken or hostile.
+const MAX_HEAD_BYTES: usize = 8 * 1024;
+
+/// Cap on header count, so a request of many tiny headers can't be used to burn CPU under the
+/// byte cap.
+const MAX_HEADERS: usize = 100;
+
+/// How many connections are handled concurrently. Hook traffic is a trickle (a few events per
+/// agent turn), so this is purely a bound on pathological behaviour, not a throughput knob.
+const MAX_IN_FLIGHT: usize = 16;
+
+/// The header the forwarder puts the token in.
+const AUTH_HEADER: &str = "authorization";
+
+/// One agent's most recent hook fact, as stored for the rail to read.
+#[derive(Debug, Clone)]
+pub struct HookRecord {
+    /// The parsed event - see [`crate::hooks::event::parse`].
+    pub report: HookReport,
+    /// When it arrived, for the freshness check in [`crate::rail::status::HookSignal`].
+    pub received_at: Instant,
+}
+
+/// Every agent's latest hook fact, shared between the listener thread and the UI thread.
+///
+/// Deliberately "latest wins" rather than an accumulated history: a hook stream is a sequence of
+/// state *transitions*, so the most recent event is by definition the agent's current state.
+/// This is what keeps a routine `PostToolUseFailure` (a failing test, a `grep` that matched
+/// nothing - both extremely common and both things Claude Code recovers from without help) from
+/// pinning a row to "Failed": the very next `PreToolUse` overwrites it. A failure only *stays*
+/// visible if the agent produced no further events after it, which is exactly the case where a
+/// human really does want to know something broke and nothing has happened since.
+#[derive(Debug, Default)]
+pub struct HookInbox {
+    latest: HashMap<AgentId, HookRecord>,
+}
+
+impl HookInbox {
+    /// This agent's most recent hook fact, if it has ever reported one.
+    pub fn get(&self, id: AgentId) -> Option<&HookRecord> {
+        self.latest.get(&id)
+    }
+
+    /// Records a freshly parsed event as `id`'s current state.
+    pub fn record(&mut self, id: AgentId, report: HookReport) {
+        self.latest.insert(
+            id,
+            HookRecord {
+                report,
+                received_at: Instant::now(),
+            },
+        );
+    }
+
+    /// Drops an agent's facts - called when the agent closes, so a recycled
+    /// [`AgentId`] can never inherit a dead agent's status.
+    pub fn forget(&mut self, id: AgentId) {
+        self.latest.remove(&id);
+    }
+}
+
+/// A running loopback listener. Dropping it stops the accept loop.
+pub struct HookListener {
+    port: u16,
+    token: String,
+    inbox: Arc<Mutex<HookInbox>>,
+    shutdown: Arc<AtomicBool>,
+}
+
+impl HookListener {
+    /// Binds `127.0.0.1:0`, reads back the real assigned port, generates this launch's token and
+    /// starts the accept loop on a dedicated thread.
+    ///
+    /// Returns the bind error rather than panicking: a machine with no usable loopback is a real
+    /// (if strange) state, and it must degrade to "no hook signal, quiescence heuristic as
+    /// before" rather than failing app startup - see `crate::root::state`'s call site.
+    pub fn start() -> std::io::Result<HookListener> {
+        let listener = TcpListener::bind(("127.0.0.1", 0))?;
+        let port = listener.local_addr()?.port();
+        let token = generate_token();
+        let inbox: Arc<Mutex<HookInbox>> = Arc::new(Mutex::new(HookInbox::default()));
+        let shutdown = Arc::new(AtomicBool::new(false));
+
+        let thread_token = token.clone();
+        let thread_inbox = Arc::clone(&inbox);
+        let thread_shutdown = Arc::clone(&shutdown);
+        std::thread::Builder::new()
+            .name("jerry-hook-listener".to_owned())
+            .spawn(move || {
+                let in_flight = Arc::new(AtomicUsize::new(0));
+                for stream in listener.incoming() {
+                    if thread_shutdown.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    let Ok(stream) = stream else {
+                        // A single failed accept (an interrupted syscall, a client that vanished
+                        // between the SYN and the accept) must not kill the listener for the
+                        // whole app session.
+                        continue;
+                    };
+                    if !is_loopback(&stream) {
+                        let _ = stream.shutdown(Shutdown::Both);
+                        continue;
+                    }
+                    if in_flight.load(Ordering::Relaxed) >= MAX_IN_FLIGHT {
+                        let _ = stream.shutdown(Shutdown::Both);
+                        continue;
+                    }
+                    in_flight.fetch_add(1, Ordering::Relaxed);
+                    let handler_token = thread_token.clone();
+                    let handler_inbox = Arc::clone(&thread_inbox);
+                    let handler_in_flight = Arc::clone(&in_flight);
+                    let spawned = std::thread::Builder::new()
+                        .name("jerry-hook-conn".to_owned())
+                        .spawn(move || {
+                            handle_connection(stream, &handler_token, &handler_inbox);
+                            handler_in_flight.fetch_sub(1, Ordering::Relaxed);
+                        });
+                    if spawned.is_err() {
+                        in_flight.fetch_sub(1, Ordering::Relaxed);
+                    }
+                }
+            })?;
+
+        Ok(HookListener {
+            port,
+            token,
+            inbox,
+            shutdown,
+        })
+    }
+
+    /// The real OS-assigned port, for the `JERRY_HOOK_PORT` env var.
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// This launch's token, for the `JERRY_HOOK_TOKEN` env var.
+    pub fn token(&self) -> &str {
+        &self.token
+    }
+
+    /// The shared inbox the rail reads from.
+    pub fn inbox(&self) -> &Arc<Mutex<HookInbox>> {
+        &self.inbox
+    }
+
+    /// This agent's current hook fact and how long ago it arrived, ready for
+    /// [`crate::rail::status::HookSignal`]. A poisoned lock reports "no signal" rather than
+    /// panicking - a hook fact is an optional refinement, and losing it must never take the rail
+    /// down (same rule `crate::persisted_state_lock` applies to its own poisoned mutex).
+    pub fn signal_for(&self, id: AgentId) -> crate::rail::status::HookSignal {
+        let Ok(inbox) = self.inbox.lock() else {
+            return crate::rail::status::HookSignal::default();
+        };
+        match inbox.get(id) {
+            Some(record) => crate::rail::status::HookSignal {
+                fact: Some(record.report.fact),
+                age: record.received_at.elapsed(),
+            },
+            None => crate::rail::status::HookSignal::default(),
+        }
+    }
+
+    /// This agent's current hook-derived activity/question text, if any is fresh enough to show.
+    /// Returns `(activity, question)`.
+    pub fn text_for(&self, id: AgentId) -> (Option<String>, Option<String>) {
+        let Ok(inbox) = self.inbox.lock() else {
+            return (None, None);
+        };
+        match inbox.get(id) {
+            Some(record) if record.received_at.elapsed() < event::HOOK_SIGNAL_TTL => (
+                record.report.activity.clone(),
+                record.report.question.clone(),
+            ),
+            _ => (None, None),
+        }
+    }
+
+    /// Drops an agent's recorded facts - see [`HookInbox::forget`].
+    pub fn forget(&self, id: AgentId) {
+        if let Ok(mut inbox) = self.inbox.lock() {
+            inbox.forget(id);
+        }
+    }
+}
+
+impl Drop for HookListener {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::Relaxed);
+        // Unblock the accept loop so the flag is actually observed: `incoming()` is blocking, so
+        // setting the flag alone would leave the thread parked in `accept` until the next real
+        // connection. A self-connect is the portable way to wake it.
+        let _ = TcpStream::connect(("127.0.0.1", self.port));
+    }
+}
+
+/// Whether the peer really is on the loopback interface - see the module docs.
+fn is_loopback(stream: &TcpStream) -> bool {
+    match stream.peer_addr() {
+        Ok(SocketAddr::V4(addr)) => addr.ip().is_loopback(),
+        Ok(SocketAddr::V6(addr)) => {
+            let ip = *addr.ip();
+            ip.is_loopback()
+                || ip
+                    .to_ipv4_mapped()
+                    .is_some_and(|mapped| IpAddr::V4(mapped).is_loopback())
+        }
+        Err(_) => false,
+    }
+}
+
+/// A 256-bit token, hex encoded.
+///
+/// Uses `rand`'s CSPRNG (`rand::rngs::OsRng` via `rand::rng`) rather than this codebase's usual
+/// `std::process::id()` + `AtomicU64` uniqueness convention: that convention exists to make temp
+/// *filenames* unique, where predictability costs nothing. Here predictability is the whole
+/// attack - a token derived from a pid and a counter is guessable by any local process that can
+/// read `/proc`.
+fn generate_token() -> String {
+    use rand::RngCore;
+    let mut bytes = [0u8; 32];
+    rand::rng().fill_bytes(&mut bytes);
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+/// Compares two secrets without an early return, so a caller can't binary-search the token by
+/// timing. Length is compared first and non-secretly (the token's length is fixed and public).
+fn constant_time_eq(a: &str, b: &str) -> bool {
+    let (a, b) = (a.as_bytes(), b.as_bytes());
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// Percent-decodes one query-string value. Hook event names and agent ids are plain ASCII, so
+/// this exists only so a percent-encoded value round-trips rather than being silently mangled
+/// into a name that matches nothing.
+fn percent_decode(input: &str) -> String {
+    let mut out = Vec::with_capacity(input.len());
+    let bytes = input.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'%' if index + 2 < bytes.len() => {
+                let hex = std::str::from_utf8(&bytes[index + 1..index + 3]).unwrap_or("");
+                match u8::from_str_radix(hex, 16) {
+                    Ok(byte) => {
+                        out.push(byte);
+                        index += 3;
+                    }
+                    Err(_) => {
+                        out.push(bytes[index]);
+                        index += 1;
+                    }
+                }
+            }
+            b'+' => {
+                out.push(b' ');
+                index += 1;
+            }
+            byte => {
+                out.push(byte);
+                index += 1;
+            }
+        }
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// Pulls `key`'s value out of a raw query string (`event=Stop&agent=7`).
+fn query_value(query: &str, key: &str) -> Option<String> {
+    query.split('&').find_map(|pair| {
+        let (name, value) = pair.split_once('=')?;
+        (name == key).then(|| percent_decode(value))
+    })
+}
+
+/// The outcome of reading one request, kept separate from the socket work so it is testable.
+#[derive(Debug, PartialEq, Eq)]
+enum Response {
+    /// Accepted (whether or not the payload turned out to be an event Jerry acts on).
+    NoContent,
+    BadRequest,
+    Unauthorized,
+    NotFound,
+    PayloadTooLarge,
+}
+
+impl Response {
+    fn status_line(&self) -> &'static str {
+        match self {
+            Response::NoContent => "HTTP/1.1 204 No Content",
+            Response::BadRequest => "HTTP/1.1 400 Bad Request",
+            Response::Unauthorized => "HTTP/1.1 401 Unauthorized",
+            Response::NotFound => "HTTP/1.1 404 Not Found",
+            Response::PayloadTooLarge => "HTTP/1.1 413 Payload Too Large",
+        }
+    }
+}
+
+/// Reads one request off `stream`, records whatever it turned out to be, and writes a response.
+fn handle_connection(mut stream: TcpStream, token: &str, inbox: &Arc<Mutex<HookInbox>>) {
+    let _ = stream.set_read_timeout(Some(READ_TIMEOUT));
+    let _ = stream.set_write_timeout(Some(READ_TIMEOUT));
+
+    let response = read_and_record(&mut stream, token, inbox).unwrap_or(Response::BadRequest);
+
+    // Always `Connection: close` and always a `Content-Length: 0` body, so a client that speaks
+    // HTTP/1.1 keep-alive doesn't sit waiting for a body that isn't coming.
+    let reply = format!(
+        "{}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        response.status_line()
+    );
+    let _ = stream.write_all(reply.as_bytes());
+    let _ = stream.flush();
+    let _ = stream.shutdown(Shutdown::Both);
+}
+
+/// The real request handling: parse, authenticate, bound, record. Returns `None` on any I/O
+/// failure, which the caller turns into a 400.
+fn read_and_record(
+    stream: &mut TcpStream,
+    token: &str,
+    inbox: &Arc<Mutex<HookInbox>>,
+) -> Option<Response> {
+    let mut reader = BufReader::new(stream.try_clone().ok()?);
+
+    // -- request line, bounded --
+    let mut request_line = String::new();
+    let mut head_budget = MAX_HEAD_BYTES;
+    let read = read_line_bounded(&mut reader, &mut request_line, head_budget)?;
+    head_budget = head_budget.saturating_sub(read);
+
+    let mut parts = request_line.split_whitespace();
+    let method = parts.next()?;
+    let target = parts.next()?;
+    if method != "POST" {
+        return Some(Response::NotFound);
+    }
+
+    // -- headers, bounded in both bytes and count --
+    let mut content_length: Option<usize> = None;
+    let mut authorization: Option<String> = None;
+    for _ in 0..MAX_HEADERS {
+        let mut line = String::new();
+        let read = read_line_bounded(&mut reader, &mut line, head_budget)?;
+        head_budget = head_budget.saturating_sub(read);
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if trimmed.is_empty() {
+            break;
+        }
+        let Some((name, value)) = trimmed.split_once(':') else {
+            return Some(Response::BadRequest);
+        };
+        let name = name.trim().to_ascii_lowercase();
+        let value = value.trim();
+        match name.as_str() {
+            "content-length" => content_length = Some(value.parse().ok()?),
+            AUTH_HEADER => authorization = Some(value.to_owned()),
+            _ => {}
+        }
+    }
+
+    // -- authenticate before reading a single body byte --
+    let supplied = authorization?;
+    let supplied = supplied
+        .strip_prefix("Bearer ")
+        .or_else(|| supplied.strip_prefix("bearer "))
+        .unwrap_or(&supplied);
+    if !constant_time_eq(supplied, token) {
+        return Some(Response::Unauthorized);
+    }
+
+    // -- route --
+    let (path, query) = match target.split_once('?') {
+        Some((path, query)) => (path, query),
+        None => (target, ""),
+    };
+    if path != "/hook" {
+        return Some(Response::NotFound);
+    }
+
+    // -- bound the body by the declared length before buffering any of it --
+    let length = content_length?;
+    if length > MAX_PAYLOAD_BYTES {
+        return Some(Response::PayloadTooLarge);
+    }
+    let mut body = vec![0u8; length];
+    // `read_exact` over a `take` so a `Content-Length` that overstates the real body dies on the
+    // read timeout instead of blocking forever, and one that understates it can't bleed the next
+    // request's bytes into this payload.
+    reader
+        .by_ref()
+        .take(length as u64)
+        .read_exact(&mut body)
+        .ok()?;
+
+    let event_name = query_value(query, "event").unwrap_or_default();
+    let agent_id: Option<AgentId> = query_value(query, "agent").and_then(|id| id.parse().ok());
+
+    // An unparseable or absent agent id is a real, expected case (the forwarder ran outside a
+    // Jerry-spawned pane, or a hand-made request): accept the request so the client isn't left
+    // retrying, but record nothing - there is no row it could belong to.
+    if let (Some(agent_id), Some(report)) = (agent_id, event::parse(&event_name, &body)) {
+        if let Ok(mut inbox) = inbox.lock() {
+            inbox.record(agent_id, report);
+        }
+    }
+    Some(Response::NoContent)
+}
+
+/// [`BufRead::read_line`] with a hard byte budget, so a client that never sends a newline can't
+/// grow Jerry's memory without bound. Returns the bytes consumed.
+fn read_line_bounded(
+    reader: &mut BufReader<TcpStream>,
+    out: &mut String,
+    budget: usize,
+) -> Option<usize> {
+    let mut limited = reader.take(budget as u64);
+    let mut raw = Vec::new();
+    let read = limited.read_until(b'\n', &mut raw).ok()?;
+    if read == 0 {
+        return None;
+    }
+    // A line that exactly consumed the budget without a terminator is over-long: refuse rather
+    // than silently treating the truncation as a complete line.
+    if read == budget && !raw.ends_with(b"\n") {
+        return None;
+    }
+    out.push_str(&String::from_utf8_lossy(&raw));
+    Some(read)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hooks::event::HookFact;
+
+    /// Sends one raw request to a live listener and returns the raw response.
+    fn raw_request(port: u16, request: &str) -> String {
+        let mut stream = TcpStream::connect(("127.0.0.1", port)).expect("connect");
+        stream.set_read_timeout(Some(Duration::from_secs(5))).ok();
+        stream.write_all(request.as_bytes()).expect("write");
+        stream.flush().ok();
+        let mut response = String::new();
+        let _ = stream.read_to_string(&mut response);
+        response
+    }
+
+    fn post(port: u16, token: &str, query: &str, body: &str) -> String {
+        raw_request(
+            port,
+            &format!(
+                "POST /hook?{query} HTTP/1.1\r\nHost: 127.0.0.1\r\nAuthorization: Bearer {token}\r\nContent-Length: {}\r\n\r\n{body}",
+                body.len()
+            ),
+        )
+    }
+
+    #[test]
+    fn a_real_tokened_post_round_trips_into_the_inbox() {
+        let listener = HookListener::start().expect("listener must start");
+        assert!(listener.port() > 0, "the OS must have assigned a real port");
+
+        let body = r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"cargo test"}}"#;
+        let response = post(
+            listener.port(),
+            listener.token(),
+            "event=PreToolUse&agent=7",
+            body,
+        );
+        assert!(
+            response.starts_with("HTTP/1.1 204"),
+            "expected 204, got {response:?}"
+        );
+
+        let signal = listener.signal_for(7);
+        assert_eq!(signal.fact, Some(HookFact::Working));
+        let (activity, question) = listener.text_for(7);
+        assert_eq!(activity.as_deref(), Some("Bash: cargo test"));
+        assert_eq!(question, None);
+        // A different agent id must be untouched by another agent's event.
+        assert_eq!(listener.signal_for(8).fact, None);
+    }
+
+    #[test]
+    fn every_launch_gets_a_distinct_high_entropy_token() {
+        let a = HookListener::start().expect("start a");
+        let b = HookListener::start().expect("start b");
+        assert_ne!(
+            a.token(),
+            b.token(),
+            "tokens must not repeat across launches"
+        );
+        assert_eq!(a.token().len(), 64, "256 bits, hex encoded");
+        assert!(a.token().chars().all(|c| c.is_ascii_hexdigit()));
+        assert_ne!(a.port(), b.port(), "each listener gets its own real port");
+    }
+
+    #[test]
+    fn a_request_without_the_right_token_is_refused_and_records_nothing() {
+        let listener = HookListener::start().expect("listener must start");
+        let body = r#"{"hook_event_name":"Stop"}"#;
+
+        // Wrong token.
+        let wrong = post(
+            listener.port(),
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "event=Stop&agent=3",
+            body,
+        );
+        assert!(wrong.starts_with("HTTP/1.1 401"), "got {wrong:?}");
+
+        // No Authorization header at all.
+        let missing = raw_request(
+            listener.port(),
+            &format!(
+                "POST /hook?event=Stop&agent=3 HTTP/1.1\r\nHost: x\r\nContent-Length: {}\r\n\r\n{body}",
+                body.len()
+            ),
+        );
+        assert!(missing.starts_with("HTTP/1.1 400"), "got {missing:?}");
+
+        // A token that is a prefix of the real one must not be accepted either.
+        let prefix = post(
+            listener.port(),
+            &listener.token()[..32],
+            "event=Stop&agent=3",
+            body,
+        );
+        assert!(prefix.starts_with("HTTP/1.1 401"), "got {prefix:?}");
+
+        assert_eq!(
+            listener.signal_for(3).fact,
+            None,
+            "no unauthenticated request may reach the inbox"
+        );
+    }
+
+    #[test]
+    fn an_oversized_body_is_refused_without_being_buffered() {
+        let listener = HookListener::start().expect("listener must start");
+        let response = raw_request(
+            listener.port(),
+            &format!(
+                "POST /hook?event=Stop&agent=1 HTTP/1.1\r\nAuthorization: Bearer {}\r\nContent-Length: {}\r\n\r\n",
+                listener.token(),
+                MAX_PAYLOAD_BYTES + 1
+            ),
+        );
+        assert!(response.starts_with("HTTP/1.1 413"), "got {response:?}");
+        assert_eq!(listener.signal_for(1).fact, None);
+    }
+
+    #[test]
+    fn malformed_truncated_and_hostile_requests_neither_crash_nor_hang_the_listener() {
+        let listener = HookListener::start().expect("listener must start");
+        let token = listener.token().to_owned();
+        let port = listener.port();
+
+        // Garbage, an empty request, a wrong method, a wrong path, an unterminated header,
+        // a non-numeric Content-Length, a body shorter than its declared length.
+        let hostile = vec![
+            "not http at all\r\n\r\n".to_owned(),
+            "\r\n".to_owned(),
+            format!("GET /hook?event=Stop&agent=1 HTTP/1.1\r\nAuthorization: Bearer {token}\r\n\r\n"),
+            format!("POST /evil?event=Stop&agent=1 HTTP/1.1\r\nAuthorization: Bearer {token}\r\nContent-Length: 2\r\n\r\n{{}}"),
+            format!("POST /hook?event=Stop&agent=1 HTTP/1.1\r\nAuthorization: Bearer {token}\r\nContent-Length: notanumber\r\n\r\n"),
+            format!("POST /hook?event=Stop&agent=1 HTTP/1.1\r\nAuthorization Bearer {token}\r\n\r\n"),
+            // A header line far past the head budget, never terminated.
+            format!("POST /hook?event=Stop&agent=1 HTTP/1.1\r\nX-Huge: {}", "A".repeat(MAX_HEAD_BYTES * 2)),
+        ];
+        for request in hostile {
+            // The assertion that matters is that this returns at all - a hang here is the bug.
+            let _ = raw_request(port, &request);
+        }
+
+        assert_eq!(
+            listener.signal_for(1).fact,
+            None,
+            "none of the hostile requests may have recorded a fact"
+        );
+
+        // The listener must still be alive and correct after all of that.
+        let good = post(
+            port,
+            &token,
+            "event=Stop&agent=1",
+            r#"{"hook_event_name":"Stop"}"#,
+        );
+        assert!(good.starts_with("HTTP/1.1 204"), "got {good:?}");
+        assert_eq!(listener.signal_for(1).fact, Some(HookFact::TurnEnded));
+    }
+
+    #[test]
+    fn a_valid_request_for_an_event_jerry_ignores_is_accepted_but_records_nothing() {
+        let listener = HookListener::start().expect("listener must start");
+        let response = post(
+            listener.port(),
+            listener.token(),
+            "event=PreCompact&agent=5",
+            r#"{"hook_event_name":"PreCompact"}"#,
+        );
+        assert!(response.starts_with("HTTP/1.1 204"), "got {response:?}");
+        assert_eq!(listener.signal_for(5).fact, None);
+    }
+
+    #[test]
+    fn a_request_with_no_usable_agent_id_is_accepted_but_records_nothing() {
+        // Exactly what a forwarder run outside a Jerry-spawned pane would produce.
+        let listener = HookListener::start().expect("listener must start");
+        for query in [
+            "event=Stop",
+            "event=Stop&agent=",
+            "event=Stop&agent=notanumber",
+        ] {
+            let response = post(
+                listener.port(),
+                listener.token(),
+                query,
+                r#"{"hook_event_name":"Stop"}"#,
+            );
+            assert!(
+                response.starts_with("HTTP/1.1 204"),
+                "{query}: {response:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_latest_event_replaces_the_previous_one_for_the_same_agent() {
+        // "Latest wins" is what keeps a routine tool failure from pinning a row to Failed - see
+        // `HookInbox`'s own docs.
+        let listener = HookListener::start().expect("listener must start");
+        post(
+            listener.port(),
+            listener.token(),
+            "event=PostToolUseFailure&agent=2",
+            r#"{"hook_event_name":"PostToolUseFailure","tool_name":"Bash","error":"exit 1"}"#,
+        );
+        assert_eq!(listener.signal_for(2).fact, Some(HookFact::TurnFailed));
+
+        post(
+            listener.port(),
+            listener.token(),
+            "event=PreToolUse&agent=2",
+            r#"{"hook_event_name":"PreToolUse","tool_name":"Edit","tool_input":{"file_path":"/tmp/a.rs"}}"#,
+        );
+        assert_eq!(
+            listener.signal_for(2).fact,
+            Some(HookFact::Working),
+            "the next real event must supersede the failure"
+        );
+    }
+
+    #[test]
+    fn forgetting_an_agent_clears_its_facts_so_a_reused_id_cannot_inherit_them() {
+        let listener = HookListener::start().expect("listener must start");
+        post(
+            listener.port(),
+            listener.token(),
+            "event=Stop&agent=9",
+            r#"{"hook_event_name":"Stop"}"#,
+        );
+        assert_eq!(listener.signal_for(9).fact, Some(HookFact::TurnEnded));
+        listener.forget(9);
+        assert_eq!(listener.signal_for(9).fact, None);
+        assert_eq!(listener.text_for(9), (None, None));
+    }
+
+    #[test]
+    fn constant_time_eq_is_a_real_comparison() {
+        // A "constant time" helper that always returned true would pass a naive auth test, so
+        // this pins the actual semantics.
+        assert!(constant_time_eq("abc", "abc"));
+        assert!(!constant_time_eq("abc", "abd"));
+        assert!(!constant_time_eq("abc", "ab"));
+        assert!(!constant_time_eq("", "a"));
+        assert!(constant_time_eq("", ""));
+    }
+
+    #[test]
+    fn query_values_are_parsed_and_percent_decoded() {
+        assert_eq!(
+            query_value("event=PreToolUse&agent=12", "event").as_deref(),
+            Some("PreToolUse")
+        );
+        assert_eq!(
+            query_value("event=PreToolUse&agent=12", "agent").as_deref(),
+            Some("12")
+        );
+        assert_eq!(query_value("event=a%20b", "event").as_deref(), Some("a b"));
+        assert_eq!(query_value("event=x", "missing"), None);
+        assert_eq!(query_value("", "event"), None);
+    }
+}

--- a/crates/app/src/hooks/server.rs
+++ b/crates/app/src/hooks/server.rs
@@ -26,13 +26,18 @@
 //!   it is refused before its body is read, let alone parsed. There is deliberately no "no token
 //!   configured" fallback path: the token is generated in [`HookListener::start`] and is not
 //!   optional, so there is no configuration under which the check silently becomes a no-op.
-//! - **Hard bounds on everything read.** A 2-second read timeout, an 8 KiB cap on the request
-//!   line plus headers, a 100-header cap, and [`crate::hooks::event::MAX_PAYLOAD_BYTES`] on the
-//!   body - refused by `Content-Length` *before* a single body byte is buffered, and enforced
-//!   again while reading in case the header lied. A connection that stalls mid-request dies on
-//!   the read timeout rather than pinning a thread.
+//! - **Hard bounds on everything read.** An 8 KiB cap on the request line plus headers, a
+//!   100-header cap, and [`crate::hooks::event::MAX_PAYLOAD_BYTES`] on the body - refused by
+//!   `Content-Length` *before* a single body byte is buffered, and enforced again while reading
+//!   in case the header lied.
+//! - **A bound on request *time*, not just size.** [`REQUEST_DEADLINE`] caps the whole exchange
+//!   from a single absolute instant, and each blocking read is clamped to the time left. A
+//!   per-read timeout alone is not enough and was a real hole: `SO_RCVTIMEO` resets on every byte
+//!   that arrives, so a client dripping one byte per second held a handler for hours - pre-auth,
+//!   since the token is not checked until the headers are read.
 //! - **A cap on concurrent handlers.** [`MAX_IN_FLIGHT`] connections are handled at once; past
-//!   that, new connections are closed immediately rather than spawning unbounded threads.
+//!   that, new connections are closed immediately rather than spawning unbounded threads. Slots
+//!   are released by an RAII guard ([`InFlightSlot`]), so a panic cannot leak one.
 //!
 //! What this deliberately does *not* defend against: another process running as this same user
 //! reading Jerry's generated settings file to learn the token. That is not a boundary this can
@@ -47,7 +52,7 @@
 //! [`crate::rail::status::derive_status`]).
 
 use std::collections::HashMap;
-use std::io::{BufRead, BufReader, Read, Write};
+use std::io::{BufReader, Read, Write};
 use std::net::{IpAddr, Shutdown, SocketAddr, TcpListener, TcpStream};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -56,8 +61,26 @@ use std::time::{Duration, Instant};
 use crate::hooks::event::{self, HookReport, MAX_PAYLOAD_BYTES};
 use crate::work_surface::agents::AgentId;
 
-/// How long a single connection may take to deliver its request before it is dropped.
+/// How long a single blocking read may wait for *some* data to arrive.
+///
+/// This alone is not a bound on the request: see [`REQUEST_DEADLINE`].
 const READ_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// The wall-clock budget for one entire request, start to finish.
+///
+/// [`READ_TIMEOUT`] is a socket option (`SO_RCVTIMEO`) and therefore bounds each individual
+/// `recv`, not the request - every byte that arrives resets it. A client dripping one byte just
+/// inside that window, never sending a newline, keeps a handler thread alive for
+/// `MAX_HEAD_BYTES * READ_TIMEOUT` - hours - and doing that on [`MAX_IN_FLIGHT`] connections
+/// starves every real hook for as long as it cares to. Worse, it costs nothing to mount: the
+/// token is not checked until the headers have been read, so this is reachable *pre-auth*.
+///
+/// So every read is additionally bounded by an absolute deadline taken once per connection, and
+/// each blocking read's timeout is clamped to the time actually left. Five seconds is generous
+/// for a loopback POST of a few hundred bytes from a `curl` on the same machine, and is the
+/// timeout the forwarder itself gives up at anyway (`--max-time 5`), so a request still running
+/// past this has already lost its client.
+const REQUEST_DEADLINE: Duration = Duration::from_secs(5);
 
 /// Cap on the request line plus all headers. Real Claude Code hook requests carry a handful of
 /// short headers; anything approaching this is either broken or hostile.
@@ -73,6 +96,16 @@ const MAX_IN_FLIGHT: usize = 16;
 
 /// The header the forwarder puts the token in.
 const AUTH_HEADER: &str = "authorization";
+
+/// Most agents [`HookInbox`] will track at once - see [`HookInbox::record`].
+///
+/// Far above any real usage (each entry is one live agent pane) and far below anything that
+/// matters for memory, which is the right place for a bound whose only job is to stop unbounded
+/// growth.
+const MAX_TRACKED_AGENTS: usize = 512;
+
+/// How long [`HookListener::drop`]'s self-connect may block the dropping thread - see that impl.
+const SHUTDOWN_WAKE_TIMEOUT: Duration = Duration::from_millis(250);
 
 /// One agent's most recent hook fact, as stored for the rail to read.
 #[derive(Debug, Clone)]
@@ -103,8 +136,27 @@ impl HookInbox {
         self.latest.get(&id)
     }
 
-    /// Records a freshly parsed event as `id`'s current state.
+    /// Records a freshly parsed event as `id`'s current state, evicting the oldest entry if that
+    /// would push the inbox past [`MAX_TRACKED_AGENTS`].
+    ///
+    /// The cap exists because the id in a request is not checked against the set of live agents -
+    /// the listener has no view of that, and adding one would couple it to `AdeApp` state behind
+    /// a lock it would then hold on every request. So a client that knows the token (see the
+    /// module docs on what that does and does not defend) can name arbitrary ids, and without a
+    /// cap each one would allocate a permanent entry. Eviction is by arrival time, which keeps
+    /// the real agents - the ones actually emitting events - and sheds invented ids that never
+    /// report again.
     pub fn record(&mut self, id: AgentId, report: HookReport) {
+        if self.latest.len() >= MAX_TRACKED_AGENTS && !self.latest.contains_key(&id) {
+            if let Some(oldest) = self
+                .latest
+                .iter()
+                .min_by_key(|(_, record)| record.received_at)
+                .map(|(id, _)| *id)
+            {
+                self.latest.remove(&oldest);
+            }
+        }
         self.latest.insert(
             id,
             HookRecord {
@@ -118,6 +170,29 @@ impl HookInbox {
     /// [`AgentId`] can never inherit a dead agent's status.
     pub fn forget(&mut self, id: AgentId) {
         self.latest.remove(&id);
+    }
+}
+
+/// Holds one of the [`MAX_IN_FLIGHT`] connection slots, releasing it on drop.
+///
+/// An RAII guard rather than a `fetch_sub` at the end of the handler: the handler parses
+/// untrusted input, and a panic anywhere in it would skip a trailing decrement and leak the slot
+/// permanently. Sixteen such panics and the listener stops accepting anything, for the rest of
+/// the session, with no error path that would ever say so. No such panic exists today - every
+/// parse step returns `Option` - but "no panic today" is a property of the current code, whereas
+/// this is a property of the type.
+struct InFlightSlot(Arc<AtomicUsize>);
+
+impl InFlightSlot {
+    fn take(counter: Arc<AtomicUsize>) -> InFlightSlot {
+        counter.fetch_add(1, Ordering::Relaxed);
+        InFlightSlot(counter)
+    }
+}
+
+impl Drop for InFlightSlot {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::Relaxed);
     }
 }
 
@@ -168,18 +243,21 @@ impl HookListener {
                         let _ = stream.shutdown(Shutdown::Both);
                         continue;
                     }
-                    in_flight.fetch_add(1, Ordering::Relaxed);
+                    // The slot is released by `InFlightSlot`'s `Drop`, so a panic anywhere in
+                    // the handler returns it instead of leaking it - see that type's docs.
+                    let slot = InFlightSlot::take(Arc::clone(&in_flight));
                     let handler_token = thread_token.clone();
                     let handler_inbox = Arc::clone(&thread_inbox);
-                    let handler_in_flight = Arc::clone(&in_flight);
                     let spawned = std::thread::Builder::new()
                         .name("jerry-hook-conn".to_owned())
                         .spawn(move || {
+                            let _slot = slot;
                             handle_connection(stream, &handler_token, &handler_inbox);
-                            handler_in_flight.fetch_sub(1, Ordering::Relaxed);
                         });
-                    if spawned.is_err() {
-                        in_flight.fetch_sub(1, Ordering::Relaxed);
+                    if let Err(err) = spawned {
+                        // The slot was moved into the closure only on success; on failure it was
+                        // dropped with the un-spawned closure, which already released it.
+                        log::warn!("could not spawn a hook connection handler: {err}");
                     }
                 }
             })?;
@@ -248,12 +326,21 @@ impl HookListener {
 }
 
 impl Drop for HookListener {
+    /// Signals the accept loop to stop and wakes it so it notices.
+    ///
+    /// `incoming()` is blocking, so setting the flag alone would leave the thread parked in
+    /// `accept` until the next real connection; a self-connect is the portable way to wake it.
+    /// It uses `connect_timeout` rather than a plain `connect` because this runs on whichever
+    /// thread drops `AdeApp` - in practice the UI thread - and a bare loopback connect, though
+    /// almost always instant, has no upper bound the OS is obliged to honour.
+    ///
+    /// The accept thread is deliberately *not* joined. It exits on its own as soon as it observes
+    /// the flag, holding nothing but its own listener, and joining would trade a bounded wake-up
+    /// for an unbounded wait on the UI thread - the very thing the timeout above is avoiding.
     fn drop(&mut self) {
         self.shutdown.store(true, Ordering::Relaxed);
-        // Unblock the accept loop so the flag is actually observed: `incoming()` is blocking, so
-        // setting the flag alone would leave the thread parked in `accept` until the next real
-        // connection. A self-connect is the portable way to wake it.
-        let _ = TcpStream::connect(("127.0.0.1", self.port));
+        let address = SocketAddr::from(([127, 0, 0, 1], self.port));
+        let _ = TcpStream::connect_timeout(&address, SHUTDOWN_WAKE_TIMEOUT);
     }
 }
 
@@ -368,10 +455,14 @@ impl Response {
 
 /// Reads one request off `stream`, records whatever it turned out to be, and writes a response.
 fn handle_connection(mut stream: TcpStream, token: &str, inbox: &Arc<Mutex<HookInbox>>) {
+    // One absolute budget for the whole exchange, taken before the first byte is read - see
+    // `REQUEST_DEADLINE`.
+    let deadline = Instant::now() + REQUEST_DEADLINE;
     let _ = stream.set_read_timeout(Some(READ_TIMEOUT));
     let _ = stream.set_write_timeout(Some(READ_TIMEOUT));
 
-    let response = read_and_record(&mut stream, token, inbox).unwrap_or(Response::BadRequest);
+    let response =
+        read_and_record(&mut stream, token, inbox, deadline).unwrap_or(Response::BadRequest);
 
     // Always `Connection: close` and always a `Content-Length: 0` body, so a client that speaks
     // HTTP/1.1 keep-alive doesn't sit waiting for a body that isn't coming.
@@ -390,13 +481,14 @@ fn read_and_record(
     stream: &mut TcpStream,
     token: &str,
     inbox: &Arc<Mutex<HookInbox>>,
+    deadline: Instant,
 ) -> Option<Response> {
     let mut reader = BufReader::new(stream.try_clone().ok()?);
 
-    // -- request line, bounded --
+    // -- request line, bounded in bytes and in time --
     let mut request_line = String::new();
     let mut head_budget = MAX_HEAD_BYTES;
-    let read = read_line_bounded(&mut reader, &mut request_line, head_budget)?;
+    let read = read_line_bounded(&mut reader, &mut request_line, head_budget, deadline)?;
     head_budget = head_budget.saturating_sub(read);
 
     let mut parts = request_line.split_whitespace();
@@ -411,7 +503,7 @@ fn read_and_record(
     let mut authorization: Option<String> = None;
     for _ in 0..MAX_HEADERS {
         let mut line = String::new();
-        let read = read_line_bounded(&mut reader, &mut line, head_budget)?;
+        let read = read_line_bounded(&mut reader, &mut line, head_budget, deadline)?;
         head_budget = head_budget.saturating_sub(read);
         let trimmed = line.trim_end_matches(['\r', '\n']);
         if trimmed.is_empty() {
@@ -454,14 +546,11 @@ fn read_and_record(
         return Some(Response::PayloadTooLarge);
     }
     let mut body = vec![0u8; length];
-    // `read_exact` over a `take` so a `Content-Length` that overstates the real body dies on the
-    // read timeout instead of blocking forever, and one that understates it can't bleed the next
-    // request's bytes into this payload.
-    reader
-        .by_ref()
-        .take(length as u64)
-        .read_exact(&mut body)
-        .ok()?;
+    // Exactly `length` bytes and no more, so a `Content-Length` that understates the real body
+    // can't bleed the next request's bytes into this payload - and under the same absolute
+    // deadline, so one that *overstates* it (or a client that simply stops sending) fails fast
+    // instead of holding the handler for as long as the client keeps dripping.
+    read_exact_bounded(&mut reader, &mut body, deadline)?;
 
     let event_name = query_value(query, "event").unwrap_or_default();
     let agent_id: Option<AgentId> = query_value(query, "agent").and_then(|id| id.parse().ok());
@@ -477,26 +566,76 @@ fn read_and_record(
     Some(Response::NoContent)
 }
 
-/// [`BufRead::read_line`] with a hard byte budget, so a client that never sends a newline can't
-/// grow Jerry's memory without bound. Returns the bytes consumed.
+/// Time left before `deadline`, or `None` once it has passed.
+fn time_left(deadline: Instant) -> Option<Duration> {
+    let now = Instant::now();
+    (now < deadline).then(|| deadline - now)
+}
+
+/// Arms the socket so the *next* blocking read cannot outlast `deadline`, returning `None` once
+/// there is no time left.
+///
+/// Clamping to the remaining budget is what makes [`REQUEST_DEADLINE`] real rather than advisory:
+/// without it a drip-feeding client resets [`READ_TIMEOUT`] forever and no single read ever fails.
+fn arm_read(reader: &BufReader<TcpStream>, deadline: Instant) -> Option<()> {
+    let left = time_left(deadline)?;
+    reader
+        .get_ref()
+        .set_read_timeout(Some(left.min(READ_TIMEOUT)))
+        .ok()
+}
+
+/// Reads one `\n`-terminated line under both a byte budget and an absolute deadline. Returns the
+/// bytes consumed.
+///
+/// Reads a byte at a time deliberately. [`BufRead::read_until`] loops internally until it finds
+/// the delimiter, so the deadline could only be checked *after* it returned - which is exactly
+/// the hole a drip-feeding client walks through. Going byte by byte puts a deadline check between
+/// every byte; it is not a syscall per byte, because [`BufReader`] serves them from its buffer.
 fn read_line_bounded(
     reader: &mut BufReader<TcpStream>,
     out: &mut String,
     budget: usize,
+    deadline: Instant,
 ) -> Option<usize> {
-    let mut limited = reader.take(budget as u64);
     let mut raw = Vec::new();
-    let read = limited.read_until(b'\n', &mut raw).ok()?;
-    if read == 0 {
-        return None;
+    while raw.len() < budget {
+        arm_read(reader, deadline)?;
+        let mut byte = [0u8; 1];
+        match reader.read(&mut byte) {
+            // A clean EOF mid-line is a truncated request, not a complete one.
+            Ok(0) => return None,
+            Ok(_) => raw.push(byte[0]),
+            // A timeout lands here too, which is the deadline doing its job.
+            Err(_) => return None,
+        }
+        if byte[0] == b'\n' {
+            out.push_str(&String::from_utf8_lossy(&raw));
+            return Some(raw.len());
+        }
     }
-    // A line that exactly consumed the budget without a terminator is over-long: refuse rather
-    // than silently treating the truncation as a complete line.
-    if read == budget && !raw.ends_with(b"\n") {
-        return None;
+    // Budget exhausted with no terminator: over-long, so refuse rather than silently treating the
+    // truncation as a complete line.
+    None
+}
+
+/// Fills `buf` under an absolute deadline - [`Read::read_exact`]'s bounded counterpart, for the
+/// same reason [`read_line_bounded`] exists.
+fn read_exact_bounded(
+    reader: &mut BufReader<TcpStream>,
+    buf: &mut [u8],
+    deadline: Instant,
+) -> Option<()> {
+    let mut filled = 0;
+    while filled < buf.len() {
+        arm_read(reader, deadline)?;
+        match reader.read(&mut buf[filled..]) {
+            Ok(0) => return None,
+            Ok(read) => filled += read,
+            Err(_) => return None,
+        }
     }
-    out.push_str(&String::from_utf8_lossy(&raw));
-    Some(read)
+    Some(())
 }
 
 #[cfg(test)]
@@ -658,6 +797,121 @@ mod tests {
         );
         assert!(good.starts_with("HTTP/1.1 204"), "got {good:?}");
         assert_eq!(listener.signal_for(1).fact, Some(HookFact::TurnEnded));
+    }
+
+    #[test]
+    fn a_slow_drip_client_is_cut_off_by_the_deadline_instead_of_holding_a_handler() {
+        // The hole `REQUEST_DEADLINE` exists to close, and one the existing hostile-request test
+        // structurally cannot catch because it sends everything in a single `write_all`:
+        // `SO_RCVTIMEO` bounds each `recv`, not the request, so a client dripping a byte just
+        // inside the window and never sending a newline resets the clock forever. Pre-auth, so
+        // it costs an attacker nothing.
+        let listener = HookListener::start().expect("listener");
+        let port = listener.port();
+
+        // Absolute bounds, deliberately not expressed in terms of `REQUEST_DEADLINE`: an
+        // assertion scaled by the very constant under test passes trivially when that constant is
+        // wrong, which is exactly how a test like this fails to catch the bug it was written for.
+        let mut stream = TcpStream::connect(("127.0.0.1", port)).expect("connect");
+        stream.set_read_timeout(Some(Duration::from_secs(30))).ok();
+        let started = Instant::now();
+        // Never a newline, so the request line never completes. Drips for up to 30s, which is far
+        // longer than the handler is allowed to wait.
+        let dripped = std::thread::spawn(move || {
+            for _ in 0..60 {
+                if stream.write_all(b"A").is_err() || stream.flush().is_err() {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(500));
+            }
+            let mut response = String::new();
+            let _ = stream.read_to_string(&mut response);
+            response
+        });
+
+        let response = dripped.join().expect("the drip thread must finish");
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed < Duration::from_secs(15),
+            "the handler must give up on a drip-feeding client, but the connection lived {elapsed:?}"
+        );
+        assert!(
+            response.is_empty() || response.starts_with("HTTP/1.1 400"),
+            "a request that never completed must not be accepted, got {response:?}"
+        );
+
+        // The listener must still be fully usable afterwards - the slot has to have been
+        // released, not leaked.
+        let good = post(
+            port,
+            listener.token(),
+            "event=Stop&agent=1",
+            r#"{"hook_event_name":"Stop"}"#,
+        );
+        assert!(good.starts_with("HTTP/1.1 204"), "got {good:?}");
+    }
+
+    #[test]
+    fn many_slow_clients_at_once_cannot_starve_a_real_hook() {
+        // The reason the deadline matters in practice: `MAX_IN_FLIGHT` drip-feeders holding every
+        // handler thread would silently stop every real Claude hook for as long as they liked.
+        let listener = HookListener::start().expect("listener");
+        let port = listener.port();
+
+        // Every slot occupied by a client that drips for ~25s and never completes a request.
+        let mut drips = Vec::new();
+        for _ in 0..MAX_IN_FLIGHT {
+            drips.push(std::thread::spawn(move || {
+                let Ok(mut stream) = TcpStream::connect(("127.0.0.1", port)) else {
+                    return;
+                };
+                for _ in 0..50 {
+                    if stream.write_all(b"A").is_err() {
+                        break;
+                    }
+                    let _ = stream.flush();
+                    std::thread::sleep(Duration::from_millis(500));
+                }
+            }));
+        }
+
+        // A fixed wait, longer than the handler deadline but well inside the drippers' lifetime,
+        // so the only way real traffic gets served here is if the handlers really did give up.
+        // Absolute rather than derived from `REQUEST_DEADLINE` - see the sibling test.
+        std::thread::sleep(Duration::from_secs(9));
+        let good = post(
+            port,
+            listener.token(),
+            "event=Stop&agent=99",
+            r#"{"hook_event_name":"Stop"}"#,
+        );
+        assert!(
+            good.starts_with("HTTP/1.1 204"),
+            "a real hook must still be served while slow clients are connected, got {good:?}"
+        );
+        assert_eq!(listener.signal_for(99).fact, Some(HookFact::TurnEnded));
+
+        for drip in drips {
+            let _ = drip.join();
+        }
+    }
+
+    #[test]
+    fn the_inbox_is_capped_so_invented_agent_ids_cannot_grow_it_without_bound() {
+        let mut inbox = HookInbox::default();
+        let report = crate::hooks::event::parse("Stop", br#"{"hook_event_name":"Stop"}"#)
+            .expect("must parse");
+        for id in 0..(MAX_TRACKED_AGENTS as u64 + 50) {
+            inbox.record(id, report.clone());
+        }
+        assert_eq!(
+            inbox.latest.len(),
+            MAX_TRACKED_AGENTS,
+            "the inbox must not grow past its cap"
+        );
+        // Eviction is oldest-first, so the most recent ids - the ones still reporting - survive.
+        assert!(inbox.get(MAX_TRACKED_AGENTS as u64 + 49).is_some());
+        assert!(inbox.get(0).is_none());
     }
 
     #[test]

--- a/crates/app/src/hooks/settings_file.rs
+++ b/crates/app/src/hooks/settings_file.rs
@@ -77,6 +77,10 @@ pub const TOKEN_ENV: &str = "JERRY_HOOK_TOKEN";
 /// Env var carrying the pane's `crate::work_surface::agents::AgentId`.
 pub const AGENT_ENV: &str = "JERRY_AGENT_ID";
 
+/// Name prefix of every launch directory - see [`create_private_dir`] and
+/// [`sweep_stale_directories`], which are the two places that have to agree on it.
+const DIRECTORY_PREFIX: &str = "jerry-hooks-";
+
 /// The forwarder script's file name inside the launch directory.
 const FORWARDER_NAME: &str = "jerry-hook-forwarder.sh";
 /// The generated settings file's name inside the launch directory.
@@ -128,35 +132,18 @@ impl HookFiles {
     /// `--settings`, so a `claude` the user starts from their own terminal is completely
     /// untouched by Jerry having been installed.
     pub fn write_in(parent: &Path) -> io::Result<HookFiles> {
-        // Process id *and* a process-global counter, exactly like
-        // `crate::review::baseline_state::ReviewBaselineState::save_at`'s temp-file naming and for
-        // the identical reason: several `AdeApp` instances genuinely share one process (GitHub
-        // issue #90's "New Window", and every test that builds more than one app). A pid-only name
-        // would make all of them share one directory - so the second instance's `write_in` would
-        // delete the first's files out from under its running agents, and whichever instance
-        // closed first would remove the directory the other was still using, silently killing its
-        // hooks for the rest of the session.
-        static INSTANCE_COUNTER: std::sync::atomic::AtomicU64 =
-            std::sync::atomic::AtomicU64::new(0);
-        let instance = INSTANCE_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let directory = parent.join(format!("jerry-hooks-{}-{instance}", std::process::id()));
-        // A stale directory left by a dead process that happened to reuse this pid is removed
-        // rather than merged into, so a leftover file can never be reused with a dead launch's
-        // token.
-        let _ = std::fs::remove_dir_all(&directory);
-        std::fs::create_dir_all(&directory)?;
-        restrict_to_owner(&directory, 0o700)?;
+        // Tidy away anything a previously crashed Jerry left here. Best-effort and never fatal.
+        sweep_stale_directories(parent);
+
+        let directory = create_private_dir(parent)?;
 
         let forwarder = directory.join(FORWARDER_NAME);
-        std::fs::write(&forwarder, FORWARDER_SCRIPT)?;
-        // Executable, but only by this user - the settings file next to it holds the token.
-        restrict_to_owner(&forwarder, 0o700)?;
+        // Executable, but only by this user.
+        write_private_file(&forwarder, FORWARDER_SCRIPT.as_bytes(), 0o700)?;
 
         let settings = directory.join(SETTINGS_NAME);
-        std::fs::write(&settings, settings_json(&forwarder)?)?;
-        // Not executable, and readable only by this user: this file names the forwarder, and the
-        // directory it lives in is the thing an attacker would want to tamper with.
-        restrict_to_owner(&settings, 0o600)?;
+        // Not executable, and readable only by this user.
+        write_private_file(&settings, settings_json(&forwarder)?.as_bytes(), 0o600)?;
 
         Ok(HookFiles {
             directory,
@@ -175,17 +162,162 @@ impl Drop for HookFiles {
     }
 }
 
-/// Sets owner-only permissions on Unix. A no-op elsewhere - see [`is_supported`] for why this
-/// path isn't reached on Windows at all.
-#[cfg(unix)]
-fn restrict_to_owner(path: &Path, mode: u32) -> io::Result<()> {
-    use std::os::unix::fs::PermissionsExt;
-    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
+/// Creates this instance's launch directory: unpredictably named, owner-only from the instant it
+/// exists, and refusing to reuse anything already at that path.
+///
+/// All three properties are load-bearing, and an earlier version of this had none of them. It
+/// built a fully predictable name (`jerry-hooks-<pid>-<counter>`) under the world-writable OS temp
+/// directory, called `create_dir_all`, and only *then* chmod'ed to `0o700`. That is two real bugs:
+///
+/// - **A permissions window.** `mkdir` applies `0o777 & !umask`, so under a permissive umask
+///   (`002`, `000` - both real in the wild) the directory was group- or world-writable for the
+///   window between creation and the chmod.
+/// - **A symlink attack, which is the serious one.** `create_dir_all` on a path that is already a
+///   symlink to a directory returns `Ok`, and `set_permissions` follows symlinks. So a local
+///   attacker who pre-created `<temp>/jerry-hooks-<pid>-0` as a symlink - trivial, since every
+///   component of the name was predictable - got the forwarder script written into, and `0o700`
+///   applied to, a directory of their choosing. Verified empirically before fixing.
+///
+/// The fix is to make creation itself atomic and exclusive rather than to repair the state after:
+/// [`std::fs::DirBuilder`] with an explicit `mode` applies the permissions in the `mkdir` syscall
+/// (umask can only *remove* bits, so the result is never more permissive than `0o700`), and
+/// `create` - unlike `recursive(true)` - fails with `AlreadyExists` if anything is already at the
+/// path, symlink included. A random suffix then removes the predictability that made pre-creation
+/// worth attempting at all, and the retry loop covers the (vanishing) chance of a collision.
+///
+/// The pid stays in the name so [`sweep_stale_directories`] can still tell a dead instance's
+/// leftovers from a live instance's working directory.
+fn create_private_dir(parent: &Path) -> io::Result<PathBuf> {
+    std::fs::create_dir_all(parent)?;
+    let mut last_error = None;
+    for _ in 0..16 {
+        let directory = parent.join(format!(
+            "{DIRECTORY_PREFIX}{}-{}",
+            std::process::id(),
+            random_suffix()
+        ));
+        match new_dir_owner_only(&directory) {
+            Ok(()) => return Ok(directory),
+            Err(err) => last_error = Some(err),
+        }
+    }
+    Err(last_error.unwrap_or_else(|| io::Error::other("could not create a private hook directory")))
 }
 
+/// `mkdir(path, 0o700)`, failing if anything already exists at `path`.
+#[cfg(unix)]
+fn new_dir_owner_only(path: &Path) -> io::Result<()> {
+    use std::os::unix::fs::DirBuilderExt;
+    std::fs::DirBuilder::new().mode(0o700).create(path)
+}
+
+/// Windows has no `mode`; hook injection is disabled there anyway ([`is_supported`]), so this
+/// exists only to keep the module compiling.
 #[cfg(not(unix))]
-fn restrict_to_owner(_path: &Path, _mode: u32) -> io::Result<()> {
-    Ok(())
+fn new_dir_owner_only(path: &Path) -> io::Result<()> {
+    std::fs::DirBuilder::new().create(path)
+}
+
+/// Writes `contents` to a newly created file with `mode`, refusing to follow or overwrite
+/// anything already at `path`.
+///
+/// `create_new` is `O_EXCL | O_CREAT`, which fails on an existing file *and* on a symlink rather
+/// than writing through it, and the mode is applied by `open` itself rather than by a later
+/// chmod - the same "atomic, not repaired afterwards" reasoning as [`create_private_dir`]. The
+/// containing directory is already `0o700` and unpredictably named by the time this runs, so this
+/// is defence in depth rather than the primary barrier.
+fn write_private_file(path: &Path, contents: &[u8], mode: u32) -> io::Result<()> {
+    use std::io::Write;
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(mode);
+    }
+    #[cfg(not(unix))]
+    let _ = mode;
+    let mut file = options.open(path)?;
+    file.write_all(contents)?;
+    file.sync_all()
+}
+
+/// Removes launch directories left behind by Jerry instances that are no longer running.
+///
+/// [`HookFiles::drop`] handles the normal case, but `Drop` does not run for a `SIGKILL`, a hard
+/// crash, or an `abort` - so without this, every abnormal exit leaves a small directory in the OS
+/// temp directory forever. Called once per [`HookFiles::write_in`], which is the only moment
+/// Jerry is guaranteed to be looking at this directory anyway.
+///
+/// Liveness is decided by the pid embedded in the name, *not* by age. An age-based sweep - the
+/// convention this codebase uses for its `*.tmp` siblings - would be wrong here: a Jerry left open
+/// for a week is entirely normal, and deleting its forwarder script out from under its running
+/// agents would silently kill their hooks, which is precisely the bug the per-instance directory
+/// naming exists to prevent.
+///
+/// Everything is best-effort. A directory whose name doesn't parse, or that belongs to a live
+/// process, or that refuses to delete (another user's, on a shared temp directory) is simply left
+/// alone - this is tidying, and it must never be able to fail a launch.
+fn sweep_stale_directories(parent: &Path) {
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return;
+    };
+    let own_pid = std::process::id();
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        let Some(rest) = name.strip_prefix(DIRECTORY_PREFIX) else {
+            continue;
+        };
+        // `<pid>-<random>`; anything else was not written by this code.
+        let Some((pid, _)) = rest.split_once('-') else {
+            continue;
+        };
+        let Ok(pid) = pid.parse::<u32>() else {
+            continue;
+        };
+        if pid == own_pid || process_is_alive(pid) {
+            continue;
+        }
+        if !entry.file_type().is_ok_and(|kind| kind.is_dir()) {
+            continue;
+        }
+        let _ = std::fs::remove_dir_all(entry.path());
+    }
+}
+
+/// Whether a process with this id currently exists.
+///
+/// `kill(pid, 0)` is the portable POSIX existence check - it sends no signal and only reports
+/// whether the process exists and could be signalled. `EPERM` counts as alive: the process is
+/// real, it simply belongs to another user, which is a case that genuinely occurs on a shared
+/// `/tmp` and must not be read as "dead, delete its files".
+#[cfg(unix)]
+fn process_is_alive(pid: u32) -> bool {
+    // SAFETY: `kill` with signal 0 performs only an existence/permission check. It has no effect
+    // on the target process, and takes no pointers, so there is nothing to invalidate.
+    let result = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    if result == 0 {
+        return true;
+    }
+    io::Error::last_os_error().kind() == io::ErrorKind::PermissionDenied
+}
+
+/// Windows: hook injection is disabled ([`is_supported`]), so nothing is ever written to sweep.
+/// Reporting "alive" is the conservative answer - it deletes nothing.
+#[cfg(not(unix))]
+fn process_is_alive(_pid: u32) -> bool {
+    true
+}
+
+/// A short random, hex-encoded suffix - see [`create_private_dir`].
+fn random_suffix() -> String {
+    use rand::RngCore;
+    let mut bytes = [0u8; 8];
+    rand::rng().fill_bytes(&mut bytes);
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
 }
 
 /// Whether Jerry can install hooks on this platform at all.
@@ -302,6 +434,152 @@ mod tests {
                 "the settings file must be owner-read/write only"
             );
         }
+    }
+
+    #[test]
+    fn a_pre_planted_symlink_cannot_capture_the_generated_files() {
+        // The real attack the old `create_dir_all` + chmod sequence allowed: the directory name
+        // was fully predictable, `create_dir_all` returns `Ok` on an existing symlink-to-dir, and
+        // `set_permissions` follows it - so a local attacker got Jerry's forwarder script written
+        // into, and 0o700 applied to, a directory of their choosing.
+        //
+        // Two properties now block that, and this asserts both: the name is unpredictable, and
+        // creation is exclusive (`mkdir` fails rather than reusing whatever is already there).
+        if !cfg!(unix) {
+            return;
+        }
+        let temp = tempfile::tempdir().expect("temp dir");
+        let parent = temp.path().join("parent");
+        let attacker = temp.path().join("attacker-owned");
+        std::fs::create_dir_all(&parent).expect("parent");
+        std::fs::create_dir_all(&attacker).expect("attacker dir");
+
+        // Plant symlinks over every name the old scheme would have used.
+        #[cfg(unix)]
+        for instance in 0..4 {
+            let planted = parent.join(format!(
+                "{DIRECTORY_PREFIX}{}-{instance}",
+                std::process::id()
+            ));
+            std::os::unix::fs::symlink(&attacker, &planted).expect("plant symlink");
+        }
+
+        let files = HookFiles::write_in(&parent).expect("must still succeed");
+
+        // Nothing may have been written through a symlink into the attacker's directory.
+        let captured: Vec<_> = std::fs::read_dir(&attacker)
+            .expect("read attacker dir")
+            .flatten()
+            .map(|entry| entry.file_name())
+            .collect();
+        assert!(
+            captured.is_empty(),
+            "files were captured by a planted symlink: {captured:?}"
+        );
+
+        // And the real directory must be a genuine directory, not a symlink.
+        let metadata = std::fs::symlink_metadata(&files.directory).expect("stat");
+        assert!(
+            metadata.file_type().is_dir() && !metadata.file_type().is_symlink(),
+            "the launch directory must be a real directory Jerry created itself"
+        );
+
+        // Pin the exclusivity property on its own, independently of the name being unpredictable -
+        // an attacker who guessed the name anyway must still get a hard error rather than a
+        // captured directory. This is the assertion that would fail against the old
+        // `create_dir_all`, which returns `Ok` here.
+        #[cfg(unix)]
+        {
+            let guessed = parent.join("guessed-name");
+            std::os::unix::fs::symlink(&attacker, &guessed).expect("plant");
+            let error = new_dir_owner_only(&guessed).expect_err("must refuse an existing path");
+            assert_eq!(
+                error.kind(),
+                io::ErrorKind::AlreadyExists,
+                "creation must be exclusive, never reuse-what's-there"
+            );
+            // Same for the files.
+            let planted_file = parent.join("planted-file");
+            std::os::unix::fs::symlink(attacker.join("captured.sh"), &planted_file).expect("plant");
+            let error = write_private_file(&planted_file, b"x", 0o600)
+                .expect_err("must refuse to write through a symlink");
+            assert_eq!(error.kind(), io::ErrorKind::AlreadyExists);
+            assert!(
+                !attacker.join("captured.sh").exists(),
+                "nothing may be written through the planted symlink"
+            );
+        }
+    }
+
+    #[test]
+    fn the_launch_directory_is_owner_only_from_the_moment_it_exists() {
+        if !cfg!(unix) {
+            return;
+        }
+        let temp = tempfile::tempdir().expect("temp dir");
+        let files = HookFiles::write_in(temp.path()).expect("files");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = files.directory.metadata().unwrap().permissions().mode() & 0o777;
+            assert_eq!(
+                mode, 0o700,
+                "the launch directory must never be group- or world-accessible"
+            );
+        }
+    }
+
+    #[test]
+    fn a_dead_instance_s_directory_is_swept_but_a_live_one_s_is_left_alone() {
+        // `Drop` cannot run for a SIGKILLed Jerry, so without a sweep every hard crash leaves a
+        // directory behind forever. The sweep must be keyed on process liveness, not age: deleting
+        // a *live* instance's directory would remove the forwarder script out from under its
+        // running agents.
+        if !cfg!(unix) {
+            return;
+        }
+        let temp = tempfile::tempdir().expect("temp dir");
+
+        // pid 1 always exists; a "dead" pid that no longer does.
+        let live = temp.path().join(format!("{DIRECTORY_PREFIX}1-deadbeef"));
+        let dead = temp
+            .path()
+            .join(format!("{DIRECTORY_PREFIX}4294967294-cafebabe"));
+        // Something that simply isn't ours.
+        let unrelated = temp.path().join("someone-elses-directory");
+        for path in [&live, &dead, &unrelated] {
+            std::fs::create_dir_all(path).expect("create");
+            std::fs::write(path.join("marker"), b"x").expect("write");
+        }
+
+        sweep_stale_directories(temp.path());
+
+        assert!(
+            live.exists(),
+            "a live instance's directory must be left alone"
+        );
+        assert!(!dead.exists(), "a dead instance's directory must be swept");
+        assert!(
+            unrelated.exists(),
+            "unrelated entries must never be touched"
+        );
+    }
+
+    #[test]
+    fn the_sweep_never_removes_this_instance_s_own_directory() {
+        // The sweep runs from inside `write_in`, so getting this wrong would delete the files of
+        // the very instance that just asked for them - and of every sibling window in this process.
+        if !cfg!(unix) {
+            return;
+        }
+        let temp = tempfile::tempdir().expect("temp dir");
+        let first = HookFiles::write_in(temp.path()).expect("first");
+        let second = HookFiles::write_in(temp.path()).expect("second");
+        assert!(
+            first.settings_path().is_file(),
+            "the first instance's files must survive the second's startup sweep"
+        );
+        assert!(second.settings_path().is_file());
     }
 
     #[test]

--- a/crates/app/src/hooks/settings_file.rs
+++ b/crates/app/src/hooks/settings_file.rs
@@ -238,6 +238,25 @@ fn write_private_file(path: &Path, contents: &[u8], mode: u32) -> io::Result<()>
     #[cfg(not(unix))]
     let _ = mode;
     let mut file = options.open(path)?;
+
+    // `open`'s mode is masked by the process umask, which can *remove* bits the file genuinely
+    // needs. That is harmless for the 0o600 settings file (umask only ever makes it stricter),
+    // but not for the 0o700 forwarder: a umask with owner bits set - 0o100 and 0o700 are unusual
+    // but entirely legal - creates it non-executable, Claude Code's shell invocation exits 126,
+    // and hooks then silently never fire, with the rail quietly falling back to the Phase 1
+    // heuristics and no error anywhere. Verified: under umask 0o100, `open(.., 0o700)` yields
+    // 0o600, and this `fchmod` restores 0o700.
+    //
+    // Safe to do *after* creation, unlike the chmod-after-`create_dir_all` this module used to
+    // do: `File::set_permissions` is `fchmod` on a descriptor already exclusively owned (the file
+    // was just created with `O_EXCL`), so no path is re-resolved and there is no symlink or
+    // TOCTOU window to reopen - the C2 race came from re-resolving a *path*, not from ordering.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        file.set_permissions(std::fs::Permissions::from_mode(mode))?;
+    }
+
     file.write_all(contents)?;
     file.sync_all()
 }
@@ -443,8 +462,13 @@ mod tests {
         // `set_permissions` follows it - so a local attacker got Jerry's forwarder script written
         // into, and 0o700 applied to, a directory of their choosing.
         //
-        // Two properties now block that, and this asserts both: the name is unpredictable, and
-        // creation is exclusive (`mkdir` fails rather than reusing whatever is already there).
+        // Asserted directly against the creation primitives rather than by planting symlinks at
+        // the names the *old* scheme would have picked: under the random suffix those names can
+        // never be chosen, so such a test would pass without exercising anything. What actually
+        // has to hold is that creation is exclusive - an attacker who guesses the name anyway
+        // still gets a hard error instead of a captured directory - and that is what this pins.
+        // Both assertions below fail against the old `create_dir_all`/`fs::write`, which return
+        // `Ok` here and write straight through the symlink.
         if !cfg!(unix) {
             return;
         }
@@ -454,40 +478,6 @@ mod tests {
         std::fs::create_dir_all(&parent).expect("parent");
         std::fs::create_dir_all(&attacker).expect("attacker dir");
 
-        // Plant symlinks over every name the old scheme would have used.
-        #[cfg(unix)]
-        for instance in 0..4 {
-            let planted = parent.join(format!(
-                "{DIRECTORY_PREFIX}{}-{instance}",
-                std::process::id()
-            ));
-            std::os::unix::fs::symlink(&attacker, &planted).expect("plant symlink");
-        }
-
-        let files = HookFiles::write_in(&parent).expect("must still succeed");
-
-        // Nothing may have been written through a symlink into the attacker's directory.
-        let captured: Vec<_> = std::fs::read_dir(&attacker)
-            .expect("read attacker dir")
-            .flatten()
-            .map(|entry| entry.file_name())
-            .collect();
-        assert!(
-            captured.is_empty(),
-            "files were captured by a planted symlink: {captured:?}"
-        );
-
-        // And the real directory must be a genuine directory, not a symlink.
-        let metadata = std::fs::symlink_metadata(&files.directory).expect("stat");
-        assert!(
-            metadata.file_type().is_dir() && !metadata.file_type().is_symlink(),
-            "the launch directory must be a real directory Jerry created itself"
-        );
-
-        // Pin the exclusivity property on its own, independently of the name being unpredictable -
-        // an attacker who guessed the name anyway must still get a hard error rather than a
-        // captured directory. This is the assertion that would fail against the old
-        // `create_dir_all`, which returns `Ok` here.
         #[cfg(unix)]
         {
             let guessed = parent.join("guessed-name");
@@ -496,9 +486,9 @@ mod tests {
             assert_eq!(
                 error.kind(),
                 io::ErrorKind::AlreadyExists,
-                "creation must be exclusive, never reuse-what's-there"
+                "directory creation must be exclusive, never reuse-what's-there"
             );
-            // Same for the files.
+
             let planted_file = parent.join("planted-file");
             std::os::unix::fs::symlink(attacker.join("captured.sh"), &planted_file).expect("plant");
             let error = write_private_file(&planted_file, b"x", 0o600)
@@ -509,6 +499,78 @@ mod tests {
                 "nothing may be written through the planted symlink"
             );
         }
+
+        // A real run alongside that junk must still succeed, and must produce a genuine directory
+        // rather than anything it adopted from the parent.
+        let files = HookFiles::write_in(&parent).expect("must still succeed");
+        let metadata = std::fs::symlink_metadata(&files.directory).expect("stat");
+        assert!(
+            metadata.file_type().is_dir() && !metadata.file_type().is_symlink(),
+            "the launch directory must be a real directory Jerry created itself"
+        );
+        let captured: Vec<_> = std::fs::read_dir(&attacker)
+            .expect("read attacker dir")
+            .flatten()
+            .map(|entry| entry.file_name())
+            .collect();
+        assert!(
+            captured.is_empty(),
+            "nothing may have reached the attacker's directory: {captured:?}"
+        );
+    }
+
+    #[test]
+    fn a_written_file_gets_exactly_the_mode_asked_for_not_the_umask_s_opinion_of_it() {
+        // `open`'s mode argument is masked by the umask, which can *remove* bits the file needs.
+        // For the 0o700 forwarder that is a silent failure with real consequences: under a umask
+        // with owner bits set (0o100 is unusual but entirely legal) it would be created
+        // non-executable, Claude Code's shell invocation would exit 126, and hooks would simply
+        // never fire - the rail falling back to the Phase 1 heuristics with nothing reporting an
+        // error anywhere. `write_private_file` therefore `fchmod`s the descriptor it already owns.
+        //
+        // Deliberately *not* tested by setting the process umask: it is process-wide, `cargo test`
+        // runs these in threads, and an earlier version of this test that did so caused spurious
+        // `PermissionDenied` failures in unrelated tests running concurrently.
+        //
+        // Instead it asks for a mode that any ordinary umask would strip something from (0o022 and
+        // 0o002 are the common defaults, and both strip bits from 0o777) and requires it back
+        // exactly. Without the `fchmod` this yields 0o755 under the usual 0o022 and fails; the
+        // only umask it cannot discriminate under is 0o000, where there is nothing to strip.
+        if !cfg!(unix) {
+            return;
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let temp = tempfile::tempdir().expect("temp dir");
+            let path = temp.path().join("mode-probe");
+            write_private_file(&path, b"x", 0o777).expect("write");
+            let mode = path.metadata().unwrap().permissions().mode() & 0o777;
+            assert_eq!(
+                mode, 0o777,
+                "the requested mode must survive the umask, got {mode:o}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_generated_forwarder_is_directly_executable() {
+        // The property the 0o700 mode exists for, asserted end-to-end rather than as bits: if
+        // this ever regresses, Claude Code's invocation of the hook exits 126 and every hook
+        // silently stops firing.
+        if !cfg!(unix) {
+            return;
+        }
+        let temp = tempfile::tempdir().expect("temp dir");
+        let files = HookFiles::write_in(temp.path()).expect("files");
+        let forwarder = files.settings_path().with_file_name(FORWARDER_NAME);
+        let output = std::process::Command::new(&forwarder)
+            .arg("Stop")
+            .env_remove(PORT_ENV)
+            .stdin(std::process::Stdio::null())
+            .output()
+            .expect("the forwarder must be directly executable, not merely readable");
+        assert!(output.status.success());
     }
 
     #[test]

--- a/crates/app/src/hooks/settings_file.rs
+++ b/crates/app/src/hooks/settings_file.rs
@@ -1,0 +1,503 @@
+//! Generating the real `--settings` file and forwarder script Jerry hands a spawned `claude`
+//! (GitHub issue #239, phase 2).
+//!
+//! ## `--settings` merges hook arrays, it does not replace them - verified, not assumed
+//!
+//! The dangerous version of this feature is the one where Jerry's generated settings file
+//! silently disables hooks the *user* configured. That would be a real regression: someone's
+//! formatter-on-write or commit-guard hook quietly stopping the moment they open the agent in
+//! Jerry, with no error and no clue why.
+//!
+//! So it was tested against a real `claude` binary (2.1.228) on a real scratch project rather
+//! than inferred from the docs, whose wording on the point is indirect. Three hooks were declared
+//! on the same `SessionStart` event at three different layers - user (`~/.claude/settings.json`,
+//! via a temp `HOME`), project (`.claude/settings.json`), and a Jerry-style `--settings` file
+//! outside the project - each appending a distinct marker to a file. A real session was run.
+//! **All three markers were written**: hook arrays are merged across every settings layer, and a
+//! `--settings` file adds to them rather than overriding them.
+//!
+//! That is why nothing here reads or splices the user's existing settings: doing so would be
+//! *worse* than useless. Claude Code already merges, so a Jerry file that also copied the user's
+//! hooks in would run every one of them twice.
+//!
+//! This is a real behavioural dependency on Claude Code, so it is pinned by a real test
+//! (`crate::hooks::integration_tests`) that runs the actual binary when one is installed.
+//!
+//! ## Why a script rather than an inline one-liner
+//!
+//! The settings file names one small script, written once per launch and shared by every hook
+//! entry and every agent, instead of embedding a shell pipeline in each of nine `command`
+//! strings. The nine entries then differ only by the event name they pass as `$1`, which keeps
+//! the quoting problem to exactly one place.
+//!
+//! ## Why the forwarder is dumb, and why that is the safety property
+//!
+//! It reads stdin, POSTs it verbatim, and exits 0. It parses no JSON - all extraction happens in
+//! Jerry's own Rust ([`crate::hooks::event`]) with a real parser, because a shell script picking
+//! fields out of untrusted JSON with `sed` is exactly how a payload becomes a command.
+//!
+//! Two properties are load-bearing:
+//!
+//! - **It no-ops outside Jerry.** If `JERRY_HOOK_PORT`/`JERRY_HOOK_TOKEN`/`JERRY_AGENT_ID` are
+//!   not all set, it exits 0 immediately, having done nothing. Those variables are injected on
+//!   the spawned process (see `crate::terminal::pane::TerminalSpec::env`), so they exist only
+//!   inside a pane Jerry spawned. If a user ever copies the generated command into their own
+//!   settings, or runs the script by hand, it does nothing at all rather than posting their
+//!   session's payloads at whatever now answers on that port.
+//! - **It always exits 0.** A hook's exit code is not advisory - exit code 2 *blocks the tool
+//!   call*, and any other non-zero code surfaces a "hook error" to the user. If Jerry has since
+//!   quit, or the port is dead, or `curl` isn't installed, the agent must carry on completely
+//!   unaffected. `curl`'s status is therefore discarded rather than propagated: the worst
+//!   outcome of a broken listener is that Jerry falls back to the Phase 1 heuristics, never that
+//!   the user's agent stops working.
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// The hook events Jerry declares. Every one is a real, current Claude Code event
+/// (<https://code.claude.com/docs/en/hooks>), and every one maps to a real
+/// [`crate::hooks::event::HookFact`] - Jerry declares nothing it does not act on, so a user
+/// inspecting the generated file sees exactly the surface Jerry actually uses.
+pub const FORWARDED_EVENTS: [&str; 9] = [
+    "SessionStart",
+    "UserPromptSubmit",
+    "PreToolUse",
+    "PostToolUse",
+    "PostToolUseFailure",
+    "PermissionRequest",
+    "Notification",
+    "Stop",
+    "StopFailure",
+];
+
+/// Env var carrying the loopback listener's real port.
+pub const PORT_ENV: &str = "JERRY_HOOK_PORT";
+/// Env var carrying this launch's auth token.
+pub const TOKEN_ENV: &str = "JERRY_HOOK_TOKEN";
+/// Env var carrying the pane's `crate::work_surface::agents::AgentId`.
+pub const AGENT_ENV: &str = "JERRY_AGENT_ID";
+
+/// The forwarder script's file name inside the launch directory.
+const FORWARDER_NAME: &str = "jerry-hook-forwarder.sh";
+/// The generated settings file's name inside the launch directory.
+const SETTINGS_NAME: &str = "jerry-hook-settings.json";
+
+/// The POSIX `sh` forwarder - see the module docs for why it is shaped exactly like this.
+///
+/// `$1` is the event name, supplied per hook entry by the generated settings file.
+const FORWARDER_SCRIPT: &str = r#"#!/bin/sh
+# Written by Jerry (github.com/ColinEspinas/jerry) to forward Claude Code hook payloads to the
+# Jerry instance that spawned this agent. Safe to run anywhere: without the JERRY_* environment
+# variables Jerry injects on the panes it spawns, this exits immediately having done nothing.
+[ -n "$JERRY_HOOK_PORT" ] || exit 0
+[ -n "$JERRY_HOOK_TOKEN" ] || exit 0
+[ -n "$JERRY_AGENT_ID" ] || exit 0
+[ -n "$1" ] || exit 0
+command -v curl >/dev/null 2>&1 || exit 0
+
+# Never propagate curl's exit status: a non-zero hook exit blocks the agent's tool call (exit 2)
+# or shows the user a hook error. A dead listener must cost nothing.
+curl --silent --show-error --output /dev/null --max-time 5 \
+  --request POST \
+  --header "Authorization: Bearer $JERRY_HOOK_TOKEN" \
+  --header "Content-Type: application/json" \
+  --data-binary @- \
+  "http://127.0.0.1:$JERRY_HOOK_PORT/hook?event=$1&agent=$JERRY_AGENT_ID" >/dev/null 2>&1
+
+exit 0
+"#;
+
+/// The real on-disk files backing one Jerry launch's hook injection. Removed on drop.
+#[derive(Debug)]
+pub struct HookFiles {
+    directory: PathBuf,
+    settings: PathBuf,
+}
+
+impl HookFiles {
+    /// The path to pass as `claude --settings <path>`.
+    pub fn settings_path(&self) -> &Path {
+        &self.settings
+    }
+
+    /// Writes this launch's forwarder script and settings file into a fresh private directory.
+    ///
+    /// `parent` is the directory to create the launch directory inside - the OS temp directory in
+    /// production. Deliberately *not* `~/.claude/settings.json` or any path Claude Code reads on
+    /// its own: this file must only ever affect sessions Jerry itself spawned with an explicit
+    /// `--settings`, so a `claude` the user starts from their own terminal is completely
+    /// untouched by Jerry having been installed.
+    pub fn write_in(parent: &Path) -> io::Result<HookFiles> {
+        // Process id *and* a process-global counter, exactly like
+        // `crate::review::baseline_state::ReviewBaselineState::save_at`'s temp-file naming and for
+        // the identical reason: several `AdeApp` instances genuinely share one process (GitHub
+        // issue #90's "New Window", and every test that builds more than one app). A pid-only name
+        // would make all of them share one directory - so the second instance's `write_in` would
+        // delete the first's files out from under its running agents, and whichever instance
+        // closed first would remove the directory the other was still using, silently killing its
+        // hooks for the rest of the session.
+        static INSTANCE_COUNTER: std::sync::atomic::AtomicU64 =
+            std::sync::atomic::AtomicU64::new(0);
+        let instance = INSTANCE_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let directory = parent.join(format!("jerry-hooks-{}-{instance}", std::process::id()));
+        // A stale directory left by a dead process that happened to reuse this pid is removed
+        // rather than merged into, so a leftover file can never be reused with a dead launch's
+        // token.
+        let _ = std::fs::remove_dir_all(&directory);
+        std::fs::create_dir_all(&directory)?;
+        restrict_to_owner(&directory, 0o700)?;
+
+        let forwarder = directory.join(FORWARDER_NAME);
+        std::fs::write(&forwarder, FORWARDER_SCRIPT)?;
+        // Executable, but only by this user - the settings file next to it holds the token.
+        restrict_to_owner(&forwarder, 0o700)?;
+
+        let settings = directory.join(SETTINGS_NAME);
+        std::fs::write(&settings, settings_json(&forwarder)?)?;
+        // Not executable, and readable only by this user: this file names the forwarder, and the
+        // directory it lives in is the thing an attacker would want to tamper with.
+        restrict_to_owner(&settings, 0o600)?;
+
+        Ok(HookFiles {
+            directory,
+            settings,
+        })
+    }
+}
+
+impl Drop for HookFiles {
+    /// Removes the whole launch directory. Best-effort: a failure here is not worth surfacing (a
+    /// leftover directory in the OS temp directory is harmless - it holds no secret, since the
+    /// token lives only in this process's memory and its children's environments, never in these
+    /// files), and `Drop` cannot report one anyway.
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.directory);
+    }
+}
+
+/// Sets owner-only permissions on Unix. A no-op elsewhere - see [`is_supported`] for why this
+/// path isn't reached on Windows at all.
+#[cfg(unix)]
+fn restrict_to_owner(path: &Path, mode: u32) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
+}
+
+#[cfg(not(unix))]
+fn restrict_to_owner(_path: &Path, _mode: u32) -> io::Result<()> {
+    Ok(())
+}
+
+/// Whether Jerry can install hooks on this platform at all.
+///
+/// Unix only, and honestly so: the forwarder is a POSIX `sh` script, and Claude Code would need a
+/// different (`cmd`/PowerShell) forwarder plus different quoting on Windows. Rather than write a
+/// Windows path that has never been run against a real `claude`, hook injection is skipped there
+/// entirely and every agent falls back to the Phase 1 title/OSC and quiescence signals - which
+/// work identically on all platforms. This is a real, documented gap, not a silent failure.
+pub const fn is_supported() -> bool {
+    cfg!(unix)
+}
+
+/// Builds the real `--settings` JSON declaring every [`FORWARDED_EVENTS`] entry against
+/// `forwarder`.
+///
+/// Built with `serde_json` rather than string formatting so the script's path is escaped
+/// correctly no matter what it contains. The path is additionally single-quoted *within* the
+/// shell command string, because Claude Code runs a `command` hook through a shell - an unquoted
+/// path containing a space would otherwise be split into a wrong program plus stray arguments.
+fn settings_json(forwarder: &Path) -> io::Result<String> {
+    let quoted = shell_quote(&forwarder.to_string_lossy());
+    let mut hooks = serde_json::Map::new();
+    for event in FORWARDED_EVENTS {
+        hooks.insert(
+            event.to_string(),
+            serde_json::json!([{
+                "hooks": [{
+                    "type": "command",
+                    "command": format!("{quoted} {event}"),
+                }]
+            }]),
+        );
+    }
+    let document = serde_json::json!({ "hooks": serde_json::Value::Object(hooks) });
+    serde_json::to_string_pretty(&document)
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
+}
+
+/// Wraps `value` in POSIX single quotes, escaping any single quote inside it via the standard
+/// `'\''` idiom. Single quotes are used rather than double because inside them the shell expands
+/// nothing at all - so a path containing `$`, backticks or `\` is passed through literally.
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', r"'\''"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_generated_settings_declare_every_forwarded_event_against_the_real_script() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let files = HookFiles::write_in(temp.path()).expect("must write");
+
+        let raw = std::fs::read_to_string(files.settings_path()).expect("settings must exist");
+        let parsed: serde_json::Value = serde_json::from_str(&raw).expect("must be valid JSON");
+        let hooks = parsed
+            .get("hooks")
+            .and_then(serde_json::Value::as_object)
+            .expect("a hooks object");
+
+        assert_eq!(
+            hooks.len(),
+            FORWARDED_EVENTS.len(),
+            "Jerry must declare exactly the events it acts on, no more"
+        );
+        for event in FORWARDED_EVENTS {
+            let command = hooks
+                .get(event)
+                .and_then(|entries| entries.get(0))
+                .and_then(|entry| entry.get("hooks"))
+                .and_then(|entries| entries.get(0))
+                .and_then(|hook| hook.get("command"))
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_else(|| panic!("{event} must declare a command hook"));
+            assert!(
+                command.ends_with(&format!(" {event}")),
+                "{event}: the event name must be passed to the forwarder, got {command:?}"
+            );
+            assert!(
+                command.contains(FORWARDER_NAME),
+                "{event}: must point at the real generated script, got {command:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_generated_files_really_exist_and_the_script_is_executable() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let files = HookFiles::write_in(temp.path()).expect("must write");
+        assert!(files.settings_path().is_file());
+
+        let forwarder = files.settings_path().with_file_name(FORWARDER_NAME);
+        assert!(forwarder.is_file(), "the forwarder script must be written");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let script_mode = forwarder.metadata().unwrap().permissions().mode() & 0o777;
+            assert_eq!(
+                script_mode, 0o700,
+                "the script must be owner-only executable"
+            );
+            let settings_mode = files
+                .settings_path()
+                .metadata()
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(
+                settings_mode, 0o600,
+                "the settings file must be owner-read/write only"
+            );
+        }
+    }
+
+    #[test]
+    fn the_auth_token_is_never_written_into_any_generated_file() {
+        // The token lives only in this process's memory and in the environment of the children
+        // Jerry spawns - never on disk. That is what keeps a leaked or undeleted temp directory
+        // (a `SIGKILL`ed Jerry leaves one behind) from being a credential leak, and it is what
+        // `HookFiles::drop`'s "these files hold no secret" reasoning depends on. A refactor that
+        // moved the token into the settings file would silently invalidate both.
+        let temp = tempfile::tempdir().expect("temp dir");
+        let listener = crate::hooks::server::HookListener::start().expect("listener");
+        let token = listener.token().to_owned();
+        let files = HookFiles::write_in(temp.path()).expect("files");
+
+        let settings = std::fs::read_to_string(files.settings_path()).expect("read settings");
+        let forwarder =
+            std::fs::read_to_string(files.settings_path().with_file_name(FORWARDER_NAME))
+                .expect("read forwarder");
+
+        assert!(
+            !settings.contains(&token),
+            "the settings file must never contain the auth token"
+        );
+        assert!(
+            !forwarder.contains(&token),
+            "the forwarder script must never contain the auth token - it reads it from the environment"
+        );
+        // It must genuinely read the token from the environment instead.
+        assert!(
+            forwarder.contains(TOKEN_ENV),
+            "the forwarder must take the token from ${TOKEN_ENV}"
+        );
+    }
+
+    #[test]
+    fn two_instances_in_one_process_never_share_or_delete_each_other_s_files() {
+        // GitHub issue #90's "New Window" puts two real `AdeApp`s in one process. With a
+        // pid-only directory name they collided: the second's `write_in` deleted the first's
+        // files, and the first's `Drop` then removed the directory the second was still using -
+        // silently killing hook delivery for every agent in that window.
+        let temp = tempfile::tempdir().expect("temp dir");
+        let first = HookFiles::write_in(temp.path()).expect("first");
+        let second = HookFiles::write_in(temp.path()).expect("second");
+
+        assert_ne!(
+            first.directory, second.directory,
+            "two instances in one process must not share a launch directory"
+        );
+        assert!(first.settings_path().is_file());
+        assert!(second.settings_path().is_file());
+
+        let second_settings = second.settings_path().to_path_buf();
+        let second_forwarder = second_settings.with_file_name(FORWARDER_NAME);
+        drop(first);
+        assert!(
+            second_settings.is_file(),
+            "closing one window must not delete the other's settings file"
+        );
+        assert!(
+            second_forwarder.is_file(),
+            "closing one window must not delete the other's forwarder script"
+        );
+    }
+
+    #[test]
+    fn dropping_the_files_removes_the_whole_launch_directory() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let settings_path;
+        let directory;
+        {
+            let files = HookFiles::write_in(temp.path()).expect("must write");
+            settings_path = files.settings_path().to_path_buf();
+            directory = files.directory.clone();
+            assert!(settings_path.exists());
+        }
+        assert!(
+            !settings_path.exists(),
+            "the generated settings file must not outlive the launch"
+        );
+        assert!(!directory.exists(), "the launch directory must be removed");
+    }
+
+    #[test]
+    fn the_forwarder_no_ops_without_jerry_env_vars_and_never_reports_failure() {
+        // The property that makes the generated command safe to run outside Jerry (see the module
+        // docs). Run the real script, with a real JSON payload on stdin, with no JERRY_* set.
+        if !cfg!(unix) {
+            return;
+        }
+        let temp = tempfile::tempdir().expect("temp dir");
+        let files = HookFiles::write_in(temp.path()).expect("must write");
+        let forwarder = files.settings_path().with_file_name(FORWARDER_NAME);
+
+        let output = std::process::Command::new("/bin/sh")
+            .arg(&forwarder)
+            .arg("Stop")
+            .env_remove(PORT_ENV)
+            .env_remove(TOKEN_ENV)
+            .env_remove(AGENT_ENV)
+            .stdin(std::process::Stdio::null())
+            .output()
+            .expect("the forwarder must be runnable");
+        assert!(
+            output.status.success(),
+            "the forwarder must exit 0 outside Jerry, got {:?}",
+            output.status
+        );
+        assert!(
+            output.stdout.is_empty(),
+            "it must produce no output that Claude Code would feed back as context"
+        );
+    }
+
+    #[test]
+    fn the_forwarder_exits_zero_even_when_the_listener_is_dead() {
+        // A hook that exits non-zero blocks the agent's tool call. Jerry having quit must never
+        // do that, so this points the forwarder at a port nothing is listening on.
+        if !cfg!(unix) {
+            return;
+        }
+        let temp = tempfile::tempdir().expect("temp dir");
+        let files = HookFiles::write_in(temp.path()).expect("must write");
+        let forwarder = files.settings_path().with_file_name(FORWARDER_NAME);
+
+        // Bind and immediately drop, so the port is real but certainly closed.
+        let dead_port = {
+            let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("bind");
+            listener.local_addr().expect("addr").port()
+        };
+
+        let mut child = std::process::Command::new("/bin/sh")
+            .arg(&forwarder)
+            .arg("Stop")
+            .env(PORT_ENV, dead_port.to_string())
+            .env(TOKEN_ENV, "irrelevant")
+            .env(AGENT_ENV, "1")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn");
+        {
+            use std::io::Write;
+            let mut stdin = child.stdin.take().expect("stdin");
+            stdin.write_all(br#"{"hook_event_name":"Stop"}"#).ok();
+        }
+        let output = child.wait_with_output().expect("wait");
+        assert!(
+            output.status.success(),
+            "a dead listener must not fail the hook, got {:?}",
+            output.status
+        );
+        assert!(
+            output.stderr.is_empty(),
+            "a dead listener must not print a hook error for the user, got {:?}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[test]
+    fn a_path_with_shell_metacharacters_is_quoted_rather_than_split() {
+        assert_eq!(shell_quote("/tmp/plain"), "'/tmp/plain'");
+        assert_eq!(shell_quote("/tmp/with space"), "'/tmp/with space'");
+        assert_eq!(shell_quote("/tmp/$(evil)"), "'/tmp/$(evil)'");
+        assert_eq!(shell_quote("/tmp/it's"), r"'/tmp/it'\''s'");
+    }
+
+    #[test]
+    fn a_directory_with_a_space_still_produces_a_runnable_command() {
+        // The real reason `shell_quote` exists - an unquoted path here would make Claude Code run
+        // a program that doesn't exist.
+        let temp = tempfile::tempdir().expect("temp dir");
+        let spaced = temp.path().join("a directory with spaces");
+        std::fs::create_dir_all(&spaced).expect("create");
+        let files = HookFiles::write_in(&spaced).expect("must write");
+
+        let raw = std::fs::read_to_string(files.settings_path()).expect("read");
+        let parsed: serde_json::Value = serde_json::from_str(&raw).expect("valid JSON");
+        let command = parsed["hooks"]["Stop"][0]["hooks"][0]["command"]
+            .as_str()
+            .expect("a Stop command");
+        assert!(command.starts_with('\''), "got {command:?}");
+
+        if cfg!(unix) {
+            // Run the generated command string through a real shell to prove it resolves.
+            let output = std::process::Command::new("/bin/sh")
+                .arg("-c")
+                .arg(command)
+                .stdin(std::process::Stdio::null())
+                .output()
+                .expect("run");
+            assert!(
+                output.status.success(),
+                "the generated command must be runnable by a real shell: {:?}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+    }
+}

--- a/crates/app/src/hooks/store.rs
+++ b/crates/app/src/hooks/store.rs
@@ -43,6 +43,12 @@ use crate::rail::status::Status;
 /// `crate::review::baseline_state::REVIEW_BASELINE_FILE_NAME`.
 pub const AGENT_STATUS_FILE_NAME: &str = "agent-status.toml";
 
+/// How many agent records are kept - see [`AgentStatusState::prune_to_most_recent`].
+///
+/// Generous for a history UI (issue #227) while keeping the file small enough that rewriting it
+/// on every status change stays cheap.
+pub const MAX_RECORDED_AGENTS: usize = 500;
+
 /// The status file for a given real settings-file path - identical reasoning to
 /// `crate::review::baseline_state::review_baseline_path_for`: a test supplying a temp-dir
 /// settings path gets real, isolated persistence there, and a `None` settings path gets none.
@@ -190,6 +196,7 @@ impl AgentStatusState {
                     merged.agents.insert(key.clone(), entry.clone());
                 }
             }
+            merged.prune_to_most_recent(MAX_RECORDED_AGENTS);
             merged.save_at(path)
         })
     }
@@ -237,6 +244,34 @@ impl AgentStatusState {
     /// One recorded agent, if present and readable.
     pub fn get(&self, key: &str) -> Option<&PersistedAgentStatus> {
         self.agents.get(key)
+    }
+
+    /// Keeps only the `limit` most recently updated records, dropping the oldest.
+    ///
+    /// This file is history and never deletes a key on its own (see the module docs), which on its
+    /// own means unbounded growth: every agent ever run adds a permanent entry, and the whole file
+    /// is re-serialised and `fsync`ed - under the process-wide persistence lock - on every change.
+    /// A user who runs a few dozen agents a day would be rewriting an ever-larger file forever.
+    ///
+    /// Trimming by `updated_at_unix` keeps exactly what GitHub issue #227 would want to show
+    /// first - the most recent agents - and discards the tail no history UI would realistically
+    /// page back to. Applied at save time rather than on insert so a merge that pulls in another
+    /// instance's records is bounded too.
+    pub fn prune_to_most_recent(&mut self, limit: usize) {
+        if self.agents.len() <= limit {
+            return;
+        }
+        let mut by_recency: Vec<(String, i64)> = self
+            .agents
+            .iter()
+            .map(|(key, record)| (key.clone(), record.updated_at_unix))
+            .collect();
+        // Most recent first; the key breaks ties so the result is deterministic rather than
+        // dependent on iteration order for records written in the same second.
+        by_recency.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        for (key, _) in by_recency.into_iter().skip(limit) {
+            self.agents.remove(&key);
+        }
     }
 }
 
@@ -407,6 +442,62 @@ mod tests {
             AgentStatusState::load_at(&path).get(&key).is_some(),
             "a closed agent's record must not be deleted"
         );
+    }
+
+    #[test]
+    fn the_record_is_capped_keeping_the_most_recent_agents() {
+        // This file never deletes a key on its own (it is history), which without a cap means it
+        // grows forever and is fully re-serialised and fsynced on every change.
+        let mut state = AgentStatusState::default();
+        for index in 0..(MAX_RECORDED_AGENTS as i64 + 25) {
+            let key = key_for(&format!("/repo/wt-{index}"), index);
+            state.set(
+                key,
+                Path::new(&format!("/repo/wt-{index}")),
+                "Claude",
+                index,
+                Status::Idle,
+                None,
+                None,
+                index, // updated_at_unix ascending, so higher index == more recent
+            );
+        }
+        assert!(state.agents.len() > MAX_RECORDED_AGENTS);
+        state.prune_to_most_recent(MAX_RECORDED_AGENTS);
+        assert_eq!(state.agents.len(), MAX_RECORDED_AGENTS);
+
+        // The most recent survive; the oldest are the ones dropped.
+        let newest = key_for(
+            &format!("/repo/wt-{}", MAX_RECORDED_AGENTS as i64 + 24),
+            MAX_RECORDED_AGENTS as i64 + 24,
+        );
+        assert!(
+            state.get(&newest).is_some(),
+            "the newest record must be kept"
+        );
+        assert!(
+            state.get(&key_for("/repo/wt-0", 0)).is_none(),
+            "the oldest record must be the one pruned"
+        );
+    }
+
+    #[test]
+    fn pruning_a_file_already_under_the_cap_changes_nothing() {
+        let mut state = AgentStatusState::default();
+        let key = key_for("/repo/wt-a", 1);
+        state.set(
+            key.clone(),
+            Path::new("/repo/wt-a"),
+            "Claude",
+            1,
+            Status::Run,
+            None,
+            None,
+            10,
+        );
+        let before = state.clone();
+        state.prune_to_most_recent(MAX_RECORDED_AGENTS);
+        assert_eq!(state, before);
     }
 
     #[test]

--- a/crates/app/src/hooks/store.rs
+++ b/crates/app/src/hooks/store.rs
@@ -1,0 +1,440 @@
+//! Real, on-disk persistence for what Jerry learned about each agent from its hooks (GitHub
+//! issue #239, phase 2 - groundwork for issue #227).
+//!
+//! ## What this is for, and what it deliberately is not
+//!
+//! Issue #227 ("Agent history and resume/recover") wants to show past and closed agents and let a
+//! user resume them. That needs real, structured data about agents that are no longer running -
+//! and until hooks existed, Jerry had none worth persisting: a status derived from pty silence is
+//! a guess, and a guess written to disk is still a guess an hour later.
+//!
+//! A hook fact is different. "This agent finished its turn at 14:32, its last tool call was
+//! `Edit: src/auth.rs`" is a real, dated, structured statement the agent itself made. That is
+//! worth keeping, so this module keeps it as it is learned.
+//!
+//! **No UI reads this yet, and that is intentional** - browsing and resuming past agents is issue
+//! #227's job, not this phase's. This module exists so that work has real data to build on rather
+//! than having to invent a capture mechanism first. It is written, and it round-trips; nothing
+//! renders it.
+//!
+//! ## Everything about the file format mirrors `crate::review::baseline_state`
+//!
+//! Same directory (a sibling of the real `settings.toml`), same `BTreeMap` for a stable diffable
+//! file, same lossless `utf8:`/`bytes:` worktree encoding, same atomic write (temp sibling,
+//! `sync_all`, rename, directory sync), and the same merge-on-save under
+//! `crate::persisted_state_lock::with_locked_merge` so a second Jerry instance can't erase this
+//! one's records. The keys are even the same [`crate::review::state::baseline_key`] values, so a
+//! future issue #227 implementation can join a persisted status straight onto its review
+//! baseline without a translation table.
+//!
+//! Like `baseline_state` and unlike its other siblings, a key absent from memory is **not**
+//! deleted from disk on save: this is history, and an agent the user closed is exactly the agent
+//! issue #227 most wants to show.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::io;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::rail::status::Status;
+
+/// The status file's name, resolved next to the real `settings.toml` - mirrors
+/// `crate::review::baseline_state::REVIEW_BASELINE_FILE_NAME`.
+pub const AGENT_STATUS_FILE_NAME: &str = "agent-status.toml";
+
+/// The status file for a given real settings-file path - identical reasoning to
+/// `crate::review::baseline_state::review_baseline_path_for`: a test supplying a temp-dir
+/// settings path gets real, isolated persistence there, and a `None` settings path gets none.
+pub fn agent_status_path_for(settings_path: &Path) -> PathBuf {
+    match settings_path.parent() {
+        Some(parent) => parent.join(AGENT_STATUS_FILE_NAME),
+        None => PathBuf::from(AGENT_STATUS_FILE_NAME),
+    }
+}
+
+/// One agent's last known real state, as learned from its own hook events.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct PersistedAgentStatus {
+    /// Lossless worktree encoding - `crate::review::state::encode_worktree`.
+    pub worktree: String,
+    /// `crate::work_surface::agents::AgentKind::label`.
+    pub kind: String,
+    /// The agent's spawn second, the durable half of its identity (a live `AgentId` is
+    /// process-local and means nothing after a restart).
+    pub spawned_at_unix: i64,
+    /// The derived [`Status`], as a stable string key rather than the enum - so a future release
+    /// that adds a status can still read a file written by this one.
+    pub status: String,
+    /// The last hook-derived activity line, if any.
+    pub activity: Option<String>,
+    /// The last hook-derived question/permission text, if any.
+    pub question: Option<String>,
+    /// When this record was last updated.
+    pub updated_at_unix: i64,
+}
+
+impl PersistedAgentStatus {
+    /// The real worktree path, or `None` for a record this app didn't write.
+    pub fn worktree_path(&self) -> Option<PathBuf> {
+        crate::review::state::decode_worktree(&self.worktree)
+    }
+}
+
+/// The stable on-disk spelling of a [`Status`].
+///
+/// A dedicated mapping rather than `#[derive(Serialize)]` on [`Status`] itself: the file is a
+/// compatibility surface a future issue #227 release must still be able to read, and deriving it
+/// would silently couple the file format to an enum this codebase renames freely.
+pub fn status_key(status: Status) -> &'static str {
+    match status {
+        Status::Ask => "ask",
+        Status::Fail => "fail",
+        Status::Review => "review",
+        Status::Run => "run",
+        Status::Idle => "idle",
+    }
+}
+
+/// The inverse of [`status_key`] - `None` for anything this release doesn't know, which a reader
+/// treats as "unusable record" rather than guessing.
+pub fn status_from_key(key: &str) -> Option<Status> {
+    match key {
+        "ask" => Some(Status::Ask),
+        "fail" => Some(Status::Fail),
+        "review" => Some(Status::Review),
+        "run" => Some(Status::Run),
+        "idle" => Some(Status::Idle),
+        _ => None,
+    }
+}
+
+/// The whole on-disk file: every agent this app has recorded a real hook-derived status for.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct AgentStatusState {
+    pub agents: BTreeMap<String, PersistedAgentStatus>,
+}
+
+impl AgentStatusState {
+    /// Loads `path`, falling back to an empty state for any failure - the same "never important
+    /// enough to fail startup over" rule every sibling state file follows.
+    pub fn load_at(path: &Path) -> AgentStatusState {
+        let Ok(contents) = std::fs::read_to_string(path) else {
+            return AgentStatusState::default();
+        };
+        match toml::from_str::<AgentStatusState>(&contents) {
+            Ok(state) => state,
+            Err(err) => {
+                log::warn!(
+                    "{} failed to parse ({err}) - starting from no recorded agent statuses",
+                    path.display()
+                );
+                AgentStatusState::default()
+            }
+        }
+    }
+
+    /// Writes `self` to `path` atomically - a sibling `*.tmp`, `sync_all`, rename, directory
+    /// sync. Copied from `crate::review::baseline_state::ReviewBaselineState::save_at`, including
+    /// the `{file}.{pid}.{counter}.tmp` recipe (process id *and* a process-global counter,
+    /// because several `AdeApp` instances share one process).
+    pub fn save_at(&self, path: &Path) -> io::Result<()> {
+        use std::io::Write;
+
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let contents = toml::to_string_pretty(self)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+        let file_name = path
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| AGENT_STATUS_FILE_NAME.to_string());
+        static WRITE_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let unique = WRITE_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let temp = path.with_file_name(format!("{file_name}.{}.{unique}.tmp", std::process::id()));
+
+        let write_result = (|| -> io::Result<()> {
+            let mut file = std::fs::File::create(&temp)?;
+            file.write_all(contents.as_bytes())?;
+            file.sync_all()
+        })();
+        if let Err(err) = write_result {
+            let _ = std::fs::remove_file(&temp);
+            return Err(err);
+        }
+        if let Err(err) = std::fs::rename(&temp, path) {
+            let _ = std::fs::remove_file(&temp);
+            return Err(err);
+        }
+        if let Some(parent) = path.parent() {
+            if let Ok(dir) = std::fs::File::open(parent) {
+                let _ = dir.sync_all();
+            }
+        }
+        Ok(())
+    }
+
+    /// The app's real write path: merges the entries this instance owns into whatever is on disk,
+    /// then writes the result.
+    ///
+    /// Like `ReviewBaselineState::save_merged_at`, a key absent from `self` is left alone rather
+    /// than deleted - see the module docs on this being history.
+    pub fn save_merged_at(&self, path: &Path, owned: &BTreeSet<String>) -> io::Result<()> {
+        crate::persisted_state_lock::with_locked_merge(|| {
+            let mut merged = AgentStatusState::load_at(path);
+            for key in owned {
+                if let Some(entry) = self.agents.get(key) {
+                    merged.agents.insert(key.clone(), entry.clone());
+                }
+            }
+            merged.save_at(path)
+        })
+    }
+
+    /// Records one agent's real, current hook-derived state. Returns whether anything actually
+    /// changed, so a caller can skip an otherwise pointless disk write on every render.
+    #[allow(clippy::too_many_arguments)]
+    pub fn set(
+        &mut self,
+        key: String,
+        worktree: &Path,
+        kind: &str,
+        spawned_at_unix: i64,
+        status: Status,
+        activity: Option<String>,
+        question: Option<String>,
+        now_unix: i64,
+    ) -> bool {
+        let record = PersistedAgentStatus {
+            worktree: crate::review::state::encode_worktree(worktree),
+            kind: kind.to_owned(),
+            spawned_at_unix,
+            status: status_key(status).to_owned(),
+            activity,
+            question,
+            updated_at_unix: now_unix,
+        };
+        // Compare on everything except the timestamp: a status that hasn't changed must not
+        // rewrite the file (and re-fsync) purely because time passed.
+        let unchanged = self.agents.get(&key).is_some_and(|existing| {
+            existing.worktree == record.worktree
+                && existing.kind == record.kind
+                && existing.spawned_at_unix == record.spawned_at_unix
+                && existing.status == record.status
+                && existing.activity == record.activity
+                && existing.question == record.question
+        });
+        if unchanged {
+            return false;
+        }
+        self.agents.insert(key, record);
+        true
+    }
+
+    /// One recorded agent, if present and readable.
+    pub fn get(&self, key: &str) -> Option<&PersistedAgentStatus> {
+        self.agents.get(key)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::work_surface::agents::AgentKind;
+
+    fn key_for(worktree: &str, spawned: i64) -> String {
+        crate::review::state::baseline_key(Path::new(worktree), AgentKind::Claude, spawned)
+    }
+
+    #[test]
+    fn the_status_file_lives_next_to_the_real_settings_file() {
+        assert_eq!(
+            agent_status_path_for(Path::new("/home/someone/.config/jerry/settings.toml")),
+            PathBuf::from("/home/someone/.config/jerry/agent-status.toml")
+        );
+    }
+
+    #[test]
+    fn a_recorded_status_really_round_trips_through_a_real_file() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join(AGENT_STATUS_FILE_NAME);
+
+        let mut state = AgentStatusState::default();
+        let key = key_for("/repo/wt-a", 1_700_000_000);
+        assert!(state.set(
+            key.clone(),
+            Path::new("/repo/wt-a"),
+            "Claude",
+            1_700_000_000,
+            Status::Review,
+            Some("Edit: src/auth.rs".to_owned()),
+            None,
+            1_700_000_500,
+        ));
+
+        let owned: BTreeSet<String> = std::iter::once(key.clone()).collect();
+        state.save_merged_at(&path, &owned).expect("must save");
+        assert!(path.is_file(), "a real file must be written");
+
+        let reloaded = AgentStatusState::load_at(&path);
+        let record = reloaded.get(&key).expect("the record must survive");
+        assert_eq!(record.worktree_path(), Some(PathBuf::from("/repo/wt-a")));
+        assert_eq!(record.kind, "Claude");
+        assert_eq!(record.spawned_at_unix, 1_700_000_000);
+        assert_eq!(status_from_key(&record.status), Some(Status::Review));
+        assert_eq!(record.activity.as_deref(), Some("Edit: src/auth.rs"));
+        assert_eq!(record.question, None);
+        assert_eq!(record.updated_at_unix, 1_700_000_500);
+    }
+
+    #[test]
+    fn an_unchanged_status_reports_no_change_so_it_never_rewrites_the_file() {
+        // `set` is called from a render-frequency path; without this it would fsync constantly.
+        let mut state = AgentStatusState::default();
+        let key = key_for("/repo/wt-a", 10);
+        let args = |now| {
+            (
+                key.clone(),
+                Path::new("/repo/wt-a"),
+                "Claude",
+                10i64,
+                Status::Run,
+                Some("Bash: cargo test".to_owned()),
+                None,
+                now,
+            )
+        };
+        let (k, w, kind, spawned, status, activity, question, now) = args(100);
+        assert!(
+            state.set(k, w, kind, spawned, status, activity, question, now),
+            "the first record is a real change"
+        );
+        let (k, w, kind, spawned, status, activity, question, now) = args(999);
+        assert!(
+            !state.set(k, w, kind, spawned, status, activity, question, now),
+            "only the timestamp differs - this must not count as a change"
+        );
+
+        // A real status change does count.
+        let key2 = key.clone();
+        assert!(state.set(
+            key2,
+            Path::new("/repo/wt-a"),
+            "Claude",
+            10,
+            Status::Review,
+            Some("Bash: cargo test".to_owned()),
+            None,
+            1000,
+        ));
+    }
+
+    #[test]
+    fn saving_merges_rather_than_clobbering_another_instances_records() {
+        // The real hazard: two Jerry instances sharing one `~/.config/jerry`.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join(AGENT_STATUS_FILE_NAME);
+
+        let other_key = key_for("/repo/other", 1);
+        let mut other = AgentStatusState::default();
+        other.set(
+            other_key.clone(),
+            Path::new("/repo/other"),
+            "Claude",
+            1,
+            Status::Run,
+            None,
+            None,
+            5,
+        );
+        other
+            .save_merged_at(&path, &std::iter::once(other_key.clone()).collect())
+            .expect("save");
+
+        let mine_key = key_for("/repo/mine", 2);
+        let mut mine = AgentStatusState::default();
+        mine.set(
+            mine_key.clone(),
+            Path::new("/repo/mine"),
+            "Claude",
+            2,
+            Status::Ask,
+            None,
+            Some("Bash needs permission: rm -rf /".to_owned()),
+            6,
+        );
+        mine.save_merged_at(&path, &std::iter::once(mine_key.clone()).collect())
+            .expect("save");
+
+        let merged = AgentStatusState::load_at(&path);
+        assert!(
+            merged.get(&other_key).is_some(),
+            "the other instance's record must survive this instance's save"
+        );
+        assert!(merged.get(&mine_key).is_some());
+    }
+
+    #[test]
+    fn a_record_absent_from_memory_is_kept_on_disk_because_this_is_history() {
+        // The deliberate divergence from `fold_state`/`tab_order_state`, matching
+        // `baseline_state`: a closed agent is exactly what issue #227 wants to show.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join(AGENT_STATUS_FILE_NAME);
+        let key = key_for("/repo/wt-a", 3);
+
+        let mut state = AgentStatusState::default();
+        state.set(
+            key.clone(),
+            Path::new("/repo/wt-a"),
+            "Claude",
+            3,
+            Status::Review,
+            None,
+            None,
+            7,
+        );
+        let owned: BTreeSet<String> = std::iter::once(key.clone()).collect();
+        state.save_merged_at(&path, &owned).expect("save");
+
+        // Now the agent is gone from memory, but still "owned" by this instance.
+        let empty = AgentStatusState::default();
+        empty.save_merged_at(&path, &owned).expect("save");
+
+        assert!(
+            AgentStatusState::load_at(&path).get(&key).is_some(),
+            "a closed agent's record must not be deleted"
+        );
+    }
+
+    #[test]
+    fn a_missing_or_corrupt_file_loads_as_empty_rather_than_failing() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let missing = dir.path().join("nope.toml");
+        assert_eq!(
+            AgentStatusState::load_at(&missing),
+            AgentStatusState::default()
+        );
+
+        let corrupt = dir.path().join("corrupt.toml");
+        std::fs::write(&corrupt, "this is not valid toml {{{").expect("write");
+        assert_eq!(
+            AgentStatusState::load_at(&corrupt),
+            AgentStatusState::default()
+        );
+    }
+
+    #[test]
+    fn status_keys_round_trip_and_cover_every_status() {
+        for status in Status::ORDER {
+            assert_eq!(
+                status_from_key(status_key(status)),
+                Some(status),
+                "{status:?} must round-trip through its stable file spelling"
+            );
+        }
+        assert_eq!(status_from_key("a_status_from_a_future_release"), None);
+    }
+}

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -12,6 +12,7 @@ pub mod code_surface;
 pub mod env_info;
 pub mod fonts;
 pub mod graph_view;
+pub mod hooks;
 pub mod icon_pack;
 pub mod keymap;
 pub mod keymap_overrides;

--- a/crates/app/src/merge/flow.rs
+++ b/crates/app/src/merge/flow.rs
@@ -1018,6 +1018,7 @@ mod merge_regression_tests {
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
+                None,
                 window,
                 cx,
             )
@@ -1097,6 +1098,7 @@ mod merge_regression_tests {
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
+                None,
                 window,
                 cx,
             )
@@ -1122,6 +1124,7 @@ mod merge_regression_tests {
                 second_feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
+                None,
                 window,
                 cx,
             )
@@ -1182,6 +1185,7 @@ mod merge_regression_tests {
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
+                None,
                 window,
                 cx,
             )
@@ -1294,6 +1298,7 @@ mod merge_regression_tests {
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
+                None,
                 window,
                 cx,
             )
@@ -1398,6 +1403,7 @@ mod merge_regression_tests {
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
+                None,
                 window,
                 cx,
             )
@@ -1466,6 +1472,7 @@ mod merge_regression_tests {
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
+                None,
                 window,
                 cx,
             )
@@ -1552,6 +1559,7 @@ mod merge_regression_tests {
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
+                None,
                 window,
                 cx,
             )
@@ -1671,6 +1679,7 @@ mod merge_regression_tests {
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
+                None,
                 window,
                 cx,
             )
@@ -1804,6 +1813,7 @@ mod merge_regression_tests {
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
+                None,
                 window,
                 cx,
             )
@@ -1909,6 +1919,7 @@ mod merge_regression_tests {
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
+                None,
                 window,
                 cx,
             )
@@ -2009,6 +2020,7 @@ mod merge_regression_tests {
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
+                None,
                 window,
                 cx,
             )
@@ -2174,6 +2186,7 @@ mod merge_regression_tests {
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
+                None,
                 window,
                 cx,
             )
@@ -2228,6 +2241,7 @@ mod merge_regression_tests {
                 second_feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
+                None,
                 window,
                 cx,
             )
@@ -2337,6 +2351,7 @@ mod merge_regression_tests {
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
+                None,
                 window,
                 cx,
             )
@@ -2434,6 +2449,7 @@ mod merge_regression_tests {
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
+                None,
                 window,
                 cx,
             )
@@ -2550,6 +2566,7 @@ mod merge_regression_tests {
                 feature.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
+                None,
                 window,
                 cx,
             )

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -130,14 +130,34 @@ impl AdeApp {
                     .find(|item| item.path == agent.cwd)
                     .and_then(|item| item.branch.clone());
 
-                let question_preview = if status_value == Status::Ask {
-                    pane.visible_text_lines()
-                        .into_iter()
-                        .rev()
-                        .find(|line| !line.trim().is_empty())
-                } else {
-                    None
+                // GitHub issue #239 phase 2: real, structured text straight from this agent's own
+                // hook payloads, when it has fired any recently enough to still be describing the
+                // present (`crate::hooks::event::HOOK_SIGNAL_TTL`).
+                let (hook_activity, hook_question) = match &self.hook_runtime {
+                    Some(runtime) => runtime.text_for(agent.id),
+                    None => (None, None),
                 };
+
+                // The grid scrape stays, as the fallback it now is. It is a genuinely worse
+                // signal - the last non-blank line of whatever the CLI happened to have rendered,
+                // which for a permission prompt is as likely to be a box-drawing border or a
+                // truncated menu item as the actual question - but it is the *only* signal for
+                // a Codex agent, a shell, or a Claude agent whose hooks haven't fired yet, so
+                // removing it would be a real regression for every one of those.
+                let question_preview = hook_question.or_else(|| {
+                    if status_value == Status::Ask {
+                        pane.visible_text_lines()
+                            .into_iter()
+                            .rev()
+                            .find(|line| !line.trim().is_empty())
+                    } else {
+                        None
+                    }
+                });
+
+                // Only shown while the agent is actually running: a stale "Bash: cargo test" next
+                // to an idle or review-ready row would describe something that already finished.
+                let activity = hook_activity.filter(|_| status_value == Status::Run);
 
                 let title = match agent.cwd.file_name() {
                     Some(name) => name.to_string_lossy().into_owned(),
@@ -167,9 +187,7 @@ impl AdeApp {
                     del: diff.map(|summary| summary.del).unwrap_or(0),
                     question_preview,
                     exit_code: pane.exit_status().map(|status| status.exit_code()),
-                    // See `AgentRow::activity`'s own docs: no real PTY-activity heuristic is
-                    // wired up yet, so every row threads `None` through for now.
-                    activity: None,
+                    activity,
                     elapsed: agent.spawned_at.elapsed(),
                     review_file_count,
                 }
@@ -326,6 +344,11 @@ impl AdeApp {
                     this.ahead_behind_cache = snapshot.ahead_behind;
                     this.process_stats = process_samples;
                     this.apply_review_measurements(review_measurements);
+                    // GitHub issue #239 phase 2: fold each agent's real, hook-derived state into
+                    // the persisted record for issue #227 to build on. Rides this existing timer
+                    // rather than adding one, and only touches the disk when something actually
+                    // changed - see `AdeApp::record_agent_statuses`.
+                    this.record_agent_statuses(cx);
                     cx.notify();
                 });
                 if updated.is_err() {
@@ -1849,6 +1872,7 @@ mod rail_row_tests {
                 repo.path().to_path_buf(),
                 12.0,
                 None,
+                None,
                 window,
                 cx,
             );
@@ -1917,6 +1941,7 @@ mod rail_row_tests {
                 wt.path().to_path_buf(),
                 12.0,
                 None,
+                None,
                 window,
                 cx,
             );
@@ -1975,6 +2000,7 @@ mod rail_row_tests {
                 ProcessKind::Shell,
                 wt.path().to_path_buf(),
                 12.0,
+                None,
                 None,
                 window,
                 cx,
@@ -2039,6 +2065,7 @@ mod rail_row_tests {
                 wt_a.path().to_path_buf(),
                 12.0,
                 None,
+                None,
                 window,
                 cx,
             );
@@ -2047,6 +2074,7 @@ mod rail_row_tests {
                 ProcessKind::Shell,
                 wt_b.path().to_path_buf(),
                 12.0,
+                None,
                 None,
                 window,
                 cx,
@@ -2103,6 +2131,7 @@ mod rail_row_tests {
                 busy_wt.path().to_path_buf(),
                 12.0,
                 None,
+                None,
                 window,
                 cx,
             );
@@ -2110,6 +2139,7 @@ mod rail_row_tests {
                 ProcessKind::codex(),
                 busy_wt.path().to_path_buf(),
                 12.0,
+                None,
                 None,
                 window,
                 cx,
@@ -2586,6 +2616,7 @@ mod agent_chip_icon_pack_tests {
                 ProcessKind::claude(),
                 wt.path().to_path_buf(),
                 12.0,
+                None,
                 None,
                 window,
                 cx,

--- a/crates/app/src/rail/state.rs
+++ b/crates/app/src/rail/state.rs
@@ -52,11 +52,17 @@ pub struct AgentRow {
     /// rather than every one of those call sites suddenly needing to supply or ignore an
     /// `activity` payload for a `Run` variant they don't care about.
     ///
-    /// **Always `None` today.** The real PTY-output-to-activity-text heuristic is a separate,
-    /// parallel piece of work (this revision's Phase 0 is data-model-and-persistence only); this
-    /// field exists so that work has a real, already-plumbed-through place to write into -
-    /// [`crate::rail::render::AdeApp::build_agent_rows`] is where a live value would be filled
-    /// in, the same real construction site [`Self::question_preview`] is already filled in from.
+    /// Real as of GitHub issue #239 phase 2, and only ever from a real source: this is a Claude
+    /// Code hook payload's own `tool_name` plus the relevant `tool_input` field (`Bash: cargo
+    /// test`, `Edit: src/auth.rs`), parsed by `crate::hooks::event`. It was deliberately left
+    /// `None` before that, rather than filled from a PTY-output heuristic, because guessing "the
+    /// live tool call" from rendered terminal text is exactly the kind of plausible-but-wrong
+    /// string this field would be worst as.
+    ///
+    /// Still `None` whenever there is no real answer: a Codex agent or a shell (neither has
+    /// hooks), a Claude agent whose hooks haven't fired yet or have gone stale
+    /// (`crate::hooks::event::HOOK_SIGNAL_TTL`), and any row that isn't [`Status::Run`] - a
+    /// finished agent's last tool call describes the past, not what it is doing.
     pub activity: Option<String>,
     /// Wall-clock time since `crate::work_surface::agents::Agent::spawned_at` - the agent
     /// row's line-1 elapsed time (§2.3: "elapsed 9.5px mono right"). See [`format_elapsed`] for

--- a/crates/app/src/rail/status.rs
+++ b/crates/app/src/rail/status.rs
@@ -281,7 +281,14 @@ pub struct HookSignal {
 impl HookSignal {
     /// The fact, but only while it is still recent enough to describe the present - see
     /// [`crate::hooks::event::HOOK_SIGNAL_TTL`] for why an expiry exists at all.
-    fn fresh(self) -> Option<HookFact> {
+    ///
+    /// `pub(crate)` so callers outside status derivation ask the same question the same way.
+    /// `crate::hooks::flow` in particular must use *this* rather than testing `fact.is_some()`:
+    /// gating on the raw field means an expired fact still qualifies its agent for persistence,
+    /// while the status derived for that agent has already fallen back to the quiescence
+    /// heuristic and resumed oscillating - which puts the fsync-per-transition storm straight
+    /// back, just narrowed to agents whose hooks have gone stale.
+    pub(crate) fn fresh(self) -> Option<HookFact> {
         self.fact.filter(|_| self.age < HOOK_SIGNAL_TTL)
     }
 }

--- a/crates/app/src/rail/status.rs
+++ b/crates/app/src/rail/status.rs
@@ -80,9 +80,47 @@
 //! sense: a shell prompt, a `vim` session, or a `printf '\e]0;...\a'` in someone's `.bashrc` can
 //! put any glyph or word in a shell's title, and none of that makes a shell an agent session
 //! that can need input. That gate is pinned by its own test below.
+//!
+//! ## The third signal: what the agent *reports* (GitHub issue #239, phase 2)
+//!
+//! A title glyph is still presentation - something the CLI drew for a human, which Jerry reads
+//! over its shoulder. Claude Code also emits a real, documented, structured side-channel for
+//! programs: hooks, fired at named lifecycle events, each handed a JSON payload. Jerry installs
+//! those per-launch and receives them on a loopback listener (`crate::hooks`), and
+//! [`HookSignal`] carries the resulting fact here.
+//!
+//! It is ranked above both other signals, because it is a categorically different kind of
+//! evidence - the agent stating what it just did, rather than Jerry inferring it from silence or
+//! from a spinner. Concretely: [`HookFact::Working`] means [`Status::Run`],
+//! [`HookFact::NeedsInput`] means [`Status::Ask`], [`HookFact::TurnFailed`] means
+//! [`Status::Fail`].
+//!
+//! [`HookFact::TurnEnded`] is the one that buys a genuinely new capability rather than a faster
+//! version of an old one. Before this, [`Status::Review`] was reachable *only* by a process
+//! exiting - but a real Claude Code session does not exit when it finishes a turn, it sits at its
+//! prompt waiting for the next one. So the single most useful moment in the whole workflow ("this
+//! agent just finished; there is something to look at") was invisible until the user closed the
+//! CLI outright. A `Stop` hook is exactly that moment, and it is gated on the same real #225
+//! review-baseline diff the exit path uses, so `Review` means the same thing however it is
+//! reached.
+//!
+//! Three limits keep this from being another way to be confidently wrong:
+//!
+//! - **It expires.** A hook fact is a point-in-time observation, so it only outranks the other
+//!   signals while fresh ([`crate::hooks::event::HOOK_SIGNAL_TTL`]); past that the quiescence
+//!   floor takes back over. An agent whose hooks silently stopped firing must not pin a stale
+//!   status forever.
+//! - **It never argues with an exit.** Like [`TerminalSignal`], it is consulted only in the
+//!   [`ProcessSignal::Running`] branch. A process that has exited is an exact fact.
+//! - **It never reaches a shell.** Hooks are only ever installed for
+//!   [`crate::work_surface::agents::AgentKind::Claude`] spawns, so a shell should structurally
+//!   never have one - and this function additionally refuses to consult it for a
+//!   [`crate::work_surface::agents::ProcessKind::Shell`] even if one somehow arrived, which is
+//!   pinned by its own test below.
 
 use std::time::Duration;
 
+use crate::hooks::event::{HookFact, HOOK_SIGNAL_TTL};
 use crate::rail::title_signal::TitleSignal;
 use crate::terminal::osc::Progress;
 use crate::work_surface::agents::ProcessKind;
@@ -223,19 +261,75 @@ impl TerminalSignal {
     }
 }
 
+/// What the agent said about itself through Claude Code's real hook side-channel, as opposed to
+/// what it rendered into its terminal ([`TerminalSignal`]) or what its silence implies
+/// ([`ProcessSignal`]) - see the module docs' "third signal" section (GitHub issue #239, phase 2).
+///
+/// Built by the caller (`crate::work_surface::render::AdeApp::agent_status`) from
+/// `crate::hooks::server::HookListener::signal_for`. [`Default`] is "this agent has never
+/// reported a hook", which is both the honest starting state and what every non-Claude agent and
+/// every shell is handed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct HookSignal {
+    /// The most recent hook fact this agent reported, if any.
+    pub fact: Option<HookFact>,
+    /// How long ago it arrived - the freshness check against
+    /// [`crate::hooks::event::HOOK_SIGNAL_TTL`]. Meaningless when `fact` is `None`.
+    pub age: Duration,
+}
+
+impl HookSignal {
+    /// The fact, but only while it is still recent enough to describe the present - see
+    /// [`crate::hooks::event::HOOK_SIGNAL_TTL`] for why an expiry exists at all.
+    fn fresh(self) -> Option<HookFact> {
+        self.fact.filter(|_| self.age < HOOK_SIGNAL_TTL)
+    }
+}
+
 /// Derives the [`Status`] for one agent from its process signal, what its own terminal claims
-/// about it ([`TerminalSignal`]), and whether it has a non-empty diff against its worktree's
-/// base - see the module docs for the Run/Ask split and how the two signals combine.
+/// about it ([`TerminalSignal`]), what it reported through the hook side-channel
+/// ([`HookSignal`]), and whether it has a non-empty diff against its worktree's base - see the
+/// module docs for the Run/Ask split and how the three signals combine.
 pub fn derive_status(
     kind: ProcessKind,
     signal: ProcessSignal,
     terminal: TerminalSignal,
+    hooks: HookSignal,
     has_reviewable_diff: bool,
 ) -> Status {
     match signal {
         ProcessSignal::NoProcess => Status::Idle,
         ProcessSignal::Running { idle } => {
             if kind.is_agent_session() {
+                // The hook signal outranks both the title/OSC signal and the idle clock, because
+                // it is categorically better evidence: the other two are inferences from what the
+                // process rendered or from how long it has been quiet, while this is the agent
+                // reporting its own lifecycle event through a documented, structured channel.
+                // It is checked only for a real agent session, and only for a live process, so a
+                // stale fact can never argue with an exit (see the `Exited` arm below).
+                if let Some(fact) = hooks.fresh() {
+                    return match fact {
+                        HookFact::Working => Status::Run,
+                        HookFact::NeedsInput => Status::Ask,
+                        HookFact::TurnFailed => Status::Fail,
+                        // The real new capability this phase adds: a turn that *ended* is a
+                        // review boundary even though the process is still very much alive.
+                        // Before hooks, `Review` could only ever be reached by a process
+                        // exiting - so an agent that finished its work and sat waiting at its
+                        // prompt (which is what Claude Code actually does) was reported as
+                        // `Ask` or `Idle`, and the review surface for it only appeared once the
+                        // user closed the CLI. The gate is the same real #225 review-baseline
+                        // diff used by the exit path immediately below, so "review ready" means
+                        // exactly the same thing however it was reached.
+                        HookFact::TurnEnded => {
+                            if has_reviewable_diff {
+                                Status::Review
+                            } else {
+                                Status::Idle
+                            }
+                        }
+                    };
+                }
                 // Both of these deliberately outrank the idle clock in both directions - see the
                 // module docs' "second signal" section. `wants_attention` is checked first: an
                 // agent that is both spinning a busy glyph and has an unanswered notification
@@ -275,6 +369,37 @@ pub fn derive_status(
 mod tests {
     use super::*;
     use crate::terminal::osc::ProgressState;
+
+    /// The pre-phase-2 four-argument call shape, deliberately shadowing [`super::derive_status`]
+    /// for the tests below.
+    ///
+    /// Every test written before the hook side-channel existed means "this agent has never
+    /// reported a hook", and every one of them must keep producing exactly the same answer now
+    /// that a third signal exists - that is the real claim, and routing them through this
+    /// forwarder states it once instead of sprinkling `HookSignal::default()` through thirty call
+    /// sites. The phase-2 tests call `super::derive_status` directly with a real signal.
+    fn derive_status(
+        kind: ProcessKind,
+        signal: ProcessSignal,
+        terminal: TerminalSignal,
+        has_reviewable_diff: bool,
+    ) -> Status {
+        super::derive_status(
+            kind,
+            signal,
+            terminal,
+            HookSignal::default(),
+            has_reviewable_diff,
+        )
+    }
+
+    /// A hook fact that arrived just now - the normal live case.
+    fn hooked(fact: HookFact) -> HookSignal {
+        HookSignal {
+            fact: Some(fact),
+            age: Duration::ZERO,
+        }
+    }
 
     /// The "this process said nothing through its terminal" signal - what every pre-existing
     /// test below means, and exactly what a CLI that sets no title and sends no OSC produces.
@@ -649,6 +774,263 @@ mod tests {
             derive_status(ProcessKind::claude(), signal, quiet(), false),
             Status::Idle
         );
+    }
+
+    #[test]
+    fn a_fresh_hook_fact_maps_onto_the_status_it_reports() {
+        // The core of phase 2. Checked at an idle time that would otherwise say `Ask` (well past
+        // the threshold), so every one of these is genuinely the hook signal deciding and not the
+        // quiescence heuristic agreeing by coincidence.
+        let long_quiet = ProcessSignal::Running {
+            idle: AGENT_ASK_IDLE_THRESHOLD * 10,
+        };
+        assert_eq!(
+            super::derive_status(
+                ProcessKind::claude(),
+                long_quiet,
+                quiet(),
+                HookSignal::default(),
+                false
+            ),
+            Status::Ask,
+            "baseline: with no hook signal this is the old quiescence answer"
+        );
+        for (fact, expected) in [
+            (HookFact::Working, Status::Run),
+            (HookFact::NeedsInput, Status::Ask),
+            (HookFact::TurnFailed, Status::Fail),
+        ] {
+            assert_eq!(
+                super::derive_status(
+                    ProcessKind::claude(),
+                    long_quiet,
+                    quiet(),
+                    hooked(fact),
+                    false
+                ),
+                expected,
+                "{fact:?} must report {expected:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_stop_hook_reaches_review_without_the_process_ever_exiting() {
+        // The genuinely new capability: before phase 2, `Review` was reachable only via
+        // `ProcessSignal::Exited`. A real Claude Code session does not exit when it finishes a
+        // turn - it sits at its prompt - so this moment was previously invisible.
+        let alive = ProcessSignal::Running {
+            idle: Duration::from_millis(50),
+        };
+        assert_eq!(
+            super::derive_status(
+                ProcessKind::claude(),
+                alive,
+                quiet(),
+                hooked(HookFact::TurnEnded),
+                true
+            ),
+            Status::Review,
+            "a finished turn with real unreviewed changes is review-ready while still running"
+        );
+        // ...and the gate is real: nothing to review means idle, not a review row with nothing in it.
+        assert_eq!(
+            super::derive_status(
+                ProcessKind::claude(),
+                alive,
+                quiet(),
+                hooked(HookFact::TurnEnded),
+                false
+            ),
+            Status::Idle
+        );
+    }
+
+    #[test]
+    fn a_hook_fact_outranks_a_contradicting_title_and_progress_report() {
+        // A title glyph is what the CLI drew for a human; a hook is what it reported. When they
+        // disagree, the report wins - see the module docs' "third signal" section.
+        let busy_looking = TerminalSignal {
+            title: Some(TitleSignal::Busy),
+            attention_pinged: false,
+            progress: Some(Progress {
+                state: ProgressState::Normal,
+                percent: Some(60),
+            }),
+        };
+        let barely_quiet = ProcessSignal::Running {
+            idle: Duration::from_millis(50),
+        };
+        assert_eq!(
+            super::derive_status(
+                ProcessKind::claude(),
+                barely_quiet,
+                busy_looking,
+                HookSignal::default(),
+                true
+            ),
+            Status::Run,
+            "baseline: the title alone says this agent is working"
+        );
+        assert_eq!(
+            super::derive_status(
+                ProcessKind::claude(),
+                barely_quiet,
+                busy_looking,
+                hooked(HookFact::TurnEnded),
+                true
+            ),
+            Status::Review,
+            "a real `Stop` report must beat a spinner the CLI simply hasn't cleared yet"
+        );
+
+        // And the other direction: an attention ping must not hold `Ask` once the agent has
+        // reported it is working again.
+        let pinged = TerminalSignal {
+            attention_pinged: true,
+            ..TerminalSignal::default()
+        };
+        assert_eq!(
+            super::derive_status(
+                ProcessKind::claude(),
+                barely_quiet,
+                pinged,
+                HookSignal::default(),
+                false
+            ),
+            Status::Ask,
+            "baseline: an unanswered ping alone means Ask"
+        );
+        assert_eq!(
+            super::derive_status(
+                ProcessKind::claude(),
+                barely_quiet,
+                pinged,
+                hooked(HookFact::Working),
+                false
+            ),
+            Status::Run
+        );
+    }
+
+    #[test]
+    fn a_stale_hook_fact_expires_and_hands_the_decision_back_to_the_other_signals() {
+        // An agent whose hooks silently stopped firing must not pin a stale status forever - see
+        // `HOOK_SIGNAL_TTL`'s own docs for why an expiry exists.
+        let long_quiet = ProcessSignal::Running {
+            idle: AGENT_ASK_IDLE_THRESHOLD * 10,
+        };
+        let stale = HookSignal {
+            fact: Some(HookFact::Working),
+            age: HOOK_SIGNAL_TTL + Duration::from_secs(1),
+        };
+        assert_eq!(
+            super::derive_status(ProcessKind::claude(), long_quiet, quiet(), stale, false),
+            Status::Ask,
+            "past the TTL the quiescence floor takes back over"
+        );
+        // Just inside the TTL it still counts.
+        let fresh_enough = HookSignal {
+            fact: Some(HookFact::Working),
+            age: HOOK_SIGNAL_TTL - Duration::from_secs(1),
+        };
+        assert_eq!(
+            super::derive_status(
+                ProcessKind::claude(),
+                long_quiet,
+                quiet(),
+                fresh_enough,
+                false
+            ),
+            Status::Run
+        );
+    }
+
+    #[test]
+    fn a_hook_fact_never_overrides_an_exit_or_a_missing_process() {
+        // An exit is an exact fact. A `Working` hook from just before the process died must not
+        // resurrect it - the same rule `TerminalSignal` already obeys.
+        for fact in [
+            HookFact::Working,
+            HookFact::NeedsInput,
+            HookFact::TurnEnded,
+            HookFact::TurnFailed,
+        ] {
+            assert_eq!(
+                super::derive_status(
+                    ProcessKind::claude(),
+                    ProcessSignal::Exited { success: false },
+                    quiet(),
+                    hooked(fact),
+                    false
+                ),
+                Status::Fail,
+                "{fact:?} must not argue with a non-zero exit"
+            );
+            assert_eq!(
+                super::derive_status(
+                    ProcessKind::claude(),
+                    ProcessSignal::NoProcess,
+                    quiet(),
+                    hooked(fact),
+                    true
+                ),
+                Status::Idle,
+                "{fact:?} must not invent a process that was never started"
+            );
+        }
+        assert_eq!(
+            super::derive_status(
+                ProcessKind::claude(),
+                ProcessSignal::Exited { success: true },
+                quiet(),
+                hooked(HookFact::Working),
+                true
+            ),
+            Status::Review
+        );
+    }
+
+    #[test]
+    fn a_hook_fact_can_never_change_a_shell_row() {
+        // Defensive, and deliberately so. Hooks are only ever installed for `AgentKind::Claude`
+        // spawns, so a shell should structurally never carry one - but "structurally impossible"
+        // is exactly the kind of claim that quietly stops being true, and a shell that could be
+        // driven to `Ask`/`Review`/`Fail` by an inbox entry would be a real bug. This pins the
+        // gate rather than trusting the surrounding architecture to keep holding.
+        for fact in [
+            HookFact::Working,
+            HookFact::NeedsInput,
+            HookFact::TurnEnded,
+            HookFact::TurnFailed,
+        ] {
+            assert_eq!(
+                super::derive_status(
+                    ProcessKind::Shell,
+                    ProcessSignal::Running {
+                        idle: AGENT_ASK_IDLE_THRESHOLD * 2
+                    },
+                    quiet(),
+                    hooked(fact),
+                    true
+                ),
+                Status::Idle,
+                "a quiet shell stays Idle regardless of a {fact:?} hook"
+            );
+            assert_eq!(
+                super::derive_status(
+                    ProcessKind::Shell,
+                    ProcessSignal::Running {
+                        idle: Duration::from_millis(50)
+                    },
+                    quiet(),
+                    hooked(fact),
+                    true
+                ),
+                Status::Run,
+                "a freshly-active shell stays Run regardless of a {fact:?} hook"
+            );
+        }
     }
 
     #[test]

--- a/crates/app/src/review/render.rs
+++ b/crates/app/src/review/render.rs
@@ -1235,6 +1235,9 @@ mod review_flow_tests {
             // An exit is an exact fact; no terminal-title/OSC signal takes part in it (see
             // `crate::rail::status`'s module docs), so the default "said nothing" is right here.
             crate::rail::status::TerminalSignal::default(),
+            // Likewise no hook signal: this pins the *exit* path to `Review`, which is the one
+            // that existed before GitHub issue #239 phase 2 and must keep working unchanged.
+            crate::rail::status::HookSignal::default(),
             has_unreviewed,
         );
         assert_eq!(
@@ -1352,6 +1355,7 @@ mod review_flow_tests {
                 other_a.path().to_path_buf(),
                 12.0,
                 None,
+                None,
                 window,
                 cx,
             );
@@ -1362,6 +1366,7 @@ mod review_flow_tests {
                 ProcessKind::Shell,
                 other_b.path().to_path_buf(),
                 12.0,
+                None,
                 None,
                 window,
                 cx,
@@ -1506,7 +1511,11 @@ mod review_flow_tests {
             "recorded against the real worktree, decodably"
         );
         app.read_with(cx, |app, _| {
-            let agent = app.agents.iter().find(|a| a.id == id).expect("the sole agent");
+            let agent = app
+                .agents
+                .iter()
+                .find(|a| a.id == id)
+                .expect("the sole agent");
             let ProcessKind::Agent(kind) = agent.kind else {
                 unreachable!("sole_agent always spawns a real agent, never a shell");
             };

--- a/crates/app/src/root/focus.rs
+++ b/crates/app/src/root/focus.rs
@@ -604,6 +604,7 @@ mod tab_strip_keybinding_tests {
                 repo.path().to_path_buf(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
+                None,
                 window,
                 cx,
             )
@@ -649,6 +650,7 @@ mod tab_strip_keybinding_tests {
                 repo.path().to_path_buf(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
+                None,
                 window,
                 cx,
             )
@@ -852,6 +854,7 @@ mod tab_strip_keybinding_tests {
                     repo.path().to_path_buf(),
                     app.settings.appearance.terminal_font_size,
                     app.settings.terminal.shell_override(),
+                    None,
                     window,
                     cx,
                 )

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -412,6 +412,10 @@ pub struct AdeApp {
     /// it - in both cases every agent simply falls back to the Phase 1 terminal-title and
     /// quiescence signals, which is exactly the pre-phase-2 behaviour.
     pub(crate) hook_runtime: Option<crate::hooks::HookRuntime>,
+    /// Whether bring-up of [`Self::hook_runtime`] has already been attempted, so a *failed*
+    /// attempt is not silently retried on every subsequent Claude spawn - see
+    /// `crate::hooks::flow::AdeApp::hook_injection_for`.
+    pub(crate) hook_runtime_tried: bool,
     /// The on-disk record of what [`Self::hook_runtime`] learned, for GitHub issue #227 to build
     /// on - see `crate::hooks::store`'s module docs, including the honest note that no UI reads
     /// it back yet.

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -405,6 +405,24 @@ pub struct AdeApp {
     /// a double-click starting two overlapping `git write-tree` runs against the same worktree,
     /// mirroring [`Self::worktree_history_op_in_flight`]'s own single-flight discipline.
     pub(crate) review_mark_in_flight: Option<AgentId>,
+    /// The live agent-hook side-channel for this launch (GitHub issue #239 phase 2): a loopback
+    /// listener plus the generated `--settings`/forwarder files every Claude agent is spawned
+    /// against. `None` when hook support couldn't start (an unsupported platform, a loopback that
+    /// wouldn't bind, an unwritable temp directory) *or* for the many tests that never opted into
+    /// it - in both cases every agent simply falls back to the Phase 1 terminal-title and
+    /// quiescence signals, which is exactly the pre-phase-2 behaviour.
+    pub(crate) hook_runtime: Option<crate::hooks::HookRuntime>,
+    /// The on-disk record of what [`Self::hook_runtime`] learned, for GitHub issue #227 to build
+    /// on - see `crate::hooks::store`'s module docs, including the honest note that no UI reads
+    /// it back yet.
+    pub(crate) agent_status_state: crate::hooks::store::AgentStatusState,
+    /// Where [`Self::agent_status_state`] is persisted - a sibling of the real `settings.toml`, or
+    /// `None` for a test that hasn't opted into real persistence, mirroring
+    /// [`Self::review_baseline_path`].
+    pub(crate) agent_status_path: Option<PathBuf>,
+    /// Which persisted agent-status keys *this* instance owns, for the merge-not-clobber write
+    /// path - mirrors [`Self::review_baselines_owned`].
+    pub(crate) agent_status_owned: std::collections::BTreeSet<String>,
     /// Real expand/collapse state for the file tree - a directory's absolute path is in this set
     /// iff it is expanded (see `crate::sidebar::file_tree::visible_entries`, which this set feeds
     /// directly). **Absence means collapsed**, so a worktree opened for the first time shows only
@@ -780,6 +798,10 @@ pub struct AdeApp {
     /// here (unlike the two above), because every save writes the *whole* merged state, so a
     /// newer one genuinely supersedes an older one. Mirrors `AdeApp::_tab_order_save_task`.
     pub(crate) _review_persist_task: Option<Task<()>>,
+    /// Holds the in-flight write of [`Self::agent_status_state`] - see
+    /// `crate::hooks::flow::AdeApp::record_agent_statuses`. A `Task` cancels on drop, so this
+    /// must be stored for the write to actually land.
+    pub(crate) _agent_status_persist_task: Option<Task<()>>,
     /// The in-flight `wt_core::graph::build_graph` background load, one slot - a fresh load
     /// supersedes an older one still running, mirroring [`Self::_load_diff_task`].
     pub(crate) _load_graph_task: Option<Task<()>>,
@@ -2362,6 +2384,8 @@ impl AdeApp {
                 path.clone(),
                 self.settings.appearance.terminal_font_size,
                 self.settings.terminal.shell_override(),
+                // A shell, so no hook injection - `Agents::spawn` would discard one anyway.
+                None,
                 window,
                 cx,
             );
@@ -3829,6 +3853,7 @@ mod repo_list_tests {
                 ProcessKind::claude(),
                 repo_a.path().to_path_buf(),
                 12.0,
+                None,
                 None,
                 window,
                 cx,

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -116,6 +116,23 @@ impl AdeApp {
             .map(crate::review::baseline_state::ReviewBaselineState::load_at)
             .unwrap_or_default();
 
+        // GitHub issue #239 phase 2's hook-learned agent statuses resolve identically, and for
+        // the identical reason (see `crate::hooks::store`'s module docs, including the honest
+        // note that no UI reads these back yet - that is issue #227's job).
+        let agent_status_path = settings_path
+            .as_deref()
+            .map(crate::hooks::store::agent_status_path_for);
+        let agent_status_state = agent_status_path
+            .as_deref()
+            .map(crate::hooks::store::AgentStatusState::load_at)
+            .unwrap_or_default();
+
+        // The hook side-channel starts out absent and is brought up lazily, on the first Claude
+        // agent this instance spawns - see `AdeApp::hook_injection_for`. Still exactly one
+        // listener per instance, shared by every Claude agent it ever spawns; just not one opened
+        // by a window that may never run an agent at all.
+        let hook_runtime = None;
+
         // The repo-list file mirrors the fold-state file's own resolution one line up (see
         // `rail::repo`'s module docs for why it's the identical pattern): a sibling of whatever
         // settings path this instance was given, `None` (and so no persistence at all) for a test
@@ -244,6 +261,10 @@ impl AdeApp {
             review_baseline_path,
             review_baselines_owned: std::collections::BTreeSet::new(),
             review_mark_in_flight: None,
+            hook_runtime,
+            agent_status_state,
+            agent_status_path,
+            agent_status_owned: std::collections::BTreeSet::new(),
             review_tab_open: None,
             review_tab_active: false,
             review_focus_handle: cx.focus_handle(),
@@ -255,6 +276,7 @@ impl AdeApp {
             _review_mark_task: None,
             _review_release_tasks: HashMap::new(),
             _review_persist_task: None,
+            _agent_status_persist_task: None,
             // Both are filled in immediately after this literal, through the same single
             // chokepoints every later change uses (`set_file_tree_root` +
             // `reload_expanded_dirs_from_fold_state`) - a second, constructor-only copy of that
@@ -605,6 +627,7 @@ impl AdeApp {
                     path.clone(),
                     this.settings.appearance.terminal_font_size,
                     this.settings.terminal.shell_override(),
+                    None,
                     window,
                     cx,
                 );

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -262,6 +262,7 @@ impl AdeApp {
             review_baselines_owned: std::collections::BTreeSet::new(),
             review_mark_in_flight: None,
             hook_runtime,
+            hook_runtime_tried: false,
             agent_status_state,
             agent_status_path,
             agent_status_owned: std::collections::BTreeSet::new(),

--- a/crates/app/src/terminal/pane.rs
+++ b/crates/app/src/terminal/pane.rs
@@ -294,6 +294,18 @@ pub struct TerminalSpec {
     pub program: PathBuf,
     pub args: Vec<String>,
     pub cwd: PathBuf,
+    /// Extra environment variables set on the spawned child, *on top of* the environment Jerry
+    /// itself inherited (`portable_pty`'s `CommandBuilder::env` adds to the inherited
+    /// environment rather than replacing it, which is what makes this safe to use for a couple
+    /// of variables without having to reconstruct a whole environment).
+    ///
+    /// Empty for every spawn except a Claude agent, where it carries the hook listener's port,
+    /// this launch's token and the pane's own agent id (GitHub issue #239 phase 2 -
+    /// `crate::hooks::HookRuntime::spawn_extras`). Those three are what let the dumb forwarder
+    /// script know where to post and which row an event belongs to, and putting them in the
+    /// environment rather than in the generated settings file is what allows one settings file
+    /// to serve every agent this launch spawns.
+    pub env: Vec<(String, String)>,
 }
 
 impl TerminalSpec {
@@ -318,6 +330,7 @@ impl TerminalSpec {
                 .unwrap_or_else(Self::default_shell_program),
             args: Vec::new(),
             cwd,
+            env: Vec::new(),
         }
     }
 
@@ -359,6 +372,22 @@ impl TerminalSpec {
             program: program.into(),
             args,
             cwd,
+            env: Vec::new(),
+        }
+    }
+
+    /// [`Self::command`] plus extra environment variables for the child - see [`Self::env`].
+    pub fn command_with_env(
+        program: impl Into<PathBuf>,
+        args: Vec<String>,
+        cwd: PathBuf,
+        env: Vec<(String, String)>,
+    ) -> Self {
+        Self {
+            program: program.into(),
+            args,
+            cwd,
+            env,
         }
     }
 }
@@ -1124,12 +1153,14 @@ impl TerminalPane {
             let spawn_result: Result<PtySession, PtyError> = cx
                 .background_executor()
                 .spawn(async move {
-                    pty_core::spawn(
-                        SpawnOptions::new(spec.program)
-                            .args(spec.args)
-                            .cwd(spec.cwd)
-                            .size(TERMINAL_ROWS, TERMINAL_COLS),
-                    )
+                    let mut options = SpawnOptions::new(spec.program)
+                        .args(spec.args)
+                        .cwd(spec.cwd)
+                        .size(TERMINAL_ROWS, TERMINAL_COLS);
+                    for (key, value) in spec.env {
+                        options = options.env(key, value);
+                    }
+                    pty_core::spawn(options)
                 })
                 .await;
 

--- a/crates/app/src/title_bar/menu.rs
+++ b/crates/app/src/title_bar/menu.rs
@@ -1297,6 +1297,7 @@ mod title_menu_tests {
                 worktree_path.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
+                None,
                 window,
                 cx,
             )
@@ -1398,6 +1399,7 @@ mod title_menu_tests {
                 worktree_path.clone(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
+                None,
                 window,
                 cx,
             )
@@ -1530,6 +1532,7 @@ mod title_menu_tests {
                 repo.path().to_path_buf(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
+                None,
                 window,
                 cx,
             );
@@ -1538,6 +1541,7 @@ mod title_menu_tests {
                 repo.path().to_path_buf(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
+                None,
                 window,
                 cx,
             );
@@ -1550,6 +1554,7 @@ mod title_menu_tests {
                 other_wt.path().to_path_buf(),
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
+                None,
                 window,
                 cx,
             );

--- a/crates/app/src/title_bar/render.rs
+++ b/crates/app/src/title_bar/render.rs
@@ -927,6 +927,7 @@ mod agent_state_chip_live_tests {
                 wt_b.path().to_path_buf(),
                 12.0,
                 None,
+                None,
                 window,
                 cx,
             )

--- a/crates/app/src/work_surface/agents.rs
+++ b/crates/app/src/work_surface/agents.rs
@@ -110,11 +110,30 @@ impl ProcessKind {
     /// (`crate::settings::store::TerminalSettings::shell_override`, GitHub issue #213) and only
     /// reaches [`ProcessKind::Shell`]: an agent CLI spawns its own fixed binary directly, never
     /// through a shell, so which shell the user prefers genuinely cannot affect it.
-    fn spec(self, cwd: PathBuf, shell_override: Option<&str>) -> TerminalSpec {
+    ///
+    /// `extras` is `(args, env)` to append for a real agent CLI - in practice
+    /// `crate::hooks::HookRuntime::spawn_extras`'s `--settings <path>` plus the `JERRY_*`
+    /// environment that lets that agent's hooks find their way home (GitHub issue #239 phase 2).
+    /// It is deliberately handed in by the caller rather than derived here: whether hooks are
+    /// available at all is a live, per-launch fact owned by `crate::root::AdeApp`, and this
+    /// function is a pure `ProcessKind` -> `TerminalSpec` mapping that must stay testable without
+    /// one.
+    ///
+    /// A [`ProcessKind::Shell`] discards `extras` outright. That is a real gate, not an
+    /// oversight: a shell must never be handed the hook token or an agent id, because a shell is
+    /// an interactive terminal running whatever the user types, and anything it ran would inherit
+    /// the credentials for reporting status as some other pane.
+    fn spec(
+        self,
+        cwd: PathBuf,
+        shell_override: Option<&str>,
+        extras: Option<SpawnExtras>,
+    ) -> TerminalSpec {
         match self {
             ProcessKind::Shell => TerminalSpec::shell(cwd, shell_override),
             ProcessKind::Agent(agent) => {
-                TerminalSpec::command(agent.binary_name(), Vec::new(), cwd)
+                let (args, env) = extras.unwrap_or_default();
+                TerminalSpec::command_with_env(agent.binary_name(), args, cwd, env)
             }
         }
     }
@@ -129,6 +148,10 @@ impl ProcessKind {
         matches!(self, ProcessKind::Agent(_))
     }
 }
+
+/// Extra spawn arguments and environment for one agent - `(args, env)`, as produced by
+/// `crate::hooks::HookInjection::spawn_extras` and consumed by [`ProcessKind::spec`].
+pub type SpawnExtras = (Vec<String>, Vec<(String, String)>);
 
 impl From<AgentKind> for ProcessKind {
     fn from(agent: AgentKind) -> Self {
@@ -279,19 +302,38 @@ impl Agents {
     /// shell (`crate::settings::store::TerminalSettings::shell_override`) - `None` means "the
     /// real OS default", and it only affects [`ProcessKind::Shell`] tabs (see
     /// [`ProcessKind::spec`]).
+    ///
+    /// `hooks` is this launch's hook injection (GitHub issue #239 phase 2), or `None` when hook
+    /// support isn't running - see [`crate::hooks::HookRuntime::start`] for every real reason it
+    /// may not be. It is consumed *only* for [`AgentKind::Claude`]: hooks are a Claude Code
+    /// feature, so a Codex agent and a shell are spawned byte-for-byte as they were before this
+    /// phase, and both fall back to the terminal-title and quiescence signals.
+    // Eight parameters, one past clippy's threshold. Every one is a distinct, live value read
+    // fresh from settings or app state at each of this method's ~40 call sites (see the docs
+    // above for why each is threaded rather than read here), so bundling them into a struct would
+    // add a type whose only purpose is to be constructed inline at every call site and
+    // immediately destructured here - moving the argument count rather than reducing it.
+    #[allow(clippy::too_many_arguments)]
     pub fn spawn(
         &mut self,
         kind: ProcessKind,
         cwd: PathBuf,
         terminal_font_size_px: f32,
         shell_override: Option<&str>,
+        hooks: Option<&crate::hooks::HookInjection>,
         window: &mut Window,
         cx: &mut Context<AdeApp>,
     ) -> AgentId {
         let id = self.next_id;
         self.next_id += 1;
 
-        let spec = kind.spec(cwd.clone(), shell_override);
+        // Claude Code only, and gated here rather than inside `spec` so the gate is one
+        // legible line next to the spawn it guards.
+        let extras = match (kind, hooks) {
+            (ProcessKind::Agent(AgentKind::Claude), Some(hooks)) => Some(hooks.spawn_extras(id)),
+            _ => None,
+        };
+        let spec = kind.spec(cwd.clone(), shell_override, extras);
         let pane = cx.new(|cx| TerminalPane::new(spec, terminal_font_size_px, cx));
         let link_subscription =
             cx.subscribe_in(&pane, window, move |app, _pane, event, window, cx| {
@@ -566,6 +608,40 @@ mod tests {
         );
     }
 
+    #[test]
+    fn a_shell_never_receives_the_hook_injection_even_when_one_is_offered() {
+        // A shell runs whatever the user types, so handing it the hook token and an agent id
+        // would let anything it ran report status as some other pane. `spec` discards `extras`
+        // for the shell arm outright - this pins that.
+        let extras = Some((
+            vec!["--settings".to_owned(), "/tmp/jerry.json".to_owned()],
+            vec![("JERRY_HOOK_TOKEN".to_owned(), "secret".to_owned())],
+        ));
+        let shell = ProcessKind::Shell.spec(PathBuf::from("/tmp"), None, extras);
+        assert!(shell.args.is_empty(), "a shell must get no injected args");
+        assert!(
+            shell.env.is_empty(),
+            "a shell must never see the hook token"
+        );
+    }
+
+    #[test]
+    fn an_agent_given_a_hook_injection_really_spawns_with_it() {
+        // The other half: the injection must actually reach the spawn, or the whole side-channel
+        // silently does nothing.
+        let extras = Some((
+            vec!["--settings".to_owned(), "/tmp/jerry.json".to_owned()],
+            vec![("JERRY_HOOK_PORT".to_owned(), "5000".to_owned())],
+        ));
+        let spec = ProcessKind::claude().spec(PathBuf::from("/tmp"), None, extras);
+        assert_eq!(spec.program, PathBuf::from("claude"));
+        assert_eq!(spec.args, vec!["--settings", "/tmp/jerry.json"]);
+        assert_eq!(
+            spec.env,
+            vec![("JERRY_HOOK_PORT".to_owned(), "5000".to_owned())]
+        );
+    }
+
     /// `spec` is private, but the fact it reads through `AgentKind::binary_name` (rather than a
     /// second hardcoded list) is what keeps the Settings › Agents `$PATH` search honest: the name
     /// that card searches for must be the name actually spawned. This asserts the shared source,
@@ -573,7 +649,7 @@ mod tests {
     #[test]
     fn the_settings_path_search_and_the_real_spawn_read_the_same_binary_name() {
         for agent in [AgentKind::Claude, AgentKind::Codex] {
-            let spec = ProcessKind::Agent(agent).spec(PathBuf::from("/tmp"), None);
+            let spec = ProcessKind::Agent(agent).spec(PathBuf::from("/tmp"), None, None);
             assert_eq!(
                 spec.program,
                 PathBuf::from(agent.binary_name()),
@@ -581,19 +657,23 @@ mod tests {
             );
             assert!(
                 spec.args.is_empty(),
-                "{agent:?} is spawned bare, with no arguments"
+                "{agent:?} with no hook injection is spawned bare, exactly as before issue #239"
+            );
+            assert!(
+                spec.env.is_empty(),
+                "{agent:?} with no hook injection gets no extra environment either"
             );
         }
         // `shell_override` reaches only the shell arm - an agent CLI is spawned directly, never
         // through a shell, so the user's preferred shell genuinely cannot affect it.
-        let shell = ProcessKind::Shell.spec(PathBuf::from("/tmp"), Some("/bin/dash"));
+        let shell = ProcessKind::Shell.spec(PathBuf::from("/tmp"), Some("/bin/dash"), None);
         assert_eq!(
             shell.program,
             PathBuf::from("/bin/dash"),
             "a shell resolves the user's configured shell, not a fixed agent binary"
         );
         let agent_ignoring_override =
-            ProcessKind::claude().spec(PathBuf::from("/tmp"), Some("/bin/dash"));
+            ProcessKind::claude().spec(PathBuf::from("/tmp"), Some("/bin/dash"), None);
         assert_eq!(
             agent_ignoring_override.program,
             PathBuf::from("claude"),

--- a/crates/app/src/work_surface/agents.rs
+++ b/crates/app/src/work_surface/agents.rs
@@ -330,7 +330,7 @@ impl Agents {
         // Claude Code only, and gated here rather than inside `spec` so the gate is one
         // legible line next to the spawn it guards.
         let extras = match (kind, hooks) {
-            (ProcessKind::Agent(AgentKind::Claude), Some(hooks)) => Some(hooks.spawn_extras(id)),
+            (ProcessKind::Agent(AgentKind::Claude), Some(hooks)) => hooks.spawn_extras(id),
             _ => None,
         };
         let spec = kind.spec(cwd.clone(), shell_override, extras);

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -77,11 +77,17 @@ impl AdeApp {
             return;
         }
         let cwd = self.active_agent_cwd();
+        // GitHub issue #239 phase 2: a Claude agent is spawned against this instance's generated
+        // `--settings` file and told, through its environment, where to report its hooks. Taken as
+        // an owned snapshot because `self.agents.spawn` borrows `self.agents` mutably - see
+        // `crate::hooks::HookRuntime::injection`.
+        let hook_injection = self.hook_injection_for(kind);
         let id = self.agents.spawn(
             kind,
             cwd,
             self.settings.appearance.terminal_font_size,
             self.settings.terminal.shell_override(),
+            hook_injection.as_ref(),
             window,
             cx,
         );
@@ -353,8 +359,17 @@ impl AdeApp {
         // with more than one open agent this is always `false`, so no agent there claims review
         // readiness it can't honestly substantiate. Such an agent lands on `Idle` instead, which
         // is the same state it would show with an empty review.
+        // GitHub issue #239 phase 2: the third and strongest signal - what the agent reported
+        // about itself through Claude Code's hook side-channel. `Default` (no fact) for every
+        // agent that has never fired one, which is every Codex agent, every shell, and every
+        // Claude agent whose first hook hasn't arrived yet - all of which therefore land on
+        // exactly the Phase 1 behaviour above.
+        let hooks = match &self.hook_runtime {
+            Some(runtime) => runtime.signal_for(agent.id),
+            None => status::HookSignal::default(),
+        };
         let has_unreviewed_changes = self.agent_has_unreviewed_changes(agent.id);
-        status::derive_status(agent.kind, signal, terminal, has_unreviewed_changes)
+        status::derive_status(agent.kind, signal, terminal, hooks, has_unreviewed_changes)
     }
 
     /// The context bar's and idle-status footer's `Archive` action - closes the tab via
@@ -414,6 +429,15 @@ impl AdeApp {
             self.close_review_tab(window, cx);
         }
         self.release_review_baseline(id, cx);
+        // GitHub issue #239 phase 2: drop this agent's live hook facts. Agent ids are handed out
+        // by a monotonic counter so they are not reused today, but a stale entry keeping a dead
+        // agent's status alive in the inbox would be a real bug the moment that ever changed -
+        // and there is no reason to keep facts about a pane that no longer exists. The *persisted*
+        // record deliberately survives, exactly like the review baseline immediately above:
+        // that closed agent is what GitHub issue #227 exists to show.
+        if let Some(runtime) = &self.hook_runtime {
+            runtime.forget(id);
+        }
         self.agents.close(id, skip_focus_move, window, cx);
         if self
             .merge_flow
@@ -459,11 +483,16 @@ impl AdeApp {
         let kind = agent.kind;
         let cwd = agent.cwd.clone();
         self.close_agent(id, window, cx);
+        // A respawned agent is a freshly spawned one in every other respect, so it gets the same
+        // real hook injection - otherwise "Retry" would silently produce an agent whose status
+        // fell back to the quiescence heuristic.
+        let hook_injection = self.hook_injection_for(kind);
         self.agents.spawn(
             kind,
             cwd,
             self.settings.appearance.terminal_font_size,
             self.settings.terminal.shell_override(),
+            hook_injection.as_ref(),
             window,
             cx,
         );
@@ -496,6 +525,7 @@ impl AdeApp {
                     cwd,
                     self.settings.appearance.terminal_font_size,
                     self.settings.terminal.shell_override(),
+                    None,
                     window,
                     cx,
                 );
@@ -1451,11 +1481,13 @@ impl AdeApp {
             // (`Self::focus_newly_spawned_agent`) - `Entity::update_in` provides it.
             let _ = this.update_in(cx, |this, window, cx| {
                 let kind = installed.unwrap_or(settings::AGENT_KINDS[0]);
+                let hook_injection = this.hook_injection_for(ProcessKind::Agent(kind));
                 this.agents.spawn(
                     ProcessKind::Agent(kind),
                     cwd,
                     this.settings.appearance.terminal_font_size,
                     this.settings.terminal.shell_override(),
+                    hook_injection.as_ref(),
                     window,
                     cx,
                 );
@@ -2744,6 +2776,7 @@ mod tab_scoping_tests {
                 wt_a.path().to_path_buf(),
                 12.0,
                 None,
+                None,
                 window,
                 cx,
             );
@@ -2751,6 +2784,7 @@ mod tab_scoping_tests {
                 ProcessKind::claude(),
                 wt_a.path().to_path_buf(),
                 12.0,
+                None,
                 None,
                 window,
                 cx,
@@ -2833,6 +2867,7 @@ mod tab_scoping_tests {
                 wt_a.path().to_path_buf(),
                 12.0,
                 None,
+                None,
                 window,
                 cx,
             );
@@ -2841,6 +2876,7 @@ mod tab_scoping_tests {
                 ProcessKind::Shell,
                 wt_b.path().to_path_buf(),
                 12.0,
+                None,
                 None,
                 window,
                 cx,
@@ -2895,6 +2931,7 @@ mod tab_scoping_tests {
                 wt_a.path().to_path_buf(),
                 12.0,
                 None,
+                None,
                 window,
                 cx,
             );
@@ -2902,6 +2939,7 @@ mod tab_scoping_tests {
                 ProcessKind::Shell,
                 wt_a.path().to_path_buf(),
                 12.0,
+                None,
                 None,
                 window,
                 cx,
@@ -2958,6 +2996,7 @@ mod tab_scoping_tests {
                 wt_a.path().to_path_buf(),
                 12.0,
                 None,
+                None,
                 window,
                 cx,
             )
@@ -2968,6 +3007,7 @@ mod tab_scoping_tests {
                 ProcessKind::Shell,
                 wt_b.path().to_path_buf(),
                 12.0,
+                None,
                 None,
                 window,
                 cx,
@@ -3016,6 +3056,7 @@ mod tab_scoping_tests {
                 repo.path().to_path_buf(),
                 12.0,
                 None,
+                None,
                 window,
                 cx,
             );
@@ -3023,6 +3064,7 @@ mod tab_scoping_tests {
                 ProcessKind::Shell,
                 repo.path().to_path_buf(),
                 12.0,
+                None,
                 None,
                 window,
                 cx,
@@ -3130,6 +3172,7 @@ mod tab_scoping_tests {
                 repo.path().to_path_buf(),
                 12.0,
                 None,
+                None,
                 window,
                 cx,
             );
@@ -3205,6 +3248,7 @@ mod tab_scoping_tests {
                 repo.path().to_path_buf(),
                 12.0,
                 None,
+                None,
                 window,
                 cx,
             );
@@ -3263,6 +3307,7 @@ mod tab_scoping_tests {
                 ProcessKind::claude(),
                 repo.path().to_path_buf(),
                 12.0,
+                None,
                 None,
                 window,
                 cx,
@@ -3368,6 +3413,7 @@ mod tab_scoping_tests {
                 repo.path().to_path_buf(),
                 12.0,
                 None,
+                None,
                 window,
                 cx,
             );
@@ -3445,6 +3491,7 @@ mod tab_scoping_tests {
                 ProcessKind::Shell,
                 repo.path().to_path_buf(),
                 12.0,
+                None,
                 None,
                 window,
                 cx,
@@ -3549,6 +3596,7 @@ mod tab_scoping_tests {
                 repo.path().to_path_buf(),
                 12.0,
                 None,
+                None,
                 window,
                 cx,
             );
@@ -3607,6 +3655,7 @@ mod tab_scoping_tests {
                 wt_a.path().to_path_buf(),
                 12.0,
                 None,
+                None,
                 window,
                 cx,
             );
@@ -3614,6 +3663,7 @@ mod tab_scoping_tests {
                 ProcessKind::claude(),
                 wt_a.path().to_path_buf(),
                 12.0,
+                None,
                 None,
                 window,
                 cx,
@@ -3653,6 +3703,7 @@ mod tab_scoping_tests {
                 wt_a.path().to_path_buf(),
                 12.0,
                 None,
+                None,
                 window,
                 cx,
             );
@@ -3668,6 +3719,7 @@ mod tab_scoping_tests {
                 ProcessKind::claude(),
                 wt_a.path().to_path_buf(),
                 12.0,
+                None,
                 None,
                 window,
                 cx,
@@ -3702,6 +3754,7 @@ mod tab_scoping_tests {
                 ProcessKind::Shell,
                 wt_a.path().to_path_buf(),
                 12.0,
+                None,
                 None,
                 window,
                 cx,
@@ -3896,6 +3949,7 @@ mod tab_scoping_tests {
                 wt_a.path().to_path_buf(),
                 12.0,
                 None,
+                None,
                 window,
                 cx,
             );
@@ -3903,6 +3957,7 @@ mod tab_scoping_tests {
                 ProcessKind::claude(),
                 wt_a.path().to_path_buf(),
                 12.0,
+                None,
                 None,
                 window,
                 cx,
@@ -3979,6 +4034,7 @@ mod tab_scoping_tests {
                 repo.path().to_path_buf(),
                 12.0,
                 None,
+                None,
                 window,
                 cx,
             )
@@ -4044,6 +4100,7 @@ mod tab_scoping_tests {
                 wt_a.path().to_path_buf(),
                 12.0,
                 None,
+                None,
                 window,
                 cx,
             );
@@ -4096,6 +4153,7 @@ mod tab_scoping_tests {
                 ProcessKind::Shell,
                 wt_a.path().to_path_buf(),
                 12.0,
+                None,
                 None,
                 window,
                 cx,
@@ -4213,6 +4271,7 @@ mod terminal_clear_action_tests {
                 repo.path().to_path_buf(),
                 12.0,
                 None,
+                None,
                 window,
                 cx,
             );
@@ -4220,6 +4279,7 @@ mod terminal_clear_action_tests {
                 ProcessKind::Shell,
                 repo.path().to_path_buf(),
                 12.0,
+                None,
                 None,
                 window,
                 cx,
@@ -4334,6 +4394,7 @@ mod tab_order_persistence_tests {
                 repo.path().to_path_buf(),
                 12.0,
                 None,
+                None,
                 window,
                 cx,
             );
@@ -4373,6 +4434,7 @@ mod tab_order_persistence_tests {
                 ProcessKind::claude(),
                 repo.path().to_path_buf(),
                 12.0,
+                None,
                 None,
                 window,
                 cx,
@@ -4483,6 +4545,7 @@ mod terminal_clipboard_action_tests {
                 ProcessKind::Shell,
                 repo.path().to_path_buf(),
                 12.0,
+                None,
                 None,
                 window,
                 cx,

--- a/crates/app/src/worktree_history/flow.rs
+++ b/crates/app/src/worktree_history/flow.rs
@@ -270,6 +270,7 @@ mod worktree_history_regression_tests {
                 cwd,
                 app.settings.appearance.terminal_font_size,
                 app.settings.terminal.shell_override(),
+                None,
                 window,
                 cx,
             )


### PR DESCRIPTION
## Summary

Phase 2 of issue #239 — a real Claude Code hook side-channel, layered on top of Phase 1's terminal-signal work (#244, this PR's base branch). Stacked: merge #244 first.

- A loopback-only HTTP listener (127.0.0.1, ephemeral port, per-session random token) that Jerry spawns once per app session.
- Per-launch `--settings <generated file>` injection when spawning a Claude agent — never touches the user's own `~/.claude/settings.json` or any project config. Verified empirically against real `claude` 2.1.228 that `--settings` genuinely **merges** with the user's own settings rather than replacing them, so Jerry does no read-and-splice of existing hooks (which would double-run every user hook).
- A dumb POSIX shell forwarder script (env-guarded no-op outside Jerry) that pipes each hook's stdin to the listener.
- Real JSON parsing of Claude's hook payloads → tool activity / permission reason / notification message, extending (not replacing) the Phase 1 terminal-signal path — Shell and unhooked agents still fall back to Phase 1 heuristics.
- A new, genuine capability: `Stop` → `Status::Review` while the process is still alive (previously required an exit), gated against #225's unreviewed-changes tracking.
- A minimal on-disk persistence layer for a future #227 resume UI to build on (deliberately not built here).

## Security

This went through two full rounds of independent adversarial review (not just self-report):

1. First pass found 2 Critical issues: a slow-drip DoS (per-`recv` timeout, not per-request, letting a local attacker starve the listener for hours) and a non-atomic file-permission window with a symlink race on the generated secrets directory. Both fixed.
2. Second pass mutation-tested both fixes (reverted them, confirmed the regression tests correctly fail) and confirmed them genuinely fixed, while surfacing 3 smaller residuals: a write-phase deadline gap, a rare-umask exec-bit stripping edge case, and one integration test that didn't honor the new strict-CI env var. All three fixed and verified in a final pass.
3. A known, deliberately accepted residual is documented inline: an attacker holding all in-flight connection slots and reconnecting on each expiry can still degrade (not compromise) the channel — bounded by, and consistent with, this feature's existing same-machine/same-user threat model.

Also fixed along the way: generated files were originally keyed on PID alone, colliding across two `AdeApp` instances from issue #90's "New Window" (now PID + a process-global counter), and persistence was fsyncing on every terminal-signal transition rather than only real hook events, which was the actual root cause of 3 unrelated text-undo tests flaking under load.

## Test plan
- [x] `cargo build --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check` all clean
- [x] `hooks::` test suite green under `JERRY_REQUIRE_REAL_CLAUDE=1` (55 tests, real `claude` binary genuinely exercised, no vacuous skips)
- [x] Full workspace suite green aside from already-documented environmental flakes (inotify contention under load), each confirmed passing standalone
- [x] Security-critical fixes (deadline enforcement, symlink-safe file creation, token-never-on-disk) each mutation-tested: reverting the fix makes the corresponding regression test fail for the right reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)