### PR TITLE
refactor(status): rename "Review ready" to "Finished" everywhere it renders

### DIFF
--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -6,14 +6,21 @@ use std::sync::Arc;
 /// The agent row's line-2 state word (§2.3) - deliberately distinct from [`Status::label`]
 /// (`"Idle"`, used everywhere else this enum shows text, e.g. the work-surface context bar):
 /// only the rail agent row uses `"paused"` for [`Status::Idle`], since that's the one place the
-/// design gives it a different word ("needs input / failed / running / review ready / paused" -
-/// no "idle" appears in that list at all). Changing [`Status::label`] itself to match would have
+/// design gives it a different word ("needs input / failed / running / finished / paused" - no
+/// "idle" appears in that list at all). Changing [`Status::label`] itself to match would have
 /// renamed it everywhere else in the app too.
+///
+/// [`Status::Review`]'s word is `"finished"` (the lowercase form of [`Status::label`]'s own
+/// `Finished`) as of revision 6 / GitHub issue #280 - never `"review ready"`, which stated a
+/// judgement the agent cannot make and collided with the user's own review progress. The
+/// trailing file count beside it ([`agent_trailing_text`]) carries what there is to look at,
+/// and an agent that finished with no measured files reads as a bare `finished` rather than
+/// being mislabelled as ready for review.
 fn agent_state_word(status: Status) -> &'static str {
     match status {
         Status::Ask => "needs input",
         Status::Fail => "failed",
-        Status::Review => "review ready",
+        Status::Review => "finished",
         Status::Run => "running",
         Status::Idle => "paused",
     }
@@ -21,7 +28,7 @@ fn agent_state_word(status: Status) -> &'static str {
 
 /// The agent row's line-2 trailing text (§2.3's exact per-status table): empty for `needs
 /// input` (the dot and state word are the whole message), the live activity for `running`, the
