### PR TITLE
feat(app): real native macOS menu bar

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -194,7 +194,16 @@ use gpui::{
 ///   five non-editor text-input surfaces (a filter row, a query field, a rename prompt) that
 ///   would need claiming there.
 pub fn default_key_bindings() -> Vec<gpui::KeyBinding> {
-    vec![
+    // GitHub issue #235: `cmd-q` (macOS only - appended below, not part of this literal list) is
+    // the one real exception to this function's own "no new global keybinding" discipline every
+    // entry above documents. macOS convention makes Quit's keyboard shortcut a near-mandatory
+    // affordance (unlike any of the other new menu commands issue #235 added, none of which have
+    // a keystroke of their own), and there is zero collision risk with a focused terminal/agent:
+    // `keystroke_to_bytes` (`crate::terminal::pane`) returns `None` for *any* keystroke with
+    // `modifiers.platform` set, so a real Cmd-modified key never reaches a pty in the first
+    // place - the same real fact `"cmd-k"`/`"cmd-c"`/`"cmd-v"` below already rely on for
+    // `TerminalClear`/`TerminalCopy`/`TerminalPaste`.
+    let mut bindings = vec![
         gpui::KeyBinding::new("secondary-n", root::NewAgent, None),
         // The palette's real shortcut, matching the VS Code/Sublime "command palette" convention
         // directly rather than reusing "secondary-k". "secondary-k" was the original binding, but
@@ -595,7 +604,10 @@ pub fn default_key_bindings() -> Vec<gpui::KeyBinding> {
             root::TerminalPaste,
             Some("terminal"),
         ),
-    ]
+    ];
+    #[cfg(target_os = "macos")]
+    bindings.push(gpui::KeyBinding::new("cmd-q", root::Quit, None));
+    bindings
 }
 
 /// The [`WindowOptions`] every ADE window opens with - both the one real window [`run`] itself
@@ -699,6 +711,27 @@ pub fn run(repo_path: Option<PathBuf>) {
             }
 
             cx.bind_keys(default_key_bindings());
+
+            // GitHub issue #235: the four macOS application-menu commands with no `AdeApp`/
+            // `Window` to run against (Quit must work even with no window focused, e.g. invoked
+            // from the Dock; Hide/Hide Others/Show All are pure `gpui::App`-level window-manager
+            // calls) - registered as real global `App`-level action listeners rather than on any
+            // one window's root, so they still fire with nothing focused at all. Every other real
+            // `MenuCommand` this issue added dispatches through a window-scoped `on_action` on
+            // `AdeApp`'s own root instead - see `crate::root::menu_commands`'s own docs for why
+            // these four are the one deliberate exception.
+            cx.on_action(|_: &root::Quit, cx| cx.quit());
+            cx.on_action(|_: &root::Hide, cx| cx.hide());
+            cx.on_action(|_: &root::HideOthers, cx| cx.hide_other_apps());
+            cx.on_action(|_: &root::ShowAll, cx| cx.unhide_other_apps());
+
+            // Must run after `bind_keys` above: `gpui::App::set_menus` reads the current
+            // `Keymap` right now to resolve each real item's own displayed key equivalent
+            // (`gpui_macos`'s menu-item construction reads `keymap.bindings_for_action`), so
+            // calling it first would install a menu with no keycap shown for anything
+            // `default_key_bindings` bound.
+            #[cfg(target_os = "macos")]
+            cx.set_menus(title_bar::native_menu::native_menus());
 
             let options = default_window_options(cx);
             let opened = cx.open_window(options, {

--- a/crates/app/src/root/menu_commands.rs
+++ b/crates/app/src/root/menu_commands.rs
@@ -1,0 +1,540 @@
+//! GitHub issue #235: the state-aware half of `crate::title_bar::menu_model::MenuCommand` - is a
+//! given command enabled right now ([`AdeApp::menu_command_enabled`]), and what does picking it
+//! actually do ([`AdeApp::perform_menu_command`]). `menu_model` itself is deliberately
+//! window/state-free (see that module's own docs for why); the two functions here are what layer
+//! real `AdeApp` state on top of its pure data, and they are the **only** place either question
+//! is answered - both the Windows/Linux in-window popover (`crate::title_bar::menu`) and the real
+//! macOS menu (`crate::title_bar::native_menu`) go through them rather than each keeping its own
+//! copy, so enablement and effect can never drift between the two surfaces.
+//!
+//! Every real effect in [`AdeApp::perform_menu_command`] is copied verbatim from the `on_click`
+//! closure the pre-issue-#235 popover already had for that same row - this file does not invent
+//! new behavior, it centralizes existing behavior so a second real caller (the native macOS menu)
+//! can reach it too.
+//!
+//! ## Enablement drives real `gpui` action availability, not just the popover's dimming
+//!
+//! [`Self::menu_command_enabled`] is also what gates whether this file's own `handle_*_menu_command`
+//! listeners are attached to the root element at all (see `impl Render for AdeApp` in
+//! `crate::root::mod`) - a command whose predicate is currently `false` has **no** `on_action`
+//! listener on the dispatch path this render, so `gpui::App::is_action_available` genuinely
+//! returns `false` for it. That is what lets the real macOS `NSMenu` grey the item out on its own
+//! (`gpui_macos`'s `on_validate_app_menu_command` calls exactly that), with no manual `disabled:`
+//! bookkeeping anywhere in `crate::title_bar::native_menu` - see that module's own docs.
+//!
+//! ## Not every command gets a `handle_*_menu_command` here
+//!
+//! Several [`MenuCommand`] variants reuse an already-existing `gpui::Action` that already has a
+//! real handler registered somewhere else in the tree, scoped to the surface that action is
+//! really about (`EditorSave`/`EditorCut`/`EditorCopy`/`EditorPaste`/`EditorSelectAll` on the
+//! code-surface container in `crate::code_surface::render`; `TextUndo`/`TextRedo` on every real
+//! text-input surface; `TogglePalette`/`ToggleSettings`/`NewTerminal`/`NewAgentPane` already
+//! unconditionally on this very root). Adding a *second*, root-level handler for one of those
+//! would either never fire (a more specific node's own handler already stops propagation first)
+//! or - worse - fire from a context that action was never meant to run in. Those commands'
+//! [`Self::perform_menu_command`] arm still calls the real handler directly (the popover's own
+//! click path, which never goes through `gpui` action dispatch at all - see that function's own
+//! docs), but they get **no** entry in the `handle_*_menu_command` methods below and **no** new
+//! `.on_action`/`.when(...)` registration in `impl Render for AdeApp` - their existing
+//! registration (already unconditional for `TogglePalette`/`ToggleSettings`, or already correctly
+//! scoped for the editor/text-input actions) is left exactly as it was. `NewTerminal`/
+//! `NewAgentPane` are the one pre-existing pair that *did* need a change - from unconditional to
+//! `.when(self.menu_command_enabled(...), ..)` - so `is_action_available` can genuinely reflect
+//! [`Self::menu_command_enabled`]; see the comment at that call site in `crate::root::mod`.
+use super::*;
+use crate::title_bar::menu_model::MenuCommand;
+
+impl AdeApp {
+    /// Whether `cmd` genuinely has something to do right now, using the exact same real
+    /// predicates the pre-issue-#235 popover rows already dimmed on (see each arm's own
+    /// commentary for which `crate::title_bar::menu` row it replaces). Commands with no real
+    /// precondition - opening a picker, opening Settings, closing this window, the application
+    /// menu's Hide/Show/Quit quartet - are always enabled, matching those rows' own `true` literal
+    /// today.
+    pub(crate) fn menu_command_enabled(&self, cmd: MenuCommand) -> bool {
+        match cmd {
+            MenuCommand::Save => self.active_edit_buffer().is_some(),
+            MenuCommand::Undo => self
+                .active_edit_buffer()
+                .is_some_and(|buffer| buffer.can_undo()),
+            MenuCommand::Redo => self
+                .active_edit_buffer()
+                .is_some_and(|buffer| buffer.can_redo()),
+            MenuCommand::Cut | MenuCommand::Copy | MenuCommand::Paste | MenuCommand::SelectAll => {
+                self.active_edit_buffer().is_some()
+            }
+            // The same `code_surface_showing` predicate `crate::title_bar::menu::view_menu_rows`
+            // computes today: Surface C (the File/Diff code view) must genuinely be on screen for
+            // a zoom level to mean anything.
+            MenuCommand::ZoomIn | MenuCommand::ZoomOut | MenuCommand::ResetZoom => {
+                self.open_change.is_some()
+                    && (self.open_diff_file_cache.is_some()
+                        || self.code_view == code_view::CodeView::File)
+            }
+            // GitHub issue #90: a genuinely empty window has no real repo root to spawn an agent
+            // into - see `crate::work_surface::render::AdeApp::new_agent`'s own docs.
+            MenuCommand::NewTerminal | MenuCommand::NewAgentPane => self.focused_repo().is_some(),
+            MenuCommand::NextAgent | MenuCommand::PreviousAgent => {
+                self.current_worktree_agents().count() > 1
+            }
+            MenuCommand::ArchiveAgent => self.agents.active_id().is_some(),
+            MenuCommand::KeepAllChanges => {
+                self.agents.active_id().is_some()
+                    && self.worktree_history_op_in_flight
+                        != Some(worktree_history::WorktreeHistoryOpKind::Keep)
+            }
+            MenuCommand::DiscardWorktree => {
+                self.agents.active_id().is_some()
+                    && self.worktree_history_op_in_flight
+                        != Some(worktree_history::WorktreeHistoryOpKind::Discard)
+            }
+            MenuCommand::OpenFile
+            | MenuCommand::OpenFolder
+            | MenuCommand::NewWindow
+            | MenuCommand::Settings
+            | MenuCommand::CloseWindow
+            | MenuCommand::CommandPalette
+            | MenuCommand::Documentation
+            | MenuCommand::ReportIssue
+            | MenuCommand::About
+            | MenuCommand::Hide
+            | MenuCommand::HideOthers
+            | MenuCommand::ShowAll
+            | MenuCommand::Quit => true,
+        }
+    }
+
+    /// Runs `cmd`'s real effect - the same call, in the same order, the pre-issue-#235 popover's
+    /// own `on_click` closure for that row already made. Never called for a `cmd` this instant's
+    /// [`Self::menu_command_enabled`] says is `false`: every real caller (the popover's row
+    /// `on_click`, and `handle_*_menu_command` below, itself only ever attached to the dispatch
+    /// tree while enabled) already guards on that first.
+    pub(crate) fn perform_menu_command(
+        &mut self,
+        cmd: MenuCommand,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        match cmd {
+            MenuCommand::OpenFile => {
+                self.title_menu_open = None;
+                self.open_palette(window, cx);
+                // `open_palette` always resets `palette_scope` to `PaletteScope::default()`, so
+                // this must be set after it returns, not before - see
+                // `crate::title_bar::menu::AdeApp::file_menu_rows`'s identical historical row for
+                // the same ordering requirement.
+                self.palette_scope = palette::PaletteScope::Files;
+                cx.notify();
+            }
+            MenuCommand::OpenFolder => {
+                self.title_menu_open = None;
+                self.start_choose_repo_folder(cx);
+                cx.notify();
+            }
+            MenuCommand::NewWindow => {
+                self.title_menu_open = None;
+                let options = crate::default_window_options(cx);
+                let settings = self.settings.clone();
+                let settings_path = self.settings_path.clone();
+                let opened = cx.open_window(options, move |window, cx| {
+                    cx.new(|cx| {
+                        AdeApp::new_with_settings(None, false, settings, settings_path, window, cx)
+                    })
+                });
+                if let Err(err) = opened {
+                    log::error!("failed to open a new ADE window: {err}");
+                }
+                cx.notify();
+            }
+            MenuCommand::Save => {
+                self.title_menu_open = None;
+                self.handle_editor_save_action(&EditorSave, window, cx);
+            }
+            MenuCommand::Settings => {
+                self.title_menu_open = None;
+                self.open_settings(window, cx);
+            }
+            MenuCommand::CloseWindow => {
+                // The real `Window::remove_window` the title bar's own close control (both the
+                // macOS dot and the Windows/Linux caption button) already calls - see
+                // `crate::title_bar::render::AdeApp::render_window_controls`'s own docs. This row
+                // was labelled "Quit" before issue #235; it never actually quit the app (see
+                // `MenuCommand::label`'s own docs for why it was renamed).
+                window.remove_window();
+            }
+            MenuCommand::Undo => {
+                self.title_menu_open = None;
+                self.perform_text_undo(cx);
+            }
+            MenuCommand::Redo => {
+                self.title_menu_open = None;
+                self.perform_text_redo(cx);
+            }
+            MenuCommand::Cut => {
+                self.title_menu_open = None;
+                self.handle_editor_cut_action(&EditorCut, window, cx);
+            }
+            MenuCommand::Copy => {
+                self.title_menu_open = None;
+                self.handle_editor_copy_action(&EditorCopy, window, cx);
+            }
+            MenuCommand::Paste => {
+                self.title_menu_open = None;
+                self.handle_editor_paste_action(&EditorPaste, window, cx);
+            }
+            MenuCommand::SelectAll => {
+                self.title_menu_open = None;
+                self.handle_editor_select_all_action(&EditorSelectAll, window, cx);
+            }
+            MenuCommand::CommandPalette => {
+                self.title_menu_open = None;
+                self.open_palette(window, cx);
+            }
+            MenuCommand::ZoomIn => self.zoom_in(cx),
+            MenuCommand::ZoomOut => self.zoom_out(cx),
+            MenuCommand::ResetZoom => self.reset_zoom(cx),
+            MenuCommand::NewTerminal => {
+                self.title_menu_open = None;
+                self.handle_new_terminal_action(&NewTerminal, window, cx);
+            }
+            MenuCommand::NewAgentPane => {
+                self.title_menu_open = None;
+                self.handle_new_agent_pane_action(&NewAgentPane, window, cx);
+            }
+            MenuCommand::NextAgent => {
+                self.title_menu_open = None;
+                self.select_relative_agent(1isize, window, cx);
+            }
+            MenuCommand::PreviousAgent => {
+                self.title_menu_open = None;
+                self.select_relative_agent(-1isize, window, cx);
+            }
+            MenuCommand::ArchiveAgent => {
+                if let Some(id) = self.agents.active_id() {
+                    self.title_menu_open = None;
+                    self.archive_agent(id, window, cx);
+                }
+            }
+            MenuCommand::KeepAllChanges => {
+                if let Some(id) = self.agents.active_id() {
+                    self.title_menu_open = None;
+                    self.keep_all_changes(id, cx);
+                }
+            }
+            MenuCommand::DiscardWorktree => {
+                if let Some(id) = self.agents.active_id() {
+                    self.request_discard_worktree(id, window, cx);
+                    // The first click only arms confirmation
+                    // (`AdeApp::discard_confirm_armed`) - keep the menu open so its own row can
+                    // swap to "confirm discard?" for a real second click, mirroring the agent
+                    // footer's identical two-step button and the pre-issue-#235 popover's own
+                    // `agent_menu_rows` handler for this exact row.
+                    if self.discard_confirm_armed != Some(id) {
+                        self.title_menu_open = None;
+                    }
+                    cx.notify();
+                }
+            }
+            MenuCommand::Documentation => {
+                self.title_menu_open = None;
+                cx.open_url("https://github.com/ColinEspinas/jerry#readme");
+                cx.notify();
+            }
+            MenuCommand::ReportIssue => {
+                self.title_menu_open = None;
+                cx.open_url("https://github.com/ColinEspinas/jerry/issues");
+                cx.notify();
+            }
+            MenuCommand::About => {
+                self.title_menu_open = None;
+                self.open_settings(window, cx);
+                self.select_settings_page(settings::SettingsPage::About, window, cx);
+            }
+            // The macOS application menu's own quartet - kept here purely so this `match` stays
+            // exhaustive and every command's real effect is documented in the one place this
+            // module's own docs promise, even though this arm is never actually reached in
+            // practice: `MenuCommand::app_menu_rows` (the only place these four appear in any
+            // menu) is only ever consumed by the macOS-only native menu
+            // (`crate::title_bar::native_menu`), never by the Windows/Linux popover, which is
+            // this function's only real caller. The real live path for these four is `crate::run`'s
+            // global `cx.on_action` listeners - registered at the `App` level (no `AdeApp`/`Window`
+            // in scope for a menu click with no window focused, e.g. Quit from the Dock menu),
+            // calling the exact same `gpui::App`/`Context` methods as here.
+            MenuCommand::Hide => cx.hide(),
+            MenuCommand::HideOthers => cx.hide_other_apps(),
+            MenuCommand::ShowAll => cx.unhide_other_apps(),
+            MenuCommand::Quit => cx.quit(),
+        }
+    }
+
+    // The `handle_*_menu_command` methods below are the real macOS-menu-reachable half of every
+    // `MenuCommand` that has no existing action handler anywhere else in the tree - see this
+    // module's own "Not every command gets a `handle_*_menu_command` here" docs for the commands
+    // deliberately excluded (they keep their own existing, correctly-scoped handler untouched).
+    // Each one is a one-line delegation to `Self::perform_menu_command`, registered on
+    // `impl Render for AdeApp`'s root element in `crate::root::mod` - unconditionally for a
+    // command `Self::menu_command_enabled` always reports `true` for, or behind
+    // `.when(self.menu_command_enabled(..), ..)` for one that can genuinely be disabled.
+
+    pub(crate) fn handle_open_file_menu_command(
+        &mut self,
+        _: &OpenFile,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.perform_menu_command(MenuCommand::OpenFile, window, cx);
+    }
+
+    pub(crate) fn handle_open_folder_menu_command(
+        &mut self,
+        _: &OpenFolder,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.perform_menu_command(MenuCommand::OpenFolder, window, cx);
+    }
+
+    pub(crate) fn handle_new_window_menu_command(
+        &mut self,
+        _: &NewWindow,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.perform_menu_command(MenuCommand::NewWindow, window, cx);
+    }
+
+    pub(crate) fn handle_close_window_menu_command(
+        &mut self,
+        _: &CloseWindow,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.perform_menu_command(MenuCommand::CloseWindow, window, cx);
+    }
+
+    pub(crate) fn handle_zoom_in_menu_command(
+        &mut self,
+        _: &ZoomIn,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.perform_menu_command(MenuCommand::ZoomIn, window, cx);
+    }
+
+    pub(crate) fn handle_zoom_out_menu_command(
+        &mut self,
+        _: &ZoomOut,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.perform_menu_command(MenuCommand::ZoomOut, window, cx);
+    }
+
+    pub(crate) fn handle_reset_zoom_menu_command(
+        &mut self,
+        _: &ResetZoom,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.perform_menu_command(MenuCommand::ResetZoom, window, cx);
+    }
+
+    pub(crate) fn handle_next_agent_menu_command(
+        &mut self,
+        _: &NextAgent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.perform_menu_command(MenuCommand::NextAgent, window, cx);
+    }
+
+    pub(crate) fn handle_previous_agent_menu_command(
+        &mut self,
+        _: &PreviousAgent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.perform_menu_command(MenuCommand::PreviousAgent, window, cx);
+    }
+
+    pub(crate) fn handle_archive_agent_menu_command(
+        &mut self,
+        _: &ArchiveAgent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.perform_menu_command(MenuCommand::ArchiveAgent, window, cx);
+    }
+
+    pub(crate) fn handle_keep_all_changes_menu_command(
+        &mut self,
+        _: &KeepAllChanges,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.perform_menu_command(MenuCommand::KeepAllChanges, window, cx);
+    }
+
+    pub(crate) fn handle_discard_worktree_menu_command(
+        &mut self,
+        _: &DiscardWorktree,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.perform_menu_command(MenuCommand::DiscardWorktree, window, cx);
+    }
+
+    pub(crate) fn handle_open_documentation_menu_command(
+        &mut self,
+        _: &OpenDocumentation,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.perform_menu_command(MenuCommand::Documentation, window, cx);
+    }
+
+    pub(crate) fn handle_report_issue_menu_command(
+        &mut self,
+        _: &ReportIssue,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.perform_menu_command(MenuCommand::ReportIssue, window, cx);
+    }
+
+    pub(crate) fn handle_about_menu_command(
+        &mut self,
+        _: &About,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.perform_menu_command(MenuCommand::About, window, cx);
+    }
+}
+
+#[cfg(test)]
+mod menu_command_tests {
+    use super::*;
+    use crate::root::focus::palette_focus_tests::open_test_app;
+    use gpui::TestAppContext;
+
+    /// `menu_command_enabled(Save)` must track real edit-buffer state: `false` with nothing
+    /// open, `true` once a real file is loaded into the File view.
+    #[gpui::test]
+    fn menu_command_enabled_save_tracks_the_real_active_edit_buffer(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let file_path = repo.path().join("notes.txt");
+        std::fs::write(&file_path, "hello\n").expect("write notes.txt");
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
+
+        assert!(
+            !app.read_with(cx, |app, _| app.menu_command_enabled(MenuCommand::Save)),
+            "Save must be disabled with nothing open"
+        );
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_file_view(file_path.clone(), window, cx);
+        });
+        cx.run_until_parked();
+
+        assert!(
+            app.read_with(cx, |app, _| app.menu_command_enabled(MenuCommand::Save)),
+            "Save must be enabled once a real file is open"
+        );
+    }
+
+    /// `menu_command_enabled(ZoomIn)` requires a real code surface actually on screen - `false`
+    /// in a genuinely empty window.
+    #[gpui::test]
+    fn menu_command_enabled_zoom_requires_a_real_code_surface(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
+
+        assert!(
+            !app.read_with(cx, |app, _| app.menu_command_enabled(MenuCommand::ZoomIn)),
+            "Zoom must be disabled with no code surface open"
+        );
+    }
+
+    /// `menu_command_enabled(ArchiveAgent)` requires a real active agent - `true` for
+    /// `open_test_app`'s own real initial shell agent, `false` once every agent has really been
+    /// archived (a genuinely reachable state, not a premise the test only imagines - `open_test_app`
+    /// opens a real repo, which `AdeApp::new_with_settings`'s own docs say always spawns one
+    /// initial shell agent, so "no active agent" has to be reached by really archiving it).
+    #[gpui::test]
+    fn menu_command_enabled_archive_agent_tracks_the_real_active_agent(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        let initial_id = app
+            .read_with(cx, |app, _| app.agents.active_id())
+            .expect("premise: open_test_app must really start with one active agent");
+        assert!(
+            app.read_with(cx, |app, _| app
+                .menu_command_enabled(MenuCommand::ArchiveAgent)),
+            "Archive Agent must be enabled with a real active agent"
+        );
+
+        app.update_in(cx, |app, window, cx| {
+            app.archive_agent(initial_id, window, cx);
+        });
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.agents.active_id()),
+            None,
+            "premise: archiving the only agent must really leave none active"
+        );
+        assert!(
+            !app.read_with(cx, |app, _| app
+                .menu_command_enabled(MenuCommand::ArchiveAgent)),
+            "Archive Agent must be disabled once every real agent has been archived"
+        );
+    }
+
+    /// A real `cx.dispatch_action(ZoomIn)` with a code surface genuinely on screen must reach
+    /// `Self::zoom_in` through the exact same path the native macOS menu's own "Zoom In" row
+    /// will dispatch through - not just a direct method call.
+    #[gpui::test]
+    fn dispatching_zoom_in_action_reaches_the_real_zoom_in_handler(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let file_path = repo.path().join("notes.rs");
+        std::fs::write(&file_path, "fn main() {}\n").expect("write notes.rs");
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_file_view(file_path.clone(), window, cx);
+        });
+        cx.run_until_parked();
+        assert!(
+            app.read_with(cx, |app, _| app.menu_command_enabled(MenuCommand::ZoomIn)),
+            "premise: a real code surface must be showing for Zoom In to be enabled"
+        );
+        let zoom_before = app.read_with(cx, |app, _| app.settings.appearance.editor_zoom_percent);
+
+        cx.dispatch_action(ZoomIn);
+        cx.run_until_parked();
+
+        assert!(
+            app.read_with(cx, |app, _| app.settings.appearance.editor_zoom_percent) > zoom_before,
+            "dispatching the real ZoomIn action must really increase the zoom level"
+        );
+    }
+
+    /// With no code surface showing, `is_action_available` for `ZoomIn` must genuinely be
+    /// `false` - the real signal the native macOS menu greys its own "Zoom In" row from, with no
+    /// separate `disabled:` bookkeeping.
+    #[gpui::test]
+    fn zoom_in_action_is_unavailable_with_no_code_surface_showing(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
+        let _ = app;
+
+        assert!(
+            !cx.update(|window, cx| window.is_action_available(&ZoomIn, cx)),
+            "ZoomIn must be unavailable with no code surface open, mirroring \
+             menu_command_enabled(ZoomIn)"
+        );
+    }
+}

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -86,6 +86,7 @@ use crate::status_bar::process_stats;
 use crate::text_history;
 use crate::theme;
 use crate::title_bar::menu as title_bar;
