### PR TITLE
feat(app): reopen every tab you had open, on relaunch

### DIFF
--- a/crates/app/src/code_surface/tabs.rs
+++ b/crates/app/src/code_surface/tabs.rs
@@ -228,6 +228,11 @@ impl AdeApp {
         self.dismiss_hover();
         self.dismiss_completions();
         self.close_tab_confirm_armed = None;
+        // A newly opened file tab changes this worktree's real tab session, so it reopens on the
+        // next launch - see `crate::work_surface::session`. A no-op when `push_open_file` above
+        // found the tab already open (an already-open path is reused, never duplicated), since the
+        // recorder compares against what is already on disk before writing.
+        self.record_worktree_session(cx);
         cx.notify();
     }
 
@@ -374,6 +379,9 @@ impl AdeApp {
         self.prune_confirm_armed = false;
         self.discard_confirm_armed = None;
         self.close_tab_confirm_armed = None;
+        // `push_open_file` above can genuinely add a tab here (see this method's own docs on why
+        // it calls it at all), so this is a real session change, not just an activation.
+        self.record_worktree_session(cx);
         cx.notify();
     }
 
@@ -476,6 +484,9 @@ impl AdeApp {
         }
         self.prune_confirm_armed = false;
         self.discard_confirm_armed = None;
+        // A closed file tab must stay closed across a relaunch - see
+        // `crate::work_surface::session`.
+        self.record_worktree_session(cx);
         cx.notify();
     }
 

--- a/crates/app/src/hooks/flow.rs
+++ b/crates/app/src/hooks/flow.rs
@@ -109,6 +109,10 @@ impl AdeApp {
         self.capture_review_baseline(id, cx);
         self.close_gated_review_tab(window, cx);
         self.focus_newly_spawned_agent(window, cx);
+        // A resumed agent is a real new tab in this worktree, and one whose whole point is that it
+        // carries a real session id forward - so it belongs in the persisted tab session too, and
+        // will itself be resumable again after the next quit. See `crate::work_surface::session`.
+        self.record_worktree_session(cx);
         self.prune_confirm_armed = false;
         self.discard_confirm_armed = None;
         cx.notify();
@@ -280,6 +284,17 @@ impl AdeApp {
 
         if changed {
             self.persist_agent_statuses(cx);
+            // A live agent's `session_id` is learned *here*, from its own hooks, some time after
+            // its tab was created and recorded - so the tab session written when the tab opened
+            // still says "no resumable session" for it. Re-recording on a real change is what
+            // turns that into a genuinely resumable entry before the user ever quits; without it,
+            // relaunching would honestly refuse to restore an agent that was, in fact, resumable
+            // the whole time (`crate::work_surface::session::AdeApp::restore_worktree_session`).
+            //
+            // Cheap despite riding the status poll: the recorder compares against what is already
+            // recorded and returns without touching the disk when nothing changed, which is every
+            // tick after the first one that learns an id.
+            self.record_worktree_session(cx);
         }
     }
 

--- a/crates/app/src/rail/repo.rs
+++ b/crates/app/src/rail/repo.rs
@@ -193,13 +193,28 @@ pub struct RepoState {
     pub last_focused: Option<String>,
 }
 
-/// One repo's persisted record - just its display name today. The map key (a [`repo_key`]) is
-/// the path; nothing about `Repo::worktrees` is persisted here (see that field's own docs for
-/// why - it isn't populated yet at all).
+/// One repo's persisted record. The map key (a [`repo_key`]) is the path; the repo's *worktree
+/// list* is deliberately not persisted at all (see [`Repo::worktrees`]'s own docs - it is always
+/// re-fetched from real git), only which one of them was last worked in.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct RepoRecord {
     pub name: String,
+    /// The real path of the worktree of this repo that `crate::root::AdeApp::select_worktree` most
+    /// recently selected, so relaunching Jerry lands back in it rather than always in the main
+    /// checkout - the per-repo counterpart to [`RepoState::last_focused`], and the half that makes
+    /// "everything reopens" true at launch rather than only after the user clicks the right rail
+    /// row (a worktree's own tabs are restored when it is genuinely selected - see
+    /// `crate::work_surface::session`).
+    ///
+    /// Stored as a plain path string rather than a [`PathBuf`] for the same reason every other
+    /// field in this file is a string: it is a TOML value that must survive a build that has never
+    /// heard of it. `None` for a repo whose worktrees were never selected in, and for a record
+    /// written before this field existed (`#[serde(default)]`). Never trusted blindly on read -
+    /// [`RepoState::remembered_worktree`] checks it still names a real directory, and
+    /// `crate::rail::worktrees::selection_for_opened_repo` independently checks it still names a
+    /// real worktree of the repo, falling back to the main checkout if not.
+    pub selected_worktree: Option<String>,
 }
 
 /// How stale a `*.tmp` sibling must be before [`sweep_orphaned_temp_files`] deletes it - the
@@ -381,6 +396,17 @@ impl RepoState {
         // repo" and failing downstream once something tries to actually read it as one.
         path.is_dir().then_some(path)
     }
+
+    /// [`RepoRecord::selected_worktree`] for `key`, if it still names a real directory on disk -
+    /// [`Self::last_focused_existing_path`]'s own "remembered, and still there" check, applied one
+    /// level down. `None` for an unknown repo, a repo never selected in, or a worktree since
+    /// removed/pruned; every one of those falls back to
+    /// `crate::rail::worktrees::selection_for_opened_repo`'s ordinary main-checkout answer rather
+    /// than to a broken selection.
+    pub fn remembered_worktree(&self, key: &str) -> Option<PathBuf> {
+        let path = PathBuf::from(self.repos.get(key)?.selected_worktree.as_ref()?);
+        path.is_dir().then_some(path)
+    }
 }
 
 #[cfg(test)]
@@ -424,6 +450,44 @@ mod tests {
         assert_eq!(RepoState::load_at(&path), RepoState::default());
     }
 
+    /// The per-repo "land back where I left off" record: remembered, still on disk, and really
+    /// returned - plus the three real ways it must fall back to `None` rather than to a broken
+    /// selection (unknown repo, never selected in, since deleted).
+    #[test]
+    fn a_remembered_worktree_is_returned_only_while_it_still_exists() {
+        let worktree = tempfile::tempdir().expect("tempdir");
+        let mut state = RepoState::default();
+        state.repos.insert(
+            "/repo/a".to_string(),
+            RepoRecord {
+                name: "a".to_string(),
+                selected_worktree: Some(worktree.path().to_string_lossy().into_owned()),
+            },
+        );
+        state.repos.insert(
+            "/repo/never-selected".to_string(),
+            RepoRecord {
+                name: "never-selected".to_string(),
+                selected_worktree: None,
+            },
+        );
+
+        assert_eq!(
+            state.remembered_worktree("/repo/a"),
+            Some(worktree.path().to_path_buf())
+        );
+        assert_eq!(state.remembered_worktree("/repo/never-selected"), None);
+        assert_eq!(state.remembered_worktree("/repo/not-a-known-repo"), None);
+
+        drop(worktree);
+        assert_eq!(
+            state.remembered_worktree("/repo/a"),
+            None,
+            "a worktree removed or pruned since it was remembered must fall back, not be \
+             selected into a directory that no longer exists"
+        );
+    }
+
     #[test]
     fn saving_and_loading_round_trips_a_real_file() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -433,12 +497,14 @@ mod tests {
             "/repo/a".to_string(),
             RepoRecord {
                 name: "a".to_string(),
+                selected_worktree: None,
             },
         );
         state.repos.insert(
             "/repo/b".to_string(),
             RepoRecord {
                 name: "b".to_string(),
+                selected_worktree: None,
             },
         );
         state.save_at(&path).expect("save");
@@ -456,6 +522,7 @@ mod tests {
             "/repo/a".to_string(),
             RepoRecord {
                 name: "a".to_string(),
+                selected_worktree: None,
             },
         );
         state.save_at(&path).expect("save");
@@ -486,6 +553,7 @@ mod tests {
             "/repo/a".to_string(),
             RepoRecord {
                 name: "a".to_string(),
+                selected_worktree: None,
             },
         );
         let owned_a: std::collections::BTreeSet<String> =
@@ -498,6 +566,7 @@ mod tests {
             "/repo/b".to_string(),
             RepoRecord {
                 name: "b".to_string(),
+                selected_worktree: None,
             },
         );
         let owned_b: std::collections::BTreeSet<String> =
@@ -527,6 +596,7 @@ mod tests {
             "/repo/a".to_string(),
             RepoRecord {
                 name: "a".to_string(),
+                selected_worktree: None,
             },
         );
         state.save_merged_at(&path, &owned).expect("save");
@@ -572,6 +642,7 @@ mod tests {
             key.clone(),
             RepoRecord {
                 name: "deleted-repo".to_string(),
+                selected_worktree: None,
             },
         );
         state.last_focused = Some(key);
@@ -602,6 +673,7 @@ mod tests {
             key.clone(),
             RepoRecord {
                 name: "was-a-repo".to_string(),
+                selected_worktree: None,
             },
         );
         state.last_focused = Some(key);
@@ -634,6 +706,7 @@ mod tests {
             key.clone(),
             RepoRecord {
                 name: "repo".to_string(),
+                selected_worktree: None,
             },
         );
         state.last_focused = Some(key);
@@ -658,6 +731,7 @@ mod tests {
             "/repo/a".to_string(),
             RepoRecord {
                 name: "a".to_string(),
+                selected_worktree: None,
             },
         );
         state.last_focused = Some("/repo/a".to_string());
