### PR TITLE
Rail: fix agent/history row indent + filter row padding drift (#289 follow-up)

### DIFF
--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -1736,12 +1736,21 @@ impl AdeApp {
                     .pt(px(4.0))
                     .pb(px(5.0))
                     .gap(px(2.0))
-                    .border_l(if is_selected { px(2.0) } else { px(1.0) })
-                    .border_color(if is_selected {
-                        status.color()
-                    } else {
-                        theme::border::ZONE.into()
-                    })
+                    // `Jerry.dc.html`'s own agent row: `border-left:2px solid {{ a.edge }}`, with
+                    // `edge: live ? st.color : 'transparent'` - a *fixed* 2px slot painted only
+                    // for the focused agent. Two things were wrong with the width/colour pair
+                    // this replaces (`2px status` selected, `1px #1e2225` otherwise), both of
+                    // them created by moving the indent onto the wrapper above: the 1px fallback
+                    // is the *same* `#1e2225` as the connector `div` immediately to its left, so
+                    // an unselected row drew the connector twice as thick as the design's own
+                    // 1px; and the width flipping 1px -> 2px on selection shifted this row's
+                    // whole content box sideways by a pixel the moment you clicked it. The 2px
+                    // gutter is now always reserved and simply left unpainted when this agent
+                    // isn't the focused one - the same "a channel with one meaning has exactly
+                    // two states, on and off" the worktree row's own edge follows
+                    // (`worktree_row_edge`).
+                    .border_l(px(2.0))
+                    .when(is_selected, |el| el.border_color(status.color()))
                     .when(is_selected, |el| el.bg(theme::surface::ROW_SELECTED))
                     .when(!is_selected, |el| {
                         el.hover(|el| el.bg(theme::rail::WORKTREE_HOVER_BG))
@@ -1912,8 +1921,16 @@ impl AdeApp {
                     .pt(px(6.0))
                     .pb(px(7.0))
                     .gap(px(2.0))
+                    // The 2px slot is reserved so a history row's content lines up with the live
+                    // agent rows above it, and deliberately left **unpainted**. A past agent has
+                    // no selected state (there is no pane behind it - see this function's own
+                    // docs), so the only thing a painted edge here could restate is the status,
+                    // which this row already says twice on its second line: the 4px status dot
+                    // and the `was <state>` word. That is §4m's rule 2 exactly - "the edge was
+                    // the third statement... and always the least precise" - and painting it
+                    // would make a finished run the loudest thing in a rail whose §4n hierarchy
+                    // work is about pushing children *below* their parent, not above it.
                     .border_l(px(2.0))
-                    .border_color(status.color())
                     .child(
                         div()
                             .flex()

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -1704,98 +1704,116 @@ impl AdeApp {
 
         div()
             .id(("agent-row", id))
+            .debug_selector(move || format!("agent-row-{id:?}"))
             .cursor_pointer()
             .flex()
-            .flex_col()
             .pl(px(13.0))
-            .pr(px(10.0))
-            // §4n's tighter agent block: `5 10 6 7` -> `4 10 5 7`. The leading 13 here is this
-            // row's *indent* under its worktree rather than padding (the connector/status edge
-            // sits on it), so only the vertical pair moves.
-            .pt(px(4.0))
-            .pb(px(5.0))
-            .gap(px(2.0))
-            .border_l(if is_selected { px(2.0) } else { px(1.0) })
-            .border_color(if is_selected {
-                status.color()
-            } else {
-                theme::border::ZONE.into()
-            })
-            .when(is_selected, |el| el.bg(theme::surface::ROW_SELECTED))
-            .when(!is_selected, |el| {
-                el.hover(|el| el.bg(theme::rail::WORKTREE_HOVER_BG))
-            })
+            // The row's real indent under its worktree: 13px of empty space (padding, not a
+            // sized column - the connector doesn't sit centered *within* the 13px, it comes
+            // after it), carrying the 1px `#1e2225` connector line, then the agent's own content
+            // box - never padding *on* that content box, which would draw its border-left (the
+            // status edge) flush with the worktree row's own left edge instead of indented under
+            // it. `Jerry.dc.html`'s own agent row is exactly this shape (an outer
+            // `padding-left:13px` flex wrapper holding the connector `div`, then the content
+            // `div` with its own `border-left`) - GPUI's border draws at a box's outer edge same
+            // as CSS, so folding padding-left and border-left onto one div here reproduced the
+            // bug the opposite way.
             .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
                 this.select_agent(id, window, cx);
             }))
+            .child(div().flex_none().w(px(1.0)).bg(theme::border::ZONE))
             .child(
-                // Line 1: chip · task title · elapsed.
                 div()
+                    .debug_selector(move || format!("agent-row-content-{id:?}"))
+                    .flex_1()
+                    .min_w_0()
                     .flex()
-                    .items_center()
-                    .gap(px(6.0))
-                    .child(chip_icon)
+                    .flex_col()
+                    .pl(px(7.0))
+                    .pr(px(10.0))
+                    // §4n's tighter agent block: `5 10 6 7` -> `4 10 5 7`.
+                    .pt(px(4.0))
+                    .pb(px(5.0))
+                    .gap(px(2.0))
+                    .border_l(if is_selected { px(2.0) } else { px(1.0) })
+                    .border_color(if is_selected {
+                        status.color()
+                    } else {
+                        theme::border::ZONE.into()
+                    })
+                    .when(is_selected, |el| el.bg(theme::surface::ROW_SELECTED))
+                    .when(!is_selected, |el| {
+                        el.hover(|el| el.bg(theme::rail::WORKTREE_HOVER_BG))
+                    })
                     .child(
+                        // Line 1: chip · task title · elapsed.
                         div()
-                            .flex_1()
-                            .min_w_0()
-                            .truncate()
-                            .font(font(theme::font::SANS))
-                            .text_size(self.ui_text_size(11.0))
-                            .text_color(agent_title_color(status, is_selected))
-                            .child(agent.title.clone()),
+                            .flex()
+                            .items_center()
+                            .gap(px(6.0))
+                            .child(chip_icon)
+                            .child(
+                                div()
+                                    .flex_1()
+                                    .min_w_0()
+                                    .truncate()
+                                    .font(font(theme::font::SANS))
+                                    .text_size(self.ui_text_size(11.0))
+                                    .text_color(agent_title_color(status, is_selected))
+                                    .child(agent.title.clone()),
+                            )
+                            .child(
+                                div()
+                                    .flex_none()
+                                    // §4k: always the neutral time token, whatever the status.
+                                    .font(font(theme::font::MONO))
+                                    .text_size(self.ui_text_size(9.5))
+                                    .text_color(theme::text::GHOST)
+                                    .child(rail::format_elapsed(agent.elapsed)),
+                            ),
                     )
                     .child(
+                        // Line 2, indented 21 to the text column (chip width 15 + gap 6): status
+                        // dot · state word · trailing text · model.
                         div()
-                            .flex_none()
-                            // §4k: always the neutral time token, whatever the status.
-                            .font(font(theme::font::MONO))
-                            .text_size(self.ui_text_size(9.5))
-                            .text_color(theme::text::GHOST)
-                            .child(rail::format_elapsed(agent.elapsed)),
-                    ),
-            )
-            .child(
-                // Line 2, indented 21 to the text column (chip width 15 + gap 6): status dot ·
-                // state word · trailing text · model.
-                div()
-                    .flex()
-                    .items_center()
-                    .gap(px(6.0))
-                    .pl(px(21.0))
-                    .child(
-                        div()
-                            .flex_none()
-                            .w(px(4.0))
-                            .h(px(4.0))
-                            .rounded_full()
-                            .bg(status.color()),
-                    )
-                    .child(
-                        div()
-                            .flex_none()
-                            .font(font(theme::font::SANS))
-                            .text_size(self.ui_text_size(9.5))
-                            .text_color(state_color)
-                            .child(agent_state_word(status)),
-                    )
-                    .child(
-                        div()
-                            .flex_1()
-                            .min_w_0()
-                            .truncate()
-                            .font(font(theme::font::SANS))
-                            .text_size(self.ui_text_size(9.5))
-                            .text_color(trailing_color)
-                            .child(trailing_text),
-                    )
-                    .child(
-                        div()
-                            .flex_none()
-                            .font(font(theme::font::MONO))
-                            .text_size(self.ui_text_size(9.5))
-                            .text_color(theme::text::PATH)
-                            .child(agent.kind.label()),
+                            .flex()
+                            .items_center()
+                            .gap(px(6.0))
+                            .pl(px(21.0))
+                            .child(
+                                div()
+                                    .flex_none()
+                                    .w(px(4.0))
+                                    .h(px(4.0))
+                                    .rounded_full()
+                                    .bg(status.color()),
+                            )
+                            .child(
+                                div()
+                                    .flex_none()
+                                    .font(font(theme::font::SANS))
+                                    .text_size(self.ui_text_size(9.5))
+                                    .text_color(state_color)
+                                    .child(agent_state_word(status)),
+                            )
+                            .child(
+                                div()
+                                    .flex_1()
+                                    .min_w_0()
+                                    .truncate()
+                                    .font(font(theme::font::SANS))
+                                    .text_size(self.ui_text_size(9.5))
+                                    .text_color(trailing_color)
+                                    .child(trailing_text),
+                            )
+                            .child(
+                                div()
+                                    .flex_none()
+                                    .font(font(theme::font::MONO))
+                                    .text_size(self.ui_text_size(9.5))
+                                    .text_color(theme::text::PATH)
+                                    .child(agent.kind.label()),
+                            ),
                     ),
             )
     }
@@ -4853,6 +4871,51 @@ mod rail_rev6_render_tests {
             px(27.0),
             "and the row's full 27px height - a caret you can only hit in an 11px square is the \
              defect §4o names"
+        );
+    }
+
+    /// `Jerry.dc.html`'s own agent row indents under its worktree by a real 13px, holding the 1px
+    /// `#1e2225` connector the design's own §4n text calls out ("the connector... was already
+    /// there and does its job once the groups are separated") - so the agent's own status edge
+    /// sits *inset* under the worktree row, not flush with its left edge. A real, measured
+    /// regression: an earlier cut folded the 13px indent and the status-edge border onto the same
+    /// element, which (GPUI draws a border at a box's own outer edge, same as CSS) put the edge
+    /// at the worktree row's own x, not indented under it - the hierarchy the row is supposed to
+    /// show collapsed into the same left rail every other row in the tree already uses.
+    #[gpui::test]
+    fn the_agent_row_is_really_indented_under_its_worktree_not_flush_with_it(
+        cx: &mut TestAppContext,
+    ) {
+        let (_repo, wt, app, cx) = open_with_a_failed_agent(cx);
+
+        // `open_with_a_failed_agent` opens the app (which spawns its own default shell in the
+        // *repo's* own path) and then explicitly spawns the real failed agent this test cares
+        // about in `wt`'s own path - the two are real, distinct tempdirs, so filtering on cwd
+        // finds the right one regardless of spawn order.
+        let wt_path = wt.path().to_path_buf();
+        let agent_id = app.update(cx, |app, _cx| {
+            app.agents
+                .iter()
+                .find(|a| a.cwd == wt_path)
+                .expect("the real failed agent this helper seeds, in its own worktree")
+                .id
+        });
+        let row_selector = selector(format!("agent-row-{agent_id:?}"));
+        let content_selector = selector(format!("agent-row-content-{agent_id:?}"));
+
+        let row = cx
+            .debug_bounds(row_selector)
+            .expect("a real agent row must paint under its worktree");
+        let content = cx
+            .debug_bounds(content_selector)
+            .expect("the agent row's own content box must paint inside it");
+
+        assert_eq!(
+            content.origin.x - row.origin.x,
+            px(14.0),
+            "the content box (and the status-edge border painted on it) must start 14px in from \
+             the row's own left edge - 13px of indent plus the 1px connector line - never flush \
+             with x=0, which is what the worktree row's own edge uses"
         );
     }
 

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -929,7 +929,8 @@ impl AdeApp {
             .flex_none()
             .items_center()
             .gap(px(6.0))
-            .px(px(10.0))
+            // `Jerry.dc.html:109` - `padding:0 12px`, not 10px.
+            .px(px(12.0))
             .h(theme::band::FILTER_ROW)
             .border_b_1()
             .border_color(theme::border::RAIL_INNER)
@@ -1893,80 +1894,96 @@ impl AdeApp {
         div()
             .id(format!("history-row-{key}"))
             .flex()
-            .flex_col()
             .pl(px(13.0))
-            .pr(px(10.0))
-            .py(px(4.0))
-            .gap(px(2.0))
-            .border_l(px(1.0))
-            .border_color(theme::border::ZONE)
+            // Same real indent under its worktree the live agent row uses (and the same bug this
+            // row had until now: padding-left and border-left folded onto one div put the edge
+            // flush at x=0 instead of indented under it). `Jerry.dc.html`'s own history row
+            // (`g.rows`/`h.*`) is the identical shape: outer `padding-left:13px`, a separate 1px
+            // `#1e2225` connector, then a content box with its own `border-left:2px`.
+            .child(div().flex_none().w(px(1.0)).bg(theme::border::ZONE))
             .child(
                 div()
+                    .flex_1()
+                    .min_w_0()
                     .flex()
-                    .items_center()
-                    .gap(px(6.0))
-                    .child(chip_icon)
+                    .flex_col()
+                    .pl(px(7.0))
+                    .pr(px(10.0))
+                    .pt(px(6.0))
+                    .pb(px(7.0))
+                    .gap(px(2.0))
+                    .border_l(px(2.0))
+                    .border_color(status.color())
                     .child(
                         div()
-                            .flex_1()
-                            .min_w_0()
-                            .truncate()
-                            .font(font(theme::font::SANS))
-                            .text_size(self.ui_text_size(11.5))
-                            .text_color(theme::text::DIM)
-                            .child(summary),
+                            .flex()
+                            .items_center()
+                            .gap(px(6.0))
+                            .child(chip_icon)
+                            .child(
+                                div()
+                                    .flex_1()
+                                    .min_w_0()
+                                    .truncate()
+                                    .font(font(theme::font::SANS))
+                                    .text_size(self.ui_text_size(11.5))
+                                    .text_color(theme::text::DIM)
+                                    .child(summary),
+                            )
+                            .child(
+                                div()
+                                    .flex_none()
+                                    .font(font(theme::font::MONO))
+                                    .text_size(self.ui_text_size(9.5))
+                                    .text_color(theme::text::GHOST)
+                                    .child(last_active),
+                            ),
                     )
                     .child(
                         div()
-                            .flex_none()
-                            .font(font(theme::font::MONO))
-                            .text_size(self.ui_text_size(9.5))
-                            .text_color(theme::text::GHOST)
-                            .child(last_active),
-                    ),
-            )
-            .child(
-                div()
-                    .flex()
-                    .items_center()
-                    .gap(px(6.0))
-                    .pl(px(21.0))
-                    .child(
-                        div()
-                            .flex_none()
-                            .w(px(4.0))
-                            .h(px(4.0))
-                            .rounded_full()
-                            .bg(status.color()),
-                    )
-                    .child(
-                        div()
-                            .flex_1()
-                            .min_w_0()
-                            .truncate()
-                            .font(font(theme::font::SANS))
-                            .text_size(self.ui_text_size(9.5))
-                            .text_color(theme::text::FAINT)
-                            .child(format!("was {}", agent_state_word(status))),
-                    )
-                    .child(
-                        div()
-                            .id(format!("history-resume-{resume_key}"))
-                            .flex_none()
-                            .cursor_pointer()
-                            .px(px(6.0))
-                            .py(px(2.0))
-                            .rounded(theme::radius::CHIP)
-                            .bg(theme::button::BLUE_BG)
-                            .hover(|el| el.bg(theme::button::BLUE_BG_HOVER))
-                            .font(font(theme::font::SANS))
-                            .text_size(self.ui_text_size(9.5))
-                            .text_color(theme::button::BLUE_FG)
-                            .child(resume_label)
-                            .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
-                                cx.stop_propagation();
-                                this.resume_past_agent(&resume_key, window, cx);
-                            })),
+                            .flex()
+                            .items_center()
+                            .gap(px(6.0))
+                            .pl(px(21.0))
+                            .child(
+                                div()
+                                    .flex_none()
+                                    .w(px(4.0))
+                                    .h(px(4.0))
+                                    .rounded_full()
+                                    .bg(status.color()),
+                            )
+                            .child(
+                                div()
+                                    .flex_1()
+                                    .min_w_0()
+                                    .truncate()
+                                    .font(font(theme::font::SANS))
+                                    .text_size(self.ui_text_size(9.5))
+                                    .text_color(theme::text::FAINT)
+                                    .child(format!("was {}", agent_state_word(status))),
+                            )
+                            .child(
+                                div()
+                                    .id(format!("history-resume-{resume_key}"))
+                                    .flex_none()
+                                    .cursor_pointer()
+                                    .px(px(6.0))
+                                    .py(px(2.0))
+                                    .rounded(theme::radius::CHIP)
+                                    .bg(theme::button::BLUE_BG)
+                                    .hover(|el| el.bg(theme::button::BLUE_BG_HOVER))
+                                    .font(font(theme::font::SANS))
+                                    .text_size(self.ui_text_size(9.5))
+                                    .text_color(theme::button::BLUE_FG)
+                                    .child(resume_label)
+                                    .on_click(cx.listener(
+                                        move |this, _event: &ClickEvent, window, cx| {
+                                            cx.stop_propagation();
+                                            this.resume_past_agent(&resume_key, window, cx);
+                                        },
+                                    )),
+                            ),
                     ),
             )
     }


