### PR TITLE
feat(app): agent history and resume/recover (issue #227)

### DIFF
--- a/crates/app/src/hooks/event.rs
+++ b/crates/app/src/hooks/event.rs
@@ -109,6 +109,22 @@ pub struct HookReport {
     /// The real permission reason / notification message, already truncated to
     /// [`QUESTION_MAX_CHARS`]. `None` unless the event actually carries human-facing text.
     pub question: Option<String>,
+    /// The real Claude Code `session_id` this payload carried, if any (GitHub issue #227).
+    ///
+    /// Verified present on *every* real event type this module parses - a real `claude` 2.1.228
+    /// binary was driven through `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`
+    /// and `Stop` (a scratch project, `--settings` pointed at a capture script) and every single
+    /// payload carried the same `session_id` for the whole conversation, including across a real
+    /// `claude --resume <session_id>` re-invocation (`SessionStart`'s `source` simply reads
+    /// `"resume"` instead of `"startup"`). That is the real, durable identifier `claude
+    /// --resume`/`-r` takes - confirmed against the same real binary: resuming by this id and
+    /// asking what the agent had just done answered correctly, proving it is the *same*
+    /// conversation rather than a fresh one that merely inherited some context.
+    ///
+    /// `None` for a payload that omits it (untrusted input off the socket - not every hand-made
+    /// or malformed request will carry one), which a reader must treat as "no id available",
+    /// never as a reason to fail the rest of the report.
+    pub session_id: Option<String>,
 }
 
 impl HookReport {
@@ -119,6 +135,7 @@ impl HookReport {
             fact,
             activity: None,
             question: None,
+            session_id: None,
         }
     }
 }
@@ -209,7 +226,16 @@ pub fn parse(event_name: &str, payload: &[u8]) -> Option<HookReport> {
         return None;
     }
 
-    match event_name {
+    // Read once, attached to whatever report the match below produces (GitHub issue #227): every
+    // real event carries the same session-scoped `session_id`, so extracting it per-arm would be
+    // pure repetition - see [`HookReport::session_id`]'s own docs for why this field exists at
+    // all and how it was verified.
+    let session_id = value
+        .get("session_id")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_owned);
+
+    let report = match event_name {
         "SessionStart" | "UserPromptSubmit" => Some(HookReport::bare(HookFact::Working)),
 
         "PreToolUse" | "PostToolUse" => {
@@ -223,6 +249,7 @@ pub fn parse(event_name: &str, payload: &[u8]) -> Option<HookReport> {
                 fact: HookFact::Working,
                 activity,
                 question: None,
+                session_id: None,
             })
         }
 
@@ -238,6 +265,7 @@ pub fn parse(event_name: &str, payload: &[u8]) -> Option<HookReport> {
                     .get("error")
                     .and_then(serde_json::Value::as_str)
                     .and_then(|error| truncated(error, QUESTION_MAX_CHARS)),
+                session_id: None,
             })
         }
 
@@ -257,6 +285,7 @@ pub fn parse(event_name: &str, payload: &[u8]) -> Option<HookReport> {
                 fact: HookFact::NeedsInput,
                 activity: None,
                 question,
+                session_id: None,
             })
         }
 
@@ -275,6 +304,7 @@ pub fn parse(event_name: &str, payload: &[u8]) -> Option<HookReport> {
                     .get("message")
                     .and_then(serde_json::Value::as_str)
                     .and_then(|message| truncated(message, QUESTION_MAX_CHARS)),
+                session_id: None,
             })
         }
 
@@ -287,10 +317,16 @@ pub fn parse(event_name: &str, payload: &[u8]) -> Option<HookReport> {
                 .get("error_message")
                 .and_then(serde_json::Value::as_str)
                 .and_then(|message| truncated(message, QUESTION_MAX_CHARS)),
+            session_id: None,
         }),
 
         _ => None,
-    }
+    }?;
+
+    Some(HookReport {
+        session_id,
+        ..report
+    })
 }
 
 #[cfg(test)]
@@ -319,6 +355,7 @@ mod tests {
             Some("Bash: echo hello-from-jerry")
         );
         assert_eq!(report.question, None);
+        assert_eq!(report.session_id.as_deref(), Some("5a4bef04"));
     }
 
     #[test]
@@ -331,6 +368,7 @@ mod tests {
             report.activity.as_deref(),
             Some("Write: /tmp/capture/done.txt")
         );
+        assert_eq!(report.session_id.as_deref(), Some("5a4bef04"));
     }
 
     #[test]
@@ -341,6 +379,37 @@ mod tests {
         // see the module docs.
         assert_eq!(report.activity, None);
         assert_eq!(report.question, None);
+        // A turn-boundary event still carries the real session id - GitHub issue #227's resume
+        // flow needs it from `Stop` just as much as from a `PreToolUse`, since `Stop` is the last
+        // event an agent that then sits idle (and is later closed) will ever send.
+        assert_eq!(report.session_id.as_deref(), Some("5a4bef04"));
+    }
+
+    #[test]
+    fn a_payload_with_no_session_id_leaves_it_none_rather_than_a_fabricated_value() {
+        // Untrusted input off the socket: a hand-made or malformed request may simply omit the
+        // field, and that must read back as "no id available", not panic or a wrong guess.
+        let report = parse(
+            "Stop",
+            br#"{"hook_event_name":"Stop","stop_hook_active":false}"#,
+        )
+        .expect("must parse");
+        assert_eq!(report.session_id, None);
+    }
+
+    #[test]
+    fn a_resumed_sessions_hooks_report_the_same_session_id() {
+        // The real proof this field is worth persisting: `claude --resume <id>` (verified against
+        // a real 2.1.228 binary) keeps firing hooks under the *same* `session_id` it resumed -
+        // only `SessionStart`'s `source` changes, from `"startup"` to `"resume"`. Pinned from a
+        // real captured payload of exactly that resumed run.
+        let real_resumed_session_start = br#"{"session_id":"5af4c210-34fa-4ab2-9c35-f6ceab76551c","transcript_path":"/home/colin/.claude/projects/x/5af4c210.jsonl","cwd":"/tmp/hook_capture/project","hook_event_name":"SessionStart","source":"resume"}"#;
+        let report = parse("SessionStart", real_resumed_session_start).expect("must parse");
+        assert_eq!(report.fact, HookFact::Working);
+        assert_eq!(
+            report.session_id.as_deref(),
+            Some("5af4c210-34fa-4ab2-9c35-f6ceab76551c")
+        );
     }
 
     #[test]

--- a/crates/app/src/hooks/flow.rs
+++ b/crates/app/src/hooks/flow.rs
@@ -5,15 +5,116 @@
 //! [`crate::root::AdeApp::agent_status_state`], and persists only when something genuinely
 //! changed.
 //!
-//! Nothing renders any of this. It exists so GitHub issue #227 ("Agent history and
-//! resume/recover") has real, structured, dated data to build on rather than having to invent a
-//! capture mechanism first - see [`crate::hooks::store`]'s module docs.
+//! Originally nothing rendered any of this - it existed so GitHub issue #227 ("Agent history and
+//! resume/recover") would have real, structured, dated data to build on rather than having to
+//! invent a capture mechanism first (see [`crate::hooks::store`]'s module docs). Issue #227's own
+//! read side now reads it back - [`crate::hooks::history`] and the rail's history rows.
 
-use gpui::Context;
+use gpui::{Context, Window};
 
 use crate::root::AdeApp;
