### PR TITLE
Rail: revision 6 corrections — selection-only edges, split urgency counts, icon prune (#289)

### DIFF
--- a/assets/themes/ember.toml
+++ b/assets/themes/ember.toml
@@ -170,10 +170,12 @@ tree_modified = "#8a5c21"  # "M" mark
 # spine/selection edges) already has one, reused directly at the call site rather than
 # duplicated here under a second name.
 [rail]
-repo_header_name   = "#576064"
+repo_header_name   = "#6e777b"  # Repo group header's uppercase name.
 worktree_active_bg = "#151a1c"
 worktree_hover_bg  = "#14181a"  # Worktree row hover background (§2.2: "hover #16191c").
-prunable_edge      = "#252c2f"
+agent_title        = "#747c81"
+repo_ask_count     = "#a66730"  # The repo header's amber urgency **count**
+repo_fail_count    = "#984d60"  # The repo header's red urgency **count**
 
 # One tint per agent - the **agent tint pool**.
 [agent]
@@ -193,7 +195,7 @@ prunable_edge      = "#252c2f"
 edge_uncommitted  = "#224959"  # UNCOMMITTED's 2px left edge - what is dirty in the checkout.
 edge_neutral      = "#1c2124"  # COMMITS' 2px left edge.
 edge_against_main = "#8d689f"  # AGAINST MAIN's 2px left edge
-section_label     = "#576064"  # Section header label - 9.5px/600 uppercase, .08em tracking.
+section_label     = "#6e777b"  # Section header label - 9.5px/600 uppercase, .09em tracking.
 section_count     = "#373f44"  # Section header count
 section_caret     = "#454d51"  # The section header's own disclosure caret (▾/▸).
 section_stat_add  = "#689057"  # The right-aligned per-section diffstat's +N, 10px mono.

--- a/assets/themes/jerry-dim.toml
+++ b/assets/themes/jerry-dim.toml
@@ -170,10 +170,12 @@ tree_modified = "#938040"  # "M" mark
 # spine/selection edges) already has one, reused directly at the call site rather than
 # duplicated here under a second name.
 [rail]
-repo_header_name   = "#72777e"
+repo_header_name   = "#8f949b"  # Repo group header's uppercase name.
 worktree_active_bg = "#202326"
 worktree_hover_bg  = "#1e2023"  # Worktree row hover background (§2.2: "hover #16191c").
-prunable_edge      = "#34393e"
+agent_title        = "#969ba1"
+repo_ask_count     = "#b3914a"  # The repo header's amber urgency **count**
+repo_fail_count    = "#b46d61"  # The repo header's red urgency **count**
 
 # One tint per agent - the **agent tint pool**.
 [agent]
@@ -193,7 +195,7 @@ prunable_edge      = "#34393e"
 edge_uncommitted  = "#435971"  # UNCOMMITTED's 2px left edge - what is dirty in the checkout.
 edge_neutral      = "#292c30"  # COMMITS' 2px left edge.
 edge_against_main = "#bb83aa"  # AGAINST MAIN's 2px left edge
-section_label     = "#72777e"  # Section header label - 9.5px/600 uppercase, .08em tracking.
+section_label     = "#8f949b"  # Section header label - 9.5px/600 uppercase, .09em tracking.
 section_count     = "#4b5056"  # Section header count
 section_caret     = "#5c6166"  # The section header's own disclosure caret (▾/▸).
 section_stat_add  = "#70b693"  # The right-aligned per-section diffstat's +N, 10px mono.

--- a/assets/themes/moss.toml
+++ b/assets/themes/moss.toml
@@ -170,10 +170,12 @@ tree_modified = "#8a7847"  # "M" mark
 # spine/selection edges) already has one, reused directly at the call site rather than
 # duplicated here under a second name.
 [rail]
-repo_header_name   = "#6b7075"
+repo_header_name   = "#878c91"  # Repo group header's uppercase name.
 worktree_active_bg = "#1a1d1f"
 worktree_hover_bg  = "#181a1d"  # Worktree row hover background (§2.2: "hover #16191c").
-prunable_edge      = "#2e3236"
+agent_title        = "#8f9398"
+repo_ask_count     = "#a88954"  # The repo header's amber urgency **count**
+repo_fail_count    = "#a46963"  # The repo header's red urgency **count**
 
 # One tint per agent - the **agent tint pool**.
 [agent]
@@ -193,7 +195,7 @@ prunable_edge      = "#2e3236"
 edge_uncommitted  = "#3f5264"  # UNCOMMITTED's 2px left edge - what is dirty in the checkout.
 edge_neutral      = "#232528"  # COMMITS' 2px left edge.
 edge_against_main = "#ab80a1"  # AGAINST MAIN's 2px left edge
-section_label     = "#6b7075"  # Section header label - 9.5px/600 uppercase, .08em tracking.
+section_label     = "#878c91"  # Section header label - 9.5px/600 uppercase, .09em tracking.
 section_count     = "#45494e"  # Section header count
 section_caret     = "#55595e"  # The section header's own disclosure caret (▾/▸).
 section_stat_add  = "#76aa8b"  # The right-aligned per-section diffstat's +N, 10px mono.

--- a/assets/themes/paper.toml
+++ b/assets/themes/paper.toml
@@ -170,10 +170,12 @@ tree_modified = "#907843"  # "M" mark
 # spine/selection edges) already has one, reused directly at the call site rather than
 # duplicated here under a second name.
 [rail]
-repo_header_name   = "#80868b"
+repo_header_name   = "#666b70"  # Repo group header's uppercase name.
 worktree_active_bg = "#dfe3e7"
 worktree_hover_bg  = "#e3e6ea"  # Worktree row hover background (§2.2: "hover #16191c").
-prunable_edge      = "#c3c9ce"
+agent_title        = "#61656a"
+repo_ask_count     = "#846127"  # The repo header's amber urgency **count**
+repo_fail_count    = "#a66663"  # The repo header's red urgency **count**
 
 # One tint per agent - the **agent tint pool**.
 [agent]
@@ -193,7 +195,7 @@ prunable_edge      = "#c3c9ce"
 edge_uncommitted  = "#90a9bf"  # UNCOMMITTED's 2px left edge - what is dirty in the checkout.
 edge_neutral      = "#d3d8dc"  # COMMITS' 2px left edge.
 edge_against_main = "#80577b"  # AGAINST MAIN's 2px left edge
-section_label     = "#80868b"  # Section header label - 9.5px/600 uppercase, .08em tracking.
+section_label     = "#666b70"  # Section header label - 9.5px/600 uppercase, .09em tracking.
 section_count     = "#a9aeb5"  # Section header count
 section_caret     = "#979da2"  # The section header's own disclosure caret (▾/▸).
 section_stat_add  = "#366948"  # The right-aligned per-section diffstat's +N, 10px mono.

--- a/assets/themes/slate.toml
+++ b/assets/themes/slate.toml
@@ -170,10 +170,12 @@ tree_modified = "#746019"  # "M" mark
 # spine/selection edges) already has one, reused directly at the call site rather than
 # duplicated here under a second name.
 [rail]
-repo_header_name   = "#555b61"
+repo_header_name   = "#6b7177"  # Repo group header's uppercase name.
 worktree_active_bg = "#161a1d"
 worktree_hover_bg  = "#15181b"  # Worktree row hover background (§2.2: "hover #16191c").
-prunable_edge      = "#262a2f"
+agent_title        = "#71767c"
+repo_ask_count     = "#8f6c1d"  # The repo header's amber urgency **count**
+repo_fail_count    = "#934c43"  # The repo header's red urgency **count**
 
 # One tint per agent - the **agent tint pool**.
 [agent]
@@ -193,7 +195,7 @@ prunable_edge      = "#262a2f"
 edge_uncommitted  = "#2d435b"  # UNCOMMITTED's 2px left edge - what is dirty in the checkout.
 edge_neutral      = "#1d2024"  # COMMITS' 2px left edge.
 edge_against_main = "#955f86"  # AGAINST MAIN's 2px left edge
-section_label     = "#555b61"  # Section header label - 9.5px/600 uppercase, .08em tracking.
+section_label     = "#6b7177"  # Section header label - 9.5px/600 uppercase, .09em tracking.
 section_count     = "#383c43"  # Section header count
 section_caret     = "#45494f"  # The section header's own disclosure caret (▾/▸).
 section_stat_add  = "#468e6b"  # The right-aligned per-section diffstat's +N, 10px mono.

--- a/crates/app/src/hooks/mod.rs
+++ b/crates/app/src/hooks/mod.rs
@@ -26,7 +26,7 @@
 //!
 //!   rail render
 //!     └── AdeApp::agent_status ──▶ rail::status::derive_status(.., HookSignal, ..)
-//!     └── AdeApp::build_agent_rows ──▶ AgentRow::activity / question_preview
+//!     └── AdeApp::build_agent_rows ──▶ AgentRow::activity
 //!                                       └── AgentStatusState (agent-status.toml)  [store]
 //!
 //!   agent closes / app restarts, later reopened (GitHub issue #227)

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -47,7 +47,169 @@ fn agent_trailing_text(agent: &AgentRow) -> String {
     }
 }
 