### PR DESCRIPTION
## Summary

Replaces #313, which GitHub auto-closed (and would not let me reopen) when its base branch `issue-289-rail-corrections` was deleted on merging #311. Same branch, same work, now based directly on `master`.

Two real gaps found by independently comparing the whole rail against `Jerry.dc.html` after #289 landed:

1. **Agent row indent** — the live agent row's status edge was flush at x=0 instead of indented 14px under its worktree (13px indent + 1px connector). An earlier cut folded the indent (padding-left) and the status edge (border-left) onto the same div; GPUI draws a border at a box's own outer edge same as CSS, so that put the edge at the row's own x=0 instead of inset. Restructured to match the mock's real shape: outer padding-left wrapper → 1px connector → content box with its own border-left.

2. **History row, same bug class** — `render_past_agent_row` had the identical structural issue, plus padding that didn't match the mock's asymmetric `6 10 7 7`.

3. **Filter row padding drift** — 10px horizontal padding where the mock uses 12px (`Jerry.dc.html:109`).

## Added on rebase (design-fidelity follow-up)

Moving the indent onto a wrapper div exposed two artefacts on the row's own edge, both fixed in the third commit:

- An unselected agent row carried `border-left: 1px #1e2225` — the *same* colour as the 1px connector `div` immediately left of it — so the design's 1px connector painted as a 2px line. The width also flipped 1px → 2px on selection, shifting the row's whole content box sideways by a pixel on click. `Jerry.dc.html`'s rail agent row is a fixed `border-left:2px solid {{ a.edge }}` with `edge: live ? st.color : 'transparent'`: the slot is always 2px and simply unpainted when that agent isn't focused. Matched exactly — the same on/off channel `worktree_row_edge` follows (STAGE-A-CHANGELOG.md §4m).
- The history row's edge goes the same way, reserved but unpainted rather than always status-coloured. A past agent has no selected state, so a painted edge there could only restate the status — which the row already says twice on its second line (the 4px status dot and the `was <state>` word). §4m rule 2 verbatim: "the edge was the third statement… and always the least precise". It also made a finished run the loudest thing in a rail whose §4n hierarchy work is about pushing children *below* their parent.

## Test plan
- [x] Real geometry test (`the_agent_row_is_really_indented_under_its_worktree_not_flush_with_it`) measures actual painted bounds, not source
- [x] `cargo build --workspace` / `cargo clippy --workspace --all-targets` / `cargo fmt --all --check` all clean
- [x] `cargo test -p app --lib`: 2509 passed; the only 15 failures are the known inotify `max_user_instances` contention flakes (`file_tree_watch`/`worktree_watch`/`repo_list_tests`), all green on re-run with `--test-threads=1`