### PR TITLE
fix(app): double-border and selection layout-shift on graph/changes/review rows

### DIFF
--- a/crates/app/src/graph_view/render.rs
+++ b/crates/app/src/graph_view/render.rs
@@ -1715,21 +1715,21 @@ impl AdeApp {
             .items_center()
             .w_full()
             .h(theme::graph::ROW)
-            .border_b_1()
-            .border_color(theme::border::ROW)
             .cursor_pointer()
-            // The left selection edge is a real, separate child - not `border_l_2()` - because
-            // GPUI's `Style::border_color` is one shared value for every edge of a single
-            // element (confirmed directly in `gpui`'s own `style.rs`: `border_color:
-            // Option<Hsla>`, not per-edge). `border_l_2()` on this same div would silently
-            // overwrite the `border_b_1()` separator's colour above with whichever colour
-            // selection picks - toggling *both* edges together, so a selected row would flash a
-            // second border along its own bottom, not just gain one on the left. Splitting them
-            // into two real elements is what actually fixes that, on top of the layout-shift fix
-            // this already had: `left_0().top_0().bottom_0()` reserves the same 2px of space
-            // whether or not this row is selected (only its own `bg` colour toggles), the same
-            // "always paint the box, only recolour it" convention the tab strip's own selection
-            // underline already uses (`crate::work_surface::render::AdeApp::render_tab_chrome`'s
+            // No bottom border at all - a real, reported design bug, not the row's own intended
+            // separator: this row used to carry a permanent `border_b_1()` alongside a
+            // conditional `border_l_2()` for its selection edge, and because GPUI's
+            // `Style::border_color` is one shared value for every edge of a single element
+            // (confirmed directly in `gpui`'s own `style.rs`: `border_color: Option<Hsla>`, not
+            // per-edge), selecting a row silently recoloured the bottom edge to the selection
+            // colour too - a real border appearing along the bottom on selection, not merely an
+            // intended static separator. The correct fix is not "give the bottom edge its own
+            // colour" - it is "there is no bottom border here at all, only the left selection
+            // edge below", a real, separate child element: `left_0().top_0().bottom_0()`
+            // reserves the same 2px of space whether or not this row is selected (only its own
+            // `bg` colour toggles), the same "always paint the box, only recolour it" convention
+            // the tab strip's own selection underline already uses
+            // (`crate::work_surface::render::AdeApp::render_tab_chrome`'s
             // `div().flex_none().w_full().h(px(1.0)).bg(colors.underline)`).
             .child(
                 div()
@@ -3185,24 +3185,27 @@ fn render_graph_lane_canvas(
     let mut canvas = div()
         .relative()
         .flex_none()
-        // Pinned to the row's own top edge, never centred in it. `render_graph_row` is
-        // `.h(ROW).border_b_1()` and GPUI's taffy layout is *border-box* (`Style::to_taffy`,
-        // `vendor/zed/crates/gpui/src/taffy.rs`, never sets `box_sizing`, so taffy's own
-        // `BoxSizing::BorderBox` default applies) - so the row is 26 tall on the outside but its
-        // content box is only 25, while this canvas is a full `ROW` = 26. Under the row's
-        // `.items_center()` that centres to `(25 - 26) / 2` = **-0.5px**, and every horizontal 1px
-        // stroke in here - the elbow bridge's `h(px(1.0))` and both curve boxes' `border_t_1()`/
-        // `border_b_1()` - then lands on a half-pixel boundary and renders smeared across two
-        // physical pixel rows at half intensity, while the vertical lane lines (x is untouched)
-        // stay crisp. That is the reported "the lines and elbows do not align correctly
-        // vertically", and it is also why four earlier rounds of 1px elbow-seam fixes each only
-        // half-worked: the geometry was computed on an integer grid and every test measured that
-        // integer grid, but the whole canvas was painted half a pixel off it.
+        // Pinned to the row's own top edge, never centred in it. `render_graph_row` used to carry
+        // a permanent `border_b_1()` (removed - see that function's own docs for why a real
+        // border there was itself the bug), and GPUI's taffy layout is *border-box*
+        // (`Style::to_taffy`, `vendor/zed/crates/gpui/src/taffy.rs`, never sets `box_sizing`, so
+        // taffy's own `BoxSizing::BorderBox` default applies) - so with that border present the
+        // row was 26 tall on the outside but its content box was only 25, while this canvas is a
+        // full `ROW` = 26. Under the row's `.items_center()` that centred to `(25 - 26) / 2` =
+        // **-0.5px**, and every horizontal 1px stroke in here - the elbow bridge's `h(px(1.0))`
+        // and both curve boxes' `border_t_1()`/`border_b_1()` - then landed on a half-pixel
+        // boundary and rendered smeared across two physical pixel rows at half intensity, while
+        // the vertical lane lines (x is untouched) stayed crisp. That was the reported "the lines
+        // and elbows do not align correctly vertically", and it is also why four earlier rounds
+        // of 1px elbow-seam fixes each only half-worked: the geometry was computed on an integer
+        // grid and every test measured that integer grid, but the whole canvas was painted half a
+        // pixel off it.
         //
-        // The row has no *top* border, so its content-box top is its border-box top: pinning here
-        // puts the canvas on whole pixels and keeps consecutive canvases exactly `ROW` apart. The
-        // 1px it now overflows past the content box is the row's own separator border, which lane
-        // lines must run through anyway for a line to read as continuous across rows.
+        // `self_start()` is left in place now that the row's content box and border box are the
+        // same 26px (no border on any edge at all): it costs nothing, and it keeps this position
+        // correct - on whole pixels, `ROW` apart between consecutive rows - independent of
+        // whatever the row's own box model happens to be, rather than silently relying on content
+        // box and canvas height staying equal.
         .self_start()
         .overflow_hidden()
         .w(graph_lane_canvas_width(lane_count))
@@ -5374,14 +5377,18 @@ mod graph_elbow_render_tests {
     /// see: it only ever compares one lane canvas against *another* lane canvas, so a constant
     /// offset shared by every row passes it untouched.
     ///
-    /// `render_graph_row` is `.h(ROW).border_b_1()`, and GPUI's taffy layout is border-box
-    /// (`Style::to_taffy` in `vendor/zed/crates/gpui/src/taffy.rs` never sets `box_sizing`, so
-    /// taffy's `BoxSizing::BorderBox` default applies) - so the row's *content* box is 25px while
-    /// the lane canvas is a full `ROW` = 26px. The row's own `.items_center()` then centred it to
-    /// `(25 - 26) / 2` = -0.5px, and every horizontal 1px stroke in the canvas - the elbow's
-    /// straight bridge and both curve boxes' horizontal borders - landed on a half-pixel boundary,
-    /// rendering smeared over two physical pixel rows while the vertical lane lines stayed crisp.
-    /// `render_graph_lane_canvas`'s `.self_start()` is what holds this.
+    /// `render_graph_row` used to be `.h(ROW).border_b_1()`, and GPUI's taffy layout is
+    /// border-box (`Style::to_taffy` in `vendor/zed/crates/gpui/src/taffy.rs` never sets
+    /// `box_sizing`, so taffy's `BoxSizing::BorderBox` default applies) - so with that border
+    /// present the row's *content* box was 25px while the lane canvas is a full `ROW` = 26px.
+    /// The row's own `.items_center()` then centred it to `(25 - 26) / 2` = -0.5px, and every
+    /// horizontal 1px stroke in the canvas - the elbow's straight bridge and both curve boxes'
+    /// horizontal borders - landed on a half-pixel boundary, rendering smeared over two physical
+    /// pixel rows while the vertical lane lines stayed crisp. The row's bottom border is gone now
+    /// (a real, reported design bug in its own right - see `render_graph_row`'s own docs), so
+    /// content box and border box are equal and this could no longer occur even without
+    /// `render_graph_lane_canvas`'s own `.self_start()` - which stays regardless, since it costs
+    /// nothing and keeps this correct independent of the row's own box model.
     ///
     /// Asserted on the canvas' offset *within its own row*, and on the offset being a whole
     /// pixel - the two facts the centring broke, neither of which any existing test looked at.
@@ -5436,8 +5443,8 @@ mod graph_elbow_render_tests {
     /// tall and each sits `ROW` below the last, so the pixel row where one canvas' clip cuts the
     /// line is the very pixel row where the next canvas' own full-height `LaneSegment` resumes it.
     /// A gap or an overlap here would turn the clip into a visible dash (or bring back the doubled
-    /// line an earlier round fixed), and neither is visible from geometry alone - it depends on the
-    /// real flex layout of a row whose `border_b_1()` makes its content box shorter than `ROW`.
+    /// line an earlier round fixed), and neither is visible from geometry alone - it depends on
+    /// the row's own real flex layout, not just the two numbers this test's own docs cite.
     #[gpui::test]
     fn consecutive_lane_canvases_tile_exactly_so_the_row_clip_loses_no_line(
         cx: &mut TestAppContext,

--- a/crates/app/src/graph_view/render.rs
+++ b/crates/app/src/graph_view/render.rs
@@ -1710,6 +1710,7 @@ impl AdeApp {
         div()
             .id(("graph-row", index))
             .debug_selector(move || format!("graph-row-{index}"))
+            .relative()
             .flex()
             .items_center()
             .w_full()
@@ -1717,19 +1718,33 @@ impl AdeApp {
             .border_b_1()
             .border_color(theme::border::ROW)
             .cursor_pointer()
-            // `border_l_2()` is applied unconditionally, reserving the 2px of space whether or
-            // not this row is selected, so selecting a row never shifts its content (lane
-            // canvas, ref chips, subject, everything) 2px to the right - only the border's
-            // *colour* toggles. Mirrors `crate::work_surface::state`'s own `TRANSPARENT`
-            // convention (see its doc comment: "so every button/tab can always call
-            // `.bg()`/`.border_color()` uniformly rather than conditionally skipping the call,
-            // which would also shift the box model by the border's width").
-            .border_l_2()
-            .border_color(if selected {
-                theme::border::SELECTED_EDGE.into()
-            } else {
-                work_surface::TRANSPARENT
-            })
+            // The left selection edge is a real, separate child - not `border_l_2()` - because
+            // GPUI's `Style::border_color` is one shared value for every edge of a single
+            // element (confirmed directly in `gpui`'s own `style.rs`: `border_color:
+            // Option<Hsla>`, not per-edge). `border_l_2()` on this same div would silently
+            // overwrite the `border_b_1()` separator's colour above with whichever colour
+            // selection picks - toggling *both* edges together, so a selected row would flash a
+            // second border along its own bottom, not just gain one on the left. Splitting them
+            // into two real elements is what actually fixes that, on top of the layout-shift fix
+            // this already had: `left_0().top_0().bottom_0()` reserves the same 2px of space
+            // whether or not this row is selected (only its own `bg` colour toggles), the same
+            // "always paint the box, only recolour it" convention the tab strip's own selection
+            // underline already uses (`crate::work_surface::render::AdeApp::render_tab_chrome`'s
+            // `div().flex_none().w_full().h(px(1.0)).bg(colors.underline)`).
+            .child(
+                div()
+                    .debug_selector(move || format!("graph-row-{index}-selection-edge"))
+                    .absolute()
+                    .left_0()
+                    .top_0()
+                    .bottom_0()
+                    .w(px(2.0))
+                    .bg(if selected {
+                        theme::border::SELECTED_EDGE.into()
+                    } else {
+                        work_surface::TRANSPARENT
+                    }),
+            )
             .when(selected, |el| el.bg(theme::surface::ROW_SELECTED))
             .when(!selected, |el| {
                 el.hover(|el| el.bg(theme::surface::ROW_HOVER))
@@ -5574,6 +5589,58 @@ mod graph_selection_render_tests {
             "selecting a row must never resize its own content (unselected: {:?}, selected: \
              {:?})",
             bounds_unselected, bounds_selected
+        );
+    }
+
+    /// The reported "double border left and bottom" - GPUI's `Style::border_color` is one
+    /// shared value for every edge of a single element (confirmed directly in `gpui`'s own
+    /// `style.rs`: `border_color: Option<Hsla>`, not per-edge), so a row using both
+    /// `border_b_1()` (its own permanent separator) and a conditional `border_l_2()` (its
+    /// selection edge) on the *same* div used to have the second `.border_color()` call
+    /// silently overwrite the first - recolouring the bottom separator to the selection colour
+    /// too, on every selected row, everywhere this pattern was used. The fix is a real, separate
+    /// child element for the left edge (`Self::render_graph_row`'s own docs). This proves that
+    /// child exists and is genuinely unconditional - painted with the same bounds whether or not
+    /// the row is selected, only its colour differs (which this test harness has no way to
+    /// inspect directly, but a `debug_bounds` miss on the unselected row would mean the child is
+    /// still conditionally created, i.e. this fix regressed back to the broken pattern).
+    #[gpui::test]
+    fn the_selection_edge_is_a_real_element_painted_regardless_of_selection(
+        cx: &mut TestAppContext,
+    ) {
+        let (_repo, app, cx) = open_seeded_graph(cx);
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.graph_state.selected_row),
+            Some(0),
+            "premise: row 0 is auto-selected on load, so row 1 starts genuinely unselected"
+        );
+
+        let edge_unselected = cx.debug_bounds("graph-row-1-selection-edge").expect(
+            "the selection-edge child must be painted even while row 1 is unselected - if \
+                 it's `None` here, the edge is still only created `.when(selected, ...)`, the \
+                 exact regression this test exists to catch",
+        );
+
+        app.update(cx, |app, cx| {
+            app.select_graph_row(1, cx);
+        });
+        cx.run_until_parked();
+
+        let edge_selected = cx
+            .debug_bounds("graph-row-1-selection-edge")
+            .expect("the selection-edge child must still be painted while row 1 is selected");
+
+        assert_eq!(
+            edge_unselected.origin, edge_selected.origin,
+            "the selection edge's own position must never move - only its colour toggles \
+             (unselected: {:?}, selected: {:?})",
+            edge_unselected, edge_selected
+        );
+        assert_eq!(
+            edge_unselected.size, edge_selected.size,
+            "the selection edge's own size must never change (unselected: {:?}, selected: {:?})",
+            edge_unselected, edge_selected
         );
     }
 

--- a/crates/app/src/review/render.rs
+++ b/crates/app/src/review/render.rs
@@ -400,14 +400,14 @@ impl AdeApp {
             .gap(px(6.0))
             .h(theme::band::CHANGE_ROW)
             .px(px(10.0))
-            .border_b_1()
-            .border_color(theme::border::ROW)
             .cursor_pointer()
-            // See `crate::graph_view::render::AdeApp::render_graph_row`'s identical fix for why
-            // this is a real, separate child rather than a conditional `border_l_2()`: GPUI's
-            // `Style::border_color` is one shared value for the whole element, so `border_l_2()`
-            // here used to silently recolour the `border_b_1()` separator above too, and only
-            // reserved its own space while selected, shifting every row's content on click.
+            // No bottom border at all - see `crate::graph_view::render::AdeApp::render_graph_row`'s
+            // identical fix for why: GPUI's `Style::border_color` is one shared value for the
+            // whole element, so a conditional `border_l_2()` here used to silently recolour a
+            // permanent `border_b_1()` separator too, a real border appearing along the bottom on
+            // selection - and it only reserved its own space while selected, shifting every row's
+            // content on click. Fixed the same way: no bottom border, and a real, separate,
+            // always-painted child for the left selection edge.
             .child(
                 div()
                     .debug_selector({

--- a/crates/app/src/review/render.rs
+++ b/crates/app/src/review/render.rs
@@ -393,6 +393,7 @@ impl AdeApp {
         div()
             .id(format!("review-row-{}", file.path.display()))
             .debug_selector(|| format!("review-row-{}", file.path.display()))
+            .relative()
             .flex()
             .w_full()
             .items_center()
@@ -402,11 +403,29 @@ impl AdeApp {
             .border_b_1()
             .border_color(theme::border::ROW)
             .cursor_pointer()
-            .when(selected, |el| {
-                el.bg(theme::surface::ROW_SELECTED)
-                    .border_l_2()
-                    .border_color(theme::border::SELECTED_EDGE)
-            })
+            // See `crate::graph_view::render::AdeApp::render_graph_row`'s identical fix for why
+            // this is a real, separate child rather than a conditional `border_l_2()`: GPUI's
+            // `Style::border_color` is one shared value for the whole element, so `border_l_2()`
+            // here used to silently recolour the `border_b_1()` separator above too, and only
+            // reserved its own space while selected, shifting every row's content on click.
+            .child(
+                div()
+                    .debug_selector({
+                        let path = file.path.clone();
+                        move || format!("review-row-{}-selection-edge", path.display())
+                    })
+                    .absolute()
+                    .left_0()
+                    .top_0()
+                    .bottom_0()
+                    .w(px(2.0))
+                    .bg(if selected {
+                        theme::border::SELECTED_EDGE.into()
+                    } else {
+                        work_surface::TRANSPARENT
+                    }),
+            )
+            .when(selected, |el| el.bg(theme::surface::ROW_SELECTED))
             .when(!selected, |el| {
                 el.hover(|el| el.bg(theme::surface::ROW_HOVER))
             })
@@ -1169,6 +1188,64 @@ mod review_flow_tests {
                  view's, which stays independent"
             );
         });
+    }
+
+    /// The reported "double border left and bottom" applied to the review panel's own rows -
+    /// see `crate::graph_view::render::AdeApp::render_graph_row`'s own docs for the full GPUI
+    /// `Style::border_color`-is-one-shared-value explanation this fix is built on.
+    #[gpui::test]
+    fn the_selection_edge_is_a_real_element_painted_regardless_of_selection(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = diverged_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        let id = sole_agent(&app, cx);
+        std::fs::write(repo.path().join("agent_work.rs"), "fn main() {}\n").expect("write");
+
+        app.update_in(cx, |app, window, cx| app.open_review_tab(id, window, cx));
+        cx.run_until_parked();
+
+        assert!(
+            cx.debug_bounds("review-row-agent_work.rs").is_some(),
+            "sanity check: the real unreviewed file must really have painted as a row"
+        );
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.open_change, None,
+                "premise: nothing is selected yet, so this genuinely exercises the unselected \
+                 case"
+            );
+        });
+
+        let edge_unselected = cx
+            .debug_bounds("review-row-agent_work.rs-selection-edge")
+            .expect(
+                "the selection-edge child must be painted even while the row is unselected - if \
+                 it's `None` here, the edge is still only created `.when(selected, ...)`, the \
+                 exact regression this test exists to catch",
+            );
+
+        app.update(cx, |app, cx| {
+            app.open_review_file(PathBuf::from("agent_work.rs"), cx)
+        });
+        cx.run_until_parked();
+
+        let edge_selected = cx
+            .debug_bounds("review-row-agent_work.rs-selection-edge")
+            .expect("the selection-edge child must still be painted while the row is selected");
+
+        assert_eq!(
+            edge_unselected.origin, edge_selected.origin,
+            "the selection edge's own position must never move - only its colour toggles \
+             (unselected: {:?}, selected: {:?})",
+            edge_unselected, edge_selected
+        );
+        assert_eq!(
+            edge_unselected.size, edge_selected.size,
+            "the selection edge's own size must never change (unselected: {:?}, selected: {:?})",
+            edge_unselected, edge_selected
+        );
     }
 
     /// **The reachability proof.** Every other test in this module opens the review tab by

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -1793,17 +1793,18 @@ impl AdeApp {
             // similar-looking bare number that happens to already clear the *old*,
             // insufficient value.
             .pr(px(scrollbar::CONTENT_CLEARANCE))
-            .border_b_1()
-            .border_color(theme::border::ROW)
             .cursor_pointer()
-            // A real, separate child for the left selection edge - not `border_l_2()` inside the
-            // `when` below, which used to also silently recolour this row's own `border_b_1()`
-            // separator above (GPUI's `Style::border_color` is one shared value for every edge
-            // of a single element, not per-edge - confirmed directly in `gpui`'s own
-            // `style.rs`), and which only reserved its 2px of space *while* selected, shifting
-            // every row's content 2px right the instant it was clicked. See
+            // No bottom border at all - this row used to carry a permanent `border_b_1()`
+            // alongside a conditional `border_l_2()` inside the `when` below, and because GPUI's
+            // `Style::border_color` is one shared value for every edge of a single element (not
+            // per-edge - confirmed directly in `gpui`'s own `style.rs`), selecting a row silently
+            // recoloured the bottom edge to the selection colour too - a real border appearing
+            // along the bottom on selection, not an intended static separator. The old
+            // `border_l_2()` also only reserved its 2px of space *while* selected, shifting every
+            // row's content 2px right the instant it was clicked. See
             // `crate::graph_view::render::AdeApp::render_graph_row`'s identical fix for the full
-            // reasoning - same bug, same shape, same fix.
+            // reasoning - same bug, same shape, same fix: no bottom border, and a real, separate,
+            // always-painted child for the left selection edge.
             .child(
                 div()
                     .debug_selector({

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -1779,6 +1779,7 @@ impl AdeApp {
         div()
             .id(format!("change-row-{}", file.path.display()))
             .debug_selector(|| format!("change-row-{}", file.path.display()))
+            .relative()
             .flex()
             .w_full()
             .items_center()
@@ -1795,11 +1796,32 @@ impl AdeApp {
             .border_b_1()
             .border_color(theme::border::ROW)
             .cursor_pointer()
-            .when(selected, |el| {
-                el.bg(theme::surface::ROW_SELECTED)
-                    .border_l_2()
-                    .border_color(theme::border::SELECTED_EDGE)
-            })
+            // A real, separate child for the left selection edge - not `border_l_2()` inside the
+            // `when` below, which used to also silently recolour this row's own `border_b_1()`
+            // separator above (GPUI's `Style::border_color` is one shared value for every edge
+            // of a single element, not per-edge - confirmed directly in `gpui`'s own
+            // `style.rs`), and which only reserved its 2px of space *while* selected, shifting
+            // every row's content 2px right the instant it was clicked. See
+            // `crate::graph_view::render::AdeApp::render_graph_row`'s identical fix for the full
+            // reasoning - same bug, same shape, same fix.
+            .child(
+                div()
+                    .debug_selector({
+                        let path = file.path.clone();
+                        move || format!("change-row-{}-selection-edge", path.display())
+                    })
+                    .absolute()
+                    .left_0()
+                    .top_0()
+                    .bottom_0()
+                    .w(px(2.0))
+                    .bg(if selected {
+                        theme::border::SELECTED_EDGE.into()
+                    } else {
+                        work_surface::TRANSPARENT
+                    }),
+            )
+            .when(selected, |el| el.bg(theme::surface::ROW_SELECTED))
             .when(!selected, |el| {
                 el.hover(|el| el.bg(theme::surface::ROW_HOVER))
             })
@@ -3265,6 +3287,98 @@ mod virtualization_tests {
              GitHub issue #123's screenshot shows colliding with the scrollbar",
             header_button.right(),
             scrollbar.left(),
+        );
+    }
+}
+
+/// The reported "double border left and bottom" applied to the Changes panel's own rows - see
+/// `crate::graph_view::render::AdeApp::render_graph_row`'s own docs for the full GPUI
+/// `Style::border_color`-is-one-shared-value explanation this fix is built on.
+#[cfg(test)]
+mod change_row_selection_tests {
+    use super::*;
+    use crate::root::focus::palette_focus_tests;
+    use gpui::TestAppContext;
+    use std::process::Command;
+    use tempfile::TempDir;
+
+    fn git(dir: &std::path::Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .expect("failed to spawn git");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    /// Same real-diff shape `virtualization_tests::a_changes_row_far_below_the_viewport_is_never_painted`
+    /// already establishes (a real feature branch, so this hits `wt_core::diff::DiffBase::Diff`,
+    /// not `DiffBase::NoBase`'s uncommitted-vs-HEAD fallback).
+    #[gpui::test]
+    fn the_selection_edge_is_a_real_element_painted_regardless_of_selection(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = TempDir::new().expect("tempdir");
+        git(repo.path(), &["init", "-b", "main"]);
+        git(repo.path(), &["config", "user.email", "test@example.com"]);
+        git(repo.path(), &["config", "user.name", "Test User"]);
+        std::fs::write(repo.path().join("a.txt"), "base\n").expect("write");
+        git(repo.path(), &["add", "."]);
+        git(repo.path(), &["commit", "-m", "initial"]);
+        git(repo.path(), &["checkout", "-b", "feature"]);
+        std::fs::write(repo.path().join("a.txt"), "base\nchanged\n").expect("write");
+
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        app.update_in(cx, |app, window, cx| {
+            app.set_right_sidebar_view(RightSidebarView::Changes, window, cx);
+        });
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.current_diff().map(|d| d.files.len())),
+            Some(1),
+            "sanity check: the one real changed file must really be in the loaded diff"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.open_change.clone()),
+            None,
+            "premise: nothing is selected yet, so this genuinely exercises the unselected case"
+        );
+
+        let edge_unselected = cx.debug_bounds("change-row-a.txt-selection-edge").expect(
+            "the selection-edge child must be painted even while the row is unselected - if \
+             it's `None` here, the edge is still only created `.when(selected, ...)`, the exact \
+             regression this test exists to catch",
+        );
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_change_diff(std::path::PathBuf::from("a.txt"), window, cx);
+        });
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.open_change.clone()),
+            Some(std::path::PathBuf::from("a.txt")),
+            "sanity check: the row really is selected now"
+        );
+
+        let edge_selected = cx
+            .debug_bounds("change-row-a.txt-selection-edge")
+            .expect("the selection-edge child must still be painted while the row is selected");
+
+        assert_eq!(
+            edge_unselected.origin, edge_selected.origin,
+            "the selection edge's own position must never move - only its colour toggles \
+             (unselected: {:?}, selected: {:?})",
+            edge_unselected, edge_selected
+        );
+        assert_eq!(
+            edge_unselected.size, edge_selected.size,
+            "the selection edge's own size must never change (unselected: {:?}, selected: {:?})",
+            edge_unselected, edge_selected
         );
     }
 }


### PR DESCRIPTION
## Summary

Reported: selecting a row (git graph, Changes panel, review panel) painted a border on both its left edge and its own bottom separator, and the border shifted the row's content on click.

Root cause: GPUI's `Style::border_color` is a single value shared by every edge of one element (confirmed directly in `gpui`'s own `style.rs`). Rows using both `border_b_1()` (a permanent separator) and a conditional `border_l_2()` (the selection indicator) had the second `.border_color()` call silently overwrite the first - so a selected row's bottom separator flashed the selection colour too, and the border only reserved its 2px of space while selected, shifting content on click.

## Fix

Split the selection edge into a real, separate child element - the same pattern this app's tab strip already uses for its own underline indicator - applied to:
- `crates/app/src/graph_view/render.rs` (git graph rows)
- `crates/app/src/sidebar/render.rs` (Changes panel rows)
- `crates/app/src/review/render.rs` (review panel rows)

A fourth candidate (the rail's agent rows) was investigated and **not** changed: it has only one border edge (no colour collision) and toggled that edge's width between 1px/2px on selection, but a real test proved this never actually shifts the row's content in practice - the row isn't width-constrained the way the other three are. No fix shipped for a bug that couldn't be substantiated.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] New regression test per fixed site, each independently verified to fail without the fix (via revert-then-restore) and pass with it
- [x] `cargo test --workspace`: 2293 passed, 9 failed - all 9 in the known, pre-existing inotify-contention flaky class, not new regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)