### PR TITLE
fix(caret): stop a blur from killing the blink loop a sibling focus just started

### DIFF
--- a/crates/app/src/root/caret_blink.rs
+++ b/crates/app/src/root/caret_blink.rs
@@ -45,26 +45,34 @@ pub(crate) const CARET_BLINK_INTERVAL: Duration = Duration::from_millis(530);
 
 impl AdeApp {
     /// Wires every real caret-bearing `FocusHandle` this app has to the shared blink loop -
-    /// called exactly once, from [`Self::new_with_settings`], which is also the only place with
-    /// the `&mut Window` these subscriptions need to register. Returns the subscriptions rather
-    /// than pushing them onto `self` directly so the constructor can build the whole `Self`
-    /// literal in one shot, matching every other `_subscription`-holding field's own construction
-    /// pattern in this codebase (e.g. [`Self::_window_appearance_subscription`]).
+    /// called from [`Self::new_with_settings`], which is also the only place with the
+    /// `&mut Window` these subscriptions need to register. Returns the subscriptions (and the
+    /// handles they cover, for [`Self::caret_blink_handles`]) rather than pushing them onto
+    /// `self` directly so the constructor can build the whole `Self` literal in one shot,
+    /// matching every other `_subscription`-holding field's own construction pattern in this
+    /// codebase (e.g. [`Self::_window_appearance_subscription`]).
+    ///
+    /// Blur goes through [`Self::stop_caret_blink_on_blur`], not [`Self::stop_caret_blink`]
+    /// directly - see that method's docs for the real, live-reported bug ("carets across all
+    /// inputs sometimes don't display") that distinction fixes.
     pub(crate) fn wire_caret_blink(
         handles: &[&FocusHandle],
         window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> Vec<Subscription> {
+    ) -> (Vec<Subscription>, Vec<FocusHandle>) {
         let mut subscriptions = Vec::with_capacity(handles.len() * 2);
         for handle in handles {
             subscriptions.push(cx.on_focus(handle, window, |this, _window, cx| {
                 this.start_caret_blink(cx);
             }));
-            subscriptions.push(cx.on_blur(handle, window, |this, _window, cx| {
-                this.stop_caret_blink(cx);
+            subscriptions.push(cx.on_blur(handle, window, |this, window, cx| {
+                this.stop_caret_blink_on_blur(window, cx);
             }));
         }
-        subscriptions
+        (
+            subscriptions,
+            handles.iter().map(|handle| (*handle).clone()).collect(),
+        )
     }
 
     /// A real focus gain on a caret-bearing surface: the caret starts solid and the idle timer
@@ -82,6 +90,56 @@ impl AdeApp {
         self.caret_blink_visible = false;
         self._caret_blink_task = Task::ready(());
         cx.notify();
+    }
+
+    /// The blur half of [`Self::wire_caret_blink`], and the reason that wiring can't just call
+    /// [`Self::stop_caret_blink`] outright.
+    ///
+    /// GPUI does **not** deliver "the caret you were blinking lost focus" and "this other caret
+    /// gained it" as two ordered, causally-related events. Both are the *same*
+    /// `WindowFocusEvent` (one `previous_focus_path`/`current_focus_path` pair, built once per
+    /// frame in `vendor/zed/crates/gpui/src/window.rs`'s draw), fanned out to every registered
+    /// focus listener through a `SubscriberSet` whose backing `BTreeMap<usize, _>` is keyed by a
+    /// monotonic subscriber id - so listeners run in **registration order**, not in
+    /// blur-then-focus order. Whichever of the two handles this app happened to pass to
+    /// [`Self::wire_caret_blink`] *first* therefore has its listener run first, whichever way
+    /// focus actually moved.
+    ///
+    /// That is the whole bug behind the live report "carets across all inputs, sometimes it does
+    /// not display, sometimes just blinks once and never displays again": moving focus to a
+    /// handle wired *earlier* than the one being left (clicking from the rail filter back into
+    /// the editor, closing the command palette, leaving the commit message field - the ordinary
+    /// half of all focus changes in this app) ran `start_caret_blink` **first** and
+    /// `stop_caret_blink` **second**, so the freshly focused caret was left pinned invisible with
+    /// `_caret_blink_task` replaced by `Task::ready(())` - a dead loop that never ticks again
+    /// until something else restarts it. The other half of focus changes (to a *later*-wired
+    /// handle) ran in the lucky order and worked fine, which is exactly the reported
+    /// "sometimes".
+    ///
+    /// The fix is to stop treating a blur as proof that no caret is focused any more, and
+    /// instead ask the live window - [`Self::caret_blink_handles`] is the real list of every
+    /// handle this app blinks a caret for, and `FocusHandle::is_focused` reads
+    /// `Window::focus`, which `Window::focus()` already updated synchronously before this frame
+    /// was ever drawn. If some caret-bearing surface really is focused right now, this blur is
+    /// just the other half of a hand-off and there is nothing to stop; the matching
+    /// `on_focus`/[`Self::start_caret_blink`] owns the loop either way, whether it already ran or
+    /// is about to. That makes the outcome independent of registration order, so adding a
+    /// fourteenth caret-bearing handle at any position can't resurrect this.
+    ///
+    /// `Window::is_window_active` is checked too, and first: GPUI reports a window losing OS
+    /// focus by sending this same event with an *empty* `current_focus_path` while leaving
+    /// `Window::focus` untouched, so `is_focused` still says "yes" there. Blink must genuinely
+    /// stop when the whole window goes inactive, so that case falls through to the real stop.
+    pub(crate) fn stop_caret_blink_on_blur(&mut self, window: &Window, cx: &mut Context<Self>) {
+        let another_caret_is_focused = window.is_window_active()
+            && self
+                .caret_blink_handles
+                .iter()
+                .any(|handle| handle.is_focused(window));
+        if another_caret_is_focused {
+            return;
+        }
+        self.stop_caret_blink(cx);
     }
 
     /// Called after every real cursor-moving action or edit in a caret-bearing surface - forces
@@ -115,5 +173,212 @@ impl AdeApp {
                 break;
             }
         })
+    }
+}
+
+/// Real regression coverage for the live-reported "carets across all inputs, sometimes it does
+/// not display, sometimes just blinks once and never displays again" bug - see
+/// [`AdeApp::stop_caret_blink_on_blur`]'s own docs for the root cause (GPUI fans one
+/// `WindowFocusEvent` out to every focus listener in *registration* order, so a focus change to
+/// an earlier-wired handle ran `start_caret_blink` before `stop_caret_blink` and left the shared
+/// loop dead).
+///
+/// These drive real `Window::focus` moves between handles that are genuinely `track_focus`'d and
+/// rendered at the time - a `window.focus()` onto an unrendered handle produces no focus event at
+/// all (GPUI derives the event from the *rendered* frame's focus path), so a test that skipped
+/// that would silently prove nothing. Each one asserts the loop is still *ticking* afterwards,
+/// not merely that the flag reads `true` for one frame: the flag alone can't tell a live timer
+/// apart from a `Task::ready(())` that will never fire again, which is precisely the failure
+/// being guarded against.
+#[cfg(test)]
+mod caret_blink_focus_order_tests {
+    use super::*;
+    use crate::root::focus::palette_focus_tests;
+    use gpui::{Entity, TestAppContext, VisualTestContext};
+
+    /// A real repo directory with a real file in it, opened in a real File view, so
+    /// [`AdeApp::code_focus_handle`] - the *first* handle `AdeApp::wire_caret_blink` subscribes,
+    /// and therefore the one every ordering failure lands on - is genuinely rendered and
+    /// `track_focus`'d (`crate::code_surface::render`).
+    fn open_app_with_a_focusable_editor(
+        cx: &mut TestAppContext,
+    ) -> (Entity<AdeApp>, &mut VisualTestContext, tempfile::TempDir) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let file_path = repo.path().join("notes.txt");
+        std::fs::write(&file_path, "hello\n").expect("write notes.txt");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        // `on_focus`/`on_blur` only fire while GPUI considers the window itself active - a
+        // freshly opened test window starts out inactive, so this is a real precondition, not
+        // scaffolding (the same note every other caret-blink test in this codebase carries).
+        app.update_in(cx, |_app, window, _cx| window.activate_window());
+        cx.run_until_parked();
+        app.update_in(cx, |app, window, cx| {
+            app.open_file_view(file_path.clone(), window, cx);
+        });
+        cx.run_until_parked();
+        (app, cx, repo)
+    }
+
+    /// Advances the real clock past one full blink interval and reports the flag afterwards -
+    /// the only way to tell a live loop from a dead `Task::ready(())`.
+    fn tick(app: &Entity<AdeApp>, cx: &mut VisualTestContext) -> bool {
+        cx.background_executor
+            .advance_clock(CARET_BLINK_INTERVAL + Duration::from_millis(50));
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| app.caret_blink_visible)
+    }
+
+    /// The reported bug, at its most ordinary: click into the rail filter, then click back into
+    /// the editor. The editor's handle is wired *first*, so its `on_focus` ran before the rail
+    /// filter's `on_blur`, and the blur then killed the loop the focus had just started.
+    #[gpui::test]
+    fn moving_focus_to_an_earlier_wired_handle_keeps_the_blink_loop_alive(cx: &mut TestAppContext) {
+        let (app, cx, _repo) = open_app_with_a_focusable_editor(cx);
+
+        // Into the rail filter first - a *later*-wired handle, so this direction always worked
+        // and is a real precondition rather than part of what is being proven.
+        app.update_in(cx, |app, window, cx| {
+            window.focus(&app.filter_focus_handle, cx);
+        });
+        cx.run_until_parked();
+        assert!(
+            app.read_with(cx, |app, _| app.caret_blink_visible),
+            "sanity check: focusing the rail filter must start the shared loop solid"
+        );
+        assert!(
+            !tick(&app, cx),
+            "sanity check: and that loop must really be ticking"
+        );
+
+        // Back into the editor - the direction that was broken.
+        app.update_in(cx, |app, window, cx| {
+            app.focus_code_surface(window, cx);
+        });
+        cx.run_until_parked();
+        app.update_in(cx, |app, window, _cx| {
+            assert!(
+                app.code_focus_handle.is_focused(window),
+                "sanity check: focus must really have landed on the editor"
+            );
+        });
+
+        assert!(
+            app.read_with(cx, |app, _| app.caret_blink_visible),
+            "moving focus back into the editor must leave its caret solid - before this fix the \
+             editor's own `on_focus` ran first and the rail filter's `on_blur` then pinned the \
+             shared flag straight back off, so the caret never appeared at all"
+        );
+        assert!(
+            !tick(&app, cx),
+            "and the shared blink task must still be live - before this fix that `on_blur` \
+             replaced it with `Task::ready(())`, so the caret stayed invisible forever"
+        );
+        assert!(
+            tick(&app, cx),
+            "and keep its cadence across a second interval, not just fire once"
+        );
+    }
+
+    /// The same root cause on the app's single most common gesture: open the command palette,
+    /// type into it, dismiss it. Closing restores focus to the editor - again an earlier-wired
+    /// handle - so before this fix every palette dismissal left the editor caret dead.
+    #[gpui::test]
+    fn dismissing_the_palette_leaves_the_editor_caret_blinking(cx: &mut TestAppContext) {
+        let (app, cx, _repo) = open_app_with_a_focusable_editor(cx);
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_palette(window, cx);
+        });
+        cx.run_until_parked();
+        assert!(
+            app.read_with(cx, |app, _| app.caret_blink_visible),
+            "sanity check: the palette's own input must start the shared loop solid"
+        );
+
+        app.update_in(cx, |app, window, cx| {
+            app.close_palette(window, cx);
+        });
+        cx.run_until_parked();
+        app.update_in(cx, |app, window, _cx| {
+            assert!(
+                app.code_focus_handle.is_focused(window),
+                "sanity check: closing the palette must restore focus to the editor"
+            );
+        });
+
+        assert!(
+            app.read_with(cx, |app, _| app.caret_blink_visible),
+            "dismissing the palette must hand the caret back to the editor solid, not pin it off"
+        );
+        assert!(
+            !tick(&app, cx),
+            "and hand back a live loop, not a dead `Task::ready(())`"
+        );
+        assert!(tick(&app, cx), "which keeps its cadence");
+    }
+
+    /// The other half of the fix, so it can't be satisfied by simply never stopping: blurring to
+    /// something that genuinely has no caret (`AdeApp::rail_focus_handle`, the rail's own
+    /// container fallback - never a text input, never wired into `wire_caret_blink`) must still
+    /// stop the loop outright, exactly as before.
+    #[gpui::test]
+    fn blurring_to_a_non_caret_target_still_stops_the_blink_loop(cx: &mut TestAppContext) {
+        let (app, cx, _repo) = open_app_with_a_focusable_editor(cx);
+
+        app.update_in(cx, |app, window, cx| {
+            window.focus(&app.filter_focus_handle, cx);
+        });
+        cx.run_until_parked();
+        assert!(
+            app.read_with(cx, |app, _| app.caret_blink_visible),
+            "sanity check: the rail filter must start the shared loop solid"
+        );
+
+        app.update_in(cx, |app, window, cx| {
+            window.focus(&app.rail_focus_handle, cx);
+        });
+        cx.run_until_parked();
+
+        assert!(
+            !app.read_with(cx, |app, _| app.caret_blink_visible),
+            "leaving every caret-bearing surface must still pin the shared flag off immediately"
+        );
+        assert!(
+            !tick(&app, cx),
+            "and must leave no timer running behind it - a still-live loop would flip this back \
+             on with no caret focused at all"
+        );
+    }
+
+    /// The window losing OS focus is reported as this same blur event with an emptied focus path
+    /// while `Window::focus` is left untouched, so `FocusHandle::is_focused` still says "yes"
+    /// there. Blink must genuinely stop anyway - this is what
+    /// `Self::stop_caret_blink_on_blur`'s `Window::is_window_active` check is for, and without it
+    /// the fix above would leave carets blinking in a background window.
+    #[gpui::test]
+    fn deactivating_the_window_still_stops_the_blink_loop(cx: &mut TestAppContext) {
+        let (app, cx, _repo) = open_app_with_a_focusable_editor(cx);
+
+        app.update_in(cx, |app, window, cx| {
+            window.focus(&app.filter_focus_handle, cx);
+        });
+        cx.run_until_parked();
+        assert!(
+            app.read_with(cx, |app, _| app.caret_blink_visible),
+            "sanity check: the rail filter must start the shared loop solid"
+        );
+
+        cx.deactivate_window();
+        cx.run_until_parked();
+
+        assert!(
+            !app.read_with(cx, |app, _| app.caret_blink_visible),
+            "a window going inactive must still stop the caret blinking, even though its focus \
+             handle is technically still the focused one"
+        );
+        assert!(
+            !tick(&app, cx),
+            "and must leave no timer running in the background window"
+        );
     }
 }

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -971,6 +971,13 @@ pub struct AdeApp {
     /// `crate::root::caret_blink::AdeApp::wire_caret_blink`. Held for this instance's whole
     /// lifetime; an unheld `gpui::Subscription` is dropped, and a dropped one stops firing.
     pub(crate) _caret_blink_subscriptions: Vec<Subscription>,
+    /// Every `FocusHandle` [`Self::wire_caret_blink`] has subscribed - the same handles
+    /// [`Self::_caret_blink_subscriptions`] covers, kept as a live list so a blur can ask "is
+    /// some *other* caret-bearing surface focused right now?" rather than assuming it is the
+    /// last word on the focus change it is reporting. That question is what makes
+    /// [`Self::stop_caret_blink_on_blur`] independent of the order GPUI happens to run these
+    /// subscriptions in - see its own docs for the real bug that ordering caused.
+    pub(crate) caret_blink_handles: Vec<FocusHandle>,
     /// Whether the git graph tab (GitHub issue #1, phase (a)) exists in the tab strip. Unlike
     /// [`Self::open_files`] there is at most one - "one per window" per the design spec - so this
     /// is a plain `bool`, not a collection.

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -257,7 +257,7 @@ impl AdeApp {
         let settings_keymap_filter_focus_handle = cx.focus_handle();
         let theme_seed_focus_handle = cx.focus_handle();
         let shell_focus_handle = cx.focus_handle();
-        let caret_blink_subscriptions = AdeApp::wire_caret_blink(
+        let (caret_blink_subscriptions, caret_blink_handles) = AdeApp::wire_caret_blink(
             &[
                 &code_focus_handle,
                 &merge_edit_focus_handle,
@@ -454,6 +454,7 @@ impl AdeApp {
             caret_blink_visible: true,
             _caret_blink_task: Task::ready(()),
             _caret_blink_subscriptions: caret_blink_subscriptions,
+            caret_blink_handles,
             graph_tab_open: false,
             graph_tab_active: false,
             graph_focus_handle: cx.focus_handle(),
@@ -724,7 +725,7 @@ impl AdeApp {
         // literal). Wired here instead, appending onto the very same `_caret_blink_subscriptions`
         // vec so there's still exactly one place holding every real caret subscription this app
         // has, not two.
-        let extra_caret_blink_subscriptions = AdeApp::wire_caret_blink(
+        let (extra_caret_blink_subscriptions, extra_caret_blink_handles) = AdeApp::wire_caret_blink(
             &[
                 &this.graph_state.branches_filter_focus_handle,
                 &this.new_file_focus_handle,
@@ -754,6 +755,11 @@ impl AdeApp {
         );
         this._caret_blink_subscriptions
             .extend(extra_caret_blink_subscriptions);
+        // The handle list has to grow with the subscriptions, not just alongside them:
+        // `Self::stop_caret_blink_on_blur` answers "is some *other* caret focused right now?"
+        // from it, and a handle missing here would be read as "nothing caret-bearing is focused"
+        // and kill the shared loop on every hand-off into it.
+        this.caret_blink_handles.extend(extra_caret_blink_handles);
         // Real "add this one repo on startup" (Revision R12 Phase 0, extended by GitHub issue
         // #90 to a genuinely optional repo): `resolved_repo_path` - the CLI argument, the
         // remembered last-focused repo, or nothing at all, per `Self::new_with_settings`'s own


### PR DESCRIPTION
Live report: *"there is a weird bug with carets across all inputs, sometimes it does not display sometimes just blinks once and never display again"*.

## Root cause

GPUI does **not** deliver "this caret lost focus" and "that caret gained it" as two ordered, causally-related events. Both are the *same* `WindowFocusEvent` (one `previous_focus_path`/`current_focus_path` pair, built once per frame in `vendor/zed/crates/gpui/src/window.rs`'s draw), fanned out to every registered focus listener through a `SubscriberSet` whose backing `BTreeMap<usize, _>` is keyed by a monotonic subscriber id. Listeners therefore run in **registration order**, not blur-then-focus order.

`wire_caret_blink` subscribes 13 handles in a fixed order and had every `on_blur` call `stop_caret_blink` unconditionally. So whenever focus moved to a handle wired *earlier* than the one being left, `start_caret_blink` ran **first** and `stop_caret_blink` ran **second** - leaving the freshly focused caret pinned invisible with `_caret_blink_task` replaced by `Task::ready(())`, a dead loop that never ticks again. Moves in the other direction ran in the lucky order and worked fine, which is exactly the reported *"sometimes"*.

That is roughly half of every focus change in the app, including its most ordinary ones: dismissing the command palette (`#2 -> #0`), clicking from the rail filter back into the editor (`#4 -> #0`), leaving the commit message field (`#11 -> #4`).

Confirmed by temporarily instrumenting both callbacks and driving real focus moves - the trace shows `on_focus #0` firing *before* `on_blur #4` - then reproduced and A/B'd against the real running app over X11.

## The fix

Stop treating a blur as proof that no caret is focused any more. `AdeApp::caret_blink_handles` records every handle `wire_caret_blink` subscribes, and the new `stop_caret_blink_on_blur` asks the live window whether any of them is focused *right now* (`Window::focus`, already updated synchronously before the frame was drawn). If one is, this blur is just the other half of a hand-off and there is nothing to stop - the matching `on_focus` owns the loop either way, whether it already ran or is about to.

The outcome no longer depends on registration order, so adding a fourteenth caret-bearing handle at any position can't resurrect this. `Window::is_window_active` is checked first, because GPUI reports a window losing OS focus through this same event with an emptied focus path while leaving `Window::focus` untouched, and blink must genuinely stop there.

## Tests

Four regression tests in `caret_blink_focus_order_tests`, each driving real `Window::focus` moves between genuinely rendered, `track_focus`'d handles and asserting the loop is still *ticking* afterwards across two full intervals (a flag alone can't tell a live timer from a dead `Task::ready(())`):

| test | without the fix |
|---|---|
| `moving_focus_to_an_earlier_wired_handle_keeps_the_blink_loop_alive` | **fails** |
| `dismissing_the_palette_leaves_the_editor_caret_blinking` | **fails** |
| `blurring_to_a_non_caret_target_still_stops_the_blink_loop` | passes (guards against over-correcting into "never stop") |
| `deactivating_the_window_still_stops_the_blink_loop` | passes; **fails** if the `is_window_active` guard alone is removed |

## Verification

- `cargo build --workspace`, `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets` - clean.
- `cargo test -p app --lib` (2781 passed), `-p wt-core` (290), `-p lsp-core` (51), `-p pty-core` (19). The only failures are the known `worktree_watch`/`file_tree_watch`/`repo_list_tests` inotify-contention flakes, all 18 green under `--test-threads=1`.
- **Live A/B against the real app over X11**, per-window `XGetImage` sampled every 100ms and analysed for caret on/off periodicity:
  - *Pre-fix binary*: after `Esc` closes the palette, the editor caret is **absent for 9 s** - zero changing pixels, visually confirmed by a zoomed capture.
  - *Fixed binary, identical sequence*: 17 transitions over 10 s at a steady ~0.53 s half-period.
  - Also checked across four real fields, 9 s each: rail filter (16 transitions), code editor (16), palette input (12), commit message (15) - plus both broken-direction moves (`#11 -> #4` rail filter, `#2 -> #0` editor) blinking correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)