### PR TITLE
Theme layer: adopt the rev-6 design token set and the reserved-hue allocation rule

### DIFF
--- a/assets/themes/ember.toml
+++ b/assets/themes/ember.toml
@@ -80,13 +80,10 @@ diagnostic_card_footer = "#251d22"  # The Diagnostic popover's own footer band's
 indent_guide        = "#1c2124"
 indent_guide_active = "#224959"  # The guide for a level in the selected file's ancestor chain
 
-# The overlay scrollbar's own colours (GitHub issue #30) - not from design_handoff_jerry_ade
-# (that mockup has no scrollbar spec at all: every scrollable region there relies on raw,
-# invisible browser/OS scrolling), so these are a deliberate, judgment-call derivation from
-# existing neutral tokens rather than a transcription.
+# The overlay scrollbar (GitHub issue #30).
 [scrollbar]
-thumb       = "#2d3336"
-thumb_hover = "#3f484d"
+thumb       = "#222a2d"
+thumb_hover = "#2e373c"
 
 
 # ──────────────────────────────────────────────────────────────────────────────────────────────
@@ -178,16 +175,43 @@ worktree_active_bg = "#151a1c"
 worktree_hover_bg  = "#14181a"  # Worktree row hover background (§2.2: "hover #16191c").
 prunable_edge      = "#252c2f"
 
-# One tint per agent.
+# One tint per agent - the **agent tint pool**.
 [agent]
-"sonnet.fg" = "#b36f25"
-"sonnet.bg" = "#311f0c"
-"codex.fg"  = "#5f863c"
-"codex.bg"  = "#1e2a1a"
-"haiku.fg"  = "#8d689f"
-"haiku.bg"  = "#281c2f"
-"local.fg"  = "#4277a3"
-"local.bg"  = "#102538"
+"sonnet.fg" = "#a65b49"  # Copper - sonnet-4.5.
+"sonnet.bg" = "#2e1a0f"  # Copper - sonnet-4.5.
+"codex.fg"  = "#368666"  # Teal - gpt-5-codex.
+"codex.bg"  = "#11291f"  # Teal - gpt-5-codex.
+"haiku.fg"  = "#606dab"  # Periwinkle - haiku-4.5.
+"haiku.bg"  = "#1a1d30"  # Periwinkle - haiku-4.5.
+"local.fg"  = "#4277a3"  # Steel blue - qwen-local.
+"local.bg"  = "#102538"  # Steel blue - qwen-local.
+
+# The Changes panel - four stacked, collapsible sections in one scroller
+# (design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md §1), plus the file row's own
+# seen/unseen and discard states (STAGE-A-CHANGELOG.md §4i).
+[changes]
+edge_uncommitted  = "#224959"  # UNCOMMITTED's 2px left edge - what is dirty in the checkout.
+edge_neutral      = "#1c2124"  # COMMITS' 2px left edge.
+edge_against_main = "#8d689f"  # AGAINST MAIN's 2px left edge
+section_label     = "#576064"  # Section header label - 9.5px/600 uppercase, .08em tracking.
+section_count     = "#373f44"  # Section header count
+section_caret     = "#454d51"  # The section header's own disclosure caret (▾/▸).
+section_stat_add  = "#689057"  # The right-aligned per-section diffstat's +N, 10px mono.
+section_stat_del  = "#984d60"  # The right-aligned per-section diffstat's −N, 10px mono.
+filename_unseen   = "#9da3a6"  # A filename not seen since the agent last changed it
+filename_seen     = "#555e63"  # A filename seen since the agent last changed it
+discard_bg        = "#26151c"  # The armed Discard? pill's fill.
+discard_border    = "#3f1b25"  # The armed Discard? pill's 1px border.
+discard_fg        = "#ac586d"  # The armed Discard? pill's label.
+
+# Per-provider rate-limit budget - the meter on an agent tab and in the budget popover
+# (design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md §2).
+[budget]
+ok       = "#689057"  # Above 40% remaining.
+warn     = "#a66730"  # 15-40% remaining.
+critical = "#984d60"  # Below 15% remaining.
+track    = "#1c2124"  # The unfilled remainder of the meter
+stale    = "#4e565b"
 
 
 # ──────────────────────────────────────────────────────────────────────────────────────────────
@@ -291,26 +315,28 @@ link_underline_hover = "#3f8099"
 # The integrated terminal's own rendered-content palette - the colours a program running inside
 # a terminal pane actually paints its characters with.
 [terminal]
-background = "#0e1112"  # The terminal pane's own fill
-foreground = "#777f84"  # Unstyled output
-cursor     = "#00789d"  # What NamedColor::Cursor resolves to
-selection  = "#16323e"  # The fill painted behind a selected cell
-"ansi.0"   = "#000000"
-"ansi.1"   = "#cd3131"
-"ansi.2"   = "#0dbc79"
-"ansi.3"   = "#e5e510"
-"ansi.4"   = "#2472c8"
-"ansi.5"   = "#bc3fbc"
-"ansi.6"   = "#11a8cd"
-"ansi.7"   = "#e5e5e5"
-"ansi.8"   = "#666666"
-"ansi.9"   = "#f14c4c"
-"ansi.10"  = "#23d18b"
-"ansi.11"  = "#f5f543"
-"ansi.12"  = "#3b8eea"
-"ansi.13"  = "#d670d6"
-"ansi.14"  = "#29b8db"
-"ansi.15"  = "#ffffff"
+background     = "#0e1112"  # The terminal pane's own fill
+foreground     = "#777f84"  # Unstyled output
+cursor         = "#00789d"  # What NamedColor::Cursor resolves to
+selection      = "#16323e"  # The fill painted behind a selected cell
+spawn_error    = "#c53c6b"
+process_exited = "#d08637"  # The process exited label, once the child is gone.
+"ansi.0"       = "#000000"
+"ansi.1"       = "#cd3131"
+"ansi.2"       = "#0dbc79"
+"ansi.3"       = "#e5e510"
+"ansi.4"       = "#2472c8"
+"ansi.5"       = "#bc3fbc"
+"ansi.6"       = "#11a8cd"
+"ansi.7"       = "#e5e5e5"
+"ansi.8"       = "#666666"
+"ansi.9"       = "#f14c4c"
+"ansi.10"      = "#23d18b"
+"ansi.11"      = "#f5f543"
+"ansi.12"      = "#3b8eea"
+"ansi.13"      = "#d670d6"
+"ansi.14"      = "#29b8db"
+"ansi.15"      = "#ffffff"
 
 # Exact colours for Surface C's real Completions popup item rows - read directly from
 # design_handoff_jerry_ade/revision/Jerry.dc.html's own completions/KBG/KFG data (the sel ? ...
@@ -451,3 +477,10 @@ local_border = "#1c2124"  # Defaults to border::DIVIDER's own value.
 "css.bg"     = "#241b28"  # "css"
 "unknown.fg" = "#4e565b"
 "unknown.bg" = "#1d2225"
+
+# The status bar's three type tiers (design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md
+# §3).
+[status_bar]
+primary   = "#788186"  # Tier 1
+recessive = "#373f44"  # Tier 3
+divider   = "#222a2d"  # The 1px, 13-high rules between tiers.

--- a/assets/themes/jerry-dim.toml
+++ b/assets/themes/jerry-dim.toml
@@ -80,13 +80,10 @@ diagnostic_card_footer = "#312829"  # The Diagnostic popover's own footer band's
 indent_guide        = "#292c30"
 indent_guide_active = "#435971"  # The guide for a level in the selected file's ancestor chain
 
-# The overlay scrollbar's own colours (GitHub issue #30) - not from design_handoff_jerry_ade
-# (that mockup has no scrollbar spec at all: every scrollable region there relies on raw,
-# invisible browser/OS scrolling), so these are a deliberate, judgment-call derivation from
-# existing neutral tokens rather than a transcription.
+# The overlay scrollbar (GitHub issue #30).
 [scrollbar]
-thumb       = "#3d4146"
-thumb_hover = "#555b62"
+thumb       = "#31353b"
+thumb_hover = "#40464c"
 
 
 # ──────────────────────────────────────────────────────────────────────────────────────────────
@@ -178,16 +175,43 @@ worktree_active_bg = "#202326"
 worktree_hover_bg  = "#1e2023"  # Worktree row hover background (§2.2: "hover #16191c").
 prunable_edge      = "#34393e"
 
-# One tint per agent.
+# One tint per agent - the **agent tint pool**.
 [agent]
-"sonnet.fg" = "#bf9d47"
-"sonnet.bg" = "#362e18"
-"codex.fg"  = "#5caa7d"
-"codex.bg"  = "#23382e"
-"haiku.fg"  = "#bb83aa"
-"haiku.bg"  = "#392633"
-"local.fg"  = "#7c8dc2"
-"local.bg"  = "#282e45"
+"sonnet.fg" = "#bb8253"  # Copper - sonnet-4.5.
+"sonnet.bg" = "#352817"  # Copper - sonnet-4.5.
+"codex.fg"  = "#4aa49d"  # Teal - gpt-5-codex.
+"codex.bg"  = "#1a3533"  # Teal - gpt-5-codex.
+"haiku.fg"  = "#9683bf"  # Periwinkle - haiku-4.5.
+"haiku.bg"  = "#2c2537"  # Periwinkle - haiku-4.5.
+"local.fg"  = "#7c8dc2"  # Steel blue - qwen-local.
+"local.bg"  = "#282e45"  # Steel blue - qwen-local.
+
+# The Changes panel - four stacked, collapsible sections in one scroller
+# (design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md §1), plus the file row's own
+# seen/unseen and discard states (STAGE-A-CHANGELOG.md §4i).
+[changes]
+edge_uncommitted  = "#435971"  # UNCOMMITTED's 2px left edge - what is dirty in the checkout.
+edge_neutral      = "#292c30"  # COMMITS' 2px left edge.
+edge_against_main = "#bb83aa"  # AGAINST MAIN's 2px left edge
+section_label     = "#72777e"  # Section header label - 9.5px/600 uppercase, .08em tracking.
+section_count     = "#4b5056"  # Section header count
+section_caret     = "#5c6166"  # The section header's own disclosure caret (▾/▸).
+section_stat_add  = "#70b693"  # The right-aligned per-section diffstat's +N, 10px mono.
+section_stat_del  = "#b46d61"  # The right-aligned per-section diffstat's −N, 10px mono.
+filename_unseen   = "#c7cacf"  # A filename not seen since the agent last changed it
+filename_seen     = "#70767c"  # A filename seen since the agent last changed it
+discard_bg        = "#311f1f"  # The armed Discard? pill's fill.
+discard_border    = "#4d2a25"  # The armed Discard? pill's 1px border.
+discard_fg        = "#cc7c6f"  # The armed Discard? pill's label.
+
+# Per-provider rate-limit budget - the meter on an agent tab and in the budget popover
+# (design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md §2).
+[budget]
+ok       = "#70b693"  # Above 40% remaining.
+warn     = "#b3914a"  # 15-40% remaining.
+critical = "#b46d61"  # Below 15% remaining.
+track    = "#292c30"  # The unfilled remainder of the meter
+stale    = "#676c72"
 
 
 # ──────────────────────────────────────────────────────────────────────────────────────────────
@@ -291,26 +315,28 @@ link_underline_hover = "#7499bf"
 # The integrated terminal's own rendered-content palette - the colours a program running inside
 # a terminal pane actually paints its characters with.
 [terminal]