+use crate::title_bar::menu_model::MenuCommand;
 use crate::updater;
 use crate::work_surface::agents::{AgentId, Agents, ProcessKind};
 use crate::work_surface::state as work_surface;
@@ -198,6 +199,36 @@ actions!(
         TerminalClear,
         TerminalCopy,
         TerminalPaste,
+        // GitHub issue #235: a real macOS `NSApp.mainMenu`/`gpui::App::set_menus` menu, and the
+        // matching macOS application menu (Hide/Hide Others/Show All/Quit) that only a real
+        // `NSApp.mainMenu` can host. `crate::title_bar::menu_model::MenuCommand` is the shared
+        // source of truth that maps every one of these (plus the already-existing actions it
+        // reuses as-is - `EditorSave`, `ToggleSettings`, `TextUndo`, `TextRedo`, `EditorCut`,
+        // `EditorCopy`, `EditorPaste`, `EditorSelectAll`, `TogglePalette`, `NewTerminal`,
+        // `NewAgentPane`) onto a label, an optional keystroke spec, and a row position - so the
+        // Windows/Linux in-window popover (`crate::title_bar::menu`) and the real macOS menu
+        // (`crate::title_bar::native_menu`, a later revision) can never drift onto two different
+        // command sets. No `KeyBinding` is added alongside any of these here; the one real
+        // `cmd-q` binding this issue needs is added separately once `Quit` has a real handler.
+        OpenFile,
+        OpenFolder,
+        NewWindow,
+        CloseWindow,
+        Quit,
+        Hide,
+        HideOthers,
+        ShowAll,
+        ZoomIn,
+        ZoomOut,
+        ResetZoom,
+        NextAgent,
+        PreviousAgent,
+        ArchiveAgent,
+        KeepAllChanges,
+        DiscardWorktree,
+        OpenDocumentation,
+        ReportIssue,
+        About,
     ]
 );
 
