### PR TITLE
Diff-line review notes: draft/sent, batched, sent to the run's agent (#288)

### DIFF
--- a/assets/themes/ember.toml
+++ b/assets/themes/ember.toml
@@ -226,6 +226,29 @@ critical = "#984d60"  # Below 15% remaining.
 track    = "#1c2124"  # The unfilled remainder of the meter
 stale    = "#4e565b"
 
+# Diff-line review notes (GitHub issue #288, STAGE-A-CHANGELOG.md §1's two §6.2 rows and the
+# audit's top-5 #2) - the notes bar above the hunks and the card pinned beneath a line.
+[notes]
+edge             = "#00789d"
+card_bg          = "#12191c"  # The pinned card's fill.
+card_border      = "#1a333f"
+card_fg          = "#8a9194"  # The card's own note text.
+card_placeholder = "#454d51"  # The placeholder shown in an empty, still-being-typed card.
+mark_draft       = "#488199"  # A card's draft mark
+mark_sent        = "#689057"  # A card's sent mark, and the bar's own ✓ sent confirmation.
+dot              = "#518fa8"
+dot_empty        = "#2d3336"  # The same column's ○
+bar_bg           = "#11191d"  # The notes bar's band.
+bar_border       = "#152b35"  # Its 1px bottom rule against the hunks below it.
+bar_label        = "#6599ae"  # The bar's count sentence (1 note on this file).
+bar_meta         = "#454d51"
+bar_error        = "#984d60"
+send_bg          = "#112027"
+send_border      = "#144a5c"  # Its 1px border, and its keycaps' border.
+send_hover_bg    = "#132830"  # Its hover fill.
+send_fg          = "#6599ae"  # Its label.
+send_cap_fg      = "#488199"  # Its ⌘⏎ keycaps' glyphs.
+
 
 # ──────────────────────────────────────────────────────────────────────────────────────────────
 # The code surface

--- a/assets/themes/jerry-dim.toml
+++ b/assets/themes/jerry-dim.toml
@@ -226,6 +226,29 @@ critical = "#b46d61"  # Below 15% remaining.
 track    = "#292c30"  # The unfilled remainder of the meter
 stale    = "#676c72"
 
+# Diff-line review notes (GitHub issue #288, STAGE-A-CHANGELOG.md §1's two §6.2 rows and the
+# audit's top-5 #2) - the notes bar above the hunks and the card pinned beneath a line.
+[notes]
+edge             = "#5e8dc4"
+card_bg          = "#1d2126"  # The pinned card's fill.
+card_border      = "#323f51"
+card_fg          = "#b0b4b9"  # The card's own note text.
+card_placeholder = "#5c6166"  # The placeholder shown in an empty, still-being-typed card.
+mark_draft       = "#7a9abe"  # A card's draft mark
+mark_sent        = "#70b693"  # A card's sent mark, and the bar's own ✓ sent confirmation.
+dot              = "#88abd2"
+dot_empty        = "#3d4146"  # The same column's ○
+bar_bg           = "#1c2127"  # The notes bar's band.
+bar_border       = "#2a3544"  # Its 1px bottom rule against the hunks below it.
+bar_label        = "#99b8d9"  # The bar's count sentence (1 note on this file).
+bar_meta         = "#5c6166"
+bar_error        = "#b46d61"
+send_bg          = "#202933"
+send_border      = "#3c5975"  # Its 1px border, and its keycaps' border.
+send_hover_bg    = "#26323e"  # Its hover fill.
+send_fg          = "#99b8d9"  # Its label.
+send_cap_fg      = "#7a9abe"  # Its ⌘⏎ keycaps' glyphs.
+
 
 # ──────────────────────────────────────────────────────────────────────────────────────────────
 # The code surface

--- a/assets/themes/moss.toml
+++ b/assets/themes/moss.toml
@@ -226,6 +226,29 @@ critical = "#a46963"  # Below 15% remaining.
 track    = "#232528"  # The unfilled remainder of the meter
 stale    = "#606469"
 
+# Diff-line review notes (GitHub issue #288, STAGE-A-CHANGELOG.md §1's two §6.2 rows and the
+# audit's top-5 #2) - the notes bar above the hunks and the card pinned beneath a line.
+[notes]
+edge             = "#5c86b0"
+card_bg          = "#181b1f"  # The pinned card's fill.
+card_border      = "#2d3946"
+card_fg          = "#a8acaf"  # The card's own note text.
+card_placeholder = "#55595e"  # The placeholder shown in an empty, still-being-typed card.
+mark_draft       = "#7692ae"  # A card's draft mark
+mark_sent        = "#76aa8b"  # A card's sent mark, and the bar's own ✓ sent confirmation.
+dot              = "#84a3c0"
+dot_empty        = "#373a3e"  # The same column's ○
+bar_bg           = "#171b20"  # The notes bar's band.
+bar_border       = "#242f3a"  # Its 1px bottom rule against the hunks below it.
+bar_label        = "#95b0c9"  # The bar's count sentence (1 note on this file).
+bar_meta         = "#55595e"
+bar_error        = "#a46963"
+send_bg          = "#1b232a"
+send_border      = "#395267"  # Its 1px border, and its keycaps' border.
+send_hover_bg    = "#212b35"  # Its hover fill.
+send_fg          = "#95b0c9"  # Its label.
+send_cap_fg      = "#7692ae"  # Its ⌘⏎ keycaps' glyphs.
+
 
 # ──────────────────────────────────────────────────────────────────────────────────────────────
 # The code surface

--- a/assets/themes/paper.toml
+++ b/assets/themes/paper.toml
@@ -226,6 +226,29 @@ critical = "#a66663"  # Below 15% remaining.
 track    = "#d3d8dc"  # The unfilled remainder of the meter
 stale    = "#8c9197"
 
+# Diff-line review notes (GitHub issue #288, STAGE-A-CHANGELOG.md §1's two §6.2 rows and the
+# audit's top-5 #2) - the notes bar above the hunks and the card pinned beneath a line.
+[notes]
+edge             = "#4678a3"
+card_bg          = "#e0e6eb"  # The pinned card's fill.
+card_border      = "#b2c3d5"
+card_fg          = "#4c5053"  # The card's own note text.
+card_placeholder = "#979da2"  # The placeholder shown in an empty, still-being-typed card.
+mark_draft       = "#4b6c87"  # A card's draft mark
+mark_sent        = "#366948"  # A card's sent mark, and the bar's own ✓ sent confirmation.
+dot              = "#3b5e7a"
+dot_empty        = "#b9bec3"  # The same column's ○
+bar_bg           = "#dfe6ed"  # The notes bar's band.
+bar_border       = "#bfcfde"  # Its 1px bottom rule against the hunks below it.
+bar_label        = "#355269"  # The bar's count sentence (1 note on this file).
+bar_meta         = "#979da2"
+bar_error        = "#a66663"
+send_bg          = "#d1dde8"
+send_border      = "#8babc4"  # Its 1px border, and its keycaps' border.
+send_hover_bg    = "#c4d4e1"  # Its hover fill.
+send_fg          = "#355269"  # Its label.
+send_cap_fg      = "#4b6c87"  # Its ⌘⏎ keycaps' glyphs.
+
 
 # ──────────────────────────────────────────────────────────────────────────────────────────────
 # The code surface

--- a/assets/themes/slate.toml
+++ b/assets/themes/slate.toml
@@ -226,6 +226,29 @@ critical = "#934c43"  # Below 15% remaining.
 track    = "#1d2024"  # The unfilled remainder of the meter
 stale    = "#4d5258"
 
+# Diff-line review notes (GitHub issue #288, STAGE-A-CHANGELOG.md §1's two §6.2 rows and the
+# audit's top-5 #2) - the notes bar above the hunks and the card pinned beneath a line.
+[notes]
+edge             = "#396ba2"
+card_bg          = "#14181d"  # The pinned card's fill.
+card_border      = "#213041"
+card_fg          = "#85898e"  # The card's own note text.
+card_placeholder = "#45494f"  # The placeholder shown in an empty, still-being-typed card.
+mark_draft       = "#557699"  # A card's draft mark
+mark_sent        = "#468e6b"  # A card's sent mark, and the bar's own ✓ sent confirmation.
+dot              = "#5e83a9"
+dot_empty        = "#2d3136"  # The same column's ○
+bar_bg           = "#13181e"  # The notes bar's band.
+bar_border       = "#1c2836"  # Its 1px bottom rule against the hunks below it.
+bar_label        = "#6e8dae"  # The bar's count sentence (1 note on this file).
+bar_meta         = "#45494f"
+bar_error        = "#934c43"
+send_bg          = "#151e28"
+send_border      = "#26435f"  # Its 1px border, and its keycaps' border.
+send_hover_bg    = "#192532"  # Its hover fill.
+send_fg          = "#6e8dae"  # Its label.
+send_cap_fg      = "#557699"  # Its ⌘⏎ keycaps' glyphs.
+
 
 # ──────────────────────────────────────────────────────────────────────────────────────────────
 # The code surface

--- a/crates/app/src/code_surface/diff_view.rs
+++ b/crates/app/src/code_surface/diff_view.rs
@@ -3,6 +3,7 @@
 
 use super::zoom::zoom_scoped;
 use super::*;
+use crate::review_notes::{NoteAnchor, NoteMark};
 #[cfg(test)]
 use crate::root::focus::palette_focus_tests;
 use crate::root::plural;
@@ -40,6 +41,21 @@ enum DiffRow {
         line: usize,
         row: usize,
     },
+    /// One pinned review note (GitHub issue #288), directly beneath the diff line it is anchored
+    /// to.
+    ///
+    /// A note is a **row of this list**, not a sibling panel and not an overlay:
+    /// `STAGE-A-CHANGELOG.md` §1's own wording is *"pinned beneath the line"*, and the issue is
+    /// explicit that notes *"interleave into the existing `DiffRow` stream (adjust the enum; reuse
+    /// the diff renderer - no parallel list)"*. Being a real item is also what makes a note
+    /// virtualize, scroll and measure exactly like everything around it rather than needing its
+    /// own answer to any of those.
+    ///
+    /// It names its `anchor`, not the note's text, for the same reason every other variant here
+    /// names a position rather than content: the row builder is `'static`, so it re-resolves the
+    /// note out of `AdeApp` by (worktree, path, anchor) at build time. `note_row` is a flat
+    /// per-file counter that names this row's own `diff-note-{n}` debug selector.
+    Note { anchor: NoteAnchor, note_row: usize },
     /// The trailing `... diff truncated for this file` notice - a genuine final *item* of the
     /// list, not a sibling below it (see [`render_diff_truncated_row`]).
     Truncated,
@@ -62,11 +78,22 @@ enum DiffRow {
 /// would exceed it still contributes its header (and fold marker) before the plan stops. That is
 /// deliberately preserved rather than "cleaned up" - it is what makes the truncation notice read
 /// as sitting under a real hunk boundary instead of mid-hunk.
-fn diff_rows(file: &DiffFile) -> Vec<DiffRow> {
-    // At most one header + one fold marker per hunk, the capped line count, and the notice.
-    let mut rows: Vec<DiffRow> =
-        Vec::with_capacity(file.hunks.len() * 2 + MAX_RENDERED_DIFF_LINES_PER_FILE + 1);
+///
+/// `noted` is the set of [`NoteAnchor`]s this worktree really has a review note pinned on for this
+/// path (GitHub issue #288). A note row is appended directly after the line it is anchored to,
+/// which is what makes *"pinned beneath the line"* a fact about the row plan rather than about
+/// where something is drawn. Note rows deliberately do **not** count toward
+/// [`MAX_RENDERED_DIFF_LINES_PER_FILE`]: that cap exists to bound how much *diff* is built per
+/// frame, and a reviewer's own notes on the lines already within it are neither unbounded nor
+/// something the cap has any business hiding.
+fn diff_rows(file: &DiffFile, noted: &[NoteAnchor]) -> Vec<DiffRow> {
+    // At most one header + one fold marker per hunk, the capped line count, the notice, and one
+    // row per real note.
+    let mut rows: Vec<DiffRow> = Vec::with_capacity(
+        file.hunks.len() * 2 + MAX_RENDERED_DIFF_LINES_PER_FILE + 1 + noted.len(),
+    );
     let mut rendered_lines = 0usize;
+    let mut note_rows = 0usize;
     let mut hunks_truncated = false;
     let mut previous_header: Option<&str> = None;
     'hunks: for (hunk_index, hunk) in file.hunks.iter().enumerate() {
@@ -81,6 +108,15 @@ fn diff_rows(file: &DiffFile) -> Vec<DiffRow> {
         previous_header = Some(hunk.header.as_str());
         rows.push(DiffRow::HunkHeader(hunk_index));
 
+        // Derived here rather than read off `AdeApp::diff_highlight_cache`'s index-aligned copy:
+        // this function is pure and directly testable without a window, and that is the whole
+        // reason the row plan lives apart from the render method.
+        let numbers = if noted.is_empty() {
+            Vec::new()
+        } else {
+            changes::hunk_line_numbers(hunk)
+        };
+
         for line_index in 0..hunk.lines.len() {
             if rendered_lines >= MAX_RENDERED_DIFF_LINES_PER_FILE {
                 hunks_truncated = true;
@@ -92,6 +128,17 @@ fn diff_rows(file: &DiffFile) -> Vec<DiffRow> {
                 row: rendered_lines,
             });
             rendered_lines += 1;
+            let anchor = numbers
+                .get(line_index)
+                .copied()
+                .and_then(NoteAnchor::from_gutter);
+            if let Some(anchor) = anchor.filter(|anchor| noted.contains(anchor)) {
+                rows.push(DiffRow::Note {
+                    anchor,
+                    note_row: note_rows,
+                });
+                note_rows += 1;
+            }
         }
     }
 
@@ -99,6 +146,31 @@ fn diff_rows(file: &DiffFile) -> Vec<DiffRow> {
         rows.push(DiffRow::Truncated);
     }
     rows
+}
+
+/// Every diff line of `file` that a review note could be pinned to, in the order the diff really
+/// lays them out, top to bottom.
+///
+/// GitHub issue #288's batched prompt has to list its notes *"line-anchored"* in the order the
+/// reviewer sees them - not in whatever order a `BTreeMap` happens to hold anchors, which puts
+/// every `New` before every `Old` and so would jumble a hunk that removed and added around the
+/// same place. `crate::review_notes::flow::AdeApp::batched_review_prompt` sorts by position in
+/// this list.
+pub(crate) fn note_anchors_in_diff_order(file: &DiffFile) -> Vec<NoteAnchor> {
+    let mut anchors = Vec::new();
+    let mut rendered_lines = 0usize;
+    'hunks: for hunk in &file.hunks {
+        for numbers in changes::hunk_line_numbers(hunk) {
+            if rendered_lines >= MAX_RENDERED_DIFF_LINES_PER_FILE {
+                break 'hunks;
+            }
+            rendered_lines += 1;
+            if let Some(anchor) = NoteAnchor::from_gutter(numbers) {
+                anchors.push(anchor);
+            }
+        }
+    }
+    anchors
 }
 
 /// Which surface [`AdeApp::render_diff_file_detail`] is drawing into.
@@ -351,7 +423,30 @@ impl AdeApp {
         // file that many times per frame - most of the cost this change exists to remove.
         // It also has to exist before the list does, since `uniform_list` needs a real item count
         // up front, and both must come from the same plan.
-        let rows: Rc<Vec<DiffRow>> = Rc::new(diff_rows(file));
+        // GitHub issue #288. Resolved once per frame, like `rows` itself and for the same reason,
+        // and empty on any surface but the Uncommitted diff - see
+        // `crate::review_notes::flow::AdeApp::review_notes_file` for why notes are scoped to that
+        // one surface rather than to every place this renderer is used.
+        let notes_path: Option<PathBuf> = match surface {
+            DiffDetailSurface::Changes => {
+                self.review_notes_file().filter(|path| path == &file.path)
+            }
+            DiffDetailSurface::Review => None,
+        };
+        let noted: Vec<NoteAnchor> = notes_path
+            .as_ref()
+            .map(|path| {
+                self.review_notes_store()
+                    .anchors(&self.review_notes_worktree(), path)
+            })
+            .unwrap_or_default();
+        let notes_enabled = notes_path.is_some();
+        // The bar is built after the list, from the same resolution - one `Rc`, so the row builder
+        // and the bar can never be looking at two different files.
+        let notes_path: Option<Rc<PathBuf>> = notes_path.map(Rc::new);
+        let bar_path = notes_path.clone();
+
+        let rows: Rc<Vec<DiffRow>> = Rc::new(diff_rows(file, &noted));
         let row_count = rows.len();
 
         // GitHub issue #287's gutter attribution, resolved once per frame for the same reason
@@ -375,7 +470,7 @@ impl AdeApp {
             // same one showing new content.
             format!("{}-detail-{}", surface.id_prefix(), file.path.display()),
             row_count,
-            cx.processor(move |this: &mut Self, range: Range<usize>, _window, _cx| {
+            cx.processor(move |this: &mut Self, range: Range<usize>, _window, cx| {
                 // Re-resolved from `this` through `surface` rather than a hardcoded field,
                 // mirroring `crate::graph_view::render::AdeApp::render_graph_rows`' identical
                 // re-resolve: the closure is `'static` and cannot borrow the `&DiffFile` this
@@ -432,20 +527,62 @@ impl AdeApp {
                                     let author = line_authors
                                         .get(hunk)
                                         .and_then(|authors| authors.get(line));
-                                    render_diff_line(
-                                        diff_line,
+                                    // The note channel reads its anchor from the same guarded
+                                    // gutter numbers, so a line whose identity this frame cannot
+                                    // confirm is simply not annotatable - never annotatable at a
+                                    // guessed line.
+                                    let anchor = notes_enabled
+                                        .then(|| NoteAnchor::from_gutter(numbers))
+                                        .flatten();
+                                    let note = anchor.zip(notes_path.as_ref()).and_then(
+                                        |(anchor, path)| {
+                                            this.review_notes_store()
+                                                .note(
+                                                    &this.review_notes_worktree(),
+                                                    path.as_path(),
+                                                    anchor,
+                                                )
+                                                .map(|note| note.mark())
+                                        },
+                                    );
+                                    let chrome = DiffLineChrome {
                                         rendered,
                                         numbers,
-                                        surface.id_prefix(),
-                                        row,
+                                        selector_prefix: surface.id_prefix(),
+                                        row_index: row,
                                         author,
-                                        author_filter.as_ref(),
-                                    )
-                                    .into_any_element()
+                                        filter: author_filter.as_ref(),
+                                        anchor,
+                                        note,
+                                        notes_enabled,
+                                        is_note_cursor: anchor.is_some()
+                                            && this.note_cursor.as_ref().is_some_and(|cursor| {
+                                                notes_path
+                                                    .as_ref()
+                                                    .is_some_and(|path| cursor.path == **path)
+                                                    && Some(cursor.anchor) == anchor
+                                            }),
+                                    };
+                                    render_diff_line(diff_line, chrome, cx).into_any_element()
                                 }
                                 None => render_blank_diff_row().into_any_element(),
                             }
                         }
+                        DiffRow::Note { anchor, note_row } => match notes_path.as_ref() {
+                            Some(path) => this
+                                .render_review_note_card(
+                                    path.as_ref().clone(),
+                                    anchor,
+                                    surface.id_prefix(),
+                                    note_row,
+                                    cx,
+                                )
+                                .into_any_element(),
+                            // Only reachable if the notes surface changed under this frame's own
+                            // row plan; an empty row of the shared height keeps the list's
+                            // geometry honest instead of drawing a note for a file it is not on.
+                            None => render_blank_diff_row().into_any_element(),
+                        },
                         DiffRow::Truncated => render_diff_truncated_row().into_any_element(),
                     })
                     .collect::<Vec<_>>()
@@ -459,7 +596,15 @@ impl AdeApp {
         // handle (`crate::root::scrollbar::AdeApp::render_vertical_scrollbar`).
         .track_scroll(surface.scroll_handle(self));
 
-        zoom_scoped(rem_px, self.wrap_with_scrollbar(surface, list, cx))
+        let hunks = zoom_scoped(rem_px, self.wrap_with_scrollbar(surface, list, cx));
+        match bar_path {
+            // GitHub issue #288: *"A notes bar above the hunks"* - the audit's "send from the top
+            // of the diff", which is one of the three things Orca is quoted as having learned the
+            // hard way. Deliberately **outside** `zoom_scoped`: the bar is chrome, not code, and
+            // zooming the diff's text has no business resizing a button.
+            Some(path) => self.wrap_diff_with_notes(path.as_ref().clone(), hunks, cx),
+            None => hunks,
+        }
     }
 
     /// Wraps the Diff view's `uniform_list` in the real, non-scrolling `.relative()` sibling
@@ -704,15 +849,37 @@ fn render_diff_gutter_number(number: Option<usize>) -> impl IntoElement {
 /// `crate::provenance::render::FILTER_DIM_OPACITY` (the mock's 0.32). A line with no author is
 /// deliberately **not** dimmed - `Jerry.dc.html`'s own `muted = attr && who && who !== attr` - so
 /// filtering by one author never hides the context its work sits in.
+///
+/// ## The note channel (GitHub issue #288)
+///
+/// A **third** left-edge channel, and by the same discipline: *is there a note on this line* is
+/// its own fact, so it gets its own column rather than sharing one. `Jerry.dc.html` draws it as a
+/// 14px centred glyph immediately after the gutters - `●` where a note is pinned. `○` is the note
+/// **cursor**: the line `C` would toggle a note on, which in the mock is the "a note exists here
+/// but is hidden" state and here is "this is the line you are on". A line with neither draws
+/// nothing at all, following the author bar's own rule that the honest rendering of no answer is
+/// an empty column.
+///
+/// The whole row becomes clickable when - and only when - `chrome.anchor` is `Some`, i.e. when the
+/// line really has a stable file-line identity to pin a note to. A line the diff cannot name is
+/// not annotatable, and it does not pretend to be by being clickable.
 pub(in crate::code_surface) fn render_diff_line(
     line: &wt_core::diff::DiffLine,
-    rendered: Option<&code_view::RenderedLine>,
-    numbers: (Option<usize>, Option<usize>),
-    selector_prefix: &'static str,
-    row_index: usize,
-    author: Option<&crate::provenance::Author>,
-    filter: Option<&crate::provenance::Author>,
+    chrome: DiffLineChrome<'_>,
+    cx: &mut Context<AdeApp>,
 ) -> impl IntoElement {
+    let DiffLineChrome {
+        rendered,
+        numbers,
+        selector_prefix,
+        row_index,
+        author,
+        filter,
+        anchor,
+        note,
+        is_note_cursor,
+        notes_enabled,
+    } = chrome;
     // `accent` (`Some` only for Added/Removed) drives both the left-edge bar below and the sign
     // glyph's own color - [`theme::diff::ADD_FG`]/[`DEL_FG`], not the more muted `ADD_SIGN`/
     // `DEL_SIGN` (still used elsewhere, for the Changes list's +n/-n stat bar - see
@@ -742,7 +909,12 @@ pub(in crate::code_surface) fn render_diff_line(
     let author_bar = author.and_then(crate::provenance::render::author_gutter_color);
     let dimmed = crate::provenance::render::line_is_dimmed(author, filter);
 
+    let row_selector = format!("{selector_prefix}-line-{row_index}");
     let mut row = div()
+        // Stateful since GitHub issue #288: the row is the note gesture's own hit target, and
+        // `on_click`/`hover` both need a real element id. The id is the selector, so the two can
+        // never name different rows.
+        .id(gpui::SharedString::from(row_selector.clone()))
         .flex()
         .items_center()
         .font(font(theme::font::MONO))
@@ -752,7 +924,7 @@ pub(in crate::code_surface) fn render_diff_line(
         // row's painted bounds and confirm the diff view's own rows are genuinely reachable, the
         // same pattern `render_file_view_line`'s `file-view-text-row-{n}` selector already
         // establishes for the File view.
-        .debug_selector(move || format!("{selector_prefix}-line-{row_index}"));
+        .debug_selector(move || row_selector);
     if let Some(bg) = bg {
         row = row.bg(bg);
     }
@@ -817,7 +989,8 @@ pub(in crate::code_surface) fn render_diff_line(
         }
     }
 
-    row.child(render_diff_gutter_number(numbers.0))
+    row.children(notes_enabled.then(|| render_note_column(note, is_note_cursor)))
+        .child(render_diff_gutter_number(numbers.0))
         .child(render_diff_gutter_number(numbers.1))
         .child(
             div()
@@ -829,6 +1002,75 @@ pub(in crate::code_surface) fn render_diff_line(
                 .child(sign),
         )
         .child(text_row)
+        // The gesture itself, and only where a line really has an identity to pin a note to.
+        .when_some(anchor, |el, anchor| {
+            el.cursor_pointer()
+                .hover(|style| style.bg(theme::surface::ROW_HOVER))
+                .tooltip(crate::root::widgets::text_tooltip(match note {
+                    Some(_) => NOTE_LINE_TOOLTIP_EXISTING,
+                    None => NOTE_LINE_TOOLTIP_NEW,
+                }))
+                .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
+                    this.toggle_line_note(anchor, window, cx);
+                }))
+        })
+}
+
+/// `Jerry.dc.html`'s own 14px note column: `●` for a pinned note, `○` for the note cursor, and
+/// genuinely nothing for a line that is neither.
+fn render_note_column(note: Option<NoteMark>, is_note_cursor: bool) -> impl IntoElement {
+    let (glyph, color) = match (note, is_note_cursor) {
+        (Some(_), _) => ("\u{25cf}", theme::notes::DOT),
+        (None, true) => ("\u{25cb}", theme::notes::DOT_EMPTY),
+        (None, false) => ("", theme::notes::DOT_EMPTY),
+    };
+    div()
+        .flex_none()
+        .w(px(14.0))
+        .text_center()
+        .text_size(px(9.0))
+        .text_color(color)
+        .child(glyph)
+}
+
+/// The two halves of what a click on a diff line does, as tooltips - ride-along I11's *"every
+/// icon-only or otherwise unlabelled control"*, and a whole diff row with a hover state and no
+/// label is exactly that.
+const NOTE_LINE_TOOLTIP_NEW: &str = "Click to pin a review note on this line";
+const NOTE_LINE_TOOLTIP_EXISTING: &str = "Click to edit this line's review note";
+
+/// Everything [`render_diff_line`] needs beyond the diff line itself.
+///
+/// A struct rather than eight more parameters: this row now carries four independent channels
+/// (diff kind, author, note, and the line numbers), each added by its own issue, and a
+/// nine-argument function is both unreadable and past `clippy::too_many_arguments`. Grouping them
+/// also makes the row builder's own resolution of each channel read as one block.
+pub(in crate::code_surface) struct DiffLineChrome<'a> {
+    /// This line's per-token syntax highlighting, or `None` when the cache identity guard could
+    /// not confirm the cache belongs to this file.
+    pub rendered: Option<&'a code_view::RenderedLine>,
+    /// `(old, new)` gutter numbers, same source and same guard.
+    pub numbers: (Option<usize>, Option<usize>),
+    /// `diff` or `review` - see [`DiffDetailSurface::id_prefix`].
+    pub selector_prefix: &'static str,
+    /// The flat rendered-line counter this row's selector is expressed in.
+    pub row_index: usize,
+    /// Who wrote this line (GitHub issue #287).
+    pub author: Option<&'a crate::provenance::Author>,
+    /// The per-author filter in force, if any.
+    pub filter: Option<&'a crate::provenance::Author>,
+    /// This line's review-note anchor, or `None` for a line with no stable file-line identity -
+    /// which is also what makes the row un-clickable (GitHub issue #288).
+    pub anchor: Option<NoteAnchor>,
+    /// The mark of the note pinned here, if there is one.
+    pub note: Option<NoteMark>,
+    /// Whether this is the line `C` would toggle a note on.
+    pub is_note_cursor: bool,
+    /// Whether this surface takes review notes at all. Gates the 14px note column outright, so
+    /// the Review tab - where a note can never exist - carries no permanently-blank column, while
+    /// the Uncommitted diff keeps the column on *every* row so pinning a note never shifts the
+    /// lines around it sideways.
+    pub notes_enabled: bool,
 }
 
 /// Real, render-level coverage for the Diff view's per-token syntax highlighting and its
@@ -1266,7 +1508,7 @@ mod diff_row_plan_tests {
         );
 
         assert_eq!(
-            diff_rows(&file),
+            diff_rows(&file, &[]),
             vec![
                 DiffRow::HunkHeader(0),
                 DiffRow::Line {
@@ -1314,7 +1556,7 @@ mod diff_row_plan_tests {
             false,
         );
         assert!(
-            !diff_rows(&file)
+            !diff_rows(&file, &[])
                 .iter()
                 .any(|row| matches!(row, DiffRow::FoldMarker { .. })),
             "there is no unchanged span between these two hunks, so there must be no `⋯ N \
@@ -1339,7 +1581,7 @@ mod diff_row_plan_tests {
             false,
         );
 
-        let rows = diff_rows(&file);
+        let rows = diff_rows(&file, &[]);
         let line_rows = rows
             .iter()
             .filter(|row| matches!(row, DiffRow::Line { .. }))
@@ -1368,7 +1610,130 @@ mod diff_row_plan_tests {
             }],
             true,
         );
-        assert_eq!(diff_rows(&file).last(), Some(&DiffRow::Truncated));
+        assert_eq!(diff_rows(&file, &[]).last(), Some(&DiffRow::Truncated));
+    }
+
+    /// GitHub issue #288: a note is a real row of *this* list, directly after the line it is
+    /// anchored to - the structural half of *"pinned beneath the line"* and of *"no parallel
+    /// list"*.
+    #[test]
+    fn a_note_row_interleaves_directly_beneath_the_line_it_is_anchored_to() {
+        // `@@ -4,2 +4,2 @@`: old lines 4-5, new lines 4-5. The removed line is old 4, the added
+        // line is new 4.
+        let file = file_with(
+            vec![wt_core::diff::DiffHunk {
+                header: "@@ -4,2 +4,2 @@".to_string(),
+                lines: vec![
+                    line(DiffLineKind::Removed, "old"),
+                    line(DiffLineKind::Added, "new"),
+                    line(DiffLineKind::Context, "same"),
+                ],
+            }],
+            false,
+        );
+
+        assert_eq!(
+            diff_rows(&file, &[NoteAnchor::New(4)]),
+            vec![
+                DiffRow::HunkHeader(0),
+                DiffRow::Line {
+                    hunk: 0,
+                    line: 0,
+                    row: 0
+                },
+                DiffRow::Line {
+                    hunk: 0,
+                    line: 1,
+                    row: 1
+                },
+                DiffRow::Note {
+                    anchor: NoteAnchor::New(4),
+                    note_row: 0
+                },
+                DiffRow::Line {
+                    hunk: 0,
+                    line: 2,
+                    row: 2
+                },
+            ],
+            "the note sits between its own line and the next one, and the diff's own flat `row` \
+             counter is untouched by it - a note is not a diff line and must not shift the \
+             selectors or the cap"
+        );
+    }
+
+    /// The removed-line half: `NoteAnchor::Old(4)` and `NoteAnchor::New(4)` are different lines of
+    /// the same hunk, and each pins its note under its own.
+    #[test]
+    fn a_note_on_a_removed_line_pins_under_the_removed_line() {
+        let file = file_with(
+            vec![wt_core::diff::DiffHunk {
+                header: "@@ -4,2 +4,2 @@".to_string(),
+                lines: vec![
+                    line(DiffLineKind::Removed, "old"),
+                    line(DiffLineKind::Added, "new"),
+                ],
+            }],
+            false,
+        );
+
+        let rows = diff_rows(&file, &[NoteAnchor::Old(4)]);
+        let note_at = rows
+            .iter()
+            .position(|row| matches!(row, DiffRow::Note { .. }))
+            .expect("the note must be planned");
+        assert_eq!(
+            rows[note_at - 1],
+            DiffRow::Line {
+                hunk: 0,
+                line: 0,
+                row: 0
+            },
+            "an `Old` anchor pins under the removed line, not under the added line that happens \
+             to carry the same number on the other side of the diff"
+        );
+    }
+
+    /// An anchor naming a line this diff does not show pins nothing, rather than pinning to
+    /// whatever line is nearest.
+    #[test]
+    fn an_anchor_no_longer_in_the_diff_plans_no_note_row() {
+        let file = file_with(
+            vec![wt_core::diff::DiffHunk {
+                header: "@@ -4,1 +4,1 @@".to_string(),
+                lines: vec![line(DiffLineKind::Context, "same")],
+            }],
+            false,
+        );
+        assert!(
+            !diff_rows(&file, &[NoteAnchor::New(900)])
+                .iter()
+                .any(|row| matches!(row, DiffRow::Note { .. })),
+            "a note whose line is not on screen is simply not drawn - never drawn somewhere else"
+        );
+    }
+
+    /// The order the batched prompt lists its notes in has to be the order the reviewer sees
+    /// them, which is neither of the two orders a `BTreeMap<NoteAnchor, _>` offers.
+    #[test]
+    fn diff_order_interleaves_removed_and_added_anchors_the_way_the_hunk_does() {
+        let file = file_with(
+            vec![wt_core::diff::DiffHunk {
+                header: "@@ -4,3 +4,3 @@".to_string(),
+                lines: vec![
+                    line(DiffLineKind::Context, "context"),
+                    line(DiffLineKind::Removed, "old"),
+                    line(DiffLineKind::Added, "new"),
+                ],
+            }],
+            false,
+        );
+        assert_eq!(
+            note_anchors_in_diff_order(&file),
+            vec![NoteAnchor::New(4), NoteAnchor::Old(5), NoteAnchor::New(5),],
+            "sorting the anchors themselves would have put both `New`s before the `Old`, which is \
+             not the order the lines are on screen"
+        );
     }
 
     /// And a whole, untruncated diff must not grow a notice out of nowhere.
@@ -1381,7 +1746,7 @@ mod diff_row_plan_tests {
             }],
             false,
         );
