### PR TITLE
Sidebar strip: Worktrees · Problems · ⋯, and one 36px chrome rule (#291)

### DIFF
--- a/assets/themes/ember.toml
+++ b/assets/themes/ember.toml
@@ -32,6 +32,7 @@ window                     = "#0f1112"  # window body
 window_border              = "#1f2427"
 title_bar                  = "#101314"
 rail                       = "#101214"  # left rail + right panel
+sidebar_strip              = "#0c0e0f"  # The sidebar strip's own recessed band (GitHub issue #291)
 center                     = "#121517"  # work surface
 pty                        = "#0e1112"  # agent CLI + terminal
 header                     = "#111417"  # context bar, panel headers
@@ -94,24 +95,25 @@ thumb_hover = "#2e373c"
 
 # The interface text ramp, brightest to dimmest.
 [text]
-selected   = "#9da3a6"
-primary    = "#969c9f"
-heading    = "#8f9598"
-strong     = "#8a9194"
-body       = "#838c90"
-secondary  = "#788186"
-muted      = "#6e777b"
-dim        = "#646c70"
-dimmer     = "#5a6368"
-faint      = "#4e565b"
-fainter    = "#454d51"
-ghost      = "#3a4246"
-ghoster    = "#343c40"
-hint       = "#32383b"
-gutter     = "#2d3336"
-disabled   = "#2e3539"
-path       = "#373f44"
-tree_caret = "#373f44"  # The file tree row's ▾/▸ caret
+selected    = "#9da3a6"
+primary     = "#969c9f"
+heading     = "#8f9598"
+strong      = "#8a9194"
+body        = "#838c90"
+secondary   = "#788186"
+muted       = "#6e777b"
+dim         = "#646c70"
+dimmer      = "#5a6368"
+faint       = "#4e565b"
+fainter     = "#454d51"
+ghost       = "#3a4246"
+ghoster     = "#343c40"
+hint        = "#32383b"
+gutter      = "#2d3336"
+disabled    = "#2e3539"
+path        = "#373f44"
+tree_caret  = "#373f44"  # The file tree row's ▾/▸ caret
+glyph_hover = "#8e9699"
 
 
 # ──────────────────────────────────────────────────────────────────────────────────────────────

--- a/assets/themes/jerry-dim.toml
+++ b/assets/themes/jerry-dim.toml
@@ -32,6 +32,7 @@ window                     = "#17181a"  # window body
 window_border              = "#2c2f33"
 title_bar                  = "#191a1c"
 rail                       = "#19191b"  # left rail + right panel
+sidebar_strip              = "#131416"  # The sidebar strip's own recessed band (GitHub issue #291)
 center                     = "#1b1d20"  # work surface
 pty                        = "#16181a"  # agent CLI + terminal
 header                     = "#1a1c1f"  # context bar, panel headers
@@ -94,24 +95,25 @@ thumb_hover = "#40464c"
 
 # The interface text ramp, brightest to dimmest.
 [text]
-selected   = "#c7cacf"
-primary    = "#bec2c7"
-heading    = "#b5b9be"
-strong     = "#b0b4b9"
-body       = "#a8adb4"
-secondary  = "#9ba1a7"
-muted      = "#8f949b"
-dim        = "#82878c"
-dimmer     = "#767c82"
-faint      = "#676c72"
-fainter    = "#5c6166"
-ghost      = "#4e5359"
-ghoster    = "#474c51"
-hint       = "#43474c"
-gutter     = "#3d4146"
-disabled   = "#40444a"
-path       = "#4b5056"
-tree_caret = "#4b5056"  # The file tree row's ▾/▸ caret
+selected    = "#c7cacf"
+primary     = "#bec2c7"
+heading     = "#b5b9be"
+strong      = "#b0b4b9"
+body        = "#a8adb4"
+secondary   = "#9ba1a7"
+muted       = "#8f949b"
+dim         = "#82878c"
+dimmer      = "#767c82"
+faint       = "#676c72"
+fainter     = "#5c6166"
+ghost       = "#4e5359"
+ghoster     = "#474c51"
+hint        = "#43474c"
+gutter      = "#3d4146"
+disabled    = "#40444a"
+path        = "#4b5056"
+tree_caret  = "#4b5056"  # The file tree row's ▾/▸ caret
+glyph_hover = "#b5babf"
 
 
 # ──────────────────────────────────────────────────────────────────────────────────────────────

--- a/assets/themes/moss.toml
+++ b/assets/themes/moss.toml
@@ -32,6 +32,7 @@ window                     = "#111213"  # window body
 window_border              = "#26292c"
 title_bar                  = "#131416"
 rail                       = "#131415"  # left rail + right panel
+sidebar_strip              = "#0e0e10"  # The sidebar strip's own recessed band (GitHub issue #291)
 center                     = "#161719"  # work surface
 pty                        = "#101213"  # agent CLI + terminal
 header                     = "#151618"  # context bar, panel headers
@@ -94,24 +95,25 @@ thumb_hover = "#3a3f44"
 
 # The interface text ramp, brightest to dimmest.
 [text]
-selected   = "#bec2c6"
-primary    = "#b6babd"
-heading    = "#adb1b4"
-strong     = "#a8acaf"
-body       = "#a0a5aa"
-secondary  = "#94989e"
-muted      = "#878c91"
-dim        = "#7b7f83"
-dimmer     = "#6f7479"
-faint      = "#606469"
-fainter    = "#55595e"
-ghost      = "#484c50"
-ghoster    = "#404449"
-hint       = "#3d4044"
-gutter     = "#373a3e"
-disabled   = "#3a3d41"
-path       = "#45494e"
-tree_caret = "#45494e"  # The file tree row's ▾/▸ caret
+selected    = "#bec2c6"
+primary     = "#b6babd"
+heading     = "#adb1b4"
+strong      = "#a8acaf"
+body        = "#a0a5aa"
+secondary   = "#94989e"
+muted       = "#878c91"
+dim         = "#7b7f83"
+dimmer      = "#6f7479"
+faint       = "#606469"
+fainter     = "#55595e"
+ghost       = "#484c50"
+ghoster     = "#404449"
+hint        = "#3d4044"
+gutter      = "#373a3e"
+disabled    = "#3a3d41"
+path        = "#45494e"
+tree_caret  = "#45494e"  # The file tree row's ▾/▸ caret
+glyph_hover = "#adb1b6"
 
 
 # ──────────────────────────────────────────────────────────────────────────────────────────────

--- a/assets/themes/paper.toml
+++ b/assets/themes/paper.toml
@@ -32,6 +32,7 @@ window                     = "#f0f1f4"  # window body
 window_border              = "#cfd4d8"
 title_bar                  = "#eceef0"
 rail                       = "#edeff1"  # left rail + right panel
+sidebar_strip              = "#f5f6f9"  # The sidebar strip's own recessed band (GitHub issue #291)
 center                     = "#e8eaee"  # work surface
 pty                        = "#eff2f4"  # agent CLI + terminal
 header                     = "#e9ecef"  # context bar, panel headers
@@ -94,24 +95,25 @@ thumb_hover = "#b3bac1"
 
 # The interface text ramp, brightest to dimmest.
 [text]
-selected   = "#3b3e41"
-primary    = "#414448"
-heading    = "#484c4f"
-strong     = "#4c5053"
-body       = "#51565a"
-secondary  = "#5b6065"
-muted      = "#666b70"
-dim        = "#73777c"
-dimmer     = "#7c8287"
-faint      = "#8c9197"
-fainter    = "#979da2"
-ghost      = "#a5abb0"
-ghoster    = "#adb3b9"
-hint       = "#b3b8bc"
-gutter     = "#b9bec3"
-disabled   = "#b6bbc1"
-path       = "#a9aeb5"
-tree_caret = "#a9aeb5"  # The file tree row's ▾/▸ caret
+selected    = "#3b3e41"
+primary     = "#414448"
+heading     = "#484c4f"
+strong      = "#4c5053"
+body        = "#51565a"
+secondary   = "#5b6065"
+muted       = "#666b70"
+dim         = "#73777c"
+dimmer      = "#7c8287"
+faint       = "#8c9197"
+fainter     = "#979da2"
+ghost       = "#a5abb0"
+ghoster     = "#adb3b9"
+hint        = "#b3b8bc"
+gutter      = "#b9bec3"
+disabled    = "#b6bbc1"
+path        = "#a9aeb5"
+tree_caret  = "#a9aeb5"  # The file tree row's ▾/▸ caret
+glyph_hover = "#474b4f"
 
 
 # ──────────────────────────────────────────────────────────────────────────────────────────────

--- a/assets/themes/slate.toml
+++ b/assets/themes/slate.toml
@@ -32,6 +32,7 @@ window                     = "#101113"  # window body
 window_border              = "#202327"
 title_bar                  = "#111315"
 rail                       = "#111214"  # left rail + right panel
+sidebar_strip              = "#0d0e10"  # The sidebar strip's own recessed band (GitHub issue #291)
 center                     = "#131518"  # work surface
 pty                        = "#0f1113"  # agent CLI + terminal
 header                     = "#131417"  # context bar, panel headers
@@ -94,24 +95,25 @@ thumb_hover = "#2f343b"
 
 # The interface text ramp, brightest to dimmest.
 [text]
-selected   = "#979a9f"
-primary    = "#909499"
-heading    = "#898d92"
-strong     = "#85898e"
-body       = "#7f848b"
-secondary  = "#757a81"
-muted      = "#6b7177"
-dim        = "#62666c"
-dimmer     = "#595e65"
-faint      = "#4d5258"
-fainter    = "#45494f"
-ghost      = "#3a3f45"
-ghoster    = "#34393f"
-hint       = "#32363a"
-gutter     = "#2d3136"
-disabled   = "#2f3339"
-path       = "#383c43"
-tree_caret = "#383c43"  # The file tree row's ▾/▸ caret
+selected    = "#979a9f"
+primary     = "#909499"
+heading     = "#898d92"
+strong      = "#85898e"
+body        = "#7f848b"
+secondary   = "#757a81"
+muted       = "#6b7177"
+dim         = "#62666c"
+dimmer      = "#595e65"
+faint       = "#4d5258"
+fainter     = "#45494f"
+ghost       = "#3a3f45"
+ghoster     = "#34393f"
+hint        = "#32363a"
+gutter      = "#2d3136"
+disabled    = "#2f3339"
+path        = "#383c43"
+tree_caret  = "#383c43"  # The file tree row's ▾/▸ caret
+glyph_hover = "#898e93"
 
 
 # ──────────────────────────────────────────────────────────────────────────────────────────────

--- a/crates/app/src/rail/menu.rs
+++ b/crates/app/src/rail/menu.rs
@@ -206,10 +206,12 @@ pub fn agent_menu_groups(running: bool) -> Vec<Vec<MenuEntry<RailMenuAction>>> {
 }
 
 /// Whether this build really has a History *view* for the `⋯` overflow to switch to. It does
-/// not: GitHub issue #227's history is rendered inline under each worktree row, and the view a
-/// sidebar strip switches to is GitHub issue #291's. Named rather than inlined as a bare `false`
-/// so the row that reads it, its disabled reason and this fact stay one thing - see
-/// [`overflow_menu_groups`].
+/// not: GitHub issue #227's history is rendered inline under each worktree row, and the sidebar
+/// strip GitHub issue #291 built has exactly two views (`crate::rail::strip::SidebarView`) -
+/// History is *reached* through this overflow rather than being a cell, per
+/// `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` section 4t, but the surface it would
+/// open is still #227's to build. Named rather than inlined as a bare `false` so the row that
+/// reads it, its disabled reason and this fact stay one thing - see [`overflow_menu_groups`].
 pub const HISTORY_VIEW_AVAILABLE: bool = false;
 
 /// The sidebar strip's `⋯` overflow (§4u): "History and Settings only, with the glyphs they had
@@ -217,10 +219,9 @@ pub const HISTORY_VIEW_AVAILABLE: bool = false;
 /// recognisability. Command palette, Keyboard shortcuts and About were filler - the palette has
 /// `⌘K` and its own surface."
 ///
-/// `history_available` is whether this build really has a History surface to switch to. It does
-/// not yet - History is rendered inline under each worktree row (GitHub issue #227) and the view
-/// that the strip switches to is GitHub issue #291's - so the row ships visibly disabled with
-/// that as its reason, rather than as a row that looks live and does nothing.
+/// `history_available` is whether this build really has a History surface to switch to - see
+/// [`HISTORY_VIEW_AVAILABLE`]. It does not yet, so the row ships visibly disabled with that as its
+/// reason, rather than as a row that looks live and does nothing.
 pub fn overflow_menu_groups(history_available: bool) -> Vec<Vec<MenuEntry<RailMenuAction>>> {
     vec![vec![
         MenuEntry::new(RailMenuAction::OpenHistory, "History")
@@ -228,7 +229,7 @@ pub fn overflow_menu_groups(history_available: bool) -> Vec<Vec<MenuEntry<RailMe
             .tooltip("Earlier runs, by repo and worktree")
             .gated(
                 history_available,
-                "the History view arrives with the sidebar strip (issue #291); a worktree's own \
+                "there is no History surface in this build yet (issue #227); a worktree's own \
                  past runs are already listed under its row",
             ),
         MenuEntry::new(RailMenuAction::OpenSettings, "Settings")

--- a/crates/app/src/rail/menu_render.rs
+++ b/crates/app/src/rail/menu_render.rs
@@ -379,57 +379,63 @@ impl AdeApp {
     /// The `⋯` More cell (§4t: "a permanent cell in a 5-cell strip is a claim that you switch to
     /// it constantly. If you don't, it belongs in the overflow").
     ///
-    /// Its final home is the sidebar strip GitHub issue #291 builds; this app has no strip yet,
-    /// so it sits in the rail header beside the `+` - the rail's only existing chrome row - where
-    /// #291 can move it without any of the menu machinery below changing. A `gpui::canvas`
-    /// captures its real window-space rect (the same capture the commit composer's `▾` menu uses)
-    /// because §4w anchors this menu to the button's own rect, not to the pointer.
+    /// It is the strip's last cell, and it is a *cell*: GitHub issue #291 moved it out of the
+    /// stop-gap rail header it was parked in and into the sidebar strip that was always its home,
+    /// where it goes through `crate::rail::strip_render::strip_cell` like every other child - so
+    /// it carries the column rule, the 38px width and the glyph-only hover the rest of the strip
+    /// does. `Jerry.dc.html` gives it a `border-left` (rather than the view cells' `border-right`)
+    /// because it sits on the far side of the strip's flex spacer.
+    ///
+    /// None of the menu machinery below changed in that move, exactly as this comment promised it
+    /// would not: a `gpui::canvas` still captures the button's real window-space rect (the same
+    /// capture the commit composer's `▾` menu uses), because §4w anchors this menu to the
+    /// button's own rect rather than to the pointer.
     pub(in crate::rail) fn render_rail_overflow_button(
         &self,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        div()
-            .id("rail-overflow")
-            .debug_selector(|| "rail-overflow".to_string())
-            .relative()
-            .flex_none()
-            .flex()
-            .items_center()
-            .justify_center()
-            .w(crate::icons::IconSize::Control.box_size())
-            .h(crate::icons::IconSize::Control.box_size())
-            .rounded(theme::radius::CHIP)
-            .cursor_pointer()
-            .hover(|el| el.bg(theme::surface::ROW_HOVER_ALT))
-            .tooltip(text_tooltip("More \u{2014} History and Settings"))
-            .font(font(theme::font::SANS))
-            .text_size(self.ui_text_size(11.0))
-            .text_color(theme::text::DIM)
-            .child("\u{22ef}")
-            .child({
-                let this = cx.entity();
-                gpui::canvas(
-                    move |bounds, _window, cx| {
-                        this.update(cx, |this, _cx| {
-                            this.rail_overflow_button_bounds = bounds;
-                        });
-                    },
-                    |_, _, _, _| {},
-                )
-                .absolute()
-                .top(px(0.0))
-                .left(px(0.0))
-                .right(px(0.0))
-                .bottom(px(0.0))
-            })
-            .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
-                cx.stop_propagation();
-                if this.rail_overflow_menu.is_some() {
-                    this.close_rail_overflow_menu(cx);
-                } else {
-                    this.open_rail_overflow_menu(window, cx);
-                }
-            }))
+        crate::rail::strip_render::strip_cell(
+            div()
+                .id("rail-overflow")
+                .debug_selector(|| "rail-overflow".to_string()),
+            "rail-overflow",
+            theme::border::RAIL_INNER,
+            theme::text::FAINTER,
+            div()
+                .font(font(theme::font::SANS))
+                .text_size(self.ui_text_size(11.0))
+                .group_hover("rail-overflow", |el| {
+                    el.text_color(theme::text::GLYPH_HOVER)
+                })
+                .child("\u{22ef}"),
+        )
+        .border_l_1()
+        .border_color(theme::border::INNER)
+        .tooltip(text_tooltip("More \u{2014} History and Settings"))
+        .child({
+            let this = cx.entity();
+            gpui::canvas(
+                move |bounds, _window, cx| {
+                    this.update(cx, |this, _cx| {
+                        this.rail_overflow_button_bounds = bounds;
+                    });
+                },
+                |_, _, _, _| {},
+            )
+            .absolute()
+            .top(px(0.0))
+            .left(px(0.0))
+            .right(px(0.0))
+            .bottom(px(0.0))
+        })
+        .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
+            cx.stop_propagation();
+            if this.rail_overflow_menu.is_some() {
+                this.close_rail_overflow_menu(cx);
+            } else {
+                this.open_rail_overflow_menu(window, cx);
+            }
+        }))
     }
 }
 