@@ -2715,8 +2746,21 @@ impl Render for AdeApp {
             .on_action(cx.listener(Self::handle_toggle_palette_action))
             .on_action(cx.listener(Self::handle_toggle_settings_action))
             .on_action(cx.listener(Self::handle_goto_definition_action))
-            .on_action(cx.listener(Self::handle_new_terminal_action))
-            .on_action(cx.listener(Self::handle_new_agent_pane_action))
+            // GitHub issue #235: wrapped in `.when(...)` (rather than the unconditional
+            // registration every other `on_action` on this element uses) so
+            // `gpui::App::is_action_available` genuinely reports `false` for `NewTerminal`/
+            // `NewAgentPane` while `menu_command_enabled` says there's no focused repo to spawn
+            // into - the real macOS menu (`crate::title_bar::native_menu`) greys its own "New
+            // Terminal"/"New Agent Pane" rows off exactly that signal, with no separate
+            // `disabled:` bookkeeping of its own. `new_agent`/`new_agent_pane` already no-op
+            // internally on the same condition (see their own docs), so this changes what
+            // `is_action_available` reports, not what a keystroke or click actually does.
+            .when(self.menu_command_enabled(MenuCommand::NewTerminal), |el| {
+                el.on_action(cx.listener(Self::handle_new_terminal_action))
+            })
+            .when(self.menu_command_enabled(MenuCommand::NewAgentPane), |el| {
+                el.on_action(cx.listener(Self::handle_new_agent_pane_action))
+            })
             .on_action(cx.listener(Self::handle_new_git_graph_action))
             .on_action(cx.listener(Self::handle_next_changed_file_action))
             .on_action(cx.listener(Self::handle_jump_to_agent_1_action))
@@ -2731,6 +2775,47 @@ impl Render for AdeApp {
             .on_action(cx.listener(Self::handle_terminal_clear_action))
             .on_action(cx.listener(Self::handle_terminal_copy_action))
             .on_action(cx.listener(Self::handle_terminal_paste_action))
+            // GitHub issue #235: the `MenuCommand` variants with no existing handler anywhere
+            // else in the tree - see `crate::root::menu_commands`'s own "Not every command gets
+            // a `handle_*_menu_command` here" docs for the ones deliberately absent from this
+            // list (they keep whatever pre-existing registration already covers their reused
+            // action). Unconditional for a command `menu_command_enabled` always reports `true`
+            // for; `.when(...)` for one that can genuinely be disabled, so
+            // `gpui::App::is_action_available` reflects real state for the native macOS menu.
+            .on_action(cx.listener(Self::handle_open_file_menu_command))
+            .on_action(cx.listener(Self::handle_open_folder_menu_command))
+            .on_action(cx.listener(Self::handle_new_window_menu_command))
+            .on_action(cx.listener(Self::handle_close_window_menu_command))
+            .on_action(cx.listener(Self::handle_open_documentation_menu_command))
+            .on_action(cx.listener(Self::handle_report_issue_menu_command))
+            .on_action(cx.listener(Self::handle_about_menu_command))
+            .when(self.menu_command_enabled(MenuCommand::ZoomIn), |el| {
+                el.on_action(cx.listener(Self::handle_zoom_in_menu_command))
+            })
+            .when(self.menu_command_enabled(MenuCommand::ZoomOut), |el| {
+                el.on_action(cx.listener(Self::handle_zoom_out_menu_command))
+            })
+            .when(self.menu_command_enabled(MenuCommand::ResetZoom), |el| {
+                el.on_action(cx.listener(Self::handle_reset_zoom_menu_command))
+            })
+            .when(self.menu_command_enabled(MenuCommand::NextAgent), |el| {
+                el.on_action(cx.listener(Self::handle_next_agent_menu_command))
+            })
+            .when(
+                self.menu_command_enabled(MenuCommand::PreviousAgent),
+                |el| el.on_action(cx.listener(Self::handle_previous_agent_menu_command)),
+            )
+            .when(self.menu_command_enabled(MenuCommand::ArchiveAgent), |el| {
+                el.on_action(cx.listener(Self::handle_archive_agent_menu_command))
+            })
+            .when(
+                self.menu_command_enabled(MenuCommand::KeepAllChanges),
+                |el| el.on_action(cx.listener(Self::handle_keep_all_changes_menu_command)),
+            )
+            .when(
+                self.menu_command_enabled(MenuCommand::DiscardWorktree),
+                |el| el.on_action(cx.listener(Self::handle_discard_worktree_menu_command)),
+            )
             .child(self.render_title_bar(cx))
             // The Settings surface (`design_handoff_jerry_ade/README.md`: "a separate surface,
             // not a modal: it replaces the three zones while the title bar and status bar
@@ -4255,6 +4340,7 @@ mod repo_list_tests {
 pub(crate) mod caret_blink;
 pub(crate) mod focus;
 pub mod layout;
+pub(crate) mod menu_commands;
 pub(crate) mod menus;
 pub(crate) mod new_file;
 pub(crate) mod rem_scope;

--- a/crates/app/src/title_bar/menu.rs
+++ b/crates/app/src/title_bar/menu.rs
@@ -1,13 +1,15 @@
-//! The Windows/Linux title bar's five real `File Edit View Agent Help` dropdowns -
-//! which rows each one offers, and which already-existing real `AdeApp` method every row
-//! calls. Split out of [`super::render`] (the band's own chrome) because the two answer
-//! genuinely different questions: "what does the title bar look like" versus "what can I
-//! actually do from it".
+//! The Windows/Linux title bar's five real `File Edit View Agent Help` dropdowns - which rows
+//! each one offers, in the canonical order [`crate::title_bar::menu_model::MenuCommand::rows`]
+//! defines (GitHub issue #235's shared source of truth, also read by the real macOS menu,
+//! `crate::title_bar::native_menu`). Split out of [`super::render`] (the band's own chrome)
+//! because the two answer genuinely different questions: "what does the title bar look like"
+//! versus "what can I actually do from it".
 
 use super::*;
 #[cfg(test)]
 use crate::root::focus::palette_focus_tests;
 use crate::root::widgets::{menu_popover_chrome, render_menu_group_divider};
+use crate::title_bar::menu_model::{MenuCommand, MenuRow};
 use crate::work_surface::render::render_dropdown_menu_row;
 
 /// The Windows/Linux title bar's five real menu dropdowns (`File Edit View Agent Help`) - see
@@ -84,9 +86,9 @@ impl AdeApp {
     /// scrim closes the menu on any click outside it, and the popover itself is absolutely
     /// positioned directly off the open label's own painted bounds
     /// ([`AdeApp::title_menu_button_bounds`]) rather than a second, independently-computed
-    /// offset. Every row is a real [`render_dropdown_menu_row`] wired to a real, already-existing
-    /// `AdeApp` method via the matching `*_menu_rows` builder below - see each one's own docs for
-    /// which real method backs which row, and why.
+    /// offset. Every row is a real [`render_dropdown_menu_row`] built by [`Self::title_menu_rows`]
+    /// from [`crate::title_bar::menu_model::MenuCommand`] - the same shared model the real macOS
+    /// menu (`crate::title_bar::native_menu`, a later revision) reads too (GitHub issue #235).
     ///
     /// ## No new keybinding opens or drives this menu
     ///
@@ -108,13 +110,7 @@ impl AdeApp {
     ) -> gpui::AnyElement {
         let bounds = self.title_menu_button_bounds[menu.index()];
         let macos = self.window_controls_style().is_macos();
-        let rows = match menu {
-            TitleMenu::File => self.file_menu_rows(macos, cx),
-            TitleMenu::Edit => self.edit_menu_rows(macos, cx),
-            TitleMenu::View => self.view_menu_rows(cx),
-            TitleMenu::Agent => self.agent_menu_rows(macos, cx),
-            TitleMenu::Help => self.help_menu_rows(cx),
-        };
+        let rows = self.title_menu_rows(menu, macos, cx);
 
         div()
             .id("title-menu-scrim")
@@ -157,581 +153,301 @@ impl AdeApp {
         render_menu_group_divider()
     }
 
-    /// The File menu: open a file (the same real, files-scoped command palette the `+` menu's
-    /// own "Open file…" row opens), open a folder or a brand-new empty window (GitHub issue #90,
-    /// see [`Self::render_title_menu`]'s own row-by-row docs below), save the active file (real,
-    /// same handler `secondary-s` dispatches - a safe no-op with nothing dirty to save, per
-    /// [`crate::code_surface::editing::AdeApp::save_active_file`]'s own guard), open Settings, and quit
-    /// (the same real [`Window::remove_window`] the title bar's own close control uses).
-    fn file_menu_rows(&self, macos: bool, cx: &mut Context<Self>) -> Vec<gpui::AnyElement> {
-        let can_save = self.active_edit_buffer().is_some();
-        let mut save_row = render_dropdown_menu_row(
-            "S",
-            theme::text::DIM.into(),
-            theme::surface::CHIP_NEUTRAL.into(),
-            "Save",
-            "active file".to_string(),
-            keymap::resolve_combo("mod+s", macos),
-            can_save,
-        );
-        if can_save {
-            save_row = save_row.on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
-                this.title_menu_open = None;
-                this.handle_editor_save_action(&EditorSave, window, cx);
-                cx.notify();
+    /// The real row order for one of the five `File Edit View Agent Help` popovers -
+    /// [`MenuCommand::rows`]'s own canonical order (GitHub issue #235's shared source of truth,
+    /// see `crate::title_bar::menu_model`'s own docs), each turned into a real row by
+    /// [`Self::menu_command_row`]. Replaces what used to be five separately hand-written
+    /// `file_menu_rows`/`edit_menu_rows`/`view_menu_rows`/`agent_menu_rows`/`help_menu_rows`
+    /// builders, each of which duplicated this exact chip/label/sub-label/keystroke/enabled/
+    /// on_click shape by hand for every one of its own rows.
+    fn title_menu_rows(
+        &self,
+        menu: TitleMenu,
+        macos: bool,
+        cx: &mut Context<Self>,
+    ) -> Vec<gpui::AnyElement> {
+        MenuCommand::rows(menu)
+            .iter()
+            .map(|row| match row {
+                MenuRow::Separator => Self::render_title_menu_divider(),
+                MenuRow::Command(cmd) => self.menu_command_row(*cmd, macos, cx),
+            })
+            .collect()
+    }
+
+    /// One real row for `cmd`, in whichever popover [`Self::title_menu_rows`] is currently
+    /// building. Chip glyph/colors and sub-label come from [`Self::menu_command_chip`]/
+    /// [`Self::menu_command_sub_label`], except [`MenuCommand::NewAgentPane`]: its real chip/
+    /// sub-label depend on [`Self::resolved_new_agent_kind`] (which agent a fresh pane would
+    /// actually spawn right now, per `crate::work_surface::agent_tint`/`agent_initial`) rather
+    /// than anything the window-free `crate::title_bar::menu_model` could know statically, so
+    /// that one case is resolved here instead.
+    ///
+    /// Enablement and the row's real effect both come from `crate::root::menu_commands`
+    /// ([`AdeApp::menu_command_enabled`]/[`AdeApp::perform_menu_command`]) - the same two
+    /// functions the real macOS menu (`crate::title_bar::native_menu`, a later revision) uses, so
+    /// a row here can never show as enabled/disabled or do something different from what its
+    /// native-menu counterpart would. A disabled row gets no `on_click` at all (rather than one
+    /// that silently no-ops), matching [`render_dropdown_menu_row`]'s own enabled/disabled
+    /// contract every pre-issue-#235 row already followed.
+    fn menu_command_row(
+        &self,
+        cmd: MenuCommand,
+        macos: bool,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        let (chip_glyph, chip_fg, chip_bg, sub) = if cmd == MenuCommand::NewAgentPane {
+            let resolved_agent = self.resolved_new_agent_kind();
+            let resolved_kind = ProcessKind::from(resolved_agent);
+            let (agent_fg, agent_bg) = work_surface::agent_tint(resolved_kind);
+            let agent_initial = work_surface::agent_initial(resolved_kind);
+            (
+                agent_initial,
+                agent_fg,
+                agent_bg,
+                resolved_agent.label().to_string(),
+            )
+        } else {
+            let (glyph, fg, bg) = Self::menu_command_chip(cmd);
+            (glyph, fg, bg, self.menu_command_sub_label(cmd))
+        };
+        let label = self.menu_command_label(cmd);
+        let keys = cmd
+            .keystroke_spec()
+            .map(|spec| keymap::resolve_combo(spec, macos))
+            .unwrap_or_default();
+        let enabled = self.menu_command_enabled(cmd);
+
+        let mut row =
+            render_dropdown_menu_row(chip_glyph, chip_fg, chip_bg, label, sub, keys, enabled);
+        if enabled {
+            row = row.on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
+                this.perform_menu_command(cmd, window, cx);
             }));
         }
+        row.into_any_element()
+    }
 
-        vec![
-            render_dropdown_menu_row(
+    /// This command's real chip glyph/colors in the popover - the same literal glyph and
+    /// `theme::text::DIM`/`theme::surface::CHIP_NEUTRAL` (or, for the two command-style rows and
+    /// the one destructive row, their own distinct colors) every pre-issue-#235 `*_menu_rows`
+    /// builder already used for this exact row. [`MenuCommand::NewAgentPane`]'s real chip is
+    /// dynamic ([`Self::menu_command_row`] resolves it directly instead) - this arm, and the four
+    /// macOS-application-menu-only commands (the popover never renders a row for them at all, see
+    /// [`crate::title_bar::menu_model::MenuCommand::app_menu_rows`]'s own docs), are never
+    /// actually shown; kept only so this match stays total rather than reaching for a wildcard
+    /// that could silently start covering a real future command too.
+    fn menu_command_chip(cmd: MenuCommand) -> (&'static str, gpui::Rgba, gpui::Rgba) {
+        match cmd {
+            MenuCommand::OpenFile => (
                 "@",
                 theme::palette::COMMAND_CHIP.0.into(),
                 theme::palette::COMMAND_CHIP.1.into(),
-                "Open File\u{2026}",
-                "search this worktree".to_string(),
-                Vec::new(),
-                true,
-            )
-            .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
-                this.title_menu_open = None;
-                this.open_palette(window, cx);
-                // `open_palette` always resets `palette_scope` to `PaletteScope::default()`, so
-                // this must be set after it returns, not before - the same ordering
-                // `crate::work_surface::render::AdeApp::render_plus_menu`'s identical "Open
-                // file…" row already established.
-                this.palette_scope = palette::PaletteScope::Files;
-                cx.notify();
-            }))
-            .into_any_element(),
-            // GitHub issue #90's "Open Folder…" - a real native OS directory picker
-            // ([`AdeApp::start_choose_repo_folder`], the same `gpui::App::prompt_for_paths`
-            // shape `crate::settings::render::AdeApp::start_choose_icon_pack_folder` already
-            // uses), opening the chosen folder as a real, focused repo in *this* window - unlike
-            // the "New Window" row just below, which deliberately opens a brand-new, empty one.
-            // No keybinding (`Vec::new()` combo), matching this menu's own "Open File…" row just
-            // above: this app never binds a keystroke that could also be a plain character a
-            // focused terminal/agent needs, and this row isn't part of `crate::default_key_bindings`
-            // for that same reason.
-            render_dropdown_menu_row(
+            ),
+            MenuCommand::OpenFolder => (
                 "F",
                 theme::text::DIM.into(),
                 theme::surface::CHIP_NEUTRAL.into(),
-                "Open Folder\u{2026}",
-                "open a repository".to_string(),
-                Vec::new(),
-                true,
-            )
-            .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
-                this.title_menu_open = None;
-                this.start_choose_repo_folder(cx);
-                cx.notify();
-            }))
-            .into_any_element(),
-            // GitHub issue #90's "New Window" - a brand-new ADE window in a genuinely empty
-            // state (`AdeApp::new_with_settings`'s own `use_remembered_repo` docs), not this
-            // window's repo and deliberately not whatever folder was last remembered either - the
-            // issue's own wording is explicit that a new window starts empty. Shares
-            // `crate::default_window_options` with [`crate::run`]'s own real startup window, so
-            // the two can never silently drift apart on bounds/titlebar/decorations.
-            //
-            // Deliberately calls `AdeApp::new_with_settings` with *this* window's own already-
-            // loaded `self.settings`/`self.settings_path` - not `AdeApp::new`, which would re-run
-            // `settings_store::Settings::load_or_init()` from scratch. Two real reasons, not just
-            // one: the new window should show the exact settings/keymap/theme this one already
-            // has loaded rather than risk a second, independent disk read racing a concurrent
-            // edit; and `Settings::load_or_init` really does write a fresh default file to disk
-            // the first time it's ever called (`Settings::load_or_init_at`'s own docs) - firing
-            // that unconditionally from a menu click (including from a test that clicks this real
-            // row, per this codebase's own test rule that a test must never touch the real
-            // settings file - `crate::root::focus::palette_focus_tests::open_test_app`'s own
-            // docs) would be a real, surprising side effect a plain "open another window" click
-            // has no business causing.
-            render_dropdown_menu_row(
+            ),
+            MenuCommand::NewWindow => (
                 "N",
                 theme::text::DIM.into(),
                 theme::surface::CHIP_NEUTRAL.into(),
-                "New Window",
-                "empty window".to_string(),
-                Vec::new(),
-                true,
-            )
-            .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
-                this.title_menu_open = None;
-                let options = crate::default_window_options(cx);
-                let settings = this.settings.clone();
-                let settings_path = this.settings_path.clone();
-                let opened = cx.open_window(options, move |window, cx| {
-                    cx.new(|cx| {
-                        AdeApp::new_with_settings(None, false, settings, settings_path, window, cx)
-                    })
-                });
-                if let Err(err) = opened {
-                    log::error!("failed to open a new ADE window: {err}");
-                }
-                cx.notify();
-            }))
-            .into_any_element(),
-            Self::render_title_menu_divider(),
-            save_row.into_any_element(),
-            render_dropdown_menu_row(
+            ),
+            MenuCommand::Save => (
+                "S",
+                theme::text::DIM.into(),
+                theme::surface::CHIP_NEUTRAL.into(),
+            ),
+            MenuCommand::Settings => (
                 "P",
                 theme::text::DIM.into(),
                 theme::surface::CHIP_NEUTRAL.into(),
-                "Settings\u{2026}",
-                "preferences".to_string(),
-                keymap::resolve_combo("mod+,", macos),
-                true,
-            )
-            .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
-                this.title_menu_open = None;
-                this.open_settings(window, cx);
-            }))
-            .into_any_element(),
-            render_dropdown_menu_row(
+            ),
+            MenuCommand::CloseWindow => (
                 "\u{d7}",
                 theme::text::DIM.into(),
                 theme::surface::CHIP_NEUTRAL.into(),
-                "Quit",
-                "close window".to_string(),
-                Vec::new(),
-                true,
-            )
-            .on_click(cx.listener(|_this, _event: &ClickEvent, window, _cx| {
-                // The same real `Window::remove_window` the title bar's own close control (both
-                // the macOS dot and the Windows/Linux caption button) already calls - see
-                // `Self::render_window_controls`'s own docs.
-                window.remove_window();
-            }))
-            .into_any_element(),
-        ]
-    }
-
-    /// The Edit menu: real **text** `Undo`/`Redo` for whichever edit buffer is currently active
-    /// (GitHub issue #17, `crate::text_history`), then Cut/Copy/Paste/Select All against the real
-    /// active edit buffer (File view or merge hand-edit -
-    /// [`crate::code_surface::editing::AdeApp::active_edit_buffer`]), dimmed when there's no real
-    /// edit target right now.
-    ///
-    /// The text rows are dimmed, per [`crate::work_surface::render::render_dropdown_menu_row`]'s
-    /// own enabled/disabled convention, whenever there is genuinely nothing to undo or redo -
-    /// rather than looking exactly as actionable as a working row and silently doing nothing.
-    ///
-    /// Their sub-line says `"editor"`, not `"text"`, and that word is load-bearing: enablement
-    /// comes from [`crate::code_surface::editing::AdeApp::active_edit_buffer`], which only ever
-    /// resolves to an `EditBuffer` (the File view or the merge hand-edit surface). The app's five
-    /// single-line `crate::text_history::TextField` inputs - palette query, rail filter, Settings
-    /// keybindings filter, New file prompt, and the file tree's inline name editor - have real,
-    /// working undo histories of their own that
-    /// this menu genuinely cannot reach, so a row labelled `"text"` would sit permanently dimmed
-    /// while `mod+z` worked perfectly well inside them. Found by an independent adversarial audit.
-    /// Narrowing the label is the honest fix rather than routing the menu through whatever widget
-    /// happens to be focused: a menu click moves focus to the menu, so "the focused text widget"
-    /// is not a thing this row could resolve at click time anyway.
-    fn edit_menu_rows(&self, macos: bool, cx: &mut Context<Self>) -> Vec<gpui::AnyElement> {
-        let editing = self.active_edit_buffer().is_some();
-        let can_text_undo = self
-            .active_edit_buffer()
-            .is_some_and(|buffer| buffer.can_undo());
-        let can_text_redo = self
-            .active_edit_buffer()
-            .is_some_and(|buffer| buffer.can_redo());
-
-        let mut rows = vec![
-            {
-                let mut row = render_dropdown_menu_row(
-                    "U",
-                    theme::text::DIM.into(),
-                    theme::surface::CHIP_NEUTRAL.into(),
-                    "Undo",
-                    "editor".to_string(),
-                    keymap::resolve_combo("mod+z", macos),
-                    can_text_undo,
-                );
-                if can_text_undo {
-                    row = row.on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
-                        this.title_menu_open = None;
-                        this.perform_text_undo(cx);
-                    }));
-                }
-                row.into_any_element()
-            },
-            {
-                let mut row = render_dropdown_menu_row(
-                    "R",
-                    theme::text::DIM.into(),
-                    theme::surface::CHIP_NEUTRAL.into(),
-                    "Redo",
-                    "editor".to_string(),
-                    keymap::resolve_combo("mod+shift+z", macos),
-                    can_text_redo,
-                );
-                if can_text_redo {
-                    row = row.on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
-                        this.title_menu_open = None;
-                        this.perform_text_redo(cx);
-                    }));
-                }
-                row.into_any_element()
-            },
-            Self::render_title_menu_divider(),
-        ];
-
-        macro_rules! edit_action_row {
-            ($chip:expr, $label:expr, $sub:expr, $spec:expr, $handler:ident, $action:expr) => {{
-                let mut row = render_dropdown_menu_row(
-                    $chip,
-                    theme::text::DIM.into(),
-                    theme::surface::CHIP_NEUTRAL.into(),
-                    $label,
-                    $sub.to_string(),
-                    keymap::resolve_combo($spec, macos),
-                    editing,
-                );
-                if editing {
-                    row = row.on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
-                        this.title_menu_open = None;
-                        this.$handler($action, window, cx);
-                    }));
-                }
-                rows.push(row.into_any_element());
-            }};
-        }
-        edit_action_row!(
-            "X",
-            "Cut",
-            "selection",
-            "mod+x",
-            handle_editor_cut_action,
-            &EditorCut
-        );
-        edit_action_row!(
-            "C",
-            "Copy",
-            "selection",
-            "mod+c",
-            handle_editor_copy_action,
-            &EditorCopy
-        );
-        edit_action_row!(
-            "V",
-            "Paste",
-            "clipboard",
-            "mod+v",
-            handle_editor_paste_action,
-            &EditorPaste
-        );
-        edit_action_row!(
-            "A",
-            "Select All",
-            "active buffer",
-            "mod+a",
-            handle_editor_select_all_action,
-            &EditorSelectAll
-        );
-
-        rows
-    }
-
-    /// The View menu: the command palette, and the real code-surface zoom controls
-    /// ([`crate::code_surface::zoom::AdeApp::zoom_in`]/`zoom_out`/`reset_zoom` - the same ones
-    /// the Diff/File toolbar's own zoom group calls), dimmed while no file/diff view is actually
-    /// showing to zoom (the exact predicate
-    /// [`crate::code_surface::editing::AdeApp::active_edit_target`]'s own docs give for "Surface C is
-    /// genuinely on screen").
-    fn view_menu_rows(&self, cx: &mut Context<Self>) -> Vec<gpui::AnyElement> {
-        let code_surface_showing = self.open_change.is_some()
-            && (self.open_diff_file_cache.is_some() || self.code_view == code_view::CodeView::File);
-
-        let mut rows = vec![
-            render_dropdown_menu_row(
+            ),
+            MenuCommand::Undo => (
+                "U",
+                theme::text::DIM.into(),
+                theme::surface::CHIP_NEUTRAL.into(),
+            ),
+            MenuCommand::Redo => (
+                "R",
+                theme::text::DIM.into(),
+                theme::surface::CHIP_NEUTRAL.into(),
+            ),
+            MenuCommand::Cut => (
+                "X",
+                theme::text::DIM.into(),
+                theme::surface::CHIP_NEUTRAL.into(),
+            ),
+            MenuCommand::Copy => (
+                "C",
+                theme::text::DIM.into(),
+                theme::surface::CHIP_NEUTRAL.into(),
+            ),
+            MenuCommand::Paste => (
+                "V",
+                theme::text::DIM.into(),
+                theme::surface::CHIP_NEUTRAL.into(),
+            ),
+            MenuCommand::SelectAll => (
+                "A",
+                theme::text::DIM.into(),
+                theme::surface::CHIP_NEUTRAL.into(),
+            ),
+            MenuCommand::CommandPalette => (
                 "P",
                 theme::palette::COMMAND_CHIP.0.into(),
                 theme::palette::COMMAND_CHIP.1.into(),
-                "Command Palette",
-                "search everything".to_string(),
-                keymap::resolve_combo("mod+P", self.window_controls_style().is_macos()),
-                true,
-            )
-            .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
-                this.title_menu_open = None;
-                this.open_palette(window, cx);
-            }))
-            .into_any_element(),
-            Self::render_title_menu_divider(),
-        ];
-
-        macro_rules! zoom_row {
-            ($chip:expr, $label:expr, $sub:expr, $method:ident) => {{
-                let mut row = render_dropdown_menu_row(
-                    $chip,
-                    theme::text::DIM.into(),
-                    theme::surface::CHIP_NEUTRAL.into(),
-                    $label,
-                    $sub,
-                    Vec::new(),
-                    code_surface_showing,
-                );
-                if code_surface_showing {
-                    row = row.on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
-                        this.$method(cx);
-                    }));
-                }
-                rows.push(row.into_any_element());
-            }};
-        }
-        zoom_row!("+", "Zoom In", "code view".to_string(), zoom_in);
-        zoom_row!("\u{2212}", "Zoom Out", "code view".to_string(), zoom_out);
-        zoom_row!(
-            "0",
-            "Reset Zoom",
-            format!("{}%", self.settings.appearance.editor_zoom_percent),
-            reset_zoom
-        );
-
-        rows
-    }
-
-    /// The Agent menu: spawn a terminal or agent pane (the same two real actions the `+`
-    /// menu's own top two rows call), cycle the active agent tab
-    /// ([`crate::work_surface::render::AdeApp::select_relative_agent`]), and the real,
-    /// per-active-agent worktree-history actions - archive, "Keep all changes", and "Discard
-    /// worktree". The last two reuse the exact same real methods
-    /// ([`crate::worktree_history::flow::AdeApp::keep_all_changes`]/`request_discard_worktree`)
-    /// and the same busy/two-click-confirm state
-    /// ([`AdeApp::worktree_history_op_in_flight`]/[`AdeApp::discard_confirm_armed`]) the agent
-    /// footer's own buttons already use - a first click on "Discard worktree" only arms
-    /// confirmation and deliberately does **not** close the menu (so the row's own label can
-    /// swap to "confirm discard?" for a real second click); every other row closes the menu on
-    /// click, matching the `+` menu's own convention.
-    fn agent_menu_rows(&self, macos: bool, cx: &mut Context<Self>) -> Vec<gpui::AnyElement> {
-        let resolved_agent = self.resolved_new_agent_kind();
-        let resolved_kind = ProcessKind::from(resolved_agent);
-        let (agent_fg, agent_bg) = work_surface::agent_tint(resolved_kind);
-        let agent_initial = work_surface::agent_initial(resolved_kind);
-        let agent_label = resolved_agent.label();
-        // Scoped to the *currently selected worktree*'s own agents, matching
-        // `AdeApp::select_relative_agent`'s own real cycling scope (see that method's docs) -
-        // otherwise this row could show "enabled" while the real cycle it drives is a genuine
-        // no-op (or worse, silently jumps to a different worktree) whenever other worktrees have
-        // agents open but this one doesn't have a second one of its own.
-        let can_cycle = self.current_worktree_agents().count() > 1;
-        let active_id = self.agents.active_id();
-        // GitHub issue #90: a genuinely empty window has no real repo root to spawn a new agent
-        // into - see `crate::work_surface::render::AdeApp::new_agent`'s own docs for the real
-        // guard these two rows must agree with, and the concrete bug (a PTY silently spawned
-        // against a different, unopened repo) an independent audit found here.
-        let has_focused_repo = self.focused_repo().is_some();
-
-        let mut new_terminal_row = render_dropdown_menu_row(
-            "\u{276f}",
-            theme::text::DIM.into(),
-            theme::surface::CHIP_NEUTRAL.into(),
-            "New Terminal",
-            "in this worktree".to_string(),
-            keymap::resolve_combo("ctrl+shift+T", macos),
-            has_focused_repo,
-        );
-        if has_focused_repo {
-            new_terminal_row =
-                new_terminal_row.on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
-                    this.title_menu_open = None;
-                    this.handle_new_terminal_action(&NewTerminal, window, cx);
-                }));
-        }
-        let mut new_agent_pane_row = render_dropdown_menu_row(
-            agent_initial,
-            agent_fg,
-            agent_bg,
-            "New Agent Pane",
-            agent_label.to_string(),
-            keymap::resolve_combo("mod+shift+N", macos),
-            has_focused_repo,
-        );
-        if has_focused_repo {
-            new_agent_pane_row = new_agent_pane_row.on_click(cx.listener(
-                |this, _event: &ClickEvent, window, cx| {
-                    this.title_menu_open = None;
-                    this.handle_new_agent_pane_action(&NewAgentPane, window, cx);
-                },
-            ));
-        }
-
-        let mut rows = vec![
-            new_terminal_row.into_any_element(),
-            new_agent_pane_row.into_any_element(),
-            Self::render_title_menu_divider(),
-        ];
-
-        macro_rules! cyclic_row {
-            ($chip:expr, $label:expr, $delta:expr) => {{
-                let mut row = render_dropdown_menu_row(
-                    $chip,
-                    theme::text::DIM.into(),
-                    theme::surface::CHIP_NEUTRAL.into(),
-                    $label,
-                    "cycle tabs".to_string(),
-                    Vec::new(),
-                    can_cycle,
-                );
-                if can_cycle {
-                    row = row.on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
-                        this.title_menu_open = None;
-                        this.select_relative_agent($delta, window, cx);
-                    }));
-                }
-                rows.push(row.into_any_element());
-            }};
-        }
-        cyclic_row!("\u{203a}", "Next Agent", 1isize);
-        cyclic_row!("\u{2039}", "Previous Agent", -1isize);
-        rows.push(Self::render_title_menu_divider());
-
-        let mut archive_row = render_dropdown_menu_row(
-            "A",
-            theme::text::DIM.into(),
-            theme::surface::CHIP_NEUTRAL.into(),
-            "Archive Agent",
-            "close the active tab".to_string(),
-            Vec::new(),
-            active_id.is_some(),
-        );
-        if let Some(id) = active_id {
-            archive_row =
-                archive_row.on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
-                    this.title_menu_open = None;
-                    this.archive_agent(id, window, cx);
-                }));
-        }
-        rows.push(archive_row.into_any_element());
-
-        let keep_busy = self.worktree_history_op_in_flight
-            == Some(worktree_history::WorktreeHistoryOpKind::Keep);
-        let keep_label: &'static str = if keep_busy {
-            "keeping\u{2026}"
-        } else {
-            "Keep All Changes"
-        };
-        let mut keep_row = render_dropdown_menu_row(
-            "K",
-            theme::text::DIM.into(),
-            theme::surface::CHIP_NEUTRAL.into(),
-            keep_label,
-            "commit the active worktree".to_string(),
-            Vec::new(),
-            active_id.is_some() && !keep_busy,
-        );
-        if let Some(id) = active_id {
-            if !keep_busy {
-                keep_row = keep_row.on_click(cx.listener(
-                    move |this, _event: &ClickEvent, _window, cx| {
-                        this.title_menu_open = None;
-                        this.keep_all_changes(id, cx);
-                    },
-                ));
-            }
-        }
-        rows.push(keep_row.into_any_element());
-
-        let discard_busy = self.worktree_history_op_in_flight
-            == Some(worktree_history::WorktreeHistoryOpKind::Discard);
-        let discard_armed = active_id.is_some() && self.discard_confirm_armed == active_id;
-        let discard_label: &'static str = if discard_busy {
-            "discarding\u{2026}"
-        } else if discard_armed {
-            "confirm discard?"
-        } else {
-            "Discard Worktree"
-        };
-        let mut discard_row = render_dropdown_menu_row(
-            "D",
-            theme::diff::STAT_DEL.into(),
-            theme::surface::CHIP_NEUTRAL.into(),
-            discard_label,
-            "force-remove uncommitted content".to_string(),
-            Vec::new(),
-            active_id.is_some() && !discard_busy,
-        );
-        if let Some(id) = active_id {
-            if !discard_busy {
-                discard_row = discard_row.on_click(cx.listener(
-                    move |this, _event: &ClickEvent, window, cx| {
-                        this.request_discard_worktree(id, window, cx);
-                        // The first click only arms confirmation
-                        // (`AdeApp::discard_confirm_armed`) - keep the menu open so this row's
-                        // own label can swap to "confirm discard?" for a real second click,
-                        // mirroring the agent footer's identical two-step button
-                        // (`crate::work_surface::render::AdeApp::render_footer_action_button`).
-                        // Only the second click - which actually executes and clears the arm
-                        // flag - closes the menu.
-                        if this.discard_confirm_armed != Some(id) {
-                            this.title_menu_open = None;
-                        }
-                        cx.notify();
-                    },
-                ));
-            }
-        }
-        rows.push(discard_row.into_any_element());
-
-        rows
-    }
-
-    /// The Help menu: real links to this project's own GitHub repository (README and issue
-    /// tracker, opened via the real platform `Window`-manager call
-    /// `vendor/zed/crates/gpui/src/app.rs:1408`'s `App::open_url`), and About (the same real,
-    /// already-shipped Settings page - `crate::settings::state::SettingsPage::About` - the palette and
-    /// Settings' own nav already reach; still an honest nav-only placeholder page, per
-    /// `crate::settings::state`'s own module docs, but navigating there is exactly what the Settings
-    /// nav sidebar's own "About" row already does, not a new fabricated affordance).
-    fn help_menu_rows(&self, cx: &mut Context<Self>) -> Vec<gpui::AnyElement> {
-        vec![
-            render_dropdown_menu_row(
+            ),
+            MenuCommand::ZoomIn => (
+                "+",
+                theme::text::DIM.into(),
+                theme::surface::CHIP_NEUTRAL.into(),
+            ),
+            MenuCommand::ZoomOut => (
+                "\u{2212}",
+                theme::text::DIM.into(),
+                theme::surface::CHIP_NEUTRAL.into(),
+            ),
+            MenuCommand::ResetZoom => (
+                "0",
+                theme::text::DIM.into(),
+                theme::surface::CHIP_NEUTRAL.into(),
+            ),
+            MenuCommand::NewTerminal => (
+                "\u{276f}",
+                theme::text::DIM.into(),
+                theme::surface::CHIP_NEUTRAL.into(),
+            ),
+            MenuCommand::NextAgent => (
+                "\u{203a}",
+                theme::text::DIM.into(),
+                theme::surface::CHIP_NEUTRAL.into(),
+            ),
+            MenuCommand::PreviousAgent => (
+                "\u{2039}",
+                theme::text::DIM.into(),
+                theme::surface::CHIP_NEUTRAL.into(),
+            ),
+            MenuCommand::ArchiveAgent => (
+                "A",
+                theme::text::DIM.into(),
+                theme::surface::CHIP_NEUTRAL.into(),
+            ),
+            MenuCommand::KeepAllChanges => (
+                "K",
+                theme::text::DIM.into(),
+                theme::surface::CHIP_NEUTRAL.into(),
+            ),
+            MenuCommand::DiscardWorktree => (
+                "D",
+                theme::diff::STAT_DEL.into(),
+                theme::surface::CHIP_NEUTRAL.into(),
+            ),
+            MenuCommand::Documentation => (
                 "?",
                 theme::text::DIM.into(),
                 theme::surface::CHIP_NEUTRAL.into(),
-                "Documentation",
-                "README on GitHub".to_string(),
-                Vec::new(),
-                true,
-            )
-            .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
-                this.title_menu_open = None;
-                cx.open_url("https://github.com/ColinEspinas/jerry#readme");
-                cx.notify();
-            }))
-            .into_any_element(),
-            render_dropdown_menu_row(
+            ),
+            MenuCommand::ReportIssue => (
                 "!",
                 theme::text::DIM.into(),
                 theme::surface::CHIP_NEUTRAL.into(),
-                "Report an Issue",
-                "GitHub issues".to_string(),
-                Vec::new(),
-                true,
-            )
-            .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
-                this.title_menu_open = None;
-                cx.open_url("https://github.com/ColinEspinas/jerry/issues");
-                cx.notify();
-            }))
-            .into_any_element(),
-            Self::render_title_menu_divider(),
-            render_dropdown_menu_row(
+            ),
+            MenuCommand::About => (
                 "i",
                 theme::text::DIM.into(),
                 theme::surface::CHIP_NEUTRAL.into(),
-                "About",
-                "Jerry".to_string(),
-                Vec::new(),
-                true,
-            )
-            .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
-                this.title_menu_open = None;
-                this.open_settings(window, cx);
-                this.select_settings_page(settings::SettingsPage::About, window, cx);
-            }))
-            .into_any_element(),
-        ]
+            ),
+            MenuCommand::NewAgentPane
+            | MenuCommand::Hide
+            | MenuCommand::HideOthers
+            | MenuCommand::ShowAll
+            | MenuCommand::Quit => (
+                "?",
+                theme::text::DIM.into(),
+                theme::surface::CHIP_NEUTRAL.into(),
+            ),
+        }
+    }
+
+    /// This command's real sub-label in the popover - reused verbatim from the pre-issue-#235
+    /// `*_menu_rows` builders. [`MenuCommand::ResetZoom`]'s is the one dynamic case that isn't
+    /// [`MenuCommand::NewAgentPane`] (resolved by [`Self::menu_command_row`] instead): the real
+    /// current zoom percentage. The four macOS-application-menu-only commands have no popover row
+    /// to show a sub-label in at all - same "never actually reached" note as
+    /// [`Self::menu_command_chip`].
+    fn menu_command_sub_label(&self, cmd: MenuCommand) -> String {
+        match cmd {
+            MenuCommand::OpenFile => "search this worktree".to_string(),
+            MenuCommand::OpenFolder => "open a repository".to_string(),
+            MenuCommand::NewWindow => "empty window".to_string(),
+            MenuCommand::Save => "active file".to_string(),
+            MenuCommand::Settings => "preferences".to_string(),
+            MenuCommand::CloseWindow => "close window".to_string(),
+            MenuCommand::Undo | MenuCommand::Redo => "editor".to_string(),
+            MenuCommand::Cut | MenuCommand::Copy => "selection".to_string(),
+            MenuCommand::Paste => "clipboard".to_string(),
+            MenuCommand::SelectAll => "active buffer".to_string(),
+            MenuCommand::CommandPalette => "search everything".to_string(),
+            MenuCommand::ZoomIn | MenuCommand::ZoomOut => "code view".to_string(),
+            MenuCommand::ResetZoom => {
+                format!("{}%", self.settings.appearance.editor_zoom_percent)
+            }
+            MenuCommand::NewTerminal => "in this worktree".to_string(),
+            MenuCommand::NextAgent | MenuCommand::PreviousAgent => "cycle tabs".to_string(),
+            MenuCommand::ArchiveAgent => "close the active tab".to_string(),
+            MenuCommand::KeepAllChanges => "commit the active worktree".to_string(),
+            MenuCommand::DiscardWorktree => "force-remove uncommitted content".to_string(),
+            MenuCommand::Documentation => "README on GitHub".to_string(),
+            MenuCommand::ReportIssue => "GitHub issues".to_string(),
+            MenuCommand::About => "Jerry".to_string(),
+            MenuCommand::NewAgentPane
+            | MenuCommand::Hide
+            | MenuCommand::HideOthers
+            | MenuCommand::ShowAll
+            | MenuCommand::Quit => String::new(),
+        }
+    }
+
+    /// This command's real display label - [`MenuCommand::label`] for every command except the
+    /// two whose real label is a live status string (GitHub issue #235 preserves both dynamic
+    /// labels exactly as the pre-issue popover had them): [`MenuCommand::KeepAllChanges`] swaps
+    /// to `"keeping…"` mid-flight, and [`MenuCommand::DiscardWorktree`] swaps to `"discarding…"`
+    /// mid-flight or `"confirm discard?"` once armed by a first click - see
+    /// [`AdeApp::perform_menu_command`]'s own `DiscardWorktree` arm for the real arm/confirm
+    /// state machine this label mirrors.
+    fn menu_command_label(&self, cmd: MenuCommand) -> &'static str {
+        match cmd {
+            MenuCommand::KeepAllChanges => {
+                if self.worktree_history_op_in_flight
+                    == Some(worktree_history::WorktreeHistoryOpKind::Keep)
+                {
+                    "keeping\u{2026}"
+                } else {
+                    cmd.label()
+                }
+            }
+            MenuCommand::DiscardWorktree => {
+                let active_id = self.agents.active_id();
+                let discard_busy = self.worktree_history_op_in_flight
+                    == Some(worktree_history::WorktreeHistoryOpKind::Discard);
+                let discard_armed = active_id.is_some() && self.discard_confirm_armed == active_id;
+                if discard_busy {
+                    "discarding\u{2026}"
+                } else if discard_armed {
+                    "confirm discard?"
+                } else {
+                    cmd.label()
+                }
+            }
+            _ => cmd.label(),
+        }
     }
 }
 

