### PR TITLE
fix(review): wire the review-note field into the real caret-blink loop

### DIFF
--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -740,6 +740,14 @@ impl AdeApp {
                 // no subscription ever called `start_caret_blink` for this handle), so the caret
                 // rendered as a permanently solid bar instead of blinking.
                 &this.commit_message_focus_handle,
+                // GitHub issue #288's review-note field is a fifth, and the same live report came
+                // in again the same night: another real `text_history::TextField` built inside
+                // this same `Self` literal (`crate::review_notes::flow`), never threaded through
+                // `Self::wire_caret_blink`, so its caret never blinked - it painted only if
+                // `caret_blink_visible` happened to be `true` from some *other* handle's timer at
+                // the moment this one gained focus, and never toggled after that, reading as no
+                // caret at all most of the time.
+                &this.note_focus_handle,
             ],
             window,
             cx,


### PR DESCRIPTION
## Summary
- Live report: the review-note editor's caret is invisible.
- Same recurring bug class (GitHub issue #45) that's hit the rail filter, the new-file prompt, the branch prompt, and the commit-message field before it: `note_focus_handle` is a real `FocusHandle` behind a real `text_history::TextField`, but it was never threaded through `AdeApp::wire_caret_blink`.
- Without that wiring, `caret_blink_visible` never toggles in response to this handle's own focus events - it paints only if some *other* handle's blink timer happened to leave the shared flag `true` at the exact moment this one gained focus, then never toggles again.
- One-line fix: add `&this.note_focus_handle` to the same `wire_caret_blink` call that already carries `commit_message_focus_handle`.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets` (clean)
- [x] `cargo fmt --all -- --check` (clean)
- [x] `cargo test -p app --lib caret` - 56 passed