### PR TITLE
Agent pane: identity-only context bar, action-bar cuts, readout strip

### DIFF
--- a/crates/app/src/merge/flow.rs
+++ b/crates/app/src/merge/flow.rs
@@ -65,14 +65,34 @@ impl AdeApp {
         self._merge_cleanup_task = Some(task);
     }
 
-    /// The context bar's `Merge` action (see `render_merge_button`) - starts
-    /// `wt_core::merge::attempt_merge` of `id`'s worktree branch into the repository's detected
-    /// base branch, on the background executor (a `gix` open, a `git status` dirty-check, and a
-    /// spawned `git merge` child process - see that function's own docs).
+    /// Merges `id`'s worktree branch into the repository's detected base branch, on the
+    /// background executor (a `gix` open, a `git status` dirty-check, and a spawned `git merge`
+    /// child process - see `wt_core::merge::attempt_merge`'s own docs).
     ///
-    /// Only one merge flow is tracked at a time; a click while one is already in progress for
+    /// Only one merge flow is tracked at a time; a start while one is already in progress for
     /// any agent is a no-op, since two concurrent `git merge` invocations would race over the
     /// same base worktree.
+    ///
+    /// ## No UI entry point right now - deliberately, and tracked
+    ///
+    /// This used to be the agent context bar's `Merge` button. GitHub issue #295 deleted that
+    /// button outright (`STAGE-A-CHANGELOG.md` §4e: a **worktree** verb in an **agent** header,
+    /// offered twice for one two-agent worktree, offered while the agent was `Needs input`, and
+    /// "merge has preconditions - committed, base current, no live writers - and the header can
+    /// show none of them"), and §4e/#285 both name the git graph as where merging belongs.
+    ///
+    /// The graph has the *other* direction already ([`Self::start_merge_from_graph_branch`],
+    /// "Merge into current branch…"); **this** direction - a branch into its base - is the first
+    /// open bullet of GitHub issue #241, and inventing that surface was explicitly out of scope
+    /// for #295. So the flow, its `MergeOutcome` folding and its full regression suite below are
+    /// kept intact and unreachable rather than deleted and rebuilt later: the alternative is
+    /// throwing away tested behaviour a tracked issue is about to need. `#[allow(dead_code)]`
+    /// states that honestly instead of leaving a bare compiler warning for someone to silence.
+    ///
+    /// Nothing else about it is dormant: `wt_core::merge::attempt_merge` (the engine),
+    /// [`fold_merge_result`] (the shared `MergeOutcome` → UI-state mapping) and the whole
+    /// `crate::merge::render` conflict resolver are all live today via the graph direction.
+    #[allow(dead_code)]
     pub(crate) fn start_merge(&mut self, id: AgentId, cx: &mut Context<Self>) {
         if self.merge_flow.is_some() {
             return;
@@ -947,6 +967,11 @@ enum MergeEditReparseOutcome {
 /// `abortable_worktree` via [`wt_core::merge::find_in_progress_merge`] rather than assuming a
 /// merge is or isn't in progress just because this call failed. If that lookup itself fails,
 /// `abortable_worktree` is `None`.
+///
+/// Reached only through [`run_merge_attempt`], so it shares that function's "no UI entry point
+/// until GitHub issue #241's graph merge-into-base lands" state - see
+/// [`AdeApp::start_merge`]'s own docs for why it is kept rather than deleted.
+#[allow(dead_code)]
 pub(in crate::merge) fn merge_error_state(
     repo_path: &std::path::Path,
     message: String,
@@ -967,6 +992,11 @@ pub(in crate::merge) fn merge_error_state(
 /// thread. For a [`wt_core::merge::MergeOutcome::Conflicted`], this also classifies every
 /// conflicted path (`wt_core::merge::classify_conflicted_file`) here, still off-thread, rather
 /// than leaving that as a second round-trip.
+///
+/// Its only caller is [`AdeApp::start_merge`], whose UI entry point GitHub issue #295 deleted and
+/// GitHub issue #241 will restore on the git graph - see that method's own docs. Its twin
+/// [`run_merge_attempt_into_current`] and their shared [`fold_merge_result`] are both live today.
+#[allow(dead_code)]
 pub(in crate::merge) fn run_merge_attempt(
     repo_path: &std::path::Path,
     worktree_path: &std::path::Path,

--- a/crates/app/src/merge/state.rs
+++ b/crates/app/src/merge/state.rs
@@ -1,4 +1,4 @@
-//! Pure (GPUI-free) state for the context bar's `Merge` action and Surface D's
+//! Pure (GPUI-free) state for the git graph's merge actions and Surface D's
 //! conflict-resolution flow - mirrors `crate::rail::state`/`crate::rail::status`'s own split: this module
 //! only holds already-computed facts (from `wt_core::merge` calls made in `crate::root`, which
 //! has the `Context<AdeApp>` background-thread access those calls need) and pure transitions

--- a/crates/app/src/review/render.rs
+++ b/crates/app/src/review/render.rs
@@ -1293,8 +1293,8 @@ mod review_flow_tests {
             assert!(
                 app.agent_has_unreviewed_changes(id),
                 "the status poll alone must make an agent's real work reviewable - without it, \
-                 `Status::Review` could never fire, so the footer's `Review` door could never \
-                 appear, so the tab could never be opened at all"
+                 `Status::Review` could never fire, so the review door could never appear, so \
+                 the tab could never be opened at all"
             );
             assert_eq!(
                 app.agent_review_file_count(id),
@@ -1303,7 +1303,15 @@ mod review_flow_tests {
             );
             assert!(
                 app.review_available_for(id),
-                "so the footer door is genuinely offerable"
+                "so the door is genuinely offerable"
+            );
+            // GitHub issue #295 moved that door from the finished agent's pane footer (§4r
+            // emptied it entirely) to the title bar's Agent menu. Same gate, new home - and it
+            // must really be enabled, not merely listed.
+            assert!(
+                app.menu_command_enabled(crate::title_bar::menu_model::MenuCommand::ReviewAgent),
+                "the Agent menu's `Review Agent` row is the review tab's only door now, so it \
+                 must be enabled exactly when `review_available_for` is true"
             );
         });
 
@@ -1330,12 +1338,12 @@ mod review_flow_tests {
             crate::rail::status::Status::Review,
             "a successfully-exited agent with real unreviewed work must reach Status::Review"
         );
+        // GitHub issue #295 / §4r: that status's footer must now carry **nothing at all** - "a
+        // finished transcript is a record; its actions live where their object lives". The door
+        // asserted above (the Agent menu's `Review Agent`) is where it went.
         assert!(
-            work_surface::footer_actions(status_on_exit)
-                .iter()
-                .any(|action| action.kind == work_surface::ActionKind::OpenReview
-                    && action.implemented),
-            "and that status's footer must carry the real, implemented `Review` door"
+            work_surface::footer_actions(status_on_exit).is_empty(),
+            "a finished agent's pane strip must offer no action buttons at all"
         );
     }
 

--- a/crates/app/src/root/menu_commands.rs
+++ b/crates/app/src/root/menu_commands.rs
@@ -78,6 +78,15 @@ impl AdeApp {
                 self.current_worktree_agents().count() > 1
             }
             MenuCommand::ArchiveAgent => self.agents.active_id().is_some(),
+            // GitHub issue #295 moved the agent review door here from the pane footer, which §4r
+            // emptied ("a finished transcript is a record; its actions live where their object
+            // lives"). It keeps issue #225's own gate exactly: a review needs a real captured
+            // baseline, and it is only meaningful when this agent is the sole agent in its
+            // worktree - see `crate::review::flow::AdeApp::review_available_for`.
+            MenuCommand::ReviewAgent => self
+                .agents
+                .active_id()
+                .is_some_and(|id| self.review_available_for(id)),
             MenuCommand::KeepAllChanges => {
                 self.agents.active_id().is_some()
                     && self.worktree_history_op_in_flight
@@ -213,6 +222,12 @@ impl AdeApp {
                 if let Some(id) = self.agents.active_id() {
                     self.title_menu_open = None;
                     self.archive_agent(id, window, cx);
+                }
+            }
+            MenuCommand::ReviewAgent => {
+                if let Some(id) = self.agents.active_id() {
+                    self.title_menu_open = None;
+                    self.open_review_tab(id, window, cx);
                 }
             }
             MenuCommand::KeepAllChanges => {
@@ -364,6 +379,15 @@ impl AdeApp {
         cx: &mut Context<Self>,
     ) {
         self.perform_menu_command(MenuCommand::ArchiveAgent, window, cx);
+    }
+
+    pub(crate) fn handle_review_agent_menu_command(
+        &mut self,
+        _: &ReviewAgent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.perform_menu_command(MenuCommand::ReviewAgent, window, cx);
     }
 
     pub(crate) fn handle_keep_all_changes_menu_command(

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -256,6 +256,7 @@ actions!(
         NextAgent,
         PreviousAgent,
         ArchiveAgent,
+        ReviewAgent,
         KeepAllChanges,
         DiscardWorktree,
         OpenDocumentation,
@@ -1521,9 +1522,12 @@ pub struct AdeApp {
     /// not-found binary measures ~30ms, which would cap the whole Settings surface's frame rate
     /// if run inline. `Vec::new()` until the first load completes.
     pub(crate) agent_rows: Vec<settings::AgentRow>,
-    /// The context bar's `Merge` action and Surface D's conflict-resolution flow - see
-    /// [`crate::merge::state::MergeFlow`]'s docs. `None` when no agent has an in-flight merge or
-    /// unresolved conflict.
+    /// The git graph's `Merge into current branch\u{2026}` action and Surface D's
+    /// conflict-resolution flow - see [`crate::merge::state::MergeFlow`]'s docs. `None` when no
+    /// agent has an in-flight merge or unresolved conflict. (The agent context bar's own `Merge`
+    /// button was deleted by GitHub issue #295; see
+    /// `crate::merge::flow::AdeApp::start_merge`'s docs for the direction that is waiting on
+    /// issue #241.)
     pub(crate) merge_flow: Option<merge::MergeFlow>,
     /// `true` for the duration of an in-flight `Complete merge`/`Abort merge` git operation -
     /// guards against a fast Abort-after-Complete double-click letting `git merge --abort` race
@@ -3197,6 +3201,9 @@ impl Render for AdeApp {
             )
             .when(self.menu_command_enabled(MenuCommand::ArchiveAgent), |el| {
                 el.on_action(cx.listener(Self::handle_archive_agent_menu_command))
+            })
+            .when(self.menu_command_enabled(MenuCommand::ReviewAgent), |el| {
+                el.on_action(cx.listener(Self::handle_review_agent_menu_command))
             })
             .when(
                 self.menu_command_enabled(MenuCommand::KeepAllChanges),

--- a/crates/app/src/status_bar/render.rs
+++ b/crates/app/src/status_bar/render.rs
@@ -17,7 +17,7 @@ use crate::status_bar::resources::{
 /// *every frame*, for a value that cannot change while the process is running. This is one
 /// `OnceLock` instead - and deliberately not a field on `AdeApp`, since it is a property of the
 /// machine rather than of any window.
-fn available_cores() -> usize {
+pub(crate) fn available_cores() -> usize {
     static CORES: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
     *CORES.get_or_init(|| {
         std::thread::available_parallelism()
@@ -49,7 +49,7 @@ pub(crate) enum StatusTier {
 }
 
 impl StatusTier {
-    fn color(self) -> theme::ColorToken {
+    pub(crate) fn color(self) -> theme::ColorToken {
         match self {
             StatusTier::Primary => theme::status_bar::PRIMARY,
             StatusTier::Secondary => theme::status_bar::SECONDARY,
@@ -58,14 +58,14 @@ impl StatusTier {
     }
 
     /// §4c's per-tier sizes: `10.5px/450` primary, `10.5px` secondary, `9.5-10.5px` tertiary.
-    fn text_size(self) -> f32 {
+    pub(crate) fn text_size(self) -> f32 {
         match self {
             StatusTier::Primary | StatusTier::Secondary => 10.5,
             StatusTier::Recessive => 10.0,
         }
     }
 
-    fn weight(self) -> gpui::FontWeight {
+    pub(crate) fn weight(self) -> gpui::FontWeight {
         match self {
             StatusTier::Primary => gpui::FontWeight::MEDIUM,
             StatusTier::Secondary | StatusTier::Recessive => gpui::FontWeight::NORMAL,

--- a/crates/app/src/status_bar/resources.rs
+++ b/crates/app/src/status_bar/resources.rs
@@ -152,12 +152,23 @@ impl ResourceTree {
 
     /// The status bar's own recessive readout: `"41% cpu · 3.4 GB"`, the sum of this tree.
     pub fn bar_readout(&self) -> String {
-        format!(
-            "{} cpu \u{b7} {}",
-            cpu_label(self.cpu_percent()),
-            memory_label(self.memory_bytes())
-        )
+        agent_readout(self.cpu_percent(), self.memory_bytes())
     }
+}
+
+/// One process's cost in the window's one readout wording: `"6.2% cpu · 0.51 GB"`.
+///
+/// Shared verbatim by [`ResourceTree::bar_readout`] (the whole-window total) and the agent pane's
+/// per-agent strip (`STAGE-A-CHANGELOG.md` §4t, GitHub issue #295 -
+/// `crate::work_surface::render::AdeApp::render_agent_cost_readout`). Two surfaces stating a cost
+/// in two different formats would be two vocabularies for one fact, so there is exactly one
+/// formatter and both call it.
+pub fn agent_readout(cpu_percent: Option<f32>, memory_bytes: Option<u64>) -> String {
+    format!(
+        "{} cpu \u{b7} {}",
+        cpu_label(cpu_percent),
+        memory_label(memory_bytes)
+    )
 }
 
 /// Sums whatever CPU readings are genuinely known - `None` only when not one row has a reading at

--- a/crates/app/src/terminal/pane.rs
+++ b/crates/app/src/terminal/pane.rs
@@ -871,8 +871,8 @@ impl TerminalPane {
     }
 
     /// Sends `Ctrl-C` (`0x03`) to the child process's pty, exactly as [`Self::handle_key_down`]
-    /// would for an actual `Ctrl-C` keystroke - backs the surface footer's `Interrupt
-    /// \u{2303}C` action. A no-op when no session is live.
+    /// would for an actual `Ctrl-C` keystroke - backs the rail agent menu's `Pause` row. A
+    /// no-op when no session is live.
     pub fn interrupt(&mut self, _cx: &mut Context<Self>) {
         let Some(session) = &self.session else {
             return;

--- a/crates/app/src/theme.rs
+++ b/crates/app/src/theme.rs
@@ -3324,8 +3324,8 @@ pub mod band {
     pub const SURFACE_FOOTER: Pixels = px(28.0);
     pub const PTY_HEADER: Pixels = px(27.0);
     /// The terminal pane's info footer band (`pid` · grid dimensions · environment chip ·
-    /// right-aligned static copy) - distinct from [`SURFACE_FOOTER`] (the agent-level
-    /// Interrupt/Retry/Archive action footer, rendered separately below it).
+    /// right-aligned static copy) - distinct from [`SURFACE_FOOTER`] (the agent-level readout
+    /// strip, rendered separately below it: GitHub issue #295 / `STAGE-A-CHANGELOG.md` §4t).
     pub const PTY_INFO_FOOTER: Pixels = px(26.0);
     pub const BREADCRUMB: Pixels = px(26.0);
     /// 26 -> 28 (`CHANGELOG.md`'s change 7: "Height 26 -> 28"), then 28 -> 30 for rev 6's

--- a/crates/app/src/title_bar/menu.rs
+++ b/crates/app/src/title_bar/menu.rs
@@ -339,6 +339,11 @@ impl AdeApp {
                 theme::text::DIM.into(),
                 theme::surface::CHIP_NEUTRAL.into(),
             ),
+            MenuCommand::ReviewAgent => (
+                "R",
+                theme::text::DIM.into(),
+                theme::surface::CHIP_NEUTRAL.into(),
+            ),
             MenuCommand::KeepAllChanges => (
                 "K",
                 theme::text::DIM.into(),
@@ -402,6 +407,7 @@ impl AdeApp {
             MenuCommand::NewTerminal => "in this worktree".to_string(),
             MenuCommand::NextAgent | MenuCommand::PreviousAgent => "cycle tabs".to_string(),
             MenuCommand::ArchiveAgent => "close the active tab".to_string(),
+            MenuCommand::ReviewAgent => "what this agent changed".to_string(),
             MenuCommand::KeepAllChanges => "commit the active worktree".to_string(),
             MenuCommand::DiscardWorktree => "force-remove uncommitted content".to_string(),
             MenuCommand::Documentation => "README on GitHub".to_string(),
@@ -1130,14 +1136,16 @@ mod title_menu_tests {
         });
         cx.run_until_parked();
 
-        // The Discard row is the 7th real row (index 6, 0-based) in the Agent menu: New
-        // Terminal, New Agent Pane, [divider], Next Agent, Previous Agent, [divider],
-        // Archive Agent, Keep All Changes, Discard Worktree - six real rows and two dividers
-        // sit above it (see `AdeApp::agent_menu_rows`'s own row order).
+        // The Discard row is the 8th real row (index 7, 0-based) in the Agent menu: New
+        // Terminal, New Agent Pane, [divider], Next Agent, Previous Agent, [divider], Review
+        // Agent, Archive Agent, Keep All Changes, Discard Worktree - seven real rows and two
+        // dividers sit above it (see `MenuCommand::rows`'s own row order). `Review Agent` joined
+        // that third group with GitHub issue #295, which deleted the agent pane footer's own
+        // `Review` door along with the rest of the finished-agent action bar.
         let bounds = app.read_with(cx, |app, _| {
             app.title_menu_button_bounds[TitleMenu::Agent.index()]
         });
-        let discard_row_point = nth_row_click_point(bounds, 6, 2);
+        let discard_row_point = nth_row_click_point(bounds, 7, 2);
 
         // First, arming click on the real rendered Discard row.
         cx.simulate_click(discard_row_point, gpui::Modifiers::none());

--- a/crates/app/src/title_bar/menu_model.rs
+++ b/crates/app/src/title_bar/menu_model.rs
@@ -68,6 +68,7 @@ pub(crate) enum MenuCommand {
     NextAgent,
     PreviousAgent,
     ArchiveAgent,
+    ReviewAgent,
     KeepAllChanges,
     DiscardWorktree,
     // Help
@@ -98,7 +99,7 @@ impl MenuCommand {
     /// ([`Self::action`], [`Self::label`], [`Self::keystroke_spec`]) are exhaustive over this
     /// same enum, so nothing here can silently end up with only some of the three - the same
     /// guarantee [`crate::root::menus::MenuSurface::ALL`] gives its own two matches.
-    pub(crate) const ALL: [MenuCommand; 30] = [
+    pub(crate) const ALL: [MenuCommand; 31] = [
         MenuCommand::OpenFile,
         MenuCommand::OpenFolder,
         MenuCommand::NewWindow,
@@ -120,6 +121,7 @@ impl MenuCommand {
         MenuCommand::NextAgent,
         MenuCommand::PreviousAgent,
         MenuCommand::ArchiveAgent,
+        MenuCommand::ReviewAgent,
         MenuCommand::KeepAllChanges,
         MenuCommand::DiscardWorktree,
         MenuCommand::Documentation,
@@ -163,6 +165,7 @@ impl MenuCommand {
             MenuCommand::NextAgent => Box::new(root::NextAgent),
             MenuCommand::PreviousAgent => Box::new(root::PreviousAgent),
             MenuCommand::ArchiveAgent => Box::new(root::ArchiveAgent),
+            MenuCommand::ReviewAgent => Box::new(root::ReviewAgent),
             MenuCommand::KeepAllChanges => Box::new(root::KeepAllChanges),
             MenuCommand::DiscardWorktree => Box::new(root::DiscardWorktree),
             MenuCommand::Documentation => Box::new(root::OpenDocumentation),
@@ -205,6 +208,7 @@ impl MenuCommand {
             MenuCommand::NextAgent => "Next Agent",
             MenuCommand::PreviousAgent => "Previous Agent",
             MenuCommand::ArchiveAgent => "Archive Agent",
+            MenuCommand::ReviewAgent => "Review Agent",
             MenuCommand::KeepAllChanges => "Keep All Changes",
             MenuCommand::DiscardWorktree => "Discard Worktree",
             MenuCommand::Documentation => "Documentation",
@@ -247,6 +251,7 @@ impl MenuCommand {
             | MenuCommand::NextAgent
             | MenuCommand::PreviousAgent
             | MenuCommand::ArchiveAgent
+            | MenuCommand::ReviewAgent
             | MenuCommand::KeepAllChanges
             | MenuCommand::DiscardWorktree
             | MenuCommand::Documentation
@@ -297,6 +302,7 @@ impl MenuCommand {
                 Command(MenuCommand::NextAgent),
                 Command(MenuCommand::PreviousAgent),
                 Separator,
+                Command(MenuCommand::ReviewAgent),
                 Command(MenuCommand::ArchiveAgent),
                 Command(MenuCommand::KeepAllChanges),
                 Command(MenuCommand::DiscardWorktree),

--- a/crates/app/src/work_surface/mod.rs
+++ b/crates/app/src/work_surface/mod.rs
@@ -21,7 +21,6 @@
 use crate::code_surface::code_view;
 use crate::env_info;
 use crate::keymap::{self};
-use crate::merge::state as merge;
 use crate::palette::state as palette;
 use crate::rail::status::{self, Status};
 use crate::rail::title_signal;

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -412,9 +412,14 @@ impl AdeApp {
         status::derive_status(agent.kind, signal, terminal, hooks, has_unreviewed_changes)
     }
 
-    /// The context bar's and idle-status footer's `Archive` action - closes the tab via
-    /// [`Self::close_agent`] (see that method's docs for why every close path must go through
-    /// it rather than `Agents::close` directly).
+    /// The `Archive` action - closes the tab via [`Self::close_agent`] (see that method's docs
+    /// for why every close path must go through it rather than `Agents::close` directly).
+    ///
+    /// Its homes since GitHub issue #295 deleted the agent context bar's own copy
+    /// (`STAGE-A-CHANGELOG.md` §4e: "`Archive` is worktree lifecycle and belongs on the rail row
+    /// with prune and delete"): the rail's agent (`Archive run`) and worktree (`Archive N
+    /// agents`) context menus (`crate::rail::menu`, issue #290), and the title bar's
+    /// `Agent → Archive Agent`.
     pub(crate) fn archive_agent(
         &mut self,
         id: AgentId,
@@ -428,16 +433,16 @@ impl AdeApp {
     }
 
     /// Closes agent `id`'s tab (`Agents::close` tears down its child process and moves focus
-    /// onto whichever agent becomes active) and, if `id` is the agent whose `Merge` click
-    /// started [`Self::merge_flow`], cleans that up too (see
-    /// [`Self::clear_merge_flow_for_closed_agent`]).
+    /// onto whichever agent becomes active) and, if `id` is the agent [`Self::merge_flow`] is
+    /// running under, cleans that up too (see [`Self::clear_merge_flow_for_closed_agent`]).
     ///
     /// Every close path - [`Self::archive_agent`], [`Self::respawn_agent`]'s
     /// close-then-respawn, and the tab strip's own `×` - must go through this function rather
-    /// than `Agents::close` directly: previously only `archive_agent` cleared `merge_flow`,
-    /// so archiving (or retrying) a mid-merge agent left `merge_flow.agent_id` pointing at a
-    /// agent that no longer existed, permanently disabling the `Merge` button for every
-    /// agent (`Self::render_merge_button`'s disabled check never cleared).
+    /// than `Agents::close` directly: previously only `archive_agent` cleared `merge_flow`, so
+    /// archiving (or retrying) a mid-merge agent left `merge_flow.agent_id` pointing at an agent
+    /// that no longer existed, permanently blocking every later merge (only one flow runs at a
+    /// time - `crate::merge::flow::AdeApp::start_merge_from_graph_branch`'s own single-flight
+    /// refusal).
     ///
     /// Tells `Agents::close` to skip its own focus move whenever the centre pane isn't
     /// actually showing an agent's pane right now - a file tab is open, *or* Settings has
@@ -498,8 +503,10 @@ impl AdeApp {
         self.record_worktree_session(cx);
     }
 
-    /// The surface footer's `Interrupt ⌃C` action - sends `Ctrl-C` to the agent's pty via
-    /// `TerminalPane::interrupt`.
+    /// The rail agent menu's `Pause` action - sends `Ctrl-C` to the agent's pty via
+    /// `TerminalPane::interrupt`. The pane strip's own `Interrupt` button is gone (GitHub issue
+    /// #295 / §4t: "the pane is a terminal: `⌃C` already interrupts ... a button duplicating
+    /// a keystroke that works in the focused surface" is unearned space).
     pub(crate) fn interrupt_agent(&mut self, id: AgentId, cx: &mut Context<Self>) {
         let Some(agent) = self.agents.iter().find(|agent| agent.id == id) else {
             return;
@@ -508,7 +515,8 @@ impl AdeApp {
         pane.update(cx, |pane, cx| pane.interrupt(cx));
     }
 
-    /// The surface footer's `Retry ⌘R` (failed agents) / `Resume ⌘⏎` (idle agents) action.
+    /// The pane strip's `Retry ⌘R` (failed agents) / `Resume ⌘⏎` (idle agents) action, and the
+    /// rail agent menu's `Resume` row - the two verbs GitHub issue #295 left on that strip.
     /// This app has no saved-agent resumability to resume *from* (see
     /// `crate::work_surface::state::pty_state_label`'s docs), so the honest equivalent is: close this
     /// tab, then spawn a fresh agent of the same kind into the same worktree - not literally
@@ -548,8 +556,11 @@ impl AdeApp {
         cx.notify();
     }
 
-    /// The surface footer's `Open terminal` action - selects an already-open `Shell` agent in
-    /// the same worktree, or spawns one if none exists. Each agent is its own independent tab/
+    /// The no-agent empty state's `Open terminal` action
+    /// ([`Self::render_no_agents_empty_state`]) - selects an already-open `Shell` agent in the
+    /// same worktree, or spawns one if none exists. §4e keeps this verb there and nowhere else
+    /// in the pane: everywhere else it "was always a duplicate of the `zsh` tab three rows
+    /// above". Each agent is its own independent tab/
     /// process (`crate::work_surface::agents`'s module docs), so "open terminal" just means "get me a shell
     /// in this worktree", the same capability as the rail's "+ New Shell" button.
     pub(in crate::work_surface) fn open_companion_terminal(
@@ -1859,9 +1870,25 @@ impl AdeApp {
 
     /// The agent context bar: agent badge/name, a divider, branch, the worktree path (the one
     /// flexible, ellipsising child - every other child is `flex_none` and non-wrapping, so the
-    /// bar never wraps when the centre narrows), a status pill, and `Merge`/`Archive` - or, for a
-    /// bare worktree (Revision R12 §3: [`Self::current_worktree_is_bare`]), the agent name greyed
-    /// to `no agent` and a single blue `Start an agent` button in `Merge`/`Archive`'s place.
+    /// bar never wraps when the centre narrows), and a status pill. **Identity and status only**
+    /// (GitHub issue #295, `STAGE-A-CHANGELOG.md` §4e): the `Merge` and `Archive` buttons that
+    /// used to close this bar are deleted, not hidden.
+    ///
+    /// Both were **worktree** verbs gated only on "there is an agent", sitting in an **agent**
+    /// header. §4e's three reasons, verbatim: a two-agent worktree "offered `Merge` **twice for
+    /// one worktree**"; it was offered "while the agent was `Needs input`, blocked mid-run on a
+    /// question about two conflicting migrations"; and "merge has preconditions - committed, base
+    /// current, no live writers - and the header can show none of them". Their homes now:
+    /// merging is the git graph's job (GitHub issue #241 - its "merge branch into base" half is
+    /// still open, so that direction is genuinely unavailable until it lands), and archiving is
+    /// the rail's agent/worktree context menus (`crate::rail::menu`, issue #290) plus the title
+    /// bar's Agent menu.
+    ///
+    /// The one button that stays is a bare worktree's (Revision R12 §3:
+    /// [`Self::current_worktree_is_bare`]) `Start an agent`, with the agent name greyed to
+    /// `no agent` - it is not one of the removed worktree verbs, and §4e's own rule ("an action
+    /// belongs in the scope of the object it acts on") puts starting an agent squarely in an
+    /// agent surface.
     pub(in crate::work_surface) fn render_agent_context_bar(
         &self,
         agent: &Agent,
@@ -1893,10 +1920,10 @@ impl AdeApp {
             .find(|item| item.path == agent.cwd)
             .and_then(|item| item.branch.clone());
         let worktree_path = agent.cwd.display().to_string();
-        let id = agent.id;
 
         let bar = div()
             .id("agent-context-bar")
+            .debug_selector(|| "agent-context-bar".to_string())
             .flex()
             .flex_none()
             .items_center()
@@ -1959,20 +1986,24 @@ impl AdeApp {
             .child(render_status_pill(status_value));
 
         if is_bare {
-            bar.child(self.render_start_agent_button(cx))
+            bar.child(self.render_start_agent_button("context-bar-start-agent", cx))
         } else {
-            bar.child(self.render_merge_button(id, cx))
-                .child(self.render_archive_button(id, cx))
+            bar
         }
     }
 
-    /// A bare worktree's context bar action (Revision R12 §3): a filled blue `Start an agent`
-    /// button with a `mod+shift+N` keycap hint, replacing `Merge`/`Archive` outright rather than
-    /// sitting alongside them - neither has anything to act on yet in a worktree with no agent.
-    /// Real, not decorative: dispatches [`Self::new_agent_pane`], the same entry point the tab
-    /// strip's `+` menu row and its own global `secondary-shift-n` keybinding already use.
+    /// The `Start an agent` button - a filled blue button with a `mod+shift+N` keycap hint. Real,
+    /// not decorative: dispatches [`Self::new_agent_pane`], the same entry point the tab strip's
+    /// `+` menu row and its own global `secondary-shift-n` keybinding already use.
+    ///
+    /// Rendered in exactly two places, both of which genuinely have no agent to act on: a bare
+    /// worktree's context bar (Revision R12 §3), where it replaced the deleted `Merge`/`Archive`
+    /// pair; and the no-agent empty state ([`Self::render_no_agents_empty_state`]), which §4t
+    /// keeps buttoned because "with no agent there is no keystroke to duplicate and no readout to
+    /// show". `element_id` distinguishes the two so GPUI never sees one id painted twice.
     pub(in crate::work_surface) fn render_start_agent_button(
         &self,
+        element_id: &'static str,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
         let colors = work_surface::action_button_colors(work_surface::ActionStyle::PrimaryBlue);
@@ -1980,7 +2011,8 @@ impl AdeApp {
         let parts = keymap::resolve_combo("mod+shift+N", macos);
 
         div()
-            .id("context-bar-start-agent")
+            .id(element_id)
+            .debug_selector(move || element_id.to_string())
             .flex_none()
             .cursor_pointer()
             .h(px(20.0))
@@ -2008,82 +2040,6 @@ impl AdeApp {
             ))
             .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
                 this.new_agent_pane(cx);
-            }))
-    }
-
-    /// The context bar's `Merge` button - starts [`Self::start_merge`]. Disabled (dimmed,
-    /// non-interactive) whenever any merge flow is already active, own agent or not (only one
-    /// runs at a time - see [`Self::start_merge`]'s docs), and shows `Merging…` in place of
-    /// `Merge` while this agent's own attempt is the one running.
-    pub(in crate::work_surface) fn render_merge_button(
-        &self,
-        id: AgentId,
-        cx: &mut Context<Self>,
-    ) -> impl IntoElement {
-        let active_for_this_agent = self
-            .merge_flow
-            .as_ref()
-            .is_some_and(|flow| flow.agent_id == id);
-        let running = active_for_this_agent
-            && matches!(
-                self.merge_flow.as_ref().map(|flow| &flow.state),
-                Some(merge::MergeFlowState::Running)
-            );
-        let disabled = self.merge_flow.is_some();
-        let label = if running { "Merging\u{2026}" } else { "Merge" };
-
-        let base = div()
-            .id(("context-bar-merge", id))
-            .flex_none()
-            .h(px(20.0))
-            .px(px(8.0))
-            .rounded(theme::radius::BUTTON)
-            .border_1()
-            .flex()
-            .items_center()
-            .font(font(theme::font::SANS))
-            .font_weight(gpui::FontWeight::MEDIUM)
-            .text_size(px(10.5))
-            .child(label);
-
-        if disabled {
-            base.cursor_default()
-                .border_color(theme::border::BUTTON_DISABLED)
-                .text_color(theme::text::GHOSTER)
-        } else {
-            base.cursor_pointer()
-                .border_color(theme::border::BUTTON)
-                .text_color(theme::text::SECONDARY)
-                .hover(|el| el.bg(theme::surface::ROW_HOVER_ALT))
-                .on_click(cx.listener(move |this, _event: &ClickEvent, _window, cx| {
-                    this.start_merge(id, cx);
-                }))
-        }
-    }
-
-    /// The context bar's `Archive` button - see [`Self::archive_agent`].
-    pub(in crate::work_surface) fn render_archive_button(
-        &self,
-        id: AgentId,
-        cx: &mut Context<Self>,
-    ) -> impl IntoElement {
-        div()
-            .id(("context-bar-archive", id))
-            .flex_none()
-            .cursor_pointer()
-            .h(px(20.0))
-            .px(px(8.0))
-            .rounded(theme::radius::BUTTON)
-            .flex()
-            .items_center()
-            .font(font(theme::font::SANS))
-            .font_weight(gpui::FontWeight::MEDIUM)
-            .text_size(px(10.5))
-            .text_color(theme::text::FAINT)
-            .hover(|el| el.bg(theme::surface::ROW_HOVER_ALT))
-            .child("Archive")
-            .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
-                this.archive_agent(id, window, cx);
             }))
     }
 
@@ -2188,7 +2144,7 @@ impl AdeApp {
     /// `TerminalPane` is the same component behind a `Shell` tab and a `Claude`/`Codex` tab (see
     /// that module's docs), so pid, grid dimensions, and `clear` are equally meaningful for
     /// either. Distinct from, and rendered alongside, [`Self::render_pty_footer`] - the
-    /// agent-level Interrupt/Retry/Archive action footer.
+    /// agent-level readout strip (GitHub issue #295 / §4t).
     pub(in crate::work_surface) fn render_pty_info_footer(
         &self,
         agent: &Agent,
@@ -2263,24 +2219,39 @@ impl AdeApp {
         )
     }
 
-    /// Surface A/B's shared footer: git-level actions appropriate to the agent's status - see
-    /// `crate::work_surface::state::footer_actions`/[`Self::render_footer_action_button`] for which
-    /// actions are implemented vs. disabled. No longer shows a `JERRY` wordmark (deliberate
-    /// deviation from the design mockup, per direct user request - see this crate's `lib.rs`/
-    /// `BUILD-LOG.md` for context, not a bug fix).
+    /// Surface A/B's shared bottom strip - **a readout, not an action bar** (GitHub issue #295,
+    /// `STAGE-A-CHANGELOG.md` §4t).
+    ///
+    /// It renders **whenever there is an agent**, not only when that agent's status happens to
+    /// offer an action, which is what turns the now-buttonless `ask`/`run`/`finished` states from
+    /// absent strips into useful ones. Left to right: whatever run-scoped verbs the status really
+    /// earns ([`work_surface::footer_actions`] - none at all for three of the five statuses), a
+    /// spacer, then this one agent's own cost, right-aligned
+    /// ([`Self::render_agent_cost_readout`]).
+    ///
+    /// Still missing from the strip: the per-agent provider budget §4t puts to the right of the
+    /// cost. That is GitHub issue #294's own research spike (`5h ▓▓▓▓▓▓░ 92%   7d ▓▓▓▓░░░ 65%`,
+    /// plus the popover §4u′ moved into this strip) and is deliberately not faked here - there is
+    /// no real rate-limit source in this build to read it from yet.
+    ///
+    /// No `JERRY` wordmark (deliberate deviation from the design mockup, per direct user request -
+    /// see this crate's `lib.rs`/`BUILD-LOG.md` for context, not a bug fix).
     pub(in crate::work_surface) fn render_pty_footer(
         &self,
         agent: &Agent,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
         let status_value = self.agent_status(agent, cx);
-        let is_running = agent.pane.read(cx).is_running();
+        let (is_running, pid) = {
+            let pane = agent.pane.read(cx);
+            (pane.is_running(), pane.pid())
+        };
         let actions = work_surface::footer_actions(status_value);
         let id = agent.id;
-        let cwd = agent.cwd.clone();
 
         let mut footer = div()
             .id("pty-footer")
+            .debug_selector(|| "pty-footer".to_string())
             .flex()
             .flex_none()
             .items_center()
@@ -2302,33 +2273,20 @@ impl AdeApp {
             {
                 enabled = false;
             }
-            // GitHub issue #225's single-agent gate, applied to the footer door: `Review` is real
-            // backing logic (`implemented: true`), but it is only *offerable* when this agent
-            // really has a baseline and is the sole agent in its worktree. Disabled rather than
-            // hidden, so the row doesn't shift around as agents come and go - and disabled here
-            // means genuinely inert (`Self::render_footer_action_button` drops
-            // `cursor_pointer`/hover/`on_click` entirely), never a clickable-looking no-op.
-            if action.kind == work_surface::ActionKind::OpenReview && !self.review_available_for(id)
+            // `Discard worktree` shares the worktree-history in-flight guard
+            // (`Self::worktree_history_op_in_flight`) with the title bar's Agent menu row and the
+            // rail's own `Remove worktree…` - see `crate::worktree_history::flow`'s module docs.
+            // Disabled, not just relabelled, while busy - mirrors `Self::render_rail_footer`'s own
+            // `prune_in_flight` gating.
+            if action.kind == work_surface::ActionKind::DiscardWorktree
+                && self.worktree_history_op_in_flight.is_some()
             {
-                enabled = false;
-            }
-            // `Keep all`/`Discard worktree` (Revision R10) share one in-flight guard
-            // (`Self::worktree_history_op_in_flight`) - see `crate::worktree_history::flow`'s own
-            // module docs for why one flag is enough discipline here. Disabled, not just
-            // relabelled, while busy - mirrors `Self::render_rail_footer`'s own `prune_in_flight`
-            // gating.
-            let is_worktree_history_action = matches!(
-                action.kind,
-                work_surface::ActionKind::KeepAllChanges
-                    | work_surface::ActionKind::DiscardWorktree
-            );
-            if is_worktree_history_action && self.worktree_history_op_in_flight.is_some() {
                 enabled = false;
             }
             // Busy labels are keyed off the *specific* in-flight kind, not just "something is
             // running" - a real, live-reproduced bug an audit caught: keying this off the bare
             // in-flight flag alone made every visible `Discard worktree` button across every
-            // agent read "discarding…" while an unrelated `Keep all` was running.
+            // agent read "discarding…" while an unrelated worktree-history op was running.
             let label = match action.kind {
                 work_surface::ActionKind::DiscardWorktree
                     if self.worktree_history_op_in_flight
@@ -2341,25 +2299,63 @@ impl AdeApp {
                 {
                     "confirm discard?".to_string()
                 }
-                work_surface::ActionKind::KeepAllChanges
-                    if self.worktree_history_op_in_flight
-                        == Some(worktree_history::WorktreeHistoryOpKind::Keep) =>
-                {
-                    "keeping\u{2026}".to_string()
-                }
                 _ => action.label.to_string(),
             };
-            footer = footer.child(self.render_footer_action_button(
-                id,
-                cwd.clone(),
-                action,
-                label,
-                enabled,
-                cx,
-            ));
+            footer = footer.child(self.render_footer_action_button(id, action, label, enabled, cx));
         }
 
-        footer.child(div().flex_1())
+        footer = footer.child(div().flex_1());
+        match self.render_agent_cost_readout(is_running, pid) {
+            Some(readout) => footer.child(readout),
+            None => footer,
+        }
+    }
+
+    /// §4t's per-agent cost readout: `6.2% cpu · 0.51 GB` for **this** agent's own pid, at the
+    /// status bar's own recessive tier so the pane strip and the window footer speak in the same
+    /// type sizes rather than inventing a second scale.
+    ///
+    /// `None` - genuinely nothing rendered, not a dimmed placeholder - in the two cases §4t and
+    /// `crate::status_bar::render::AdeApp::render_status_resources_readout` already agree on:
+    /// "blank for an agent that is not running" (an exited pane has no pid to sample and no cost
+    /// to report), and a build whose platform has no real sampling backend at all
+    /// (`process_stats::PLATFORM_SAMPLING_SUPPORTED`), where a permanent `...% cpu` could never
+    /// resolve.
+    ///
+    /// Reads the same `AdeApp::process_stats` sample map and the same
+    /// `crate::status_bar::resources` formatters the Resources popover and the status bar total
+    /// use - one sampling pipeline, three surfaces, never a second derivation that could disagree
+    /// with the total this agent is part of.
+    pub(in crate::work_surface) fn render_agent_cost_readout(
+        &self,
+        is_running: bool,
+        pid: Option<u32>,
+    ) -> Option<impl IntoElement> {
+        if !crate::status_bar::process_stats::PLATFORM_SAMPLING_SUPPORTED {
+            return None;
+        }
+        let pid = pid.filter(|_| is_running)?;
+        let (cpu, memory) = crate::status_bar::resources::row_sample(
+            pid,
+            &self.process_stats,
+            crate::status_bar::render::available_cores(),
+        );
+        let tier = crate::status_bar::render::StatusTier::Recessive;
+
+        Some(
+            div()
+                .id("pty-footer-cost")
+                .debug_selector(|| "pty-footer-cost".to_string())
+                .flex_none()
+                .font(font(theme::font::MONO))
+                .font_weight(tier.weight())
+                .text_size(self.ui_text_size(tier.text_size()))
+                .text_color(tier.color())
+                .tooltip(text_tooltip(
+                    "What this agent is costing this machine right now".to_string(),
+                ))
+                .child(crate::status_bar::resources::agent_readout(cpu, memory)),
+        )
     }
 
     /// One footer action button - interactive (`cursor_pointer`, hover, `on_click` dispatch on
@@ -2368,7 +2364,6 @@ impl AdeApp {
     pub(in crate::work_surface) fn render_footer_action_button(
         &self,
         id: AgentId,
-        cwd: PathBuf,
         action: work_surface::FooterAction,
         label: String,
         enabled: bool,
@@ -2381,8 +2376,10 @@ impl AdeApp {
         // text swaps above), and an element's `id` should stay stable across that, matching
         // `Self::render_rail_footer`'s own static `"rail-prune"` id for its own label-swapping
         // button.
+        let selector = format!("footer-action-{kind:?}");
         let mut button = div()
             .id(format!("footer-action-{id}-{kind:?}"))
+            .debug_selector(move || selector)
             .h(px(23.0))
             .px(px(10.0))
             .rounded(theme::radius::BUTTON)
@@ -2437,19 +2434,10 @@ impl AdeApp {
                 .hover(|el| el.bg(theme::surface::ROW_HOVER_ALT))
                 .on_click(
                     cx.listener(move |this, _event: &ClickEvent, window, cx| match kind {
-                        work_surface::ActionKind::Interrupt => this.interrupt_agent(id, cx),
-                        work_surface::ActionKind::OpenTerminal => {
-                            this.open_companion_terminal(cwd.clone(), window, cx)
-                        }
                         work_surface::ActionKind::Respawn => this.respawn_agent(id, window, cx),
-                        work_surface::ActionKind::KeepAllChanges => this.keep_all_changes(id, cx),
                         work_surface::ActionKind::DiscardWorktree => {
                             this.request_discard_worktree(id, window, cx)
                         }
-                        work_surface::ActionKind::OpenReview => {
-                            this.open_review_tab(id, window, cx)
-                        }
-                        work_surface::ActionKind::Unimplemented => {}
                     }),
                 );
         } else {
@@ -2551,22 +2539,81 @@ impl AdeApp {
                     .child(self.render_agent_context_bar(agent, cx))
                     .child(body)
             }
-            None => surface.child(
+            None => surface.child(self.render_no_agents_empty_state(cx)),
+        }
+        .into_any_element()
+    }
+
+    /// The centre pane with no agent open in this worktree at all.
+    ///
+    /// The one surface GitHub issue #295 leaves buttoned, quoting §4t verbatim: "The empty-worktree
+    /// case keeps its buttons: with no agent there is no keystroke to duplicate and no readout to
+    /// show." `Start an agent` (the primary CTA, [`Self::new_agent_pane`]) and `Open terminal`
+    /// (§4e: "`Open terminal` survives only in the no-agents empty state, where it is the
+    /// legitimate secondary CTA", [`Self::open_companion_terminal`]) - the same two the design's
+    /// `noAgents` branch renders, and the only home either verb has left in this pane.
+    ///
+    /// `open_companion_terminal` is given the worktree that is genuinely selected right now
+    /// ([`Self::current_worktree_path`]), not a remembered agent cwd: with no agent open there is
+    /// no agent cwd to inherit, and spawning a shell anywhere but the selected worktree is what
+    /// that method's own docs already forbid.
+    fn render_no_agents_empty_state(&mut self, cx: &mut Context<Self>) -> gpui::AnyElement {
+        let cwd = self.current_worktree_path();
+        let colors = work_surface::action_button_colors(work_surface::ActionStyle::Outline);
+
+        div()
+            .flex()
+            .flex_1()
+            .flex_col()
+            .min_h_0()
+            .items_center()
+            .justify_center()
+            .gap(px(14.0))
+            .child(
                 div()
-                    .flex()
-                    .flex_1()
-                    .min_h_0()
-                    .items_center()
-                    .justify_center()
                     .font(font(theme::font::SANS))
                     .text_size(px(11.5))
                     .text_color(theme::text::FAINT)
-                    .child(
-                        "no agents open in this worktree - start one with the tab strip's + menu",
-                    ),
-            ),
-        }
-        .into_any_element()
+                    .child("no agents open in this worktree"),
+            )
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .gap(px(8.0))
+                    .child(self.render_start_agent_button("empty-state-start-agent", cx))
+                    // Only when a real worktree is genuinely selected: with none,
+                    // `open_companion_terminal` would have nowhere to spawn, and a button that
+                    // could only no-op is exactly what this app renders disabled or not at all.
+                    .children(cwd.map(|cwd| {
+                        div()
+                            .id("empty-state-open-terminal")
+                            .debug_selector(|| "empty-state-open-terminal".to_string())
+                            .flex_none()
+                            .cursor_pointer()
+                            .h(px(20.0))
+                            .px(px(8.0))
+                            .rounded(theme::radius::BUTTON)
+                            .border_1()
+                            .border_color(colors.border)
+                            .bg(colors.bg)
+                            .flex()
+                            .items_center()
+                            .hover(|el| el.bg(theme::surface::ROW_HOVER_ALT))
+                            .child(
+                                div()
+                                    .font(font(theme::font::SANS))
+                                    .font_weight(gpui::FontWeight::MEDIUM)
+                                    .text_size(px(10.5))
+                                    .text_color(colors.fg)
+                                    .child("Open terminal"),
+                            )
+                            .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
+                                this.open_companion_terminal(cwd.clone(), window, cx);
+                            }))
+                    })),
+            )
+            .into_any_element()
     }
 }
 
@@ -2844,6 +2891,10 @@ pub(in crate::work_surface) fn tab_settle_animation_id(
 /// The agent context bar's status pill: a coloured dot plus label in the status colour.
 pub(in crate::work_surface) fn render_status_pill(status: Status) -> impl IntoElement {
     div()
+        // Measured by `agent_pane_readout_tests` to prove the context bar really ends here
+        // (GitHub issue #295 / §4e: "identity and status only") - any re-added trailing button
+        // would push this pill left of the bar's own right padding.
+        .debug_selector(|| "agent-context-bar-status".to_string())
         .flex_none()
         .flex()
         .items_center()
@@ -5272,5 +5323,383 @@ mod select_agent_cross_repo_tests {
             );
             let _ = cx;
         });
+    }
+}
+
+/// GitHub issue #295: the agent pane's context bar is identity-only, and its bottom strip is a
+/// readout rather than an action bar (`design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md`
+/// §4e/§4r/§4t).
+///
+/// These drive the real painted surface - real spawned child processes, real
+/// `VisualTestContext::debug_bounds` measurements of what actually reached the screen, and real
+/// simulated clicks - rather than re-asserting `footer_actions`'s pure output, which
+/// `crate::work_surface::state`'s own tests already pin. The point of measuring is that a removed
+/// button must be absent from the *paint*, not merely absent from a list.
+#[cfg(test)]
+mod agent_pane_readout_tests {
+    use super::*;
+    use crate::rail::worktrees::WorktreeItem;
+    use crate::root::focus::palette_focus_tests;
+    use gpui::TestAppContext;
+
+    fn git(dir: &std::path::Path, args: &[&str]) {
+        let status = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .status()
+            .expect("run git");
+        assert!(status.success(), "git {args:?} failed in {}", dir.display());
+    }
+
+    fn init_repo() -> tempfile::TempDir {
+        let repo = tempfile::tempdir().expect("tempdir");
+        git(repo.path(), &["init", "-b", "main"]);
+        git(repo.path(), &["config", "user.email", "test@example.com"]);
+        git(repo.path(), &["config", "user.name", "Test User"]);
+        std::fs::write(repo.path().join("base.txt"), "base\n").expect("write");
+        git(repo.path(), &["add", "base.txt"]);
+        git(repo.path(), &["commit", "-m", "initial"]);
+        repo
+    }
+
+    /// Spawns one real shell agent in `cwd` (optionally under a `shell_override` that exits by
+    /// itself) and selects it, so the centre pane really is that agent's pty surface.
+    fn spawn_and_select(
+        app: &gpui::Entity<AdeApp>,
+        cx: &mut gpui::VisualTestContext,
+        cwd: PathBuf,
+        shell_override: Option<&'static str>,
+    ) -> AgentId {
+        let id = app.update_in(cx, |app, window, cx| {
+            app.agents.spawn(
+                ProcessKind::Shell,
+                cwd,
+                12.0,
+                shell_override,
+                None,
+                window,
+                cx,
+            )
+        });
+        app.update_in(cx, |app, window, cx| app.select_agent(id, window, cx));
+        cx.run_until_parked();
+        id
+    }
+
+    /// Waits for a real child process to genuinely exit - the same real-clock-plus-advance loop
+    /// `crate::sidebar::render`'s own `/bin/false` test uses, not an assumption that it has.
+    fn wait_for_exit(app: &gpui::Entity<AdeApp>, cx: &mut gpui::VisualTestContext, id: AgentId) {
+        for _ in 0..200 {
+            app.update(cx, |_app, cx| cx.notify());
+            cx.run_until_parked();
+            let exited = app.read_with(cx, |app, cx| {
+                app.agents
+                    .iter()
+                    .find(|agent| agent.id == id)
+                    .is_some_and(|agent| !agent.pane.read(cx).is_running())
+            });
+            if exited {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+            cx.executor()
+                .advance_clock(std::time::Duration::from_millis(50));
+        }
+        panic!("premise: the spawned child must really have exited");
+    }
+
+    /// A real, non-bare worktree row for `path`. Seeded explicitly because a test app whose
+    /// worktree list has not loaded reads as *bare* (`AdeApp::current_worktree_is_bare`), which is
+    /// the branch that legitimately still renders `Start an agent` in the context bar - not the
+    /// branch these tests are about.
+    fn worktree_row(path: PathBuf, branch: &str) -> WorktreeItem {
+        WorktreeItem {
+            path,
+            label: branch.to_string(),
+            branch: Some(branch.to_string()),
+            is_main: true,
+            is_bare: false,
+            is_detached: false,
+            short_sha: None,
+            is_locked: false,
+            lock_reason: None,
+            is_broken: false,
+            broken_reason: None,
+            error: None,
+        }
+    }
+
+    /// §4e: the context bar "now carries identity and status only" - `Merge` and `Archive` are
+    /// **deleted**, not hidden or disabled. Both were worktree verbs sitting in an agent header:
+    /// offered twice for one two-agent worktree, offered while the agent was `Needs input`, and
+    /// gated on preconditions the header cannot show.
+    ///
+    /// Measured rather than read off the source: the status pill is now the bar's **last** child,
+    /// so its painted right edge must sit within the bar's own 12px right padding. Any re-added
+    /// trailing button pushes the pill left by that button's full width. Mutation-verified - a
+    /// re-added `Archive` button leaves the pill 83px short and fails this assertion.
+    #[gpui::test]
+    fn the_context_bar_ends_at_the_status_pill_with_no_merge_or_archive(cx: &mut TestAppContext) {
+        let repo = init_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        app.update_in(cx, |app, window, cx| {
+            app.worktrees = vec![worktree_row(repo.path().to_path_buf(), "main")];
+            app.select_worktree(0, window, cx);
+        });
+        let id = spawn_and_select(&app, cx, repo.path().to_path_buf(), None);
+        // A real spawned child, relabelled to a real agent kind - `current_worktree_is_bare`
+        // counts agent *sessions*, and a plain shell leaves the worktree bare (which is the
+        // branch that legitimately keeps `Start an agent`). Same real-process-plus-relabel the
+        // Runs-section tests use.
+        app.update(cx, |app, cx| {
+            app.agents.set_kind_for_test(id, ProcessKind::claude());
+            cx.notify();
+        });
+        cx.run_until_parked();
+        assert!(
+            !app.read_with(cx, |app, _| app.current_worktree_is_bare()),
+            "premise: a real, non-bare worktree - the bare branch keeps its own `Start an agent`"
+        );
+
+        let bar = cx
+            .debug_bounds("agent-context-bar")
+            .expect("the agent context bar must really paint for a selected agent");
+        let pill = cx
+            .debug_bounds("agent-context-bar-status")
+            .expect("its status pill must really paint");
+        assert!(
+            cx.debug_bounds("context-bar-start-agent").is_none(),
+            "premise: a worktree that already has an agent renders no `Start an agent` either"
+        );
+
+        let trailing_gap = (bar.origin.x + bar.size.width) - (pill.origin.x + pill.size.width);
+        assert!(
+            trailing_gap <= px(13.0),
+            "the status pill must be the last thing in the context bar - it ends {trailing_gap:?} \
+             from the bar's right edge, more than the bar's own 12px padding, so something is \
+             painted after it. \u{a7}4e deleted `Merge` (now the git graph's job, issue #241) and \
+             `Archive` (now the rail's agent/worktree menus, issue #290)."
+        );
+    }
+
+    /// §4t: "The bar now renders whenever there is an agent, not only when there are actions - so
+    /// the finished and asking states, which §4r emptied, are useful strips again rather than
+    /// absent ones."
+    ///
+    /// A freshly spawned shell has just written its prompt, so it is `Status::Run` - the status
+    /// §4t emptied of buttons entirely (`⌃C` in the focused pty is the interrupt). The strip must
+    /// still paint, and must carry this agent's own cost readout.
+    #[gpui::test]
+    fn a_running_agents_strip_still_paints_and_carries_its_own_cost(cx: &mut TestAppContext) {
+        let repo = init_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        let id = spawn_and_select(&app, cx, repo.path().to_path_buf(), None);
+
+        let status = app.read_with(cx, |app, cx| {
+            let agent = app
+                .agents
+                .iter()
+                .find(|agent| agent.id == id)
+                .expect("the spawned agent");
+            app.agent_status(agent, cx)
+        });
+        assert_eq!(
+            status,
+            Status::Run,
+            "premise: a shell that just printed its prompt is `Run`, the status §4t emptied"
+        );
+        assert!(
+            work_surface::footer_actions(status).is_empty(),
+            "premise: `Run` offers no footer actions at all"
+        );
+
+        assert!(
+            cx.debug_bounds("pty-footer").is_some(),
+            "the strip must paint for an agent with no actions - that is exactly the state §4t \
+             turned from an absent bar into a readout"
+        );
+        assert!(
+            cx.debug_bounds("pty-footer-cost").is_some(),
+            "and it must carry this one agent's own `X% cpu \u{b7} Y GB`, from the same per-pid \
+             sampling the status bar's total sums (issue #283)"
+        );
+        assert!(
+            cx.debug_bounds("footer-action-Respawn").is_none()
+                && cx.debug_bounds("footer-action-DiscardWorktree").is_none(),
+            "and no action button at all may paint on a running agent"
+        );
+    }
+
+    /// §4t: the cost is "blank for an agent that is not running". Not a dimmed `...`, not a
+    /// fabricated `0% cpu` - nothing at all, which is what the `Option` return states.
+    #[gpui::test]
+    fn the_cost_readout_is_blank_for_an_agent_that_is_not_running(cx: &mut TestAppContext) {
+        let repo = init_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.render_agent_cost_readout(false, Some(1234)).is_none(),
+                "a pid that is no longer running has no cost to report"
+            );
+            assert!(
+                app.render_agent_cost_readout(true, None).is_none(),
+                "and a pane with no pid at all has nothing to sample"
+            );
+        });
+    }
+
+    /// §4e/§4r's one surviving pair, and its two-click safety: `failed` keeps `Retry` and
+    /// `Discard worktree`, and the discard really arms before it destroys.
+    ///
+    /// Driven through the genuinely painted button (`debug_bounds` + `simulate_click`), not
+    /// through `request_discard_worktree` directly - the point is that this strip still offers
+    /// those two, and that `Open terminal` (which used to sit between them) does not paint.
+    #[gpui::test]
+    fn a_failed_run_keeps_retry_and_a_two_click_discard_and_nothing_else(cx: &mut TestAppContext) {
+        let repo = init_repo();
+        let worktree_container = tempfile::tempdir().expect("tempdir");
+        let worktree_path = worktree_container.path().join("feature-wt");
+        drop(worktree_container);
+        git(
+            repo.path(),
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "feature",
+                worktree_path.to_str().expect("utf8 path"),
+            ],
+        );
+
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        // `/bin/false` is a real child that really exits non-zero, so `Status::Fail` is derived
+        // from a genuine `ProcessSignal::Exited { success: false }` rather than being set.
+        let id = spawn_and_select(&app, cx, worktree_path.clone(), Some("/bin/false"));
+        wait_for_exit(&app, cx, id);
+
+        let status = app.read_with(cx, |app, cx| {
+            let agent = app
+                .agents
+                .iter()
+                .find(|agent| agent.id == id)
+                .expect("the spawned agent");
+            app.agent_status(agent, cx)
+        });
+        assert_eq!(status, Status::Fail, "premise: the run really failed");
+
+        assert!(
+            cx.debug_bounds("footer-action-Respawn").is_some(),
+            "a failed run keeps its `Retry`"
+        );
+        let discard = cx
+            .debug_bounds("footer-action-DiscardWorktree")
+            .expect("and its two-click `Discard worktree`");
+
+        cx.simulate_click(discard.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.discard_confirm_armed),
+            Some(id),
+            "the first click must only arm - this is the one irreversible thing in the pane"
+        );
+        assert!(
+            worktree_path.exists(),
+            "and an armed-but-unconfirmed discard must not have touched the real worktree"
+        );
+    }
+
+    /// §4t, verbatim: "The empty-worktree case keeps its buttons: with no agent there is no
+    /// keystroke to duplicate and no readout to show." `Open terminal` survives here and nowhere
+    /// else in this pane (§4e: "the legitimate secondary CTA"), and it really spawns a shell.
+    #[gpui::test]
+    fn the_no_agent_empty_state_really_starts_a_terminal(cx: &mut TestAppContext) {
+        let repo = init_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        // Close whatever the app opened on startup, so the centre pane really is the empty state.
+        let startup: Vec<AgentId> = app.read_with(cx, |app, _| {
+            app.agents.iter().map(|agent| agent.id).collect()
+        });
+        app.update_in(cx, |app, window, cx| {
+            for id in startup {
+                app.close_agent(id, window, cx);
+            }
+        });
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.agents.iter().count()),
+            0,
+            "premise: no agents left, so the empty state is what paints"
+        );
+
+        assert!(
+            cx.debug_bounds("empty-state-start-agent").is_some(),
+            "the empty state keeps its primary `Start an agent` CTA"
+        );
+        let open_terminal = cx
+            .debug_bounds("empty-state-open-terminal")
+            .expect("and its secondary `Open terminal` CTA - §4e's one surviving home for it");
+
+        cx.simulate_click(open_terminal.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.agents.iter().count(),
+                1,
+                "clicking it must really spawn a shell, not decorate the empty state"
+            );
+            assert!(
+                app.agents
+                    .iter()
+                    .all(|agent| agent.kind == ProcessKind::Shell),
+                "and that spawn is a terminal, which is what the button says"
+            );
+        });
+    }
+
+    /// Revision R12 §3's one context-bar button that #295 does *not* remove: a bare worktree has
+    /// no agent, so it has no agent verbs to offer and no worktree verbs to misplace - just the
+    /// primary CTA that gives it one.
+    #[gpui::test]
+    fn a_bare_worktree_keeps_its_start_an_agent_button(cx: &mut TestAppContext) {
+        let repo = init_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        spawn_and_select(&app, cx, repo.path().to_path_buf(), None);
+
+        // A real bare worktree row, selected - the exact condition
+        // `AdeApp::current_worktree_is_bare` reads.
+        app.update_in(cx, |app, window, cx| {
+            app.worktrees = vec![WorktreeItem {
+                path: repo.path().to_path_buf(),
+                label: "bare".to_string(),
+                branch: None,
+                is_main: true,
+                is_bare: true,
+                is_detached: false,
+                short_sha: None,
+                is_locked: false,
+                lock_reason: None,
+                is_broken: false,
+                broken_reason: None,
+                error: None,
+            }];
+            app.select_worktree(0, window, cx);
+        });
+        cx.run_until_parked();
+
+        assert!(
+            cx.debug_bounds("context-bar-start-agent").is_some(),
+            "a bare worktree's context bar keeps `Start an agent` - it is not one of the \
+             worktree verbs §4e removed"
+        );
     }
 }

--- a/crates/app/src/work_surface/state.rs
+++ b/crates/app/src/work_surface/state.rs
@@ -465,40 +465,25 @@ pub fn action_button_colors(style: ActionStyle) -> ActionColors {
 /// handlers dispatch on this. Every variant either has real backing logic wired up, or is
 /// rendered honestly disabled (see [`FooterAction::implemented`]) - never a button that looks
 /// clickable but silently does nothing.
+///
+/// GitHub issue #295 cut this enum from seven variants to two. `Interrupt`, `OpenTerminal`,
+/// `KeepAllChanges`, `OpenReview` and `Unimplemented` (`Open in editor`) are **deleted**, not
+/// hidden: `STAGE-A-CHANGELOG.md` §4t makes the agent pane's bottom strip a readout rather than
+/// an action bar, and `REVISION-2026-08-14.md` §7 rule 5 forbids leaving the old keys behind
+/// ("Replacing a control means deleting its old keys in the same edit - a key defined twice is
+/// two specifications of one thing, and the reader cannot tell which is real").
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ActionKind {
-    /// Sends a `Ctrl-C` to the agent's pty (`TerminalPane::interrupt`).
-    Interrupt,
-    /// Finds-or-spawns a `Shell` agent in the same cwd and selects it.
-    OpenTerminal,
     /// Closes this tab and spawns a fresh agent of the same kind/cwd - an approximate
     /// stand-in for `Retry`/`Resume` (this app has no saved-agent resumability to actually
     /// resume *from* - see [`pty_state_label`] on the same gap).
     Respawn,
-    /// `crate::worktree_history::flow::AdeApp::keep_all_changes` (Revision R10): a real,
-    /// undoable `wt_core::undo::commit_all_changes` on this agent's worktree.
-    KeepAllChanges,
     /// `crate::worktree_history::flow::AdeApp::request_discard_worktree` (Revision R10): a real
     /// `wt_core::undo::discard_worktree`, behind the same two-click confirmation as the rail
     /// footer's `prune` button (see that method's own docs for why - this is a real, destructive
     /// action that force-removes a worktree, preserving uncommitted/untracked content in a real
     /// git stash first).
     DiscardWorktree,
-    /// GitHub issue #225: opens this agent's **review** tab
-    /// (`crate::review::render::AdeApp::open_review_tab`) - what has changed since this agent
-    /// started, or since the user last marked it reviewed. Deliberately not a second door: this
-    /// row has existed as [`ActionKind::Unimplemented`] since the original design, waiting for
-    /// exactly this feature, and was wired up rather than replaced.
-    ///
-    /// Real, but *conditionally* so: the render call site disables it whenever
-    /// `crate::review::flow::AdeApp::review_available_for` is false (no baseline captured yet, or
-    /// more than one agent open in this worktree - see that method's docs), the same
-    /// state-dependent enablement layered on top of [`FooterAction::implemented`] that
-    /// [`ActionKind::Respawn`] already uses.
-    OpenReview,
-    /// No backing logic exists yet (the editor-surface workflow) - always rendered disabled
-    /// regardless of [`FooterAction::implemented`] (always `false` for these).
-    Unimplemented,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -517,77 +502,40 @@ pub struct FooterAction {
     pub implemented: bool,
 }
 
-/// The footer action strip for one [`Status`]: review gets `Keep all ⌘⏎` (green, real - Revision
-/// R10) · `Review diff` (still unimplemented) · `Open in editor` (still unimplemented) ·
-/// `Discard worktree` (real - Revision R10); ask gets `Open terminal` · `Interrupt ⌃C`; fail gets
-/// `Retry ⌘R` · `Open terminal` · `Discard worktree` (real - Revision R10); run gets
-/// `Interrupt ⌃C` · `Open terminal`; idle gets `Resume ⌘⏎` (blue) alone - `Archive` is
-/// deliberately not repeated here (GitHub issue #20): the context bar's own
-/// `Self::render_archive_button` already renders it unconditionally for every non-bare agent, so
-/// an idle agent used to show it twice.
+/// The footer action strip for one [`Status`] - GitHub issue #295's final state
+/// (`STAGE-A-CHANGELOG.md` §4e/§4r/§4t).
+///
+/// The agent pane is a terminal, so a button that duplicates a keystroke which already works in
+/// the focused surface is unearned space (§4t), and an action whose object is the *worktree* or
+/// the *branch* does not belong under one agent of a possibly multi-agent worktree (§4e/§4r).
+/// What is left is only what is run-scoped and has no other home:
+///
+/// | Status | Actions | Why the rest went |
+/// |---|---|---|
+/// | `Ask` (needs input) | none | "there is nothing to interrupt; the question is answered in the pane" (§4e) |
+/// | `Run` (running) | none | `⌃C` in the focused pty *is* the interrupt (§4t) |
+/// | `Fail` (failed) | `Retry ⌘R` · `Discard worktree` | the run really can be restarted, and the two-click discard is this app's only worktree deletion under an agent |
+/// | `Review` (finished) | none | "a finished transcript is a record; its actions live where their object lives" (§4r) |
+/// | `Idle` (paused) | `Resume ⌘⏎` | the one verb that restarts a stopped run |
+///
+/// Deleted outright rather than hidden, per `REVISION-2026-08-14.md` §7 rule 5 - see
+/// [`ActionKind`]'s own docs. The verbs that still exist elsewhere kept their real homes:
+/// `Archive` is the rail's agent/worktree context menus (`crate::rail::menu`, GitHub issue #290)
+/// and the title bar's Agent menu; `Keep all changes` and `Discard worktree` are also on that
+/// Agent menu; `Review` moved to it (`crate::title_bar::menu_model::MenuCommand::ReviewAgent`);
+/// `Open terminal` is the no-agent empty state's secondary CTA
+/// (`crate::work_surface::render::AdeApp::render_no_agents_empty_state`), where §4t keeps it
+/// because "with no agent there is no keystroke to duplicate and no readout to show".
 pub fn footer_actions(status: Status) -> Vec<FooterAction> {
     match status {
-        Status::Review => vec![
-            FooterAction {
-                kind: ActionKind::KeepAllChanges,
-                label: "Keep all",
-                // No keycap: the original mockup shows `mod+enter`, but this app has no real
-                // global keybinding for it - see `crate::default_key_bindings`'s own docs on
-                // why a global `Ctrl+Enter`/`Cmd+Enter` isn't safe to add casually (the same
-                // "app-level shortcut steals terminal input" risk class already documented
-                // there for `CloseFocusedTab`, which scopes itself away from a focused terminal
-                // rather than accept the collision; this app's whole domain is running agent
-                // CLIs in terminals, and Ctrl+Enter/Cmd+Enter is a plausible binding one
-                // of them could reasonably use for its own "submit" gesture). An audit caught
-                // this row still advertising the keycap after being promoted from
-                // `implemented: false` - a real keycap must never render for a keystroke that
-                // does nothing, the same rule `Self::render_pty_header`'s own `clear` hint
-                // already follows for the identical reason.
-                keycap: None,
-                style: ActionStyle::PrimaryGreen,
-                implemented: true,
-            },
-            FooterAction {
-                kind: ActionKind::OpenReview,
-                // "Review", not "Review diff" (GitHub issue #225): this door leads to the
-                // agent-review surface, and "diff" is the git side's word - see
-                // `crate::review`'s own module docs on the enforced vocabulary split.
-                label: "Review",
-                keycap: None,
-                style: ActionStyle::Outline,
-                implemented: true,
-            },
-            FooterAction {
-                kind: ActionKind::Unimplemented,
-                label: "Open in editor",
-                keycap: None,
-                style: ActionStyle::Ghost,
-                implemented: false,
-            },
-            FooterAction {
-                kind: ActionKind::DiscardWorktree,
-                label: "Discard worktree",
-                keycap: None,
-                style: ActionStyle::Ghost,
-                implemented: true,
-            },
-        ],
-        Status::Ask => vec![
-            FooterAction {
-                kind: ActionKind::OpenTerminal,
-                label: "Open terminal",
-                keycap: None,
-                style: ActionStyle::Outline,
-                implemented: true,
-            },
-            FooterAction {
-                kind: ActionKind::Interrupt,
-                label: "Interrupt",
-                keycap: Some("ctrl+C"),
-                style: ActionStyle::Ghost,
-                implemented: true,
-            },
-        ],
+        // §4r: "`review` now renders no bar, matching `ask`". `Keep all` was "a fiction borrowed
+        // from buffer-based inline-diff tools" (the edits are already on disk), `Review`/`Open in
+        // editor` were navigation, and `Discard worktree` under one agent of a two-agent worktree
+        // "throws away the other agent's work from a pane that never mentions them".
+        Status::Review => Vec::new(),
+        // §4e: "`Interrupt` offered on an agent that is *waiting for you* - there is nothing to
+        // interrupt", and a second terminal does not answer the question the agent is asking.
+        Status::Ask => Vec::new(),
         Status::Fail => vec![
             FooterAction {
                 kind: ActionKind::Respawn,
@@ -597,13 +545,6 @@ pub fn footer_actions(status: Status) -> Vec<FooterAction> {
                 implemented: true,
             },
             FooterAction {
-                kind: ActionKind::OpenTerminal,
-                label: "Open terminal",
-                keycap: None,
-                style: ActionStyle::Ghost,
-                implemented: true,
-            },
-            FooterAction {
                 kind: ActionKind::DiscardWorktree,
                 label: "Discard worktree",
                 keycap: None,
@@ -611,22 +552,10 @@ pub fn footer_actions(status: Status) -> Vec<FooterAction> {
                 implemented: true,
             },
         ],
-        Status::Run => vec![
-            FooterAction {
-                kind: ActionKind::Interrupt,
-                label: "Interrupt",
-                keycap: Some("ctrl+C"),
-                style: ActionStyle::Outline,
-                implemented: true,
-            },
-            FooterAction {
-                kind: ActionKind::OpenTerminal,
-                label: "Open terminal",
-                keycap: None,
-                style: ActionStyle::Ghost,
-                implemented: true,
-            },
-        ],
+        // §4t: "`Interrupt` was the last button on it, and the pane is a terminal: `⌃C` already
+        // interrupts and `mod+R` already retries, so a button duplicating a keystroke that works
+        // in the focused surface is the same unearned space as §4r."
+        Status::Run => Vec::new(),
         Status::Idle => vec![FooterAction {
             kind: ActionKind::Respawn,
             label: "Resume",
@@ -755,82 +684,102 @@ mod tests {
         );
     }
 
-    /// GitHub issue #225 promoted the review row from a permanently-disabled placeholder to a
-    /// real door into the agent review surface. `Open in editor` is the only row in this strip
-    /// with no backing logic left.
+    /// GitHub issue #295 / §4t: every action that survives has real backing logic. The
+    /// permanently-inert `Open in editor` row is gone with the rest, so there is no longer any
+    /// such thing as an unimplemented footer action.
     #[test]
-    fn every_review_footer_action_except_open_in_editor_now_has_real_backing() {
-        let actions = footer_actions(Status::Review);
-        for action in &actions {
-            let should_be_implemented = !matches!(action.kind, ActionKind::Unimplemented);
-            assert_eq!(
-                action.implemented, should_be_implemented,
-                "{} implemented={} - only `Open in editor` should still be unimplemented",
-                action.label, action.implemented
-            );
+    fn every_surviving_footer_action_has_real_backing_logic() {
+        for status in Status::ORDER {
+            for action in footer_actions(status) {
+                assert!(
+                    action.implemented,
+                    "{status:?}'s {:?} action is not implemented - issue #295 deleted the \
+                     placeholder row rather than keeping an inert button",
+                    action.label
+                );
+            }
         }
-        let unimplemented: Vec<&str> = actions
-            .iter()
-            .filter(|action| !action.implemented)
-            .map(|action| action.label)
-            .collect();
-        assert_eq!(unimplemented, vec!["Open in editor"]);
     }
 
-    /// The review door must be a real [`ActionKind::OpenReview`], not the old placeholder - and
-    /// it must not say "diff", which is the git side's word (see `crate::review`'s module docs on
-    /// the enforced vocabulary split).
+    /// §4r, verbatim: "a finished transcript is a record; its actions live where their object
+    /// lives". `Keep all`, `Review`, `Open in editor` and `Discard worktree` all left.
     #[test]
-    fn the_review_footer_door_is_real_and_never_says_diff() {
-        let actions = footer_actions(Status::Review);
-        let review = actions
-            .iter()
-            .find(|action| action.kind == ActionKind::OpenReview)
-            .expect("the Review status footer must offer a real review door");
-        assert!(review.implemented);
-        assert_eq!(review.label, "Review");
-        assert!(
-            !review.label.to_lowercase().contains("diff"),
-            "the review door must not use the git side's own word - got {:?}",
-            review.label
-        );
+    fn a_finished_agent_offers_no_footer_actions_at_all() {
+        assert!(footer_actions(Status::Review).is_empty());
     }
 
+    /// §4e: "`Interrupt` offered on an agent that is *waiting for you* - there is nothing to
+    /// interrupt", and `Open terminal` "opens a *different* terminal, which does not answer the
+    /// question the agent is asking".
     #[test]
-    fn ask_actions_are_open_terminal_then_interrupt_both_real() {
-        let actions = footer_actions(Status::Ask);
-        let labels: Vec<&str> = actions.iter().map(|a| a.label).collect();
-        assert_eq!(labels, vec!["Open terminal", "Interrupt"]);
-        assert!(actions.iter().all(|a| a.implemented));
+    fn an_asking_agent_offers_no_footer_actions_at_all() {
+        assert!(footer_actions(Status::Ask).is_empty());
     }
 
+    /// §4t: `⌃C` in the focused pty is the interrupt, so the button duplicating it is deleted.
     #[test]
-    fn fail_actions_include_a_real_retry_and_a_real_discard() {
+    fn a_running_agent_offers_no_footer_actions_at_all() {
+        assert!(footer_actions(Status::Run).is_empty());
+    }
+
+    /// The one status that keeps two verbs: the run really can be retried, and the two-click
+    /// discard is a real destructive action with no keystroke behind it. `Open terminal` went.
+    #[test]
+    fn fail_actions_are_exactly_a_real_retry_then_a_real_discard() {
         let actions = footer_actions(Status::Fail);
+        let labels: Vec<&str> = actions.iter().map(|action| action.label).collect();
+        assert_eq!(labels, vec!["Retry", "Discard worktree"]);
         assert_eq!(actions[0].kind, ActionKind::Respawn);
-        assert!(actions[0].implemented);
-        assert_eq!(actions.last().unwrap().kind, ActionKind::DiscardWorktree);
-        assert!(actions.last().unwrap().implemented);
+        assert_eq!(actions[1].kind, ActionKind::DiscardWorktree);
+        assert!(actions.iter().all(|action| action.implemented));
     }
 
-    /// GitHub issue #20: idle no longer repeats `Archive` in the footer - the context bar already
-    /// renders it unconditionally for every non-bare agent (`Self::render_archive_button`).
+    /// GitHub issue #20 kept `Archive` out of the idle footer because the context bar already
+    /// rendered it; issue #295 then deleted the context bar's copy too, so `Archive` now lives
+    /// only in the rail menus and the title bar's Agent menu - and idle is still just `Resume`.
     #[test]
-    fn idle_actions_are_just_a_real_resume_not_a_second_archive() {
+    fn idle_actions_are_just_a_real_resume() {
         let actions = footer_actions(Status::Idle);
         assert_eq!(actions.len(), 1);
         assert_eq!(actions[0].kind, ActionKind::Respawn);
+        assert_eq!(actions[0].label, "Resume");
         assert!(actions[0].implemented);
     }
 
+    /// The two verbs §4t names as already-bound keystrokes, and the four §4e/§4r moved to their
+    /// objects' own surfaces, must not come back to any status's footer.
     #[test]
-    fn every_status_produces_a_non_empty_action_list() {
+    fn no_status_offers_a_verb_that_lives_somewhere_else_now() {
         for status in Status::ORDER {
-            assert!(
-                !footer_actions(status).is_empty(),
-                "{status:?} produced no footer actions at all"
-            );
+            for action in footer_actions(status) {
+                assert!(
+                    !matches!(
+                        action.label,
+                        "Interrupt"
+                            | "Open terminal"
+                            | "Keep all"
+                            | "Review"
+                            | "Review diff"
+                            | "Open in editor"
+                            | "Merge"
+                            | "Archive"
+                    ),
+                    "{status:?} still offers {:?}, which GitHub issue #295 moved out of the \
+                     agent pane's bottom strip",
+                    action.label
+                );
+            }
         }
+    }
+
+    /// Every remaining button keeps its keycap where it really has one (issue #295's ride-along),
+    /// and never advertises one it does not - `Discard worktree` has no keybinding in this app.
+    #[test]
+    fn surviving_buttons_advertise_only_keycaps_that_really_exist() {
+        let fail = footer_actions(Status::Fail);
+        assert_eq!(fail[0].keycap, Some("mod+R"));
+        assert_eq!(fail[1].keycap, None);
+        assert_eq!(footer_actions(Status::Idle)[0].keycap, Some("mod+enter"));
     }
 
     /// A live title is the label, verbatim - no branch, no ordinal, nothing appended.

--- a/crates/app/src/worktree_history/flow.rs
+++ b/crates/app/src/worktree_history/flow.rs
@@ -1,7 +1,13 @@
-//! Real backing for the work surface footer's `Keep all`/`Discard worktree` buttons
-//! ([`work_surface::ActionKind::KeepAllChanges`]/[`work_surface::ActionKind::DiscardWorktree`])
-//! and, since Revision R12 §5, the Changes panel commit composer's "commit staged files"
+//! Real backing for `Keep all changes` and `Discard worktree` and, since Revision R12 §5, the
+//! Changes panel commit composer's "commit staged files"
 //! (`crate::sidebar::render::AdeApp::commit_staged_files`).
+//!
+//! Their surfaces, after GitHub issue #295 cut the agent pane's action bar down to a readout
+//! (`STAGE-A-CHANGELOG.md` §4t): `Discard worktree` is the failed-run strip's second button
+//! ([`work_surface::ActionKind::DiscardWorktree`]) and the rail worktree menu's
+//! `Remove worktree…`; `Keep all changes` is the title bar's `Agent` menu, which is now its only
+//! home - §4r deleted the finished-agent button as "a fiction borrowed from buffer-based
+//! inline-diff tools", since the agent's edits are already on disk.
 //!
 //! ## One in-flight flag for all three operations
 //!


### PR DESCRIPTION
Closes #295.

`design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4e / §4r / §4t, plus `REVISION-2026-08-14.md` §7 rule 5.

## Context bar — identity only (§4e)

`Merge` and `Archive` are **deleted** from the agent context bar. `render_merge_button` and `render_archive_button` are gone from the source, not hidden and not disabled — §7 rule 5, quoted in the issue: *"Replacing a control means deleting its old keys in the same edit."*

Both were **worktree** verbs gated only on "there is an agent", sitting in an **agent** header. §4e's own three reasons: a two-agent worktree "offered `Merge` **twice for one worktree**"; it was offered "while the agent was `Needs input`, blocked mid-run on a question about two conflicting migrations"; and "merge has preconditions — committed, base current, no live writers — and the header can show none of them."

The bar now ends at the status pill. A bare worktree keeps its `Start an agent` button, which is not one of the removed worktree verbs.

## Footer verbs by status (§4e/§4r/§4t)

`ActionKind` drops from seven variants to two (`Respawn`, `DiscardWorktree`).

| status | before | after | why |
|---|---|---|---|
| `needs input` | `Open terminal` · `Interrupt` | none | §4e: "there is nothing to interrupt", and a second terminal "does not answer the question the agent is asking" |
| `running` | `Interrupt` · `Open terminal` | none | §4t: `⌃C` in the focused pty *is* the interrupt |
| `failed` | `Retry` · `Open terminal` · `Discard worktree` | `Retry` · `Discard worktree` | the two-click discard is the pane's one irreversible action |
| `finished` | `Keep all` · `Review` · `Open in editor` · `Discard worktree` | none | §4r: "a finished transcript is a record; its actions live where their object lives" |
| `paused/idle` | `Resume` | `Resume` | unchanged |
| no agent | a line of text | `Start an agent` · `Open terminal` | §4t: "with no agent there is no keystroke to duplicate and no readout to show" |

## The strip is a readout (§4t)

`render_pty_footer` renders **whenever there is an agent**, not only when the status offers an action — which is what turns the three now-buttonless states from absent strips into useful ones. Right-aligned it carries this one agent's own cost, from the same per-pid sampling (#283) and the same `status_bar::resources` formatters the window total is the sum of (#293), at the status bar's own recessive tier. Blank — genuinely nothing painted, never a dimmed placeholder — for an agent that is not running, and on a platform with no real sampling backend.

**Not included:** §4t's provider budget half. That is #294's own research spike and there is no real rate-limit source in this build; faking it was not an option. Noted in `render_pty_footer`'s docs.

## Where the removed verbs live now

| verb | home | status |
|---|---|---|
| `Archive` | rail agent/worktree context menus (#290), title bar `Agent → Archive Agent` | already built |
| `Keep all changes` | title bar `Agent → Keep All Changes` | already built |
| `Discard worktree` | the failed-run strip, title bar Agent menu, rail `Remove worktree…` | already built |
| `Open terminal` | the no-agent empty state (§4e's "legitimate secondary CTA") | built here |
| `Review` | new `MenuCommand::ReviewAgent` on the title bar's Agent menu | built here |
| `Merge` | the git graph's merge-into-base action, #241 | **not built — real gap** |

**On `Review`.** #295's list of deleted finished-state buttons includes `Review diff`, and this repo's `Review` button occupies that exact slot (#225 promoted it from the design's own placeholder row). But it was the review tab's **only** entry point, and #288/#330 are live work on that surface — deleting it outright would have made a shipped, in-progress feature unreachable and, under §7 rule 5, demanded deleting the whole `review`/`review_notes` subsystem. It is re-homed on the Agent menu beside the `Keep all changes`/`Discard worktree`/`Archive Agent` rows that already dual-home there, carrying #225's `review_available_for` gate unchanged. Flagged explicitly rather than decided quietly.

**On `Merge`.** #241's "merge branch into base" bullet is still open, so there is genuinely no other home for that direction today — which #295 anticipates by naming #241 as the future one. Rather than delete `AdeApp::start_merge` and its 15-test regression suite for #241 to rebuild, it is kept intact, `#[allow(dead_code)]`'d and documented as awaiting that issue. The graph's opposite direction (`Merge into current branch…`, `start_merge_from_graph_branch`) is untouched and still live, as is the shared conflict resolver.

## Verification

- `cargo build --workspace`, `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets` — all clean, no warnings.
- `cargo test -p wt-core` (290), `-p lsp-core` (51), `-p pty-core` (19) — all pass.
- `cargo test -p app --lib` — 2782 pass. The 22 failures are the known families (`worktree_watch`/`file_tree_watch`/`repo_list_tests` inotify exhaustion, `text_undo_scoping`/`tree_ops` undo scoping, `agent_state_chip_live`, the rust-analyzer wiring test); **every one of them passes in isolation** once a leaked test process holding 109 of the system's 128 inotify instances was killed.
- New `agent_pane_readout_tests` (6 `#[gpui::test]`s) drive the real painted surface with real child processes, `debug_bounds` measurement and simulated clicks. The context-bar assertion is **mutation-verified**: re-adding an `Archive` button leaves the status pill 83px short of the bar's right edge and fails the test.
- Real X11 capture of the running app against a real `claude` agent: context bar reads `C | Claude | main | /tmp/jerry-vis | ● Running` with nothing painted after the pill, and the strip below shows no buttons and a live `0.0% cpu · 237.4 MB`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)