--- a/crates/app/src/title_bar/menu_model.rs
+++ b/crates/app/src/title_bar/menu_model.rs
@@ -1,0 +1,422 @@
+//! The one shared, pure-data description of every real menu command the app offers through a
+//! `File Edit View Agent Help` menu - what [`MenuCommand::action`] it dispatches, what
+//! [`MenuCommand::label`] and [`MenuCommand::keystroke_spec`] it shows, and which
+//! [`MenuCommand::rows`]/[`MenuCommand::app_menu_rows`] order it appears in - consumed by both
+//! the Windows/Linux in-window popover ([`crate::title_bar::menu`]) and the real macOS
+//! `NSApp.mainMenu` (`crate::title_bar::native_menu`) so the two surfaces can never silently
+//! drift onto two different command sets (GitHub issue #235).
+//!
+//! Deliberately window-free: no `AdeApp`, no `Context`, no enablement predicate, no click
+//! handler. Those all need live app state this module has no access to (and, for `AdeApp`
+//! itself, importing it back here would be circular - `AdeApp` lives in `crate::root`, which is
+//! *above* `crate::title_bar` in the module tree). This module only answers "what commands exist
+//! and in what order" - `crate::root::menu_commands` layers "is this one enabled right now" and
+//! "what does clicking it actually do" on top, on `AdeApp` itself, not in here.
+//!
+//! ## One enum, one `ALL`, exhaustive matches - not parallel tables
+//!
+//! Same discipline as [`crate::root::menus::MenuSurface`]: a payload-free enum, an exhaustive
+//! `ALL` array in declaration order, and exhaustive `match`es in [`MenuCommand::action`],
+//! [`MenuCommand::label`], and [`MenuCommand::keystroke_spec`] rather than four separately
+//! declared arrays that happen to agree today. Adding a variant here is a compile error in all
+//! three matches until it's really given an action, a label, and a keystroke spec (even if that
+//! spec is `None`) - there is no way for a new command to end up with only some of the three.
+//!
+//! ## `#[allow(dead_code)]` covers only the macOS-only half
+//!
+//! [`MenuCommand::label`]/[`MenuCommand::keystroke_spec`]/[`MenuCommand::rows`] are read by
+//! `crate::title_bar::menu`'s popover on every platform. [`MenuCommand::action`] and
+//! [`MenuCommand::app_menu_rows`] are read only by `crate::title_bar::native_menu`, which is
+//! `#[cfg(target_os = "macos")]` - so on a Linux/Windows build those two genuinely have no call
+//! site at all, which is what this attribute covers. On macOS itself, nothing here is actually
+//! dead.
+#![allow(dead_code)]
+
+use crate::root;
+use crate::title_bar::menu::TitleMenu;
+use gpui::Action;
+
+/// One of the real commands behind the five `File Edit View Agent Help` menus and the macOS
+/// application menu (`Hide`/`Hide Others`/`Show All`/`Quit`). Every variant maps to exactly one
+/// already-existing or newly-added `gpui::Action` type via [`Self::action`] - never two variants
+/// sharing one action type, since that would mean disabling/dispatching one variant also
+/// disabled/dispatched the other.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum MenuCommand {
+    // File
+    OpenFile,
+    OpenFolder,
+    NewWindow,
+    Save,
+    Settings,
+    CloseWindow,
+    // Edit
+    Undo,
+    Redo,
+    Cut,
+    Copy,
+    Paste,
+    SelectAll,
+    // View
+    CommandPalette,
+    ZoomIn,
+    ZoomOut,
+    ResetZoom,
+    // Agent
+    NewTerminal,
+    NewAgentPane,
+    NextAgent,
+    PreviousAgent,
+    ArchiveAgent,
+    KeepAllChanges,
+    DiscardWorktree,
+    // Help
+    Documentation,
+    ReportIssue,
+    About,
+    // App menu (macOS only in practice - a real `NSApp.mainMenu` application-name submenu - but
+    // modeled here like every other command rather than carved out as a special case).
+    Hide,
+    HideOthers,
+    ShowAll,
+    Quit,
+}
+
+/// One row of a rendered menu: either a real, clickable [`MenuCommand`], or a plain visual
+/// divider between two groups of them. Kept separate from [`MenuCommand`] itself (rather than a
+/// `MenuCommand::Separator` variant) so [`MenuCommand::ALL`] only ever enumerates real,
+/// dispatchable commands - a separator is not a command a `TypeId` check or an `action()` call
+/// would make sense for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MenuRow {
+    Command(MenuCommand),
+    Separator,
+}
+
+impl MenuCommand {
+    /// Every real command, in declaration order. The three `match`es below
+    /// ([`Self::action`], [`Self::label`], [`Self::keystroke_spec`]) are exhaustive over this
+    /// same enum, so nothing here can silently end up with only some of the three - the same
+    /// guarantee [`crate::root::menus::MenuSurface::ALL`] gives its own two matches.
+    pub(crate) const ALL: [MenuCommand; 30] = [
+        MenuCommand::OpenFile,
+        MenuCommand::OpenFolder,
+        MenuCommand::NewWindow,
+        MenuCommand::Save,
+        MenuCommand::Settings,
+        MenuCommand::CloseWindow,
+        MenuCommand::Undo,
+        MenuCommand::Redo,
+        MenuCommand::Cut,
+        MenuCommand::Copy,
+        MenuCommand::Paste,
+        MenuCommand::SelectAll,
+        MenuCommand::CommandPalette,
+        MenuCommand::ZoomIn,
+        MenuCommand::ZoomOut,
+        MenuCommand::ResetZoom,
+        MenuCommand::NewTerminal,
+        MenuCommand::NewAgentPane,
+        MenuCommand::NextAgent,
+        MenuCommand::PreviousAgent,
+        MenuCommand::ArchiveAgent,
+        MenuCommand::KeepAllChanges,
+        MenuCommand::DiscardWorktree,
+        MenuCommand::Documentation,
+        MenuCommand::ReportIssue,
+        MenuCommand::About,
+        MenuCommand::Hide,
+        MenuCommand::HideOthers,
+        MenuCommand::ShowAll,
+        MenuCommand::Quit,
+    ];
+
+    /// The real `gpui::Action` this command dispatches - a fresh boxed instance every call,
+    /// matching every other `Box<dyn Action>` call site in this codebase (there is no reusable
+    /// singleton to hand back, since `gpui`'s dispatch APIs take ownership).
+    ///
+    /// Reuses the app's already-existing action types wherever one already means exactly this
+    /// (`Save` → [`root::EditorSave`], `CommandPalette` → [`root::TogglePalette`], and so on -
+    /// see this module's own docs for the full "don't duplicate" list) rather than adding a
+    /// second, redundant action type per command; only commands with no existing equivalent got
+    /// a brand new `actions!` entry in `crate::root`.
+    pub(crate) fn action(self) -> Box<dyn Action> {
+        match self {
+            MenuCommand::OpenFile => Box::new(root::OpenFile),
+            MenuCommand::OpenFolder => Box::new(root::OpenFolder),
+            MenuCommand::NewWindow => Box::new(root::NewWindow),
+            MenuCommand::Save => Box::new(root::EditorSave),
+            MenuCommand::Settings => Box::new(root::ToggleSettings),
+            MenuCommand::CloseWindow => Box::new(root::CloseWindow),
+            MenuCommand::Undo => Box::new(root::TextUndo),
+            MenuCommand::Redo => Box::new(root::TextRedo),
+            MenuCommand::Cut => Box::new(root::EditorCut),
+            MenuCommand::Copy => Box::new(root::EditorCopy),
+            MenuCommand::Paste => Box::new(root::EditorPaste),
+            MenuCommand::SelectAll => Box::new(root::EditorSelectAll),
+            MenuCommand::CommandPalette => Box::new(root::TogglePalette),
+            MenuCommand::ZoomIn => Box::new(root::ZoomIn),
+            MenuCommand::ZoomOut => Box::new(root::ZoomOut),
+            MenuCommand::ResetZoom => Box::new(root::ResetZoom),
+            MenuCommand::NewTerminal => Box::new(root::NewTerminal),
+            MenuCommand::NewAgentPane => Box::new(root::NewAgentPane),
+            MenuCommand::NextAgent => Box::new(root::NextAgent),
+            MenuCommand::PreviousAgent => Box::new(root::PreviousAgent),
+            MenuCommand::ArchiveAgent => Box::new(root::ArchiveAgent),
+            MenuCommand::KeepAllChanges => Box::new(root::KeepAllChanges),
+            MenuCommand::DiscardWorktree => Box::new(root::DiscardWorktree),
+            MenuCommand::Documentation => Box::new(root::OpenDocumentation),
+            MenuCommand::ReportIssue => Box::new(root::ReportIssue),
+            MenuCommand::About => Box::new(root::About),
+            MenuCommand::Hide => Box::new(root::Hide),
+            MenuCommand::HideOthers => Box::new(root::HideOthers),
+            MenuCommand::ShowAll => Box::new(root::ShowAll),
+            MenuCommand::Quit => Box::new(root::Quit),
+        }
+    }
+
+    /// This command's shared display label - reused verbatim from the labels
+    /// `crate::title_bar::menu`'s `*_menu_rows` builders already render, with exactly one
+    /// deliberate rename: the File menu's last row was labelled `"Quit"` (its sub-label already
+    /// said "close window" - it only ever really called `Window::remove_window`, never a real
+    /// app quit) and is now honestly labelled [`MenuCommand::CloseWindow`]'s `"Close Window"`.
+    /// The real app-wide quit only exists as [`MenuCommand::Quit`], on the macOS application
+    /// menu.
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            MenuCommand::OpenFile => "Open File\u{2026}",
+            MenuCommand::OpenFolder => "Open Folder\u{2026}",
+            MenuCommand::NewWindow => "New Window",
+            MenuCommand::Save => "Save",
+            MenuCommand::Settings => "Settings\u{2026}",
+            MenuCommand::CloseWindow => "Close Window",
+            MenuCommand::Undo => "Undo",
+            MenuCommand::Redo => "Redo",
+            MenuCommand::Cut => "Cut",
+            MenuCommand::Copy => "Copy",
+            MenuCommand::Paste => "Paste",
+            MenuCommand::SelectAll => "Select All",
+            MenuCommand::CommandPalette => "Command Palette",
+            MenuCommand::ZoomIn => "Zoom In",
+            MenuCommand::ZoomOut => "Zoom Out",
+            MenuCommand::ResetZoom => "Reset Zoom",
+            MenuCommand::NewTerminal => "New Terminal",
+            MenuCommand::NewAgentPane => "New Agent Pane",
+            MenuCommand::NextAgent => "Next Agent",
+            MenuCommand::PreviousAgent => "Previous Agent",
+            MenuCommand::ArchiveAgent => "Archive Agent",
+            MenuCommand::KeepAllChanges => "Keep All Changes",
+            MenuCommand::DiscardWorktree => "Discard Worktree",
+            MenuCommand::Documentation => "Documentation",
+            MenuCommand::ReportIssue => "Report an Issue",
+            MenuCommand::About => "About",
+            MenuCommand::Hide => "Hide Jerry",
+            MenuCommand::HideOthers => "Hide Others",
+            MenuCommand::ShowAll => "Show All",
+            MenuCommand::Quit => "Quit Jerry",
+        }
+    }
+
+    /// The `"mod+s"`-style spec `crate::keymap::resolve_combo` already turns into per-platform
+    /// keycap glyphs for the popover - reused verbatim from the specs `crate::title_bar::menu`
+    /// already passes it today. `None` for every command with no real keystroke behind it today,
+    /// including [`MenuCommand::Quit`]: the real `cmd-q` `gpui::KeyBinding` is added directly in
+    /// `crate::default_key_bindings` by a later revision, not synthesized from this spec string -
+    /// this function only covers combos [`crate::keymap::resolve_combo`] already renders for the
+    /// popover.
+    pub(crate) fn keystroke_spec(self) -> Option<&'static str> {
+        match self {
+            MenuCommand::Save => Some("mod+s"),
+            MenuCommand::Settings => Some("mod+,"),
+            MenuCommand::Undo => Some("mod+z"),
+            MenuCommand::Redo => Some("mod+shift+z"),
+            MenuCommand::Cut => Some("mod+x"),
+            MenuCommand::Copy => Some("mod+c"),
+            MenuCommand::Paste => Some("mod+v"),
+            MenuCommand::SelectAll => Some("mod+a"),
+            MenuCommand::CommandPalette => Some("mod+P"),
+            MenuCommand::NewTerminal => Some("ctrl+shift+T"),
+            MenuCommand::NewAgentPane => Some("mod+shift+N"),
+            MenuCommand::OpenFile
+            | MenuCommand::OpenFolder
+            | MenuCommand::NewWindow
+            | MenuCommand::CloseWindow
+            | MenuCommand::ZoomIn
+            | MenuCommand::ZoomOut
+            | MenuCommand::ResetZoom
+            | MenuCommand::NextAgent
+            | MenuCommand::PreviousAgent
+            | MenuCommand::ArchiveAgent
+            | MenuCommand::KeepAllChanges
+            | MenuCommand::DiscardWorktree
+            | MenuCommand::Documentation
+            | MenuCommand::ReportIssue
+            | MenuCommand::About
+            | MenuCommand::Hide
+            | MenuCommand::HideOthers
+            | MenuCommand::ShowAll
+            | MenuCommand::Quit => None,
+        }
+    }
+
+    /// The canonical row order for one of the five real `File Edit View Agent Help` menus -
+    /// reused row-for-row from `crate::title_bar::menu`'s own `*_menu_rows` builders, which this
+    /// becomes the shared source of truth for.
+    pub(crate) fn rows(menu: TitleMenu) -> &'static [MenuRow] {
+        use MenuRow::{Command, Separator};
+        match menu {
+            TitleMenu::File => &[
+                Command(MenuCommand::OpenFile),
+                Command(MenuCommand::OpenFolder),
+                Command(MenuCommand::NewWindow),
+                Separator,
+                Command(MenuCommand::Save),
+                Command(MenuCommand::Settings),
+                Command(MenuCommand::CloseWindow),
+            ],
+            TitleMenu::Edit => &[
+                Command(MenuCommand::Undo),
+                Command(MenuCommand::Redo),
+                Separator,
+                Command(MenuCommand::Cut),
+                Command(MenuCommand::Copy),
+                Command(MenuCommand::Paste),
+                Command(MenuCommand::SelectAll),
+            ],
+            TitleMenu::View => &[
+                Command(MenuCommand::CommandPalette),
+                Separator,
+                Command(MenuCommand::ZoomIn),
+                Command(MenuCommand::ZoomOut),
+                Command(MenuCommand::ResetZoom),
+            ],
+            TitleMenu::Agent => &[
+                Command(MenuCommand::NewTerminal),
+                Command(MenuCommand::NewAgentPane),
+                Separator,
+                Command(MenuCommand::NextAgent),
+                Command(MenuCommand::PreviousAgent),
+                Separator,
+                Command(MenuCommand::ArchiveAgent),
+                Command(MenuCommand::KeepAllChanges),
+                Command(MenuCommand::DiscardWorktree),
+            ],
+            TitleMenu::Help => &[
+                Command(MenuCommand::Documentation),
+                Command(MenuCommand::ReportIssue),
+                Separator,
+                Command(MenuCommand::About),
+            ],
+        }
+    }
+
+    /// The macOS application menu's own row order (the submenu under the app's own name, left of
+    /// `File`) - `About`, `Settings`, then the real `Hide`/`Hide Others`/`Show All`/`Quit` quartet
+    /// only a real `NSApp.mainMenu` can host at all (the Windows/Linux popover has no equivalent
+    /// surface for these four, since there is no window-manager-level "hide this app" concept to
+    /// wire them to there).
+    ///
+    /// The `Services` submenu that also belongs on this application menu
+    /// (`gpui::MenuItem::os_submenu`) is deliberately not represented as a [`MenuRow`] here: it
+    /// isn't a [`MenuCommand`] at all
+    /// (no label/keystroke/action of its own - the OS populates it), so
+    /// `crate::title_bar::native_menu::native_menus` (a later revision) inserts it directly
+    /// alongside these rows rather than this module inventing a `MenuRow` variant with no real
+    /// content behind it.
+    pub(crate) fn app_menu_rows() -> &'static [MenuRow] {
+        use MenuRow::{Command, Separator};
+        &[
+            Command(MenuCommand::About),
+            Separator,
+            Command(MenuCommand::Settings),
+            Separator,
+            Command(MenuCommand::Hide),
+            Command(MenuCommand::HideOthers),
+            Command(MenuCommand::ShowAll),
+            Separator,
+            Command(MenuCommand::Quit),
+        ]
+    }
+}
+
+#[cfg(test)]
+mod menu_model_tests {
+    use super::*;
+    use std::any::TypeId;
+    use std::collections::HashSet;
+
+    /// Every command must have something real to show - an empty label would be a silently
+    /// broken menu row.
+    #[test]
+    fn every_command_has_a_non_empty_label() {
+        for command in MenuCommand::ALL {
+            assert!(
+                !command.label().is_empty(),
+                "{command:?} must have a real, non-empty label"
+            );
+        }
+    }
+
+    /// No two commands may share one action type - if they did, disabling/dispatching one would
+    /// silently disable/dispatch the other too, since `gpui` keys enablement and dispatch off the
+    /// action's own `TypeId`.
+    #[test]
+    fn no_two_commands_share_the_same_action_type() {
+        let mut seen: HashSet<TypeId> = HashSet::new();
+        for command in MenuCommand::ALL {
+            let type_id = command.action().as_any().type_id();
+            assert!(
+                seen.insert(type_id),
+                "{command:?}'s action type is already used by another MenuCommand - two menu \
+                 rows must never share one action type"
+            );
+        }
+    }
+
+    /// Every real command must appear in at least one real menu - a command declared in
+    /// [`MenuCommand::ALL`] but never placed in any [`MenuCommand::rows`]/
+    /// [`MenuCommand::app_menu_rows`] would be permanently unreachable from any menu.
+    #[test]
+    fn every_command_appears_in_at_least_one_menu() {
+        let mut covered: HashSet<MenuCommand> = HashSet::new();
+        for menu in TitleMenu::ALL {
+            for row in MenuCommand::rows(menu) {
+                if let MenuRow::Command(command) = row {
+                    covered.insert(*command);
+                }
+            }
+        }
+        for row in MenuCommand::app_menu_rows() {
+            if let MenuRow::Command(command) = row {
+                covered.insert(*command);
+            }
+        }
+
+        for command in MenuCommand::ALL {
+            assert!(
+                covered.contains(&command),
+                "{command:?} is declared in MenuCommand::ALL but never appears in any real menu"
+            );
+        }
+    }
+
+    /// Regression pin for the File menu's exact row order -
+    /// `crate::title_bar::menu::title_menu_tests::nth_row_click_point`-style tests implicitly
+    /// depend on this order to compute a row's real click point, so a silent reorder here would
+    /// break them in a much more confusing way than this direct assertion does.
+    #[test]
+    fn file_menu_row_order_matches_the_popover() {
+        assert_eq!(
+            MenuCommand::rows(TitleMenu::File),
+            &[
+                MenuRow::Command(MenuCommand::OpenFile),
+                MenuRow::Command(MenuCommand::OpenFolder),
+                MenuRow::Command(MenuCommand::NewWindow),
+                MenuRow::Separator,
+                MenuRow::Command(MenuCommand::Save),
+                MenuRow::Command(MenuCommand::Settings),
+                MenuRow::Command(MenuCommand::CloseWindow),
+            ]
+        );
+    }
+}

