### PR TITLE
Fix agent-chip icon packs rendering as empty boxes

### DIFF
--- a/crates/app/src/icon_pack.rs
+++ b/crates/app/src/icon_pack.rs
@@ -16,10 +16,20 @@
 //! ## Real icon files, not a theme tint
 //!
 //! Unlike this app's own bundled UI icons (styled shapes/glyphs that all pick up a theme color
-//! token), a user-supplied pack icon is rendered via `gpui::svg().external_path(..)` with **no**
-//! `.text_color()` tint applied - a real, user-chosen brand icon (e.g. a real Claude/Codex logo)
-//! keeps whatever colors its own SVG file defines, rather than being flattened to a single
-//! theme-matched fill the way this app's own icon-font-free UI chrome is.
+//! token), a user-supplied pack icon is rendered via `gpui::img(..)` (GitHub issue #309) - a real,
+//! user-chosen brand icon (e.g. a real Claude/Codex logo) keeps whatever colors its own file
+//! defines, rather than being flattened to a single theme-matched fill the way this app's own
+//! icon-font-free UI chrome is.
+//!
+//! This must be `img()`, never `svg()`: GPUI's `svg()` rasterises to an alpha mask and paints it
+//! uniformly tinted with the element's own `style.text.color`, skipping the paint entirely when
+//! that color is unset (`vendor/zed/crates/gpui/src/elements/svg.rs`'s `paint`). An untinted
+//! `svg()` pack icon therefore does not "keep its own colors" - it paints nothing at all, an
+//! empty box. `img()` decodes the source's real pixels (raster formats and SVG alike) and paints
+//! them as a full-color sprite regardless of any text color, which is what "keeps its own
+//! colors" actually requires in this GPUI version. (`crate::icons`' shipped Phosphor icons are
+//! the opposite, intentional case: they *should* tint like text, and correctly go through
+//! `svg()` with an explicit color for exactly that reason - see that module's own docs.)
 
 use std::path::PathBuf;
 

--- a/crates/app/src/icons.rs
+++ b/crates/app/src/icons.rs
@@ -60,8 +60,14 @@
 //! module uses (`folder`, `trash`, ...), so a pack author needs nothing but the name.
 //!
 //! Note this module deliberately does not change `crate::root::widgets`'