@@ -684,12 +758,14 @@ mod tests {
             "/repo/a".to_string(),
             RepoRecord {
                 name: "a".to_string(),
+                selected_worktree: None,
             },
         );
         state.repos.insert(
             "/repo/b".to_string(),
             RepoRecord {
                 name: "b".to_string(),
+                selected_worktree: None,
             },
         );
         state.last_focused = Some("/repo/a".to_string());

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -1924,17 +1924,17 @@ pub struct AdeApp {
     /// Each worktree's own real, drag-chosen tab order (GitHub issue #16) - agent and file
     /// tabs interleaved, keyed by that worktree's cwd. Never itself the source of truth for
     /// which tabs exist (`Agents`/[`Self::open_files`] still are - see
-    /// [`Self::combined_tab_order`]'s own docs); only [`Self::reorder_tab`] writes to it. A
-    /// worktree with no entry here yet falls back to [`Self::tab_order_state`]'s real, persisted
-    /// order (`crate::work_surface::tab_order_state::TabOrderState::file_order`) rather than the old
-    /// two-block "agents then files" layout - see [`Self::combined_tab_order`]'s own docs for
-    /// exactly where that fallback happens.
+    /// [`Self::combined_tab_order`]'s own docs). Two writers: [`Self::reorder_tab`] (a real drag)
+    /// and `crate::work_surface::session::AdeApp::restore_worktree_session` (a worktree's
+    /// remembered order, seeded at the moment it is genuinely activated). A worktree with no entry
+    /// here reconciles against an empty slice, i.e. the plain "every agent, then every file"
+    /// default.
     pub(crate) tab_order: HashMap<PathBuf, Vec<work_surface::TabRef>>,
-    /// The tab strip's real, on-disk drag order (GitHub issue #16: "the resulting layout...
-    /// persists per session/worktree and restores on relaunch") - loaded once at startup
-    /// (`Self::new_with_settings`), updated by [`Self::reorder_tab`] alongside [`Self::tab_order`]
-    /// itself, and read by [`Self::combined_tab_order`] as the fallback for a worktree
-    /// [`Self::tab_order`] hasn't touched yet this session.
+    /// The tab strip's real, on-disk session (GitHub issue #16: "the resulting layout... persists
+    /// per session/worktree and restores on relaunch", widened into "which tabs were open at all"
+    /// by `crate::work_surface::session`) - loaded once at startup (`Self::new_with_settings`),
+    /// written by `crate::work_surface::session::AdeApp::record_worktree_session` on every real tab
+    /// change, and read back by that module's own restore to reopen them.
     pub(crate) tab_order_state: crate::work_surface::tab_order_state::TabOrderState,
     /// [`Self::tab_order_state`]'s resolved on-disk path
     /// (`crate::work_surface::tab_order_state::tab_order_path_for`), `None` for the same tests that get
@@ -1950,6 +1950,44 @@ pub struct AdeApp {
     /// [`Self::fold_state_save_pending`]'s coalescing queue, a new reorder simply starts a fresh
     /// save rather than needing one to be pending while another runs.
     pub(crate) _tab_order_save_task: Option<Task<()>>,
+    /// Every worktree whose persisted tab session this window has already dealt with - see
+    /// `crate::work_surface::session::AdeApp::restore_worktree_session`, which is the only writer.
+    ///
+    /// Two jobs, both load-bearing:
+    ///
+    /// 1. **Restore exactly once per worktree per window.** Restoring reopens file tabs and spawns
+    ///    real processes; running it again on the next rail click back into the same worktree would
+    ///    stack a second shell (and a second resumed agent) on top of the first every time.
+    /// 2. **Gate recording on restore having happened.** A worktree whose session hasn't been
+    ///    restored yet still looks empty, and
+    ///    [`crate::work_surface::session::AdeApp::record_worktree_session`] writing that emptiness
+    ///    to disk would erase the very session the next selection was about to reopen. Membership
+    ///    here is what makes "the live tab strip is now the truth for this worktree" a real,
+    ///    checkable fact rather than an assumption.
+    pub(crate) session_restored: HashSet<PathBuf>,
+    /// Every real reason a persisted tab could not be reopened this session - "`src/gone.rs` no
+    /// longer exists", "a Codex agent has no resumable session id". One degraded tab never fails
+    /// the rest of a restore (see
+    /// [`crate::work_surface::session::AdeApp::restore_worktree_session`]), but it must not
+    /// silently vanish either: each entry is logged as it happens and kept here.
+    ///
+    /// Nothing renders these yet - deliberately, and stated plainly rather than implied: this
+    /// carries the same "real data captured, no UI reads it back" contract
+    /// `crate::hooks::store`'s own module docs already established for its first phase. Bounded by
+    /// [`crate::work_surface::session::MAX_SESSION_RESTORE_NOTICES`] so a user who visits many
+    /// worktrees in one long-running window can't grow it without limit.
+    pub(crate) session_restore_notices: Vec<String>,
+    /// Which worktree of each repo (keyed by `crate::rail::repo::repo_key`) was last genuinely
+    /// selected - the live mirror of `crate::rail::repo::RepoRecord::selected_worktree`, seeded
+    /// from `repos.toml` at startup and updated by [`Self::select_worktree`].
+    ///
+    /// A map rather than a single value because [`Self::selected`] only ever describes the
+    /// *focused* repo: [`Self::repo_state_snapshot`] has to write a real remembered worktree for
+    /// every repo it persists, including the ones this window has not looked at since launch, and
+    /// without this it would blank theirs out on the next save (`RepoState::save_merged_at`
+    /// replaces a whole record for every key in [`Self::repo_state_owned`], and startup's own
+    /// `add_repo` puts every restored repo in that set).
+    pub(crate) selected_worktree_by_repo: HashMap<String, PathBuf>,
     /// The unified tab strip's real, precise drop-target indicator (GitHub issue #16's "better
     /// visual feedback" ask): `Some((target, insert_after))` while a tab is being dragged over
     /// `target`'s own tab, where `insert_after` says whether the cursor is over the right half
@@ -2693,10 +2731,20 @@ impl AdeApp {
         let mut state = repo::RepoState::default();
         for r in &self.repos {
             if let Some(key) = repo::repo_key(&r.path) {
+                // Read straight back out of the live mirror rather than from `Self::selected`,
+                // which only ever describes the *focused* repo - see
+                // [`Self::selected_worktree_by_repo`]'s own docs for why blanking every other
+                // repo's remembered worktree on each save would be a real regression, not a
+                // cosmetic one.
+                let selected_worktree = self
+                    .selected_worktree_by_repo
+                    .get(&key)
+                    .map(|path| path.to_string_lossy().into_owned());
                 state.repos.insert(
                     key,
                     repo::RepoRecord {
                         name: r.name.clone(),
+                        selected_worktree,
                     },
                 );
             }
@@ -3619,6 +3667,7 @@ mod repo_list_tests {
             canonical_b.clone(),
             crate::rail::repo::RepoRecord {
                 name: "repo-b".to_string(),
+                selected_worktree: None,
             },
         );
         seed.save_at(&repo_state_path).expect("seed save");
@@ -4560,6 +4609,7 @@ mod repo_list_tests {
             canonical,
             crate::rail::repo::RepoRecord {
                 name: "other-repo".to_string(),
+                selected_worktree: None,
             },
         );
         seed.save_at(&repo_state_path).expect("seed save");

--- a/crates/app/src/root/new_file.rs
+++ b/crates/app/src/root/new_file.rs
@@ -431,6 +431,12 @@ impl AdeApp {
         self.dismiss_completions();
         self.save_active_file(cx);
         self.load_file_tree(self.file_tree_root.clone(), cx);
+        // A just-created file gets a real tab here, without going through
+        // `crate::code_surface::tabs::AdeApp::open_and_focus_file` (this method does that work
+        // itself, plus a seeded empty edit buffer) - so it needs its own recording call, or the
+        // tab a user just made would be the one kind that didn't survive a relaunch. See
+        // `crate::work_surface::session`.
+        self.record_worktree_session(cx);
         cx.notify();
         Ok(())
     }

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -183,6 +183,23 @@ impl AdeApp {
             });
             next_repo_id += 1;
         }
+        // The live mirror of every restored repo's own last-selected worktree - see
+        // `Self::selected_worktree_by_repo`'s own docs for why this has to be a whole map rather
+        // than a single value, and `Self::restore_worktree_session` for what a selection then
+        // reopens. Deliberately seeded from the raw records rather than through
+        // `RepoState::remembered_worktree`'s "still exists on disk" filter: this map's job is to
+        // faithfully mirror what is on disk so a save doesn't blank another window's entry, and
+        // the existence check belongs at the two points that actually *act* on a remembered
+        // worktree (the startup selection below, and `selection_for_opened_repo`'s own check that
+        // it is still a real worktree of the repo).
+        let selected_worktree_by_repo: HashMap<String, PathBuf> = loaded_repo_state
+            .repos
+            .iter()
+            .filter_map(|(key, record)| {
+                let worktree = record.selected_worktree.as_ref()?;
+                Some((key.clone(), PathBuf::from(worktree)))
+            })
+            .collect();
 
         // GitHub issue #90: the one real resolution point for "what repo (if any) should this
         // window start focused on" - see `Self::new_with_settings`'s own docs for the full
@@ -201,6 +218,13 @@ impl AdeApp {
         // produce a repo whose agents matched no worktree row at all; see that function's own
         // docs. The remembered-repo branch needs no such call: `RepoState`'s keys are already
         // `repo::repo_key` output, which is canonical by construction.
+        //
+        // `opened_from_memory` is the second half of that same decision, and exists only for the
+        // worktree-level restore below: an explicitly named path (a CLI argument) is a real
+        // statement about *where to work* and is honoured literally, while a repo resolved purely
+        // from memory carries no such statement and can therefore honour the finer-grained memory
+        // of which worktree of it was last worked in. See the `opened_target` note further down.
+        let opened_from_memory = repo_path.is_none() && use_remembered_repo;
         let resolved_repo_path: Option<PathBuf> = match repo_path {
             Some(path) => Some(repo::canonical_repo_path(&path)),
             None if use_remembered_repo => loaded_repo_state.last_focused_existing_path(),
@@ -574,6 +598,9 @@ impl AdeApp {
             tab_order_path,
             tab_order_owned: std::collections::BTreeSet::new(),
             _tab_order_save_task: None,
+            session_restored: HashSet::new(),
+            session_restore_notices: Vec::new(),
+            selected_worktree_by_repo,
             tab_drag_insertion: None,
             dragging_tab: None,
             dropped_tab_settle: None,
@@ -671,7 +698,26 @@ impl AdeApp {
                 // spawn/baseline/focus block almost verbatim; both now funnel through that one
                 // method, so a CLI launch and "Open Folder…" can no longer drift apart on which
                 // worktree the window lands in.
-                this.load_worktrees_for_opened_repo(path.clone(), cx);
+                //
+                // `opened_target` is what that sequence resolves its selection against
+                // (`crate::rail::worktrees::selection_for_opened_repo`: an exact match on this
+                // path, else the main checkout). For a repo resolved purely from memory - the
+                // plain "relaunch Jerry" gesture - that is the remembered worktree, so relaunching
+                // genuinely lands back in the worktree you were last in, and
+                // `Self::restore_worktree_session` then reopens its tabs. For an explicitly named
+                // path it stays the path itself, unchanged: `jerry ~/repo` is a real statement
+                // about where to work, and silently opening some other worktree of that repo
+                // because it was the last one visited would be overriding the user, not helping
+                // them. `selection_for_opened_repo` needs no change either way - a remembered
+                // worktree that has since been removed simply matches nothing and falls back to
+                // the main checkout, exactly as an unrecognised path already does.
+                let opened_target = match opened_from_memory {
+                    true => repo::repo_key(&path)
+                        .and_then(|key| loaded_repo_state.remembered_worktree(&key))
+                        .unwrap_or_else(|| path.clone()),
+                    false => path.clone(),
+                };
+                this.load_worktrees_for_opened_repo(opened_target, cx);
                 // Keyboard focus while that fetch is in flight. Without this the window would
                 // render its first frames with `Window::focus == None` - the dangling-focus bug
                 // class this crate's `OverlayFocus`/`restore_focus` machinery exists to prevent -
@@ -762,6 +808,14 @@ impl AdeApp {
         let Some(cwd) = self.active_agent_cwd() else {
             return;
         };
+        // Deliberately *before* the guaranteed-shell check below, not after: this worktree may
+        // have had a whole tab session last time, terminal included, and reopening it first is
+        // what lets the check below see a worktree that already has its own real agent and decline
+        // to stack a redundant extra shell on top. See
+        // `crate::work_surface::session::AdeApp::restore_worktree_session`'s own docs. A no-op
+        // whenever `Self::select_worktree` already restored this worktree a moment ago (the
+        // ordinary path), and whenever there is nothing recorded at all.
+        self.restore_worktree_session(cwd.clone(), window, cx);
         if self.agents.iter_for_cwd(cwd.clone()).next().is_none() {
             let startup_agent = self.agents.spawn(
                 ProcessKind::Shell,
@@ -779,6 +833,9 @@ impl AdeApp {
             // site rather than inside `Agents` itself. Missing this would leave exactly one agent
             // - the one every window starts with - permanently without a review.
             self.capture_review_baseline(startup_agent, cx);
+            // The guaranteed startup shell is a real tab like any other, so it is part of this
+            // worktree's persisted session too - see `crate::work_surface::session`.
+            self.record_worktree_session(cx);
         }
         // Makes this worktree's own tab the globally active one, whether it was just spawned
         // above or was already running from an earlier visit.
@@ -1436,10 +1493,28 @@ impl AdeApp {
             return;
         }
         let path = item.path.clone();
+        // The safety net for the tab session of whatever is being switched *away* from
+        // (`crate::work_surface::session`): every real tab mutation records as it happens, so this
+        // is normally a no-op that compares an unchanged snapshot and returns - but it means a
+        // future mutation path that forgets to record still can't lose a user's tabs, since
+        // leaving a worktree is something every such path is eventually followed by. Must run
+        // before `self.selected` moves below, while `Self::active_agent_cwd` still resolves to the
+        // worktree being left.
+        self.record_worktree_session(cx);
         self.selected = Some(index);
         // A real, explicit user selection supersedes any stale "fell back to main" notice a
         // previous refresh may have left up - see `Self::worktree_selection_notice`'s own docs.
         self.worktree_selection_notice = None;
+        // "Which worktree of this repo was I last in" - the per-repo memory a later launch reads
+        // back to land here again (`crate::rail::repo::RepoRecord::selected_worktree`, resolved at
+        // startup in `Self::new_with_settings`). Recorded for the *focused* repo only, which is
+        // the only repo `self.worktrees`/`self.selected` ever describe.
+        if let Some(key) = self.focused_repo().and_then(|r| repo::repo_key(&r.path)) {
+            if self.selected_worktree_by_repo.get(&key) != Some(&path) {
+                self.selected_worktree_by_repo.insert(key, path.clone());
+                self.persist_repo_state(cx);
+            }
+        }
         // Makes this worktree's own last-active tab (or its first agent, or none) the
         // globally active one - see `Agents::activate_for_worktree`'s own docs for why this
         // invariant ("the active agent always belongs to the selected worktree") is the real
@@ -1447,7 +1522,13 @@ impl AdeApp {
         // at all, so the centre pane could keep showing a completely different worktree's
         // terminal after a rail click.
         self.agents.activate_for_worktree(&path, cx);
-        self.reset_repo_scoped_state(path, window, cx);
+        self.reset_repo_scoped_state(path.clone(), window, cx);
+        // Last, and deliberately so: `reset_repo_scoped_state` is what re-roots
+        // `Self::file_tree_root` onto this worktree, and restoring file tabs before that would
+        // file them under whichever worktree was just left (`Self::open_files_mut` is keyed by
+        // that root). It also moves focus, which the restore then re-does for whatever it spawned.
+        // A no-op for a worktree already restored in this window, or with nothing recorded.
+        self.restore_worktree_session(path, window, cx);
     }
 
     /// The shared core of "something completely different is now the single-repo-scoped root

--- a/crates/app/src/work_surface/mod.rs
+++ b/crates/app/src/work_surface/mod.rs
@@ -9,6 +9,10 @@
 //!   belongs to, and which one is active for the centre pane.
 //! - [`render`] - the real GPUI tab strip, agent context bar, terminal pane
 //!   header/footer and centre-pane composition, as `impl AdeApp` methods.
+//! - [`session`] - recording one worktree's whole tab session to disk and genuinely reopening it
+//!   on that worktree's next real activation, as `impl AdeApp` methods. Split out of [`render`]
+//!   rather than added to it because it draws nothing at all: it is the live-state half of
+//!   [`tab_order_state`]'s durable half.
 //!
 //! `render` glob-imports this module (`use super::*`), which is why the shared imports it
 //! needs live here rather than at the top of that file - the same convention `crate::root`
@@ -36,3 +40,4 @@ pub mod state;
 pub mod tab_order_state;
 
 pub(crate) mod render;
+pub(crate) mod session;

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -106,6 +106,8 @@ impl AdeApp {
         // `crate::review::flow::AdeApp::capture_review_baseline` for the small, accepted race
         // between the process starting and the snapshot landing.
         self.capture_review_baseline(id, cx);
+        // A new tab changes this worktree's real tab session - see `crate::work_surface::session`.
+        self.record_worktree_session(cx);
         // A second agent in this worktree closes the single-agent gate on every agent already
         // there, so a review tab open for one of them must really close now - see
         // `crate::review::render::AdeApp::close_gated_review_tab` for why this is a real close
@@ -491,6 +493,9 @@ impl AdeApp {
         {
             window.focus(&self.rail_focus_handle, cx);
         }
+        // A closed tab is as real a session change as an opened one: relaunching must not reopen
+        // a tab the user deliberately closed. See `crate::work_surface::session`.
+        self.record_worktree_session(cx);
     }
 
     /// The surface footer's `Interrupt ⌃C` action - sends `Ctrl-C` to the agent's pty via
@@ -535,6 +540,9 @@ impl AdeApp {
             cx,
         );
         self.focus_newly_spawned_agent(window, cx);
+        // The close above and the spawn here are two real session changes; both are recorded, so a
+        // relaunch reopens the retried agent's slot rather than the one it replaced.
+        self.record_worktree_session(cx);
         self.prune_confirm_armed = false;
         self.discard_confirm_armed = None;
         cx.notify();
@@ -568,6 +576,9 @@ impl AdeApp {
                     cx,
                 );
                 self.focus_newly_spawned_agent(window, cx);
+                // Only this arm spawned anything - the `Some(id)` arm above just selects a
+                // terminal that is already part of the recorded session.
+                self.record_worktree_session(cx);
                 self.prune_confirm_armed = false;
                 self.discard_confirm_armed = None;
                 cx.notify();
@@ -603,27 +614,24 @@ impl AdeApp {
         };
         let agents_for_cwd: Vec<&Agent> = self.agents.iter_for_cwd(cwd.clone()).collect();
         let agent_ids: Vec<AgentId> = agents_for_cwd.iter().map(|agent| agent.id).collect();
-        // `Self::tab_order` hasn't been touched for yet *this session* falls back to its real,
-        // on-disk order (GitHub issue #16's own "persists... and restores on relaunch") instead
-        // of the empty slice a brand new session would otherwise reconcile against - see
-        // `Self::tab_order`'s own docs. Recomputed fresh each call rather than cached back into
-        // `Self::tab_order`: `crate::work_surface::tab_order_state::TabOrderState` is already
-        // fully loaded in memory (no I/O here), and leaving `Self::tab_order` itself untouched
-        // until a real drag happens is what keeps `Self::tab_order_owned` scoped to worktrees
-        // this instance has actually *changed*, not merely visited.
-        let persisted_fallback;
+        // A worktree with no [`Self::tab_order`] entry reconciles against an empty slice, which is
+        // the old, deliberate two-block default ("every agent, then every file" - see
+        // `work_surface::state::reconcile_tab_order`'s own docs).
+        //
+        // This method used to read a *file-only* persisted order (`TabOrderState::file_order`)
+        // here instead, as GitHub issue #16's own "restores on relaunch". That fallback is gone,
+        // replaced rather than dropped: `crate::work_surface::session::AdeApp::
+        // restore_worktree_session` now seeds `Self::tab_order` with the real remembered order
+        // directly, at the one moment a worktree is genuinely activated - and does it for *every*
+        // tab kind, agents included, which a fallback keyed off persisted file paths structurally
+        // could not. Keeping both would have been actively wrong, not merely redundant: since a
+        // worktree's session is now recorded on every ordinary tab change rather than only after a
+        // drag, this fallback would fire for never-dragged worktrees too and silently reorder
+        // their strip to "files first, then agents" - the exact inversion of the documented
+        // default.
         let stored: &[work_surface::TabRef] = match self.tab_order.get(&cwd) {
             Some(order) => order.as_slice(),
-            None => {
-                persisted_fallback = self
-                    .tab_order_state
-                    .file_order(&cwd)
-                    .into_iter()
-                    .filter_map(|absolute| absolute.strip_prefix(&cwd).ok().map(Path::to_path_buf))
-                    .map(work_surface::TabRef::File)
-                    .collect::<Vec<_>>();
-                &persisted_fallback
-            }
+            None => &[],
         };
         work_surface::reconcile_tab_order(
             stored,
@@ -657,25 +665,15 @@ impl AdeApp {
         };
         let mut order = self.combined_tab_order();
         work_surface::move_tab_order(&mut order, &dragged, &target, insert_after);
-        self.tab_order.insert(cwd.clone(), order.clone());
+        self.tab_order.insert(cwd.clone(), order);
 
-        // The file half of the same order, persisted to disk (GitHub issue #16) - see
-        // `work_surface::tab_order_state`'s own module docs for why agent-tab entries are never
-        // recorded here at all.
-        let files: Vec<PathBuf> = order
-            .iter()
-            .filter_map(|tab_ref| match tab_ref {
-                work_surface::TabRef::File(path) => Some(cwd.join(path)),
-                work_surface::TabRef::Agent(_)
-                | work_surface::TabRef::Graph
-                | work_surface::TabRef::Review(_) => None,
-            })
-            .collect();
-        self.tab_order_state.set_file_order(&cwd, &files);
-        if let Some(key) = crate::work_surface::tab_order_state::worktree_key(&cwd) {
-            self.tab_order_owned.insert(key);
-        }
-        self.persist_tab_order(cx);
+        // The same order, persisted to disk (GitHub issue #16, widened by the tab-session restore
+        // work into "every tab, of every kind, in this order" - see
+        // `crate::work_surface::session`). Deliberately the one shared recorder rather than a
+        // second, drag-specific encoding: a drag is just one more way this worktree's tab session
+        // changes, and having it write the file through a different path than every other change
+        // is exactly how the two would drift.
+        self.record_worktree_session(cx);
         cx.notify();
     }
 
@@ -1593,6 +1591,9 @@ impl AdeApp {
                     cx,
                 );
                 this.focus_newly_spawned_agent(window, cx);
+                // See `Self::new_agent`'s own identical call - this is the same real new tab,
+                // reached through the `+` menu's background `$PATH` search instead.
+                this.record_worktree_session(cx);
                 this.prune_confirm_armed = false;
                 cx.notify();
             });

--- a/crates/app/src/work_surface/session.rs
+++ b/crates/app/src/work_surface/session.rs
@@ -1,0 +1,1037 @@
+//! Recording and restoring one worktree's whole tab session - "quit Jerry with some set of tabs
+//! open across some set of worktrees and repos, relaunch it, and everything you had open comes
+//! back".
+//!
+//! [`crate::work_surface::tab_order_state`] is the durable half (what the file looks like, what
+//! survives a restart, and why); this is the live half: turning the real tab strip into a
+//! [`crate::work_surface::tab_order_state::SessionTab`] list on every change
+//! ([`AdeApp::record_worktree_session`]), and turning that list back into real tabs, real files and
+//! real processes ([`AdeApp::restore_worktree_session`]).
+//!
+//! ## Scope and timing: restore per worktree, on its first real activation
+//!
+//! The obvious design - restore everything at launch - was rejected deliberately, and this is the
+//! one genuinely product-shaped decision in this module, so it is written down rather than left
+//! implicit.
+//!
+//! A restored tab is not a row in a list; it is a real OS process. A user who has worked in a
+//! dozen worktrees across three repos would, on a naive eager restore, watch Jerry fork a dozen
+//! shells and resume a handful of Claude conversations - real PTYs, real CPU, real token spend on
+//! conversations they did not ask to continue - before the first frame they could act on. That is
+//! slow, expensive, and surprising in a way "restore my tabs" does not ask for.
+//!
+//! So restore is **lazy and per worktree**: a worktree's session is reopened the first time that
+//! worktree is genuinely selected in this window, and never again in it (see
+//! [`crate::root::AdeApp::session_restored`]). What that buys, concretely:
+//!
+//! - **Launch still lands you back where you were**, with your tabs, because startup genuinely
+//!   selects a worktree on the way in (`crate::root::AdeApp::load_worktrees_for_opened_repo` ->
+//!   `crate::rail::worktrees::selection_for_opened_repo`), and - new here - it prefers the
+//!   worktree you were last in (`crate::rail::repo::RepoRecord::selected_worktree`) rather than
+//!   always the main checkout. One worktree's worth of processes, not every worktree's.
+//! - **Every other worktree and repo comes back the instant you go there**, at the cost of exactly
+//!   the visit the user just performed anyway. From the user's side "everything reopened"; from
+//!   the machine's side, nothing was spawned that was never looked at.
+//! - **PR #265's invariant holds structurally rather than by care.** That change established that
+//!   a tab is never shown, never spawnable, and never implicitly attributed to anything except a
+//!   real, currently-selected worktree. Restore hangs off *selection itself*, so there is no path
+//!   through this module that can produce a tab for a worktree that isn't selected - and
+//!   [`AdeApp::restore_worktree_session`] additionally refuses outright if it is ever handed a
+//!   worktree that isn't the live one.
+//!
+//! The honest cost of the choice: switching into a worktree you haven't visited yet this run spawns
+//! its processes at that moment, so that one switch is heavier than a plain switch used to be. That
+//! is the same cost the eager design pays, just moved to the moment it buys something.
+//!
+//! ## What restoring can and cannot honestly do
+//!
+//! - A **file tab** is reopened outright. A file deleted or moved since the last session is
+//!   skipped with a real reason ([`crate::root::AdeApp::session_restore_notices`]) - never a
+//!   phantom tab for a path that no longer resolves.
+//! - A **terminal tab** is a fresh shell in the same worktree, in the same slot. A real OS shell
+//!   process cannot survive an app quit and this codebase has no process-reattachment to pretend
+//!   otherwise with, so that is exactly what is claimed and exactly what happens.
+//! - An **agent tab** is restored only as a genuine `claude --resume <session_id>`
+//!   ([`crate::work_surface::agents::Agents::spawn_resume`], GitHub issue #227's real, verified
+//!   resume path) - the same conversation, carried forward. An agent with no recorded session id
+//!   (every Codex agent, since no hooks exist for Codex at all, and any Claude agent that closed
+//!   before a hook reported one) is **not** restored, and says why. Spawning a fresh, contextless
+//!   agent into that slot would look like a restored conversation and be nothing of the kind.
+//!
+//! One tab degrading never fails the rest of the restore - each is decided on its own.
+
+use std::path::{Path, PathBuf};
+
+use gpui::{Context, Window};
+
+use crate::root::AdeApp;
+use crate::work_surface::agents::{AgentKind, ProcessKind};
+use crate::work_surface::state::TabRef;
+use crate::work_surface::tab_order_state::{worktree_key, SessionTab};
+
+/// How many [`crate::root::AdeApp::session_restore_notices`] entries are kept. A window left open
+/// for days, visiting worktree after worktree, must not accumulate an unbounded `Vec` of strings
+/// nothing has read yet; the newest are the ones a user could still act on, so the oldest are
+/// dropped first.
+pub(crate) const MAX_SESSION_RESTORE_NOTICES: usize = 50;
+
+impl AdeApp {
+    /// Records the currently selected worktree's real, live tab strip as its persisted session -
+    /// the write side of this module. Called from every real tab mutation (a file tab opened or
+    /// closed, an agent or shell spawned or closed, a drag-reorder) and, as a safety net, from
+    /// [`Self::select_worktree`] just before it switches away.
+    ///
+    /// Cheap enough to call that freely: it snapshots an already-in-memory tab order, compares it
+    /// against what is already recorded, and returns without touching the disk at all when nothing
+    /// changed - which is the common case for the safety-net call.
+    ///
+    /// Refuses, deliberately, in three cases:
+    ///
+    /// - No worktree genuinely selected ([`Self::active_agent_cwd`] is `None`). There is no such
+    ///   thing as a session belonging to a repo rather than to a worktree, so there is nothing to
+    ///   file it under.
+    /// - This worktree's own session hasn't been restored yet
+    ///   ([`Self::session_restored`]). Until it has, the live tab strip is *not* the truth about
+    ///   this worktree - it is whatever exists before the restore that was about to run - and
+    ///   writing it would erase the session the next selection was going to reopen. This is the
+    ///   real ordering hazard in the whole feature, and this check is where it is closed.
+    /// - `graph`/`review` tabs are dropped from the recorded session rather than persisted. Both
+    ///   are single, window-wide slots ([`Self::graph_tab_open`], [`Self::review_tab_open`]) rather
+    ///   than per-worktree tabs, and a review tab additionally names a live
+    ///   [`crate::work_surface::agents::AgentId`] that no restart can resolve; recording either
+    ///   would mean inventing a per-worktree existence neither actually has. They simply reopen
+    ///   the way they always have, from their own live state.
+    pub(crate) fn record_worktree_session(&mut self, cx: &mut Context<Self>) {
+        let Some(cwd) = self.active_agent_cwd() else {
+            return;
+        };
+        if !self.session_restored.contains(&cwd) {
+            return;
+        }
+        let tabs = self.session_tabs_for(&cwd);
+        // A real disk write is a background merge against a file other Jerry instances share
+        // (`TabOrderState::save_merged_at`), so it is worth *not* doing when the answer is
+        // unchanged - and the unchanged case is genuinely common, since this is also called from
+        // `select_worktree`'s safety-net position on every single switch.
+        if self.tab_order_state.session_tabs(&cwd) == tabs {
+            return;
+        }
+        self.tab_order_state.set_session_tabs(&cwd, &tabs);
+        if let Some(key) = worktree_key(&cwd) {
+            self.tab_order_owned.insert(key);
+        }
+        self.persist_tab_order(cx);
+    }
+
+    /// `cwd`'s live tab strip, as the session record that would be written for it - split out of
+    /// [`Self::record_worktree_session`] so the mapping from real tabs to persisted ones is one
+    /// readable list rather than buried in that method's own guards.
+    ///
+    /// Reads [`Self::combined_tab_order`], not `Agents`/[`Self::open_files`] directly, so the
+    /// recorded order is by construction the order the user actually sees - including a
+    /// drag-chosen interleaving of agents and files, which is the whole thing issue #16 persists
+    /// and which reading the two underlying lists separately would silently flatten back into
+    /// "agents, then files".
+    fn session_tabs_for(&self, cwd: &Path) -> Vec<SessionTab> {
+        self.combined_tab_order()
+            .iter()
+            .filter_map(|tab_ref| match tab_ref {
+                TabRef::File(relative) => Some(SessionTab::File(cwd.join(relative))),
+                TabRef::Agent(id) => {
+                    let agent = self.agents.iter().find(|agent| agent.id == *id)?;
+                    Some(match agent.kind {
+                        ProcessKind::Shell => SessionTab::Shell,
+                        ProcessKind::Agent(kind) => SessionTab::Agent {
+                            kind,
+                            session_id: self.live_agent_session_id(agent, kind),
+                        },
+                    })
+                }
+                // See `Self::record_worktree_session`'s own docs for why neither is recorded.
+                TabRef::Graph | TabRef::Review(_) => None,
+            })
+            .collect()
+    }
+
+    /// The real Claude Code `session_id` currently known for a live agent, or `None`.
+    ///
+    /// Deliberately read out of [`Self::agent_status_state`] - GitHub issue #239 phase 2's
+    /// hook-learned facts, keyed by `crate::review::state::baseline_key` - rather than tracked as a
+    /// second copy on [`crate::work_surface::agents::Agent`]. That store is already the one place
+    /// a session id is ever learned (an agent's own hooks report it), already keyed by exactly the
+    /// three durable facts available here, and already what
+    /// `crate::hooks::flow::AdeApp::resume_past_agent` resumes from - so a session recorded here
+    /// and a session resumed from the rail's history rows can never disagree about what a given
+    /// agent's conversation is.
+    ///
+    /// `None` is a real and common answer, not a failure: a Codex agent has no hooks at all, and a
+    /// Claude agent that has not yet run a single turn has not reported one yet.
+    fn live_agent_session_id(
+        &self,
+        agent: &crate::work_surface::agents::Agent,
+        kind: AgentKind,
+    ) -> Option<String> {
+        let key = crate::review::state::baseline_key(&agent.cwd, kind, agent.spawned_at_unix);
+        self.agent_status_state.get(&key)?.session_id.clone()
+    }
+
+    /// Reopens `cwd`'s persisted tab session for real - the read side of this module, and the one
+    /// place tabs are ever created from a persisted record.
+    ///
+    /// Called from exactly the two places a worktree becomes genuinely, currently selected:
+    /// [`Self::select_worktree`] (every rail click, and every programmatic selection that goes
+    /// through it) and [`Self::spawn_initial_shell_for_opened_repo`] (a just-opened repo, which
+    /// also covers `active_agent_cwd`'s one documented no-usable-worktree last resort). Ordering
+    /// matters at the second: this runs *before* that method's guaranteed initial shell, so a
+    /// worktree whose session already contains a terminal gets its own remembered one back rather
+    /// than that one plus a redundant fresh one - the "already has an agent" check there does the
+    /// rest.
+    ///
+    /// Refuses without marking anything when it is handed a worktree that isn't the live one
+    /// (`cwd != self.file_tree_root`): the file tabs it reopens are stored per worktree keyed by
+    /// exactly that root ([`Self::open_files_mut`]), so restoring against a stale root would file
+    /// one worktree's tabs under another. Refusing rather than marking is what lets the real,
+    /// correctly-ordered call a moment later still do the work.
+    ///
+    /// A no-op for a window with no real persistence at all ([`Self::tab_order_path`] is `None` -
+    /// every GPUI test that hasn't opted into a real settings path), and for a worktree with
+    /// nothing recorded. Neither is an error: a worktree Jerry has never seen has no session, and
+    /// opens exactly as it always has.
+    ///
+    /// One selection path deliberately doesn't reach here: `Self::load_worktrees`'s own
+    /// fall-back-to-main recovery, which re-points [`Self::selected`] from a background task with
+    /// no `&mut Window` to move focus (or spawn anything) with - see that arm's own docs. A
+    /// worktree reached that way keeps its recorded session untouched (the recorder's gate refuses
+    /// a worktree that hasn't been through here) and restores it on the next real selection, which
+    /// is the honest outcome: an external `git worktree remove` is not the user asking to reopen
+    /// somewhere.
+    pub(crate) fn restore_worktree_session(
+        &mut self,
+        cwd: PathBuf,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if cwd != self.file_tree_root {
+            return;
+        }
+        if !self.session_restored.insert(cwd.clone()) {
+            return;
+        }
+        // Deliberately *after* the mark above, not before it. A window with no persisted state at
+        // all has, trivially, nothing to restore - and marking it restored anyway is what keeps
+        // [`Self::record_worktree_session`]'s gate meaning "the live strip is the truth for this
+        // worktree" rather than "this window persists things": with no file to erase, there is no
+        // hazard for that gate to protect against, and blocking the recorder here would silently
+        // stop maintaining the in-memory [`Self::tab_order_state`] a `None`-path window still
+        // reads back through `Self::combined_tab_order`.
+        if self.tab_order_path.is_none() {
+            return;
+        }
+        let tabs = self.tab_order_state.session_tabs(&cwd);
+        if tabs.is_empty() {
+            return;
+        }
+
+        // Built as each tab is really restored, so a skipped entry leaves no gap behind: the
+        // restored strip is exactly the tabs that genuinely came back, in their remembered
+        // relative order.
+        let mut order: Vec<TabRef> = Vec::new();
+        for tab in tabs {
+            match tab {
+                SessionTab::File(absolute) => {
+                    let Ok(relative) = absolute.strip_prefix(&cwd) else {
+                        continue;
+                    };
+                    let relative = relative.to_path_buf();
+                    // `is_file`, not `exists`: a path that has since become a *directory* is as
+                    // unopenable as a deleted one, and opening a tab for it would leave the code
+                    // surface showing a real error for a file the user never asked for.
+                    if !absolute.is_file() {
+                        self.note_session_restore_failure(format!(
+                            "{} was open last session but no longer exists - its tab was not \
+                             reopened",
+                            absolute.display()
+                        ));
+                        continue;
+                    }
+                    if !self.open_files().contains(&relative) {
+                        self.open_files_mut().push(relative.clone());
+                    }
+                    order.push(TabRef::File(relative));
+                }
+                SessionTab::Shell => {
+                    let id = self.agents.spawn(
+                        ProcessKind::Shell,
+                        cwd.clone(),
+                        self.settings.appearance.terminal_font_size,
+                        self.settings.terminal.shell_override(),
+                        // A shell, so no hook injection - `Agents::spawn` would discard one anyway.
+                        None,
+                        window,
+                        cx,
+                    );
+                    // GitHub issue #225: a restored shell is a real agent like any other and needs
+                    // a real review baseline too, exactly as
+                    // `Self::spawn_initial_shell_for_opened_repo`'s own spawn does.
+                    self.capture_review_baseline(id, cx);
+                    order.push(TabRef::Agent(id));
+                }
+                SessionTab::Agent {
+                    kind: AgentKind::Claude,
+                    session_id: Some(session_id),
+                } => {
+                    let hook_injection = self.hook_injection_for(ProcessKind::claude());
+                    let id = self.agents.spawn_resume(
+                        AgentKind::Claude,
+                        cwd.clone(),
+                        self.settings.appearance.terminal_font_size,
+                        self.settings.terminal.shell_override(),
+                        hook_injection.as_ref(),
+                        session_id,
+                        window,
+                        cx,
+                    );
+                    self.capture_review_baseline(id, cx);
+                    order.push(TabRef::Agent(id));
+                }
+                SessionTab::Agent { kind, session_id } => {
+                    debug_assert!(
+                        session_id.is_none() || kind != AgentKind::Claude,
+                        "the resumable case is handled by the arm above"
+                    );
+                    self.note_session_restore_failure(format!(
+                        "a {} agent was open last session but has no resumable session id - its \
+                         tab was not reopened (a fresh agent would not be the same conversation)",
+                        kind.label()
+                    ));
+                }
+            }
+        }
+
+        // The restored strip's own order, seeded straight into the live per-worktree order so the
+        // very first render draws it as remembered. `Self::combined_tab_order`'s own persisted
+        // fallback can't do this job: it only knows about file tabs (an agent's slot there is
+        // decided by whichever live agent exists), and the ids these restored agents just got
+        // exist only now, in this window.
+        if !order.is_empty() {
+            self.tab_order.insert(cwd.clone(), order);
+        }
+        // The restore just changed which agents exist in this worktree - re-establish "the active
+        // agent always belongs to the selected worktree" and put real keyboard focus somewhere
+        // that is genuinely in the rendered tree, the same pair `Agents::activate_for_worktree`'s
+        // own docs require of every caller.
+        self.agents.activate_for_worktree(&cwd, cx);
+        self.focus_newly_spawned_agent(window, cx);
+        // What was just restored *is* the session now - written straight back so a tab that could
+        // not be reopened (a deleted file, an unresumable agent) stops being retried on every
+        // future launch, and so the freshly-assigned agent slots are what the next restore reads.
+        self.record_worktree_session(cx);
+        cx.notify();
+    }
+
+    /// Records one real "this tab could not be reopened, and here is why" - logged as it happens
+    /// and kept on [`Self::session_restore_notices`], oldest dropped first past
+    /// [`MAX_SESSION_RESTORE_NOTICES`].
+    fn note_session_restore_failure(&mut self, notice: String) {
+        log::warn!("session restore: {notice}");
+        self.session_restore_notices.push(notice);
+        if self.session_restore_notices.len() > MAX_SESSION_RESTORE_NOTICES {
+            let excess = self.session_restore_notices.len() - MAX_SESSION_RESTORE_NOTICES;
+            self.session_restore_notices.drain(..excess);
+        }
+    }
+}
+
+/// End-to-end coverage for the real thing this module exists to do: quit Jerry, launch it again,
+/// and get your tabs back.
+///
+/// Every test here performs a genuine relaunch - a second, independently constructed [`AdeApp`]
+/// against the *same* real settings directory, exactly as a real process restart does - rather
+/// than reading the persisted file back and asserting on its contents. The file format already has
+/// its own unit coverage in `crate::work_surface::tab_order_state`; what these prove is that the
+/// live app really writes it, really reads it, and really reopens what it names.
+#[cfg(test)]
+mod session_restore_tests {
+    use super::*;
+    use crate::rail::status::Status;
+    use crate::settings::store as settings_store;
+    use gpui::TestAppContext;
+    use std::process::Command;
+    use tempfile::TempDir;
+
+    fn git(dir: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .output()
+            .expect("failed to spawn git");
+        assert!(output.status.success(), "git {args:?} failed in {dir:?}");
+    }
+
+    /// A real repo with a real initial commit, so `git worktree list --porcelain` reports a real
+    /// main-worktree row for the app to select - and so `git worktree add` below works at all.
+    /// Returns the *canonicalized* path, because every one of this app's per-worktree lookups is an
+    /// exact comparison against git's own fully-resolved answers (see
+    /// `crate::rail::repo::canonical_repo_path`'s own docs).
+    fn init_repo() -> (TempDir, PathBuf) {
+        let dir = TempDir::new().expect("tempdir");
+        git(dir.path(), &["init", "-b", "main"]);
+        git(dir.path(), &["config", "user.email", "test@example.com"]);
+        git(dir.path(), &["config", "user.name", "Test User"]);
+        std::fs::write(dir.path().join("README.md"), "hello\n").expect("write");
+        git(dir.path(), &["add", "README.md"]);
+        git(dir.path(), &["commit", "-m", "initial"]);
+        let canonical = std::fs::canonicalize(dir.path()).expect("canonicalize");
+        (dir, canonical)
+    }
+
+    /// A real linked worktree of `repo`, created under `container` (worktrees live outside the
+    /// repo - `crate::rail::repo::Repo::path`'s own docs).
+    fn add_worktree(repo: &Path, container: &Path, branch: &str) -> PathBuf {
+        let path = container.join(branch);
+        git(
+            repo,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                branch,
+                path.to_str().expect("utf8 path"),
+            ],
+        );
+        std::fs::canonicalize(&path).expect("canonicalize")
+    }
+
+    /// One real launch: a fresh [`AdeApp`] against a real settings path. `repo_path: None` with
+    /// `use_remembered_repo` is the real no-CLI-argument process launch (see
+    /// `AdeApp::new_with_settings`'s own decision table); `Some` is a real `jerry <path>`.
+    fn launch(
+        cx: &mut TestAppContext,
+        repo_path: Option<PathBuf>,
+        settings_path: PathBuf,
+    ) -> (gpui::Entity<AdeApp>, &mut gpui::VisualTestContext) {
+        cx.add_window_view(|window, cx| {
+            AdeApp::new_with_settings(
+                repo_path,
+                true,
+                settings_store::Settings::default(),
+                Some(settings_path),
+                window,
+                cx,
+            )
+        })
+    }
+
+    /// The index of `path` in the live worktree list, so a test can select a worktree the same way
+    /// a real rail click does.
+    fn worktree_index(app: &AdeApp, path: &Path) -> usize {
+        app.worktrees
+            .iter()
+            .position(|item| item.path == path)
+            .unwrap_or_else(|| {
+                panic!(
+                    "{} must be a real worktree row - the list is {:?}",
+                    path.display(),
+                    app.worktrees
+                        .iter()
+                        .map(|item| item.path.clone())
+                        .collect::<Vec<_>>()
+                )
+            })
+    }
+
+    /// A worktree's tab strip reduced to something a test can assert on by *identity*, since a
+    /// restored agent's own [`crate::work_surface::agents::AgentId`] is by definition a different
+    /// number than the one it had last session (that is the entire reason ids are never persisted).
+    #[derive(Debug, PartialEq, Eq)]
+    enum Slot {
+        File(String),
+        Shell,
+        Claude,
+    }
+
+    fn strip(app: &AdeApp) -> Vec<Slot> {
+        app.combined_tab_order()
+            .iter()
+            .filter_map(|tab_ref| match tab_ref {
+                TabRef::File(path) => Some(Slot::File(path.to_string_lossy().into_owned())),
+                TabRef::Agent(id) => {
+                    let agent = app.agents.iter().find(|agent| agent.id == *id)?;
+                    Some(match agent.kind {
+                        ProcessKind::Shell => Slot::Shell,
+                        ProcessKind::Agent(AgentKind::Claude) => Slot::Claude,
+                        ProcessKind::Agent(AgentKind::Codex) => {
+                            panic!("no test here spawns a Codex agent into a live strip")
+                        }
+                    })
+                }
+                TabRef::Graph | TabRef::Review(_) => None,
+            })
+            .collect()
+    }
+
+    /// The headline behaviour, end to end: file tabs *and* terminal tabs, in a real drag-chosen
+    /// interleaved order, across two real worktrees - quit, relaunch, and get every one of them
+    /// back, in the same order, under the same worktree.
+    ///
+    /// The interleaving matters specifically: reconstructing "all the agents, then all the files"
+    /// would pass a naive per-kind assertion while silently losing the one thing GitHub issue #16's
+    /// drag order exists to record.
+    #[gpui::test]
+    fn a_relaunch_reopens_every_file_and_terminal_tab_in_its_real_drag_order(
+        cx: &mut TestAppContext,
+    ) {
+        let (_repo, repo_path) = init_repo();
+        let container = TempDir::new().expect("tempdir");
+        let feature = add_worktree(&repo_path, container.path(), "feature");
+        let settings_dir = TempDir::new().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+
+        std::fs::write(repo_path.join("a.txt"), "a\n").expect("write");
+        std::fs::write(repo_path.join("b.txt"), "b\n").expect("write");
+        std::fs::write(feature.join("c.txt"), "c\n").expect("write");
+
+        // ---- Launch 1: really open some tabs, and really drag one of them. ----
+        {
+            let (app, cx) = launch(cx, Some(repo_path.clone()), settings_path.clone());
+            cx.run_until_parked();
+
+            app.update_in(cx, |app, window, cx| {
+                app.open_file_view(repo_path.join("a.txt"), window, cx);
+                app.open_file_view(repo_path.join("b.txt"), window, cx);
+                // A second terminal alongside the one every window starts with.
+                app.new_agent(ProcessKind::Shell, window, cx);
+            });
+            cx.run_until_parked();
+            // A real drag, dropping the second terminal in between the two file tabs - so the
+            // recorded order is one no per-kind reconstruction ("every agent, then every file", or
+            // the reverse) could ever produce by accident.
+            app.update(cx, |app, cx| {
+                let dragged = app
+                    .combined_tab_order()
+                    .into_iter()
+                    .rfind(|tab| matches!(tab, TabRef::Agent(_)))
+                    .expect("the second terminal");
+                app.reorder_tab(dragged, TabRef::File(PathBuf::from("b.txt")), false, cx);
+            });
+            cx.run_until_parked();
+            assert_eq!(
+                app.read_with(cx, |app, _| strip(app)),
+                vec![
+                    Slot::Shell,
+                    Slot::File("a.txt".to_string()),
+                    Slot::Shell,
+                    Slot::File("b.txt".to_string()),
+                ],
+                "premise: launch 1 really has this interleaved strip in the main worktree"
+            );
+
+            // A second worktree, with its own separate tab.
+            app.update_in(cx, |app, window, cx| {
+                let index = worktree_index(app, &feature);
+                app.select_worktree(index, window, cx);
+                app.open_file_view(feature.join("c.txt"), window, cx);
+            });
+            cx.run_until_parked();
+        }
+
+        // ---- Launch 2: a genuinely fresh app against the same real settings directory. ----
+        let (app, cx) = launch(cx, Some(repo_path.clone()), settings_path);
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| strip(app)),
+            vec![
+                Slot::Shell,
+                Slot::File("a.txt".to_string()),
+                Slot::Shell,
+                Slot::File("b.txt".to_string()),
+            ],
+            "the main worktree's whole strip must come back - both file tabs, both terminals, and \
+             the real drag-chosen order that interleaved them"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.agents.iter().count()),
+            2,
+            "exactly the two terminals that were open - the guaranteed startup shell must not \
+             stack a third one on top of a restored session that already has terminals"
+        );
+
+        // The second worktree's own session comes back on its first real selection, not at launch.
+        app.update_in(cx, |app, window, cx| {
+            let index = worktree_index(app, &feature);
+            app.select_worktree(index, window, cx);
+        });
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| strip(app)),
+            vec![Slot::File("c.txt".to_string())],
+            "the other worktree's own tab must come back too, under that worktree - and only its \
+             own, never the main worktree's"
+        );
+    }
+
+    /// The scope/timing decision made observable: a worktree the user has not gone to yet this
+    /// launch has spawned nothing at all. Restoring every worktree eagerly would show up here as
+    /// the feature worktree's terminal already running before it was ever selected.
+    #[gpui::test]
+    fn an_unvisited_worktrees_session_costs_nothing_until_it_is_really_selected(
+        cx: &mut TestAppContext,
+    ) {
+        let (_repo, repo_path) = init_repo();
+        let container = TempDir::new().expect("tempdir");
+        let feature = add_worktree(&repo_path, container.path(), "feature");
+        let settings_dir = TempDir::new().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+
+        {
+            let (app, cx) = launch(cx, Some(repo_path.clone()), settings_path.clone());
+            cx.run_until_parked();
+            // Give the feature worktree two real terminals of its own.
+            app.update_in(cx, |app, window, cx| {
+                let index = worktree_index(app, &feature);
+                app.select_worktree(index, window, cx);
+                // Two real, explicit terminals: switching to a worktree does not itself spawn one
+                // (only *opening a repo* carries the guaranteed-initial-shell contract - see
+                // `AdeApp::spawn_initial_shell_for_opened_repo`), so both of these are the user's.
+                app.new_agent(ProcessKind::Shell, window, cx);
+                app.new_agent(ProcessKind::Shell, window, cx);
+            });
+            cx.run_until_parked();
+            assert_eq!(
+                app.read_with(cx, |app, _| app
+                    .agents
+                    .iter_for_cwd(feature.clone())
+                    .count()),
+                2,
+                "premise: the feature worktree really had two terminals when the app was quit"
+            );
+        }
+
+        let (app, cx) = launch(cx, Some(repo_path.clone()), settings_path);
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app
+                .agents
+                .iter_for_cwd(feature.clone())
+                .count()),
+            0,
+            "the feature worktree was not selected at launch, so not one of its processes may \
+             have been spawned - restoring every worktree eagerly is exactly what this module's \
+             scope decision rejects"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.agents.iter().count()),
+            1,
+            "only the worktree actually landed in got a real terminal"
+        );
+
+        app.update_in(cx, |app, window, cx| {
+            let index = worktree_index(app, &feature);
+            app.select_worktree(index, window, cx);
+        });
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app
+                .agents
+                .iter_for_cwd(feature.clone())
+                .count()),
+            2,
+            "and going there really does bring both of its terminals back"
+        );
+    }
+
+    /// A file deleted between sessions must degrade to exactly one missing tab, with a real
+    /// reason - never a panic, and never a phantom tab for a path that no longer resolves.
+    #[gpui::test]
+    fn a_file_deleted_between_sessions_is_skipped_with_a_real_reason(cx: &mut TestAppContext) {
+        let (_repo, repo_path) = init_repo();
+        let settings_dir = TempDir::new().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+        std::fs::write(repo_path.join("kept.txt"), "kept\n").expect("write");
+        std::fs::write(repo_path.join("gone.txt"), "gone\n").expect("write");
+
+        {
+            let (app, cx) = launch(cx, Some(repo_path.clone()), settings_path.clone());
+            cx.run_until_parked();
+            app.update_in(cx, |app, window, cx| {
+                app.open_file_view(repo_path.join("gone.txt"), window, cx);
+                app.open_file_view(repo_path.join("kept.txt"), window, cx);
+            });
+            cx.run_until_parked();
+        }
+
+        // The real thing that happens between sessions: the file is deleted (or moved, or renamed
+        // by a branch switch) while Jerry isn't running.
+        std::fs::remove_file(repo_path.join("gone.txt")).expect("remove");
+
+        let (app, cx) = launch(cx, Some(repo_path.clone()), settings_path);
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.open_files().to_vec()),
+            vec![PathBuf::from("kept.txt")],
+            "the surviving file must still reopen - one missing file may not cost the user the \
+             rest of the session"
+        );
+        let notices = app.read_with(cx, |app, _| app.session_restore_notices.clone());
+        assert_eq!(notices.len(), 1, "exactly one real refusal: {notices:?}");
+        assert!(
+            notices[0].contains("gone.txt") && notices[0].contains("no longer exists"),
+            "the refusal must name the real file and the real reason - got {:?}",
+            notices[0]
+        );
+    }
+
+    /// The agent half, and the part that makes it worth doing at all: a Claude agent whose real
+    /// `session_id` was captured last session comes back as a genuine
+    /// `claude --resume <session_id>` - the same conversation, not a fresh one in the same slot.
+    ///
+    /// Asserted against the restored pane's real [`crate::terminal::pane::TerminalSpec`], mirroring
+    /// `crate::work_surface::render`'s own `spawn_resume_prepends_resume_ahead_of_the_real_hook_
+    /// injection` - the same way GitHub issue #227's resume proves continuity, since the argument
+    /// list is what the `claude` binary itself acts on.
+    #[gpui::test]
+    fn a_claude_agent_is_restored_by_a_real_resume_carrying_its_own_session_id(
+        cx: &mut TestAppContext,
+    ) {
+        let (_repo, repo_path) = init_repo();
+        let settings_dir = TempDir::new().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+        let session_id = "5af4c210-34fa-4ab2-9c35-f6ceab76551c";
+
+        {
+            let (app, cx) = launch(cx, Some(repo_path.clone()), settings_path.clone());
+            cx.run_until_parked();
+            app.update_in(cx, |app, window, cx| {
+                // `Agents::spawn` directly rather than `Self::new_agent`: the two differ only in
+                // that `new_agent` would additionally bring up a real hook listener for this
+                // launch, and this test supplies the hook *fact* (the session id) by hand below
+                // anyway, since no real `claude` binary is running to report one.
+                app.agents.spawn(
+                    ProcessKind::claude(),
+                    repo_path.clone(),
+                    12.0,
+                    None,
+                    None,
+                    window,
+                    cx,
+                );
+            });
+            // Exactly what `crate::hooks::flow::AdeApp::record_agent_statuses` writes when a real
+            // Claude hook reports a session id, under the identical key.
+            app.update(cx, |app, cx| {
+                let agent = app
+                    .agents
+                    .iter()
+                    .find(|agent| agent.kind == ProcessKind::claude())
+                    .expect("the agent just spawned");
+                let (cwd, spawned_at_unix) = (agent.cwd.clone(), agent.spawned_at_unix);
+                let key =
+                    crate::review::state::baseline_key(&cwd, AgentKind::Claude, spawned_at_unix);
+                app.agent_status_state.set(
+                    key,
+                    &cwd,
+                    "Claude",
+                    spawned_at_unix,
+                    Status::Idle,
+                    None,
+                    None,
+                    Some(session_id.to_owned()),
+                    spawned_at_unix,
+                );
+                app.record_worktree_session(cx);
+            });
+            cx.run_until_parked();
+        }
+
+        let (app, cx) = launch(cx, Some(repo_path.clone()), settings_path);
+        cx.run_until_parked();
+
+        let pane = app.read_with(cx, |app, _| {
+            app.agents
+                .iter()
+                .find(|agent| agent.kind == ProcessKind::claude())
+                .expect("the Claude agent must have been restored as a real tab")
+                .pane
+                .clone()
+        });
+        let spec = pane.read_with(cx, |pane, _| pane.spec_for_test().clone());
+        assert_eq!(
+            spec.program,
+            PathBuf::from("claude"),
+            "a restored agent must spawn the real claude binary"
+        );
+        assert_eq!(
+            spec.args[0..2],
+            ["--resume".to_owned(), session_id.to_owned()],
+            "the restored agent must genuinely resume the same conversation it was in last \
+             session - a fresh, contextless spawn in the same slot is not a restored agent"
+        );
+        assert_eq!(
+            spec.cwd,
+            repo_path.clone(),
+            "and resume into the same worktree it was running in"
+        );
+        assert!(
+            app.read_with(cx, |app, _| app.session_restore_notices.is_empty()),
+            "a genuinely resumable agent must not be reported as a refusal"
+        );
+    }
+
+    /// The honest failure the request asks for: an agent with no resumable session id (every Codex
+    /// agent - no hooks exist for it at all - and any Claude agent that closed before one was ever
+    /// reported) is **not** restored, and says why. Spawning a fresh agent into that slot would
+    /// look like a restored conversation and be nothing of the kind.
+    ///
+    /// The rest of the session must survive the refusal - that is the "degrade a single tab, don't
+    /// fail the whole restore" half.
+    #[gpui::test]
+    fn an_agent_with_no_resumable_session_is_refused_honestly_and_alone(cx: &mut TestAppContext) {
+        let (_repo, repo_path) = init_repo();
+        let settings_dir = TempDir::new().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+        std::fs::write(repo_path.join("kept.txt"), "kept\n").expect("write");
+
+        {
+            let (app, cx) = launch(cx, Some(repo_path.clone()), settings_path.clone());
+            cx.run_until_parked();
+            app.update_in(cx, |app, window, cx| {
+                // No hook ever reported a session id for either of these - the real state of every
+                // Codex agent, and of a Claude agent that never ran a turn.
+                app.agents.spawn(
+                    ProcessKind::codex(),
+                    repo_path.clone(),
+                    12.0,
+                    None,
+                    None,
+                    window,
+                    cx,
+                );
+                app.agents.spawn(
+                    ProcessKind::claude(),
+                    repo_path.clone(),
+                    12.0,
+                    None,
+                    None,
+                    window,
+                    cx,
+                );
+                app.open_file_view(repo_path.join("kept.txt"), window, cx);
+            });
+            app.update(cx, |app, cx| app.record_worktree_session(cx));
+            cx.run_until_parked();
+        }
+
+        let (app, cx) = launch(cx, Some(repo_path.clone()), settings_path);
+        cx.run_until_parked();
+
+        assert!(
+            app.read_with(cx, |app, _| app
+                .agents
+                .iter()
+                .all(|agent| agent.kind == ProcessKind::Shell)),
+            "neither unresumable agent may come back as a real agent tab"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.open_files().to_vec()),
+            vec![PathBuf::from("kept.txt")],
+            "and the rest of the session must be entirely unaffected by the two refusals"
+        );
+        let notices = app.read_with(cx, |app, _| app.session_restore_notices.clone());
+        assert_eq!(notices.len(), 2, "one refusal each: {notices:?}");
+        assert!(
+            notices.iter().any(|notice| notice.contains("Codex"))
+                && notices.iter().any(|notice| notice.contains("Claude")),
+            "each refusal must name the real agent it is about - got {notices:?}"
+        );
+        assert!(
+            notices
+                .iter()
+                .all(|notice| notice.contains("no resumable session id")),
+            "and the real reason, not a generic failure - got {notices:?}"
+        );
+    }
+
+    /// "Relaunch Jerry" (no CLI argument at all - the real process-launch path) must land back in
+    /// the worktree you were actually last working in, with its tabs, rather than in the main
+    /// checkout with someone else's. Without the per-repo
+    /// [`crate::rail::repo::RepoRecord::selected_worktree`] memory this whole feature would only
+    /// pay off after the user manually clicked the right rail row.
+    #[gpui::test]
+    fn relaunching_with_no_cli_argument_lands_back_in_the_last_worktree_with_its_tabs(
+        cx: &mut TestAppContext,
+    ) {
+        let (_repo, repo_path) = init_repo();
+        let container = TempDir::new().expect("tempdir");
+        let feature = add_worktree(&repo_path, container.path(), "feature");
+        let settings_dir = TempDir::new().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+        std::fs::write(feature.join("only-here.txt"), "hi\n").expect("write");
+
+        {
+            let (app, cx) = launch(cx, Some(repo_path.clone()), settings_path.clone());
+            cx.run_until_parked();
+            app.update_in(cx, |app, window, cx| {
+                let index = worktree_index(app, &feature);
+                app.select_worktree(index, window, cx);
+                app.open_file_view(feature.join("only-here.txt"), window, cx);
+            });
+            cx.run_until_parked();
+        }
+
+        // No CLI argument: the real "just launch Jerry again" gesture.
+        let (app, cx) = launch(cx, None, settings_path);
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.file_tree_root.clone()),
+            feature,
+            "the relaunch must land in the worktree that was really being worked in, not in the \
+             repo's main checkout"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| strip(app)),
+            vec![Slot::File("only-here.txt".to_string()), Slot::Shell],
+            "and that worktree's own tab must be the one that came back. The trailing terminal is \
+             not a restored tab - this worktree had none open (a plain worktree switch never \
+             spawns one) - it is the guaranteed initial shell every *opened repo* gets, landing \
+             after the restored tab exactly as a freshly spawned tab always does"
+        );
+    }
+
+    /// An explicitly named path is a real statement about where to work, and must win over the
+    /// remembered worktree - the deliberate other half of the decision the previous test covers.
+    /// Silently opening a different worktree because it was the last one visited would be
+    /// overriding the user, not helping them.
+    #[gpui::test]
+    fn an_explicitly_named_path_still_wins_over_the_remembered_worktree(cx: &mut TestAppContext) {
+        let (_repo, repo_path) = init_repo();
+        let container = TempDir::new().expect("tempdir");
+        let feature = add_worktree(&repo_path, container.path(), "feature");
+        let settings_dir = TempDir::new().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+
+        {
+            let (app, cx) = launch(cx, Some(repo_path.clone()), settings_path.clone());
+            cx.run_until_parked();
+            app.update_in(cx, |app, window, cx| {
+                let index = worktree_index(app, &feature);
+                app.select_worktree(index, window, cx);
+            });
+            cx.run_until_parked();
+        }
+
+        let (app, cx) = launch(cx, Some(repo_path.clone()), settings_path);
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.file_tree_root.clone()),
+            repo_path,
+            "`jerry <repo>` names the repo's own checkout, and must open exactly it"
+        );
+    }
+
+    /// The multi-repo reading of "everything should reopen": quit with two real repos open, each
+    /// with its own tabs, relaunch, and both are back - the focused one immediately, the other the
+    /// moment the user goes to it.
+    #[gpui::test]
+    fn both_repos_tab_sessions_survive_a_relaunch(cx: &mut TestAppContext) {
+        let (_repo_a, repo_a) = init_repo();
+        let (_repo_b, repo_b) = init_repo();
+        let settings_dir = TempDir::new().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+        std::fs::write(repo_a.join("in-a.txt"), "a\n").expect("write");
+        std::fs::write(repo_b.join("in-b.txt"), "b\n").expect("write");
+
+        {
+            let (app, cx) = launch(cx, Some(repo_a.clone()), settings_path.clone());
+            cx.run_until_parked();
+            app.update_in(cx, |app, window, cx| {
+                app.open_file_view(repo_a.join("in-a.txt"), window, cx);
+            });
+            cx.run_until_parked();
+            // A real second repo, opened in the same window exactly as "Open Folder…" does.
+            app.update_in(cx, |app, window, cx| {
+                app.open_repo_in_current_window(repo_b.clone(), window, cx);
+            });
+            cx.run_until_parked();
+            app.update_in(cx, |app, window, cx| {
+                app.open_file_view(repo_b.join("in-b.txt"), window, cx);
+            });
+            cx.run_until_parked();
+        }
+
+        // Relaunch with no CLI argument - repo B was the last focused, so that is where this
+        // lands, with its own tab.
+        let (app, cx) = launch(cx, None, settings_path);
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.repos.len()),
+            2,
+            "premise: both repos are still known after the relaunch (`repos.toml`)"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| strip(app)),
+            vec![Slot::Shell, Slot::File("in-b.txt".to_string())],
+            "the repo that was focused at quit comes back with its own tab"
+        );
+
+        // And the other repo's session comes back on the first real visit to its worktree - the
+        // same lazy restore any other unvisited worktree gets, across a repo boundary.
+        app.update_in(cx, |app, window, cx| {
+            app.select_worktree_by_path(&repo_a, window, cx);
+        });
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.file_tree_root.clone()),
+            repo_a,
+            "premise: the click really moved to the other repo's worktree"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| strip(app)),
+            vec![Slot::Shell, Slot::File("in-a.txt".to_string())],
+            "the other repo's own tabs must come back too - 'everything reopens' spans repos, not \
+             just the one that happened to be focused"
+        );
+    }
+
+    /// The other direction, and the reason the recorder is wired into every close path: a tab the
+    /// user deliberately closed must stay closed across a relaunch. A restore that only ever added
+    /// tabs would quietly resurrect them forever.
+    #[gpui::test]
+    fn a_deliberately_closed_tab_stays_closed_across_a_relaunch(cx: &mut TestAppContext) {
+        let (_repo, repo_path) = init_repo();
+        let settings_dir = TempDir::new().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+        std::fs::write(repo_path.join("kept.txt"), "kept\n").expect("write");
+        std::fs::write(repo_path.join("closed.txt"), "closed\n").expect("write");
+
+        {
+            let (app, cx) = launch(cx, Some(repo_path.clone()), settings_path.clone());
+            cx.run_until_parked();
+            app.update_in(cx, |app, window, cx| {
+                app.open_file_view(repo_path.join("kept.txt"), window, cx);
+                app.open_file_view(repo_path.join("closed.txt"), window, cx);
+                app.close_file_tab(PathBuf::from("closed.txt"), window, cx);
+            });
+            cx.run_until_parked();
+        }
+
+        let (app, cx) = launch(cx, Some(repo_path.clone()), settings_path);
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.open_files().to_vec()),
+            vec![PathBuf::from("kept.txt")],
+            "only the tab that was still open at quit may come back"
+        );
+        assert!(
+            app.read_with(cx, |app, _| app.session_restore_notices.is_empty()),
+            "and a tab that was never recorded is not a refusal - `closed.txt` still exists on \
+             disk; it simply wasn't open"
+        );
+    }
+}