+use crate::work_surface::agents::{AgentKind, ProcessKind};
 
 impl AdeApp {
+    /// Every currently open agent's own persisted-status key
+    /// (`crate::review::state::baseline_key`) - GitHub issue #227's "this one is still live, don't
+    /// show it twice under History" exclusion set for
+    /// [`crate::hooks::history::past_agents_for_worktree`].
+    ///
+    /// A live agent's key is computed the identical way [`Self::record_agent_statuses`] computes
+    /// it before writing - same function, same three inputs (`cwd`, `kind`, `spawned_at_unix`) -
+    /// so this can never drift into excluding the wrong record.
+    pub(crate) fn live_agent_status_keys(&self) -> std::collections::HashSet<String> {
+        self.agents
+            .iter()
+            .filter_map(|agent| {
+                let ProcessKind::Agent(kind) = agent.kind else {
+                    return None;
+                };
+                Some(crate::review::state::baseline_key(
+                    &agent.cwd,
+                    kind,
+                    agent.spawned_at_unix,
+                ))
+            })
+            .collect()
+    }
+
+    /// GitHub issue #227's resume action: looks `key` up in
+    /// [`Self::agent_status_state`], selects its worktree, and spawns a real agent back into it.
+    ///
+    /// **Literal conversation resume** (`claude --resume <session_id>`, via
+    /// [`crate::work_surface::agents::Agents::spawn_resume`]) when the record actually carries a
+    /// real Claude Code `session_id` - verified against a real `claude` 2.1.228 binary to
+    /// genuinely pick the same conversation back up (see
+    /// [`crate::hooks::event::HookReport::session_id`]'s own docs for how). Otherwise, a fresh
+    /// agent of the same recorded kind spawned into the same worktree - the honest fallback for a
+    /// Codex record (Codex has no hooks and so never captures a session id at all - Jerry never
+    /// claims otherwise) or for a Claude record predating this field. That fallback reconnects the
+    /// user to the right *place*, even though it cannot continue the exact prior conversation.
+    ///
+    /// A no-op returning `false` if `key` no longer names a decodable record, or its worktree is
+    /// no longer one of [`crate::root::AdeApp::worktrees`] (removed or pruned since it was
+    /// recorded) - there is no real place left to resume into.
+    pub(crate) fn resume_past_agent(
+        &mut self,
+        key: &str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        let Some(past) = crate::hooks::history::find(&self.agent_status_state, key) else {
+            return false;
+        };
+        if !self
+            .worktrees
+            .iter()
+            .any(|item| item.path == past.worktree && item.error.is_none())
+        {
+            return false;
+        }
+
+        self.select_worktree_by_path(&past.worktree, window, cx);
+
+        let process_kind = ProcessKind::Agent(past.kind);
+        // GitHub issue #239 phase 2's injection, exactly as a fresh spawn would get it - a
+        // resumed conversation is exactly as real an agent as a new one, and should keep
+        // reporting its status through the same hook side-channel.
+        let hook_injection = self.hook_injection_for(process_kind);
+        let font_size = self.settings.appearance.terminal_font_size;
+        let shell_override = self.settings.terminal.shell_override();
+        let id = match (past.kind, past.session_id.clone()) {
+            (AgentKind::Claude, Some(session_id)) => self.agents.spawn_resume(
+                AgentKind::Claude,
+                past.worktree.clone(),
+                font_size,
+                shell_override,
+                hook_injection.as_ref(),
+                session_id,
+                window,
+                cx,
+            ),
+            _ => self.agents.spawn(
+                process_kind,
+                past.worktree.clone(),
+                font_size,
+                shell_override,
+                hook_injection.as_ref(),
+                window,
+                cx,
+            ),
+        };
+        // Mirrors `crate::work_surface::render::AdeApp::new_agent`'s own post-spawn steps: a real
+        // review baseline for the newly spawned pane, closing a now-invalid gated review tab, and
+        // moving focus onto it.
+        self.capture_review_baseline(id, cx);
+        self.close_gated_review_tab(window, cx);
+        self.focus_newly_spawned_agent(window, cx);
+        self.prune_confirm_armed = false;
+        self.discard_confirm_armed = None;
+        cx.notify();
+        true
+    }
+
     /// The hook injection for an agent about to be spawned, bringing the listener up on first use.
     ///
     /// `None` for anything that isn't a Claude agent, and `None` if the runtime can't start - both
@@ -119,7 +220,7 @@ impl AdeApp {
             return;
         }
 
-        let entries: Vec<(String, std::path::PathBuf, &'static str, i64, _, _, _)> = recordable
+        let entries: Vec<(String, std::path::PathBuf, &'static str, i64, _, _, _, _)> = recordable
             .into_iter()
             .filter_map(|(id, key, cwd, kind_label, spawned_at_unix)| {
                 let agent = self.agents.iter().find(|agent| agent.id == id)?;
@@ -128,6 +229,15 @@ impl AdeApp {
                     Some(runtime) => runtime.text_for(id),
                     None => (None, None),
                 };
+                // GitHub issue #227: the real Claude Code session id this agent's hooks have
+                // reported, if any - deliberately read without the `fresh()`/TTL gate
+                // `text_for` applies (see `HookRuntime::session_id_for`'s own docs), since a
+                // conversation stays exactly as resumable after its hooks go quiet as it was
+                // the instant its last one fired.
+                let session_id = self
+                    .hook_runtime
+                    .as_ref()
+                    .and_then(|runtime| runtime.session_id_for(id));
                 Some((
                     key,
                     cwd,
@@ -136,11 +246,14 @@ impl AdeApp {
                     status,
                     activity,
                     question,
+                    session_id,
                 ))
             })
             .collect();
 
-        for (key, cwd, kind_label, spawned_at_unix, status, activity, question) in entries {
+        for (key, cwd, kind_label, spawned_at_unix, status, activity, question, session_id) in
+            entries
+        {
             if self.agent_status_state.set(
                 key.clone(),
                 &cwd,
@@ -149,6 +262,7 @@ impl AdeApp {
                 status,
                 activity,
                 question,
+                session_id,
                 now,
             ) {
                 changed = true;

--- a/crates/app/src/hooks/history.rs
+++ b/crates/app/src/hooks/history.rs
@@ -1,0 +1,298 @@
+//! The read side of [`crate::hooks::store`] (GitHub issue #227): turns the persisted
+//! [`crate::hooks::store::AgentStatusState`] into the list of past agents a UI can show.
+//!
+//! Phase 2 (`crate::hooks::store`'s own module docs) wrote this data and deliberately read none
+//! of it back - "nothing reads `agent-status.toml` back - that's #227's job". This is that job's
+//! data layer: GPUI-free, so it's directly unit-testable, and honest about the shape of what it
+//! returns - every field on [`PastAgent`] traces back to a real, persisted
+//! [`crate::hooks::store::PersistedAgentStatus`] field. Nothing here is invented to fill a gap in
+//! what Phase 2 actually captured.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use crate::hooks::store::{status_from_key, AgentStatusState, PersistedAgentStatus};
+use crate::rail::status::Status;
+use crate::work_surface::agents::AgentKind;
+
+/// One closed (or at least not-currently-open) agent's real, persisted state - what a history UI
+/// needs to render a row and, where possible, offer a real resume.
+///
+/// Deliberately does **not** carry a conversation title, a transcript excerpt, or anything else
+/// Phase 2 never captured - see [`crate::hooks::store::PersistedAgentStatus`]'s own field list for
+/// exactly what a hook payload gave Jerry to keep. [`Self::activity`]/[`Self::question`] are the
+/// closest real substitute for "what was it doing" this data actually has.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PastAgent {
+    /// The persisted record's own key (`crate::review::state::baseline_key`) - stable identity
+    /// for a resume click handler to look the full record back up by.
+    pub key: String,
+    pub worktree: PathBuf,
+    pub kind: AgentKind,
+    pub spawned_at_unix: i64,
+    /// This agent's last known real status before it stopped being recorded (either because it
+    /// closed, or because its hooks simply stopped firing) - not necessarily "closed cleanly".
+    pub status: Status,
+    pub activity: Option<String>,
+    pub question: Option<String>,
+    /// When this record was last updated - the real "last active" timestamp a history row shows.
+    pub updated_at_unix: i64,
+    /// The real Claude Code `session_id` this agent's hooks last reported, if any - see
+    /// [`crate::hooks::event::HookReport::session_id`] for what it is and how a real `claude
+    /// --resume <session_id>` was verified to use it. `None` covers a Codex agent (no hooks exist
+    /// for Codex at all) and a Claude agent that closed before any hook reported one.
+    pub session_id: Option<String>,
+}
+
+impl PastAgent {
+    /// Decodes one raw persisted record into a [`PastAgent`], or `None` if it isn't usable - an
+    /// unencodable worktree, or a status key this build doesn't recognise (a record written by a
+    /// future release). Skipping a record like this, rather than showing it wrong, mirrors
+    /// `PersistedAgentStatus::worktree_path`/`status_from_key`'s own "unusable record" contract.
+    fn from_record(key: &str, record: &PersistedAgentStatus) -> Option<PastAgent> {
+        let worktree = record.worktree_path()?;
+        let kind = AgentKind::from_label(&record.kind)?;
+        let status = status_from_key(&record.status)?;
+        Some(PastAgent {
+            key: key.to_owned(),
+            worktree,
+            kind,
+            spawned_at_unix: record.spawned_at_unix,
+            status,
+            activity: record.activity.clone(),
+            question: record.question.clone(),
+            updated_at_unix: record.updated_at_unix,
+            session_id: record.session_id.clone(),
+        })
+    }
+}
+
+/// Every real, readable past agent in `state`, most recently active first. A record that fails to
+/// decode is silently skipped - see [`PastAgent::from_record`].
+pub fn past_agents(state: &AgentStatusState) -> Vec<PastAgent> {
+    let mut agents: Vec<PastAgent> = state
+        .agents
+        .iter()
+        .filter_map(|(key, record)| PastAgent::from_record(key, record))
+        .collect();
+    // Most recent first; the key breaks ties deterministically, mirroring
+    // `AgentStatusState::prune_to_most_recent`'s own ordering.
+    agents.sort_by(|a, b| {
+        b.updated_at_unix
+            .cmp(&a.updated_at_unix)
+            .then_with(|| a.key.cmp(&b.key))
+    });
+    agents
+}
+
+/// [`past_agents`] filtered to exactly one worktree, and to records that are genuinely *past* -
+/// excluding any key in `live_keys`.
+///
+/// That exclusion matters because a persisted record also exists for an agent that is still
+/// running: `crate::hooks::flow::AdeApp::record_agent_statuses` records every agent with a fresh
+/// hook fact, live ones included, not just closed ones (see that function's own module docs on
+/// why "past" isn't something the store itself can decide). A still-open agent already has a
+/// real, live rail row; showing it again under "History" would be the same agent rendered twice.
+/// `live_keys` is `crate::review::state::baseline_key` for every currently open agent, computed by
+/// the caller from live `Agent` state - this module has no notion of "currently open" itself.
+pub fn past_agents_for_worktree(
+    state: &AgentStatusState,
+    worktree: &Path,
+    live_keys: &HashSet<String>,
+) -> Vec<PastAgent> {
+    past_agents(state)
+        .into_iter()
+        .filter(|agent| agent.worktree == worktree && !live_keys.contains(&agent.key))
+        .collect()
+}
+
+/// One past agent's real record, by its persisted key - the resume click handler's lookup
+/// (`crate::hooks::flow::AdeApp::resume_past_agent`), so it doesn't have to re-filter/re-sort the
+/// whole history just to find the one record a click named.
+pub fn find(state: &AgentStatusState, key: &str) -> Option<PastAgent> {
+    let record = state.get(key)?;
+    PastAgent::from_record(key, record)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key_for(worktree: &str, spawned: i64) -> String {
+        crate::review::state::baseline_key(Path::new(worktree), AgentKind::Claude, spawned)
+    }
+
+    /// The real round trip GitHub issue #227's whole read side depends on: a record written
+    /// through `AgentStatusState`'s real save path, reloaded from a real file, and turned into a
+    /// UI-facing `PastAgent` with every field intact.
+    #[test]
+    fn a_persisted_record_really_round_trips_into_a_past_agent() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join(crate::hooks::store::AGENT_STATUS_FILE_NAME);
+
+        let key = key_for("/repo/wt-a", 1_700_000_000);
+        let mut state = AgentStatusState::default();
+        state.set(
+            key.clone(),
+            Path::new("/repo/wt-a"),
+            "Claude",
+            1_700_000_000,
+            Status::Review,
+            Some("Edit: src/auth.rs".to_owned()),
+            None,
+            Some("5af4c210-34fa-4ab2-9c35-f6ceab76551c".to_owned()),
+            1_700_000_500,
+        );
+        state
+            .save_merged_at(&path, &std::iter::once(key.clone()).collect())
+            .expect("save");
+
+        let reloaded = AgentStatusState::load_at(&path);
+        let agents = past_agents(&reloaded);
+        assert_eq!(agents.len(), 1);
+        let agent = &agents[0];
+        assert_eq!(agent.key, key);
+        assert_eq!(agent.worktree, PathBuf::from("/repo/wt-a"));
+        assert_eq!(agent.kind, AgentKind::Claude);
+        assert_eq!(agent.spawned_at_unix, 1_700_000_000);
+        assert_eq!(agent.status, Status::Review);
+        assert_eq!(agent.activity.as_deref(), Some("Edit: src/auth.rs"));
+        assert_eq!(agent.question, None);
+        assert_eq!(agent.updated_at_unix, 1_700_000_500);
+        assert_eq!(
+            agent.session_id.as_deref(),
+            Some("5af4c210-34fa-4ab2-9c35-f6ceab76551c")
+        );
+    }
+
+    #[test]
+    fn past_agents_are_sorted_most_recently_active_first() {
+        let mut state = AgentStatusState::default();
+        state.set(
+            key_for("/repo/wt-old", 1),
+            Path::new("/repo/wt-old"),
+            "Claude",
+            1,
+            Status::Idle,
+            None,
+            None,
+            None,
+            100,
+        );
+        state.set(
+            key_for("/repo/wt-new", 2),
+            Path::new("/repo/wt-new"),
+            "Codex",
+            2,
+            Status::Idle,
+            None,
+            None,
+            None,
+            999,
+        );
+        let agents = past_agents(&state);
+        assert_eq!(agents.len(), 2);
+        assert_eq!(agents[0].worktree, PathBuf::from("/repo/wt-new"));
+        assert_eq!(agents[1].worktree, PathBuf::from("/repo/wt-old"));
+    }
+
+    #[test]
+    fn a_record_with_an_unrecognised_status_key_is_skipped_not_shown_wrong() {
+        // The real reason `status_from_key` returning `None` matters here: a record written by a
+        // future release must not be shown with some default/guessed status.
+        let mut state = AgentStatusState::default();
+        let key = key_for("/repo/wt-a", 1);
+        state.agents.insert(
+            key,
+            PersistedAgentStatus {
+                worktree: crate::review::state::encode_worktree(Path::new("/repo/wt-a")),
+                kind: "Claude".to_owned(),
+                spawned_at_unix: 1,
+                status: "a_status_from_a_future_release".to_owned(),
+                activity: None,
+                question: None,
+                updated_at_unix: 1,
+                session_id: None,
+            },
+        );
+        assert!(past_agents(&state).is_empty());
+    }
+
+    #[test]
+    fn a_record_with_an_unrecognised_kind_is_skipped_not_shown_wrong() {
+        let mut state = AgentStatusState::default();
+        let key = key_for("/repo/wt-a", 1);
+        state.agents.insert(
+            key,
+            PersistedAgentStatus {
+                worktree: crate::review::state::encode_worktree(Path::new("/repo/wt-a")),
+                kind: "SomeFutureAgent".to_owned(),
+                spawned_at_unix: 1,
+                status: "idle".to_owned(),
+                activity: None,
+                question: None,
+                updated_at_unix: 1,
+                session_id: None,
+            },
+        );
+        assert!(past_agents(&state).is_empty());
+    }
+
+    #[test]
+    fn past_agents_for_worktree_filters_by_path_and_excludes_live_keys() {
+        let mut state = AgentStatusState::default();
+        let closed_key = key_for("/repo/wt-a", 1);
+        let live_key = key_for("/repo/wt-a", 2);
+        let other_worktree_key = key_for("/repo/wt-b", 3);
+        for (key, worktree, spawned) in [
+            (closed_key.clone(), "/repo/wt-a", 1),
+            (live_key.clone(), "/repo/wt-a", 2),
+            (other_worktree_key.clone(), "/repo/wt-b", 3),
+        ] {
+            state.set(
+                key,
+                Path::new(worktree),
+                "Claude",
+                spawned,
+                Status::Idle,
+                None,
+                None,
+                None,
+                spawned,
+            );
+        }
+
+        let live_keys: HashSet<String> = std::iter::once(live_key.clone()).collect();
+        let history = past_agents_for_worktree(&state, Path::new("/repo/wt-a"), &live_keys);
+        assert_eq!(history.len(), 1, "only the closed wt-a agent must show");
+        assert_eq!(history[0].key, closed_key);
+    }
+
+    #[test]
+    fn a_worktree_with_no_persisted_history_shows_nothing() {
+        let state = AgentStatusState::default();
+        assert!(
+            past_agents_for_worktree(&state, Path::new("/repo/wt-a"), &HashSet::new()).is_empty()
+        );
+    }
+
+    #[test]
+    fn find_looks_up_one_record_by_its_real_persisted_key() {
+        let mut state = AgentStatusState::default();
+        let key = key_for("/repo/wt-a", 1);
+        state.set(
+            key.clone(),
+            Path::new("/repo/wt-a"),
+            "Claude",
+            1,
+            Status::Idle,
+            None,
+            None,
+            Some("session-abc".to_owned()),
+            10,
+        );
+        let found = find(&state, &key).expect("the record must be found");
+        assert_eq!(found.session_id.as_deref(), Some("session-abc"));
+        assert_eq!(find(&state, "no-such-key"), None);
+    }
+}

--- a/crates/app/src/hooks/mod.rs
+++ b/crates/app/src/hooks/mod.rs
@@ -28,6 +28,13 @@
 //!     └── AdeApp::agent_status ──▶ rail::status::derive_status(.., HookSignal, ..)
 //!     └── AdeApp::build_agent_rows ──▶ AgentRow::activity / question_preview
 //!                                       └── AgentStatusState (agent-status.toml)  [store]
+//!
+//!   agent closes / app restarts, later reopened (GitHub issue #227)
+//!     └── AdeApp::build_worktree_rows ──▶ history::past_agents_for_worktree(state, wt, live_keys)
+//!                                          └── WorktreeRow::history  ──▶  rail "History" rows
+//!     └── click Resume ──▶ AdeApp::resume_past_agent
+//!           ├── real session_id captured  ──▶ Agents::spawn_resume (`claude --resume <id>`)
+//!           └── no session_id (Codex, or predates this field) ──▶ Agents::spawn (fresh agent)
 //! ```
 //!
 //! ## Claude Code only, and per-launch only
@@ -47,6 +54,7 @@
 
 pub mod event;
 pub mod flow;
+pub mod history;
 pub mod server;
 pub mod settings_file;
 pub mod store;
@@ -127,6 +135,13 @@ impl HookRuntime {
     /// This agent's current hook-derived `(activity, question)` text, for its rail row.
     pub fn text_for(&self, id: AgentId) -> (Option<String>, Option<String>) {
         self.listener.text_for(id)
+    }
+
+    /// This agent's real Claude Code `session_id` (GitHub issue #227), if its hooks have ever
+    /// reported one - see [`server::HookListener::session_id_for`] for why this deliberately
+    /// isn't gated by staleness the way [`Self::text_for`] is.
+    pub fn session_id_for(&self, id: AgentId) -> Option<String> {
+        self.listener.session_id_for(id)
     }
 
     /// Drops an agent's recorded facts, so a future [`AgentId`] can't inherit them.

--- a/crates/app/src/hooks/server.rs
+++ b/crates/app/src/hooks/server.rs
@@ -345,6 +345,20 @@ impl HookListener {
             inbox.forget(id);
         }
     }
+
+    /// This agent's most recently reported real Claude Code `session_id` (GitHub issue #227),
+    /// if it has ever reported one - the id `claude --resume`/`-r` takes, verified against a real
+    /// binary (see [`crate::hooks::event::HookReport::session_id`]).
+    ///
+    /// Deliberately **not** gated by [`event::HOOK_SIGNAL_TTL`] the way [`Self::text_for`] is: an
+    /// activity/question line describes the *present* and must not outlive its truth, but a
+    /// session id identifies a *conversation*, which stays exactly as resumable an hour after the
+    /// agent went quiet as it was the instant its last hook fired - the whole reason GitHub
+    /// issue #227 wants to persist it at all.
+    pub fn session_id_for(&self, id: AgentId) -> Option<String> {
+        let inbox = self.inbox.lock().ok()?;
+        inbox.get(id)?.report.session_id.clone()
+    }
 }
 
 impl Drop for HookListener {
@@ -720,6 +734,28 @@ mod tests {
         assert_eq!(question, None);
         // A different agent id must be untouched by another agent's event.
         assert_eq!(listener.signal_for(8).fact, None);
+    }
+
+    #[test]
+    fn a_real_session_id_round_trips_into_the_inbox_for_history_and_resume() {
+        // GitHub issue #227's whole resume flow starts here: the real `session_id` a hook payload
+        // carries must reach `session_id_for` unchanged.
+        let listener = HookListener::start().expect("listener must start");
+        let body =
+            r#"{"session_id":"5af4c210-34fa-4ab2-9c35-f6ceab76551c","hook_event_name":"Stop"}"#;
+        let response = post(
+            listener.port(),
+            listener.token(),
+            "event=Stop&agent=11",
+            body,
+        );
+        assert!(response.starts_with("HTTP/1.1 204"), "got {response:?}");
+        assert_eq!(
+            listener.session_id_for(11).as_deref(),
+            Some("5af4c210-34fa-4ab2-9c35-f6ceab76551c")
+        );
+        // No event ever recorded for this id: no session id to report.
+        assert_eq!(listener.session_id_for(12), None);
     }
 
     #[test]

--- a/crates/app/src/hooks/store.rs
+++ b/crates/app/src/hooks/store.rs
@@ -12,10 +12,12 @@
 //! `Edit: src/auth.rs`" is a real, dated, structured statement the agent itself made. That is
 //! worth keeping, so this module keeps it as it is learned.
 //!
-//! **No UI reads this yet, and that is intentional** - browsing and resuming past agents is issue
-//! #227's job, not this phase's. This module exists so that work has real data to build on rather
-//! than having to invent a capture mechanism first. It is written, and it round-trips; nothing
-//! renders it.
+//! **Originally, no UI read this back** - browsing and resuming past agents was left as issue
+//! #227's job, deliberately out of this phase's scope, so the module existed purely so that work
+//! would have real data to build on rather than having to invent a capture mechanism first. Issue
+//! #227's read side is [`crate::hooks::history`] (the plain `AgentStatusState` -> UI-facing
+//! `PastAgent` list) and the rail's own history rows - this module remains the write/persistence
+//! half only, unchanged in shape by that later work.
 //!
 //! ## Everything about the file format mirrors `crate::review::baseline_state`
 //!
@@ -23,9 +25,9 @@
 //! file, same lossless `utf8:`/`bytes:` worktree encoding, same atomic write (temp sibling,
 //! `sync_all`, rename, directory sync), and the same merge-on-save under
 //! `crate::persisted_state_lock::with_locked_merge` so a second Jerry instance can't erase this
-//! one's records. The keys are even the same [`crate::review::state::baseline_key`] values, so a
-//! future issue #227 implementation can join a persisted status straight onto its review
-//! baseline without a translation table.
+//! one's records. The keys are even the same [`crate::review::state::baseline_key`] values, so
+//! [`crate::hooks::history`] can join a persisted status straight onto its review baseline without
+//! a translation table.
 //!
 //! Like `baseline_state` and unlike its other siblings, a key absent from memory is **not**
 //! deleted from disk on save: this is history, and an agent the user closed is exactly the agent
@@ -79,6 +81,12 @@ pub struct PersistedAgentStatus {
     pub question: Option<String>,
     /// When this record was last updated.
     pub updated_at_unix: i64,
+    /// The real Claude Code `session_id` this agent's hooks last reported (GitHub issue #227) -
+    /// see `crate::hooks::event::HookReport::session_id` for what it is and how it was verified.
+    /// This is what makes a literal `claude --resume <session_id>` possible; `None` for a Codex
+    /// agent (no hooks exist for it at all) or a Claude agent whose hooks never fired before this
+    /// field started being captured.
+    pub session_id: Option<String>,
 }
 
 impl PersistedAgentStatus {
@@ -213,6 +221,7 @@ impl AgentStatusState {
         status: Status,
         activity: Option<String>,
         question: Option<String>,
+        session_id: Option<String>,
         now_unix: i64,
     ) -> bool {
         let record = PersistedAgentStatus {
@@ -223,6 +232,7 @@ impl AgentStatusState {
             activity,
             question,
             updated_at_unix: now_unix,
+            session_id,
         };
         // Compare on everything except the timestamp: a status that hasn't changed must not
         // rewrite the file (and re-fsync) purely because time passed.
@@ -233,6 +243,7 @@ impl AgentStatusState {
                 && existing.status == record.status
                 && existing.activity == record.activity
                 && existing.question == record.question
+                && existing.session_id == record.session_id
         });
         if unchanged {
             return false;
@@ -307,6 +318,7 @@ mod tests {
             Status::Review,
             Some("Edit: src/auth.rs".to_owned()),
             None,
+            Some("5af4c210-34fa-4ab2-9c35-f6ceab76551c".to_owned()),
             1_700_000_500,
         ));
 
@@ -323,6 +335,10 @@ mod tests {
         assert_eq!(record.activity.as_deref(), Some("Edit: src/auth.rs"));
         assert_eq!(record.question, None);
         assert_eq!(record.updated_at_unix, 1_700_000_500);
+        assert_eq!(
+            record.session_id.as_deref(),
+            Some("5af4c210-34fa-4ab2-9c35-f6ceab76551c")
+        );
     }
 
     #[test]
@@ -339,17 +355,18 @@ mod tests {
                 Status::Run,
                 Some("Bash: cargo test".to_owned()),
                 None,
+                None,
                 now,
             )
         };
-        let (k, w, kind, spawned, status, activity, question, now) = args(100);
+        let (k, w, kind, spawned, status, activity, question, session_id, now) = args(100);
         assert!(
-            state.set(k, w, kind, spawned, status, activity, question, now),
+            state.set(k, w, kind, spawned, status, activity, question, session_id, now),
             "the first record is a real change"
         );
-        let (k, w, kind, spawned, status, activity, question, now) = args(999);
+        let (k, w, kind, spawned, status, activity, question, session_id, now) = args(999);
         assert!(
-            !state.set(k, w, kind, spawned, status, activity, question, now),
+            !state.set(k, w, kind, spawned, status, activity, question, session_id, now),
             "only the timestamp differs - this must not count as a change"
         );
 
@@ -363,8 +380,47 @@ mod tests {
             Status::Review,
             Some("Bash: cargo test".to_owned()),
             None,
+            None,
             1000,
         ));
+    }
+
+    #[test]
+    fn a_newly_reported_session_id_counts_as_a_real_change() {
+        // Not just timestamps: an agent's hooks may only report a `session_id` after this record
+        // already exists (its first-ever hook could be `PostToolUseFailure`, which carries none -
+        // see `crate::hooks::event::parse`), and that must not be treated as a no-op write.
+        let mut state = AgentStatusState::default();
+        let key = key_for("/repo/wt-a", 20);
+        assert!(state.set(
+            key.clone(),
+            Path::new("/repo/wt-a"),
+            "Claude",
+            20,
+            Status::Run,
+            None,
+            None,
+            None,
+            100,
+        ));
+        assert!(
+            state.set(
+                key.clone(),
+                Path::new("/repo/wt-a"),
+                "Claude",
+                20,
+                Status::Run,
+                None,
+                None,
+                Some("5af4c210-34fa-4ab2-9c35-f6ceab76551c".to_owned()),
+                101,
+            ),
+            "a real session id appearing where there was none must count as a change"
+        );
+        assert_eq!(
+            state.get(&key).and_then(|record| record.session_id.clone()),
+            Some("5af4c210-34fa-4ab2-9c35-f6ceab76551c".to_owned())
+        );
     }
 
     #[test]
@@ -383,6 +439,7 @@ mod tests {
             Status::Run,
             None,
             None,
+            None,
             5,
         );
         other
@@ -399,6 +456,7 @@ mod tests {
             Status::Ask,
             None,
             Some("Bash needs permission: rm -rf /".to_owned()),
+            None,
             6,
         );
         mine.save_merged_at(&path, &std::iter::once(mine_key.clone()).collect())
@@ -429,6 +487,7 @@ mod tests {
             Status::Review,
             None,
             None,
+            None,
             7,
         );
         let owned: BTreeSet<String> = std::iter::once(key.clone()).collect();
@@ -457,6 +516,7 @@ mod tests {
                 "Claude",
                 index,
                 Status::Idle,
+                None,
                 None,
                 None,
                 index, // updated_at_unix ascending, so higher index == more recent
@@ -491,6 +551,7 @@ mod tests {
             "Claude",
             1,
             Status::Run,
+            None,
             None,
             None,
             10,

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -195,11 +195,29 @@ impl AdeApp {
             .collect()
     }
 
-    /// Builds one [`WorktreeRow`] per worktree, folding in every currently open agent
-    /// (`crate::rail::state::build_worktree_rows`) - the single real per-render source both rail modes
-    /// now build their list from (see [`Self::render_rail_list`]).
+    /// Builds one [`WorktreeRow`] per worktree, folding in every currently open agent and (GitHub
+    /// issue #227) every real persisted-but-not-currently-running agent
+    /// (`crate::rail::state::build_worktree_rows_with_history`) - the single real per-render
+    /// source both rail modes now build their list from (see [`Self::render_rail_list`]).
     pub(in crate::rail) fn build_worktree_rows(&self, cx: &App) -> Vec<WorktreeRow> {
-        rail::build_worktree_rows(&self.build_worktree_entries(), &self.build_agent_rows(cx))
+        let live_keys = self.live_agent_status_keys();
+        let history: Vec<crate::hooks::history::PastAgent> = self
+            .worktrees
+            .iter()
+            .filter(|item| item.error.is_none())
+            .flat_map(|item| {
+                crate::hooks::history::past_agents_for_worktree(
+                    &self.agent_status_state,
+                    &item.path,
+                    &live_keys,
+                )
+            })
+            .collect();
+        rail::build_worktree_rows_with_history(
+            &self.build_worktree_entries(),
+            &self.build_agent_rows(cx),
+            &history,
+        )
     }
 
     /// Builds the worktree list: every worktree `wt_core::list_worktrees` reported, including
@@ -1150,7 +1168,12 @@ impl AdeApp {
 
         let is_selected = self.active_agent_cwd() == row.path;
         let has_agents = !row.agents.is_empty();
-        let is_expanded = has_agents && self.worktree_is_expanded(row);
+        let has_history = !row.history.is_empty();
+        // GitHub issue #227: a worktree with no live agent but real persisted history must still
+        // be expandable - the caret/expand state used to be gated on `has_agents` alone, which
+        // would hide a bare worktree's history behind a caret that never rendered at all.
+        let has_children = has_agents || has_history;
+        let is_expanded = has_children && self.worktree_is_expanded(row);
         let status = row.aggregate_status();
 
         // 2px left edge = the colour of the worktree's most urgent agent - bare/prunable get
@@ -1172,7 +1195,7 @@ impl AdeApp {
             theme::text::DIM.into()
         };
 
-        let caret = if has_agents {
+        let caret = if has_children {
             let worktree_path = row.path.clone();
             Some(
                 div()
@@ -1281,6 +1304,9 @@ impl AdeApp {
         if is_expanded {
             for agent in &row.agents {
                 container = container.child(self.render_agent_row(agent, cx));
+            }
+            if has_history {
+                container = container.child(self.render_history_section(&row.history, cx));
             }
         }
 
@@ -1453,6 +1479,159 @@ impl AdeApp {
                             .text_size(self.ui_text_size(9.5))
                             .text_color(theme::text::PATH)
                             .child(agent.kind.label()),
+                    ),
+            )
+    }
+
+    /// A worktree row's "History" section (GitHub issue #227): a small label, then one
+    /// [`Self::render_past_agent_row`] per real persisted-but-not-running agent. Only ever called
+    /// when `past` is non-empty - see [`Self::render_worktree_row`]'s own `has_history` gate,
+    /// which is also this app's answer to "a worktree with no persisted history shows nothing":
+    /// no empty state renders here at all, because this whole section is never reached for one.
+    fn render_history_section(
+        &self,
+        past: &[crate::hooks::history::PastAgent],
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        // Real wall-clock seconds since the Unix epoch, mirroring
+        // `crate::work_surface::agents::unix_now`'s own `unwrap_or(0)` for a nonsense clock.
+        let now_unix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|elapsed| elapsed.as_secs() as i64)
+            .unwrap_or(0);
+        div()
+            .flex()
+            .flex_col()
+            .child(
+                div()
+                    .pl(px(13.0))
+                    .pt(px(4.0))
+                    .pb(px(2.0))
+                    .font(font(theme::font::MONO))
+                    .text_size(self.ui_text_size(8.5))
+                    .text_color(theme::text::GHOSTER)
+                    .child("HISTORY"),
+            )
+            .children(
+                past.iter()
+                    .map(|past_agent| self.render_past_agent_row(past_agent, now_unix, cx)),
+            )
+    }
+
+    /// One row under a worktree's "History" section: a real, persisted-but-not-currently-running
+    /// agent (`crate::hooks::history::PastAgent`). Deliberately not selectable/highlightable the
+    /// way [`Self::render_agent_row`] is - there is no live pane behind it to switch to - so its
+    /// only real interaction is the trailing resume button.
+    ///
+    /// The button reads "Resume" when [`crate::hooks::history::PastAgent::session_id`] is real -
+    /// a literal `claude --resume <session_id>`, verified against a real binary (see
+    /// `crate::hooks::event::HookReport::session_id`'s own docs) - and "Reopen" otherwise, the
+    /// honest label for the fallback (`crate::hooks::flow::AdeApp::resume_past_agent`) of simply
+    /// spawning a fresh agent back into this worktree. Never claims to continue a conversation it
+    /// cannot.
+    fn render_past_agent_row(
+        &self,
+        past: &crate::hooks::history::PastAgent,
+        now_unix: i64,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let status = past.status;
+        let chip_icon = self.render_agent_chip_icon(
+            ProcessKind::Agent(past.kind),
+            px(15.0),
+            self.ui_text_size(9.0),
+        );
+        let last_active = crate::graph_view::state::relative_time(past.updated_at_unix, now_unix);
+        let summary = past
+            .question
+            .clone()
+            .or_else(|| past.activity.clone())
+            .unwrap_or_else(|| format!("{} session", past.kind.label()));
+        let resume_label = if past.session_id.is_some() {
+            "Resume"
+        } else {
+            "Reopen"
+        };
+        let key = past.key.clone();
+        let resume_key = key.clone();
+
+        div()
+            .id(format!("history-row-{key}"))
+            .flex()
+            .flex_col()
+            .pl(px(13.0))
+            .pr(px(10.0))
+            .py(px(4.0))
+            .gap(px(2.0))
+            .border_l(px(1.0))
+            .border_color(theme::border::ZONE)
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .gap(px(6.0))
+                    .child(chip_icon)
+                    .child(
+                        div()
+                            .flex_1()
+                            .min_w_0()
+                            .truncate()
+                            .font(font(theme::font::SANS))
+                            .text_size(self.ui_text_size(11.5))
+                            .text_color(theme::text::DIM)
+                            .child(summary),
+                    )
+                    .child(
+                        div()
+                            .flex_none()
+                            .font(font(theme::font::MONO))
+                            .text_size(self.ui_text_size(9.5))
+                            .text_color(theme::text::GHOST)
+                            .child(last_active),
+                    ),
+            )
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .gap(px(6.0))
+                    .pl(px(21.0))
+                    .child(
+                        div()
+                            .flex_none()
+                            .w(px(4.0))
+                            .h(px(4.0))
+                            .rounded_full()
+                            .bg(status.color()),
+                    )
+                    .child(
+                        div()
+                            .flex_1()
+                            .min_w_0()
+                            .truncate()
+                            .font(font(theme::font::SANS))
+                            .text_size(self.ui_text_size(9.5))
+                            .text_color(theme::text::FAINT)
+                            .child(format!("was {}", agent_state_word(status))),
+                    )
+                    .child(
+                        div()
+                            .id(format!("history-resume-{resume_key}"))
+                            .flex_none()
+                            .cursor_pointer()
+                            .px(px(6.0))
+                            .py(px(2.0))
+                            .rounded(theme::radius::CHIP)
+                            .bg(theme::button::BLUE_BG)
+                            .hover(|el| el.bg(theme::button::BLUE_BG_HOVER))
+                            .font(font(theme::font::SANS))
+                            .text_size(self.ui_text_size(9.5))
+                            .text_color(theme::button::BLUE_FG)
+                            .child(resume_label)
+                            .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
+                                cx.stop_propagation();
+                                this.resume_past_agent(&resume_key, window, cx);
+                            })),
                     ),
             )
     }
@@ -2205,6 +2384,246 @@ mod rail_row_tests {
             1,
             "sanity check: the *displayed* rows really did narrow to the one matching worktree \
              - proving the filter query took effect at all, just not on the header count"
+        );
+    }
+
+    /// GitHub issue #227's read side, exercised through the real `AdeApp`/rail pipeline rather
+    /// than the pure `crate::rail::state` function directly: a worktree with no persisted history
+    /// shows none, a real closed agent's record shows up under `.history`, and a record that
+    /// *also* still has a live agent open (the same real key `record_agent_statuses` would
+    /// persist for a still-running one) is excluded rather than duplicated.
+    #[gpui::test]
+    fn build_worktree_rows_shows_real_persisted_history_and_excludes_a_currently_live_agent(
+        cx: &mut TestAppContext,
+    ) {
+        use crate::work_surface::agents::AgentKind;
+
+        let repo = tempfile::tempdir().expect("tempdir");
+        let wt = tempfile::tempdir().expect("tempdir wt");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+
+        app.update(cx, |app, _cx| {
+            app.worktrees = vec![worktree_item(wt.path().to_path_buf(), "wt")];
+        });
+
+        let no_history_row = app.update(cx, |app, cx| {
+            app.build_worktree_rows(cx)
+                .into_iter()
+                .find(|row| row.path == wt.path())
+                .expect("the seeded worktree must produce a row")
+        });
+        assert!(
+            no_history_row.history.is_empty(),
+            "premise: a worktree with no persisted history shows none"
+        );
+
+        let live_id = app.update_in(cx, |app, window, cx| {
+            app.select_worktree(0, window, cx);
+            app.agents.spawn(
+                ProcessKind::claude(),
+                wt.path().to_path_buf(),
+                12.0,
+                None,
+                None,
+                window,
+                cx,
+            )
+        });
+        let live_spawned_at = app.read_with(cx, |app, _| {
+            app.agents
+                .iter()
+                .find(|agent| agent.id == live_id)
+                .expect("the just-spawned agent")
+                .spawned_at_unix
+        });
+        let live_key =
+            crate::review::state::baseline_key(wt.path(), AgentKind::Claude, live_spawned_at);
+        let closed_key =
+            crate::review::state::baseline_key(wt.path(), AgentKind::Claude, 1_700_000_000);
+
+        app.update(cx, |app, _cx| {
+            // A real closed agent's persisted record, written through the real `set` the app's
+            // own hook-status poll uses (`crate::hooks::flow::AdeApp::record_agent_statuses`).
+            app.agent_status_state.set(
+                closed_key.clone(),
+                wt.path(),
+                "Claude",
+                1_700_000_000,
+                Status::Review,
+                Some("Edit: src/auth.rs".to_owned()),
+                None,
+                Some("session-closed".to_owned()),
+                1_700_000_500,
+            );
+            // A record for an agent that is *also* still open right now - the real case
+            // `record_agent_statuses` produces for a live agent (it records every agent with a
+            // fresh hook fact, not just closed ones). It must not show up twice.
+            app.agent_status_state.set(
+                live_key.clone(),
+                wt.path(),
+                "Claude",
+                live_spawned_at,
+                Status::Run,
+                None,
+                None,
+                None,
+                1_700_000_600,
+            );
+        });
+
+        let rows = app.update(cx, |app, cx| app.build_worktree_rows(cx));
+        let wt_row = rows
+            .iter()
+            .find(|row| row.path == wt.path())
+            .expect("the seeded worktree must still produce a row");
+        assert_eq!(
+            wt_row.history.len(),
+            1,
+            "exactly the closed agent's record must show, not the live agent's own"
+        );
+        assert_eq!(wt_row.history[0].key, closed_key);
+        assert_eq!(
+            wt_row.history[0].session_id.as_deref(),
+            Some("session-closed")
+        );
+    }
+
+    /// The literal resume path (GitHub issue #227): a real persisted record carrying a real
+    /// `session_id` must spawn a genuine `claude --resume <session_id>`, not just a fresh agent
+    /// in the same worktree.
+    #[gpui::test]
+    fn resume_past_agent_with_a_real_session_id_spawns_a_real_claude_resume(
+        cx: &mut TestAppContext,
+    ) {
+        use crate::work_surface::agents::AgentKind;
+
+        let repo = tempfile::tempdir().expect("tempdir");
+        let wt = tempfile::tempdir().expect("tempdir wt");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        app.update(cx, |app, _cx| {
+            app.worktrees = vec![worktree_item(wt.path().to_path_buf(), "wt")];
+        });
+
+        let key = crate::review::state::baseline_key(wt.path(), AgentKind::Claude, 1);
+        app.update(cx, |app, _cx| {
+            app.agent_status_state.set(
+                key.clone(),
+                wt.path(),
+                "Claude",
+                1,
+                Status::Idle,
+                None,
+                None,
+                Some("5af4c210-34fa-4ab2-9c35-f6ceab76551c".to_owned()),
+                2,
+            );
+        });
+
+        let resumed = app.update_in(cx, |app, window, cx| {
+            app.resume_past_agent(&key, window, cx)
+        });
+        assert!(
+            resumed,
+            "a real, decodable record naming a real, known worktree must resume"
+        );
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.selected),
+            Some(0),
+            "resuming must select the record's own worktree"
+        );
+
+        let new_pane = app.read_with(cx, |app, _cx| {
+            app.agents
+                .iter_for_cwd(wt.path().to_path_buf())
+                .last()
+                .expect("a new agent must have been spawned into wt")
+                .pane
+                .clone()
+        });
+        let spec = new_pane.read_with(cx, |pane, _| pane.spec_for_test().clone());
+        assert_eq!(spec.program, PathBuf::from("claude"));
+        assert_eq!(
+            spec.args[0..2],
+            [
+                "--resume".to_owned(),
+                "5af4c210-34fa-4ab2-9c35-f6ceab76551c".to_owned()
+            ],
+            "the real session id must lead the resumed spawn's arguments"
+        );
+    }
+
+    /// The honest fallback (GitHub issue #227): a record with no real session id - a Codex
+    /// record, since Codex has no hooks and so never captures one, or a Claude record that
+    /// predates this field - must spawn a *fresh* agent of the recorded kind into the same
+    /// worktree, and must never fabricate a `--resume` flag with no real id behind it.
+    #[gpui::test]
+    fn resume_past_agent_without_a_session_id_reopens_a_fresh_agent_instead(
+        cx: &mut TestAppContext,
+    ) {
+        use crate::work_surface::agents::AgentKind;
+
+        let repo = tempfile::tempdir().expect("tempdir");
+        let wt = tempfile::tempdir().expect("tempdir wt");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        app.update(cx, |app, _cx| {
+            app.worktrees = vec![worktree_item(wt.path().to_path_buf(), "wt")];
+        });
+
+        let key = crate::review::state::baseline_key(wt.path(), AgentKind::Codex, 1);
+        app.update(cx, |app, _cx| {
+            app.agent_status_state.set(
+                key.clone(),
+                wt.path(),
+                "Codex",
+                1,
+                Status::Idle,
+                None,
+                None,
+                None,
+                2,
+            );
+        });
+
+        let resumed = app.update_in(cx, |app, window, cx| {
+            app.resume_past_agent(&key, window, cx)
+        });
+        assert!(resumed);
+
+        let new_pane = app.read_with(cx, |app, _cx| {
+            app.agents
+                .iter_for_cwd(wt.path().to_path_buf())
+                .last()
+                .expect("a new agent must have been spawned into wt")
+                .pane
+                .clone()
+        });
+        let spec = new_pane.read_with(cx, |pane, _| pane.spec_for_test().clone());
+        assert_eq!(spec.program, PathBuf::from("codex"));
+        assert!(
+            spec.args.is_empty(),
+            "with no real session id, the fallback must not fabricate a --resume flag - got \
+             {:?}",
+            spec.args
+        );
+    }
+
+    /// A stale/unknown key (the record was pruned, or never existed) must be a genuine no-op -
+    /// nothing is spawned, and nothing else about the app's state changes.
+    #[gpui::test]
+    fn resume_past_agent_is_a_no_op_for_an_unknown_key(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let count_before = app.read_with(cx, |app, _| app.agents.iter().count());
+
+        let resumed = app.update_in(cx, |app, window, cx| {
+            app.resume_past_agent("no-such-key", window, cx)
+        });
+        assert!(!resumed);
+        assert_eq!(
+            app.read_with(cx, |app, _| app.agents.iter().count()),
+            count_before,
+            "a no-op resume must not spawn anything"
         );
     }
 }