-background = "#16181a"  # The terminal pane's own fill
-foreground = "#9a9ea5"  # Unstyled output
-cursor     = "#5e8dc4"  # What NamedColor::Cursor resolves to
-selection  = "#2e3d4f"  # The fill painted behind a selected cell
-"ansi.0"   = "#000000"
-"ansi.1"   = "#cd3131"
-"ansi.2"   = "#0dbc79"
-"ansi.3"   = "#e5e510"
-"ansi.4"   = "#2472c8"
-"ansi.5"   = "#bc3fbc"
-"ansi.6"   = "#11a8cd"
-"ansi.7"   = "#e5e5e5"
-"ansi.8"   = "#666666"
-"ansi.9"   = "#f14c4c"
-"ansi.10"  = "#23d18b"
-"ansi.11"  = "#f5f543"
-"ansi.12"  = "#3b8eea"
-"ansi.13"  = "#d670d6"
-"ansi.14"  = "#29b8db"
-"ansi.15"  = "#ffffff"
+background     = "#16181a"  # The terminal pane's own fill
+foreground     = "#9a9ea5"  # Unstyled output
+cursor         = "#5e8dc4"  # What NamedColor::Cursor resolves to
+selection      = "#2e3d4f"  # The fill painted behind a selected cell
+spawn_error    = "#e86759"
+process_exited = "#dfbb5e"  # The process exited label, once the child is gone.
+"ansi.0"       = "#000000"
+"ansi.1"       = "#cd3131"
+"ansi.2"       = "#0dbc79"
+"ansi.3"       = "#e5e510"
+"ansi.4"       = "#2472c8"
+"ansi.5"       = "#bc3fbc"
+"ansi.6"       = "#11a8cd"
+"ansi.7"       = "#e5e5e5"
+"ansi.8"       = "#666666"
+"ansi.9"       = "#f14c4c"
+"ansi.10"      = "#23d18b"
+"ansi.11"      = "#f5f543"
+"ansi.12"      = "#3b8eea"
+"ansi.13"      = "#d670d6"
+"ansi.14"      = "#29b8db"
+"ansi.15"      = "#ffffff"
 
 # Exact colours for Surface C's real Completions popup item rows - read directly from
 # design_handoff_jerry_ade/revision/Jerry.dc.html's own completions/KBG/KFG data (the sel ? ...
@@ -451,3 +477,10 @@ local_border = "#292c30"  # Defaults to border::DIVIDER's own value.
 "css.bg"     = "#32252e"  # "css"
 "unknown.fg" = "#676c72"
 "unknown.bg" = "#292d31"
+
+# The status bar's three type tiers (design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md
+# §3).
+[status_bar]
+primary   = "#9ba1a7"  # Tier 1
+recessive = "#4b5056"  # Tier 3
+divider   = "#31353b"  # The 1px, 13-high rules between tiers.

--- a/assets/themes/moss.toml
+++ b/assets/themes/moss.toml
@@ -80,13 +80,10 @@ diagnostic_card_footer = "#292224"  # The Diagnostic popover's own footer band's
 indent_guide        = "#232528"
 indent_guide_active = "#3f5264"  # The guide for a level in the selected file's ancestor chain
 
-# The overlay scrollbar's own colours (GitHub issue #30) - not from design_handoff_jerry_ade
-# (that mockup has no scrollbar spec at all: every scrollable region there relies on raw,
-# invisible browser/OS scrolling), so these are a deliberate, judgment-call derivation from
-# existing neutral tokens rather than a transcription.
+# The overlay scrollbar (GitHub issue #30).
 [scrollbar]
-thumb       = "#373a3e"
-thumb_hover = "#4f5459"
+thumb       = "#2b2f33"
+thumb_hover = "#3a3f44"
 
 
 # ──────────────────────────────────────────────────────────────────────────────────────────────
@@ -178,16 +175,43 @@ worktree_active_bg = "#1a1d1f"
 worktree_hover_bg  = "#181a1d"  # Worktree row hover background (§2.2: "hover #16191c").
 prunable_edge      = "#2e3236"
 
-# One tint per agent.
+# One tint per agent - the **agent tint pool**.
 [agent]
-"sonnet.fg" = "#b49555"
-"sonnet.bg" = "#2f2816"
-"codex.fg"  = "#669e77"
-"codex.bg"  = "#213028"
-"haiku.fg"  = "#ab80a1"
-"haiku.bg"  = "#30212d"
-"local.fg"  = "#7586b0"
-"local.bg"  = "#22283a"
+"sonnet.fg" = "#ac7c5b"  # Copper - sonnet-4.5.
+"sonnet.bg" = "#2d2215"  # Copper - sonnet-4.5.
+"codex.fg"  = "#569990"  # Teal - gpt-5-codex.
+"codex.bg"  = "#192d2b"  # Teal - gpt-5-codex.
+"haiku.fg"  = "#8a7faf"  # Periwinkle - haiku-4.5.
+"haiku.bg"  = "#24202e"  # Periwinkle - haiku-4.5.
+"local.fg"  = "#7586b0"  # Steel blue - qwen-local.
+"local.bg"  = "#22283a"  # Steel blue - qwen-local.
+
+# The Changes panel - four stacked, collapsible sections in one scroller
+# (design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md §1), plus the file row's own
+# seen/unseen and discard states (STAGE-A-CHANGELOG.md §4i).
+[changes]
+edge_uncommitted  = "#3f5264"  # UNCOMMITTED's 2px left edge - what is dirty in the checkout.
+edge_neutral      = "#232528"  # COMMITS' 2px left edge.
+edge_against_main = "#ab80a1"  # AGAINST MAIN's 2px left edge
+section_label     = "#6b7075"  # Section header label - 9.5px/600 uppercase, .08em tracking.
+section_count     = "#45494e"  # Section header count
+section_caret     = "#55595e"  # The section header's own disclosure caret (▾/▸).
+section_stat_add  = "#76aa8b"  # The right-aligned per-section diffstat's +N, 10px mono.
+section_stat_del  = "#a46963"  # The right-aligned per-section diffstat's −N, 10px mono.
+filename_unseen   = "#bec2c6"  # A filename not seen since the agent last changed it
+filename_seen     = "#696e73"  # A filename seen since the agent last changed it
+discard_bg        = "#281a1b"  # The armed Discard? pill's fill.
+discard_border    = "#422623"  # The armed Discard? pill's 1px border.
+discard_fg        = "#ba7972"  # The armed Discard? pill's label.
+
+# Per-provider rate-limit budget - the meter on an agent tab and in the budget popover
+# (design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md §2).
+[budget]
+ok       = "#76aa8b"  # Above 40% remaining.
+warn     = "#a88954"  # 15-40% remaining.
+critical = "#a46963"  # Below 15% remaining.
+track    = "#232528"  # The unfilled remainder of the meter
+stale    = "#606469"
 
 
 # ──────────────────────────────────────────────────────────────────────────────────────────────
@@ -291,26 +315,28 @@ link_underline_hover = "#7191ae"
 # The integrated terminal's own rendered-content palette - the colours a program running inside
 # a terminal pane actually paints its characters with.
 [terminal]
-background = "#101213"  # The terminal pane's own fill
-foreground = "#92969b"  # Unstyled output
-cursor     = "#5c86b0"  # What NamedColor::Cursor resolves to
-selection  = "#293644"  # The fill painted behind a selected cell
-"ansi.0"   = "#000000"
-"ansi.1"   = "#cd3131"
-"ansi.2"   = "#0dbc79"
-"ansi.3"   = "#e5e510"
-"ansi.4"   = "#2472c8"
-"ansi.5"   = "#bc3fbc"
-"ansi.6"   = "#11a8cd"
-"ansi.7"   = "#e5e5e5"
-"ansi.8"   = "#666666"
-"ansi.9"   = "#f14c4c"
-"ansi.10"  = "#23d18b"
-"ansi.11"  = "#f5f543"
-"ansi.12"  = "#3b8eea"
-"ansi.13"  = "#d670d6"
-"ansi.14"  = "#29b8db"
-"ansi.15"  = "#ffffff"
+background     = "#101213"  # The terminal pane's own fill
+foreground     = "#92969b"  # Unstyled output
+cursor         = "#5c86b0"  # What NamedColor::Cursor resolves to
+selection      = "#293644"  # The fill painted behind a selected cell
+spawn_error    = "#d16a63"
+process_exited = "#d3b26c"  # The process exited label, once the child is gone.
+"ansi.0"       = "#000000"
+"ansi.1"       = "#cd3131"
+"ansi.2"       = "#0dbc79"
+"ansi.3"       = "#e5e510"
+"ansi.4"       = "#2472c8"
+"ansi.5"       = "#bc3fbc"
+"ansi.6"       = "#11a8cd"
+"ansi.7"       = "#e5e5e5"
+"ansi.8"       = "#666666"
+"ansi.9"       = "#f14c4c"
+"ansi.10"      = "#23d18b"
+"ansi.11"      = "#f5f543"
+"ansi.12"      = "#3b8eea"
+"ansi.13"      = "#d670d6"
+"ansi.14"      = "#29b8db"
+"ansi.15"      = "#ffffff"
 
 # Exact colours for Surface C's real Completions popup item rows - read directly from
 # design_handoff_jerry_ade/revision/Jerry.dc.html's own completions/KBG/KFG data (the sel ? ...
@@ -451,3 +477,10 @@ local_border = "#232528"  # Defaults to border::DIVIDER's own value.
 "css.bg"     = "#2a1f27"  # "css"
 "unknown.fg" = "#606469"
 "unknown.bg" = "#232629"
+
+# The status bar's three type tiers (design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md
+# §3).
+[status_bar]
+primary   = "#94989e"  # Tier 1
+recessive = "#45494e"  # Tier 3
+divider   = "#2b2f33"  # The 1px, 13-high rules between tiers.

--- a/assets/themes/paper.toml
+++ b/assets/themes/paper.toml
@@ -80,13 +80,10 @@ diagnostic_card_footer = "#dfd5d7"  # The Diagnostic popover's own footer band's
 indent_guide        = "#d3d8dc"
 indent_guide_active = "#90a9bf"  # The guide for a level in the selected file's ancestor chain
 
-# The overlay scrollbar's own colours (GitHub issue #30) - not from design_handoff_jerry_ade
-# (that mockup has no scrollbar spec at all: every scrollable region there relies on raw,
-# invisible browser/OS scrolling), so these are a deliberate, judgment-call derivation from
-# existing neutral tokens rather than a transcription.
+# The overlay scrollbar (GitHub issue #30).
 [scrollbar]
-thumb       = "#b9bec3"
-thumb_hover = "#9da3a9"
+thumb       = "#c6cdd3"
+thumb_hover = "#b3bac1"
 
 
 # ──────────────────────────────────────────────────────────────────────────────────────────────
@@ -178,16 +175,43 @@ worktree_active_bg = "#dfe3e7"
 worktree_hover_bg  = "#e3e6ea"  # Worktree row hover background (§2.2: "hover #16191c").
 prunable_edge      = "#c3c9ce"
 
-# One tint per agent.
+# One tint per agent - the **agent tint pool**.
 [agent]