--- a/crates/app/src/work_surface/tab_order_state.rs
+++ b/crates/app/src/work_surface/tab_order_state.rs
@@ -1,19 +1,41 @@
-//! Real, on-disk persistence for the tab strip's per-worktree drag order (GitHub issue #16:
-//! "the resulting layout... persists per session/worktree and restores on relaunch").
-//! `crate::root::AdeApp::tab_order` is the live, in-session mirror of one worktree's order; this
-//! module is what makes a drag-reordered tab strip survive an app restart, not just a worktree
-//! switch within the same run.
+//! Real, on-disk persistence for **one worktree's whole tab session** - which tabs were open, of
+//! which kind, in which order - so quitting Jerry and relaunching it brings them all back.
 //!
-//! ## Only file tabs are ever recorded
+//! Started life as GitHub issue #16's drag-order-only store ("the resulting layout... persists per
+//! session/worktree and restores on relaunch"), and still is exactly that for file tabs;
+//! [`WorktreeTabOrder::tabs`] widened it from "the order of whatever happens to be open" into "the
+//! real set of tabs that *were* open", which is what `crate::work_surface::session` needs to
+//! genuinely reopen them. `crate::root::AdeApp::tab_order` remains the live, in-session mirror of
+//! one worktree's order; this module is the durable half.
+//!
+//! ## Why an agent tab *can* be recorded now, when it deliberately couldn't before
 //!
 //! A [`crate::work_surface::state::TabRef::Agent`] carries an