-        assert!(!diff_rows(&file).contains(&DiffRow::Truncated));
+        assert!(!diff_rows(&file, &[]).contains(&DiffRow::Truncated));
     }
 }
 
@@ -1581,7 +1946,7 @@ mod diff_virtualization_tests {
                 file.hunks.iter().map(|h| &h.header).collect::<Vec<_>>()
             );
             assert!(
-                diff_rows(file)
+                diff_rows(file, &[])
                     .iter()
                     .any(|row| matches!(row, DiffRow::FoldMarker { .. })),
                 "precondition: the two hunks must have a real unchanged span between them"
@@ -1742,7 +2107,7 @@ mod diff_virtualization_tests {
                     .expect("the guard must accept the cache built for this very file");
 
             let mut checked_second_hunk = 0usize;
-            for row in diff_rows(file) {
+            for row in diff_rows(file, &[]) {
                 let DiffRow::Line { hunk, line, .. } = row else {
                     continue;
                 };

--- a/crates/app/src/code_surface/diff_view.rs
+++ b/crates/app/src/code_surface/diff_view.rs
@@ -1028,13 +1028,17 @@ pub(in crate::code_surface) fn render_diff_line(
         )
         .child(text_row)
         // The gesture itself, and only where a line really has an identity to pin a note to.
+        // The gesture itself, and only where a line really has an identity to pin a note to.
+        //
+        // Deliberately **no tooltip on the row**. Ride-along I11 asks for one on *"every icon-only
+        // or otherwise unlabelled control"*, and a diff line is neither - it is content, and the
+        // note column beside it is the affordance. A row-wide tooltip also turned out to be a real
+        // interaction hazard rather than only noise: it is a deferred overlay drawn next to the
+        // pointer, i.e. potentially directly under it, where it can absorb the very click it is
+        // describing. The card and the send button, which *are* controls, keep theirs.
         .when_some(anchor, |el, anchor| {
             el.cursor_pointer()
                 .hover(|style| style.bg(theme::surface::ROW_HOVER))
-                .tooltip(crate::root::widgets::text_tooltip(match note {
-                    Some(_) => NOTE_LINE_TOOLTIP_EXISTING,
-                    None => NOTE_LINE_TOOLTIP_NEW,
-                }))
                 .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
                     this.toggle_line_note(anchor, window, cx);
                 }))
@@ -1057,12 +1061,6 @@ fn render_note_column(note: Option<NoteMark>, is_note_cursor: bool) -> impl Into
         .text_color(color)
         .child(glyph)
 }
-
-/// The two halves of what a click on a diff line does, as tooltips - ride-along I11's *"every
-/// icon-only or otherwise unlabelled control"*, and a whole diff row with a hover state and no
-/// label is exactly that.
-const NOTE_LINE_TOOLTIP_NEW: &str = "Click to pin a review note on this line";
-const NOTE_LINE_TOOLTIP_EXISTING: &str = "Click to edit this line's review note";
 
 /// Everything [`render_diff_line`] needs beyond the diff line itself.
 ///

--- a/crates/app/src/code_surface/diff_view.rs
+++ b/crates/app/src/code_surface/diff_view.rs
@@ -441,6 +441,26 @@ impl AdeApp {
             })
             .unwrap_or_default();
         let notes_enabled = notes_path.is_some();
+        // Each line's note anchor, resolved once per frame from the same
+        // `changes::hunk_line_numbers` the row plan itself uses - deliberately **not** from
+        // `diff_highlight_cache`. A line's identity is a fact about the diff, not about whether
+        // its syntax colouring has been recomputed yet: reading it off the cache would mean that
+        // every time the agent writes to the open file (invalidating the cache's full-value
+        // identity guard until the next highlight pass) every note dot vanished and no line could
+        // be clicked, with the already-pinned cards still on screen and no explanation.
+        let line_anchors: Rc<Vec<Vec<Option<NoteAnchor>>>> = Rc::new(if notes_enabled {
+            file.hunks
+                .iter()
+                .map(|hunk| {
+                    changes::hunk_line_numbers(hunk)
+                        .into_iter()
+                        .map(NoteAnchor::from_gutter)
+                        .collect()
+                })
+                .collect()
+        } else {
+            Vec::new()
+        });
         // The bar is built after the list, from the same resolution - one `Rc`, so the row builder
         // and the bar can never be looking at two different files.
         let notes_path: Option<Rc<PathBuf>> = notes_path.map(Rc::new);
@@ -483,6 +503,13 @@ impl AdeApp {
                 let Some(file) = surface.open_file(this) else {
                     return Vec::new();
                 };
+                // Guarded exactly like the highlight cache below: this frame's notes belong to
+                // the file the plan was built from, and if the surface has since resolved a
+                // *different* file, drawing them would put file A's notes on file B's rows - and
+                // a click would then write a note under A's path against B's line.
+                let notes_path = notes_path
+                    .as_ref()
+                    .filter(|open| open.as_path() == file.path);
                 // The real identity guard - a cache entry only counts as usable for these rows if
                 // it was built from this exact file (see this method's own "Cache identity guard"
                 // docs, and `diff_highlight_cache_for`'s own docs/tests for the pure logic).
@@ -527,24 +554,24 @@ impl AdeApp {
                                     let author = line_authors
                                         .get(hunk)
                                         .and_then(|authors| authors.get(line));
-                                    // The note channel reads its anchor from the same guarded
-                                    // gutter numbers, so a line whose identity this frame cannot
-                                    // confirm is simply not annotatable - never annotatable at a
-                                    // guessed line.
-                                    let anchor = notes_enabled
-                                        .then(|| NoteAnchor::from_gutter(numbers))
+                                    // Positional, and guarded exactly like the author bar beside
+                                    // it: a shape change between this frame's plan and this call
+                                    // means "not annotatable", never a neighbouring line's
+                                    // anchor.
+                                    let anchor = line_anchors
+                                        .get(hunk)
+                                        .and_then(|anchors| anchors.get(line))
+                                        .copied()
                                         .flatten();
-                                    let note = anchor.zip(notes_path.as_ref()).and_then(
-                                        |(anchor, path)| {
-                                            this.review_notes_store()
-                                                .note(
-                                                    &this.review_notes_worktree(),
-                                                    path.as_path(),
-                                                    anchor,
-                                                )
-                                                .map(|note| note.mark())
-                                        },
-                                    );
+                                    let note = anchor.zip(notes_path).and_then(|(anchor, path)| {
+                                        this.review_notes_store()
+                                            .note(
+                                                &this.review_notes_worktree(),
+                                                path.as_path(),
+                                                anchor,
+                                            )
+                                            .map(|note| note.mark())
+                                    });
                                     let chrome = DiffLineChrome {
                                         rendered,
                                         numbers,
@@ -557,9 +584,7 @@ impl AdeApp {
                                         notes_enabled,
                                         is_note_cursor: anchor.is_some()
                                             && this.note_cursor.as_ref().is_some_and(|cursor| {
-                                                notes_path
-                                                    .as_ref()
-                                                    .is_some_and(|path| cursor.path == **path)
+                                                notes_path.is_some_and(|path| cursor.path == **path)
                                                     && Some(cursor.anchor) == anchor
                                             }),
                                     };
@@ -568,7 +593,7 @@ impl AdeApp {
                                 None => render_blank_diff_row().into_any_element(),
                             }
                         }
-                        DiffRow::Note { anchor, note_row } => match notes_path.as_ref() {
+                        DiffRow::Note { anchor, note_row } => match notes_path {
                             Some(path) => this
                                 .render_review_note_card(
                                     path.as_ref().clone(),

--- a/crates/app/src/keymap_overrides.rs
+++ b/crates/app/src/keymap_overrides.rs
@@ -211,8 +211,14 @@ pub fn real_context_stacks() -> Vec<Vec<&'static str>> {
         // reason: it is why `ToggleLineNote`'s plain `c` carries `&& !text-input` while
         // `SendReviewNotes`' `mod+enter` deliberately does not (see
         // `crate::default_key_bindings`).
-        vec!["app", "diff-view"],
-        vec!["app", "diff-view", "text-input"],
+        //
+        // Note the `"diff"` frame ahead of both: the notes container is a *descendant* of
+        // `crate::code_surface::render`'s own node, so `"diff"`-scoped bindings are live over a
+        // focused note card. Getting this wrong here is not academic - it is exactly what hid the
+        // live bug where `v` (`ToggleChangeSeen`) and `]` (`NextChangedFile`) swallowed those
+        // characters instead of letting them be typed into a note.
+        vec!["app", "diff", "diff-view"],
+        vec!["app", "diff", "diff-view", "text-input"],
         // The file tree (GitHub issue #19), built by calling the *same* function the renderer
         // calls, over both of its inputs - not by restating its literals here. See
         // [`file_tree_key_context`] for why that indirection is load-bearing rather than tidy.

--- a/crates/app/src/keymap_overrides.rs
+++ b/crates/app/src/keymap_overrides.rs
@@ -205,6 +205,14 @@ pub fn real_context_stacks() -> Vec<Vec<&'static str>> {
         // plain-letter bindings carry `&& !text-input` (see `crate::default_key_bindings`).
         vec!["app", "rebase-plan"],
         vec!["app", "rebase-plan", "text-input"],
+        // The diff pane's review-notes surface (GitHub issue #288), and the same surface with one
+        // of its pinned note cards open for typing - a real `"text-input"` node nested *inside*
+        // the `"diff-view"` container, exactly like `"rebase-plan"` above and for the same
+        // reason: it is why `ToggleLineNote`'s plain `c` carries `&& !text-input` while
+        // `SendReviewNotes`' `mod+enter` deliberately does not (see
+        // `crate::default_key_bindings`).
+        vec!["app", "diff-view"],
+        vec!["app", "diff-view", "text-input"],
         // The file tree (GitHub issue #19), built by calling the *same* function the renderer
         // calls, over both of its inputs - not by restating its literals here. See
         // [`file_tree_key_context`] for why that indirection is load-bearing rather than tidy.
@@ -726,15 +734,16 @@ mod tests {
         let sites = key_context_call_sites();
         let call_sites: usize = sites.iter().map(|(_, count)| count).sum();
         assert_eq!(
-            call_sites, 16,
-            "real_context_stacks() is hand-derived from exactly sixteen .key_context(..) call \
-             sites (ten of which emit the same bare \"text-input\": the palette, the rail \
+            call_sites, 18,
+            "real_context_stacks() is hand-derived from exactly eighteen .key_context(..) call \
+             sites (eleven of which emit the same bare \"text-input\": the palette, the rail \
              filter, the new-file prompt, the Branches filter, the Keybindings filter, the \
              Themes page's \"Generate from colour\" seed input, the General page's \"Shell\" \
              field (GitHub issue #213), GitHub issue #241's git graph row menu's \"Create \
              branch here\" prompt, GitHub issue #242 phase B's interactive-rebase plan row's own \
-             reword message field, and - newest, GitHub issue #285's Changes panel commit \
-             message field, plus GitHub issue #304's own \"rebase-plan\") - a new one means \
+             reword message field, GitHub issue #285's Changes panel commit message field, and - \
+             newest, GitHub issue #288's pinned review-note card - plus GitHub issue #304's own \
+             \"rebase-plan\" and issue #288's own \"diff-view\") - a new one means \
              that list, and every disjointness answer built on \
              it, needs updating. Real sites found: {sites:?}"
         );

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -242,7 +242,18 @@ pub fn default_key_bindings() -> Vec<gpui::KeyBinding> {
         gpui::KeyBinding::new("ctrl-shift-t", root::NewTerminal, None),
         gpui::KeyBinding::new("secondary-shift-n", root::NewAgentPane, None),
         gpui::KeyBinding::new("secondary-shift-g", root::NewGitGraph, None),
-        gpui::KeyBinding::new("]", root::NextChangedFile, Some("diff && !file-editor")),
+        // `&& !text-input` was added by GitHub issue #288, and it is a real fix rather than
+        // defensive padding: that issue puts a pinned review-note card - a genuine
+        // `"text-input"` node - *inside* the diff surface, so with the old predicate a plain `]`
+        // typed into a note would jump to the next changed file instead of being typed. It is a
+        // no-op for every stack that existed before: the only `"text-input"` node under `"diff"`
+        // was the File editor, which already carries `"file-editor"` on the same node and was
+        // therefore already excluded.
+        gpui::KeyBinding::new(
+            "]",
+            root::NextChangedFile,
+            Some("diff && !file-editor && !text-input"),
+        ),
         // GitHub issue #286 / `STAGE-A-CHANGELOG.md` §4i: "opening a file marks it seen - that is
         // what the word means - and `V` unmarks. The convention is stated in the name's own
         // tooltip", with `V mark seen` in the Changes panel's own legend.
@@ -255,7 +266,15 @@ pub fn default_key_bindings() -> Vec<gpui::KeyBinding> {
         // keeps it off the editable File view, where `v` is a character to type; `"diff"`'s File
         // arm adds `"file-editor"` onto the same node rather than replacing it, which is the exact
         // live bug that narrowed `"]"`'s own predicate.
-        gpui::KeyBinding::new("v", root::ToggleChangeSeen, Some("diff && !file-editor")),
+        // Same `&& !text-input` addition, same reason, and the one this was actually caught by:
+        // `v` typed into a review note used to mark the file seen instead of writing a `v`
+        // (`crate::review_notes::integration_tests`' real-file persistence test typed the word
+        // "survives" and got back "suries").
+        gpui::KeyBinding::new(
+            "v",
+            root::ToggleChangeSeen,
+            Some("diff && !file-editor && !text-input"),
+        ),
         gpui::KeyBinding::new("secondary-1", root::JumpToAgent1, None),
         gpui::KeyBinding::new("secondary-2", root::JumpToAgent2, None),
         gpui::KeyBinding::new("secondary-3", root::JumpToAgent3, None),

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -30,6 +30,11 @@ pub(crate) mod persisted_state_lock;
 pub mod provenance;
 pub mod rail;
 pub mod review;
+// GitHub issue #288: diff-line review notes - draft/sent, batched, sent to the run's
+// agent. Its own folder rather than a file inside `review`: that module answers *what has this
+// agent changed since I last looked*, which is a different question with a different base and
+// different persisted state.
+pub mod review_notes;
 pub mod root;
 pub mod settings;
 pub mod sidebar;
@@ -672,6 +677,24 @@ pub fn default_key_bindings() -> Vec<gpui::KeyBinding> {
         ),
         gpui::KeyBinding::new("d", root::RebaseDropRow, Some("rebase-plan && !text-input")),
         gpui::KeyBinding::new("secondary-enter", root::RebaseStart, Some("rebase-plan")),
+        // GitHub issue #288: the notes bar draws `mod+enter` as real keycaps
+        // (`crate::review_notes::render::SEND_NOTES_SPEC`, the same string resolved here), so it
+        // has to be a real binding - ride-along I10's whole point is that a keycap is a promise.
+        //
+        // Scoped to `"diff-view"`, the key context
+        // `crate::review_notes::render::AdeApp::wrap_diff_with_notes` puts on the diff pane's own
+        // container. Deliberately **without** `&& !text-input`, exactly like `RebaseStart` above
+        // and for the same reason: the open note card *is* a `"text-input"` node inside this
+        // container, and having just finished typing a note is the single most likely moment to
+        // want to send the batch. `secondary-enter` is not a keystroke this app's single-line
+        // fields have any other use for.
+        gpui::KeyBinding::new("secondary-enter", root::SendReviewNotes, Some("diff-view")),
+        // The footer hint's `C note on line`. A plain letter, so it carries the `&& !text-input`
+        // conjunct every other plain-letter binding in this list does - without it, typing a `c`
+        // into a note card would toggle that very card shut, since GPUI dispatches a matching
+        // `KeyBinding` before any `on_key_down` listener (see the `TerminalCopy` entry above for
+        // that fact with its source references).
+        gpui::KeyBinding::new("c", root::ToggleLineNote, Some("diff-view && !text-input")),
     ];
     #[cfg(target_os = "macos")]
     bindings.push(gpui::KeyBinding::new("cmd-q", root::Quit, None));
@@ -977,6 +1000,8 @@ mod undo_scoping_matrix_tests {
              new-file prompt)",
             "the interactive-rebase plan surface, no reword field focused",
             "the interactive-rebase plan surface with one of its reword message fields focused",
+            "the diff's review-notes surface, no note card focused",
+            "the diff's review-notes surface with one of its pinned note cards focused",
             "the focused file tree, no overlay open",
             "the file tree's inline name editor (new file / new folder / rename)",
         ]
@@ -1039,7 +1064,12 @@ mod undo_scoping_matrix_tests {
             // ...but a focused `reword` message field on one of its rows is one, and this row is
             // exactly why those plain-letter bindings carry `&& !text-input`: this stack is live
             // whenever a real commit message is being typed inside the rebase surface.
-            true, // The file tree with no editor open is not a text surface.
+            true,
+            // GitHub issue #288's review-notes surface, the same shape one row up: the container
+            // itself is not a text surface (its `mod+enter` send and its `c` note-on-line live
+            // there), but a pinned note card open for typing is - and that row is exactly why
+            // `ToggleLineNote`'s plain `c` carries `&& !text-input`.
+            false, true, // The file tree with no editor open is not a text surface.
             false,
             // ...but its inline name editor *is* one. This row is the whole reason issue #19's
             // tree had to gain issue #17's `"text-input"` tag when the two branches merged:

--- a/crates/app/src/provenance/render.rs
+++ b/crates/app/src/provenance/render.rs
@@ -446,7 +446,11 @@ impl AdeApp {
     /// the CLI tab chip already use, so a user's own icon pack (GitHub issue #5) applies here too
     /// and an agent is one recognisable mark everywhere it appears. `you` is not an agent and has
     /// no icon-pack entry, so it draws the neutral chip directly.
-    fn render_author_chip(&self, author: &Author, style: &AuthorStyle) -> gpui::AnyElement {
+    pub(crate) fn render_author_chip(
+        &self,
+        author: &Author,
+        style: &AuthorStyle,
+    ) -> gpui::AnyElement {
         if let Author::Agent(key) = author {
             if let Some(kind) = key.kind() {
                 return self.render_agent_chip_icon(ProcessKind::Agent(kind), px(13.0), px(7.5));

--- a/crates/app/src/review_notes/flow.rs
+++ b/crates/app/src/review_notes/flow.rs
@@ -1,0 +1,516 @@
+//! The `impl AdeApp` half of diff-line review notes (GitHub issue #288): pinning one on a line,
+//! typing into it, resolving **which agent** a file's notes belong to, and the send itself.
+//!
+//! Nothing here draws anything (that is [`super::render`]) and nothing here decides what the
+//! prompt says (that is [`super::prompt`]). What lives here is the state machine and the two
+//! resolutions the issue is really about: *which line* and *which agent*.
+
+use super::persist_state::ReviewNotesState;
+use super::prompt::BatchedPrompt;
+use super::{NoteAnchor, NoteRef, NoteStore};
+use crate::provenance::{render::chip_authors, Author};
+use crate::root::AdeApp;
+use crate::text_history::TextField;
+use crate::work_surface::agents::{AgentId, ProcessKind};
+use gpui::{Context, Window};
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+/// The one note currently open for typing, and its own text buffer.
+///
+/// **One at a time, and deliberately.** A per-note `TextField` + `FocusHandle` would have to be
+/// created and destroyed as a virtualized diff row scrolls in and out of existence, and a focus
+/// handle that disappears under the caret is the class of bug that is very hard to see and very
+/// easy to ship. One draft, named by the note it belongs to, is enough: a reviewer writes one note
+/// at a time, and the pinned cards around it are read-only text until they are clicked.
+///
+/// The buffer is a real [`TextField`], not a bare `String`, so a note gets the same per-widget
+/// undo history every other hand-rolled input in this app has (`crate::text_history`'s own module
+/// docs list the five; this is the sixth).
+pub(crate) struct NoteDraft {
+    /// Which note this buffer belongs to.
+    pub at: NoteRef,
+    /// Its live text.
+    pub field: TextField,
+}
+
+/// Who a file's review notes are going to, resolved and ready to be sent to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NoteTarget {
+    /// The live agent tab that will receive the prompt.
+    pub agent: AgentId,
+    /// Which CLI it is - what the send button's chip and label are drawn from.
+    pub kind: ProcessKind,
+    /// Whether this target came from the file's own attribution, or from the worktree's primary
+    /// agent because the file named nobody. Only the send button's tooltip distinguishes them,
+    /// but it is a real difference and the reviewer should be able to see it.
+    pub from_file_author: bool,
+}
+
+impl NoteTarget {
+    /// The name the send button says: `Send notes to <this>`.
+    pub fn label(&self) -> &'static str {
+        self.kind.label()
+    }
+}
+
+/// Why a send did not happen. Every one of these is said out loud in the notes bar rather than
+/// swallowed - audit item I12's whole complaint about this design is that nothing in it ever
+/// fails, and a review note that silently never reached anyone is the worst possible version of
+/// that.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum NoteSendError {
+    /// Nothing real to send.
+    NothingToSend,
+    /// No agent in this worktree to send to - the file names nobody and the worktree has no agent
+    /// session open.
+    NoTarget,
+    /// The target agent's pty refused the write (see
+    /// `crate::terminal::pane::TerminalPane::send_prompt`, which never sends hopefully).
+    DeliveryFailed,
+}
+
+impl NoteSendError {
+    /// What the notes bar says.
+    pub fn message(&self) -> &'static str {
+        match self {
+            NoteSendError::NothingToSend => "nothing to send yet",
+            NoteSendError::NoTarget => "no agent open in this worktree to send to",
+            NoteSendError::DeliveryFailed => "the agent's terminal refused the prompt",
+        }
+    }
+}
+
+impl AdeApp {
+    /// Which worktree the notes on screen belong to.
+    ///
+    /// [`Self::diff_root`] rather than the rail's selection: notes are keyed to the checkout the
+    /// diff was read out of, and that is the only place the lines they are anchored to exist.
+    pub(crate) fn review_notes_worktree(&self) -> PathBuf {
+        self.diff_root.clone()
+    }
+
+    /// The file the notes surface is currently about, if any.
+    ///
+    /// [`Self::open_change`] - the **Uncommitted** diff. Notes are scoped to that one surface on
+    /// purpose: `AUDIT-2026-08-13-competitive-v2.md` §3.2 puts a *second* `Send notes` on each
+    /// row of the `Runs` section, with its own per-run scope and its own target, and shipping a
+    /// notes bar on the Review tab too would quietly answer that question in a way §3.2 has
+    /// already answered differently. One surface, one scope, until the Runs one is really built.
+    pub(crate) fn review_notes_file(&self) -> Option<PathBuf> {
+        self.open_change.clone()
+    }
+
+    /// Reads `review-notes.toml` back into the live store. Called once, from the constructor.
+    pub(crate) fn restore_review_notes(&mut self) {
+        let Some(path) = self.review_notes_path.clone() else {
+            return;
+        };
+        let state = ReviewNotesState::load_at(&path);
+        if state.worktrees.is_empty() {
+            return;
+        }
+        self.review_notes_owned
+            .extend(state.worktrees.keys().cloned());
+        let (restored, discarded) = state.restore_into(&mut self.review_notes);
+        if discarded > 0 {
+            log::warn!(
+                "{}: restored {restored} review notes, discarded {discarded} this build could \
+                 not read",
+                path.display()
+            );
+        }
+    }
+
+    /// Writes the live store back out, off-thread, merging under the shared lock.
+    ///
+    /// Called at every point a note's *content* has settled - not per keystroke: a save per
+    /// character would be a real file write per character, and the draft buffer is the live
+    /// source of truth in between anyway.
+    fn persist_review_notes(&mut self, cx: &mut Context<Self>) {
+        let Some(path) = self.review_notes_path.clone() else {
+            return;
+        };
+        self.review_notes_owned
+            .insert(crate::review::state::encode_worktree(
+                &self.review_notes_worktree(),
+            ));
+        let state = ReviewNotesState::capture(&self.review_notes);
+        let owned = self.review_notes_owned.clone();
+        let task = cx.spawn(async move |_this, cx| {
+            let save_path = path.clone();
+            let result = cx
+                .background_executor()
+                .spawn(async move { state.save_merged_at(&save_path, &owned) })
+                .await;
+            if let Err(err) = result {
+                log::warn!("failed to save {}: {err}", path.display());
+            }
+        });
+        self._review_notes_persist_task = Some(task);
+    }
+
+    /// Clicking a diff line: pin a note beneath it, or - if the click landed on the line whose
+    /// note is already open for typing - close that note again.
+    ///
+    /// `STAGE-A-CHANGELOG.md` §1 says the gesture *toggles*, and `Jerry.dc.html` implements that
+    /// against a fixed set of pre-authored notes, where "toggle" can only mean show/hide. Here the
+    /// note does not exist until you make one, so toggling has to mean create/remove - with one
+    /// deliberate asymmetry: a card you have **written into** is never destroyed by a click. It
+    /// closes, and stays pinned. Only a card that is still blank (i.e. the click was a mistake)
+    /// goes away again, which is exactly the case the toggle exists for. Emptying a note's text
+    /// is the way to remove one you meant to write.
+    pub(crate) fn toggle_line_note(
+        &mut self,
+        anchor: NoteAnchor,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(path) = self.review_notes_file() else {
+            return;
+        };
+        let at = NoteRef::new(path, anchor);
+        self.note_cursor = Some(at.clone());
+        if self.note_draft.as_ref().is_some_and(|draft| draft.at == at) {
+            self.close_note_draft(window, cx);
+            cx.notify();
+            return;
+        }
+        let worktree = self.review_notes_worktree();
+        self.review_notes.begin(&worktree, &at.path, anchor);
+        self.open_note_draft(at, window, cx);
+    }
+
+    /// Opens `at`'s card for typing, seeding the buffer from whatever the note already says, and
+    /// moves real keyboard focus into it.
+    pub(in crate::review_notes) fn open_note_draft(
+        &mut self,
+        at: NoteRef,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        // Whatever was open before settles first, so a half-typed blank card left behind on
+        // another line does not linger.
+        self.close_note_draft(window, cx);
+        let worktree = self.review_notes_worktree();
+        let text = self
+            .review_notes
+            .note(&worktree, &at.path, at.anchor)
+            .map(|note| note.text.clone())
+            .unwrap_or_default();
+        self.note_cursor = Some(at.clone());
+        self.note_draft = Some(NoteDraft {
+            at,
+            field: TextField::seeded(&text),
+        });
+        self.note_send_error = None;
+        window.focus(&self.note_focus_handle, cx);
+        cx.notify();
+    }
+
+    /// Closes whatever note is open for typing, discarding it if nothing was ever written into it,
+    /// and hands keyboard focus back to the diff pane.
+    ///
+    /// The single removal point in the whole feature (besides emptying a note's text, which lands
+    /// here too). Nothing about sending calls it.
+    ///
+    /// The focus hand-off is load-bearing, not tidiness. The card only carries
+    /// [`Self::note_focus_handle`] while it is *being edited* (see
+    /// `crate::review_notes::render::AdeApp::render_review_note_card` for why exactly one element
+    /// may), so closing the draft removes that node from the dispatch tree - and a focus handle
+    /// whose node is no longer rendered is GPUI's **empty context stack**, where
+    /// `KeyBindingContextPredicate::eval_inner` short-circuits to `false` and every scoped binding
+    /// silently dies. That is a real, repeatedly-hit bug class in this codebase (see
+    /// `crate::keymap_overrides::real_context_stacks`' own docs, which include the empty stack for
+    /// exactly this reason), and it would take `mod+enter` and `c` with it.
+    pub(crate) fn close_note_draft(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(draft) = self.note_draft.take() else {
+            return;
+        };
+        let worktree = self.review_notes_worktree();
+        self.review_notes
+            .discard_if_blank(&worktree, &draft.at.path, draft.at.anchor);
+        window.focus(&self.diff_notes_focus_handle, cx);
+        self.persist_review_notes(cx);
+    }
+
+    /// One keystroke into the open note card - the same hand-rolled single-line input
+    /// `crate::sidebar::render::AdeApp::handle_commit_message_key_down` implements, against the
+    /// same [`TextField`], so a note gets the same real undo history as every other field here.
+    pub(crate) fn handle_note_key_down(
+        &mut self,
+        event: &gpui::KeyDownEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(draft) = self.note_draft.as_mut() else {
+            return;
+        };
+        let keystroke = &event.keystroke;
+        // The same guard `crate::sidebar::render::AdeApp::handle_commit_message_key_down` uses,
+        // and it is what lets `mod+enter` reach `SendReviewNotes` from inside this very field
+        // rather than being typed into it.
+        if keystroke.modifiers.platform || keystroke.modifiers.control || keystroke.modifiers.alt {
+            return;
+        }
+        let changed = match keystroke.key.as_str() {
+            "backspace" => draft.field.pop(Instant::now()),
+            _ => match keystroke.key_char.as_deref() {
+                Some(text) if !text.is_empty() => draft.field.push_str(text, Instant::now()),
+                _ => false,
+            },
+        };
+        if !changed {
+            return;
+        }
+        let at = draft.at.clone();
+        let text = draft.field.as_str().to_string();
+        let worktree = self.review_notes_worktree();
+        self.review_notes
+            .set_text(&worktree, &at.path, at.anchor, &text);
+        cx.notify();
+        cx.stop_propagation();
+    }
+
+    /// Text undo/redo inside the open note card, wired exactly like the commit composer's.
+    pub(crate) fn handle_note_text_undo(
+        &mut self,
+        _action: &crate::root::TextUndo,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.apply_note_history(|field| field.undo(), cx);
+    }
+
+    pub(crate) fn handle_note_text_redo(
+        &mut self,
+        _action: &crate::root::TextRedo,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.apply_note_history(|field| field.redo(), cx);
+    }
+
+    fn apply_note_history(
+        &mut self,
+        step: impl FnOnce(&mut TextField) -> bool,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(draft) = self.note_draft.as_mut() else {
+            return;
+        };
+        if !step(&mut draft.field) {
+            return;
+        }
+        let at = draft.at.clone();
+        let text = draft.field.as_str().to_string();
+        let worktree = self.review_notes_worktree();
+        self.review_notes
+            .set_text(&worktree, &at.path, at.anchor, &text);
+        cx.notify();
+    }
+
+    /// **Which agent this file's notes belong to.**
+    ///
+    /// `STAGE-A-CHANGELOG.md` §1: *"`noteTarget` resolves to the file's first author, falling back
+    /// to the worktree's primary agent - so in a shared worktree the notes go to whoever wrote the
+    /// lines"*. Both halves are real here:
+    ///
+    /// 1. **The file's first author** is GitHub issue #287's own answer, read from the same place
+    ///    the `⚠` ring reads it (`crate::provenance::render::chip_authors`, whose order is the
+    ///    chip order on the row), filtered to authors that are agents and that are still open in
+    ///    this worktree. `you` is skipped rather than treated as a target: the human is who the
+    ///    notes are *from*.
+    /// 2. **The worktree's primary agent** is `crate::work_surface::agents::Agents::primary_for_cwd`
+    ///    - the same rule that decides which tab the centre pane shows for this worktree - further
+    ///      filtered to a real agent session. A shell shares the worktree but cannot revise
+    ///      anything, and typing a review prompt into somebody's `bash` would be both useless
+    ///      and, since it would arrive at a shell prompt, actively unpleasant.
+    ///
+    /// `None` when there is nobody at all - and then the bar says so and the button is not drawn,
+    /// rather than a button that names a target it does not have.
+    pub(crate) fn review_note_target(&self, path: &Path) -> Option<NoteTarget> {
+        let worktree = self.review_notes_worktree();
+        if let Some(entry) = self.uncommitted_change_set.entry(path) {
+            for author in chip_authors(entry) {
+                let Author::Agent(key) = &author else {
+                    continue;
+                };
+                let found = self
+                    .agents
+                    .iter_for_cwd(worktree.clone())
+                    .filter(|agent| agent.kind.is_agent_session())
+                    .find(|agent| match agent.kind {
+                        ProcessKind::Agent(kind) => {
+                            crate::review::state::baseline_key(
+                                &agent.cwd,
+                                kind,
+                                agent.spawned_at_unix,
+                            ) == key.as_str()
+                        }
+                        ProcessKind::Shell => false,
+                    });
+                if let Some(agent) = found {
+                    return Some(NoteTarget {
+                        agent: agent.id,
+                        kind: agent.kind,
+                        from_file_author: true,
+                    });
+                }
+            }
+        }
+
+        let primary = self.agents.primary_for_cwd(&worktree);
+        let agent = match primary {
+            Some(agent) if agent.kind.is_agent_session() => Some(agent),
+            // The primary tab is a shell, so fall through to this worktree's first real agent
+            // session rather than refusing outright - "the worktree's primary agent" means the
+            // agent it is primarily running, and a terminal open alongside it does not change
+            // that.
+            _ => self
+                .agents
+                .iter_for_cwd(worktree.clone())
+                .find(|agent| agent.kind.is_agent_session()),
+        }?;
+        Some(NoteTarget {
+            agent: agent.id,
+            kind: agent.kind,
+            from_file_author: false,
+        })
+    }
+
+    /// The one batched prompt this file's notes would compose into right now, in diff order.
+    ///
+    /// `order` is the anchors as the diff view really lays them out, top to bottom - see
+    /// [`Self::review_note_order`]. Falls back to plain anchor order for anything the diff no
+    /// longer shows, so a note pinned to a line that has since moved out of a hunk is still
+    /// delivered rather than silently dropped.
+    pub(crate) fn batched_review_prompt(&self, path: &Path) -> Option<BatchedPrompt> {
+        let worktree = self.review_notes_worktree();
+        let mut notes = self.review_notes.deliverable(&worktree, path);
+        let order = self.review_note_order(path);
+        notes.sort_by_key(|(anchor, _)| {
+            (
+                order
+                    .iter()
+                    .position(|known| known == anchor)
+                    .unwrap_or(usize::MAX),
+                *anchor,
+            )
+        });
+        BatchedPrompt::compose(path, &notes)
+    }
+
+    /// The anchors of `path`'s notes in the order the open diff really pins them, top to bottom.
+    /// Empty when that file is not the one on screen, which is exactly when "diff order" has no
+    /// meaning.
+    fn review_note_order(&self, path: &Path) -> Vec<NoteAnchor> {
+        let Some(file) = self.open_diff_file_cache.as_ref() else {
+            return Vec::new();
+        };
+        if file.path != path {
+            return Vec::new();
+        }
+        crate::code_surface::diff_view::note_anchors_in_diff_order(file)
+    }
+
+    /// **The send.** One batched prompt, into one agent's real pty, once.
+    ///
+    /// Everything this method does after a successful write is the issue's *"pinned after send"*
+    /// half: it flips each note's mark by recording the wording that was delivered, and it does
+    /// not remove anything. There is no clear-on-send path to review, because there is no code
+    /// here that could clear one.
+    pub(crate) fn send_review_notes(
+        &mut self,
+        path: PathBuf,
+        cx: &mut Context<Self>,
+    ) -> Result<usize, NoteSendError> {
+        // A half-typed card is part of the batch too - settle it first so what is on screen and
+        // what goes down the pty cannot differ.
+        if let Some(draft) = self.note_draft.as_ref() {
+            let at = draft.at.clone();
+            let text = draft.field.as_str().to_string();
+            let worktree = self.review_notes_worktree();
+            self.review_notes
+                .set_text(&worktree, &at.path, at.anchor, &text);
+        }
+
+        let prompt = self
+            .batched_review_prompt(&path)
+            .ok_or(NoteSendError::NothingToSend)?;
+        let target = self
+            .review_note_target(&path)
+            .ok_or(NoteSendError::NoTarget)?;
+        let pane = self
+            .agents
+            .iter()
+            .find(|agent| agent.id == target.agent)
+            .ok_or(NoteSendError::NoTarget)?
+            .pane
+            .clone();
+
+        let delivered = pane.update(cx, |pane, cx| {
+            // The form is chosen from the *target's* live terminal mode, which is the only place
+            // the answer exists - see `BatchedPrompt::for_delivery` and `TerminalPane::send_prompt`
+            // for why getting this wrong would turn one prompt into N.
+            let text = prompt.for_delivery(pane.bracketed_paste_enabled());
+            pane.send_prompt(&text, cx)
+        });
+        if !delivered {
+            self.note_send_error = Some(NoteSendError::DeliveryFailed.message().to_string());
+            cx.notify();
+            return Err(NoteSendError::DeliveryFailed);
+        }
+
+        let worktree = self.review_notes_worktree();
+        let marked = self.review_notes.mark_sent(&worktree, &path);
+        self.note_send_error = None;
+        self.persist_review_notes(cx);
+        cx.notify();
+        Ok(marked)
+    }
+
+    /// `mod+enter` over the diff - the keycaps the notes bar draws, as a real binding.
+    pub(crate) fn handle_send_review_notes(
+        &mut self,
+        _action: &crate::root::SendReviewNotes,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(path) = self.review_notes_file() else {
+            return;
+        };
+        if let Err(err) = self.send_review_notes(path, cx) {
+            self.note_send_error = Some(err.message().to_string());
+            cx.notify();
+        }
+    }
+
+    /// `C` over the diff - *"note on line"*, the footer hint's own wording.
+    ///
+    /// Acts on [`Self::note_cursor`]: the line whose note you last opened, which a click sets. A
+    /// keyboard-only "which line" would need a diff-line caret, and this read-only virtualized
+    /// list deliberately has none (see `crate::code_surface::diff_view`); inventing a hidden one
+    /// so a hint could be literal would be worse than this. With no cursor yet, `C` does nothing
+    /// rather than guessing a line.
+    pub(crate) fn handle_toggle_line_note(
+        &mut self,
+        _action: &crate::root::ToggleLineNote,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(cursor) = self.note_cursor.clone() else {
+            return;
+        };
+        if self.review_notes_file().as_deref() != Some(cursor.path.as_path()) {
+            return;
+        }
+        self.toggle_line_note(cursor.anchor, window, cx);
+    }
+
+    /// The notes on the open file, for the render layer - text, mark, and whether this one is the
+    /// card currently being typed into.
+    pub(crate) fn review_notes_store(&self) -> &NoteStore {
+        &self.review_notes
+    }
+}

--- a/crates/app/src/review_notes/flow.rs
+++ b/crates/app/src/review_notes/flow.rs
@@ -134,8 +134,15 @@ impl AdeApp {
         if state.worktrees.is_empty() {
             return;
         }
-        self.review_notes_owned
-            .extend(state.worktrees.keys().cloned());
+        // Deliberately **not** claiming ownership of every key just read.
+        //
+        // `save_merged_at` rewrites every worktree in `review_notes_owned` from this window's own
+        // snapshot, so claiming the whole file at startup would mean: window A launches, window B
+        // adds a note in worktree X, window A then saves anything at all and overwrites X from
+        // its launch-time copy - B's note gone. `crate::provenance::flow` does claim the whole
+        // file, but provenance is regenerable from the files themselves and a review note is not.
+        // Ownership is taken in `write_review_notes`, per worktree, only where this window has
+        // really written something.
         let (restored, discarded) = state.restore_into(&mut self.review_notes);
         if discarded > 0 {
             log::warn!(
@@ -150,8 +157,8 @@ impl AdeApp {
     ///
     /// Called at every point a note's content has genuinely settled - a card closing, a batch
     /// being sent - where the write should not wait for anything.
-    fn persist_review_notes(&mut self, cx: &mut Context<Self>) {
-        self.write_review_notes(None, cx);
+    fn persist_review_notes(&mut self, worktree: &Path, cx: &mut Context<Self>) {
+        self.write_review_notes(worktree, None, cx);
     }
 
     /// The same write, debounced - what a keystroke schedules.
@@ -167,21 +174,28 @@ impl AdeApp {
     /// `crate::code_surface::editing::AdeApp::schedule_rehighlight` already uses, and the state is
     /// captured *inside* the task after the wait, so a coalesced write is a write of the newest
     /// content rather than of whatever was there when the first keystroke landed.
-    fn schedule_review_notes_persist(&mut self, cx: &mut Context<Self>) {
-        self.write_review_notes(Some(REVIEW_NOTES_PERSIST_DEBOUNCE), cx);
+    fn schedule_review_notes_persist(&mut self, worktree: &Path, cx: &mut Context<Self>) {
+        self.write_review_notes(worktree, Some(REVIEW_NOTES_PERSIST_DEBOUNCE), cx);
     }
 
     /// Two slots, not one: a debounced write and an immediate one are different promises. Sharing
     /// a slot would let the next keystroke's timer *cancel* an already-committed write from
     /// `close_note_draft`/`send_review_notes` before it ran.
-    fn write_review_notes(&mut self, after: Option<std::time::Duration>, cx: &mut Context<Self>) {
+    /// `worktree` is the checkout whose notes really changed - the *draft's* own worktree on the
+    /// editing paths, not whichever one the diff pane happens to have open. Claiming the wrong
+    /// one would leave the real change unmerged and rewrite an innocent worktree from this
+    /// window's snapshot.
+    fn write_review_notes(
+        &mut self,
+        worktree: &Path,
+        after: Option<std::time::Duration>,
+        cx: &mut Context<Self>,
+    ) {
         let Some(path) = self.review_notes_path.clone() else {
             return;
         };
         self.review_notes_owned
-            .insert(crate::review::state::encode_worktree(
-                &self.review_notes_worktree(),
-            ));
+            .insert(crate::review::state::encode_worktree(worktree));
         let task = cx.spawn(async move |this, cx| {
             if let Some(delay) = after {
                 cx.background_executor().timer(delay).await;
@@ -296,7 +310,7 @@ impl AdeApp {
         self.review_notes
             .discard_if_blank(&draft.worktree, &draft.at.path, draft.at.anchor);
         window.focus(&self.diff_notes_focus_handle, cx);
-        self.persist_review_notes(cx);
+        self.persist_review_notes(&draft.worktree, cx);
     }
 
     /// One keystroke into the open note card - the same hand-rolled single-line input
@@ -333,7 +347,7 @@ impl AdeApp {
         let text = draft.field.as_str().to_string();
         self.review_notes
             .set_text(&worktree, &at.path, at.anchor, &text);
-        self.schedule_review_notes_persist(cx);
+        self.schedule_review_notes_persist(&worktree, cx);
         cx.notify();
         cx.stop_propagation();
     }
@@ -373,7 +387,7 @@ impl AdeApp {
         let text = draft.field.as_str().to_string();
         self.review_notes
             .set_text(&worktree, &at.path, at.anchor, &text);
-        self.schedule_review_notes_persist(cx);
+        self.schedule_review_notes_persist(&worktree, cx);
         cx.notify();
     }
 
@@ -538,7 +552,7 @@ impl AdeApp {
             .review_notes
             .mark_sent_as(&worktree, &path, prompt.delivered());
         self.note_send_error = None;
-        self.persist_review_notes(cx);
+        self.persist_review_notes(&worktree, cx);
         cx.notify();
         Ok(marked)
     }

--- a/crates/app/src/review_notes/flow.rs
+++ b/crates/app/src/review_notes/flow.rs
@@ -16,6 +16,13 @@ use gpui::{Context, Window};
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
+/// How long after the last keystroke a note is written to disk.
+///
+/// Sized against the same question `crate::text_history::COALESCE_IDLE` (600ms) answers - long
+/// enough that an ordinary typing burst is one write, short enough that stepping away and closing
+/// the window cannot lose what is on screen.
+const REVIEW_NOTES_PERSIST_DEBOUNCE: std::time::Duration = std::time::Duration::from_millis(600);
+
 /// The one note currently open for typing, and its own text buffer.
 ///
 /// **One at a time, and deliberately.** A per-note `TextField` + `FocusHandle` would have to be
@@ -28,10 +35,27 @@ use std::time::Instant;
 /// undo history every other hand-rolled input in this app has (`crate::text_history`'s own module
 /// docs list the five; this is the sixth).
 pub(crate) struct NoteDraft {
+    /// Which **checkout** this note belongs to.
+    ///
+    /// Carried on the draft rather than re-read from [`AdeApp::diff_root`] at each store call,
+    /// and that is a correctness point: `diff_root` is reassigned wholesale on every worktree
+    /// switch (`crate::code_surface::tabs::AdeApp::load_diff`), so a draft opened in worktree A
+    /// and still open after a switch to B would otherwise have every one of its writes land under
+    /// B's key - overwriting B's own note on the same path and line, and persisting it there.
+    pub worktree: PathBuf,
     /// Which note this buffer belongs to.
     pub at: NoteRef,
     /// Its live text.
     pub field: TextField,
+}
+
+impl NoteDraft {
+    /// Whether this draft really is the one open for `worktree`'s `at` - the guard every read and
+    /// write of the draft goes through, so a draft left over from another checkout matches
+    /// nothing rather than matching by path alone.
+    pub fn is(&self, worktree: &Path, at: &NoteRef) -> bool {
+        self.worktree == worktree && &self.at == at
+    }
 }
 
 /// Who a file's review notes are going to, resolved and ready to be sent to.
@@ -124,10 +148,33 @@ impl AdeApp {
 
     /// Writes the live store back out, off-thread, merging under the shared lock.
     ///
-    /// Called at every point a note's *content* has settled - not per keystroke: a save per
-    /// character would be a real file write per character, and the draft buffer is the live
-    /// source of truth in between anyway.
+    /// Called at every point a note's content has genuinely settled - a card closing, a batch
+    /// being sent - where the write should not wait for anything.
     fn persist_review_notes(&mut self, cx: &mut Context<Self>) {
+        self.write_review_notes(None, cx);
+    }
+
+    /// The same write, debounced - what a keystroke schedules.
+    ///
+    /// A note has to survive the app closing, and "persist when the card closes" is not that: a
+    /// reviewer who types a note and then quits with the caret still in it would lose it, and
+    /// losing review text is the one failure this feature cannot have. Writing per character
+    /// instead would be a real `fsync`'d file write per character.
+    ///
+    /// So: one slot ([`AdeApp::_review_notes_persist_task`]), newest wins. Assigning a fresh task
+    /// drops - and therefore cancels - whatever earlier timer was still waiting, so only the last
+    /// keystroke's timer fires. Exactly the mechanism
+    /// `crate::code_surface::editing::AdeApp::schedule_rehighlight` already uses, and the state is
+    /// captured *inside* the task after the wait, so a coalesced write is a write of the newest
+    /// content rather than of whatever was there when the first keystroke landed.
+    fn schedule_review_notes_persist(&mut self, cx: &mut Context<Self>) {
+        self.write_review_notes(Some(REVIEW_NOTES_PERSIST_DEBOUNCE), cx);
+    }
+
+    /// Two slots, not one: a debounced write and an immediate one are different promises. Sharing
+    /// a slot would let the next keystroke's timer *cancel* an already-committed write from
+    /// `close_note_draft`/`send_review_notes` before it ran.
+    fn write_review_notes(&mut self, after: Option<std::time::Duration>, cx: &mut Context<Self>) {
         let Some(path) = self.review_notes_path.clone() else {
             return;
         };
@@ -135,9 +182,19 @@ impl AdeApp {
             .insert(crate::review::state::encode_worktree(
                 &self.review_notes_worktree(),
             ));
-        let state = ReviewNotesState::capture(&self.review_notes);
-        let owned = self.review_notes_owned.clone();
-        let task = cx.spawn(async move |_this, cx| {
+        let task = cx.spawn(async move |this, cx| {
+            if let Some(delay) = after {
+                cx.background_executor().timer(delay).await;
+            }
+            // Captured after the wait, so a debounced write carries the newest content.
+            let Ok((state, owned)) = this.read_with(cx, |this, _| {
+                (
+                    ReviewNotesState::capture(&this.review_notes),
+                    this.review_notes_owned.clone(),
+                )
+            }) else {
+                return;
+            };
             let save_path = path.clone();
             let result = cx
                 .background_executor()
@@ -147,7 +204,10 @@ impl AdeApp {
                 log::warn!("failed to save {}: {err}", path.display());
             }
         });
-        self._review_notes_persist_task = Some(task);
+        match after {
+            Some(_) => self._review_notes_debounce_task = Some(task),
+            None => self._review_notes_persist_task = Some(task),
+        }
     }
 
     /// Clicking a diff line: pin a note beneath it, or - if the click landed on the line whose
@@ -171,12 +231,16 @@ impl AdeApp {
         };
         let at = NoteRef::new(path, anchor);
         self.note_cursor = Some(at.clone());
-        if self.note_draft.as_ref().is_some_and(|draft| draft.at == at) {
+        let worktree = self.review_notes_worktree();
+        if self
+            .note_draft
+            .as_ref()
+            .is_some_and(|draft| draft.is(&worktree, &at))
+        {
             self.close_note_draft(window, cx);
             cx.notify();
             return;
         }
-        let worktree = self.review_notes_worktree();
         self.review_notes.begin(&worktree, &at.path, anchor);
         self.open_note_draft(at, window, cx);
     }
@@ -200,6 +264,7 @@ impl AdeApp {
             .unwrap_or_default();
         self.note_cursor = Some(at.clone());
         self.note_draft = Some(NoteDraft {
+            worktree,
             at,
             field: TextField::seeded(&text),
         });
@@ -227,9 +292,9 @@ impl AdeApp {
         let Some(draft) = self.note_draft.take() else {
             return;
         };
-        let worktree = self.review_notes_worktree();
+        // The draft's own worktree, never the currently-open one - see [`NoteDraft::worktree`].
         self.review_notes
-            .discard_if_blank(&worktree, &draft.at.path, draft.at.anchor);
+            .discard_if_blank(&draft.worktree, &draft.at.path, draft.at.anchor);
         window.focus(&self.diff_notes_focus_handle, cx);
         self.persist_review_notes(cx);
     }
@@ -263,11 +328,12 @@ impl AdeApp {
         if !changed {
             return;
         }
+        let worktree = draft.worktree.clone();
         let at = draft.at.clone();
         let text = draft.field.as_str().to_string();
-        let worktree = self.review_notes_worktree();
         self.review_notes
             .set_text(&worktree, &at.path, at.anchor, &text);
+        self.schedule_review_notes_persist(cx);
         cx.notify();
         cx.stop_propagation();
     }
@@ -302,11 +368,12 @@ impl AdeApp {
         if !step(&mut draft.field) {
             return;
         }
+        let worktree = draft.worktree.clone();
         let at = draft.at.clone();
         let text = draft.field.as_str().to_string();
-        let worktree = self.review_notes_worktree();
         self.review_notes
             .set_text(&worktree, &at.path, at.anchor, &text);
+        self.schedule_review_notes_persist(cx);
         cx.notify();
     }
 
@@ -428,9 +495,9 @@ impl AdeApp {
         // A half-typed card is part of the batch too - settle it first so what is on screen and
         // what goes down the pty cannot differ.
         if let Some(draft) = self.note_draft.as_ref() {
+            let worktree = draft.worktree.clone();
             let at = draft.at.clone();
             let text = draft.field.as_str().to_string();
-            let worktree = self.review_notes_worktree();
             self.review_notes
                 .set_text(&worktree, &at.path, at.anchor, &text);
         }
@@ -463,7 +530,13 @@ impl AdeApp {
         }
 
         let worktree = self.review_notes_worktree();
-        let marked = self.review_notes.mark_sent(&worktree, &path);
+        // Marked with what was really **delivered**, not with the raw buffer: the prompt's own
+        // sanitisation collapses control characters and whitespace runs
+        // (`crate::review_notes::prompt`), so storing the buffer would have the card's own
+        // "sent earlier" tooltip quote wording the agent never received.
+        let marked = self
+            .review_notes
+            .mark_sent_as(&worktree, &path, prompt.delivered());
         self.note_send_error = None;
         self.persist_review_notes(cx);
         cx.notify();
@@ -481,8 +554,13 @@ impl AdeApp {
             return;
         };
         if let Err(err) = self.send_review_notes(path, cx) {
-            self.note_send_error = Some(err.message().to_string());
-            cx.notify();
+            // `NothingToSend` deliberately says nothing: the bar only exists once the file has a
+            // real note, so there is nowhere to show it now - and setting it would leave the
+            // message sitting in the bar the moment a note *was* written.
+            if err != NoteSendError::NothingToSend {
+                self.note_send_error = Some(err.message().to_string());
+                cx.notify();
+            }
         }
     }
 

--- a/crates/app/src/review_notes/integration_tests.rs
+++ b/crates/app/src/review_notes/integration_tests.rs
@@ -979,3 +979,59 @@ fn a_draft_left_open_across_a_worktree_switch_never_writes_into_the_other_checko
         );
     });
 }
+
+/// A second window's notes must survive this one saving.
+///
+/// `save_merged_at` rewrites every worktree key this window claims **ownership** of, from its own
+/// in-memory snapshot. Claiming the whole file at startup (which is what `crate::provenance` does,
+/// and what this used to copy) makes that a real loss path: launch, let another window add a note
+/// elsewhere, then save anything at all and the other window's note is overwritten by a
+/// launch-time copy. Ownership is now taken per worktree, only where this window really wrote.
+#[gpui::test]
+fn saving_does_not_overwrite_a_worktree_this_window_only_read(cx: &mut TestAppContext) {
+    let (repo, store) = repo_with_an_agent_authored_change(1_700_000_000);
+    let shim_dir = TempDir::new().expect("tempdir");
+    let state_dir = TempDir::new().expect("tempdir");
+    let notes_file =
+        super::persist_state::review_notes_path_for(&state_dir.path().join("settings.toml"));
+
+    // Another window's worktree, already on disk before this one launches.
+    let other = PathBuf::from("/repo/another-window");
+    let mut theirs = super::NoteStore::default();
+    theirs.set_text(&other, Path::new(PATH), NoteAnchor::New(1), "theirs");
+    super::persist_state::ReviewNotesState::capture(&theirs)
+        .save_at(&notes_file)
+        .expect("seed the other window's notes");
+
+    let (app, cx, _agent) = open_review(cx, &repo, &shim_dir, store, 1_700_000_000);
+    app.update(cx, |app, _| {
+        app.review_notes_path = Some(notes_file.clone());
+        // Exactly what a launch does: read the whole file into memory.
+        app.restore_review_notes();
+    });
+    cx.run_until_parked();
+
+    // Now write in *this* window's own worktree, and let the save land.
+    click_line(cx, 2);
+    cx.simulate_input("ours");
+    cx.run_until_parked();
+    cx.background_executor
+        .advance_clock(Duration::from_millis(700));
+    cx.run_until_parked();
+
+    let mut merged = super::NoteStore::default();
+    super::persist_state::ReviewNotesState::load_at(&notes_file).restore_into(&mut merged);
+    assert_eq!(
+        merged
+            .note(&other, Path::new(PATH), NoteAnchor::New(1))
+            .map(|note| note.text.as_str()),
+        Some("theirs"),
+        "a worktree this window only read must come back untouched"
+    );
+    let worktree = app.read_with(cx, |app, _| app.review_notes_worktree());
+    assert_eq!(
+        merged.file_state(&worktree, Path::new(PATH)).count,
+        1,
+        "and this window's own note must really have been written"
+    );
+}

--- a/crates/app/src/review_notes/integration_tests.rs
+++ b/crates/app/src/review_notes/integration_tests.rs
@@ -6,7 +6,7 @@
 //! with a real child process on a real pty, real clicks and real keystrokes - and measured against
 //! real painted bounds and real terminal output.
 
-use super::render::{notes_bar_label, SEND_NOTES_SPEC};
+use super::render::notes_bar_label;
 use super::{FileNoteState, NoteAnchor};
 use crate::provenance::{store::ProvenanceStore, AgentKey};
 use crate::root::focus::palette_focus_tests::open_test_app;
@@ -594,10 +594,6 @@ fn the_send_shortcut_the_bar_draws_really_sends(cx: &mut TestAppContext) {
         "ctrl-enter"
     });
     cx.run_until_parked();
-    assert_eq!(
-        SEND_NOTES_SPEC, "mod+enter",
-        "the keycaps and the binding must come from one string"
-    );
 
     let state = app.read_with(cx, |app, _| {
         app.review_notes
@@ -691,6 +687,295 @@ fn a_note_on_a_removed_line_anchors_and_reads_as_removed(cx: &mut TestAppContext
             prompt.lines()[1].starts_with("removed line "),
             "and the prompt says so, so the agent looks in the right column - got {:?}",
             prompt.lines()[1]
+        );
+    });
+}
+
+/// A note has to survive the window closing, and "written when the card closes" is not that: the
+/// realistic way to lose one is to type it and then quit with the caret still in it.
+///
+/// So this types into a card, never closes it, and asserts the note really reached the real file
+/// on disk once the debounce elapsed - and, before that, that nothing was written per keystroke.
+#[gpui::test]
+fn a_note_still_being_typed_reaches_the_real_file_on_its_own(cx: &mut TestAppContext) {
+    let (repo, store) = repo_with_an_agent_authored_change(1_700_000_000);
+    let shim_dir = TempDir::new().expect("tempdir");
+    let state_dir = TempDir::new().expect("tempdir");
+    let notes_file =
+        super::persist_state::review_notes_path_for(&state_dir.path().join("settings.toml"));
+    let (app, cx, _agent) = open_review(cx, &repo, &shim_dir, store, 1_700_000_000);
+    app.update(cx, |app, _| {
+        app.review_notes_path = Some(notes_file.clone());
+    });
+
+    click_line(cx, 2);
+    cx.simulate_input("survives the window closing");
+    cx.run_until_parked();
+    assert!(
+        !notes_file.exists(),
+        "nothing may be written per keystroke - that would be a real fsync'd file write per \
+         character"
+    );
+
+    // The debounce, and nothing else - the card is still open and still focused.
+    cx.background_executor
+        .advance_clock(Duration::from_millis(700));
+    cx.run_until_parked();
+
+    let mut restored = super::NoteStore::default();
+    let (ok, dropped) =
+        super::persist_state::ReviewNotesState::load_at(&notes_file).restore_into(&mut restored);
+    assert_eq!((ok, dropped), (1, 0), "the note must be on disk by itself");
+    let worktree = app.read_with(cx, |app, _| app.review_notes_worktree());
+    let anchor = restored.anchors(&worktree, Path::new(PATH));
+    assert_eq!(anchor.len(), 1);
+    assert_eq!(
+        restored
+            .note(&worktree, Path::new(PATH), anchor[0])
+            .expect("the note")
+            .text,
+        "survives the window closing"
+    );
+}
+
+/// Regression: a plain letter bound over the **diff** must not be swallowed while a note card is
+/// being typed into.
+///
+/// The note card is a real `"text-input"` node *inside* `crate::code_surface::render`'s own
+/// `"diff"` node, so `v` (`ToggleChangeSeen`) and `]` (`NextChangedFile`) - both scoped
+/// `Some("diff && !file-editor")` before GitHub issue #288 - were live over it, and GPUI
+/// dispatches a matching `KeyBinding` before any `on_key_down` listener. Typing "survives" into a
+/// note produced "suries", and pressing `]` jumped to another file mid-sentence. Both bindings
+/// now carry `&& !text-input`.
+#[gpui::test]
+fn plain_letters_bound_over_the_diff_are_typed_into_a_note_not_swallowed(cx: &mut TestAppContext) {
+    let (repo, store) = repo_with_an_agent_authored_change(1_700_000_000);
+    let shim_dir = TempDir::new().expect("tempdir");
+    let (app, cx, _agent) = open_review(cx, &repo, &shim_dir, store, 1_700_000_000);
+
+    let seen_before = app.read_with(cx, |app, _| app.seen_files.clone());
+    click_line(cx, 2);
+    cx.simulate_input("verify v] here");
+    cx.run_until_parked();
+
+    app.read_with(cx, |app, _| {
+        let worktree = app.review_notes_worktree();
+        let anchor = app.review_notes.anchors(&worktree, Path::new(PATH))[0];
+        assert_eq!(
+            app.review_notes
+                .note(&worktree, Path::new(PATH), anchor)
+                .expect("the note")
+                .text,
+            "verify v] here",
+            "every character typed into a note must land in the note"
+        );
+        assert_eq!(
+            app.seen_files, seen_before,
+            "and `v` must not have marked the file seen behind the caret"
+        );
+        assert_eq!(
+            app.open_change.as_deref(),
+            Some(Path::new(PATH)),
+            "and `]` must not have jumped to another file mid-sentence"
+        );
+    });
+}
+
+/// **Regression for the worst failure this feature can have: input silently going nowhere.**
+///
+/// The pinned card is a row of a virtualized `uniform_list`, so it stops being built at all once
+/// it scrolls out of view. If the card were the element carrying the note's `FocusHandle`, that
+/// would delete the focused node from GPUI's dispatch tree mid-sentence - and GPUI then evaluates
+/// every predicate against an empty context stack, where they all short-circuit to `false`. Typed
+/// characters, `mod+enter` and `c` would all stop working, with nothing on screen saying so.
+///
+/// So: open a note near the top of a long diff, scroll it far out of view, and keep typing.
+#[gpui::test]
+fn typing_into_a_note_keeps_working_after_the_card_scrolls_out_of_view(cx: &mut TestAppContext) {
+    let repo = TempDir::new().expect("tempdir");
+    git(repo.path(), &["init", "-b", "main"]);
+    git(repo.path(), &["config", "user.email", "test@example.com"]);
+    git(repo.path(), &["config", "user.name", "Test User"]);
+    std::fs::write(repo.path().join("big.rs"), "fn noop() {}\n").expect("seed");
+    git(repo.path(), &["add", "-A"]);
+    git(repo.path(), &["commit", "-m", "initial"]);
+    // Far more lines than any viewport, so the note's own row genuinely leaves the built range.
+    let mut content = String::from("fn noop() {}\n");
+    for index in 0..300 {
+        content.push_str(&format!("fn generated_{index}() -> i32 {{ {index} }}\n"));
+    }
+    std::fs::write(repo.path().join("big.rs"), &content).expect("rewrite");
+
+    let shim_dir = TempDir::new().expect("tempdir");
+    let program = agent_stand_in(shim_dir.path());
+    let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
+    app.update_in(cx, |app, window, cx| {
+        app.settings.terminal.shell = Some(program);
+        app.set_right_sidebar_view(RightSidebarView::Changes, window, cx);
+        app.new_agent(ProcessKind::Shell, window, cx);
+        let id = app.agents.active_id().expect("the tab");
+        app.agents.set_kind_for_test(id, ProcessKind::claude());
+        app.open_change_diff(PathBuf::from("big.rs"), window, cx);
+    });
+    cx.run_until_parked();
+
+    click_line(cx, 1);
+    cx.simulate_input("before");
+    cx.run_until_parked();
+    assert!(
+        cx.debug_bounds("diff-note-0").is_some(),
+        "precondition: the card is on screen while it is being typed into"
+    );
+
+    // A deliberately huge delta - `uniform_list` clamps to its own real maximum scroll offset.
+    let anchor = cx
+        .debug_bounds("diff-line-1")
+        .expect("the noted line must be painted before scrolling");
+    cx.simulate_event(gpui::ScrollWheelEvent {
+        position: anchor.center(),
+        delta: gpui::ScrollDelta::Pixels(gpui::point(gpui::px(0.0), gpui::px(-100_000.0))),
+        modifiers: gpui::Modifiers::default(),
+        touch_phase: gpui::TouchPhase::Moved,
+    });
+    cx.run_until_parked();
+    assert!(
+        cx.debug_bounds("diff-note-0").is_none(),
+        "precondition: the card really did stop being built - otherwise this test proves nothing"
+    );
+
+    cx.simulate_input(" and after");
+    cx.run_until_parked();
+
+    app.read_with(cx, |app, _| {
+        let worktree = app.review_notes_worktree();
+        let anchor = app.review_notes.anchors(&worktree, Path::new("big.rs"))[0];
+        assert_eq!(
+            app.review_notes
+                .note(&worktree, Path::new("big.rs"), anchor)
+                .expect("the note")
+                .text,
+            "before and after",
+            "keystrokes must keep reaching the note after its card scrolled out of the list"
+        );
+    });
+
+    // And the shortcuts the bar advertises must still be live, for the same reason.
+    cx.simulate_keystrokes(if cfg!(target_os = "macos") {
+        "cmd-enter"
+    } else {
+        "ctrl-enter"
+    });
+    cx.run_until_parked();
+    app.read_with(cx, |app, _| {
+        assert!(
+            app.review_notes
+                .file_state(&app.review_notes_worktree(), Path::new("big.rs"))
+                .all_sent,
+            "`mod+enter` must still fire with the card off screen"
+        );
+    });
+}
+
+/// A send that really failed says so in the bar, and - critically - does **not** mark anything
+/// sent. Audit item I12's whole complaint about this design is that nothing in it ever fails.
+#[gpui::test]
+fn a_send_to_a_dead_agent_fails_loudly_and_marks_nothing(cx: &mut TestAppContext) {
+    let (repo, store) = repo_with_an_agent_authored_change(1_700_000_000);
+    let shim_dir = TempDir::new().expect("tempdir");
+    let (app, cx, agent) = open_review(cx, &repo, &shim_dir, store, 1_700_000_000);
+
+    click_line(cx, 2);
+    cx.simulate_input("never delivered");
+    cx.run_until_parked();
+
+    // End the real child the way a user would - a real `Ctrl+C` down the real pty - and let the
+    // pane's own poll loop genuinely observe the exit.
+    let pane = app.read_with(cx, |app, _| {
+        app.agents
+            .iter()
+            .find(|a| a.id == agent)
+            .expect("the agent")
+            .pane
+            .clone()
+    });
+    pane.update(cx, |pane, cx| pane.interrupt(cx));
+    assert!(
+        pump_until(cx, |cx| pane
+            .read_with(cx, |pane, _| pane.exit_status().is_some())),
+        "the real child must actually have ended before this test means anything"
+    );
+
+    let send = cx.debug_bounds("diff-notes-send").expect("the send button");
+    cx.simulate_click(send.center(), gpui::Modifiers::none());
+    cx.run_until_parked();
+
+    app.read_with(cx, |app, _| {
+        assert!(
+            !app.review_notes
+                .file_state(&app.review_notes_worktree(), Path::new(PATH))
+                .all_sent,
+            "nothing reached anybody, so nothing may claim to have been sent - and `sent` only \
+             ever reverts by editing the note, so this would be unrecoverable"
+        );
+        assert!(
+            app.note_send_error.is_some(),
+            "and the failure must be said out loud rather than swallowed"
+        );
+    });
+    assert!(
+        cx.debug_bounds("diff-notes-bar-error").is_some(),
+        "the notes bar must really paint the failure"
+    );
+    assert!(
+        cx.debug_bounds("diff-notes-bar-sent").is_none(),
+        "and must not also be showing a sent confirmation"
+    );
+}
+
+/// A draft opened in one worktree must never write into another checkout's notes.
+///
+/// `AdeApp::diff_root` is reassigned wholesale on a worktree switch, so a draft that re-read it at
+/// each store call would land every subsequent keystroke under the *new* worktree's key -
+/// overwriting its note on the same path and line, and persisting it there.
+#[gpui::test]
+fn a_draft_left_open_across_a_worktree_switch_never_writes_into_the_other_checkout(
+    cx: &mut TestAppContext,
+) {
+    let (repo, store) = repo_with_an_agent_authored_change(1_700_000_000);
+    let shim_dir = TempDir::new().expect("tempdir");
+    let (app, cx, _agent) = open_review(cx, &repo, &shim_dir, store, 1_700_000_000);
+
+    click_line(cx, 2);
+    cx.simulate_input("belongs to the first checkout");
+    cx.run_until_parked();
+    let (first, anchor) = app.read_with(cx, |app, _| {
+        let worktree = app.review_notes_worktree();
+        let anchor = app.review_notes.anchors(&worktree, Path::new(PATH))[0];
+        (worktree, anchor)
+    });
+
+    // The switch itself, at the one field that defines "which checkout these notes belong to".
+    let second = repo.path().join("..").join("other-checkout");
+    app.update(cx, |app, cx| {
+        app.diff_root = second.clone();
+        cx.notify();
+    });
+    cx.run_until_parked();
+    cx.simulate_input(" - typed after the switch");
+    cx.run_until_parked();
+
+    app.read_with(cx, |app, _| {
+        assert!(
+            app.review_notes.file(&second, Path::new(PATH)).is_none(),
+            "not one character may land in the checkout the draft does not belong to"
+        );
+        assert_eq!(
+            app.review_notes
+                .note(&first, Path::new(PATH), anchor)
+                .expect("the draft's own note")
+                .text,
+            "belongs to the first checkout - typed after the switch",
+            "and the draft keeps writing where it was opened"
         );
     });
 }

--- a/crates/app/src/review_notes/integration_tests.rs
+++ b/crates/app/src/review_notes/integration_tests.rs
@@ -1,0 +1,696 @@
+//! GitHub issue #288, end to end in a real window: the mock's own acceptance sequence, the
+//! resolution of *which agent* a file's notes go to, real delivery into that agent's real pty, and
+//! the two properties the whole feature rests on (a note survives, and sending never clears one).
+//!
+//! Everything below is built from real parts - a real git repo with a real diff, a real agent tab
+//! with a real child process on a real pty, real clicks and real keystrokes - and measured against
+//! real painted bounds and real terminal output.
+
+use super::render::{notes_bar_label, SEND_NOTES_SPEC};
+use super::{FileNoteState, NoteAnchor};
+use crate::provenance::{store::ProvenanceStore, AgentKey};
+use crate::root::focus::palette_focus_tests::open_test_app;
+use crate::root::AdeApp;
+use crate::sidebar::render::RightSidebarView;
+use crate::work_surface::agents::{AgentId, AgentKind, ProcessKind};
+use gpui::TestAppContext;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+use tempfile::TempDir;
+
+const PATH: &str = "src/api/users.rs";
+
+/// As committed.
+const BASE: &str = "\
+impl UserApi {
+    pub async fn list(&self, page: Page) -> Result<Vec<User>> {
+        let sql = self.orm.select(&[\"id\", \"email\"]);
+    }
+}
+";
+
+/// After an agent rewrote the body - one real removed line and one real added line.
+const AFTER: &str = "\
+impl UserApi {
+    pub async fn list(&self, page: Page) -> Result<Vec<User>> {
+        let q = QueryBuilder::table(\"users\").select(&[\"id\", \"email\"]);
+    }
+}
+";
+
+fn git(dir: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("failed to spawn git");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// A real repo with a real one-line change in `src/api/users.rs`, plus provenance recording that
+/// one real agent wrote it.
+fn repo_with_an_agent_authored_change(spawned_at: i64) -> (TempDir, ProvenanceStore) {
+    let dir = TempDir::new().expect("tempdir");
+    let repo = dir.path();
+    git(repo, &["init", "-b", "main"]);
+    git(repo, &["config", "user.email", "test@example.com"]);
+    git(repo, &["config", "user.name", "Test User"]);
+    std::fs::create_dir_all(repo.join("src/api")).expect("mkdir");
+    std::fs::write(repo.join(PATH), BASE).expect("seed");
+    git(repo, &["add", "-A"]);
+    git(repo, &["commit", "-m", "initial"]);
+
+    let file = repo.join(PATH);
+    let mut store = ProvenanceStore::default();
+    let key = AgentKey::new(crate::review::state::baseline_key(
+        repo,
+        AgentKind::Claude,
+        spawned_at,
+    ));
+    store.begin_agent_edit(repo, &file);
+    std::fs::write(&file, AFTER).expect("the agent's own write");
+    store.record_agent_edit(repo, &file, &key);
+    (dir, store)
+}
+
+/// A real, executable stand-in for an agent CLI: it turns bracketed paste on (exactly as a real
+/// agent's full-screen TUI does) and then writes back whatever is typed into it.
+///
+/// Real, not simulated. It is spawned through this app's own spawn path onto a real pty, so the
+/// prompt appearing in its pane is round-tripped evidence that the bytes genuinely left the app.
+///
+/// `stty -echo` is load-bearing, not tidiness: with the pty's own line-discipline echo left on,
+/// every delivered byte would appear on the pane **twice** (once echoed by the driver, once
+/// written by `cat`), and "how many prompts arrived" - the one thing
+/// [`two_notes_are_delivered_as_one_prompt_not_two`] exists to measure - would be uncountable.
+/// The same technique `crate::terminal::pane`'s own
+/// `shutdown_joins_reader_thread_even_with_local_echo_disabled` already uses.
+fn agent_stand_in(dir: &Path) -> String {
+    let script = dir.join("agent-stand-in.sh");
+    std::fs::write(
+        &script,
+        "#!/bin/sh\nstty -echo\nprintf '\\033[?2004h'\nexec cat\n",
+    )
+    .expect("write shim");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod +x");
+    }
+    script.to_string_lossy().into_owned()
+}
+
+/// Opens the app on `repo` with the Changes panel showing and `PATH`'s diff open, plus one real
+/// agent tab whose child is [`agent_stand_in`].
+///
+/// The tab is spawned as a `Shell` (which is the one spawn path that lets a test name the real
+/// program) and then retagged to a real agent kind through `Agents::set_kind_for_test` - the
+/// established seam this crate already uses for exactly this ("everything downstream of the
+/// recorded `kind` field behaves exactly as if a real agent CLI had been spawned, without the
+/// process weight of one"). The *process* is real either way, which is the half this test needs.
+fn open_review<'a>(
+    cx: &'a mut TestAppContext,
+    repo: &TempDir,
+    shim_dir: &TempDir,
+    store: ProvenanceStore,
+    spawned_at: i64,
+) -> (
+    gpui::Entity<AdeApp>,
+    &'a mut gpui::VisualTestContext,
+    AgentId,
+) {
+    let program = agent_stand_in(shim_dir.path());
+    let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
+    let id = app.update_in(cx, |app, window, cx| {
+        app.settings.terminal.shell = Some(program);
+        app.set_right_sidebar_view(RightSidebarView::Changes, window, cx);
+        app.new_agent(ProcessKind::Shell, window, cx);
+        app.agents.active_id().expect("the tab we just spawned")
+    });
+    cx.run_until_parked();
+    app.update_in(cx, |app, window, cx| {
+        // Retagged to a real agent kind, and to the exact spawn second the provenance store
+        // recorded, so the file's own author really resolves to this live tab.
+        app.agents.set_kind_for_test(id, ProcessKind::claude());
+        app.agents.set_spawned_at_unix_for_test(id, spawned_at);
+        app.line_provenance = store;
+        app.rebuild_change_set();
+        app.open_change_diff(PathBuf::from(PATH), window, cx);
+    });
+    cx.run_until_parked();
+    (app, cx, id)
+}
+
+/// Pumps the real poll loop until `ready`, mixing virtual-clock advance with a real sleep - the
+/// same discipline `crate::work_surface::render`'s `wait_for_real_pty_output` uses, and for the
+/// same reason: the pty reader is a real OS thread.
+fn pump_until(
+    cx: &mut gpui::VisualTestContext,
+    mut ready: impl FnMut(&mut gpui::VisualTestContext) -> bool,
+) -> bool {
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
+    loop {
+        // The pane's own real poll interval (8ms); named here rather than imported so this
+        // test module needs nothing widened in `crate::terminal::pane` for its sake.
+        cx.background_executor
+            .advance_clock(Duration::from_millis(8));
+        cx.run_until_parked();
+        if ready(cx) {
+            return true;
+        }
+        if std::time::Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(5));
+    }
+}
+
+fn agent_screen(
+    app: &gpui::Entity<AdeApp>,
+    cx: &mut gpui::VisualTestContext,
+    id: AgentId,
+) -> String {
+    let pane = app.read_with(cx, |app, _| {
+        app.agents
+            .iter()
+            .find(|agent| agent.id == id)
+            .expect("the agent")
+            .pane
+            .clone()
+    });
+    pane.read_with(cx, |pane, _| pane.visible_text_lines().join("\n"))
+}
+
+/// Clicks a diff line by its row selector and lets the app settle.
+fn click_line(cx: &mut gpui::VisualTestContext, row: usize) {
+    let selector: &'static str = Box::leak(format!("diff-line-{row}").into_boxed_str());
+    let bounds = cx
+        .debug_bounds(selector)
+        .unwrap_or_else(|| panic!("{selector} must really paint"));
+    cx.simulate_click(bounds.center(), gpui::Modifiers::none());
+    cx.run_until_parked();
+}
+
+/// **The acceptance sequence, exactly as `STAGE-A-CHANGELOG.md` §3 states it:** *"Note pins on
+/// click, bar reads `1 note on this file`, send → `1 note sent — awaiting revision` + `✓ sent`,
+/// card mark `draft → sent`, note still pinned."*
+///
+/// Every step is a real gesture on a real painted element, and the send really writes into a real
+/// child process's real pty.
+#[gpui::test]
+fn the_mocks_acceptance_sequence_runs_end_to_end_against_a_real_agent(cx: &mut TestAppContext) {
+    let (repo, store) = repo_with_an_agent_authored_change(1_700_000_000);
+    let shim_dir = TempDir::new().expect("tempdir");
+    let (app, cx, agent) = open_review(cx, &repo, &shim_dir, store, 1_700_000_000);
+
+    // Before any note there is no bar at all - not an empty one.
+    assert!(
+        cx.debug_bounds("diff-notes-bar").is_none(),
+        "a file with no notes shows no notes bar"
+    );
+
+    // 1. A note pins on click.
+    click_line(cx, 2);
+    assert!(
+        cx.debug_bounds("diff-note-0").is_some(),
+        "clicking a diff line must pin a card beneath it, as a real row of the diff's own list"
+    );
+    cx.simulate_input("cache key must include tenant_id");
+    cx.run_until_parked();
+
+    // 2. The bar reads `1 note on this file`.
+    assert!(
+        cx.debug_bounds("diff-notes-bar-label").is_some(),
+        "the notes bar must really paint above the hunks"
+    );
+    let (state, anchor) = app.read_with(cx, |app, _| {
+        let worktree = app.review_notes_worktree();
+        (
+            app.review_notes.file_state(&worktree, Path::new(PATH)),
+            app.review_notes
+                .anchors(&worktree, Path::new(PATH))
+                .first()
+                .copied()
+                .expect("one anchor"),
+        )
+    });
+    assert_eq!(
+        notes_bar_label(state),
+        "1 note on this file",
+        "the design's own wording, through the pluralisation helper"
+    );
+    assert_eq!(
+        state,
+        FileNoteState {
+            count: 1,
+            all_sent: false
+        }
+    );
+
+    // 3. Send.
+    let send = cx
+        .debug_bounds("diff-notes-send")
+        .expect("the `Send notes to <agent>` button must really paint");
+    cx.simulate_click(send.center(), gpui::Modifiers::none());
+    cx.run_until_parked();
+
+    // 4. The bar flips, with the `✓ sent` confirmation.
+    let after = app.read_with(cx, |app, _| {
+        app.review_notes
+            .file_state(&app.review_notes_worktree(), Path::new(PATH))
+    });
+    assert_eq!(
+        notes_bar_label(after),
+        "1 note sent \u{2014} awaiting revision",
+        "the bar must say the revision is awaited, verbatim"
+    );
+    assert!(
+        cx.debug_bounds("diff-notes-bar-sent").is_some(),
+        "and the `\u{2713} sent` confirmation must really paint"
+    );
+    assert!(
+        cx.debug_bounds("diff-notes-bar-error").is_none(),
+        "a send that really landed must not also be reporting a failure"
+    );
+
+    // 5. The card's mark flipped `draft -> sent`, and the note is **still pinned**.
+    app.read_with(cx, |app, _| {
+        let note = app
+            .review_notes
+            .note(&app.review_notes_worktree(), Path::new(PATH), anchor)
+            .expect("the note is still pinned after sending - it is never cleared");
+        assert_eq!(note.mark(), super::NoteMark::Sent);
+        assert_eq!(note.text, "cache key must include tenant_id");
+    });
+    assert!(
+        cx.debug_bounds("diff-note-0").is_some(),
+        "the card must still be a painted row of the diff after the send"
+    );
+    assert!(
+        cx.debug_bounds("diff-note-0-mark").is_some(),
+        "including its own draft/sent mark"
+    );
+
+    // 6. And the prompt really arrived in the agent's real pty.
+    assert!(
+        pump_until(cx, |cx| agent_screen(&app, cx, agent)
+            .contains("cache key must include tenant_id")),
+        "the batched prompt must really reach the target agent's child process - got:\n{}",
+        agent_screen(&app, cx, agent)
+    );
+    let screen = agent_screen(&app, cx, agent);
+    assert!(
+        screen.contains("Review notes on src/api/users.rs"),
+        "including the batch's own line-anchored header - got:\n{screen}"
+    );
+}
+
+/// The rule the audit calls out as the thing Orca learned the hard way: **one** prompt, however
+/// many notes. Two notes on one file must produce one delivery containing both, never two.
+#[gpui::test]
+fn two_notes_are_delivered_as_one_prompt_not_two(cx: &mut TestAppContext) {
+    let (repo, store) = repo_with_an_agent_authored_change(1_700_000_000);
+    let shim_dir = TempDir::new().expect("tempdir");
+    let (app, cx, agent) = open_review(cx, &repo, &shim_dir, store, 1_700_000_000);
+
+    click_line(cx, 2);
+    cx.simulate_input("ade-note-alpha");
+    cx.run_until_parked();
+    click_line(cx, 3);
+    cx.simulate_input("ade-note-beta");
+    cx.run_until_parked();
+
+    let prompt = app
+        .read_with(cx, |app, _| app.batched_review_prompt(Path::new(PATH)))
+        .expect("two real notes compose one prompt");
+    assert_eq!(prompt.note_count, 2);
+    assert_eq!(
+        prompt.lines().len(),
+        4,
+        "one header, one line per note, one closing instruction - a single prompt, not two"
+    );
+
+    let send = cx.debug_bounds("diff-notes-send").expect("the send button");
+    cx.simulate_click(send.center(), gpui::Modifiers::none());
+    cx.run_until_parked();
+
+    assert!(
+        pump_until(cx, |cx| {
+            let screen = agent_screen(&app, cx, agent);
+            screen.contains("ade-note-alpha") && screen.contains("ade-note-beta")
+        }),
+        "both notes must arrive, in the same delivery - got:\n{}",
+        agent_screen(&app, cx, agent)
+    );
+    // One prompt means one header. Two sends would have produced two.
+    let screen = agent_screen(&app, cx, agent);
+    assert_eq!(
+        screen.matches("Review notes on").count(),
+        1,
+        "exactly one batched prompt reached the agent - got:\n{screen}"
+    );
+}
+
+/// *"Editing after send starts a new draft state for that note"*, observed through the surface
+/// rather than only through the model: the bar goes back to counting notes, and the card's mark
+/// goes back to `draft`, while the note itself stays pinned.
+#[gpui::test]
+fn editing_a_sent_note_puts_the_card_and_the_bar_back_into_draft(cx: &mut TestAppContext) {
+    let (repo, store) = repo_with_an_agent_authored_change(1_700_000_000);
+    let shim_dir = TempDir::new().expect("tempdir");
+    let (app, cx, _agent) = open_review(cx, &repo, &shim_dir, store, 1_700_000_000);
+
+    click_line(cx, 2);
+    cx.simulate_input("first wording");
+    cx.run_until_parked();
+    let send = cx.debug_bounds("diff-notes-send").expect("the send button");
+    cx.simulate_click(send.center(), gpui::Modifiers::none());
+    cx.run_until_parked();
+    assert!(cx.debug_bounds("diff-notes-bar-sent").is_some());
+
+    // Type one more character into the same card.
+    let card = cx.debug_bounds("diff-note-0").expect("the pinned card");
+    cx.simulate_click(card.center(), gpui::Modifiers::none());
+    cx.simulate_input("!");
+    cx.run_until_parked();
+
+    let state = app.read_with(cx, |app, _| {
+        app.review_notes
+            .file_state(&app.review_notes_worktree(), Path::new(PATH))
+    });
+    assert_eq!(
+        notes_bar_label(state),
+        "1 note on this file",
+        "the agent has not seen this wording, so the bar must stop claiming a revision is awaited"
+    );
+    assert!(
+        cx.debug_bounds("diff-notes-bar-sent").is_none(),
+        "and the `\u{2713} sent` confirmation must go with it"
+    );
+    app.read_with(cx, |app, _| {
+        let worktree = app.review_notes_worktree();
+        let anchor = app.review_notes.anchors(&worktree, Path::new(PATH))[0];
+        let note = app
+            .review_notes
+            .note(&worktree, Path::new(PATH), anchor)
+            .expect("still pinned");
+        assert_eq!(note.mark(), super::NoteMark::Draft);
+        assert_eq!(
+            note.superseded_text(),
+            Some("first wording"),
+            "and what the agent really was told must still be recoverable"
+        );
+    });
+}
+
+/// *"`noteTarget` resolves to the file's first author"* - the live agent whose key the provenance
+/// store recorded against this file, not merely whichever tab happens to be open.
+#[gpui::test]
+fn the_target_is_the_files_own_author_when_one_is_live(cx: &mut TestAppContext) {
+    let (repo, store) = repo_with_an_agent_authored_change(1_700_000_000);
+    let shim_dir = TempDir::new().expect("tempdir");
+    let (app, cx, authored_by) = open_review(cx, &repo, &shim_dir, store, 1_700_000_000);
+
+    // A second, later agent in the same worktree, which the file names nowhere.
+    let second = app.update_in(cx, |app, window, cx| {
+        app.new_agent(ProcessKind::Shell, window, cx);
+        let id = app.agents.active_id().expect("the second tab");
+        app.agents.set_kind_for_test(id, ProcessKind::codex());
+        app.agents.set_spawned_at_unix_for_test(id, 1_700_000_900);
+        id
+    });
+    cx.run_until_parked();
+
+    app.read_with(cx, |app, _| {
+        let target = app
+            .review_note_target(Path::new(PATH))
+            .expect("a target must resolve");
+        assert_eq!(
+            target.agent, authored_by,
+            "in a shared worktree the notes go to whoever wrote the lines, not to the tab that \
+             happens to be active"
+        );
+        assert!(target.from_file_author);
+        assert_ne!(target.agent, second);
+    });
+}
+
+/// The fallback half: a file this worktree has no attribution for still has a target - *"falling
+/// back to the worktree's primary agent"*.
+#[gpui::test]
+fn a_file_with_no_author_falls_back_to_the_worktrees_primary_agent(cx: &mut TestAppContext) {
+    let (repo, _store) = repo_with_an_agent_authored_change(1_700_000_000);
+    let shim_dir = TempDir::new().expect("tempdir");
+    // Deliberately no provenance installed, so the file names nobody at all.
+    let (app, cx, agent) = open_review(cx, &repo, &shim_dir, ProvenanceStore::default(), 1);
+
+    app.read_with(cx, |app, _| {
+        let target = app
+            .review_note_target(Path::new(PATH))
+            .expect("the worktree's primary agent is still a target");
+        assert_eq!(target.agent, agent);
+        assert!(
+            !target.from_file_author,
+            "and the button's tooltip must be able to say so"
+        );
+    });
+}
+
+/// A shell shares the worktree but authors nothing and cannot revise anything, so it is never a
+/// send target - and with no real agent open at all there is no button rather than one that names
+/// a target it does not have.
+#[gpui::test]
+fn a_worktree_whose_only_tab_is_a_shell_offers_no_send_target(cx: &mut TestAppContext) {
+    let (repo, _store) = repo_with_an_agent_authored_change(1_700_000_000);
+    let shim_dir = TempDir::new().expect("tempdir");
+    let program = agent_stand_in(shim_dir.path());
+    let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
+    app.update_in(cx, |app, window, cx| {
+        app.settings.terminal.shell = Some(program);
+        app.set_right_sidebar_view(RightSidebarView::Changes, window, cx);
+        app.new_agent(ProcessKind::Shell, window, cx);
+        app.open_change_diff(PathBuf::from(PATH), window, cx);
+    });
+    cx.run_until_parked();
+
+    app.read_with(cx, |app, _| {
+        assert!(
+            app.review_note_target(Path::new(PATH)).is_none(),
+            "a shell is not somebody who can revise code"
+        );
+    });
+
+    click_line(cx, 2);
+    cx.simulate_input("nobody to send this to");
+    cx.run_until_parked();
+    assert!(
+        cx.debug_bounds("diff-notes-bar").is_some(),
+        "the note still pins and the bar still counts it"
+    );
+    assert!(
+        cx.debug_bounds("diff-notes-send").is_none(),
+        "but there is no send button, rather than one naming an agent that is not there"
+    );
+}
+
+/// *"Notes are keyed per worktree + path + line and survive scrolling/reopening."* Opening another
+/// file and coming back must find the note exactly where it was, with its state intact.
+#[gpui::test]
+fn a_note_survives_leaving_the_file_and_coming_back(cx: &mut TestAppContext) {
+    let (repo, store) = repo_with_an_agent_authored_change(1_700_000_000);
+    let shim_dir = TempDir::new().expect("tempdir");
+    let (app, cx, _agent) = open_review(cx, &repo, &shim_dir, store, 1_700_000_000);
+
+    click_line(cx, 2);
+    cx.simulate_input("still here later");
+    cx.run_until_parked();
+    let send = cx.debug_bounds("diff-notes-send").expect("the send button");
+    cx.simulate_click(send.center(), gpui::Modifiers::none());
+    cx.run_until_parked();
+
+    // Away to a file with no notes at all...
+    app.update_in(cx, |app, window, cx| {
+        app.open_change_diff(PathBuf::from("nonexistent.rs"), window, cx);
+    });
+    cx.run_until_parked();
+    assert!(
+        cx.debug_bounds("diff-notes-bar").is_none(),
+        "another file's diff must not carry this file's notes"
+    );
+
+    // ...and back.
+    app.update_in(cx, |app, window, cx| {
+        app.open_change_diff(PathBuf::from(PATH), window, cx);
+    });
+    cx.run_until_parked();
+    assert!(
+        cx.debug_bounds("diff-note-0").is_some(),
+        "the note must be pinned again on the line it was anchored to"
+    );
+    let state = app.read_with(cx, |app, _| {
+        app.review_notes
+            .file_state(&app.review_notes_worktree(), Path::new(PATH))
+    });
+    assert_eq!(
+        notes_bar_label(state),
+        "1 note sent \u{2014} awaiting revision",
+        "with its sent state intact"
+    );
+}
+
+/// A card opened by a stray click and never written into is not a note: clicking the same line
+/// again takes it away, and nothing about it is ever counted or delivered.
+#[gpui::test]
+fn a_blank_card_toggles_away_again_but_a_written_one_stays(cx: &mut TestAppContext) {
+    let (repo, store) = repo_with_an_agent_authored_change(1_700_000_000);
+    let shim_dir = TempDir::new().expect("tempdir");
+    let (_app, cx, _agent) = open_review(cx, &repo, &shim_dir, store, 1_700_000_000);
+
+    click_line(cx, 2);
+    assert!(cx.debug_bounds("diff-note-0").is_some());
+    assert!(
+        cx.debug_bounds("diff-notes-bar").is_none(),
+        "a blank card is a click, not a note - it is not counted"
+    );
+
+    click_line(cx, 2);
+    assert!(
+        cx.debug_bounds("diff-note-0").is_none(),
+        "clicking the same line again takes the blank card away"
+    );
+
+    click_line(cx, 2);
+    cx.simulate_input("real note");
+    cx.run_until_parked();
+    click_line(cx, 2);
+    assert!(
+        cx.debug_bounds("diff-note-0").is_some(),
+        "but a card that has been written into is never destroyed by a click - it closes, and \
+         stays pinned"
+    );
+}
+
+/// The `mod+enter` keycaps the bar draws are a real binding, not decoration (ride-along I10).
+#[gpui::test]
+fn the_send_shortcut_the_bar_draws_really_sends(cx: &mut TestAppContext) {
+    let (repo, store) = repo_with_an_agent_authored_change(1_700_000_000);
+    let shim_dir = TempDir::new().expect("tempdir");
+    let (app, cx, agent) = open_review(cx, &repo, &shim_dir, store, 1_700_000_000);
+
+    click_line(cx, 2);
+    cx.simulate_input("ade-note-by-keystroke");
+    cx.run_until_parked();
+
+    // The same spec string the keycaps are rendered from, as a real keystroke.
+    cx.simulate_keystrokes(if cfg!(target_os = "macos") {
+        "cmd-enter"
+    } else {
+        "ctrl-enter"
+    });
+    cx.run_until_parked();
+    assert_eq!(
+        SEND_NOTES_SPEC, "mod+enter",
+        "the keycaps and the binding must come from one string"
+    );
+
+    let state = app.read_with(cx, |app, _| {
+        app.review_notes
+            .file_state(&app.review_notes_worktree(), Path::new(PATH))
+    });
+    assert!(
+        state.all_sent,
+        "the shortcut the bar advertises must really send the batch"
+    );
+    assert!(
+        pump_until(cx, |cx| agent_screen(&app, cx, agent)
+            .contains("ade-note-by-keystroke")),
+        "and it must reach the same real pty the button does - got:\n{}",
+        agent_screen(&app, cx, agent)
+    );
+}
+
+/// `C note on line`, the footer hint's own wording, as a real binding on the note cursor.
+#[gpui::test]
+fn the_note_shortcut_toggles_a_note_on_the_line_the_cursor_is_on(cx: &mut TestAppContext) {
+    let (repo, store) = repo_with_an_agent_authored_change(1_700_000_000);
+    let shim_dir = TempDir::new().expect("tempdir");
+    let (app, cx, _agent) = open_review(cx, &repo, &shim_dir, store, 1_700_000_000);
+
+    // The cursor is set by clicking a line; `C` then toggles that line's note.
+    click_line(cx, 2);
+    let anchor = app.read_with(cx, |app, _| {
+        app.note_cursor.as_ref().map(|cursor| cursor.anchor)
+    });
+    assert!(anchor.is_some(), "clicking a line sets the note cursor");
+
+    // Focus has to leave the card first, or `c` is a character being typed into it - which is
+    // exactly what the binding's own `&& !text-input` conjunct guarantees.
+    app.update_in(cx, |app, window, cx| {
+        // Closing the draft is what hands focus back to the diff container - see
+        // `AdeApp::close_note_draft`.
+        app.close_note_draft(window, cx);
+    });
+    cx.run_until_parked();
+    assert!(
+        cx.debug_bounds("diff-note-0").is_none(),
+        "the blank card went with the closed draft"
+    );
+
+    cx.simulate_keystrokes("c");
+    cx.run_until_parked();
+    assert!(
+        cx.debug_bounds("diff-note-0").is_some(),
+        "`C` must pin a note on the line the cursor is on"
+    );
+}
+
+/// A note pinned to a removed line has its own anchor, and it says so in the prompt - the half a
+/// single-integer line key would have silently collapsed.
+#[gpui::test]
+fn a_note_on_a_removed_line_anchors_and_reads_as_removed(cx: &mut TestAppContext) {
+    let (repo, store) = repo_with_an_agent_authored_change(1_700_000_000);
+    let shim_dir = TempDir::new().expect("tempdir");
+    let (app, cx, _agent) = open_review(cx, &repo, &shim_dir, store, 1_700_000_000);
+
+    // Row 1 of this diff is the removed line (`let sql = ...`), row 2 the added one.
+    let removed_row = app.read_with(cx, |app, _| {
+        let file = app.open_diff_file_cache.as_ref().expect("the open diff");
+        let mut row = 0usize;
+        for hunk in &file.hunks {
+            for line in &hunk.lines {
+                if line.kind == wt_core::diff::DiffLineKind::Removed {
+                    return row;
+                }
+                row += 1;
+            }
+        }
+        panic!("this seed must produce a real removed line");
+    });
+    click_line(cx, removed_row);
+    cx.simulate_input("why did this go?");
+    cx.run_until_parked();
+
+    app.read_with(cx, |app, _| {
+        let anchors = app
+            .review_notes
+            .anchors(&app.review_notes_worktree(), Path::new(PATH));
+        assert!(
+            matches!(anchors.as_slice(), [NoteAnchor::Old(_)]),
+            "a removed line anchors to its old-file number, got {anchors:?}"
+        );
+        let prompt = app
+            .batched_review_prompt(Path::new(PATH))
+            .expect("a prompt");
+        assert!(
+            prompt.lines()[1].starts_with("removed line "),
+            "and the prompt says so, so the agent looks in the right column - got {:?}",
+            prompt.lines()[1]
+        );
+    });
+}

--- a/crates/app/src/review_notes/mod.rs
+++ b/crates/app/src/review_notes/mod.rs
@@ -165,11 +165,15 @@ impl ReviewNote {
         self.text.trim().is_empty()
     }
 
-    /// The card's mark. `sent` **only** while the delivered wording and the current wording are
-    /// the same string.
+    /// The card's mark. `sent` **only** while what was delivered still says what this note says.
+    ///
+    /// Compared through [`delivered_form`] rather than by raw string equality, because the batch
+    /// does not deliver the buffer verbatim - it collapses control characters and whitespace runs
+    /// (`crate::review_notes::prompt`). Without that, a note containing a tab or a double space
+    /// would come back reading `draft` the instant it was sent, having changed not at all.
     pub fn mark(&self) -> NoteMark {
         match self.sent.as_deref() {
-            Some(sent) if sent == self.text => NoteMark::Sent,
+            Some(sent) if sent == delivered_form(&self.text) => NoteMark::Sent,
             _ => NoteMark::Draft,
         }
     }
@@ -178,10 +182,19 @@ impl ReviewNote {
     /// honest half of the draft/sent history, surfaced as the card's tooltip.
     pub fn superseded_text(&self) -> Option<&str> {
         match self.sent.as_deref() {
-            Some(sent) if sent != self.text => Some(sent),
+            Some(sent) if sent != delivered_form(&self.text) => Some(sent),
             _ => None,
         }
     }
+}
+
+/// How a note's text reads once the batch has composed it - the one place the model and
+/// [`prompt`] agree on what "the same note" means.
+///
+/// Re-exported from [`prompt`] rather than reimplemented, so [`ReviewNote::mark`]'s comparison and
+/// the string actually delivered can never drift apart.
+pub fn delivered_form(text: &str) -> String {
+    prompt::sanitize(text.trim())
 }
 
 /// One note's address inside a worktree: which file, and which line of it.
@@ -314,6 +327,9 @@ impl NoteStore {
     ///
     /// Blank cards are deliberately skipped rather than marked: nothing about them went down the
     /// pty, so nothing about them may claim to have.
+    ///
+    /// Real sends go through [`Self::mark_sent_as`] instead - see its docs for why the *delivered*
+    /// wording, not the buffer, is what belongs in [`ReviewNote::sent`].
     pub fn mark_sent(&mut self, worktree: &Path, path: &Path) -> usize {
         let Some(file) = self
             .worktrees
@@ -328,6 +344,40 @@ impl NoteStore {
                 continue;
             }
             note.sent = Some(note.text.clone());
+            marked += 1;
+        }
+        marked
+    }
+
+    /// The same, but recording **what the agent actually received** for each anchor.
+    ///
+    /// [`ReviewNote::sent`] is documented, here and in the persisted file, as *the exact text that
+    /// was delivered*, and the batched prompt does not deliver the buffer verbatim: it sanitises
+    /// control characters and collapses whitespace runs
+    /// (`crate::review_notes::prompt`). Marking with the buffer would make the card's own
+    /// "sent earlier, and since edited" tooltip quote wording the agent never saw - which is
+    /// precisely the dishonesty keeping the delivered wording exists to prevent.
+    ///
+    /// An anchor with no delivered entry is left alone: nothing about it went down the pty.
+    pub fn mark_sent_as(
+        &mut self,
+        worktree: &Path,
+        path: &Path,
+        delivered: &[(NoteAnchor, String)],
+    ) -> usize {
+        let Some(file) = self
+            .worktrees
+            .get_mut(worktree)
+            .and_then(|files| files.get_mut(path))
+        else {
+            return 0;
+        };
+        let mut marked = 0;
+        for (anchor, text) in delivered {
+            let Some(note) = file.get_mut(anchor) else {
+                continue;
+            };
+            note.sent = Some(text.clone());
             marked += 1;
         }
         marked

--- a/crates/app/src/review_notes/mod.rs
+++ b/crates/app/src/review_notes/mod.rs
@@ -1,0 +1,594 @@
+//! Diff-line review notes (GitHub issue #288): line-anchored comments on a diff, **batched** into
+//! one prompt, delivered to a **named** agent's pty, and **kept pinned** afterwards so the
+//! revision can be checked against them.
+//!
+//! Spec of record: `design_handoff_jerry_ade/revision 5/AUDIT-2026-08-13-competitive-v2.md`
+//! §6 top-5 #2, `STAGE-A-CHANGELOG.md` §1 (the two `§6.2` rows) and §3's verification list, and
+//! `Jerry.dc.html`'s `Review · uncommitted` state for the markup.
+//!
+//! ## The three rules, and where each one lives
+//!
+//! The audit is explicit that this is Orca's `Annotate AI Diff` *"including the parts they learned
+//! the hard way"*, and it names three:
+//!
+//! 1. **Batch.** *"sending comments one at a time causes the agent to swing back and forth"*.
+//!    [`prompt`] composes every note on the file into **one** string, and
+//!    [`crate::terminal::pane::TerminalPane::send_prompt`] delivers it with exactly **one**
+//!    submit byte. That is not a convention here, it is a checked invariant - see `send_prompt`'s
+//!    own docs for the real, reachable way a multi-line payload would otherwise become N separate
+//!    messages, and the refusal that stops it.
+//! 2. **Send from the top of the diff.** [`render`]'s notes bar, above the hunks.
+//! 3. **Keep them pinned after the revision.** [`flow`]'s send path only ever *sets*
+//!    [`ReviewNote::sent`]; there is no code path anywhere in this folder that removes a note as
+//!    a consequence of sending one.
+//!
+//! ## Layout
+//!
+//! Split the way every feature folder in this crate is (see `crate::provenance`'s own docs):
+//!
+//! - this file - the pure, GPUI-free model: what a note is, what it is anchored to, and the
+//!   draft/sent state machine.
+//! - [`prompt`] - the pure composition of a batch of notes into the one string that goes down the
+//!   pty, including the two delivery forms and the sanitisation that keeps a note's text from
+//!   ever being read as terminal control input.
+//! - [`persist_state`] - `review-notes.toml`, so a note survives closing the file and the app.
+//! - [`flow`] - the `impl AdeApp` glue: toggling a note on a line, typing into one, resolving the
+//!   target agent, and the send itself.
+//! - [`render`] - the notes bar and the pinned card. The only module here that knows a colour.
+
+pub mod flow;
+#[cfg(test)]
+mod integration_tests;
+pub mod persist_state;
+pub mod prompt;
+pub mod render;
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+/// Which line of a diff a note is pinned beneath.
+///
+/// **Not a row index.** `Jerry.dc.html`'s own `noteDefs` key notes by their position in the
+/// rendered line array, which is fine for a mock whose diff never changes and fatal here: this
+/// app re-reads the working tree constantly, and a row index would silently re-anchor every note
+/// on a file the moment a hunk above it grew by a line. The issue's requirement is that notes are
+/// *"keyed per worktree + path + line"*, and the only stable meaning of "line" in a unified diff
+/// is a **file** line number.
+///
+/// Two variants rather than one number, because a unified diff has two line-number columns and a
+/// removed line genuinely has no new-file number at all. *"Why did you delete this?"* is a real
+/// review note, so removed lines have to be annotatable; collapsing both columns into one integer
+/// would make old line 7 and new line 7 the same anchor, which they are not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum NoteAnchor {
+    /// A line that exists in the new file - an added line, or a context line.
+    New(usize),
+    /// A removed line, by its old-file number. It has no new-file number to key on.
+    Old(usize),
+}
+
+impl NoteAnchor {
+    /// The anchor for a diff line whose gutter numbers are `(old, new)` -
+    /// `crate::sidebar::changes::hunk_line_numbers`' own output shape.
+    ///
+    /// New wins when both are present (a context line is a line of the file as it stands now).
+    /// `None` for a line with neither, which is not a shape git produces but is what the numbers
+    /// degrade to when they cannot be parsed - and a line whose own identity is unknown is a line
+    /// no note can honestly be pinned to.
+    pub fn from_gutter(numbers: (Option<usize>, Option<usize>)) -> Option<NoteAnchor> {
+        match numbers {
+            (_, Some(new)) => Some(NoteAnchor::New(new)),
+            (Some(old), None) => Some(NoteAnchor::Old(old)),
+            (None, None) => None,
+        }
+    }
+
+    /// How this anchor names itself inside the batched prompt - the phrase the agent reads.
+    pub fn prompt_label(self) -> String {
+        match self {
+            NoteAnchor::New(line) => format!("line {line}"),
+            NoteAnchor::Old(line) => format!("removed line {line}"),
+        }
+    }
+
+    /// The persisted-state key, and the debug-selector suffix. Tagged, so the two columns can
+    /// never collide - the same "injective by construction, not by luck" rule
+    /// `crate::review::state::encode_worktree` states for its own encoding.
+    pub fn encode(self) -> String {
+        match self {
+            NoteAnchor::New(line) => format!("new:{line}"),
+            NoteAnchor::Old(line) => format!("old:{line}"),
+        }
+    }
+
+    /// The inverse of [`Self::encode`]. `None` - not a panic and not a guess - for anything this
+    /// build cannot read, so a hand-edited or future-version state file costs one dropped note
+    /// rather than the whole file's notes.
+    pub fn decode(key: &str) -> Option<NoteAnchor> {
+        let (tag, number) = key.split_once(':')?;
+        let line = number.parse().ok()?;
+        match tag {
+            "new" => Some(NoteAnchor::New(line)),
+            "old" => Some(NoteAnchor::Old(line)),
+            _ => None,
+        }
+    }
+}
+
+/// The `draft`/`sent` mark on a card, and the word it renders as.
+///
+/// Derived from [`ReviewNote`] rather than stored beside it - see [`ReviewNote::mark`] for why
+/// that is the whole of the issue's "editing after send starts a new draft state" requirement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NoteMark {
+    /// Written, not yet delivered - or delivered and since edited.
+    Draft,
+    /// Delivered to an agent exactly as it currently reads.
+    Sent,
+}
+
+impl NoteMark {
+    /// The card's own word, verbatim from `Jerry.dc.html`'s `noteMark`.
+    pub fn label(self) -> &'static str {
+        match self {
+            NoteMark::Draft => "draft",
+            NoteMark::Sent => "sent",
+        }
+    }
+}
+
+/// One review note.
+///
+/// `sent` is **the exact text that was delivered**, not a boolean, and that is the whole of the
+/// issue's *"Editing after send starts a new draft state for that note"* requirement: with a
+/// boolean, editing a sent note would either leave it claiming `sent` (a lie - the agent never saw
+/// this wording) or clear the flag outright (also a lie - something *was* sent, and the review
+/// history is supposed to stay honest). Keeping the delivered wording means the card can go back
+/// to `draft` while still being able to say what the agent actually received.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ReviewNote {
+    /// What the note says right now.
+    pub text: String,
+    /// The exact text last delivered to an agent, if this note has ever been sent.
+    pub sent: Option<String>,
+}
+
+impl ReviewNote {
+    /// A note with nothing typed into it yet - what a click on a bare diff line creates.
+    pub fn empty() -> ReviewNote {
+        ReviewNote::default()
+    }
+
+    /// Whether this note carries any real text at all. An empty note is a click, not a note: it
+    /// is never delivered, never counted, and is discarded the moment it loses focus.
+    pub fn is_blank(&self) -> bool {
+        self.text.trim().is_empty()
+    }
+
+    /// The card's mark. `sent` **only** while the delivered wording and the current wording are
+    /// the same string.
+    pub fn mark(&self) -> NoteMark {
+        match self.sent.as_deref() {
+            Some(sent) if sent == self.text => NoteMark::Sent,
+            _ => NoteMark::Draft,
+        }
+    }
+
+    /// What the agent was actually told, for a note that has been sent and then edited - the
+    /// honest half of the draft/sent history, surfaced as the card's tooltip.
+    pub fn superseded_text(&self) -> Option<&str> {
+        match self.sent.as_deref() {
+            Some(sent) if sent != self.text => Some(sent),
+            _ => None,
+        }
+    }
+}
+
+/// One note's address inside a worktree: which file, and which line of it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NoteRef {
+    pub path: PathBuf,
+    pub anchor: NoteAnchor,
+}
+
+impl NoteRef {
+    pub fn new(path: impl Into<PathBuf>, anchor: NoteAnchor) -> NoteRef {
+        NoteRef {
+            path: path.into(),
+            anchor,
+        }
+    }
+}
+
+/// Every review note this window is holding, keyed worktree -> path -> anchor.
+///
+/// Nested rather than flat, for the same two reasons `crate::provenance::store` is: the persisted
+/// shape is the same nesting, and every real read here is *"the notes on this one open file"*,
+/// which a flat map would have to scan for.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct NoteStore {
+    worktrees: BTreeMap<PathBuf, BTreeMap<PathBuf, BTreeMap<NoteAnchor, ReviewNote>>>,
+}
+
+impl NoteStore {
+    /// Every note on one file, in anchor order.
+    pub fn file(&self, worktree: &Path, path: &Path) -> Option<&BTreeMap<NoteAnchor, ReviewNote>> {
+        self.worktrees.get(worktree)?.get(path)
+    }
+
+    /// One note.
+    pub fn note(&self, worktree: &Path, path: &Path, anchor: NoteAnchor) -> Option<&ReviewNote> {
+        self.file(worktree, path)?.get(&anchor)
+    }
+
+    /// Whether a note is pinned on this line at all - the diff row's own `●` predicate, and the
+    /// one read that happens per rendered row.
+    pub fn has_note(&self, worktree: &Path, path: &Path, anchor: NoteAnchor) -> bool {
+        self.note(worktree, path, anchor).is_some()
+    }
+
+    /// Every anchor on one file that carries a note, which is exactly what the diff view's row
+    /// plan needs and all it needs.
+    pub fn anchors(&self, worktree: &Path, path: &Path) -> Vec<NoteAnchor> {
+        self.file(worktree, path)
+            .map(|notes| notes.keys().copied().collect())
+            .unwrap_or_default()
+    }
+
+    /// The notes on one file that would really be delivered - every non-blank one, in anchor
+    /// order. Blank cards are clicks that have not become notes yet.
+    pub fn deliverable(&self, worktree: &Path, path: &Path) -> Vec<(NoteAnchor, &ReviewNote)> {
+        self.file(worktree, path)
+            .map(|notes| {
+                notes
+                    .iter()
+                    .filter(|(_, note)| !note.is_blank())
+                    .map(|(anchor, note)| (*anchor, note))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Pins an empty note on a line that has none. Returns whether one was really created, so the
+    /// caller can tell "opened a new note" from "focused the one already there".
+    pub fn begin(&mut self, worktree: &Path, path: &Path, anchor: NoteAnchor) -> bool {
+        let file = self
+            .worktrees
+            .entry(worktree.to_path_buf())
+            .or_default()
+            .entry(path.to_path_buf())
+            .or_default();
+        if file.contains_key(&anchor) {
+            return false;
+        }
+        file.insert(anchor, ReviewNote::empty());
+        true
+    }
+
+    /// Writes a note's text. Creates the note if it is not there yet, so the editing path never
+    /// has to care whether the click that opened it already landed.
+    pub fn set_text(&mut self, worktree: &Path, path: &Path, anchor: NoteAnchor, text: &str) {
+        self.worktrees
+            .entry(worktree.to_path_buf())
+            .or_default()
+            .entry(path.to_path_buf())
+            .or_default()
+            .entry(anchor)
+            .or_default()
+            .text = text.to_string();
+    }
+
+    /// Removes a note. Returns whether one was really there.
+    ///
+    /// The **only** removal path in this folder, and it is reachable from exactly two places -
+    /// a card that lost focus with nothing typed into it, and the explicit toggle-off of such a
+    /// card. Nothing about sending calls it: *"it never clears the notes"* is structural here,
+    /// not a rule the send path has to remember.
+    pub fn remove(&mut self, worktree: &Path, path: &Path, anchor: NoteAnchor) -> bool {
+        let Some(files) = self.worktrees.get_mut(worktree) else {
+            return false;
+        };
+        let Some(file) = files.get_mut(path) else {
+            return false;
+        };
+        let removed = file.remove(&anchor).is_some();
+        if file.is_empty() {
+            files.remove(path);
+        }
+        if files.is_empty() {
+            self.worktrees.remove(worktree);
+        }
+        removed
+    }
+
+    /// Discards a note that was opened and never written into. Returns whether one really went.
+    pub fn discard_if_blank(&mut self, worktree: &Path, path: &Path, anchor: NoteAnchor) -> bool {
+        match self.note(worktree, path, anchor) {
+            Some(note) if note.is_blank() => self.remove(worktree, path, anchor),
+            _ => false,
+        }
+    }
+
+    /// Records that every deliverable note on this file has just been sent, exactly as it reads
+    /// now. Returns how many notes were marked.
+    ///
+    /// Blank cards are deliberately skipped rather than marked: nothing about them went down the
+    /// pty, so nothing about them may claim to have.
+    pub fn mark_sent(&mut self, worktree: &Path, path: &Path) -> usize {
+        let Some(file) = self
+            .worktrees
+            .get_mut(worktree)
+            .and_then(|files| files.get_mut(path))
+        else {
+            return 0;
+        };
+        let mut marked = 0;
+        for note in file.values_mut() {
+            if note.is_blank() {
+                continue;
+            }
+            note.sent = Some(note.text.clone());
+            marked += 1;
+        }
+        marked
+    }
+
+    /// The bar's own state for one file: how many real notes it carries, and whether every one of
+    /// them has been delivered exactly as it currently reads.
+    ///
+    /// The second half is what makes the bar honest after an edit: `STAGE-A-CHANGELOG.md` §1 has
+    /// the bar flip to *"N notes sent — awaiting revision"* on send, and the issue then requires
+    /// that editing a sent note goes back to being a draft. A per-file boolean (which is what the
+    /// mock stores) would leave the bar claiming the agent had seen wording it never saw.
+    pub fn file_state(&self, worktree: &Path, path: &Path) -> FileNoteState {
+        let notes = self.deliverable(worktree, path);
+        FileNoteState {
+            count: notes.len(),
+            all_sent: !notes.is_empty()
+                && notes.iter().all(|(_, note)| note.mark() == NoteMark::Sent),
+        }
+    }
+
+    /// Every worktree this store holds notes for - the persistence layer's ownership set.
+    pub fn worktrees(&self) -> impl Iterator<Item = &PathBuf> {
+        self.worktrees.keys()
+    }
+
+    /// Every file with notes in one worktree, for persistence.
+    pub fn files(
+        &self,
+        worktree: &Path,
+    ) -> Option<&BTreeMap<PathBuf, BTreeMap<NoteAnchor, ReviewNote>>> {
+        self.worktrees.get(worktree)
+    }
+
+    /// Restores one note straight from persisted state, without going through the editing path.
+    pub fn restore(&mut self, worktree: &Path, path: &Path, anchor: NoteAnchor, note: ReviewNote) {
+        self.worktrees
+            .entry(worktree.to_path_buf())
+            .or_default()
+            .entry(path.to_path_buf())
+            .or_default()
+            .insert(anchor, note);
+    }
+}
+
+/// What the notes bar needs to know about the open file - see [`NoteStore::file_state`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FileNoteState {
+    /// How many real (non-blank) notes are pinned on the file.
+    pub count: usize,
+    /// Whether every one of them has been delivered exactly as it currently reads.
+    pub all_sent: bool,
+}
+
+/// The pure model: anchoring, the draft/sent state machine, and the two rules that are structural
+/// rather than remembered (sending never removes, blank is never a note).
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn wt() -> PathBuf {
+        PathBuf::from("/repo/wt-a")
+    }
+
+    fn file() -> PathBuf {
+        PathBuf::from("src/api/users.rs")
+    }
+
+    /// A context line has both numbers; the new one wins, because a context line is a line of the
+    /// file as it stands now and that is what an agent will go and read.
+    #[test]
+    fn a_line_with_both_numbers_anchors_to_the_new_file() {
+        assert_eq!(
+            NoteAnchor::from_gutter((Some(7), Some(9))),
+            Some(NoteAnchor::New(9))
+        );
+        assert_eq!(
+            NoteAnchor::from_gutter((None, Some(9))),
+            Some(NoteAnchor::New(9))
+        );
+    }
+
+    /// The half a single-integer key would have lost: a removed line is annotatable, and its
+    /// anchor is a different thing from the new-file line of the same number.
+    #[test]
+    fn a_removed_line_anchors_to_its_old_number_and_never_collides_with_a_new_one() {
+        assert_eq!(
+            NoteAnchor::from_gutter((Some(7), None)),
+            Some(NoteAnchor::Old(7))
+        );
+        assert_ne!(NoteAnchor::Old(7), NoteAnchor::New(7));
+        assert_ne!(NoteAnchor::Old(7).encode(), NoteAnchor::New(7).encode());
+    }
+
+    /// A line whose own identity is unknown carries no note, rather than one pinned to a guess.
+    #[test]
+    fn a_line_with_no_numbers_at_all_cannot_be_anchored() {
+        assert_eq!(NoteAnchor::from_gutter((None, None)), None);
+    }
+
+    #[test]
+    fn an_anchor_round_trips_through_its_persisted_key_and_rejects_anything_else() {
+        for anchor in [NoteAnchor::New(1), NoteAnchor::Old(4_000)] {
+            assert_eq!(NoteAnchor::decode(&anchor.encode()), Some(anchor));
+        }
+        assert_eq!(NoteAnchor::decode("sideways:3"), None);
+        assert_eq!(NoteAnchor::decode("new:three"), None);
+        assert_eq!(NoteAnchor::decode("new"), None);
+    }
+
+    /// The exact acceptance sequence's state half, at the level the model decides it.
+    #[test]
+    fn a_note_is_draft_until_it_is_sent_and_sent_only_while_it_still_reads_that_way() {
+        let mut store = NoteStore::default();
+        assert!(store.begin(&wt(), &file(), NoteAnchor::New(13)));
+        store.set_text(&wt(), &file(), NoteAnchor::New(13), "needs tenant_id");
+
+        assert_eq!(
+            store
+                .note(&wt(), &file(), NoteAnchor::New(13))
+                .expect("the note")
+                .mark(),
+            NoteMark::Draft
+        );
+        assert_eq!(
+            store.file_state(&wt(), &file()),
+            FileNoteState {
+                count: 1,
+                all_sent: false
+            }
+        );
+
+        assert_eq!(store.mark_sent(&wt(), &file()), 1);
+        assert_eq!(
+            store
+                .note(&wt(), &file(), NoteAnchor::New(13))
+                .expect("the note is still there - sending never clears it")
+                .mark(),
+            NoteMark::Sent
+        );
+        assert_eq!(
+            store.file_state(&wt(), &file()),
+            FileNoteState {
+                count: 1,
+                all_sent: true
+            }
+        );
+    }
+
+    /// *"Editing after send starts a new draft state for that note"* - and the record of what was
+    /// really delivered survives the edit, which is the half a boolean flag would have thrown away.
+    #[test]
+    fn editing_a_sent_note_goes_back_to_draft_without_losing_what_was_actually_sent() {
+        let mut store = NoteStore::default();
+        store.set_text(
+            &wt(),
+            &file(),
+            NoteAnchor::New(5),
+            "drops the page argument",
+        );
+        store.mark_sent(&wt(), &file());
+        store.set_text(
+            &wt(),
+            &file(),
+            NoteAnchor::New(5),
+            "drops the page argument, and the limit",
+        );
+
+        let note = store
+            .note(&wt(), &file(), NoteAnchor::New(5))
+            .expect("the note");
+        assert_eq!(
+            note.mark(),
+            NoteMark::Draft,
+            "the agent has not seen this wording, so the card must not claim it has"
+        );
+        assert_eq!(
+            note.superseded_text(),
+            Some("drops the page argument"),
+            "and what it really was told must still be recoverable - the review history stays \
+             honest"
+        );
+        assert!(
+            !store.file_state(&wt(), &file()).all_sent,
+            "so the bar goes back to counting notes rather than claiming a revision is awaited"
+        );
+    }
+
+    /// The requirement stated as a property of the type rather than of the send path: the store's
+    /// send-side operation cannot remove anything, whatever it is handed.
+    #[test]
+    fn marking_a_file_sent_never_removes_a_note() {
+        let mut store = NoteStore::default();
+        store.set_text(&wt(), &file(), NoteAnchor::New(5), "one");
+        store.set_text(&wt(), &file(), NoteAnchor::Old(7), "two");
+        store.begin(&wt(), &file(), NoteAnchor::New(9)); // blank - opened, never written into
+
+        let before = store.anchors(&wt(), &file());
+        store.mark_sent(&wt(), &file());
+        assert_eq!(
+            store.anchors(&wt(), &file()),
+            before,
+            "every anchor, including the blank one, is still pinned after a send"
+        );
+    }
+
+    /// A blank card is a click, not a note: it is never counted and never delivered.
+    #[test]
+    fn a_blank_card_is_not_a_note() {
+        let mut store = NoteStore::default();
+        store.begin(&wt(), &file(), NoteAnchor::New(5));
+        store.set_text(&wt(), &file(), NoteAnchor::New(9), "   ");
+
+        assert_eq!(store.file_state(&wt(), &file()).count, 0);
+        assert!(store.deliverable(&wt(), &file()).is_empty());
+        assert_eq!(
+            store.mark_sent(&wt(), &file()),
+            0,
+            "and nothing about it may claim to have been sent"
+        );
+        assert_eq!(
+            store
+                .note(&wt(), &file(), NoteAnchor::New(5))
+                .expect("still pinned while it is being typed into")
+                .mark(),
+            NoteMark::Draft
+        );
+    }
+
+    #[test]
+    fn discarding_a_blank_card_leaves_a_written_one_alone() {
+        let mut store = NoteStore::default();
+        store.begin(&wt(), &file(), NoteAnchor::New(5));
+        store.set_text(&wt(), &file(), NoteAnchor::New(9), "real");
+
+        assert!(store.discard_if_blank(&wt(), &file(), NoteAnchor::New(5)));
+        assert!(!store.discard_if_blank(&wt(), &file(), NoteAnchor::New(9)));
+        assert_eq!(store.anchors(&wt(), &file()), vec![NoteAnchor::New(9)]);
+    }
+
+    /// Notes on one file must never be visible on another, or in another checkout of the same
+    /// path - the issue's "keyed per worktree + path + line".
+    #[test]
+    fn notes_are_keyed_by_worktree_and_path_together() {
+        let mut store = NoteStore::default();
+        store.set_text(&wt(), &file(), NoteAnchor::New(5), "here");
+
+        assert!(store.file(Path::new("/repo/wt-b"), &file()).is_none());
+        assert!(store.file(&wt(), Path::new("src/other.rs")).is_none());
+        assert_eq!(store.deliverable(&wt(), &file()).len(), 1);
+    }
+
+    /// Removing the last note on a path must not leave an empty shell behind that later reads as
+    /// "this file has notes".
+    #[test]
+    fn removing_the_last_note_leaves_no_empty_file_or_worktree_entry() {
+        let mut store = NoteStore::default();
+        store.set_text(&wt(), &file(), NoteAnchor::New(5), "one");
+        assert!(store.remove(&wt(), &file(), NoteAnchor::New(5)));
+        assert!(store.file(&wt(), &file()).is_none());
+        assert_eq!(store.worktrees().count(), 0);
+        assert!(!store.remove(&wt(), &file(), NoteAnchor::New(5)));
+    }
+}

--- a/crates/app/src/review_notes/persist_state.rs
+++ b/crates/app/src/review_notes/persist_state.rs
@@ -1,0 +1,444 @@
+//! `review-notes.toml` - the sibling file that makes a review note survive scrolling past it,
+//! closing the file, and closing the app.
+//!
+//! The issue's requirement is that notes *"are keyed per worktree + path + line and survive
+//! scrolling/reopening"*. Scrolling alone would only need app state (the diff view is a
+//! `uniform_list`, so a note scrolled off screen stops being an element), but "reopening" means
+//! the working tree can be closed and come back, and a review that evaporates when you look at
+//! another file is not a review. So this is real durable state, in exactly the shape every other
+//! persisted Jerry state already takes: a TOML sibling of `settings.toml`, written atomically,
+//! merged under the shared lock so a second window cannot erase notes it knows nothing about.
+//!
+//! Copied deliberately, not abstracted: `crate::provenance::persist_state`,
+//! `crate::review::baseline_state`, `crate::sidebar::fold_state`,
+//! `crate::work_surface::tab_order_state` and `crate::rail::repo` are all the same five methods,
+//! and this project's own convention (see `fold_state::FoldState::save_at`'s docs) is that they
+//! stay parallel rather than growing a framework.
+
+use super::{NoteAnchor, NoteStore, ReviewNote};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::io;
+use std::path::{Component, Path, PathBuf};
+
+/// The file's own name, next to `settings.toml`.
+pub const REVIEW_NOTES_FILE_NAME: &str = "review-notes.toml";
+
+/// Where the notes file lives, given where this instance's real `settings.toml` is.
+pub fn review_notes_path_for(settings_path: &Path) -> PathBuf {
+    match settings_path.parent() {
+        Some(parent) => parent.join(REVIEW_NOTES_FILE_NAME),
+        None => PathBuf::from(REVIEW_NOTES_FILE_NAME),
+    }
+}
+
+/// The whole file: worktree key -> its files.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ReviewNotesState {
+    pub worktrees: BTreeMap<String, PersistedWorktree>,
+}
+
+/// One worktree's files, keyed by `/`-joined relative path.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct PersistedWorktree {
+    pub paths: BTreeMap<String, PersistedFile>,
+}
+
+/// One file's notes, keyed by [`NoteAnchor::encode`].
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct PersistedFile {
+    pub notes: BTreeMap<String, PersistedNote>,
+}
+
+/// One note.
+///
+/// `sent` is the delivered *wording*, not a flag, for the reason [`ReviewNote`] itself records:
+/// the draft/sent mark is derived by comparing it against the current text, so a restart has to
+/// bring the wording back or every previously-sent note would come back reading `draft`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct PersistedNote {
+    pub text: String,
+    /// Absent for a note that has never been delivered. `Option`, not an empty string: "never
+    /// sent" and "sent while empty" would otherwise be the same record, and only one of them is
+    /// reachable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sent: Option<String>,
+}
+
+impl ReviewNotesState {
+    /// Reads the file, or an empty state - a missing file is the ordinary first-run case, and a
+    /// corrupt one costs the notes rather than the launch.
+    pub fn load_at(path: &Path) -> ReviewNotesState {
+        let Ok(contents) = std::fs::read_to_string(path) else {
+            return ReviewNotesState::default();
+        };
+        match toml::from_str::<ReviewNotesState>(&contents) {
+            Ok(state) => state,
+            Err(err) => {
+                log::warn!(
+                    "{} failed to parse ({err}) - starting from no saved review notes",
+                    path.display()
+                );
+                ReviewNotesState::default()
+            }
+        }
+    }
+
+    /// Writes `self` to `path` atomically - a process-unique sibling `*.tmp`, `sync_all`, rename,
+    /// then a parent-directory sync. Same as
+    /// `crate::provenance::persist_state::LineProvenanceState::save_at`; see
+    /// `crate::sidebar::fold_state::FoldState::save_at` for the full reasoning.
+    pub fn save_at(&self, path: &Path) -> io::Result<()> {
+        use std::io::Write;
+
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let contents = toml::to_string_pretty(self)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+        let file_name = path
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| REVIEW_NOTES_FILE_NAME.to_string());
+        static WRITE_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let unique = WRITE_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let temp = path.with_file_name(format!("{file_name}.{}.{unique}.tmp", std::process::id()));
+
+        let write_result = (|| -> io::Result<()> {
+            let mut file = std::fs::File::create(&temp)?;
+            file.write_all(contents.as_bytes())?;
+            file.sync_all()
+        })();
+        if let Err(err) = write_result {
+            let _ = std::fs::remove_file(&temp);
+            return Err(err);
+        }
+        if let Err(err) = std::fs::rename(&temp, path) {
+            let _ = std::fs::remove_file(&temp);
+            return Err(err);
+        }
+        if let Some(parent) = path.parent() {
+            if let Ok(dir) = std::fs::File::open(parent) {
+                let _ = dir.sync_all();
+            }
+        }
+        Ok(())
+    }
+
+    /// The app's real write path: replaces only the worktree keys this window has actually
+    /// touched, so a second window reviewing a different worktree cannot erase notes it knows
+    /// nothing about.
+    ///
+    /// A key this window owns and now holds nothing for **is** removed - deleting your last note
+    /// on a worktree has to be able to stick. Same asymmetry as
+    /// `LineProvenanceState::save_merged_at`, and for the same reason: this is live state, not
+    /// history.
+    pub fn save_merged_at(&self, path: &Path, owned: &BTreeSet<String>) -> io::Result<()> {
+        crate::persisted_state_lock::with_locked_merge(|| {
+            let mut merged = ReviewNotesState::load_at(path);
+            for key in owned {
+                match self.worktrees.get(key) {
+                    Some(entry) => merged.worktrees.insert(key.clone(), entry.clone()),
+                    None => merged.worktrees.remove(key),
+                };
+            }
+            merged.save_at(path)
+        })
+    }
+
+    /// Snapshots a live store into persistable form.
+    ///
+    /// Blank notes are skipped: a card that was opened and never written into is a click, and
+    /// writing it out would restore a phantom card on the next launch.
+    pub fn capture(store: &NoteStore) -> ReviewNotesState {
+        let mut state = ReviewNotesState::default();
+        for worktree in store.worktrees() {
+            let Some(files) = store.files(worktree) else {
+                continue;
+            };
+            let mut paths: BTreeMap<String, PersistedFile> = BTreeMap::new();
+            for (relative, notes) in files {
+                let Some(key) = relative_key(relative) else {
+                    continue;
+                };
+                let mut persisted: BTreeMap<String, PersistedNote> = BTreeMap::new();
+                for (anchor, note) in notes {
+                    if note.is_blank() {
+                        continue;
+                    }
+                    persisted.insert(
+                        anchor.encode(),
+                        PersistedNote {
+                            text: note.text.clone(),
+                            sent: note.sent.clone(),
+                        },
+                    );
+                }
+                if persisted.is_empty() {
+                    continue;
+                }
+                paths.insert(key, PersistedFile { notes: persisted });
+            }
+            if paths.is_empty() {
+                continue;
+            }
+            state.worktrees.insert(
+                crate::review::state::encode_worktree(worktree),
+                PersistedWorktree { paths },
+            );
+        }
+        state
+    }
+
+    /// Loads this state into a live store. Returns `(restored, discarded)` - a hand-edited or
+    /// future-version file costs the rows this build cannot read, never the launch.
+    pub fn restore_into(&self, store: &mut NoteStore) -> (usize, usize) {
+        let mut restored = 0usize;
+        let mut discarded = 0usize;
+        for (worktree_key, worktree) in &self.worktrees {
+            let Some(worktree_path) = crate::review::state::decode_worktree(worktree_key) else {
+                discarded += worktree
+                    .paths
+                    .values()
+                    .map(|file| file.notes.len())
+                    .sum::<usize>();
+                continue;
+            };
+            for (path_key, file) in &worktree.paths {
+                let Some(relative) = path_from_key(path_key) else {
+                    discarded += file.notes.len();
+                    continue;
+                };
+                for (anchor_key, note) in &file.notes {
+                    let Some(anchor) = NoteAnchor::decode(anchor_key) else {
+                        discarded += 1;
+                        continue;
+                    };
+                    if note.text.trim().is_empty() {
+                        discarded += 1;
+                        continue;
+                    }
+                    store.restore(
+                        &worktree_path,
+                        &relative,
+                        anchor,
+                        ReviewNote {
+                            text: note.text.clone(),
+                            sent: note.sent.clone(),
+                        },
+                    );
+                    restored += 1;
+                }
+            }
+        }
+        (restored, discarded)
+    }
+}
+
+/// A worktree-relative path as a `/`-joined key. `None` for anything that is not a plain relative
+/// path, which is the write-side half of the traversal guard below.
+fn relative_key(relative: &Path) -> Option<String> {
+    let mut parts: Vec<&str> = Vec::new();
+    for component in relative.components() {
+        match component {
+            Component::Normal(part) => parts.push(part.to_str()?),
+            _ => return None,
+        }
+    }
+    (!parts.is_empty()).then(|| parts.join("/"))
+}
+
+/// The read-side inverse, with the traversal guard a hand-editable file needs - identical to
+/// `crate::provenance::persist_state`'s own, and load-bearing for the same reason: a key naming
+/// `..` must never resolve to something outside the worktree it is filed under.
+fn path_from_key(key: &str) -> Option<PathBuf> {
+    if key.is_empty() || key.contains('\\') {
+        return None;
+    }
+    let mut path = PathBuf::new();
+    for part in key.split('/') {
+        if part.is_empty() || part == "." || part == ".." {
+            return None;
+        }
+        path.push(part);
+    }
+    Some(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn wt() -> PathBuf {
+        PathBuf::from("/repo/wt-a")
+    }
+
+    fn file() -> PathBuf {
+        PathBuf::from("src/api/users.rs")
+    }
+
+    fn seeded() -> NoteStore {
+        let mut store = NoteStore::default();
+        store.set_text(&wt(), &file(), NoteAnchor::New(13), "needs tenant_id");
+        store.set_text(&wt(), &file(), NoteAnchor::Old(7), "why did this go?");
+        store.mark_sent(&wt(), &file());
+        store.set_text(
+            &wt(),
+            &file(),
+            NoteAnchor::New(5),
+            "drops the page argument",
+        );
+        store
+    }
+
+    /// The whole point: a note - and, critically, its *sent* wording - comes back exactly as it
+    /// went out, so a restart cannot turn a sent note back into a draft.
+    #[test]
+    fn a_store_round_trips_through_a_real_file_with_its_draft_and_sent_states_intact() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = review_notes_path_for(&dir.path().join("settings.toml"));
+
+        ReviewNotesState::capture(&seeded())
+            .save_at(&path)
+            .expect("save");
+        assert!(path.exists(), "a real file, next to settings.toml");
+
+        let mut restored = NoteStore::default();
+        let (ok, dropped) = ReviewNotesState::load_at(&path).restore_into(&mut restored);
+        assert_eq!((ok, dropped), (3, 0));
+        assert_eq!(
+            restored,
+            seeded(),
+            "including which notes had been delivered and exactly what they said when they were"
+        );
+        assert!(
+            restored.file_state(&wt(), &file()).count == 3
+                && !restored.file_state(&wt(), &file()).all_sent,
+            "and the derived bar state comes back with it"
+        );
+    }
+
+    /// A blank card is a click. It must not survive a restart as a phantom note.
+    #[test]
+    fn a_blank_card_is_never_written_out() {
+        let mut store = NoteStore::default();
+        store.begin(&wt(), &file(), NoteAnchor::New(5));
+        let state = ReviewNotesState::capture(&store);
+        assert!(
+            state.worktrees.is_empty(),
+            "a worktree whose only card is blank has nothing to persist"
+        );
+    }
+
+    /// A hand-edited file must cost the rows this build cannot read, not the launch, and must
+    /// never resolve a path outside the worktree it is filed under.
+    #[test]
+    fn unreadable_rows_are_discarded_rather_than_trusted() {
+        let mut state = ReviewNotesState::default();
+        let mut paths = BTreeMap::new();
+        paths.insert(
+            "../../etc/passwd".to_string(),
+            PersistedFile {
+                notes: BTreeMap::from([(
+                    "new:1".to_string(),
+                    PersistedNote {
+                        text: "escape".to_string(),
+                        sent: None,
+                    },
+                )]),
+            },
+        );
+        paths.insert(
+            "src/api/users.rs".to_string(),
+            PersistedFile {
+                notes: BTreeMap::from([
+                    (
+                        "sideways:3".to_string(),
+                        PersistedNote {
+                            text: "unreadable anchor".to_string(),
+                            sent: None,
+                        },
+                    ),
+                    (
+                        "new:5".to_string(),
+                        PersistedNote {
+                            text: "readable".to_string(),
+                            sent: None,
+                        },
+                    ),
+                ]),
+            },
+        );
+        state.worktrees.insert(
+            crate::review::state::encode_worktree(&wt()),
+            PersistedWorktree { paths },
+        );
+
+        let mut store = NoteStore::default();
+        let (ok, dropped) = state.restore_into(&mut store);
+        assert_eq!((ok, dropped), (1, 2));
+        assert_eq!(store.anchors(&wt(), &file()), vec![NoteAnchor::New(5)]);
+        assert!(
+            store
+                .files(&wt())
+                .expect("the worktree")
+                .keys()
+                .all(|path| path == &file()),
+            "the traversal key must resolve to nothing at all, not to something outside the \
+             worktree"
+        );
+    }
+
+    /// A second window's worktree must survive this window's write.
+    #[test]
+    fn merging_leaves_another_windows_worktree_alone_and_still_lets_a_deletion_stick() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = review_notes_path_for(&dir.path().join("settings.toml"));
+
+        let mut other = NoteStore::default();
+        other.set_text(
+            Path::new("/repo/wt-b"),
+            &file(),
+            NoteAnchor::New(1),
+            "another window's note",
+        );
+        ReviewNotesState::capture(&other)
+            .save_at(&path)
+            .expect("seed the other window's notes");
+
+        let owned = BTreeSet::from([crate::review::state::encode_worktree(&wt())]);
+        ReviewNotesState::capture(&seeded())
+            .save_merged_at(&path, &owned)
+            .expect("merge");
+
+        let mut merged = NoteStore::default();
+        ReviewNotesState::load_at(&path).restore_into(&mut merged);
+        assert_eq!(merged.file_state(&wt(), &file()).count, 3);
+        assert_eq!(
+            merged.file_state(Path::new("/repo/wt-b"), &file()).count,
+            1,
+            "the other window's worktree is untouched"
+        );
+
+        // And this window deleting its last note really removes its rows.
+        ReviewNotesState::capture(&NoteStore::default())
+            .save_merged_at(&path, &owned)
+            .expect("merge an emptied store");
+        let mut after = NoteStore::default();
+        ReviewNotesState::load_at(&path).restore_into(&mut after);
+        assert_eq!(after.file_state(&wt(), &file()).count, 0);
+        assert_eq!(after.file_state(Path::new("/repo/wt-b"), &file()).count, 1);
+    }
+
+    #[test]
+    fn the_file_sits_next_to_settings_toml() {
+        assert_eq!(
+            review_notes_path_for(Path::new("/home/x/.config/jerry/settings.toml")),
+            PathBuf::from("/home/x/.config/jerry/review-notes.toml")
+        );
+    }
+}

--- a/crates/app/src/review_notes/prompt.rs
+++ b/crates/app/src/review_notes/prompt.rs
@@ -1,0 +1,281 @@
+//! The batched prompt: every review note on one file, composed into **one** string, in the two
+//! forms a pty can actually carry it.
+//!
+//! Pure and GPUI-free, because the one thing this feature must not get wrong is what it types into
+//! somebody's running agent, and that has to be assertable without a window.
+//!
+//! ## Why there are two forms
+//!
+//! `AUDIT-2026-08-13-competitive-v2.md` §6 top-5 #2 is built on one hard-won competitor finding:
+//! *"sending comments one at a time causes the agent to swing back and forth"*. So the whole
+//! feature is worthless unless delivery is genuinely **one** message. On a pty that is not a
+//! property of the text, it is a property of the bytes:
+//!
+//! - With **bracketed paste** on (`DECSET 2004`, which every full-screen agent TUI turns on while
+//!   its prompt is up), `ESC[200~ … ESC[201~` tells the receiving program the whole blob was
+//!   pasted. Newlines inside it are just newlines - the program does not run each line. One
+//!   trailing `\r` then submits the lot. This is the form worth reading, so it is the one used
+//!   whenever it is available.
+//! - With bracketed paste **off**, `crate::terminal::pane::paste_payload` normalises every `\n`
+//!   to `\r`, which is the Enter byte. A five-line prompt would arrive as **five** submissions -
+//!   exactly the failure mode this feature exists to prevent, and it would look like it worked.
+//!   So the fallback form contains no line breaks at all: the same sentences, joined with the
+//!   design's own `·` separator, delivered with one `\r`.
+//!
+//! Both forms are one submission. [`crate::terminal::pane::TerminalPane::send_prompt`] enforces
+//! that rather than trusting it - see its own docs.
+
+use super::{NoteAnchor, ReviewNote};
+use crate::root::plural;
+use std::path::Path;
+
+/// The separator the single-line delivery form joins its lines with - the design's own `·`, the
+/// same glyph every meta line in this app already uses to join two facts on one row.
+const FLAT_SEPARATOR: &str = " \u{b7} ";
+
+/// One batched, line-anchored prompt, as its own lines, before either delivery form is chosen.
+///
+/// Kept as lines rather than one pre-joined string precisely so [`Self::for_delivery`] can pick
+/// the joiner, and so the tests can read the composition and the framing apart.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BatchedPrompt {
+    lines: Vec<String>,
+    /// How many real notes went into it - what the bar counts and what the caller marks sent.
+    pub note_count: usize,
+}
+
+impl BatchedPrompt {
+    /// Composes every note on `path` into one prompt.
+    ///
+    /// `notes` arrives in the order the notes are **pinned in the diff**, top to bottom, which is
+    /// the order the reviewer wrote them in and the order the agent will read the file in.
+    ///
+    /// `None` when there is nothing real to send. A prompt for zero notes is not an empty prompt,
+    /// it is not a prompt.
+    pub fn compose(path: &Path, notes: &[(NoteAnchor, &ReviewNote)]) -> Option<BatchedPrompt> {
+        let notes: Vec<(NoteAnchor, &ReviewNote)> = notes
+            .iter()
+            .filter(|(_, note)| !note.is_blank())
+            .copied()
+            .collect();
+        if notes.is_empty() {
+            return None;
+        }
+
+        let mut lines = Vec::with_capacity(notes.len() + 2);
+        lines.push(format!(
+            "Review notes on {} \u{2014} {}, one prompt, line-anchored.",
+            sanitize(&path.display().to_string()),
+            plural::count(notes.len(), "note", None)
+        ));
+        for (anchor, note) in &notes {
+            lines.push(format!(
+                "{}: {}",
+                anchor.prompt_label(),
+                sanitize(note.text.trim())
+            ));
+        }
+        lines.push(
+            "Please address every note above in one revision, then tell me what you changed."
+                .to_string(),
+        );
+
+        Some(BatchedPrompt {
+            note_count: notes.len(),
+            lines,
+        })
+    }
+
+    /// The prompt's own lines, for tests and for anything that wants to show what will be sent.
+    pub fn lines(&self) -> &[String] {
+        &self.lines
+    }
+
+    /// The exact text to hand to the pty, given whether the target really has bracketed paste on.
+    ///
+    /// See this module's own docs for why the two differ, and why the difference is a correctness
+    /// requirement rather than a formatting preference.
+    pub fn for_delivery(&self, bracketed_paste: bool) -> String {
+        if bracketed_paste {
+            self.lines.join("\n")
+        } else {
+            self.lines.join(FLAT_SEPARATOR)
+        }
+    }
+}
+
+/// Strips every control character out of text that is about to be typed into a terminal.
+///
+/// A review note is text the user wrote, not text the user is trusted to have written *for a
+/// terminal*: a pasted stack trace or a snippet copied out of a log can genuinely contain `ESC`,
+/// and `ESC` in a payload is not a character, it is an instruction. `paste_payload`'s own bracket
+/// guard already strips `ESC` on the bracketed path (a note containing `ESC[201~` could otherwise
+/// close the paste early and have the rest read as commands), but the flat path has no such guard
+/// and `\r`/`\n`/`\t` matter there too - a stray `\r` in a note would be a second submission, the
+/// one thing this whole module exists to make impossible.
+///
+/// Replaced with a space rather than removed, so two words never silently fuse into one.
+fn sanitize(text: &str) -> String {
+    text.chars()
+        .map(|ch| if ch.is_control() { ' ' } else { ch })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn note(text: &str) -> ReviewNote {
+        ReviewNote {
+            text: text.to_string(),
+            sent: None,
+        }
+    }
+
+    fn path() -> PathBuf {
+        PathBuf::from("src/api/users.rs")
+    }
+
+    /// The composition, end to end, against the mock's own two authored notes for this file.
+    #[test]
+    fn a_batch_names_the_file_the_count_and_every_line_it_is_anchored_to() {
+        let first = note("This drops the page argument on the floor.");
+        let second = note("get_or_load caches across tenants.");
+        let prompt = BatchedPrompt::compose(
+            &path(),
+            &[(NoteAnchor::New(5), &first), (NoteAnchor::New(13), &second)],
+        )
+        .expect("two real notes compose a prompt");
+
+        assert_eq!(prompt.note_count, 2);
+        assert_eq!(
+            prompt.lines()[0],
+            "Review notes on src/api/users.rs \u{2014} 2 notes, one prompt, line-anchored.",
+            "the count goes through the pluralisation helper like every other count in the window"
+        );
+        assert_eq!(
+            prompt.lines()[1],
+            "line 5: This drops the page argument on the floor."
+        );
+        assert_eq!(
+            prompt.lines()[2],
+            "line 13: get_or_load caches across tenants."
+        );
+        assert!(prompt
+            .lines()
+            .last()
+            .expect("a closing line")
+            .starts_with("Please address every note above in one revision"));
+    }
+
+    /// One note is `1 note`, not `1 notes` - the same helper, the same rule.
+    #[test]
+    fn a_single_note_reads_as_one_note() {
+        let only = note("only one");
+        let prompt = BatchedPrompt::compose(&path(), &[(NoteAnchor::New(5), &only)])
+            .expect("one real note is still a prompt");
+        assert!(prompt.lines()[0].contains("\u{2014} 1 note, one prompt"));
+    }
+
+    /// A removed line says so, so the agent looks in the right column.
+    #[test]
+    fn a_note_on_a_removed_line_says_removed() {
+        let only = note("why did this go?");
+        let prompt =
+            BatchedPrompt::compose(&path(), &[(NoteAnchor::Old(7), &only)]).expect("a prompt");
+        assert_eq!(prompt.lines()[1], "removed line 7: why did this go?");
+    }
+
+    #[test]
+    fn nothing_real_to_send_is_no_prompt_at_all() {
+        let blank = note("   ");
+        assert_eq!(BatchedPrompt::compose(&path(), &[]), None);
+        assert_eq!(
+            BatchedPrompt::compose(&path(), &[(NoteAnchor::New(5), &blank)]),
+            None,
+            "a card that was opened and never written into is not a note"
+        );
+    }
+
+    /// The whole point of the feature, at the level the bytes decide it: whichever form goes down
+    /// the pty, it is **one** message.
+    #[test]
+    fn the_flat_delivery_form_contains_no_line_break_of_any_kind() {
+        let first = note("one");
+        let second = note("two");
+        let prompt = BatchedPrompt::compose(
+            &path(),
+            &[(NoteAnchor::New(5), &first), (NoteAnchor::New(9), &second)],
+        )
+        .expect("a prompt");
+
+        let flat = prompt.for_delivery(false);
+        assert!(
+            !flat.contains('\n') && !flat.contains('\r'),
+            "without bracketed paste every newline becomes the Enter byte, so a line break here \
+             would be a second submission - the exact 'one comment at a time' failure the audit \
+             says makes the agent swing back and forth. Got {flat:?}"
+        );
+        assert!(flat.contains("line 5: one \u{b7} line 9: two"));
+    }
+
+    /// And the readable form really is the multi-line one, so a bracketed-paste-capable agent
+    /// gets a prompt worth reading rather than the fallback's run-on line.
+    #[test]
+    fn the_bracketed_delivery_form_keeps_one_note_per_line() {
+        let first = note("one");
+        let second = note("two");
+        let prompt = BatchedPrompt::compose(
+            &path(),
+            &[(NoteAnchor::New(5), &first), (NoteAnchor::New(9), &second)],
+        )
+        .expect("a prompt");
+
+        let delivered = prompt.for_delivery(true);
+        assert_eq!(delivered.lines().count(), 4);
+        assert!(delivered.contains("\nline 5: one\nline 9: two\n"));
+    }
+
+    /// A note is user text, not terminal input. Nothing in it may be read as an instruction, and
+    /// nothing in it may become a second submission.
+    #[test]
+    fn control_characters_in_a_note_never_reach_the_delivery_string() {
+        let nasty = note("before\x1b[201~\rrm -rf /\nafter\ttab");
+        let prompt =
+            BatchedPrompt::compose(&path(), &[(NoteAnchor::New(5), &nasty)]).expect("a prompt");
+
+        for delivered in [prompt.for_delivery(true), prompt.for_delivery(false)] {
+            assert!(
+                !delivered.contains('\x1b'),
+                "an ESC in a note would close a bracketed paste early and have the rest read as \
+                 commands. Got {delivered:?}"
+            );
+            assert!(
+                !delivered.contains('\r') && !delivered.contains('\t'),
+                "and a CR would submit mid-note. Got {delivered:?}"
+            );
+        }
+        assert_eq!(
+            prompt.lines()[1],
+            "line 5: before [201~ rm -rf / after tab",
+            "the words survive - control characters become spaces rather than fusing two words"
+        );
+    }
+
+    /// A path is user-controlled too (it comes off the real working tree), so it goes through the
+    /// same guard as the note text.
+    #[test]
+    fn a_path_is_sanitised_the_same_way_the_notes_are() {
+        let only = note("fine");
+        let prompt = BatchedPrompt::compose(
+            Path::new("src/we\x1bird.rs"),
+            &[(NoteAnchor::New(1), &only)],
+        )
+        .expect("a prompt");
+        assert!(!prompt.for_delivery(true).contains('\x1b'));
+    }
+}

--- a/crates/app/src/review_notes/prompt.rs
+++ b/crates/app/src/review_notes/prompt.rs
@@ -40,6 +40,10 @@ const FLAT_SEPARATOR: &str = " \u{b7} ";
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BatchedPrompt {
     lines: Vec<String>,
+    /// What each anchor's note really says **as delivered**, in the same order. This is what
+    /// `NoteStore::mark_sent_as` records, so a card can never claim to have sent wording the
+    /// agent did not receive.
+    delivered: Vec<(NoteAnchor, String)>,
     /// How many real notes went into it - what the bar counts and what the caller marks sent.
     pub note_count: usize,
 }
@@ -63,17 +67,16 @@ impl BatchedPrompt {
         }
 
         let mut lines = Vec::with_capacity(notes.len() + 2);
+        let mut delivered = Vec::with_capacity(notes.len());
         lines.push(format!(
             "Review notes on {} \u{2014} {}, one prompt, line-anchored.",
             sanitize(&path.display().to_string()),
             plural::count(notes.len(), "note", None)
         ));
         for (anchor, note) in &notes {
-            lines.push(format!(
-                "{}: {}",
-                anchor.prompt_label(),
-                sanitize(note.text.trim())
-            ));
+            let text = sanitize(note.text.trim());
+            lines.push(format!("{}: {text}", anchor.prompt_label()));
+            delivered.push((*anchor, text));
         }
         lines.push(
             "Please address every note above in one revision, then tell me what you changed."
@@ -82,8 +85,14 @@ impl BatchedPrompt {
 
         Some(BatchedPrompt {
             note_count: notes.len(),
+            delivered,
             lines,
         })
+    }
+
+    /// What each note really says as delivered - see [`Self::delivered`]'s own field docs.
+    pub fn delivered(&self) -> &[(NoteAnchor, String)] {
+        &self.delivered
     }
 
     /// The prompt's own lines, for tests and for anything that wants to show what will be sent.
@@ -115,7 +124,7 @@ impl BatchedPrompt {
 /// one thing this whole module exists to make impossible.
 ///
 /// Replaced with a space rather than removed, so two words never silently fuse into one.
-fn sanitize(text: &str) -> String {
+pub(super) fn sanitize(text: &str) -> String {
     text.chars()
         .map(|ch| if ch.is_control() { ' ' } else { ch })
         .collect::<String>()

--- a/crates/app/src/review_notes/render.rs
+++ b/crates/app/src/review_notes/render.rs
@@ -1,0 +1,464 @@
+//! The two surfaces GitHub issue #288 adds: the **notes bar** above the hunks, and the **card**
+//! pinned beneath a line.
+//!
+//! Both are transcribed from `Jerry.dc.html`'s `Review · uncommitted` state - the bar is the
+//! `hasNotes` block, the card is the `l.isNote` branch of the diff row loop. Every colour is a
+//! [`crate::theme::notes`] token, and every string that is design copy is quoted in the doc
+//! comment beside it.
+
+use super::{NoteAnchor, NoteMark};
+use crate::provenance::render::author_style;
+use crate::provenance::Author;
+use crate::root::widgets::{render_keycap_row, text_tooltip, KeycapSize};
+use crate::root::{plural, AdeApp};
+use crate::theme;
+use crate::{keymap, work_surface};
+use gpui::prelude::*;
+use gpui::{div, font, px, rems, ClickEvent, Context, IntoElement, SharedString};
+
+/// The bar's fixed second line, **verbatim** from `Jerry.dc.html` and from `STAGE-A-CHANGELOG.md`
+/// §1's own row for this feature: *"A notes bar above the hunks: count, the line `one prompt,
+/// line-anchored · pinned after the revision`, and `Send notes to <agent>` with `⌘⏎` keycaps"*.
+pub const NOTES_BAR_META: &str = "one prompt, line-anchored \u{b7} pinned after the revision";
+
+/// The send button's tooltip, verbatim from the mock's own `title=` attribute.
+pub const SEND_TOOLTIP: &str = "Send every note as one prompt to this run's agent";
+
+/// The `crate::keymap::resolve_combo` spec behind the send button's keycaps, and behind the real
+/// `crate::root::SendReviewNotes` binding - one string, so the keycaps can never advertise a
+/// shortcut that is not bound. Same discipline as
+/// `crate::provenance::render::AUTHOR_FILTER_SPEC`.
+pub const SEND_NOTES_SPEC: &str = "mod+enter";
+
+/// What an empty card says while it is waiting to be written into.
+///
+/// **A derivation, not a transcription.** `Jerry.dc.html`'s cards are all pre-authored demo data,
+/// so the mock has no empty state for one at all - in it, "toggle a note" can only ever mean
+/// show/hide something that already exists. A real reviewer starts from nothing, and a blank card
+/// with no prompt would read as a rendering fault.
+const NOTE_PLACEHOLDER: &str = "what should change on this line?";
+
+/// The notes bar's own count sentence, and the design copy it is checked against.
+///
+/// A pure function, apart from the element that draws it, precisely so the exact wording is
+/// assertable: `STAGE-A-CHANGELOG.md` §3's verification list is *"bar reads `1 note on this file`,
+/// send → `1 note sent — awaiting revision`"*, and those two strings are the acceptance criteria.
+/// A render test can prove the label painted; only this can prove it says the right thing.
+///
+/// Both counts go through [`plural::count`] (GitHub issue #281's helper), so `1 note` and
+/// `2 notes` are the helper's answer rather than a second, inlined rule.
+pub fn notes_bar_label(state: super::FileNoteState) -> String {
+    let count = plural::count(state.count, "note", None);
+    if state.all_sent {
+        format!("{count} sent \u{2014} awaiting revision")
+    } else {
+        format!("{count} on this file")
+    }
+}
+
+impl AdeApp {
+    /// Wraps the diff's hunks with the notes bar above them (GitHub issue #288's *"batched, from
+    /// the top"*).
+    ///
+    /// The container carries the `diff-view` key context and a real focus handle, which is what
+    /// makes `mod+enter` (send) and `c` (note on line) bound keystrokes rather than decoration -
+    /// the same arrangement `crate::graph_view::rebase_render`'s `rebase-plan` surface uses, and
+    /// for the same reason: those hints are drawn as keycaps, so they have to be real.
+    pub(crate) fn wrap_diff_with_notes(
+        &self,
+        path: std::path::PathBuf,
+        hunks: gpui::AnyElement,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        div()
+            .flex()
+            .flex_col()
+            .flex_1()
+            .min_h_0()
+            .track_focus(&self.diff_notes_focus_handle)
+            .key_context("diff-view")
+            .on_action(cx.listener(Self::handle_send_review_notes))
+            .on_action(cx.listener(Self::handle_toggle_line_note))
+            .children(self.render_review_notes_bar(&path, cx))
+            .child(hunks)
+            .into_any_element()
+    }
+
+    /// The notes bar itself. `None` - no bar at all, not an empty one - when the file carries no
+    /// real note, exactly as the mock's `sc-if value="{{ hasNotes }}"` does.
+    fn render_review_notes_bar(
+        &self,
+        path: &std::path::Path,
+        cx: &mut Context<Self>,
+    ) -> Option<gpui::AnyElement> {
+        let state = self
+            .review_notes_store()
+            .file_state(&self.review_notes_worktree(), path);
+        if state.count == 0 {
+            return None;
+        }
+        // `STAGE-A-CHANGELOG.md` §1: send flips the bar to *"N notes sent — awaiting revision"*.
+        // It flips back the moment a sent note is edited - see `NoteStore::file_state`.
+        let label = notes_bar_label(state);
+        let target = self.review_note_target(path);
+        let send_path = path.to_path_buf();
+
+        Some(
+            div()
+                .id("diff-notes-bar")
+                .debug_selector(|| "diff-notes-bar".to_string())
+                .flex_none()
+                .flex()
+                .items_center()
+                .gap(px(9.0))
+                .px(px(12.0))
+                .py(px(6.0))
+                .bg(theme::notes::BAR_BG)
+                .border_b_1()
+                .border_color(theme::notes::BAR_BORDER)
+                // The mock's 5px selection-blue square, which is the whole of what marks this
+                // band as belonging to the notes rather than to the diff.
+                .child(
+                    div()
+                        .flex_none()
+                        .w(px(5.0))
+                        .h(px(5.0))
+                        .rounded(px(1.0))
+                        .bg(theme::notes::EDGE),
+                )
+                .child(
+                    div()
+                        .debug_selector(|| "diff-notes-bar-label".to_string())
+                        .flex_none()
+                        .whitespace_nowrap()
+                        .font(font(theme::font::SANS))
+                        .text_size(px(11.0))
+                        .text_color(theme::notes::BAR_LABEL)
+                        .child(label),
+                )
+                .child(
+                    div()
+                        .flex_1()
+                        .min_w_0()
+                        .overflow_hidden()
+                        .whitespace_nowrap()
+                        .font(font(theme::font::MONO))
+                        .text_size(px(10.5))
+                        .text_color(theme::notes::BAR_META)
+                        .child(NOTES_BAR_META),
+                )
+                // A delivery that really failed says so here, rather than leaving the bar looking
+                // exactly as it did before the click.
+                .children(self.note_send_error.clone().map(|message| {
+                    div()
+                        .debug_selector(|| "diff-notes-bar-error".to_string())
+                        .flex_none()
+                        .whitespace_nowrap()
+                        .font(font(theme::font::MONO))
+                        .text_size(px(10.5))
+                        .text_color(theme::notes::BAR_ERROR)
+                        .child(message)
+                }))
+                // The mock's `✓ sent` confirmation, next to the button that produced it.
+                .when(state.all_sent, |el| {
+                    el.child(
+                        div()
+                            .debug_selector(|| "diff-notes-bar-sent".to_string())
+                            .flex_none()
+                            .whitespace_nowrap()
+                            .font(font(theme::font::MONO))
+                            .text_size(px(10.5))
+                            .text_color(theme::notes::MARK_SENT)
+                            .child("\u{2713} sent"),
+                    )
+                })
+                .children(target.map(|target| self.render_send_notes_button(send_path, target, cx)))
+                .into_any_element(),
+        )
+    }
+
+    /// `Send notes to <agent>` - the agent's own chip, its name, and the `mod+enter` keycaps.
+    ///
+    /// Drawn only when a target really resolved. A button naming an agent that is not there is
+    /// worse than no button: `REVISION-2026-08-14.md` §7's rule 1 is *"ship the affordance with
+    /// the behaviour, or ship neither"*.
+    fn render_send_notes_button(
+        &self,
+        path: std::path::PathBuf,
+        target: super::flow::NoteTarget,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        let macos = self.window_controls_style().is_macos();
+        let (fg, bg) = work_surface::state::agent_tint(target.kind);
+        let initial = work_surface::state::agent_initial(target.kind);
+        let tooltip = if target.from_file_author {
+            format!(
+                "{SEND_TOOLTIP} \u{2014} {} wrote the lines in this file",
+                target.label()
+            )
+        } else {
+            format!(
+                "{SEND_TOOLTIP} \u{2014} {} is this worktree's agent; the file names no author",
+                target.label()
+            )
+        };
+        div()
+            .id("diff-notes-send")
+            .debug_selector(|| "diff-notes-send".to_string())
+            .flex_none()
+            .h(px(22.0))
+            .px(px(8.0))
+            .rounded(theme::radius::BUTTON)
+            .flex()
+            .items_center()
+            .gap(px(6.0))
+            .bg(theme::notes::SEND_BG)
+            .border_1()
+            .border_color(theme::notes::SEND_BORDER)
+            .hover(|style| style.bg(theme::notes::SEND_HOVER_BG))
+            .tooltip(text_tooltip(tooltip))
+            .on_click(cx.listener(move |this, _event: &ClickEvent, _window, cx| {
+                if let Err(err) = this.send_review_notes(path.clone(), cx) {
+                    this.note_send_error = Some(err.message().to_string());
+                    cx.notify();
+                }
+            }))
+            .child(
+                div()
+                    .flex_none()
+                    .w(px(14.0))
+                    .h(px(14.0))
+                    .rounded(theme::radius::CHIP)
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .bg(bg)
+                    .text_color(fg)
+                    .font(font(theme::font::MONO))
+                    .text_size(px(8.0))
+                    .child(initial),
+            )
+            .child(
+                div()
+                    .whitespace_nowrap()
+                    .font(font(theme::font::SANS))
+                    .text_size(px(10.5))
+                    .text_color(theme::notes::SEND_FG)
+                    .child(format!("Send notes to {}", target.label())),
+            )
+            .child(
+                div()
+                    .text_color(theme::notes::SEND_CAP_FG)
+                    .child(render_keycap_row(
+                        &keymap::resolve_combo(SEND_NOTES_SPEC, macos),
+                        KeycapSize::Standard,
+                    )),
+            )
+            .into_any_element()
+    }
+
+    /// One pinned note, as a row of the diff's own `uniform_list`.
+    ///
+    /// ## The one place this is not the mock
+    ///
+    /// `Jerry.dc.html` draws the card as a free-height block whose text wraps. It cannot be one
+    /// here: since GitHub issue #224 the diff is a `gpui::uniform_list`, which measures item 0 and
+    /// lays **every** slot out at exactly that height (`rems(1.6)`, a diff line's own line
+    /// height). A taller card would be silently clipped, and a list that measured itself from a
+    /// card would make every diff line as tall as one.
+    ///
+    /// The alternative considered and rejected was letting a note occupy N slots and painting
+    /// bands of one card across them: `N` would have to be guessed from the text before layout
+    /// knows the pane's width, so a wrong guess either clips a review comment or leaves a hole -
+    /// and it would fail outright the moment the card's head scrolled off the top, since only
+    /// visible slots are ever built.
+    ///
+    /// So the card is one row: the same four elements in the same order (selection-blue left edge,
+    /// author chip, text, `draft`/`sent` mark), with the text kept on one line and the whole of it
+    /// available as a tooltip. That is a real, stated loss against the mock's wrapping card, taken
+    /// because the surface it lives in has a hard constraint the mock does not - and it is also
+    /// exactly the shape of every other text input in this app, all five of which are single-line
+    /// (`crate::text_history`'s own module docs).
+    pub(crate) fn render_review_note_card(
+        &self,
+        path: std::path::PathBuf,
+        anchor: NoteAnchor,
+        selector_prefix: &'static str,
+        note_row: usize,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        let worktree = self.review_notes_worktree();
+        let note = self.review_notes_store().note(&worktree, &path, anchor);
+        let editing = self
+            .note_draft
+            .as_ref()
+            .is_some_and(|draft| draft.at.path == path && draft.at.anchor == anchor);
+        let text = match (&self.note_draft, note) {
+            (Some(draft), _) if editing => draft.field.as_str().to_string(),
+            (_, Some(note)) => note.text.clone(),
+            _ => String::new(),
+        };
+        let mark = note.map(|note| note.mark()).unwrap_or(NoteMark::Draft);
+        // The honest half of the draft/sent history: a card that has been sent and then edited
+        // can still say what the agent really was told.
+        let tooltip = note
+            .and_then(|note| note.superseded_text())
+            .map(|sent| format!("Sent earlier, and since edited: \u{201c}{sent}\u{201d}"))
+            .unwrap_or_else(|| match mark {
+                NoteMark::Sent => "Sent to the agent, exactly as it reads now".to_string(),
+                NoteMark::Draft => "Not sent yet \u{2014} click to edit".to_string(),
+            });
+        let selector = format!("{selector_prefix}-note-{note_row}");
+        let text_selector = format!("{selector}-text");
+        let mark_selector = format!("{selector}-mark");
+        let is_blank = text.trim().is_empty();
+
+        let body =
+            div()
+                .id(SharedString::from(selector.clone()))
+                .debug_selector(move || selector)
+                .flex_1()
+                .h_full()
+                .flex()
+                .items_center()
+                .rounded(theme::radius::CARD_SM)
+                .bg(theme::notes::CARD_BG)
+                .border_1()
+                .border_color(theme::notes::CARD_BORDER)
+                // So the blue edge below is clipped by the card's own rounded corners.
+                .overflow_hidden()
+                .cursor_text()
+                .tooltip(text_tooltip(tooltip))
+                .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
+                    // Stops the click reaching the diff row underneath, which would toggle the note
+                    // shut while the caret is being placed in it.
+                    cx.stop_propagation();
+                    this.focus_review_note(anchor, window, cx);
+                }))
+                // *"the selection-blue left edge"*. A real 2px child rather than a second border
+                // colour: GPUI's `Style` carries **one** `border_color` for all four sides, so
+                // `.border_l(px(2.0)).border_color(EDGE)` after `.border_color(CARD_BORDER)` would
+                // have repainted the whole outline blue - the mock's `border:1px solid #2b3d4f;
+                // border-left:2px solid #5a9ad4` has no single-element equivalent here. Same
+                // technique the diff row's own author gutter already uses.
+                .child(
+                    div()
+                        .flex_none()
+                        .w(px(2.0))
+                        .self_stretch()
+                        .bg(theme::notes::EDGE),
+                )
+                .child(
+                    div()
+                        .flex_1()
+                        .min_w_0()
+                        .h_full()
+                        .flex()
+                        .items_center()
+                        .gap(px(8.0))
+                        .px(px(8.0))
+                        // The note author. `you`, through the same chip vocabulary GitHub issue #287
+                        // gave every other author mark in this app, rather than the mock's bare `Y`:
+                        // one author is one recognisable mark wherever it appears.
+                        .children(
+                            author_style(&Author::You)
+                                .map(|style| self.render_author_chip(&Author::You, &style)),
+                        )
+                        .when(editing && is_blank, |el| {
+                            el.child(self.render_simple_input_caret(
+                                "diff-note-caret",
+                                &self.note_focus_handle,
+                            ))
+                        })
+                        .child(
+                            div()
+                                .debug_selector(move || text_selector)
+                                .flex_1()
+                                .min_w_0()
+                                .overflow_hidden()
+                                .whitespace_nowrap()
+                                .font(font(theme::font::SANS))
+                                .text_size(px(11.5))
+                                .text_color(if is_blank {
+                                    theme::notes::CARD_PLACEHOLDER
+                                } else {
+                                    theme::notes::CARD_FG
+                                })
+                                .child(if is_blank {
+                                    NOTE_PLACEHOLDER.to_string()
+                                } else {
+                                    text
+                                }),
+                        )
+                        .when(editing && !is_blank, |el| {
+                            el.child(self.render_simple_input_caret(
+                                "diff-note-caret",
+                                &self.note_focus_handle,
+                            ))
+                        })
+                        .child(
+                            div()
+                                .debug_selector(move || mark_selector)
+                                .flex_none()
+                                .whitespace_nowrap()
+                                .font(font(theme::font::MONO))
+                                .text_size(px(9.5))
+                                .text_color(match mark {
+                                    NoteMark::Draft => theme::notes::MARK_DRAFT,
+                                    NoteMark::Sent => theme::notes::MARK_SENT,
+                                })
+                                .child(mark.label()),
+                        ),
+                );
+
+        // The text-input machinery goes on **only** the card being typed into.
+        //
+        // Not on every card, and that is a correctness point rather than a saving: two elements
+        // tracking one `FocusHandle` in the same frame put two nodes with the same `FocusId` into
+        // GPUI's dispatch tree, and which of them a keystroke resolves against is then an accident
+        // of traversal order. A pinned card that is not being edited is read-only text, and says
+        // so by not being a `"text-input"` node at all - which is also what makes
+        // `ToggleLineNote`'s `&& !text-input` conjunct mean what it says.
+        let card = if editing {
+            body.track_focus(&self.note_focus_handle)
+                .key_context("text-input")
+                .on_action(cx.listener(Self::handle_note_text_undo))
+                .on_action(cx.listener(Self::handle_note_text_redo))
+                .on_key_down(cx.listener(Self::handle_note_key_down))
+                .into_any_element()
+        } else {
+            body.into_any_element()
+        };
+
+        div()
+            // The slot. `rems(1.6)`, like every other item of this list, with 1px of breathing
+            // room top and bottom so the card reads as a card rather than as a band.
+            .h(rems(1.6))
+            .py(px(1.0))
+            // The mock's own inset: the card starts where the code text does, not at the gutter,
+            // so it visibly belongs to the line above it.
+            .pl(px(74.0))
+            .pr(px(14.0))
+            .flex()
+            .child(card)
+            .into_any_element()
+    }
+
+    /// Moves the caret into an already-pinned note without toggling it - what clicking the card
+    /// itself does, as opposed to clicking the line above it.
+    fn focus_review_note(
+        &mut self,
+        anchor: NoteAnchor,
+        window: &mut gpui::Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(path) = self.review_notes_file() else {
+            return;
+        };
+        let at = super::NoteRef::new(path, anchor);
+        if self.note_draft.as_ref().is_some_and(|draft| draft.at == at) {
+            return;
+        }
+        self.open_note_draft(at, window, cx);
+    }
+}

--- a/crates/app/src/review_notes/render.rs
+++ b/crates/app/src/review_notes/render.rs
@@ -79,9 +79,47 @@ impl AdeApp {
             .key_context("diff-view")
             .on_action(cx.listener(Self::handle_send_review_notes))
             .on_action(cx.listener(Self::handle_toggle_line_note))
+            .children(self.render_note_input_node(cx))
             .children(self.render_review_notes_bar(&path, cx))
             .child(hunks)
             .into_any_element()
+    }
+
+    /// The open note's real keyboard input node - zero-sized, and deliberately **not** inside the
+    /// diff's row list.
+    ///
+    /// This looks like misdirection and is the opposite. The pinned card is a row of a
+    /// `gpui::uniform_list`, which builds only the rows in its visible range: put the
+    /// `track_focus`/`key_context`/`on_key_down` on the card and scrolling the card off screen
+    /// deletes the focused node from the dispatch tree mid-sentence. GPUI then evaluates every
+    /// predicate against an **empty context stack**, where
+    /// `KeyBindingContextPredicate::eval_inner` short-circuits to `false` - so the keystrokes
+    /// stop being typed, `mod+enter` and `c` stop firing, and nothing on screen says so. That is
+    /// the exact bug class `crate::keymap_overrides::real_context_stacks` includes the empty
+    /// stack for, and it is reachable here without anyone calling
+    /// [`AdeApp::close_note_draft`].
+    ///
+    /// Anchoring the node here instead makes the input's lifetime the *draft's* lifetime rather
+    /// than the scroll position's. The card keeps the caret (which only *reads*
+    /// `FocusHandle::is_focused`, so it needs no node of its own) and the text; exactly one
+    /// element ever tracks [`AdeApp::note_focus_handle`], which is the other half of the same
+    /// rule.
+    fn render_note_input_node(&self, cx: &mut Context<Self>) -> Option<gpui::AnyElement> {
+        self.note_draft.as_ref()?;
+        Some(
+            div()
+                .id("diff-note-input")
+                .debug_selector(|| "diff-note-input".to_string())
+                .flex_none()
+                .w(px(0.0))
+                .h(px(0.0))
+                .track_focus(&self.note_focus_handle)
+                .key_context("text-input")
+                .on_action(cx.listener(Self::handle_note_text_undo))
+                .on_action(cx.listener(Self::handle_note_text_redo))
+                .on_key_down(cx.listener(Self::handle_note_key_down))
+                .into_any_element(),
+        )
     }
 
     /// The notes bar itself. `None` - no bar at all, not an empty one - when the file carries no
@@ -411,25 +449,6 @@ impl AdeApp {
                         ),
                 );
 
-        // The text-input machinery goes on **only** the card being typed into.
-        //
-        // Not on every card, and that is a correctness point rather than a saving: two elements
-        // tracking one `FocusHandle` in the same frame put two nodes with the same `FocusId` into
-        // GPUI's dispatch tree, and which of them a keystroke resolves against is then an accident
-        // of traversal order. A pinned card that is not being edited is read-only text, and says
-        // so by not being a `"text-input"` node at all - which is also what makes
-        // `ToggleLineNote`'s `&& !text-input` conjunct mean what it says.
-        let card = if editing {
-            body.track_focus(&self.note_focus_handle)
-                .key_context("text-input")
-                .on_action(cx.listener(Self::handle_note_text_undo))
-                .on_action(cx.listener(Self::handle_note_text_redo))
-                .on_key_down(cx.listener(Self::handle_note_key_down))
-                .into_any_element()
-        } else {
-            body.into_any_element()
-        };
-
         div()
             // The slot. `rems(1.6)`, like every other item of this list, with 1px of breathing
             // room top and bottom so the card reads as a card rather than as a band.
@@ -440,7 +459,7 @@ impl AdeApp {
             .pl(px(74.0))
             .pr(px(14.0))
             .flex()
-            .child(card)
+            .child(body)
             .into_any_element()
     }
 
@@ -455,8 +474,20 @@ impl AdeApp {
         let Some(path) = self.review_notes_file() else {
             return;
         };
+        let worktree = self.review_notes_worktree();
         let at = super::NoteRef::new(path, anchor);
-        if self.note_draft.as_ref().is_some_and(|draft| draft.at == at) {
+        if self
+            .note_draft
+            .as_ref()
+            .is_some_and(|draft| draft.is(&worktree, &at))
+        {
+            // Already the open draft - but focus still has to be taken back, not left alone.
+            // `.track_focus` makes an element focus its own handle on mouse-down, and the notes
+            // container is one, so the click that got here has just moved focus off the note's
+            // input node and onto the container. Returning without this would leave the caret
+            // visibly in a card that no longer receives a single keystroke.
+            window.focus(&self.note_focus_handle, cx);
+            cx.notify();
             return;
         }
         self.open_note_draft(at, window, cx);

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -274,6 +274,14 @@ actions!(
         RebaseSquashRow,
         RebaseDropRow,
         RebaseStart,
+        // GitHub issue #288's two diff-line review-note gestures. Both are scoped to the
+        // `"diff-view"` key context the notes surface puts on its own container
+        // (`crate::review_notes::render::AdeApp::wrap_diff_with_notes`), never global - see
+        // `crate::default_key_bindings` for each one's own scoping, and in particular why
+        // `ToggleLineNote`'s plain `c` needs the `&& !text-input` conjunct that `SendReviewNotes`
+        // deliberately does not.
+        SendReviewNotes,
+        ToggleLineNote,
     ]
 );
 
@@ -554,6 +562,30 @@ pub struct AdeApp {
     /// diff and serves the Against-main section; the two are separate because their scopes are,
     /// and rebuilt together through one function so neither can go stale on its own.
     pub(crate) uncommitted_change_set: crate::provenance::change_set::ChangeSet,
+    /// Every diff-line review note this window holds (GitHub issue #288), keyed worktree -> path
+    /// -> line anchor. See `crate::review_notes` for the model and the three rules it enforces.
+    pub(crate) review_notes: crate::review_notes::NoteStore,
+    /// Where [`Self::review_notes`] is persisted - `review-notes.toml`, next to `settings.toml`.
+    /// `None` only when this instance has no real settings path at all (an in-test app).
+    pub(crate) review_notes_path: Option<PathBuf>,
+    /// Which encoded worktree keys this window may rewrite in that file - the same
+    /// merge-ownership set [`Self::line_provenance_owned`] keeps, and for the same reason.
+    pub(crate) review_notes_owned: std::collections::BTreeSet<String>,
+    /// The one note currently open for typing, if any - see `crate::review_notes::flow::NoteDraft`
+    /// for why there is exactly one rather than one per card.
+    pub(crate) note_draft: Option<crate::review_notes::flow::NoteDraft>,
+    /// The diff line `C` would toggle a note on: the last one a note was opened on. There is no
+    /// diff-line caret in this read-only virtualized list, so this is the whole of "the line you
+    /// are on" - see `crate::review_notes::flow::AdeApp::handle_toggle_line_note`.
+    pub(crate) note_cursor: Option<crate::review_notes::NoteRef>,
+    /// Why the last send failed, if it did. Shown in the notes bar rather than swallowed: a review
+    /// note that silently reached nobody is the worst outcome this feature has.
+    pub(crate) note_send_error: Option<String>,
+    /// Focus for the open note card's own hand-rolled single-line input.
+    pub(crate) note_focus_handle: FocusHandle,
+    /// Focus for the diff pane's notes container, which is what makes its `"diff-view"` key
+    /// context - and so the `mod+enter`/`c` bindings the bar draws as keycaps - really live.
+    pub(crate) diff_notes_focus_handle: FocusHandle,
     /// The per-author diff filter (GitHub issue #287), if one is in force: which file it was
     /// entered from, and whose lines it keeps at full opacity.
     ///
@@ -1040,6 +1072,10 @@ pub struct AdeApp {
     /// `crate::provenance::flow::AdeApp::persist_line_provenance`. One slot, newest wins: the
     /// state is captured whole at spawn time, so a newer write genuinely supersedes an older one.
     pub(crate) _line_provenance_persist_task: Option<Task<()>>,
+    /// Holds the in-flight write of [`Self::review_notes`] - see
+    /// `crate::review_notes::flow::AdeApp::persist_review_notes`. One slot, newest wins, exactly
+    /// like the provenance write above it.
+    pub(crate) _review_notes_persist_task: Option<Task<()>>,
     /// The in-flight `wt_core::graph::build_graph` background load, one slot - a fresh load
     /// supersedes an older one still running, mirroring [`Self::_load_diff_task`].
     pub(crate) _load_graph_task: Option<Task<()>>,

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -1072,10 +1072,15 @@ pub struct AdeApp {
     /// `crate::provenance::flow::AdeApp::persist_line_provenance`. One slot, newest wins: the
     /// state is captured whole at spawn time, so a newer write genuinely supersedes an older one.
     pub(crate) _line_provenance_persist_task: Option<Task<()>>,
-    /// Holds the in-flight write of [`Self::review_notes`] - see
+    /// Holds the in-flight *immediate* write of [`Self::review_notes`] - see
     /// `crate::review_notes::flow::AdeApp::persist_review_notes`. One slot, newest wins, exactly
     /// like the provenance write above it.
     pub(crate) _review_notes_persist_task: Option<Task<()>>,
+    /// Holds the in-flight **debounced** write, kept apart from the immediate one on purpose: a
+    /// `Task` cancels on drop, so one shared slot would let the next keystroke's timer cancel a
+    /// write that a closing card or a send had already committed to. See
+    /// `crate::review_notes::flow::AdeApp::schedule_review_notes_persist`.
+    pub(crate) _review_notes_debounce_task: Option<Task<()>>,
     /// The in-flight `wt_core::graph::build_graph` background load, one slot - a fresh load
     /// supersedes an older one still running, mirroring [`Self::_load_diff_task`].
     pub(crate) _load_graph_task: Option<Task<()>>,

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -392,6 +392,7 @@ impl AdeApp {
             _agent_status_persist_task: None,
             _line_provenance_persist_task: None,
             _review_notes_persist_task: None,
+            _review_notes_debounce_task: None,
             // Both are filled in immediately after this literal, through the same single
             // chokepoints every later change uses (`set_file_tree_root` +
             // `reload_expanded_dirs_from_fold_state`) - a second, constructor-only copy of that

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -157,6 +157,12 @@ impl AdeApp {
             .as_deref()
             .map(crate::provenance::persist_state::line_provenance_path_for);
 
+        // GitHub issue #288's diff-line review notes resolve the same way, and are read back at
+        // startup by `restore_review_notes` once this literal exists.
+        let review_notes_path = settings_path
+            .as_deref()
+            .map(crate::review_notes::persist_state::review_notes_path_for);
+
         // The hook side-channel starts out absent and is brought up lazily, on the first Claude
         // agent this instance spawns - see `AdeApp::hook_injection_for`. Still exactly one
         // listener per instance, shared by every Claude agent it ever spawns; just not one opened
@@ -352,6 +358,14 @@ impl AdeApp {
             change_set: crate::provenance::change_set::ChangeSet::default(),
             uncommitted_diff: crate::sidebar::sections::ScopeLoad::Loading,
             uncommitted_change_set: crate::provenance::change_set::ChangeSet::default(),
+            review_notes: crate::review_notes::NoteStore::default(),
+            review_notes_path,
+            review_notes_owned: std::collections::BTreeSet::new(),
+            note_draft: None,
+            note_cursor: None,
+            note_send_error: None,
+            note_focus_handle: cx.focus_handle(),
+            diff_notes_focus_handle: cx.focus_handle(),
             author_filter: None,
             branch_commits: crate::sidebar::sections::ScopeLoad::Loading,
             changes_sections: crate::sidebar::sections::SectionCollapse::default(),
@@ -377,6 +391,7 @@ impl AdeApp {
             _review_persist_task: None,
             _agent_status_persist_task: None,
             _line_provenance_persist_task: None,
+            _review_notes_persist_task: None,
             // Both are filled in immediately after this literal, through the same single
             // chokepoints every later change uses (`set_file_tree_root` +
             // `reload_expanded_dirs_from_fold_state`) - a second, constructor-only copy of that
@@ -763,6 +778,7 @@ impl AdeApp {
         // when nothing was ever recorded - and deliberately before the first render, so a restored
         // worktree's attribution is live from the first frame rather than appearing a poll later.
         this.restore_line_provenance();
+        this.restore_review_notes();
         // Applies the real, persisted theme selection at startup (`Self::apply_theme_selection`)
         // - if `follow_system` is also on, the real, current OS appearance takes priority over
         // whatever `theme.name` was last persisted as, matching `Self::sync_theme_to_system_

--- a/crates/app/src/settings/state.rs
+++ b/crates/app/src/settings/state.rs
@@ -605,6 +605,10 @@ pub(crate) fn action_label(action: &dyn gpui::Action) -> Option<&'static str> {
         "app::RebaseSquashRow" => Some("Rebase plan: squash"),
         "app::RebaseDropRow" => Some("Rebase plan: drop"),
         "app::RebaseStart" => Some("Rebase plan: start rebase"),
+        // GitHub issue #288 - the diff's own review-note verbs. `mod+enter` is drawn as real
+        // keycaps on the notes bar, so it is rebindable here like everything else that is.
+        "app::SendReviewNotes" => Some("Diff: send review notes to the agent"),
+        "app::ToggleLineNote" => Some("Diff: note on this line"),
         _ => None,
     }
 }
@@ -2007,6 +2011,8 @@ mod tests {
                 "Rebase plan: squash",
                 "Rebase plan: drop",
                 "Rebase plan: start rebase",
+                "Diff: send review notes to the agent",
+                "Diff: note on this line",
             ]
         );
     }
@@ -2088,6 +2094,12 @@ mod tests {
         // under `Some("rebase-plan && !text-input")` (5 - see `crate::default_key_bindings` for
         // why the negated conjunct is load-bearing over a surface that contains a real text
         // field) and `RebaseStart` under plain `Some("rebase-plan")` (1).
+        // GitHub issue #288 added 2 more real scoped bindings, on the diff's own review-notes
+        // surface: `SendReviewNotes` (`mod+enter`) under plain `Some("diff-view")` - the notes
+        // bar draws it as keycaps, and having just typed a note is the likeliest moment to send
+        // the batch - and `ToggleLineNote` (`c`) under `Some("diff-view && !text-input")`, the
+        // same negated conjunct and the same reason as the rebase plan's plain letters above:
+        // the pinned note card is a real text field inside that very container.
         let bindings = crate::default_key_bindings();
         let rows = keybinding_rows(&bindings, &[]);
         assert!(!rows.is_empty());
@@ -2095,7 +2107,7 @@ mod tests {
             rows.iter().filter(|row| row.context != "global").collect();
         assert_eq!(
             scoped.len(),
-            82,
+            84,
             "expected `] -> NextChangedFile` (1) plus every real Editor* binding (19) plus \
              every real Completions* binding (5) plus every real merge-editor binding (18) plus \
              TextUndo/TextRedo (3, GitHub issue #17) plus every real \
@@ -2105,8 +2117,8 @@ mod tests {
              GitHub issue #28) plus every real GitHub issue #26 binding (7, not counting \
              EditorCollapseCursors above, which is issue #28's own action) plus TerminalClear \
              (1, GitHub issue #20) plus TerminalCopy/TerminalPaste (2, GitHub issue #158) plus \
-             every real interactive-rebase plan binding (6, GitHub issue #304) to be \
-             scoped, not global"
+             every real interactive-rebase plan binding (6, GitHub issue #304) plus every \
+             real review-note binding (2, GitHub issue #288) to be scoped, not global"
         );
         assert!(
             scoped

--- a/crates/app/src/settings/theme_file_format.rs
+++ b/crates/app/src/settings/theme_file_format.rs
@@ -50,7 +50,7 @@ const SECTIONS: &[(&str, &[&str])] = &[
     (
         "Meaning and state (colour carries information here)",
         &[
-            "status", "diff", "tag", "rail", "agent", "changes", "budget",
+            "status", "diff", "tag", "rail", "agent", "changes", "budget", "notes",
         ],
     ),
     (

--- a/crates/app/src/terminal/pane.rs
+++ b/crates/app/src/terminal/pane.rs
@@ -1032,13 +1032,36 @@ impl TerminalPane {
             cx.notify();
             return false;
         }
+        // A prompt is only worth claiming as delivered if there is really something running to
+        // read it. `session.is_some()` alone is not that: the poll loop only clears `session`
+        // once it has *observed* EOF, which lags the child's real exit by at least a tick plus
+        // `MAX_EOF_POLL_TICKS`' grace, and in that window a write into a dead agent would return
+        // `true`. GitHub issue #288 flips every note on the file to `sent` on that `true`, with
+        // no way back, so this checks the two facts the pane already knows about the child's
+        // liveness before it writes anything.
+        if self.exit_status.is_some() || self.eof_pending {
+            self.spawn_error = Some("refused to send: this agent's process has ended".to_string());
+            cx.notify();
+            return false;
+        }
         let Some(session) = &self.session else {
             return false;
         };
-        let mut payload = paste_payload(text, bracketed).into_bytes();
+        // Two writes, deliberately, and in this order.
+        //
+        // The paste and its submit go to the pty as two separate `write_all`+`flush` calls on the
+        // writer thread rather than one, so a full-screen agent TUI gets a real read boundary
+        // between "here is a pasted blob" and "now send it". These TUIs commit a bracketed paste
+        // asynchronously (Ink debounces it), and a CR arriving inside the *same* read chunk can
+        // be consumed before the paste has been committed - which drops the submit, or submits a
+        // prefix. Ordering is still guaranteed: both go down one `mpsc` to one writer thread.
+        if let Err(err) = session.write_input(paste_payload(text, bracketed).as_bytes()) {
+            self.spawn_error = Some(format!("failed to write input: {err}"));
+            cx.notify();
+            return false;
+        }
         // The submit. One byte, once - see this method's own docs.
-        payload.push(b'\r');
-        if let Err(err) = session.write_input(&payload) {
+        if let Err(err) = session.write_input(b"\r") {
             self.spawn_error = Some(format!("failed to write input: {err}"));
             cx.notify();
             return false;

--- a/crates/app/src/terminal/pane.rs
+++ b/crates/app/src/terminal/pane.rs
@@ -984,6 +984,68 @@ impl TerminalPane {
         true
     }
 
+    /// Whether the program running in this pane currently has bracketed paste on (`DECSET 2004`).
+    ///
+    /// Read live off the real terminal mode, never latched - see
+    /// [`crate::terminal::grid::TerminalGrid::bracketed_paste_enabled`]'s own docs. Exposed
+    /// because GitHub issue #288's batched review-note prompt has to *compose itself differently*
+    /// depending on the answer, not merely frame itself differently: see [`Self::send_prompt`].
+    pub fn bracketed_paste_enabled(&self) -> bool {
+        self.grid.bracketed_paste_enabled()
+    }
+
+    /// Delivers `text` into this pane's real pty as **one** prompt, submitted once - the whole of
+    /// GitHub issue #288's *"Sending delivers one batched, line-anchored prompt into the target
+    /// agent's pty - never one message per note"*.
+    ///
+    /// Returns whether bytes were really written.
+    ///
+    /// ## Why this is not just `paste_from_clipboard` with a `\r` after it
+    ///
+    /// The bytes are framed by [`paste_payload`], exactly as a paste is, and then **one** `\r` -
+    /// [`keystroke_to_bytes`]' own Enter byte - is appended, in the same write, so the child sees
+    /// a paste followed by a single Enter: precisely what a human does. Nothing else in this app
+    /// submits on the user's behalf, so this is the only place that byte is written
+    /// programmatically, and it is written exactly once per call.
+    ///
+    /// The refusal below is the load-bearing part. With bracketed paste **off**, `paste_payload`
+    /// normalises every `\n` to `\r`, and `\r` is Enter: a five-line prompt would arrive as
+    /// **five** submissions. That is not a hypothetical - it is exactly the "one comment at a
+    /// time" behaviour `AUDIT-2026-08-13-competitive-v2.md` §6 top-5 #2 says *"causes the agent to
+    /// swing back and forth"*, i.e. the failure this whole feature exists to prevent, and it would
+    /// look on screen like it had worked. So a payload that could split is refused outright rather
+    /// than sent hopefully. The caller's job is to hand over a form that cannot split;
+    /// [`crate::review_notes::prompt::BatchedPrompt::for_delivery`] takes
+    /// [`Self::bracketed_paste_enabled`] and does exactly that, and this check is what makes that
+    /// contract checked rather than assumed.
+    pub fn send_prompt(&mut self, text: &str, cx: &mut Context<Self>) -> bool {
+        if text.is_empty() {
+            return false;
+        }
+        let bracketed = self.grid.bracketed_paste_enabled();
+        if !bracketed && text.contains(['\n', '\r']) {
+            self.spawn_error = Some(
+                "refused to send: this program has bracketed paste off, so a multi-line prompt \
+                 would arrive as several separate messages"
+                    .to_string(),
+            );
+            cx.notify();
+            return false;
+        }
+        let Some(session) = &self.session else {
+            return false;
+        };
+        let mut payload = paste_payload(text, bracketed).into_bytes();
+        // The submit. One byte, once - see this method's own docs.
+        payload.push(b'\r');
+        if let Err(err) = session.write_input(&payload) {
+            self.spawn_error = Some(format!("failed to write input: {err}"));
+            cx.notify();
+            return false;
+        }
+        true
+    }
+
     /// Maps a window-space pointer position onto the grid cell under it, or `None` before this
     /// pane has ever painted (no measured [`Self::content_bounds`] to resolve against yet).
     ///
@@ -3434,6 +3496,182 @@ mod clipboard_tests {
         cx.update(|cx| cx.write_to_clipboard(gpui::ClipboardItem::new_string(String::new())));
         let pasted = pane.update(cx, |pane, cx| pane.paste_from_clipboard(cx));
         assert!(!pasted);
+    }
+}
+
+/// GitHub issue #288's delivery mechanism, against a real pty and a real child process.
+///
+/// [`TerminalPane::send_prompt`] is the only place this app ever types on the user's behalf, and
+/// the one property the whole review-notes feature rests on is that a batch arrives as **one**
+/// message. Both halves are checked here for real: the bytes genuinely leave the app (observed
+/// through a real `cat`'s own echo, the same way `clipboard_tests` and `clear_pty_signal_tests`
+/// observe theirs), and the refusal that stops a batch from silently becoming N messages really
+/// fires.
+#[cfg(test)]
+mod send_prompt_tests {
+    use super::*;
+    use gpui::TestAppContext;
+
+    /// A real child on a real pty. `program`/`args` are spawned as-is.
+    fn new_pane(
+        cx: &mut TestAppContext,
+        program: &str,
+        args: Vec<String>,
+    ) -> gpui::Entity<TerminalPane> {
+        cx.new(|cx| {
+            TerminalPane::new(
+                TerminalSpec::command(program, args, std::env::temp_dir()),
+                ROW_FONT_SIZE_PX,
+                cx,
+            )
+        })
+    }
+
+    /// Pumps the real poll loop until `ready`, or gives up after a real wall-clock deadline.
+    /// Mixes virtual-clock advance with a real `sleep`, exactly as
+    /// `crate::work_surface::render`'s own `wait_for_real_pty_output` does and for the same
+    /// reason: the pty reader is a real OS thread, so a virtual-clock-only loop races it.
+    fn pump_until(
+        cx: &mut TestAppContext,
+        mut ready: impl FnMut(&mut TestAppContext) -> bool,
+    ) -> bool {
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            cx.background_executor.advance_clock(POLL_INTERVAL);
+            cx.run_until_parked();
+            if ready(cx) {
+                return true;
+            }
+            if std::time::Instant::now() >= deadline {
+                return false;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+    }
+
+    /// The real thing: a child that turns bracketed paste on (exactly as an agent's full-screen
+    /// TUI does) receives a real multi-line batch, in one write, and echoes it back.
+    #[gpui::test]
+    fn a_multi_line_batch_reaches_a_real_pty_whose_child_has_bracketed_paste_on(
+        cx: &mut TestAppContext,
+    ) {
+        // `printf` sets `DECSET 2004` on its own output, which is how the grid - and therefore
+        // `bracketed_paste_enabled` - learns about it. Nothing here is simulated: the mode really
+        // arrives over the pty from a real child, then `cat` echoes whatever is written back.
+        let pane = new_pane(
+            cx,
+            "sh",
+            vec!["-c".to_string(), "printf '\\033[?2004h'; cat".to_string()],
+        );
+        cx.run_until_parked();
+        assert!(
+            pump_until(cx, |cx| pane
+                .read_with(cx, |pane, _| pane.bracketed_paste_enabled())),
+            "precondition: the real child must have turned bracketed paste on"
+        );
+
+        let sent = pane.update(cx, |pane, cx| {
+            pane.send_prompt(
+                "Review notes on src/api/users.rs \u{2014} 1 note, one prompt, line-anchored.\n\
+                 line 13: ade-note-tenant-id",
+                cx,
+            )
+        });
+        assert!(
+            sent,
+            "a live session with bracketed paste on must accept it"
+        );
+
+        assert!(
+            pump_until(cx, |cx| {
+                pane.read_with(cx, |pane, _| {
+                    pane.visible_text_lines()
+                        .iter()
+                        .any(|line| line.contains("ade-note-tenant-id"))
+                })
+            }),
+            "the real pty's own echo of the batched prompt must appear in the grid - this is \
+             round-tripped evidence the note text genuinely left the app, not an assertion that \
+             `write_input` was called"
+        );
+    }
+
+    /// The refusal. Without bracketed paste, `paste_payload` turns every `\n` into the Enter
+    /// byte, so a multi-line batch would arrive as several separate messages - the exact "one
+    /// comment at a time" failure the audit says makes an agent swing back and forth. It must be
+    /// refused outright, and nothing may reach the child.
+    #[gpui::test]
+    fn a_multi_line_batch_is_refused_when_the_child_has_bracketed_paste_off(
+        cx: &mut TestAppContext,
+    ) {
+        let pane = new_pane(cx, "cat", Vec::new());
+        cx.run_until_parked();
+        assert!(
+            !pane.read_with(cx, |pane, _| pane.bracketed_paste_enabled()),
+            "precondition: a plain `cat` never turns bracketed paste on"
+        );
+
+        let sent = pane.update(cx, |pane, cx| {
+            pane.send_prompt("line 5: ade-refused-one\nline 9: ade-refused-two", cx)
+        });
+        assert!(
+            !sent,
+            "a payload that could split must be refused, not sent"
+        );
+
+        // Pumped for real, so "nothing arrived" is a measured fact rather than an assumption
+        // about timing.
+        for _ in 0..40 {
+            cx.background_executor.advance_clock(POLL_INTERVAL);
+            cx.run_until_parked();
+            std::thread::sleep(Duration::from_millis(2));
+        }
+        pane.read_with(cx, |pane, _| {
+            assert!(
+                !pane
+                    .visible_text_lines()
+                    .iter()
+                    .any(|line| line.contains("ade-refused")),
+                "not one byte of a refused batch may reach the child"
+            );
+            assert!(
+                pane.spawn_error.is_some(),
+                "and the refusal must be said out loud on the pane, not swallowed"
+            );
+        });
+    }
+
+    /// The other half of the same rule: the single-line delivery form
+    /// (`BatchedPrompt::for_delivery(false)`) really is accepted and really does arrive, so the
+    /// refusal above is a guard on a genuine hazard rather than a blanket block.
+    #[gpui::test]
+    fn the_single_line_form_is_delivered_to_a_child_with_bracketed_paste_off(
+        cx: &mut TestAppContext,
+    ) {
+        let pane = new_pane(cx, "cat", Vec::new());
+        cx.run_until_parked();
+
+        let sent = pane.update(cx, |pane, cx| {
+            pane.send_prompt("line 5: ade-flat-one \u{b7} line 9: ade-flat-two", cx)
+        });
+        assert!(sent);
+        assert!(
+            pump_until(cx, |cx| {
+                pane.read_with(cx, |pane, _| {
+                    pane.visible_text_lines()
+                        .iter()
+                        .any(|line| line.contains("ade-flat-two"))
+                })
+            }),
+            "the flat form must really reach the child"
+        );
+    }
+
+    #[gpui::test]
+    fn an_empty_prompt_writes_nothing(cx: &mut TestAppContext) {
+        let pane = new_pane(cx, "cat", Vec::new());
+        cx.run_until_parked();
+        assert!(!pane.update(cx, |pane, cx| pane.send_prompt("", cx)));
     }
 }
 

--- a/crates/app/src/theme.rs
+++ b/crates/app/src/theme.rs
@@ -286,6 +286,7 @@ pub const TOKEN_GROUPS: &[(&str, &[(&str, ColorToken)])] = &[
     ("changes", changes::TOKENS),
     ("budget", budget::TOKENS),
     ("status_bar", status_bar::TOKENS),
+    ("notes", notes::TOKENS),
 ];
 
 /// Every real registered [`ColorToken`], flattened across [`TOKEN_GROUPS`] - registry order
@@ -2904,6 +2905,94 @@ pub mod status_bar {
         ("LOAD_NEUTRAL", LOAD_NEUTRAL),
         ("LOAD_ELEVATED", LOAD_ELEVATED),
         ("LOAD_CRITICAL", LOAD_CRITICAL),
+    ];
+}
+
+/// Diff-line review notes (GitHub issue #288, `STAGE-A-CHANGELOG.md` §1's two `§6.2` rows and
+/// the audit's top-5 #2) - the notes bar above the hunks and the card pinned beneath a line.
+///
+/// Every value here is transcribed directly from `Jerry.dc.html`'s own inline styles for that
+/// surface (the `hasNotes` bar and the `l.isNote` branch of the diff row loop), not derived.
+///
+/// The one colour worth naming twice is [`EDGE`]: `#5a9ad4` is this palette's *selection* blue -
+/// the same value [`super::editor::SELECTION`] carries - and §6.2 asks for "the selection-blue
+/// left edge" on the card by name. It gets its own key rather than reusing the editor's because
+/// the two are different facts (a text selection vs. "this is your annotation"), and a re-theme
+/// that moved one has no business silently moving the other - the same reasoning
+/// [`super::status_bar::LOAD_ELEVATED`] already records for its amber.
+pub mod notes {
+    use super::{token, ColorToken};
+
+    /// The card's 2px left edge, and the 5px square that opens the notes bar - selection blue.
+    pub const EDGE: ColorToken = token("notes.edge", 0x5a9ad4);
+    /// The pinned card's fill.
+    pub const CARD_BG: ColorToken = token("notes.card_bg", 0x151a1f);
+    /// The pinned card's 1px border (the three sides that are not [`EDGE`]).
+    pub const CARD_BORDER: ColorToken = token("notes.card_border", 0x2b3d4f);
+    /// The card's own note text.
+    pub const CARD_FG: ColorToken = token("notes.card_fg", 0xc2c7cc);
+    /// The placeholder shown in an empty, still-being-typed card.
+    pub const CARD_PLACEHOLDER: ColorToken = token("notes.card_placeholder", 0x5e646a);
+
+    /// A card's `draft` mark - it has not been delivered to anyone yet.
+    pub const MARK_DRAFT: ColorToken = token("notes.mark_draft", 0x7fa9cf);
+    /// A card's `sent` mark, and the bar's own `✓ sent` confirmation.
+    pub const MARK_SENT: ColorToken = token("notes.mark_sent", 0x7fc79a);
+
+    /// The diff row's note column when a note really is pinned on that line (`●`).
+    pub const DOT: ColorToken = token("notes.dot", 0x8fbde6);
+    /// The same column's `○` - a line that is the note cursor but carries no note yet.
+    pub const DOT_EMPTY: ColorToken = token("notes.dot_empty", 0x3a3f44);
+
+    /// The notes bar's band.
+    pub const BAR_BG: ColorToken = token("notes.bar_bg", 0x141a20);
+    /// Its 1px bottom rule against the hunks below it.
+    pub const BAR_BORDER: ColorToken = token("notes.bar_border", 0x223140);
+    /// The bar's count sentence (`1 note on this file`).
+    pub const BAR_LABEL: ColorToken = token("notes.bar_label", 0xa5cdf0);
+    /// The bar's fixed explanatory line (*one prompt, line-anchored · pinned after the
+    /// revision*), deliberately recessive against [`BAR_LABEL`].
+    pub const BAR_META: ColorToken = token("notes.bar_meta", 0x5e646a);
+    /// A delivery that really failed, said out loud in the bar rather than swallowed.
+    ///
+    /// **A derivation, not a transcription** - the mock has no failure state for this surface
+    /// (audit item I12 is a whole Stage B item). It takes [`super::status::FAIL`]'s value, which
+    /// is what every other real failure in this app is already painted.
+    pub const BAR_ERROR: ColorToken = token("notes.bar_error", 0xc4726d);
+
+    /// The `Send notes to <agent>` button's fill, border, hover fill and label.
+    pub const SEND_BG: ColorToken = token("notes.send_bg", 0x18232d);
+    /// Its 1px border, and its keycaps' border.
+    pub const SEND_BORDER: ColorToken = token("notes.send_border", 0x365b78);
+    /// Its hover fill.
+    pub const SEND_HOVER_BG: ColorToken = token("notes.send_hover_bg", 0x1e2d3a);
+    /// Its label.
+    pub const SEND_FG: ColorToken = token("notes.send_fg", 0xa5cdf0);
+    /// Its `⌘⏎` keycaps' glyphs.
+    pub const SEND_CAP_FG: ColorToken = token("notes.send_cap_fg", 0x7fa9cf);
+
+    /// Every real [`ColorToken`] this module declares, paired with its own Rust `const` name -
+    /// the module's slice of [`super::TOKEN_GROUPS`]'s whole-app registry.
+    pub const TOKENS: &[(&str, ColorToken)] = &[
+        ("EDGE", EDGE),
+        ("CARD_BG", CARD_BG),
+        ("CARD_BORDER", CARD_BORDER),
+        ("CARD_FG", CARD_FG),
+        ("CARD_PLACEHOLDER", CARD_PLACEHOLDER),
+        ("MARK_DRAFT", MARK_DRAFT),
+        ("MARK_SENT", MARK_SENT),
+        ("DOT", DOT),
+        ("DOT_EMPTY", DOT_EMPTY),
+        ("BAR_BG", BAR_BG),
+        ("BAR_BORDER", BAR_BORDER),
+        ("BAR_LABEL", BAR_LABEL),
+        ("BAR_META", BAR_META),
+        ("BAR_ERROR", BAR_ERROR),
+        ("SEND_BG", SEND_BG),
+        ("SEND_BORDER", SEND_BORDER),
+        ("SEND_HOVER_BG", SEND_HOVER_BG),
+        ("SEND_FG", SEND_FG),
+        ("SEND_CAP_FG", SEND_CAP_FG),
     ];
 }
 

--- a/crates/app/src/work_surface/agents.rs
+++ b/crates/app/src/work_surface/agents.rs
@@ -283,6 +283,30 @@ impl Agents {
         self.count_for_cwd(&agent.cwd) == 1
     }
 
+    /// **The worktree's primary agent**: its own last-active tab (see [`Self::active_by_cwd`]),
+    /// or - for a worktree that has never had one recorded - its first open agent in creation
+    /// order. `None` if the worktree has no open agents at all.
+    ///
+    /// This is the rule [`Self::activate_for_worktree`] has always applied when the rail moves to
+    /// a worktree; it is factored out here because GitHub issue #288 needs the same answer to a
+    /// different question - *"which agent do this file's review notes go to, when the file itself
+    /// names nobody"* - and two copies of "which agent does this worktree mean" is exactly how the
+    /// centre pane and a send target would come to disagree on screen.
+    ///
+    /// Deliberately **not** filtered to agent sessions here: this answers "which tab is this
+    /// worktree's", and a worktree whose only tab is a shell really does have that shell as its
+    /// primary. Callers that need a party capable of *revising code* filter on
+    /// `ProcessKind::is_agent_session` themselves - `crate::review_notes::flow` does, and says
+    /// why.
+    pub fn primary_for_cwd(&self, cwd: &Path) -> Option<&Agent> {
+        let remembered = self
+            .active_by_cwd
+            .get(cwd)
+            .copied()
+            .and_then(|id| self.agents.iter().find(|agent| agent.id == id));
+        remembered.or_else(|| self.agents.iter().find(|agent| agent.cwd == cwd))
+    }
+
     pub fn active_id(&self) -> Option<AgentId> {
         self.active
     }
@@ -456,6 +480,20 @@ impl Agents {
         }
     }
 
+    /// Test-only sibling of [`Self::set_kind_for_test`]: overrides an already-spawned agent's
+    /// recorded spawn second without touching its real process.
+    ///
+    /// The spawn second is half of `crate::review::state::baseline_key`, i.e. half of the durable
+    /// identity `crate::provenance` files a line's author under. A test that seeds provenance for
+    /// a specific agent has to be able to make a live tab carry that same key, and the alternative
+    /// - waiting for the wall clock to land on the right second - is not a test.
+    #[cfg(test)]
+    pub(crate) fn set_spawned_at_unix_for_test(&mut self, id: AgentId, spawned_at_unix: i64) {
+        if let Some(agent) = self.agents.iter_mut().find(|agent| agent.id == id) {
+            agent.spawned_at_unix = spawned_at_unix;
+        }
+    }
+
     /// Real `SIGSTOP`, via `TerminalPane::pause`, against every real agent session (never a bare
     /// [`ProcessKind::Shell`] - mirrors [`Self::count_for_cwd`]'s own "a shell has no turns and
     /// nothing to review" convention) currently open in `cwd` - GitHub issue #242 phase B's
@@ -550,17 +588,7 @@ impl Agents {
     /// keyboard focus in the same step (the previously-active agent's pane may no longer be
     /// rendered at all once the tab strip's own per-worktree filter applies).
     pub fn activate_for_worktree(&mut self, cwd: &Path, cx: &mut Context<AdeApp>) {
-        let remembered = self
-            .active_by_cwd
-            .get(cwd)
-            .copied()
-            .filter(|id| self.agents.iter().any(|agent| agent.id == *id));
-        let id = remembered.or_else(|| {
-            self.agents
-                .iter()
-                .find(|agent| agent.cwd == cwd)
-                .map(|agent| agent.id)
-        });
+        let id = self.primary_for_cwd(cwd).map(|agent| agent.id);
         self.active = id;
         if let Some(id) = id {
             self.active_by_cwd.insert(cwd.to_path_buf(), id);

--- a/crates/pty-core/src/lib.rs
+++ b/crates/pty-core/src/lib.rs
@@ -157,7 +157,9 @@ use std::io::{Read, Write};
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, Receiver};
+use std::sync::Arc;
 use std::thread::JoinHandle;
 // Only `#[cfg(unix)]` code below (the process-tree kill path, and the two grace-period
 // consts) uses `Duration` outside of `#[cfg(test)]`; the test module below imports it
@@ -434,6 +436,9 @@ pub struct PtySession {
     output_rx: Receiver<Vec<u8>>,
     reader_thread: Option<JoinHandle<()>>,
     writer_tx: Option<mpsc::Sender<Vec<u8>>>,
+    /// Raised by [`run_writer_loop`] when a real write to the pty fails, so
+    /// [`PtySession::write_input`] stops reporting success into a broken pipe. See its docs.
+    writer_failed: Arc<AtomicBool>,
     writer_thread: Option<JoinHandle<()>>,
     shutdown_write: Option<filedescriptor::FileDescriptor>,
 }
@@ -517,8 +522,12 @@ pub fn spawn(options: SpawnOptions) -> Result<PtySession, PtyError> {
     };
 
     let (writer_tx, writer_rx) = mpsc::channel::<Vec<u8>>();
-    let writer_thread = std::thread::spawn(move || {
-        run_writer_loop(writer, writer_rx);
+    let writer_failed = Arc::new(AtomicBool::new(false));
+    let writer_thread = std::thread::spawn({
+        let writer_failed = Arc::clone(&writer_failed);
+        move || {
+            run_writer_loop(writer, writer_rx, writer_failed);
+        }
     });
 
     Ok(PtySession {
@@ -528,6 +537,7 @@ pub fn spawn(options: SpawnOptions) -> Result<PtySession, PtyError> {
         output_rx,
         reader_thread: Some(reader_thread),
         writer_tx: Some(writer_tx),
+        writer_failed,
         writer_thread: Some(writer_thread),
         shutdown_write,
     })
@@ -634,12 +644,18 @@ fn run_reader_loop(mut reader: Box<dyn Read + Send>, output_tx: mpsc::SyncSender
 /// Body of the background writer thread: serializes writes from [`PtySession::write_input`]
 /// so the pty's actual (possibly blocking) `write` syscall never happens on a caller's
 /// thread. Exits once its `Sender` is dropped (channel disconnected) or a write fails.
-fn run_writer_loop(mut writer: Box<dyn Write + Send>, rx: mpsc::Receiver<Vec<u8>>) {
+///
+/// `failed` is raised on a real write/flush error before the loop exits, and is what lets
+/// [`PtySession::write_input`] stop reporting success once the pipe is genuinely broken - see
+/// that method's own docs for why "enqueued" and "written" are not the same claim.
+fn run_writer_loop(
+    mut writer: Box<dyn Write + Send>,
+    rx: mpsc::Receiver<Vec<u8>>,
+    failed: Arc<AtomicBool>,
+) {
     while let Ok(data) = rx.recv() {
-        if writer.write_all(&data).is_err() {
-            break;
-        }
-        if writer.flush().is_err() {
+        if writer.write_all(&data).is_err() || writer.flush().is_err() {
+            failed.store(true, Ordering::SeqCst);
             break;
         }
     }
@@ -659,12 +675,34 @@ impl PtySession {
     /// user or piped in by another process). The actual write happens on a dedicated
     /// background thread, so this call does not block on pty I/O even if the child
     /// isn't currently reading its input.
+    ///
+    /// ## What `Ok` does and does not promise
+    ///
+    /// `Ok` means the bytes were handed to the writer thread, **not** that they reached the fd -
+    /// the write itself happens later, on that thread, and cannot be awaited here without
+    /// reintroducing exactly the blocking this indirection exists to avoid.
+    ///
+    /// What it *does* promise, since GitHub issue #288: the writer thread has not already died.
+    /// It used to swallow a failed `write_all`/`flush` and exit silently, so every subsequent
+    /// `write_input` kept returning `Ok` into a pipe that no longer went anywhere - and a caller
+    /// that treats `Ok` as "delivered" (issue #288's review notes flip to `sent` on it) would
+    /// then claim a delivery that never happened, with no way back. [`Self::writer_failed`] is
+    /// raised by [`run_writer_loop`] before it breaks, and checked here first.
     pub fn write_input(&self, data: &[u8]) -> Result<(), PtyError> {
+        if self.writer_failed.load(Ordering::SeqCst) {
+            return Err(PtyError::WriterClosed);
+        }
         self.writer_tx
             .as_ref()
             .ok_or(PtyError::WriterClosed)?
             .send(data.to_vec())
             .map_err(|_| PtyError::WriterClosed)
+    }
+
+    /// Whether this session's writer thread has already failed a real write to the pty - see
+    /// [`Self::write_input`]'s own docs.
+    pub fn writer_failed(&self) -> bool {
+        self.writer_failed.load(Ordering::SeqCst)
     }
 
     /// Resizes the pty. Propagates the resize down to the kernel, which will notify the
@@ -1554,6 +1592,36 @@ mod tests {
              the output channel does not appear to be backpressuring (expected growth \
              bounded by the channel capacity, well under 20MB)"
         );
+    }
+
+    /// The healthy half of GitHub issue #288's writer-health check: a live session must report a
+    /// working writer and must keep accepting writes. The check is a real gate on
+    /// `write_input`, so a version of it that were ever true by accident would silently make
+    /// every paste and every sent prompt in the app fail.
+    #[test]
+    fn a_live_session_reports_a_healthy_writer_and_keeps_accepting_writes() {
+        let session = spawn(SpawnOptions::new("cat")).expect("spawning `cat` should succeed");
+        assert!(!session.writer_failed());
+        for _ in 0..3 {
+            session
+                .write_input(b"still-writing\n")
+                .expect("a healthy writer must keep accepting writes");
+        }
+        assert!(!session.writer_failed());
+        let output = drain_until_contains(&session, "still-writing", Duration::from_secs(5));
+        assert!(String::from_utf8_lossy(&output).contains("still-writing"));
+    }
+
+    /// And the closed half: once the session has been shut down there is no writer at all, so a
+    /// write must be a typed error rather than a silent success into nothing.
+    #[test]
+    fn a_shut_down_session_refuses_writes() {
+        let mut session = spawn(SpawnOptions::new("cat")).expect("spawning `cat` should succeed");
+        session.shutdown().expect("shutdown");
+        assert!(matches!(
+            session.write_input(b"too late"),
+            Err(PtyError::WriterClosed)
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Audit top-5 #2 (`AUDIT-2026-08-13-competitive-v2.md` §6.2), built as `STAGE-A-CHANGELOG.md` §1's two `§6.2` rows describe it and verified against §3's own acceptance list. Nothing like this existed in the app before — there was no comment model anywhere, and no way at all to say something back to an agent about a specific line.

## What it does

Orca's `Annotate AI Diff`, including the three parts the audit says they learned the hard way — each structural here rather than a rule someone has to remember:

- **Batch.** *"sending comments one at a time causes the agent to swing back and forth"*. `review_notes::prompt::BatchedPrompt` composes every note on a file into one string, and `TerminalPane::send_prompt` delivers it with exactly one submit byte. It also **refuses** a payload that could split: with bracketed paste off, `paste_payload` turns every `\n` into the Enter byte, so a five-line batch would arrive as five separate messages and look like it worked. `for_delivery` therefore has two forms — multi-line when the target really has `DECSET 2004` on, `·`-joined with no line breaks when it does not — and `send_prompt` checks that invariant rather than trusting it.
- **Send from the top.** A notes bar above the hunks: the count (through #281's pluralisation helper), the design's line verbatim — *one prompt, line-anchored · pinned after the revision* — and `Send notes to <agent>` with real `mod+enter` keycaps behind a real binding (ride-along I10). Every control carries a tooltip (I11).
- **Keep them pinned.** Sending only ever *sets* `ReviewNote::sent`; there is no code path in the folder that removes a note as a consequence of sending one.

Notes interleave into the existing `DiffRow` stream as a new `DiffRow::Note` variant — no parallel list, one diff renderer — and are anchored to a real **file line number** (`NoteAnchor::New`/`Old`) rather than a row index, so a hunk growing above them cannot silently re-anchor every note. Removed lines are annotatable and keep their own old-file anchor. State persists in `review-notes.toml`, keyed worktree → path → anchor, merged under the shared lock.

`draft`/`sent` is derived, not stored: `ReviewNote::sent` holds the exact wording delivered, so editing a sent note goes back to `draft` while the history stays honest about what the agent really was told.

**Target resolution** is §1's `noteTarget`: the file's first author from #287's provenance, resolved to a live agent session in this worktree, falling back to the worktree's primary agent — now one rule, `Agents::primary_for_cwd`, factored out of `activate_for_worktree` so the centre pane and a send target cannot disagree. A shell is never a target.

## Two deliberate departures from the mock, both documented at the code

- **The card is one row tall.** Since #224 the diff is a `gpui::uniform_list`, which lays every slot out at the height measured from item 0, so a free-height wrapping card is not representable; the multi-slot alternative would have to guess a line count before layout knows the pane width, and would vanish the moment its head scrolled off. Same four elements in the same order, text on one line with the whole of it in a tooltip.
- **The selection-blue left edge is a real 2px child**, because GPUI carries one `border_color` per element and the mock's two-colour border has no single-element equivalent.

## Verification

The mock's own acceptance sequence, end to end in a real window against a real spawned agent process: click pins a card → bar reads `1 note on this file` → send → bar reads `1 note sent — awaiting revision` with `✓ sent`, the card's mark flips `draft → sent`, **the note stays pinned** — and the batched prompt really arrives in that agent's real pty, observed through the child's own output rather than by asserting `write_input` was called. Done both as a `#[gpui::test]` and as a live X11 run with screenshots.

The second commit closes eight defects an adversarial review found, including one critical: the note's focus node used to live on the card, so scrolling it out of the virtualized list deleted the focused node mid-sentence and every keystroke went silently nowhere. Also fixed: `v` and `]` (bound under `"diff"`) were swallowing characters typed into a note; a note being typed was lost on quit; `sent` could be claimed for a delivery into a dead agent; a draft was not bound to a checkout. See that commit's message for all eight.

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)