-"sonnet.fg" = "#7b5702"
-"sonnet.bg" = "#ded2bb"
-"codex.fg"  = "#3e764a"
-"codex.bg"  = "#c1d5c7"
-"haiku.fg"  = "#80577b"
-"haiku.bg"  = "#e2cedf"
-"local.fg"  = "#586f99"
-"local.bg"  = "#c7d3ec"
+"sonnet.fg" = "#945f3e"  # Copper - sonnet-4.5.
+"sonnet.bg" = "#e7d5c4"  # Copper - sonnet-4.5.
+"codex.fg"  = "#2e7a6e"  # Teal - gpt-5-codex.
+"codex.bg"  = "#bfd9d4"  # Teal - gpt-5-codex.
+"haiku.fg"  = "#6f669a"  # Periwinkle - haiku-4.5.
+"haiku.bg"  = "#dbd7ed"  # Periwinkle - haiku-4.5.
+"local.fg"  = "#586f99"  # Steel blue - qwen-local.
+"local.bg"  = "#c7d3ec"  # Steel blue - qwen-local.
+
+# The Changes panel - four stacked, collapsible sections in one scroller
+# (design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md §1), plus the file row's own
+# seen/unseen and discard states (STAGE-A-CHANGELOG.md §4i).
+[changes]
+edge_uncommitted  = "#90a9bf"  # UNCOMMITTED's 2px left edge - what is dirty in the checkout.
+edge_neutral      = "#d3d8dc"  # COMMITS' 2px left edge.
+edge_against_main = "#80577b"  # AGAINST MAIN's 2px left edge
+section_label     = "#80868b"  # Section header label - 9.5px/600 uppercase, .08em tracking.
+section_count     = "#a9aeb5"  # Section header count
+section_caret     = "#979da2"  # The section header's own disclosure caret (▾/▸).
+section_stat_add  = "#366948"  # The right-aligned per-section diffstat's +N, 10px mono.
+section_stat_del  = "#a66663"  # The right-aligned per-section diffstat's −N, 10px mono.
+filename_unseen   = "#3b3e41"  # A filename not seen since the agent last changed it
+filename_seen     = "#82888d"  # A filename seen since the agent last changed it
+discard_bg        = "#f0dadc"  # The armed Discard? pill's fill.
+discard_border    = "#e8c0be"  # The armed Discard? pill's 1px border.
+discard_fg        = "#975351"  # The armed Discard? pill's label.
+
+# Per-provider rate-limit budget - the meter on an agent tab and in the budget popover
+# (design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md §2).
+[budget]
+ok       = "#366948"  # Above 40% remaining.
+warn     = "#846127"  # 15-40% remaining.
+critical = "#a66663"  # Below 15% remaining.
+track    = "#d3d8dc"  # The unfilled remainder of the meter
+stale    = "#8c9197"
 
 
 # ──────────────────────────────────────────────────────────────────────────────────────────────
@@ -291,26 +315,28 @@ link_underline_hover = "#486e8a"
 # The integrated terminal's own rendered-content palette - the colours a program running inside
 # a terminal pane actually paints its characters with.
 [terminal]
-background = "#eff2f4"  # The terminal pane's own fill
-foreground = "#5e6267"  # Unstyled output
-cursor     = "#4678a3"  # What NamedColor::Cursor resolves to
-selection  = "#b4c7d9"  # The fill painted behind a selected cell
-"ansi.0"   = "#000000"
-"ansi.1"   = "#cd3131"
-"ansi.2"   = "#00bc00"
-"ansi.3"   = "#949800"
-"ansi.4"   = "#0451a5"
-"ansi.5"   = "#bc05bc"
-"ansi.6"   = "#0598bc"
-"ansi.7"   = "#555555"
-"ansi.8"   = "#666666"
-"ansi.9"   = "#cd3131"
-"ansi.10"  = "#14ce14"
-"ansi.11"  = "#b5ba00"
-"ansi.12"  = "#0451a5"
-"ansi.13"  = "#bc05bc"
-"ansi.14"  = "#0598bc"
-"ansi.15"  = "#a5a5a5"
+background     = "#eff2f4"  # The terminal pane's own fill
+foreground     = "#5e6267"  # Unstyled output
+cursor         = "#4678a3"  # What NamedColor::Cursor resolves to
+selection      = "#b4c7d9"  # The fill painted behind a selected cell
+spawn_error    = "#ad3f44"
+process_exited = "#5c4000"  # The process exited label, once the child is gone.
+"ansi.0"       = "#000000"
+"ansi.1"       = "#cd3131"
+"ansi.2"       = "#00bc00"
+"ansi.3"       = "#949800"
+"ansi.4"       = "#0451a5"
+"ansi.5"       = "#bc05bc"
+"ansi.6"       = "#0598bc"
+"ansi.7"       = "#555555"
+"ansi.8"       = "#666666"
+"ansi.9"       = "#cd3131"
+"ansi.10"      = "#14ce14"
+"ansi.11"      = "#b5ba00"
+"ansi.12"      = "#0451a5"
+"ansi.13"      = "#bc05bc"
+"ansi.14"      = "#0598bc"
+"ansi.15"      = "#a5a5a5"
 
 # Exact colours for Surface C's real Completions popup item rows - read directly from
 # design_handoff_jerry_ade/revision/Jerry.dc.html's own completions/KBG/KFG data (the sel ? ...
@@ -451,3 +477,10 @@ local_border = "#d3d8dc"  # Defaults to border::DIVIDER's own value.
 "css.bg"     = "#e4d5e1"  # "css"
 "unknown.fg" = "#8c9197"
 "unknown.bg" = "#d2d7db"
+
+# The status bar's three type tiers (design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md
+# §3).
+[status_bar]
+primary   = "#5b6065"  # Tier 1
+recessive = "#a9aeb5"  # Tier 3
+divider   = "#c6cdd3"  # The 1px, 13-high rules between tiers.

--- a/assets/themes/slate.toml
+++ b/assets/themes/slate.toml
@@ -80,13 +80,10 @@ diagnostic_card_footer = "#251d1e"  # The Diagnostic popover's own footer band's
 indent_guide        = "#1d2024"
 indent_guide_active = "#2d435b"  # The guide for a level in the selected file's ancestor chain
 
-# The overlay scrollbar's own colours (GitHub issue #30) - not from design_handoff_jerry_ade
-# (that mockup has no scrollbar spec at all: every scrollable region there relies on raw,
-# invisible browser/OS scrolling), so these are a deliberate, judgment-call derivation from
-# existing neutral tokens rather than a transcription.
+# The overlay scrollbar (GitHub issue #30).
 [scrollbar]
-thumb       = "#2d3136"
-thumb_hover = "#3f454b"
+thumb       = "#23282e"
+thumb_hover = "#2f343b"
 
 
 # ──────────────────────────────────────────────────────────────────────────────────────────────
@@ -178,16 +175,43 @@ worktree_active_bg = "#161a1d"
 worktree_hover_bg  = "#15181b"  # Worktree row hover background (§2.2: "hover #16191c").
 prunable_edge      = "#262a2f"
 
-# One tint per agent.
+# One tint per agent - the **agent tint pool**.
 [agent]
-"sonnet.fg" = "#99760b"
-"sonnet.bg" = "#2a220a"
-"codex.fg"  = "#338557"
-"codex.bg"  = "#162b21"
-"haiku.fg"  = "#955f86"
-"haiku.bg"  = "#2d1a28"
-"local.fg"  = "#596a9f"
-"local.bg"  = "#1b2238"
+"sonnet.fg" = "#975e2e"  # Copper - sonnet-4.5.
+"sonnet.bg" = "#2a1d0b"  # Copper - sonnet-4.5.
+"codex.fg"  = "#168079"  # Teal - gpt-5-codex.
+"codex.bg"  = "#0c2826"  # Teal - gpt-5-codex.
+"haiku.fg"  = "#73609d"  # Periwinkle - haiku-4.5.
+"haiku.bg"  = "#211a2c"  # Periwinkle - haiku-4.5.
+"local.fg"  = "#596a9f"  # Steel blue - qwen-local.
+"local.bg"  = "#1b2238"  # Steel blue - qwen-local.
+
+# The Changes panel - four stacked, collapsible sections in one scroller
+# (design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md §1), plus the file row's own
+# seen/unseen and discard states (STAGE-A-CHANGELOG.md §4i).
+[changes]
+edge_uncommitted  = "#2d435b"  # UNCOMMITTED's 2px left edge - what is dirty in the checkout.
+edge_neutral      = "#1d2024"  # COMMITS' 2px left edge.
+edge_against_main = "#955f86"  # AGAINST MAIN's 2px left edge
+section_label     = "#555b61"  # Section header label - 9.5px/600 uppercase, .08em tracking.
+section_count     = "#383c43"  # Section header count
+section_caret     = "#45494f"  # The section header's own disclosure caret (▾/▸).
+section_stat_add  = "#468e6b"  # The right-aligned per-section diffstat's +N, 10px mono.
+section_stat_del  = "#934c43"  # The right-aligned per-section diffstat's −N, 10px mono.
+filename_unseen   = "#979a9f"  # A filename not seen since the agent last changed it
+filename_seen     = "#545a60"  # A filename seen since the agent last changed it
+discard_bg        = "#261515"  # The armed Discard? pill's fill.
+discard_border    = "#3e1c18"  # The armed Discard? pill's 1px border.
+discard_fg        = "#a6574c"  # The armed Discard? pill's label.
+
+# Per-provider rate-limit budget - the meter on an agent tab and in the budget popover
+# (design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md §2).
+[budget]
+ok       = "#468e6b"  # Above 40% remaining.
+warn     = "#8f6c1d"  # 15-40% remaining.
+critical = "#934c43"  # Below 15% remaining.
+track    = "#1d2024"  # The unfilled remainder of the meter
+stale    = "#4d5258"
 
 
 # ──────────────────────────────────────────────────────────────────────────────────────────────
@@ -291,26 +315,28 @@ link_underline_hover = "#4f759b"
 # The integrated terminal's own rendered-content palette - the colours a program running inside
 # a terminal pane actually paints its characters with.
 [terminal]
-background = "#0f1113"  # The terminal pane's own fill
-foreground = "#787d83"  # Unstyled output
-cursor     = "#396ba2"  # What NamedColor::Cursor resolves to
-selection  = "#1f2e40"  # The fill painted behind a selected cell
-"ansi.0"   = "#000000"
-"ansi.1"   = "#cd3131"
-"ansi.2"   = "#0dbc79"
-"ansi.3"   = "#e5e510"
-"ansi.4"   = "#2472c8"
-"ansi.5"   = "#bc3fbc"
-"ansi.6"   = "#11a8cd"
-"ansi.7"   = "#e5e5e5"
-"ansi.8"   = "#666666"
-"ansi.9"   = "#f14c4c"
-"ansi.10"  = "#23d18b"
-"ansi.11"  = "#f5f543"
-"ansi.12"  = "#3b8eea"
-"ansi.13"  = "#d670d6"
-"ansi.14"  = "#29b8db"
-"ansi.15"  = "#ffffff"
+background     = "#0f1113"  # The terminal pane's own fill
+foreground     = "#787d83"  # Unstyled output
+cursor         = "#396ba2"  # What NamedColor::Cursor resolves to
+selection      = "#1f2e40"  # The fill painted behind a selected cell
+spawn_error    = "#c03d35"
+process_exited = "#b28c23"  # The process exited label, once the child is gone.
+"ansi.0"       = "#000000"
+"ansi.1"       = "#cd3131"
+"ansi.2"       = "#0dbc79"
+"ansi.3"       = "#e5e510"
+"ansi.4"       = "#2472c8"
+"ansi.5"       = "#bc3fbc"
+"ansi.6"       = "#11a8cd"
+"ansi.7"       = "#e5e5e5"
+"ansi.8"       = "#666666"
+"ansi.9"       = "#f14c4c"
+"ansi.10"      = "#23d18b"
+"ansi.11"      = "#f5f543"
+"ansi.12"      = "#3b8eea"
+"ansi.13"      = "#d670d6"
+"ansi.14"      = "#29b8db"
+"ansi.15"      = "#ffffff"
 
 # Exact colours for Surface C's real Completions popup item rows - read directly from
 # design_handoff_jerry_ade/revision/Jerry.dc.html's own completions/KBG/KFG data (the sel ? ...
@@ -451,3 +477,10 @@ local_border = "#1d2024"  # Defaults to border::DIVIDER's own value.
 "css.bg"     = "#271a23"  # "css"
 "unknown.fg" = "#4d5258"
 "unknown.bg" = "#1e2125"
+
+# The status bar's three type tiers (design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md
+# §3).
+[status_bar]
+primary   = "#757a81"  # Tier 1
+recessive = "#383c43"  # Tier 3
+divider   = "#23282e"  # The 1px, 13-high rules between tiers.

--- a/crates/app/src/root/scrollbar.rs
+++ b/crates/app/src/root/scrollbar.rs
@@ -105,9 +105,32 @@ use super::*;
 use crate::root::scrollbar_geometry as geometry;
 
 /// The scrollbar's own thickness (track + thumb width/height) - the hit target as well as the