--- a/crates/app/src/rail/state.rs
+++ b/crates/app/src/rail/state.rs
@@ -295,6 +295,12 @@ pub struct WorktreeRow {
     /// Every agent currently open in this worktree, in tab-strip order (creation order,
     /// matching `crate::work_surface::agents::Agents::iter_for_cwd`).
     pub agents: Vec<AgentRow>,
+    /// This worktree's real, persisted-but-not-currently-running agents (GitHub issue #227),
+    /// most recently active first - see [`crate::hooks::history::past_agents_for_worktree`] for
+    /// how "currently running" is excluded. Empty for a worktree with no persisted history, which
+    /// the rail renders as no section at all (no empty-state clutter - see
+    /// `crate::rail::render::AdeApp::render_worktree_row`).
+    pub history: Vec<crate::hooks::history::PastAgent>,
 }
 
 impl WorktreeRow {
@@ -376,13 +382,35 @@ impl WorktreeRow {
 /// the old `ProjectChild`-based `build_project_children` had: `agents.iter().find(...)` only
 /// ever surfaced one agent per worktree, silently hiding any additional ones). Every worktree
 /// appears here, including ones with no agent (e.g. `main`, or a merged/prunable leftover).
+///
+/// Thin wrapper over [`build_worktree_rows_with_history`] with an empty history list, for the
+/// many existing call sites (including most of this module's own tests) that predate GitHub issue
+/// #227 and have no persisted history to fold in.
 pub fn build_worktree_rows(worktrees: &[WorktreeEntry], agents: &[AgentRow]) -> Vec<WorktreeRow> {
+    build_worktree_rows_with_history(worktrees, agents, &[])
+}
+
+/// [`build_worktree_rows`], plus GitHub issue #227's history rows: every entry in `history` is
+/// folded into whichever [`WorktreeRow`] its own [`crate::hooks::history::PastAgent::worktree`]
+/// matches, exactly the way `agents` already is. `history` is expected to already be filtered to
+/// "genuinely past" (see [`crate::hooks::history::past_agents_for_worktree`]) - this function only
+/// groups by path, it does not re-derive which records are live.
+pub fn build_worktree_rows_with_history(
+    worktrees: &[WorktreeEntry],
+    agents: &[AgentRow],
+    history: &[crate::hooks::history::PastAgent],
+) -> Vec<WorktreeRow> {
     worktrees
         .iter()
         .map(|worktree| {
             let agents: Vec<AgentRow> = agents
                 .iter()
                 .filter(|agent| agent.cwd == worktree.path)
+                .cloned()
+                .collect();
+            let history: Vec<crate::hooks::history::PastAgent> = history
+                .iter()
+                .filter(|past| past.worktree == worktree.path)
                 .cloned()
                 .collect();
             WorktreeRow {
@@ -392,6 +420,7 @@ pub fn build_worktree_rows(worktrees: &[WorktreeEntry], agents: &[AgentRow]) -> 
                 note: worktree.note.clone(),
                 error: worktree.error.clone(),
                 agents,
+                history,
             }
         })
         .collect()
@@ -1035,6 +1064,45 @@ mod tests {
     }
 
     #[test]
+    fn build_worktree_rows_with_history_folds_past_agents_into_their_own_matching_worktree() {
+        // GitHub issue #227: a worktree with no live agent at all must still be able to carry
+        // real persisted history - grouping is by path, exactly like `agents` already is, and
+        // must not implicitly require a live agent to be present too.
+        let worktrees = vec![
+            worktree_entry("/repo", clean_note(true)),
+            worktree_entry("/repo-wt/bare-with-history", clean_note(false)),
+            worktree_entry("/repo-wt/no-history", clean_note(false)),
+        ];
+        let past = crate::hooks::history::PastAgent {
+            key: "past-1".to_string(),
+            worktree: PathBuf::from("/repo-wt/bare-with-history"),
+            kind: crate::work_surface::agents::AgentKind::Claude,
+            spawned_at_unix: 1,
+            status: Status::Idle,
+            activity: None,
+            question: None,
+            updated_at_unix: 100,
+            session_id: None,
+        };
+
+        let rows = build_worktree_rows_with_history(&worktrees, &[], std::slice::from_ref(&past));
+        assert_eq!(rows.len(), 3);
+        assert!(
+            rows[0].history.is_empty(),
+            "the unrelated /repo row must not receive another worktree's history"
+        );
+        assert_eq!(
+            rows[1].history,
+            vec![past],
+            "the matching worktree must receive its own real history entry"
+        );
+        assert!(
+            rows[2].history.is_empty(),
+            "a worktree with no persisted history must show none - no empty-state entry either"
+        );
+    }
+
+    #[test]
     fn aggregate_status_picks_the_most_urgent_contained_agent() {
         let worktrees = vec![worktree_entry("/repo-wt/a", clean_note(false))];
         let agents = vec![
@@ -1315,6 +1383,7 @@ mod tests {
             note: clean_note(false),
             error: None,
             agents: Vec::new(),
+            history: Vec::new(),
         }];
 
         let groups = group_worktrees_by_repo(vec![repo_worktrees_split(

--- a/crates/app/src/terminal/pane.rs
+++ b/crates/app/src/terminal/pane.rs
@@ -1105,6 +1105,15 @@ impl TerminalPane {
         self.font_size_px
     }
 
+    /// Test-only seam: the real [`TerminalSpec`] this pane was constructed with - lets a test
+    /// outside this module (GitHub issue #227's resume flow) assert on the actual program/args/env
+    /// a real [`crate::work_surface::agents::Agents::spawn`]/`spawn_resume` call produced, rather
+    /// than only on its side effects.
+    #[cfg(test)]
+    pub(crate) fn spec_for_test(&self) -> &TerminalSpec {
+        &self.spec
+    }
+
     /// Test-only seam: the palette the most recent real paint used - see
     /// [`Self::last_painted_palette`].
     #[cfg(test)]

--- a/crates/app/src/work_surface/agents.rs
+++ b/crates/app/src/work_surface/agents.rs
@@ -52,6 +52,17 @@ impl AgentKind {
         }
     }
 
+    /// The inverse of [`Self::label`] - `None` for anything this build doesn't recognise, which a
+    /// reader of persisted data (`crate::hooks::store::PersistedAgentStatus::kind`, GitHub issue
+    /// #227) must treat as "this record isn't usable" rather than guessing a kind.
+    pub fn from_label(label: &str) -> Option<AgentKind> {
+        match label {
+            "Claude" => Some(AgentKind::Claude),
+            "Codex" => Some(AgentKind::Codex),
+            _ => None,
+        }
+    }
+
     /// The literal command name this agent's CLI spawns as. Infallible - there is no
     /// "this kind has no fixed binary" case to model, precisely because an `AgentKind` is never
     /// a shell (before the shell/agent split this was an `Option<&'static str>` every caller had
@@ -324,14 +335,89 @@ impl Agents {
         window: &mut Window,
         cx: &mut Context<AdeApp>,
     ) -> AgentId {
+        self.spawn_inner(
+            kind,
+            cwd,
+            terminal_font_size_px,
+            shell_override,
+            hooks,
+            Vec::new(),
+            window,
+            cx,
+        )
+    }
+
+    /// [`Self::spawn`], but for a real Claude Code `--resume <session_id>` (GitHub issue #227):
+    /// spawns `agent_kind` into `cwd` exactly as a fresh agent would, plus `--resume
+    /// <session_id>` prepended to its arguments - verified against a real `claude` 2.1.228 binary
+    /// to genuinely pick the named conversation back up, not merely start a new one in the same
+    /// directory (`crate::hooks::event::HookReport::session_id`'s own docs cover how that was
+    /// checked).
+    ///
+    /// Still receives `hooks`, and still gets the same `--settings`/environment injection a fresh
+    /// [`AgentKind::Claude`] spawn would: a resumed conversation is exactly as real an agent as a
+    /// new one, and Jerry's rail should keep tracking it the same way (also verified against the
+    /// real binary - `--settings` and `--resume` coexist without conflict, and the resumed
+    /// session's hooks report the same `session_id` it resumed).
+    // Nine parameters, matching `Self::spawn`'s own already-`#[allow]`'d count plus the one real
+    // addition (`session_id`) - see that method's docs for why bundling the rest into a struct
+    // wouldn't reduce anything.
+    #[allow(clippy::too_many_arguments)]
+    pub fn spawn_resume(
+        &mut self,
+        agent_kind: AgentKind,
+        cwd: PathBuf,
+        terminal_font_size_px: f32,
+        shell_override: Option<&str>,
+        hooks: Option<&crate::hooks::HookInjection>,
+        session_id: String,
+        window: &mut Window,
+        cx: &mut Context<AdeApp>,
+    ) -> AgentId {
+        self.spawn_inner(
+            ProcessKind::Agent(agent_kind),
+            cwd,
+            terminal_font_size_px,
+            shell_override,
+            hooks,
+            vec!["--resume".to_owned(), session_id],
+            window,
+            cx,
+        )
+    }
+
+    /// The real shared core of [`Self::spawn`]/[`Self::spawn_resume`] - identical in every way
+    /// except which extra CLI arguments (if any) are prepended ahead of the hook injection's own
+    /// `--settings <path>`. Kept private and `#[allow(clippy::too_many_arguments)]`'d here rather
+    /// than on both public callers, so the many "no extra args" call sites through [`Self::spawn`]
+    /// keep their existing, unchanged arity.
+    #[allow(clippy::too_many_arguments)]
+    fn spawn_inner(
+        &mut self,
+        kind: ProcessKind,
+        cwd: PathBuf,
+        terminal_font_size_px: f32,
+        shell_override: Option<&str>,
+        hooks: Option<&crate::hooks::HookInjection>,
+        mut leading_args: Vec<String>,
+        window: &mut Window,
+        cx: &mut Context<AdeApp>,
+    ) -> AgentId {
         let id = self.next_id;
         self.next_id += 1;
 
         // Claude Code only, and gated here rather than inside `spec` so the gate is one
         // legible line next to the spawn it guards.
-        let extras = match (kind, hooks) {
+        let hook_extras = match (kind, hooks) {
             (ProcessKind::Agent(AgentKind::Claude), Some(hooks)) => hooks.spawn_extras(id),
             _ => None,
+        };
+        let extras = if leading_args.is_empty() {
+            hook_extras
+        } else {
+            let (mut hook_args, env) = hook_extras.unwrap_or_default();
+            leading_args.append(&mut hook_args);
+            Some((leading_args, env))
         };
         let spec = kind.spec(cwd.clone(), shell_override, extras);
         let pane = cx.new(|cx| TerminalPane::new(spec, terminal_font_size_px, cx));
@@ -595,6 +681,21 @@ mod tests {
         assert_eq!(ProcessKind::codex().label(), AgentKind::Codex.label());
         assert_eq!(AgentKind::Claude.label(), "Claude");
         assert_eq!(AgentKind::Codex.label(), "Codex");
+    }
+
+    #[test]
+    fn from_label_is_the_real_inverse_of_label_for_every_agent_kind() {
+        // GitHub issue #227's history reader (`crate::hooks::history`) decodes a persisted
+        // `PersistedAgentStatus::kind` string back into a real `AgentKind` through this - it must
+        // agree with `label` exactly, or a real persisted record would silently fail to decode.
+        for kind in [AgentKind::Claude, AgentKind::Codex] {
+            assert_eq!(AgentKind::from_label(kind.label()), Some(kind));
+        }
+        assert_eq!(
+            AgentKind::from_label("SomeFutureAgent"),
+            None,
+            "an unrecognised label must be `None`, never a guessed kind"
+        );
     }
 
     #[test]

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -2802,6 +2802,66 @@ mod tab_scoping_tests {
         );
     }
 
+    /// GitHub issue #227's resume flow: `Agents::spawn_resume` must really produce a
+    /// `claude --resume <session_id> --settings <path>` spawn - `--resume` prepended ahead of the
+    /// real hook injection's own `--settings`, not dropped in favour of it, and the hook
+    /// injection's `JERRY_*` environment still riding along so a resumed conversation keeps
+    /// reporting its status exactly like a fresh one. Uses a real [`crate::hooks::HookRuntime`]
+    /// (a real bound loopback listener, real generated files) rather than a hand-built
+    /// injection, so this exercises the exact object `crate::hooks::flow::AdeApp::
+    /// hook_injection_for` would hand a real spawn.
+    #[gpui::test]
+    fn spawn_resume_prepends_resume_ahead_of_the_real_hook_injection(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+
+        let hook_temp = tempfile::tempdir().expect("hook temp dir");
+        let runtime = crate::hooks::HookRuntime::start(hook_temp.path())
+            .expect("the hook runtime must start in a test sandbox");
+        let injection = runtime.injection();
+        let session_id = "5af4c210-34fa-4ab2-9c35-f6ceab76551c".to_owned();
+
+        let pane = app.update_in(cx, |app, window, cx| {
+            let id = app.agents.spawn_resume(
+                AgentKind::Claude,
+                repo.path().to_path_buf(),
+                12.0,
+                None,
+                Some(&injection),
+                session_id.clone(),
+                window,
+                cx,
+            );
+            app.agents
+                .iter()
+                .find(|agent| agent.id == id)
+                .expect("the agent this call just spawned")
+                .pane
+                .clone()
+        });
+
+        let spec = pane.read_with(cx, |pane, _| pane.spec_for_test().clone());
+        assert_eq!(
+            spec.program,
+            PathBuf::from("claude"),
+            "a resumed agent must still spawn the real claude binary"
+        );
+        assert_eq!(
+            spec.args[0..2],
+            ["--resume".to_owned(), session_id],
+            "--resume <session_id> must lead the argument list"
+        );
+        assert_eq!(
+            spec.args[2], "--settings",
+            "the real hook injection's own --settings must still follow, not be dropped"
+        );
+        assert!(
+            !spec.env.is_empty(),
+            "the hook injection's JERRY_* environment must still ride along on a resume spawn, \
+             so a resumed conversation keeps reporting its status like a fresh one"
+        );
+    }
+
     /// The real gap this revision's own self-audit found: switching to a worktree with *no*
     /// open agent leaves `Agents::focus_active` with nothing to focus (a genuine no-op), so
     /// a previously-focused agent's pane - now unrendered once the tab strip's own


### PR DESCRIPTION
## Summary

Stacked on #248 (Phase 2 hooks) — merge #244 → #248 → this, in order.

- Reads back #239 Phase 2's persisted `agent-status.toml` (deliberately left unread by Phase 2, explicitly scoped to this issue) into a "History" section in the rail, shown per-worktree when it has persisted-but-not-currently-running agents.
- Real, literal Claude Code conversation resume: `claude --resume <session_id>`, verified end-to-end against the real `claude` 2.1.228 binary — captured a real `session_id` from a hook payload, resumed in a fresh process, and confirmed it answered a question about the prior turn correctly (genuine continuation, not just a fresh session in the same directory).
- Extends Phase 2's persisted record with `session_id` (present on every real hook payload type, confirmed empirically) — small, additive change to data already flowing through the parser.
- Falls back to an honest "reopen a fresh agent in this worktree" when no `session_id` was ever captured (old record, or a session that never reported one) — never fabricates a `--resume` flag.

## Codex

`codex` isn't installed in this environment, so no Codex resume mechanism could be verified — none was assumed. Codex records still show in history for visibility, with the action always using the honest reopen-fallback.

## Test plan
- [x] Real round-trip test: a fabricated record through `AgentStatusState::set` → real temp file → decoded `PastAgent`, exact match
- [x] Real GPUI end-to-end test asserting the actual spawned `TerminalSpec`'s argv (`--resume <id>` in the right place) and env for a resume spawn, plus the no-session-id and Codex fallback paths
- [x] Real hook listener session-id round-trip test
- [x] Reused Phase 2's existing real-`claude`-binary integration tests, still green
- [x] `cargo build --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check` all clean
- [x] `hooks::` suite green under `JERRY_REQUIRE_REAL_CLAUDE=1` (66 tests), `rail::` (133 tests), `work_surface::` (98 tests) all pass
- [x] Confirmed the `session_id` addition to `hooks/server.rs`/`event.rs` is purely additive (a new read accessor + one new field in the JSON parser) — doesn't touch any of the auth/deadline/permission logic Phase 2's security review hardened

🤖 Generated with [Claude Code](https://claude.com/claude-code)