### PR TITLE
fix(app): unbreak master after the current_worktree_path rename

### DIFF
--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -1498,7 +1498,7 @@ impl AdeApp {
         // is normally a no-op that compares an unchanged snapshot and returns - but it means a
         // future mutation path that forgets to record still can't lose a user's tabs, since
         // leaving a worktree is something every such path is eventually followed by. Must run
-        // before `self.selected` moves below, while `Self::active_agent_cwd` still resolves to the
+        // before `self.selected` moves below, while `Self::current_worktree_path` still resolves to the
         // worktree being left.
         self.record_worktree_session(cx);
         self.selected = Some(index);

--- a/crates/app/src/work_surface/session.rs
+++ b/crates/app/src/work_surface/session.rs
@@ -87,7 +87,7 @@ impl AdeApp {
     ///
     /// Refuses, deliberately, in three cases:
     ///
-    /// - No worktree genuinely selected ([`Self::active_agent_cwd`] is `None`). There is no such
+    /// - No worktree genuinely selected ([`Self::current_worktree_path`] is `None`). There is no such
     ///   thing as a session belonging to a repo rather than to a worktree, so there is nothing to
     ///   file it under.
     /// - This worktree's own session hasn't been restored yet
@@ -102,7 +102,7 @@ impl AdeApp {
     ///   would mean inventing a per-worktree existence neither actually has. They simply reopen
     ///   the way they always have, from their own live state.
     pub(crate) fn record_worktree_session(&mut self, cx: &mut Context<Self>) {
-        let Some(cwd) = self.active_agent_cwd() else {
+        let Some(cwd) = self.current_worktree_path() else {
             return;
         };
         if !self.session_restored.contains(&cwd) {
@@ -181,7 +181,7 @@ impl AdeApp {
     /// Called from exactly the two places a worktree becomes genuinely, currently selected:
     /// [`Self::select_worktree`] (every rail click, and every programmatic selection that goes
     /// through it) and [`Self::spawn_initial_shell_for_opened_repo`] (a just-opened repo, which
-    /// also covers `active_agent_cwd`'s one documented no-usable-worktree last resort). Ordering
+    /// also covers `current_worktree_path`'s one documented no-usable-worktree last resort). Ordering
     /// matters at the second: this runs *before* that method's guaranteed initial shell, so a
     /// worktree whose session already contains a terminal gets its own remembered one back rather
     /// than that one plus a redundant fresh one - the "already has an agent" check there does the


### PR DESCRIPTION
**Master does not compile. This is the fix — safe to merge immediately.**

```
error[E0599]: no method named `active_agent_cwd` found for mutable reference
              `&mut root::AdeApp` in the current scope
   --> crates/app/src/work_surface/session.rs:105:30
```

## Cause

Two PRs that were each correct in isolation:

- **#275** renamed `active_agent_cwd` → `current_worktree_path` (58 references).
- **#272** was developed in parallel against the old name and added a **new** call site in `work_surface/session.rs` that didn't exist when #275 was written.

Both merged (`6da4bd4` then `b0bec1f`), and master stopped compiling. Neither branch could see the other's change.

## Fix

Renames the one real call site plus three stale doc/comment references (`session.rs:90`, `session.rs:184`, `root/state.rs:1501`). No behaviour change.

## Verification

- `cargo build --workspace` — green
- `cargo clippy --workspace --all-targets -- -D warnings` — green
- `cargo fmt` — clean
- `work_surface::session` 9 passed, `status_bar::` 21 passed, `root::` 127 passed

## My mistake, and the process lesson

I ran the rename in #275 while ~10 branches were in flight in this repo. A rename touching 58 references across 9 files was always going to collide with whatever landed next, and I didn't check for in-flight call sites before pushing it — I only verified it against its own branch.

Wide renames should either land last, or every open branch should be rebased onto them before merge. Worth a quick `grep -rn active_agent_cwd` on any branch still open from before `fe3c364`; the same break will recur on merge otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
