### PR TITLE
One pluralisation helper for every count in the window

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,18 @@ crates already follow everywhere, and new code is expected to match them:
   CLI (worktree add/remove, merges) — see that crate's module docs. This matters for
   correctness (filenames with spaces/quotes) as much as safety; don't build git commands
   by formatting a string.
+- **Every user-visible count goes through the pluralisation helper; never inline a ternary.**
+  `crates/app/src/root/plural.rs` is the one place that decides singular vs plural. Write
+  `plural::count(n, "file", None)` (or `Some("matches")` for an irregular plural), and
+  `plural::form(n, "needs", "need")` for anything else in the sentence that has to agree with
+  the number — a verb, an auxiliary, a pronoun. Do not write `if n == 1 { "" } else { "s" }`
+  at the call site, and do not hardcode the plural noun (`format!("{n} agents")`), which is
+  the same bug wearing a disguise: the single-item case is usually the *common* one, so those
+  labels sat on screen reading `1 agents` / `1 servers · 1 errors`. Zero is plural in English
+  (`0 files`), and the helper already knows that; hiding a counter at zero, or saying
+  something qualitatively different there (`"nothing unreviewed"`), stays the call site's own
+  decision. Labels with no noun to agree with (`3 wt`, `12 shown`, `hunk 2 of 5`) have nothing
+  to conjugate and are left alone. See that module's docs for the full rule and its rationale.
 - **No fake functionality.** No UI element bound to hardcoded/sample data standing in for
   a real data source, no simulated command output, no button that looks wired up but
   isn't. If a subsystem genuinely isn't built yet, the convention in this codebase is to

--- a/crates/app/src/code_surface/blame.rs
+++ b/crates/app/src/code_surface/blame.rs
@@ -25,6 +25,7 @@
 //! rewrite could restore byte-identical content with a new mtime, or vice versa, so both must
 //! agree.
 
+use crate::root::plural;
 use wt_core::blame::BlameLine;
 
 /// The all-zero sha `git blame` uses for a line whose content hasn't been committed yet -
@@ -120,9 +121,10 @@ pub fn format_relative_date(then_unix: i64, now_unix: i64) -> String {
     }
     for (threshold, unit) in RELATIVE_DATE_BUCKETS {
         if elapsed >= *threshold {
-            let count = elapsed / threshold;
-            let plural = if count == 1 { "" } else { "s" };
-            return format!("{count} {unit}{plural} ago");
+            // `elapsed >= *threshold > 0`, so this is a genuine, non-negative count and the
+            // `as usize` cast cannot wrap.
+            let count = (elapsed / threshold) as usize;
+            return format!("{} ago", plural::count(count, unit, None));
         }
     }
     // Unreachable in practice (60s is `RELATIVE_DATE_BUCKETS`'s own smallest threshold, and

--- a/crates/app/src/code_surface/diff_view.rs
+++ b/crates/app/src/code_surface/diff_view.rs
@@ -5,6 +5,7 @@ use super::zoom::zoom_scoped;
 use super::*;
 #[cfg(test)]
 use crate::root::focus::palette_focus_tests;
+use crate::root::plural;
 use crate::root::widgets::render_sidebar_message;
 use std::rc::Rc;
 
@@ -579,8 +580,8 @@ pub(in crate::code_surface) fn render_fold_marker(
         .text_size(rems(0.85))
         .text_color(theme::diff::FOLD_FG)
         .child(format!(
-            "\u{22ef} {gap} unchanged line{}",
-            if gap == 1 { "" } else { "s" }
+            "\u{22ef} {}",
+            plural::count(gap, "unchanged line", None)
         ))
 }
 

--- a/crates/app/src/code_surface/editing.rs
+++ b/crates/app/src/code_surface/editing.rs
@@ -61,6 +61,7 @@ use crate::code_surface::lsp_ui::{
 };
 use crate::code_surface::symbols;
 use crate::lsp::diagnostics as diagnostics_view;
+use crate::root::plural;
 use crate::root::{
     AdeApp, EditorBackspace, EditorCollapseCursors, EditorCopy, EditorCut, EditorDedent,
     EditorDelete, EditorDown, EditorEnd, EditorEnter, EditorEscape, EditorHome, EditorIndent,
@@ -1606,8 +1607,8 @@ fn render_fold_marker(hidden_count: usize, line_number: usize) -> impl IntoEleme
         // marker documents.
         .text_size(gpui::rems(0.85))
         .child(format!(
-            "\u{22ef} {hidden_count} line{}",
-            if hidden_count == 1 { "" } else { "s" }
+            "\u{22ef} {}",
+            plural::count(hidden_count, "line", None)
         ))
 }
 

--- a/crates/app/src/code_surface/file_view.rs
+++ b/crates/app/src/code_surface/file_view.rs
@@ -10,6 +10,7 @@ use super::*;
 use crate::lsp::client::{lsp_file_status, LspFileStatus};
 #[cfg(test)]
 use crate::root::focus::palette_focus_tests;
+use crate::root::plural;
 use crate::root::widgets::render_sidebar_message;
 use std::collections::HashSet;
 
@@ -1630,7 +1631,11 @@ fn lsp_status_label(status: &LspFileStatus, binary: Option<&str>) -> (gpui::Rgba
             let label = if *errors == 0 && *warnings == 0 {
                 format!("{binary}: no diagnostics")
             } else {
-                format!("{binary}: {errors} errors, {warnings} warnings")
+                format!(
+                    "{binary}: {}, {}",
+                    plural::count(*errors, "error", None),
+                    plural::count(*warnings, "warning", None)
+                )
             };
             (color.into(), label)
         }
@@ -1764,8 +1769,30 @@ mod lsp_status_label_tests {
                 binary_for("vue")
             )
             .1,
-            "vue-language-server: 2 errors, 1 warnings"
+            "vue-language-server: 2 errors, 1 warning"
         );