-//! `render_agent_chip_icon`, the one older icon-pack call site - its no-tint path predates this
-//! issue and is a separate, already-shipped surface.
+//! `render_agent_chip_icon`, the one older icon-pack call site - it is a separate,
+//! already-shipped surface with a real difference from this one: a shipped Phosphor icon is
+//! deliberately monochrome and *should* pick up a theme tint (point 1 above), while an
+//! agent-chip pack icon is a full-color, user-supplied brand image that must keep its own
+//! colors. GitHub issue #309 fixed that older call site's own version of point 2 above (it drew
+//! empty boxes for the same "no text color" reason) by switching it to `gpui::img()`, which
+//! doesn't consult `style.text.color` at all - not by adding a tint, which would have been wrong
+//! for a full-color logo.
 
 use std::borrow::Cow;
 use std::path::PathBuf;

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -4501,14 +4501,15 @@ mod rail_filter_caret_tests {
 
 /// GitHub issue #5's "custom icon packs" - real coverage that the rail agent row's chip
 /// (`AdeApp::render_agent_chip_icon`, the one real call site this feature is wired to today)
-/// actually switches between the app's default letter chip and a real pack SVG, rather than
-/// just trusting the render code's own claim to do so.
+/// actually switches between the app's default letter chip and a real pack icon, rather than
+/// just trusting the render code's own claim to do so. GitHub issue #309's own regression test
+/// lives here too - see `the_pack_icon_element_is_a_real_image_not_a_colour_dependent_svg`.
 #[cfg(test)]
 mod agent_chip_icon_pack_tests {
     use crate::rail::worktrees::WorktreeItem;
     use crate::root::focus::palette_focus_tests;
     use crate::work_surface::agents::ProcessKind;
-    use gpui::TestAppContext;
+    use gpui::{px, TestAppContext};
 
     fn worktree_item(path: std::path::PathBuf, label: &str) -> WorktreeItem {
         WorktreeItem {
@@ -4577,8 +4578,8 @@ mod agent_chip_icon_pack_tests {
             "with no icon pack configured, the rail's own default agent chip must paint"
         );
         assert!(
-            cx.debug_bounds("agent-chip-icon-pack-svg").is_none(),
-            "with no icon pack configured, no pack SVG element must paint at all"
+            cx.debug_bounds("agent-chip-icon-pack-image").is_none(),
+            "with no icon pack configured, no pack image element must paint at all"
         );
     }
 
@@ -4599,14 +4600,57 @@ mod agent_chip_icon_pack_tests {
         cx.run_until_parked();
 
         assert!(
-            cx.debug_bounds("agent-chip-icon-pack-svg").is_some(),
-            "once a real pack directory with a matching shell.svg is configured, the rail row \
-             must really switch to painting the pack's own SVG element"
+            cx.debug_bounds("agent-chip-icon-pack-image").is_some(),
+            "once a real pack directory with a matching claude.svg is configured, the rail row \
+             must really switch to painting the pack's own image element"
         );
         assert!(
             cx.debug_bounds("agent-chip-icon-default").is_none(),
             "the default letter chip must not also paint once the pack icon takes over - \
              exactly one of the two must be showing, never both at once"
+        );
+    }
+
+    /// GitHub issue #309: `debug_bounds` (the two tests above) only proves the pack-icon element
+    /// exists in the render tree - `Interactivity::paint` records it *before* running the
+    /// element's own paint closure, so it stays `Some(..)` even for an element whose paint
+    /// closure draws nothing. That is exactly how the empty-box bug shipped past those two tests
+    /// in the first place: the old pack-icon branch built a `gpui::svg()` with no `.text_color()`
+    /// set, and GPUI's `Svg::paint` (`vendor/zed/crates/gpui/src/elements/svg.rs`) zips its path
+    /// with `style.text.color` and skips painting outright when that's `None` - a real, silent,
+    /// invisible empty box that both bounds-only tests above were blind to.
+    ///
+    /// This test instead inspects the real element `AdeApp::render_agent_chip_icon` hands back,
+    /// downcasting the type-erased `AnyElement` (`gpui::AnyElement::downcast_mut`) to check which
+    /// concrete GPUI element type is actually behind it. `gpui::Img::paint`
+    /// (`vendor/zed/crates/gpui/src/elements/img.rs`) never reads `style.text.color` at all - it
+    /// paints real decoded pixels unconditionally - so this is the real, structural guarantee
+    /// that the pack icon cannot regress back into the invisible-alpha-mask failure mode.
+    #[gpui::test]
+    fn the_pack_icon_element_is_a_real_image_not_a_colour_dependent_svg(cx: &mut TestAppContext) {
+        let pack_dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(pack_dir.path().join("claude.svg"), "<svg></svg>").expect("write");
+
+        let (_repo, _wt, app, cx) = open_with_a_running_agent(cx);
+        app.update(cx, |app, cx| {
+            app.settings.icon_pack.directory = Some(pack_dir.path().to_path_buf());
+            cx.notify();
+        });
+        cx.run_until_parked();
+
+        let mut element = app.read_with(cx, |app, _cx| {
+            app.render_agent_chip_icon(ProcessKind::claude(), px(15.0), app.ui_text_size(9.0))
+        });
+        assert!(
+            element.downcast_mut::<gpui::Img>().is_some(),
+            "a configured pack icon must be built through gpui::img(), whose paint never \
+             consults style.text.color, not gpui::svg(), whose paint silently skips painting \
+             altogether when no text colour is set"
+        );
+        assert!(
+            element.downcast_mut::<gpui::Svg>().is_none(),
+            "a configured pack icon must not be a gpui::svg() element - that is the exact shape \
+             of GitHub issue #309's empty-box bug"
         );
     }
 }

--- a/crates/app/src/root/widgets.rs
+++ b/crates/app/src/root/widgets.rs
@@ -463,14 +463,25 @@ fn simple_input_caret_opacity(is_focused: bool, blink_visible: bool) -> Option<f
 }
 
 impl AdeApp {
-    /// One agent-kind chip (GitHub issue #5's "custom icon packs"): a real, user-supplied SVG
+    /// One agent-kind chip (GitHub issue #5's "custom icon packs"): a real, user-supplied image
     /// from the active icon pack (`crate::icon_pack::resolve_icon`) if one exists for `kind`, at
     /// its own real colors (no theme tint - see `crate::icon_pack`'s own module docs on why),
     /// else this app's existing default look (a `size`-square rounded chip, tinted per
     /// `work_surface::agent_tint`, showing `work_surface::agent_initial`'s single letter) -
-    /// unchanged from before this feature existed. `size` is also the SVG's real width/height,
+    /// unchanged from before this feature existed. `size` is also the image's real width/height,
     /// so a pack icon fills exactly the same box the default chip already occupies at every one
     /// of this helper's real call sites, rather than needing per-call-site size plumbing.
+    ///
+    /// Painted with `gpui::img()`, not `gpui::svg()` (GitHub issue #309): `svg()` rasterises to
+    /// an alpha mask and paints it tinted with the element's own `style.text.color`
+    /// (`vendor/zed/crates/gpui/src/elements/svg.rs`'s `paint` zips the path with that color and
+    /// skips painting entirely when it's `None`), so a full-color pack icon drawn through `svg()`
+    /// with no `.text_color()` set - the case this branch was in before this fix - painted
+    /// nothing at all, an empty box, regardless of what colors the pack's own file defined.
+    /// `img()`'s `paint` (`elements/img.rs`) never consults `style.text.color`; it decodes the
+    /// source's own real pixels (raster or SVG - `Img::extensions()` covers both) and paints them
+    /// as a full-color `PolychromeSprite`, which is what "keeps its own colours" actually
+    /// requires in this GPUI version.
     pub(crate) fn render_agent_chip_icon(
         &self,
         kind: ProcessKind,
@@ -481,12 +492,11 @@ impl AdeApp {
             &self.settings.icon_pack,
             work_surface::agent_icon_name(kind),
         ) {
-            return gpui::svg()
-                .external_path(icon_path.to_string_lossy().into_owned())
+            return gpui::img(icon_path)
                 .flex_none()
                 .w(size)
                 .h(size)
-                .debug_selector(|| "agent-chip-icon-pack-svg".to_string())
+                .debug_selector(|| "agent-chip-icon-pack-image".to_string())
                 .into_any_element();
         }
         let (chip_fg, chip_bg) = work_surface::agent_tint(kind);


### PR DESCRIPTION
## Summary

- `AdeApp::render_agent_chip_icon` (`crates/app/src/root/widgets.rs`) drew a configured pack icon with `gpui::svg().external_path(..)` and no `.text_color()` call. GPUI's `Svg::paint` zips the element's path with `style.text.color` and skips painting entirely when that color is `None` (`vendor/zed/crates/gpui/src/elements/svg.rs`), so a configured icon pack painted nothing at all - an empty box - regardless of what colors the pack's own SVG defined. `icon_pack.rs`'s doc comment claimed pack icons "keep their own colours" via this path; that claim was false.
- `svg()` is fundamentally single-color (an alpha mask uniformly tinted by one color) in this pinned GPUI version, so a real fix can't just add a tint - that would flatten a full-color brand logo to one flat color, which isn't "keeping its own colours" either. Switched the pack-icon branch to `gpui::img()`, whose `paint` never reads `style.text.color` at all and instead decodes and paints the source's real pixels - which is what "keeps its own colours" actually requires.
- Corrected `icon_pack.rs`'s and `icons.rs`'s doc comments to describe GPUI's actual `svg()`/`img()` behavior, and to explain why `crate::icons`' shipped Phosphor icons correctly keep using `svg()` with an explicit tint (a different, intentionally-monochrome surface, unaffected by this change).

## Regression test

The existing icon-pack tests (`rail::render::agent_chip_icon_pack_tests`) never caught this because they only assert on `debug_bounds`, which GPUI's `Interactivity::paint` records *before* running the element's own paint closure - so it stayed `Some(..)` even when `svg()` silently painted nothing.

Added `the_pack_icon_element_is_a_real_image_not_a_colour_dependent_svg`, which instead downcasts the `AnyElement` `AdeApp::render_agent_chip_icon` returns (`gpui::AnyElement::downcast_mut`) to check its concrete GPUI element type directly. Verified by hand that this test (and the renamed-selector assertion in the two adjacent tests) fails against the pre-fix `svg()`-based code and passes against this fix.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets` (warning-free)
- [x] `cargo test -p app --lib` - 2631 passed; 15 failed under parallel load, all in the known-flaky `worktree_watch`/`file_tree_watch`/`repo_list_tests` group (inotify contention), all re-verified passing in isolation with `--test-threads=1`
- [x] Manually reverted the fix locally and re-ran the new/changed tests to confirm they fail against the old `svg()`-based code and pass against this fix

Closes #309