-/// visual width, kept slim to match this UI's generally compact chrome (`theme::band::TREE_ROW`
-/// is 22px; a 12px `list_example.rs`-style scrollbar would visually dominate a row that short).
-const SCROLLBAR_SIZE: f32 = 8.0;
+/// visual width.
+///
+/// This used to be a local `8.0` chosen to match this UI's compact chrome, because the mockup had
+/// no scrollbar spec at all. Rev 6 supplies one (`design_handoff_jerry_ade/revision 5/
+/// STAGE-A-CHANGELOG.md` §4p, whose own note is that "for the Rust build this is a spec, not
+/// CSS"), so the number now tracks [`theme::scrollbar::WIDTH`] along with the rest of §4p's table:
+/// [`theme::scrollbar::THUMB_RADIUS`], [`theme::scrollbar::THUMB_INSET`], and a *transparent*
+/// track. The thumb is inset on each side, so what is actually painted is `10 - 2*2 = 6px` wide,
+/// visually slimmer than the old flush 8px bar, on a larger hit target.
+///
+/// This is a plain `f32` rather than the [`gpui::Pixels`] token itself only because
+/// [`CONTENT_CLEARANCE`] below has to be a `const` and `Pixels`' inner field is crate-private to
+/// GPUI, so it cannot be unwrapped in a const context.
+/// `scrollbar_spec_tests::the_local_size_constants_match_the_design_tokens` asserts the two are
+/// the same number, so they cannot drift.
+const SCROLLBAR_SIZE: f32 = 10.0;
+
+/// How far clear of the track's edges the painted thumb floats - STAGE-A-CHANGELOG.md §4p's "2px
+/// transparent border". A plain `f32` mirror of [`theme::scrollbar::THUMB_INSET`], for the same
+/// const-context reason [`SCROLLBAR_SIZE`] is, and pinned to it by the same test.
+const THUMB_INSET: f32 = 2.0;
+
+/// The inset only means anything if it leaves a thumb to paint. Both operands are `const`, so this
+/// is a genuine compile-time guard rather than a test - retuning §4p's numbers into a combination
+/// that paints nothing fails to build, in every profile, not just under `cargo test`.
+const _: () = assert!(SCROLLBAR_SIZE - 2.0 * THUMB_INSET > 0.0);
 
 /// How much real right-side clearance row/header content next to this scrollbar needs, in
 /// addition to `SCROLLBAR_SIZE` itself - GitHub issue #123 ("Add padding to the file tree right