-//! [`crate::work_surface::agents::AgentId`] - a process-local identity that a fresh launch's
-//! freshly-spawned agents can never match again. Persisting an agent-tab entry would therefore
-//! write a value nothing could ever read back successfully; [`WorktreeTabOrder::files`] only
-//! ever holds `TabRef::File` entries, in their real relative drag order, and an agent tab always
-//! lands wherever a freshly spawned agent naturally lands
-//! (`work_surface::state::reconcile_tab_order`'s own "append what's open but not yet in
-//! `stored`" rule) rather than at some remembered position that no longer means anything.
+//! [`crate::work_surface::agents::AgentId`] - a per-window counter that restarts at zero on every
+//! launch, so a freshly-spawned agent can never match a persisted one by id, and this module's
+//! original docs correctly refused to write a value nothing could read back.
+//!
+//! [`SessionTab::Agent`] persists something else entirely: never an id, only the two facts that
+//! genuinely survive a restart - the [`crate::work_surface::agents::AgentKind`] and the real
+//! Claude Code `session_id` (`crate::hooks::event::HookReport::session_id`, GitHub issue #227)
+//! that a literal `claude --resume <session_id>` can pick the same conversation back up from.
+//! A record with no session id is therefore *not* resumable and is honestly dropped at restore
+//! time rather than turned into a fresh, contextless agent occupying the same slot - see
+//! `crate::work_surface::session::AdeApp::restore_worktree_session`'s own docs.
+//!
+//! [`SessionTab::Shell`] carries nothing at all, for the same honesty: a real OS shell process
+//! cannot survive an app quit, so "restoring" one can only ever mean spawning a fresh shell into
+//! the same worktree, in the same tab slot. There is no process-reattachment anywhere in this
+//! codebase to pretend otherwise with.
+//!
+//! ## [`WorktreeTabOrder::files`] is kept, written, and never independently authored
+//!
+//! [`WorktreeTabOrder::tabs`] is authoritative. `files` is issue #16's original field, still
+//! written on every save - derived by the one writer ([`TabOrderState::set_session_tabs`]) from
+//! the very same list - purely so a Jerry build older than this one, sharing a `~/.config/jerry`,
+//! keeps reading a real drag order rather than an empty one. It is read back only when `tabs` is
+//! absent (a file written *by* such a build), which is why the two can never disagree: nothing
+//! ever sets one without setting the other in the same call.
 //!
 //! ## Everything else - file format, atomicity, multi-instance merge - mirrors `fold_state`
 //!
