### PR TITLE
fix(app): a tab always belongs to a real, selected worktree - never to a repo

### DIFF
--- a/crates/app/src/palette/render.rs
+++ b/crates/app/src/palette/render.rs
@@ -157,7 +157,15 @@ impl AdeApp {
             })
             .collect();
 
-        let active_cwd = self.active_agent_cwd();
+        // The three spawn commands below name the real worktree they would spawn into. With no
+        // worktree genuinely selected they would spawn nothing at all (`Self::new_agent`/
+        // `Self::new_agent_pane` both refuse outright), so the honest thing to show is that -
+        // rather than the repo root, which is what `Self::active_agent_cwd` used to hand back and
+        // which was never a place a tab could legitimately belong to. See that method's own docs.
+        let spawn_target = match self.active_agent_cwd() {
+            Some(cwd) => format!("in {}", cwd.display()),
+            None => "- select a worktree first".to_string(),
+        };
         let next_sidebar_view = match self.right_sidebar_view {
             RightSidebarView::Files => "Changes",
             RightSidebarView::Changes => "Files",
@@ -165,15 +173,15 @@ impl AdeApp {
         let mut commands = vec![
             palette::CommandCandidate {
                 command: palette::PaletteCommand::NewShell,
-                secondary: format!("spawn a shell in {}", active_cwd.display()),
+                secondary: format!("spawn a shell {spawn_target}"),
             },
             palette::CommandCandidate {
                 command: palette::PaletteCommand::NewClaudeAgent,
-                secondary: format!("spawn claude in {}", active_cwd.display()),
+                secondary: format!("spawn claude {spawn_target}"),
             },
             palette::CommandCandidate {
                 command: palette::PaletteCommand::NewCodexAgent,
-                secondary: format!("spawn codex in {}", active_cwd.display()),
+                secondary: format!("spawn codex {spawn_target}"),
             },
             palette::CommandCandidate {
                 command: palette::PaletteCommand::ToggleFilesChanges,

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -1163,7 +1163,10 @@ impl AdeApp {
     pub(in crate::rail) fn worktree_is_expanded(&self, row: &WorktreeRow) -> bool {
         match self.rail_collapse_overrides.get(&row.path) {
             Some(expanded) => *expanded,
-            None => self.active_agent_cwd() == row.path || row.aggregate_status() != Status::Idle,
+            None => {
+                self.active_agent_cwd().as_deref() == Some(row.path.as_path())
+                    || row.aggregate_status() != Status::Idle
+            }
         }
     }
 
@@ -1227,7 +1230,12 @@ impl AdeApp {
                 .into_any_element();
         }
 
-        let is_selected = self.active_agent_cwd() == row.path;
+        // The rail's own "this row is the selected worktree" state, read from the exact same
+        // single source of truth the tab strip scopes itself to - so the two can never disagree.
+        // With `Self::active_agent_cwd`'s repo-root fallback removed, "nothing is selected" now
+        // genuinely draws *no* row as selected, rather than lighting up whichever row happened to
+        // sit at the repo root while the tab strip showed something else entirely.
+        let is_selected = self.active_agent_cwd().as_deref() == Some(row.path.as_path());
         let has_agents = !row.agents.is_empty();
         let has_history = !row.history.is_empty();
         // GitHub issue #227: a worktree with no live agent but real persisted history must still
@@ -2205,7 +2213,7 @@ mod rail_row_tests {
         });
         assert_eq!(
             app.read_with(cx, |app, _| app.active_agent_cwd()),
-            wt.path(),
+            Some(wt.path().to_path_buf()),
             "premise: `wt` really is the currently selected worktree"
         );
 
@@ -3142,7 +3150,7 @@ mod repo_checkout_tests {
             );
             assert_eq!(
                 app.active_agent_cwd(),
-                repo_b_feature,
+                Some(repo_b_feature.clone()),
                 "the whole point of the switch: new work now targets the clicked worktree"
             );
             assert_eq!(
@@ -3418,6 +3426,491 @@ mod repo_checkout_tests {
             repo_b.path(),
             "sanity check: the row is keyed by git's own resolved path"
         );
+    }
+}
+
+/// The reported "at the start of the program you select something and a tab bar has a terminal;
+/// then I select a worktree and this is lost" - and the architectural invariant that replaced the
+/// family of bugs behind it:
+///
+/// **A tab is never shown, never spawnable, and never implicitly attributed to anything except a
+/// real, currently-selected worktree. There is no such thing as "a repo's own tab".**
+///
+/// Every test here drives real, painted rail rows through `cx.simulate_click` on real
+/// `debug_bounds`, against real `git init`-ed repositories and real PTY processes - the same
+/// technique `repo_checkout_tests` above uses - rather than calling selection methods directly,
+/// because the whole class of bugs being fixed was about what the *rendered* rail, tab strip, and
+/// centre pane each independently believed.
+#[cfg(test)]
+mod worktree_tab_attribution_tests {
+    use crate::root::focus::palette_focus_tests;
+    use crate::work_surface::state::TabRef;
+    use gpui::TestAppContext;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+    use tempfile::TempDir;
+
+    fn git(dir: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .output()
+            .expect("failed to spawn git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
+            args,
+            dir,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    /// A real repository with a real commit - `wt_core::list_worktrees_porcelain` reports nothing
+    /// at all for a bare `tempfile::tempdir()`, so these tests need a genuine main worktree row.
+    fn init_repo() -> TempDir {
+        let dir = TempDir::new().expect("tempdir");
+        git(dir.path(), &["init", "-b", "main"]);
+        git(dir.path(), &["config", "user.email", "test@example.com"]);
+        git(dir.path(), &["config", "user.name", "Test User"]);
+        std::fs::write(dir.path().join("base.txt"), "base\n").expect("write");
+        git(dir.path(), &["add", "base.txt"]);
+        git(dir.path(), &["commit", "-m", "initial"]);
+        dir
+    }
+
+    fn add_worktree(repo_path: &Path, branch: &str, name: &str) -> PathBuf {
+        let container = TempDir::new().expect("tempdir");
+        let path = container.path().join(name);
+        drop(container);
+        git(
+            repo_path,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                branch,
+                path.to_str().expect("utf8 path"),
+            ],
+        );
+        path
+    }
+
+    /// Clicks the real, painted rail row for `worktree_path`, exactly as a user would - resolving
+    /// the row's own `debug_selector` from the very `build_repo_groups` output it was rendered
+    /// from, the same idiom `repo_checkout_tests::
+    /// clicking_a_non_focused_repos_worktree_row_switches_repo_and_selects_it` established.
+    fn click_worktree_row(
+        app: &gpui::Entity<crate::root::AdeApp>,
+        cx: &mut gpui::VisualTestContext,
+        worktree_path: &Path,
+    ) {
+        let index = app
+            .update(cx, |app, cx| app.build_repo_groups(cx))
+            .iter()
+            .find_map(|group| group.rows.iter().position(|row| row.path == worktree_path))
+            .expect("the worktree must be a real, rendered rail row");
+        let selector: &'static str =
+            Box::leak(format!("worktree-row-{index}-{}", worktree_path.display()).into_boxed_str());
+        let bounds = cx
+            .debug_bounds(selector)
+            .expect("the worktree row must have painted");
+        cx.simulate_click(bounds.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+    }
+
+    /// The startup half of the reported bug. A fresh `jerry <repo>` launch spawns a real shell and
+    /// shows its tab - but it used to leave `AdeApp::selected` at `None`, so *the user never
+    /// selected the worktree that tab belongs to*. The tab rendered only because
+    /// `AdeApp::active_agent_cwd`'s repo-root fallback happened to coincide with the main
+    /// worktree's own path. This asserts the real thing instead: the main worktree is genuinely
+    /// selected, and the startup shell genuinely lives in it.
+    #[gpui::test]
+    fn a_fresh_launch_genuinely_selects_the_repos_own_main_worktree(cx: &mut TestAppContext) {
+        let repo = init_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            let selected = app
+                .selected
+                .and_then(|index| app.worktrees.get(index))
+                .map(|item| item.path.clone());
+            assert_eq!(
+                selected,
+                Some(repo.path().to_path_buf()),
+                "a fresh launch must land on the repo's own main worktree as a real selection - \
+                 `AdeApp::selected` staying `None` here is the reported bug, not a neutral \
+                 starting state"
+            );
+            assert_eq!(
+                app.active_agent_cwd(),
+                Some(repo.path().to_path_buf()),
+                "and it must be a real selection, not `active_agent_cwd`'s old repo-root fallback"
+            );
+            let startup_shell_cwds: Vec<PathBuf> =
+                app.agents.iter().map(|agent| agent.cwd.clone()).collect();
+            assert_eq!(
+                startup_shell_cwds,
+                vec![repo.path().to_path_buf()],
+                "the guaranteed startup shell must have been spawned into that same, genuinely \
+                 selected worktree"
+            );
+            assert_eq!(
+                app.combined_tab_order().len(),
+                1,
+                "and its tab must be the one thing the strip shows"
+            );
+        });
+    }
+
+    /// The reported gesture end to end, through real clicks: the startup terminal must not be
+    /// *lost* when the user selects a different worktree - it must be a real, reversible switch
+    /// between two genuinely selected worktrees, with the same live process still there on the
+    /// way back.
+    ///
+    /// Before this revision, step 1 had no selection behind it at all, which is what made step 2
+    /// read as destruction rather than navigation.
+    #[gpui::test]
+    fn the_startup_terminal_is_a_real_worktrees_tab_and_survives_switching_away_and_back(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = init_repo();
+        let feature = add_worktree(repo.path(), "feature", "feature");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        let startup_agent = app.read_with(cx, |app, _| {
+            let agents: Vec<_> = app.agents.iter().map(|agent| agent.id).collect();
+            assert_eq!(agents.len(), 1, "exactly one startup shell");
+            agents[0]
+        });
+
+        // Step 1: the main worktree really is the selected one, and really owns the tab.
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.active_agent_cwd(),
+                Some(repo.path().to_path_buf()),
+                "premise: the startup terminal's own worktree must be genuinely selected before \
+                 the user ever clicks anything - that is what makes the switch below a \
+                 reversible navigation rather than an unexplained loss"
+            );
+            assert_eq!(
+                app.combined_tab_order(),
+                vec![TabRef::Agent(startup_agent)],
+                "and the startup shell must be that worktree's own single tab"
+            );
+        });
+
+        // Step 2: a real click on the linked worktree's row - an honest switch to a worktree that
+        // has no tabs of its own yet.
+        click_worktree_row(&app, cx, &feature);
+        app.read_with(cx, |app, cx| {
+            assert_eq!(
+                app.active_agent_cwd(),
+                Some(feature.clone()),
+                "the clicked worktree must be the selected one"
+            );
+            assert!(
+                app.combined_tab_order().is_empty(),
+                "and it genuinely has no tabs - an honestly empty strip, not a fabricated one"
+            );
+            let shell = app
+                .agents
+                .iter()
+                .find(|agent| agent.id == startup_agent)
+                .expect("the startup shell must still exist - switching worktrees never kills it");
+            assert!(
+                shell.pane.read(cx).is_running(),
+                "and it must still be a real, live process, merely not the shown one"
+            );
+        });
+
+        // Step 3: clicking back must restore the very same tab, not a respawned lookalike.
+        click_worktree_row(&app, cx, repo.path());
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.combined_tab_order(),
+                vec![TabRef::Agent(startup_agent)],
+                "clicking back to the main worktree must restore the exact same startup shell \
+                 tab - the process was never lost, only unshown"
+            );
+            assert_eq!(
+                app.agents.active_id(),
+                Some(startup_agent),
+                "and the centre pane must genuinely be showing it again"
+            );
+        });
+    }
+
+    /// The real, permanent-loss half of the bug, live-reproduced before the fix: launching against
+    /// a *subdirectory* of a repo (`jerry ./crates` - an entirely ordinary invocation).
+    ///
+    /// `AdeApp::active_agent_cwd` used to resolve to that bare subdirectory, which
+    /// `git worktree list --porcelain` reports as no worktree at all. The startup shell spawned
+    /// there rendered a real tab in the strip while *every* rail row read as unselected, and the
+    /// moment any worktree row was clicked the tab vanished for good - its `cwd` could never again
+    /// equal any row's path, so the live PTY was orphaned with no reachable way back.
+    #[gpui::test]
+    fn launching_against_a_subdirectory_still_attributes_its_shell_to_a_real_worktree(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = init_repo();
+        std::fs::create_dir_all(repo.path().join("crates")).expect("mkdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().join("crates"));
+        cx.run_until_parked();
+
+        let startup_agent = app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.active_agent_cwd(),
+                Some(repo.path().to_path_buf()),
+                "a subdirectory is not a worktree - this must land on the repo's real main \
+                 worktree rather than on the subdirectory itself"
+            );
+            let agents: Vec<_> = app
+                .agents
+                .iter()
+                .map(|agent| (agent.id, agent.cwd.clone()))
+                .collect();
+            assert_eq!(
+                agents.len(),
+                1,
+                "the guaranteed startup shell must still exist"
+            );
+            assert_eq!(
+                agents[0].1,
+                repo.path().to_path_buf(),
+                "and it must have been spawned into the real main worktree, not the \
+                 subdirectory - a shell whose cwd matches no worktree row can never be reached \
+                 from the rail again"
+            );
+            agents[0].0
+        });
+
+        // The row that reads as selected must be a real one, and clicking it must be a no-op that
+        // keeps the tab - the exact click that used to orphan it forever.
+        click_worktree_row(&app, cx, repo.path());
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.combined_tab_order(),
+                vec![TabRef::Agent(startup_agent)],
+                "clicking the worktree the startup shell actually belongs to must keep its tab, \
+                 not make it unreachable"
+            );
+        });
+    }
+
+    /// Launching directly inside a linked worktree (`jerry ~/repo-wt/feature`) must land on *that*
+    /// worktree, not silently redirect to the repo's main one.
+    #[gpui::test]
+    fn launching_inside_a_linked_worktree_selects_that_worktree_not_main(cx: &mut TestAppContext) {
+        let repo = init_repo();
+        let feature = add_worktree(repo.path(), "feature", "feature");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, feature.clone());
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.active_agent_cwd(),
+                Some(feature.clone()),
+                "the worktree the user actually pointed at must be the selected one"
+            );
+            assert_eq!(
+                app.agents.iter().map(|a| a.cwd.clone()).collect::<Vec<_>>(),
+                vec![feature.clone()],
+                "and the startup shell must live in it"
+            );
+        });
+    }
+
+    /// GitHub issue #90's "Open Folder…" is the other real opening gesture, and it duplicated the
+    /// constructor's spawn-into-the-bare-repo-path logic almost verbatim. Both now funnel through
+    /// the same `AdeApp::load_worktrees_for_opened_repo`, so they cannot drift apart on which
+    /// worktree the window lands in - this proves the "Open Folder…" half directly.
+    #[gpui::test]
+    fn opening_a_folder_lands_on_a_real_worktree_and_spawns_its_shell_there(
+        cx: &mut TestAppContext,
+    ) {
+        let repo_a = init_repo();
+        let repo_b = init_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        cx.run_until_parked();
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_repo_in_current_window(repo_b.path().to_path_buf(), window, cx);
+        });
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            let selected = app
+                .selected
+                .and_then(|index| app.worktrees.get(index))
+                .map(|item| item.path.clone());
+            assert_eq!(
+                selected,
+                Some(repo_b.path().to_path_buf()),
+                "opening a folder must land on that repo's own main worktree as a real selection"
+            );
+            assert_eq!(
+                app.combined_tab_order().len(),
+                1,
+                "and the shell it guarantees must be that worktree's own single tab"
+            );
+            assert!(
+                app.agents
+                    .iter()
+                    .any(|agent| agent.cwd == repo_b.path()
+                        && Some(agent.id) == app.agents.active_id()),
+                "and the active tab must genuinely be an agent in repo B's main worktree"
+            );
+        });
+    }
+
+    /// The real race the opening path has to survive, found reviewing this revision's own diff:
+    /// the worktree-list fetch is asynchronous, so a user can click a worktree row while it is
+    /// still in flight.
+    ///
+    /// That click sets `AdeApp::selected`, which makes `crate::rail::worktrees::recover_selection`
+    /// report `Unchanged` rather than `NoPriorSelection` when the fetch finally lands. An
+    /// `Opening` handler living *inside* that one match arm - which is how this was first written
+    /// - would therefore silently skip the window's guaranteed initial shell altogether, leaving a
+    /// freshly opened repo with no terminal at all. The handler is keyed off `AdeApp::selected`
+    /// after the match instead, so a raced click is simply respected: the worktree the user
+    /// actually chose stays selected, and the shell is spawned into *that*.
+    #[gpui::test]
+    fn a_worktree_click_racing_the_open_fetch_still_gets_its_guaranteed_shell(
+        cx: &mut TestAppContext,
+    ) {
+        let repo_a = init_repo();
+        let repo_b = init_repo();
+        let feature = add_worktree(repo_b.path(), "feature", "feature");
+
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        cx.run_until_parked();
+        // Repo B is already a known repo with a real, already-fetched worktree list - which is
+        // what makes the racing click below able to resolve a row at all.
+        app.update(cx, |app, cx| {
+            app.add_repo(repo_b.path().to_path_buf(), cx);
+        });
+        cx.run_until_parked();
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_repo_in_current_window(repo_b.path().to_path_buf(), window, cx);
+            // Deliberately no `run_until_parked` between these two: this is the whole race - the
+            // click lands while the opening fetch is genuinely still in flight.
+            app.select_worktree_by_path(&feature, window, cx);
+        });
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.active_agent_cwd(),
+                Some(feature.clone()),
+                "the worktree the user actually clicked must win over the one the in-flight open \
+                 fetch would have picked on its own"
+            );
+            assert!(
+                app.agents.iter().any(|agent| agent.cwd == feature),
+                "and the window's guaranteed initial shell must still have been spawned - into \
+                 the raced-to worktree. Skipping it here (because `recover_selection` reported \
+                 `Unchanged` rather than `NoPriorSelection`) would leave a freshly opened repo \
+                 with no terminal at all"
+            );
+            assert!(
+                !app.combined_tab_order().is_empty(),
+                "so the tab strip genuinely shows it"
+            );
+        });
+    }
+
+    /// The invariant's negative half, and the third live-reproduced inconsistency: while nothing
+    /// is genuinely selected, *nothing* may claim to be showing.
+    ///
+    /// Before this revision, `AdeApp::checkout_repo_from_rail` left `AdeApp::selected` at `None`
+    /// while `active_agent_cwd` still resolved to the repo root, producing a real three-way
+    /// disagreement: the rail drew the main-worktree row as selected, the tab strip drew the root
+    /// shell's tab, and the centre pane rendered nothing at all (`Agents::clear_active` having
+    /// genuinely cleared it). All three now agree.
+    ///
+    /// `checkout_repo_from_rail` deliberately still selects nothing of its own - see its own docs,
+    /// and `repo_list_tests::checking_out_a_repo_from_the_rail_never_selects_a_worktree_on_its_own`
+    /// - it is an internal sub-step of a worktree-row click, never a resting state a user can
+    /// reach. This asserts that that transient state is now genuinely self-consistent rather than
+    /// merely looking plausible.
+    #[gpui::test]
+    fn nothing_selected_means_nothing_shown_anywhere(cx: &mut TestAppContext) {
+        let repo_a = init_repo();
+        let repo_b = init_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        cx.run_until_parked();
+
+        // Repo B enters through the real "Open Folder…" gesture, so it genuinely has a live shell
+        // in its own main worktree - the precondition that made the old disagreement visible.
+        app.update_in(cx, |app, window, cx| {
+            app.open_repo_in_current_window(repo_b.path().to_path_buf(), window, cx);
+        });
+        cx.run_until_parked();
+
+        let repo_a_id = app.read_with(cx, |app, _| {
+            app.repos
+                .iter()
+                .find(|repo| repo.path == repo_a.path())
+                .expect("repo A is known")
+                .id
+        });
+        let repo_b_id = app.read_with(cx, |app, _| {
+            app.repos
+                .iter()
+                .find(|repo| repo.path == repo_b.path())
+                .expect("repo B is known")
+                .id
+        });
+        app.update_in(cx, |app, window, cx| {
+            app.checkout_repo_from_rail(repo_a_id, window, cx);
+        });
+        cx.run_until_parked();
+        app.update_in(cx, |app, window, cx| {
+            app.checkout_repo_from_rail(repo_b_id, window, cx);
+        });
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, cx| {
+            assert_eq!(app.selected, None, "premise: nothing is selected");
+            assert_eq!(
+                app.active_agent_cwd(),
+                None,
+                "so there is genuinely no active worktree - not the repo root standing in for one"
+            );
+            assert!(
+                app.combined_tab_order().is_empty(),
+                "the tab strip must therefore be honestly empty, even though repo B really does \
+                 have a live shell in its own root: that shell belongs to a worktree nobody has \
+                 selected"
+            );
+            assert_eq!(
+                app.agents.active_id(),
+                None,
+                "and the centre pane must be showing nothing - the state the tab strip used to \
+                 contradict"
+            );
+            let any_row_selected = app
+                .build_worktree_rows(cx)
+                .iter()
+                .any(|row| app.active_agent_cwd().as_deref() == Some(row.path.as_path()));
+            assert!(
+                !any_row_selected,
+                "and no rail row may read as selected either - the rail used to light up the \
+                 main-worktree row here purely because `active_agent_cwd` fell back to the repo \
+                 root"
+            );
+            assert!(
+                app.agents
+                    .iter()
+                    .any(|agent| agent.cwd == repo_b.path() && agent.pane.read(cx).is_running()),
+                "repo B's own shell must still be a real, live background process throughout - \
+                 cross-repo agent persistence is untouched by any of this"
+            );
+        });
     }
 }
 