--- a/crates/app/src/title_bar/mod.rs
+++ b/crates/app/src/title_bar/mod.rs
@@ -8,23 +8,30 @@
 //!   caption buttons, and the left/right cluster composition.
 //! - [`menu`] - the Windows/Linux `File Edit View Agent Help` dropdowns: which rows each
 //!   one offers and what real `AdeApp` method each row calls.
+//! - [`menu_model`] - the pure-data command model ([`menu_model::MenuCommand`],
+//!   [`menu_model::MenuRow`]) both [`menu`]'s popover and `native_menu`'s real macOS menu
+//!   render from, so the two can never silently offer two different command sets (GitHub issue
+//!   #235).
+//! - `native_menu` (macOS only) - the real `NSApp.mainMenu`, built from [`menu_model`] and
+//!   installed via `gpui::App::set_menus` in `crate::run`.
 //!
 //! Both glob-import this module (`use super::*`), which is why the shared imports they need
 //! live here rather than at the top of each file - the same convention `crate::root`
 //! established for its own submodules.
 
-use crate::code_surface::code_view;
 #[cfg(test)]
 use crate::code_surface::edit_buffer;
 use crate::keymap;
 #[cfg(test)]
 use crate::keymap::WindowControlsStyle;
+#[cfg(test)]
 use crate::palette::state as palette;
 use crate::rail::state::{self as rail, AgentRow};
 use crate::rail::status::Status;
 #[cfg(test)]
 use crate::rail::worktrees::WorktreeItem;
 use crate::root::*;
