### PR TITLE
fix(app): pin tab ordinal suffixes to spawn order, not display order

### DIFF
--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -3641,6 +3641,83 @@ mod repo_list_tests {
         });
     }
 
+    /// Real user report: a repo with zero linked worktrees (just the main checkout on its
+    /// current branch) correctly shows one worktree row right after opening it, but switching
+    /// away to a different repo and back makes that row disappear. Uses two real git repos
+    /// (`git init`, no linked worktrees on either) and `Self::open_repo_in_current_window` for
+    /// both switches, `cx.run_until_parked()` after each so [`AdeApp::load_worktrees`]'s real
+    /// background task has actually resolved before the next switch - this is a same-thread,
+    /// strictly-sequential repro, not a race between overlapping loads.
+    #[gpui::test]
+    fn switching_away_from_a_zero_linked_worktree_repo_and_back_keeps_its_worktree_row(
+        cx: &mut TestAppContext,
+    ) {
+        let repo_a = tempfile::tempdir().expect("tempdir");
+        git(repo_a.path(), &["init", "-b", "main"]);
+        git(repo_a.path(), &["config", "user.email", "test@example.com"]);
+        git(repo_a.path(), &["config", "user.name", "Test User"]);
+        std::fs::write(repo_a.path().join("a.txt"), "hello\n").expect("write");
+        git(repo_a.path(), &["add", "a.txt"]);
+        git(repo_a.path(), &["commit", "-m", "init"]);
+
+        let repo_b = tempfile::tempdir().expect("tempdir");
+        git(repo_b.path(), &["init", "-b", "main"]);
+        git(repo_b.path(), &["config", "user.email", "test@example.com"]);
+        git(repo_b.path(), &["config", "user.name", "Test User"]);
+        std::fs::write(repo_b.path().join("b.txt"), "hello\n").expect("write");
+        git(repo_b.path(), &["add", "b.txt"]);
+        git(repo_b.path(), &["commit", "-m", "init"]);
+
+        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.worktrees.len(),
+                1,
+                "repo A must show its own main checkout as one real worktree row right after \
+                 opening, got: {:?}",
+                app.worktrees
+            );
+        });
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_repo_in_current_window(repo_b.path().to_path_buf(), window, cx);
+        });
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.focused_repo_path(), repo_b.path());
+            assert_eq!(
+                app.worktrees.len(),
+                1,
+                "repo B must also show one real worktree row"
+            );
+        });
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_repo_in_current_window(repo_a.path().to_path_buf(), window, cx);
+        });
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.focused_repo_path(), repo_a.path());
+            assert_eq!(
+                app.worktrees.len(),
+                1,
+                "switching back to repo A must still show its one real worktree row, not lose \
+                 it - got: {:?}",
+                app.worktrees
+            );
+            assert!(
+                app.worktrees[0].branch.is_some(),
+                "repo A's worktree row must still carry its real current branch after \
+                 switching back, got: {:?}",
+                app.worktrees
+            );
+        });
+    }
+
     fn git(dir: &std::path::Path, args: &[&str]) {
         let output = std::process::Command::new("git")
             .current_dir(dir)

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -759,10 +759,28 @@ impl AdeApp {
     ) -> Vec<String> {
         let is_bare = self.current_worktree_is_bare();
         let branch = self.current_worktree_branch();
-        let raw: Vec<String> = agent_ids
+
+        // Ordinals must be assigned in a real, stable order - `AgentId`'s own monotonic
+        // assignment at spawn time (`Agents::spawn`'s `next_id`), never `agent_ids`' own input
+        // order. The caller passes `agent_ids` from `Self::combined_tab_order`, which the tab
+        // strip's drag-to-reorder freely rewrites - a `#N` suffix that changes because a tab
+        // moved is not a real identifier, it just relabels whichever agent happens to render
+        // first. Sorting here keeps the numbers pinned to spawn order regardless of what order
+        // the tab strip currently renders in.
+        let mut stable: Vec<(AgentId, &Agent)> = agent_ids
             .iter()
-            .filter_map(|id| self.agents.iter().find(|agent| agent.id == *id))
-            .map(|agent| match work_surface::tab_chip_kind(agent.kind) {
+            .filter_map(|id| {
+                self.agents
+                    .iter()
+                    .find(|agent| agent.id == *id)
+                    .map(|agent| (*id, agent))
+            })
+            .collect();
+        stable.sort_unstable_by_key(|(id, _)| *id);
+
+        let raw: Vec<String> = stable
+            .iter()
+            .map(|(_, agent)| match work_surface::tab_chip_kind(agent.kind) {
                 work_surface::TabChipKind::Cli => agent.pane.read(cx).program_label(),
                 work_surface::TabChipKind::Term => {
                     if is_bare {
@@ -776,7 +794,20 @@ impl AdeApp {
                 }
             })
             .collect();
-        work_surface::disambiguate_tab_labels(raw)
+        let disambiguated = work_surface::disambiguate_tab_labels(raw);
+
+        // Re-align to `agent_ids`' own input order (this function's existing contract), which
+        // may differ from `stable`'s spawn order - the numbers themselves stay spawn-order-
+        // derived, only the returned vec's own ordering follows what the caller asked for.
+        let label_by_id: std::collections::HashMap<AgentId, String> = stable
+            .into_iter()
+            .map(|(id, _)| id)
+            .zip(disambiguated)
+            .collect();
+        agent_ids
+            .iter()
+            .filter_map(|id| label_by_id.get(id).cloned())
+            .collect()
     }
 
     /// The tab strip: one tab per entry of [`Self::combined_tab_order`], in that exact order -
@@ -3618,6 +3649,57 @@ mod tab_scoping_tests {
             labels,
             vec!["claude #1".to_string(), "claude #2".to_string()],
             "two agents of the same kind must never render two identical tab labels"
+        );
+    }
+
+    /// The bug this guards against: `current_worktree_agent_tab_labels` is called with
+    /// `agent_ids` from `Self::combined_tab_order`, which the tab strip's drag-to-reorder
+    /// freely rewrites - if ordinals were assigned in *that* order, dragging a tab past
+    /// another would relabel both, turning `#N` into a number that means nothing (it wouldn't
+    /// even stay attached to the same agent). Passing the two ids in reverse of spawn order -
+    /// exactly what a drag produces - must still yield the same `#1`/`#2` pinned to spawn
+    /// order, and the returned vec must still align to the *requested* (reversed) order.
+    #[gpui::test]
+    fn dragging_a_tab_past_another_never_changes_either_ordinal(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let wt_a = tempfile::tempdir().expect("tempdir a");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+
+        app.update(cx, |app, _cx| {
+            app.worktrees = vec![worktree_item(wt_a.path().to_path_buf(), "wt-a")];
+        });
+        let (first_id, second_id) = app.update_in(cx, |app, window, cx| {
+            app.select_worktree(0, window, cx);
+            let first_id = app.agents.spawn(
+                ProcessKind::claude(),
+                wt_a.path().to_path_buf(),
+                12.0,
+                None,
+                window,
+                cx,
+            );
+            let second_id = app.agents.spawn(
+                ProcessKind::claude(),
+                wt_a.path().to_path_buf(),
+                12.0,
+                None,
+                window,
+                cx,
+            );
+            (first_id, second_id)
+        });
+
+        // Spawn order: [first_id, second_id]. A drag that moves the first tab past the second
+        // would hand this function [second_id, first_id] instead.
+        let labels = app.update(cx, |app, cx| {
+            app.current_worktree_agent_tab_labels(&[second_id, first_id], cx)
+        });
+        assert_eq!(
+            labels,
+            vec!["claude #2".to_string(), "claude #1".to_string()],
+            "the requested (post-drag) order must be preserved in the return value, but the \
+             ordinals themselves must stay pinned to real spawn order - `first_id` is always \
+             #1, `second_id` is always #2, regardless of which order they're asked for in"
         );
     }
 


### PR DESCRIPTION
## Summary

Real user report while testing #244: dragging a tab past another same-kind tab (e.g. "claude #1"/"claude #2") relabels both, because the `#N` ordinal was computed from `combined_tab_order` - the tab strip's own drag-reorder overlay - instead of a stable identity.

- `current_worktree_agent_tab_labels` now sorts by `AgentId` (a real monotonic spawn-order counter) before disambiguating, then re-aligns the result to the caller's requested order. The numbers stay pinned to which agent spawned first, regardless of how the tab strip is currently arranged.

## Also included

While investigating a related report from the same testing session (a repo with zero linked worktrees loses its one worktree row after switching to a different repo and back), I added a regression test for the correct sequential behavior. I was not able to reproduce an actual failure: a sequential A→B→A test passes, and a deliberately-raced variant (two `open_repo_in_current_window` calls with no `run_until_parked()` between them) also passes - `AdeApp::load_worktrees`'s single-slot `_load_worktrees_task` field appears to already be protected by GPUI's Task-cancellation-on-drop semantics against the stale-response race I suspected. I'm flagging this as still-open rather than closed: it's possible the real bug needs live reproduction I couldn't construct in a unit test, or more specific repro steps.

## Test plan
- [x] New regression test `dragging_a_tab_past_another_never_changes_either_ordinal`, verified via revert-then-restore to genuinely fail without the fix (asserted `["claude #1", "claude #2"]` when the fix instead correctly returns `["claude #2", "claude #1"]` for a reversed request order)
- [x] New test `switching_away_from_a_zero_linked_worktree_repo_and_back_keeps_its_worktree_row` (real git repos, passes both before and after this change - not a regression, just added coverage)
- [x] Full `work_surface::` (95 tests) and `root::repo_list_tests::` (20 tests) suites pass
- [x] `cargo build`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` all clean (only the pre-existing, unrelated violation at `crates/app/src/review/render.rs:1503` remains, untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)