--- a/crates/app/src/rail/worktrees.rs
+++ b/crates/app/src/rail/worktrees.rs
@@ -175,6 +175,41 @@ pub fn recover_selection(
     }
 }
 
+/// Which worktree a repo that is being **opened** (a real CLI launch, or GitHub issue #90's
+/// "Open Folder…") should land on - the pure half of this revision's central invariant: *a
+/// focused repo always has a real, genuinely selected worktree, never a `None` limbo state that
+/// merely happens to render a plausible-looking tab through a fallback.*
+///
+/// `opened_path` is the path the user actually named, and it is tried first for a real reason:
+/// launching directly inside a linked worktree (`jerry ~/repo-wt/feature`) is an ordinary
+/// gesture, and landing that window on the repo's *main* worktree instead of the one the user
+/// pointed at would be a silent, surprising redirect. Only when `opened_path` is not itself a
+/// worktree does this fall back to [`WorktreeItem::is_main`] - which covers both the common
+/// `jerry .` case (where the two are the same row anyway) and the real, live-reproduced
+/// subdirectory launch (`jerry ./crates`), where `opened_path` is a genuine directory that is
+/// nonetheless not any worktree at all.
+///
+/// `None` only when the repo has no *usable* worktree whatsoever (an empty list, or one whose
+/// every entry is [`WorktreeItem::error`]-bearing) - a real, honest "there is nothing here to
+/// select" state, deliberately distinct from "we forgot to select something that exists". See
+/// `crate::root::AdeApp::active_agent_cwd`'s own docs for the single documented last resort that
+/// covers it.
+///
+/// Unusable ([`WorktreeItem::error`]) entries are skipped by both rules, matching the identical
+/// `error.is_none()` gate every other selection/spawn/diff call site in this crate already
+/// applies - selecting a prunable worktree would hand every one of those a path that no longer
+/// exists on disk.
+pub fn selection_for_opened_repo(opened_path: &Path, items: &[WorktreeItem]) -> Option<usize> {
+    items
+        .iter()
+        .position(|item| item.path == opened_path && item.error.is_none())
+        .or_else(|| {
+            items
+                .iter()
+                .position(|item| item.is_main && item.error.is_none())
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -381,5 +416,86 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    // --- `selection_for_opened_repo` -----------------------------------------------------
+
+    /// The overwhelmingly common `jerry .` case: the opened path *is* the main worktree, so
+    /// both of this function's rules agree and it lands on the one obvious row.
+    #[test]
+    fn opening_a_repo_root_selects_its_own_main_worktree() {
+        let items = vec![
+            item("/repo", true, None),
+            item("/repo-wt/feature", false, None),
+        ];
+        assert_eq!(
+            selection_for_opened_repo(Path::new("/repo"), &items),
+            Some(0)
+        );
+    }
+
+    /// `jerry ~/repo-wt/feature` - launching directly inside a linked worktree must land on
+    /// *that* worktree, never silently redirect to main.
+    #[test]
+    fn opening_a_linked_worktree_directly_selects_that_worktree_not_main() {
+        let items = vec![
+            item("/repo", true, None),
+            item("/repo-wt/feature", false, None),
+        ];
+        assert_eq!(
+            selection_for_opened_repo(Path::new("/repo-wt/feature"), &items),
+            Some(1),
+            "the worktree the user actually pointed at must win over the main worktree"
+        );
+    }
+
+    /// The real, live-reproduced subdirectory launch (`jerry ./crates`): the opened path is a
+    /// genuine directory but not any worktree, so nothing can match it exactly. Before this
+    /// rule existed, `AdeApp::active_agent_cwd` fell back to that bare subdirectory path, and
+    /// the startup shell it spawned there belonged to no rail row at all - a real, live tab
+    /// that no worktree claimed, and which became permanently unreachable the moment any
+    /// worktree row was clicked.
+    #[test]
+    fn opening_a_subdirectory_of_a_repo_falls_back_to_the_main_worktree() {
+        let items = vec![
+            item("/repo", true, None),
+            item("/repo-wt/feature", false, None),
+        ];
+        assert_eq!(
+            selection_for_opened_repo(Path::new("/repo/crates"), &items),
+            Some(0),
+            "a subdirectory is not a worktree, so this must land on the real main worktree \
+             rather than on the subdirectory itself"
+        );
+    }
+
+    /// A repo with genuinely nothing usable to select is a real, honest state - reported as
+    /// such rather than papered over with an index that doesn't resolve to a usable row.
+    #[test]
+    fn opening_a_repo_with_no_usable_worktree_at_all_selects_nothing() {
+        assert_eq!(selection_for_opened_repo(Path::new("/repo"), &[]), None);
+    }
+
+    /// An exact path match that is nonetheless *broken* must not be selected - it would hand
+    /// every downstream consumer a path that isn't on disk. Falls through to main instead.
+    #[test]
+    fn a_broken_exact_match_is_skipped_in_favour_of_a_usable_main() {
+        let items = vec![
+            item("/repo", true, None),
+            item("/repo-wt/gone", false, Some("worktree is prunable")),
+        ];
+        assert_eq!(
+            selection_for_opened_repo(Path::new("/repo-wt/gone"), &items),
+            Some(0),
+            "a prunable exact match is not usable, so this must fall back to main"
+        );
+    }
+
+    /// And a broken *main* is skipped too, leaving the honest "nothing usable" answer rather
+    /// than an index pointing at an unusable row.
+    #[test]
+    fn a_broken_main_worktree_is_not_selected_either() {
+        let items = vec![item("/repo", true, Some("worktree is prunable"))];
+        assert_eq!(selection_for_opened_repo(Path::new("/repo"), &items), None);
     }
 }

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -46,6 +46,33 @@
 //! drives the file tree, and which worktree `active_agent_cwd` resolves to for the *next* "New
 //! terminal"/"New agent pane" click - that part is unchanged. Spawning an agent is still always
 //! its own explicit action, never an implicit side effect of browsing.
+//!
+//! ### A tab always belongs to a real, selected worktree - never to a repo
+//!
+//! The invariant that ties all of the above together, and the one a family of reported bugs all
+//! turned out to be violations of:
+//!
+//! > **A tab is never shown, never spawnable, and never implicitly attributed to anything except a
+//! > real, currently-selected worktree. There is no such thing as "a repo's own tab".**
+//!
+//! [`AdeApp::active_agent_cwd`] is the single chokepoint that enforces it, and it returns
+//! `Option<PathBuf>` precisely so that "nothing is selected" is a state the app can *say* rather
+//! than paper over. It used to fall back to [`AdeApp::focused_repo_path`] whenever
+//! [`AdeApp::selected`] was `None`, which quietly made a repo root behave like a worktree it is
+//! not - see that method's own docs for the three live-reproduced failures that produced
+//! (a real tab no rail row claimed and that a single click orphaned forever; the rail, tab strip,
+//! and centre pane disagreeing three ways; and the reported "I select a worktree and the startup
+//! terminal is lost").
+//!
+//! The other half is that the `None` state is kept genuinely rare rather than merely handled: the
+//! two real "open a repo" gestures - a CLI launch ([`AdeApp::new_with_settings`]) and "Open
+//! Folder…" ([`AdeApp::open_repo_in_current_window`]) - both funnel through
+//! [`AdeApp::load_worktrees_for_opened_repo`], which resolves the repo's real worktree list,
+//! genuinely selects the right worktree of it
+//! ([`crate::rail::worktrees::selection_for_opened_repo`]), and only then spawns that window's
+//! guaranteed initial shell, into that concretely-selected worktree. So a focused repo at rest
+//! always has a real worktree selected; `None` is confined to the brief in-flight window before
+//! that first fetch lands, and to genuine error states.
 
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -2461,23 +2488,22 @@ impl AdeApp {
         self.palette_focus
             .forget_target(&self.empty_state_focus_handle);
 
-        if self.agents.iter_for_cwd(path.clone()).next().is_none() {
-            self.agents.spawn(
-                ProcessKind::Shell,
-                path.clone(),
-                self.settings.appearance.terminal_font_size,
-                self.settings.terminal.shell_override(),
-                // A shell, so no hook injection - `Agents::spawn` would discard one anyway.
-                None,
-                window,
-                cx,
-            );
-        }
-        self.agents.activate_for_worktree(&path, cx);
+        // Nothing is selected *yet* - `load_worktrees_for_opened_repo` below resolves the repo's
+        // real worktree list and genuinely selects the right worktree of it, which is what
+        // `Self::selected` ends up as. Cleared here (rather than left holding an index into the
+        // repo being *left*) so the interim frames between this call and that fetch landing
+        // render an honestly empty tab strip rather than a stale one - with
+        // `Self::active_agent_cwd`'s repo-root fallback gone, "nothing selected" is now a real,
+        // self-consistent state everywhere instead of one that silently resolves to the repo root.
         self.selected = None;
         self.worktree_selection_notice = None;
-        self.reset_repo_scoped_state(path, window, cx);
-        self.load_worktrees(cx);
+        self.reset_repo_scoped_state(path.clone(), window, cx);
+        // Owns the whole "land this repo on a real worktree and give it its guaranteed initial
+        // shell there" sequence - see its own docs. This method used to spawn that shell inline,
+        // into the bare `path`, and leave `Self::selected` at `None`: the reported bug, since the
+        // resulting tab belonged to no worktree at all and only rendered because
+        // `Self::active_agent_cwd` fell back to this same repo path while nothing was selected.
+        self.load_worktrees_for_opened_repo(path, cx);
         self.start_worktree_watch(cx);
         self.start_status_polling(cx);
     }
@@ -4270,14 +4296,31 @@ mod repo_list_tests {
         });
     }
 