-/// exit code for `failed`, the review's file count for `review ready`, and `resumable · Nh` for
+/// exit code for `failed`, the review's file count for `finished`, and `resumable · Nh` for
 /// `paused`.
 fn agent_trailing_text(agent: &AgentRow) -> String {
     match agent.status {
@@ -4149,6 +4156,125 @@ mod agent_chip_icon_pack_tests {
             cx.debug_bounds("agent-chip-icon-default").is_none(),
             "the default letter chip must not also paint once the pack icon takes over - \
              exactly one of the two must be showing, never both at once"
+        );
+    }
+}
+
+/// Revision 6's status rename (`design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4g,
+/// GitHub issue #280): [`Status::Review`] renders as `Finished`/`finished`, and the old
+/// `Review ready` wording must never come back to any rendered surface.
+///
+/// Pure, GPUI-window-free coverage over the real production functions every status-derived
+/// string in the window comes out of - the same "collect every rendered string, then assert one
+/// forbidden word is in none of them" idiom `crate::review::state`'s own
+/// `no_review_wording_anywhere_says_a_bare_diff` test already uses for the review surface's
+/// "diff" ban. Hand-built [`AgentRow`]s, the same idiom `crate::rail::state`'s `urgency_counts`
+/// tests use.
+///
+/// The title bar's own chip texts are swept by the twin test in `crate::title_bar::render`'s
+/// `agent_state_chip_text_tests`, since that formatter is private to that module.
+#[cfg(test)]
+mod status_wording_tests {
+    use super::*;
+    use crate::sound::SoundEventKind;
+    use crate::work_surface::state::{footer_actions, pty_state_label};
+    use std::time::Duration;
+
+    fn row(status: Status, review_file_count: Option<usize>) -> AgentRow {
+        AgentRow {
+            id: 1,
+            kind: ProcessKind::claude(),
+            title: "agent-1".to_string(),
+            cwd: PathBuf::from("/wt-1"),
+            status,
+            branch: Some("feature-x".to_string()),
+            add: 0,
+            del: 0,
+            question_preview: None,
+            exit_code: Some(0),
+            activity: None,
+            elapsed: Duration::from_secs(90),
+            review_file_count,
+        }
+    }
+
+    /// Every user-visible string this app derives from a [`Status`], gathered from the real
+    /// functions that produce them: the shared [`Status::label`] (work-surface context-bar
+    /// status pill), the rail agent row's own state word and trailing text, the rail history
+    /// row's `was <state>` line, the agent context bar's footer action labels, the terminal
+    /// pane header's pty-state text, and the Sounds settings page's row label/hint for the
+    /// event this status raises.
+    fn every_rendered_status_string() -> Vec<String> {
+        let mut wording: Vec<String> = Vec::new();
+        for status in Status::ORDER {
+            wording.push(status.label().to_string());
+            wording.push(agent_state_word(status).to_string());
+            // `Self::render_past_agent_row`'s history line.
+            wording.push(format!("was {}", agent_state_word(status)));
+            for count in [None, Some(0), Some(1), Some(12)] {
+                wording.push(agent_trailing_text(&row(status, count)));
+            }
+            for action in footer_actions(status) {
+                wording.push(action.label.to_string());
+            }
+            for is_running in [true, false] {
+                for exit_code in [None, Some(0), Some(1)] {
+                    wording.push(pty_state_label(is_running, status, exit_code));
+                }
+            }
+        }
+        for event in SoundEventKind::ALL {
+            wording.push(event.label().to_string());
+            wording.push(event.description().to_string());
+        }
+        wording
+    }
+
+    #[test]
+    fn no_rendered_status_string_anywhere_says_review_ready() {
+        for text in every_rendered_status_string() {
+            assert!(
+                !text.to_lowercase().contains("review ready"),
+                "revision 6 renamed this status to 'Finished' - no rendered label, state word \
+                 or tooltip may say 'review ready' again, got {text:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_finished_status_renders_the_rev6_words_in_both_cases() {
+        assert_eq!(
+            Status::Review.label(),
+            "Finished",
+            "the shared status label (work-surface context bar, and everywhere else \
+             `Status::label` is rendered) must be the rev-6 word"
+        );
+        assert_eq!(
+            agent_state_word(Status::Review),
+            "finished",
+            "the rail agent row's state word is the lowercase form, per §2.3's state-word \
+             convention"
+        );
+    }
+
+    /// §4g: "an agent that finished with **no** files reads `finished` with no count - legible
+    /// rather than mislabelled as ready for review", and a real count renders beside the word
+    /// as `finished · N files` (the row's two elements, dot-separated by layout).
+    #[test]
+    fn a_finished_agent_shows_its_file_count_beside_the_word_and_nothing_when_unmeasured() {
+        assert_eq!(
+            agent_trailing_text(&row(Status::Review, None)),
+            "",
+            "an unmeasured file count must render nothing at all, never a fabricated 0"
+        );
+        assert_eq!(
+            agent_trailing_text(&row(Status::Review, Some(0))),
+            "0 files"
+        );
+        assert_eq!(agent_trailing_text(&row(Status::Review, Some(1))), "1 file");
+        assert_eq!(
+            agent_trailing_text(&row(Status::Review, Some(12))),
+            "12 files"
         );
     }
 }

--- a/crates/app/src/rail/state.rs
+++ b/crates/app/src/rail/state.rs
@@ -69,9 +69,9 @@ pub struct AgentRow {
     /// how this becomes the rendered `4m`/`1h` text.
     pub elapsed: Duration,
     /// How many files **this agent** has changed since its own review baseline, for a
-    /// [`Status::Review`] row only - §2.3's "review ready" trailing text (`12 files`). `None` for
-    /// every other status (§2.3: "Do not put a per-agent file count here" - review-ready is the
-    /// one documented exception).
+    /// [`Status::Review`] row only - §2.3's trailing text for that state (`12 files`, rendered
+    /// beside the `finished` state word). `None` for every other status (§2.3: "Do not put a
+    /// per-agent file count here" - this one state is the documented exception).
     ///
     /// GitHub issue #225 made this a genuinely per-agent number: it comes from
     /// `crate::review::flow::AdeApp::agent_review_file_count`, a real
@@ -324,7 +324,7 @@ impl WorktreeRow {
     /// Lower sorts first (more urgent).
     ///
     /// The first five steps are exactly [`Status::urgency_rank`] (§2.3's own agent state words -
-    /// `needs input`/`failed`/`review ready`/`running`/`paused` - map one-to-one onto
+    /// `needs input`/`failed`/`finished`/`running`/`paused` - map one-to-one onto
     /// [`Status::Ask`]/[`Status::Fail`]/[`Status::Review`]/[`Status::Run`]/[`Status::Idle`], see
     /// that enum's own docs), reused rather than re-derived. The last two only apply to a
     /// agent-less row, which [`Self::aggregate_status`] alone can't distinguish from a row

--- a/crates/app/src/rail/status.rs
+++ b/crates/app/src/rail/status.rs
@@ -154,8 +154,10 @@ pub enum Status {
 
 impl Status {
     /// Rank used to sort the "by urgency" group order from
-    /// `design_handoff_jerry_ade/README.md`: `Needs input → Failed → Review ready → Running →
-    /// Idle`. Lower sorts first.
+    /// `design_handoff_jerry_ade/README.md`: `Needs input → Failed → Finished → Running →
+    /// Idle`. Lower sorts first. (The README spells that third group `Review ready`; revision 6
+    /// renamed the rendered word to `Finished` - see [`Self::label`] - without touching the
+    /// order itself.)
     pub fn urgency_rank(self) -> u8 {
         match self {
             Status::Ask => 0,
@@ -166,12 +168,19 @@ impl Status {
         }
     }
 
-    /// The label text from the README's status table.
+    /// The label text from the README's status table, with revision 6's one rename applied:
+    /// [`Status::Review`] renders as `Finished`, never `Review ready`
+    /// (`design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4g, GitHub issue #280). The
+    /// old label "states a judgement the agent cannot make", collides with the user's own review
+    /// progress, and contradicts the file's own vocabulary; `Finished` states the fact, and the
+    /// file count rendered beside it (see `crate::rail::render`'s `agent_trailing_text`) carries
+    /// what there is to look at. The *variant* deliberately keeps its `Review` name - the enum is
+    /// an internal identifier, this is only about the rendered string.
     pub fn label(self) -> &'static str {
         match self {
             Status::Ask => "Needs input",
             Status::Fail => "Failed",
-            Status::Review => "Review ready",
+            Status::Review => "Finished",
             Status::Run => "Running",
             Status::Idle => "Idle",
         }

--- a/crates/app/src/title_bar/render.rs
+++ b/crates/app/src/title_bar/render.rs
@@ -415,7 +415,7 @@ fn title_bar_agent_state_chips(rows: &[AgentRow]) -> Vec<(Status, String)> {
 /// `design_handoff_jerry_ade/revision 3/CHANGELOG.md`'s own "Counts" section). `None` for a
 /// zero count - hidden entirely, never an empty chip - and for [`Status::Review`]/
 /// [`Status::Idle`]: the design's own title-bar example names exactly three states
-/// (`Status::Ask`/`Status::Fail`/`Status::Run`), and review-ready/idle counts already have a
+/// (`Status::Ask`/`Status::Fail`/`Status::Run`), and finished/idle counts already have a
 /// real home - the rail's own agent rows, and the status bar's five-way dot row - so repeating
 /// them a third time here would just restate the same number in a fourth place.
 ///
@@ -782,11 +782,32 @@ mod agent_state_chip_text_tests {
 
     #[test]
     fn review_and_idle_never_get_a_title_bar_chip_even_with_a_real_nonzero_count() {
-        // The design's own title-bar example names exactly three states (§4) - review-ready
-        // and idle counts already have a real home in the rail's own agent rows and the status
+        // The design's own title-bar example names exactly three states (§4) - finished and
+        // idle counts already have a real home in the rail's own agent rows and the status
         // bar's five-way dot row, so they must stay silent here even when genuinely non-zero.
         assert_eq!(title_bar_agent_state_chip_text(Status::Review, 3), None);
         assert_eq!(title_bar_agent_state_chip_text(Status::Idle, 5), None);
+    }
+
+    /// The title bar's half of revision 6's `Review ready` → `Finished` rename (GitHub issue
+    /// #280) - twin of `crate::rail::render`'s `status_wording_tests`, which sweeps every other
+    /// status-derived string in the window. Kept here because this formatter is private to this
+    /// module. Today [`Status::Review`] produces no chip at all, so this passes vacuously for
+    /// that status; the point is that it keeps passing if a future revision gives it one.
+    #[test]
+    fn no_title_bar_chip_text_ever_says_review_ready() {
+        for status in Status::ORDER {
+            for count in [0, 1, 2, 12] {
+                let Some(text) = title_bar_agent_state_chip_text(status, count) else {
+                    continue;
+                };
+                assert!(
+                    !text.to_lowercase().contains("review ready"),
+                    "revision 6 renamed this status to 'Finished' - no title-bar chip may say \
+                     'review ready' again, got {text:?} for {status:?}"
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #280

Revision 6 (`design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4g) renames the `Status::Review` status word. In the review's own words, the old label "states a judgement the agent cannot make", "collides with the user's own review progress", and "contradicts vocabulary already in the file". `Finished` states the fact; the file count beside it carries what there is to look at.

This is purely a rendered-string change. The enum variant keeps its `Review` name, and the on-disk status key (`hooks::store::status_key` -> `"review"`) is untouched, so persisted agent history still round-trips.

## Rendered strings changed

| Surface | Before | After |
| --- | --- | --- |
| `rail::status::Status::label()` — work-surface context-bar status pill, and every other surface rendering the shared label | `Review ready` | `Finished` |
| `rail::render::agent_state_word()` — rail agent row's line-2 state word | `review ready` | `finished` |
| rail history row's line-2 (`format!("was {}", agent_state_word(status))`) | `was review ready` | `was finished` |

The trailing text beside the state word is unchanged and already correct: `finished · 12 files`, and a bare `finished` with no count when the file count has not been measured ("legible rather than mislabelled as ready for review", §4g).

Two surfaces the issue lists needed no code change, verified rather than assumed:

- **Title-bar chips**: `title_bar_agent_state_chip_text` returns `None` for `Status::Review`/`Status::Idle` by design (§4's example names exactly three states), so no title-bar chip ever rendered the old wording. A guardrail test now pins that it stays that way if a future revision gives it a chip.
- **Status-bar urgency counters**: they render coloured squares plus a bare count, with no per-status tooltip on `master`, so there is no string there to rename.
- **Sounds settings** (the settings row that names this status's event) already reads `Agent finished` / "Play a sound when an agent finishes its turn." — already the rev-6 word; now swept by the guardrail test so it can't drift back.

Doc comments that quoted the rendered word (`rail/state.rs`'s `review_file_count` and rank docs, `title_bar/render.rs`'s chip docs) were updated with it. Comments describing *derivation* semantics elsewhere (`review/`, `hooks/`, `work_surface/`) were left alone to keep the diff focused on rendered text.

## Guardrail test

Modelled on this codebase's existing wording test, `review::state`'s `no_review_wording_anywhere_says_a_bare_diff` — collect every rendered string from the real production functions, then assert the forbidden word appears in none of them.

`rail::render::status_wording_tests::no_rendered_status_string_anywhere_says_review_ready` sweeps, for every `Status::ORDER` variant: the shared `Status::label()`, the rail state word, the history `was <state>` line, `agent_trailing_text` at four file counts, `work_surface::state::footer_actions` labels, `pty_state_label` across running/exit-code combinations, and every `SoundEventKind` label/description. `title_bar::render::…::no_title_bar_chip_text_ever_says_review_ready` is its twin for the chip formatter that is private to that module.

Two companion tests pin the positive facts: both cases of the new word, and that an unmeasured file count renders nothing rather than a fabricated `0`.

**Revert-then-restore check**, both arms:

- Reintroduced `Status::Review => "Review ready"` in `label()` → `no_rendered_status_string_anywhere_says_review_ready` FAILED with `got "Review ready"`, and `the_finished_status_renders_the_rev6_words_in_both_cases` FAILED. Reverted.
- Reintroduced `Status::Review => "review ready"` in `agent_state_word()` → both FAILED again, `got "review ready"`. Reverted; suite green.

## Out of scope

Run-history's own outcome vocabulary stays `done` for past runs (REVISION-2026-08-13.md §5, coordinated with #227) — one fact, one word per tense: `finished` live, `done` in history.

## Verification

- `cargo build --workspace` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean for every file this PR touches. One **pre-existing** diff remains in `crates/app/src/sound/flow.rs:378`, present on an untouched `origin/master` checkout too (confirmed by stashing); left alone as unrelated to this issue.
- `cargo test --workspace` — 2413 passed in `app`, plus `lsp_core` 51, `pty_core` 17, `wt_core` 246, all green. Failures were confined to the known flaky-under-load class (`file_tree_watch`/`worktree_watch`/`repo_list_tests`, `text_undo_scoping_tests`, one `title_menu_tests` text-undo row) and every one passes on isolation rerun. Root cause confirmed live, not assumed: `/proc/sys/fs/inotify/max_user_instances` is 128 and 122 instances were already held system-wide during the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
