### PR TITLE
fix(app): unbreak `clippy -D warnings` off macOS without breaking macOS

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -203,6 +203,13 @@ pub fn default_key_bindings() -> Vec<gpui::KeyBinding> {
     // `modifiers.platform` set, so a real Cmd-modified key never reaches a pty in the first
     // place - the same real fact `"cmd-k"`/`"cmd-c"`/`"cmd-v"` below already rely on for
     // `TerminalClear`/`TerminalCopy`/`TerminalPaste`.
+    // `mut` is real, but only on macOS: the `Cmd+Q` binding below is `#[cfg(target_os = "macos")]`,
+    // so on every other platform nothing is ever pushed and `unused_mut` fires - which under this
+    // project's `-D warnings` is a hard build failure on Linux and Windows while macOS stays
+    // green. Silenced exactly where it is spurious rather than taken at its word: clippy's own
+    // suggestion here is to drop the `mut`, which is platform-blind advice that would break the
+    // macOS build outright.
+    #[cfg_attr(not(target_os = "macos"), allow(unused_mut))]
     let mut bindings = vec![
         gpui::KeyBinding::new("secondary-n", root::NewAgent, None),
         // The palette's real shortcut, matching the VS Code/Sublime "command palette" convention


### PR DESCRIPTION
`master` does not currently pass `cargo clippy --workspace --all-targets -- -D warnings` on Linux or Windows:

```
error: variable does not need to be mutable
  --> crates/app/src/lib.rs:206:9
    = note: `-D unused-mut` implied by `-D warnings`
```

## Why it went unnoticed

`default_key_bindings`' `let mut bindings` is only ever mutated by the `#[cfg(target_os = "macos")] bindings.push(...)` that adds Cmd+Q (`lib.rs:609`). Off macOS nothing is pushed, so `unused_mut` fires — and under this project's `-D warnings` that's a hard build failure. On macOS, where the binding *is* compiled, the lint doesn't fire at all and the tree looks green.

## Why not just do what clippy says

Clippy's suggestion is *"remove this `mut`"*. That advice is platform-blind — the `mut` is genuinely required on macOS, so taking it would swap a Linux/Windows build failure for a macOS one.

The lint is silenced only on the targets where it is spurious:

```rust
#[cfg_attr(not(target_os = "macos"), allow(unused_mut))]
let mut bindings = vec![
```

macOS therefore keeps warning for real if that `push` ever goes away, rather than the `mut` becoming permanently unauditable everywhere.

## Verification

`cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --check` clean on Linux. The macOS arm is reasoned through, not compiled — no Apple SDK on this machine — but the cfg logic is symmetric: on macOS the attribute is not applied and the `mut` is used by the `push`; off macOS the attribute is applied and the `mut` is unused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)