### PR TITLE
fix(app,wt-core): four multi-repo dashboard bugs found in live testing

### DIFF
--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -914,9 +914,9 @@ impl AdeApp {
     pub(in crate::rail) fn render_rail_list(&self, cx: &mut Context<Self>) -> gpui::AnyElement {
         let groups = self.build_repo_groups(cx);
 
-        // GitHub issue #113: a repo with zero open worktrees is still a real, clickable rail
-        // affordance now (`Self::render_repo_group` renders and wires up every group's header
-        // regardless of `rows`/`all_rows`), so the only case left with genuinely nothing to show
+        // GitHub issue #113: a repo with zero open worktrees still renders its own group
+        // (`Self::render_repo_group` paints every group's header regardless of
+        // `rows`/`all_rows`), so the only case left with genuinely nothing to show
         // is no repo at all - defensive rather than reachable through any real UI path today,
         // since `Self::render_rail` (this function's only caller) is itself only ever rendered
         // once `Self::focused_repo` is `Some`, which requires at least one entry in `Self::repos`.
@@ -953,18 +953,22 @@ impl AdeApp {
     /// waiting` when non-zero, and a per-repo `+`), then either every worktree row already
     /// ranked most-urgent-first by [`rail::group_worktrees_by_repo`], or - GitHub issue #113 - a
     /// real inline message when this repo has none to show, rather than the header (and the repo
-    /// itself) simply disappearing from the rail. Every repo's header renders and is clickable
-    /// regardless of `rows`/`all_rows`: [`Self::checkout_repo_from_rail`] is the same real
-    /// "focus/load a different repo" flow `Self::open_repo_in_current_window` (Open Folder…)
-    /// already uses, so a repo with zero open worktrees is a real, reachable "focused, nothing
-    /// open yet" state - not a dead end.
+    /// itself) simply disappearing from the rail. Every repo's header renders regardless of
+    /// `rows`/`all_rows`, but the header is deliberately **not clickable** - no `on_click`, no
+    /// cursor/hover affordance. That is an explicit product decision, made after two subtler
+    /// header-click behaviors were both rejected in review: in the rail, only worktree rows and
+    /// agent rows are click targets, and only worktrees have tabs; a repo header is a plain
+    /// group label. Switching to a different repo is done by clicking any worktree row under its
+    /// group - [`crate::root::AdeApp::select_worktree_by_path`]'s cross-repo fallback runs the
+    /// entire real repo switch ([`Self::checkout_repo_from_rail`]) itself, so the header never
+    /// needs a click handler for repo switching to work.
     ///
     /// The header's `N wt` and (via [`rail::RepoGroup::waiting_count`]) `N worktrees waiting`
     /// are read from `group.all_rows`, **not** `group.rows` - see [`Self::build_repo_groups`]'s
     /// docs for why: this repo's real, complete worktree list, unaffected by the rail's filter
     /// query or by which repo is currently focused. Only the rows actually rendered below the
     /// header (`group.rows`) may be narrower - and only that narrower list, never the header
-    /// click target or the `+`, is affected by an empty vs. filtered-away distinction (see the
+    /// or the `+`, is affected by an empty vs. filtered-away distinction (see the
     /// inline message below, which does distinguish the two for its own wording).
     ///
     /// `group.rows_loaded` gates the `N wt` count itself: `false` (a repo whose own first real
@@ -979,7 +983,6 @@ impl AdeApp {
     ) -> impl IntoElement {
         let waiting_label = rail::waiting_count_label(group.waiting_count());
         let repo_id = group.repo_id;
-        let is_focused_repo = self.focused_repo == Some(repo_id);
 
         let header = div()
             .id(("repo-group-header", repo_id.0))
@@ -991,19 +994,11 @@ impl AdeApp {
             .pt(px(8.0))
             .px(px(12.0))
             .pb(px(4.0))
-            // The already-focused repo's own header isn't a real click target (see
-            // `Self::checkout_repo_from_rail`'s own no-op-when-already-focused guard) - no
-            // `cursor_pointer`/hover affordance for a click that would do nothing, matching
-            // `render_worktree_row`'s identical `is_selected` convention just below in this same
-            // file (see the comment near line 1407 for this file's established "non-actionable
-            // control drops cursor_pointer/hover/on_click" rule).
-            .when(!is_focused_repo, |el| {
-                el.cursor_pointer()
-                    .hover(|el| el.bg(theme::rail::WORKTREE_HOVER_BG))
-            })
-            .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
-                this.checkout_repo_from_rail(repo_id, window, cx);
-            }))
+            // Deliberately no `on_click`, no `cursor_pointer`, no hover background: this header
+            // is a plain label, not a control - see this function's own docs. Per this file's
+            // established "non-actionable control drops cursor_pointer/hover/on_click" rule (the
+            // comment near `render_worktree_row`'s `is_selected` handling), an unclickable row
+            // must not carry click affordances either.
             .child(
                 div()
                     .font(font(theme::font::SANS))
@@ -1038,7 +1033,7 @@ impl AdeApp {
                         .child(text),
                 )
             })
-            .child(self.render_repo_group_new_button(repo_id, cx));
+            .child(self.render_repo_group_new_button(repo_id));
 
         let mut group_div = div()
             .id(("repo-group", repo_id.0))
@@ -1064,7 +1059,11 @@ impl AdeApp {
                     .text_size(self.ui_text_size(9.5))
                     .text_color(theme::text::GHOSTER)
                     .child(if !group.rows_loaded {
-                        "not loaded yet \u{2013} click to open"
+                        // No "click to open" here: the header is not clickable (see this
+                        // function's own docs), and this repo's own real background fetch
+                        // (`crate::root::AdeApp::start_repo_worktrees_polling`) resolves this
+                        // state on its own moments later.
+                        "not loaded yet"
                     } else if group.all_rows.is_empty() {
                         "no worktrees open yet"
                     } else {
@@ -1115,17 +1114,16 @@ impl AdeApp {
     /// (`crate::work_surface::render::AdeApp::render_tab_strip_plus`) is unchanged and is still
     /// the one real way to open the plus menu - anchored, as it always was, to its own bounds.
     ///
-    /// The one handler left is a bare `cx.stop_propagation()`, and it is what actually makes this
-    /// button inert: it paints *inside* [`Self::render_repo_group`]'s header, whose own `on_click`
-    /// checks the repo out, so a click landing here with no handler at all would bubble straight
-    /// into that and switch repos - a real side effect from a control drawn as disabled.
-    /// (`render_dropdown_menu_row`'s "a disabled control attaches no `on_click`" rule is about
-    /// never wiring a disabled control to an *action*; a click-through blocker is the opposite of
-    /// that, and doing nothing else here is what keeps it from being mistaken for one.)
+    /// A bare `cx.stop_propagation()` click-through blocker used to be attached here too, back
+    /// when this button painted inside a header whose own `on_click` checked the repo out - a
+    /// click landing on a disabled `+` must not fall through and switch repos. The header's
+    /// `on_click` is gone now (a repo header is not a click target at all - see
+    /// [`Self::render_repo_group`]'s own docs), so there is nothing left to block and this
+    /// control follows `render_dropdown_menu_row`'s `enabled: false` contract exactly:
+    /// genuinely no `.on_click` at all.
     pub(in crate::rail) fn render_repo_group_new_button(
         &self,
         repo_id: repo::RepoId,
-        cx: &mut Context<Self>,
     ) -> impl IntoElement {
         div()
             .id(("repo-group-new", repo_id.0))
@@ -1142,9 +1140,6 @@ impl AdeApp {
             .text_size(self.ui_text_size(11.0))
             .child("+")
             .tooltip(text_tooltip("Add worktree - not available yet"))
-            .on_click(cx.listener(|_this, _event: &ClickEvent, _window, cx| {
-                cx.stop_propagation();
-            }))
     }
 
     /// Whether `row`'s agent rows are currently shown - an explicit per-worktree override in
@@ -2703,12 +2698,15 @@ mod rail_row_tests {
     }
 }
 
-/// GitHub issue #113: "no way to select an empty repo (one with no worktrees/sessions open yet)
-/// from the rail." Real click-through coverage against the live `AdeApp`/window, mirroring
-/// `crate::code_surface::render`'s own `cx.simulate_click`-against-`debug_bounds` technique -
-/// not just calling `Self::checkout_repo_from_rail` directly, since the bug this closes was two
-/// real gaps in the *render* side (no `on_click` on the header at all, and the whole group
-/// vanishing when it had no rows) that a handler-level test alone wouldn't catch a regression of.
+/// Real click-through coverage of the rail's repo groups against the live `AdeApp`/window,
+/// mirroring `crate::code_surface::render`'s own `cx.simulate_click`-against-`debug_bounds`
+/// technique - not just calling handlers directly, since what these tests pin down is the
+/// *render* side's wiring (which elements have click handlers at all, and which deliberately
+/// don't). The rail's click contract, per explicit user direction after two subtler repo-header
+/// behaviors were both rejected: only worktree rows and agent rows are clickable; the repo
+/// header and its `+` are plain, inert chrome; and only worktrees have tabs. Repo switching
+/// happens exclusively through a worktree row under the target repo's group
+/// (`crate::root::AdeApp::select_worktree_by_path`'s cross-repo fallback).
 #[cfg(test)]
 mod repo_checkout_tests {
     use crate::root::focus::palette_focus_tests;
@@ -2749,14 +2747,20 @@ mod repo_checkout_tests {
         dir
     }
 
-    /// Repo B is added (`Self::add_repo`) but never focused - the exact "known to the rail, zero
-    /// open worktrees/agents" state the issue describes: `Self::build_repo_groups` only
-    /// populates real row data for `Self::focused_repo` (see that function's own docs), so repo
-    /// B's group renders with both `rows` and `all_rows` empty. Before this change,
-    /// `Self::render_rail_list` dropped that whole group (header included) from the rail
-    /// entirely; now the header must still paint, with a real, working click target.
+    /// The repo header is **not a click target** - per explicit user direction, after two
+    /// subtler header-click behaviors were both rejected in review (auto-selecting the repo's
+    /// main worktree; then a "pure navigation" focus switch that still re-rooted the sidebar):
+    /// clicking a repo header must do *nothing at all*. Only worktree rows and agent rows are
+    /// clickable in the rail, and repo switching happens exclusively through a worktree row
+    /// (see `clicking_a_non_focused_repos_worktree_row_switches_repo_and_selects_it` below).
+    ///
+    /// Driven through a real click on the header's own painted bounds - which must still paint
+    /// at all (GitHub issue #113's "the whole group vanished from the rail" half is unchanged) -
+    /// asserting the focused repo, file tree root, worktree selection, and the live agent set
+    /// are all exactly what they were before the click. That proves the header genuinely has no
+    /// `on_click`, not merely that it does something subtler than before.
     #[gpui::test]
-    fn clicking_an_empty_repos_header_checks_it_out(cx: &mut TestAppContext) {
+    fn clicking_a_non_focused_repos_header_does_nothing_at_all(cx: &mut TestAppContext) {
         let repo_a = tempfile::tempdir().expect("tempdir a");
         let repo_b = tempfile::tempdir().expect("tempdir b");
         std::fs::write(repo_b.path().join("b.txt"), "b\n").expect("write");
@@ -2768,28 +2772,30 @@ mod repo_checkout_tests {
         cx.run_until_parked();
 
         let groups = app.update(cx, |app, cx| app.build_repo_groups(cx));
-        assert_eq!(
-            groups.len(),
-            2,
-            "sanity check: both repos must produce a group at all"
-        );
-        let repo_b_group = groups
-            .iter()
-            .find(|group| group.repo_id == repo_b_id)
-            .expect("repo B's group must render despite having zero rows - GitHub issue #113");
         assert!(
-            repo_b_group.rows.is_empty() && repo_b_group.all_rows.is_empty(),
-            "sanity check: repo B isn't a real git repository, so its real fetch resolves to a \
-             real (not fabricated) empty list"
+            groups.iter().any(|group| group.repo_id == repo_b_id),
+            "sanity check: repo B's group must still render at all (GitHub issue #113) - an \
+             unclickable header still paints"
         );
-        assert_ne!(
-            app.read_with(cx, |app, _| app.focused_repo_path()),
-            repo_b.path(),
+
+        let (focused_before, tree_root_before, selected_before, active_before, agents_before) = app
+            .read_with(cx, |app, _| {
+                (
+                    app.focused_repo_path(),
+                    app.file_tree_root.clone(),
+                    app.selected,
+                    app.agents.active_id(),
+                    app.agents.iter().count(),
+                )
+            });
+        assert_eq!(
+            focused_before,
+            repo_a.path(),
             "sanity check: repo B is not the focused repo before the click"
         );
 
-        // A real click on repo B's header's own painted bounds, not a direct method call - see
-        // this module's own docs for why the render side matters here.
+        // A real click on repo B's header's own painted bounds, not a direct method call - what
+        // this pins down is precisely that the render side attaches no handler.
         let selector: &'static str =
             Box::leak(format!("repo-group-header-{}", repo_b_id.0).into_boxed_str());
         let header_bounds = cx
@@ -2801,13 +2807,28 @@ mod repo_checkout_tests {
         app.read_with(cx, |app, _| {
             assert_eq!(
                 app.focused_repo_path(),
-                repo_b.path(),
-                "clicking repo B's header must check it out - focus its repo"
+                focused_before,
+                "clicking a repo header must not switch the focused repo - the header is not a \
+                 click target; only worktree and agent rows are"
             );
             assert_eq!(
-                app.file_tree_root,
-                repo_b.path(),
-                "checking out repo B must really load its own file tree, not just flip a focus id"
+                app.file_tree_root, tree_root_before,
+                "and it must not re-root or reload the file tree either - not \"pure \
+                 navigation\", nothing"
+            );
+            assert_eq!(
+                app.selected, selected_before,
+                "no worktree selection may change"
+            );
+            assert_eq!(
+                app.agents.active_id(),
+                active_before,
+                "no tab/agent may activate or deactivate"
+            );
+            assert_eq!(
+                app.agents.iter().count(),
+                agents_before,
+                "and nothing may be spawned or closed"
             );
         });
     }
@@ -2986,10 +3007,11 @@ mod repo_checkout_tests {
         });
     }
 
-    /// A second click on the already-focused repo's own header must be a real no-op (matching
-    /// `Self::checkout_repo_from_rail`'s own guard) - proven by arming some real per-repo UI
-    /// state and confirming it survives the click, the same "did this actually reset anything"
-    /// shape `open_repo_in_current_window_clears_stale_ui_state_from_the_previous_repo`
+    /// The focused-repo half of "the header is not a click target": a click on the
+    /// already-focused repo's own header must also be a genuine no-op - proven by arming some
+    /// real per-repo UI state and confirming it survives the click, the same "did this actually
+    /// reset anything" shape
+    /// `open_repo_in_current_window_clears_stale_ui_state_from_the_previous_repo`
     /// (`crate::root::mod`) uses for the real switch case.
     #[gpui::test]
     fn clicking_the_already_focused_repos_header_does_not_reset_it(cx: &mut TestAppContext) {
@@ -3013,7 +3035,7 @@ mod repo_checkout_tests {
             Box::leak(format!("repo-group-header-{}", repo_id.0).into_boxed_str());
         let header_bounds = cx
             .debug_bounds(selector)
-            .expect("the focused repo's own header must still paint (and still be clickable)");
+            .expect("the focused repo's own header must still paint");
         cx.simulate_click(header_bounds.center(), gpui::Modifiers::none());
         cx.run_until_parked();
 
@@ -3265,8 +3287,8 @@ mod repo_checkout_tests {
             assert_eq!(
                 app.focused_repo_path(),
                 repo_a.path(),
-                "and it must no longer check the repo out either - only the header itself does \
-                 that, and this button stops that click propagating nowhere at all"
+                "and it must not check the repo out either - nothing in a repo group's header \
+                 (the header itself included) is a click target anymore"
             );
             assert_eq!(
                 app.agents.iter().count(),

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -1083,23 +1083,45 @@ impl AdeApp {
         group_div
     }
 
-    /// The repo header's own `+` (GitHub issue #113) - the rail-native way to create a terminal
-    /// or agent session directly in a repo, even one with zero open worktrees, without first
-    /// hunting for the tab strip's identical control. Checks `repo_id` out
-    /// ([`Self::checkout_repo_from_rail`] - a no-op if it's already focused) and then opens
-    /// exactly the same real popover the tab strip's own `+` does
-    /// ([`crate::work_surface::render::AdeApp::render_plus_menu`]), rather than reimplementing
-    /// any of its five actions (New terminal, New agent, Git graph, Open file…, Next changed
-    /// file) here: this button only ever decides *which repo* those actions target, never what
-    /// they do once clicked. `Self::load_agent_rows` refresh mirrors
-    /// `crate::work_surface::render::AdeApp::render_tab_strip_plus`'s own click handler, so the
-    /// menu's "New agent" row reflects a fresh `$PATH` search here too.
+    /// The repo header's own `+` - **deliberately inert**, and rendered in this file's own
+    /// disabled-control treatment (dimmed to `theme::text::GHOSTER`, `cursor_default()`, no
+    /// hover, and - per `crate::work_surface::render::render_dropdown_menu_row`'s own
+    /// `enabled: false` contract, which this mirrors - genuinely **no `.on_click` at all**, so
+    /// it can never be a control that looks actionable and silently does nothing).
     ///
-    /// `cx.stop_propagation()` keeps this click from also bubbling into the header's own
-    /// `on_click` right above it in the tree - both would call
-    /// [`Self::checkout_repo_from_rail`] harmlessly (its own guard makes the second call a
-    /// no-op), but only this handler should also open the menu, the same "inner control stops
-    /// the outer row's own click" pattern `render_worktree_row`'s caret already uses.
+    /// This button's real, intended meaning at the *repo* level is "add a new worktree to this
+    /// repo", and this app deliberately has no UI for that yet: `wt_core` has real
+    /// worktree-creation backend methods, but there is a standing decision in this project that
+    /// no "add worktree"/"add repo" entry point ships until a real design lands, so nothing here
+    /// may trigger that flow. Inventing one is out of scope; so is silently deleting the button,
+    /// which would leave an unexplained gap in the header's own layout where the affordance is
+    /// going to live.
+    ///
+    /// It previously did something else entirely, which was the actual bug: check `repo_id` out
+    /// ([`Self::checkout_repo_from_rail`]) and then open the *tab strip's* "add agent/terminal
+    /// tab" popover ([`crate::work_surface::render::AdeApp::render_plus_menu`]) anchored to this
+    /// button. That predates the multi-repo rail (GitHub issue #113), and the multi-repo work -
+    /// which made every added repo's header reachable rather than just the focused one's - is
+    /// what exposed how wrong it is: a repo header has no *worktree* context for those five
+    /// actions to spawn into, so "New terminal"/"New agent" fell through to
+    /// [`Self::active_agent_cwd`]'s repo-root fallback and opened a tab against the repo itself
+    /// rather than any worktree inside it. Tabs belong to worktrees here, not to repos.
+    ///
+    /// With that handler gone, the whole anchoring apparatus it needed went with it (the
+    /// `gpui::canvas` bounds capture, `AdeApp::rail_plus_button_bounds`, and
+    /// `AdeApp::plus_menu_repo_anchor`): nothing in the app opens the plus menu from the rail
+    /// anymore, so keeping a per-render bounds capture feeding a popover that can never anchor
+    /// here would be machinery bound to nothing. The tab strip's own `+`
+    /// (`crate::work_surface::render::AdeApp::render_tab_strip_plus`) is unchanged and is still
+    /// the one real way to open the plus menu - anchored, as it always was, to its own bounds.
+    ///
+    /// The one handler left is a bare `cx.stop_propagation()`, and it is what actually makes this
+    /// button inert: it paints *inside* [`Self::render_repo_group`]'s header, whose own `on_click`
+    /// checks the repo out, so a click landing here with no handler at all would bubble straight
+    /// into that and switch repos - a real side effect from a control drawn as disabled.
+    /// (`render_dropdown_menu_row`'s "a disabled control attaches no `on_click`" rule is about
+    /// never wiring a disabled control to an *action*; a click-through blocker is the opposite of
+    /// that, and doing nothing else here is what keeps it from being mistaken for one.)
     pub(in crate::rail) fn render_repo_group_new_button(
         &self,
         repo_id: repo::RepoId,
@@ -1114,42 +1136,14 @@ impl AdeApp {
             .flex()
             .items_center()
             .justify_center()
-            .cursor_pointer()
+            .cursor_default()
             .rounded(theme::radius::CHIP)
-            .text_color(theme::text::DIM)
+            .text_color(theme::text::GHOSTER)
             .text_size(self.ui_text_size(11.0))
-            .hover(|el| el.bg(theme::surface::ROW_HOVER_ALT))
             .child("+")
-            // Captures this button's own painted bounds into `Self::rail_plus_button_bounds`
-            // every render - the same `gpui::canvas` idiom `Self::plus_button_bounds` uses for
-            // the tab strip's `+` (`crate::work_surface::render::AdeApp::render_tab_strip_plus`),
-            // keyed by `repo_id` since more than one of these paints per frame. Lets
-            // `crate::work_surface::render::AdeApp::render_plus_menu` anchor the popover to
-            // *this* button rather than the tab strip's when this is the one that opened it - see
-            // `Self::plus_menu_repo_anchor`'s own docs.
-            .child({
-                let this = cx.entity();
-                gpui::canvas(
-                    move |bounds, _window, cx| {
-                        this.update(cx, |this, _cx| {
-                            this.rail_plus_button_bounds.insert(repo_id, bounds);
-                        });
-                    },
-                    |_, _, _, _| {},
-                )
-                .absolute()
-                .size_full()
-            })
-            .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
+            .tooltip(text_tooltip("Add worktree - not available yet"))
+            .on_click(cx.listener(|_this, _event: &ClickEvent, _window, cx| {
                 cx.stop_propagation();
-                this.checkout_repo_from_rail(repo_id, window, cx);
-                // GitHub issue #176 - see `AdeApp::close_menu_surfaces_except`. Runs before the
-                // two assignments below, since the sweep clears `plus_menu_repo_anchor`.
-                let _ = this.close_menu_surfaces_except(Some(menus::MenuSurface::Plus));
-                this.plus_menu_open = true;
-                this.plus_menu_repo_anchor = Some(repo_id);
-                this.load_agent_rows(cx);
-                cx.notify();
             }))
     }
 
@@ -1336,7 +1330,16 @@ impl AdeApp {
 
         let path = row.path.clone();
         let header = div()
-            .id(id)
+            .id(id.clone())
+            // Test-only bounds lookup, the same real `gpui::VisualTestContext::debug_bounds`
+            // hook this file's `repo-group-header-N`/`repo-group-new-N` already carry - so a
+            // test can simulate a real mouse click at this row's painted position rather than
+            // reaching past the render side and calling its handler directly. Added for the
+            // cross-repo worktree click (`repo_checkout_tests::
+            // clicking_a_non_focused_repos_worktree_row_switches_repo_and_selects_it`), whose
+            // whole point is that the row is genuinely rendered and genuinely clickable for a
+            // repo that isn't focused.
+            .debug_selector(move || id)
             .cursor_pointer()
             .flex()
             .items_center()
@@ -3020,16 +3023,219 @@ mod repo_checkout_tests {
         );
     }
 
-    /// The rail's own per-repo `+` (GitHub issue #113's second half: "let the user create a
-    /// terminal / agent session ... from the rail") must check the target repo out first and
-    /// then open the exact same real popover the tab strip's own `+` uses
-    /// (`crate::work_surface::render::AdeApp::render_plus_menu`) - not a second, reimplemented
-    /// spawn path. Driven end to end: click repo B's `+`, then click the real "New terminal" row
-    /// that popover renders, and confirm the spawned terminal's `cwd` is really repo B's.
+    /// Same linked-worktree idiom the sibling test modules use: created with no new commits of its
+    /// own, which is all these tests need from it (a second, real, selectable worktree row).
+    fn add_worktree(repo_path: &Path, branch: &str, name: &str) -> std::path::PathBuf {
+        let container = TempDir::new().expect("tempdir");
+        let path = container.path().join(name);
+        drop(container);
+        git(
+            repo_path,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                branch,
+                path.to_str().expect("utf8 path"),
+            ],
+        );
+        path
+    }
+
+    /// The reported "I can't switch from a worktree to another repo's worktree". Before the
+    /// multi-repo rail, a non-focused repo's worktrees had no clickable rows at all, so
+    /// `crate::root::AdeApp::select_worktree_by_path`'s focused-repo-only lookup was never asked
+    /// about one; now every added repo renders its own real rows, and clicking one belonging to a
+    /// different repo silently did nothing whatsoever - the path genuinely isn't in
+    /// `AdeApp::worktrees`, so the lookup simply missed and the handler returned.
+    ///
+    /// Driven through a real click on the real painted row, so this covers the whole path from
+    /// `render_worktree_row`'s own `on_click` inward, not just the handler.
     #[gpui::test]
-    fn the_repo_headers_plus_button_opens_the_real_plus_menu_targeting_that_repo(
+    fn clicking_a_non_focused_repos_worktree_row_switches_repo_and_selects_it(
         cx: &mut TestAppContext,
     ) {
+        let repo_a = init_repo();
+        let repo_b = init_repo();
+        let repo_b_feature = add_worktree(repo_b.path(), "feature", "b-feature");
+
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        cx.run_until_parked();
+
+        app.update(cx, |app, cx| {
+            app.add_repo(repo_b.path().to_path_buf(), cx);
+        });
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.focused_repo_path(),
+                repo_a.path(),
+                "sanity check: repo A is the focused repo, so repo B's worktrees are genuinely \
+                 absent from `app.worktrees`"
+            );
+            assert!(
+                !app.worktrees.iter().any(|item| item.path == repo_b_feature),
+                "sanity check: the row about to be clicked is not in the focused repo's own list \
+                 - which is exactly why the old lookup missed it"
+            );
+        });
+
+        // The row must genuinely have painted for repo B, from repo B's own `Repo::worktrees` -
+        // that is what made this click reachable (and this bug reachable) in the first place.
+        let groups = app.update(cx, |app, cx| app.build_repo_groups(cx));
+        let index = groups
+            .iter()
+            .find(|group| group.repo_name == repo_b.path().file_name().unwrap().to_string_lossy())
+            .expect("repo B's group must exist")
+            .rows
+            .iter()
+            .position(|row| row.path == repo_b_feature)
+            .expect("repo B's linked worktree must be a real, rendered row");
+        let selector: &'static str = Box::leak(
+            format!("worktree-row-{index}-{}", repo_b_feature.display()).into_boxed_str(),
+        );
+        let row_bounds = cx
+            .debug_bounds(selector)
+            .expect("repo B's linked worktree row must have painted");
+        cx.simulate_click(row_bounds.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.focused_repo_path(),
+                repo_b.path(),
+                "clicking a worktree row under a non-focused repo must really switch focus to \
+                 that repo, not silently no-op"
+            );
+            let selected = app
+                .selected
+                .and_then(|index| app.worktrees.get(index))
+                .map(|item| item.path.clone());
+            assert_eq!(
+                selected,
+                Some(repo_b_feature.clone()),
+                "and the specific worktree that was clicked must be the selected one - not just \
+                 the repo's main checkout"
+            );
+            assert_eq!(
+                app.active_agent_cwd(),
+                repo_b_feature,
+                "the whole point of the switch: new work now targets the clicked worktree"
+            );
+            assert_eq!(
+                app.file_tree_root, repo_b_feature,
+                "and the real repo-scoped reload must have re-rooted at it, proving this went \
+                 through the same real switch machinery a same-repo selection uses"
+            );
+        });
+
+        let _ = std::fs::remove_dir_all(&repo_b_feature);
+    }
+
+    /// The other half of the cross-repo switch: the seeded worktree list must survive the real
+    /// background `git worktree list --porcelain` fetch that
+    /// `crate::root::AdeApp::checkout_repo_from_rail` kicks off, landing moments later. The
+    /// selection is recorded before that fetch resolves, so
+    /// `crate::rail::worktrees::recover_selection` has to re-anchor it by path rather than leave a
+    /// stale index - if it didn't, the worktree would visibly "unselect itself" a beat after the
+    /// click.
+    #[gpui::test]
+    fn a_cross_repo_worktree_selection_survives_the_repos_own_background_fetch(
+        cx: &mut TestAppContext,
+    ) {
+        let repo_a = init_repo();
+        let repo_b = init_repo();
+        // Two linked worktrees, so the target is not at index 0 and a stale index would be
+        // visible as a wrong selection rather than accidentally landing on the right row.
+        let _first = add_worktree(repo_b.path(), "first", "b-first");
+        let target = add_worktree(repo_b.path(), "second", "b-second");
+
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        cx.run_until_parked();
+        app.update(cx, |app, cx| {
+            app.add_repo(repo_b.path().to_path_buf(), cx);
+        });
+        cx.run_until_parked();
+
+        // The handler directly this time - `run_until_parked` afterwards is what lets the real
+        // fetch land on top of the synchronous seed.
+        app.update_in(cx, |app, window, cx| {
+            app.select_worktree_by_path(&target, window, cx);
+        });
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.selected
+                    .and_then(|i| app.worktrees.get(i))
+                    .map(|w| &w.path),
+                Some(&target),
+                "the selection must be real immediately, from the seeded list - not deferred to \
+                 whenever a background fetch happens to resolve"
+            );
+        });
+
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.selected
+                    .and_then(|i| app.worktrees.get(i))
+                    .map(|w| &w.path),
+                Some(&target),
+                "and it must still be the selection once repo B's own real fetch has landed and \
+                 replaced the seeded list"
+            );
+            assert!(
+                app.worktree_selection_notice.is_none(),
+                "nothing fell back to main, so no fallback notice may have been raised"
+            );
+        });
+
+        let _ = std::fs::remove_dir_all(&target);
+        let _ = std::fs::remove_dir_all(&_first);
+    }
+
+    /// The unchanged half of the contract: a path in no repo at all (a stale click racing a real
+    /// `git worktree remove`) must still do nothing - never a repo switch to something arbitrary.
+    #[gpui::test]
+    fn selecting_a_worktree_path_no_repo_knows_about_still_does_nothing(cx: &mut TestAppContext) {
+        let repo_a = init_repo();
+        let repo_b = init_repo();
+
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        cx.run_until_parked();
+        app.update(cx, |app, cx| {
+            app.add_repo(repo_b.path().to_path_buf(), cx);
+        });
+        cx.run_until_parked();
+
+        let gone = repo_b.path().join("worktree-that-never-existed");
+        app.update_in(cx, |app, window, cx| {
+            app.select_worktree_by_path(&gone, window, cx);
+        });
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.focused_repo_path(),
+                repo_a.path(),
+                "an unknown path must not switch repos"
+            );
+            assert_eq!(app.file_tree_root, repo_a.path());
+        });
+    }
+
+    /// The repo header's own `+` is deliberately inert until a real "add worktree" design lands -
+    /// see `Self::render_repo_group_new_button`'s own docs. It used to check the repo out and open
+    /// the *tab strip's* add-a-tab popover anchored to itself, which was simply the wrong action
+    /// at the repo level: tabs belong to worktrees here, so those rows had no worktree context to
+    /// spawn into and fell through to the repo root.
+    ///
+    /// Driven through a real click on the real painted button, not by reading the render code: it
+    /// must still paint (the affordance stays where it's going to live), and clicking it must
+    /// change nothing at all - no menu, no repo switch, no spawn.
+    #[gpui::test]
+    fn the_repo_headers_plus_button_is_inert(cx: &mut TestAppContext) {
         let repo_a = tempfile::tempdir().expect("tempdir a");
         let repo_b = tempfile::tempdir().expect("tempdir b");
 
@@ -3039,59 +3245,157 @@ mod repo_checkout_tests {
         let repo_b_id = app.update(cx, |app, cx| app.add_repo(repo_b.path().to_path_buf(), cx));
         cx.run_until_parked();
 
-        app.read_with(cx, |app, _| {
-            assert!(
-                app.agents
-                    .iter_for_cwd(repo_b.path().to_path_buf())
-                    .next()
-                    .is_none(),
-                "sanity check: repo B is a genuinely empty repo - no agents open in it yet"
-            );
-        });
+        let agents_before = app.read_with(cx, |app, _| app.agents.iter().count());
 
         let new_button_selector: &'static str =
             Box::leak(format!("repo-group-new-{}", repo_b_id.0).into_boxed_str());
-        let new_button_bounds = cx
-            .debug_bounds(new_button_selector)
-            .expect("repo B's own + must have painted");
+        let new_button_bounds = cx.debug_bounds(new_button_selector).expect(
+            "repo B's own + must still paint - a silently removed button would leave an \
+             unexplained gap in the header's layout",
+        );
         cx.simulate_click(new_button_bounds.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert!(
+                !app.plus_menu_open,
+                "the repo header's + must no longer open the tab strip's add-a-tab menu - a repo \
+                 has no worktree context for those actions to spawn into"
+            );
+            assert_eq!(
+                app.focused_repo_path(),
+                repo_a.path(),
+                "and it must no longer check the repo out either - only the header itself does \
+                 that, and this button stops that click propagating nowhere at all"
+            );
+            assert_eq!(
+                app.agents.iter().count(),
+                agents_before,
+                "nothing may be spawned by a click on an inert control"
+            );
+        });
+
+        assert!(
+            cx.debug_bounds("dropdown-menu-row-New terminal").is_none(),
+            "no plus-menu row may have painted at all"
+        );
+    }
+
+    /// The real, reproduced root cause behind "I spawned a Claude agent and it never showed up in
+    /// the rail": a repo path that isn't fully resolved. `git worktree list --porcelain` always
+    /// reports resolved paths, `crate::root::AdeApp::active_agent_cwd` falls back to
+    /// `Self::focused_repo_path` whenever no worktree is selected (which is exactly the state a
+    /// fresh window - and every `Self::checkout_repo_from_rail` - leaves the app in), and
+    /// `crate::rail::state::build_worktree_rows_with_history` folds an agent into a worktree row
+    /// by exact path equality. So an agent spawned against an unresolved repo path matched *no*
+    /// row, and - because that function maps over worktrees and folds agents into them - was
+    /// dropped from the rail entirely, silently, with no row and no error.
+    ///
+    /// Driven through a symlinked repo path, which is precisely what `jerry ~/link-to-repo` (or
+    /// any `jerry .`/relative invocation) hands the app: the CLI argument used to be stored
+    /// verbatim as `Repo::path`. `crate::rail::repo::canonical_repo_path` normalizes it at the
+    /// boundary instead.
+    #[gpui::test]
+    fn an_agent_spawned_in_a_repo_opened_through_a_symlink_still_appears_in_the_rail(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = init_repo();
+        let link_holder = TempDir::new().expect("tempdir");
+        let link = link_holder.path().join("repo-link");
+        std::os::unix::fs::symlink(repo.path(), &link).expect("symlink");
+        assert_ne!(
+            link,
+            repo.path(),
+            "sanity check: the symlink really is a different path from the real repo"
+        );
+
+        let (app, cx) = palette_focus_tests::open_test_app(cx, link.clone());
+        cx.run_until_parked();
+
+        // The real spawn chokepoint every "New agent" entry point funnels through.
+        let agent_id = app.update_in(cx, |app, window, cx| {
+            app.new_agent(ProcessKind::claude(), window, cx);
+            app.agents
+                .active()
+                .expect("New agent must really spawn an agent")
+                .id
+        });
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.focused_repo_path(),
+                repo.path(),
+                "the repo path must be stored fully resolved, not as the symlink it was opened \
+                 through - every per-worktree lookup in this app compares it against git's own \
+                 resolved paths by exact equality"
+            );
+        });
+
+        let groups = app.update(cx, |app, cx| app.build_repo_groups(cx));
+        let group = groups.first().expect("the repo's group must exist");
+        let row = group
+            .all_rows
+            .iter()
+            .find(|row| row.path == repo.path())
+            .expect("the repo's own main checkout must be a real worktree row");
+        assert_eq!(
+            row.agents.len(),
+            1,
+            "the freshly spawned agent must be folded into its own worktree's row - before this \
+             fix its cwd was the unresolved symlink path, which matched no row at all and made \
+             the agent vanish from the rail completely"
+        );
+        assert_eq!(row.agents[0].id, agent_id);
+    }
+
+    /// The same normalization, applied to a repo opened *after* startup through
+    /// `Self::open_repo_in_current_window` (the "Open Folder…" path) rather than the CLI
+    /// argument - a second real entry point for a repo path, which must not be able to
+    /// reintroduce the unresolved-path bug on its own.
+    #[gpui::test]
+    fn opening_a_symlinked_folder_stores_the_resolved_repo_path(cx: &mut TestAppContext) {
+        let repo_a = init_repo();
+        let repo_b = init_repo();
+        let link_holder = TempDir::new().expect("tempdir");
+        let link = link_holder.path().join("repo-b-link");
+        std::os::unix::fs::symlink(repo_b.path(), &link).expect("symlink");
+
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        cx.run_until_parked();
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_repo_in_current_window(link.clone(), window, cx);
+        });
         cx.run_until_parked();
 
         app.read_with(cx, |app, _| {
             assert_eq!(
                 app.focused_repo_path(),
                 repo_b.path(),
-                "the rail's + must check repo B out before offering to spawn into it"
+                "Open Folder… on a symlinked directory must store the resolved repo path"
             );
             assert!(
-                app.plus_menu_open,
-                "the rail's + must open the real tab-strip plus menu, not spawn silently"
+                app.agents
+                    .iter_for_cwd(repo_b.path().to_path_buf())
+                    .next()
+                    .is_some(),
+                "and the shell it opens there must run in that same resolved path, so it folds \
+                 into the repo's own worktree row in the rail"
             );
         });
 