+#[cfg(test)]
 use crate::settings::state as settings;
 use crate::theme;
 use crate::title_bar::menu::TitleMenu;
@@ -44,4 +51,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 pub(crate) mod menu;
+pub(crate) mod menu_model;
+#[cfg(target_os = "macos")]
+pub(crate) mod native_menu;
 pub(crate) mod render;

--- a/crates/app/src/title_bar/native_menu.rs
+++ b/crates/app/src/title_bar/native_menu.rs
@@ -1,0 +1,148 @@
+//! GitHub issue #235: the real macOS `NSApp.mainMenu`, built via `gpui::App::set_menus` from the
+//! exact same shared model the Windows/Linux in-window popover already reads
+//! (`crate::title_bar::menu_model`) - so the two surfaces can never silently offer two different
+//! command sets. Only ever compiled on macOS (see this module's `#[cfg(target_os = "macos")]` in
+//! `crate::title_bar`'s own module declaration) - Windows/Linux keep the in-window popover as
+//! their only menu surface, which is the whole reason `crate::title_bar::menu` exists.
+//!
+//! ## No `disabled:` bookkeeping in here
+//!
+//! Every item built here leaves `disabled: false` - real enablement comes entirely from
+//! `crate::root::menu_commands::AdeApp::menu_command_enabled`, which gates whether that command's
+//! `on_action` listener is even attached to the focused window's dispatch tree (see that module's
+//! own docs). `gpui_macos`'s `on_validate_app_menu_command` calls `gpui::App::is_action_available`
+//! to decide what AppKit greys out, which reads exactly that - so this module never needs to
+//! recompute or mirror the predicate itself.
+use gpui::{Menu, MenuItem, SystemMenuType};
+
+use crate::title_bar::menu::TitleMenu;
+use crate::title_bar::menu_model::{MenuCommand, MenuRow};
+
+/// One real `MenuItem::Action` for `cmd`, built as the literal struct rather than through
+/// [`MenuItem::action`]'s own builder: that builder takes `impl Action` *by value* (one concrete
+/// action type), while [`MenuCommand::action`] hands back a `Box<dyn Action>` - it has to, since
+/// one function returning ~30 different concrete action types has no single concrete type to
+/// give back. `gpui::MenuItem::Action` is a public enum variant with public fields precisely so
+/// callers holding a `Box<dyn Action>` can still build one directly.
+fn menu_item_for(cmd: MenuCommand) -> MenuItem {
+    MenuItem::Action {
+        name: cmd.label().into(),
+        action: cmd.action(),
+        os_action: None,
+        checked: false,
+        disabled: false,
+    }
+}
+
+/// Turns one [`MenuCommand::rows`]/[`MenuCommand::app_menu_rows`] slice into the real
+/// `gpui::MenuItem` list a `gpui::Menu` renders.
+fn menu_items(rows: &[MenuRow]) -> Vec<MenuItem> {
+    rows.iter()
+        .map(|row| match row {
+            MenuRow::Separator => MenuItem::separator(),
+            MenuRow::Command(cmd) => menu_item_for(*cmd),
+        })
+        .collect()
+}
+
+/// The real menu bar `crate::run` hands to `gpui::App::set_menus`: the macOS application menu
+/// (the app's own name, left of `File`), then the five `File Edit View Agent Help` menus in the
+/// same order [`TitleMenu::ALL`] gives the Windows/Linux popover.
+///
+/// The application menu's `Services` submenu (`gpui::MenuItem::os_submenu`) is inserted here,
+/// not represented in [`MenuCommand::app_menu_rows`] at all - it isn't a real [`MenuCommand`] (no
+/// label/keystroke/action of its own; the OS populates its contents at runtime), so
+/// `menu_model` has no row for it to be. It's placed right after the Hide/Hide Others/Show All
+/// group and before the separator that leads into Quit - the conventional macOS application-menu
+/// position (see e.g. TextEdit.app's own application menu: About, Preferences, Services, Hide
+/// group, Quit).
+pub(crate) fn native_menus() -> Vec<Menu> {
+    let mut app_menu_items = menu_items(MenuCommand::app_menu_rows());
+    // `app_menu_rows()`'s own order is `About, sep, Settings, sep, Hide, HideOthers, ShowAll,
+    // sep, Quit` - nine entries, indices 0-8. `ShowAll` is index 6; Services goes right after it,
+    // before the separator (currently index 7) that leads into Quit.
+    debug_assert_eq!(
+        app_menu_items.len(),
+        9,
+        "MenuCommand::app_menu_rows changed shape - re-check where Services belongs"
+    );
+    app_menu_items.insert(
+        7,
+        MenuItem::os_submenu("Services", SystemMenuType::Services),
+    );
+
+    let mut menus = vec![Menu::new("Jerry").items(app_menu_items)];
+    for menu in TitleMenu::ALL {
+        menus.push(Menu::new(menu.label()).items(menu_items(MenuCommand::rows(menu))));
+    }
+    menus
+}
+
+#[cfg(test)]
+mod native_menu_tests {
+    use super::*;
+
+    /// `native_menus()` is real, static data - buildable with no live `App`/`Window` at all,
+    /// which is exactly why this is a plain `#[test]`, not a `#[gpui::test]`.
+    #[test]
+    fn native_menus_returns_the_application_menu_plus_all_five_real_menus() {
+        let menus = native_menus();
+        assert_eq!(
+            menus.len(),
+            6,
+            "the application menu plus File/Edit/View/Agent/Help"
+        );
+
+        assert_eq!(menus[0].name.as_ref(), "Jerry");
+        assert!(
+            !menus[0].items.is_empty(),
+            "the application menu must have real items"
+        );
+
+        let expected_names = ["File", "Edit", "View", "Agent", "Help"];
+        for (menu, expected_name) in menus[1..].iter().zip(expected_names) {
+            assert_eq!(menu.name.as_ref(), expected_name);
+            assert!(
+                !menu.items.is_empty(),
+                "{expected_name} must have real items"
+            );
+        }
+    }
+
+    /// The application menu's own two macOS-only affordances - a real Quit item, and a real
+    /// Services submenu inserted at the conventional position - not just a non-empty item list.
+    #[test]
+    fn the_application_menu_has_a_real_quit_item_and_a_services_submenu() {
+        let menus = native_menus();
+        let app_menu = &menus[0];
+
+        let has_quit = app_menu.items.iter().any(
+            |item| matches!(item, MenuItem::Action { name, .. } if name.as_ref() == "Quit Jerry"),
+        );
+        assert!(has_quit, "the application menu must have a real Quit item");
+
+        let has_services = app_menu
+            .items
+            .iter()
+            .any(|item| matches!(item, MenuItem::SystemMenu(_)));
+        assert!(
+            has_services,
+            "the application menu must have a real Services submenu"
+        );
+    }
+
+    /// Every real item count matches its `MenuCommand` source exactly - a stray extra/missing
+    /// row here would silently offer a different command set than the popover's own
+    /// `MenuCommand::rows`/`app_menu_rows`.
+    #[test]
+    fn every_menu_has_exactly_as_many_items_as_its_menu_command_rows() {
+        let menus = native_menus();
+        // The application menu has one extra real item (Services) beyond `app_menu_rows`' own
+        // count.
+        assert_eq!(menus[0].items.len(), MenuCommand::app_menu_rows().len() + 1);
+
+        for (menu, title_menu) in menus[1..].iter().zip(TitleMenu::ALL) {
+            assert_eq!(menu.items.len(), MenuCommand::rows(title_menu).len());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a real native macOS menu bar via `gpui::App::set_menus`, closing #235.

Previously the `File`/`Edit`/`View`/`Agent`/`Help` menus existed only as a custom in-window dropdown row that was deliberately never rendered on macOS (`render_title_bar` skips it `if macos`). On macOS there was no `NSApp.mainMenu` content at all — nothing showed up hovering the top edge in fullscreen, and nothing existed in windowed mode either.

## What changed

- **`title_bar::menu_model`** (new): pure-data `MenuCommand`/`MenuRow` — label, keystroke spec, action mapping, and canonical row order for every command across File/Edit/View/Agent/Help plus the macOS application menu (Hide/Hide Others/Show All/Quit). This is now the single source of truth shared by both surfaces, so the Windows/Linux popover and the native macOS menu can't silently drift onto two different command sets.
- **`root::menu_commands`** (new): `AdeApp::menu_command_enabled` / `perform_menu_command` — the one real place enablement and effect are decided, reused by both surfaces. Enablement gates whether each command's `on_action` is even attached to the window root, so `gpui::App::is_action_available` genuinely reflects state and AppKit greys out native items with no manual `disabled:` bookkeeping.
- **`title_bar::menu`**: the popover now builds every row from the shared model instead of five hand-written builders. The old File → "Quit" row (which only ever called `window.remove_window()`) is honestly relabeled "Close Window"; the real app-wide Quit now lives only on the macOS application menu.
- **`title_bar::native_menu`** (new, macOS only): builds the real `gpui::Menu` tree from the shared model and inserts the OS-populated Services submenu at the conventional position.
- **`lib.rs`**: wires `cx.set_menus(...)` after `bind_keys` (so keycaps resolve correctly), registers global `App`-level listeners for Quit/Hide/Hide Others/Show All (must work with no window focused), and adds the `cmd-q` keybinding, macOS-only.

New `gpui::Action`s: `OpenFile`, `OpenFolder`, `NewWindow`, `CloseWindow`, `Quit`, `Hide`, `HideOthers`, `ShowAll`, `ZoomIn`, `ZoomOut`, `ResetZoom`, `NextAgent`, `PreviousAgent`, `ArchiveAgent`, `KeepAllChanges`, `DiscardWorktree`, `OpenDocumentation`, `ReportIssue`, `About`.

## Testing

- `cargo build` / `cargo clippy -D warnings` / `cargo fmt --check` clean on the `app` crate
- Per-module tests green: `menu_model` 4/4, `menu_commands` 6/6, `title_bar::menu` 34/35 (the one failure is a pre-existing, unrelated flake confirmed on unmodified HEAD via `git stash`), `native_menu` 3/3
- Full `cargo test --workspace` left to CI

## Screenshots 

<img width="2560" height="1440" alt="Capture d’écran 2026-08-12 à 18 50 37" src="https://github.com/user-attachments/assets/0384333e-b00c-411f-84a8-3726d39e9443" />

## Follow-up

Filed #238 for a separate, verified `gpui`/`gpui_macos` limitation found while wiring this: native menu items have no way to get the OS-standard icon AppKit gives Hide/Hide Others/Show All/Zoom In/Zoom Out/Reset Zoom (`gpui::OsAction` has no Hide-family variants, and `gpui_macos` never sets an `NSImage` on any menu item) — out of scope here.

Closes #235