-    /// The reported "we can add a tab to the repo itself" - checking out a repo from the rail
-    /// used to leave `AdeApp::selected` at `None` until the user explicitly clicked a worktree
-    /// row, and `AdeApp::active_agent_cwd`'s fallback to the bare repo path for exactly that
-    /// `None` state let a tab strip "+" click spawn a tab with no worktree behind it at all. A
-    /// freshly checked-out repo must instead land on its own main worktree as a real selection
-    /// immediately - checked *before* `cx.run_until_parked()` runs, so this proves the
-    /// synchronous seed in `AdeApp::checkout_repo_from_rail` itself, not just the fallback
-    /// `AdeApp::load_worktrees` background fetch that lands moments later.
+    /// The reported "we can add a tab to the repo itself". [`AdeApp::checkout_repo_from_rail`] is
+    /// pure navigation - which repo's worktree rows the rail shows - and must never select a
+    /// worktree on the user's behalf; only a real click on a worktree row does that. An earlier
+    /// attempt at this bug auto-selected the main worktree here and was rejected in review: back
+    /// when the repo header was still a click target, that just moved "the repo itself is
+    /// actionable" one level deeper.
+    ///
+    /// (The doc comment here previously described that *rejected* behavior rather than what the
+    /// body actually asserts - corrected in the same revision that fixed the underlying flaw.)
+    ///
+    /// The premise is unchanged, but the reason it is now *safe* is different, and worth stating
+    /// because it is this revision's whole point. `AdeApp::selected` staying `None` used to be a
+    /// limbo state that still rendered a plausible-looking tab, because
+    /// `AdeApp::active_agent_cwd` fell back to the bare repo path for exactly that `None` - so the
+    /// rail lit up the main-worktree row, the tab strip drew the repo root's shell, and the centre
+    /// pane showed nothing, all at the same time. That fallback is gone (see `active_agent_cwd`'s
+    /// own docs), so "nothing selected" is now genuinely inert *everywhere* rather than merely
+    /// inert here - proven directly by `crate::rail::render::worktree_tab_attribution_tests::
+    /// nothing_selected_means_nothing_shown_anywhere`.
+    ///
+    /// This is not a resting state a user can reach: the repo header is not a click target at all,
+    /// so `checkout_repo_from_rail`'s only caller is [`AdeApp::select_worktree_by_path`]'s
+    /// cross-repo case, which selects the clicked worktree synchronously right afterwards.
+    /// Asserted both before and after `cx.run_until_parked()`, so neither the synchronous half nor
+    /// `AdeApp::load_worktrees`'s own background fetch may introduce a selection.
     #[gpui::test]
     fn checking_out_a_repo_from_the_rail_never_selects_a_worktree_on_its_own(
         cx: &mut TestAppContext,

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -8,6 +8,29 @@ use std::sync::atomic::{AtomicU64, Ordering};
 /// uniqueness isn't enough.
 static NEXT_TREE_UNDO_INSTANCE_ID: AtomicU64 = AtomicU64::new(0);
 
+/// Why a `git worktree list --porcelain` fetch is happening - the one thing that differs between
+/// [`AdeApp::load_worktrees`] and [`AdeApp::load_worktrees_for_opened_repo`], passed explicitly
+/// rather than inferred from state once the fetch lands.
+///
+/// It has to be explicit: by the time the fetch resolves, "this repo was just opened" and "a
+/// background poll tick fired for a repo that happens to have nothing selected" are
+/// indistinguishable from [`AdeApp`]'s own fields alone, and they must behave in opposite ways -
+/// the first *must* land on a real worktree (leaving it unselected is the reported bug), the
+/// second must never select anything on the user's behalf.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum WorktreeLoadIntent {
+    /// A steady-state reload: the live watcher/poll loop, a post-prune or post-merge refresh, or
+    /// [`AdeApp::checkout_repo_from_rail`]'s own follow-up fetch. Never changes *whether*
+    /// something is selected, only re-anchors an existing selection by path
+    /// ([`crate::rail::worktrees::recover_selection`]).
+    Refresh,
+    /// A repo is being opened for real work - a CLI launch or "Open Folder…". `opened_path` is
+    /// the path the user actually named (which may be the repo root, a linked worktree, or a
+    /// mere subdirectory of the repo - see
+    /// [`crate::rail::worktrees::selection_for_opened_repo`] for how each resolves).
+    Opening { opened_path: PathBuf },
+}
+
 impl AdeApp {
     /// Production entry point - loads `~/.config/jerry/settings.toml` (`Settings::load_or_init`)
     /// and delegates to [`Self::new_with_settings`]. Blocking the foreground thread here is a
@@ -637,29 +660,26 @@ impl AdeApp {
         this.apply_theme_selection(cx);
         match resolved_repo_path {
             Some(path) => {
-                // A fresh window starts with one shell in the repo root, as a tab like any
-                // other. `focus_active` below moves real keyboard focus onto it - see
-                // `Agents::focus_active`'s docs and this crate's `OverlayFocus`/`restore_focus`
-                // docs for why a *focused* window must never start with `Window::focus == None`.
-                let startup_agent = this.agents.spawn(
-                    ProcessKind::Shell,
-                    path.clone(),
-                    this.settings.appearance.terminal_font_size,
-                    this.settings.terminal.shell_override(),
-                    None,
-                    window,
-                    cx,
-                );
-                // GitHub issue #225: the startup shell is a real agent like any other and needs a
-                // real review baseline too. This is the *second* `Agents::spawn` call site in the
-                // app (`Self::new_agent` is the other), and it is deliberately hooked separately
-                // rather than folded into `Agents::spawn` itself - see
-                // `crate::review::flow::AdeApp::capture_review_baseline`'s docs for why `Agents`
-                // stays out of the git-snapshot business. Missing this would have left exactly one
-                // agent - the one every window starts with - permanently without a review.
-                this.capture_review_baseline(startup_agent, cx);
-                this.agents.focus_active(window, cx);
-                this.load_worktrees(cx);
+                // A fresh window starts with one shell - but in the repo's real, genuinely
+                // *selected* worktree, not in the bare repo path. `load_worktrees_for_opened_repo`
+                // owns that whole sequence (resolve the real worktree list, select the right
+                // worktree of it, spawn the initial shell into that worktree, focus it); see its
+                // own docs for why the spawn is deferred until that real fetch lands rather than
+                // done synchronously right here, as it used to be.
+                //
+                // This constructor previously duplicated `Self::open_repo_in_current_window`'s
+                // spawn/baseline/focus block almost verbatim; both now funnel through that one
+                // method, so a CLI launch and "Open Folder…" can no longer drift apart on which
+                // worktree the window lands in.
+                this.load_worktrees_for_opened_repo(path.clone(), cx);
+                // Keyboard focus while that fetch is in flight. Without this the window would
+                // render its first frames with `Window::focus == None` - the dangling-focus bug
+                // class this crate's `OverlayFocus`/`restore_focus` machinery exists to prevent -
+                // since the agent that focus used to land on doesn't exist yet. The rail's own
+                // root container is part of the rendered tree for exactly this state (a focused
+                // repo showing the workspace body), and `spawn_initial_shell_for_opened_repo`
+                // moves focus onto the real terminal the moment there is one.
+                window.focus(&this.rail_focus_handle, cx);
                 this.load_file_tree(path.clone(), cx);
                 this.load_diff(path, cx);
                 this.start_status_polling(cx);
@@ -718,6 +738,105 @@ impl AdeApp {
     /// effect; gone or newly broken → falls back to the main worktree and sets
     /// [`Self::worktree_selection_notice`]. See that function's docs for the full state machine.
     pub(crate) fn load_worktrees(&mut self, cx: &mut Context<Self>) {
+        self.load_worktrees_with_intent(WorktreeLoadIntent::Refresh, cx);
+    }
+
+    /// Gives a just-opened repo its guaranteed initial shell, in the worktree that was *genuinely
+    /// selected* a moment earlier - the second half of [`Self::load_worktrees_for_opened_repo`]'s
+    /// own contract, split out so the "which worktree" decision and the "spawn into it" step are
+    /// visibly separate steps rather than one tangled block.
+    ///
+    /// Spawns into [`Self::active_agent_cwd`] and refuses outright when that is `None`, which is
+    /// the whole point: there is no such thing as a tab attributed to a repo rather than to a
+    /// worktree, so if nothing real is selected there is nothing legitimate to spawn. (Today the
+    /// caller has already either selected a real worktree or fallen into
+    /// `active_agent_cwd`'s one documented last resort, so `None` here means the repo stopped
+    /// being focused entirely between the fetch being issued and it landing - a real race, worth
+    /// refusing rather than guessing through.)
+    ///
+    /// Idempotent against a worktree that already has a real agent open - a repo revisited after
+    /// being unfocused keeps whatever agents it already had running (see
+    /// [`crate::root::AdeApp::open_repo_in_current_window`]'s cross-repo persistence docs), so
+    /// this must never stack a redundant second shell onto one that is already there.
+    fn spawn_initial_shell_for_opened_repo(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(cwd) = self.active_agent_cwd() else {
+            return;
+        };
+        if self.agents.iter_for_cwd(cwd.clone()).next().is_none() {
+            let startup_agent = self.agents.spawn(
+                ProcessKind::Shell,
+                cwd.clone(),
+                self.settings.appearance.terminal_font_size,
+                self.settings.terminal.shell_override(),
+                // A shell, so no hook injection - `Agents::spawn` would discard one anyway.
+                None,
+                window,
+                cx,
+            );
+            // GitHub issue #225: the startup shell is a real agent like any other and needs a
+            // real review baseline too - see `crate::review::flow::AdeApp::
+            // capture_review_baseline`'s docs for why this is hooked at the `Agents::spawn` call
+            // site rather than inside `Agents` itself. Missing this would leave exactly one agent
+            // - the one every window starts with - permanently without a review.
+            self.capture_review_baseline(startup_agent, cx);
+        }
+        // Makes this worktree's own tab the globally active one, whether it was just spawned
+        // above or was already running from an earlier visit.
+        self.agents.activate_for_worktree(&cwd, cx);
+        // `focus_newly_spawned_agent`, not a bare `Agents::focus_active`: a focused window must
+        // never be left with `Window::focus == None` (see this crate's `OverlayFocus`/
+        // `restore_focus` docs), but it must equally never point focus at a terminal pane that
+        // isn't in the rendered tree. "Open Folder…" is reachable *with Settings open* (the File
+        // menu is an unconditional sibling of the Settings/workspace-body swap), and Settings
+        // replaces the entire workspace body - so that guard is a real one here, not a formality.
+        self.focus_newly_spawned_agent(window, cx);
+        cx.notify();
+    }
+
+    /// [`Self::load_worktrees`] for the two real "this repo is being opened for genuine work"
+    /// gestures - a CLI launch ([`Self::new_with_settings`]) and GitHub issue #90's "Open
+    /// Folder…" ([`crate::root::AdeApp::open_repo_in_current_window`]).
+    ///
+    /// Both used to spawn their guaranteed initial shell *immediately*, into the bare repo path,
+    /// and leave [`Self::selected`] at `None` - so the tab that shell produced belonged to no
+    /// worktree at all and only rendered because [`Self::active_agent_cwd`]'s old repo-root
+    /// fallback happened to coincide with the main worktree's own path. That is the reported bug
+    /// ("at the start of the program you select something and a tab bar has a terminal; then I
+    /// select a worktree and this is lost"), and its fix is not to patch the fallback but to make
+    /// the opening gesture do the real thing: resolve the repo's actual worktree list, genuinely
+    /// select the right worktree of it ([`crate::rail::worktrees::selection_for_opened_repo`]),
+    /// and spawn the initial shell into *that concretely-selected worktree*.
+    ///
+    /// The initial shell is therefore deliberately deferred until this real fetch lands rather
+    /// than spawned synchronously beforehand. `git worktree list --porcelain` is a background
+    /// call (this method never blocks the main thread on git - see [`Self::load_worktrees`]'s own
+    /// task), and there is genuinely nothing correct to spawn *into* until it answers: a
+    /// synchronous spawn would have to guess a cwd, and guessing the repo root is precisely the
+    /// bug being removed. The interim frame or two is a real, honest "focused repo, nothing
+    /// selected yet, empty tab strip" - not a fabricated tab - and [`Self::rail_focus_handle`]
+    /// holds keyboard focus meanwhile so no frame ever renders with `Window::focus` dangling.
+    ///
+    /// Seeding synchronously from already-known data (the trick
+    /// [`Self::select_worktree_by_path`]'s cross-repo case uses) is deliberately *not* used here:
+    /// that case can only work because the row the user clicked was itself rendered from a
+    /// [`crate::rail::repo::Repo::worktrees`] list that had already been fetched. A repo being
+    /// opened for the first time has no such list by definition, so there would be nothing real
+    /// to seed from in exactly the case that matters.
+    pub(crate) fn load_worktrees_for_opened_repo(
+        &mut self,
+        opened_path: PathBuf,
+        cx: &mut Context<Self>,
+    ) {
+        self.load_worktrees_with_intent(WorktreeLoadIntent::Opening { opened_path }, cx);
+    }
+
+    /// The shared body of [`Self::load_worktrees`]/[`Self::load_worktrees_for_opened_repo`] -
+    /// one real `git worktree list --porcelain` fetch, with `intent` deciding only what happens
+    /// to [`Self::selected`] once it lands. Kept as one function (rather than two similar ones)
+    /// so the fetch, the [`crate::rail::repo::Repo::worktrees`] mirror, and the
+    /// [`crate::rail::worktrees::recover_selection`] state machine can never drift apart between
+    /// the opening path and the steady-state refresh path.
+    fn load_worktrees_with_intent(&mut self, intent: WorktreeLoadIntent, cx: &mut Context<Self>) {
         let repo_path = self.focused_repo_path();
         // Captured now, not re-read via `this.focused_repo` once the fetch below completes: a
         // rapid double repo-switch could otherwise land this fetch's *old* result on whatever
@@ -728,7 +847,11 @@ impl AdeApp {
                 .background_executor()
                 .spawn(async move { wt_core::list_worktrees_porcelain(&repo_path) })
                 .await;
-            let _ = this.update(cx, |this, cx| {
+            // `update_in`, not `update`: the `Opening` intent below performs a real worktree
+            // selection and spawns this window's initial shell, both of which need a genuine
+            // `&mut Window` (moving keyboard focus onto the terminal that results). The same
+            // real pattern `Self::start_choose_repo_folder`'s own picker continuation uses.
+            let _ = this.update_in(cx, |this, window, cx| {
                 // Captured *before* `this.worktrees` is overwritten below - `recover_selection`
                 // needs the old entry's own path/label, which won't exist in the new list.
                 let previously_selected = this
@@ -761,11 +884,22 @@ impl AdeApp {
                 }
 
                 match worktrees::recover_selection(previously_selected.as_ref(), &this.worktrees) {
-                    // Deliberately stays unselected - see `crate::root::AdeApp::
-                    // checkout_repo_from_rail`'s own docs for why nothing here may auto-select a
-                    // worktree on the user's behalf. Real tab spawning is gated on
-                    // `Self::selected` directly ([`crate::work_surface::render::AdeApp::
-                    // new_agent`]/`new_agent_pane`'s own guard), not worked around here.
+                    // Nothing was selected before this fetch. What that *means* depends entirely
+                    // on why the fetch happened, which is why `intent` is an explicit parameter
+                    // rather than something guessed at from state here:
+                    //
+                    // - `Opening`: this repo is being opened for real work, and leaving it
+                    //   unselected is exactly the reported bug - a focused repo with a live
+                    //   startup terminal that belongs to no worktree. Land on a real worktree
+                    //   (`selection_for_opened_repo`) and spawn the initial shell into it.
+                    // - `Refresh`: a background watcher/poll tick, a post-prune reload, or
+                    //   `checkout_repo_from_rail`'s own follow-up fetch. None of these are a
+                    //   user asking to work somewhere, so none may select on the user's behalf -
+                    //   see `crate::root::AdeApp::checkout_repo_from_rail`'s own docs. This is
+                    //   now genuinely inert rather than merely *looking* inert: with
+                    //   `Self::active_agent_cwd`'s repo-root fallback gone, an unselected repo
+                    //   renders an honestly empty tab strip and no selected rail row, instead of
+                    //   the three-way rail/tab-strip/centre-pane disagreement it used to.
                     worktrees::SelectionRecovery::NoPriorSelection => {}
                     worktrees::SelectionRecovery::Unchanged(index) => {
                         this.selected = Some(index);
@@ -792,6 +926,37 @@ impl AdeApp {
                         this.load_file_tree(new_root.clone(), cx);
                         this.load_diff(new_root, cx);
                     }
+                }
+
+                // Deliberately *after* the recovery match rather than inside its
+                // `NoPriorSelection` arm, and keyed off `this.selected` rather than off which arm
+                // ran. Both matter, for the same real race: this fetch is asynchronous, so the
+                // user can click a worktree row while it is still in flight. That click sets
+                // `Self::selected`, which makes `recover_selection` report `Unchanged`/
+                // `FellBackToMain` here instead of `NoPriorSelection` - and an `Opening` handler
+                // living inside that one arm would then silently skip the window's *guaranteed*
+                // initial shell entirely, leaving a freshly opened repo with no terminal at all.
+                //
+                // Written this way, a raced click is simply respected: the worktree the user
+                // actually chose stays selected, and the initial shell is spawned into that, not
+                // into whatever this fetch would have picked on its own.
+                if let WorktreeLoadIntent::Opening { opened_path } = &intent {
+                    if this.selected.is_none() {
+                        if let Some(index) =
+                            worktrees::selection_for_opened_repo(opened_path, &this.worktrees)
+                        {
+                            // The one real selection entry point, deliberately - it is what
+                            // re-roots the file tree/diff, activates the worktree's own remembered
+                            // tab, and moves focus. Reimplementing a partial copy here is exactly
+                            // how the opening path would drift away from an ordinary rail click.
+                            this.select_worktree(index, window, cx);
+                        }
+                    }
+                    // Runs whether or not a worktree was selectable: a repo with no usable
+                    // worktree at all (an unreadable path, or a directory that is not a git
+                    // repository) still gets its guaranteed initial shell, via
+                    // `Self::active_agent_cwd`'s one documented last resort. See its own docs.
+                    this.spawn_initial_shell_for_opened_repo(window, cx);
                 }
 
                 this.load_disk_usage(cx);
@@ -1193,15 +1358,68 @@ impl AdeApp {
         self._file_tree_watch_task = Some(task);
     }
 
-    /// The worktree a *new* agent should be spawned into: the selected worktree's real
-    /// path if one is selected and readable, otherwise the repo root - see the module docs'
-    /// "Agents/tabs" section for why this is resolved at spawn time rather than tracked as
-    /// a per-tab "current worktree".
-    pub(crate) fn active_agent_cwd(&self) -> PathBuf {
-        match self.selected.and_then(|index| self.worktrees.get(index)) {
-            Some(item) if item.error.is_none() => item.path.clone(),
-            _ => self.focused_repo_path(),
+    /// The **one** real answer to "which worktree is the app currently working in" - the single
+    /// path the tab strip is scoped to, a new agent spawns into, and the rail draws its selected
+    /// row from. See the module docs' "Agents/tabs" section for why this is resolved on demand
+    /// rather than tracked as a per-tab "current worktree".
+    ///
+    /// ## Why this returns `Option`
+    ///
+    /// This used to be infallible, falling back to [`Self::focused_repo_path`] whenever
+    /// [`Self::selected`] was `None`. That fallback was the shared root cause of a family of
+    /// reported bugs - the same underlying flaw as the three already fixed on this branch, not a
+    /// separate one - because *a repo root is not a worktree*. Concretely, live-reproduced:
+    ///
+    /// - **A real tab that no rail row claims.** Launching against a subdirectory of a repo
+    ///   (`jerry ./crates` - an entirely ordinary invocation) made this resolve to
+    ///   `<repo>/crates`, which `git worktree list --porcelain` reports as no worktree at all.
+    ///   The startup shell spawned there rendered a real tab in the strip while *every* rail row
+    ///   read as unselected, and the instant any worktree row was clicked the tab vanished with
+    ///   no path back - its `cwd` could never again equal any row's path, so the live PTY was
+    ///   permanently orphaned.
+    /// - **The rail, the tab strip, and the centre pane disagreeing three ways.** With
+    ///   [`Self::selected`] `None` but a real agent already open in the repo root, the rail drew
+    ///   its main-worktree row as selected (this fallback matched it), the tab strip drew that
+    ///   agent's tab (`Self::combined_tab_order` scoped to this same fallback), and the centre
+    ///   pane rendered nothing at all (`Agents::active` having been genuinely cleared).
+    /// - **The reported "I select a worktree and the startup terminal is lost."** The startup
+    ///   shell's tab showed only because this fallback happened to coincide with the main
+    ///   worktree's own path while nothing was selected - so the user never performed the
+    ///   selection that owned it, and had no model of where it went or that clicking the main
+    ///   row brings it back.
+    ///
+    /// `None` is therefore a real, honest state now - "no worktree is genuinely selected" - and
+    /// every caller renders it as such (an empty tab strip, an empty centre pane, no rail row
+    /// reading as selected, and no spawn) rather than silently substituting the repo root.
+    ///
+    /// ## The one documented last resort
+    ///
+    /// A focused repo whose worktree list has genuinely *landed* and contains nothing usable -
+    /// an unreadable path, or a directory that isn't a git repository at all, both of which
+    /// `wt_core::list_worktrees_porcelain` reports as a real `Err` that
+    /// [`Self::load_worktrees`] turns into an empty [`Self::worktrees`] - still resolves to the
+    /// repo root. This is a real error state, not the common path, and it is self-consistent in
+    /// a way the old blanket fallback never was: there are no worktree rows at all, so there is
+    /// no row that could disagree with it, and the repo root is the only honest place left to
+    /// work in. Gated on [`crate::rail::repo::Repo::worktrees_loaded`] specifically so the
+    /// window *before* the first fetch lands - when [`Self::worktrees`] is empty merely because
+    /// nothing has been asked yet - reports the honest `None` instead of briefly reintroducing
+    /// the very fallback this removes.
+    pub(crate) fn active_agent_cwd(&self) -> Option<PathBuf> {
+        if let Some(item) = self.selected.and_then(|index| self.worktrees.get(index)) {
+            if item.error.is_none() {
+                return Some(item.path.clone());
+            }
         }
+        // See "The one documented last resort" above.
+        let list_has_landed = self
+            .focused_repo()
+            .is_some_and(|repo| repo.worktrees_loaded);
+        let nothing_usable = !self.worktrees.iter().any(|item| item.error.is_none());
+        if list_has_landed && nothing_usable {
+            return Some(self.focused_repo_path());
+        }
+        None
     }
 
     pub(crate) fn select_worktree(

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -76,7 +76,14 @@ impl AdeApp {
         if self.focused_repo().is_none() {
             return;
         }
-        let cwd = self.active_agent_cwd();
+        // A tab is only ever attributable to a real, currently-selected worktree - there is no
+        // such thing as "a repo's own tab". With no worktree genuinely selected there is nothing
+        // legitimate to spawn into, so this refuses rather than falling back to the repo root as
+        // it used to (see `Self::active_agent_cwd`'s own docs for the family of live-reproduced
+        // bugs that fallback caused).
+        let Some(cwd) = self.active_agent_cwd() else {
+            return;
+        };
         // GitHub issue #239 phase 2: a Claude agent is spawned against this instance's generated
         // `--settings` file and told, through its environment, where to report its hooks. Taken as
         // an owned snapshot because `self.agents.spawn` borrows `self.agents` mutably - see
@@ -586,7 +593,14 @@ impl AdeApp {
     /// own tab is *labeled* (`Self::current_worktree_agent_tab_labels`'s bare-shell label), just
     /// not which tabs render at all.
     pub(crate) fn combined_tab_order(&self) -> Vec<work_surface::TabRef> {
-        let cwd = self.active_agent_cwd();
+        // No worktree genuinely selected means genuinely no tabs - an honestly empty strip, not
+        // whatever happens to be open in the repo root. This used to fall through to
+        // `Self::active_agent_cwd`'s repo-root fallback, which is how a live terminal could be
+        // drawn in the strip while the centre pane showed nothing and no rail row claimed it (see
+        // that method's own docs for the live repro).
+        let Some(cwd) = self.active_agent_cwd() else {
+            return Vec::new();
+        };
         let agents_for_cwd: Vec<&Agent> = self.agents.iter_for_cwd(cwd.clone()).collect();
         let agent_ids: Vec<AgentId> = agents_for_cwd.iter().map(|agent| agent.id).collect();
         // `Self::tab_order` hasn't been touched for yet *this session* falls back to its real,
@@ -636,7 +650,11 @@ impl AdeApp {
         insert_after: bool,
         cx: &mut Context<Self>,
     ) {
-        let cwd = self.active_agent_cwd();
+        // A drag can only ever have started from a tab that was genuinely rendered, which means a
+        // real worktree is selected - this refusal is defensive, not a reachable path.
+        let Some(cwd) = self.active_agent_cwd() else {
+            return;
+        };
         let mut order = self.combined_tab_order();
         work_surface::move_tab_order(&mut order, &dragged, &target, insert_after);
         self.tab_order.insert(cwd.clone(), order.clone());
@@ -837,7 +855,7 @@ impl AdeApp {
     /// [`Self::render_agent_context_bar`]'s own branch lookup so both read the same fact the
     /// same way.
     fn current_worktree_branch(&self) -> Option<String> {
-        let cwd = self.active_agent_cwd();
+        let cwd = self.active_agent_cwd()?;
         self.worktrees
             .iter()
             .find(|item| item.path == cwd)
@@ -1596,7 +1614,11 @@ impl AdeApp {
         if self.focused_repo().is_none() {
             return;
         }
-        let cwd = self.active_agent_cwd();
+        // The identical "no worktree selected means nothing legitimate to spawn into" refusal
+        // [`Self::new_agent`] applies - see its own docs.
+        let Some(cwd) = self.active_agent_cwd() else {
+            return;
+        };
         let task = cx.spawn(async move |this, cx| {
             let installed = cx
                 .background_executor()


### PR DESCRIPTION
## The bug, as reported

> "at the start of the program idk what you do, you select something and a tab bar has a terminal. Then I select a worktree and this is lost. I think you need to overhaul the tab handling and how it works to simplify it, only link tabs to worktrees."

## Base note

This was scoped as a follow-up commit on `fix-multi-repo-bugs` / PR #258, but #258 is **already merged** and its branch is deleted on the remote, so a push there would have attached to nothing and would have dropped #260 and #264. This is based on `origin/master` instead, which contains all of #258 plus those two — a strict superset of the intended base. Hence a new PR rather than a push to #258.

## What was actually wrong

`AdeApp::active_agent_cwd` fell back to `AdeApp::focused_repo_path()` whenever `AdeApp::selected` was `None`. That quietly made **a repo root behave like a worktree it is not** — and it is the same underlying flaw as the three bugs already fixed on #258 (repo-rooted tabs, the header opening a plus-menu with no worktree context, checkout reactivating a stale agent), not a separate one. Each of those was fixed at its own call site; the fallback that made them all possible survived.

Both opening gestures — a CLI launch and "Open Folder…", which duplicated each other's logic almost verbatim — spawned their guaranteed initial shell into the bare repo path and left `selected` at `None`. So the tab the user saw at startup **belonged to no worktree at all**, and rendered only because the fallback happened to coincide with the main worktree's own path.

## Reproduced live first

Three distinct failures, captured frame by frame against a real `AdeApp`, real `git worktree list --porcelain` data and real PTYs, before writing any fix:

**1. A real tab no rail row claims, orphaned forever by one click.** `jerry ./crates` — an ordinary invocation — resolved `active_agent_cwd` to `<repo>/crates`, which git reports as no worktree:

```
selected          = None
active_agent_cwd  = "/tmp/.tmp3FxSuK/crates"
worktrees         = [("/tmp/.tmp3FxSuK", true)]
combined_tab_order= [Agent(0)]                     <- a real tab IS showing
rail row selected = [("/tmp/.tmp3FxSuK", false)]   <- NO rail row claims it
```

One click on the only worktree row:

```
combined_tab_order= []                             <- tab gone
agents            = [(0, "/tmp/.tmp3FxSuK/crates")] <- process still alive
```

No path back exists: no row will ever have that path, so the live PTY is permanently unreachable.

**2. Rail, tab strip and centre pane disagreeing three ways.** With `selected == None` and a real agent in the repo root, the rail drew the main-worktree row as **selected**, the tab strip drew that agent's tab, and the centre pane rendered **nothing** (`Agents::clear_active` having genuinely cleared it).

**3. The reported gesture.** In the ordinary `jerry .` case the process *does* survive and clicking back *does* restore it — confirmed live, so nothing was dying. But the user never performed the selection that owned the tab, so its disappearance had no explanation and no discoverable way back.

## The invariant

> **A tab is never shown, never spawnable, and never implicitly attributed to anything except a real, currently-selected worktree. There is no such thing as "a repo's own tab".**

- **`active_agent_cwd` now returns `Option<PathBuf>`.** "Nothing is selected" is a state the app can *say* rather than paper over, and every caller renders it honestly: empty tab strip, empty centre pane, no rail row selected, no spawn. The one documented last resort left is a focused repo whose worktree list has genuinely *landed* with nothing usable — a real error state, self-consistent because there are then no rows that could disagree with it, and gated on `Repo::worktrees_loaded` so the window *before* the first fetch reports the honest `None`.
- **One opening path.** Both gestures funnel through `load_worktrees_for_opened_repo`: resolve the real worktree list, genuinely select the right worktree (`rail::worktrees::selection_for_opened_repo`), *then* spawn the initial shell into that concretely-selected worktree. The spawn is deliberately deferred until the real fetch lands — there is nothing correct to spawn into until git answers, and guessing the repo root is the bug being removed. No synchronous git call was added; `rail_focus_handle` holds focus meanwhile so no frame renders with `Window::focus` dangling.
- **`selection_for_opened_repo`** prefers the path the user actually named (`jerry ~/repo-wt/feature` lands on *that* worktree, not main), falling back to the main worktree (so a subdirectory launch lands somewhere real).
- **`WorktreeLoadIntent`** makes *why* a fetch is happening explicit rather than guessed once it resolves — by then "just opened" and "a poll tick for a repo with nothing selected" are indistinguishable from state alone, and must behave in opposite ways.
- **A race closed while reviewing this diff:** the opening handler is keyed off `selected` *after* the recovery match, not inside its `NoPriorSelection` arm. The fetch is async, so a click landing first makes `recover_selection` report `Unchanged` — an in-arm handler would have silently skipped the guaranteed initial shell, leaving a freshly opened repo with no terminal at all. A raced click is now simply respected.

## Explicitly unchanged

- **The repo header stays entirely inert.** Not a click target in any form. Nothing here reopens any path to it doing something.
- **Cross-repo agent persistence is untouched.** Background agents in every repo keep running and keep reporting live rail status.
- **`checkout_repo_from_rail` still selects nothing of its own**, and its test still passes unmodified. What changed is *why that is safe*: leaving nothing selected is now genuinely inert everywhere, instead of rendering a plausible-looking tab through the fallback. Its doc comment described an earlier **rejected** behaviour rather than what its body asserts — corrected here, with no assertion touched.

**No test was deleted, weakened, or had an assertion changed.**

## Verification

8 new `#[gpui::test]`s driving **real painted rail rows** through `debug_bounds`/`simulate_click` (not by calling selection methods directly — the whole bug class was about what the *rendered* rail, tab strip and centre pane each independently believed), plus 6 pure unit tests for the new selection rule.

Every test was verified to **discriminate**, by reverting the fix in two independent halves and confirming each fails with its own specific assertion message before restoring:

- *Restore the blanket fallback* → `nothing_selected_means_nothing_shown_anywhere` fails: `left: Some("/tmp/.tmpuo77OR"), right: None` — "so there is genuinely no active worktree - not the repo root standing in for one".
- *Remove selection-on-open* → all 5 opening tests fail, e.g. "a fresh launch must land on the repo's own main worktree as a real selection - `AdeApp::selected` staying `None` here is the reported bug, not a neutral starting state".
- *Move the opening handler back into the `NoPriorSelection` arm* → the race test fails with its own message.

`cargo build --workspace`, `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --check` all clean. Full `cargo test --workspace`: **2313 pass**. The only failures are this environment's known load-contention classes — `file_tree_watch`/`worktree_watch` (inotify `max_user_instances` exhaustion under concurrent load) and the rust-analyzer LSP test — **all 28 of which pass in isolation**, verified.
