### PR TITLE
Review notes: the card's real width, the caret's real position, and a send control that says why it cannot send

### DIFF
--- a/crates/app/src/code_surface/diff_view.rs
+++ b/crates/app/src/code_surface/diff_view.rs
@@ -941,6 +941,22 @@ pub(in crate::code_surface) fn render_diff_line(
         // never name different rows.
         .id(gpui::SharedString::from(row_selector.clone()))
         .flex()
+        // A row is at least as wide as the pane, and may be wider.
+        //
+        // Live report, found while reproducing GitHub issue #288's own: a click in the empty
+        // space to the right of a short diff line did **nothing at all**. The row is the note
+        // gesture's hit target (see the `on_click` at the bottom of this function), and a
+        // `gpui::uniform_list` item whose own width is `auto` is laid out at its *content* width -
+        // `Drawable::layout_as_root` never goes through the `stretch_auto_size_to_fill` the window
+        // root does (see `crate::review_notes::render::AdeApp::render_review_note_card`'s own
+        // note on the same mechanism). So the hit box, the hover lift and the add/remove tint all
+        // stopped at the last glyph of the line, several hundred pixels short of the pane, with
+        // nothing on screen saying where the clickable part ended.
+        //
+        // `min_w_full` rather than `w_full` deliberately: a line longer than the pane must still
+        // be able to lay itself out at its real width (the list's own content width is measured
+        // from these items), which a hard `width:100%` would forbid.
+        .min_w_full()
         .items_center()
         .font(font(theme::font::MONO))
         .text_size(rems(1.0))

--- a/crates/app/src/graph_view/render.rs
+++ b/crates/app/src/graph_view/render.rs
@@ -5,7 +5,7 @@
 
 use super::*;
 use crate::root::widgets::{
-    menu_popover_chrome, modal_scrim_bg, render_sidebar_message, render_status_letter,
+    menu_popover_chrome, modal_scrim_bg, render_sidebar_message, render_status_letter, SimpleInput,
 };
 use crate::settings::widgets;
 use crate::sidebar::changes;
@@ -2953,7 +2953,6 @@ impl AdeApp {
         count: usize,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        let has_query = !self.graph_state.branches_filter.is_empty();
         div()
             .id("graph-branches-filter")
             .track_focus(&self.graph_state.branches_filter_focus_handle)
@@ -2979,51 +2978,20 @@ impl AdeApp {
                     .text_color(theme::text::GHOST)
                     .child("/"),
             )
-            .child(
-                div()
-                    .flex_1()
-                    .flex()
-                    .items_center()
-                    // No decorative gap before the caret - see
-                    // `crate::rail::render::AdeApp::render_rail_filter_row`'s own
-                    // comment for why (live report: it read as a gap between the
-                    // typed text and where it's actually being typed).
-                    // GitHub issue #45 / live report: this filter row had *no* caret element at
-                    // all - `branches_filter_focus_handle` was never threaded into
-                    // `AdeApp::wire_caret_blink` (see `Self::new_with_settings`'s own comment on
-                    // why it's wired separately, after `graph_state` exists), so there was
-                    // nothing to paint here regardless. Now matches
-                    // `crate::rail::render::AdeApp::render_rail_filter_row`'s own fixed
-                    // before-placeholder / after-text placement.
-                    .when(!has_query, |el| {
-                        el.child(self.render_simple_input_caret(
-                            "graph-branches-filter-caret",
-                            &self.graph_state.branches_filter_focus_handle,
-                        ))
-                    })
-                    .child(
-                        div()
-                            .font(font(theme::font::MONO))
-                            .text_size(px(10.5))
-                            .text_color(if has_query {
-                                theme::text::DIM
-                            } else {
-                                theme::text::GHOST
-                            })
-                            .child(if has_query {
-                                self.graph_state.branches_filter.as_str().to_string()
-                            } else {
-                                "filter branches".to_string()
-                            })
-                            .debug_selector(|| "graph-branches-filter-text".to_string()),
-                    )
-                    .when(has_query, |el| {
-                        el.child(self.render_simple_input_caret(
-                            "graph-branches-filter-caret",
-                            &self.graph_state.branches_filter_focus_handle,
-                        ))
-                    }),
-            )
+            // Caret placement, the empty/typed ordering and the flex structure around them all
+            // through the one helper that owns them - see
+            // `AdeApp::render_simple_input_row`'s own docs.
+            .child(self.render_simple_input_row(SimpleInput {
+                caret_selector: "graph-branches-filter-caret".into(),
+                text_selector: "graph-branches-filter-text".into(),
+                focus_handle: Some(&self.graph_state.branches_filter_focus_handle),
+                text: self.graph_state.branches_filter.as_str(),
+                placeholder: "filter branches",
+                font: theme::font::MONO,
+                text_size: px(10.5),
+                text_color: theme::text::DIM,
+                placeholder_color: theme::text::GHOST,
+            }))
             .child(
                 div()
                     .font(font(theme::font::MONO))

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::root::plural;
-use crate::root::widgets::{render_disclosure_caret, text_tooltip};
+use crate::root::widgets::{render_disclosure_caret, text_tooltip, SimpleInput};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -939,8 +939,6 @@ impl AdeApp {
         view: rail_strip::SidebarView,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        let has_query = !self.filter_query.is_empty();
-
         div()
             .id("rail-filter-row")
             .track_focus(&self.filter_focus_handle)
@@ -969,58 +967,20 @@ impl AdeApp {
                     .text_color(theme::text::GHOST)
                     .child("/"),
             )
-            .child(
-                div()
-                    .flex_1()
-                    .min_w_0()
-                    .flex()
-                    .items_center()
-                    // Live report: a decorative gap between the real text and its own caret
-                    // reads as "there's a space between the char and where it's typed" - a
-                    // cursor sits flush against the last glyph, it doesn't float clear of it.
-                    // Removed here and everywhere else this same caret+text pair appears.
-                    // GitHub issue #45 / live report: the caret used to be a fixed trailing
-                    // child, which put it visually *after* the placeholder text whenever
-                    // `filter_query` was empty. It now sits before the placeholder (the real
-                    // cursor position, 0, for an empty field - matching
-                    // `crate::palette::render::AdeApp::render_palette_caret`'s own empty-query
-                    // placement) and after the real typed text once there is any, never
-                    // appended past whatever placeholder string happens to render.
-                    .when(!has_query, |el| {
-                        el.child(self.render_simple_input_caret(
-                            "rail-filter-caret",
-                            &self.filter_focus_handle,
-                        ))
-                    })
-                    .child(
-                        div()
-                            .font(font(theme::font::MONO))
-                            .text_size(self.ui_text_size(10.5))
-                            .text_color(if has_query {
-                                theme::text::DIM
-                            } else {
-                                theme::text::GHOST
-                            })
-                            .child(if has_query {
-                                self.filter_query.as_str().to_string()
-                            } else {
-                                match view {
-                                    rail_strip::SidebarView::Worktrees => {
-                                        "filter worktrees and agents"
-                                    }
-                                    rail_strip::SidebarView::Problems => "filter problems",
-                                }
-                                .to_string()
-                            })
-                            .debug_selector(|| "rail-filter-text".to_string()),
-                    )
-                    .when(has_query, |el| {
-                        el.child(self.render_simple_input_caret(
-                            "rail-filter-caret",
-                            &self.filter_focus_handle,
-                        ))
-                    }),
-            )
+            .child(self.render_simple_input_row(SimpleInput {
+                caret_selector: "rail-filter-caret".into(),
+                text_selector: "rail-filter-text".into(),
+                focus_handle: Some(&self.filter_focus_handle),
+                text: self.filter_query.as_str(),
+                placeholder: match view {
+                    rail_strip::SidebarView::Worktrees => "filter worktrees and agents",
+                    rail_strip::SidebarView::Problems => "filter problems",
+                },
+                font: theme::font::MONO,
+                text_size: self.ui_text_size(10.5),
+                text_color: theme::text::DIM,
+                placeholder_color: theme::text::GHOST,
+            }))
     }
 
     /// Builds this rail's repo groups fresh from live state every render (cheap: no I/O, just

--- a/crates/app/src/review_notes/flow.rs
+++ b/crates/app/src/review_notes/flow.rs
@@ -82,7 +82,7 @@ impl NoteTarget {
 /// swallowed - audit item I12's whole complaint about this design is that nothing in it ever
 /// fails, and a review note that silently never reached anyone is the worst possible version of
 /// that.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum NoteSendError {
     /// Nothing real to send.
     NothingToSend,
@@ -538,7 +538,7 @@ impl AdeApp {
             pane.send_prompt(&text, cx)
         });
         if !delivered {
-            self.note_send_error = Some(NoteSendError::DeliveryFailed.message().to_string());
+            self.note_send_error = Some(NoteSendError::DeliveryFailed);
             cx.notify();
             return Err(NoteSendError::DeliveryFailed);
         }
@@ -572,7 +572,7 @@ impl AdeApp {
             // real note, so there is nowhere to show it now - and setting it would leave the
             // message sitting in the bar the moment a note *was* written.
             if err != NoteSendError::NothingToSend {
-                self.note_send_error = Some(err.message().to_string());
+                self.note_send_error = Some(err);
                 cx.notify();
             }
         }

--- a/crates/app/src/review_notes/integration_tests.rs
+++ b/crates/app/src/review_notes/integration_tests.rs
@@ -497,6 +497,141 @@ fn a_worktree_whose_only_tab_is_a_shell_offers_no_send_target(cx: &mut TestAppCo
         cx.debug_bounds("diff-notes-send").is_none(),
         "but there is no send button, rather than one naming an agent that is not there"
     );
+    assert!(
+        cx.debug_bounds("diff-notes-send-unavailable").is_some(),
+        "the control is still drawn, muted and naming what is missing - see \
+         `the_send_control_says_why_it_cannot_send_rather_than_vanishing`"
+    );
+}
+
+/// **Live report: *"I can't really submit the comments, maybe there is something I don't
+/// understand"*.**
+///
+/// There was nothing to understand. The bar drew its send button only once
+/// [`AdeApp::review_note_target`] resolved a live agent session in the worktree, and drew nothing
+/// whatsoever otherwise - so a reviewer who opened a diff before starting an agent (the ordinary
+/// order: read the change, *then* ask for the revision) saw a bar that counted their notes,
+/// promised they would go out as one prompt, and offered no control, no keycaps and no
+/// explanation. `mod+enter` was bound the whole time, but the only place that shortcut is ever
+/// advertised is inside the button that was not being drawn.
+///
+/// So this asserts the two halves that were missing, in the state that produced the report - a
+/// real note on a real diff in a worktree with no agent at all:
+///
+/// 1. a send control is really painted, and
+/// 2. it says what is missing, rather than naming an agent that is not there.
+///
+/// And it asserts the recovery: the moment a real agent session exists, the same slot becomes the
+/// real button.
+#[gpui::test]
+fn the_send_control_says_why_it_cannot_send_rather_than_vanishing(cx: &mut TestAppContext) {
+    let (repo, _store) = repo_with_an_agent_authored_change(1_700_000_000);
+    let shim_dir = TempDir::new().expect("tempdir");
+    let program = agent_stand_in(shim_dir.path());
+    let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
+    app.update_in(cx, |app, window, cx| {
+        app.settings.terminal.shell = Some(program);
+        app.set_right_sidebar_view(RightSidebarView::Changes, window, cx);
+        app.open_change_diff(PathBuf::from(PATH), window, cx);
+    });
+    cx.run_until_parked();
+
+    click_line(cx, 2);
+    cx.simulate_input("this needs a tenant id");
+    cx.run_until_parked();
+
+    let unavailable = cx.debug_bounds("diff-notes-send-unavailable").expect(
+        "with no agent in the worktree the send control must still be drawn - a bar that counts \
+         notes and offers nothing to do with them is the whole of the live report",
+    );
+    assert!(
+        unavailable.size.width > gpui::px(0.0),
+        "and it must be a real, measurable control rather than a zero-width placeholder"
+    );
+    assert!(
+        cx.debug_bounds("diff-notes-send-unavailable-label")
+            .is_some(),
+        "carrying its own label, which is what says *why* it cannot send"
+    );
+    assert!(
+        super::render::SEND_UNAVAILABLE_LABEL.contains("no agent"),
+        "and that label names the missing thing rather than an agent that is not there - got {:?}",
+        super::render::SEND_UNAVAILABLE_LABEL
+    );
+    assert!(
+        cx.debug_bounds("diff-notes-send").is_none(),
+        "the real button stays absent while there is genuinely nobody to send to"
+    );
+
+    // The recovery: one real agent session, and the same slot becomes the real button.
+    app.update_in(cx, |app, window, cx| {
+        app.new_agent(ProcessKind::Shell, window, cx);
+        let id = app.agents.active_id().expect("the tab we just spawned");
+        app.agents.set_kind_for_test(id, ProcessKind::claude());
+    });
+    cx.run_until_parked();
+    assert!(
+        cx.debug_bounds("diff-notes-send").is_some(),
+        "the moment a real agent session exists the send button must appear"
+    );
+    assert!(
+        cx.debug_bounds("diff-notes-send-unavailable").is_none(),
+        "and the muted stand-in must go, rather than both being drawn"
+    );
+}
+
+/// A `NoTarget` failure is a statement about the worktree, and starting an agent makes it false.
+///
+/// Observed on a real window while reproducing this feature's other reports: pressing `mod+enter`
+/// with no agent open left `no agent open in this worktree to send to` sitting in the bar, in red,
+/// where it stayed after an agent was started - directly beside the live `Send notes to Claude`
+/// button it was contradicting. The bar now filters the recorded failure against what is true at
+/// render time, which is why `AdeApp::note_send_error` holds the error rather than its sentence.
+#[gpui::test]
+fn a_no_target_failure_stops_being_shown_once_an_agent_really_is_open(cx: &mut TestAppContext) {
+    let (repo, _store) = repo_with_an_agent_authored_change(1_700_000_000);
+    let shim_dir = TempDir::new().expect("tempdir");
+    let program = agent_stand_in(shim_dir.path());
+    let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
+    app.update_in(cx, |app, window, cx| {
+        app.settings.terminal.shell = Some(program);
+        app.set_right_sidebar_view(RightSidebarView::Changes, window, cx);
+        app.open_change_diff(PathBuf::from(PATH), window, cx);
+    });
+    cx.run_until_parked();
+
+    click_line(cx, 2);
+    cx.simulate_input("no one is listening yet");
+    cx.run_until_parked();
+    // The same spec string the keycaps are rendered from, as a real keystroke.
+    cx.simulate_keystrokes(if cfg!(target_os = "macos") {
+        "cmd-enter"
+    } else {
+        "ctrl-enter"
+    });
+    cx.run_until_parked();
+
+    assert_eq!(
+        app.read_with(cx, |app, _| app.note_send_error),
+        Some(super::flow::NoteSendError::NoTarget),
+        "the keystroke is bound and really reports the failure rather than doing nothing"
+    );
+    assert!(
+        cx.debug_bounds("diff-notes-bar-error").is_some(),
+        "and while it is still true, the bar says it out loud"
+    );
+
+    app.update_in(cx, |app, window, cx| {
+        app.new_agent(ProcessKind::Shell, window, cx);
+        let id = app.agents.active_id().expect("the tab we just spawned");
+        app.agents.set_kind_for_test(id, ProcessKind::claude());
+    });
+    cx.run_until_parked();
+    assert!(
+        cx.debug_bounds("diff-notes-bar-error").is_none(),
+        "once a real target exists the bar must stop claiming there is none, rather than leaving \
+         a red contradiction beside a live send button"
+    );
 }
 
 /// *"Notes are keyed per worktree + path + line and survive scrolling/reopening."* Opening another
@@ -1042,4 +1177,211 @@ fn saving_does_not_overwrite_a_worktree_this_window_only_read(cx: &mut TestAppCo
         1,
         "and this window's own note must really have been written"
     );
+}
+
+/// **Live report: *"when clicking on the line the comment popover is changing width strangely"*.**
+///
+/// It really was. A `gpui::uniform_list` lays each item out through `Drawable::layout_as_root`,
+/// which - unlike the *window* root, the only node `TaffyLayoutEngine::stretch_auto_size_to_fill`
+/// is ever applied to - leaves an `auto` width sized to the item's own **content**. So the card's
+/// `flex_1` body resolved against the note's text rather than against the pane: the card grew a
+/// few pixels per keystroke, and jumped to a different width on every line clicked.
+///
+/// Measured against the diff's own rows rather than against a hardcoded number, because "the
+/// pane's width" is the actual claim: a card is the row's width less the mock's own
+/// `margin: … 14px … 74px` inset, whatever the note says.
+#[gpui::test]
+fn a_note_card_is_the_panes_width_whatever_the_note_says(cx: &mut TestAppContext) {
+    let (repo, store) = repo_with_an_agent_authored_change(1_700_000_000);
+    let shim_dir = TempDir::new().expect("tempdir");
+    let (_app, cx, _agent) = open_review(cx, &repo, &shim_dir, store, 1_700_000_000);
+
+    let row = cx
+        .debug_bounds("diff-line-2")
+        .expect("a real diff row to measure the pane against");
+
+    click_line(cx, 2);
+    let blank = cx
+        .debug_bounds("diff-note-0")
+        .expect("the card must paint as soon as the line is clicked");
+
+    cx.simulate_input("x");
+    cx.run_until_parked();
+    let short = cx.debug_bounds("diff-note-0").expect("still painted");
+
+    cx.simulate_input(" and then a great deal more text than that, several times over");
+    cx.run_until_parked();
+    let long = cx.debug_bounds("diff-note-0").expect("still painted");
+
+    assert_eq!(
+        (blank.size.width, short.size.width),
+        (long.size.width, long.size.width),
+        "an empty card, a one-character card and a long one must all be exactly the same width - \
+         the width the *pane* gives them, not the width their own text happens to want"
+    );
+    // 74px inset on the left, 14px on the right (the mock's own margins), and a 1px border on
+    // each side of the row's own content box.
+    let expected = row.size.width - gpui::px(74.0 + 14.0);
+    assert!(
+        (long.size.width - expected).abs() <= gpui::px(1.0),
+        "and that width is the row's own width less the card's inset - expected about {expected:?}, \
+         got {:?} against a {:?}-wide row",
+        long.size.width,
+        row.size.width,
+    );
+}
+
+/// **Live report: *"Caret is not right, does not follow the typing of the user and just stays on
+/// the right side"*.**
+///
+/// The third caret defect this one field shipped, and the second one of a class that has now hit
+/// nine hand-rolled inputs in this app: `.flex_1().min_w_0()` sat on the note's **text** element,
+/// so that element's box stretched across the whole card whatever the text said, and the
+/// `flex_none` caret after it was pushed to the card's far right edge - beside the `draft` mark,
+/// not against the last glyph. It is invisible in any field narrow enough for the text to fill it,
+/// which is why it kept shipping; it became unmissable here the moment the card above was given
+/// its real, full pane width.
+///
+/// The structure now comes from `AdeApp::render_simple_input_row`, which owns that placement in
+/// one place. This measures the result the same way `rail::render::rail_filter_caret_tests` does:
+/// against real painted bounds, in both the empty state (caret at position 0, before the
+/// placeholder) and the typed state (caret against the text, nowhere near the card's edge).
+#[gpui::test]
+fn the_note_caret_sits_against_the_text_not_at_the_far_edge_of_the_card(cx: &mut TestAppContext) {
+    let (repo, store) = repo_with_an_agent_authored_change(1_700_000_000);
+    let shim_dir = TempDir::new().expect("tempdir");
+    let (_app, cx, _agent) = open_review(cx, &repo, &shim_dir, store, 1_700_000_000);
+
+    click_line(cx, 2);
+    let empty_caret = cx
+        .debug_bounds("diff-note-0-caret")
+        .expect("a card being typed into paints a real caret");
+    let placeholder = cx
+        .debug_bounds("diff-note-0-text")
+        .expect("the placeholder must really paint");
+    assert!(
+        empty_caret.origin.x <= placeholder.origin.x,
+        "an empty note's real cursor position is 0, so its caret sits before the placeholder - \
+         got caret {empty_caret:?} vs placeholder {placeholder:?}"
+    );
+
+    cx.simulate_input("tenant id");
+    cx.run_until_parked();
+
+    let card = cx.debug_bounds("diff-note-0").expect("the card");
+    let text = cx
+        .debug_bounds("diff-note-0-text")
+        .expect("the typed text must really paint");
+    let caret = cx.debug_bounds("diff-note-0-caret").expect("and its caret");
+    assert!(
+        caret.origin.x >= text.origin.x + text.size.width - gpui::px(1.0),
+        "the caret must sit at the typed text's own right edge - got caret {caret:?} vs text \
+         {text:?}"
+    );
+    assert!(
+        caret.origin.x < text.origin.x + text.size.width + gpui::px(4.0),
+        "and *against* it, with no gap: a cursor sits flush against the last glyph - got caret \
+         {caret:?} vs text {text:?}"
+    );
+    let mark = cx
+        .debug_bounds("diff-note-0-mark")
+        .expect("the draft/sent mark");
+    assert!(
+        caret.origin.x + caret.size.width < mark.origin.x - gpui::px(8.0),
+        "which is nowhere near the card's own right edge, where it used to sit next to the \
+         `draft` mark - got caret {caret:?}, mark {mark:?}, card {card:?}"
+    );
+}
+
+/// Exactly one card carries a caret: the one being typed into.
+///
+/// There is one `note_focus_handle` for the whole feature (one draft at a time - see
+/// `crate::review_notes::flow::NoteDraft`'s own docs), so a card that rendered the shared caret
+/// unconditionally would paint one in *every* pinned card the moment any of them was focused.
+/// `AdeApp::render_simple_input_row` takes an `Option<&FocusHandle>` rather than a handle plus a
+/// hope for exactly this reason.
+#[gpui::test]
+fn only_the_card_being_typed_into_paints_a_caret(cx: &mut TestAppContext) {
+    let (repo, store) = repo_with_an_agent_authored_change(1_700_000_000);
+    let shim_dir = TempDir::new().expect("tempdir");
+    let (_app, cx, _agent) = open_review(cx, &repo, &shim_dir, store, 1_700_000_000);
+
+    click_line(cx, 2);
+    cx.simulate_input("first");
+    cx.run_until_parked();
+    click_line(cx, 3);
+    cx.simulate_input("second");
+    cx.run_until_parked();
+
+    assert!(
+        cx.debug_bounds("diff-note-0").is_some() && cx.debug_bounds("diff-note-1").is_some(),
+        "both cards must really be pinned for this to be measuring anything"
+    );
+    assert!(
+        cx.debug_bounds("diff-note-0-caret").is_none(),
+        "the card that is merely pinned must paint no caret at all - it is read-only text"
+    );
+    let caret = cx
+        .debug_bounds("diff-note-1-caret")
+        .expect("the open draft's own caret");
+    let open = cx
+        .debug_bounds("diff-note-1")
+        .expect("the card that is being typed into");
+    assert!(
+        open.contains(&caret.center()),
+        "and the one caret there is must be inside that card - got caret {caret:?} against card \
+         {open:?}"
+    );
+}
+
+/// A click in the empty space to the right of a short diff line must pin a note.
+///
+/// Found while reproducing the two reports above, on a real window: it did nothing at all. The
+/// diff row is the note gesture's hit target, and a `uniform_list` item with an `auto` width is
+/// laid out at its *content* width (the same mechanism as
+/// [`a_note_card_is_the_panes_width_whatever_the_note_says`]), so the hit box, the hover lift and
+/// the add/remove tint all stopped at the last glyph of the line - several hundred pixels short of
+/// the pane on a short line, with nothing on screen saying where the clickable part ended.
+#[gpui::test]
+fn a_click_past_the_end_of_a_short_line_still_pins_a_note(cx: &mut TestAppContext) {
+    let (repo, store) = repo_with_an_agent_authored_change(1_700_000_000);
+    let shim_dir = TempDir::new().expect("tempdir");
+    let (app, cx, _agent) = open_review(cx, &repo, &shim_dir, store, 1_700_000_000);
+
+    // The reference is the *longest* row in this diff, not the one being clicked: measuring a
+    // content-width row against itself can never see this bug, because its own right edge moves
+    // with its text. The x below is far beyond the short row's own last glyph and still well
+    // inside the pane.
+    let long = cx
+        .debug_bounds("diff-line-2")
+        .expect("the rewritten `QueryBuilder` line - the longest real row in this diff");
+    let short = cx
+        .debug_bounds("diff-line-4")
+        .expect("the closing `}` line - one of the shortest");
+    assert!(
+        long.size.width > short.size.width + gpui::px(80.0)
+            || (short.size.width - long.size.width).abs() <= gpui::px(1.0),
+        "sanity: either the rows are content-width (and genuinely differ) or they are already          uniform - got long {long:?} vs short {short:?}"
+    );
+    let past_the_text = gpui::point(
+        long.origin.x + long.size.width - gpui::px(6.0),
+        short.center().y,
+    );
+    cx.simulate_click(past_the_text, gpui::Modifiers::none());
+    cx.run_until_parked();
+
+    assert!(
+        cx.debug_bounds("diff-note-0").is_some(),
+        "a click in the blank space to the right of a short line must pin a card, exactly as a \
+         click on its text does - the whole row is the gesture's target"
+    );
+    app.read_with(cx, |app, _| {
+        assert_eq!(
+            app.review_notes
+                .anchors(&app.review_notes_worktree(), Path::new(PATH))
+                .len(),
+            1,
+            "and it must pin exactly one, on the line that was really clicked"
+        );
+    });
 }

--- a/crates/app/src/review_notes/render.rs
+++ b/crates/app/src/review_notes/render.rs
@@ -6,10 +6,10 @@
 //! [`crate::theme::notes`] token, and every string that is design copy is quoted in the doc
 //! comment beside it.
 
-use super::{NoteAnchor, NoteMark};
+use super::{flow, NoteAnchor, NoteMark};
 use crate::provenance::render::author_style;
 use crate::provenance::Author;
-use crate::root::widgets::{render_keycap_row, text_tooltip, KeycapSize};
+use crate::root::widgets::{render_keycap_row, text_tooltip, KeycapSize, SimpleInput};
 use crate::root::{plural, AdeApp};
 use crate::theme;
 use crate::{keymap, work_surface};
@@ -23,6 +23,19 @@ pub const NOTES_BAR_META: &str = "one prompt, line-anchored \u{b7} pinned after 
 
 /// The send button's tooltip, verbatim from the mock's own `title=` attribute.
 pub const SEND_TOOLTIP: &str = "Send every note as one prompt to this run's agent";
+
+/// What the send control says while this worktree has no agent session to send to - see
+/// [`AdeApp::render_send_notes_unavailable`].
+///
+/// **A derivation, not a transcription.** The mock's diff always has a run beside it, so it has
+/// no empty state for this control at all; it names the *missing thing* rather than an agent
+/// precisely because there is no agent to name.
+pub const SEND_UNAVAILABLE_LABEL: &str = "Send notes \u{2014} no agent in this worktree";
+
+/// And why, at the length a tooltip can afford.
+pub const SEND_UNAVAILABLE_TOOLTIP: &str =
+    "These notes are kept. Start an agent in this worktree and they can be sent to it as one \
+     prompt.";
 
 /// The `crate::keymap::resolve_combo` spec behind the send button's keycaps, and behind the real
 /// `crate::root::SendReviewNotes` binding - one string, so the keycaps can never advertise a
@@ -187,16 +200,29 @@ impl AdeApp {
                 )
                 // A delivery that really failed says so here, rather than leaving the bar looking
                 // exactly as it did before the click.
-                .children(self.note_send_error.clone().map(|message| {
-                    div()
-                        .debug_selector(|| "diff-notes-bar-error".to_string())
-                        .flex_none()
-                        .whitespace_nowrap()
-                        .font(font(theme::font::MONO))
-                        .text_size(px(10.5))
-                        .text_color(theme::notes::BAR_ERROR)
-                        .child(message)
-                }))
+                //
+                // Filtered against what is true *now*, not merely against what happened: a
+                // `NoTarget` recorded while the worktree had no agent is a statement about the
+                // worktree, and starting an agent makes it false. Left unfiltered it sat in the
+                // bar in red directly beside the live `Send notes to Claude` button it was
+                // contradicting - observed on a real window while reproducing this feature's
+                // other reports.
+                .children(
+                    self.note_send_error
+                        .filter(|err| {
+                            !matches!(err, flow::NoteSendError::NoTarget) || target.is_none()
+                        })
+                        .map(|err| {
+                            div()
+                                .debug_selector(|| "diff-notes-bar-error".to_string())
+                                .flex_none()
+                                .whitespace_nowrap()
+                                .font(font(theme::font::MONO))
+                                .text_size(px(10.5))
+                                .text_color(theme::notes::BAR_ERROR)
+                                .child(err.message())
+                        }),
+                )
                 // The mock's `✓ sent` confirmation, next to the button that produced it.
                 .when(state.all_sent, |el| {
                     el.child(
@@ -210,9 +236,71 @@ impl AdeApp {
                             .child("\u{2713} sent"),
                     )
                 })
-                .children(target.map(|target| self.render_send_notes_button(send_path, target, cx)))
+                .child(match target {
+                    Some(target) => self.render_send_notes_button(send_path, target, cx),
+                    None => self.render_send_notes_unavailable(),
+                })
                 .into_any_element(),
         )
+    }
+
+    /// The send control when there is **nobody to send to** - drawn, muted, and saying why.
+    ///
+    /// Live report: *"I can't really submit the comments, maybe there is something I don't
+    /// understand"*. There was nothing to understand. This bar used to render the send button
+    /// only once [`AdeApp::review_note_target`] resolved a live agent session in the worktree,
+    /// and to render **nothing at all** otherwise - so a reviewer who opened a diff before
+    /// starting an agent (which is the ordinary order: you read the change, then you ask for a
+    /// revision) got a bar that counted their notes, explained that they would be sent as one
+    /// prompt, and offered no control, no keycaps, and no explanation. `mod+enter` was bound the
+    /// whole time and would have said `no agent open in this worktree to send to` - but the only
+    /// place that keystroke is ever advertised is *inside the button that was not being drawn*.
+    ///
+    /// `REVISION-2026-08-14.md` §7 rule 1 (*"ship the affordance with the behaviour, or ship
+    /// neither"*) is what the original shape was reaching for, and it is not violated here: the
+    /// behaviour **is** shipped - the batch, the binding, the delivery - and the only thing
+    /// missing is a target the reviewer can supply in one keystroke. What that rule forbids is a
+    /// control that pretends to do something it cannot, which is why this one is deliberately not
+    /// clickable, carries no hover, and names the thing that is missing rather than an agent.
+    fn render_send_notes_unavailable(&self) -> gpui::AnyElement {
+        let macos = self.window_controls_style().is_macos();
+        div()
+            .id("diff-notes-send-unavailable")
+            .debug_selector(|| "diff-notes-send-unavailable".to_string())
+            .flex_none()
+            .h(px(22.0))
+            .px(px(8.0))
+            .rounded(theme::radius::BUTTON)
+            .flex()
+            .items_center()
+            .gap(px(6.0))
+            .bg(theme::surface::CARD_SUNK)
+            .border_1()
+            .border_color(theme::border::CARD_FIELD)
+            // Ride-along I11's rule for an unlabelled or inert control: say what would make it
+            // work, in the one place the pointer is already resting.
+            .tooltip(text_tooltip(SEND_UNAVAILABLE_TOOLTIP))
+            .child(
+                div()
+                    .debug_selector(|| "diff-notes-send-unavailable-label".to_string())
+                    .whitespace_nowrap()
+                    .font(font(theme::font::SANS))
+                    .text_size(px(10.5))
+                    .text_color(theme::text::GHOST)
+                    .child(SEND_UNAVAILABLE_LABEL),
+            )
+            // The keycaps stay. They are the only advertisement `mod+enter` has, the binding is
+            // real either way, and pressing it here produces this bar's own
+            // `no agent open in this worktree to send to` rather than silence.
+            .child(
+                div()
+                    .text_color(theme::text::GHOST)
+                    .child(render_keycap_row(
+                        &keymap::resolve_combo(SEND_NOTES_SPEC, macos),
+                        KeycapSize::Standard,
+                    )),
+            )
+            .into_any_element()
     }
 
     /// `Send notes to <agent>` - the agent's own chip, its name, and the `mod+enter` keycaps.