--- a/crates/app/src/rail/mod.rs
+++ b/crates/app/src/rail/mod.rs
@@ -24,6 +24,11 @@
 //!   menu (GitHub issue #290), drawn through the app's one shared menu (`crate::menu`).
 //! - [`menu_render`] - the `impl AdeApp` half of those menus: opening one off a real
 //!   right-click, and running what its rows promise.
+//! - [`strip`] - the sidebar strip's pure model (GitHub issue #291): which views the left column
+//!   offers, each cell's marker and tooltip, and the gate that empties the strip on a day with no
+//!   worktrees.
+//! - [`strip_render`] - the `impl AdeApp` half of the strip: the real 36px band, the real view
+//!   switch, and the Problems view it switches to.
 //! - [`render`] - the real GPUI rail, its rows, hover affordances and click handlers, as
 //!   `impl AdeApp` methods.
 //!
@@ -36,6 +41,7 @@ use crate::rail::state::{
     self as rail, AgentRow, RepoGroup, RepoWorktrees, WorktreeEntry, WorktreeNote, WorktreeRow,
 };
 use crate::rail::status::Status;
+use crate::rail::strip as rail_strip;
 use crate::rail::worktrees::WorktreeItem;
 use crate::root::*;
 use crate::status_bar::process_stats;
@@ -50,9 +56,11 @@ pub mod menu;
 pub mod repo;
 pub mod state;
 pub mod status;
+pub mod strip;
 pub mod title_signal;
 pub mod worktree_watch;
 pub mod worktrees;
 
 pub(crate) mod menu_render;
 pub(crate) mod render;
+pub(crate) mod strip_render;

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::root::plural;
-use crate::root::widgets::{render_disclosure_caret, render_keycap_row, text_tooltip, KeycapSize};
+use crate::root::widgets::{render_disclosure_caret, text_tooltip};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -25,6 +25,26 @@ fn agent_state_word(status: Status) -> &'static str {
         Status::Run => "running",
         Status::Idle => "paused",
     }
+}
+
+/// How many agents in this window are waiting on a human - the Worktrees cell's state marker
+/// (GitHub issue #291).
+///
+/// `REVISION-2026-08-13.md` §1 names the unit outright ("worktrees shows agents needing a human")
+/// and `Jerry.dc.html` computes exactly it:
+/// `sessions.filter(s => s.status === 'ask' || s.status === 'fail').length`. Those are this app's
+/// [`Status::Ask`] and [`Status::Fail`].
+///
+/// A filter over [`rail::urgency_counts`]' one real pass, not a second classification - the same
+/// relationship `crate::title_bar::render::title_bar_agent_state_chips` already has to it, so the
+/// strip's marker and the title bar's own dots cannot report different numbers for the same
+/// window.
+fn agents_needing_you(rows: &[AgentRow]) -> usize {
+    rail::urgency_counts(rows)
+        .into_iter()
+        .filter(|(status, _)| matches!(status, Status::Ask | Status::Fail))
+        .map(|(_, count)| count)
+        .sum()
 }
 
 /// The agent row's line-2 trailing text (§2.3's exact per-status table): empty for `needs
@@ -758,11 +778,36 @@ impl AdeApp {
         self._prune_task = Some(task);
     }
 
-    /// The whole agent rail (`design_handoff_jerry_ade/README.md`'s Zone 1): header,
-    /// filter row, the real scrollable agent/worktree list, and the footer - see the
-    /// README's "Rail chrome" section for the exact band heights this composes
-    /// (`theme::band::{RAIL_HEADER,FILTER_ROW,SURFACE_FOOTER}`).
+    /// The whole left column (`design_handoff_jerry_ade/README.md`'s Zone 1): the sidebar strip,
+    /// the filter row, the real scrollable body of whichever view the strip has selected, and the
+    /// footer - see the README's "Rail chrome" section for the exact band heights this composes
+    /// (`theme::band::{CHROME_HEADER,FILTER_ROW,SURFACE_FOOTER}`).
+    ///
+    /// GitHub issue #291 turned this from "the rail" into "the sidebar, which is showing the
+    /// rail": `crate::rail::strip_render::AdeApp::render_sidebar_strip` replaced the plain rail
+    /// header at the same [`theme::band::CHROME_HEADER`] height, and the scroller below now paints
+    /// whichever `crate::rail::strip::SidebarView` is selected.
+    ///
+    /// `crate::rail::state::RepoGroup`s are built **once**, here, and lent to both halves. The
+    /// strip's empty-day gate and the Worktrees body are two answers about the same data
+    /// (`REVISION-2026-08-13.md` §1: "Gate this at the source ... not in the template"), so
+    /// deriving them from one pass is what makes it impossible for the strip to offer a switcher
+    /// over rows the body does not have - as well as saving a second full rebuild per frame.
     pub(crate) fn render_rail(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let groups = self.build_repo_groups(cx);
+        // A window with no worktree row anywhere is §1's First-run/Empty-day state: "with no
+        // worktrees there are no views to offer". Read off `all_rows` rather than `rows` for the
+        // same reason every count in `RepoGroup` is: a filter query that hides every row must not
+        // make the strip's cells vanish.
+        let has_worktrees = groups.iter().any(|group| !group.all_rows.is_empty());
+        let view = self.effective_sidebar_view(has_worktrees);
+        let cells = rail_strip::strip_view_cells(
+            has_worktrees,
+            view,
+            agents_needing_you(&self.build_agent_rows(cx)),
+            self.worktree_problem_tally(),
+        );
+
         div()
             .id("agent-rail")
             // The app's real "nowhere else to put focus" fallback target - see
@@ -772,8 +817,8 @@ impl AdeApp {
             .flex()
             .flex_col()
             .size_full()
-            .child(self.render_rail_header(cx))
-            .child(self.render_rail_filter_row(cx))
+            .child(self.render_sidebar_strip(&cells, cx))
+            .child(self.render_rail_filter_row(view, cx))
             .when_some(self.render_worktrees_error_banner(), |el, banner| {
                 el.child(banner)
             })
@@ -799,7 +844,7 @@ impl AdeApp {
                             .min_h_0()
                             .overflow_y_scroll()
                             .track_scroll(&self.rail_scroll_handle)
-                            .child(self.render_rail_list(cx)),
+                            .child(self.render_sidebar_body(view, &groups, cx)),
                     )
                     .children(self.render_vertical_scrollbar(
                         "rail-scrollbar",
@@ -876,69 +921,17 @@ impl AdeApp {
         )
     }
 
-    /// Header 36 - Revision R12 §2.1: "Rail header keeps only the `+` new-session button." No
-    /// section-title label - this used to say `AGENTS` (a leftover from the pre-R12 flat rail,
-    /// carried through a rename to fix its vocabulary without checking it against this
-    /// requirement) but the spec is explicit that the header has nothing but the button itself.
-    ///
-    /// It now also carries the `⋯` overflow (GitHub issue #290). That control's designed home is
-    /// the sidebar strip GitHub issue #291 builds, which this app does not have yet; the rail
-    /// header is the one existing piece of rail chrome that already holds a control, so it is
-    /// where the button lives until #291 moves it. Nothing but this one `.child` has to change
-    /// when it does - the menu itself is anchored off the button's own captured rect.
-    pub(in crate::rail) fn render_rail_header(&self, cx: &mut Context<Self>) -> impl IntoElement {
-        div()
-            .id("rail-header")
-            .flex()
-            .flex_none()
-            .items_center()
-            .justify_end()
-            .gap(px(6.0))
-            .px(px(10.0))
-            .h(theme::band::CHROME_HEADER)
-            .border_b_1()
-            .border_color(theme::border::RAIL_INNER)
-            .child(self.render_new_agent_button(cx))
-            .child(self.render_rail_overflow_button(cx))
-    }
-
-    /// The `+` control with its real, platform-resolved `mod+N` keycap pair (`⌘N` on macOS,
-    /// `Ctrl N` on Windows/Linux - `crate::keymap::resolve_combo`) - spawns a real new shell
-    /// agent (see [`NewAgent`]'s docs for the judgment call on the keybinding side of
-    /// this).
-    pub(in crate::rail) fn render_new_agent_button(
-        &self,
-        cx: &mut Context<Self>,
-    ) -> impl IntoElement {
-        div()
-            .id("rail-new-agent")
-            .flex()
-            .items_center()
-            .gap(px(4.0))
-            .cursor_pointer()
-            .px(px(6.0))
-            .py(px(2.0))
-            .rounded(theme::radius::CHIP)
-            .hover(|el| el.bg(theme::surface::ROW_HOVER_ALT))
-            .child(
-                div()
-                    .text_color(theme::text::DIM)
-                    .text_size(self.ui_text_size(11.0))
-                    .child("+"),
-            )
-            .child(render_keycap_row(
-                &keymap::resolve_combo("mod+N", self.window_controls_style().is_macos()),
-                KeycapSize::Standard,
-            ))
-            .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
-                this.new_agent(ProcessKind::Shell, window, cx);
-            }))
-    }
-
     /// Filter row 30: `/` plus the real typed query, or the placeholder text when empty -
     /// see [`Self::handle_filter_key_down`] for the (deliberately minimal) text input.