+/// An agent row's title colour (`STAGE-A-CHANGELOG.md` §4n, `Jerry.dc.html`'s own `titleFg`).
+///
+/// Three states, in order: the globally active agent is [`theme::text::SELECTED`]; an
+/// [`Status::Idle`] one drops to [`theme::text::DIMMER`] (it is paused, and the rail's job is
+/// "who needs me"); everything else is [`theme::rail::AGENT_TITLE`], one clear step below the
+/// worktree branch above it rather than the same [`theme::text::BODY`] it used to share with it.
+///
+/// A near-miss §4n records is worth carrying: the colour change was first applied by a
+/// non-global regex on `titleFg:`, which matches three surfaces in the mock - the flat session
+/// list, the rail's agent rows, and History rows - and hit the wrong one. Pulling this out as a
+/// named function is that lesson as code: the rail's agent title has exactly one definition, and
+/// `AdeApp::render_past_agent_row`'s History title is deliberately *not* routed through it.
+fn agent_title_color(status: Status, is_selected: bool) -> theme::ColorToken {
+    if is_selected {
+        theme::text::SELECTED
+    } else if status == Status::Idle {
+        theme::text::DIMMER
+    } else {
+        theme::rail::AGENT_TITLE
+    }
+}
+
+/// A worktree row's 2px left edge: **selection or nothing**.
+///
+/// `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4m is the whole of this function,
+/// and the three parameters are its history. The rail used to paint each worktree row with its
+/// most urgent agent's status colour, with dedicated greys for the bare and prunable cases. All
+/// three are deleted:
+///
+/// 1. **A worktree has no status. Its agents do.** Colouring the worktree row states an agent's
+///    condition on the wrong object.
+/// 2. **It was a lossy `max()`** - one colour for N agents, while the row already carries the
+///    honest version at the right granularity (the per-agent dots when collapsed, the full agent
+///    rows when expanded).
+/// 3. **It made one property mean two things in one list**: selected file rows, history rows and
+///    the selected worktree all use a 2px left edge for *selection*.
+///
+/// A first cut kept a dim edge on unselected rows and a lighter one on prunable rows. Both were
+/// caught on the next pass and are gone too: "if the edge means selection, an edge on an
+/// unselected row means nothing, and `prunable` is already stated in words on the row (`merged ·
+/// prunable`). **A channel with one meaning has exactly two states - on and off.**"
+///
+/// `aggregate_status` and `is_prunable` are still taken, unused, on purpose: they are exactly the
+/// two inputs that used to move this value, and keeping them in the signature is what lets
+/// `rail_correction_tests` prove - across every status, prunable or not - that neither can move
+/// it again. `None` is the off state (a transparent border, so the 2px gutter still holds the
+/// row's text alignment, per §4m's "The 2px gutter stays for alignment").
+fn worktree_row_edge(
+    _aggregate_status: Status,
+    _is_prunable: bool,
+    is_selected: bool,
+) -> Option<theme::ColorToken> {
+    is_selected.then_some(theme::border::SELECTED_EDGE)
+}
+
+/// Which of the repo header's **two** urgency counts a dot+count pair is
+/// (`design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md` §4: "`● 2` amber... needs input
+/// and `● 1` red... failed").
+///
+/// An enum rather than two near-identical render functions, so the pair really is one control
+/// drawn twice - the thing that goes wrong otherwise is §4l's own defect, two copies of a row
+/// that drift apart in size or spacing. The *counts* themselves are separate by design and are
+/// never summed (§7 rule 4); only their rendering is shared.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UrgencyCount {
+    /// Worktrees needing input - amber.
+    NeedsInput,
+    /// Worktrees holding a failed agent - red. A worktree in both states is counted only here
+    /// (see [`rail::RepoGroup::needs_input_count`]).
+    Failed,
+}
+
+impl UrgencyCount {
+    /// The 5px dot's fill - the same two status hues the title bar's own `● 2  ● 1  ● 4` cluster
+    /// and a worktree row's per-agent dots use, which is exactly why §4q could drop the sentence:
+    /// "Replaced with the rail's existing vocabulary."
+    fn dot(self) -> theme::ColorToken {
+        match self {
+            UrgencyCount::NeedsInput => theme::status::ASK,
+            UrgencyCount::Failed => theme::status::FAIL,
+        }
+    }
+
+    /// The count's own text colour - the desaturated partner of [`Self::dot`], per §4's
+    /// `#e2a336` dot / `#c99b4e` text and `#e0625c` dot / `#c4726d` text pairs.
+    fn text(self) -> theme::ColorToken {
+        match self {
+            UrgencyCount::NeedsInput => theme::rail::REPO_ASK_COUNT,
+            UrgencyCount::Failed => theme::rail::REPO_FAIL_COUNT,
+        }
+    }
+
+    /// This pair's own tooltip sentence (§4: "each with its own tooltip").
+    fn tooltip(self, count: usize) -> String {
+        match self {
+            UrgencyCount::NeedsInput => rail::needs_input_tooltip(count),
+            UrgencyCount::Failed => rail::failed_tooltip(count),
+        }
+    }
+
+    /// The debug-selector suffix a test locates this pair by.
+    fn selector_name(self) -> &'static str {
+        match self {
+            UrgencyCount::NeedsInput => "ask",
+            UrgencyCount::Failed => "fail",
+        }
+    }
+}
+
 impl AdeApp {
+    /// One of the repo header's two urgency dot+count pairs, or **nothing at all** at zero
+    /// (`REVISION-2026-08-14.md` §4: "Each hidden at zero").
+    ///
+    /// Returns `Option` rather than an empty element so the zero case really does draw nothing -
+    /// the same "hidden at zero" shape `crate::title_bar::render::title_bar_agent_state_chip_text`
+    /// already uses, and the reason the header's right side is empty rather than holding two blank
+    /// slots for a quiet repo.
+    ///
+    /// `flex:none` and `white-space:nowrap` on both the pair and its number: §4 makes the repo
+    /// *name* the only shrinkable thing in the row, so a long repo name ellipsises and the counts
+    /// - the one thing in the header you are meant to catch at a glance - never shrink or wrap.
+    fn render_repo_urgency_count(
+        &self,
+        repo_id: repo::RepoId,
+        kind: UrgencyCount,
+        count: usize,
+    ) -> Option<impl IntoElement> {
+        if count == 0 {
+            return None;
+        }
+        let name = kind.selector_name();
+        Some(
+            div()
+                // `name` (not one shared literal) keeps the two pairs' element ids distinct
+                // within the one header they both render into.
+                .id((name, repo_id.0))
+                .debug_selector(move || format!("repo-{name}-count-{}", repo_id.0))
+                .flex_none()
+                .flex()
+                .items_center()
+                .gap(px(4.0))
+                .tooltip(text_tooltip(kind.tooltip(count)))
+                .child(
+                    div()
+                        .flex_none()
+                        .w(px(5.0))
+                        .h(px(5.0))
+                        .rounded_full()
+                        .bg(kind.dot()),
+                )
+                .child(
+                    div()
+                        .flex_none()
+                        .whitespace_nowrap()
+                        .font(font(theme::font::MONO))
+                        .font_weight(gpui::FontWeight::MEDIUM)
+                        .text_size(self.ui_text_size(9.5))
+                        .text_color(kind.text())
+                        .child(count.to_string()),
+                ),
+        )
+    }
+
     /// Types (or backspaces/clears) into [`Self::filter_query`] - a small, hand-rolled text
     /// field (append/backspace only, no cursor positioning or selection) rather than
     /// `vendor/zed/crates/gpui/examples/input.rs`'s full `EntityInputHandler`, judged out of
@@ -156,27 +318,17 @@ impl AdeApp {
                 // GitHub issue #239 phase 2: real, structured text straight from this agent's own
                 // hook payloads, when it has fired any recently enough to still be describing the
                 // present (`crate::hooks::event::HOOK_SIGNAL_TTL`).
-                let (hook_activity, hook_question) = match &self.hook_runtime {
-                    Some(runtime) => runtime.text_for(agent.id),
-                    None => (None, None),
+                //
+                // Only the *activity* half is read here. The question half used to feed a rail
+                // question-preview card, which revision 6 removed outright (see
+                // `Self::render_worktree_row`'s own note, and the field this row no longer
+                // carries) - it is still recorded, from this same real source, by
+                // `crate::hooks::flow::AdeApp::record_agent_statuses`, which is what History and a
+                // restored session read it back from.
+                let hook_activity = match &self.hook_runtime {
+                    Some(runtime) => runtime.text_for(agent.id).0,
+                    None => None,
                 };
-
-                // The grid scrape stays, as the fallback it now is. It is a genuinely worse
-                // signal - the last non-blank line of whatever the CLI happened to have rendered,
-                // which for a permission prompt is as likely to be a box-drawing border or a
-                // truncated menu item as the actual question - but it is the *only* signal for
-                // a Codex agent, a shell, or a Claude agent whose hooks haven't fired yet, so
-                // removing it would be a real regression for every one of those.
-                let question_preview = hook_question.or_else(|| {
-                    if status_value == Status::Ask {
-                        pane.visible_text_lines()
-                            .into_iter()
-                            .rev()
-                            .find(|line| !line.trim().is_empty())
-                    } else {
-                        None
-                    }
-                });
 
                 // Only shown while the agent is actually running: a stale "Bash: cargo test" next
                 // to an idle or review-ready row would describe something that already finished.
@@ -208,7 +360,6 @@ impl AdeApp {
                     branch,
                     add: diff.map(|summary| summary.add).unwrap_or(0),
                     del: diff.map(|summary| summary.del).unwrap_or(0),
-                    question_preview,
                     exit_code: pane.exit_status().map(|status| status.exit_code()),
                     activity,
                     elapsed: agent.spawned_at.elapsed(),
@@ -940,8 +1091,8 @@ impl AdeApp {
         }
 
         let mut list = div().id("rail-repo-groups").flex().flex_col();
-        for group in &groups {
-            list = list.child(self.render_repo_group(group, cx));
+        for (index, group) in groups.iter().enumerate() {
+            list = list.child(self.render_repo_group(group, index, cx));
         }
         list.into_any_element()
     }
@@ -964,8 +1115,8 @@ impl AdeApp {
             .into_any_element()
     }
 
-    /// One repo group (§2.0-2.1): the header (name, `N wt` count, the amber `N worktrees
-    /// waiting` when non-zero, and a per-repo `+`), then either every worktree row already
+    /// One repo group (§2.0-2.1): the header (name, `N wt` count, the two urgency dot+count pairs
+    /// when non-zero, and a per-repo `+`), then either every worktree row already
     /// ranked most-urgent-first by [`rail::group_worktrees_by_repo`], or - GitHub issue #113 - a
     /// real inline message when this repo has none to show, rather than the header (and the repo
     /// itself) simply disappearing from the rail. Every repo's header renders regardless of
@@ -978,37 +1129,61 @@ impl AdeApp {
     /// entire real repo switch ([`Self::checkout_repo_from_rail`]) itself, so the header never
     /// needs a click handler for repo switching to work.
     ///
-    /// The header's `N wt` and (via [`rail::RepoGroup::waiting_count`]) `N worktrees waiting`
-    /// are read from `group.all_rows`, **not** `group.rows` - see [`Self::build_repo_groups`]'s
-    /// docs for why: this repo's real, complete worktree list, unaffected by the rail's filter
-    /// query or by which repo is currently focused. Only the rows actually rendered below the
-    /// header (`group.rows`) may be narrower - and only that narrower list, never the header
-    /// or the `+`, is affected by an empty vs. filtered-away distinction (see the
-    /// inline message below, which does distinguish the two for its own wording).
+    /// The header's `N wt` and its two urgency counts ([`rail::RepoGroup::needs_input_count`],
+    /// [`rail::RepoGroup::failed_count`]) are read from `group.all_rows`, **not** `group.rows` -
+    /// see [`Self::build_repo_groups`]'s docs for why: this repo's real, complete worktree list,
+    /// unaffected by the rail's filter query or by which repo is currently focused. Only the rows
+    /// actually rendered below the header (`group.rows`) may be narrower - and only that narrower
+    /// list, never the header or the `+`, is affected by an empty vs. filtered-away distinction
+    /// (see the inline message below, which does distinguish the two for its own wording).
     ///
     /// `group.rows_loaded` gates the `N wt` count itself: `false` (a repo whose own first real
     /// fetch hasn't resolved yet - see [`rail::RepoWorktrees::rows_loaded`]'s docs) renders an
     /// honest em dash instead of `0 wt`, since this repo's real worktree count was never fetched
     /// and may well be nonzero - a literal `0 wt` would be a false claim about state this app
     /// hasn't actually loaded.
+    ///
+    /// ## Revision 6 (`REVISION-2026-08-14.md` §4, `STAGE-A-CHANGELOG.md` §4q/§4s/§4u)
+    ///
+    /// - **A rule, not a box.** The band is a bare `border-top` with **no fill**: "a filled band
+    ///   reads as a container, so it implied the worktrees below were *inside* something... A repo
+    ///   header is a rule between groups, not a box around one." The line sits **above** the
+    ///   label, where a separator belongs.
+    /// - **`index == 0` carries no rule at all** (§4u): the filter row's own bottom border already
+    ///   ends the chrome, and two hairlines a few px apart "read as one broken double line rather
+    ///   than two separators". Repo-to-repo separation is the 12px spacer above every *later*
+    ///   band instead.
+    /// - **26 high, content vertically centred** (§4s), 3px above its own first row while rows sit
+    ///   7px apart - "the header is visibly closer to its own rows than the rows are to each
+    ///   other, which is the whole job of a section header".
+    /// - **The name is the only shrinkable thing in the row** (§4): `flex:0 1 auto`,
+    ///   `min-width:0`, ellipsis. Every count is `flex:none` and must not wrap - §4l records the
+    ///   twin defect on the Changes panel's own labels, where `flex:none` *without* nowrap let
+    ///   `AGAINST MAIN` wrap to two lines and grow its header.
+    /// - **Two urgency counts, not one sentence.** See [`Self::render_repo_urgency_count`].
     pub(in crate::rail) fn render_repo_group(
         &self,
         group: &RepoGroup,
+        index: usize,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        let waiting_label = rail::waiting_count_label(group.waiting_count());
         let repo_id = group.repo_id;
+        let is_first = index == 0;
 
         let header = div()
             .id(("repo-group-header", repo_id.0))
             .debug_selector(move || format!("repo-group-header-{}", repo_id.0))
-            // Padding `8 12 4` (§2.1).
             .flex()
             .items_center()
             .gap(px(6.0))
-            .pt(px(8.0))
+            .h(px(26.0))
             .px(px(12.0))
-            .pb(px(4.0))
+            // §4s: 3px to this header's own first worktree row, against the 7px between rows.
+            .mb(px(3.0))
+            // §4s/§4u: a bare rule above the label, and none at all on the first band.
+            .when(!is_first, |el| {
+                el.border_t_1().border_color(theme::border::DIVIDER)
+            })
             // Deliberately no `on_click`, no `cursor_pointer`, no hover background: this header
             // is a plain label, not a control - see this function's own docs. Per this file's
             // established "non-actionable control drops cursor_pointer/hover/on_click" rule (the
@@ -1016,6 +1191,10 @@ impl AdeApp {
             // must not carry click affordances either.
             .child(
                 div()
+                    // The one shrinkable thing in the row (§4).
+                    .min_w_0()
+                    .flex_shrink_1()
+                    .truncate()
                     .font(font(theme::font::SANS))
                     .font_weight(gpui::FontWeight::SEMIBOLD)
                     .text_size(self.ui_text_size(9.5))
@@ -1024,6 +1203,8 @@ impl AdeApp {
             )
             .child(
                 div()
+                    .flex_none()
+                    .whitespace_nowrap()
                     .font(font(theme::font::MONO))
                     .text_size(self.ui_text_size(9.5))
                     .text_color(theme::text::PATH)
@@ -1037,23 +1218,25 @@ impl AdeApp {
                         "\u{2014} wt".to_string()
                     }),
             )
-            .child(div().flex_1())
-            .when_some(waiting_label, |el, text| {
-                el.child(
-                    div()
-                        .font(font(theme::font::SANS))
-                        .font_weight(gpui::FontWeight::MEDIUM)
-                        .text_size(self.ui_text_size(9.5))
-                        .text_color(theme::status::ASK_CARD_FG)
-                        .child(text),
-                )
-            })
+            .child(div().flex_1().min_w(px(4.0)))
+            .children(self.render_repo_urgency_count(
+                repo_id,
+                UrgencyCount::NeedsInput,
+                group.needs_input_count(),
+            ))
+            .children(self.render_repo_urgency_count(
+                repo_id,
+                UrgencyCount::Failed,
+                group.failed_count(),
+            ))
             .child(self.render_repo_group_new_button(repo_id));
 
         let mut group_div = div()
             .id(("repo-group", repo_id.0))
             .flex()
             .flex_col()
+            // §4u: repo-to-repo separation is a 12px spacer above every band but the first.
+            .when(!is_first, |el| el.pt(px(12.0)))
             .child(header);
 
         if group.rows.is_empty() {
@@ -1258,17 +1441,9 @@ impl AdeApp {
         // would hide a bare worktree's history behind a caret that never rendered at all.
         let has_children = has_agents || has_history;
         let is_expanded = has_children && self.worktree_is_expanded(row);
-        let status = row.aggregate_status();
 
-        // 2px left edge = the colour of the worktree's most urgent agent - bare/prunable get
-        // their own dedicated colours (§2.2).
-        let edge_color: gpui::Rgba = if has_agents {
-            status.color()
-        } else if row.note.is_prunable() {
-            theme::rail::PRUNABLE_EDGE.into()
-        } else {
-            theme::status::IDLE_BG.into()
-        };
+        let edge_color =
+            worktree_row_edge(row.aggregate_status(), row.note.is_prunable(), is_selected);
 
         // `#dde2e7` active / `#c2c7cc` with agents / `#8b9197` bare (§2.2).
         let branch_color: gpui::Rgba = if is_selected {
@@ -1279,29 +1454,43 @@ impl AdeApp {
             theme::text::DIM.into()
         };
 
-        // The caret slot is always emitted, even for a childless worktree - it stays empty
-        // rather than disappearing, so every row's branch label lands at the same x offset
-        // (design_handoff_jerry_ade revision 5's own `w.caret` binding does the same: the glyph
-        // is emptied to "" but its fixed-width wrapper div never leaves the layout).
+        // The app's **one** disclosure caret (§4o/§4p): 10px `#8b9197` in a 13-wide box the full
+        // height of the row, "so the whole left column is clickable", with a hover lift and a
+        // tooltip. It was 8px `#6b7178` in an 11px box - "the smallest interactive target in the
+        // window and the one you hit most while triaging". §4p draws the line this sits on: a
+        // *disclosure* caret (rail rows, panel sections, group headers) gets this treatment, while
+        // a *dropdown chevron* bound to a button or chip stays at 8-8.5px.
+        //
+        // The slot itself is always emitted, even for a childless worktree - it stays empty
+        // (no glyph, no tooltip, no hover, no click) rather than disappearing, so every row's
+        // branch label lands at the same x offset regardless of whether that row has anything to
+        // expand (design_handoff_jerry_ade revision 5's own `w.caret` binding does the same: the
+        // glyph is emptied to "" but its fixed-width wrapper div never leaves the layout).
         let caret = {
             let worktree_path = row.path.clone();
             div()
                 .id(("worktree-caret", index as u64))
+                .debug_selector(move || format!("worktree-caret-{index}"))
                 .flex_none()
-                .w(px(11.0))
-                .h(px(11.0))
+                .w(px(13.0))
+                .h(px(27.0))
                 .flex()
                 .items_center()
                 .justify_center()
                 .font(font(theme::font::MONO))
-                .text_size(self.ui_text_size(8.0))
-                .text_color(theme::text::FAINT)
+                .text_size(self.ui_text_size(10.0))
+                .text_color(theme::text::DIM)
                 .when(has_children, |el| {
                     el.cursor_pointer()
                         // GitHub issue #128 - same lightweight text-only hover
                         // `Self::render_status_zoom_value` uses for an equally small, box-free
                         // clickable glyph.
-                        .hover(|el| el.text_color(theme::text::SELECTED))
+                        .hover(|el| el.text_color(theme::text::STRONG))
+                        // §4's "tooltips on every icon-only control". The wording is
+                        // `Jerry.dc.html`'s own, which states the thing the glyph cannot: this
+                        // control toggles the group *without* selecting the worktree, which is
+                        // what the `stop_propagation` below actually does.
+                        .tooltip(text_tooltip("Collapse or expand without selecting"))
                         .child(if is_expanded { "\u{25be}" } else { "\u{25b8}" })
                         .on_click(cx.listener(move |this, _event: &ClickEvent, _window, cx| {
                             cx.stop_propagation();
@@ -1323,6 +1512,10 @@ impl AdeApp {
         let mut trailing = div().flex().flex_none().items_center().gap(px(4.0));
         if has_agents {
             if !is_expanded {
+                // The collapsed row's per-agent status dots - along with the full agent rows when
+                // expanded, these are what carry status now that the row's own left edge no
+                // longer does (§4m). One dot per agent, most urgent first: the honest, per-agent
+                // version of the lossy `max()` the edge used to state.
                 let mut dot_statuses: Vec<Status> =
                     row.agents.iter().map(|agent| agent.status).collect();
                 dot_statuses.sort_by_key(|status| status.urgency_rank());
@@ -1336,15 +1529,31 @@ impl AdeApp {
                     }),
                 ));
             }
-            let (add, del) = row.diff_totals();
-            if add > 0 || del > 0 {
+            // §4o: the rail's diffstat is coloured like every other diffstat in the app, which is
+            // only possible because `rail::diff_stat_parts` returns its parts rather than one
+            // pre-joined string. The prose fallbacks below (`checkout · clean`, `merged ·
+            // prunable`) are a different kind of value and stay neutral.
+            if let Some((add, del)) = row.diff_stat_parts() {
                 trailing = trailing.child(
                     div()
+                        .flex_none()
+                        .whitespace_nowrap()
                         .font(font(theme::font::MONO))
                         .text_size(self.ui_text_size(9.5))
-                        .text_color(theme::text::GHOST)
-                        .child(format!("+{add} \u{2212}{del}")),
+                        .text_color(theme::diff::STAT_ADD)
+                        .child(add),
                 );
+                if let Some(del) = del {
+                    trailing = trailing.child(
+                        div()
+                            .flex_none()
+                            .whitespace_nowrap()
+                            .font(font(theme::font::MONO))
+                            .text_size(self.ui_text_size(9.5))
+                            .text_color(theme::diff::STAT_DEL)
+                            .child(del),
+                    );
+                }
             }
         }
 
@@ -1367,8 +1576,11 @@ impl AdeApp {
             .pl(px(6.0))
             .pr(px(10.0))
             .gap(px(6.0))
+            // The 2px gutter is always reserved (§4m: "The 2px gutter stays for alignment"); it
+            // is only *painted* when this row is the selected one. A `None` border colour paints
+            // nothing at all, which is the off state of a one-meaning channel.
             .border_l(px(2.0))
-            .border_color(edge_color)
+            .when_some(edge_color, |el, token| el.border_color(token))
             .when(is_selected, |el| el.bg(theme::rail::WORKTREE_ACTIVE_BG))
             .when(!is_selected, |el| {
                 el.hover(|el| el.bg(theme::rail::WORKTREE_HOVER_BG))
@@ -1395,6 +1607,11 @@ impl AdeApp {
             .id(("worktree-group", index as u64))
             .flex()
             .flex_col()
+            // §4n/§4s: 7px between worktree groups, against the 1px this had before and the 3px
+            // the repo header now sits above its own first row. "The ratio is the point: space
+            // inside a group is now smaller than the space between groups, so a worktree and its
+            // agents read as one block."
+            .pb(px(7.0))
             .child(header);
         if is_expanded {
             for agent in &row.agents {
@@ -1428,31 +1645,16 @@ impl AdeApp {
             container = container.tooltip(text_tooltip(tooltip_text));
         }
 
-        // The most urgently-waiting open agent's own question preview, if any - matches the
-        // old per-agent row's card exactly, just picked from among this worktree's several
-        // possible tabs rather than always having exactly one to show.
-        let question_preview = row
-            .agents
-            .iter()
-            .filter(|agent| agent.status == Status::Ask)
-            .find_map(|agent| agent.question_preview.as_ref());
-        if let Some(preview) = question_preview {
-            container = container.child(
-                div()
-                    .mt(px(4.0))
-                    .px(px(6.0))
-                    .py(px(4.0))
-                    .rounded(theme::radius::CHIP)
-                    .bg(theme::status::ASK_CARD_BG)
-                    .border_l(px(2.0))
-                    .border_color(theme::status::ASK_CARD_EDGE)
-                    .font(font(theme::font::SANS))
-                    .text_size(self.ui_text_size(10.5))
-                    .text_color(theme::status::ASK_CARD_FG)
-                    .child(preview.clone()),
-            );
-        }
-
+        // No question-preview card renders here, deliberately. `design_handoff_jerry_ade/revision
+        // 3/REVISION-2026-07-31.md` §2.3, verbatim: "**No question preview.** The amber ask box is
+        // gone from the rail; the question belongs in the agent pane where it can be answered."
+        // This is a design-driven removal of a card that really did ship (GitHub issue #268),
+        // confirmed as deliberate on 2026-08-14, not a regression: an amber box quoting a question
+        // in a surface with no way to answer it costs the rail's densest column two lines per
+        // asking worktree while the pane one click away already shows the question in full, live.
+        // The row's `needs input` dot and state word are what the rail is for. `AgentRow` carries
+        // no preview field at all any more (and `Self::build_agent_rows` no longer scrapes the pty
+        // grid for one) - see `rail_correction_tests`.
         container.into_any_element()
     }
 
@@ -1461,6 +1663,25 @@ impl AdeApp {
     /// elapsed, then status dot/state word/trailing text/model. Clicking it selects this
     /// agent's tab *and* its worktree (`Self::select_agent` - already does both: it's the
     /// same real entry point the palette/tab-strip use to jump straight to one agent).
+    ///
+    /// **The status edge stays here.** §4m deleted the *worktree* row's status edge because a
+    /// worktree has no status of its own - "Agent rows keep their status edge; there the status
+    /// genuinely belongs to the row's object."
+    ///
+    /// **The child no longer outranks its parent** (`STAGE-A-CHANGELOG.md` §4n). The title was
+    /// `450 11.5px/16px` in [`theme::text::BODY`] (`#b8bfc6`) while the worktree branch above it
+    /// was `500 11px` mono in the brighter [`theme::text::STRONG`] - "Larger and equally bright,
+    /// one level down. The eye landed on agent titles first and had to work backwards to find
+    /// which worktree they belonged to." It is now 11px in [`theme::rail::AGENT_TITLE`], with
+    /// tighter vertical block padding, and the fix is deliberately all on this side: **"Fix
+    /// hierarchy by shrinking the child, never by growing the parent"** - a first cut that
+    /// strengthened the branch instead pushed real branch names into ellipsis, and the branch name
+    /// is what you scan the rail for.
+    ///
+    /// The elapsed time is [`theme::text::GHOST`] (`#4e545a`) for **every** status (§4k: "the time
+    /// does not need to have a color here"). Urgency lives in the dot and the state word; an
+    /// asking agent used to carry three amber elements, and the third of them stated *when*, which
+    /// is not a severity.
     pub(in crate::rail) fn render_agent_row(
         &self,
         agent: &AgentRow,
@@ -1488,7 +1709,11 @@ impl AdeApp {
             .flex_col()
             .pl(px(13.0))
             .pr(px(10.0))
-            .py(px(4.0))
+            // §4n's tighter agent block: `5 10 6 7` -> `4 10 5 7`. The leading 13 here is this
+            // row's *indent* under its worktree rather than padding (the connector/status edge
+            // sits on it), so only the vertical pair moves.
+            .pt(px(4.0))
+            .pb(px(5.0))
             .gap(px(2.0))
             .border_l(if is_selected { px(2.0) } else { px(1.0) })
             .border_color(if is_selected {
@@ -1516,17 +1741,14 @@ impl AdeApp {
                             .min_w_0()
                             .truncate()
                             .font(font(theme::font::SANS))
-                            .text_size(self.ui_text_size(11.5))
-                            .text_color(if is_selected {
-                                theme::text::SELECTED
-                            } else {
-                                theme::text::BODY
-                            })
+                            .text_size(self.ui_text_size(11.0))
+                            .text_color(agent_title_color(status, is_selected))
                             .child(agent.title.clone()),
                     )
                     .child(
                         div()
                             .flex_none()
+                            // §4k: always the neutral time token, whatever the status.
                             .font(font(theme::font::MONO))
                             .text_size(self.ui_text_size(9.5))
                             .text_color(theme::text::GHOST)
@@ -1750,51 +1972,97 @@ impl AdeApp {
         }
     }
 
-    /// Footer 28: real aggregate stats (`N worktrees · disk usage`) plus the real `prune`
-    /// action.
+    /// The total real disk these prune candidates would free, or `None` while the background
+    /// scan ([`Self::load_disk_usage`], whose per-worktree half is [`Self::worktree_disk_usage`])
+    /// has not yet measured **every** one of them.
+    ///
+    /// All-or-nothing on purpose: a partial sum presented as "frees N" would be a number that is
+    /// wrong in the one direction that matters (too small), and the caller
+    /// ([`rail::prune_tooltip`]) drops the clause entirely rather than under-reporting. The
+    /// `truncated` flag is OR-ed across candidates, since one truncated walk makes the whole sum
+    /// a floor.
+    pub(in crate::rail) fn prunable_disk_usage(&self, paths: &[PathBuf]) -> Option<(u64, bool)> {
+        let mut total = 0u64;
+        let mut truncated = false;
+        for path in paths {
+            let (bytes, was_truncated) = self.worktree_disk_usage.get(path).copied()?;
+            total = total.saturating_add(bytes);
+            truncated |= was_truncated;
+        }
+        Some((total, truncated))
+    }
+
+    /// Footer 28: real aggregate stats (`N worktrees · disk usage`) plus the real prune action.
+    ///
+    /// `prune` is a **bin icon at a 17px hit box** as of revision 6 (`REVISION-2026-08-14.md` §4):
+    /// "it was the only text action in a rail otherwise made of rows". The text-button path is
+    /// deleted in the same edit that added the icon, per §7 rule 5 - a control described twice is
+    /// two specifications of one thing. What the word could not carry moves into the tooltip
+    /// ([`rail::prune_tooltip`]), which now states what pruning means, how many candidates there
+    /// are, and how much disk it buys back.
+    ///
+    /// The two-click arm/confirm is unchanged, only restated: an armed control turns
+    /// [`theme::button::DANGER_FG`] and its tooltip becomes [`rail::prune_armed_tooltip`]. The
+    /// glyph is `crate::icons::Icon::Trash`, drawn through the shared `crate::icons::IconRow` at
+    /// `crate::icons::IconSize::Control` - the 17px box §7 rule 7 exists to keep every icon
+    /// button in the app sharing.
     pub(in crate::rail) fn render_rail_footer(&self, cx: &mut Context<Self>) -> impl IntoElement {
         // Includes error'd entries - the count should match what `wt_core::list_worktrees`
         // reported, problems included, not silently shrink.
         let worktree_count = self.worktrees.len();
         let disk_label = self.disk_usage_label();
-        let prunable_count = self.prunable_worktree_paths().len();
-        let prune_label = if self.prune_in_flight {
-            "pruning\u{2026}".to_string()
-        } else if self.prune_confirm_armed {
-            format!("confirm prune ({prunable_count})?")
+        let prunable_paths = self.prunable_worktree_paths();
+        let prunable_count = prunable_paths.len();
+
+        // Mirrors `Self::render_merge_flow_footer`'s `in_flight` gating: while a prune batch is
+        // running - and, equally, when there is nothing to prune (§7 rule 2: "A control that acts
+        // on results does not exist when there are none") - this control drops
+        // `cursor_pointer`/hover/`on_click` entirely rather than staying enabled-looking and
+        // inviting a click `Self::execute_prune`'s guard would silently swallow.
+        let enabled = !self.prune_in_flight && prunable_count > 0;
+        let tooltip_text = if self.prune_in_flight {
+            rail::pruning_label(prunable_count)
+        } else if self.prune_confirm_armed && prunable_count > 0 {
+            rail::prune_armed_tooltip(prunable_count)
         } else {
-            format!("prune ({prunable_count})")
+            rail::prune_tooltip(prunable_count, self.prunable_disk_usage(&prunable_paths))
+        };
+        let armed = enabled && self.prune_confirm_armed;
+        let icon_color = if !enabled {
+            theme::text::DISABLED
+        } else if armed {
+            theme::button::DANGER_FG
+        } else {
+            theme::text::FAINT
         };
 
         let prune_button = div()
             .id("rail-prune")
-            .px(px(6.0))
-            .py(px(2.0))
+            .debug_selector(|| "rail-prune".to_string())
+            .flex_none()
+            .flex()
+            .items_center()
+            .justify_center()
+            .w(crate::icons::IconSize::Control.box_size())
+            .h(crate::icons::IconSize::Control.box_size())
             .rounded(theme::radius::CHIP)
-            .font(font(theme::font::MONO))
-            .text_size(self.ui_text_size(10.0));
-        // Mirrors `Self::render_merge_flow_footer`'s `in_flight` gating: while a prune batch
-        // is running, this button drops `cursor_pointer`/hover/`on_click` entirely rather
-        // than staying enabled-looking and inviting a click `Self::execute_prune`'s guard
-        // would silently swallow.
-        let prune_button = if self.prune_in_flight {
-            prune_button
-                .cursor_default()
-                .text_color(theme::text::DISABLED)
-                .child(prune_label)
-        } else {
+            .tooltip(text_tooltip(tooltip_text))
+            .child(
+                crate::icons::IconRow::new(
+                    &self.settings.icon_pack,
+                    crate::icons::IconSize::Control,
+                )
+                .draw(crate::icons::Icon::Trash, icon_color),
+            );
+        let prune_button = if enabled {
             prune_button
                 .cursor_pointer()
-                .text_color(if prunable_count > 0 {
-                    theme::button::DANGER_FG
-                } else {
-                    theme::text::DISABLED
-                })
                 .hover(|el| el.bg(theme::surface::ROW_HOVER_ALT))
-                .child(prune_label)
                 .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
                     this.request_prune(cx);
                 }))
+        } else {
+            prune_button.cursor_default()
         };
 
         div()
@@ -1858,7 +2126,6 @@ mod agent_trailing_text_count_tests {
             branch: Some("feature-x".to_string()),
             add: 0,
             del: 0,
-            question_preview: None,
             exit_code: None,
             activity: None,
             elapsed: Duration::ZERO,
@@ -2129,7 +2396,6 @@ mod rail_row_tests {
             branch: Some("wt".to_string()),
             add: 0,
             del: 0,
-            question_preview: None,
             exit_code: None,
             activity: None,
             elapsed: std::time::Duration::from_secs(1),
@@ -4234,7 +4500,6 @@ mod status_wording_tests {
             branch: Some("feature-x".to_string()),
             add: 0,
             del: 0,
-            question_preview: None,
             exit_code: Some(0),
             activity: None,
             elapsed: Duration::from_secs(90),
@@ -4319,6 +4584,376 @@ mod status_wording_tests {
         assert_eq!(
             agent_trailing_text(&row(Status::Review, Some(12))),
             "12 files"
+        );
+    }
+}
+
+/// Revision 6's rail corrections (GitHub issue #289, `design_handoff_jerry_ade/revision 5/
+/// REVISION-2026-08-14.md` §4 and `STAGE-A-CHANGELOG.md` §4k-§4s), in their pure, window-free
+/// half: the two colour decisions that were structurally wrong before, and the deletion of the
+/// rail's ask card.
+#[cfg(test)]
+mod rail_correction_tests {
+    use super::*;
+
+    /// §4m, the whole rule: the worktree row's 2px left edge means **selection or nothing**.
+    ///
+    /// Swept across every real [`Status`] and both `prunable` values, because those are exactly
+    /// the two inputs that used to move this colour - the most urgent agent's status, and the
+    /// prunable/bare distinction. A regression that reintroduced either one would light up an
+    /// unselected row here, and the sweep is what makes "all three are deleted" a checkable claim
+    /// rather than a comment.
+    #[test]
+    fn the_worktree_edge_is_selection_or_nothing_whatever_the_row_holds() {
+        for status in Status::ORDER {
+            for is_prunable in [false, true] {
+                assert_eq!(
+                    worktree_row_edge(status, is_prunable, false),
+                    None,
+                    "an unselected row must draw no edge at all - not a status colour, not the \
+                     old prunable grey, not a bare grey (status {status:?}, prunable \
+                     {is_prunable})"
+                );
+                assert_eq!(
+                    worktree_row_edge(status, is_prunable, true),
+                    Some(theme::border::SELECTED_EDGE),
+                    "the selected row's edge is the app's one selection blue, whatever its \
+                     agents are doing (status {status:?}, prunable {is_prunable})"
+                );
+            }
+        }
+    }
+
+    /// §4n: the agent title is dimmer than the worktree branch above it, and dimmer still when
+    /// the agent is paused - "Fix hierarchy by shrinking the child, never by growing the parent."
+    #[test]
+    fn the_agent_title_sits_below_its_parent_branch_in_the_hierarchy() {
+        assert_eq!(
+            agent_title_color(Status::Run, false),
+            theme::rail::AGENT_TITLE,
+            "a live agent's title is the rail's own agent-title token, one step below the \
+             branch's `text::STRONG`"
+        );
+        assert_ne!(
+            agent_title_color(Status::Run, false),
+            theme::text::STRONG,
+            "the child must not share the parent's colour - equal brightness one level down is \
+             the exact defect §4n names"
+        );
+        assert_eq!(
+            agent_title_color(Status::Idle, false),
+            theme::text::DIMMER,
+            "a paused agent drops further still"
+        );
+        assert_eq!(
+            agent_title_color(Status::Fail, true),
+            theme::text::SELECTED,
+            "the globally active agent's title is the selection colour whatever its status"
+        );
+    }
+
+    /// The rail's amber question-preview card is gone (`REVISION-2026-07-31.md` §2.3: "No
+    /// question preview. The amber ask box is gone from the rail; the question belongs in the
+    /// agent pane where it can be answered"), and this is the guard that keeps it gone.
+    ///
+    /// Two independent facts, neither of which a comment could hold:
+    ///
+    /// 1. **The data is gone.** `AgentRow` carries no preview field, so there is nothing in the
+    ///    rail's own model for a card to render. That is a compile-time fact - the name appearing
+    ///    in this file's source at all would mean it came back.
+    /// 2. **The card's ink is gone.** `status.ask_card_*` were the three tokens that painted it,
+    ///    and they were the rail's only use of them. The tokens themselves stay in the palette
+    ///    (the card moves to the agent pane, it is not abolished), so the check that matters is
+    ///    that *this file* no longer reaches for them.
+    ///
+    /// Source-level, the same `include_str!`-your-own-file idiom `crate::theme`'s
+    /// `token_registry_tests` already uses, because the thing under test is the absence of code
+    /// rather than the behaviour of any.
+    #[test]
+    fn no_rail_render_code_reaches_for_the_removed_ask_card() {
+        const SOURCE: &str = include_str!("render.rs");
+        // Comment lines (doc comments included) are dropped: this file explains the removal in
+        // prose in three places, and prose naming a thing is not code reaching for it.
+        let code = SOURCE
+            .lines()
+            .filter(|line| !line.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        // Both needles are assembled at runtime rather than written as literals: this test's own
+        // source is inside the string it scans, so a literal would match itself.
+        let card_tokens = format!("{}{}", "ASK_", "CARD");
+        let removed_field = format!("{}{}", "question_", "preview");
+        assert!(
+            !code.contains(&card_tokens),
+            "the rail's ask card was deliberately removed - no rail code may paint \
+             `status.ask_card_*` again"
+        );
+        assert!(
+            !code.contains(&removed_field),
+            "`AgentRow`'s removed preview field was deleted with the card it fed; a reference to \
+             it here means the field (and the pty grid scrape behind it) came back"
+        );
+    }
+}
+
+/// Revision 6's rail corrections, in their *painted* half: real windows, real spawned processes,
+/// real measured bounds. Every assertion here is about something the previous rail genuinely drew
+/// differently, so each would fail against the code this issue replaced.
+#[cfg(test)]
+mod rail_rev6_render_tests {
+    use super::*;
+    use crate::rail::worktrees::WorktreeItem;
+    use crate::root::focus::palette_focus_tests;
+    use gpui::TestAppContext;
+
+    fn worktree_item(path: PathBuf, label: &str) -> WorktreeItem {
+        WorktreeItem {
+            path,
+            label: label.to_string(),
+            branch: Some(label.to_string()),
+            is_main: false,
+            is_bare: false,
+            is_detached: false,
+            short_sha: None,
+            is_locked: false,
+            lock_reason: None,
+            is_broken: false,
+            broken_reason: None,
+            error: None,
+        }
+    }
+
+    /// `gpui::VisualTestContext::debug_bounds` takes a `&'static str`, and every selector here is
+    /// built from a real runtime path or repo id - the same `Box::leak` idiom this file's own
+    /// `click_worktree_row` and `crate::settings::render`'s `row_selector` already use, in a test
+    /// binary that exits moments later.
+    fn selector(name: String) -> &'static str {
+        Box::leak(name.into_boxed_str())
+    }
+
+    /// A real agent whose process genuinely failed to start - a `ProcessKind::Shell` spawn with a
+    /// `shell_override` naming a binary that does not exist, retagged to a real agent kind
+    /// (`Agents::set_kind_for_test`, which touches only the bookkeeping) so the rail produces a
+    /// row for it at all. `TerminalPane::spawn_error` is then really set, which
+    /// `AdeApp::agent_status` reads as `ProcessSignal::Exited { success: false }` and
+    /// `rail::status::derive_status` turns into a real [`Status::Fail`].
+    ///
+    /// Deliberately not a real `claude` spawn: that would pass or fail depending on whether the
+    /// machine running the suite has the binary installed, which is not something this test is
+    /// about.
+    fn open_with_a_failed_agent(
+        cx: &mut TestAppContext,
+    ) -> (
+        tempfile::TempDir,
+        tempfile::TempDir,
+        gpui::Entity<crate::root::AdeApp>,
+        &mut gpui::VisualTestContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let wt = tempfile::tempdir().expect("tempdir wt");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+
+        app.update(cx, |app, _cx| {
+            app.worktrees = vec![worktree_item(wt.path().to_path_buf(), "wt")];
+        });
+        app.update_in(cx, |app, window, cx| {
+            app.select_worktree(0, window, cx);
+            let id = app.agents.spawn(
+                ProcessKind::Shell,
+                wt.path().to_path_buf(),
+                12.0,
+                Some("/nonexistent/jerry-issue-289-not-a-real-binary"),
+                None,
+                window,
+                cx,
+            );
+            app.agents.set_kind_for_test(id, ProcessKind::claude());
+        });
+        cx.run_until_parked();
+        (repo, wt, app, cx)
+    }
+
+    /// §4/§4q and §9's checklist box 7, painted: a repo holding a failed agent shows the **red**
+    /// dot+count pair in its header, and shows **no amber one at all** - not an amber `0`, not an
+    /// amber pair that also counts it.
+    ///
+    /// This is the live counterpart to `crate::rail::state`'s pure
+    /// `a_worktree_holding_both_an_asking_and_a_failed_agent_counts_once_as_failed`: that one
+    /// proves the arithmetic, this one proves the header is really wired to it and that the
+    /// hidden-at-zero rule really removes the element rather than drawing an empty slot.
+    #[gpui::test]
+    fn a_failed_agent_paints_the_repo_headers_red_pair_and_no_amber_one(cx: &mut TestAppContext) {
+        let (_repo, _wt, app, cx) = open_with_a_failed_agent(cx);
+
+        let (repo_id, groups) =
+            app.update(cx, |app, cx| (app.repos[0].id.0, app.build_repo_groups(cx)));
+        assert_eq!(
+            groups[0].failed_count(),
+            1,
+            "sanity check: the seeded agent really did fail to start, so this repo really does \
+             hold one failed worktree"
+        );
+        assert_eq!(groups[0].needs_input_count(), 0, "sanity check");
+
+        assert!(
+            cx.debug_bounds(selector(format!("repo-fail-count-{repo_id}")))
+                .is_some(),
+            "the repo header must paint its red dot+count pair for a repo holding a failed agent"
+        );
+        assert!(
+            cx.debug_bounds(selector(format!("repo-ask-count-{repo_id}")))
+                .is_none(),
+            "and must paint no amber pair at all at zero - hidden entirely, never an empty slot \
+             (and never counting the failed worktree a second time in amber)"
+        );
+    }
+
+    /// §4q's "each hidden at zero", driven through the real render function for both pairs and
+    /// both sides of the boundary - the half of the rule a repo with a failed agent alone cannot
+    /// exercise.
+    #[gpui::test]
+    fn each_urgency_pair_is_an_element_only_when_its_own_count_is_nonzero(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        app.update(cx, |app, _cx| {
+            let repo_id = app.repos[0].id;
+            for kind in [UrgencyCount::NeedsInput, UrgencyCount::Failed] {
+                assert!(
+                    app.render_repo_urgency_count(repo_id, kind, 0).is_none(),
+                    "{kind:?} must render nothing at all at zero"
+                );
+                assert!(
+                    app.render_repo_urgency_count(repo_id, kind, 1).is_some(),
+                    "{kind:?} must render its pair as soon as it has something to report"
+                );
+            }
+        });
+    }
+
+    /// §4o: the caret is "10px `#8b9197` in a 13x27 box (the row's full height, so the whole left
+    /// column is clickable)" - it was 8px in an 11px box, "the smallest interactive target in the
+    /// window and the one you hit most while triaging".
+    ///
+    /// Measured, not asserted from the source: a real painted hit box, in a real window, on a
+    /// real worktree row that really has an agent under it.
+    #[gpui::test]
+    fn the_worktree_caret_is_a_full_row_height_hit_box(cx: &mut TestAppContext) {
+        let (_repo, _wt, _app, cx) = open_with_a_failed_agent(cx);
+
+        let caret = cx
+            .debug_bounds("worktree-caret-0")
+            .expect("a worktree row with an agent under it must paint a caret");
+        assert_eq!(
+            caret.size.width,
+            px(13.0),
+            "the caret's hit box spans the row's whole left column"
+        );
+        assert_eq!(
+            caret.size.height,
+            px(27.0),
+            "and the row's full 27px height - a caret you can only hit in an 11px square is the \
+             defect §4o names"
+        );
+    }
+
+    /// §4/§8: `prune` is a bin icon at a 17px hit box, and the text button it replaced is gone -
+    /// "it was the only text action in a rail otherwise made of rows", and §7 rule 5 requires the
+    /// old path to go in the same edit.
+    #[gpui::test]
+    fn the_prune_control_is_a_bin_icon_in_a_seventeen_pixel_box(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (_app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        let button = cx
+            .debug_bounds("rail-prune")
+            .expect("the rail footer must paint its prune control");
+        assert_eq!(button.size.width, px(17.0));
+        assert_eq!(
+            button.size.height,
+            px(17.0),
+            "the shared 17px icon-button box (`icons::IconSize::Control`), not a text button's \
+             own intrinsic size"
+        );
+        assert!(
+            cx.debug_bounds("icon-trash").is_some(),
+            "and the real vendored Phosphor `trash` SVG must be what paints inside it"
+        );
+    }
+
+    /// §4s's spacing ratio, measured: "the header is visibly closer to its own rows than the rows
+    /// are to each other, which is the whole job of a section header" - 3px below the band, 7px
+    /// between worktrees (§4n raised the latter from 1px, where "ten groups ran together as one
+    /// stream").
+    #[gpui::test]
+    fn the_repo_header_sits_closer_to_its_rows_than_the_rows_sit_to_each_other(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let alpha = tempfile::tempdir().expect("tempdir alpha");
+        let beta = tempfile::tempdir().expect("tempdir beta");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        app.update(cx, |app, cx| {
+            app.worktrees = vec![
+                worktree_item(alpha.path().to_path_buf(), "alpha"),
+                worktree_item(beta.path().to_path_buf(), "beta"),
+            ];
+            // Without this the seeded list never reaches a paint pass, and `debug_bounds` below
+            // would be reading the startup window's own tree.
+            cx.notify();
+        });
+        cx.run_until_parked();
+
+        // The rendered order is `WorktreeRow::urgency_rank`'s, not the order they were seeded in,
+        // so the two row selectors are read back from the real groups this render pass built -
+        // the same idiom `worktree_tab_attribution_tests::click_worktree_row` uses.
+        let (repo_id, rendered_paths) = app.update(cx, |app, cx| {
+            let groups = app.build_repo_groups(cx);
+            (
+                app.repos[0].id.0,
+                groups[0]
+                    .rows
+                    .iter()
+                    .map(|row| row.path.clone())
+                    .collect::<Vec<_>>(),
+            )
+        });
+        assert_eq!(
+            rendered_paths.len(),
+            2,
+            "sanity check: both seeded worktrees are real rows in this repo's one group"
+        );
+
+        let header = cx
+            .debug_bounds(selector(format!("repo-group-header-{repo_id}")))
+            .expect("the repo band must paint");
+        let first = cx
+            .debug_bounds(selector(format!(
+                "worktree-row-0-{}",
+                rendered_paths[0].display()
+            )))
+            .expect("the first worktree row must paint");
+        let second = cx
+            .debug_bounds(selector(format!(
+                "worktree-row-1-{}",
+                rendered_paths[1].display()
+            )))
+            .expect("the second worktree row must paint");
+
+        assert_eq!(
+            header.size.height,
+            px(26.0),
+            "§4s: the band is 26 high with its content vertically centred, not held by \
+             asymmetric padding"
+        );
+        let header_to_row = first.origin.y - (header.origin.y + header.size.height);
+        let row_to_row = second.origin.y - (first.origin.y + first.size.height);
+        assert_eq!(header_to_row, px(3.0), "3px below the band");
+        assert_eq!(row_to_row, px(7.0), "7px between worktree groups");
+        assert!(
+            header_to_row < row_to_row,
+            "the ratio is the point: a header that sits as far from its own rows as they sit \
+             from each other groups nothing"
         );
     }
 }

--- a/crates/app/src/rail/state.rs
+++ b/crates/app/src/rail/state.rs
@@ -35,10 +35,6 @@ pub struct AgentRow {
     /// every changed file. Both `0` if the diff hasn't loaded yet or there are no changes.
     pub add: usize,
     pub del: usize,
-    /// Tail-of-pty text for a waiting agent (`TerminalPane::visible_text_lines`, trimmed to
-    /// the last non-blank line) - the design's "question preview". Only populated for
-    /// [`Status::Ask`] rows.
-    pub question_preview: Option<String>,
     /// The process exit code, only for [`Status::Fail`]/[`Status::Review`]/exited-`Idle`
     /// rows. `None` while still running or never started.
     pub exit_code: Option<u32>,
@@ -46,9 +42,8 @@ pub struct AgentRow {
     /// `design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §2.3: "the live tool call -
     /// `writing auth.rs`, `editing reports.rs`, `bench 3 of 5`, `148 of 312`".
     ///
-    /// A sibling field here rather than a payload on [`Status::Run`] itself, mirroring
-    /// [`Self::question_preview`]'s own shape immediately above (also status-conditional, also a
-    /// row-level fact rather than part of the status enum) - keeping [`Status`] itself a plain
+    /// A sibling field here rather than a payload on [`Status::Run`] itself (status-conditional,
+    /// but a row-level fact rather than part of the status enum) - keeping [`Status`] itself a plain
     /// `Copy` value users of `Status::ORDER`/`urgency_rank`/`color` etc. can keep relying on,
     /// rather than every one of those call sites suddenly needing to supply or ignore an
     /// `activity` payload for a `Run` variant they don't care about.
@@ -357,6 +352,22 @@ impl WorktreeRow {
             .unwrap_or((0, 0))
     }
 
+    /// This row's diffstat as its two **separately coloured parts**, or `None` when there is no
+    /// real diff to show - see [`diff_stat_parts`], which this is [`Self::diff_totals`] fed into.
+    pub fn diff_stat_parts(&self) -> Option<(String, Option<String>)> {
+        let (add, del) = self.diff_totals();
+        diff_stat_parts(add, del)
+    }
+
+    /// Whether any agent open in this worktree currently holds `status` - the exact granularity
+    /// the repo header's two urgency counts are defined at (see [`RepoGroup::failed_count`]), as
+    /// opposed to [`Self::aggregate_status`]'s single most-urgent answer. A worktree holding one
+    /// asking agent *and* one failed agent genuinely holds both facts; collapsing it to one
+    /// status first is what made the old single amber count claim it was only asking.
+    pub fn has_agent_with(&self, status: Status) -> bool {
+        self.agents.iter().any(|agent| agent.status == status)
+    }
+
     /// Whether this row matches a rail filter query - its own label/branch/path (see
     /// [`matches_filter_worktree_entry`]) or any of its open agents' own title/branch/kind
     /// (see [`AgentRow::matches_filter`]).
@@ -494,22 +505,48 @@ pub struct RepoGroup {
 }
 
 impl RepoGroup {
-    /// The group header's right-aligned amber `N worktrees waiting` (§2.1: "counting worktrees
-    /// in that repo holding an asking or failed agent, hidden at zero"). Deliberately worktree-
-    /// level, not agent-level: a worktree with two asking agents still counts once, since the
-    /// header is answering "how many rows in this group want me", not "how many agents".
+    /// The group header's **red** urgency count: worktrees in this repo holding at least one
+    /// failed agent, hidden at zero.
+    ///
+    /// Revision 6 (`design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md` §4,
+    /// `STAGE-A-CHANGELOG.md` §4q) split the header's single amber `N worktrees waiting` into two
+    /// counts, because merging them "said 'three worktrees want you' when one of the three had
+    /// actually died, and amber is the wrong colour for that". §7 rule 4, verbatim: **"Two states
+    /// distinguished anywhere in the app are never summed anywhere in it."** The title bar has
+    /// always shown `ask`/`fail`/`running` apart; the rail header now does too.
+    ///
+    /// Deliberately worktree-level, not agent-level: a worktree with two failed agents still
+    /// counts once, since the header answers "how many rows in this group want me", not "how many
+    /// agents".
     ///
     /// Reads [`Self::all_rows`], **not** [`Self::rows`]: this count must survive a filter query
     /// that hides the very row it's counting, and must survive the group's rows being collapsed
-    /// away for a non-focused repo, per this same section's "a repo you have scrolled past
-    /// still reports that something in it wants a human".
-    pub fn waiting_count(&self) -> usize {
+    /// away for a non-focused repo, per §2.0's "a repo you have scrolled past still reports that
+    /// something in it wants a human".
+    pub fn failed_count(&self) -> usize {
         self.all_rows
             .iter()
-            .filter(|row| {
-                !row.agents.is_empty()
-                    && matches!(row.aggregate_status(), Status::Ask | Status::Fail)
-            })
+            .filter(|row| row.has_agent_with(Status::Fail))
+            .count()
+    }
+
+    /// The group header's **amber** urgency count: worktrees holding at least one asking agent
+    /// **and no failed one**, hidden at zero.
+    ///
+    /// The `and no failed one` half is the whole point of §9's checklist box 7 ("a both-states
+    /// worktree counts once as failed") and of §4q's own rule: "A worktree holding both an asking
+    /// and a failed agent counts **once, as failed** - the worse state wins, so the two counts sum
+    /// to the number of worktrees needing you rather than double-counting." Written against
+    /// [`WorktreeRow::has_agent_with`] rather than [`WorktreeRow::aggregate_status`] on purpose:
+    /// `aggregate_status` ranks `Ask` *above* `Fail` ([`Status::urgency_rank`]), so a both-states
+    /// worktree aggregates to `Ask` and would have landed in the amber count - the exact
+    /// mis-colouring §4q rejected.
+    ///
+    /// Reads [`Self::all_rows`] for the same reason [`Self::failed_count`] does.
+    pub fn needs_input_count(&self) -> usize {
+        self.all_rows
+            .iter()
+            .filter(|row| !row.has_agent_with(Status::Fail) && row.has_agent_with(Status::Ask))
             .count()
     }
 
@@ -529,25 +566,62 @@ impl RepoGroup {
     }
 }
 
-/// The group header's amber waiting-count text (§2.1's `N worktrees waiting`) - `None` at zero
-/// (hidden entirely, never an empty chip, mirroring
-/// `crate::title_bar::render::title_bar_agent_state_chip_text`'s own "hidden at zero" rule),
-/// singular for exactly one (`"1 worktree waiting"`), plural otherwise (`"N worktrees
-/// waiting"`) - the design doc's own example (`3 worktrees waiting`) never shows the singular
-/// case, but the rest of this codebase already conjugates every other counter correctly (see
-/// that same title-bar function's `"1 agent needs input"` vs `"2 agents need input"`), so this
-/// one must too.
+/// The tooltip on the repo header's **amber** dot+count pair: `"2 worktrees here need input"`.
 ///
-/// The conjugation itself is [`crate::root::plural`]'s, not a hand-written match arm per count:
-/// hiding at zero is this function's own decision (a content choice), agreeing at one versus
-/// many is not.
-pub fn waiting_count_label(count: usize) -> Option<String> {
-    if count == 0 {
+/// Revision 6 replaced the header's one prose run (`3 worktrees waiting`) with two bare
+/// dot+count pairs, and put the sentence in a tooltip instead - `STAGE-A-CHANGELOG.md` §4q's own
+/// rule: **"a count belongs in the header, a sentence belongs in a tooltip. If a header needs a
+/// sentence to be understood, the signal is wrong, not the copy."** The old
+/// `waiting_count_label` text path was deleted in the same edit that added these two, per §7
+/// rule 5 ("Replacing a control means deleting its old keys in the same edit - a key defined
+/// twice is two specifications of one thing, and the reader cannot tell which is real").
+///
+/// Both the noun and the verb agree through [`crate::root::plural`] rather than a hand-written
+/// ternary (§7 rule 9) - `Jerry.dc.html`'s own `askTip` conjugates `needs`/`need` too, and a
+/// tooltip reading "1 worktrees here need input" would be exactly the defect that rule exists for.
+/// Hiding at zero is the *caller's* decision (a content choice, made at the render site by not
+/// drawing the pair at all), so this function is total and always returns a real sentence.
+pub fn needs_input_tooltip(count: usize) -> String {
+    format!(
+        "{} here {} input",
+        plural::count(count, "worktree", None),
+        plural::form(count, "needs", "need")
+    )
+}
+
+/// The tooltip on the repo header's **red** dot+count pair: `"1 worktree here has a failed
+/// agent"` / `"2 worktrees here have failed agents"`. See [`needs_input_tooltip`] for why the
+/// sentence lives in a tooltip at all, and for the conjugation rule.
+pub fn failed_tooltip(count: usize) -> String {
+    format!(
+        "{} here {} failed {}",
+        plural::count(count, "worktree", None),
+        plural::form(count, "has a", "have"),
+        plural::form(count, "agent", "agents")
+    )
+}
+
+/// A rail worktree row's diffstat, as the two parts it is **coloured** in - `("+152",
+/// Some("−11"))` - or `None` when there is no real diff to show.
+///
+/// `STAGE-A-CHANGELOG.md` §4o, verbatim: **"A value that is coloured anywhere must be coloured
+/// everywhere, which means the logic returns its parts, not a pre-joined string."** The rail used
+/// to compose `+152 −11` into one neutral `#5e646a` string here, which is precisely why it could
+/// not be coloured, while run rows, uncommitted rows, commit rows and section headers all split
+/// theirs into `diff::STAT_ADD`/`diff::STAT_DEL`. Same number, read the same way, styled two
+/// different ways depending on which panel it was in.
+///
+/// The deletion half is `Option` rather than a `−0`: `Jerry.dc.html`'s own `wtStats` returns
+/// `del: d ? '−' + d : ''`, so a pure-addition diff shows one part, not a second one that says
+/// nothing. Both zero is `None` outright - the row's prose fallback (`checkout · clean`, `merged ·
+/// prunable`), which stays neutral, is what occupies that slot instead.
+pub fn diff_stat_parts(add: usize, del: usize) -> Option<(String, Option<String>)> {
+    if add == 0 && del == 0 {
         return None;
     }
-    Some(format!(
-        "{} waiting",
-        plural::count(count, "worktree", None)
+    Some((
+        format!("+{add}"),
+        (del > 0).then(|| format!("\u{2212}{del}")),
     ))
 }
 
@@ -560,6 +634,51 @@ pub fn worktree_disk_label(worktree_count: usize, disk_label: &str) -> String {
     format!(
         "{} \u{b7} {disk_label}",
         plural::count(worktree_count, "worktree", None)
+    )
+}
+
+/// The rail footer's prune control's tooltip - `"Prune merged worktrees \u{2014} 1 prunable,
+/// frees 214 MB"`.
+///
+/// `REVISION-2026-08-14.md` §4 turned `prune` from the rail's one text button into a bin icon at a
+/// 17px hit box, "the only text action in a rail otherwise made of rows" - and the tooltip is
+/// where the words went. It deliberately carries **more** than the button's old `prune (1)` label
+/// could: what pruning means (merged worktrees), how many are candidates, and what it buys back.
+///
+/// `freed_bytes` is `Some((bytes, truncated))` only once the real background disk scan
+/// (`crate::root::AdeApp::load_disk_usage`, whose per-worktree half lives in
+/// `crate::root::AdeApp::worktree_disk_usage`) has reported a size for **every** prune candidate.
+/// While any candidate is unmeasured it is `None` and the `, frees N` clause is simply absent
+/// rather than under-reported - the same honesty rule `crate::rail::render::AdeApp::
+/// disk_usage_label`'s `...` and the repo header's em-dash `\u{2014} wt` already follow. The
+/// `truncated` flag (a scan that hit its own walk limit) renders `frees 214 MB+`, exactly as
+/// [`format_bytes`]' caller in `disk_usage_label` does.
+///
+/// At zero candidates the sentence changes shape rather than reading `0 prunable`: nothing is
+/// offered, so the tooltip says so.
+pub fn prune_tooltip(prunable_count: usize, freed_bytes: Option<(u64, bool)>) -> String {
+    if prunable_count == 0 {
+        return "Prune merged worktrees \u{2014} nothing prunable".to_string();
+    }
+    let freed = match freed_bytes {
+        Some((bytes, truncated)) => {
+            let suffix = if truncated { "+" } else { "" };
+            format!(", frees {}{suffix}", format_bytes(bytes))
+        }
+        None => String::new(),
+    };
+    format!(
+        "Prune merged worktrees \u{2014} {} prunable{freed}",
+        prunable_count
+    )
+}
+
+/// The prune control's armed-state tooltip - the second half of the two-click arm/confirm the
+/// icon inherits unchanged from the text button it replaced.
+pub fn prune_armed_tooltip(prunable_count: usize) -> String {
+    format!(
+        "Click again to remove {}",
+        plural::count(prunable_count, "worktree", None)
     )
 }
 
@@ -839,7 +958,6 @@ mod tests {
             branch: Some("feature-x".to_string()),
             add: 0,
             del: 0,
-            question_preview: None,
             exit_code: None,
             activity: None,
             elapsed: Duration::ZERO,
@@ -1363,8 +1481,10 @@ mod tests {
         );
     }
 
+    /// §4q's split: the header's one amber count became an amber `needs input` count and a red
+    /// `failed` count, each counting worktrees (not agents), each zero when nothing qualifies.
     #[test]
-    fn repo_group_waiting_count_counts_worktrees_asking_or_failed_hiding_zero_otherwise() {
+    fn repo_group_urgency_counts_report_asking_and_failed_worktrees_separately() {
         let worktrees = vec![
             worktree_entry("/repo-wt/asking", clean_note(false)),
             worktree_entry("/repo-wt/failed", clean_note(false)),
@@ -1379,9 +1499,15 @@ mod tests {
         let rows = build_worktree_rows(&worktrees, &agents);
         let groups = group_worktrees_by_repo(vec![repo_worktrees(0, "jerry-core", rows)]);
         assert_eq!(
-            groups[0].waiting_count(),
-            2,
-            "counts the asking and the failed worktree, not the running or bare ones"
+            groups[0].needs_input_count(),
+            1,
+            "the amber count is the asking worktree alone - never summed with the failed one \
+             (§7 rule 4: two states distinguished anywhere are never summed anywhere)"
+        );
+        assert_eq!(
+            groups[0].failed_count(),
+            1,
+            "the red count is the failed worktree alone, not the running or bare ones"
         );
 
         let all_quiet = build_worktree_rows(
@@ -1389,14 +1515,53 @@ mod tests {
             &[row(1, Status::Run, "run", "/repo-wt/running-only")],
         );
         let quiet_groups = group_worktrees_by_repo(vec![repo_worktrees(0, "quiet", all_quiet)]);
+        assert_eq!(quiet_groups[0].needs_input_count(), 0);
         assert_eq!(
-            quiet_groups[0].waiting_count(),
+            quiet_groups[0].failed_count(),
             0,
-            "hidden at zero - no asking or failed worktrees"
+            "both counts are zero for a repo whose only agent is running - the render side hides \
+             each pair at zero"
         );
     }
 
-    /// The bug the coordinator's audit found: `RepoGroup::waiting_count` and the header's
+    /// `REVISION-2026-08-14.md` §9's checklist box 7, verbatim: "Repo header shows ask and fail
+    /// separately; **a both-states worktree counts once as failed**."
+    ///
+    /// The trap this guards is real and specific: [`WorktreeRow::aggregate_status`] ranks `Ask`
+    /// *above* `Fail` ([`Status::urgency_rank`]), so a worktree holding one of each aggregates to
+    /// `Ask`. A count written against the aggregate would put this worktree in the **amber**
+    /// column - which is exactly §4q's "amber is the wrong colour for that" defect, and would also
+    /// make the two counts sum to more, or to the wrong colour, rather than to "the number of
+    /// worktrees needing you".
+    #[test]
+    fn a_worktree_holding_both_an_asking_and_a_failed_agent_counts_once_as_failed() {
+        let worktrees = vec![worktree_entry("/repo-wt/both", clean_note(false))];
+        let agents = vec![
+            row(1, Status::Ask, "ask", "/repo-wt/both"),
+            row(2, Status::Fail, "fail", "/repo-wt/both"),
+        ];
+        let rows = build_worktree_rows(&worktrees, &agents);
+        assert_eq!(
+            rows[0].aggregate_status(),
+            Status::Ask,
+            "sanity check: the aggregate really does rank Ask above Fail, so counting off it \
+             would put this worktree in the amber column"
+        );
+
+        let groups = group_worktrees_by_repo(vec![repo_worktrees(0, "jerry-core", rows)]);
+        assert_eq!(
+            groups[0].failed_count(),
+            1,
+            "the worse state wins: this worktree is counted in red"
+        );
+        assert_eq!(
+            groups[0].needs_input_count(),
+            0,
+            "and never also in amber - counted once, not twice"
+        );
+    }
+
+    /// The bug the coordinator's audit found: the header's urgency counts and the header's
     /// `N wt` count (`group.all_rows.len()` at the render site) must come from the repo's real,
     /// complete worktree list, never from whatever narrower set happens to be rendered below the
     /// header. Builds a repo whose `rows` (the "currently displayed" set - what a filter query
@@ -1449,9 +1614,9 @@ mod tests {
             "sanity check: the displayed rows really are a narrower, different set"
         );
         assert_eq!(
-            groups[0].waiting_count(),
+            groups[0].needs_input_count(),
             1,
-            "the amber waiting count must be derived from the real worktree list too - the \
+            "the amber urgency count must be derived from the real worktree list too - the \
              asking worktree exists in `all_rows` even though it isn't in the displayed `rows`"
         );
     }
@@ -1486,29 +1651,71 @@ mod tests {
         );
     }
 
+    /// §4q's "each with its own tooltip", conjugated in both the noun and the verb (§7 rule 9).
     #[test]
-    fn waiting_count_label_is_hidden_at_zero() {
-        assert_eq!(waiting_count_label(0), None);
+    fn the_two_urgency_tooltips_agree_with_their_own_counts_in_noun_and_verb() {
+        assert_eq!(needs_input_tooltip(1), "1 worktree here needs input");
+        assert_eq!(needs_input_tooltip(2), "2 worktrees here need input");
+        assert_eq!(failed_tooltip(1), "1 worktree here has a failed agent");
+        assert_eq!(failed_tooltip(3), "3 worktrees here have failed agents");
     }
 
+    /// §4o: the rail's diffstat is returned as its two coloured parts, never as one pre-joined
+    /// string - and a diff with no deletions renders one part, not a `\u{2212}0` that says nothing.
     #[test]
-    fn waiting_count_label_is_singular_for_exactly_one() {
+    fn diff_stat_parts_splits_the_rail_diffstat_and_drops_an_empty_deletion() {
         assert_eq!(
-            waiting_count_label(1).as_deref(),
-            Some("1 worktree waiting")
+            diff_stat_parts(152, 11),
+            Some(("+152".to_string(), Some("\u{2212}11".to_string())))
+        );
+        assert_eq!(diff_stat_parts(9, 0), Some(("+9".to_string(), None)));
+        assert_eq!(
+            diff_stat_parts(0, 4),
+            Some(("+0".to_string(), Some("\u{2212}4".to_string()))),
+            "a pure-deletion diff still states its (zero) additions - the pair is how a diffstat \
+             reads, and `+0 \u{2212}4` is a real answer where a bare `\u{2212}4` would be a \
+             differently-shaped one"
+        );
+        assert_eq!(
+            diff_stat_parts(0, 0),
+            None,
+            "no diff at all renders no diffstat - the row's neutral prose fallback occupies that \
+             slot instead"
         );
     }
 
+    /// §4's prune tooltip: "Prune merged worktrees \u{2014} 1 prunable, frees 214 MB" - the words
+    /// the icon itself cannot carry, including the size only when it is really known.
     #[test]
-    fn waiting_count_label_is_plural_for_two_or_more() {
+    fn the_prune_tooltip_states_the_count_and_only_a_measured_size() {
         assert_eq!(
-            waiting_count_label(2).as_deref(),
-            Some("2 worktrees waiting")
+            prune_tooltip(1, Some((214 * 1024 * 1024, false))),
+            "Prune merged worktrees \u{2014} 1 prunable, frees 214.0 MB"
         );
         assert_eq!(
-            waiting_count_label(7).as_deref(),
-            Some("7 worktrees waiting")
+            prune_tooltip(3, Some((2 * 1024 * 1024 * 1024, true))),
+            "Prune merged worktrees \u{2014} 3 prunable, frees 2.0 GB+",
+            "a truncated scan keeps the `+` suffix `disk_usage_label` already uses - the number \
+             is a floor, and the tooltip must not round it into a claim"
         );
+        assert_eq!(
+            prune_tooltip(1, None),
+            "Prune merged worktrees \u{2014} 1 prunable",
+            "an unmeasured candidate drops the whole clause rather than reporting a size that \
+             leaves it out"
+        );
+        assert_eq!(
+            prune_tooltip(0, Some((0, false))),
+            "Prune merged worktrees \u{2014} nothing prunable",
+            "zero candidates changes the sentence's shape rather than reading `0 prunable`"
+        );
+    }
+
+    /// The armed half of the two-click prune, kept from the text button it replaced.
+    #[test]
+    fn the_armed_prune_tooltip_conjugates_its_own_count() {
+        assert_eq!(prune_armed_tooltip(1), "Click again to remove 1 worktree");
+        assert_eq!(prune_armed_tooltip(2), "Click again to remove 2 worktrees");
     }
 
     /// The rail footer and Settings → Disk share this one line, and it used to read

--- a/crates/app/src/settings/custom_theme.rs
+++ b/crates/app/src/settings/custom_theme.rs
@@ -1987,14 +1987,14 @@ keyword = "#ff79c6"
         // A table the template itself doesn't already declare - redeclaring one would be a real
         // TOML error, not a user edit.
         let edited_toml =
-            format!("{CUSTOM_THEME_TEMPLATE_TOML}\n[rail]\nprunable_edge = \"#123456\"\n");
+            format!("{CUSTOM_THEME_TEMPLATE_TOML}\n[rail]\nagent_title = \"#123456\"\n");
         std::fs::write(&dest_path, &edited_toml).expect("simulate a user edit");
 
         let second = write_template_theme(dest_dir.path()).expect("second write");
 
         assert_eq!(second.source_path, first.source_path);
         assert_eq!(
-            second.overrides["rail.prunable_edge"],
+            second.overrides["rail.agent_title"],
             rgba(0x123456),
             "the user's edited colour must be preserved, not overwritten with the pristine template"
         );

--- a/crates/app/src/theme.rs
+++ b/crates/app/src/theme.rs
@@ -1152,26 +1152,63 @@ pub mod status {
 pub mod rail {
     use super::{token, ColorToken};
 
-    /// Repo group header's uppercase name (§2.1: "name in 9.5px uppercase Plex Sans `#787f86`").
-    pub const REPO_HEADER_NAME: ColorToken = token("rail.repo_header_name", 0x787f86);
+    /// Repo group header's uppercase name.
+    ///
+    /// Revision 6 (`design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4s) retargeted this
+    /// from the rail-only `#787f86` to the app-wide section-label value: "It was `#787f86` at
+    /// `.08em` while every other section label in the app - `Runs`, `Uncommitted`, `Commits`,
+    /// `Resources`, `Rate limits` - was already `#9aa1a8` at `.09em`. It now uses that token."
+    /// `Jerry.dc.html`'s rail band and all four Changes-panel section labels really do paint the
+    /// same `#9aa1a8`, which is why [`super::changes::SECTION_LABEL`] carries the identical value:
+    /// a repo band is a section header, not a rail-specific ornament.
+    ///
+    /// Kept under its own `rail.` key rather than folded into one shared constant because the key
+    /// is a *themable* name a user's `.toml` may already set - renaming it would silently drop
+    /// their override. The two constants are the same colour by intent, and both cite §4s.
+    pub const REPO_HEADER_NAME: ColorToken = token("rail.repo_header_name", 0x9aa1a8);
     /// Active worktree row header background (§2.2: "Active worktree header background
     /// `#181c1f`").
     pub const WORKTREE_ACTIVE_BG: ColorToken = token("rail.worktree_active_bg", 0x181c1f);
     /// Worktree row hover background (§2.2: "hover `#16191c`").
     pub const WORKTREE_HOVER_BG: ColorToken = token("rail.worktree_hover_bg", 0x16191c);
-    /// A prunable (merged, clean, agent-less) worktree's 2px left edge (§2.2: "prunable
-    /// `#2f353a`"). A bare-but-not-prunable worktree reuses [`super::status::IDLE_BG`]
-    /// (`#22262a`), an exact match for the spec's "Bare worktrees `#22262a`".
-    pub const PRUNABLE_EDGE: ColorToken = token("rail.prunable_edge", 0x2f353a);
+    /// An agent row's title, one level below its parent worktree's branch name
+    /// (`STAGE-A-CHANGELOG.md` §4n: agent title `450 11.5px/16px` `#c2c7cc` -> `450 11px/15px`
+    /// **`#a3a9b0`**). Deliberately dimmer than [`super::text::STRONG`] (`#c2c7cc`), which the
+    /// branch above it uses: "Fix hierarchy by shrinking the child, never by growing the parent."
+    /// A `crate::rail::Status::Idle` agent drops further still, to [`super::text::DIMMER`]
+    /// (`#7d848b`), exactly as `Jerry.dc.html`'s own `titleFg` does.
+    pub const AGENT_TITLE: ColorToken = token("rail.agent_title", 0xa3a9b0);
+    /// The repo header's amber urgency **count** - the number beside the [`super::status::ASK`]
+    /// dot (`REVISION-2026-08-14.md` §4: "`● 2` amber (`#e2a336` dot, `#c99b4e` text, needs
+    /// input)").
+    ///
+    /// Its own key rather than a reach into `status.ask_card_fg`, which happens to hold the same
+    /// hex: a header count and an ask card's text are unrelated concepts that would drift the
+    /// moment a theme moved one of them. Same reasoning, and same shape, as
+    /// [`super::changes::EDGE_UNCOMMITTED`] carrying its own key beside
+    /// [`super::border::SELECTED_EDGE`].
+    pub const REPO_ASK_COUNT: ColorToken = token("rail.repo_ask_count", 0xc99b4e);
+    /// The repo header's red urgency **count** - the number beside the [`super::status::FAIL`]
+    /// dot (§4: "`● 1` red (`#e0625c` dot, `#c4726d` text, failed)"). Its own key, for the reason
+    /// [`Self::REPO_ASK_COUNT`]'s docs give.
+    pub const REPO_FAIL_COUNT: ColorToken = token("rail.repo_fail_count", 0xc4726d);
 
     /// Every real [`ColorToken`] this module declares, paired with its own Rust `const` name -
     /// the module's slice of [`super::TOKEN_GROUPS`]'s whole-app registry. See that constant's
     /// own docs for what walks this and why every token has to appear here.
+    ///
+    /// `rail.prunable_edge` (`#2f353a`) was removed here in revision 6: §4m deleted the whole
+    /// status/prunable/bare left-edge channel from worktree rows ("A channel with one meaning has
+    /// exactly two states - on and off"), leaving that token with nothing to colour. It went in
+    /// the same edit as the edge itself, and out of the bundled theme files with it, rather than
+    /// being left as a themable name for a thing this app no longer draws.
     pub const TOKENS: &[(&str, ColorToken)] = &[
         ("REPO_HEADER_NAME", REPO_HEADER_NAME),
         ("WORKTREE_ACTIVE_BG", WORKTREE_ACTIVE_BG),
         ("WORKTREE_HOVER_BG", WORKTREE_HOVER_BG),
-        ("PRUNABLE_EDGE", PRUNABLE_EDGE),
+        ("AGENT_TITLE", AGENT_TITLE),
+        ("REPO_ASK_COUNT", REPO_ASK_COUNT),
+        ("REPO_FAIL_COUNT", REPO_FAIL_COUNT),
     ];
 }
 
@@ -2588,8 +2625,15 @@ pub mod changes {
     /// positions (see this module's own docs).
     pub const EDGE_AGAINST_MAIN: ColorToken = token("changes.edge_against_main", 0xc98fbf);
 
-    /// Section header label - 9.5px/600 uppercase, `.08em` tracking.
-    pub const SECTION_LABEL: ColorToken = token("changes.section_label", 0x787f86);
+    /// Section header label - 9.5px/600 uppercase, `.09em` tracking.
+    ///
+    /// `#9aa1a8`, not §1's transcribed `#787f86`: `STAGE-A-CHANGELOG.md` §4s is the later word on
+    /// the same value ("every other section label in the app - `Runs`, `Uncommitted`, `Commits`,
+    /// `Resources`, `Rate limits` - was already `#9aa1a8` at `.09em`") and `Jerry.dc.html` - which
+    /// outranks both prose files - really does paint all four of these labels `#9aa1a8`. Same
+    /// value, same citation, as [`super::rail::REPO_HEADER_NAME`]: a repo band and a Changes
+    /// section are the same kind of header.
+    pub const SECTION_LABEL: ColorToken = token("changes.section_label", 0x9aa1a8);
     /// Section header count - 9.5px mono, immediately after the label.
     pub const SECTION_COUNT: ColorToken = token("changes.section_count", 0x4a5057);
     /// The section header's own disclosure caret (`▾`/`▸`).

--- a/crates/app/src/title_bar/render.rs
+++ b/crates/app/src/title_bar/render.rs
@@ -767,7 +767,6 @@ mod agent_state_chip_text_tests {
             branch: Some("feature-x".to_string()),
             add: 0,
             del: 0,
-            question_preview: None,
             exit_code: None,
             activity: None,
             elapsed: Duration::ZERO,


### PR DESCRIPTION
Closes #289.

Rev 6's rail pass, from `design_handoff_jerry_ade/revision 5/` (`REVISION-2026-08-14.md` §4/§7/§9, `STAGE-A-CHANGELOG.md` §4k–§4u, `REVISION-2026-07-31.md` §2.3), with `Jerry.dc.html` treated as authoritative wherever the prose files disagree with it.

## The two structural reversals

**The worktree row's 2px left edge is selection-only** (§4m). It carried the most urgent agent's status colour, with separate greys for bare and prunable rows; all three are deleted. A worktree has no status — its agents do, and they state it honestly per agent in the collapsed row's dots and in the expanded agent rows. *"A channel with one meaning has exactly two states — on and off."* Agent rows keep their status edge, where the status genuinely belongs to the row's object. The now-unowned `rail.prunable_edge` token went in the same edit.

**The repo header's amber `N worktrees waiting` sentence becomes two dot+count pairs** (§4q): amber for needs-input, red for failed, each hidden at zero, each with its own tooltip sentence. A worktree holding both counts **once, as failed**. §7 rule 4, verbatim: *"Two states distinguished anywhere in the app are never summed anywhere in it."* The old `RepoGroup::waiting_count` / `waiting_count_label` path is deleted in this same change, per §7 rule 5.

The both-states rule needed care: `WorktreeRow::aggregate_status` ranks `Ask` **above** `Fail`, so a count written off the aggregate would have put a both-states worktree in the *amber* column — the exact mis-colouring §4q rejected. The two counts are written against per-agent facts instead, and a test pins that.

## The smaller corrections

- **Repo band**: 26 high with its content vertically centred, bare `border-top` and **no fill**, no rule at all on the first band (§4u — the filter row's border already ends the chrome), 12px spacer above every later band, 3px to its own rows against 7px between rows (§4s). The name is the only shrinkable thing in the row; both counts are `flex:none` + nowrap. The `N wt` count and its honest em-dash-before-load are unchanged.
- **Agent rows** (§4n): dimmer title token (new `rail.agent_title`), 11px instead of 11.5px, tighter vertical block padding, and 7px between worktree groups so space inside a group is smaller than space between them. §4k's neutral age was already correct and is now pinned by the render code's comment.
- **The ask question-preview card is removed from the rail.** This is the deliberate, design-driven removal `REVISION-2026-07-31.md` §2.3 calls for (*"the amber ask box is gone from the rail; the question belongs in the agent pane where it can be answered"*), confirmed 2026-08-14 as superseding what shipped in #268 — **not a regression**. `AgentRow`'s preview field and the pty grid-scrape fallback that fed it are gone with it; the hook side-channel's question half is still recorded by `hooks::flow::record_agent_statuses` for History and session restore.
- **Diffstats** (§4o): split into coloured `+`/`−` parts through `rail::diff_stat_parts`, which returns the parts rather than a pre-joined string. Prose fallbacks (`checkout · clean`, `merged · prunable`) stay neutral.
- **Caret** (§4o/§4p): 10px in a 13×27 full-row-height hit box, hover lift, tooltip.
- **Prune** (§4/§8): the `trash` bin icon from #282's shared `IconRow` at `IconSize::Control`'s 17px box. The tooltip carries what the word could not — *"Prune merged worktrees — 1 prunable, frees 214 MB"* — with the freed bytes summed from real per-worktree disk usage and the whole clause dropped when any candidate is unmeasured. Two-click arm/confirm is kept; the text-button path is deleted.
- **Scrollbar** (§4p): already on the shared `theme::scrollbar` tokens from #279, unchanged.

## Tests

Eight new tests, plus ported/rewritten coverage for the counts:

- `rail::state`: the two urgency counts reported separately; a both-states worktree counted once as failed (with a sanity assertion that the aggregate really would have got it wrong); both tooltip sentences conjugated in noun *and* verb; `diff_stat_parts`; the prune tooltip's measured/unmeasured/zero/truncated cases.
- `rail::render` (pure): the edge swept across every `Status` × prunable, selected and not; the agent title's three states; a source-level guard that no rail code reaches for the removed card's tokens or field again.
- `rail::render` (real windows, measured bounds): a genuinely failed agent paints the header's red pair and no amber one; each pair is an element only at nonzero; the caret's 13×27 hit box; the prune control's 17×17 box with the real vendored `trash` SVG inside it; the header/row spacing ratio (26 high, 3px below the band, 7px between rows).

## Notes

- The bundled theme files are regenerated (`JERRY_REGENERATE_THEMES=1`), which is why five `.toml`s move: `rail.repo_header_name` retargeted to §4s's app-wide section-label value, `rail.agent_title` / `rail.repo_ask_count` / `rail.repo_fail_count` added, `rail.prunable_edge` removed.
- `changes.section_label` moved to `#9aa1a8` too, so the repo band and the (not yet built) Changes-panel section headers do not carry two different specifications of one value. `Jerry.dc.html` paints both `#9aa1a8`.
- The caret tooltip is `Jerry.dc.html`'s own *"Collapse or expand without selecting"* rather than §4o's *"Collapse or expand this worktree"* — mock over prose, and it states the thing the glyph cannot (the caret toggles without selecting the row).
- The repo header's inert `+` is kept. Rev 6's mock drops it, but the standing project decision is that no add-worktree entry point changes until its design lands, and this issue does not cover it.
- The agent row's connector/status edge still sits at x=0 rather than the mock's x=13. Pre-existing, out of scope here, and §4n's listed hierarchy fixes (title token, block padding, group gap) are all applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)