### PR TITLE
fix(app): stop Claude Code notifications erasing the real hook facts (issue #239)

### DIFF
--- a/crates/app/src/hooks/event.rs
+++ b/crates/app/src/hooks/event.rs
@@ -98,9 +98,47 @@ pub enum HookFact {
     TurnFailed,
 }
 
+/// Whether an event is a real lifecycle **transition** or merely a **nudge** re-announcing a
+/// state the agent is already in.
+///
+/// This distinction is not cosmetic, and it was found empirically rather than reasoned about: a
+/// real `claude` 2.1.228 session emits `Notification` immediately *after* the lifecycle event that
+/// caused it, and every `Notification` message is one of a handful of fixed generic strings.
+/// Against [`crate::hooks::server::HookInbox`]'s "latest wins" rule that made every hook fact
+/// Jerry could ever show one of those constants:
+///
+/// - A real permission prompt fires `PermissionRequest` (carrying the real tool and its real
+///   argument - "Write needs permission: notes.txt") and then, milliseconds later, a
+///   `Notification` whose entire message is `"Claude needs your permission"`. The specific
+///   question this module carefully builds was overwritten before it could ever be rendered.
+/// - A finished turn fires `Stop` ([`HookFact::TurnEnded`], the turn boundary the whole review
+///   surface hangs off) and then, about a minute later, an `idle_prompt` `Notification`. That
+///   flipped every finished agent from `Review`/`Idle` back to `Ask` with the constant
+///   `"Claude is waiting for your input"` - erasing exactly the "a turn that ended is a review
+///   boundary" capability this phase exists to add, roughly one minute after it appeared.
+///
+/// Both were observed live against a real binary before this type existed. See
+/// [`crate::hooks::server::HookInbox::record`] for the rule that acts on it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EventKind {
+    /// A real lifecycle event: the agent moved from one state to another, and this report is the
+    /// whole truth about where it is now. Everything except `Notification`.
+    Transition,
+    /// A `Notification` that announces a *block* (`permission_prompt`, `agent_needs_input`,
+    /// `elicitation_dialog`). It may be the first Jerry hears of the block, so it can still move a
+    /// finished agent back to [`HookFact::NeedsInput`] - it just must not overwrite the richer
+    /// question a `PermissionRequest` already gave for the same block.
+    BlockedNudge,
+    /// The `idle_prompt` `Notification`: "you have not typed for a while". It carries no state at
+    /// all beyond what a turn boundary already said, so it must never overwrite one.
+    IdleNudge,
+}
+
 /// One parsed hook event, reduced to exactly what the rail row needs.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HookReport {
+    /// Whether this event is a real transition or a re-announcement - see [`EventKind`].
+    pub kind: EventKind,
     /// The state fact - see [`HookFact`].
     pub fact: HookFact,
     /// Trailing "what it is doing" text for a running row, roughly `"{tool}: {argument}"`, already