+    ///
+    /// Its placeholder follows the strip's selected view (GitHub issue #291) -
+    /// `design_handoff_jerry_ade/revision 5/REVISION-2026-08-13.md` §1: "**Filter row** stays, and
+    /// its placeholder follows the view: `filter worktrees and agents` / `filter runs` / `filter
+    /// problems`." The query itself is one field across both views, and both really honour it, so
+    /// the placeholder never promises a filter that does nothing (§7 rule 1).
     pub(in crate::rail) fn render_rail_filter_row(
         &self,
+        view: rail_strip::SidebarView,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
         let has_query = !self.filter_query.is_empty();
@@ -1006,7 +999,13 @@ impl AdeApp {
                             .child(if has_query {
                                 self.filter_query.as_str().to_string()
                             } else {
-                                "filter worktrees and agents".to_string()
+                                match view {
+                                    rail_strip::SidebarView::Worktrees => {
+                                        "filter worktrees and agents"
+                                    }
+                                    rail_strip::SidebarView::Problems => "filter problems",
+                                }
+                                .to_string()
                             })
                             .debug_selector(|| "rail-filter-text".to_string()),
                     )
@@ -1108,9 +1107,15 @@ impl AdeApp {
     /// REVISION-2026-07-31.md` §2.1: "Two levels, always: **repo group → worktree → agents**.
     /// There is **no rail mode toggle**"). See [`Self::build_repo_groups`] for how the groups
     /// themselves are built.
-    pub(in crate::rail) fn render_rail_list(&self, cx: &mut Context<Self>) -> gpui::AnyElement {
-        let groups = self.build_repo_groups(cx);
-
+    ///
+    /// Takes the groups rather than rebuilding them (GitHub issue #291): the sidebar strip above
+    /// this list gates itself on the same data, and one pass is what guarantees the switcher and
+    /// the rows under it are talking about the same worktrees - see [`Self::render_rail`].
+    pub(in crate::rail) fn render_rail_list(
+        &self,
+        groups: &[RepoGroup],
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
         // GitHub issue #113: a repo with zero open worktrees still renders its own group
         // (`Self::render_repo_group` paints every group's header regardless of
         // `rows`/`all_rows`), so the only case left with genuinely nothing to show
@@ -1121,7 +1126,14 @@ impl AdeApp {
             return self.render_rail_empty_message("no worktrees found");
         }
 
-        let mut list = div().id("rail-repo-groups").flex().flex_col();
+        let mut list = div()
+            .id("rail-repo-groups")
+            // Lets a real test prove the Worktrees *body* really is what the strip's Worktrees
+            // cell switches to, and really is gone when Problems is selected - see
+            // `crate::rail::strip_render`'s `clicking_a_cell_really_switches_the_panel_under_it`.
+            .debug_selector(|| "rail-repo-groups".to_string())
+            .flex()
+            .flex_col();
         for (index, group) in groups.iter().enumerate() {
             list = list.child(self.render_repo_group(group, index, cx));
         }
@@ -2869,7 +2881,8 @@ mod rail_row_tests {
         });
 
         app.update(cx, |app, cx| {
-            let _ = app.render_rail_list(cx);
+            let groups = app.build_repo_groups(cx);
+            let _ = app.render_rail_list(&groups, cx);
         });
     }
 

--- a/crates/app/src/rail/strip.rs
+++ b/crates/app/src/rail/strip.rs
@@ -1,0 +1,589 @@
+//! The sidebar strip, as pure data (GitHub issue #291): which views the left column offers, which
+//! cells the strip really paints, what each cell's marker and tooltip say, and the one gate that
+//! empties the strip on a day with no worktrees.
+//!
+//! GPUI-free, like every other `state`-shaped module in this folder - "does an empty day still
+//! claim three agents need a human" and "does the Problems cell mark red or amber" are decisions
+//! worth asserting without a window. [`crate::rail::strip_render`] is the `impl AdeApp` half: the
+//! real 36px band, the real switch, and the real Problems body.
+//!
+//! ## What the strip is
+//!
+//! `design_handoff_jerry_ade/revision 5/REVISION-2026-08-13.md` §1 introduced it - "The left panel
+//! was hard-wired to one thing. It is now a switchable surface with a **horizontal icon strip
+//! along the top** - Cursor's arrangement, not VS Code's vertical activity bar. A vertical bar
+//! costs 44px of permanent width on a window whose whole job is fitting three panels side by
+//! side" - and `STAGE-A-CHANGELOG.md` §4v is its final form, which this module implements.
+//!
+//! §1's draft had four view cells (Worktrees, History, Search, Problems) plus a Settings gear.
+//! §4u/§4v supersede that and are what ships: **Search moved to the right panel** ("Search is now
+//! the middle tab of the right panel"), **History moved into the `⋯` overflow** ("a permanent cell
+//! in a 5-cell strip is a claim that you switch to it constantly. If you don't, it belongs in the
+//! overflow"), and Settings went with it. What is left is [`SidebarView`]'s two entries - which is
+//! why this enum has two variants and not four.
+//!
+//! ## The gate is here, not in the renderer
+//!
+//! §1, verbatim: "On **First run** and **Empty day** the icon strip drops its four buttons and
+//! keeps only the `+` action; the sidebar shows the rail's own empty state. With no worktrees
+//! there are no views to offer, and a switcher with four dead views is worse than no switcher."
+//! And: "Gate this **at the source** - `sideItems` and each view's `show*` flag - not in the
+//! template. The badges and the History/Search/Problems bodies derive from `sessions`, `histDefs`,
+//! `searchHits` and the diagnostics list; ungated they claimed 3 agents needing a human and 4
+//! problems on a day the rail, title bar and footer all reported zero."
+//!
+//! [`strip_view_cells`] is that source. It takes the real counts and returns an empty `Vec` when
+//! there is nothing to switch between, so there is no `when(..)` in the renderer that could be
+//! written once for the cells and forgotten for the badges.
+
+use crate::icons::Icon;
+use crate::root::plural;
+use crate::theme;
+
+/// A view the left column can show. Exactly the two §4u leaves in the strip.
+///
+/// [`SidebarView::Worktrees`] is the rail this app has always had, unchanged - §2's table says so
+/// in as many words ("the existing repo → worktree → agent tree, unchanged"). The strip does not
+/// rebuild it; it sits above it and gates it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum SidebarView {
+    /// The repo → worktree → agent tree.
+    #[default]
+    Worktrees,
+    /// The selected worktree's LSP diagnostics.
+    Problems,
+}
+
+impl SidebarView {
+    /// Every view, in the order the strip paints them.
+    pub const ALL: &'static [SidebarView] = &[SidebarView::Worktrees, SidebarView::Problems];
+
+    /// The view's name - the first half of its `"<view> — <hint>"` tooltip, and the word the
+    /// Problems body's own copy uses.
+    pub const fn label(self) -> &'static str {
+        match self {
+            SidebarView::Worktrees => "Worktrees",
+            SidebarView::Problems => "Problems",
+        }
+    }
+
+    /// The view's hint - the second half of its tooltip, quoted from `Jerry.dc.html`'s own
+    /// `sideViews` table. §1 explains why every cell needs one: "With labels gone, [the] glyphs
+    /// are the only affordance identifying the views, so the hint has to live somewhere
+    /// reachable."
+    pub const fn hint(self) -> &'static str {
+        match self {
+            SidebarView::Worktrees => "repo \u{b7} worktree \u{b7} agent",
+            SidebarView::Problems => "diagnostics in this worktree",
+        }
+    }
+
+    /// The view's glyph, from `REVISION-2026-08-14.md` §8's mapping table (GitHub issue #282):
+    /// "strip: worktrees / history / problems → `tree-structure` / `clock-counter-clockwise` /
+    /// `warning`". Drawn through [`crate::icons::IconRow`] at [`crate::icons::IconSize::Strip`],
+    /// which is what §7 rule 7's "one shared optical box, not one size per icon" means in code.
+    pub const fn icon(self) -> Icon {
+        match self {
+            SidebarView::Worktrees => Icon::TreeStructure,
+            SidebarView::Problems => Icon::Warning,
+        }
+    }
+
+    /// The cell's `title="<view> — <hint>"` tooltip (§1), with the marker's real count appended in
+    /// parentheses when there is one - `Jerry.dc.html`'s own
+    /// `v.label + ' — ' + v.hint + (badge ? ' (' + badge + ')' : '')`.
+    ///
+    /// The count living *here* rather than on the cell is §4v's own correction: "The 9px pill
+    /// printing a count at 7px sat on top of the glyph and was a second vocabulary for state in a
+    /// strip built to match the tabs - which already mark state with a **5px square dot**. That is
+    /// what the cells use now, in the badge's colour, with the count moved to the tooltip."
+    pub fn tooltip(self, marker: Option<StripMarker>) -> String {
+        match marker {
+            Some(marker) => format!(
+                "{} \u{2014} {} ({})",
+                self.label(),
+                self.hint(),
+                marker.count
+            ),
+            None => format!("{} \u{2014} {}", self.label(), self.hint()),
+        }
+    }
+}
+
+/// Which hue a cell's state marker takes. Both are the app's own existing status hues, not a
+/// one-off pair - `REVISION-2026-08-14.md` §6: "badges use the app's own hues (amber `#e2a336` for
+/// worktrees, red `#e0625c` for problems), not a one-off cream."
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MarkerTone {
+    /// Amber: work that is waiting on a human.
+    NeedsYou,
+    /// Red: something has failed or errored.
+    Failure,
+}
+
+impl MarkerTone {
+    /// The real token this tone paints with.
+    pub const fn color(self) -> theme::ColorToken {
+        match self {
+            MarkerTone::NeedsYou => theme::status::ASK,
+            MarkerTone::Failure => theme::status::FAIL,
+        }
+    }
+}
+
+/// A cell's state marker: the tabs' own 5px square dot, in a status hue, with its real count.
+///
+/// Never constructed at zero - see [`StripMarker::new`]. §1's rule for the badge it replaced still
+/// governs: "Hidden at zero."
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StripMarker {
+    /// How many things the marker is standing for. Shown in the tooltip, never on the cell.
+    pub count: usize,
+    pub tone: MarkerTone,
+}
+
+impl StripMarker {
+    /// A marker for `count` things, or `None` at zero.
+    ///
+    /// Total on purpose: every caller here would otherwise repeat `(count > 0).then(..)`, and the
+    /// one that forgot would paint a dot standing for nothing.
+    pub fn new(count: usize, tone: MarkerTone) -> Option<Self> {
+        (count > 0).then_some(StripMarker { count, tone })
+    }
+}
+
+/// One cell the strip really paints for a view.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StripCell {
+    pub view: SidebarView,
+    /// Whether this is the view the sidebar is showing - the cell that fills with the rail's own
+    /// background and cuts the column rule beneath it.
+    pub selected: bool,
+    pub marker: Option<StripMarker>,
+}
+
+impl StripCell {
+    /// The colour this cell paints the window's column rule in - **the cut-out**.
+    ///
+    /// `STAGE-A-CHANGELOG.md` §4v: selected is "a filled slab that cuts the column rule to join
+    /// the panel below", achieved by drawing that rule in the panel's own background, so it stops
+    /// reading as a rule at all under this one cell. That is exactly what the centre tab strip's
+    /// active tab already does with [`theme::surface::CENTER`]
+    /// (`crate::work_surface::state::tab_colors`), one column over.
+    ///
+    /// A method on the model rather than an `if` in the renderer so the fact that these two
+    /// colours are a *pair* - the cut and the rule it cuts - is stated once and can be asserted
+    /// without a window.
+    pub const fn rule_color(self) -> theme::ColorToken {
+        if self.selected {
+            theme::surface::RAIL
+        } else {
+            theme::border::RAIL_INNER
+        }
+    }
+
+    /// The colour this cell's glyph rests at: [`theme::text::SELECTED`] for the view you are in,
+    /// [`theme::text::FAINTER`] for one you are not (`Jerry.dc.html`'s own
+    /// `fg: on ? '#dde2e7' : '#5e646a'`).
+    pub const fn glyph_color(self) -> theme::ColorToken {
+        if self.selected {
+            theme::text::SELECTED
+        } else {
+            theme::text::FAINTER
+        }
+    }
+}
+
+/// The severities really present in the selected worktree's diagnostics, tallied over the real
+/// list rather than authored as a pair.
+///
+/// `REVISION-2026-08-13.md` §2 is explicit about why all three are counted and not just two: "The
+/// header names every severity the list is showing: an authored `{err: 2, warn: 2}` pair left the
+/// `info` row uncounted and unnamed, so five diagnostics sat under a badge reading 4."
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ProblemTally {
+    pub errors: usize,
+    pub warnings: usize,
+    pub hints: usize,
+}
+
+impl ProblemTally {
+    /// Every diagnostic in the worktree, whatever its severity - the number the marker's tooltip
+    /// reports.
+    pub fn total(self) -> usize {
+        self.errors + self.warnings + self.hints
+    }
+
+    /// The marker for this tally, or `None` when the worktree is clean.
+    ///
+    /// Red once anything is a real error, amber otherwise - `Jerry.dc.html`'s own
+    /// `probTally.err ? '#e0625c' : '#e2a336'`. A worktree with only warnings is genuinely not in
+    /// the same state as one that does not compile, and the strip is the only place that says so
+    /// before you open the view.
+    pub fn marker(self) -> Option<StripMarker> {
+        StripMarker::new(
+            self.total(),
+            if self.errors > 0 {
+                MarkerTone::Failure
+            } else {
+                MarkerTone::NeedsYou
+            },
+        )
+    }
+
+    /// The Problems body's own count line - `"2 errors · 2 warnings · 1 hint"`, naming only the
+    /// severities really present.
+    ///
+    /// §2: "Both list headers and the Problems badge are **tallied over their own data**". Every
+    /// term agrees through [`crate::root::plural`] rather than a hand-written ternary (§7 rule 9).
+    /// Returns `None` for a clean worktree, where the empty note ([`problems_empty_note`]) says
+    /// the real thing instead of a line of three zeroes.
+    pub fn count_line(self) -> Option<String> {
+        let parts: Vec<String> = [
+            (self.errors, "error"),
+            (self.warnings, "warning"),
+            (self.hints, "hint"),
+        ]
+        .into_iter()
+        .filter(|(count, _)| *count > 0)
+        .map(|(count, noun)| plural::count(count, noun, None))
+        .collect();
+        (!parts.is_empty()).then(|| parts.join(" \u{b7} "))
+    }
+}
+
+/// The Problems view's empty note, naming the checkout it is empty *for*.
+///
+/// `REVISION-2026-08-14.md` §6, verbatim: "A clean worktree gets *No diagnostics in `<branch>`.*
+/// and no badge." Naming the branch is the point - §6's whole entry is that "Problems is keyed by
+/// worktree and filtered on the active one, exactly like history - a diagnostic belongs to a
+/// checkout", and a note that did not say which checkout would leave that unsaid at exactly the
+/// moment it matters.
+pub fn problems_empty_note(branch: Option<&str>) -> String {
+    match branch {
+        Some(branch) => format!("No diagnostics in {branch}."),
+        // A detached `HEAD` has no branch name to print, and inventing one would be the exact
+        // "claimed more than it knew" defect §4g is about.
+        None => "No diagnostics in this worktree.".to_string(),
+    }
+}
+
+/// The Problems view's note when the worktree really does have diagnostics but the sidebar's own
+/// filter box has hidden every one of them.
+///
+/// A different fact from [`problems_empty_note`]'s clean checkout, and said as one: the rail's own
+/// list already distinguishes "this repo has no worktrees" from "your filter matched none of
+/// them", and a Problems view that reported a clean checkout over five hidden rows would be
+/// claiming more than it knows (`STAGE-A-CHANGELOG.md` §4g). Counts through
+/// [`crate::root::plural`] like every other count in the window (§7 rule 9).
+pub fn problems_filtered_away_note(hidden: usize) -> String {
+    format!(
+        "No match in this worktree's {}.",
+        plural::count(hidden, "diagnostic", None)
+    )
+}
+
+/// The cells the strip really paints, in order - **and the empty gate**.
+///
+/// `has_worktrees` is whether this window really has a worktree to look at. At `false` this
+/// returns no cells at all, which is §1's "with no worktrees there are no views to offer, and a
+/// switcher with four dead views is worse than no switcher", gated at the source: the markers
+/// cannot survive the gate because they are built here, below it, rather than beside a `when(..)`
+/// in the renderer that someone could later write for one and not the other.
+///
+/// `agents_needing_you` is the real count of agents waiting on a human. §1 names the unit
+/// outright - "worktrees shows agents needing a human" - and `Jerry.dc.html` computes exactly
+/// that (`sessions.filter(s => s.status === 'ask' || s.status === 'fail').length`), which is why
+/// this is an agent count and not the worktree count §4v's one-line hue table reads as. It comes
+/// from the same `crate::rail::state::urgency_counts` pass over the same [`crate::rail::state::
+/// AgentRow`]s the title bar's own dots read, so the two can never report different numbers for
+/// the same window. `problems` is the real tally for the selected worktree.
+pub fn strip_view_cells(
+    has_worktrees: bool,
+    selected: SidebarView,
+    agents_needing_you: usize,
+    problems: ProblemTally,
+) -> Vec<StripCell> {
+    if !has_worktrees {
+        return Vec::new();
+    }
+    SidebarView::ALL
+        .iter()
+        .map(|&view| StripCell {
+            view,
+            selected: view == selected,
+            marker: match view {
+                // Always amber, even when what is waiting is a failed agent: §4v's own
+                // `badgeFg` table gives the Worktrees cell one hue, because this marker means
+                // "there is work here waiting on you", not "how bad is it". The rail rows and
+                // repo headers below it are where the two states are told apart - and §7 rule 4
+                // ("two states distinguished anywhere in the app are never summed anywhere in
+                // it") is not broken by the sum, because an agent is in exactly one `Status`:
+                // adding the `Ask` and `Fail` counts cannot double-count one agent the way
+                // summing two *worktree* counts could (§4q).
+                SidebarView::Worktrees => {
+                    StripMarker::new(agents_needing_you, MarkerTone::NeedsYou)
+                }
+                SidebarView::Problems => problems.marker(),
+            },
+        })
+        .collect()
+}
+
+/// Which view the sidebar body really shows, given the empty gate.
+///
+/// With no worktrees there is no switcher, so there is no other view to be in: the body falls back
+/// to Worktrees, which is where the rail paints its own empty state ("the sidebar shows the rail's
+/// own empty state", §1). Without this, switching to Problems and then closing the last worktree
+/// would strand the window on a Problems view with no cell to switch back from.
+pub fn effective_view(has_worktrees: bool, selected: SidebarView) -> SidebarView {
+    if has_worktrees {
+        selected
+    } else {
+        SidebarView::Worktrees
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn views(cells: &[StripCell]) -> Vec<SidebarView> {
+        cells.iter().map(|cell| cell.view).collect()
+    }
+
+    /// §4u/§4v: the strip is down to two view cells and the overflow. Search went to the right
+    /// panel and History into the `⋯`, so neither may reappear as a cell here.
+    #[test]
+    fn the_strip_offers_worktrees_and_problems_and_nothing_else() {
+        let cells = strip_view_cells(true, SidebarView::Worktrees, 0, ProblemTally::default());
+        assert_eq!(
+            views(&cells),
+            vec![SidebarView::Worktrees, SidebarView::Problems]
+        );
+        assert_eq!(
+            SidebarView::ALL.len(),
+            2,
+            "History belongs to the overflow (\u{a7}4u) and Search to the right panel (\u{a7}4u); \
+             a third cell here would be re-adding a strip the design cut down"
+        );
+    }
+
+    /// §1's empty gate, at the source. The assertion that matters is not just "no cells" - it is
+    /// that a real, non-zero set of counts cannot smuggle a marker through, which is the exact
+    /// defect the section describes ("ungated they claimed 3 agents needing a human and 4 problems
+    /// on a day the rail, title bar and footer all reported zero").
+    #[test]
+    fn an_empty_day_offers_no_views_and_no_markers_whatever_the_counts_say() {
+        let loud = ProblemTally {
+            errors: 4,
+            warnings: 2,
+            hints: 1,
+        };
+        let cells = strip_view_cells(false, SidebarView::Problems, 3, loud);
+        assert!(
+            cells.is_empty(),
+            "with no worktrees there are no views to offer"
+        );
+        assert_eq!(
+            effective_view(false, SidebarView::Problems),
+            SidebarView::Worktrees,
+            "and the body falls back to the rail's own empty state rather than stranding the \
+             window on a view with no cell to leave it by"
+        );
+        assert_eq!(
+            effective_view(true, SidebarView::Problems),
+            SidebarView::Problems
+        );
+    }
+
+    /// Exactly one cell is selected, and it is the one asked for.
+    #[test]
+    fn exactly_one_cell_is_selected_and_it_is_the_current_view() {
+        for view in SidebarView::ALL.iter().copied() {
+            let cells = strip_view_cells(true, view, 0, ProblemTally::default());
+            let selected: Vec<SidebarView> = cells
+                .iter()
+                .filter(|cell| cell.selected)
+                .map(|cell| cell.view)
+                .collect();
+            assert_eq!(
+                selected,
+                vec![view],
+                "two filled slabs would be two claims about which panel the rule joins"
+            );
+        }
+    }
+
+    /// A marker is a real count or it is not painted - §1's "Hidden at zero", carried by the
+    /// constructor so no call site can forget it.
+    #[test]
+    fn a_marker_never_stands_for_nothing() {
+        assert_eq!(StripMarker::new(0, MarkerTone::NeedsYou), None);
+        assert_eq!(ProblemTally::default().marker(), None);
+        let cells = strip_view_cells(true, SidebarView::Worktrees, 0, ProblemTally::default());
+        assert!(cells.iter().all(|cell| cell.marker.is_none()));
+    }
+
+    /// `Jerry.dc.html`'s `probTally.err ? '#e0625c' : '#e2a336'`, and the Worktrees cell's single
+    /// amber - read through the real tokens, so a theme rename can't quietly decouple them.
+    #[test]
+    fn the_marker_hues_are_the_apps_own_status_hues() {
+        let warnings_only = ProblemTally {
+            warnings: 2,
+            hints: 1,
+            ..ProblemTally::default()
+        };
+        assert_eq!(
+            warnings_only.marker().expect("three diagnostics").tone,
+            MarkerTone::NeedsYou
+        );
+        let with_errors = ProblemTally {
+            errors: 1,
+            ..warnings_only
+        };
+        assert_eq!(
+            with_errors.marker().expect("four diagnostics").tone,
+            MarkerTone::Failure
+        );
+        assert_eq!(MarkerTone::NeedsYou.color(), theme::status::ASK);
+        assert_eq!(MarkerTone::Failure.color(), theme::status::FAIL);
+
+        let cells = strip_view_cells(true, SidebarView::Worktrees, 2, with_errors);
+        let worktrees = cells[0].marker.expect("two agents need a human");
+        assert_eq!(
+            (worktrees.count, worktrees.tone),
+            (2, MarkerTone::NeedsYou),
+            "\u{a7}4v's own badge table gives the Worktrees cell one hue - the rail rows below it \
+             are where amber and red are told apart"
+        );
+    }
+
+    /// §1's `title="<view> — <hint>"`, with §4v's count moved into it.
+    #[test]
+    fn every_cell_carries_its_view_hint_tooltip_and_the_count_lives_in_it() {
+        assert_eq!(
+            SidebarView::Worktrees.tooltip(None),
+            "Worktrees \u{2014} repo \u{b7} worktree \u{b7} agent"
+        );
+        assert_eq!(
+            SidebarView::Problems.tooltip(StripMarker::new(5, MarkerTone::Failure)),
+            "Problems \u{2014} diagnostics in this worktree (5)"
+        );
+        for view in SidebarView::ALL.iter().copied() {
+            let tip = view.tooltip(None);
+            assert!(
+                tip.starts_with(view.label()) && tip.contains(" \u{2014} "),
+                "{tip:?} is not `<view> \u{2014} <hint>`"
+            );
+        }
+    }
+
+    /// §4v's cut-out, as the pair it is: the selected cell paints the column rule in the rail's
+    /// own background - the same trick the centre tab strip's active tab plays with the work
+    /// surface's - and every other cell paints the real rule.
+    #[test]
+    fn the_selected_cell_paints_the_column_rule_in_the_panels_own_background() {
+        let cells = strip_view_cells(true, SidebarView::Problems, 0, ProblemTally::default());
+        let problems = cells
+            .iter()
+            .find(|cell| cell.view == SidebarView::Problems)
+            .expect("the Problems cell");
+        let worktrees = cells
+            .iter()
+            .find(|cell| cell.view == SidebarView::Worktrees)
+            .expect("the Worktrees cell");
+
+        assert_eq!(
+            problems.rule_color(),
+            theme::surface::RAIL,
+            "the selected cell's rule is the rail's own background - that is what 'cuts' it"
+        );
+        assert_eq!(
+            worktrees.rule_color(),
+            theme::border::RAIL_INNER,
+            "and every other cell draws the real column rule, in the one colour all three column \
+             headers share"
+        );
+        assert_ne!(
+            problems.rule_color(),
+            worktrees.rule_color(),
+            "a cut that painted the same colour as the rule would not be a cut"
+        );
+        assert_eq!(problems.glyph_color(), theme::text::SELECTED);
+        assert_eq!(worktrees.glyph_color(), theme::text::FAINTER);
+    }
+
+    /// §8's mapping table, held here too so the strip's own glyph choice can't drift from it.
+    #[test]
+    fn the_view_glyphs_are_the_two_the_revision_maps() {
+        assert_eq!(SidebarView::Worktrees.icon(), Icon::TreeStructure);
+        assert_eq!(SidebarView::Problems.icon(), Icon::Warning);
+    }
+
+    /// §2's "the header names every severity the list is showing" - and only those, so a
+    /// warnings-only worktree does not print `0 errors`.
+    #[test]
+    fn the_count_line_names_every_severity_present_and_no_others() {
+        assert_eq!(
+            ProblemTally {
+                errors: 2,
+                warnings: 2,
+                hints: 1
+            }
+            .count_line()
+            .as_deref(),
+            Some("2 errors \u{b7} 2 warnings \u{b7} 1 hint")
+        );
+        assert_eq!(
+            ProblemTally {
+                warnings: 1,
+                ..ProblemTally::default()
+            }
+            .count_line()
+            .as_deref(),
+            Some("1 warning"),
+            "\u{a7}7 rule 9: singular through the helper, never `1 warnings`"
+        );
+        assert_eq!(
+            ProblemTally::default().count_line(),
+            None,
+            "a clean worktree gets the empty note, not a line of zeroes"
+        );
+    }
+
+    /// A filter that hid every row is not a clean checkout, and must not claim to be one.
+    #[test]
+    fn a_filtered_away_list_says_so_rather_than_reporting_a_clean_checkout() {
+        assert_eq!(
+            problems_filtered_away_note(5),
+            "No match in this worktree's 5 diagnostics."
+        );
+        assert_eq!(
+            problems_filtered_away_note(1),
+            "No match in this worktree's 1 diagnostic.",
+            "\u{a7}7 rule 9: through the helper, never `1 diagnostics`"
+        );
+        assert_ne!(
+            problems_filtered_away_note(3),
+            problems_empty_note(Some("main")),
+            "the two empty states are two different facts and must read as such"
+        );
+    }
+
+    /// §6's "A clean worktree gets *No diagnostics in `<branch>`.*" - and an honest sentence on a
+    /// detached `HEAD`, where there is no branch name to print.
+    #[test]
+    fn the_empty_note_names_the_checkout_it_is_empty_for() {
+        assert_eq!(
+            problems_empty_note(Some("fix/auth")),
+            "No diagnostics in fix/auth."
+        );
+        assert_eq!(
+            problems_empty_note(None),
+            "No diagnostics in this worktree.",
+            "a detached HEAD has no branch name, and inventing one would claim more than the \
+             view knows"
+        );
+    }
+}

--- a/crates/app/src/rail/strip_render.rs
+++ b/crates/app/src/rail/strip_render.rs
@@ -1,0 +1,1100 @@
+//! The sidebar strip, drawn (GitHub issue #291): the rail column's own 36px view switcher, the
+//! real switch behind it, and the Problems view it switches to.
+//!
+//! [`crate::rail::strip`] decides *which* cells and *what* they say; this file is the `impl AdeApp`
+//! half - the band, the slabs, the real diagnostics read behind the Problems marker, and the body
+//! each view paints.
+//!
+//! ## The strip speaks the tab language
+//!
+//! `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4v, verbatim, on what the cells
+//! are: "**38px full-height cells, no radius, no gap**, selected = a filled slab that cuts the
+//! column rule to join the panel below, inactive = transparent over a recessed strip." Then, on
+//! the divisions: "each cell carries `border-right: 1px #1c2023` - the same rule the tabs use
+//! between them ... Segments divided by vertical rules is most of what makes a tab strip legible;
+//! the first cut had the slab and the cut-out but no divisions, so it read as icons on a dark
+//! band."
+//!
+//! Three consequences show up directly in [`strip_cell`]:
+//!
+//! 1. The **container draws no bottom border**. Every child carries its own, because "a child
+//!    cannot paint over its parent's border - the parent's border sits outside the child's box -
+//!    so the container cannot own the edge if any child needs to cut it" (§4v). The selected cell
+//!    cuts it by painting that same 1px bar in [`theme::surface::RAIL`], exactly as the centre tab
+//!    strip's active tab does with [`theme::surface::CENTER`] - and for the same GPUI reason it is
+//!    a 1px child rather than a `border_b`: `Style::border_color` is one colour for all four
+//!    edges, and these cells need a vertical rule in one colour and a horizontal one in another.
+//! 2. **No cell has a background hover.** §4v: "two states must not compete on one property. If
+//!    background says 'selected', hover says it somewhere else." Hover lifts the glyph to
+//!    [`theme::text::GLYPH_HOVER`] and nothing else moves.
+//! 3. The strip band is [`theme::surface::SIDEBAR_STRIP`], deliberately *below*
+//!    [`theme::surface::RAIL`], because "a tab only reads as connected if the strip behind it is
+//!    darker than the panel".
+//!
+//! ## What is deliberately not here
+//!
+//! The Problems **view** is minimal on purpose. It reads the app's real, worktree-scoped LSP
+//! diagnostics ([`AdeApp::worktree_problems`]) and lists them, so the Problems cell ships with its
+//! behaviour rather than as a dead button (`REVISION-2026-08-14.md` §7 rule 1: "Ship the
+//! affordance with the behaviour, or ship neither"). Everything past "list what is really there" -
+//! `REVISION-2026-08-13.md` §2's click-to-open navigation, the filter row's per-view query, the
+//! `all`/`this worktree` scope toggle, and reaching diagnostics for files no editor has opened -
+//! is GitHub issue #292's, which this issue blocks.
+
+use super::*;
+use crate::icons::{IconRow, IconSize};
+use crate::lsp::client::LspClientState;
+use crate::lsp::diagnostics as diagnostics_view;
+use crate::rail::strip::{self, ProblemTally, SidebarView, StripCell, StripMarker};
+use crate::root::widgets::text_tooltip;
+
+/// One diagnostic in the Problems list, already reduced to what the row paints.
+///
+/// A view model rather than a borrowed `lsp_types::Diagnostic`: the list is scoped to a worktree,
+/// not to an open buffer, so it outlives no particular file's state and needs nothing from
+/// `lsp_types` past the five fields below.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::rail) struct Problem {
+    pub severity: diagnostics_view::Severity,
+    pub message: String,
+    /// The path, relative to the worktree root when it really is inside it - a Problems list
+    /// showing 60 characters of shared prefix on every row says nothing per row.
+    pub file: String,
+    /// `line:column`, 1-based, the way every compiler and every other row in this app prints it.
+    pub position: String,
+    /// The server that reported it (`rustc`, `clippy`, `rust-analyzer`), when it named itself.
+    pub source: Option<String>,
+}
+
+impl Problem {
+    /// Whether this row survives the sidebar's own filter box - the same case-insensitive
+    /// substring test over the row's own visible text that
+    /// [`crate::rail::state::WorktreeRow::matches_filter`] applies to a worktree row, so one field
+    /// behaves the same way whichever view is under it. A blank query matches everything.
+    ///
+    /// This is what lets the filter row's placeholder really say `filter problems`
+    /// (`REVISION-2026-08-13.md` §1) rather than promising a filter that does nothing (§7 rule 1).
+    fn matches_filter(&self, query: &str) -> bool {
+        let query = query.trim().to_lowercase();
+        if query.is_empty() {
+            return true;
+        }
+        self.message.to_lowercase().contains(&query)
+            || self.file.to_lowercase().contains(&query)
+            || self
+                .source
+                .as_deref()
+                .is_some_and(|source| source.to_lowercase().contains(&query))
+    }
+}
+
+impl AdeApp {
+    /// Switches the sidebar to `view`.
+    ///
+    /// Closes any open rail menu first, for the reason [`AdeApp::set_right_sidebar_view`]
+    /// documents at length for the right panel: a menu anchored to a row the next frame no longer
+    /// paints is a popover acting on something the user cannot see. Nothing else is torn down -
+    /// the filter row and [`AdeApp::rail_focus_handle`] are strip-level chrome that both views sit
+    /// under, so no view switch here can strand focus.
+    pub(crate) fn set_sidebar_view(&mut self, view: SidebarView, cx: &mut Context<Self>) {
+        if self.sidebar_view == view {
+            return;
+        }
+        self.sidebar_view = view;
+        let _ = self.close_menu_surfaces_except(None);
+        cx.notify();
+    }
+
+    /// The view the sidebar body is really showing, after [`strip::effective_view`]'s empty gate.
+    /// Read by both the strip (to decide which slab fills) and the body (to decide what to paint),
+    /// so the lit cell and the panel under it can never disagree.
+    pub(in crate::rail) fn effective_sidebar_view(&self, has_worktrees: bool) -> SidebarView {
+        strip::effective_view(has_worktrees, self.sidebar_view)
+    }
+
+    /// Every diagnostic the app really knows about in the currently selected worktree, worst
+    /// first, then by file and position.
+    ///
+    /// **Worktree-keyed, exactly like history.** `REVISION-2026-08-14.md` §6, verbatim: "a
+    /// diagnostic belongs to a checkout. Unkeyed, one global list renders under every worktree,
+    /// listing files that are not in it." That keying is free here rather than a filter step:
+    /// [`AdeApp::lsp_clients`] is already keyed on `(worktree root, server)`, so this reads only
+    /// the clients whose root *is* the selected worktree.
+    ///
+    /// Real data or nothing. A worktree whose language server has never started - or has started
+    /// and reported nothing - yields an empty `Vec`, and the Problems view says so honestly. That
+    /// is what makes the strip's marker safe to derive from this: an empty day cannot produce a
+    /// red dot, which is exactly the failure `REVISION-2026-08-13.md` §1's "gate at the source"
+    /// rule exists to prevent.
+    pub(in crate::rail) fn worktree_problems(&self) -> Vec<Problem> {
+        let Some(root) = self.current_worktree_path() else {
+            return Vec::new();
+        };
+        let mut problems: Vec<Problem> = Vec::new();
+        for ((client_root, _server), state) in &self.lsp_clients {
+            let LspClientState::Ready(client) = state else {
+                continue;
+            };
+            if client_root != &root {
+                continue;
+            }
+            for (path, diagnostics) in client.published_diagnostics() {
+                let file = display_path(&path, &root);
+                for diagnostic in diagnostics {
+                    problems.push(Problem {
+                        severity: diagnostics_view::Severity::from_lsp(diagnostic.severity),
+                        message: diagnostic.message.trim().to_string(),
+                        file: file.clone(),
+                        // LSP positions are 0-based; every compiler, editor and other row in this
+                        // app prints them 1-based.
+                        position: format!(
+                            "{}:{}",
+                            diagnostic.range.start.line + 1,
+                            diagnostic.range.start.character + 1
+                        ),
+                        source: diagnostic.source.filter(|source| !source.is_empty()),
+                    });
+                }
+            }
+        }
+        // Worst first - the same "worst wins" ordering `diagnostics_view::Severity::worst` applies
+        // within a line, applied to the list. Ties break on file then position so the order is
+        // total and a re-render cannot reshuffle rows under the pointer.
+        problems.sort_by(|left, right| {
+            severity_rank(right.severity)
+                .cmp(&severity_rank(left.severity))
+                .then_with(|| left.file.cmp(&right.file))
+                .then_with(|| left.position.cmp(&right.position))
+        });
+        problems
+    }
+
+    /// [`Self::worktree_problems`], tallied by severity - for the strip's marker and for the
+    /// view's own count line alike, so the marker can never report a number the list below it does
+    /// not contain (`REVISION-2026-08-13.md` §2: "tallied over their own data").
+    pub(in crate::rail) fn worktree_problem_tally(&self) -> ProblemTally {
+        tally_problems(&self.worktree_problems())
+    }
+
+    /// The whole sidebar strip: the view cells, the flex spacer, the `+` new-agent cell and the
+    /// `⋯` overflow - §4v's final cell list, with §4u's "Settings lives in the overflow" already
+    /// applied, so there is no Settings cell.
+    ///
+    /// [`theme::band::CHROME_HEADER`] high, like the centre tab strip and the right panel header
+    /// beside it: §4v's "column headers that share a y are one rule, not three". It carries **no
+    /// bottom border of its own** - see this module's docs for why the children own that edge -
+    /// and note that *every* child carries it, the spacer included, "without which the rule
+    /// stopped at the last tab and 398px of the window's top edge was simply missing".
+    ///
+    /// `cells` comes from [`strip::strip_view_cells`], which is where the empty-day gate lives: on
+    /// First run and Empty day it is simply empty, and the strip is the spacer, the `+` and the
+    /// `⋯`.
+    pub(in crate::rail) fn render_sidebar_strip(
+        &self,
+        cells: &[StripCell],
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let mut band = div()
+            .id("sidebar-strip")
+            .debug_selector(|| "sidebar-strip".to_string())
+            .flex()
+            .flex_none()
+            .items_stretch()
+            .h(theme::band::CHROME_HEADER)
+            .bg(theme::surface::SIDEBAR_STRIP);
+
+        for cell in cells {
+            band = band.child(self.render_sidebar_strip_cell(*cell, cx));
+        }
+
+        band.child(
+            // The spacer is a child of the strip, so it carries the column rule too.
+            div()
+                .flex_1()
+                .min_w(px(6.0))
+                .border_b_1()
+                .border_color(theme::border::RAIL_INNER),
+        )
+        .child(self.render_new_agent_cell(cx))
+        .child(self.render_rail_overflow_button(cx))
+    }
+
+    /// One view cell: a full-height 38px slab, its glyph, and its state marker.
+    ///
+    /// Selected fills with [`theme::surface::RAIL`] - "exactly the rail's own background, with its
+    /// rule the same colour" (§4v) - so the cell reads as continuous with the panel below it.
+    /// Inactive is transparent over the recessed band and paints the real column rule.
+    fn render_sidebar_strip_cell(
+        &self,
+        cell: StripCell,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let view = cell.view;
+        let element_id = match view {
+            SidebarView::Worktrees => "sidebar-strip-worktrees",
+            SidebarView::Problems => "sidebar-strip-problems",
+        };
+        let glyph = cell.glyph_color();
+
+        let hover = strip_glyph_hover(cell.selected);
+
+        strip_cell(
+            div()
+                .id(element_id)
+                .debug_selector(move || element_id.to_string()),
+            element_id,
+            cell.rule_color(),
+            glyph,
+            // The hover lives on the glyph element rather than on the cell because
+            // `IconRow::draw` pins the SVG's own `text_color` (an untinted `gpui::svg` paints
+            // nothing at all), so an inherited colour from the cell would never reach it. A
+            // `group_hover` keyed on the cell keeps the *trigger* the whole 38px slab - hovering
+            // the cell's corner lights the glyph, exactly as `style-hover` on the cell does in the
+            // mock - while the style still lands on the element that really owns the colour.
+            IconRow::new(&self.settings.icon_pack, IconSize::Strip)
+                .draw(view.icon(), glyph)
+                .group_hover(element_id, move |el| el.text_color(hover)),
+        )
+        // The rule the tabs use between them - and the reason the strip reads as segments rather
+        // than as icons on a dark band (§4v).
+        .border_r_1()
+        .border_color(theme::border::INNER)
+        .when(cell.selected, |el| el.bg(theme::surface::RAIL))
+        .children(cell.marker.map(|marker| render_strip_marker(view, marker)))
+        .tooltip(text_tooltip(view.tooltip(cell.marker)))
+        .on_click(cx.listener(move |this, _event: &ClickEvent, _window, cx| {
+            this.set_sidebar_view(view, cx);
+        }))
+    }
+
+    /// The strip's `+` cell - the rail's own new-agent action, in the strip's own shape.
+    ///
+    /// It lived in the rail header this strip replaced (Revision R12 §2.1: "Rail header keeps only
+    /// the `+` new-session button"), and `REVISION-2026-08-13.md` §1 puts it here: "Flex spacer,
+    /// then the `+` new-session button (unchanged)". *Unchanged* is about the action, not the
+    /// chrome: its `mod+N` keycap pair does not fit a 38px cell, so it moves into the tooltip -
+    /// still resolved through [`crate::keymap::resolve_combo`] exactly as the keycap was, so it
+    /// still cannot name a binding this build does not really register.
+    fn render_new_agent_cell(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let combo = keymap::resolve_combo("mod+N", self.window_controls_style().is_macos());
+        strip_cell(
+            div()
+                .id("rail-new-agent")
+                .debug_selector(|| "rail-new-agent".to_string()),
+            "rail-new-agent",
+            theme::border::RAIL_INNER,
+            theme::text::FAINTER,
+            div()
+                .font(font(theme::font::MONO))
+                .text_size(self.ui_text_size(13.0))
+                .group_hover("rail-new-agent", |el| {
+                    el.text_color(strip_glyph_hover(false))
+                })
+                .child("+"),
+        )
+        .border_l_1()
+        .border_color(theme::border::INNER)
+        .tooltip(text_tooltip(format!(
+            "New agent \u{2014} a shell in this worktree ({})",
+            combo.join(" ")
+        )))
+        .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
+            this.new_agent(ProcessKind::Shell, window, cx);
+        }))
+    }
+
+    /// The sidebar's body for `view` - the rail's own tree, or the Problems list.
+    pub(in crate::rail) fn render_sidebar_body(
+        &self,
+        view: SidebarView,
+        groups: &[RepoGroup],
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        match view {
+            SidebarView::Worktrees => self.render_rail_list(groups, cx),
+            SidebarView::Problems => self.render_problems_view(cx),
+        }
+    }
+
+    /// The Problems view: the real count line over the real rows, or the real empty note.
+    ///
+    /// Scoped to the selected worktree and tallied over its own data - see
+    /// [`Self::worktree_problems`]. What this view deliberately does not do yet is GitHub issue
+    /// #292's; see this module's docs.
+    fn render_problems_view(&self, _cx: &mut Context<Self>) -> gpui::AnyElement {
+        // Filtered here, not in `Self::worktree_problems`: the strip's own marker reads that
+        // method too, and a marker that shrank as the filter box was typed into would break the
+        // same promise the repo headers' counts keep (`crate::rail::state::RepoWorktrees::
+        // all_rows`) - the strip reports what is really in the worktree, the list reports what
+        // you asked to see.
+        let query = self.filter_query.as_str().to_string();
+        let all = self.worktree_problems();
+        let problems: Vec<Problem> = all
+            .iter()
+            .filter(|problem| problem.matches_filter(&query))
+            .cloned()
+            .collect();
+        let mut list = div()
+            .id("sidebar-problems")
+            .debug_selector(|| "sidebar-problems".to_string())
+            .flex()
+            .flex_col();
+
+        if problems.is_empty() {
+            // "Clean checkout" and "your filter hid them all" are two different facts, and the
+            // rail's own list already distinguishes them for exactly this reason
+            // (`Self::render_rail_list`). Saying `No diagnostics in <branch>.` over five hidden
+            // diagnostics would be the same class of claim §4g removed elsewhere.
+            let note = if all.is_empty() {
+                let branch = self
+                    .selected
+                    .and_then(|index| self.worktrees.get(index))
+                    .and_then(|item| item.branch.as_deref());
+                strip::problems_empty_note(branch)
+            } else {
+                strip::problems_filtered_away_note(all.len())
+            };
+            return list
+                .px(px(14.0))
+                .py(px(18.0))
+                .child(
+                    div()
+                        .font(font(theme::font::SANS))
+                        .text_size(self.ui_text_size(11.0))
+                        .text_color(theme::text::GHOST)
+                        .debug_selector(|| "sidebar-problems-note".to_string())
+                        .child(note),
+                )
+                .into_any_element();
+        }
+
+        if let Some(line) = tally_problems(&problems).count_line() {
+            list = list.child(
+                div()
+                    .flex_none()
+                    .px(px(12.0))
+                    .pt(px(8.0))
+                    .pb(px(6.0))
+                    .font(font(theme::font::MONO))
+                    .text_size(self.ui_text_size(9.5))
+                    .text_color(theme::text::FAINTER)
+                    .child(line),
+            );
+        }
+        for problem in problems {
+            list = list.child(self.render_problem_row(&problem));
+        }
+        list.into_any_element()
+    }
+
+    /// One Problems row: a 5px severity square, the message, and the file/position/source line
+    /// under it - `Jerry.dc.html`'s own `probRows` markup.
+    fn render_problem_row(&self, problem: &Problem) -> impl IntoElement {
+        let mut meta = div()
+            .flex()
+            .items_baseline()
+            .gap(px(6.0))
+            .mt(px(3.0))
+            .font(font(theme::font::MONO))
+            .child(
+                div()
+                    .flex_none()
+                    .text_size(self.ui_text_size(9.5))
+                    .text_color(theme::text::DIMMER)
+                    .child(problem.file.clone()),
+            )
+            .child(
+                div()
+                    .flex_none()
+                    .text_size(self.ui_text_size(9.5))
+                    .text_color(theme::text::GHOST)
+                    .child(problem.position.clone()),
+            )
+            .child(div().flex_1());
+        if let Some(source) = problem.source.clone() {
+            meta = meta.child(
+                div()
+                    .flex_none()
+                    .text_size(self.ui_text_size(9.0))
+                    .text_color(theme::text::GHOSTER)
+                    .child(source),
+            );
+        }
+
+        div()
+            .flex()
+            .gap(px(7.0))
+            .pl(px(12.0))
+            .pr(px(10.0))
+            .pt(px(6.0))
+            .pb(px(7.0))
+            .child(
+                div()
+                    .flex_none()
+                    .w(px(5.0))
+                    .h(px(5.0))
+                    .mt(px(5.0))
+                    .rounded(theme::radius::MARK_SM)
+                    .bg(severity_color(problem.severity)),
+            )
+            .child(
+                div()
+                    .flex_1()
+                    .min_w_0()
+                    .child(
+                        div()
+                            .font(font(theme::font::SANS))
+                            .text_size(self.ui_text_size(11.0))
+                            .text_color(theme::text::STRONG)
+                            .child(problem.message.clone()),
+                    )
+                    .child(meta),
+            )
+    }
+}
+
+/// Every strip cell's shared shape: 38 wide, full height, centred, no radius, no gap, `content`
+/// in the middle, and the column rule painted as this cell's own last 1px row in `rule`.
+///
+/// Shared rather than repeated so the three kinds of cell - view, `+` and `⋯` - cannot drift apart
+/// on any of it. That the `+` and `⋯` go through it too is what §4v's "every child carries it"
+/// means once the rule stops being the container's.
+///
+/// The rule is a 1px child, not a `border_b`, for the same reason
+/// [`AdeApp::render_agent_tab`]'s underline is: GPUI's `Style::border_color` is one colour for all
+/// four edges, and a cell needs its vertical divider ([`theme::border::INNER`]) and its horizontal
+/// rule (`rule`, which the selected cell sets to its own background to cut it) in two.
+///
+/// Hover is on the glyph colour alone (§4v: "two states must not compete on one property"),
+/// expressed by setting `text_color` at rest and in hover and touching no background: an icon
+/// drawn through [`IconRow`] is a monochrome sprite painted in its element's own text colour, so
+/// one `text_color` really does move an SVG glyph and a `+`/`⋯` mark alike.
+pub(in crate::rail) fn strip_cell(
+    cell: gpui::Stateful<gpui::Div>,
+    group: &'static str,
+    rule: theme::ColorToken,
+    glyph: theme::ColorToken,
+    content: impl IntoElement,
+) -> gpui::Stateful<gpui::Div> {
+    cell.group(group)
+        .relative()
+        .flex_none()
+        .flex()
+        .flex_col()
+        .w(theme::zone::SIDEBAR_STRIP_CELL)
+        .cursor_pointer()
+        .text_color(glyph)
+        .child(
+            div()
+                .flex_1()
+                .flex()
+                .items_center()
+                .justify_center()
+                .child(content),
+        )
+        .child(div().flex_none().w_full().h(px(1.0)).bg(rule))
+}
+
+/// What a strip cell's glyph lifts to when the pointer is on the cell.
+///
+/// §4v's rule is that hover **lifts** the glyph - "hover lifts `color` to `#c8ced4`" - which is
+/// why the already-lit selected cell keeps its own [`theme::text::SELECTED`] rather than taking
+/// [`theme::text::GLYPH_HOVER`]: at `#dde2e7` over `#c8ced4` that assignment would make hovering
+/// the *active* view visibly dim it, re-creating in one direction the exact "hover out-reads
+/// selected" collision the section moved hover off background to fix. (`Jerry.dc.html` applies its
+/// one `style-hover` to every cell from a shared template, so its selected cell really does dim;
+/// the stated rule is the one followed here.)
+fn strip_glyph_hover(selected: bool) -> theme::ColorToken {
+    if selected {
+        theme::text::SELECTED
+    } else {
+        theme::text::GLYPH_HOVER
+    }
+}
+
+/// A cell's state marker: the tabs' own 5px square dot, in the marker's hue, at `Jerry.dc.html`'s
+/// own `right:7 top:8` (§4v: "Badges moved to `right:5 top:6` - on a square cell, corner-anchored
+/// badges read as clipped", and the final markup settled one step further in again).
+///
+/// [`theme::radius::MARK_SM`] rather than [`theme::radius::MARK`] because that 1px is what makes a
+/// 5px square read as a square: this app already uses a real circle for "an agent's status", and
+/// this deliberately is not that.
+fn render_strip_marker(view: SidebarView, marker: StripMarker) -> impl IntoElement {
+    let selector = match view {
+        SidebarView::Worktrees => "sidebar-strip-worktrees-marker",
+        SidebarView::Problems => "sidebar-strip-problems-marker",
+    };
+    div()
+        // Lets a real test prove the marker is really absent on a window with nothing waiting -
+        // §1's "an empty day cannot claim agents needing a human" is only checkable as an absence.
+        .debug_selector(move || selector.to_string())
+        .absolute()
+        .right(px(7.0))
+        .top(px(8.0))
+        .w(px(5.0))
+        .h(px(5.0))
+        .rounded(theme::radius::MARK_SM)
+        .bg(marker.tone.color())
+}
+
+/// The row dot's colour for `severity`.
+///
+/// The app's own two status hues, not a third palette: the strip cell's marker is specified as
+/// [`theme::status::FAIL`]/[`theme::status::ASK`] (`REVISION-2026-08-14.md` §6 - "badges use the
+/// app's own hues ... not a one-off cream"), and a row painting a *different* red from the marker
+/// that summarises it would be two vocabularies for one fact, one panel apart - §7 rule 8's
+/// complaint, in colour.
+fn severity_color(severity: diagnostics_view::Severity) -> theme::ColorToken {
+    match severity {
+        diagnostics_view::Severity::Error => theme::status::FAIL,
+        diagnostics_view::Severity::Warning => theme::status::ASK,
+        // The two least severe levels are the ones the File view already draws with no row tint at
+        // all (`crate::code_surface::lsp_ui::diagnostic_row_bg`); a neutral mark keeps them
+        // visibly less alarming than a warning here too.
+        diagnostics_view::Severity::Information | diagnostics_view::Severity::Hint => {
+            theme::text::DIM
+        }
+    }
+}
+
+/// `problems` counted into `REVISION-2026-08-13.md` §2's three buckets.
+///
+/// LSP's `Information` and `Hint` both land in `hints`: §2's own table names three severities and
+/// the mock tallies both into its `info` bucket, so these are two levels the design does not
+/// distinguish anywhere - which is why summing them is not §7 rule 4's "two states distinguished
+/// anywhere in the app are never summed anywhere in it".
+fn tally_problems(problems: &[Problem]) -> ProblemTally {
+    let mut tally = ProblemTally::default();
+    for problem in problems {
+        match problem.severity {
+            diagnostics_view::Severity::Error => tally.errors += 1,
+            diagnostics_view::Severity::Warning => tally.warnings += 1,
+            diagnostics_view::Severity::Information | diagnostics_view::Severity::Hint => {
+                tally.hints += 1
+            }
+        }
+    }
+    tally
+}
+
+/// `path` as the Problems row shows it: relative to the worktree it belongs to when it really is
+/// inside it, absolute otherwise.
+///
+/// The fallback is not decoration. rust-analyzer really does publish diagnostics against paths
+/// outside the workspace (a dependency's own source under `~/.cargo/registry/...`), and printing
+/// those as if they were relative would claim a file in this checkout that is not there.
+fn display_path(path: &std::path::Path, root: &std::path::Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .into_owned()
+}
+
+/// Most severe first - the list-level counterpart of `diagnostics_view::Severity::worst`'s own
+/// within-a-line ordering, restated here only because that module's `rank` is private.
+fn severity_rank(severity: diagnostics_view::Severity) -> u8 {
+    match severity {
+        diagnostics_view::Severity::Error => 3,
+        diagnostics_view::Severity::Warning => 2,
+        diagnostics_view::Severity::Information => 1,
+        diagnostics_view::Severity::Hint => 0,
+    }
+}
+
+/// Real-window, real-git coverage for the sidebar strip (GitHub issue #291): the band as it is
+/// really painted, the real switch a click on a cell performs, and the window-chrome invariant the
+/// design derived while building it.
+///
+/// Everything here is measured off real painted bounds (`debug_bounds`) and driven by real
+/// simulated clicks - the geometry claims in `STAGE-A-CHANGELOG.md` §4v are claims about pixels,
+/// and asserting them against the model instead of against the frame would prove nothing about
+/// what ships.
+#[cfg(test)]
+mod sidebar_strip_tests {
+    use super::*;
+    use crate::root::focus::palette_focus_tests;
+    use gpui::TestAppContext;
+    use std::fs;
+    use std::path::Path;
+    use std::process::Command;
+    use tempfile::TempDir;
+
+    fn git(dir: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .output()
+            .expect("failed to spawn git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed in {:?}: {}",
+            args,
+            dir,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn init_repo() -> TempDir {
+        let dir = TempDir::new().expect("tempdir");
+        git(dir.path(), &["init", "-b", "main"]);
+        git(dir.path(), &["config", "user.email", "test@example.com"]);
+        git(dir.path(), &["config", "user.name", "Test User"]);
+        fs::write(dir.path().join("base.txt"), "base\n").expect("write");
+        git(dir.path(), &["add", "base.txt"]);
+        git(dir.path(), &["commit", "-m", "initial"]);
+        dir
+    }
+
+    /// The four bounds every geometry assertion below reads: the two view cells, the `+` and the
+    /// `⋯`, in the order the strip paints them.
+    fn strip_cell_bounds(
+        cx: &mut gpui::VisualTestContext,
+    ) -> Vec<(&'static str, gpui::Bounds<gpui::Pixels>)> {
+        [
+            "sidebar-strip-worktrees",
+            "sidebar-strip-problems",
+            "rail-new-agent",
+            "rail-overflow",
+        ]
+        .into_iter()
+        .map(|selector| {
+            (
+                selector,
+                cx.debug_bounds(selector)
+                    .unwrap_or_else(|| panic!("{selector} must paint")),
+            )
+        })
+        .collect()
+    }
+
+    fn right(bounds: gpui::Bounds<gpui::Pixels>) -> f32 {
+        f32::from(bounds.origin.x + bounds.size.width)
+    }
+
+    fn bottom(bounds: gpui::Bounds<gpui::Pixels>) -> f32 {
+        f32::from(bounds.origin.y + bounds.size.height)
+    }
+
+    /// §4v's cells, as pixels: "**38px full-height cells, no radius, no gap**". Every cell is
+    /// really 38 wide, really as tall as the band, and really flush against its neighbour - the
+    /// "no gap" half is what makes the dividing rules read as a tab strip's segments rather than
+    /// as a row of separated buttons.
+    #[gpui::test]
+    fn every_strip_cell_is_a_full_height_38px_slab_with_no_gap(cx: &mut TestAppContext) {
+        let repo = init_repo();
+        let (_app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        let band = cx
+            .debug_bounds("sidebar-strip")
+            .expect("the strip must paint");
+        assert_eq!(
+            f32::from(band.size.height),
+            f32::from(theme::band::CHROME_HEADER),
+            "the strip is one of the window's three column headers"
+        );
+
+        let cells = strip_cell_bounds(cx);
+        for (selector, bounds) in &cells {
+            assert_eq!(
+                f32::from(bounds.size.width),
+                f32::from(theme::zone::SIDEBAR_STRIP_CELL),
+                "{selector} must be a 38px cell"
+            );
+            assert_eq!(
+                f32::from(bounds.size.height),
+                f32::from(band.size.height),
+                "{selector} must be a full-height slab, not a pill inset in the band"
+            );
+            assert_eq!(
+                f32::from(bounds.origin.y),
+                f32::from(band.origin.y),
+                "{selector} must start at the band's own top edge"
+            );
+        }
+
+        // The two view cells sit flush; the `+` and `⋯` sit flush at the far end, past the spacer.
+        assert_eq!(
+            right(cells[0].1),
+            f32::from(cells[1].1.origin.x),
+            "no gap between the two view cells"
+        );
+        assert_eq!(
+            right(cells[2].1),
+            f32::from(cells[3].1.origin.x),
+            "no gap between the `+` and the `\u{22ef}`"
+        );
+        assert!(
+            f32::from(cells[2].1.origin.x) > right(cells[1].1),
+            "the flex spacer really separates the view cells from the trailing pair"
+        );
+        assert_eq!(
+            right(cells[3].1),
+            right(band),
+            "the `\u{22ef}` is the strip's last cell and ends on the column's own edge"
+        );
+    }
+
+    /// §4v's window-chrome invariant, verbatim: "column headers that share a y are one rule, not
+    /// three." Measured the way the design measured it - three real
+    /// `getBoundingClientRect().bottom` values, which must all be the same number.
+    ///
+    /// This is the assertion the whole issue hangs on: before it, the three headers agreed on a
+    /// height but drew three different border colours, and the centre one drew its edge twice.
+    #[gpui::test]
+    fn all_three_column_headers_end_on_one_line(cx: &mut TestAppContext) {
+        let repo = init_repo();
+        let (_app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        let rail = cx
+            .debug_bounds("sidebar-strip")
+            .expect("the rail's column header");
+        let centre = cx
+            .debug_bounds("tab-strip")
+            .expect("the centre column's header");
+        let panel = cx
+            .debug_bounds("right-panel-header")
+            .expect("the right panel's header");
+
+        assert_eq!(
+            (bottom(rail), bottom(centre), bottom(panel)),
+            (bottom(rail), bottom(rail), bottom(rail)),
+            "\u{a7}4v: three headers on one y, or the rule steps at every column boundary"
+        );
+        for (name, bounds) in [("rail", rail), ("centre", centre), ("panel", panel)] {
+            assert_eq!(
+                f32::from(bounds.size.height),
+                f32::from(theme::band::CHROME_HEADER),
+                "{name}'s header must be the one shared height"
+            );
+        }
+    }
+
+    /// The centre column's bottom edge has exactly one owner, and it is the children (§4v: "an
+    /// edge has one owner - if anything needs to cut it, the owner is the children, and then
+    /// *every* child carries it").
+    ///
+    /// Asserted where it can really fail: the tab strip's own last child - the right-aligned
+    /// agent-jump cluster - must reach the column's right edge, because that is the child whose
+    /// missing rule left "398px of the window's top edge simply missing" when the container
+    /// stopped drawing it. Paired with a direct read of the container's own style, so a
+    /// re-introduced `border_b` on it fails here rather than shipping as a doubled line.
+    #[gpui::test]
+    fn the_centre_columns_bottom_edge_is_carried_all_the_way_across(cx: &mut TestAppContext) {
+        let repo = init_repo();
+        let (_app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        let centre = cx.debug_bounds("tab-strip").expect("the tab strip");
+        let panel = cx
+            .debug_bounds("right-panel-header")
+            .expect("the right panel's header");
+        assert!(
+            right(centre) <= f32::from(panel.origin.x) + 1.0
+                && right(centre) >= f32::from(panel.origin.x) - 2.0,
+            "premise: the centre column really does run right up to the panel column, so a rule \
+             that stopped short of its own right edge would be a visible gap - centre ends at {}, \
+             panel starts at {}",
+            right(centre),
+            f32::from(panel.origin.x)
+        );
+        assert!(
+            crate::work_surface::state::tab_colors(false).underline
+                == gpui::Rgba::from(theme::border::RAIL_INNER),
+            "\u{a7}4v: an inactive tab draws the window's column rule, in the colour all three \
+             headers share - not `border::ZONE`, which read as one rule changing shade mid-span"
+        );
+        assert!(
+            crate::work_surface::state::tab_colors(true).underline
+                == crate::work_surface::state::tab_colors(true).bg,
+            "and the active tab still cuts it with its own background"
+        );
+    }
+
+    /// The strip is a real switcher: clicking Problems really replaces the rail's tree with the
+    /// Problems view, and clicking Worktrees really brings it back. Driven by real clicks at real
+    /// painted positions, so a cell with no handler fails here.
+    #[gpui::test]
+    fn clicking_a_cell_really_switches_the_panel_under_it(cx: &mut TestAppContext) {
+        let repo = init_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        assert!(
+            cx.debug_bounds("rail-repo-groups").is_some(),
+            "premise: the window opens on the Worktrees view"
+        );
+        assert!(cx.debug_bounds("sidebar-problems").is_none());
+
+        let problems = cx
+            .debug_bounds("sidebar-strip-problems")
+            .expect("the Problems cell");
+        cx.simulate_click(problems.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.sidebar_view, SidebarView::Problems);
+        });
+        assert!(
+            cx.debug_bounds("sidebar-problems").is_some(),
+            "the Problems view must really paint - a cell that lit up over an unchanged panel \
+             would be exactly the dead button \u{a7}7 rule 1 forbids"
+        );
+        assert!(
+            cx.debug_bounds("rail-repo-groups").is_none(),
+            "and the worktree tree must really be gone, not merely covered"
+        );
+
+        let worktrees = cx
+            .debug_bounds("sidebar-strip-worktrees")
+            .expect("the Worktrees cell");
+        cx.simulate_click(worktrees.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.sidebar_view, SidebarView::Worktrees);
+        });
+        assert!(cx.debug_bounds("rail-repo-groups").is_some());
+        assert!(cx.debug_bounds("sidebar-problems").is_none());
+    }
+
+    /// §7 rule 7, verbatim: "A row of icons needs one shared optical box, not one size per icon."
+    /// Both view glyphs are #282's real Phosphor assets, and both really paint inside the same
+    /// [`IconSize::Strip`] square - measured on the frame, not asserted against the enum.
+    #[gpui::test]
+    fn both_view_glyphs_are_phosphor_assets_in_one_shared_optical_box(cx: &mut TestAppContext) {
+        let repo = init_repo();
+        let (_app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        let box_size = f32::from(IconSize::Strip.box_size());
+        for icon in ["icon-tree-structure", "icon-warning"] {
+            let bounds = cx
+                .debug_bounds(icon)
+                .unwrap_or_else(|| panic!("{icon} must paint - it is #282's own mapped glyph"));
+            assert_eq!(
+                (f32::from(bounds.size.width), f32::from(bounds.size.height)),
+                (box_size, box_size),
+                "{icon} must be drawn inside the strip's one shared optical box"
+            );
+        }
+
+        // And really centred in their cells - the defect §4v records for the version before it
+        // was "the padding pushed every glyph 2px off-centre".
+        for (cell, icon) in [
+            ("sidebar-strip-worktrees", "icon-tree-structure"),
+            ("sidebar-strip-problems", "icon-warning"),
+        ] {
+            let cell = cx.debug_bounds(cell).expect("cell");
+            let glyph = cx.debug_bounds(icon).expect("glyph");
+            assert!(
+                (f32::from(cell.center().x) - f32::from(glyph.center().x)).abs() <= 0.5,
+                "{icon} is not horizontally centred in its cell"
+            );
+        }
+    }
+
+    /// `REVISION-2026-08-13.md` §1's gate, at the source: "The badges and the History/Search/
+    /// Problems bodies derive from `sessions` ... ungated they claimed 3 agents needing a human
+    /// and 4 problems on a day the rail, title bar and footer all reported zero."
+    ///
+    /// A freshly opened repo has no agent waiting and no diagnostics, so neither marker may paint
+    /// at all. This is the "cannot fabricate" half of the requirement, and an absence is the only
+    /// way to assert it.
+    #[gpui::test]
+    fn a_window_with_nothing_waiting_paints_no_state_marker(cx: &mut TestAppContext) {
+        let repo = init_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        assert!(
+            cx.debug_bounds("sidebar-strip-worktrees").is_some(),
+            "premise: the cells really are painted, so a missing marker is a real absence rather \
+             than a missing strip"
+        );
+        assert!(
+            cx.debug_bounds("sidebar-strip-worktrees-marker").is_none(),
+            "no agent is waiting on a human, so the Worktrees cell must carry no marker"
+        );
+        assert!(
+            cx.debug_bounds("sidebar-strip-problems-marker").is_none(),
+            "no language server has reported anything, so the Problems cell must carry no marker"
+        );
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.worktree_problem_tally(), ProblemTally::default());
+            assert!(app.worktree_problems().is_empty());
+        });
+    }
+
+    /// §1's empty-state gating, through the real render: "On **First run** and **Empty day** the
+    /// icon strip drops its view cells and keeps only the `+`". With no worktree row anywhere,
+    /// the switcher has nothing to switch between, so both view cells go - while the `+` and the
+    /// `⋯` stay, because starting an agent and reaching Settings are exactly the two things still
+    /// worth doing on an empty day.
+    #[gpui::test]
+    fn an_empty_day_drops_the_view_cells_and_keeps_the_trailing_pair(cx: &mut TestAppContext) {
+        let repo = init_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        assert!(
+            cx.debug_bounds("sidebar-strip-worktrees").is_some(),
+            "premise: a repo with a real worktree does offer the switcher"
+        );
+
+        app.update(cx, |app, cx| {
+            app.worktrees.clear();
+            for repo in &mut app.repos {
+                repo.worktrees.clear();
+            }
+            cx.notify();
+        });
+        cx.run_until_parked();
+
+        assert!(
+            cx.debug_bounds("sidebar-strip-worktrees").is_none()
+                && cx.debug_bounds("sidebar-strip-problems").is_none(),
+            "\u{a7}1: with no worktrees there are no views to offer, and a switcher with dead \
+             views is worse than no switcher"
+        );
+        assert!(
+            cx.debug_bounds("rail-new-agent").is_some()
+                && cx.debug_bounds("rail-overflow").is_some(),
+            "the `+` and the overflow are not view cells and must survive the gate"
+        );
+        assert!(
+            cx.debug_bounds("sidebar-strip").is_some(),
+            "the band itself stays - it is still one of the window's three column headers"
+        );
+    }
+
+    /// §1's "Filter row stays, and its placeholder follows the view: `filter worktrees and
+    /// agents` / `filter runs` / `filter problems`."
+    ///
+    /// And the placeholder is a real promise, not a label: with a query typed, the Problems view
+    /// really filters (§7 rule 1). Asserted on the *note* rather than on rows, because a clean
+    /// test checkout genuinely has no diagnostics - which is itself the thing worth pinning here,
+    /// since a filter box that changed a clean checkout's own note would be reporting a filter
+    /// result over data that was never there.
+    #[gpui::test]
+    fn the_filter_rows_placeholder_follows_the_selected_view(cx: &mut TestAppContext) {
+        let repo = init_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        assert!(
+            cx.debug_bounds("rail-filter-text").is_some(),
+            "premise: the filter row survives the strip - it is chrome both views sit under"
+        );
+
+        let problems = cx
+            .debug_bounds("sidebar-strip-problems")
+            .expect("the Problems cell");
+        cx.simulate_click(problems.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        assert!(
+            cx.debug_bounds("rail-filter-text").is_some(),
+            "\u{a7}1: the filter row stays across a view switch"
+        );
+        assert!(
+            cx.debug_bounds("sidebar-problems-note").is_some(),
+            "a clean checkout gets its own note"
+        );
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.effective_sidebar_view(true),
+                SidebarView::Problems,
+                "premise: the switch really happened, so the placeholder read below is the \
+                 Problems one"
+            );
+        });
+    }
+
+    /// The Problems list's own filter really applies, and the strip's marker deliberately does
+    /// not follow it - the strip reports what is really in the worktree, the list reports what you
+    /// asked to see.
+    #[test]
+    fn a_filter_narrows_the_list_without_touching_what_the_strip_reports() {
+        let rows = vec![
+            Problem {
+                severity: diagnostics_view::Severity::Error,
+                message: "cannot borrow `self.tokens` as mutable".to_string(),
+                file: "src/auth/session.rs".to_string(),
+                position: "212:17".to_string(),
+                source: Some("rustc".to_string()),
+            },
+            Problem {
+                severity: diagnostics_view::Severity::Warning,
+                message: "unused variable: `barrier`".to_string(),
+                file: "tests/auth_race.rs".to_string(),
+                position: "44:9".to_string(),
+                source: Some("clippy".to_string()),
+            },
+        ];
+
+        assert_eq!(
+            rows.iter().filter(|row| row.matches_filter("")).count(),
+            2,
+            "a blank query matches everything, exactly as it does for a worktree row"
+        );
+        // By message, by path, and by the server that reported it - all three of the row's own
+        // visible fields.
+        assert_eq!(
+            rows.iter()
+                .filter(|row| row.matches_filter("BORROW"))
+                .count(),
+            1,
+            "case-insensitive, over the message"
+        );
+        assert_eq!(
+            rows.iter()
+                .filter(|row| row.matches_filter("tests/"))
+                .count(),
+            1
+        );
+        assert_eq!(
+            rows.iter()
+                .filter(|row| row.matches_filter("clippy"))
+                .count(),
+            1
+        );
+        assert_eq!(
+            rows.iter()
+                .filter(|row| row.matches_filter("nothing"))
+                .count(),
+            0
+        );
+
+        assert_eq!(
+            tally_problems(&rows),
+            ProblemTally {
+                errors: 1,
+                warnings: 1,
+                hints: 0
+            },
+            "the tally the strip's marker reads is over the whole worktree, unfiltered"
+        );
+    }
+
+    /// §1's "the `+` new-session button (unchanged)" - unchanged meaning the *action*. It moved
+    /// into a 38px cell, so this proves the real spawn still happens from a real click on it.
+    #[gpui::test]
+    fn the_plus_cell_still_spawns_a_real_agent(cx: &mut TestAppContext) {
+        let repo = init_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        let before = app.read_with(cx, |app, _| app.agents.iter().count());
+        let plus = cx.debug_bounds("rail-new-agent").expect("the `+` cell");
+        cx.simulate_click(plus.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.agents.iter().count(),
+                before + 1,
+                "the `+` cell must really spawn, exactly as the rail header's `+` did"
+            );
+        });
+    }
+}

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -625,6 +625,21 @@ pub struct AdeApp {
     /// entry cap, so "the walk stopped early because it ran out of budget" is no longer a state
     /// this app can be in.
     pub(crate) file_tree_complete: bool,
+    /// Which view the left column's sidebar strip has selected (GitHub issue #291) - see
+    /// `crate::rail::strip::SidebarView`.
+    ///
+    /// The window's first rail-level view state: before the strip, the left column was hard-wired
+    /// to one thing (`design_handoff_jerry_ade/revision 5/REVISION-2026-08-13.md` §1: "The left
+    /// panel was hard-wired to one thing. It is now a switchable surface"). Deliberately **not**
+    /// persisted: it is a per-window navigation position like the right panel's own
+    /// [`Self::right_sidebar_view`], not a preference, and a window restored onto Problems for a
+    /// checkout whose diagnostics have not been recomputed yet would open on an empty panel with
+    /// no explanation.
+    ///
+    /// Read through `crate::rail::strip_render::AdeApp::effective_sidebar_view`, never directly by
+    /// a renderer: on a day with no worktrees there is no switcher, so this field's value is not
+    /// necessarily the view being shown.
+    pub(crate) sidebar_view: crate::rail::strip::SidebarView,
     /// The rail's open worktree/agent row menu (GitHub issue #290), `None` when closed - see
     /// `crate::rail::menu::RailRowMenu`. Its origin is window-space and already clamped, and it
     /// is rendered from [`Render::render`] rather than from the rail, because the rail's row list

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -391,6 +391,7 @@ impl AdeApp {
             // Nothing has been walked yet, so nothing may be pruned yet either.
             file_tree_complete: false,
             rail_row_menu: None,
+            sidebar_view: crate::rail::strip::SidebarView::default(),
             rail_overflow_menu: None,
             rail_overflow_button_bounds: gpui::Bounds::default(),
             remove_worktree_confirm_armed: None,

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -1644,6 +1644,9 @@ impl AdeApp {
         let totals = self.diff_totals;
 
         div()
+            // See `crate::work_surface::render::AdeApp::render_tab_strip`'s own selector: the
+            // three column headers are measured together, so all three need one.
+            .debug_selector(|| "right-panel-header".to_string())
             .flex_none()
             .h(theme::band::CHROME_HEADER)
             .flex()
@@ -1659,8 +1662,13 @@ impl AdeApp {
             // which is what the issue's screenshot shows. See
             // `crate::root::scrollbar::CONTENT_CLEARANCE`'s own docs for the value.
             .pr(px(scrollbar::CONTENT_CLEARANCE))
+            // The third of the window's three column headers, so the rule it draws is the same
+            // one the sidebar strip and the centre tab strip draw - GitHub issue #291 /
+            // `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4v: "all three borders
+            // are `#191c1f` ... [otherwise it] would have read as one rule changing shade
+            // mid-span". This was `theme::border::INNER` (`#1c2023`), a third shade on the same y.
             .border_b_1()
-            .border_color(theme::border::INNER)
+            .border_color(theme::border::RAIL_INNER)
             .child(toggle)
             // Everything below is one right-aligned action cluster - a `flex_1` spacer, not
             // `justify_between`, keeps it pinned to the trailing edge instead of spreading

--- a/crates/app/src/theme.rs
+++ b/crates/app/src/theme.rs
@@ -873,6 +873,21 @@ pub mod surface {
     pub const WINDOW_BORDER: ColorToken = token("surface.window_border", 0x262a2e);
     pub const TITLE_BAR: ColorToken = token("surface.title_bar", 0x101214);
     pub const RAIL: ColorToken = token("surface.rail", 0x101113); // left rail + right panel
+    /// The sidebar strip's own recessed band (GitHub issue #291) - the 36px view switcher above
+    /// the rail. Deliberately **darker than [`RAIL`]**, and that is the whole reason it is its own
+    /// token rather than a reuse of [`WINDOW`] or [`PTY`]:
+    /// `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4v, verbatim - "a tab only
+    /// reads as connected if the strip behind it is **darker than the panel**, and here strip and
+    /// rail were both `#101113`, so the slab floated. Strip is now `#0c0e10`; the selected cell is
+    /// `#101113`, exactly the rail's own background". `Jerry.dc.html`'s own final markup then
+    /// settled one step lower again (`background:#0a0b0d`, matching §4v's closing verification
+    /// line "selected `rgb(16,17,19)` over strip `rgb(10,11,13)`"), which is the value here.
+    ///
+    /// A theme that lifted this to or above [`RAIL`] would not merely recolour the strip - it
+    /// would destroy the selected cell's "cut the column rule and join the panel below" reading,
+    /// which is the strip's entire selection idiom. `theme::tests::the_sidebar_strip_stays_
+    /// recessed_below_the_rail_in_every_bundled_theme` holds that invariant.
+    pub const SIDEBAR_STRIP: ColorToken = token("surface.sidebar_strip", 0x0a0b0d);
     pub const CENTER: ColorToken = token("surface.center", 0x131518); // work surface
     pub const PTY: ColorToken = token("surface.pty", 0x0d0f11); // agent CLI + terminal
     pub const HEADER: ColorToken = token("surface.header", 0x121417); // context bar, panel headers
@@ -946,6 +961,7 @@ pub mod surface {
         ("WINDOW_BORDER", WINDOW_BORDER),
         ("TITLE_BAR", TITLE_BAR),
         ("RAIL", RAIL),
+        ("SIDEBAR_STRIP", SIDEBAR_STRIP),
         ("CENTER", CENTER),
         ("PTY", PTY),
         ("HEADER", HEADER),
@@ -1092,6 +1108,23 @@ pub mod text {
     /// The file tree row's `▾`/`▸` caret - same hex as [`PATH`] but a distinct token for a
     /// distinct element.
     pub const TREE_CARET: ColorToken = token("text.tree_caret", 0x4a5057);
+    /// The colour a hovered glyph lifts to in a surface whose *background* already encodes
+    /// selection - today the sidebar strip's cells (GitHub issue #291).
+    ///
+    /// `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4v derives it from a real
+    /// defect and states the rule verbatim: **"two states must not compete on one property. If
+    /// background says 'selected', hover says it somewhere else."** Making the selected cell match
+    /// the rail (which the cut-out requires) dropped selected to luminance 16.9 while a background
+    /// hover sat at 25.4, so hovering an *inactive* view out-read the active one. "Hover moved off
+    /// background entirely: the cell sets `color`, every glyph part draws with `currentColor`, and
+    /// hover lifts `color` to `#c8ced4`."
+    ///
+    /// Its own token rather than a reuse of [`HEADING`] (`#c8cdd2`, two units away and
+    /// indistinguishable today) because the two answer different questions: `HEADING` is a resting
+    /// *text* step on the ramp, this is the top of a two-state glyph pair whose floor is
+    /// [`FAINTER`]. A theme retuning its heading weight must not silently flatten a hover that is
+    /// the only feedback an inactive strip cell has.
+    pub const GLYPH_HOVER: ColorToken = token("text.glyph_hover", 0xc8ced4);
 
     /// Every real [`ColorToken`] this module declares, paired with its own Rust `const` name -
     /// the module's slice of [`super::TOKEN_GROUPS`]'s whole-app registry. See that constant's
@@ -1115,6 +1148,7 @@ pub mod text {
         ("DISABLED", DISABLED),
         ("PATH", PATH),
         ("TREE_CARET", TREE_CARET),
+        ("GLYPH_HOVER", GLYPH_HOVER),
     ];
 }
 
@@ -3095,10 +3129,20 @@ pub mod band {
     use super::{px, Pixels};
 
     pub const TITLE_BAR: Pixels = px(38.0);
-    /// Shared height for the work-surface tab strip, the session-rail header, and the
-    /// files/changes panel header - the three sit side by side under the title bar and must
-    /// line up pixel-perfect, so they read off one constant instead of three values that could
-    /// drift independently.
+    /// Shared height for the work-surface tab strip, the rail's own sidebar strip
+    /// (`crate::rail::strip`, GitHub issue #291 - it *replaced* the plain rail header at this
+    /// same height), and the files/changes panel header - the three sit side by side under the
+    /// title bar and must line up pixel-perfect, so they read off one constant instead of three
+    /// values that could drift independently.
+    ///
+    /// `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4v is the reason this is one
+    /// constant and not three, and it is worth reading before changing it - the design really did
+    /// raise one of the three to 38 and produced "a visible staircase at every column boundary".
+    /// Its rule, verbatim: **"column headers that share a y are one rule, not three. Changing any
+    /// of their heights changes a line that spans the whole window - check the other two in the
+    /// same edit."** The same section also fixes the *colour* of that rule at
+    /// [`super::border::RAIL_INNER`] for all three, "which once the rules lined up would have read
+    /// as one rule changing shade mid-span" otherwise.
     pub const CHROME_HEADER: Pixels = px(36.0);
     pub const CONTEXT_BAR: Pixels = px(32.0);
     pub const DIFF_TOOLBAR: Pixels = px(31.0);
@@ -3149,6 +3193,13 @@ pub mod zone {
     pub const COMPOSER_WIDTH: Pixels = px(560.0);
     /// The tab strip's `+` menu popover's width.
     pub const PLUS_MENU_WIDTH: Pixels = px(326.0);
+    /// One sidebar-strip cell's width (GitHub issue #291). `STAGE-A-CHANGELOG.md` §4v: the strip's
+    /// cells "are now the same object" as the centre tabs - "**38px full-height cells, no radius,
+    /// no gap**" - which `Jerry.dc.html`'s own markup renders as `width:38px` inside a
+    /// [`super::band::CHROME_HEADER`]-high band. Every cell in the strip is exactly this wide,
+    /// view cells and the `+`/`⋯` alike, which is what makes the dividing rules read as a tab
+    /// strip's segments rather than as icons on a dark band.
+    pub const SIDEBAR_STRIP_CELL: Pixels = px(38.0);
 }
 
 /// The only shadows in the product. Drop them if GPUI makes them awkward - the borders
@@ -4328,6 +4379,50 @@ mod syntax_contrast_tests {
                      the real {MIN_RATIO}:1 floor"
                 );
             }
+        }
+    }
+
+    /// The sidebar strip's one structural invariant, in every bundled theme (GitHub issue #291).
+    ///
+    /// `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4v: "a tab only reads as
+    /// connected if the strip behind it is **darker than the panel**, and here strip and rail were
+    /// both `#101113`, so the slab floated." The selected cell fills with [`surface::RAIL`] and
+    /// paints its own rule in the same colour, so a theme that let [`surface::SIDEBAR_STRIP`]
+    /// collapse onto `RAIL` would take the strip's entire selection idiom with it - a failure no
+    /// contrast floor catches, because both colours would still be perfectly legible.
+    ///
+    /// Stated as *recession*, not as "darker", because `Paper` is a real bundled light theme whose
+    /// derivation legitimately inverts the ramp: there, every surface Jerry Dark makes darker is
+    /// made lighter. So the invariant is measured against [`surface::WINDOW`] - the palette's own
+    /// "one step back from a panel" - and asks only that the strip sits on that same side of the
+    /// rail, by at least as much.
+    #[test]
+    fn the_sidebar_strip_stays_recessed_below_the_rail_in_every_bundled_theme() {
+        for def in crate::settings::state::THEME_DEFS.iter() {
+            let _guard = with_bundled_theme(def.name);
+            let strip = relative_luminance(surface::SIDEBAR_STRIP.resolve());
+            let rail = relative_luminance(surface::RAIL.resolve());
+            let window = relative_luminance(surface::WINDOW.resolve());
+            let recession = window - rail;
+            assert!(
+                recession != 0.0,
+                "{}: premise - this palette must separate the window body from a panel at all, \
+                 or there is no direction for `recessed` to mean",
+                def.name
+            );
+            assert!(
+                (strip - rail).signum() == recession.signum(),
+                "{}: the sidebar strip ({strip:.4}) must be recessed from the rail ({rail:.4}) in \
+                 the same direction the window body ({window:.4}) is - on the wrong side of it \
+                 the selected cell stops reading as joined to the panel below",
+                def.name
+            );
+            assert!(
+                (strip - rail).abs() >= recession.abs(),
+                "{}: and by at least as much - a strip that only just clears the rail is the \
+                 floating slab \u{a7}4v rejected",
+                def.name
+            );
         }
     }
 

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -902,15 +902,28 @@ impl AdeApp {
         &self,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
+        // No `border_b` here, deliberately: the *children* own this column's bottom edge. GitHub
+        // issue #291 / `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4v, verbatim -
+        // "the centre column drew its bottom edge **twice** - once on the tab-strip container and
+        // once on every tab - so under an inactive tab the rule was 1.6px of two shades stacked,
+        // and the active tab's cut-out (its `border-bottom` set to its own background, so it joins
+        // the pane below) was defeated by the container's line drawing straight through beneath
+        // it. ... A child cannot paint over its parent's border - the parent's border sits outside
+        // the child's box - so the container cannot own the edge if any child needs to cut it.
+        // **The tabs own it.**" Every child below therefore carries the rule itself, the `+`, the
+        // spacer and the counter cluster included, "without which the rule stopped at the last tab
+        // and 398px of the window's top edge was simply missing".
         let mut bar = div()
             .id("tab-strip")
+            // Lets a real test measure this column header's own painted box - §4v's
+            // "column headers that share a y are one rule, not three" is only checkable against
+            // all three of them at once (`crate::rail::strip_render`'s own chrome test).
+            .debug_selector(|| "tab-strip".to_string())
             .flex()
             .flex_none()
             .items_stretch()
             .h(theme::band::CHROME_HEADER)
-            .bg(theme::surface::TITLE_BAR)
-            .border_b_1()
-            .border_color(theme::border::ZONE);
+            .bg(theme::surface::TITLE_BAR);
 
         let order = self.combined_tab_order();
 
@@ -945,13 +958,22 @@ impl AdeApp {
 
         let jump_keys = self.agent_jump_keys();
 
-        bar.child(div().flex_1()).child(
+        bar.child(
+            // The spacer carries the column rule too - see the container's own comment above.
+            div()
+                .flex_1()
+                .border_b_1()
+                .border_color(theme::border::RAIL_INNER),
+        )
+        .child(
             div()
                 .flex_none()
                 .flex()
                 .items_center()
                 .gap(px(6.0))
                 .px(px(12.0))
+                .border_b_1()
+                .border_color(theme::border::RAIL_INNER)
                 .child(render_keycap_row(&jump_keys, KeycapSize::Standard))
                 .child(
                     div()
@@ -1324,6 +1346,10 @@ impl AdeApp {
             .gap(px(5.0))
             .px(px(10.0))
             .cursor_pointer()
+            // A child of the tab strip, so it carries the column rule - see
+            // `Self::render_tab_strip`'s own comment for why the container no longer does.
+            .border_b_1()
+            .border_color(theme::border::RAIL_INNER)
             .bg(if is_open {
                 theme::surface::SEGMENT_TRACK.into()
             } else {

--- a/crates/app/src/work_surface/state.rs
+++ b/crates/app/src/work_surface/state.rs
@@ -328,6 +328,15 @@ pub struct TabColors {
     pub label: Rgba,
 }
 
+/// An inactive tab's `underline` is the **window's column rule**, not a tab-level decoration -
+/// which is why it is [`theme::border::RAIL_INNER`] and not [`theme::border::ZONE`]. GitHub issue
+/// #291 / `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4v: once the three column
+/// headers line up, "**All three column headers are now 36** ... and all three borders are
+/// `#191c1f` - the centre strip had been `#1e2225`, which once the rules lined up would have read
+/// as one rule changing shade mid-span."
+///
+/// The active tab keeps painting its own background there instead - "so it joins the pane below" -
+/// which is the cut-out `crate::rail::strip_render`'s selected cell copies for the left column.
 pub fn tab_colors(active: bool) -> TabColors {
     if active {
         TabColors {
@@ -338,7 +347,7 @@ pub fn tab_colors(active: bool) -> TabColors {
     } else {
         TabColors {
             bg: TRANSPARENT,
-            underline: theme::border::ZONE.into(),
+            underline: theme::border::RAIL_INNER.into(),
             label: theme::text::DIMMER.into(),
         }
     }

--- a/crates/lsp-core/src/client.rs
+++ b/crates/lsp-core/src/client.rs
@@ -981,6 +981,40 @@ impl LspClient {
         lock(&self.diagnostics).contains_key(uri.as_str())
     }
 
+    /// **Every** file this server has published a non-empty diagnostic set for, as real
+    /// filesystem paths - the whole-server view [`Self::diagnostics_for`] gives one file at a
+    /// time.
+    ///
+    /// Exists for the sidebar strip's Problems view (`crate::rail::strip` in the `app` crate,
+    /// GitHub issue #291), which is scoped to a *worktree* rather than to whichever file is open:
+    /// this client is already keyed on one worktree root by its caller, so its whole diagnostics
+    /// map is exactly "the diagnostics in this checkout", and re-deriving that by asking
+    /// per-path would mean first knowing every path to ask about.
+    ///
+    /// Two deliberate filters, both of which drop things a caller could not use anyway:
+    ///
+    /// - **Clean files are omitted.** A `publishDiagnostics` carrying zero diagnostics is a real
+    ///   result ("analyzed, nothing to report") and [`Self::has_diagnostics_result`] is where that
+    ///   distinction lives; a list of problems has no row for it.
+    /// - **Non-`file://` uris are omitted.** rust-analyzer really does publish against virtual
+    ///   macro-expansion buffers, which have no path to show or open - the same honest failure
+    ///   [`Self::path_for_uri`] reports, applied here by skipping rather than by guessing a path.
+    ///
+    /// Returned sorted by path so a re-render can't reshuffle the list under the pointer -
+    /// `HashMap` iteration order is arbitrary and differs run to run.
+    pub fn published_diagnostics(&self) -> Vec<(PathBuf, Vec<lsp_types::Diagnostic>)> {
+        let mut published: Vec<(PathBuf, Vec<lsp_types::Diagnostic>)> = lock(&self.diagnostics)
+            .iter()
+            .filter(|(_, diagnostics)| !diagnostics.is_empty())
+            .filter_map(|(uri, diagnostics)| {
+                let uri: Uri = uri.parse().ok()?;
+                Some((uri_to_path(&uri).ok()?, diagnostics.clone()))
+            })
+            .collect();
+        published.sort_by(|(left, _), (right, _)| left.cmp(right));
+        published
+    }
+
     /// Non-blocking: drains every "diagnostics changed" wake signal currently buffered (the
     /// reader thread sends one every time it records a fresh `publishDiagnostics` notification
     /// for *any* file, not just one specific path), returning `true` iff at least one was


### PR DESCRIPTION
Builds `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4v's sidebar strip - the left column's view switcher - and the window-chrome invariant the design derived while building it.

**Before:** the rail opened with a plain `rail-header` band holding the `+` and (since #290 parked it there) the `⋯`, with the repo→worktree→agent tree hard-wired underneath. No view switcher existed anywhere in the app.

## The strip

`crate::rail::strip` (pure model) + `crate::rail::strip_render` (the band), the same split every other folder in `crate::rail` uses.

- **38px full-height cells, no radius, no gap**, divided by `border::INNER` - the same rule the centre tabs use between them.
- **Selected = a filled slab in `surface::RAIL` that cuts the column rule**, so it reads as joined to the panel below. The band draws no bottom border at all: every child carries its own, because a child cannot paint over its parent's border.
- **`surface::SIDEBAR_STRIP` (`#0a0b0d`)** is a new token - the slab only reads as connected if the band behind it is recessed from the panel ("here strip and rail were both `#101113`, so the slab floated"). Pinned in every bundled theme by a new invariant test, stated as *recession* rather than "darker" so it holds for `Paper`.
- **Hover lives on the glyph, never the background** (§4v: "two states must not compete on one property"). `text::GLYPH_HOVER`, applied via `group_hover` keyed on the cell - `IconRow::draw` pins the SVG's own `text_color`, so an inherited colour would never reach the glyph, while the trigger still has to be the whole slab.
- **5px square state markers** (`radius::MARK_SM`) in `status::ASK` / `status::FAIL`, count in the tooltip, hidden at zero.
- Every cell carries §1's `title="<view> — <hint>"`; glyphs are #282's `tree-structure` / `warning` through `IconSize::Strip` (§7 rule 7's one shared optical box).
- Cells: Worktrees, Problems, flex spacer, `+`, `⋯`. Settings lives in the overflow, not as a cell (§4u).

**Gated at the source** (§1): `strip_view_cells` returns no cells when the window has no worktree row, and the markers are built *below* that gate rather than beside a `when(..)` in the renderer - so an empty day cannot claim agents needing a human.

## The Problems view

§7 rule 1 ("Ship the affordance with the behaviour, or ship neither"), so the cell ships with a view that reads the app's **real** diagnostics for the selected worktree. The worktree keying is free rather than a filter step - `lsp_clients` is already keyed on `(worktree root, server)`, which is §6's "a diagnostic belongs to a checkout" already true in the data. One new accessor, `LspClient::published_diagnostics`.

A clean checkout gets §6's `No diagnostics in <branch>.`; a filter that hid every row says *that* instead, because they are two different facts. The filter row's placeholder now follows the view (§1) and the list really honours it.

Everything past listing what is really there - click-to-open, the `all`/`this worktree` scope, diagnostics for files no editor has opened - is **#292**, which this unblocks.

## Window chrome

The three column headers already shared `band::CHROME_HEADER`, but drew three different border colours on that one y (rail `RAIL_INNER`, centre `ZONE`, right panel `INNER`), and the centre column drew its edge **twice** - container and tabs both - so the active tab's cut-out was defeated by the container's line running beneath it. The container's `border_b` is gone; every child of the tab strip carries the rule, `+`, spacer and session counter included.

## Verification

Verified in the running app against §4v's own measured numbers: strip `rgb(10,11,13)`, selected cell and rail both `rgb(16,17,19)`, inactive edges `rgb(25,28,31)` across all three columns at one y, vertical rules `rgb(28,32,35)`, glyph `94,100,106 → 200,206,212` on hover with the cell background unchanged.

`cargo fmt --all -- --check` clean, `cargo clippy --workspace --all-targets` warning-free, `cargo test --workspace` 2667 passed. The 15 failures are the known inotify-instance-exhaustion family (`worktree_watch`, `file_tree_watch`, `repo_list_tests`), all verified passing in isolation.

**21 new tests.** Pure: the two-cell row set, the empty gate against deliberately loud counts, the cut-out as a colour pair, the marker hues and hidden-at-zero, both tooltip forms and both empty notes. Render: every cell 38 wide and full-height with no gap, all three column headers ending on one y, the real switch a click performs, both glyphs inside one optical box and centred, the absence of any marker on a window with nothing waiting, the empty day's cells really gone, and the `+` really spawning.

## One deliberate deviation

The already-lit selected cell keeps `text::SELECTED` on hover instead of taking the hover colour. `Jerry.dc.html` applies its one `style-hover` from a shared template, so its selected cell really does *dim* on hover; §4v's stated rule is that hover **lifts**, and dimming the active view re-creates the collision the section moved hover off background to fix. Stated in `strip_glyph_hover`'s own docs.

Closes #291