@@ -32,6 +54,8 @@ use std::io;
 use std::path::{Component, Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
+
+use crate::work_surface::agents::AgentKind;
 
 /// The tab-order file's name, resolved next to the real `settings.toml` - mirrors
 /// `crate::sidebar::fold_state::FOLD_STATE_FILE_NAME`.
@@ -133,12 +157,101 @@ pub struct TabOrderState {
     pub worktrees: BTreeMap<String, WorktreeTabOrder>,
 }
 
-/// One worktree's entry - its real file tabs' relative paths, in real drag order. See the module
-/// docs for why agent tabs are never recorded here at all.
+/// One worktree's entry - its whole tab session, in real tab-strip order.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct WorktreeTabOrder {
+    /// GitHub issue #16's original field: this worktree's file tabs' relative paths, in real drag
+    /// order. Derived from [`Self::tabs`] by the single writer and written on every save purely
+    /// for an older Jerry build sharing the same config directory - see the module docs.
     pub files: Vec<String>,
+    /// The authoritative record: every tab that was open, of every kind, in real order.
+    pub tabs: Vec<PersistedTab>,
+}
+
+/// One tab's on-disk record. Deliberately a flat struct with a [`Self::kind`] *string* tag rather
+/// than a `#[derive(Serialize)]`'d Rust enum, matching `crate::hooks::store::status_key`'s own
+/// reasoning exactly: this file is a compatibility surface a future release must still be able to
+/// read, and deriving the format from an enum would silently couple it to a type this codebase
+/// renames freely. An unrecognised `kind` is skipped on read, never guessed at
+/// ([`PersistedTab::decode`]).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct PersistedTab {
+    /// [`TAB_KIND_FILE`], [`TAB_KIND_SHELL`] or [`TAB_KIND_AGENT`].
+    pub kind: String,
+    /// [`TAB_KIND_FILE`] only: the worktree-relative path, in the same `/`-joined form
+    /// [`WorktreeTabOrder::files`] uses.
+    pub path: Option<String>,
+    /// [`TAB_KIND_AGENT`] only: `crate::work_surface::agents::AgentKind::label`.
+    pub agent: Option<String>,
+    /// [`TAB_KIND_AGENT`] only: the real Claude Code `session_id` this agent's hooks last
+    /// reported, if any. `None` for a Codex agent (no hooks exist for Codex at all) and for a
+    /// Claude agent that closed before any hook reported one - both genuinely unresumable, and
+    /// treated as such rather than downgraded to a fresh spawn.
+    pub session_id: Option<String>,
+}
+
+/// The stable on-disk spelling of a [`SessionTab`]'s kind - see [`PersistedTab::kind`].
+pub const TAB_KIND_FILE: &str = "file";
+pub const TAB_KIND_SHELL: &str = "shell";
+pub const TAB_KIND_AGENT: &str = "agent";
+
+/// One tab, decoded into the form a caller can act on - the read/write currency of this module's
+/// whole session API ([`TabOrderState::session_tabs`]/[`TabOrderState::set_session_tabs`]).
+///
+/// [`Self::File`] carries an **absolute** path (already resolved against the worktree root), so a
+/// caller never has to re-derive one and can never accidentally resolve it against the wrong root;
+/// the relative encoding is this module's own storage detail.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionTab {
+    File(PathBuf),
+    Shell,
+    Agent {
+        kind: AgentKind,
+        session_id: Option<String>,
+    },
+}
+
+impl PersistedTab {
+    /// `self`, decoded against `root`, or `None` if this record isn't usable - an unrecognised
+    /// `kind`/`agent` label (a record written by a future release), or a `path` that doesn't decode
+    /// to a plain descendant of `root` ([`absolute_from_key`]). Skipping such a record rather than
+    /// guessing at it mirrors `crate::hooks::history::PastAgent::from_record`'s own contract.
+    fn decode(&self, root: &Path) -> Option<SessionTab> {
+        match self.kind.as_str() {
+            TAB_KIND_FILE => absolute_from_key(root, self.path.as_deref()?).map(SessionTab::File),
+            TAB_KIND_SHELL => Some(SessionTab::Shell),
+            TAB_KIND_AGENT => Some(SessionTab::Agent {
+                kind: AgentKind::from_label(self.agent.as_deref()?)?,
+                session_id: self.session_id.clone(),
+            }),
+            _ => None,
+        }
+    }
+
+    /// `tab`, encoded relative to `root`, or `None` for a [`SessionTab::File`] whose path isn't a
+    /// plain, UTF-8 descendant of `root` ([`relative_key`]) - the same single unrecordable entry
+    /// [`TabOrderState::set_session_tabs`] drops without losing the real entries around it.
+    fn encode(root: &Path, tab: &SessionTab) -> Option<PersistedTab> {
+        match tab {
+            SessionTab::File(path) => Some(PersistedTab {
+                kind: TAB_KIND_FILE.to_owned(),
+                path: Some(relative_key(root, path)?),
+                ..PersistedTab::default()
+            }),
+            SessionTab::Shell => Some(PersistedTab {
+                kind: TAB_KIND_SHELL.to_owned(),
+                ..PersistedTab::default()
+            }),
+            SessionTab::Agent { kind, session_id } => Some(PersistedTab {
+                kind: TAB_KIND_AGENT.to_owned(),
+                agent: Some(kind.label().to_owned()),
+                session_id: session_id.clone(),
+                ..PersistedTab::default()
+            }),
+        }
+    }
 }
 
 impl TabOrderState {
@@ -224,57 +337,103 @@ impl TabOrderState {
         })
     }
 