@@ -250,13 +273,23 @@ impl AdeApp {
                     div()
                         .id(format!("{id}-thumb"))
                         .absolute()
-                        .top(px(thumb_top))
-                        .right_0()
-                        .w(px(SCROLLBAR_SIZE))
-                        .h(px(thumb_len))
-                        .rounded(px(SCROLLBAR_SIZE / 2.0))
-                        .bg(theme::scrollbar::THUMB.resolve().opacity(0.55))
-                        .hover(|el| el.bg(theme::scrollbar::THUMB_HOVER.resolve().opacity(0.75)))
+                        .top(px(thumb_top + THUMB_INSET))
+                        // STAGE-A-CHANGELOG.md §4p: the thumb carries "a 2px transparent border
+                        // and `background-clip:content-box` so it floats 2px clear of the edge".
+                        // Drawn directly rather than in CSS, that transparent border is simply an
+                        // inset on every edge - so the thumb is `WIDTH - 2 * INSET` wide and sits
+                        // `INSET` in from the track's own edges. The track keeps its full
+                        // `SCROLLBAR_SIZE` width and its own click-to-jump handler, so the region
+                        // the pointer can act on is unchanged; only the painted bar is slimmer.
+                        .right(theme::scrollbar::THUMB_INSET)
+                        .w(px(SCROLLBAR_SIZE - 2.0 * THUMB_INSET))
+                        .h(px(thumb_len - 2.0 * THUMB_INSET))
+                        .rounded(theme::scrollbar::THUMB_RADIUS)
+                        // Painted at full strength: §4p's `#2b3137` is already quieter than the
+                        // greys these values replaced, so the old opacity multiplier would land
+                        // somewhere the spec did not ask for.
+                        .bg(theme::scrollbar::THUMB)
+                        .hover(|el| el.bg(theme::scrollbar::THUMB_HOVER))
                         .on_mouse_down(
                             MouseButton::Left,
                             cx.listener(|_this, _event: &MouseDownEvent, _window, cx| {
@@ -294,5 +327,33 @@ impl AdeApp {
                 )
                 .into_any_element(),
         )
+    }
+}
+
+/// Pins this module's plain-`f32` geometry constants to the design tokens they mirror.
+///
+/// [`SCROLLBAR_SIZE`] and [`THUMB_INSET`] exist as bare `f32`s only because [`CONTENT_CLEARANCE`]
+/// must be a `const` and `gpui::Pixels`' inner field is crate-private to GPUI, so the token cannot
+/// be unwrapped in a const context. That is a real duplication, and the point of these assertions
+/// is that it can never become a real *divergence*: `theme::scrollbar` stays the single authority
+/// for STAGE-A-CHANGELOG.md §4p's numbers, and editing it there without editing it here fails.
+#[cfg(test)]
+mod scrollbar_spec_tests {
+    use super::*;
+
+    #[test]
+    fn the_local_size_constants_match_the_design_tokens() {
+        assert_eq!(
+            px(SCROLLBAR_SIZE),
+            theme::scrollbar::WIDTH,
+            "SCROLLBAR_SIZE has drifted from theme::scrollbar::WIDTH - §4p's scrollbar width is \
+             defined once, in the theme layer"
+        );
+        assert_eq!(
+            px(THUMB_INSET),
+            theme::scrollbar::THUMB_INSET,
+            "THUMB_INSET has drifted from theme::scrollbar::THUMB_INSET - §4p's 2px content-box \
+             float is defined once, in the theme layer"
+        );
     }
 }

--- a/crates/app/src/settings/theme_file_format.rs
+++ b/crates/app/src/settings/theme_file_format.rs
@@ -49,7 +49,9 @@ const SECTIONS: &[(&str, &[&str])] = &[
     ("Text", &["text"]),
     (
         "Meaning and state (colour carries information here)",
-        &["status", "diff", "tag", "rail", "agent"],
+        &[
+            "status", "diff", "tag", "rail", "agent", "changes", "budget",
+        ],
     ),
     (
         "The code surface",
@@ -58,7 +60,14 @@ const SECTIONS: &[(&str, &[&str])] = &[
     (
         "Chrome and widgets",
         &[
-            "button", "toggle", "settings", "palette", "graph", "env", "lang",
+            "button",
+            "toggle",
+            "settings",
+            "palette",
+            "graph",
+            "env",
+            "lang",
+            "status_bar",
         ],
     ),
 ];
@@ -503,10 +512,20 @@ mod tests {
         assert!(is_uninformative("fg"));
         assert!(!is_uninformative("window body"));
         assert!(!is_uninformative("needs input"));
-        assert_eq!(
-            key_note("agent.sonnet.fg"),
-            None,
-            "`(fg, bg)` tells a theme author nothing the key doesn't already say"
+        // `agent::SONNET` still carries the trailing `// (fg, bg)` this filter exists to reject.
+        // It used to be that token's only comment, so the key came out bare; rev 6 gave the agent
+        // tints real doc comments, so the note now falls through to the doc instead. Both halves
+        // matter: the useless trailing comment must not win, and the useful doc must.
+        let note =
+            key_note("agent.sonnet.fg").expect("agent::SONNET's doc comment is the fallback");
+        assert!(
+            !is_uninformative(note),
+            "`(fg, bg)` tells a theme author nothing the key doesn't already say, but it won \
+             anyway - the filter is no longer being applied to trailing comments"
+        );
+        assert!(
+            note.contains("Copper"),
+            "expected agent::SONNET's own doc comment to supply the note, got {note:?}"
         );
     }
 

--- a/crates/app/src/terminal/pane.rs
+++ b/crates/app/src/terminal/pane.rs
@@ -2307,7 +2307,7 @@ impl Render for TerminalPane {
             let message = format!("failed to start process: {error}");
             pane = pane.child(render_plain_line_with_links(
                 &message,
-                rgb(0xff6b6b),
+                theme::terminal::SPAWN_ERROR.resolve(),
                 &cwd,
                 cx,
             ));
@@ -2318,7 +2318,11 @@ impl Render for TerminalPane {
         }
 
         if self.grid.ended {
-            pane = pane.child(div().text_color(rgb(0xffcc66)).child("[process exited]"));
+            pane = pane.child(
+                div()
+                    .text_color(theme::terminal::PROCESS_EXITED)
+                    .child("[process exited]"),
+            );
         }
 
         pane

--- a/crates/app/src/theme.rs
+++ b/crates/app/src/theme.rs
@@ -283,6 +283,9 @@ pub const TOKEN_GROUPS: &[(&str, &[(&str, ColorToken)])] = &[
     ("scrollbar", scrollbar::TOKENS),
     ("graph", graph::TOKENS),
     ("palette", palette::TOKENS),
+    ("changes", changes::TOKENS),
+    ("budget", budget::TOKENS),
+    ("status_bar", status_bar::TOKENS),
 ];
 
 /// Every real registered [`ColorToken`], flattened across [`TOKEN_GROUPS`] - registry order
@@ -1887,6 +1890,18 @@ pub mod terminal {
     /// so the two can't drift into looking like unrelated features.
     pub const SELECTION: ColorToken = token("terminal.selection", 0x273a4d);
 
+    /// `failed to start process: ...`, the line the pane paints when a spawn never happened.
+    ///
+    /// This and [`PROCESS_EXITED`] are here because until rev 6 they were the app's only two
+    /// genuinely hard-coded colours - `rgb(0xff6b6b)` and `rgb(0xffcc66)`, inline in
+    /// `crate::terminal::pane`'s render, unthemeable and invisible to every theme file. Now that
+    /// `super::stray_hex_tests` makes an inline colour a build failure they had to become real
+    /// tokens, and their defaults are the exact values they were already painting, so no theme
+    /// and no pixel changes - only the ability to retint them at all.
+    pub const SPAWN_ERROR: ColorToken = token("terminal.spawn_error", 0xff6b6b);
+    /// The `[process exited]` label, once the child is gone.
+    pub const PROCESS_EXITED: ColorToken = token("terminal.process_exited", 0xffcc66);
+
     /// The standard ANSI 16-colour palette, indexed `0..=15` by `NamedColor`'s own discriminants
     /// and by `Color::Indexed(0..=15)`, in the conventional order: black, red, green, yellow, blue,
     /// magenta, cyan, white, then the eight bright variants in the same order.
@@ -1948,6 +1963,8 @@ pub mod terminal {
         ("FOREGROUND", FOREGROUND),
         ("CURSOR", CURSOR),
         ("SELECTION", SELECTION),
+        ("SPAWN_ERROR", SPAWN_ERROR),
+        ("PROCESS_EXITED", PROCESS_EXITED),
         ("ANSI.0", ANSI[0]),
         ("ANSI.1", ANSI[1]),
         ("ANSI.2", ANSI[2]),
@@ -1994,27 +2011,98 @@ pub mod env {
     ];
 }
 
-/// One tint per agent. Used on the rail badge, the CLI tab chip and the
-/// conflict side headers, so a colour always means the same agent.
+/// One tint per agent - the **agent tint pool**. Used on the rail badge, the CLI tab chip, the
+/// Changes panel's per-run left edge and the conflict side headers, so a colour always means the
+/// same agent.
+///
+/// # The reserved-hue allocation rule
+///
+/// Quoted verbatim from the rev-6 design bundle, `design_handoff_jerry_ade/revision 5/
+/// STAGE-A-CHANGELOG.md` §4a ("Colour allocation rule", added after review):
+///
+/// > **Five hue families are structural and reserved. Agent identity is allocated only outside
+/// > them.**
+/// >
+/// > | Family | Reserved for |
+/// > |---|---|
+/// > | amber `#e2a336` / `#d8a94a` | attention - needs input, warnings, planned pauses |
+/// > | violet `#c98fbf` | branch and graph scope (the graph pane, rebase, `Against main`) |
+/// > | green `#5cb87f` / `#7fc79a` | additions and staged state |
+/// > | red `#e0625c` / `#d1706a` | failure and deletions |
+/// > | blue `#3f5b74` / `#5a9ad4` | selection and focus |
+/// >
+/// > Adding an agent to `sessions` / `agentDefs` means picking a tint outside all five. The
+/// > current pool: copper `#cf8a5c`, teal `#4fb3a5`, periwinkle `#9d8fd4`, steel blue `#7f9ad4`.
+///
+/// **This is not a style note, it is a correctness rule**, and it is enforced by a real test
+/// ([`agent_tint_allocation_tests`]) rather than left to review. Review caught the failure it
+/// exists to prevent: `haiku-4.5`'s tint *was* `#c98fbf`, byte-identical to the violet §3.2
+/// assigns to branch scope, so inside one panel that colour meant both "haiku-4.5" and "branch" -
+/// and the two met on the same property (a 2px left edge) on the very worktree built to
+/// demonstrate per-agent attribution. Violet lines in the gutter read as "branch", not "haiku".
+///
+/// # Adding an agent
+///
+/// Pick a tint whose hue sits outside all five families, add it here as a `(fg, bg)` pair, list it
+/// in [`TOKENS`] **and** in [`TINT_POOL`], and map the agent to it in
+/// `crate::work_surface::agent_tint`. [`agent_tint_allocation_tests`] walks [`TINT_POOL`], so a
+/// tint that reintroduces the collision fails the build rather than shipping.
+///
+/// The reallocation §4a's own table specifies, applied here in full:
+///
+/// | Agent | Was | Now | Why |
+/// |---|---|---|---|
+/// | `sonnet-4.5` | `#d8a94a` / `#33280f` | copper `#cf8a5c` / `#31210f` | amber was one step from the needs-input amber it sits beside in the rail |
+/// | `haiku-4.5` | `#c98fbf` / `#332030` | periwinkle `#9d8fd4` / `#241f33` | the reported collision with branch violet |
+/// | `gpt-5-codex` | `#6ab97f` / `#1e3327` | teal `#4fb3a5` / `#12302c` | green is the additions colour and would have collided in the same gutter |
+/// | `qwen-local` | `#7f9ad4` / `#1f2941` | steel blue, unchanged | already outside all five families |
+///
+/// The token **keys** deliberately stay per-agent (`agent.sonnet.fg`, ...) rather than becoming
+/// hue names: a theme author retints "the agent that is Sonnet", and an existing hand-written
+/// theme file keeps naming the same keys. The hue names above are what the pool member *is*, and
+/// are carried as real labels in [`TINT_POOL`] so the rule's own table can be checked against it.
 pub mod agent {
     use super::{token, ColorToken};
 
+    /// Copper - `sonnet-4.5`. Was amber `#d8a94a`, one step from the needs-input amber it sits
+    /// beside in the rail (see the module docs' reallocation table).
     pub const SONNET: (ColorToken, ColorToken) = (
-        token("agent.sonnet.fg", 0xd8a94a),
-        token("agent.sonnet.bg", 0x33280f),
+        token("agent.sonnet.fg", 0xcf8a5c),
+        token("agent.sonnet.bg", 0x31210f),
     ); // (fg, bg)
+    /// Teal - `gpt-5-codex`. Was green `#6ab97f`, which is the additions colour; this also unifies
+    /// the two different greens the same agent used in `sessions` vs `histDefs`.
     pub const CODEX: (ColorToken, ColorToken) = (
-        token("agent.codex.fg", 0x6ab97f),
-        token("agent.codex.bg", 0x1e3327),
+        token("agent.codex.fg", 0x4fb3a5),
+        token("agent.codex.bg", 0x12302c),
     );
+    /// Periwinkle - `haiku-4.5`. Was `#c98fbf`, the exact branch-scope violet: the collision
+    /// review caught and the reason the allocation rule exists at all.
     pub const HAIKU: (ColorToken, ColorToken) = (
-        token("agent.haiku.fg", 0xc98fbf),
-        token("agent.haiku.bg", 0x332030),
+        token("agent.haiku.fg", 0x9d8fd4),
+        token("agent.haiku.bg", 0x241f33),
     );
+    /// Steel blue - `qwen-local`. Unchanged by §4a: already outside all five families.
     pub const LOCAL: (ColorToken, ColorToken) = (
         token("agent.local.fg", 0x7f9ad4),
         token("agent.local.bg", 0x1f2941),
     );
+
+    /// The real, enumerable agent tint pool - `(hue name, (fg, bg))` - and the list
+    /// [`super::agent_tint_allocation_tests`] walks to enforce the module docs' reserved-hue rule.
+    ///
+    /// Every tint an agent can wear must appear here. This is deliberately a separate listing
+    /// rather than a `[ColorToken; N]`: the registry's own source parser reads
+    /// `[ColorToken; N]` declarations as N *new* keys to register (see [`super::TOKEN_GROUPS`]),
+    /// so a pool built out of the already-registered tokens above has to wear a shape the parser
+    /// does not treat as a declaration. It carries no colours of its own - only references to the
+    /// four pairs above - so it cannot drift from what a theme actually resolves.
+    pub const TINT_POOL: &[(&str, (ColorToken, ColorToken))] = &[
+        ("copper", SONNET),
+        ("teal", CODEX),
+        ("periwinkle", HAIKU),
+        ("steel blue", LOCAL),
+    ];
 
     /// Every real [`ColorToken`] this module declares, paired with its own Rust `const` name -
     /// the module's slice of [`super::TOKEN_GROUPS`]'s whole-app registry. See that constant's
@@ -2340,25 +2428,249 @@ pub mod settings {
     ];
 }
 
-/// The overlay scrollbar's own colours (GitHub issue #30) - not from `design_handoff_jerry_ade`
-/// (that mockup has no scrollbar spec at all: every scrollable region there relies on raw,
-/// invisible browser/OS scrolling), so these are a deliberate, judgment-call derivation from
-/// existing neutral tokens rather than a transcription. `THUMB` defaults to [`text::GUTTER`]'s
-/// value (the line-number gutter's own muted grey - already the UI's "quiet structural chrome"
-/// colour) and `THUMB_HOVER` to [`status::IDLE`]'s (an agent's resting-state grey, one step
-/// brighter) so the two states read as "the same neutral family, one step apart" rather than
-/// inventing a third hex pair. Both are painted at reduced opacity (see `crate::root::scrollbar`) rather than full
-/// strength, matching the "overlay, not a solid rail" requirement.
+/// The overlay scrollbar (GitHub issue #30).
+///
+/// Rev 5 of the mockup had no scrollbar spec at all - every scrollable region there relied on raw
+/// browser/OS scrolling - so these values used to be a judgment-call derivation from neighbouring
+/// neutral tokens. **Rev 6 supersedes that with a real spec**, `design_handoff_jerry_ade/
+/// revision 5/STAGE-A-CHANGELOG.md` §4p, whose own note is explicit that it governs this build:
+///
+/// > | Part | Value |
+/// > |---|---|
+/// > | width / height | 10px |
+/// > | track | transparent |
+/// > | thumb | `#2b3137`, radius 5, with a 2px transparent border and `background-clip:content-box` so it floats 2px clear of the edge |
+/// > | thumb hover | `#3d444b` |
+/// > | stepper buttons, corner | removed |
+/// >
+/// > **For the Rust build this is a spec, not CSS** - GPUI draws its own scrollbars, so the
+/// > numbers above are what to draw.
+///
+/// So the numbers are transcribed here rather than derived, and `crate::root::scrollbar` draws
+/// them directly. Two consequences worth stating, because both replace an older convention:
+///
+/// - **The track has no token, deliberately.** "Transparent" is not a colour a theme should be
+///   able to fill in - a scroll affordance that paints a rail is the loud platform default §4p
+///   removed. The track is simply not painted, the same honesty
+///   [`ColorToken::literal`]'s docs describe for `crate::work_surface::TRANSPARENT`.
+/// - **The thumb is painted at full strength**, not at the reduced opacity the derived values
+///   needed. `#2b3137` is already quieter than the greys it replaced; compositing it further would
+///   land somewhere the spec did not ask for.
 pub mod scrollbar {
-    use super::{token, ColorToken};
+    use super::{px, token, ColorToken, Pixels};
 
-    pub const THUMB: ColorToken = token("scrollbar.thumb", 0x3a3f44);
-    pub const THUMB_HOVER: ColorToken = token("scrollbar.thumb_hover", 0x565d64);
+    pub const THUMB: ColorToken = token("scrollbar.thumb", 0x2b3137);
+    pub const THUMB_HOVER: ColorToken = token("scrollbar.thumb_hover", 0x3d444b);
+
+    /// The track's full width (a vertical bar) or height (a horizontal one) - §4p's `width /
+    /// height`. The thumb is [`THUMB_INSET`] narrower on each side, so what is actually painted is
+    /// `WIDTH - 2 * THUMB_INSET` wide.
+    pub const WIDTH: Pixels = px(10.0);
+    /// The thumb's corner radius - §4p's `radius 5`.
+    pub const THUMB_RADIUS: Pixels = px(5.0);
+    /// How far clear of the track's edges the thumb floats - §4p's "2px transparent border and
+    /// `background-clip:content-box`". In CSS that is a transparent border; drawn directly, it is
+    /// an inset.
+    pub const THUMB_INSET: Pixels = px(2.0);
 
     /// Every real [`ColorToken`] this module declares, paired with its own Rust `const` name -
     /// the module's slice of [`super::TOKEN_GROUPS`]'s whole-app registry. See that constant's
     /// own docs for what walks this and why every token has to appear here.
     pub const TOKENS: &[(&str, ColorToken)] = &[("THUMB", THUMB), ("THUMB_HOVER", THUMB_HOVER)];
+}
+
+/// Per-provider rate-limit budget - the meter on an agent tab and in the budget popover
+/// (`design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md` §2).
+///
+/// Rev 6 moved budget from a single global footer readout to **one meter per agent**, because a
+/// budget is per-provider and a provider belongs to an agent. The meter fills to the tighter of
+/// the two windows (`5h` / `7d`), and its fill hue is the one place in the readout where colour
+/// carries meaning:
+///
+/// > Hue `#7fc79a` above 40%, `#c99b4e` 15-40%, `#c4726d` below.
+///
+/// The three hues are thresholds on *remaining* budget, not on consumption - [`OK`] is the
+/// healthy end. They sit inside the reserved green/amber/red families on purpose: this is
+/// attention and failure signalling, exactly what those families are reserved *for*
+/// ([`agent`]'s own docs), and deliberately not agent identity.
+///
+/// §2's other rule is a negative one worth carrying next to these: **no aggregate `⚠ N` anywhere**.
+/// A provider you do not use failing to poll is telemetry about telemetry. A connected provider
+/// that goes stale shows `last read <age>` in [`STALE`] in place of its own numbers, so the signal
+/// attaches to the thing that is actually broken.
+pub mod budget {
+    use super::{token, ColorToken};
+
+    /// Above 40% remaining.
+    pub const OK: ColorToken = token("budget.ok", 0x7fc79a);
+    /// 15-40% remaining.
+    pub const WARN: ColorToken = token("budget.warn", 0xc99b4e);
+    /// Below 15% remaining.
+    pub const CRITICAL: ColorToken = token("budget.critical", 0xc4726d);
+    /// The unfilled remainder of the meter - the same neutral the diffstat bar's own empty segment
+    /// uses ([`diff::STAT_EMPTY`]'s value), given its own key so a theme can move the meter's
+    /// track without moving the diffstat's.
+    pub const TRACK: ColorToken = token("budget.track", 0x22262a);
+    /// A provider that is connected but whose last poll is stale (`last read 3m ago`), and the
+    /// `not connected` row.
+    ///
+    /// **A derivation, not a transcription** - §2 specifies this state's *behaviour* (it replaces
+    /// that provider's own numbers) but names no colour for it, so this takes [`text::FAINT`]'s
+    /// value: recessive, because §2 is explicit that a provider failing to poll must not read as
+    /// an alert when nothing about it is actionable from the bar. The three hues above are the
+    /// real transcribed ones.
+    pub const STALE: ColorToken = token("budget.stale", 0x6b7178);
+
+    /// Every real [`ColorToken`] this module declares, paired with its own Rust `const` name -
+    /// the module's slice of [`super::TOKEN_GROUPS`]'s whole-app registry. See that constant's
+    /// own docs for what walks this and why every token has to appear here.
+    pub const TOKENS: &[(&str, ColorToken)] = &[
+        ("OK", OK),
+        ("WARN", WARN),
+        ("CRITICAL", CRITICAL),
+        ("TRACK", TRACK),
+        ("STALE", STALE),
+    ];
+}
+
+/// The Changes panel - four stacked, collapsible sections in one scroller
+/// (`design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md` §1), plus the file row's own
+/// seen/unseen and discard states (`STAGE-A-CHANGELOG.md` §4i).
+///
+/// # The four sections and their left edges
+///
+/// §1's table, for the column this module owns:
+///
+/// | | **Runs** | **Uncommitted** | **Commits** | **Against main** |
+/// |---|---|---|---|---|
+/// | Answers | what *this agent* did in *this run* | what is dirty in the checkout | what is written down | what would land |
+/// | Left edge | agent tint | `#3f5b74` | neutral | `#c98fbf` |
+///
+/// The **Runs** edge has no token here on purpose: it is the agent's own tint, resolved per row
+/// from [`agent`]'s pool, which is the entire point of per-agent attribution. The other three are
+/// [`EDGE_UNCOMMITTED`], [`EDGE_NEUTRAL`] and [`EDGE_AGAINST_MAIN`].
+///
+/// `EDGE_AGAINST_MAIN` is the branch-scope violet, and this is one of its **structural**
+/// positions - see [`agent`]'s reserved-hue rule. Against-main is branch scope (what would land on
+/// `main`), so it wears the same violet the graph pane and rebase do. That is the rule working as
+/// intended, not a violation of it: the rule forbids that violet as *agent identity*, and requires
+/// it here.
+///
+/// # Seen and unseen
+///
+/// §4i moved "seen" off a separate mark and onto the filename itself, after two rounds:
+///
+/// | State | Filename |
+/// |---|---|
+/// | not seen | `#dde2e7` / 500 - reads forward |
+/// | seen | `#767d84` / 450 - recedes |
+///
+/// > when a row already contains the thing a state is *about*, style that thing. A separate
+/// > indicator is a second element to place, decode and keep from colliding with its neighbours.
+///
+/// The state these encode is **"seen since the agent last changed it"**, not "opened once": a file
+/// you read and the agent then edits again reverts to unseen. Note also that the checkbox owns
+/// *staged* and the name owns *seen* - one fact per channel. Do not reintroduce a colour for
+/// staged on the filename.
+pub mod changes {
+    use super::{token, ColorToken};
+
+    /// `UNCOMMITTED`'s 2px left edge - what is dirty in the checkout. Shares its value with
+    /// [`border::SELECTED_EDGE`] (this palette's "structural blue") but carries its own key.
+    pub const EDGE_UNCOMMITTED: ColorToken = token("changes.edge_uncommitted", 0x3f5b74);
+    /// `COMMITS`' 2px left edge.
+    ///
+    /// **A derivation, not a transcription** - §1's table says only "neutral" here, naming no
+    /// colour, so this takes [`border::DIVIDER`]'s value: what is already written down carries no
+    /// scope, so its edge is the same grey every other plain 1px rule in the app uses.
+    pub const EDGE_NEUTRAL: ColorToken = token("changes.edge_neutral", 0x22262a);
+    /// `AGAINST MAIN`'s 2px left edge - the branch-scope violet, in one of its reserved structural
+    /// positions (see this module's own docs).
+    pub const EDGE_AGAINST_MAIN: ColorToken = token("changes.edge_against_main", 0xc98fbf);
+
+    /// Section header label - 9.5px/600 uppercase, `.08em` tracking.
+    pub const SECTION_LABEL: ColorToken = token("changes.section_label", 0x787f86);
+    /// Section header count - 9.5px mono, immediately after the label.
+    pub const SECTION_COUNT: ColorToken = token("changes.section_count", 0x4a5057);
+    /// The section header's own disclosure caret (`▾`/`▸`).
+    pub const SECTION_CARET: ColorToken = token("changes.section_caret", 0x5e646a);
+    /// The right-aligned per-section diffstat's `+N`, 10px mono.
+    pub const SECTION_STAT_ADD: ColorToken = token("changes.section_stat_add", 0x7fc79a);
+    /// The right-aligned per-section diffstat's `−N`, 10px mono.
+    pub const SECTION_STAT_DEL: ColorToken = token("changes.section_stat_del", 0xc4726d);
+
+    /// A filename not seen since the agent last changed it - reads forward (§4i).
+    pub const FILENAME_UNSEEN: ColorToken = token("changes.filename_unseen", 0xdde2e7);
+    /// A filename seen since the agent last changed it - recedes (§4i).
+    pub const FILENAME_SEEN: ColorToken = token("changes.filename_seen", 0x767d84);
+
+    /// The armed `Discard?` pill's fill. Discard is the one irreversible action in the panel - it
+    /// destroys an agent's work with no git object behind it - so §4i gives it two clicks: the
+    /// first swaps the hover icon for this pill, the second commits, and leaving the row cancels.
+    pub const DISCARD_BG: ColorToken = token("changes.discard_bg", 0x2a1719);
+    /// The armed `Discard?` pill's 1px border.
+    pub const DISCARD_BORDER: ColorToken = token("changes.discard_border", 0x4a2422);
+    /// The armed `Discard?` pill's label.
+    pub const DISCARD_FG: ColorToken = token("changes.discard_fg", 0xe0847e);
+
+    /// Every real [`ColorToken`] this module declares, paired with its own Rust `const` name -
+    /// the module's slice of [`super::TOKEN_GROUPS`]'s whole-app registry. See that constant's
+    /// own docs for what walks this and why every token has to appear here.
+    pub const TOKENS: &[(&str, ColorToken)] = &[
+        ("EDGE_UNCOMMITTED", EDGE_UNCOMMITTED),
+        ("EDGE_NEUTRAL", EDGE_NEUTRAL),
+        ("EDGE_AGAINST_MAIN", EDGE_AGAINST_MAIN),
+        ("SECTION_LABEL", SECTION_LABEL),
+        ("SECTION_COUNT", SECTION_COUNT),
+        ("SECTION_CARET", SECTION_CARET),
+        ("SECTION_STAT_ADD", SECTION_STAT_ADD),
+        ("SECTION_STAT_DEL", SECTION_STAT_DEL),
+        ("FILENAME_UNSEEN", FILENAME_UNSEEN),
+        ("FILENAME_SEEN", FILENAME_SEEN),
+        ("DISCARD_BG", DISCARD_BG),
+        ("DISCARD_BORDER", DISCARD_BORDER),
+        ("DISCARD_FG", DISCARD_FG),
+    ];
+}
+
+/// The status bar's three type tiers
+/// (`design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md` §3).
+///
+/// > Three tiers instead of one flat 10px smear - the problem was never density, it was that five
+/// > readouts at `#4a5057` all read at once, so you had to read all of it to find any of it.
+///
+/// | Tier | Content | Type |
+/// |---|---|---|
+/// | Primary | `main ↑2 ↓0`, `4 agents running` | 10.5px/450 `#a9b0b7` |
+/// | Secondary | provider budgets | 10.5px mono, hue per state |
+/// | Recessive | `41% cpu · 3.4 GB` | 10px `#4a5057` |
+///
+/// **The secondary tier has no colour token of its own, and that is the spec, not a gap**: its
+/// hue *is* the budget state, so it resolves to [`budget::OK`] / [`budget::WARN`] /
+/// [`budget::CRITICAL`] (or [`budget::STALE`]) per provider. Giving it a fourth flat grey here
+/// would recreate exactly the "five readouts that all read at once" §3 removed. A tier is a
+/// weight, and only two of the three are a fixed colour.
+///
+/// §3 also fixes what must *not* go here: no worktree or agent counts, because the rail footer
+/// already carries them 30px away.
+pub mod status_bar {
+    use super::{token, ColorToken};
+
+    /// Tier 1 - the readouts you are meant to find first (`main ↑2 ↓0`, `4 agents running`).
+    pub const PRIMARY: ColorToken = token("status_bar.primary", 0xa9b0b7);
+    /// Tier 3 - resource readouts, present but never competing (`41% cpu · 3.4 GB`).
+    pub const RECESSIVE: ColorToken = token("status_bar.recessive", 0x4a5057);
+    /// The 1px, 13-high rules between tiers.
+    pub const DIVIDER: ColorToken = token("status_bar.divider", 0x2b3137);
+
+    /// Every real [`ColorToken`] this module declares, paired with its own Rust `const` name -
+    /// the module's slice of [`super::TOKEN_GROUPS`]'s whole-app registry. See that constant's
+    /// own docs for what walks this and why every token has to appear here.
+    pub const TOKENS: &[(&str, ColorToken)] = &[
+        ("PRIMARY", PRIMARY),
+        ("RECESSIVE", RECESSIVE),
+        ("DIVIDER", DIVIDER),
+    ];
 }
 
 /// The git graph tab (design handoff `design_handoff_jerry_ade/revision 2/CHANGELOG.md`,
@@ -2967,6 +3279,313 @@ mod token_registry_tests {
     }
 }
 
+/// Enforces the reserved-hue allocation rule from `design_handoff_jerry_ade/revision 5/
+/// STAGE-A-CHANGELOG.md` §4a - quoted in full in [`agent`]'s own docs, which is the rule these
+/// tests exist to make unbreakable.
+///
+/// # Why this is a test and not a review note
+///
+/// The rule was *written* because review caught a shipped collision: `haiku-4.5`'s tint was
+/// `#c98fbf`, byte-identical to the branch-scope violet, so one colour meant two things on the
+/// same property in the same panel. A convention in a changelog would not have caught it and did
+/// not - a second agent added months later, by someone who never read §4a, reintroduces it just as
+/// easily. So the rule is checked against **real perceptual colour maths** over the real,
+/// enumerable [`agent::TINT_POOL`], and adding a colliding tint fails the build.
+///
+/// # Why OKLCH hue, and not "is this hex in a list"
+///
+/// A hardcoded list of forbidden hexes would pass vacuously for any collision that is not
+/// byte-identical - `#c88fbe` would sail through while looking exactly like branch violet. Hue is
+/// the property the rule is actually about ("five hue *families*"), so hue is what gets measured,
+/// in the same OKLCH space this module already authors palettes in (see the [`oklch`] module for
+/// why not HSL) and through the same [`hue_distance`] the rest of the file uses.
+#[cfg(test)]
+mod agent_tint_allocation_tests {
+    use super::*;
+
+    /// The five structural hue families, exactly as §4a's table names them - family label and
+    /// every hex the table lists for it.
+    ///
+    /// These are deliberately spelled as literal hexes rather than read out of the token registry.
+    /// The rule is about the *design's* five families; wiring it to whatever `status::ASK`
+    /// currently happens to be would mean a theme or a retune silently moving the boundary the
+    /// rule is supposed to hold still. If one of these ever genuinely changes, §4a changed, and
+    /// editing this table should be a deliberate act with the changelog open.
+    const RESERVED_FAMILIES: &[(&str, &[u32])] = &[
+        (
+            "amber (attention, warnings, planned pauses)",
+            &[0xe2a336, 0xd8a94a],
+        ),
+        ("violet (branch and graph scope)", &[0xc98fbf]),
+        ("green (additions and staged state)", &[0x5cb87f, 0x7fc79a]),
+        ("red (failure and deletions)", &[0xe0625c, 0xd1706a]),
+        ("blue (selection and focus)", &[0x3f5b74, 0x5a9ad4]),
+    ];
+
+    /// How far, in degrees of OKLCH hue, an agent tint has to sit from every reserved family
+    /// before it reads as its own colour rather than as a shade of that family's meaning.
+    ///
+    /// Not an arbitrary round number. The tightest real clearance in the pool §4a specifies is
+    /// steel blue at **17.4°** from the blue family - §4a's own judgment that `#7f9ad4` is
+    /// "already outside all five families" is what sets the floor, and 15° sits just under it.
+    /// The three tints §4a *reallocated* measure 0.0°, 0.0° and 3.4°, so the gap between "what the
+    /// design accepts" and "what the design rejected" is wide and this threshold is inside it -
+    /// which is the property [`the_rule_actually_rejects_the_collision_review_caught`] pins.
+    const MIN_SEPARATION_DEGREES: f32 = 15.0;
+
+    /// The smallest OKLCH hue distance from `color` to any hex in any reserved family, with the
+    /// family that was closest.
+    fn nearest_reserved_family(color: Rgba) -> (&'static str, f32) {
+        let (_, _, hue) = oklch_of(color);
+        RESERVED_FAMILIES
+            .iter()
+            .flat_map(|(family, hexes)| {
+                hexes.iter().map(move |hex| {
+                    let (_, _, reserved_hue) = oklch_of(hex_rgba(*hex));
+                    (*family, hue_distance(hue, reserved_hue))
+                })
+            })
+            .fold(("", f32::MAX), |nearest, candidate| {
+                if candidate.1 < nearest.1 {
+                    candidate
+                } else {
+                    nearest
+                }
+            })
+    }
+
+    /// The rule itself: no agent may wear a hue that belongs to a structural family.
+    #[test]
+    fn every_agent_tint_sits_outside_all_five_reserved_hue_families() {
+        for (name, (foreground, _)) in agent::TINT_POOL {
+            let (family, separation) = nearest_reserved_family(foreground.default);
+            assert!(
+                separation >= MIN_SEPARATION_DEGREES,
+                "agent tint `{name}` ({:?}) is only {separation:.1}° of OKLCH hue from the \
+                 reserved {family} family - under the {MIN_SEPARATION_DEGREES}° floor, so this \
+                 colour would read as that family's *meaning* rather than as an agent's identity. \
+                 This is the failure STAGE-A-CHANGELOG.md §4a exists to prevent (haiku-4.5's tint \
+                 was the branch violet exactly, and the two met on the same 2px left edge). Pick a \
+                 hue outside all five families - see `theme::agent`'s own docs for the table.",
+                foreground.key
+            );
+        }
+    }
+
+    /// **The discrimination check**: the rule is only worth having if it genuinely rejects the
+    /// colours the design rejected. Each of these three is a real tint that really shipped and
+    /// that §4a really reallocated, so if the maths above ever degrades into something that
+    /// accepts everything, this fails first and says so.
+    #[test]
+    fn the_rule_actually_rejects_the_collision_review_caught() {
+        // (what it was, which agent wore it, the family it collided with)
+        let reallocated = [
+            (0xc98fbf, "haiku-4.5", "violet"),
+            (0xd8a94a, "sonnet-4.5", "amber"),
+            (0x6ab97f, "gpt-5-codex", "green"),
+        ];
+        for (hex, agent_name, expected_family) in reallocated {
+            let (family, separation) = nearest_reserved_family(hex_rgba(hex));
+            assert!(
+                separation < MIN_SEPARATION_DEGREES,
+                "#{hex:06x} ({agent_name}'s tint before §4a) measures {separation:.1}° from the \
+                 nearest reserved family, which the {MIN_SEPARATION_DEGREES}° floor would ACCEPT - \
+                 but this is a collision the design review actually caught and reallocated. A rule \
+                 that admits it is not enforcing anything."
+            );
+            assert!(
+                family.starts_with(expected_family),
+                "#{hex:06x} ({agent_name}) collided with {expected_family} per §4a, but the \
+                 nearest family measured here is {family}"
+            );
+        }
+    }
+
+    /// Guards the pool listing itself. [`the rule`](every_agent_tint_sits_outside_all_five_reserved_hue_families)
+    /// walks [`agent::TINT_POOL`], so a tint that exists as a token but never made it into the
+    /// pool would be unchecked - exactly the silent gap that let the original collision through.
+    #[test]
+    fn every_registered_agent_tint_is_listed_in_the_pool() {
+        for (name, token) in agent::TOKENS {
+            let Some(stripped) = name.strip_suffix(".fg") else {
+                continue;
+            };
+            assert!(
+                agent::TINT_POOL
+                    .iter()
+                    .any(|(_, (foreground, _))| foreground.key == token.key),
+                "agent::{stripped} is a registered agent tint but is missing from \
+                 agent::TINT_POOL, so the reserved-hue rule never checks it - add it to the pool \
+                 (see `theme::agent`'s \"Adding an agent\" docs)"
+            );
+        }
+        assert_eq!(
+            agent::TINT_POOL.len(),
+            agent::TOKENS.len() / 2,
+            "every agent tint is a (fg, bg) pair, so the pool should list exactly half as many \
+             entries as the module registers keys"
+        );
+    }
+
+    /// A guard on the *maths*, not the palette: if `oklch_of`/`hue_distance` ever degenerated
+    /// (returning a constant, say), every assertion above would pass or fail for the wrong reason.
+    /// The five families are five genuinely different hues, so they must measure far apart from
+    /// each other - and each family's own members must measure close together, which is what makes
+    /// them a family at all.
+    #[test]
+    fn the_reserved_families_are_themselves_distinct_and_internally_coherent() {
+        for (family, hexes) in RESERVED_FAMILIES {
+            for hex in *hexes {
+                let (_, _, hue) = oklch_of(hex_rgba(*hex));
+                for other_hex in *hexes {
+                    let (_, _, other_hue) = oklch_of(hex_rgba(*other_hex));
+                    assert!(
+                        hue_distance(hue, other_hue) < MIN_SEPARATION_DEGREES,
+                        "{family}'s own members #{hex:06x} and #{other_hex:06x} are further apart \
+                         than the collision floor - they are not one hue family"
+                    );
+                }
+            }
+        }
+        for (family, hexes) in RESERVED_FAMILIES {
+            for (other_family, other_hexes) in RESERVED_FAMILIES {
+                if family == other_family {
+                    continue;
+                }
+                for hex in *hexes {
+                    let (_, _, hue) = oklch_of(hex_rgba(*hex));
+                    for other_hex in *other_hexes {
+                        let (_, _, other_hue) = oklch_of(hex_rgba(*other_hex));
+                        assert!(
+                            hue_distance(hue, other_hue) >= MIN_SEPARATION_DEGREES,
+                            "{family} and {other_family} measure as the same hue - the OKLCH \
+                             maths behind every assertion in this module is not discriminating"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Proves the claim the whole rev-6 campaign is built on: **this file is the only place a colour
+/// literal lives**.
+///
+/// Every rev-6 issue after the token one references tokens by name, so a hex value inlined at a
+/// render call site is not a style problem - it is a colour no theme file can reach, invisible to
+/// [`TOKEN_GROUPS`], absent from every generated theme, and silently wrong in five of the six
+/// bundled themes. That is precisely the failure mode that had already happened twice here before
+/// this test existed (`crate::terminal::pane`'s spawn-error and process-exited lines, now
+/// [`terminal::SPAWN_ERROR`] and [`terminal::PROCESS_EXITED`]).
+#[cfg(test)]
+mod stray_hex_tests {
+    /// The real theme layer - the only files allowed to name a colour literally.
+    ///
+    /// `theme.rs` declares the tokens. `settings/builtin_themes.rs` carries each bundled theme's
+    /// five preview swatches, which are that theme's own identity rather than any surface's
+    /// colour, and which it writes into the `preview` key of the file it generates. Nothing else
+    /// in the app has any business spelling a colour.
+    const THEME_LAYER: &[&str] = &["app/src/theme.rs", "app/src/settings/builtin_themes.rs"];
+
+    /// Every `.rs` file under `crates/`, as `(path relative to crates/, contents)`.
+    fn workspace_sources() -> Vec<(String, String)> {
+        fn walk(
+            directory: &std::path::Path,
+            root: &std::path::Path,
+            out: &mut Vec<(String, String)>,
+        ) {
+            let entries = std::fs::read_dir(directory)
+                .unwrap_or_else(|error| panic!("reading {}: {error}", directory.display()));
+            for entry in entries {
+                let path = entry.expect("a readable directory entry").path();
+                if path.is_dir() {
+                    walk(&path, root, out);
+                } else if path.extension().is_some_and(|extension| extension == "rs") {
+                    let relative = path
+                        .strip_prefix(root)
+                        .expect("every walked path starts at the root")
+                        .to_string_lossy()
+                        .replace('\\', "/");
+                    out.push((
+                        relative,
+                        std::fs::read_to_string(&path).expect("valid utf-8"),
+                    ));
+                }
+            }
+        }
+        // `CARGO_MANIFEST_DIR` is `<repo>/crates/app`, so its parent is the whole `crates/` tree -
+        // every workspace member, not just this one.
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("crates/app always has a parent")
+            .to_path_buf();
+        let mut sources = Vec::new();
+        walk(&root, &root, &mut sources);
+        sources.sort();
+        sources
+    }
+
+    /// Does this line contain a `0x` followed by exactly six hex digits - the shape a colour
+    /// wears, and the shape a bitmask or a codepoint essentially never does?
+    fn names_a_colour_literal(line: &str) -> bool {
+        let bytes = line.as_bytes();
+        line.match_indices("0x").any(|(index, _)| {
+            let digits = bytes[index + 2..]
+                .iter()
+                .take_while(|byte| byte.is_ascii_hexdigit())
+                .count();
+            // Exactly six, and not the leading six of a longer literal.
+            digits == 6
+        })
+    }
+
+    #[test]
+    fn no_production_code_outside_the_theme_layer_names_a_colour_literally() {
+        let mut violations = Vec::new();
+        let mut scanned = 0usize;
+        for (path, source) in workspace_sources() {
+            if THEME_LAYER.iter().any(|allowed| path.ends_with(allowed)) {
+                continue;
+            }
+            scanned += 1;
+            // Test code may name colours freely - an exact-hex assertion is how several suites in
+            // this file pin a token's real value. Only shipped code is under the rule. A
+            // `#[cfg(test)] mod ... { }` is written at column 0 throughout this workspace, so its
+            // closing brace is the one line that is exactly `}`.
+            let mut in_test_module = false;
+            for (number, line) in source.lines().enumerate() {
+                if line.starts_with("#[cfg(test)]") {
+                    in_test_module = true;
+                    continue;
+                }
+                if in_test_module {
+                    if line == "}" {
+                        in_test_module = false;
+                    }
+                    continue;
+                }
+                if names_a_colour_literal(line) {
+                    violations.push(format!("  {path}:{}: {}", number + 1, line.trim()));
+                }
+            }
+        }
+        assert!(
+            scanned > 50,
+            "only scanned {scanned} source files - the walk is not finding the workspace, so this \
+             test would pass vacuously"
+        );
+        assert!(
+            violations.is_empty(),
+            "{} colour literal(s) outside the theme layer:\n{}\n\nA hex value here is a colour no \
+             theme file can reach and no generated theme mentions. Declare a real token in \
+             `crate::theme` (see its module docs for the naming rule) and reference it by name - \
+             `crate::theme` is the one place in this codebase colour literals belong.",
+            violations.len(),
+            violations.join("\n")
+        );
+    }
+}
+
 /// GitHub issue #208's own coverage inside this module: the shape of the new [`terminal`] group,
 /// and the one real special case it adds to [`derived_palette`].
 ///
@@ -2984,8 +3603,9 @@ mod terminal_palette_tests {
         let terminal_keys: Vec<&str> = terminal::TOKENS.iter().map(|(_, t)| t.key).collect();
         assert_eq!(
             terminal_keys.len(),
-            20,
-            "background, foreground, cursor, selection and the ANSI sixteen"
+            22,
+            "background, foreground, cursor, selection, the ANSI sixteen, and the two pane status \
+             lines (spawn error, process exited) rev 6 turned from inline hex into real tokens"
         );
         for key in &terminal_keys {
             assert!(

--- a/crates/app/src/work_surface/state.rs
+++ b/crates/app/src/work_surface/state.rs
@@ -216,13 +216,28 @@ pub const TRANSPARENT: Rgba = Rgba {
     a: 0.0,
 };
 
-/// The agent tint `(fg, bg)` for an agent's badge/chip. [`ProcessKind::Shell`] isn't an agent,
-/// so it gets a neutral chip instead of an invented tint.
+/// The agent tint `(fg, bg)` for an agent's badge/chip - the one place an agent is turned into a
+/// colour, so the same agent is the same colour on its rail badge, its CLI tab chip, its Changes
+/// panel run rows and the conflict side headers.
+///
+/// Every tint returned here comes from [`theme::agent`]'s pool, which rev 6 reallocated to satisfy
+/// the reserved-hue rule in `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4a: agent
+/// identity is allocated only *outside* the five structural hue families (amber, violet, green,
+/// red, blue). Claude is copper and Codex is teal; both used to sit inside a reserved family
+/// (amber and green respectively), which is exactly what §4a fixed. See [`theme::agent`]'s own
+/// docs for the full rule and table, and `theme::agent_tint_allocation_tests` for the test that
+/// keeps it true - **map a new agent to a pool tint here rather than inventing a colour**, or that
+/// test will fail.
+///
+/// [`ProcessKind::Shell`] isn't an agent, so it gets a neutral chip rather than an invented tint -
+/// and, deliberately, is not a pool member: a shell has no identity to encode.
 pub fn agent_tint(kind: ProcessKind) -> (Rgba, Rgba) {
     match kind {
+        // copper - `sonnet-4.5` in the mock's own `sessions`.
         ProcessKind::Agent(AgentKind::Claude) => {
             (theme::agent::SONNET.0.into(), theme::agent::SONNET.1.into())
         }
+        // teal - `gpt-5-codex`.
         ProcessKind::Agent(AgentKind::Codex) => {
             (theme::agent::CODEX.0.into(), theme::agent::CODEX.1.into())
         }


### PR DESCRIPTION
Closes #279

Reconciles the rev-6 bundle (`design_handoff_jerry_ade/revision 5/`) into the existing token registry and encodes STAGE-A-CHANGELOG.md §4a's colour-allocation rule as a real, enforced constraint. This is an *adjust-the-shared-layer* change, not a rewrite: the registry pattern, naming rule, and generator were already right, so the delta rides on them.

Every other rev-6 issue references these tokens by name. **This is the one place hex values enter the codebase**, and there is now a test that proves it.

---

## Token mapping

The bundle's `tokens.rs` has **243 constants** (231 colour keys once pairs/arrays are expanded). Our registry is much larger (it covers surfaces the mock has no equivalent for — the editor, graph, expanded syntax), and was already carrying nearly all of the bundle's values. So the reconciliation is a small, precise delta rather than a re-port.

**Registry: 314 → 337 keys (+23).**

### Newly added (23 keys)

| Module | Keys | Source |
|---|---|---|
| `changes` (new) | `edge_uncommitted`, `edge_neutral`, `edge_against_main`, `section_label`, `section_count`, `section_caret`, `section_stat_add`, `section_stat_del`, `filename_unseen`, `filename_seen`, `discard_bg`, `discard_border`, `discard_fg` | REVISION-2026-08-14 §1, STAGE-A-CHANGELOG §4i |
| `budget` (new) | `ok`, `warn`, `critical`, `track`, `stale` | REVISION-2026-08-14 §2 |
| `status_bar` (new) | `primary`, `recessive`, `divider` | REVISION-2026-08-14 §3 |
| `terminal` (existing, +2) | `spawn_error`, `process_exited` | — (see below) |

Two of these are **derivations, not transcriptions**, and say so in their own doc comments: `changes.edge_neutral` (§1's table says only "neutral") takes `border::DIVIDER`'s value, and `budget.stale` (§2 specifies the behaviour but names no colour) takes `text::FAINT`'s. Everything else is transcribed.

`terminal.spawn_error` / `terminal.process_exited` were the app's only two genuinely hard-coded colours — `rgb(0xff6b6b)` and `rgb(0xffcc66)`, inline in `terminal::pane`'s render, unthemeable and absent from every generated theme. They keep their exact values, so nothing changes visually; they are simply reachable now.

### Revalued in place (8 keys)

Keys deliberately **unchanged** so no existing hand-written theme file breaks — only the Jerry Dark defaults move.

| Key | Was | Now | Why |
|---|---|---|---|
| `agent.sonnet.fg/bg` | `#d8a94a` / `#33280f` | copper `#cf8a5c` / `#31210f` | amber was one step from the needs-input amber beside it in the rail |
| `agent.codex.fg/bg` | `#6ab97f` / `#1e3327` | teal `#4fb3a5` / `#12302c` | green is the additions colour; also unifies two greens the same agent used |
| `agent.haiku.fg/bg` | `#c98fbf` / `#332030` | periwinkle `#9d8fd4` / `#241f33` | **the collision review caught** — exactly the branch-scope violet |
| `agent.local.fg/bg` | `#7f9ad4` / `#1f2941` | *unchanged* | already outside all five families |
| `scrollbar.thumb` | `#3a3f44` | `#2b3137` | §4p supplies a real spec; the old value was an explicit judgment-call derivation |
| `scrollbar.thumb_hover` | `#565d64` | `#3d444b` | same |

### Reused as-is

The reserved-hue families themselves (`status::ASK`, `graph`'s violet, `diff`'s add/del, `border::SELECTED_EDGE`), the whole surface/text/syntax/editor ramp, and every other group are untouched — rev 6 doesn't move them, and the acceptance criterion is no regression on surfaces it doesn't touch.

### Renamed

**None.** Renaming `agent.sonnet.*` to hue names (`agent.copper.*`) was considered and rejected: a theme author retints "the agent that is Sonnet", and a rename would hard-error every existing user theme file via `ThemeFileError::UnknownKey`. The hue names live in `agent::TINT_POOL` as real labels instead.

---

## The reserved-hue rule

§4a's table is quoted verbatim in `theme::agent`'s docs, alongside the reallocation table and an "Adding an agent" section pointing at the pool.

The enforcement is `theme::agent_tint_allocation_tests`, and the design choice that matters is **it measures real OKLCH hue distance, not hex equality**:

- `every_agent_tint_sits_outside_all_five_reserved_hue_families` — walks `agent::TINT_POOL`, asserts every tint is ≥15° of OKLCH hue from all five families.
- `the_rule_actually_rejects_the_collision_review_caught` — asserts the three tints §4a reallocated (`#c98fbf`, `#d8a94a`, `#6ab97f`) would still be **rejected**, so the rule can't degrade into one that accepts everything.
- `every_registered_agent_tint_is_listed_in_the_pool` — a tint that exists as a token but never made it into the pool would be unchecked; that gap is what let the original collision through.
- `the_reserved_families_are_themselves_distinct_and_internally_coherent` — a guard on the maths, so nothing above can pass for the wrong reason.

**Why 15°:** not a round number. The tightest real clearance in §4a's own pool is steel blue at **17.4°** from blue — §4a's judgment that `#7f9ad4` is "already outside all five families" sets the floor. The three tints it *rejected* measure **0.0°, 0.0° and 3.4°**. The threshold sits inside a wide gap between what the design accepts and what it rejected.

`agent_tint` in `work_surface/state.rs` is re-pointed with a doc comment routing future agents to the pool. Per §4a, the branch violet now appears only in structural positions — including `changes.edge_against_main`, which is the rule working as intended: Against-main *is* branch scope.

## Scrollbar (§4p)

§4p is explicit that "for the Rust build this is a spec, not CSS", so it's wired up rather than just recorded: width 10, thumb radius 5, 2px content-box float (drawn as an inset), transparent track, and the thumb painted at full strength — `#2b3137` is already quieter than the greys it replaces, so the old opacity multiplier would land somewhere the spec didn't ask for. The track keeps its full width and click-to-jump handler, so the pointer target doesn't shrink.

The track has **no token, deliberately**: "transparent" isn't a colour a theme should be able to fill in. `scrollbar_spec_tests` pins `root/scrollbar.rs`'s two plain-`f32` mirrors to the tokens (they can't be `Pixels` because `CONTENT_CLEARANCE` must be `const` and GPUI's `Pixels` field is crate-private), plus a compile-time `const _` guard that the inset leaves a thumb to paint.

## No stray hex

`theme::stray_hex_tests` walks every `.rs` file under `crates/`, skips `#[cfg(test)]` modules (an exact-hex assertion is how several suites pin a token's value), and fails on any `0x` + six hex digits outside the theme layer — `theme.rs` plus `settings/builtin_themes.rs`, which carries each bundled theme's five preview swatches. It reports file, line and the offending line, and has a `scanned > 50` guard so it can't pass vacuously.

It found two real pre-existing violations, now fixed properly (tokenized, not allowlisted). This is the test that keeps the campaign's "reference tokens by name, never inline a hex" rule true for the ~15 issues that follow.

## Theme files

All five full built-in themes regenerated via the existing generator (`JERRY_REGENERATE_THEMES=1`), so each gains all 23 keys with derived values and doc-comment notes. `jerry-dark.toml` and `template.toml` are unchanged and correct as-is: both explicitly document that unnamed keys inherit ("New keys added by future Jerry versions inherit too, so a theme file never goes stale"), which is the issue's "documented fallbacks" allowance. The new modules are placed in `theme_file_format::SECTIONS` so they land under real headings rather than the trailing "Other".

## Unrelated drive-by

`sound/flow.rs` has a one-hunk `cargo fmt` fix. That violation is **pre-existing on master** from PR #266 — verified by running `cargo fmt --check` on a stashed clean tree (exit 1) — and had to be fixed for this branch to pass `cargo fmt --check` at all.

---

## Verification

- `cargo build --workspace` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo test --workspace` — **2415 passed, 13 failed**, all 13 in the known flaky-under-load class (`worktree_watch`, `file_tree_watch`, `file_tree_watch_integration_tests`, `repo_list_tests`, `agent_state_chip_live_tests`). Root cause confirmed directly rather than assumed: `/proc/sys/fs/inotify/max_user_instances` is 128 and the failure is `spawn_worktree_watcher` failing to allocate an instance. **All 41 tests across those five groups pass in isolation.** No theme, scrollbar, or settings test fails.

### Revert-then-restore on the hue-collision test

Two rounds, because the interesting question isn't "does it fail" but "does it discriminate":

1. Set `agent.haiku.fg` back to `#c98fbf` (the real historical bug) → failed with the intended message at **0.0°** from violet.
2. Set it to `#a8639b` — a *different* hex, different lightness and saturation, same hue family → still failed, at **1.4°**.

The second round is the one that matters: a hardcoded list of forbidden hexes would have sailed straight past it. `stray_hex_tests` got the same treatment — an inlined `rgb(0x123456)` in `work_surface/state.rs` was reported with exact file and line. Both restored and green.

> **Environment note for anyone rebuilding this:** `libasound2-dev` is not installed system-wide, so `cargo build` fails at `alsa-sys` since #266 merged. I extracted the Ubuntu `libasound2`/`libasound2-dev` debs to a local prefix and set `PKG_CONFIG_PATH` + `LIBRARY_PATH`. Nothing in the repo depends on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