@@ -132,6 +170,7 @@ impl HookReport {
     /// have no text worth rendering (see the module docs on `last_assistant_message`).
     fn bare(fact: HookFact) -> HookReport {
         HookReport {
+            kind: EventKind::Transition,
             fact,
             activity: None,
             question: None,
@@ -246,6 +285,7 @@ pub fn parse(event_name: &str, payload: &[u8]) -> Option<HookReport> {
                 None => truncated(tool, ACTIVITY_MAX_CHARS),
             };
             Some(HookReport {
+                kind: EventKind::Transition,
                 fact: HookFact::Working,
                 activity,
                 question: None,
@@ -259,6 +299,7 @@ pub fn parse(event_name: &str, payload: &[u8]) -> Option<HookReport> {
         "PostToolUseFailure" => {
             let tool = value.get("tool_name").and_then(serde_json::Value::as_str)?;
             Some(HookReport {
+                kind: EventKind::Transition,
                 fact: HookFact::TurnFailed,
                 activity: truncated(tool, ACTIVITY_MAX_CHARS),
                 question: value
@@ -282,6 +323,7 @@ pub fn parse(event_name: &str, payload: &[u8]) -> Option<HookReport> {
                 None => truncated(&format!("{tool} needs permission"), QUESTION_MAX_CHARS),
             };
             Some(HookReport {
+                kind: EventKind::Transition,
                 fact: HookFact::NeedsInput,
                 activity: None,
                 question,
@@ -298,6 +340,12 @@ pub fn parse(event_name: &str, payload: &[u8]) -> Option<HookReport> {
                 return None;
             }
             Some(HookReport {
+                // `idle_prompt` is the one type that says nothing a turn boundary hasn't already
+                // said - see [`EventKind`] for the real behaviour this distinction was found in.
+                kind: match notification_type {
+                    "idle_prompt" => EventKind::IdleNudge,
+                    _ => EventKind::BlockedNudge,
+                },
                 fact: HookFact::NeedsInput,
                 activity: None,
                 question: value
@@ -311,6 +359,7 @@ pub fn parse(event_name: &str, payload: &[u8]) -> Option<HookReport> {
         "Stop" => Some(HookReport::bare(HookFact::TurnEnded)),
 
         "StopFailure" => Some(HookReport {
+            kind: EventKind::Transition,
             fact: HookFact::TurnFailed,
             activity: None,
             question: value
@@ -467,6 +516,71 @@ mod tests {
                 parse("Notification", payload.as_bytes()),
                 None,
                 "{informational} must not be treated as needing a human"
+            );
+        }
+    }
+
+    #[test]
+    fn a_notification_is_classified_as_a_nudge_and_every_lifecycle_event_as_a_transition() {
+        // The classification `crate::hooks::server::merge_nudge` acts on. Getting `idle_prompt`
+        // wrong here is what erased the review boundary one minute after every finished turn, and
+        // getting `permission_prompt` wrong is what replaced every real permission question with
+        // a constant - see `EventKind`'s own docs for both, observed live.
+        let notification = |kind: &str| {
+            let payload = format!(
+                r#"{{"hook_event_name":"Notification","notification_type":"{kind}","message":"m"}}"#
+            );
+            parse("Notification", payload.as_bytes())
+                .unwrap_or_else(|| panic!("{kind} must parse"))
+                .kind
+        };
+        assert_eq!(notification("idle_prompt"), EventKind::IdleNudge);
+        for blocking in [
+            "permission_prompt",
+            "agent_needs_input",
+            "elicitation_dialog",
+        ] {
+            assert_eq!(
+                notification(blocking),
+                EventKind::BlockedNudge,
+                "{blocking}"
+            );
+        }
+
+        for (event, payload) in [
+            ("SessionStart", r#"{"hook_event_name":"SessionStart"}"#),
+            (
+                "UserPromptSubmit",
+                r#"{"hook_event_name":"UserPromptSubmit"}"#,
+            ),
+            (
+                "PreToolUse",
+                r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"ls"}}"#,
+            ),
+            (
+                "PostToolUse",
+                r#"{"hook_event_name":"PostToolUse","tool_name":"Bash","tool_input":{"command":"ls"}}"#,
+            ),
+            (
+                "PostToolUseFailure",
+                r#"{"hook_event_name":"PostToolUseFailure","tool_name":"Bash","error":"exit 1"}"#,
+            ),
+            (
+                "PermissionRequest",
+                r#"{"hook_event_name":"PermissionRequest","tool_name":"Write","tool_input":{"file_path":"a.txt"}}"#,
+            ),
+            ("Stop", r#"{"hook_event_name":"Stop"}"#),
+            (
+                "StopFailure",
+                r#"{"hook_event_name":"StopFailure","error_message":"boom"}"#,
+            ),
+        ] {
+            let report =
+                parse(event, payload.as_bytes()).unwrap_or_else(|| panic!("{event} must parse"));
+            assert_eq!(
+                report.kind,
+                EventKind::Transition,
+                "{event} is a real lifecycle transition and must supersede whatever came before it"
             );
         }
     }

--- a/crates/app/src/hooks/integration_tests.rs
+++ b/crates/app/src/hooks/integration_tests.rs
@@ -370,3 +370,156 @@ fn jerry_s_settings_file_does_not_disable_the_user_s_own_hooks() {
         "and Jerry's own hooks must fire too - got {fired:?}"
     );
 }
+
+/// The end-to-end test that covers what a *user* does, through the objects a user's click really
+/// goes through: [`crate::root::AdeApp::new_agent`] (what the palette's "New Claude agent", the
+/// Agent menu and the rail's "+" all call), a real
+/// [`crate::work_surface::agents::Agents::spawn`], a real pty, a real `claude`, and a real
+/// [`crate::hooks::HookRuntime`] brought up by the real lazy `hook_injection_for` gate - then
+/// asserts the fact comes back out of the app's own runtime under that agent's own real id.
+///
+/// The tests above this one hand-assemble the `--settings` argument and the `JERRY_*` environment
+/// from the production helpers and hand them to a `std::process::Command`. That pins Claude
+/// Code's half of the contract and nothing at all of Jerry's: every step between a click and the
+/// child process - the lazy runtime bring-up, the Claude-only gate, whether the `AgentId` in the
+/// environment is the one the rail reads back, `ProcessKind::spec`, `TerminalSpec::env`,
+/// `pty_core`'s `CommandBuilder` - is skipped by all of them. This one skips none of it, which is
+/// the whole reason it exists: a regression anywhere along that chain would leave every other
+/// test in this file green.
+#[gpui::test]
+fn a_claude_agent_spawned_through_the_real_app_path_really_reports_its_hooks(
+    cx: &mut gpui::TestAppContext,
+) {
+    if !cfg!(unix) {
+        return;
+    }
+    if real_claude().is_none() {
+        skip_or_fail("no `claude` binary on PATH - the real spawn path cannot be exercised");
+        return;
+    }
+
+    let repo = tempfile::tempdir().expect("tempdir");
+    let (app, cx) =
+        crate::root::focus::palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+
+    let (id, pane) = app.update_in(cx, |app, window, cx| {
+        app.new_agent(ProcessKind::claude(), window, cx);
+        let agent = app
+            .agents
+            .iter()
+            .last()
+            .expect("the agent `new_agent` just spawned");
+        (agent.id, agent.pane.clone())
+    });
+    cx.run_until_parked();
+
+    // The real command line and environment this spawn produced - asserted from the pane the app
+    // itself built, not from a reconstruction of what it ought to have built.
+    let spec = pane.read_with(cx, |pane, _| pane.spec_for_test().clone());
+    assert_eq!(spec.program, std::path::PathBuf::from("claude"));
+    assert_eq!(
+        spec.args.first().map(String::as_str),
+        Some("--settings"),
+        "a real Claude spawn must carry the generated settings file, got {:?}",
+        spec.args
+    );
+    let settings_path = std::path::PathBuf::from(&spec.args[1]);
+    assert!(
+        settings_path.is_file(),
+        "the settings path handed to `claude` must really exist on disk: {}",
+        settings_path.display()
+    );
+    assert!(
+        settings_path
+            .with_file_name("jerry-hook-forwarder.sh")
+            .is_file(),
+        "the forwarder script the settings file names must really exist"
+    );
+    let injected: std::collections::HashMap<&str, &str> = spec
+        .env
+        .iter()
+        .map(|(key, value)| (key.as_str(), value.as_str()))
+        .collect();
+    assert_eq!(
+        injected.get(AGENT_ENV).copied(),
+        Some(id.to_string().as_str()),
+        "the environment must name the same agent id the rail reads this agent's status back under"
+    );
+    assert!(injected.contains_key(PORT_ENV) && injected.contains_key(TOKEN_ENV));
+    assert!(
+        app.read_with(cx, |app, _| app.hook_runtime.is_some()),
+        "the lazy runtime must have been brought up by this spawn"
+    );
+
+    // Claude Code will not start a session in a directory it has never seen until a human answers
+    // "do you trust this folder?", and until it does, *no hook fires at all*. Jerry's whole
+    // product is spawning agents into freshly created worktrees, so that screen is the normal
+    // first thing a real agent shows, not an edge case. Answer it with a real keystroke on the
+    // real pane, exactly as a user does.
+    fn pump(cx: &mut gpui::VisualTestContext, rounds: usize) {
+        for _ in 0..rounds {
+            cx.background_executor
+                .advance_clock(Duration::from_millis(50));
+            cx.run_until_parked();
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while Instant::now() < deadline {
+        pump(cx, 10);
+        let asking = pane.read_with(cx, |pane, _| {
+            pane.visible_text_lines()
+                .iter()
+                .any(|line| line.contains("trust this folder"))
+        });
+        if asking {
+            cx.simulate_keystrokes("enter");
+            pump(cx, 10);
+            break;
+        }
+    }
+
+    // `SessionStart` fires as soon as the session really starts, so nothing has to be typed.
+    let started = Instant::now();
+    let mut fact = None;
+    while started.elapsed() < Duration::from_secs(90) && fact.is_none() {
+        pump(cx, 4);
+        fact = app.read_with(cx, |app, _| {
+            app.hook_runtime
+                .as_ref()
+                .and_then(|runtime| runtime.signal_for(id).fact)
+        });
+    }
+
+    if fact.is_none() {
+        // A sandbox with no credentials can't start a session at all - the same "`claude` is
+        // installed but unusable here" case the tests above tolerate. Reported, never silently
+        // passed off as a green run.
+        let screen = pane.read_with(cx, |pane, _| pane.visible_text_lines().join("\n"));
+        app.update_in(cx, |app, window, cx| app.close_agent(id, window, cx));
+        skip_or_fail(&format!(
+            "the installed `claude` never started a session through the real spawn path; the \
+             pane showed:\n{}",
+            screen.trim()
+        ));
+        return;
+    }
+
+    assert_eq!(
+        fact,
+        Some(HookFact::Working),
+        "a session that has really started reports itself as working"
+    );
+    // And the real session id GitHub issue #227's resume path needs comes back the same way.
+    assert!(
+        app.read_with(cx, |app, _| app
+            .hook_runtime
+            .as_ref()
+            .and_then(|runtime| runtime.session_id_for(id))
+            .is_some()),
+        "the real Claude Code session id must reach the app through the real path too"
+    );
+
+    app.update_in(cx, |app, window, cx| app.close_agent(id, window, cx));
+    cx.run_until_parked();
+}

--- a/crates/app/src/hooks/server.rs
+++ b/crates/app/src/hooks/server.rs
@@ -58,7 +58,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use crate::hooks::event::{self, HookReport, MAX_PAYLOAD_BYTES};
+use crate::hooks::event::{self, HookFact, HookReport, MAX_PAYLOAD_BYTES};
 use crate::work_surface::agents::AgentId;
 
 /// How long a single blocking read may wait for *some* data to arrive.
@@ -147,6 +147,13 @@ pub struct HookRecord {
 /// pinning a row to "Failed": the very next `PreToolUse` overwrites it. A failure only *stays*
 /// visible if the agent produced no further events after it, which is exactly the case where a
 /// human really does want to know something broke and nothing has happened since.
+///
+/// The one real exception - found by watching a live session rather than by reading the docs - is
+/// that not every hook event *is* a transition. A `Notification` is Claude Code re-announcing a
+/// state it has already reported precisely, with a fixed generic message, so under a literal
+/// "latest wins" it destroyed the better fact that had arrived moments earlier. See
+/// [`merge_nudge`] and [`event::EventKind`] for the two bugs that caused and for the rule that
+/// replaced it.
 #[derive(Debug, Default)]
 pub struct HookInbox {
     latest: HashMap<AgentId, HookRecord>,
@@ -161,6 +168,13 @@ impl HookInbox {
     /// Records a freshly parsed event as `id`'s current state, evicting the oldest entry if that
     /// would push the inbox past [`MAX_TRACKED_AGENTS`].
     ///
+    /// "Latest wins" holds for real lifecycle *transitions* only. A `Notification`
+    /// ([`event::EventKind::BlockedNudge`]/[`event::EventKind::IdleNudge`]) is Claude Code
+    /// re-announcing a state it has already reported through a precise event, and is folded into
+    /// what Jerry already knows rather than replacing it - see [`merge_nudge`] and
+    /// [`event::EventKind`] for the two real, live-observed bugs that came from treating them as
+    /// equals.
+    ///
     /// The cap exists because the id in a request is not checked against the set of live agents -
     /// the listener has no view of that, and adding one would couple it to `AdeApp` state behind
     /// a lock it would then hold on every request. So a client that knows the token (see the
@@ -169,6 +183,15 @@ impl HookInbox {
     /// the real agents - the ones actually emitting events - and sheds invented ids that never
     /// report again.
     pub fn record(&mut self, id: AgentId, report: HookReport) {
+        // Only a *fresh* previous record is worth folding into: past the TTL the rail has already
+        // stopped believing it (see `crate::rail::status::HookSignal::fresh`), so a nudge is then
+        // the only real evidence there is and must stand on its own.
+        let report = match self.latest.get(&id) {
+            Some(previous) if previous.received_at.elapsed() < event::HOOK_SIGNAL_TTL => {
+                merge_nudge(&previous.report, report)
+            }
+            _ => report,
+        };
         if self.latest.len() >= MAX_TRACKED_AGENTS && !self.latest.contains_key(&id) {
             if let Some(oldest) = self
                 .latest
@@ -192,6 +215,60 @@ impl HookInbox {
     /// [`AgentId`] can never inherit a dead agent's status.
     pub fn forget(&mut self, id: AgentId) {
         self.latest.remove(&id);
+    }
+}
+
+/// Folds a `Notification` into the fact Jerry already holds for the same agent, returning the
+/// report that should actually be stored.
+///
+/// A real lifecycle transition is returned untouched - it is the whole truth about where the agent
+/// now is, and it supersedes everything before it. A `Notification` is not: Claude Code emits one
+/// *because of* an event it has already reported, with a fixed generic message, so taken as an
+/// equal it destroys strictly better information. Both of these were observed live against a real
+/// `claude` 2.1.228 driven through Jerry's own spawn path:
+///
+/// - `PermissionRequest` ("Write needs permission: notes.txt") followed milliseconds later by a
+///   `permission_prompt` `Notification` ("Claude needs your permission"). Every permission
+///   question the rail could ever show was that one constant, and the real per-tool question this
+///   codebase parses was unreachable in practice.
+/// - `Stop` ([`HookFact::TurnEnded`] - the review boundary) followed about a minute later by an
+///   `idle_prompt` `Notification`, which flipped the finished agent to `Ask` and erased the
+///   review-ready state phase 2 exists to produce.
+///
+/// So: a nudge keeps the previous fact whenever the previous fact already *implies* it, and only
+/// takes over when it genuinely carries news.
+fn merge_nudge(previous: &HookReport, incoming: HookReport) -> HookReport {
+    let keep_previous = match incoming.kind {
+        // Not a nudge at all.
+        event::EventKind::Transition => false,
+        // A block Jerry may not have heard about yet: it must still be able to move a working or
+        // finished agent to "needs you". The one thing it may not do is overwrite the specific
+        // question a `PermissionRequest` gave for the very block it is announcing.
+        event::EventKind::BlockedNudge => previous.fact == HookFact::NeedsInput,
+        // "You have not typed for a while" - true of every agent that is blocked or done, and
+        // news about neither.
+        event::EventKind::IdleNudge => matches!(
+            previous.fact,
+            HookFact::NeedsInput | HookFact::TurnEnded | HookFact::TurnFailed
+        ),
+    };
+    if !keep_previous {
+        return incoming;
+    }
+    HookReport {
+        kind: incoming.kind,
+        fact: previous.fact,
+        activity: previous.activity.clone(),
+        // A question belongs to a row that is actually blocked. When the kept fact is a turn
+        // boundary, the generic "waiting for your input" would be rendered next to a `Review`
+        // row and describe nothing it doesn't already say.
+        question: match previous.fact {
+            HookFact::NeedsInput => previous.question.clone().or(incoming.question),
+            _ => previous.question.clone(),
+        },
+        // The nudge is the more recent payload, so prefer its session id, but never lose one by
+        // taking a payload that happened to omit it.
+        session_id: incoming.session_id.or_else(|| previous.session_id.clone()),
     }
 }
 
@@ -1041,6 +1118,142 @@ mod tests {
             Some(HookFact::Working),
             "the next real event must supersede the failure"
         );
+    }
+
+    /// The real event sequence a permission prompt produces, captured verbatim from a `claude`
+    /// 2.1.228 session driven through Jerry's own spawn path: `PreToolUse`, then
+    /// `PermissionRequest` carrying the real tool and argument, then - milliseconds later - a
+    /// `Notification` whose entire message is the constant `"Claude needs your permission"`.
+    ///
+    /// Under plain "latest wins" the rail could therefore *never* show the specific question this
+    /// codebase goes to the trouble of parsing: it was overwritten by the constant every single
+    /// time, for every tool, which made `crate::hooks::event`'s whole `PermissionRequest` arm
+    /// unreachable in practice. Observed live on the real rail before it was fixed.
+    #[test]
+    fn a_generic_permission_notification_cannot_overwrite_the_real_permission_question() {
+        let listener = HookListener::start().expect("listener must start");
+        let port = listener.port();
+        let token = listener.token().to_owned();
+
+        post(
+            port,
+            &token,
+            "event=PreToolUse&agent=4",
+            r#"{"session_id":"s-1","hook_event_name":"PreToolUse","tool_name":"Write","tool_input":{"file_path":"probe-notes.txt"}}"#,
+        );
+        post(
+            port,
+            &token,
+            "event=PermissionRequest&agent=4",
+            r#"{"session_id":"s-1","hook_event_name":"PermissionRequest","tool_name":"Write","tool_input":{"file_path":"probe-notes.txt"}}"#,
+        );
+        assert_eq!(
+            listener.text_for(4).1.as_deref(),
+            Some("Write needs permission: probe-notes.txt")
+        );
+
+        post(
+            port,
+            &token,
+            "event=Notification&agent=4",
+            r#"{"session_id":"s-1","hook_event_name":"Notification","notification_type":"permission_prompt","message":"Claude needs your permission"}"#,
+        );
+
+        assert_eq!(
+            listener.signal_for(4).fact,
+            Some(HookFact::NeedsInput),
+            "the agent is still blocked on the human"
+        );
+        assert_eq!(
+            listener.text_for(4).1.as_deref(),
+            Some("Write needs permission: probe-notes.txt"),
+            "the generic notification must not replace the real question for the same block"
+        );
+    }
+
+    /// The other half of the same real sequence: a completed turn fires `Stop`, and about a minute
+    /// later Claude Code fires an `idle_prompt` `Notification` because nobody has typed since.
+    ///
+    /// Treating that as a state transition flipped every finished agent from `Review`/`Idle` back
+    /// to `Ask` roughly one minute after it finished - erasing the "a turn that ended is a review
+    /// boundary even though the process is still alive" capability that is the entire point of
+    /// this phase, and replacing its question with the constant "Claude is waiting for your
+    /// input". Also observed live on the real rail.
+    #[test]
+    fn an_idle_notification_cannot_erase_the_turn_boundary_a_real_stop_established() {
+        let listener = HookListener::start().expect("listener must start");
+        let port = listener.port();
+        let token = listener.token().to_owned();
+
+        post(
+            port,
+            &token,
+            "event=Stop&agent=6",
+            r#"{"session_id":"s-2","hook_event_name":"Stop"}"#,
+        );
+        assert_eq!(listener.signal_for(6).fact, Some(HookFact::TurnEnded));
+
+        post(
+            port,
+            &token,
+            "event=Notification&agent=6",
+            r#"{"session_id":"s-2","hook_event_name":"Notification","notification_type":"idle_prompt","message":"Claude is waiting for your input"}"#,
+        );
+
+        assert_eq!(
+            listener.signal_for(6).fact,
+            Some(HookFact::TurnEnded),
+            "the turn really did end; an idle nudge is not evidence that it didn't"
+        );
+        assert_eq!(
+            listener.text_for(6).1,
+            None,
+            "a finished row must not carry a question describing nothing it doesn't already say"
+        );
+        // ...and the session id a resume needs must survive the fold.
+        assert_eq!(listener.session_id_for(6).as_deref(), Some("s-2"));
+    }
+
+    #[test]
+    fn a_notification_still_reports_a_block_jerry_has_not_already_heard_about() {
+        // The other side of the rule: nudges are folded in, never ignored. An agent Jerry last saw
+        // *working* that hits a permission prompt must still land on `NeedsInput` off the
+        // notification alone - which is the only signal at all for a block that fires no
+        // `PermissionRequest`.
+        let listener = HookListener::start().expect("listener must start");
+        let port = listener.port();
+        let token = listener.token().to_owned();
+
+        post(
+            port,
+            &token,
+            "event=PreToolUse&agent=7",
+            r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"cargo test"}}"#,
+        );
+        assert_eq!(listener.signal_for(7).fact, Some(HookFact::Working));
+
+        post(
+            port,
+            &token,
+            "event=Notification&agent=7",
+            r#"{"hook_event_name":"Notification","notification_type":"permission_prompt","message":"Claude needs your permission"}"#,
+        );
+        assert_eq!(listener.signal_for(7).fact, Some(HookFact::NeedsInput));
+        assert_eq!(
+            listener.text_for(7).1.as_deref(),
+            Some("Claude needs your permission"),
+            "with no better question on record, the notification's own message is the best there is"
+        );
+
+        // And a real transition after it still wins outright - the fold applies to nudges only.
+        post(
+            port,
+            &token,
+            "event=PostToolUse&agent=7",
+            r#"{"hook_event_name":"PostToolUse","tool_name":"Bash","tool_input":{"command":"cargo test"}}"#,
+        );
+        assert_eq!(listener.signal_for(7).fact, Some(HookFact::Working));
+        assert_eq!(listener.text_for(7).1, None);
     }
 
     #[test]


### PR DESCRIPTION
Investigates "the claude hook thing does not work at all or is not active", and fixes the real defects that investigation found.

## What I could *not* reproduce, and how hard I looked

**The hook side-channel does fire.** I could not find any case where it does not, and I went looking with real, live evidence rather than tests:

- Built master, ran the **real GUI app** (X11, so I could drive it with XTEST), pressed the real "new agent pane" binding, and confirmed the real child process: `claude --settings /tmp/jerry-hooks-<pid>-<rand>/jerry-hook-settings.json`, with `JERRY_HOOK_PORT` / `JERRY_HOOK_TOKEN` / `JERRY_AGENT_ID` really present in `/proc/<child>/environ`, the generated directory really `0o700`, the forwarder really `0o700`, and `agent hook listener ready on 127.0.0.1:<port>` in the log.
- Drove real turns in that live app and watched `~/.config/jerry/agent-status.toml` - which is only ever written for an agent with a *fresh hook fact* - go `run` → `ask` → `idle`, carrying a real `session_id`. The rail lit up with "1 agent needs input".
- Separately confirmed Claude Code's own half against the real 2.1.228 binary: all nine declared events exist in the binary; the generated nine-event settings file is accepted; hooks fire both headless (`-p`) and in a real interactive PTY session; `PermissionRequest` really does carry `tool_name`/`tool_input`, and `Notification` really does carry `notification_type`.

So every concrete failure point in the original report - `--settings` missing from the real command line, a stale settings schema, a non-executable forwarder, a dropped listener, env vars not reaching the child, a token/header mismatch, a "first Claude agent" gate that never fires - was checked and is **not** broken. The one thing that genuinely produces *zero* hooks is Claude Code's own **"do you trust this folder?"** screen: it fires no `SessionStart` until a human answers, and since Jerry's whole product is spawning agents into freshly created worktrees, that screen is the normal first thing every new agent shows. That is Claude Code's behaviour, not a bug Jerry can fix, but it is now explicitly exercised by the new test rather than silently avoided.

## What *is* broken, found by watching a live session

Claude Code emits a `Notification` **because of** an event it has already reported precisely - milliseconds later for a permission prompt, about a minute later when you have not typed - and every notification message is one of a handful of fixed generic strings. `HookInbox` treated those as equal "latest wins" transitions, which destroyed strictly better information every time:

1. **Every permission question the rail could show was a constant.** A real prompt fires `PermissionRequest` (real tool, real argument) and then a `permission_prompt` notification whose entire message is `"Claude needs your permission"`. The specific question `hooks::event` carefully builds was overwritten before it could ever be rendered - the whole `PermissionRequest` arm was unreachable in practice, for every tool. Watched live on the rail: `Claude needs your permission`, never `Write needs permission: …`.
2. **The review boundary was erased about a minute after every turn.** `Stop` → `TurnEnded` is what makes "a turn that ended is a review boundary even though the process is still alive" work at all. An `idle_prompt` notification then arrives and flipped the finished agent back to `Ask` with the constant `"Claude is waiting for your input"`. Also watched live: the row read `paused · resumable` and then became `needs input` with that string.

Between them, the two most visible things this phase added - a real question instead of a grid scrape, and a real turn boundary - were replaced by two constant strings shortly after they appeared. That is a fair description of "the hook thing doesn't seem to do anything".

## The fix

A notification is classified as a **nudge** (`EventKind::BlockedNudge` / `EventKind::IdleNudge`) rather than a transition, and `HookInbox::record` folds a nudge into the fact Jerry already holds instead of replacing it:

- a nudge never overwrites the richer question a `PermissionRequest` already gave for the very block it is announcing;
- an idle nudge never overwrites a turn boundary, because it is news about neither a blocked nor a finished agent;
- a nudge **still takes over when it genuinely carries news** - an agent Jerry last saw *working* that hits a block still lands on `NeedsInput` off the notification alone, which is the only signal at all for a block that fires no `PermissionRequest`;
- a stale (past-`HOOK_SIGNAL_TTL`) record is replaced outright, since the rail has already stopped believing it.

Verified live on the rebuilt app, same rig as above:

- permission prompt → `question = "Write needs permission: /…/probe-notes2.txt"` in the real persisted status, and the real rail row shows it (previously: `"Claude needs your permission"`);
- turn end → `status = "idle"` and still `idle` four minutes later, with the row reading `paused · resumable` (previously: flipped to `ask` / "Claude is waiting for your input").

## Tests

- Two regression tests replaying the **exact live-captured event sequences** (`PreToolUse` → `PermissionRequest` → `permission_prompt` notification; `Stop` → `idle_prompt` notification) through a real listener over a real socket, plus one pinning that a nudge still reports a block Jerry has not already heard about and that a real transition still wins outright.
- A classification test over every event, so `idle_prompt` and the blocking types cannot silently swap.
- **The end-to-end test that was missing.** Every existing test in `integration_tests.rs` hand-assembles `--settings` and the `JERRY_*` environment from the production helpers and hands them to a `std::process::Command` - that pins Claude Code's half of the contract and *none* of Jerry's, so a regression in the lazy runtime bring-up, the Claude-only gate, the `AgentId` the environment carries versus the one the rail reads back, `ProcessKind::spec`, `TerminalSpec::env` or `pty_core`'s `CommandBuilder` would have left the whole file green. The new one drives `AdeApp::new_agent` (what the palette, the Agent menu and the rail's "+" all call) through a real spawn, a real pty, a real `claude` and the real `HookRuntime`, answers the trust screen with a real keystroke on the real pane, and asserts the fact and the real `session_id` come back out under that agent's own id. It skips loudly (or fails hard under `JERRY_REQUIRE_REAL_CLAUDE=1`) where `claude` is absent or unusable.

## Checks

`cargo build --workspace`, `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --check` are clean. `cargo test -p app --lib hooks::` is 71/71, including the real-`claude` tests run with `JERRY_REQUIRE_REAL_CLAUDE=1` so none of them passed vacuously. `cargo test --workspace` is 2294 passed / 10 failed; all ten are this repo's known load-flake class (nine `file_tree_watch`/`worktree_watch` tests plus one settings-undo test that touches nothing here), and every one passes when re-run in isolation.

## What is *not* fixed here, and is worth its own issue

While confirming the review boundary live I found that a turn ending with real new files still reported `idle` rather than `review`, because `review_available_for` requires `is_sole_agent_in_worktree` and `Agents::count_for_cwd` counts **shell** panes - and Jerry opens a shell in the focused repo at startup. So in the default layout (that startup shell + one Claude agent) the review-ready state is gated off no matter what the hooks report. That is issue #225's deliberate single-agent gate rather than a hook bug, and changing which panes it counts is a product decision, so it is left alone here and called out instead of quietly changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