@@ -257,7 +345,7 @@ impl AdeApp {
             .tooltip(text_tooltip(tooltip))
             .on_click(cx.listener(move |this, _event: &ClickEvent, _window, cx| {
                 if let Err(err) = this.send_review_notes(path.clone(), cx) {
-                    this.note_send_error = Some(err.message().to_string());
+                    this.note_send_error = Some(err);
                     cx.notify();
                 }
             }))
@@ -349,111 +437,120 @@ impl AdeApp {
         let selector = format!("{selector_prefix}-note-{note_row}");
         let text_selector = format!("{selector}-text");
         let mark_selector = format!("{selector}-mark");
-        let is_blank = text.trim().is_empty();
+        // Per row, not one shared name: `debug_bounds` is keyed by selector, and two pinned cards
+        // sharing `diff-note-caret` would be indistinguishable to the test that proves only the
+        // open one paints a caret at all.
+        let caret_selector = format!("{selector}-caret");
 
-        let body =
-            div()
-                .id(SharedString::from(selector.clone()))
-                .debug_selector(move || selector)
-                .flex_1()
-                .h_full()
-                .flex()
-                .items_center()
-                .rounded(theme::radius::CARD_SM)
-                .bg(theme::notes::CARD_BG)
-                .border_1()
-                .border_color(theme::notes::CARD_BORDER)
-                // So the blue edge below is clipped by the card's own rounded corners.
-                .overflow_hidden()
-                .cursor_text()
-                .tooltip(text_tooltip(tooltip))
-                .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
-                    // Stops the click reaching the diff row underneath, which would toggle the note
-                    // shut while the caret is being placed in it.
-                    cx.stop_propagation();
-                    this.focus_review_note(anchor, window, cx);
-                }))
-                // *"the selection-blue left edge"*. A real 2px child rather than a second border
-                // colour: GPUI's `Style` carries **one** `border_color` for all four sides, so
-                // `.border_l(px(2.0)).border_color(EDGE)` after `.border_color(CARD_BORDER)` would
-                // have repainted the whole outline blue - the mock's `border:1px solid #2b3d4f;
-                // border-left:2px solid #5a9ad4` has no single-element equivalent here. Same
-                // technique the diff row's own author gutter already uses.
-                .child(
-                    div()
-                        .flex_none()
-                        .w(px(2.0))
-                        .self_stretch()
-                        .bg(theme::notes::EDGE),
-                )
-                .child(
-                    div()
-                        .flex_1()
-                        .min_w_0()
-                        .h_full()
-                        .flex()
-                        .items_center()
-                        .gap(px(8.0))
-                        .px(px(8.0))
-                        // The note author. `you`, through the same chip vocabulary GitHub issue #287
-                        // gave every other author mark in this app, rather than the mock's bare `Y`:
-                        // one author is one recognisable mark wherever it appears.
-                        .children(
-                            author_style(&Author::You)
-                                .map(|style| self.render_author_chip(&Author::You, &style)),
-                        )
-                        .when(editing && is_blank, |el| {
-                            el.child(self.render_simple_input_caret(
-                                "diff-note-caret",
-                                &self.note_focus_handle,
-                            ))
-                        })
-                        .child(
-                            div()
-                                .debug_selector(move || text_selector)
-                                .flex_1()
-                                .min_w_0()
-                                .overflow_hidden()
-                                .whitespace_nowrap()
-                                .font(font(theme::font::SANS))
-                                .text_size(px(11.5))
-                                .text_color(if is_blank {
-                                    theme::notes::CARD_PLACEHOLDER
-                                } else {
-                                    theme::notes::CARD_FG
-                                })
-                                .child(if is_blank {
-                                    NOTE_PLACEHOLDER.to_string()
-                                } else {
-                                    text
-                                }),
-                        )
-                        .when(editing && !is_blank, |el| {
-                            el.child(self.render_simple_input_caret(
-                                "diff-note-caret",
-                                &self.note_focus_handle,
-                            ))
-                        })
-                        .child(
-                            div()
-                                .debug_selector(move || mark_selector)
-                                .flex_none()
-                                .whitespace_nowrap()
-                                .font(font(theme::font::MONO))
-                                .text_size(px(9.5))
-                                .text_color(match mark {
-                                    NoteMark::Draft => theme::notes::MARK_DRAFT,
-                                    NoteMark::Sent => theme::notes::MARK_SENT,
-                                })
-                                .child(mark.label()),
-                        ),
-                );
+        let body = div()
+            .id(SharedString::from(selector.clone()))
+            .debug_selector(move || selector)
+            .flex_1()
+            .h_full()
+            .flex()
+            .items_center()
+            .rounded(theme::radius::CARD_SM)
+            .bg(theme::notes::CARD_BG)
+            .border_1()
+            .border_color(theme::notes::CARD_BORDER)
+            // So the blue edge below is clipped by the card's own rounded corners.
+            .overflow_hidden()
+            .cursor_text()
+            .tooltip(text_tooltip(tooltip))
+            .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
+                // Stops the click reaching the diff row underneath, which would toggle the note
+                // shut while the caret is being placed in it.
+                cx.stop_propagation();
+                this.focus_review_note(anchor, window, cx);
+            }))
+            // *"the selection-blue left edge"*. A real 2px child rather than a second border
+            // colour: GPUI's `Style` carries **one** `border_color` for all four sides, so
+            // `.border_l(px(2.0)).border_color(EDGE)` after `.border_color(CARD_BORDER)` would
+            // have repainted the whole outline blue - the mock's `border:1px solid #2b3d4f;
+            // border-left:2px solid #5a9ad4` has no single-element equivalent here. Same
+            // technique the diff row's own author gutter already uses.
+            .child(
+                div()
+                    .flex_none()
+                    .w(px(2.0))
+                    .self_stretch()
+                    .bg(theme::notes::EDGE),
+            )
+            .child(
+                div()
+                    .flex_1()
+                    .min_w_0()
+                    .h_full()
+                    .flex()
+                    .items_center()
+                    .gap(px(8.0))
+                    .px(px(8.0))
+                    // The note author. `you`, through the same chip vocabulary GitHub issue #287
+                    // gave every other author mark in this app, rather than the mock's bare `Y`:
+                    // one author is one recognisable mark wherever it appears.
+                    .children(
+                        author_style(&Author::You)
+                            .map(|style| self.render_author_chip(&Author::You, &style)),
+                    )
+                    // The caret+text pair, through the one helper that owns that structure
+                    // (`AdeApp::render_simple_input_row`) rather than hand-assembled here.
+                    // Hand-assembling it is what put this field's caret at the far right of
+                    // the card: `.flex_1().min_w_0()` used to sit on the *text* element, so
+                    // its box stretched across the whole card and the caret after it went
+                    // with it. See the helper's own docs - this is the third field in this
+                    // app to have shipped that exact bug.
+                    //
+                    // Only a card being typed into gets a caret at all; the pinned cards
+                    // around it are read-only text, so they render the same row with the
+                    // caret suppressed by a focus handle that is not theirs to hold.
+                    .child(self.render_simple_input_row(SimpleInput {
+                        caret_selector: SharedString::from(caret_selector),
+                        text_selector: SharedString::from(text_selector),
+                        focus_handle: editing.then_some(&self.note_focus_handle),
+                        text: &text,
+                        placeholder: NOTE_PLACEHOLDER,
+                        font: theme::font::SANS,
+                        text_size: px(11.5),
+                        text_color: theme::notes::CARD_FG,
+                        placeholder_color: theme::notes::CARD_PLACEHOLDER,
+                    }))
+                    .child(
+                        div()
+                            .debug_selector(move || mark_selector)
+                            .flex_none()
+                            .whitespace_nowrap()
+                            .font(font(theme::font::MONO))
+                            .text_size(px(9.5))
+                            .text_color(match mark {
+                                NoteMark::Draft => theme::notes::MARK_DRAFT,
+                                NoteMark::Sent => theme::notes::MARK_SENT,
+                            })
+                            .child(mark.label()),
+                    ),
+            );
 
         div()
             // The slot. `rems(1.6)`, like every other item of this list, with 1px of breathing
             // room top and bottom so the card reads as a card rather than as a band.
             .h(rems(1.6))
             .py(px(1.0))