+    }
+
+    /// Both diagnostic counts conjugate, and they conjugate *independently* (GitHub issue
+    /// #281). This label used to hardcode both plurals, so the single-error/single-warning
+    /// case - much the most common one while actually editing - read `1 errors, 1 warnings`.
+    #[test]
+    fn diagnostic_counts_conjugate_independently_at_zero_one_and_two() {
+        let label = |errors: usize, warnings: usize| {
+            lsp_status_label(
+                &LspFileStatus::Analyzed { errors, warnings },
+                binary_for("rs"),
+            )
+            .1
+        };
+        // 0/0 is the qualitatively different "no diagnostics" state, not a conjugation case.
+        assert_eq!(label(0, 0), "rust-analyzer: no diagnostics");
+        assert_eq!(label(1, 0), "rust-analyzer: 1 error, 0 warnings");
+        assert_eq!(label(0, 1), "rust-analyzer: 0 errors, 1 warning");
+        assert_eq!(label(1, 1), "rust-analyzer: 1 error, 1 warning");
+        assert_eq!(label(2, 1), "rust-analyzer: 2 errors, 1 warning");
+        assert_eq!(label(1, 2), "rust-analyzer: 1 error, 2 warnings");
+        assert_eq!(label(2, 2), "rust-analyzer: 2 errors, 2 warnings");
     }
 
     /// The specific bug this issue's own new `LspConnection::liveness_failure_reason` made

--- a/crates/app/src/graph_view/rebase_render.rs
+++ b/crates/app/src/graph_view/rebase_render.rs
@@ -9,6 +9,7 @@ use super::rebase::{
     RebaseActionKind, RebaseModeState, RebasePhase, ResultBlock, ResultBlockStatus,
 };
 use super::*;
+use crate::root::plural;
 use gpui::{DragMoveEvent, KeyDownEvent};
 use wt_core::rebase::RebaseOutcome;
 