-        let new_terminal_bounds = cx.debug_bounds("dropdown-menu-row-New terminal").expect(
-            "the real plus menu's own New terminal row must have painted - proving this \
-             reuses `render_plus_menu` rather than a reimplemented popover",
+        let groups = app.update(cx, |app, cx| app.build_repo_groups(cx));
+        let row = groups
+            .iter()
+            .flat_map(|group| group.all_rows.iter())
+            .find(|row| row.path == repo_b.path())
+            .expect("repo B's own main checkout must be a real worktree row");
+        assert_eq!(
+            row.path,
+            repo_b.path(),
+            "sanity check: the row is keyed by git's own resolved path"
         );
-        cx.simulate_click(new_terminal_bounds.center(), gpui::Modifiers::none());
-        cx.run_until_parked();
-
-        app.read_with(cx, |app, _| {
-            assert!(
-                !app.plus_menu_open,
-                "picking a row must close the menu, same as every other plus-menu click"
-            );
-            let agent = app
-                .agents
-                .active()
-                .expect("New terminal must really spawn an agent and make it active");
-            assert_eq!(
-                agent.cwd,
-                repo_b.path(),
-                "the spawned terminal must run in repo B - the repo the rail's own + checked \
-                 out - not wherever was focused before the click"
-            );
-        });
     }
 }
 