-    /// `root`'s real, currently-recorded file order, as absolute paths ready to feed into
-    /// [`crate::work_surface::state::TabRef::File`]. Entries that don't decode to a plain
-    /// relative path are silently skipped ([`absolute_from_key`]), and a worktree with no entry
-    /// at all (never seen, or every file tab has since closed) returns an empty order - never an
-    /// error, matching a fresh worktree's own real "nothing recorded yet" state.
-    pub fn file_order(&self, root: &Path) -> Vec<PathBuf> {
-        match worktree_key(root) {
-            Some(key) => self.file_order_with_key(&key, root),
-            None => Vec::new(),
-        }
-    }
-
-    /// [`Self::file_order`] against an already-resolved [`worktree_key`].
-    pub fn file_order_with_key(&self, root_key: &str, root: &Path) -> Vec<PathBuf> {
-        let Some(entry) = self.worktrees.get(root_key) else {
+    /// `root`'s real, currently-recorded tab session, in real tab-strip order. A worktree with no
+    /// entry at all (never seen, or every tab has since closed) returns an empty list - never an
+    /// error, matching a fresh worktree's own real "nothing recorded yet" state. Individual
+    /// records that don't decode are silently skipped ([`PersistedTab::decode`]), so one entry
+    /// written by a future release can never cost a user the rest of their session.
+    ///
+    /// Falls back to [`WorktreeTabOrder::files`] when [`WorktreeTabOrder::tabs`] is empty - see
+    /// the module docs: that is exactly a file written by a Jerry build predating the session
+    /// record, whose file tabs are still real, still in the user's real drag order, and still
+    /// worth reopening.
+    pub fn session_tabs(&self, root: &Path) -> Vec<SessionTab> {
+        let Some(key) = worktree_key(root) else {
             return Vec::new();
         };
+        let Some(entry) = self.worktrees.get(&key) else {
+            return Vec::new();
+        };
+        if entry.tabs.is_empty() {
+            return entry
+                .files
+                .iter()
+                .filter_map(|key| absolute_from_key(root, key))
+                .map(SessionTab::File)
+                .collect();
+        }
         entry
-            .files
+            .tabs
             .iter()
-            .filter_map(|key| absolute_from_key(root, key))
+            .filter_map(|tab| tab.decode(root))
             .collect()
     }
 
-    /// Records `root`'s real, current file order (already-resolved absolute paths, in their real
-    /// drag order) - the write-side counterpart to [`Self::file_order`]. A path that isn't a
-    /// plain descendant of `root`, or isn't valid UTF-8, is silently dropped from the recorded
-    /// order rather than refusing the whole call: unlike `FoldState::set_expanded`'s single-path
-    /// calls, this always records a whole worktree's order at once (`AdeApp::reorder_tab`'s own
-    /// real caller), and one unrecordable entry must not lose every other real, recordable one in
-    /// the same drag.
-    pub fn set_file_order(&mut self, root: &Path, files: &[PathBuf]) {
+    /// `root`'s recorded **file** tabs only, as absolute paths ready to feed into
+    /// [`crate::work_surface::state::TabRef::File`] - [`Self::session_tabs`] narrowed to the one
+    /// kind `crate::work_surface::render::AdeApp::combined_tab_order`'s own persisted-order
+    /// fallback can use directly (an agent tab's slot there is decided by whichever live agent
+    /// really exists, not by this file).
+    pub fn file_order(&self, root: &Path) -> Vec<PathBuf> {
+        self.session_tabs(root)
+            .into_iter()
+            .filter_map(|tab| match tab {
+                SessionTab::File(path) => Some(path),
+                SessionTab::Shell | SessionTab::Agent { .. } => None,
+            })
+            .collect()
+    }
+
+    /// Records `root`'s real, current tab session (in real tab-strip order) - the write-side
+    /// counterpart to [`Self::session_tabs`], and the **only** writer of either field, which is
+    /// what keeps [`WorktreeTabOrder::files`] from ever disagreeing with
+    /// [`WorktreeTabOrder::tabs`] (see the module docs).
+    ///
+    /// A [`SessionTab::File`] whose path isn't a plain, UTF-8 descendant of `root` is silently
+    /// dropped from the recorded session rather than refusing the whole call: unlike
+    /// `FoldState::set_expanded`'s single-path calls, this always records a whole worktree's
+    /// session at once, and one unrecordable entry must not lose every other real, recordable one
+    /// alongside it.
+    ///
+    /// An empty result removes the worktree's entry entirely rather than leaving an empty one
+    /// behind forever - the same "closing every tab forgets the worktree" contract this method's
+    /// file-only predecessor already had.
+    pub fn set_session_tabs(&mut self, root: &Path, tabs: &[SessionTab]) {
         let Some(root_key) = worktree_key(root) else {
             return;
         };
-        let keys: Vec<String> = files
+        let encoded: Vec<PersistedTab> = tabs
             .iter()
-            .filter_map(|file| relative_key(root, file))
+            .filter_map(|tab| PersistedTab::encode(root, tab))
             .collect();
-        if keys.is_empty() {
+        if encoded.is_empty() {
             self.worktrees.remove(&root_key);
-        } else {
-            self.worktrees
-                .insert(root_key, WorktreeTabOrder { files: keys });
+            return;
         }
+        let files: Vec<String> = encoded
+            .iter()
+            .filter(|tab| tab.kind == TAB_KIND_FILE)
+            .filter_map(|tab| tab.path.clone())
+            .collect();
+        self.worktrees.insert(
+            root_key,
+            WorktreeTabOrder {
+                files,
+                tabs: encoded,
+            },
+        );
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The common "these files, in this order" session, so a test about *ordering* doesn't have
+    /// to spell out a `SessionTab::File` wrapper per entry.
+    fn file_session(paths: &[PathBuf]) -> Vec<SessionTab> {
+        paths.iter().cloned().map(SessionTab::File).collect()
+    }
 
     #[test]
     fn tab_order_lives_next_to_the_real_settings_file() {
@@ -297,7 +456,10 @@ mod tests {
     fn set_and_read_round_trips_a_real_order() {
         let root = Path::new("/repo/worktree-a");
         let mut state = TabOrderState::default();
-        state.set_file_order(root, &[root.join("src/main.rs"), root.join("README.md")]);
+        state.set_session_tabs(
+            root,
+            &file_session(&[root.join("src/main.rs"), root.join("README.md")]),
+        );
         assert_eq!(
             state.file_order(root),
             vec![root.join("src/main.rs"), root.join("README.md")],
@@ -306,13 +468,13 @@ mod tests {
     }
 
     #[test]
-    fn set_file_order_with_an_empty_list_forgets_the_worktree_entirely() {
+    fn recording_an_empty_session_forgets_the_worktree_entirely() {
         let root = Path::new("/repo/worktree-a");
         let mut state = TabOrderState::default();
-        state.set_file_order(root, &[root.join("a.txt")]);
+        state.set_session_tabs(root, &file_session(&[root.join("a.txt")]));
         assert!(!state.worktrees.is_empty());
 
-        state.set_file_order(root, &[]);
+        state.set_session_tabs(root, &[]);
         assert!(
             state.worktrees.is_empty(),
             "closing every file tab must not leave an empty entry behind forever"
@@ -323,13 +485,13 @@ mod tests {
     fn a_path_outside_the_worktree_is_dropped_but_the_rest_of_the_order_survives() {
         let root = Path::new("/repo/worktree-a");
         let mut state = TabOrderState::default();
-        state.set_file_order(
+        state.set_session_tabs(
             root,
-            &[
+            &file_session(&[
                 root.join("src/main.rs"),
                 PathBuf::from("/etc/passwd"),
                 root.join("README.md"),
-            ],
+            ]),
         );
         assert_eq!(
             state.file_order(root),
@@ -344,7 +506,7 @@ mod tests {
         let a = Path::new("/repo/worktree-a");
         let b = Path::new("/repo/worktree-b");
         let mut state = TabOrderState::default();
-        state.set_file_order(a, &[a.join("src/main.rs")]);
+        state.set_session_tabs(a, &file_session(&[a.join("src/main.rs")]));
 
         assert_eq!(state.file_order(a), vec![a.join("src/main.rs")]);
         assert!(
@@ -361,7 +523,7 @@ mod tests {
         let root = Path::new("/repo/worktree-a");
 
         let mut state = TabOrderState::default();
-        state.set_file_order(root, &[root.join("a.rs"), root.join("b.rs")]);
+        state.set_session_tabs(root, &file_session(&[root.join("a.rs"), root.join("b.rs")]));
         state.save_at(&path).expect("save");
 
         let reloaded = TabOrderState::load_at(&path);
@@ -380,12 +542,12 @@ mod tests {
         let b = Path::new("/repo/worktree-b");
 
         let mut instance_a = TabOrderState::default();
-        instance_a.set_file_order(a, &[a.join("a.rs")]);
+        instance_a.set_session_tabs(a, &file_session(&[a.join("a.rs")]));
         let owned_a: BTreeSet<String> = [worktree_key(a).expect("key")].into_iter().collect();
         instance_a.save_merged_at(&path, &owned_a).expect("save a");
 
         let mut instance_b = TabOrderState::default();
-        instance_b.set_file_order(b, &[b.join("b.rs")]);
+        instance_b.set_session_tabs(b, &file_session(&[b.join("b.rs")]));
         let owned_b: BTreeSet<String> = [worktree_key(b).expect("key")].into_iter().collect();
         instance_b.save_merged_at(&path, &owned_b).expect("save b");
 
@@ -437,7 +599,7 @@ mod tests {
         let path = dir.path().join("nested").join("tab-order.toml");
         let root = Path::new("/repo/worktree-a");
         let mut state = TabOrderState::default();
-        state.set_file_order(root, &[root.join("a.rs")]);
+        state.set_session_tabs(root, &file_session(&[root.join("a.rs")]));
 
         state.save_at(&path).expect("save");
 
@@ -453,5 +615,177 @@ mod tests {
             })
             .collect();
         assert_eq!(siblings, vec!["tab-order.toml".to_string()]);
+    }
+
+    /// The whole point of the session record: a heterogeneous tab strip - a file, then a shell,
+    /// then a resumable Claude agent - must round-trip through a real file with every kind, every
+    /// payload, and the real interleaved *order* intact.
+    #[test]
+    fn a_mixed_session_round_trips_through_a_real_file_with_its_order_intact() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("tab-order.toml");
+        let root = Path::new("/repo/worktree-a");
+        let session = vec![
+            SessionTab::File(root.join("src/main.rs")),
+            SessionTab::Shell,
+            SessionTab::Agent {
+                kind: AgentKind::Claude,
+                session_id: Some("5af4c210-34fa-4ab2-9c35-f6ceab76551c".to_owned()),
+            },
+            SessionTab::File(root.join("README.md")),
+        ];
+
+        let mut state = TabOrderState::default();
+        state.set_session_tabs(root, &session);
+        state.save_at(&path).expect("save");
+
+        assert_eq!(
+            TabOrderState::load_at(&path).session_tabs(root),
+            session,
+            "every tab kind, its payload, and its real slot in the strip must survive a restart"
+        );
+    }
+
+    /// A Codex agent never has a session id (no hooks exist for it at all) - the record must still
+    /// round-trip honestly as a Codex agent with `None`, so the restore side can make its own real
+    /// "this one can't be resumed" decision rather than this layer inventing one.
+    #[test]
+    fn an_agent_with_no_session_id_round_trips_as_exactly_that() {
+        let root = Path::new("/repo/worktree-a");
+        let mut state = TabOrderState::default();
+        state.set_session_tabs(
+            root,
+            &[SessionTab::Agent {
+                kind: AgentKind::Codex,
+                session_id: None,
+            }],
+        );
+        assert_eq!(
+            state.session_tabs(root),
+            vec![SessionTab::Agent {
+                kind: AgentKind::Codex,
+                session_id: None,
+            }]
+        );
+    }
+
+    /// `files` exists only so an older Jerry build sharing this config directory keeps reading a
+    /// real drag order - it must therefore always be written, and always agree with the file half
+    /// of `tabs`, never be authored separately.
+    #[test]
+    fn the_legacy_files_field_is_always_written_from_the_same_session_record() {
+        let root = Path::new("/repo/worktree-a");
+        let mut state = TabOrderState::default();
+        state.set_session_tabs(
+            root,
+            &[
+                SessionTab::File(root.join("a.rs")),
+                SessionTab::Shell,
+                SessionTab::File(root.join("b.rs")),
+            ],
+        );
+        let entry = state
+            .worktrees
+            .get(&worktree_key(root).expect("key"))
+            .expect("entry");
+        assert_eq!(
+            entry.files,
+            vec!["a.rs".to_string(), "b.rs".to_string()],
+            "the legacy field must hold exactly the file tabs, in the same real order"
+        );
+        assert_eq!(entry.tabs.len(), 3, "and `tabs` keeps the shell as well");
+    }
+
+    /// The other half of that compatibility promise: a `tab-order.toml` written *by* such an older
+    /// build has no `tabs` at all, and its file tabs are still real, still in the user's own drag
+    /// order, and must still be restored rather than silently ignored.
+    #[test]
+    fn a_file_written_before_sessions_existed_still_restores_its_file_tabs() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("tab-order.toml");
+        std::fs::write(
+            &path,
+            "[worktrees.\"/repo/worktree-a\"]\nfiles = [\"src/main.rs\", \"README.md\"]\n",
+        )
+        .expect("write");
+
+        let root = Path::new("/repo/worktree-a");
+        assert_eq!(
+            TabOrderState::load_at(&path).session_tabs(root),
+            vec![
+                SessionTab::File(root.join("src/main.rs")),
+                SessionTab::File(root.join("README.md")),
+            ]
+        );
+    }
+
+    /// A record written by a *future* release (an unknown tab kind, or an agent label this build
+    /// doesn't know) must be skipped, never guessed at - and skipping it must not cost the user
+    /// the real tabs recorded around it.
+    #[test]
+    fn an_unrecognised_record_is_skipped_without_losing_the_real_tabs_around_it() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("tab-order.toml");
+        std::fs::write(
+            &path,
+            "[worktrees.\"/repo/worktree-a\"]\n\
+             files = []\n\
+             [[worktrees.\"/repo/worktree-a\".tabs]]\n\
+             kind = \"file\"\n\
+             path = \"a.rs\"\n\
+             [[worktrees.\"/repo/worktree-a\".tabs]]\n\
+             kind = \"holodeck\"\n\
+             [[worktrees.\"/repo/worktree-a\".tabs]]\n\
+             kind = \"agent\"\n\
+             agent = \"SomeFutureAgent\"\n\
+             [[worktrees.\"/repo/worktree-a\".tabs]]\n\
+             kind = \"shell\"\n",
+        )
+        .expect("write");
+
+        let root = Path::new("/repo/worktree-a");
+        assert_eq!(
+            TabOrderState::load_at(&path).session_tabs(root),
+            vec![SessionTab::File(root.join("a.rs")), SessionTab::Shell],
+        );
+    }
+
+    /// The same traversal guard `files` has always had, applied to a hand-edited `tabs` entry: a
+    /// `..` path must never decode into a file outside the worktree it is filed under.
+    #[test]
+    fn a_traversal_session_entry_in_a_hand_edited_file_is_ignored() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("tab-order.toml");
+        std::fs::write(
+            &path,
+            "[worktrees.\"/repo/worktree-a\"]\n\
+             files = []\n\
+             [[worktrees.\"/repo/worktree-a\".tabs]]\n\
+             kind = \"file\"\n\
+             path = \"../worktree-b/secret.rs\"\n\
+             [[worktrees.\"/repo/worktree-a\".tabs]]\n\
+             kind = \"file\"\n\
+             path = \"src/main.rs\"\n",
+        )
+        .expect("write");
+
+        assert_eq!(
+            TabOrderState::load_at(&path).session_tabs(Path::new("/repo/worktree-a")),
+            vec![SessionTab::File(PathBuf::from(
+                "/repo/worktree-a/src/main.rs"
+            ))],
+        );
+    }
+
+    /// A worktree whose whole session is a single unrecordable file (outside the root) must be
+    /// forgotten entirely rather than left with an empty entry - the same contract an explicitly
+    /// empty session already has.
+    #[test]
+    fn a_session_that_encodes_to_nothing_forgets_the_worktree() {
+        let root = Path::new("/repo/worktree-a");
+        let mut state = TabOrderState::default();
+        state.set_session_tabs(root, &file_session(&[root.join("a.rs")]));
+        state.set_session_tabs(root, &file_session(&[PathBuf::from("/etc/passwd")]));
+        assert!(state.worktrees.is_empty());
     }
 }


### PR DESCRIPTION
> "yes i mean everything should reopen"

Quit Jerry with some set of file, terminal and agent tabs open across some set of worktrees and repos, launch it again, and they come back.

Before this, only file-tab **order** was persisted (`work_surface::tab_order_state`, `files: Vec<String>` - paths and order, nothing else), and even that was only re-filtered against whatever happened to already be open; nothing was ever reopened, and terminal/agent tabs weren't recorded at all.

## What is persisted

`tab-order.toml` grows a per-worktree `tabs` array - every tab that was open, of every kind, in real tab-strip order:

```toml
[worktrees."/repo/wt-a"]
files = ["src/main.rs", "README.md"]     # legacy, still written, never independently authored
[[worktrees."/repo/wt-a".tabs]]
kind = "file"
path = "src/main.rs"
[[worktrees."/repo/wt-a".tabs]]
kind = "shell"
[[worktrees."/repo/wt-a".tabs]]
kind = "agent"
agent = "Claude"
session_id = "5af4c210-…"
```

An agent record keeps its `AgentKind` and the real Claude Code `session_id` its hooks reported - **never** an `AgentId`, which is a per-window counter no restart can resolve (the reason the module's original docs correctly refused to persist agent tabs at all). `files` is still written, derived from the same list by the same single writer, so an older build sharing one `~/.config/jerry` keeps reading a real drag order; it is read back only when `tabs` is absent.

`repos.toml`'s per-repo record grows `selected_worktree`, so a plain relaunch lands back in the worktree that was last worked in rather than always the main checkout.

## What restoring honestly does

| tab | restored as |
| --- | --- |
| file | reopened. Deleted/moved since last session → skipped with a real reason (`AdeApp::session_restore_notices`), never a phantom tab |
| terminal | a **fresh** shell in the same worktree, in the same slot. A real OS shell can't survive a quit and this codebase has no process-reattachment to claim otherwise with |
| agent | only as a genuine `claude --resume <session_id>` via issue #227's already-verified `Agents::spawn_resume` - the same conversation carried forward |

An agent with **no** recorded session id (every Codex agent - no hooks exist for it at all; any Claude agent that closed before a hook fired) is *not* restored, and says why. A fresh contextless agent in that slot would look like a resumed conversation and be nothing of the kind. One tab degrading never fails the rest of the restore.

## Scope/timing decision: lazy, per worktree, on first real activation

Restoring *everything* at launch was rejected deliberately. A restored tab is not a row in a list; it's a real OS process. A user who has worked in a dozen worktrees across three repos would watch Jerry fork a dozen shells and resume several Claude conversations - real PTYs, real CPU, real token spend on conversations they didn't ask to continue - before the first frame they could act on.

So: a worktree's session reopens the first time that worktree is **genuinely selected** in a window, and never again in it.

- **Launch still lands you back where you were, with your tabs**, because startup genuinely selects a worktree on the way in (`load_worktrees_for_opened_repo` → `selection_for_opened_repo`) and now prefers the remembered one. One worktree's worth of processes, not every worktree's.
- **Every other worktree and repo comes back the instant you go there**, at the cost of a visit the user just performed anyway.
- **PR #265's invariant holds structurally, not by care.** Restore hangs off *selection itself*, so no path here can produce a tab for a worktree that isn't the real, selected one - and `restore_worktree_session` additionally refuses outright if handed a worktree that isn't the live `file_tree_root`.

Honest cost: the first switch into a not-yet-visited worktree is heavier than a plain switch used to be. That's the same cost the eager design pays, moved to the moment it buys something.

An **explicitly named path** (`jerry ~/repo`, "Open Folder…") still wins over the remembered worktree - that's a real statement about where to work. Only the plain "relaunch Jerry" gesture (no CLI argument, repo resolved from memory) honours the finer-grained worktree memory.

## Files

- **`work_surface/tab_order_state.rs`** - `PersistedTab`/`SessionTab`/`WorktreeTabOrder::tabs`, `session_tabs`/`set_session_tabs`. File format, atomicity and the `persisted_state_lock` merge are unchanged.
- **`work_surface/session.rs`** (new) - `AdeApp::record_worktree_session` / `restore_worktree_session`, plus the 9 end-to-end GPUI tests.
- **`rail/repo.rs`** - `RepoRecord::selected_worktree`, `RepoState::remembered_worktree`.
- **`root/state.rs`** - seeds `selected_worktree_by_repo` at startup, prefers the remembered worktree for a memory-resolved launch, calls restore from `select_worktree` and (before the guaranteed initial shell) `spawn_initial_shell_for_opened_repo`, records the per-repo selection.
- **`root/mod.rs`** - `session_restored`, `session_restore_notices`, `selected_worktree_by_repo`; `repo_state_snapshot` persists the remembered worktree.
- **`work_surface/render.rs`, `code_surface/tabs.rs`, `root/new_file.rs`, `hooks/flow.rs`** - the recorder wired into every real tab mutation (spawn, close, drag, file open/activate/close, new file, resume) plus `record_agent_statuses` (a session id is learned *after* the tab was recorded; without this, a genuinely resumable agent would be honestly refused on relaunch).

`combined_tab_order`'s file-only persisted fallback is **removed**, replaced by the restore seeding `AdeApp::tab_order` with the real remembered order for every tab kind. Keeping both would have inverted the documented "agents, then files" default for never-dragged worktrees, now that sessions are recorded on every ordinary tab change.

## Tests

9 new `#[gpui::test]`s in `work_surface::session`, each performing a **genuine relaunch** - a second, independently constructed `AdeApp` against the same real settings directory - against real `git init`/`git worktree add` repos, real `Agents::spawn`, real file IO, `cx.run_until_parked()`:

- file + terminal tabs in a real drag-chosen **interleaved** order, across two worktrees, all back in order
- an unvisited worktree's session costs **zero** processes at launch, and comes back on selection
- a file deleted between sessions is skipped with a real reason, the rest survives
- a Claude agent restored by real resume - asserted on the restored pane's real `TerminalSpec` (`--resume <the same session id>`, same cwd), mirroring #227's own resume test
- an agent with no resumable session refused honestly and alone, twice (Codex + Claude), rest of session intact
- relaunch with no CLI argument lands back in the last worktree with its tabs
- an explicitly named path still wins over the remembered worktree
- both repos' tab sessions survive a relaunch (multi-repo)
- a deliberately closed tab stays closed

Plus new unit tests in `tab_order_state` (mixed-session round trip, legacy `files`-only file still restores, unrecognised/future records skipped without losing neighbours, traversal guard on `tabs`) and `repo.rs` (remembered worktree returned only while it still exists).

## Verification

- `cargo build --workspace` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo fmt --all --check` ✅
- `cargo test --workspace` - 2354 passed; the 17 failures are all the known flaky-under-load class (`file_tree_watch`/`worktree_watch`/`repo_list_tests` watcher tests = inotify `max_user_instances` exhaustion, `text_undo_scoping_tests`, `agent_state_chip_live_tests`). All pass re-run in isolation. The new tests pass 5/5 consecutive runs.

Incidental fix: `default_key_bindings`' `let mut bindings` needs `mut` only on macOS, so `clippy -- -D warnings` already failed off macOS on master - scoped with `cfg_attr` rather than a blanket allow.

## Flagged / not fully settled

- **Which tab was *active*** isn't persisted, so a restored worktree shows its tabs with none selected (unless a restored agent becomes active). Reasonable follow-up.
- **`session_restore_notices` has no UI yet.** Entries are logged and kept on a real, tested field; nothing renders them. Same "real data captured, no UI reads it back" contract `hooks::store`'s first phase established.
- **Graph and review tabs are deliberately not persisted** - both are single window-wide slots rather than per-worktree tabs, and a review tab names a live `AgentId`.
- **"New Window" (issue #90) opening the same repo twice** will restore the same session into both windows, i.e. duplicate tabs. Arguably correct ("the session reopens here too") and the same shape as the pre-existing per-window startup shell, but worth a second opinion.
- **`load_worktrees`' fall-back-to-main recovery** doesn't restore (no `&mut Window` in that background task); that worktree's session is left untouched and restores on the next real selection. Documented at the call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