@@ -157,7 +158,7 @@ impl AdeApp {
                             .font(font(theme::font::MONO))
                             .text_size(px(10.5))
                             .text_color(theme::text::DIM)
-                            .child(format!("{n} \u{2192} {m} commits")),
+                            .child(format!("{n} \u{2192} {}", plural::count(m, "commit", None))),
                     )
                     .child(
                         render_rebase_button("Cancel", false, enabled).when(enabled, |el| {
@@ -252,8 +253,8 @@ impl AdeApp {
                         .text_size(px(10.5))
                         .text_color(theme::status::FAIL)
                         .child(format!(
-                            "stopped at {stopped_at} of {total} \u{b7} {} conflict(s) in {file_label}",
-                            conflicted_files.len()
+                            "stopped at {stopped_at} of {total} \u{b7} {} in {file_label}",
+                            plural::count(conflicted_files.len(), "conflict", None)
                         )),
                 )
                 .child(div().flex_1())
@@ -636,8 +637,9 @@ impl AdeApp {
                             .text_size(px(10.0))
                             .text_color(theme::text::DIM)
                             .child(format!(
-                                "{} \u{2192} {count} commits",
-                                rebase_state.plan.len()
+                                "{} \u{2192} {}",
+                                rebase_state.plan.len(),
+                                plural::count(count, "commit", None)
                             )),
                     ),
             );
@@ -685,8 +687,9 @@ impl AdeApp {
         let enabled = !op_in_flight;
         Some(
             render_rebase_warning_shell(format!(
-                "{running} agent(s) running in this worktree - a rebase rewrites files under \
-                 them."
+                "{} running in this worktree - a rebase rewrites files under {}.",
+                plural::count(running, "agent", None),
+                plural::form(running, "it", "them")
             ))
             .child(
                 div()
@@ -761,8 +764,11 @@ fn render_rebase_result_block(block: &ResultBlock) -> gpui::AnyElement {
                     .text_color(theme::text::GHOST)
                     .child(match (block.folded_count, status_label) {
                         (0, Some(status)) => status.to_string(),
-                        (n, Some(status)) => format!("{n} commits folded in \u{b7} {status}"),
-                        (n, None) => format!("{n} commits folded in"),
+                        (n, Some(status)) => format!(
+                            "{} folded in \u{b7} {status}",
+                            plural::count(n, "commit", None)
+                        ),
+                        (n, None) => format!("{} folded in", plural::count(n, "commit", None)),
                     }),
             )
         })
@@ -776,8 +782,10 @@ fn render_rebase_remote_warning(rebase_state: &RebaseModeState) -> Option<gpui::
     }
     Some(
         render_rebase_warning_shell(format!(
-            "{count} commit(s) in this plan are already on the tracked remote branch - a \
-             force-with-lease push will be needed afterward."
+            "{} in this plan {} already on the tracked remote branch - a force-with-lease push \
+             will be needed afterward.",
+            plural::count(count, "commit", None),
+            plural::form(count, "is", "are")
         ))
         .into_any_element(),
     )
@@ -790,8 +798,9 @@ fn render_rebase_stop_count_warning(rebase_state: &RebaseModeState) -> Option<gp
     }
     Some(
         render_rebase_warning_shell(format!(
-            "Stops {n} time(s) - each `edit` row and each message-less `reword` row hands \
-             control back to you before the rebase continues."
+            "Stops {} - each `edit` row and each message-less `reword` row hands control back \
+             to you before the rebase continues.",
+            plural::count(n, "time", None)
         ))
         .into_any_element(),
     )

--- a/crates/app/src/merge/render.rs
+++ b/crates/app/src/merge/render.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::code_surface::zoom::zoom_scoped;
+use crate::root::plural;
 
 impl AdeApp {
     /// Surface D - the merge-conflict resolution surface, replacing the pty/diff body below the
@@ -108,7 +109,10 @@ impl AdeApp {
                                 .child(if files.is_empty() {
                                     "No files changed.".to_string()
                                 } else {
-                                    format!("{} file(s) staged, not yet committed.", files.len())
+                                    format!(
+                                        "{} staged, not yet committed.",
+                                        plural::count(files.len(), "file", None)
+                                    )
                                 }),
                         )
                         .children(files.iter().map(|path| {
@@ -173,7 +177,10 @@ impl AdeApp {
                                 .font_weight(gpui::FontWeight::MEDIUM)
                                 .text_size(px(11.0))
                                 .text_color(theme::status::REVIEW)
-                                .child(format!("Jerry auto-resolved {auto} of {total} files")),
+                                .child(format!(
+                                    "Jerry auto-resolved {auto} of {}",
+                                    plural::count(total, "file", None)
+                                )),
                         )
                         .child(
                             div()
@@ -183,7 +190,11 @@ impl AdeApp {
                                 .child(if remaining == 0 {
                                     "every conflict is resolved.".to_string()
                                 } else {
-                                    format!("{remaining} file(s) still need you.")
+                                    format!(
+                                        "{} still {} you.",
+                                        plural::count(remaining, "file", None),
+                                        plural::form(remaining, "needs", "need")
+                                    )
                                 }),
                         ),
                 );

--- a/crates/app/src/palette/render.rs
+++ b/crates/app/src/palette/render.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::root::plural;
 use crate::root::widgets::{render_hint_pair, render_hint_row, render_keycap_row, KeycapSize};
 use crate::settings::widgets::ChoiceOption;
 use crate::sidebar::render::RightSidebarView;
@@ -190,8 +191,8 @@ impl AdeApp {
             palette::CommandCandidate {
                 command: palette::PaletteCommand::PruneWorktrees,
                 secondary: format!(
-                    "{} prunable worktree(s)",
-                    self.prunable_worktree_paths().len()
+                    "{} prunable",
+                    plural::count(self.prunable_worktree_paths().len(), "worktree", None)
                 ),
             },
             palette::CommandCandidate {
@@ -1172,10 +1173,7 @@ impl AdeApp {
                     .font(font(theme::font::MONO))
                     .text_size(self.ui_text_size(10.0))
                     .text_color(theme::text::HINT)
-                    .child(format!(
-                        "{total} result{}",
-                        if total == 1 { "" } else { "s" }
-                    )),
+                    .child(plural::count(total, "result", None)),
             )
     }
 }

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::root::plural;
 use crate::root::widgets::{render_keycap_row, text_tooltip, KeycapSize};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -40,7 +41,7 @@ fn agent_trailing_text(agent: &AgentRow) -> String {
             .unwrap_or_default(),
         Status::Review => agent
             .review_file_count
-            .map(|count| format!("{count} file{}", if count == 1 { "" } else { "s" }))
+            .map(|count| plural::count(count, "file", None))
             .unwrap_or_default(),
         Status::Idle => format!("resumable \u{b7} {}", rail::format_elapsed(agent.elapsed)),
     }
@@ -515,10 +516,7 @@ impl AdeApp {
 
         if !self.prune_confirm_armed {
             self.prune_confirm_armed = true;
-            self.prune_status = Some(format!(
-                "click prune again to remove {} worktree(s)",
-                candidates.len()
-            ));
+            self.prune_status = Some(rail::prune_confirm_label(candidates.len()));
             cx.notify();
             return;
         }
@@ -550,7 +548,7 @@ impl AdeApp {
         }
         let repo_path = self.focused_repo_path();
         self.prune_in_flight = true;
-        self.prune_status = Some(format!("pruning {} worktree(s)...", candidates.len()));
+        self.prune_status = Some(rail::pruning_label(candidates.len()));
         cx.notify();
 
         let task = cx.spawn(async move |this, cx| {
@@ -576,7 +574,7 @@ impl AdeApp {
                 this.prune_in_flight = false;
                 let (removed, errors) = outcome;
                 this.prune_status = Some(if errors.is_empty() {
-                    format!("pruned {removed} worktree(s)")
+                    rail::pruned_label(removed)
                 } else {
                     format!(
                         "pruned {removed}; {} failed: {}",
@@ -1816,7 +1814,7 @@ impl AdeApp {
                 let status = self
                     .prune_status
                     .clone()
-                    .unwrap_or_else(|| format!("{worktree_count} worktrees \u{b7} {disk_label}"));
+                    .unwrap_or_else(|| rail::worktree_disk_label(worktree_count, &disk_label));
                 div()
                     .id("rail-footer-status")
                     .min_w_0()
@@ -1838,6 +1836,47 @@ impl AdeApp {
 /// all four `Self::request_prune` calls landing before the first batch's
 /// `wt_core::remove_worktree` has run - must leave exactly one batch in flight, never two
 /// racing ones sharing `Self::_prune_task`.
+/// The rail agent row's review-ready file count (§2.3's `12 files` trailing text), which the
+/// design calls out as needing "singular and plural both, everywhere" (GitHub issue #281).
+#[cfg(test)]
+mod agent_trailing_text_count_tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn review_row(review_file_count: Option<usize>) -> AgentRow {
+        AgentRow {
+            id: 1,
+            kind: ProcessKind::claude(),
+            title: "agent-a".to_string(),
+            cwd: std::path::PathBuf::from("/a"),
+            status: Status::Review,
+            branch: Some("feature-x".to_string()),
+            add: 0,
+            del: 0,
+            question_preview: None,
+            exit_code: None,
+            activity: None,
+            elapsed: Duration::ZERO,
+            review_file_count,
+        }
+    }
+
+    #[test]
+    fn review_file_count_conjugates_at_zero_one_and_two() {
+        assert_eq!(agent_trailing_text(&review_row(Some(0))), "0 files");
+        assert_eq!(agent_trailing_text(&review_row(Some(1))), "1 file");
+        assert_eq!(agent_trailing_text(&review_row(Some(2))), "2 files");
+        assert_eq!(agent_trailing_text(&review_row(Some(12))), "12 files");
+    }
+
+    /// No count at all is still an empty string, not `"0 files"` - the absence of a measurement
+    /// and a measured zero are different facts, and only the latter is a conjugation case.
+    #[test]
+    fn an_unmeasured_review_row_has_no_trailing_text() {
+        assert_eq!(agent_trailing_text(&review_row(None)), "");
+    }
+}
+
 #[cfg(test)]
 mod prune_regression_tests {
     use super::*;

--- a/crates/app/src/rail/state.rs
+++ b/crates/app/src/rail/state.rs
@@ -16,6 +16,7 @@ use std::time::Duration;
 
 use crate::rail::repo::RepoId;
 use crate::rail::status::Status;
+use crate::root::plural;
 use crate::work_surface::agents::ProcessKind;
 use wt_core::diff::{AheadBehind, DiffLineKind, WorktreeDiff, WorktreeMergeStatus};
 
@@ -536,12 +537,51 @@ impl RepoGroup {
 /// case, but the rest of this codebase already conjugates every other counter correctly (see
 /// that same title-bar function's `"1 agent needs input"` vs `"2 agents need input"`), so this
 /// one must too.
+///
+/// The conjugation itself is [`crate::root::plural`]'s, not a hand-written match arm per count:
+/// hiding at zero is this function's own decision (a content choice), agreeing at one versus
+/// many is not.
 pub fn waiting_count_label(count: usize) -> Option<String> {
-    match count {
-        0 => None,
-        1 => Some("1 worktree waiting".to_string()),
-        n => Some(format!("{n} worktrees waiting")),
+    if count == 0 {
+        return None;
     }
+    Some(format!(
+        "{} waiting",
+        plural::count(count, "worktree", None)
+    ))
+}
+
+/// The rail footer's and Settings → Disk's shared idle line: `"3 worktrees · 1.2 GB"`.
+///
+/// One function rather than the two independently-formatted copies these two surfaces used to
+/// carry (both of which read `1 worktrees` for a fresh single-checkout repo, which is the very
+/// first thing a new user sees).
+pub fn worktree_disk_label(worktree_count: usize, disk_label: &str) -> String {
+    format!(
+        "{} \u{b7} {disk_label}",
+        plural::count(worktree_count, "worktree", None)
+    )
+}
+
+/// The prune button's arming prompt: `"click prune again to remove 2 worktrees"`.
+pub fn prune_confirm_label(candidate_count: usize) -> String {
+    format!(
+        "click prune again to remove {}",
+        plural::count(candidate_count, "worktree", None)
+    )
+}
+
+/// The in-flight prune status: `"pruning 2 worktrees…"`.
+pub fn pruning_label(candidate_count: usize) -> String {
+    format!(
+        "pruning {}\u{2026}",
+        plural::count(candidate_count, "worktree", None)
+    )
+}
+
+/// The finished-prune status: `"pruned 1 worktree"`.
+pub fn pruned_label(removed_count: usize) -> String {
+    format!("pruned {}", plural::count(removed_count, "worktree", None))
 }
 
 /// Builds the rail's repo groups: each [`RepoWorktrees`]' rows sorted by
@@ -1469,6 +1509,56 @@ mod tests {
             waiting_count_label(7).as_deref(),
             Some("7 worktrees waiting")
         );
+    }
+
+    /// The rail footer and Settings → Disk share this one line, and it used to read
+    /// `"1 worktrees · 4.2 GB"` in both places for a fresh single-checkout repo.
+    #[test]
+    fn worktree_disk_label_conjugates_at_zero_one_and_two() {
+        assert_eq!(worktree_disk_label(0, "0 B"), "0 worktrees \u{b7} 0 B");
+        assert_eq!(worktree_disk_label(1, "4.2 GB"), "1 worktree \u{b7} 4.2 GB");
+        assert_eq!(
+            worktree_disk_label(2, "4.2 GB"),
+            "2 worktrees \u{b7} 4.2 GB"
+        );
+    }
+
+    #[test]
+    fn prune_labels_conjugate_at_zero_one_and_two() {
+        assert_eq!(
+            prune_confirm_label(0),
+            "click prune again to remove 0 worktrees"
+        );
+        assert_eq!(
+            prune_confirm_label(1),
+            "click prune again to remove 1 worktree"
+        );
+        assert_eq!(
+            prune_confirm_label(2),
+            "click prune again to remove 2 worktrees"
+        );
+
+        assert_eq!(pruning_label(0), "pruning 0 worktrees\u{2026}");
+        assert_eq!(pruning_label(1), "pruning 1 worktree\u{2026}");
+        assert_eq!(pruning_label(2), "pruning 2 worktrees\u{2026}");
+
+        assert_eq!(pruned_label(0), "pruned 0 worktrees");
+        assert_eq!(pruned_label(1), "pruned 1 worktree");
+        assert_eq!(pruned_label(2), "pruned 2 worktrees");
+    }
+
+    /// None of the prune/disk labels may fall back to the `worktree(s)` escape hatch these
+    /// three replaced - that spelling dodges the conjugation instead of doing it.
+    #[test]
+    fn no_prune_label_uses_the_parenthesised_plural_escape_hatch() {
+        for n in 0..4 {
+            for label in [prune_confirm_label(n), pruning_label(n), pruned_label(n)] {
+                assert!(
+                    !label.contains("(s)"),
+                    "prune label must conjugate, not dodge: {label}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/app/src/review/state.rs
+++ b/crates/app/src/review/state.rs
@@ -11,6 +11,7 @@ use std::path::{Path, PathBuf};
 use wt_core::diff::WorktreeDiff;
 use wt_core::review::UntrackedCoverage;
 
+use crate::root::plural;
 use crate::work_surface::agents::AgentKind;
 
 /// Why a baseline is where it is - the two, and only two, real ways a baseline is ever set
@@ -315,8 +316,7 @@ pub fn review_summary_label(review: &AgentReview) -> String {
         ReviewLoadState::Error(_) => "review unavailable".to_string(),
         ReviewLoadState::Loaded(diff) => match diff.files.len() {
             0 => "nothing unreviewed".to_string(),
-            1 => "1 file unreviewed".to_string(),
-            count => format!("{count} files unreviewed"),
+            count => format!("{} unreviewed", plural::count(count, "file", None)),
         },
     }
 }
@@ -443,6 +443,36 @@ mod tests {
         });
         assert!(review.diff().is_some());
         assert_eq!(review_summary_label(&review), "nothing unreviewed");
+    }
+
+    /// The Review strip's own count, conjugated through [`crate::root::plural`] rather than the
+    /// per-count match arms it used to spell out by hand (GitHub issue #281).
+    #[test]
+    fn review_summary_label_conjugates_at_zero_one_and_two() {
+        let label_for = |file_count: usize| {
+            let mut review = AgentReview::new(baseline(BaselineReason::Spawn, 0));
+            review.load = ReviewLoadState::Loaded(WorktreeDiff {
+                base_branch: "since it started".to_string(),
+                base_commit: "a".repeat(40),
+                files: (0..file_count)
+                    .map(|i| wt_core::diff::DiffFile {
+                        path: PathBuf::from(format!("f{i}.rs")),
+                        old_path: None,
+                        status: wt_core::diff::FileChangeStatus::Modified,
+                        is_binary: false,
+                        hunks: Vec::new(),
+                        truncated: false,
+                    })
+                    .collect(),
+                truncated: false,
+            });
+            review_summary_label(&review)
+        };
+        // Zero is the qualitatively different "nothing" wording, not a conjugation case.
+        assert_eq!(label_for(0), "nothing unreviewed");
+        assert_eq!(label_for(1), "1 file unreviewed");
+        assert_eq!(label_for(2), "2 files unreviewed");
+        assert_eq!(label_for(7), "7 files unreviewed");
     }
 
     /// Advancing the baseline must drop everything that described the old one - keeping a loaded

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -9,7 +9,9 @@
 //! the genuinely cross-zone mechanics: focus/overlay discipline ([`focus`], [`OverlayFocus`]), pane resizing
 //! ([`resize`] plus its pure width-clamp half, [`layout`]), the scoped rem-size override
 //! Surface C's zoom paints through ([`rem_scope`]), the shared keycap/chip/message widgets
-//! ([`widgets`]), the background-task slot type ([`task_pool`]), and the "New file" prompt
+//! ([`widgets`]), the app-wide pluralisation helper every counter in the window conjugates
+//! through ([`plural`] - see its module docs for the rule, which is binding on new code), the
+//! background-task slot type ([`task_pool`]), and the "New file" prompt
 //! ([`new_file`]), which is an overlay reachable from two different zones and so belongs to
 //! neither.
 //!
@@ -4726,6 +4728,7 @@ pub mod layout;
 pub(crate) mod menu_commands;
 pub(crate) mod menus;
 pub(crate) mod new_file;
+pub(crate) mod plural;
 pub(crate) mod rem_scope;
 pub(crate) mod resize;
 pub(crate) mod scrollbar;

--- a/crates/app/src/root/plural.rs
+++ b/crates/app/src/root/plural.rs
@@ -1,0 +1,131 @@
+//! The one pluralisation helper every user-visible count in this window goes through.
+//!
+//! ## The rule
+//!
+//! > **Every count goes through the pluralisation helper; never inline a ternary.**
+//!
+//! (Revision 6, `design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md` §7 rule 9,
+//! restating §6 and `REVISION-2026-08-13.md` §8a.)
+//!
+//! Before this module existed, every counter in the app conjugated itself: a dozen copies of
+//! `if count == 1 { "" } else { "s" }`, plus a second, worse population of labels that simply
+//! hardcoded the plural noun (`format!("{agent_count} agents")`) and so read `1 agents` for the
+//! single-agent case that is in fact the *common* one. The design review caught exactly this in
+//! its own mock - "the two that were written by hand both said `1 files`" - which is the point:
+//! a rule spread across thirty call sites is a rule that drifts. There is one decision point
+//! here ([`form`]) and everything else is built on it.
+//!
+//! ## Using it
+//!
+//! For a count plus its noun, call [`count`]:
+//!
+//! ```ignore
+//! plural::count(n, "file", None)            // "0 files" / "1 file" / "2 files"
+//! plural::count(n, "match", Some("matches")) // irregular plural spelled out
+//! ```
+//!
+//! For anything else that has to agree with a count - a verb, an auxiliary, a pronoun - call
+//! [`form`] directly, so the sentence still has exactly one place that looks at the number:
+//!
+//! ```ignore
+//! format!("{} {} input", plural::count(n, "agent", None), plural::form(n, "needs", "need"))
+//! // "1 agent needs input" / "2 agents need input"
+//! ```
+//!
+//! [`count`] is itself implemented in terms of [`form`], so noun agreement and verb agreement
+//! are genuinely one code path and cannot disagree about where the boundary is.
+//!
+//! ## Zero is plural
+//!
+//! English pluralises zero (`0 files`, not `0 file`), so [`form`] keys off `count == 1` alone,
+//! not off `count > 1`. Call sites that want to *hide* a counter at zero, or say something
+//! qualitatively different there (`"nothing unreviewed"`, `"nothing to prune"`), still do that
+//! themselves - that is a content decision, not a grammar one, and this helper deliberately
+//! does not try to own it.
+//!
+//! ## What does *not* belong here
+//!
+//! Labels with no noun to agree with (`"3 wt"`, `"12 shown"`, `"hunk 2 of 5"`, the
+//! `changes-header-{n}-files` debug selectors) have nothing to conjugate and must stay as they
+//! are - routing them through here would only invent a plural where the UI deliberately has
+//! none.
+
+/// Picks the wording that matches `count`: `singular` at exactly one, `plural` at everything
+/// else (**including zero** - see this module's docs).
+///
+/// This is the single place in the app that decides singular versus plural. [`count`] is built
+/// on it, and sentence-level agreement (verbs, auxiliaries) calls it directly rather than
+/// re-deriving the same `== 1` test at the call site.
+pub(crate) fn form<'a>(count: usize, singular: &'a str, plural: &'a str) -> &'a str {
+    if count == 1 {
+        singular
+    } else {
+        plural
+    }
+}
+
+/// The count and its noun, agreeing: `"0 files"`, `"1 file"`, `"2 files"`.
+///
+/// `plural` is `None` for the regular English plural (`singular` with `s` appended) and
+/// `Some(..)` for anything that does not form its plural that way (`"matches"`, `"people"`,
+/// `"branches"`). Passing `None` is not a shortcut for "probably fine" - it is a claim that the
+/// noun really is regular, so spell out irregulars rather than letting one read wrong.
+pub(crate) fn count(count: usize, singular: &str, plural: Option<&str>) -> String {
+    let regular_plural = format!("{singular}s");
+    format!(
+        "{count} {}",
+        form(count, singular, plural.unwrap_or(&regular_plural))
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn form_picks_singular_only_at_exactly_one() {
+        assert_eq!(form(0, "needs", "need"), "need");
+        assert_eq!(form(1, "needs", "need"), "needs");
+        assert_eq!(form(2, "needs", "need"), "need");
+        assert_eq!(form(7, "needs", "need"), "need");
+    }
+
+    #[test]
+    fn count_conjugates_a_regular_noun_at_zero_one_and_two() {
+        assert_eq!(count(0, "file", None), "0 files");
+        assert_eq!(count(1, "file", None), "1 file");
+        assert_eq!(count(2, "file", None), "2 files");
+        assert_eq!(count(37, "file", None), "37 files");
+    }
+
+    #[test]
+    fn count_uses_the_explicit_plural_when_one_is_given() {
+        assert_eq!(count(0, "match", Some("matches")), "0 matches");
+        assert_eq!(count(1, "match", Some("matches")), "1 match");
+        assert_eq!(count(2, "match", Some("matches")), "2 matches");
+    }
+
+    /// The explicit plural is used verbatim - it is not `singular` with something appended - so
+    /// a genuinely irregular word (no shared stem at all) survives the round trip.
+    #[test]
+    fn explicit_plural_is_not_derived_from_the_singular() {
+        assert_eq!(count(1, "person", Some("people")), "1 person");
+        assert_eq!(count(3, "person", Some("people")), "3 people");
+    }
+
+    /// The sentence-conjugation path the title bar needs, exercised through the same two
+    /// functions every other call site uses - there is no second code path for verbs.
+    #[test]
+    fn count_and_form_compose_into_an_agreeing_sentence() {
+        let sentence = |n: usize| {
+            format!(
+                "{} {} input",
+                count(n, "agent", None),
+                form(n, "needs", "need")
+            )
+        };
+        assert_eq!(sentence(0), "0 agents need input");
+        assert_eq!(sentence(1), "1 agent needs input");
+        assert_eq!(sentence(2), "2 agents need input");
+    }
+}

--- a/crates/app/src/settings/render.rs
+++ b/crates/app/src/settings/render.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::root::plural;
 use crate::root::widgets::{
     hover_keycap_row, menu_popover_chrome, render_env_chip, render_keycap_row, KeycapSize,
 };
@@ -751,8 +752,9 @@ impl AdeApp {
                                     .font(font(theme::font::MONO))
                                     .text_size(px(10.5))
                                     .text_color(theme::text::FAINTER)
-                                    .child(format!(
-                                        "{worktree_count} worktrees \u{b7} {disk_label}"
+                                    .child(crate::rail::state::worktree_disk_label(
+                                        worktree_count,
+                                        &disk_label,
                                     )),
                             )
                             .child(
@@ -2658,7 +2660,7 @@ impl AdeApp {
                             .child(if has_query {
                                 self.settings_keymap_filter.as_str().to_string()
                             } else {
-                                format!("filter {total} bindings")
+                                format!("filter {}", plural::count(total, "binding", None))
                             })
                             .debug_selector(|| "settings-keymap-filter-text".to_string()),
                     )

--- a/crates/app/src/sidebar/changes.rs
+++ b/crates/app/src/sidebar/changes.rs
@@ -11,6 +11,7 @@ use std::path::{Path, PathBuf};
 
 use gpui::Rgba;
 
+use crate::root::plural;
 use crate::theme;
 use wt_core::diff::{DiffFile, DiffHunk, DiffLineKind, FileChangeStatus};
 
@@ -280,10 +281,7 @@ pub fn commit_button_label(staged_count: usize) -> String {
     if staged_count == 0 {
         "Commit".to_string()
     } else {
-        format!(
-            "Commit {staged_count} file{}",
-            if staged_count == 1 { "" } else { "s" }
-        )
+        format!("Commit {}", plural::count(staged_count, "file", None))
     }
 }
 
@@ -296,7 +294,7 @@ pub fn draft_commit_message(staged: &[&DiffFile]) -> String {
     match staged {
         [] => String::new(),
         [only] => format!("Update {}", only.path.display()),
-        many => format!("Update {} files", many.len()),
+        many => format!("Update {}", plural::count(many.len(), "file", None)),
     }
 }
 
@@ -804,6 +802,7 @@ mod tests {
 
     #[test]
     fn commit_button_label_is_plural_for_more_than_one_staged_file() {
+        assert_eq!(commit_button_label(2), "Commit 2 files");
         assert_eq!(commit_button_label(3), "Commit 3 files");
     }
 

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::keymap;
+use crate::root::plural;
 use crate::root::scrollbar;
 use crate::root::widgets::{
     hover_bg, menu_popover_chrome, render_committed_tag, render_keycap_row,
@@ -373,8 +374,8 @@ impl AdeApp {
 
         self.worktree_history_op_in_flight = Some(worktree_history::WorktreeHistoryOpKind::Commit);
         self.worktree_history_status = Some(format!(
-            "committing {file_count} file{} in {branch_display}\u{2026}",
-            if file_count == 1 { "" } else { "s" }
+            "committing {} in {branch_display}\u{2026}",
+            plural::count(file_count, "file", None)
         ));
         cx.notify();
 
@@ -392,8 +393,8 @@ impl AdeApp {
                 match result {
                     Ok(_outcome) => {
                         this.worktree_history_status = Some(format!(
-                            "committed {file_count} file{} in {branch_display}",
-                            if file_count == 1 { "" } else { "s" }
+                            "committed {} in {branch_display}",
+                            plural::count(file_count, "file", None)
                         ));
                         for path in &paths {
                             this.staged_files.remove(path);
@@ -1080,7 +1081,7 @@ impl AdeApp {
                 vec![entry.path.clone()]
             };
             let label = if drag_paths.len() > 1 {
-                format!("{} items", drag_paths.len())
+                plural::count(drag_paths.len(), "item", None)
             } else {
                 entry.name.clone()
             };
@@ -1554,7 +1555,7 @@ impl AdeApp {
     /// "how many of those staged files is the next commit about to include" (today the same set,
     /// but a distinct question).
     ///
-    /// The `N file(s)` label counts every row the list really paints, but the progress bar's
+    /// The `N files` label counts every row the list really paints, but the progress bar's
     /// denominator is the *stageable* subset (`changes::stageable_count`): a committed-clean file
     /// (GitHub issue #220) is a real row with genuinely nothing left to stage, so counting it
     /// against the bar would pin a fully-staged worktree short of full forever.
@@ -1599,7 +1600,7 @@ impl AdeApp {
                     .font(font(theme::font::MONO))
                     .text_size(self.ui_text_size(10.0))
                     .text_color(theme::text::DIM)
-                    .child(format!("{total} file{}", if total == 1 { "" } else { "s" })),
+                    .child(plural::count(total, "file", None)),
             )
             .child(
                 div()

--- a/crates/app/src/sound/flow.rs
+++ b/crates/app/src/sound/flow.rs
@@ -378,7 +378,10 @@ mod tests {
     #[test]
     fn turn_ended_staying_true_across_ticks_does_not_re_sound() {
         assert_eq!(
-            sound_for_transition(turn_ended_state(Status::Idle), turn_ended_state(Status::Idle)),
+            sound_for_transition(
+                turn_ended_state(Status::Idle),
+                turn_ended_state(Status::Idle)
+            ),
             None
         );
     }

--- a/crates/app/src/status_bar/render.rs
+++ b/crates/app/src/status_bar/render.rs
@@ -1,7 +1,31 @@
 use super::*;
+use crate::root::plural;
 use crate::root::widgets::{
     hover_keycap_row, render_env_chip, render_keycap_row, text_tooltip, KeycapSize,
 };
+
+/// The agents cluster's text: `"1 agent · 4% cpu · 30 MB"` on Linux, `"1 agent"` elsewhere
+/// (`extras` empty). Pure, so the conjugation is testable without a live process sampler -
+/// which matters here because the single-agent case this used to render as `"1 agents"` is the
+/// *ordinary* one: every window starts with exactly one agent.
+fn status_agents_label(agent_count: usize, extras: &[&str]) -> String {
+    let agents = plural::count(agent_count, "agent", None);
+    if extras.is_empty() {
+        return agents;
+    }
+    format!("{agents} \u{b7} {}", extras.join(" \u{b7} "))
+}
+
+/// The LSP cluster's text: `"1 server"`, `"2 servers · 3 errors"`. `errors` is `None` whenever
+/// no real file's File view is on screen (see [`AdeApp::status_bar_active_parsed_file`]), in
+/// which case the error half is omitted entirely rather than shown as a stale zero.
+fn status_servers_errors_label(server_count: usize, errors: Option<usize>) -> String {
+    let servers = plural::count(server_count, "server", None);
+    match errors {
+        Some(errors) => format!("{servers} \u{b7} {}", plural::count(errors, "error", None)),
+        None => servers,
+    }
+}
 
 /// The 28px status bar (`CHANGELOG.md`'s change 7 - height 26 -> 28, gap 12 -> 9, every value
 /// 10px mono), rebuilt from the old single `8 agents · 2 waiting · …` summary string into a
@@ -294,8 +318,9 @@ impl AdeApp {
             None => "...".to_string(),
         };
 
-        self.render_status_text(format!(
-            "{agent_count} agents \u{b7} {cpu_label} \u{b7} {mem_label}"
+        self.render_status_text(status_agents_label(
+            agent_count,
+            &[cpu_label.as_str(), mem_label.as_str()],
         ))
     }
 
@@ -310,7 +335,7 @@ impl AdeApp {
             .iter()
             .filter(|agent| agent.kind.is_agent_session())
             .count();
-        self.render_status_text(format!("{agent_count} agents"))
+        self.render_status_text(status_agents_label(agent_count, &[]))
     }
 
     /// `N wt · Y GB` - both real, both already computed elsewhere: worktree count from
@@ -339,10 +364,7 @@ impl AdeApp {
             .filter(|state| matches!(state, LspClientState::Ready(_)))
             .count();
 
-        let label = match self.status_bar_error_count() {
-            Some(errors) => format!("{server_count} servers \u{b7} {errors} errors"),
-            None => format!("{server_count} servers"),
-        };
+        let label = status_servers_errors_label(server_count, self.status_bar_error_count());
         self.render_status_text(label)
     }
 
@@ -420,7 +442,7 @@ impl AdeApp {
                 row = row.child(self.render_status_text(format!("ln {line}")));
             }
             if let Some(width) = code_view::detect_indent_width(&parsed.lines) {
-                row = row.child(self.render_status_text(format!("{width} spaces")));
+                row = row.child(self.render_status_text(plural::count(width, "space", None)));
             }
             row = row.child(self.render_status_text(parsed.line_ending.label().to_string()));
             // A real, checked value (`code_view::ParsedFile::is_valid_utf8`), not a hardcoded
@@ -552,6 +574,63 @@ fn render_status_divider() -> impl IntoElement {
 /// resets zoom through [`AdeApp::reset_zoom`] - the exact same real mechanism the code toolbar's
 /// own zoom control (`code_surface::zoom::render_zoom_control`) uses, never a second, copied
 /// implementation.
+/// The two status-bar clusters that used to hardcode their plural noun and so read `1 agents`
+/// / `1 servers · 1 errors` for the single-agent, single-server case that is in fact the
+/// ordinary one (GitHub issue #281).
+#[cfg(test)]
+mod status_bar_count_conjugation_tests {
+    use super::*;
+
+    #[test]
+    fn agents_cluster_conjugates_at_zero_one_and_two() {
+        assert_eq!(status_agents_label(0, &[]), "0 agents");
+        assert_eq!(status_agents_label(1, &[]), "1 agent");
+        assert_eq!(status_agents_label(2, &[]), "2 agents");
+    }
+
+    /// The Linux build appends the real cpu/mem fields; the conjugation must not change.
+    #[test]
+    fn agents_cluster_conjugates_with_the_cpu_and_memory_fields_attached() {
+        assert_eq!(
+            status_agents_label(1, &["4% cpu", "30 MB"]),
+            "1 agent \u{b7} 4% cpu \u{b7} 30 MB"
+        );
+        assert_eq!(
+            status_agents_label(2, &["4% cpu", "30 MB"]),
+            "2 agents \u{b7} 4% cpu \u{b7} 30 MB"
+        );
+    }
+
+    #[test]
+    fn servers_cluster_conjugates_at_zero_one_and_two() {
+        assert_eq!(status_servers_errors_label(0, None), "0 servers");
+        assert_eq!(status_servers_errors_label(1, None), "1 server");
+        assert_eq!(status_servers_errors_label(2, None), "2 servers");
+    }
+
+    /// Both counts in the two-count string conjugate independently - the old label got *both*
+    /// wrong at one, and a fix that only handled the server half would still read `1 errors`.
+    #[test]
+    fn servers_and_errors_conjugate_independently() {
+        assert_eq!(
+            status_servers_errors_label(1, Some(1)),
+            "1 server \u{b7} 1 error"
+        );
+        assert_eq!(
+            status_servers_errors_label(1, Some(2)),
+            "1 server \u{b7} 2 errors"
+        );
+        assert_eq!(
+            status_servers_errors_label(2, Some(1)),
+            "2 servers \u{b7} 1 error"
+        );
+        assert_eq!(
+            status_servers_errors_label(2, Some(0)),
+            "2 servers \u{b7} 0 errors"
+        );
+    }
+}
+
 #[cfg(test)]
 mod status_bar_zoom_click_tests {
     use super::*;

--- a/crates/app/src/title_bar/render.rs
+++ b/crates/app/src/title_bar/render.rs
@@ -6,6 +6,7 @@
 use super::*;
 #[cfg(test)]
 use crate::root::focus::palette_focus_tests;
+use crate::root::plural;
 
 /// Half-diagonal of an 11×1px rect rotated ±45° about its own center - `5.5 * cos(45°)`. Used to
 /// place the close glyph's two crossing strokes (see [`render_close_glyph`]).
@@ -423,18 +424,23 @@ fn title_bar_agent_state_chips(rows: &[AgentRow]) -> Vec<(Status, String)> {
 /// ("No two counters in the window may share wording while counting different units"), and
 /// pluralizes correctly at exactly 1 vs 2+ - `Status::Ask` conjugates its verb too (`"1 agent
 /// needs input"` vs `"2 agents need input"`), matching the design's own two example counts.
+///
+/// Both halves of that agreement come from [`crate::root::plural`]: the noun via
+/// [`plural::count`], the verb via [`plural::form`]. This is the sentence-conjugation case
+/// rev 6 §7 rule 9 calls out, and it deliberately goes through the same helper as every bare
+/// `"N files"` in the window rather than keeping its own `== 1` test.
 fn title_bar_agent_state_chip_text(status: Status, count: usize) -> Option<String> {
     if count == 0 {
         return None;
     }
-    let agents = if count == 1 { "agent" } else { "agents" };
+    let agents = plural::count(count, "agent", None);
     match status {
-        Status::Ask => {
-            let verb = if count == 1 { "needs" } else { "need" };
-            Some(format!("{count} {agents} {verb} input"))
-        }
-        Status::Fail => Some(format!("{count} {agents} failed")),
-        Status::Run => Some(format!("{count} {agents} running")),
+        Status::Ask => Some(format!(
+            "{agents} {} input",
+            plural::form(count, "needs", "need")
+        )),
+        Status::Fail => Some(format!("{agents} failed")),
+        Status::Run => Some(format!("{agents} running")),
         Status::Review | Status::Idle => None,
     }
 }


### PR DESCRIPTION
Closes #281

## The helper

`crates/app/src/root/plural.rs` — a sibling of the shared `root/widgets.rs`, declared `pub(crate) mod plural;` and cross-referenced from `root/mod.rs`'s "what lives here" doc.

```rust
pub(crate) fn form<'a>(count: usize, singular: &'a str, plural: &'a str) -> &'a str
pub(crate) fn count(count: usize, singular: &str, plural: Option<&str>) -> String
```

- `plural::count(n, "file", None)` → `0 files` / `1 file` / `2 files`; `Some("matches")` spells out an irregular plural.
- `plural::form(n, "needs", "need")` handles anything else in the sentence that has to agree — a verb, an auxiliary, a pronoun.
- `count` is implemented **on top of** `form`, so the sentence-conjugation case §7 rule 9 calls out (`1 agent needs input` / `2 agents need input`) goes through the same single `== 1` decision as every bare `N files`, not a second code path.
- Zero is plural (`0 files`). Hiding a counter at zero, or saying something qualitatively different there (`nothing unreviewed`, `nothing to prune`), stays the call site's own content decision.

## Two bug classes, not one

The issue named inline ternaries. The sweep also turned up a second, worse population that hardcoded the plural noun outright — and since the single-item case is usually the *common* one, these were sitting on screen wrong:

| Was | Now |
| --- | --- |
| `1 agents · 4% cpu · 30 MB` | `1 agent · …` |
| `1 servers · 1 errors` | `1 server · 1 error` |
| `1 worktrees · 4.2 GB` (rail footer **and** Settings → Disk) | `1 worktree · 4.2 GB` |
| `rust-analyzer: 1 errors, 1 warnings` | `rust-analyzer: 1 error, 1 warning` |
| `1 → 1 commits`, `1 commits folded in` | `1 → 1 commit`, `1 commit folded in` |
| `Jerry auto-resolved 0 of 1 files` | `… 0 of 1 file` |

A third group used the `worktree(s)` / `file(s)` / `conflict(s)` escape hatch, which dodges the conjugation rather than doing it; those are converted too.

## Converted call sites

**rail** — `agent_trailing_text` review file count; `waiting_count_label`; footer worktree+disk line; three prune statuses.
**title bar** — `title_bar_agent_state_chip_text` (noun *and* verb).
**status bar** — agents cluster (both `cfg` arms), servers/errors cluster, indent-width `N spaces`.
**sidebar** — `commit_button_label`, `draft_commit_message`, committing/committed history status, Changes header count, multi-file drag label.
**palette** — results footer, prunable-worktrees secondary.
**settings** — Disk card worktree+disk line, keymap filter placeholder.
**code surface** — diff fold marker, editor fold marker, `format_relative_date`, `lsp_status_label`.
**merge** — staged-files line, auto-resolved banner, "still needs you" line.
**graph/rebase** — plan header, RESULT header, conflict banner, folded-count line, running-agents warning, remote-commits warning, stop-count warning.

Where a count sat inline in a render body I extracted a pure, unit-testable label function rather than leaving it untestable: `status_agents_label`, `status_servers_errors_label`, and `rail::state::{worktree_disk_label, prune_confirm_label, pruning_label, pruned_label}`. `worktree_disk_label` also collapses two independently-formatted copies (rail footer + Settings) that had **both** drifted to `1 worktrees`.

## Tests

Every converted site is verified at 0, 1 and 2. New/extended coverage in `plural.rs` (incl. that the explicit plural is used verbatim, not derived), `status_bar::render`, `rail::state`, `rail::render`, `review::state`, `code_surface::file_view`, `sidebar::changes`. One existing assertion in `file_view.rs` asserted the `1 warnings` bug verbatim and is corrected.

Also asserts no prune label can regress to the `(s)` escape hatch.

## Note on scope

`crates/wt-core/src/error.rs:212` still reads `{} file(s) are still unmerged`. It's outside the `app` crate, so it can't reach a `pub(crate)` helper there; routing it through this one would mean either promoting the helper to a shared crate or keeping a second copy, both of which are bigger calls than this issue authorizes. Flagging rather than silently expanding scope.

This branch also carries a **one-line unrelated `cargo fmt` fix** in `sound/flow.rs` — a pre-existing violation that landed with #266 and currently makes `cargo fmt --check` fail on `master`. Called out so it isn't mistaken for part of the sweep.