+            // **The card's width, and why it has to be stated.**
+            //
+            // Live report: *"when clicking on the line the comment popover is changing width
+            // strangely"* - and it really was. A `gpui::uniform_list` lays each item out through
+            // `Drawable::layout_as_root`, which is *not* the window root: the window's own root
+            // goes through `TaffyLayoutEngine::stretch_auto_size_to_fill` (the thing that makes a
+            // top-level `auto` width behave like the web's initial containing block), and a list
+            // item never does. So an item whose own width is `auto` is sized to its **content**,
+            // clamped to the pane - which made `body`'s `flex_1` below resolve against the note's
+            // own text rather than against the pane, and the card grew a few pixels per keystroke
+            // and jumped to a different width on every line clicked.
+            //
+            // `w_full` is a percentage against the definite width `uniform_list` really hands
+            // each item, so the card is the pane's width less the insets below, whatever it says.
+            // `Jerry.dc.html`'s own card is a block in normal flow with `margin:3px 14px 5px
+            // 74px`, i.e. exactly this: full width, inset.
+            .w_full()
             // The mock's own inset: the card starts where the code text does, not at the gutter,
             // so it visibly belongs to the line above it.
             .pl(px(74.0))

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -581,7 +581,11 @@ pub struct AdeApp {
     pub(crate) note_cursor: Option<crate::review_notes::NoteRef>,
     /// Why the last send failed, if it did. Shown in the notes bar rather than swallowed: a review
     /// note that silently reached nobody is the worst outcome this feature has.
-    pub(crate) note_send_error: Option<String>,
+    ///
+    /// The error itself, not its rendered sentence, so the bar can tell whether it is still
+    /// *true*: a `NoTarget` recorded before an agent was started must stop being shown the moment
+    /// one is, and a `String` has no way to know which failure it came from.
+    pub(crate) note_send_error: Option<crate::review_notes::flow::NoteSendError>,
     /// Focus for the open note card's own hand-rolled single-line input.
     pub(crate) note_focus_handle: FocusHandle,
     /// Focus for the diff pane's notes container, which is what makes its `"diff-view"` key

--- a/crates/app/src/root/new_file.rs
+++ b/crates/app/src/root/new_file.rs
@@ -252,8 +252,7 @@ impl AdeApp {
                             .text_color(theme::text::FAINTER)
                             .child(parent_label),
                     )
-                    .child({
-                        let has_name = !name.is_empty();
+                    .child(
                         div()
                             .px(px(8.0))
                             .py(px(5.0))
@@ -261,42 +260,27 @@ impl AdeApp {
                             .bg(theme::surface::SEGMENT_TRACK)
                             .flex()
                             .items_center()
-                            // No decorative gap before the caret - see
-                            // `crate::rail::render::AdeApp::render_rail_filter_row`'s own
-                            // comment for why (live report: it read as a gap between the
-                            // typed text and where it's actually being typed).
-                            .font(font(theme::font::MONO))
-                            .text_size(px(11.5))
-                            .text_color(theme::text::BODY)
                             // GitHub issue #45 / live report: this prompt had no caret element
                             // at all before this - just the typed name or its placeholder, no
                             // insertion-point indicator, and `new_file_focus_handle` was never
                             // wired into `crate::root::caret_blink` either (see
-                            // `Self::new_with_settings`'s own comment on the fix). Same
-                            // before-placeholder / after-text placement as
-                            // `crate::rail::render::AdeApp::render_rail_filter_row`.
-                            .when(!has_name, |el| {
-                                el.child(self.render_simple_input_caret(
-                                    "new-file-caret",
-                                    &self.new_file_focus_handle,
-                                ))
-                            })
-                            .child(
-                                div()
-                                    .debug_selector(|| "new-file-name-text".to_string())
-                                    .child(if has_name {
-                                        name
-                                    } else {
-                                        "file-name.ext".to_string()
-                                    }),
-                            )
-                            .when(has_name, |el| {
-                                el.child(self.render_simple_input_caret(
-                                    "new-file-caret",
-                                    &self.new_file_focus_handle,
-                                ))
-                            })
-                    })
+                            // `Self::new_with_settings`'s own comment on the fix). The caret and
+                            // the text around it now come from the one helper that owns that
+                            // structure - see `AdeApp::render_simple_input_row`.
+                            .child(self.render_simple_input_row(widgets::SimpleInput {
+                                caret_selector: "new-file-caret".into(),
+                                text_selector: "new-file-name-text".into(),
+                                focus_handle: Some(&self.new_file_focus_handle),
+                                text: &name,
+                                placeholder: "file-name.ext",
+                                font: theme::font::MONO,
+                                text_size: px(11.5),
+                                // One colour for both: this prompt has never dimmed its
+                                // placeholder, and the migration is not the place to change that.
+                                text_color: theme::text::BODY,
+                                placeholder_color: theme::text::BODY,
+                            })),
+                    )
                     .when_some(self.new_file_error.clone(), |el, error| {
                         el.child(
                             div()

--- a/crates/app/src/root/widgets.rs
+++ b/crates/app/src/root/widgets.rs
@@ -441,11 +441,17 @@ impl AdeApp {
     /// focused-but-blinked-off, or simply unfocused - paints nothing at all.
     pub(crate) fn render_simple_input_caret(
         &self,
-        selector: &'static str,
+        selector: impl Into<gpui::SharedString>,
         focus_handle: &FocusHandle,
     ) -> impl IntoElement {
         let caret_blink_visible = self.caret_blink_visible;
         let focus_handle = focus_handle.clone();
+        // `impl Into<SharedString>` rather than `&'static str`: a caret that belongs to a *row of
+        // a list* has one selector per row (`diff-note-3-caret`), and `debug_bounds` is a map
+        // keyed by selector - two rows sharing one name would collapse to whichever painted last,
+        // which is exactly the ambiguity `only_the_card_being_typed_into_paints_a_caret` has to be
+        // able to see through.
+        let selector = selector.into();
         div()
             .flex_none()
             .w(px(1.5))
@@ -468,6 +474,125 @@ impl AdeApp {
                 .size_full(),
             )
     }
+
+    /// **The** caret+text row every hand-rolled single-line input in this app should be built
+    /// from - the complete structure, not just the caret glyph.
+    ///
+    /// ## Why this exists (a live report, three times over)
+    ///
+    /// [`Self::render_simple_input_caret`] has been shared since GitHub issue #27, but it only
+    /// ever returned the 1.5px blinking bar. Every one of the app's ~nine simple inputs still
+    /// hand-assembled the *row around it* - where `flex_1`/`min_w_0` go, whether the row centres
+    /// its items, whether the caret is drawn before the placeholder or after the text - and that
+    /// surrounding structure is exactly what kept being got wrong, one field at a time, with a
+    /// separate live bug report each time.
+    ///
+    /// The failure is always the same one, and it is not obvious by reading a single call site:
+    /// putting `.flex_1().min_w_0()` on the **text** element makes that element's layout box
+    /// stretch across all the row's remaining width whatever the text actually says, so the
+    /// `flex_none` caret that follows it is pushed to the far right edge of the field instead of
+    /// sitting against the last glyph. It looks correct in any field narrow enough that the text
+    /// fills it, and wrong in every other one - which is why it kept shipping.
+    ///
+    /// So the rule this encodes is: **`flex_1`/`min_w_0` belong on the wrapper that holds both
+    /// the caret and the text, never on the text itself.** The text is intrinsically sized and
+    /// merely allowed to shrink and clip; the caret sits immediately after it.
+    ///
+    /// The second rule it encodes is GitHub issue #45's own: an empty field's real cursor
+    /// position is 0, so the caret is drawn **before** the placeholder while the field is blank
+    /// and **after** the text once there is any - never appended past whatever placeholder string
+    /// happens to be rendering. And there is deliberately no gap between the text and the caret:
+    /// a cursor sits flush against the last glyph (`crate::rail::render`'s own live report).
+    ///
+    /// The caller still owns the box *around* this row - its border, padding, height and
+    /// background - because that genuinely differs per field. What it no longer owns is the part
+    /// that was never supposed to differ.
+    pub(crate) fn render_simple_input_row(&self, input: SimpleInput<'_>) -> impl IntoElement {
+        let SimpleInput {
+            caret_selector,
+            text_selector,
+            focus_handle,
+            text,
+            placeholder,
+            font: font_name,
+            text_size,
+            text_color,
+            placeholder_color,
+        } = input;
+        // "Blank" by the same rule every caller used: nothing typed at all. A field holding only
+        // spaces is holding real text and shows it, with the caret after it.
+        let is_blank = text.is_empty();
+        let shown = if is_blank { placeholder } else { text }.to_string();
+        // `None` is a genuinely read-only row - a pinned note card that is not the one being
+        // typed into, say. It cannot be expressed by passing a handle that happens to be
+        // unfocused: several of these rows can be on screen sharing *one* focus handle (only one
+        // draft is ever open), and a caret keyed on that shared handle would paint in every one
+        // of them the moment any of them was focused.
+        let caret = |el: gpui::Div| match focus_handle {
+            Some(handle) => {
+                el.child(self.render_simple_input_caret(caret_selector.clone(), handle))
+            }
+            None => el,
+        };
+        div()
+            // On the wrapper, which is the whole point - see this method's own docs.
+            .flex_1()
+            .min_w_0()
+            .flex()
+            .items_center()
+            .when(is_blank, caret)
+            .child(
+                div()
+                    .debug_selector(move || text_selector.to_string())
+                    // Intrinsically sized, and allowed to shrink and clip rather than to wrap or
+                    // to push the caret out of the row: `min_w_0` here is a *floor* of zero on an
+                    // auto-sized box, which is a different thing from the `flex_1` that used to
+                    // sit beside it and is what makes a field narrower than its own text degrade
+                    // to a clipped line instead of a two-line row.
+                    .min_w_0()
+                    .overflow_hidden()
+                    .whitespace_nowrap()
+                    .font(font(font_name))
+                    .text_size(text_size)
+                    .text_color(if is_blank {
+                        placeholder_color
+                    } else {
+                        text_color
+                    })
+                    .child(shown),
+            )
+            .when(!is_blank, caret)
+    }
+}
+
+/// One [`AdeApp::render_simple_input_row`] field: what it holds, what it says while empty, and
+/// how it is painted.
+///
+/// A struct rather than eight positional parameters, for the same reason
+/// `crate::code_surface::diff_view::DiffLineChrome` is one: past `clippy::too_many_arguments`, and
+/// four of these are `&str`/colour pairs that would be trivially transposable at a call site.
+pub(crate) struct SimpleInput<'a> {
+    /// The caret element's own `debug_selector`, so a render test can assert *where* it painted.
+    /// A [`SharedString`] for the same reason [`Self::text_selector`] is one.
+    pub caret_selector: gpui::SharedString,
+    /// The text element's `debug_selector`, for the same reason. A [`SharedString`] rather than a
+    /// `&'static str` because a field that is a *row of a list* has one selector per row.
+    pub text_selector: gpui::SharedString,
+    /// The handle the caret watches - it paints only while this one is really focused. `None`
+    /// draws no caret at all, which is what a read-only row of an otherwise-editable list is.
+    pub focus_handle: Option<&'a FocusHandle>,
+    /// What the field holds right now.
+    pub text: &'a str,
+    /// What it says while that is empty.
+    pub placeholder: &'a str,
+    /// The font family, as a `crate::theme::font` name.
+    pub font: &'static str,
+    /// Already scaled by the caller's own `AdeApp::ui_text_size` where that applies.
+    pub text_size: Pixels,
+    /// The colour of real typed text.
+    pub text_color: theme::ColorToken,
+    /// The (usually dimmer) colour of the placeholder.
+    pub placeholder_color: theme::ColorToken,
 }
 
 /// [`AdeApp::render_simple_input_caret`]'s paint decision, pulled out as a pure function so it's

--- a/crates/app/src/settings/render.rs
+++ b/crates/app/src/settings/render.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::root::plural;
 use crate::root::widgets::{
     hover_keycap_row, menu_popover_chrome, render_env_chip, render_keycap_row, KeycapSize,
+    SimpleInput,
 };
 use crate::settings::widgets::ChoiceOption;
 use crate::sound::SoundEventKind;
@@ -1120,36 +1121,24 @@ impl AdeApp {
                     .border_1()
                     .border_color(theme::border::CARD_FIELD)
                     .bg(theme::surface::CARD_SUNK)
-                    // The caret sits before the placeholder (real cursor position 0) while the
-                    // field is empty, never appended after it - same fix as every other simple
-                    // input in this app (GitHub issue #45).
-                    .when(!has_shell, |el| {
-                        el.child(self.render_simple_input_caret(
-                            "settings-shell-caret",
-                            &self.shell_focus_handle,
-                        ))
-                    })
-                    .child(
-                        div()
-                            .flex_1()
-                            .min_w_0()
-                            .truncate()
-                            .font(font(theme::font::MONO))
-                            .text_size(self.ui_text_size(10.5))
-                            .text_color(if has_shell {
-                                theme::text::BODY
-                            } else {
-                                theme::text::GHOST
-                            })
-                            .child(if has_shell { shell } else { placeholder })
-                            .debug_selector(|| "settings-shell-text".to_string()),
-                    )
-                    .when(has_shell, |el| {
-                        el.child(self.render_simple_input_caret(
-                            "settings-shell-caret",
-                            &self.shell_focus_handle,
-                        ))
-                    }),
+                    // Caret placement and text sizing both through
+                    // `AdeApp::render_simple_input_row`, which owns that structure for every
+                    // simple input in this app. This field was the *second* live instance of the
+                    // bug that helper exists to make unrepeatable: `.flex_1().min_w_0()` sat on
+                    // the text element, so inside this fixed 168px box the text's layout box
+                    // filled the whole field whatever the shell path said, and the caret after it
+                    // sat pinned to the right-hand border instead of against the last character.
+                    .child(self.render_simple_input_row(SimpleInput {
+                        caret_selector: "settings-shell-caret".into(),
+                        text_selector: "settings-shell-text".into(),
+                        focus_handle: Some(&self.shell_focus_handle),
+                        text: if has_shell { &shell } else { "" },
+                        placeholder: &placeholder,
+                        font: theme::font::MONO,
+                        text_size: self.ui_text_size(10.5),
+                        text_color: theme::text::BODY,
+                        placeholder_color: theme::text::GHOST,
+                    })),
             )
     }
 
@@ -2608,8 +2597,6 @@ impl AdeApp {
         total: usize,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        let has_query = !self.settings_keymap_filter.is_empty();
-
         div()
             .id("settings-keymap-filter")
             .track_focus(&self.settings_keymap_filter_focus_handle)
@@ -2651,34 +2638,17 @@ impl AdeApp {
                     // `crate::rail::render::AdeApp::render_rail_filter_row` - the caret sits
                     // before the placeholder (real cursor position 0) while the filter is empty,
                     // never appended after it.
-                    .when(!has_query, |el| {
-                        el.child(self.render_simple_input_caret(
-                            "settings-keymap-filter-caret",
-                            &self.settings_keymap_filter_focus_handle,
-                        ))
-                    })
-                    .child(
-                        div()
-                            .font(font(theme::font::SANS))
-                            .text_size(px(11.0))
-                            .text_color(if has_query {
-                                theme::text::DIM
-                            } else {
-                                theme::text::GHOST
-                            })
-                            .child(if has_query {
-                                self.settings_keymap_filter.as_str().to_string()
-                            } else {
-                                format!("filter {}", plural::count(total, "binding", None))
-                            })
-                            .debug_selector(|| "settings-keymap-filter-text".to_string()),
-                    )
-                    .when(has_query, |el| {
-                        el.child(self.render_simple_input_caret(
-                            "settings-keymap-filter-caret",
-                            &self.settings_keymap_filter_focus_handle,
-                        ))
-                    }),
+                    .child(self.render_simple_input_row(SimpleInput {
+                        caret_selector: "settings-keymap-filter-caret".into(),
+                        text_selector: "settings-keymap-filter-text".into(),
+                        focus_handle: Some(&self.settings_keymap_filter_focus_handle),
+                        text: self.settings_keymap_filter.as_str(),
+                        placeholder: &format!("filter {}", plural::count(total, "binding", None)),
+                        font: theme::font::SANS,
+                        text_size: px(11.0),
+                        text_color: theme::text::DIM,
+                        placeholder_color: theme::text::GHOST,
+                    })),
             )
             .child(
                 div()
@@ -6048,6 +6018,71 @@ mod settings_keymap_filter_caret_tests {
              real text) - got {:?} vs {:?}",
             empty_caret.origin.x,
             typed_caret.origin.x,
+        );
+    }
+
+    /// **The second live instance of the same structural caret bug**, found by auditing every
+    /// hand-rolled input in this app after the review-note card's own report (*"Caret is not
+    /// right, does not follow the typing of the user and just stays on the right side"*).
+    ///
+    /// This field used to carry `.flex_1().min_w_0()` on its **text** element. The field itself is
+    /// a fixed 168px box, so the text's layout box filled the whole of it whatever the shell path
+    /// said, and the caret - a `flex_none` sibling *after* that box - was pinned against the
+    /// field's right-hand border rather than sitting after the last character typed.
+    ///
+    /// Both this field and the review-note card now build their caret+text row through
+    /// `AdeApp::render_simple_input_row`, which is where that placement lives now.
+    #[gpui::test]
+    fn the_shell_fields_caret_follows_the_text_rather_than_pinning_to_the_fields_edge(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        app.update_in(cx, |app, window, cx| {
+            app.open_settings(window, cx);
+            app.settings_page = crate::settings::SettingsPage::General;
+            window.focus(&app.shell_focus_handle, cx);
+        });
+        cx.run_until_parked();
+
+        let field = cx
+            .debug_bounds("settings-shell-input")
+            .expect("the shell field must really paint");
+        let empty_caret = cx
+            .debug_bounds("settings-shell-caret")
+            .expect("and its caret, with the field empty");
+        let placeholder = cx
+            .debug_bounds("settings-shell-text")
+            .expect("and its placeholder");
+        assert!(
+            empty_caret.origin.x <= placeholder.origin.x,
+            "an empty field's real cursor position is 0 - got caret {empty_caret:?} vs \
+             placeholder {placeholder:?}"
+        );
+
+        cx.simulate_input("/bin/sh");
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.shell_input.as_str().to_string()),
+            "/bin/sh",
+            "sanity check: the field really took the typed text"
+        );
+
+        let text = cx
+            .debug_bounds("settings-shell-text")
+            .expect("the typed text must really paint");
+        let caret = cx
+            .debug_bounds("settings-shell-caret")
+            .expect("and so must its caret");
+        assert!(
+            caret.origin.x >= text.origin.x + text.size.width - gpui::px(1.0)
+                && caret.origin.x < text.origin.x + text.size.width + gpui::px(4.0),
+            "the caret must sit flush against the last glyph - got caret {caret:?} vs text {text:?}"
+        );
+        assert!(
+            caret.origin.x + caret.size.width < field.origin.x + field.size.width - gpui::px(20.0),
+            "and nowhere near the field's own right border, which is where a `flex_1` on the text \
+             element used to put it - got caret {caret:?} in field {field:?}"
         );
     }
 


### PR DESCRIPTION
Three live reports on #288's diff-line review notes, each reproduced on a real X11 window with screenshots **before** anything was changed. Two of the three turn out to be the same GPUI layout fact.

### 1. `uniform_list` does not stretch its items

Each item is laid out through `Drawable::layout_as_root`, and only the *window* root ever goes through `TaffyLayoutEngine::stretch_auto_size_to_fill`. So a list item whose own width is `auto` is sized to its **content**, clamped to the pane.

- **"when clicking on the line the comment popover is changing width strangely"** — the card's `flex_1` body resolved against the note's own text. Measured live on a running window: the card was **149px, then 193px, then 389px** over one typed sentence, and a different width on every line clicked. The slot is now `w_full` — the pane's width less the mock's own `74px`/`14px` inset, whatever the note says.
- **A click in the empty space right of a short diff line did nothing at all.** Not previously reported; found while reproducing the above. The row is the note gesture's hit target, and its hit box, hover lift and add/remove tint all stopped at the last glyph. Rows are now `min_w_full` (`min`, so a long line can still lay itself out at its real width).

### 2. The caret sat at the far right of the card

**"does not follow the typing of the user and just stays on the right side"** — `.flex_1().min_w_0()` was on the **text** element, so its box filled the row whatever the text said and the `flex_none` caret after it went with it. Invisible in any field narrow enough for the text to fill it, which is why it kept shipping; unmissable once the card above got its real width.

This is the third caret defect in this one field and the ninth hand-rolled input in this app to assemble the same structure by hand, so the fix is a shared **`AdeApp::render_simple_input_row`**. `render_simple_input_caret` only ever returned the 1.5px bar; the *row around it* — where `flex_1` goes, the caret-before-placeholder / caret-after-text ordering, the no-gap rule — is what kept being got wrong. Six call sites now build from it: the review-note card, the rail filter, both Settings filters, the Settings **Shell** field, the git-graph branches filter, and the new-file prompt.

Auditing those call sites found a **second live instance of the same bug**: the Settings Shell field, a fixed 168px box whose text also carried `flex_1`, pinning its caret to the field's right border. Same migration fixes it, with its own regression test.

### 3. The send control now exists when it cannot send

**"I can't really submit the comments, maybe there is something I don't understand"** — there was nothing to understand. The bar drew its button only once a live agent session resolved in the worktree, and drew *nothing* otherwise: a reviewer who opened a diff before starting an agent (the ordinary order — read the change, then ask for the revision) got a bar that counted their notes, promised they would go out as one prompt, and offered no control, no keycaps and no explanation. `mod+enter` was bound the whole time — but the only place that shortcut is ever advertised is inside the button that was not being drawn.

There is now a muted, non-clickable control naming what is missing, carrying the keycaps and a tooltip; the real button replaces it the moment an agent exists. `REVISION-2026-08-14.md` §7 rule 1 holds: the behaviour *is* shipped, and this control is deliberately inert rather than pretending otherwise.

`note_send_error` also becomes the error rather than its rendered sentence, so the bar can tell whether it is still *true* — a `NoTarget` recorded before an agent was started used to sit in the bar in red beside the live `Send notes to Claude` button it was contradicting (observed live).

### Verification

- Reproduced and re-verified live over X11 against a real repo with real uncommitted changes, both with **no** agent and with a real spawned `claude` agent; the send still delivers into the real pty and the card still flips `draft → sent`.
- Six new regression tests, **every one mutation-verified** against the shape it replaces.
- `cargo build --workspace`, `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets` all clean (zero warnings).
- `cargo test -p app --lib` 2777 passed; the only failures are the known inotify-contention set (`worktree_watch`/`file_tree_watch`/`repo_list_tests`), all 39 green in isolation with `--test-threads=1`. `wt-core` 290, `lsp-core` 51, `pty-core` 19 — all green.

Follow-up candidates for the same helper, left alone here because each carries styling the helper does not model yet (`line_height`, an inherited-font text node): the commit composer, the git-graph branch-name prompt, the Settings theme-seed field, and the rebase reword field. All four are currently correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)