### PR TITLE
fix(app): the git graph's status-bar button no longer needs an open agent

### DIFF
--- a/crates/app/src/palette/render.rs
+++ b/crates/app/src/palette/render.rs
@@ -160,9 +160,9 @@ impl AdeApp {
         // The three spawn commands below name the real worktree they would spawn into. With no
         // worktree genuinely selected they would spawn nothing at all (`Self::new_agent`/
         // `Self::new_agent_pane` both refuse outright), so the honest thing to show is that -
-        // rather than the repo root, which is what `Self::active_agent_cwd` used to hand back and
+        // rather than the repo root, which is what `Self::current_worktree_path` used to hand back and
         // which was never a place a tab could legitimately belong to. See that method's own docs.
-        let spawn_target = match self.active_agent_cwd() {
+        let spawn_target = match self.current_worktree_path() {
             Some(cwd) => format!("in {}", cwd.display()),
             None => "- select a worktree first".to_string(),
         };

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -1103,7 +1103,7 @@ impl AdeApp {
     /// which made every added repo's header reachable rather than just the focused one's - is
     /// what exposed how wrong it is: a repo header has no *worktree* context for those five
     /// actions to spawn into, so "New terminal"/"New agent" fell through to
-    /// [`Self::active_agent_cwd`]'s repo-root fallback and opened a tab against the repo itself
+    /// [`Self::current_worktree_path`]'s repo-root fallback and opened a tab against the repo itself
     /// rather than any worktree inside it. Tabs belong to worktrees here, not to repos.
     ///
     /// With that handler gone, the whole anchoring apparatus it needed went with it (the
@@ -1149,7 +1149,7 @@ impl AdeApp {
     /// (via [`Self::render_worktree_row`]) when `row.agents` is non-empty.
     ///
     /// GitHub issue #112 (live follow-up report): the worktree currently selected
-    /// ([`Self::active_agent_cwd`] - the same real comparison [`Self::render_worktree_row`]'s own
+    /// ([`Self::current_worktree_path`] - the same real comparison [`Self::render_worktree_row`]'s own
     /// `is_selected` uses) is exempt from the idle-collapse default, absent an explicit override.
     /// Without this, a worktree the user is actively switching terminals within could silently
     /// collapse out from under them the moment its most urgent agent's status crossed into
@@ -1164,7 +1164,7 @@ impl AdeApp {
         match self.rail_collapse_overrides.get(&row.path) {
             Some(expanded) => *expanded,
             None => {
-                self.active_agent_cwd().as_deref() == Some(row.path.as_path())
+                self.current_worktree_path().as_deref() == Some(row.path.as_path())
                     || row.aggregate_status() != Status::Idle
             }
         }
@@ -1232,10 +1232,10 @@ impl AdeApp {
 
         // The rail's own "this row is the selected worktree" state, read from the exact same
         // single source of truth the tab strip scopes itself to - so the two can never disagree.
-        // With `Self::active_agent_cwd`'s repo-root fallback removed, "nothing is selected" now
+        // With `Self::current_worktree_path`'s repo-root fallback removed, "nothing is selected" now
         // genuinely draws *no* row as selected, rather than lighting up whichever row happened to
         // sit at the repo root while the tab strip showed something else entirely.
-        let is_selected = self.active_agent_cwd().as_deref() == Some(row.path.as_path());
+        let is_selected = self.current_worktree_path().as_deref() == Some(row.path.as_path());
         let has_agents = !row.agents.is_empty();
         let has_history = !row.history.is_empty();
         // GitHub issue #227: a worktree with no live agent but real persisted history must still
@@ -2173,7 +2173,7 @@ mod rail_row_tests {
     }
 
     /// GitHub issue #112 (live follow-up report): a worktree the user is actively switching
-    /// terminals within - the one [`crate::root::AdeApp::active_agent_cwd`] currently reports -
+    /// terminals within - the one [`crate::root::AdeApp::current_worktree_path`] currently reports -
     /// must never auto-collapse just because its most urgent agent's status happens to cross into
     /// `Idle` (an ordinary occurrence - a shell sitting at its prompt between commands). Before
     /// this exemption, that real, wall-clock-driven Idle transition would silently collapse the
@@ -2212,7 +2212,7 @@ mod rail_row_tests {
                 .expect("the seeded worktree must produce a row")
         });
         assert_eq!(
-            app.read_with(cx, |app, _| app.active_agent_cwd()),
+            app.read_with(cx, |app, _| app.current_worktree_path()),
             Some(wt.path().to_path_buf()),
             "premise: `wt` really is the currently selected worktree"
         );
@@ -3149,7 +3149,7 @@ mod repo_checkout_tests {
                  the repo's main checkout"
             );
             assert_eq!(
-                app.active_agent_cwd(),
+                app.current_worktree_path(),
                 Some(repo_b_feature.clone()),
                 "the whole point of the switch: new work now targets the clicked worktree"
             );
@@ -3313,7 +3313,7 @@ mod repo_checkout_tests {
 
     /// The real, reproduced root cause behind "I spawned a Claude agent and it never showed up in
     /// the rail": a repo path that isn't fully resolved. `git worktree list --porcelain` always
-    /// reports resolved paths, `crate::root::AdeApp::active_agent_cwd` falls back to
+    /// reports resolved paths, `crate::root::AdeApp::current_worktree_path` falls back to
     /// `Self::focused_repo_path` whenever no worktree is selected (which is exactly the state a
     /// fresh window - and every `Self::checkout_repo_from_rail` - leaves the app in), and
     /// `crate::rail::state::build_worktree_rows_with_history` folds an agent into a worktree row
@@ -3532,7 +3532,7 @@ mod worktree_tab_attribution_tests {
     /// The startup half of the reported bug. A fresh `jerry <repo>` launch spawns a real shell and
     /// shows its tab - but it used to leave `AdeApp::selected` at `None`, so *the user never
     /// selected the worktree that tab belongs to*. The tab rendered only because
-    /// `AdeApp::active_agent_cwd`'s repo-root fallback happened to coincide with the main
+    /// `AdeApp::current_worktree_path`'s repo-root fallback happened to coincide with the main
     /// worktree's own path. This asserts the real thing instead: the main worktree is genuinely
     /// selected, and the startup shell genuinely lives in it.
     #[gpui::test]
@@ -3554,9 +3554,9 @@ mod worktree_tab_attribution_tests {
                  starting state"
             );
             assert_eq!(
-                app.active_agent_cwd(),
+                app.current_worktree_path(),
                 Some(repo.path().to_path_buf()),
-                "and it must be a real selection, not `active_agent_cwd`'s old repo-root fallback"
+                "and it must be a real selection, not `current_worktree_path`'s old repo-root fallback"
             );
             let startup_shell_cwds: Vec<PathBuf> =
                 app.agents.iter().map(|agent| agent.cwd.clone()).collect();
@@ -3599,7 +3599,7 @@ mod worktree_tab_attribution_tests {
         // Step 1: the main worktree really is the selected one, and really owns the tab.
         app.read_with(cx, |app, _| {
             assert_eq!(
-                app.active_agent_cwd(),
+                app.current_worktree_path(),
                 Some(repo.path().to_path_buf()),
                 "premise: the startup terminal's own worktree must be genuinely selected before \
                  the user ever clicks anything - that is what makes the switch below a \
@@ -3617,7 +3617,7 @@ mod worktree_tab_attribution_tests {
         click_worktree_row(&app, cx, &feature);
         app.read_with(cx, |app, cx| {
             assert_eq!(
-                app.active_agent_cwd(),
+                app.current_worktree_path(),
                 Some(feature.clone()),
                 "the clicked worktree must be the selected one"
             );
@@ -3656,7 +3656,7 @@ mod worktree_tab_attribution_tests {
     /// The real, permanent-loss half of the bug, live-reproduced before the fix: launching against
     /// a *subdirectory* of a repo (`jerry ./crates` - an entirely ordinary invocation).
     ///
-    /// `AdeApp::active_agent_cwd` used to resolve to that bare subdirectory, which
+    /// `AdeApp::current_worktree_path` used to resolve to that bare subdirectory, which
     /// `git worktree list --porcelain` reports as no worktree at all. The startup shell spawned
     /// there rendered a real tab in the strip while *every* rail row read as unselected, and the
     /// moment any worktree row was clicked the tab vanished for good - its `cwd` could never again
@@ -3672,7 +3672,7 @@ mod worktree_tab_attribution_tests {
 
         let startup_agent = app.read_with(cx, |app, _| {
             assert_eq!(
-                app.active_agent_cwd(),
+                app.current_worktree_path(),
                 Some(repo.path().to_path_buf()),
                 "a subdirectory is not a worktree - this must land on the repo's real main \
                  worktree rather than on the subdirectory itself"
@@ -3721,7 +3721,7 @@ mod worktree_tab_attribution_tests {
 
         app.read_with(cx, |app, _| {
             assert_eq!(
-                app.active_agent_cwd(),
+                app.current_worktree_path(),
                 Some(feature.clone()),
                 "the worktree the user actually pointed at must be the selected one"
             );
@@ -3814,7 +3814,7 @@ mod worktree_tab_attribution_tests {
 
         app.read_with(cx, |app, _| {
             assert_eq!(
-                app.active_agent_cwd(),
+                app.current_worktree_path(),
                 Some(feature.clone()),
                 "the worktree the user actually clicked must win over the one the in-flight open \
                  fetch would have picked on its own"
@@ -3837,7 +3837,7 @@ mod worktree_tab_attribution_tests {
     /// is genuinely selected, *nothing* may claim to be showing.
     ///
     /// Before this revision, `AdeApp::checkout_repo_from_rail` left `AdeApp::selected` at `None`
-    /// while `active_agent_cwd` still resolved to the repo root, producing a real three-way
+    /// while `current_worktree_path` still resolved to the repo root, producing a real three-way
     /// disagreement: the rail drew the main-worktree row as selected, the tab strip drew the root
     /// shell's tab, and the centre pane rendered nothing at all (`Agents::clear_active` having
     /// genuinely cleared it). All three now agree.
@@ -3887,7 +3887,7 @@ mod worktree_tab_attribution_tests {
         app.read_with(cx, |app, cx| {
             assert_eq!(app.selected, None, "premise: nothing is selected");
             assert_eq!(
-                app.active_agent_cwd(),
+                app.current_worktree_path(),
                 None,
                 "so there is genuinely no active worktree - not the repo root standing in for one"
             );
@@ -3906,11 +3906,11 @@ mod worktree_tab_attribution_tests {
             let any_row_selected = app
                 .build_worktree_rows(cx)
                 .iter()
-                .any(|row| app.active_agent_cwd().as_deref() == Some(row.path.as_path()));
+                .any(|row| app.current_worktree_path().as_deref() == Some(row.path.as_path()));
             assert!(
                 !any_row_selected,
                 "and no rail row may read as selected either - the rail used to light up the \
-                 main-worktree row here purely because `active_agent_cwd` fell back to the repo \
+                 main-worktree row here purely because `current_worktree_path` fell back to the repo \
                  root"
             );
             assert!(

--- a/crates/app/src/rail/repo.rs
+++ b/crates/app/src/rail/repo.rs
@@ -151,7 +151,7 @@ pub fn repo_state_path_for(settings_path: &Path) -> PathBuf {
 /// `crate::root::AdeApp::diff_cache`/`worktree_notes`/`open_files_by_worktree`/`edit_buffers`.
 /// A [`Repo::path`] kept verbatim from `jerry .`, `jerry ~/link-to-repo`, or any relative
 /// argument therefore never equals git's own answer for the same directory, and
-/// `crate::root::AdeApp::active_agent_cwd`'s repo-root fallback hands exactly that unresolved
+/// `crate::root::AdeApp::current_worktree_path`'s repo-root fallback hands exactly that unresolved
 /// path to `Agents::spawn` as an agent's `cwd`. The real, reproduced consequence: an agent
 /// spawned that way matches no worktree row at all, and - because `build_worktree_rows_with_
 /// history` maps over *worktrees* and folds agents into them - is dropped from the rail

--- a/crates/app/src/rail/worktrees.rs
+++ b/crates/app/src/rail/worktrees.rs
@@ -192,7 +192,7 @@ pub fn recover_selection(
 /// `None` only when the repo has no *usable* worktree whatsoever (an empty list, or one whose
 /// every entry is [`WorktreeItem::error`]-bearing) - a real, honest "there is nothing here to
 /// select" state, deliberately distinct from "we forgot to select something that exists". See
-/// `crate::root::AdeApp::active_agent_cwd`'s own docs for the single documented last resort that
+/// `crate::root::AdeApp::current_worktree_path`'s own docs for the single documented last resort that
 /// covers it.
 ///
 /// Unusable ([`WorktreeItem::error`]) entries are skipped by both rules, matching the identical
@@ -451,7 +451,7 @@ mod tests {
 
     /// The real, live-reproduced subdirectory launch (`jerry ./crates`): the opened path is a
     /// genuine directory but not any worktree, so nothing can match it exactly. Before this
-    /// rule existed, `AdeApp::active_agent_cwd` fell back to that bare subdirectory path, and
+    /// rule existed, `AdeApp::current_worktree_path` fell back to that bare subdirectory path, and
     /// the startup shell it spawned there belonged to no rail row at all - a real, live tab
     /// that no worktree claimed, and which became permanently unreachable the moment any
     /// worktree row was clicked.

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -43,7 +43,7 @@
 //! (`crate::work_surface::agents::Agents::activate_for_worktree`, called from [`AdeApp::select_worktree`]):
 //! the active agent must always belong to the selected worktree, or the centre pane would show
 //! one worktree's terminal while the rail highlights another. [`AdeApp::selected`] itself still
-//! drives the file tree, and which worktree `active_agent_cwd` resolves to for the *next* "New
+//! drives the file tree, and which worktree `current_worktree_path` resolves to for the *next* "New
 //! terminal"/"New agent pane" click - that part is unchanged. Spawning an agent is still always
 //! its own explicit action, never an implicit side effect of browsing.
 //!
@@ -55,7 +55,7 @@
 //! > **A tab is never shown, never spawnable, and never implicitly attributed to anything except a
 //! > real, currently-selected worktree. There is no such thing as "a repo's own tab".**
 //!
-//! [`AdeApp::active_agent_cwd`] is the single chokepoint that enforces it, and it returns
+//! [`AdeApp::current_worktree_path`] is the single chokepoint that enforces it, and it returns
 //! `Option<PathBuf>` precisely so that "nothing is selected" is a state the app can *say* rather
 //! than paper over. It used to fall back to [`AdeApp::focused_repo_path`] whenever
 //! [`AdeApp::selected`] was `None`, which quietly made a repo root behave like a worktree it is
@@ -2366,7 +2366,7 @@ impl AdeApp {
     /// window has focused, so falling back to its first entry could silently resolve to a
     /// completely different, unopened repo's real path - and every real repo-scoped operation
     /// this app has (spawning an agent, committing, discarding a worktree) reads its target
-    /// through this method or [`Self::active_agent_cwd`]. Every call site that can run with no
+    /// through this method or [`Self::current_worktree_path`]. Every call site that can run with no
     /// repo focused must check [`Self::focused_repo`]/[`Self::focused_repo_path`]'s emptiness
     /// itself instead - see [`crate::work_surface::render::AdeApp::new_agent`]'s own docs for the
     /// concrete exploit this was found through and the real guard that closes it.
@@ -2524,7 +2524,7 @@ impl AdeApp {
         // `Self::selected` ends up as. Cleared here (rather than left holding an index into the
         // repo being *left*) so the interim frames between this call and that fetch landing
         // render an honestly empty tab strip rather than a stale one - with
-        // `Self::active_agent_cwd`'s repo-root fallback gone, "nothing selected" is now a real,
+        // `Self::current_worktree_path`'s repo-root fallback gone, "nothing selected" is now a real,
         // self-consistent state everywhere instead of one that silently resolves to the repo root.
         self.selected = None;
         self.worktree_selection_notice = None;
@@ -2533,7 +2533,7 @@ impl AdeApp {
         // shell there" sequence - see its own docs. This method used to spawn that shell inline,
         // into the bare `path`, and leave `Self::selected` at `None`: the reported bug, since the
         // resulting tab belonged to no worktree at all and only rendered because
-        // `Self::active_agent_cwd` fell back to this same repo path while nothing was selected.
+        // `Self::current_worktree_path` fell back to this same repo path while nothing was selected.
         self.load_worktrees_for_opened_repo(path, cx);
         self.start_worktree_watch(cx);
         self.start_status_polling(cx);
@@ -4394,9 +4394,9 @@ mod repo_list_tests {
     /// The premise is unchanged, but the reason it is now *safe* is different, and worth stating
     /// because it is this revision's whole point. `AdeApp::selected` staying `None` used to be a
     /// limbo state that still rendered a plausible-looking tab, because
-    /// `AdeApp::active_agent_cwd` fell back to the bare repo path for exactly that `None` - so the
+    /// `AdeApp::current_worktree_path` fell back to the bare repo path for exactly that `None` - so the
     /// rail lit up the main-worktree row, the tab strip drew the repo root's shell, and the centre
-    /// pane showed nothing, all at the same time. That fallback is gone (see `active_agent_cwd`'s
+    /// pane showed nothing, all at the same time. That fallback is gone (see `current_worktree_path`'s
     /// own docs), so "nothing selected" is now genuinely inert *everywhere* rather than merely
     /// inert here - proven directly by `crate::rail::render::worktree_tab_attribution_tests::
     /// nothing_selected_means_nothing_shown_anywhere`.
@@ -4540,7 +4540,7 @@ mod repo_list_tests {
 
     /// Critical fix (independent audit): a genuinely empty window has no real repo root to spawn
     /// a new agent into - `Self::focused_repo_path`'s own `Self::repos.first()` fallback (removed)
-    /// used to let `Self::active_agent_cwd` silently resolve to some *other*, unopened repo's real
+    /// used to let `Self::current_worktree_path` silently resolve to some *other*, unopened repo's real
     /// path, so `secondary-n`/`ctrl-shift-T`'s own handlers could spawn a real, invisible PTY
     /// there. `Self::new_agent`/`Self::new_agent_pane` now refuse outright with no focused repo -
     /// this proves both real entry points genuinely spawn nothing.

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -746,11 +746,11 @@ impl AdeApp {
     /// own contract, split out so the "which worktree" decision and the "spawn into it" step are
     /// visibly separate steps rather than one tangled block.
     ///
-    /// Spawns into [`Self::active_agent_cwd`] and refuses outright when that is `None`, which is
+    /// Spawns into [`Self::current_worktree_path`] and refuses outright when that is `None`, which is
     /// the whole point: there is no such thing as a tab attributed to a repo rather than to a
     /// worktree, so if nothing real is selected there is nothing legitimate to spawn. (Today the
     /// caller has already either selected a real worktree or fallen into
-    /// `active_agent_cwd`'s one documented last resort, so `None` here means the repo stopped
+    /// `current_worktree_path`'s one documented last resort, so `None` here means the repo stopped
     /// being focused entirely between the fetch being issued and it landing - a real race, worth
     /// refusing rather than guessing through.)
     ///
@@ -759,7 +759,7 @@ impl AdeApp {
     /// [`crate::root::AdeApp::open_repo_in_current_window`]'s cross-repo persistence docs), so
     /// this must never stack a redundant second shell onto one that is already there.
     fn spawn_initial_shell_for_opened_repo(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let Some(cwd) = self.active_agent_cwd() else {
+        let Some(cwd) = self.current_worktree_path() else {
             return;
         };
         if self.agents.iter_for_cwd(cwd.clone()).next().is_none() {
@@ -799,7 +799,7 @@ impl AdeApp {
     ///
     /// Both used to spawn their guaranteed initial shell *immediately*, into the bare repo path,
     /// and leave [`Self::selected`] at `None` - so the tab that shell produced belonged to no
-    /// worktree at all and only rendered because [`Self::active_agent_cwd`]'s old repo-root
+    /// worktree at all and only rendered because [`Self::current_worktree_path`]'s old repo-root
     /// fallback happened to coincide with the main worktree's own path. That is the reported bug
     /// ("at the start of the program you select something and a tab bar has a terminal; then I
     /// select a worktree and this is lost"), and its fix is not to patch the fallback but to make
@@ -897,7 +897,7 @@ impl AdeApp {
                     //   user asking to work somewhere, so none may select on the user's behalf -
                     //   see `crate::root::AdeApp::checkout_repo_from_rail`'s own docs. This is
                     //   now genuinely inert rather than merely *looking* inert: with
-                    //   `Self::active_agent_cwd`'s repo-root fallback gone, an unselected repo
+                    //   `Self::current_worktree_path`'s repo-root fallback gone, an unselected repo
                     //   renders an honestly empty tab strip and no selected rail row, instead of
                     //   the three-way rail/tab-strip/centre-pane disagreement it used to.
                     worktrees::SelectionRecovery::NoPriorSelection => {}
@@ -955,7 +955,7 @@ impl AdeApp {
                     // Runs whether or not a worktree was selectable: a repo with no usable
                     // worktree at all (an unreadable path, or a directory that is not a git
                     // repository) still gets its guaranteed initial shell, via
-                    // `Self::active_agent_cwd`'s one documented last resort. See its own docs.
+                    // `Self::current_worktree_path`'s one documented last resort. See its own docs.
                     this.spawn_initial_shell_for_opened_repo(window, cx);
                 }
 
@@ -1405,7 +1405,7 @@ impl AdeApp {
     /// window *before* the first fetch lands - when [`Self::worktrees`] is empty merely because
     /// nothing has been asked yet - reports the honest `None` instead of briefly reintroducing
     /// the very fallback this removes.
-    pub(crate) fn active_agent_cwd(&self) -> Option<PathBuf> {
+    pub(crate) fn current_worktree_path(&self) -> Option<PathBuf> {
         if let Some(item) = self.selected.and_then(|index| self.worktrees.get(index)) {
             if item.error.is_none() {
                 return Some(item.path.clone());

--- a/crates/app/src/status_bar/render.rs
+++ b/crates/app/src/status_bar/render.rs
@@ -121,24 +121,49 @@ impl AdeApp {
         .into_any_element()
     }
 
-    /// The active agent's real branch name (`self.worktrees`, the same lookup
+    /// The current worktree's real branch name (`self.worktrees`, the same lookup
     /// `Self::render_agent_context_bar` already does - not a second copy) plus its real
     /// `↑ahead ↓behind` from [`Self::ahead_behind_cache`] (populated by the same periodic
-    /// `wt_core::diff::ahead_behind_against_base` refresh as [`Self::diff_cache`]). `None` (the
-    /// whole cluster hidden) only when there is no active agent at all - a detached `HEAD`
-    /// still shows real text (`"(detached)"`), matching the agent context bar's own
+    /// `wt_core::diff::ahead_behind_against_base` refresh as [`Self::diff_cache`]). A detached
+    /// `HEAD` still shows real text (`"(detached)"`), matching the agent context bar's own
     /// convention, and a not-yet-computed ahead/behind is honestly omitted rather than shown as
     /// a fabricated `↑0 ↓0`.
     /// The branch text (design spec change 6: "the branch text became a clickable cluster (fork
     /// glyph + `main` + `↑2 ↓0`, hover `#1b1f22`) that opens the graph tab") - a real click target
     /// via `crate::graph_view::render::AdeApp::open_git_graph`, the same entry point the `+` menu
     /// and the palette's "Open git graph" use.
+    ///
+    /// ## Why this is gated on [`Self::focused_repo`], not on an active agent
+    ///
+    /// It used to open with `self.agents.active()?`, and that `?` was **not** a deliberate
+    /// visibility rule - it was how the branch got a `cwd` to look itself up by. When this
+    /// function was written (Revision R6) the app had no `repos` and no [`Self::focused_repo`]
+    /// at all, so the active pane's `cwd` was the only path available, and hiding the row when
+    /// there was no pane was an incidental side effect nobody was designing for. The git graph
+    /// tab then hung its click target, fork glyph and
+    /// `crate::graph_view::render::AdeApp::open_git_graph` call off this same function, which
+    /// silently promoted that leftover `?` into the visibility policy for the graph's primary
+    /// entry point.
+    ///
+    /// The result was a real bug: `open_git_graph` refuses only when
+    /// [`Self::focused_repo`] is `None`, so with a repo focused and simply no agent open (every
+    /// tab closed) the action worked perfectly while its only button was hidden - and the whole
+    /// cluster (fork glyph, branch, `↑ahead ↓behind`) vanished with it. The gate is now the
+    /// action's own precondition, so the button is visible exactly when clicking it does
+    /// something, and the path comes from [`Self::active_agent_cwd`] - the app's real current
+    /// git context, which already resolves the selected worktree and falls back to
+    /// [`Self::focused_repo_path`] - rather than from whichever pane happens to be focused.
     fn render_status_branch_cluster(&self, cx: &mut Context<Self>) -> Option<gpui::AnyElement> {
-        let agent = self.agents.active()?;
+        // Exactly `open_git_graph`'s own guard: this cluster is that action's button, so the two
+        // must not be able to disagree about when it is available. Unlike the `self.agents
+        // .active()?` this replaces, the value is genuinely unused - the `?` *is* the gate here,
+        // not an incidental by-product of fetching a `cwd`.
+        self.focused_repo()?;
+        let cwd = self.active_agent_cwd();
         let branch = self
             .worktrees
             .iter()
-            .find(|item| item.path == agent.cwd)
+            .find(|item| item.path == cwd)
             .and_then(|item| item.branch.clone())
             .unwrap_or_else(|| "(detached)".to_string());
 
@@ -158,7 +183,7 @@ impl AdeApp {
             .child(crate::graph_view::render::render_graph_tab_chip())
             .child(self.render_status_text(branch));
 
-        if let Some(ahead_behind) = self.ahead_behind_cache.get(&agent.cwd) {
+        if let Some(ahead_behind) = self.ahead_behind_cache.get(&cwd) {
             row = row.child(self.render_status_text(format!(
                 "\u{2191}{} \u{2193}{}",
                 ahead_behind.ahead, ahead_behind.behind
@@ -693,6 +718,105 @@ mod status_bar_error_count_tests {
             None,
             "the error count must disappear while Settings is open, not keep showing a frozen \
              snapshot of the file that was open before Settings covered the workspace"
+        );
+    }
+}
+
+/// Regression coverage for the status bar's branch cluster disappearing - and taking the git
+/// graph's primary entry point with it - whenever no agent pane happened to be open.
+///
+/// `render_status_branch_cluster` opened with `self.agents.active()?`, which was never a
+/// visibility decision: at Revision R6 the app had no `repos`/`focused_repo` at all, so the
+/// active pane's `cwd` was simply the only way to look a branch up, and hiding the row when
+/// there was no pane was an accident of that. The git graph tab later hung its click target and
+/// fork glyph off the same function, promoting the leftover `?` into the gate for its own
+/// button - while `AdeApp::open_git_graph` itself refuses only when `focused_repo()` is `None`.
+/// So with a repo focused and every tab closed, the action worked and its only button was gone.
+#[cfg(test)]
+mod status_bar_branch_cluster_visibility_tests {
+    use crate::root::focus::palette_focus_tests;
+    use gpui::TestAppContext;
+    use std::path::Path;
+
+    fn git(dir: &Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .output()
+            .expect("failed to spawn git");
+        assert!(output.status.success(), "git {args:?} failed in {dir:?}");
+    }
+
+    /// A real repo on a real branch, so the cluster has genuine branch text to show rather than
+    /// falling through to `"(detached)"` for want of a git repository at all.
+    fn seeded_repo() -> tempfile::TempDir {
+        let repo = tempfile::tempdir().expect("tempdir");
+        git(repo.path(), &["init", "-b", "main"]);
+        git(repo.path(), &["config", "user.email", "test@example.com"]);
+        git(repo.path(), &["config", "user.name", "Test User"]);
+        std::fs::write(repo.path().join("a.txt"), "1").expect("write a.txt");
+        git(repo.path(), &["add", "a.txt"]);
+        git(repo.path(), &["commit", "-m", "base"]);
+        repo
+    }
+
+    #[gpui::test]
+    fn the_branch_cluster_and_its_graph_button_survive_closing_every_agent(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = seeded_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        // Sanity check on the starting state this regression is measured against: opening a repo
+        // spawns a real startup shell, so there genuinely *is* an active agent here, and the
+        // cluster paints. Without this the test could pass by never rendering at all.
+        assert!(
+            app.read_with(cx, |app, _| app.agents.active().is_some()),
+            "sanity check: opening a repo spawns a real startup shell agent"
+        );
+        assert!(
+            cx.debug_bounds("status-bar-branch-cluster").is_some(),
+            "sanity check: the branch cluster paints while an agent is active"
+        );
+
+        // Close every agent through the real close path - the same one the tab's own ✕ uses -
+        // rather than reaching into `Agents` and clearing it, so this reproduces a state the user
+        // can genuinely reach.
+        let ids: Vec<_> = app.read_with(cx, |app, _| {
+            app.agents.iter().map(|agent| agent.id).collect()
+        });
+        app.update_in(cx, |app, window, cx| {
+            for id in ids {
+                app.close_agent(id, window, cx);
+            }
+        });
+        cx.run_until_parked();
+
+        assert!(
+            app.read_with(cx, |app, _| app.agents.active().is_none()),
+            "sanity check: closing every tab genuinely leaves no active agent"
+        );
+        assert!(
+            app.read_with(cx, |app, _| app.focused_repo().is_some()),
+            "sanity check: the repo is still focused - this is the exact state where \
+             open_git_graph still works but its button used to vanish"
+        );
+
+        // The regression itself.
+        let bounds = cx.debug_bounds("status-bar-branch-cluster").expect(
+            "the branch cluster - and so the git graph's status-bar button - must still render \
+             with a repo focused and no agent open, because AdeApp::open_git_graph still works \
+             in exactly this state",
+        );
+
+        // ...and it must be a genuinely live click target, not merely painted pixels.
+        cx.simulate_click(bounds.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+        assert!(
+            app.read_with(cx, |app, _| app.graph_tab_open),
+            "clicking the branch cluster with no agent open must really open the git graph tab, \
+             through the same AdeApp::open_git_graph the + menu and palette use"
         );
     }
 }

--- a/crates/app/src/status_bar/render.rs
+++ b/crates/app/src/status_bar/render.rs
@@ -159,7 +159,13 @@ impl AdeApp {
         // .active()?` this replaces, the value is genuinely unused - the `?` *is* the gate here,
         // not an incidental by-product of fetching a `cwd`.
         self.focused_repo()?;
-        let cwd = self.active_agent_cwd();
+        // `active_agent_cwd` is `None` only in the brief in-flight window before the worktree
+        // fetch lands, or the genuine no-usable-worktree error state - both real, but neither is
+        // a reason to hide this cluster once a repo is focused at all, so this falls back to the
+        // repo root exactly as `Self::checkout_repo_from_rail`'s synchronous seed does.
+        let cwd = self
+            .active_agent_cwd()
+            .unwrap_or_else(|| self.focused_repo_path());
         let branch = self
             .worktrees
             .iter()

--- a/crates/app/src/status_bar/render.rs
+++ b/crates/app/src/status_bar/render.rs
@@ -150,7 +150,7 @@ impl AdeApp {
     /// tab closed) the action worked perfectly while its only button was hidden - and the whole
     /// cluster (fork glyph, branch, `↑ahead ↓behind`) vanished with it. The gate is now the
     /// action's own precondition, so the button is visible exactly when clicking it does
-    /// something, and the path comes from [`Self::active_agent_cwd`] - the app's real current
+    /// something, and the path comes from [`Self::current_worktree_path`] - the app's real current
     /// git context, which already resolves the selected worktree and falls back to
     /// [`Self::focused_repo_path`] - rather than from whichever pane happens to be focused.
     fn render_status_branch_cluster(&self, cx: &mut Context<Self>) -> Option<gpui::AnyElement> {
@@ -159,12 +159,12 @@ impl AdeApp {
         // .active()?` this replaces, the value is genuinely unused - the `?` *is* the gate here,
         // not an incidental by-product of fetching a `cwd`.
         self.focused_repo()?;
-        // `active_agent_cwd` is `None` only in the brief in-flight window before the worktree
+        // `current_worktree_path` is `None` only in the brief in-flight window before the worktree
         // fetch lands, or the genuine no-usable-worktree error state - both real, but neither is
         // a reason to hide this cluster once a repo is focused at all, so this falls back to the
         // repo root exactly as `Self::checkout_repo_from_rail`'s synchronous seed does.
         let cwd = self
-            .active_agent_cwd()
+            .current_worktree_path()
             .unwrap_or_else(|| self.focused_repo_path());
         let branch = self
             .worktrees

--- a/crates/app/src/work_surface/agents.rs
+++ b/crates/app/src/work_surface/agents.rs
@@ -293,7 +293,7 @@ impl Agents {
     }
 
     /// Spawns a new agent of `kind` into `cwd` (the caller resolves this - see
-    /// `crate::root::AdeApp::active_agent_cwd`), appends it as a new tab, and makes it
+    /// `crate::root::AdeApp::current_worktree_path`), appends it as a new tab, and makes it
     /// active (both globally, [`Self::active`], and as `cwd`'s own remembered tab,
     /// [`Self::active_by_cwd`]). Returns the new agent's id.
     ///

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -52,7 +52,7 @@ pub(crate) struct TabChromeArgs {
 }
 
 impl AdeApp {
-    /// Spawns a new agent tab into [`Self::active_agent_cwd`] - the single real chokepoint every
+    /// Spawns a new agent tab into [`Self::current_worktree_path`] - the single real chokepoint every
     /// "new terminal"/"new shell" entry point in this app funnels through: `secondary-n`/
     /// `ctrl-shift-T`'s own `handle_new_agent_action`/`handle_new_terminal_action`, the `+` menu's
     /// row, the title bar's Agent menu row (`crate::title_bar::menu::AdeApp::agent_menu_rows`),
@@ -60,7 +60,7 @@ impl AdeApp {
     ///
     /// GitHub issue #90: a genuinely empty window (no [`Self::focused_repo`]) has no real repo
     /// root to spawn into at all - a real, live-reproduced bug (independent audit) found that
-    /// without this guard, [`Self::active_agent_cwd`] fell through to [`Self::focused_repo_path`],
+    /// without this guard, [`Self::current_worktree_path`] fell through to [`Self::focused_repo_path`],
     /// which itself used to fall back to *some other, unopened* known repo's real path (`Self::
     /// repos.first()`), silently spawning a real PTY - and, from there, reachable real destructive
     /// git operations (`Keep All Changes`/`Discard Worktree`) - against a repo the user never
@@ -79,9 +79,9 @@ impl AdeApp {
         // A tab is only ever attributable to a real, currently-selected worktree - there is no
         // such thing as "a repo's own tab". With no worktree genuinely selected there is nothing
         // legitimate to spawn into, so this refuses rather than falling back to the repo root as
-        // it used to (see `Self::active_agent_cwd`'s own docs for the family of live-reproduced
+        // it used to (see `Self::current_worktree_path`'s own docs for the family of live-reproduced
         // bugs that fallback caused).
-        let Some(cwd) = self.active_agent_cwd() else {
+        let Some(cwd) = self.current_worktree_path() else {
             return;
         };
         // GitHub issue #239 phase 2: a Claude agent is spawned against this instance's generated
@@ -303,7 +303,7 @@ impl AdeApp {
             // at all (the rail's own agent rows fold in every repo's agents, not just the
             // focused repo's - `Self::build_agent_rows`'s own docs) - a real, reported bug:
             // clicking such an agent set it globally active (`Agents::set_active` above) but
-            // never switched repos, so `Self::active_agent_cwd` kept resolving to whatever the
+            // never switched repos, so `Self::current_worktree_path` kept resolving to whatever the
             // *focused* repo's own selection was, `Self::combined_tab_order` built the tab strip
             // from that wrong cwd, and it came up with zero tabs - visibly "the tab bar doesn't
             // appear" - even though the agent genuinely was active underneath.
@@ -595,10 +595,10 @@ impl AdeApp {
     pub(crate) fn combined_tab_order(&self) -> Vec<work_surface::TabRef> {
         // No worktree genuinely selected means genuinely no tabs - an honestly empty strip, not
         // whatever happens to be open in the repo root. This used to fall through to
-        // `Self::active_agent_cwd`'s repo-root fallback, which is how a live terminal could be
+        // `Self::current_worktree_path`'s repo-root fallback, which is how a live terminal could be
         // drawn in the strip while the centre pane showed nothing and no rail row claimed it (see
         // that method's own docs for the live repro).
-        let Some(cwd) = self.active_agent_cwd() else {
+        let Some(cwd) = self.current_worktree_path() else {
             return Vec::new();
         };
         let agents_for_cwd: Vec<&Agent> = self.agents.iter_for_cwd(cwd.clone()).collect();
@@ -652,7 +652,7 @@ impl AdeApp {
     ) {
         // A drag can only ever have started from a tab that was genuinely rendered, which means a
         // real worktree is selected - this refusal is defensive, not a reachable path.
-        let Some(cwd) = self.active_agent_cwd() else {
+        let Some(cwd) = self.current_worktree_path() else {
             return;
         };
         let mut order = self.combined_tab_order();
@@ -819,7 +819,7 @@ impl AdeApp {
         cleared_insertion || cleared_dragging
     }
 
-    /// Every agent open in the *currently selected* worktree (`Self::active_agent_cwd`), in
+    /// Every agent open in the *currently selected* worktree (`Self::current_worktree_path`), in
     /// the same order [`Self::combined_tab_order`] renders them - never Agents' own raw
     /// creation order once a real drag has interleaved them differently, and never every agent
     /// across every worktree, per this revision's whole point (see `crate::root::mod`'s "One
@@ -857,7 +857,7 @@ impl AdeApp {
     /// same way. Tab labels deliberately no longer consult it: a branch is a fact about the
     /// worktree, not about what the process in a given tab is doing right now.
     fn current_worktree_branch(&self) -> Option<String> {
-        let cwd = self.active_agent_cwd()?;
+        let cwd = self.current_worktree_path()?;
         self.worktrees
             .iter()
             .find(|item| item.path == cwd)
@@ -1566,7 +1566,7 @@ impl AdeApp {
         }
         // The identical "no worktree selected means nothing legitimate to spawn into" refusal
         // [`Self::new_agent`] applies - see its own docs.
-        let Some(cwd) = self.active_agent_cwd() else {
+        let Some(cwd) = self.current_worktree_path() else {
             return;
         };
         let task = cx.spawn(async move |this, cx| {
@@ -5145,7 +5145,7 @@ mod terminal_clipboard_action_tests {
 /// agents, not just the focused one's (`crate::rail::render::AdeApp::build_agent_rows`'s own
 /// docs), so an agent from a non-focused repo was findable and clickable but its own worktree
 /// never was. `Agents::set_active` still ran, so the agent genuinely became active - but nothing
-/// switched repos, so `Self::active_agent_cwd` kept resolving to the *focused* repo's own
+/// switched repos, so `Self::current_worktree_path` kept resolving to the *focused* repo's own
 /// selection, `Self::combined_tab_order` built the strip from that wrong cwd, and it came up
 /// empty: a real agent, active underneath, with no tab visible for it at all.
 #[cfg(test)]


### PR DESCRIPTION
## The bug

The status bar's bottom-left cluster — fork glyph, branch name, `↑ahead ↓behind` — disappeared entirely whenever no agent pane was open, taking the git graph's primary entry point with it.

`render_status_branch_cluster` opened with:

```rust
let agent = self.agents.active()?;
```

## Why that `?` was there — and why it was never a gate

It was **not** a visibility decision. When this function was written (Revision R6, `72961ee`) the app had **no `repos` and no `focused_repo` at all** — I checked, neither exists at that commit. It was single-repo and session-centric, and the function wasn't even a button:

```rust
fn render_status_branch_cluster(&self) -> Option<gpui::AnyElement> {
    let session = self.sessions.active()?;
    let branch = self
        .worktrees
        .iter()
        .find(|item| item.path == session.cwd)   // ← the only reason active() was here
        // ...just text. No click handler, no fork glyph.
```

`sessions.active()?` existed to obtain a `cwd` to look the branch up by — it was the only path available. Hiding the row when there was no pane was an incidental side effect.

Commit `76f94f1` ("git graph tab, phase (a)") then bolted a click handler, the fork glyph and `open_git_graph` onto that same function — promoting a passive text display into the graph's primary entry point — **without revisiting the `?` that was only ever fetching a cwd.**

## The resulting mismatch

`open_git_graph` (`graph_view/render.rs`) guards on something strictly weaker:

```rust
if self.focused_repo().is_none() {
    return;
}
```

So with a repo focused and every tab closed, **the action worked perfectly while its only button was hidden.**

## The fix

Gate on the action's own precondition, and take the path from the app's real git context rather than from whichever pane happens to be focused:

```rust
self.focused_repo()?;
let cwd = self.active_agent_cwd();
```

`active_agent_cwd()` already resolves the selected worktree and falls back to `focused_repo_path()`, so the branch lookup and the `ahead_behind_cache` read are both keyed off it. The button is now visible exactly when clicking it does something. Behaviour with an agent open is unchanged.

## Test

`status_bar_branch_cluster_visibility_tests` opens a real seeded git repo, asserts the cluster paints with the startup shell active (so it can't pass by never rendering), then closes **every** agent through the real `close_agent` path — the same one the tab's ✕ uses — and asserts:

1. the cluster still paints, and
2. a real simulated click on it genuinely sets `graph_tab_open`.

Verified it fails on the old gate, with exactly assertion 1:

```
panicked at crates/app/src/status_bar/render.rs:804:
the branch cluster - and so the git graph's status-bar button - must still render
with a repo focused and no agent open, because AdeApp::open_git_graph still works
in exactly this state
```

## Checks

- `cargo build --workspace` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt` — applied
- `cargo test --workspace` — 2290 passed, 10 failed, **all in the known flaky-under-load class** (`file_tree_watch` ×7, `repo_list_tests` ×2, `tree_ops` ctrl_z ×1). Every one passes on isolation rerun; `/proc/sys/fs/inotify/max_user_instances` is 128 on this host, the documented root cause. None touch the status bar.

## Note for whoever merges the worktree-scoped-tab work

This lands on `master`, which does **not** yet contain #265. There, `active_agent_cwd()` returns `PathBuf` with the repo-root fallback built in, so it's called directly.

On the #265 line (`fix-worktree-scoped-tab-attribution` / `feat-session-tab-restore`) that fallback is deliberately removed and the signature becomes `Option<PathBuf>`. **At merge time this call site needs `.unwrap_or_else(|| self.focused_repo_path())`.** That branch is also where the bug is most visible: #265 makes "repo focused, nothing selected, no tabs" a routine state, which is how it was originally reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