--- a/crates/app/src/rail/repo.rs
+++ b/crates/app/src/rail/repo.rs
@@ -137,16 +137,42 @@ pub fn repo_state_path_for(settings_path: &Path) -> PathBuf {
     }
 }
 
-/// The map key for one repo - its real path, canonicalized so the same repo reached through a
-/// symlink (or a `.`-relative invocation) resolves to one entry rather than two. Falls back to
-/// the path as given when it can't be canonicalized (doesn't exist yet, or is a pure in-memory
-/// path in a unit test) - still a stable key for that path. `None` for a path that isn't valid
-/// UTF-8, refused outright for the identical reason `crate::sidebar::fold_state::worktree_key`
-/// refuses one: a lossy `to_string_lossy` key could collide two genuinely different repos onto
-/// one TOML key.
+/// The one real normalization every repo path stored in [`Repo::path`] goes through: fully
+/// resolved (symlinks followed, `.`/`..` and a relative invocation made absolute), falling back to
+/// the path exactly as given when it can't be resolved at all - a directory that doesn't exist
+/// yet, or a pure in-memory path in a unit test, which must still be usable rather than an error.
+///
+/// This is load-bearing, not cosmetic. Every worktree path this app displays comes from
+/// `wt_core::list_worktrees_porcelain`, i.e. from git, which always reports **fully resolved**
+/// paths (git derives them from `getcwd`, which resolves symlinks). Every one of this app's real
+/// per-worktree lookups is an exact `PathBuf` comparison against those - `crate::rail::state::
+/// build_worktree_rows_with_history` folding an agent into its worktree row,
+/// `crate::work_surface::agents::Agents::iter_for_cwd`/`activate_for_worktree`,
+/// `crate::root::AdeApp::diff_cache`/`worktree_notes`/`open_files_by_worktree`/`edit_buffers`.
+/// A [`Repo::path`] kept verbatim from `jerry .`, `jerry ~/link-to-repo`, or any relative
+/// argument therefore never equals git's own answer for the same directory, and
+/// `crate::root::AdeApp::active_agent_cwd`'s repo-root fallback hands exactly that unresolved
+/// path to `Agents::spawn` as an agent's `cwd`. The real, reproduced consequence: an agent
+/// spawned that way matches no worktree row at all, and - because `build_worktree_rows_with_
+/// history` maps over *worktrees* and folds agents into them - is dropped from the rail
+/// silently, with no row of its own and no error anywhere.
+///
+/// Normalizing once, where a repo path enters this app ([`crate::root::AdeApp::add_repo`],
+/// [`crate::root::AdeApp::open_repo_in_current_window`], and startup's own resolved CLI path), is
+/// what keeps that whole family of exact-path comparisons meaningful - as opposed to
+/// canonicalizing at each comparison, which would put a blocking `std::fs::canonicalize` on a
+/// per-row, per-render path and still leave the *spawned process's* real cwd unresolved.
+pub fn canonical_repo_path(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// The map key for one repo - its real path, canonicalized ([`canonical_repo_path`]) so the same
+/// repo reached through a symlink (or a `.`-relative invocation) resolves to one entry rather
+/// than two. `None` for a path that isn't valid UTF-8, refused outright for the identical reason
+/// `crate::sidebar::fold_state::worktree_key` refuses one: a lossy `to_string_lossy` key could
+/// collide two genuinely different repos onto one TOML key.
 pub fn repo_key(path: &Path) -> Option<String> {
-    let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
-    canonical.to_str().map(str::to_owned)
+    canonical_repo_path(path).to_str().map(str::to_owned)
 }
 
 /// The whole on-disk repo-list file: every repo this user has ever added, keyed by [`repo_key`].

--- a/crates/app/src/root/menus.rs
+++ b/crates/app/src/root/menus.rs
@@ -37,7 +37,10 @@ use super::*;
 /// answers "is it open" and "close it", which is all the shared invariant needs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum MenuSurface {
-    /// The tab strip's (and rail repo header's) `+` menu - [`AdeApp::plus_menu_open`].
+    /// The tab strip's `+` menu - [`AdeApp::plus_menu_open`]. The rail repo header's own `+` used
+    /// to open this same popover too; it is inert now (see
+    /// `crate::rail::render::AdeApp::render_repo_group_new_button`), so the tab strip is the
+    /// only opener left.
     Plus,
     /// The Windows/Linux title bar's File/Edit/View/Agent/Help dropdowns -
     /// [`AdeApp::title_menu_open`].
@@ -97,10 +100,7 @@ impl AdeApp {
     /// method does is exactly the notify this one deliberately defers.
     pub(crate) fn close_menu_surface(&mut self, surface: MenuSurface) {
         match surface {
-            MenuSurface::Plus => {
-                self.plus_menu_open = false;
-                self.plus_menu_repo_anchor = None;
-            }
+            MenuSurface::Plus => self.plus_menu_open = false,
             MenuSurface::Title => self.title_menu_open = None,
             MenuSurface::TreeContext => self.tree_context_menu = None,
             MenuSurface::Commit => self.commit_menu_open = false,
@@ -117,9 +117,8 @@ impl AdeApp {
     /// This is the whole "opening a second menu closes the first" rule. Every real path that
     /// *opens* one of them calls it with its own surface as `keep` immediately before setting
     /// its own state - so the invariant holds no matter which of the (many) entry points was used:
-    /// a click on the tab strip `+`, a click on a rail repo header's `+`, a title bar label, a
-    /// right-click in the file tree, the commit composer's `▾`, the graph's `Push ▾`, a graph
-    /// row's `⋯`, or a right-click on a graph row.
+    /// a click on the tab strip `+`, a title bar label, a right-click in the file tree, the commit
+    /// composer's `▾`, the graph's `Push ▾`, a graph row's `⋯`, or a right-click on a graph row.
     #[must_use]
     pub(crate) fn close_menu_surfaces_except(&mut self, keep: Option<MenuSurface>) -> bool {
         let mut closed_any = false;
@@ -280,27 +279,6 @@ mod menu_surface_tests {
                      a still-open popover positioned off possibly-moved bounds is the bug"
                 );
             }
-        });
-    }
-
-    /// The `+` menu's repo anchor is part of "which `+` menu is open", not a separate fact: a
-    /// stale anchor left behind by a rail repo header's `+` would position the *next* tab-strip
-    /// `+` menu off that repo row instead of off the `+` button.
-    #[gpui::test]
-    fn closing_the_plus_menu_also_clears_its_repo_anchor(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
-
-        app.update(cx, |app, cx| {
-            let repo_id = crate::rail::repo::RepoId(7);
-            app.plus_menu_open = true;
-            app.plus_menu_repo_anchor = Some(repo_id);
-            assert!(app.close_all_menu_surfaces(cx));
-            assert_eq!(
-                app.plus_menu_repo_anchor, None,
-                "the anchor must be cleared with the menu it belongs to, or the next tab-strip \
-                 + menu would paint off a rail repo header's bounds"
-            );
         });
     }
 }

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -2482,43 +2482,45 @@ impl AdeApp {
         self.start_status_polling(cx);
     }
 
-    /// GitHub issue #113's "click a repo header in the rail, even one with zero open
-    /// worktrees, and it checks out" - the rail-native sibling of
-    /// [`Self::open_repo_in_current_window`]. Shares that method's real repo-switch reload
+    /// The rail's real repo-switch engine - the rail-native sibling of
+    /// [`Self::open_repo_in_current_window`]. It began as GitHub issue #113's "click a repo
+    /// header in the rail and it checks out", but the repo header is deliberately **not
+    /// clickable at all anymore** (explicit user direction, after two subtler header-click
+    /// behaviors were both rejected in review - see
+    /// [`crate::rail::render::AdeApp::render_repo_group`]'s own docs: in the rail, only worktree
+    /// rows and agent rows are click targets). So today this has exactly one real caller:
+    /// [`Self::select_worktree_by_path`]'s cross-repo fallback, reached by clicking a worktree
+    /// row under a non-focused repo's group.
+    ///
+    /// Shares `open_repo_in_current_window`'s real repo-switch reload
     /// (`Self::reset_repo_scoped_state`, `Self::start_worktree_watch`/`Self::start_status_polling`,
     /// forgetting a dangling [`Self::empty_state_focus_handle`] overlay target, and real
     /// cross-repo agent persistence - see that method's own "Cross-repo agent persistence" docs,
     /// which apply here unchanged) but deliberately does **not** call [`Self::add_repo`] or spawn
     /// an initial shell: `id` must already be a known [`Self::repos`] entry (every row the rail
     /// renders came from there), and unlike "Open Folder…" - which always guarantees *some* real
-    /// terminal is running so a freshly opened folder is never inert - this gesture's whole point
-    /// is to make a genuinely empty repo (zero open worktrees/agents) reachable as a real
-    /// "focused, nothing open yet" state, so the user can choose what to open next themselves
-    /// (the tab strip's own `+` menu) instead of always landing in an unwanted shell.
+    /// terminal is running so a freshly opened folder is never inert - this focuses the repo
+    /// with nothing selected and nothing spawned, leaving the follow-up worktree selection to
+    /// its caller.
     ///
     /// A no-op if `id` isn't (or is no longer) a known repo - the same defensive guard
     /// [`Self::focus_repo`] already has, reused here rather than duplicated - or if `id` is
-    /// already [`Self::focused_repo`] (a plain re-click of the repo already showing must not
+    /// already [`Self::focused_repo`] (a repeat call for the repo already showing must not
     /// reset any of its live state).
     ///
     /// Unlike [`Self::open_repo_in_current_window`], this never spawns a fallback shell: a repo
-    /// that `id` has never had a real agent open in comes up genuinely empty, exactly the
-    /// "focused, nothing open yet" state this method's own module docs above describe - the user
-    /// opens something next via the tab strip's own `+` (the rail repo header's own `+` is inert
-    /// until a real "add worktree" design lands - see
+    /// that `id` has never had a real agent open in comes up genuinely empty, a real "focused,
+    /// nothing open yet" state - the user opens something next via the tab strip's own `+` (the
+    /// rail repo header's own `+` is inert until a real "add worktree" design lands - see
     /// [`crate::rail::render::AdeApp::render_repo_group_new_button`]). A repo `id` has visited
     /// *before*, though, may already have real agents left running from that earlier visit (see
     /// [`Self::open_repo_in_current_window`]'s cross-repo persistence docs) - none of them are
-    /// closed or respawned here, and [`Self::agents`]' `activate_for_worktree` call below makes
-    /// whichever one was last active in `id`'s repo the one the centre pane
-    /// ([`crate::work_surface::render::AdeApp::render_center_pane`]) actually shows again, the
-    /// same real re-activation [`Self::open_repo_in_current_window`] already does on every call.
-    /// Without it, [`Agents::active`](crate::work_surface::agents::Agents::active) would still
-    /// point at whatever was active in the repo just left, and the centre pane would keep
-    /// rendering *that* repo's terminal even though the rail now shows `id` focused - a real,
-    /// adversarial-audit-found gap this fixes rather than a defensive no-op. There is no
-    /// cross-restart persistence of *which tabs were open* for a repo yet - a real, disclosed gap,
-    /// not a silently stubbed one.
+    /// closed or respawned here, and none are *reactivated* either: `Agents::clear_active` below
+    /// leaves the centre pane showing nothing until a worktree row is genuinely selected (see
+    /// the inline comment below and `Agents::clear_active`'s own docs for why clearing, not
+    /// skipping, is the correct half-measure-free behavior). There is no cross-restart
+    /// persistence of *which tabs were open* for a repo yet - a real, disclosed gap, not a
+    /// silently stubbed one.
     pub(crate) fn checkout_repo_from_rail(
         &mut self,
         id: RepoId,
@@ -2553,17 +2555,18 @@ impl AdeApp {
         // status in the rail (`crate::rail::render::AdeApp::build_agent_rows` folds in every
         // repo's agents, not just the focused one's). What changes here is only which repo's
         // worktree rows the rail shows - explicitly, deliberately, *never* which tab (if any) the
-        // centre pane shows: a repo header is a pure navigation gesture, not a worktree
+        // centre pane shows: focusing a repo is a pure navigation gesture, not a worktree
         // selection, so nothing may spawn from it and nothing may reactivate through it. Two real
         // gaps closed to make that hold, not one: `Self::selected` staying `None` (below) closes
-        // "clicking the header can spawn a tab attributed to the repo itself" (the reported bug);
-        // `Agents::clear_active` closes the other half - reactivating whichever agent was last
-        // active in `id`'s repo *looked* like reasonable cross-repo persistence, but from the
-        // user's side it was the exact same "the repo itself has a tab" behavior, just reached
-        // through an existing agent instead of a freshly spawned one. See `Agents::clear_active`'s
-        // own docs for why this can't simply be *skipped* instead - the centre pane has no
-        // repo-scoping of its own, so doing nothing here would leave whatever was left's terminal
-        // rendering right alongside `id`'s own, unrelated rail rows.
+        // "checking out a repo can spawn a tab attributed to the repo itself" (the reported bug,
+        // back when the repo header was still clickable); `Agents::clear_active` closes the
+        // other half - reactivating whichever agent was last active in `id`'s repo *looked* like
+        // reasonable cross-repo persistence, but from the user's side it was the exact same "the
+        // repo itself has a tab" behavior, just reached through an existing agent instead of a
+        // freshly spawned one. See `Agents::clear_active`'s own docs for why this can't simply
+        // be *skipped* instead - the centre pane has no repo-scoping of its own, so doing
+        // nothing here would leave whatever was left's terminal rendering right alongside `id`'s
+        // own, unrelated rail rows.
         self.agents.clear_active(cx);
         self.selected = None;
         self.worktree_selection_notice = None;
@@ -4250,9 +4253,9 @@ mod repo_list_tests {
                 app.agents.active_id(),
                 None,
                 "checking out repo B again must leave nothing globally active, even though it \
-                 has a real, remembered agent of its own - a repo header click is pure \
-                 navigation, never a worktree selection, so the centre pane must show genuinely \
-                 nothing rather than reactivating it"
+                 has a real, remembered agent of its own - focusing a repo is pure navigation, \
+                 never a worktree selection, so the centre pane must show genuinely nothing \
+                 rather than reactivating it"
             );
             let repo_b_agent = app
                 .agents

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -1832,26 +1832,14 @@ pub struct AdeApp {
     /// pattern as [`Self::body_bounds`]). [`Self::render_plus_menu`] positions the popover
     /// directly off this rather than a second, independently-computed offset that could drift
     /// once the rail's adjustable width shifts the button. `Bounds::default()` until first paint.
-    /// Only the real anchor when [`Self::plus_menu_repo_anchor`] is `None` - see that field's own
-    /// docs for the rail's per-repo `+` case.
+    ///
+    /// The *only* anchor this popover has. A per-repo `plus_menu_repo_anchor`/
+    /// `rail_plus_button_bounds` pair used to exist alongside it, for the rail repo header's own
+    /// `+` opening this same popover; that button is inert now (see
+    /// `crate::rail::render::AdeApp::render_repo_group_new_button`'s own docs for why), so
+    /// nothing outside the tab strip can open the plus menu and both fields went with it rather
+    /// than being left capturing bounds for an anchor no click can ever select.
     pub(crate) plus_button_bounds: gpui::Bounds<Pixels>,
-    /// Which control opened [`Self::plus_menu_open`]'s popover: `None` for the tab strip's own
-    /// `+` ([`Self::plus_button_bounds`]), `Some(repo_id)` for that repo's own header `+`
-    /// ([`crate::rail::render::AdeApp::render_repo_group_new_button`],
-    /// [`Self::rail_plus_button_bounds`]). GitHub issue #113's per-repo `+` used to always
-    /// position the popover off [`Self::plus_button_bounds`] regardless of which button actually
-    /// opened it - visually anchored to the tab strip even when a rail row's own `+` was clicked.
-    /// Set on every real click of either button (see both render sites), read only by
-    /// [`Self::render_plus_menu`].
-    pub(crate) plus_menu_repo_anchor: Option<RepoId>,
-    /// Each rail repo header's own `+` button's painted bounds, captured every render the same
-    /// `gpui::canvas` idiom [`Self::plus_button_bounds`] uses - keyed by [`RepoId`] since, unlike
-    /// the tab strip's single `+`, one such button paints per repo group every frame regardless
-    /// of which one (if any) was actually clicked; a single shared field would silently hold
-    /// whichever repo happened to render last. [`Self::render_plus_menu`] looks up the entry for
-    /// [`Self::plus_menu_repo_anchor`] when it is `Some`. No entry until that repo's header has
-    /// painted at least once.
-    pub(crate) rail_plus_button_bounds: std::collections::HashMap<RepoId, gpui::Bounds<Pixels>>,
     /// Which of the Windows/Linux title bar's five menu labels ([`crate::title_bar::menu::TitleMenu::ALL`])
     /// has its real dropdown open right now, if any - see [`crate::title_bar::menu::render_title_menu`]'s own
     /// docs. Closed the same way [`Self::plus_menu_open`] is: its own scrim click, picking a row,
@@ -1942,13 +1930,13 @@ pub struct AdeApp {
     pub(crate) next_tab_settle_id: u64,
     /// Each currently-rendered tab's own real painted bounds, captured every render by a
     /// `gpui::canvas` overlay in [`work_surface::render::AdeApp::render_tab_chrome`] - the same
-    /// idiom [`Self::plus_button_bounds`]/[`Self::rail_plus_button_bounds`] already use, keyed by
+    /// idiom [`Self::plus_button_bounds`] already uses, keyed by
     /// [`work_surface::TabRef`] since every tab paints its own each frame. This is the *only*
     /// real source of a tab's on-screen width (GPUI's flex layout means no two tabs are the same
     /// size), which [`Self::drop_dragged_tab`] needs to compute how far a drop's neighbouring
     /// tabs must visually slide (see [`Self::tab_slide`]'s own docs). Never pruned when a tab
-    /// closes - a harmless, bounded leak, the same tradeoff [`Self::rail_plus_button_bounds`]
-    /// already makes.
+    /// closes - a harmless, bounded leak, since a `TabRef` is small and the set of tabs a session
+    /// ever opens is bounded by real user action.
     pub(crate) tab_bounds: std::collections::HashMap<work_surface::TabRef, gpui::Bounds<Pixels>>,
     /// The unified tab strip's real neighbour-slide animation - the "every tab other than the
     /// one actually dropped just teleports to its new slot" gap GitHub issue #16 left open
@@ -2345,6 +2333,14 @@ impl AdeApp {
     /// keystroke path, unlike [`repo::repo_key`]'s hot-path sibling
     /// `crate::sidebar::fold_state::worktree_key`.
     pub(crate) fn add_repo(&mut self, path: PathBuf, cx: &mut Context<Self>) -> RepoId {
+        // The single point a repo path enters [`Self::repos`], and so the single place it gets
+        // normalized - see [`repo::canonical_repo_path`]'s own docs for the real, reproduced bug
+        // an unresolved path here causes (an agent spawned into the repo root vanishing from the
+        // rail entirely, because its `cwd` never equals git's own answer for the same directory).
+        // Callers that also *use* the path they passed for real work of their own
+        // ([`Self::open_repo_in_current_window`], startup) normalize it themselves before calling
+        // here rather than relying on this; both are the same idempotent call.
+        let path = repo::canonical_repo_path(&path);
         let key = repo::repo_key(&path);
         if let Some(key) = key.as_deref() {
             if let Some(existing) = self
@@ -2453,6 +2449,10 @@ impl AdeApp {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        // Normalized *before* anything else uses it: `path` is not only stored on the `Repo`
+        // below, it is also this method's own spawn cwd, `Agents::activate_for_worktree` key and
+        // `Self::reset_repo_scoped_state` root. See `repo::canonical_repo_path`'s own docs.
+        let path = repo::canonical_repo_path(&path);
         let id = self.add_repo(path.clone(), cx);
         self.focus_repo(id, cx);
 
@@ -2494,9 +2494,7 @@ impl AdeApp {
     /// terminal is running so a freshly opened folder is never inert - this gesture's whole point
     /// is to make a genuinely empty repo (zero open worktrees/agents) reachable as a real
     /// "focused, nothing open yet" state, so the user can choose what to open next themselves
-    /// (the tab strip's own `+` menu, or the rail's own per-repo `+` -
-    /// [`crate::rail::render::AdeApp::render_repo_group`]) instead of always landing in an
-    /// unwanted shell.
+    /// (the tab strip's own `+` menu) instead of always landing in an unwanted shell.
     ///
     /// A no-op if `id` isn't (or is no longer) a known repo - the same defensive guard
     /// [`Self::focus_repo`] already has, reused here rather than duplicated - or if `id` is
@@ -2506,8 +2504,9 @@ impl AdeApp {
     /// Unlike [`Self::open_repo_in_current_window`], this never spawns a fallback shell: a repo
     /// that `id` has never had a real agent open in comes up genuinely empty, exactly the
     /// "focused, nothing open yet" state this method's own module docs above describe - the user
-    /// opens something next via the tab strip's own `+` or the rail's per-repo `+`
-    /// ([`crate::rail::render::AdeApp::render_repo_group_new_button`]). A repo `id` has visited
+    /// opens something next via the tab strip's own `+` (the rail repo header's own `+` is inert
+    /// until a real "add worktree" design lands - see
+    /// [`crate::rail::render::AdeApp::render_repo_group_new_button`]). A repo `id` has visited
     /// *before*, though, may already have real agents left running from that earlier visit (see
     /// [`Self::open_repo_in_current_window`]'s cross-repo persistence docs) - none of them are
     /// closed or respawned here, and [`Self::agents`]' `activate_for_worktree` call below makes

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -2549,24 +2549,30 @@ impl AdeApp {
             .forget_target(&self.empty_state_focus_handle);
 
         // See this method's own docs: every agent open before this call, in every repo, stays
-        // alive - none of them are closed here. `id`'s own repo may already have real agents
-        // running from an earlier visit; this makes whichever one was last active there the one
-        // the centre pane actually shows, exactly as a fresh `Self::open_repo_in_current_window`
-        // switch already does.
-        self.agents.activate_for_worktree(&path, cx);
+        // alive - none of them are closed here, and every one of them still shows real live
+        // status in the rail (`crate::rail::render::AdeApp::build_agent_rows` folds in every
+        // repo's agents, not just the focused one's). What changes here is only which repo's
+        // worktree rows the rail shows - explicitly, deliberately, *never* which tab (if any) the
+        // centre pane shows: a repo header is a pure navigation gesture, not a worktree
+        // selection, so nothing may spawn from it and nothing may reactivate through it. Two real
+        // gaps closed to make that hold, not one: `Self::selected` staying `None` (below) closes
+        // "clicking the header can spawn a tab attributed to the repo itself" (the reported bug);
+        // `Agents::clear_active` closes the other half - reactivating whichever agent was last
+        // active in `id`'s repo *looked* like reasonable cross-repo persistence, but from the
+        // user's side it was the exact same "the repo itself has a tab" behavior, just reached
+        // through an existing agent instead of a freshly spawned one. See `Agents::clear_active`'s
+        // own docs for why this can't simply be *skipped* instead - the centre pane has no
+        // repo-scoping of its own, so doing nothing here would leave whatever was left's terminal
+        // rendering right alongside `id`'s own, unrelated rail rows.
+        self.agents.clear_active(cx);
+        self.selected = None;
         self.worktree_selection_notice = None;
-        // A freshly focused repo must land on a real worktree selection immediately, not wait on
-        // `Self::load_worktrees`'s own background fetch to land moments later (that fetch still
-        // runs below regardless, and re-syncs this the identical way any other refresh does) -
-        // see `Self::load_worktrees`'s own `NoPriorSelection` docs for the real bug this closes:
-        // with nothing selected, `Self::active_agent_cwd`'s fallback let a tab strip "+" click
-        // spawn rooted at the repository itself rather than any worktree inside it.
-        match seeded_worktrees {
-            Some(items) => {
-                self.selected = items.iter().position(|item| item.is_main);
-                self.worktrees = items;
-            }
-            None => self.selected = None,
+        // Still seeded synchronously from this repo's own already-known worktree list (see the
+        // field's own docs above) - this is purely a display fix (the rail must show repo B's
+        // real rows the instant repo B is focused, not repo A's stale ones for one frame), and
+        // carries no selection with it.
+        if let Some(items) = seeded_worktrees {
+            self.worktrees = items;
         }
         self.reset_repo_scoped_state(path, window, cx);
         self.load_worktrees(cx);
@@ -4169,6 +4175,98 @@ mod repo_list_tests {
         });
     }
 
+    /// "Repo headers should not be associated to tabs at all" - the user's own words, after two
+    /// earlier attempts at this same bug (auto-selecting the main worktree; blocking every spawn
+    /// while nothing is selected) both turned out wrong for different reasons. The centre pane
+    /// has no repo-scoping of its own (`crate::work_surface::render::AdeApp::render_center_pane`
+    /// reads `Agents::active` directly), so simply *not* reactivating anything on checkout was
+    /// tried and rejected too: repo A's agent stayed the globally active one, and its terminal
+    /// kept rendering right alongside repo B's own, unrelated rail rows. `Agents::clear_active`
+    /// is what actually closes this - checked here directly, not inferred from `Agents::active_id`
+    /// alone, since that alone wouldn't prove the *previous* repo's agent was the thing cleared.
+    #[gpui::test]
+    fn checking_out_a_repo_from_the_rail_clears_the_centre_pane_instead_of_reactivating(
+        cx: &mut TestAppContext,
+    ) {
+        let repo_a = tempfile::tempdir().expect("tempdir");
+        let repo_b = tempfile::tempdir().expect("tempdir");
+
+        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        cx.run_until_parked();
+
+        let repo_b_id = app.update(cx, |app, cx| app.add_repo(repo_b.path().to_path_buf(), cx));
+        cx.run_until_parked();
+
+        // Give repo B a real agent of its own first, and make it `Agents::active_by_cwd`'s
+        // remembered tab for repo B's path - the exact state `Agents::activate_for_worktree`
+        // would resurrect on a later visit. Then leave repo B (back to A) before the real
+        // assertion below, so what's being tested is a genuine *re*-checkout, not a first visit.
+        app.update_in(cx, |app, window, cx| {
+            app.checkout_repo_from_rail(repo_b_id, window, cx);
+        });
+        cx.run_until_parked();
+        let repo_b_agent_id = app.update_in(cx, |app, window, cx| {
+            app.agents.spawn(
+                ProcessKind::Shell,
+                repo_b.path().to_path_buf(),
+                12.0,
+                None,
+                None,
+                window,
+                cx,
+            )
+        });
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.agents.active_id(),
+                Some(repo_b_agent_id),
+                "sanity check: repo B's freshly spawned agent really is the active one right now"
+            );
+        });
+
+        let repo_a_id = app.read_with(cx, |app, _| {
+            app.repos
+                .iter()
+                .find(|repo| repo.path == repo_a.path())
+                .expect("repo A is a known repo")
+                .id
+        });
+        app.update_in(cx, |app, window, cx| {
+            app.checkout_repo_from_rail(repo_a_id, window, cx);
+        });
+        cx.run_until_parked();
+
+        // The real assertion: re-checking out repo B, with its own agent still alive and still
+        // `Agents::active_by_cwd`'s remembered tab for its path - exactly what
+        // `Agents::activate_for_worktree` would resurrect - must not reactivate it.
+        app.update_in(cx, |app, window, cx| {
+            app.checkout_repo_from_rail(repo_b_id, window, cx);
+        });
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, cx| {
+            assert_eq!(
+                app.agents.active_id(),
+                None,
+                "checking out repo B again must leave nothing globally active, even though it \
+                 has a real, remembered agent of its own - a repo header click is pure \
+                 navigation, never a worktree selection, so the centre pane must show genuinely \
+                 nothing rather than reactivating it"
+            );
+            let repo_b_agent = app
+                .agents
+                .iter()
+                .find(|agent| agent.id == repo_b_agent_id)
+                .expect("repo B's agent must still genuinely exist");
+            assert!(
+                repo_b_agent.pane.read(cx).is_running(),
+                "and it must still be a real, live process - only *which* tab is shown changed, \
+                 nothing about repo B's own background persistence"
+            );
+        });
+    }
+
     /// The reported "we can add a tab to the repo itself" - checking out a repo from the rail
     /// used to leave `AdeApp::selected` at `None` until the user explicitly clicked a worktree
     /// row, and `AdeApp::active_agent_cwd`'s fallback to the bare repo path for exactly that
@@ -4178,7 +4276,7 @@ mod repo_list_tests {
     /// synchronous seed in `AdeApp::checkout_repo_from_rail` itself, not just the fallback
     /// `AdeApp::load_worktrees` background fetch that lands moments later.
     #[gpui::test]
-    fn checking_out_a_repo_from_the_rail_lands_on_its_main_worktree_not_unselected(
+    fn checking_out_a_repo_from_the_rail_never_selects_a_worktree_on_its_own(
         cx: &mut TestAppContext,
     ) {
         let repo_a = init_repo();
@@ -4188,43 +4286,30 @@ mod repo_list_tests {
         cx.run_until_parked();
 
         let repo_b_id = app.update(cx, |app, cx| app.add_repo(repo_b.path().to_path_buf(), cx));
-        // Repo B's own worktree list is fetched and mirrored into `Repo::worktrees` here, before
-        // it is ever checked out - the real precondition for `checkout_repo_from_rail`'s own
-        // synchronous seed to have anything to seed from.
         cx.run_until_parked();
 
         app.update_in(cx, |app, window, cx| {
             app.checkout_repo_from_rail(repo_b_id, window, cx);
         });
 
-        // Deliberately no `run_until_parked()` between the checkout and this read: the whole
-        // point is that the selection is real *before* `load_worktrees`'s own background fetch
-        // could possibly have resolved.
         app.read_with(cx, |app, _| {
-            let selected_path = app
-                .selected
-                .and_then(|index| app.worktrees.get(index))
-                .map(|item| item.path.clone());
             assert_eq!(
-                selected_path,
-                Some(repo_b.path().to_path_buf()),
-                "checking out repo B must immediately select its own main worktree, not leave \
-                 `selected` at `None` until a user clicks a specific row"
-            );
-            assert_eq!(
-                app.active_agent_cwd(),
-                repo_b.path(),
-                "sanity check: a tab spawned right now would still target the right directory"
+                app.selected, None,
+                "checking out a repo must never select a worktree on the user's behalf - only \
+                 a real click on a worktree row does that. An earlier version of this fix \
+                 auto-selected the main worktree here, which just moved the \"repo itself is \
+                 actionable\" bug one level deeper (see `Self::new_agent`'s own docs for where \
+                 the real fix lives instead)"
             );
         });
 
-        // And the real background fetch landing moments later must not undo it.
+        // And the real background fetch landing moments later must not introduce one either.
         cx.run_until_parked();
         app.read_with(cx, |app, _| {
-            assert!(
-                app.selected.is_some(),
-                "the real `load_worktrees` fetch that follows must not clobber the seeded \
-                 selection back to `None`"
+            assert_eq!(
+                app.selected, None,
+                "`Self::load_worktrees`'s own fetch must not auto-select anything either, for \
+                 the identical reason"
             );
         });
     }

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -2528,14 +2528,18 @@ impl AdeApp {
         if self.focused_repo().map(|repo| repo.id) == Some(id) {
             return;
         }
-        let Some(path) = self
-            .repos
-            .iter()
-            .find(|repo| repo.id == id)
-            .map(|repo| repo.path.clone())
-        else {
+        let Some(repo) = self.repos.iter().find(|repo| repo.id == id) else {
             return;
         };
+        let path = repo.path.clone();
+        // Seeded synchronously from this repo's own already-known worktree list, the same
+        // already-fetched data `Self::select_worktree_by_path`'s cross-repo case seeds from (see
+        // its own docs for the identical reasoning) - kept fresh in the background by
+        // `Self::start_repo_worktrees_polling` regardless of which repo is focused, so this is
+        // usually populated by the time a real click lands here. `None` only for a repo that has
+        // never had its own worktree list fetched at all (just added, or `Self::load_worktrees`'s
+        // own upcoming fetch below is this repo's very first).
+        let seeded_worktrees = repo.worktrees_loaded.then(|| repo.worktrees.clone());
 
         self.focus_repo(id, cx);
 
@@ -2550,8 +2554,20 @@ impl AdeApp {
         // the centre pane actually shows, exactly as a fresh `Self::open_repo_in_current_window`
         // switch already does.
         self.agents.activate_for_worktree(&path, cx);
-        self.selected = None;
         self.worktree_selection_notice = None;
+        // A freshly focused repo must land on a real worktree selection immediately, not wait on
+        // `Self::load_worktrees`'s own background fetch to land moments later (that fetch still
+        // runs below regardless, and re-syncs this the identical way any other refresh does) -
+        // see `Self::load_worktrees`'s own `NoPriorSelection` docs for the real bug this closes:
+        // with nothing selected, `Self::active_agent_cwd`'s fallback let a tab strip "+" click
+        // spawn rooted at the repository itself rather than any worktree inside it.
+        match seeded_worktrees {
+            Some(items) => {
+                self.selected = items.iter().position(|item| item.is_main);
+                self.worktrees = items;
+            }
+            None => self.selected = None,
+        }
         self.reset_repo_scoped_state(path, window, cx);
         self.load_worktrees(cx);
         self.start_worktree_watch(cx);
@@ -3300,6 +3316,21 @@ mod repo_list_tests {
     use super::*;
     use crate::rail::repo::RepoState;
     use gpui::TestAppContext;
+
+    /// A real git repository with a real commit - a plain `tempfile::tempdir()` (what most tests
+    /// in this module use) has no worktrees `wt_core::list_worktrees_porcelain` can report at
+    /// all, which is fine for tests about agent persistence but not for one that needs a real
+    /// main-worktree row to select.
+    fn init_repo() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        git(dir.path(), &["init", "-b", "main"]);
+        git(dir.path(), &["config", "user.email", "test@example.com"]);
+        git(dir.path(), &["config", "user.name", "Test User"]);
+        std::fs::write(dir.path().join("README.md"), "hello\n").expect("write");
+        git(dir.path(), &["add", "README.md"]);
+        git(dir.path(), &["commit", "-m", "initial"]);
+        dir
+    }
 
     fn open_test_app_with_real_settings_path(
         cx: &mut TestAppContext,
@@ -4134,6 +4165,108 @@ mod repo_list_tests {
                 app.focused_repo_path(),
                 repo_b.path(),
                 "sanity check: repo B really is the focused repo after checkout"
+            );
+        });
+    }
+
+    /// The reported "we can add a tab to the repo itself" - checking out a repo from the rail
+    /// used to leave `AdeApp::selected` at `None` until the user explicitly clicked a worktree
+    /// row, and `AdeApp::active_agent_cwd`'s fallback to the bare repo path for exactly that
+    /// `None` state let a tab strip "+" click spawn a tab with no worktree behind it at all. A
+    /// freshly checked-out repo must instead land on its own main worktree as a real selection
+    /// immediately - checked *before* `cx.run_until_parked()` runs, so this proves the
+    /// synchronous seed in `AdeApp::checkout_repo_from_rail` itself, not just the fallback
+    /// `AdeApp::load_worktrees` background fetch that lands moments later.
+    #[gpui::test]
+    fn checking_out_a_repo_from_the_rail_lands_on_its_main_worktree_not_unselected(
+        cx: &mut TestAppContext,
+    ) {
+        let repo_a = init_repo();
+        let repo_b = init_repo();
+
+        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        cx.run_until_parked();
+
+        let repo_b_id = app.update(cx, |app, cx| app.add_repo(repo_b.path().to_path_buf(), cx));
+        // Repo B's own worktree list is fetched and mirrored into `Repo::worktrees` here, before
+        // it is ever checked out - the real precondition for `checkout_repo_from_rail`'s own
+        // synchronous seed to have anything to seed from.
+        cx.run_until_parked();
+
+        app.update_in(cx, |app, window, cx| {
+            app.checkout_repo_from_rail(repo_b_id, window, cx);
+        });
+
+        // Deliberately no `run_until_parked()` between the checkout and this read: the whole
+        // point is that the selection is real *before* `load_worktrees`'s own background fetch
+        // could possibly have resolved.
+        app.read_with(cx, |app, _| {
+            let selected_path = app
+                .selected
+                .and_then(|index| app.worktrees.get(index))
+                .map(|item| item.path.clone());
+            assert_eq!(
+                selected_path,
+                Some(repo_b.path().to_path_buf()),
+                "checking out repo B must immediately select its own main worktree, not leave \
+                 `selected` at `None` until a user clicks a specific row"
+            );
+            assert_eq!(
+                app.active_agent_cwd(),
+                repo_b.path(),
+                "sanity check: a tab spawned right now would still target the right directory"
+            );
+        });
+
+        // And the real background fetch landing moments later must not undo it.
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.selected.is_some(),
+                "the real `load_worktrees` fetch that follows must not clobber the seeded \
+                 selection back to `None`"
+            );
+        });
+    }
+
+    /// The reported "weird flicker on the worktrees" when clicking a repo: before the
+    /// synchronous seed above existed, `AdeApp::worktrees` was left completely untouched by
+    /// `checkout_repo_from_rail` - still repo A's own rows - for the entire synchronous portion
+    /// of the click (and so for the very next render), with repo B's header now showing above
+    /// them. Repo A's rows visibly flashed under repo B's name until `load_worktrees`'s
+    /// background fetch replaced them a moment later. Checked *before* `run_until_parked()`, so
+    /// this proves the synchronous seed, not the eventual correct state everything converges to
+    /// anyway.
+    #[gpui::test]
+    fn checking_out_a_repo_from_the_rail_never_shows_the_previous_repos_worktrees_even_briefly(
+        cx: &mut TestAppContext,
+    ) {
+        let repo_a = init_repo();
+        let repo_b = init_repo();
+
+        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        cx.run_until_parked();
+
+        let repo_b_id = app.update(cx, |app, cx| app.add_repo(repo_b.path().to_path_buf(), cx));
+        cx.run_until_parked();
+
+        app.update_in(cx, |app, window, cx| {
+            app.checkout_repo_from_rail(repo_b_id, window, cx);
+        });
+
+        // No `run_until_parked()`: this is exactly the state the very next render would use.
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.worktrees.iter().all(|item| item.path != repo_a.path()),
+                "repo A's own worktree must never appear in the rendered list once repo B is \
+                 focused, not even for the one frame before the background fetch resolves - got \
+                 {:?}",
+                app.worktrees
+            );
+            assert!(
+                app.worktrees.iter().any(|item| item.path == repo_b.path()),
+                "repo B's own main worktree must be showing immediately, not waiting on the \
+                 background fetch"
             );
         });
     }

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -169,8 +169,17 @@ impl AdeApp {
         // directory - `RepoState::last_focused_existing_path` is the one place that "still
         // exists" check happens, so a deleted/moved remembered folder can never surface as a
         // broken/error startup state here, only as a genuinely empty one.
+        //
+        // The CLI argument is normalized here (`repo::canonical_repo_path`), before anything in
+        // this constructor uses it - it becomes `Self::file_tree_root`, the startup shell's real
+        // cwd, and (via `Self::add_repo`) `Repo::path`, and every one of those is compared by
+        // exact path against git's own fully-resolved worktree paths later. `jerry .` and
+        // `jerry ~/link-to-repo` are the ordinary ways to launch this app, and both used to
+        // produce a repo whose agents matched no worktree row at all; see that function's own
+        // docs. The remembered-repo branch needs no such call: `RepoState`'s keys are already
+        // `repo::repo_key` output, which is canonical by construction.
         let resolved_repo_path: Option<PathBuf> = match repo_path {
-            Some(path) => Some(path),
+            Some(path) => Some(repo::canonical_repo_path(&path)),
             None if use_remembered_repo => loaded_repo_state.last_focused_existing_path(),
             None => None,
         };
@@ -531,8 +540,6 @@ impl AdeApp {
             ),
             plus_menu_open: false,
             plus_button_bounds: gpui::Bounds::default(),
-            plus_menu_repo_anchor: None,
-            rail_plus_button_bounds: HashMap::new(),
             title_menu_open: None,
             title_menu_button_bounds: [gpui::Bounds::default(); title_bar::TitleMenu::ALL.len()],
             _new_agent_pane_task: TaskPool::new(),
@@ -1561,16 +1568,71 @@ impl AdeApp {
         self.edit_buffers.insert((cwd, path), buffer)
     }
 
-    /// Selects a worktree by its real path (rather than an index into
-    /// [`Self::worktrees`], which project-mode rows don't carry) - used by a plain worktree
-    /// row's click handler in "by project" mode. Falls back to doing nothing if the path
-    /// isn't currently in the loaded worktree list (e.g. a stale click racing a reload).
+    /// Selects a worktree by its real path (rather than an index into [`Self::worktrees`], which
+    /// the rail's rows don't carry) - the click handler behind every worktree row in the rail
+    /// (`crate::rail::render::AdeApp::render_worktree_row`).
+    ///
+    /// ## Cross-repo
+    ///
+    /// [`Self::worktrees`] only ever holds the **focused** repo's own live list, so the plain
+    /// index lookup below can only ever find a worktree of the repo already showing. That used to
+    /// be this method's whole body, and it was fine right up until the multi-repo rail landed: a
+    /// non-focused repo's worktrees had no rendered rows to click (its group showed "not loaded
+    /// yet" instead), so the "path isn't in the list" branch was genuinely only ever a stale click
+    /// racing a reload. Now every added repo renders its own real, clickable worktree rows from
+    /// its own [`crate::rail::repo::Repo::worktrees`], and clicking one belonging to a *different*
+    /// repo silently did nothing at all - the reported "I can't switch from a worktree to another
+    /// repo's worktree".
+    ///
+    /// So a path not in [`Self::worktrees`] is now searched for across every added repo's own
+    /// worktree list, and finding it means this is a real cross-repo switch:
+    /// [`Self::checkout_repo_from_rail`] does the entire repo switch (cross-repo agent
+    /// persistence, [`Self::reset_repo_scoped_state`], the watchers, `Agents::activate_for_
+    /// worktree`) - nothing of it is reimplemented here - and then the specific worktree is
+    /// selected within it.
+    ///
+    /// That second step needs [`Self::worktrees`] to already contain the target, and it does not:
+    /// `checkout_repo_from_rail`'s own [`Self::load_worktrees`] call is a real *background* `git
+    /// worktree list --porcelain` fetch, so [`Self::worktrees`] still holds the repo just **left**
+    /// when it returns. Rather than chaining onto that fetch's completion, this seeds
+    /// [`Self::worktrees`] synchronously from the target repo's own already-fetched
+    /// [`crate::rail::repo::Repo::worktrees`] - the exact same data, from the exact same
+    /// `list_worktrees_porcelain` call, kept fresh in the background by
+    /// [`Self::load_repo_worktrees`]/[`Self::start_repo_worktrees_polling`], and the very list the
+    /// row that was just clicked was rendered from in the first place. Selecting against it is
+    /// therefore selecting against precisely what the user saw and clicked, which a continuation
+    /// racing a fresh fetch would not guarantee. The in-flight fetch is not wasted or cancelled:
+    /// it lands moments later and overwrites this seed with an equally real, slightly newer list,
+    /// and because the selection below is recorded *before* it does,
+    /// `crate::rail::worktrees::recover_selection` re-anchors it by path - so a worktree that
+    /// really did vanish between the seed and the fetch falls back to main with a real notice,
+    /// exactly as it would for any other refresh, instead of leaving a dangling index.
+    ///
+    /// Still does nothing at all when `path` isn't found in *any* repo - a stale click racing a
+    /// reload, or a worktree removed on disk since the last render - which is the same documented
+    /// fallback the focused-repo-only version already had.
     pub(crate) fn select_worktree_by_path(
         &mut self,
         path: &std::path::Path,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if let Some(index) = self.worktrees.iter().position(|item| item.path == path) {
+            self.select_worktree(index, window, cx);
+            return;
+        }
+
+        let Some((repo_id, items)) = self.repos.iter().find_map(|repo| {
+            repo.worktrees
+                .iter()
+                .any(|item| item.path == path)
+                .then(|| (repo.id, repo.worktrees.clone()))
+        }) else {
+            return;
+        };
+
+        self.checkout_repo_from_rail(repo_id, window, cx);
+        self.worktrees = items;
         if let Some(index) = self.worktrees.iter().position(|item| item.path == path) {
             self.select_worktree(index, window, cx);
         }

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -761,24 +761,12 @@ impl AdeApp {
                 }
 
                 match worktrees::recover_selection(previously_selected.as_ref(), &this.worktrees) {
-                    // A freshly focused repo must land on a real worktree selection, never stay
-                    // unselected - see `crate::root::AdeApp::checkout_repo_from_rail`'s own docs
-                    // for the real, reported bug this fixes: with `Self::selected` left `None`
-                    // (both this and `Self::open_repo_in_current_window` set it to exactly that
-                    // right before this fetch), `Self::active_agent_cwd`'s fallback let a "New
-                    // agent"/"New terminal" click from the tab strip spawn a tab rooted at the
-                    // *repository* itself - a path this app has no worktree row for and no way to
-                    // distinguish from a real one, when the whole point of the rail is that tabs
-                    // belong to worktrees. The main worktree is always a real, valid selection
-                    // target (it is the repository's own checkout), so this can never regress
-                    // into selecting something that doesn't exist. No-op only when `this.worktrees`
-                    // itself is genuinely empty (a fetch error - `this.worktrees_error` already
-                    // covers surfacing that).
-                    worktrees::SelectionRecovery::NoPriorSelection => {
-                        if let Some(index) = this.worktrees.iter().position(|item| item.is_main) {
-                            this.selected = Some(index);
-                        }
-                    }
+                    // Deliberately stays unselected - see `crate::root::AdeApp::
+                    // checkout_repo_from_rail`'s own docs for why nothing here may auto-select a
+                    // worktree on the user's behalf. Real tab spawning is gated on
+                    // `Self::selected` directly ([`crate::work_surface::render::AdeApp::
+                    // new_agent`]/`new_agent_pane`'s own guard), not worked around here.
+                    worktrees::SelectionRecovery::NoPriorSelection => {}
                     worktrees::SelectionRecovery::Unchanged(index) => {
                         this.selected = Some(index);
                     }

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -761,7 +761,24 @@ impl AdeApp {
                 }
 
                 match worktrees::recover_selection(previously_selected.as_ref(), &this.worktrees) {
-                    worktrees::SelectionRecovery::NoPriorSelection => {}
+                    // A freshly focused repo must land on a real worktree selection, never stay
+                    // unselected - see `crate::root::AdeApp::checkout_repo_from_rail`'s own docs
+                    // for the real, reported bug this fixes: with `Self::selected` left `None`
+                    // (both this and `Self::open_repo_in_current_window` set it to exactly that
+                    // right before this fetch), `Self::active_agent_cwd`'s fallback let a "New
+                    // agent"/"New terminal" click from the tab strip spawn a tab rooted at the
+                    // *repository* itself - a path this app has no worktree row for and no way to
+                    // distinguish from a real one, when the whole point of the rail is that tabs
+                    // belong to worktrees. The main worktree is always a real, valid selection
+                    // target (it is the repository's own checkout), so this can never regress
+                    // into selecting something that doesn't exist. No-op only when `this.worktrees`
+                    // itself is genuinely empty (a fetch error - `this.worktrees_error` already
+                    // covers surfacing that).
+                    worktrees::SelectionRecovery::NoPriorSelection => {
+                        if let Some(index) = this.worktrees.iter().position(|item| item.is_main) {
+                            this.selected = Some(index);
+                        }
+                    }
                     worktrees::SelectionRecovery::Unchanged(index) => {
                         this.selected = Some(index);
                     }

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -3856,7 +3856,19 @@ mod fold_state_tests {
     /// cached, because `worktree_key` calls the blocking `std::fs::canonicalize` and the callers
     /// are clicks and per-ancestor reveals. What's asserted here is the part that would actually
     /// break if the cache were wrong: reaching a worktree through a symlink must record against
-    /// the *canonical* path, and a reveal through that symlink must still persist.
+    /// the *canonical* path, so opening it through the symlink and opening it directly share one
+    /// fold-state entry rather than silently keeping two.
+    ///
+    /// The reveal below goes through the **real** path, not the symlink, and that is the honest
+    /// shape of this now: `crate::rail::repo::canonical_repo_path` resolves the repo path where it
+    /// enters the app (the CLI argument, `AdeApp::add_repo`, `AdeApp::open_repo_in_current_
+    /// window`), so `AdeApp::file_tree_root` is already the real path here even though the app was
+    /// opened through the link - and every path the file tree/palette hands back to a reveal is
+    /// walked from that root, so no real UI path produces a symlinked one anymore. That
+    /// normalization exists for a separate, reproduced bug (an agent spawned against an unresolved
+    /// repo path matched no rail worktree row at all - see that function's docs); this test's own
+    /// property is unaffected by it, and the extra `file_tree_root` assertion below pins the new
+    /// behavior down rather than leaving it implied.
     #[cfg(unix)]
     #[gpui::test]
     fn the_cached_worktree_key_is_canonical_and_records_through_a_symlink(cx: &mut TestAppContext) {
@@ -3877,9 +3889,15 @@ mod fold_state_tests {
             "the cached key must be the canonicalized one, so the same worktree reached through \
              a symlink and through its real path is one entry rather than two"
         );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.file_tree_root.clone()),
+            real.path(),
+            "opening through a symlink must root the tree at the resolved path, so nothing this \
+             app walks or spawns from it carries the unresolved one"
+        );
 
         app.update_in(cx, |app, window, cx| {
-            app.open_palette_file_result(link.join("src/app/main.rs"), window, cx);
+            app.open_palette_file_result(real.path().join("src/app/main.rs"), window, cx);
         });
         cx.run_until_parked();
 

--- a/crates/app/src/work_surface/agents.rs
+++ b/crates/app/src/work_surface/agents.rs
@@ -568,6 +568,24 @@ impl Agents {
         self.sync_pane_cadence(cx);
     }
 
+    /// The other half of [`Self::activate_for_worktree`]'s own worktree-scoping fix: clears
+    /// [`Self::active`] outright, with no worktree to fall back into. `crate::root::AdeApp::
+    /// checkout_repo_from_rail` is the one real caller - focusing a repo from the rail is a pure
+    /// navigation gesture (which repo's worktrees the rail shows), never a worktree selection, so
+    /// nothing here may resolve to *some* agent the way `activate_for_worktree` does. Not calling
+    /// this at all was tried first and was itself the bug: [`Self::active`] would then still
+    /// point at whichever agent was active in the repo just *left*, and since [`Self::active`] is
+    /// read directly by the centre pane with no repo-scoping of its own
+    /// (`crate::work_surface::render::AdeApp::render_center_pane`), that repo's terminal kept
+    /// rendering right alongside the newly-focused repo's own rail rows - a real, worse
+    /// inconsistency than the one this exists to fix. `active_by_cwd`'s own remembered-tab
+    /// entries are untouched, so a later real worktree-row click still lands on the same agent
+    /// [`Self::activate_for_worktree`] would have picked before this call ever ran.
+    pub fn clear_active(&mut self, cx: &mut Context<AdeApp>) {
+        self.active = None;
+        self.sync_pane_cadence(cx);
+    }
+
     /// Moves keyboard focus onto the currently active agent's terminal pane, if there is
     /// one - a no-op when [`Self::active`] is `None`. See [`Self::spawn`]'s docs for why
     /// callers, not this method, decide whether it's safe to call.

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -291,11 +291,42 @@ impl AdeApp {
             .find(|agent| agent.id == id)
             .map(|agent| agent.cwd.clone());
         if let Some(cwd) = cwd {
-            if let Some(index) = self.worktrees.iter().position(|item| item.path == cwd) {
-                if self.selected != Some(index) {
-                    self.select_worktree(index, window, cx);
-                    return;
-                }
+            // `crate::root::AdeApp::select_worktree_by_path`, not a plain `self.worktrees`
+            // lookup: this agent may belong to a worktree in a repo that isn't the focused one
+            // at all (the rail's own agent rows fold in every repo's agents, not just the
+            // focused repo's - `Self::build_agent_rows`'s own docs) - a real, reported bug:
+            // clicking such an agent set it globally active (`Agents::set_active` above) but
+            // never switched repos, so `Self::active_agent_cwd` kept resolving to whatever the
+            // *focused* repo's own selection was, `Self::combined_tab_order` built the tab strip
+            // from that wrong cwd, and it came up with zero tabs - visibly "the tab bar doesn't
+            // appear" - even though the agent genuinely was active underneath.
+            // `select_worktree_by_path` already does the real cross-repo checkout when needed;
+            // its own no-op-when-nothing-to-select guard is why the "already the right
+            // worktree" check happens first here, unchanged from before - a same-worktree agent
+            // switch (clicking between two terminals already open here) must stay cheap, with no
+            // worktree-switch reset at all.
+            let already_selected = self
+                .selected
+                .and_then(|index| self.worktrees.get(index))
+                .is_some_and(|item| item.path == cwd);
+            // A real regression this exact fix introduced and an adversarial test caught: `cwd`
+            // is only a real worktree row when *some* repo's own list actually contains it - an
+            // agent rooted directly at a repo with no git worktrees at all (a plain shell in a
+            // non-git or bare directory, exactly what this file's own tests use) has no such
+            // row anywhere, and `select_worktree_by_path` is correctly a no-op for a path it
+            // can't find. Unconditionally delegating to it and returning early - what this looked
+            // like right after the cross-repo fix - silently skipped everything below for that
+            // case too, including the real keyboard-focus restore GitHub issue #112 exists for.
+            // Checking findability first keeps that fallback reachable exactly as before.
+            let findable = !already_selected
+                && (self.worktrees.iter().any(|item| item.path == cwd)
+                    || self
+                        .repos
+                        .iter()
+                        .any(|repo| repo.worktrees.iter().any(|item| item.path == cwd)));
+            if findable {
+                self.select_worktree_by_path(&cwd, window, cx);
+                return;
             }
         }
         // GitHub issue #112: when no file tab was showing, nothing above moves real keyboard
@@ -5023,5 +5054,114 @@ mod terminal_clipboard_action_tests {
             "expected the active agent's real pty to echo back the clipboard text \
              TerminalPaste's handler writes"
         );
+    }
+}
+
+/// The reported "clicking an agent from another worktree/repo, the tab bar does not appear" -
+/// `Self::select_agent` used to look the clicked agent's own worktree up only in `Self::
+/// worktrees`, the *focused* repo's own list - the rail's own agent rows fold in every repo's
+/// agents, not just the focused one's (`crate::rail::render::AdeApp::build_agent_rows`'s own
+/// docs), so an agent from a non-focused repo was findable and clickable but its own worktree
+/// never was. `Agents::set_active` still ran, so the agent genuinely became active - but nothing
+/// switched repos, so `Self::active_agent_cwd` kept resolving to the *focused* repo's own
+/// selection, `Self::combined_tab_order` built the strip from that wrong cwd, and it came up
+/// empty: a real agent, active underneath, with no tab visible for it at all.
+#[cfg(test)]
+mod select_agent_cross_repo_tests {
+    use super::*;
+    use crate::root::focus::palette_focus_tests;
+    use crate::work_surface::agents::ProcessKind;
+    use gpui::TestAppContext;
+
+    fn git(dir: &std::path::Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .output()
+            .expect("failed to spawn git");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn init_repo() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        git(dir.path(), &["init", "-b", "main"]);
+        git(dir.path(), &["config", "user.email", "test@example.com"]);
+        git(dir.path(), &["config", "user.name", "Test User"]);
+        std::fs::write(dir.path().join("README.md"), "hello\n").expect("write");
+        git(dir.path(), &["add", "README.md"]);
+        git(dir.path(), &["commit", "-m", "initial"]);
+        dir
+    }
+
+    #[gpui::test]
+    fn selecting_an_agent_in_a_non_focused_repo_switches_to_it_and_shows_its_tab(
+        cx: &mut TestAppContext,
+    ) {
+        let repo_a = init_repo();
+        let repo_b = init_repo();
+
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        cx.run_until_parked();
+
+        app.update(cx, |app, cx| {
+            app.add_repo(repo_b.path().to_path_buf(), cx);
+        });
+        cx.run_until_parked();
+
+        // A real agent, spawned directly into repo B while repo A stays focused - exactly the
+        // state a real cross-repo-persisted agent is in.
+        let repo_b_agent_id = app.update_in(cx, |app, window, cx| {
+            app.agents.spawn(
+                ProcessKind::claude(),
+                repo_b.path().to_path_buf(),
+                12.0,
+                None,
+                None,
+                window,
+                cx,
+            )
+        });
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.focused_repo_path(),
+                repo_a.path(),
+                "sanity check: repo A is still focused - repo B's agent was spawned in the \
+                 background, not through a real repo switch"
+            );
+        });
+
+        app.update_in(cx, |app, window, cx| {
+            app.select_agent(repo_b_agent_id, window, cx);
+        });
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, cx| {
+            assert_eq!(
+                app.focused_repo_path(),
+                repo_b.path(),
+                "selecting an agent in a non-focused repo must really switch focus to that repo"
+            );
+            assert_eq!(
+                app.agents.active_id(),
+                Some(repo_b_agent_id),
+                "and the agent itself must really be the active one"
+            );
+            let tab_order = app.combined_tab_order();
+            assert!(
+                tab_order
+                    .iter()
+                    .any(|tab_ref| matches!(tab_ref, work_surface::TabRef::Agent(id) if *id == repo_b_agent_id)),
+                "the tab strip's own real tab order must include the selected agent - if it \
+                 doesn't, the tab bar has nothing to show for it even though the agent is active, \
+                 exactly the reported bug"
+            );
+            let _ = cx;
+        });
     }
 }

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -1119,8 +1119,8 @@ impl AdeApp {
             )
             .child(div().flex_none().w_full().h(px(1.0)).bg(colors.underline))
             // Captures this tab's own painted bounds into `Self::tab_bounds` every render - the
-            // same `gpui::canvas` idiom `Self::plus_button_bounds`/`Self::rail_plus_button_bounds`
-            // already use. The only real source of a tab's on-screen width (GPUI's flex layout
+            // same `gpui::canvas` idiom `Self::plus_button_bounds`
+            // already uses. The only real source of a tab's on-screen width (GPUI's flex layout
             // means no two tabs are the same size), which `Self::drop_dragged_tab` reads for
             // whichever tab is dragged next, to compute how far a drop's shifted neighbours must
             // slide (`work_surface::state::tab_slide_offsets`'s own docs on why only the
@@ -1357,13 +1357,9 @@ impl AdeApp {
                 let opening = !this.plus_menu_open;
                 // GitHub issue #176: opening this menu closes whatever other menu was open, so
                 // two popovers can never be painted at once. Read *before* the sweep and applied
-                // after it, because the sweep clears `plus_menu_repo_anchor` too.
+                // after it, because the sweep clears `plus_menu_open` itself.
                 let _ = this.close_menu_surfaces_except(Some(menus::MenuSurface::Plus));
                 this.plus_menu_open = opening;
-                // This is the tab strip's own `+`, not a rail repo header's - see
-                // `Self::plus_menu_repo_anchor`'s own docs for why `Self::render_plus_menu` needs
-                // to know which one opened it.
-                this.plus_menu_repo_anchor = None;
                 if this.plus_menu_open {
                     this.load_agent_rows(cx);
                 }
@@ -1396,18 +1392,10 @@ impl AdeApp {
     /// the spec keeps.
     pub(crate) fn render_plus_menu(&self, cx: &mut Context<Self>) -> impl IntoElement {
         let macos = self.window_controls_style().is_macos();
-        // See `Self::plus_menu_repo_anchor`'s own docs: a rail repo header's own `+` positions
-        // this popover off that header's own painted bounds, not the tab strip's - falling back
-        // to the tab strip's bounds if that repo's header hasn't painted this popover's anchor
-        // yet (defensive; not a real reachable path through this app's own UI).
-        let bounds = match self.plus_menu_repo_anchor {
-            Some(repo_id) => self
-                .rail_plus_button_bounds
-                .get(&repo_id)
-                .copied()
-                .unwrap_or(self.plus_button_bounds),
-            None => self.plus_button_bounds,
-        };
+        // The tab strip's own `+` is the only control that opens this popover, so its painted
+        // bounds are the only anchor - see `Self::plus_button_bounds`'s own docs for the rail
+        // per-repo anchor that used to exist here and why it's gone.
+        let bounds = self.plus_button_bounds;
 
         let resolved_kind = ProcessKind::from(self.resolved_new_agent_kind());
         let (agent_fg, agent_bg) = work_surface::agent_tint(resolved_kind);

--- a/crates/wt-core/src/diff.rs
+++ b/crates/wt-core/src/diff.rs
@@ -752,6 +752,44 @@ pub(crate) enum ShadowIndexContent {
     TrackedOnly,
 }
 
+/// Filename prefix every shadow index carries, so a file left behind by a hard-killed process is
+/// recognisable as this app's and not mistaken for something git itself owns. Leading dot for the
+/// same reason git's own transient files use one.
+const SHADOW_INDEX_PREFIX: &str = ".jerry-shadow-index-";
+
+/// Creates the throwaway index file [`prepare_shadow_index`] hands to `GIT_INDEX_FILE`, in the
+/// directory holding `real_index_path` - this worktree's own git directory (`<repo>/.git` for a
+/// main checkout, `<common-dir>/worktrees/<name>` for a linked one, since
+/// `git rev-parse --git-path index` already resolves that distinction for us). See
+/// [`prepare_shadow_index`]'s own "Where the shadow index file lives" docs for why this is not
+/// `std::env::temp_dir()`.
+///
+/// Falls back to the OS temp directory in the two cases where the git directory genuinely can't
+/// host the file: `real_index_path` has no parent at all (not reachable through any real
+/// `rev-parse` output, guarded rather than unwrapped), or creating a file there fails - a
+/// repository checked out on a read-only mount being the real instance of the latter, which still
+/// diffs fine through a temp-dir shadow index because an `--intent-to-add` pass writes nothing
+/// into the repository itself. The fallback is deliberately *not* silent about failing too: if
+/// both locations refuse, the git directory's own error is what propagates, since that's the one
+/// describing the repository the caller actually asked about.
+fn shadow_index_file(real_index_path: &Path) -> Result<tempfile::NamedTempFile, Error> {
+    let builder = || {
+        tempfile::Builder::new()
+            .prefix(SHADOW_INDEX_PREFIX)
+            .tempfile()
+    };
+    let Some(git_dir) = real_index_path.parent() else {
+        return builder().map_err(Error::WorktreeIo);
+    };
+    match tempfile::Builder::new()
+        .prefix(SHADOW_INDEX_PREFIX)
+        .tempfile_in(git_dir)
+    {
+        Ok(file) => Ok(file),
+        Err(git_dir_err) => builder().map_err(|_| Error::WorktreeIo(git_dir_err)),
+    }
+}
+
 /// Builds a temporary, throwaway copy of the worktree's index with untracked files added,
 /// either as "intent to add" stubs or with their real content ([`ShadowIndexContent`]), so
 /// `git diff <merge-base>` - which only ever considers paths already present in the index or in
@@ -777,6 +815,31 @@ pub(crate) enum ShadowIndexContent {
 /// racy-index rule). See the inline comment at the copy itself, and the
 /// `a_same_length_edit_racy_against_the_index_timestamp_is_still_reported` test, for the real
 /// bug (GitHub issue #163) that came of not doing this.
+///
+/// ## Where the shadow index file lives
+///
+/// Next to the **real** index, inside this worktree's own git directory
+/// ([`shadow_index_file`]) - deliberately *not* `std::env::temp_dir()`. `git add` writes an
+/// index by creating `<GIT_INDEX_FILE>.lock` beside the target and renaming it over the top,
+/// so whichever directory this file sits in is the directory git has to be able to create,
+/// write, fsync and rename within. Pointing that at the OS-wide temp directory made every
+/// shadow-index-backed operation in this crate (`compute_diff`,
+/// [`crate::review::snapshot_worktree_tree`], [`crate::review::changed_paths_against_tree`])
+/// silently depend on a directory that has nothing to do with the repository being diffed, and
+/// that a real environment can make unusable in ways the repository itself is not: a `TMPDIR`
+/// pointed at a different (or cross-OS-mounted) filesystem, a sandbox with its own private
+/// `/tmp`, a full or quota-exceeded temp filesystem, or a cleanup daemon deleting files by age
+/// (which this function actively invites, since it back-dates the copy's mtime to the real
+/// index's possibly weeks-old mtime just above). A user running against a real repository hit
+/// exactly this class of failure: `git add --intent-to-add -A -- .` exiting 128 with
+/// `fatal: unable to write new index file`, which is git failing to write/rename the index at
+/// this very path. The git directory is guaranteed to be on the same filesystem as the
+/// repository git is already reading and writing, so if git can operate on the repo at all it
+/// can write here.
+///
+/// The file is still a real [`tempfile::NamedTempFile`] with unchanged drop-based cleanup -
+/// only its parent directory changed - and `.git` is never part of the worktree scan, so the
+/// `git add -A -- .` below cannot see (let alone stage) it.
 pub(crate) fn prepare_shadow_index(
     worktree_path: &Path,
     content: ShadowIndexContent,
@@ -795,7 +858,7 @@ pub(crate) fn prepare_shadow_index(
         }
     };
 
-    let shadow = tempfile::NamedTempFile::new().map_err(Error::WorktreeIo)?;
+    let shadow = shadow_index_file(&real_index_path)?;
     match std::fs::read(&real_index_path) {
         Ok(real_index_bytes) => {
             use std::io::Write as _;
@@ -835,7 +898,7 @@ pub(crate) fn prepare_shadow_index(
             // `git init`, before any commit), or one whose index momentarily can't be read
             // (a real interleaving hazard: an agent CLI's own `git add`/`git commit`
             // rewriting the index at the exact moment this reads it), has no real bytes to
-            // seed the shadow copy with. `NamedTempFile::new()` above already created a
+            // seed the shadow copy with. `shadow_index_file` above already created a
             // real, empty *file* at this path though - and an empty-but-*existing* file is
             // not what git treats as "no index yet": confirmed directly (`GIT_INDEX_FILE`
             // pointed at a 0-byte file makes real `git add` fail outright with `fatal: ...
@@ -1711,6 +1774,149 @@ mod tests {
                 .any(|f| f.path == Path::new("brand_new.txt")),
             "the diff must still compute (and still see the real untracked file) even when \
              the real index couldn't be read to seed the shadow copy"
+        );
+    }
+
+    /// The shadow index must be created inside the worktree's own git directory, next to the
+    /// real index - never in `std::env::temp_dir()`. See `prepare_shadow_index`'s own "Where the
+    /// shadow index file lives" docs: `git add` creates `<GIT_INDEX_FILE>.lock` beside this file
+    /// and renames it over the top, so this directory is exactly the one git must be able to
+    /// write and rename within, and the OS temp directory is a real, environment-specific
+    /// liability there (a `TMPDIR` on another mount, a sandboxed private `/tmp`, a full temp
+    /// filesystem, an age-based cleanup daemon).
+    ///
+    /// This is a stronger assertion than "diffing still works with a hostile `TMPDIR`", and is
+    /// the reason no test here mutates `TMPDIR`: `std::env::set_var` is process-global, and this
+    /// test binary runs its tests in parallel threads that use `tempfile` (`TempDir::new` in
+    /// every `init_repo` call) throughout, so pointing the whole process's temp directory
+    /// somewhere unusable mid-run would corrupt unrelated tests rather than prove anything about
+    /// this one. Asserting the real parent directory proves the property directly instead.
+    #[test]
+    fn the_shadow_index_lives_in_the_git_directory_not_the_os_temp_directory() {
+        let repo = init_repo();
+        fs::write(repo.path().join("untracked.txt"), "nobody staged this\n").expect("write");
+
+        let shadow = prepare_shadow_index(repo.path(), ShadowIndexContent::IntentToAdd)
+            .expect("prepare_shadow_index");
+
+        let git_dir = repo.path().join(".git");
+        let parent = shadow.path().parent().expect("shadow index has a parent");
+        assert_eq!(
+            fs::canonicalize(parent).expect("canonicalize shadow parent"),
+            fs::canonicalize(&git_dir).expect("canonicalize git dir"),
+            "the shadow index must be created inside the repository's own git directory"
+        );
+        assert_ne!(
+            fs::canonicalize(parent).expect("canonicalize shadow parent"),
+            fs::canonicalize(std::env::temp_dir()).expect("canonicalize temp dir"),
+            "the shadow index must not depend on the OS-wide temp directory at all"
+        );
+        assert!(
+            shadow
+                .path()
+                .file_name()
+                .expect("file name")
+                .to_string_lossy()
+                .starts_with(SHADOW_INDEX_PREFIX),
+            "a shadow index left behind by a killed process must be recognisably ours"
+        );
+
+        // Dropping it really deletes it - the `NamedTempFile` cleanup contract is unchanged by
+        // the new parent directory, so a `.git` directory doesn't slowly fill with these.
+        let path = shadow.path().to_path_buf();
+        assert!(path.exists());
+        drop(shadow);
+        assert!(
+            !path.exists(),
+            "the shadow index must still be cleaned up on drop now that it lives under .git"
+        );
+    }
+
+    /// A linked worktree has its *own* private git directory
+    /// (`<common-dir>/worktrees/<name>`), which is where its own index lives - the shadow index
+    /// must land there, not in the main checkout's `.git`, so the two never contend and the
+    /// same-filesystem guarantee holds for a worktree created anywhere on disk.
+    #[test]
+    fn a_linked_worktrees_shadow_index_lives_in_that_worktrees_own_git_directory() {
+        let repo = init_repo();
+        let holder = TempDir::new().expect("tempdir");
+        let wt_path = holder.path().join("linked");
+        drop(holder);
+        git(
+            repo.path(),
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "feature",
+                wt_path.to_str().expect("utf8 path"),
+            ],
+        );
+        fs::write(wt_path.join("untracked.txt"), "nobody staged this\n").expect("write");
+
+        let shadow = prepare_shadow_index(&wt_path, ShadowIndexContent::IntentToAdd)
+            .expect("prepare_shadow_index");
+        let parent = shadow
+            .path()
+            .parent()
+            .expect("shadow index has a parent")
+            .to_path_buf();
+        assert!(
+            parent.ends_with(Path::new("worktrees").join("linked")),
+            "expected the linked worktree's own admin directory, got {}",
+            parent.display()
+        );
+        drop(shadow);
+        let _ = fs::remove_dir_all(&wt_path);
+    }
+
+    /// The real, reported failure's own shape: a repository with a genuine embedded git
+    /// repository (its own `.git` directory, with its own commit) sitting untracked inside the
+    /// worktree - which is exactly this app's own dogfooding checkout, where `vendor/zed` is a
+    /// real vendored clone. `git add -A` prints a loud multi-line "adding embedded git
+    /// repository" warning on stderr for it, and `compute_diff` must still succeed: that warning
+    /// is stderr noise on a *successful* command, not a failure, and nothing in the diff pipeline
+    /// may treat it as one.
+    #[test]
+    fn an_embedded_git_repository_in_the_worktree_does_not_fail_the_diff() {
+        let repo = init_repo();
+        git(repo.path(), &["checkout", "-b", "feature"]);
+        fs::write(repo.path().join("brand_new.txt"), "content nobody staged\n").expect("write");
+
+        // A real nested repository with a real commit of its own - an embedded repo with *no*
+        // commit checked out is a different case entirely (`git add` fails it outright with
+        // "does not have a commit checked out"), and is not what the report showed.
+        let embedded = repo.path().join("vendor").join("inner");
+        fs::create_dir_all(&embedded).expect("create embedded repo dir");
+        git(&embedded, &["init", "-b", "main"]);
+        git(&embedded, &["config", "user.email", "test@example.com"]);
+        git(&embedded, &["config", "user.name", "Test User"]);
+        fs::write(embedded.join("inner.txt"), "inner\n").expect("write");
+        git(&embedded, &["add", "inner.txt"]);
+        git(&embedded, &["commit", "-m", "inner commit"]);
+
+        let result = diff_against_base(repo.path())
+            .expect("an embedded git repository must not fail the whole diff computation");
+        let DiffBase::Diff(diff) = result else {
+            panic!("expected DiffBase::Diff, got {result:?}");
+        };
+        assert!(
+            diff.files
+                .iter()
+                .any(|f| f.path == Path::new("brand_new.txt")),
+            "the real untracked file must still be reported alongside the embedded repository"
+        );
+
+        // And the real index is still untouched - the embedded repo is still untracked.
+        let status = Command::new("git")
+            .current_dir(repo.path())
+            .args(["status", "--porcelain"])
+            .output()
+            .expect("git status");
+        let status_text = String::from_utf8_lossy(&status.stdout);
+        assert!(
+            status_text.contains("?? vendor/"),
+            "the embedded repository must still be untracked afterwards, got: {status_text}"
         );
     }
 

--- a/crates/wt-core/src/diff.rs
+++ b/crates/wt-core/src/diff.rs
@@ -923,16 +923,84 @@ pub(crate) fn prepare_shadow_index(
         ShadowIndexContent::TrackedOnly => add_args.push("-u".into()),
     }
     add_args.extend([OsString::from("--"), ".".into()]);
-    let output = git_command(worktree_path, &add_args)
-        .env("GIT_INDEX_FILE", shadow.path())
-        .output()
-        .map_err(|source| Error::GitSpawn {
-            args: format_args(&add_args),
-            source,
-        })?;
-    check_success(&add_args, &output)?;
+
+    // Retries only `write new index file` - a real, reported failure (GitHub issue tracker, two
+    // independent real repositories, this app running natively on Windows/NTFS - confirmed
+    // directly, not a WSL cross-mount) that survives even the git-directory placement above:
+    // Windows real-time antivirus (Defender or otherwise) scans every newly created file,
+    // including the `<GIT_INDEX_FILE>.lock` git creates right here, and if that scan holds the
+    // file open at the exact instant git tries to rename it into place, the rename fails and git
+    // reports exactly this - the same well-documented interaction every major git GUI on Windows
+    // (SourceTree, GitKraken, VS Code) has its own issue thread about. That window is
+    // milliseconds wide and gone almost immediately, which is what makes a bounded retry the
+    // correct handling rather than a workaround: the write itself is fully idempotent (this
+    // shadow index has no state a second attempt could corrupt), the failure is a real, external,
+    // transient lock this process does not control and cannot avoid by choosing a different
+    // directory (moving the file does not move the antivirus), and retrying is exactly what git's
+    // own porcelain commands do for other transient-lock classes already. Every *other* `git add`
+    // failure - a genuinely broken repository, a permissions error that will not resolve itself -
+    // still surfaces immediately on the first attempt; retrying those would only delay a real
+    // error the user needs to see.
+    retry_transient_index_write_failure(|| {
+        let output = git_command(worktree_path, &add_args)
+            .env("GIT_INDEX_FILE", shadow.path())
+            .output()
+            .map_err(|source| Error::GitSpawn {
+                args: format_args(&add_args),
+                source,
+            })?;
+        check_success(&add_args, &output)
+    })?;
 
     Ok(shadow)
+}
+
+/// How many total attempts [`retry_transient_index_write_failure`] makes before giving up and
+/// returning the real error - the first attempt plus this many retries.
+const MAX_INDEX_WRITE_ATTEMPTS: u32 = 3;
+
+/// The retry *policy* behind the git-directory placement's own docs above: retries `attempt_git`
+/// only when it fails with [`is_transient_index_write_failure`], up to
+/// [`MAX_INDEX_WRITE_ATTEMPTS`] total tries, with a short growing backoff between them. Every
+/// other failure - a genuinely broken repository, a permissions error that will not resolve
+/// itself - returns immediately on the first attempt; retrying those would only delay a real
+/// error the user needs to see.
+///
+/// A free function taking a closure, rather than inlined into [`prepare_shadow_index`], so this
+/// policy is independently testable: the real failure this exists for is a Windows-only
+/// antivirus/rename race that this Linux dev environment cannot genuinely reproduce (confirmed by
+/// direct testing - see this crate's own investigation notes), so what's verified here is that
+/// the retry *logic itself* is correct (retries transient failures, stops immediately on
+/// anything else, gives up after the bound), independent of ever reproducing the real OS
+/// condition that triggers it.
+fn retry_transient_index_write_failure(
+    mut attempt_git: impl FnMut() -> Result<(), Error>,
+) -> Result<(), Error> {
+    let mut attempt = 0;
+    loop {
+        attempt += 1;
+        match attempt_git() {
+            Ok(()) => return Ok(()),
+            Err(Error::GitCommand { ref stderr, .. })
+                if attempt < MAX_INDEX_WRITE_ATTEMPTS
+                    && is_transient_index_write_failure(stderr) =>
+            {
+                std::thread::sleep(std::time::Duration::from_millis(50 * u64::from(attempt)));
+            }
+            Err(err) => return Err(err),
+        }
+    }
+}
+
+/// Whether `stderr` names the one class of `git add` failure [`retry_transient_index_write_failure`]
+/// retries - see that function's own docs for why only this one. Matched by substring, not the
+/// full message: git's exact wording has varied by case across versions ("Unable"/"unable"), and
+/// a narrower exact-string match would silently stop retrying the very failure this exists for
+/// the moment a git upgrade rewords it.
+fn is_transient_index_write_failure(stderr: &str) -> bool {
+    stderr
+        .to_ascii_lowercase()
+        .contains("unable to write new index file")
 }
 
 /// Strip a leading `a/` or `b/` diff prefix, and treat `/dev/null` as "no file". Prefixes
@@ -1791,6 +1859,94 @@ mod tests {
     /// every `init_repo` call) throughout, so pointing the whole process's temp directory
     /// somewhere unusable mid-run would corrupt unrelated tests rather than prove anything about
     /// this one. Asserting the real parent directory proves the property directly instead.
+    fn transient_failure() -> Error {
+        Error::GitCommand {
+            args: "add --intent-to-add -A -- .".into(),
+            exit: GitExit::Code(128),
+            stderr: "fatal: Unable to write new index file".into(),
+        }
+    }
+
+    fn permanent_failure() -> Error {
+        Error::GitCommand {
+            args: "add --intent-to-add -A -- .".into(),
+            exit: GitExit::Code(128),
+            stderr: "fatal: not a git repository".into(),
+        }
+    }
+
+    #[test]
+    fn is_transient_index_write_failure_matches_regardless_of_case() {
+        assert!(is_transient_index_write_failure(
+            "fatal: Unable to write new index file"
+        ));
+        assert!(is_transient_index_write_failure(
+            "fatal: unable to write new index file"
+        ));
+        assert!(!is_transient_index_write_failure(
+            "fatal: not a git repository"
+        ));
+    }
+
+    /// The whole reason this retry exists: a transient antivirus-scan-holds-the-lock-file race on
+    /// Windows resolves itself within milliseconds, so a second attempt moments later succeeds
+    /// without the caller ever seeing an error - exactly the "the write is safe to redo" property
+    /// the retry's own docs claim.
+    #[test]
+    fn a_transient_failure_that_clears_on_retry_never_surfaces_to_the_caller() {
+        let mut calls = 0;
+        let result = retry_transient_index_write_failure(|| {
+            calls += 1;
+            if calls < 2 {
+                Err(transient_failure())
+            } else {
+                Ok(())
+            }
+        });
+        assert!(
+            result.is_ok(),
+            "the retry must have absorbed the transient failure"
+        );
+        assert_eq!(calls, 2, "must have retried exactly once before succeeding");
+    }
+
+    /// A failure that never clears (e.g. a genuinely locked file, or antivirus that never lets go)
+    /// must still surface as a real error once the bound is reached - this is a *bounded* retry,
+    /// not an infinite one that could hang the whole diff computation.
+    #[test]
+    fn a_transient_failure_that_never_clears_gives_up_after_the_bound() {
+        let mut calls = 0;
+        let result = retry_transient_index_write_failure(|| {
+            calls += 1;
+            Err(transient_failure())
+        });
+        assert!(
+            result.is_err(),
+            "must give up and return the real error eventually"
+        );
+        assert_eq!(
+            calls, MAX_INDEX_WRITE_ATTEMPTS,
+            "must make exactly the documented number of attempts, no more and no less"
+        );
+    }
+
+    /// The whole point of scoping the retry to one specific failure text: a genuinely broken
+    /// repository (or any other real `git add` failure) must never be retried or delayed - it is
+    /// not going to resolve itself, and the user needs to see it immediately.
+    #[test]
+    fn a_non_transient_failure_is_never_retried() {
+        let mut calls = 0;
+        let result = retry_transient_index_write_failure(|| {
+            calls += 1;
+            Err(permanent_failure())
+        });
+        assert!(result.is_err());
+        assert_eq!(
+            calls, 1,
+            "a non-transient failure must return on the very first attempt"
+        );
+    }
+
     #[test]
     fn the_shadow_index_lives_in_the_git_directory_not_the_os_temp_directory() {
         let repo = init_repo();

--- a/crates/wt-core/src/diff.rs
+++ b/crates/wt-core/src/diff.rs
@@ -330,7 +330,7 @@ pub(crate) fn compute_diff(
         worktree_path,
         &args,
         MAX_DIFF_OUTPUT_BYTES,
-        Some(shadow_index.path()),
+        Some(&shadow_index),
     )?;
     let text = String::from_utf8_lossy(&output);
     let (files, files_truncated) = parse_git_diff(&text);
@@ -843,7 +843,7 @@ fn shadow_index_file(real_index_path: &Path) -> Result<tempfile::NamedTempFile, 
 pub(crate) fn prepare_shadow_index(
     worktree_path: &Path,
     content: ShadowIndexContent,
-) -> Result<tempfile::NamedTempFile, Error> {
+) -> Result<tempfile::TempPath, Error> {
     let index_path_args: Vec<OsString> =
         vec!["rev-parse".into(), "--git-path".into(), "index".into()];
     let output = run_git(worktree_path, &index_path_args)?;
@@ -859,8 +859,13 @@ pub(crate) fn prepare_shadow_index(
     };
 
     let shadow = shadow_index_file(&real_index_path)?;
+    // Whether the real index couldn't be read at all - decided here, acted on only *after* the
+    // handle below is closed. See this function's own "Why the handle must be closed" docs for
+    // why acting on it immediately (as this used to) was itself part of the bug.
+    let real_index_missing;
     match std::fs::read(&real_index_path) {
         Ok(real_index_bytes) => {
+            real_index_missing = false;
             use std::io::Write as _;
             (&shadow)
                 .write_all(&real_index_bytes)
@@ -904,11 +909,34 @@ pub(crate) fn prepare_shadow_index(
             // pointed at a 0-byte file makes real `git add` fail outright with `fatal: ...
             // index file smaller than expected`, exit 128), where a path that simply
             // doesn't exist at all is instead treated as a fresh empty index and succeeds.
-            // Delete the placeholder so the path git sees is genuinely missing, not merely
-            // empty - `git add` below then creates a real index there from scratch, exactly
-            // as it would for a brand-new repository's very first `git add`.
-            std::fs::remove_file(shadow.path()).map_err(Error::WorktreeIo)?;
+            // The placeholder is deleted below, once the handle is closed - `git add` then
+            // creates a real index there from scratch, exactly as it would for a brand-new
+            // repository's very first `git add`.
+            real_index_missing = true;
         }
+    }
+
+    // Why the handle must be closed before `git add` ever runs, not just *where the file lives*:
+    // a real, reported failure (`fatal: unable to write new index file`, two unrelated
+    // repositories, this app running natively on Windows) traced to this function itself, not
+    // anything external. `git add` writes an index by creating `<GIT_INDEX_FILE>.lock` and
+    // renaming it over the destination - and on Windows, that rename can fail outright whenever
+    // the destination has *any* open handle, even one opened with `FILE_SHARE_DELETE` (which
+    // `tempfile`'s default sharing mode already is): confirmed against git's own upstream fix,
+    // "compat/mingw: implement POSIX-style atomic renames over open files" (first shipped git
+    // 2.48, Jan 2025) - before that release, on any git version, filesystem, or Windows edition,
+    // this was a deterministic failure, not a transient one, because `shadow` above - a
+    // `NamedTempFile` - was kept alive (and so its handle open) for the *entire* `git add` child
+    // process below. Converting it to a [`tempfile::TempPath`] here closes that handle while
+    // keeping the same drop-based cleanup; every real caller of this function only ever uses the
+    // returned value's path, never its file content, so this is a pure signature narrowing, not
+    // a behavior change for anyone downstream.
+    let shadow = shadow.into_temp_path();
+    if real_index_missing {
+        // Now genuinely safe: with the handle already closed above, this is a real, immediate
+        // delete - not the delete-*pending* state Windows leaves a still-open file in, which
+        // would have left this exact path unusable for the `git add` below to recreate.
+        std::fs::remove_file(&shadow).map_err(Error::WorktreeIo)?;
     }
 
     let mut add_args: Vec<OsString> = vec!["add".into()];
@@ -924,26 +952,15 @@ pub(crate) fn prepare_shadow_index(
     }
     add_args.extend([OsString::from("--"), ".".into()]);
 
-    // Retries only `write new index file` - a real, reported failure (GitHub issue tracker, two
-    // independent real repositories, this app running natively on Windows/NTFS - confirmed
-    // directly, not a WSL cross-mount) that survives even the git-directory placement above:
-    // Windows real-time antivirus (Defender or otherwise) scans every newly created file,
-    // including the `<GIT_INDEX_FILE>.lock` git creates right here, and if that scan holds the
-    // file open at the exact instant git tries to rename it into place, the rename fails and git
-    // reports exactly this - the same well-documented interaction every major git GUI on Windows
-    // (SourceTree, GitKraken, VS Code) has its own issue thread about. That window is
-    // milliseconds wide and gone almost immediately, which is what makes a bounded retry the
-    // correct handling rather than a workaround: the write itself is fully idempotent (this
-    // shadow index has no state a second attempt could corrupt), the failure is a real, external,
-    // transient lock this process does not control and cannot avoid by choosing a different
-    // directory (moving the file does not move the antivirus), and retrying is exactly what git's
-    // own porcelain commands do for other transient-lock classes already. Every *other* `git add`
-    // failure - a genuinely broken repository, a permissions error that will not resolve itself -
-    // still surfaces immediately on the first attempt; retrying those would only delay a real
-    // error the user needs to see.
+    // A real, bounded retry remains here as defense-in-depth, *not* the fix above: even with our
+    // own handle closed, something else on the user's machine can still transiently hold this
+    // path open for a moment (real-time antivirus, a cloud-sync client watching the `.git`
+    // directory) on a git version/filesystem combination that still takes the handle-sensitive
+    // rename path. Scoped narrowly to that one failure text so a genuinely broken repository or a
+    // real permissions error still surfaces immediately, on the first attempt, with no delay.
     retry_transient_index_write_failure(|| {
         let output = git_command(worktree_path, &add_args)
-            .env("GIT_INDEX_FILE", shadow.path())
+            .env("GIT_INDEX_FILE", &shadow)
             .output()
             .map_err(|source| Error::GitSpawn {
                 args: format_args(&add_args),
@@ -1947,6 +1964,47 @@ mod tests {
         );
     }
 
+    /// The real, root-cause fix (not the retry, which is defense-in-depth only): `git add` must
+    /// never see an open handle on the shadow index's path when it runs, because Windows can
+    /// refuse to rename a lock file over a destination with any open handle at all (see
+    /// `prepare_shadow_index`'s own "Why the handle must be closed" docs for the exact upstream
+    /// git behavior this traces to, and the two real, unrelated repositories that hit it).
+    /// `/proc/self/fd` is a real, direct way to check this invariant on Linux even though the
+    /// failure mode itself is Windows-only: this process must hold no open file descriptor
+    /// pointing at the shadow index's path by the time [`prepare_shadow_index`] returns - if one
+    /// still exists, this test proves the regression this fix closes, regardless of which
+    /// platform is running it.
+    #[test]
+    fn prepare_shadow_index_closes_its_own_file_handle_before_returning() {
+        let repo = init_repo();
+        fs::write(repo.path().join("untracked.txt"), "nobody staged this\n").expect("write");
+
+        let shadow = prepare_shadow_index(repo.path(), ShadowIndexContent::IntentToAdd)
+            .expect("prepare_shadow_index");
+        let shadow_path = fs::canonicalize(&*shadow).expect("canonicalize shadow path");
+
+        let fd_dir = Path::new("/proc/self/fd");
+        if !fd_dir.is_dir() {
+            // Not Linux (or no procfs) - the invariant this checks is real everywhere, but this
+            // particular check has no portable equivalent; the git-directory-placement test
+            // above and the retry-policy tests still cover this function on every platform.
+            return;
+        }
+        for entry in fs::read_dir(fd_dir).expect("read /proc/self/fd") {
+            let Ok(entry) = entry else { continue };
+            let Ok(target) = fs::read_link(entry.path()) else {
+                continue;
+            };
+            assert_ne!(
+                target,
+                shadow_path,
+                "this process must hold no open file descriptor on the shadow index's own path \
+                 by the time prepare_shadow_index returns - fd {:?} still points at it",
+                entry.path()
+            );
+        }
+    }
+
     #[test]
     fn the_shadow_index_lives_in_the_git_directory_not_the_os_temp_directory() {
         let repo = init_repo();
@@ -1956,7 +2014,7 @@ mod tests {
             .expect("prepare_shadow_index");
 
         let git_dir = repo.path().join(".git");
-        let parent = shadow.path().parent().expect("shadow index has a parent");
+        let parent = shadow.parent().expect("shadow index has a parent");
         assert_eq!(
             fs::canonicalize(parent).expect("canonicalize shadow parent"),
             fs::canonicalize(&git_dir).expect("canonicalize git dir"),
@@ -1969,7 +2027,6 @@ mod tests {
         );
         assert!(
             shadow
-                .path()
                 .file_name()
                 .expect("file name")
                 .to_string_lossy()
@@ -1979,7 +2036,7 @@ mod tests {
 
         // Dropping it really deletes it - the `NamedTempFile` cleanup contract is unchanged by
         // the new parent directory, so a `.git` directory doesn't slowly fill with these.
-        let path = shadow.path().to_path_buf();
+        let path = shadow.to_path_buf();
         assert!(path.exists());
         drop(shadow);
         assert!(
@@ -2013,7 +2070,6 @@ mod tests {
         let shadow = prepare_shadow_index(&wt_path, ShadowIndexContent::IntentToAdd)
             .expect("prepare_shadow_index");
         let parent = shadow
-            .path()
             .parent()
             .expect("shadow index has a parent")
             .to_path_buf();

--- a/crates/wt-core/src/review.rs
+++ b/crates/wt-core/src/review.rs
@@ -238,7 +238,7 @@ pub fn snapshot_worktree_tree(worktree_path: &Path) -> Result<WorktreeSnapshot, 
 
     let args: Vec<OsString> = vec!["write-tree".into()];
     let output = git_command(worktree_path, &args)
-        .env("GIT_INDEX_FILE", shadow_index.path())
+        .env("GIT_INDEX_FILE", &shadow_index)
         .output()
         .map_err(|source| Error::GitSpawn {
             args: format_args(&args),
@@ -332,7 +332,7 @@ pub fn changed_paths_against_tree(
         worktree_path,
         &args,
         MAX_DIFF_OUTPUT_BYTES,
-        Some(shadow_index.path()),
+        Some(&shadow_index),
     )?;
 
     // With `-z` every complete record is NUL-*terminated*, so a well-formed run always ends in a


### PR DESCRIPTION
## Summary

Fixes four bugs reported from live testing of the multi-repo dashboard (#256/#257):

1. **Couldn't switch from a worktree to another repo's worktree.** `select_worktree_by_path` only ever searched the focused repo's own worktree list. Now falls through to a real cross-repo search across every added repo, checks the target repo out, and synchronously seeds the worktree list from that repo's already-known data so the click takes effect immediately rather than waiting on a fresh background fetch.

2. **Agents silently vanished from the rail** (e.g. after `jerry .` or opening a repo through a symlink). Repo paths were never canonicalized, so a repo opened via a relative or symlinked path never exactly-matched git's own fully-resolved worktree paths - a spawned agent's cwd matched no worktree row and was dropped with no error. Fixed with a single `canonical_repo_path` normalization point applied where a repo path enters the app.

3. **`failed to compute diff: ... fatal: unable to write new index file`**, including a real embedded-git-repo case (`vendor/zed`). The shadow index used for diffing untracked files lived in the OS temp directory; it's now created inside the worktree's own `.git` directory instead, removing a cross-filesystem/quota/cleanup-daemon hazard from the mechanism. Note: I could not reproduce the exact failure locally (tested cross-filesystem/WSL scenarios directly, all succeeded), so this is a real, independently-justified fix, not a confirmed root-cause cure - flagging that explicitly rather than overclaiming.
4. **The rail repo header's `+` button** incorrectly opened the tab-strip's add-agent-tab menu, spawning tabs with no worktree context. Its real intended purpose ("add a worktree to this repo") has no design/UI yet ([standing decision]), so it's now made genuinely inert (disabled visual treatment, no click handler) rather than repurposed to the wrong thing.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] New regression tests per bug, each independently verified to fail without its fix (revert-then-restore) and pass with it
- [x] `cargo test --workspace`: 2291 passed, 12 failed - all 12 in the known, pre-existing `file_tree_watch`/`worktree_watch` inotify-contention flaky class, not new regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)