### PR TITLE
fix(app): the command palette could not be opened with no tab open (#255)

### DIFF
--- a/BUILD-LOG.md
+++ b/BUILD-LOG.md
@@ -7713,3 +7713,78 @@ in isolation. An earlier run of the same suite also showed 15 `spawn_*_watcher` 
 were the host running out of inotify instances (measured at 124/128, with three other worktrees'
 suites running concurrently), not this change - no watcher file is touched by it, and all 18
 watcher tests pass once the host has headroom.
+
+## GitHub issue #255: with no tab left open, every global keybinding died, the command palette's ⌘P included
+
+The whole report, verbatim: *"Sometimes the command palette can't be opened like when there is no
+tab open."* No steps, no trace - so the first real work was finding which zero-tab states actually
+break. Nine candidate paths were written as real `simulate_keystrokes` tests against unmodified
+code; six passed and three failed, and all three failures share one root cause:
+
+1. Open a file, close the last agent tab, close the file tab.
+2. Open Settings, archive the last agent from the title bar's Agent menu, close Settings.
+3. Open the git graph tab, close the last agent tab, close the graph tab.
+
+**Root cause.** `restore_focus` (`crates/app/src/root/mod.rs`) - the shared "an overlay closed,
+put keyboard focus back somewhere real" step every focus-owning surface in this app routes
+through - ended its fallback chain at *the active agent's terminal pane*:
+
+```rust
+let focus_target = restore_target.or_else(|| agents.active().map(..));
+if let Some(handle) = focus_target { window.focus(&handle, cx); }
+```
+
+With no agent left there was nothing to end the chain with, and the `if let` then simply did
+nothing: `Window::focus` stayed pointed at the handle of the surface that had just stopped being
+rendered. GPUI resolves a dispatched action against whichever node the focused `FocusId` maps to
+in the last rendered frame and falls back to the dispatch tree's *root* when that id isn't there
+(`focus_node_id_in_rendered_frame`) - a node above every `on_action` handler `AdeApp` registers.
+So `⌘P`, `⌘,`, `Ctrl+Shift+T` and every other global binding silently did nothing until the user
+clicked something focusable. This is the same dangling-focus bug class `OverlayFocus`/
+`restore_focus` were built to close (see this file's own `ctrl_p_still_works_after_...` history);
+what was new is that a window with **no agents at all** is an ordinary state - `render_center_pane`
+has a real "no agents open in this worktree" arm - and the shared helper had no answer for it.
+Three call sites (`close_agent`, `select_worktree`/`reset_repo_scoped_state`, `cancel_new_file`)
+already hand-rolled exactly the right fallback for their own non-overlay paths, which is why the
+plainest reading of the issue ("close the only tab, press ⌘P") already worked and the three
+orderings above did not: in each of them the pre-open target *was* the agent that has since been
+closed, so `restore_focus`' own `agent_changed` guard correctly discarded it - and then had
+nothing left.
+
+**Fix.** `AdeApp::focus_fallback_handle` (`crates/app/src/root/focus.rs`) returns the one focus
+target this window is definitely rendering right now, deriving its three arms from
+`Render::render`'s own three-way body branch rather than assuming: `settings_focus_handle` while
+Settings has replaced the workspace body, `empty_state_focus_handle` for a window with no focused
+repo, `rail_focus_handle` (the rail's context-less *root*, not its `"text-input"` filter field)
+otherwise. `restore_focus` takes it as a new parameter and ends with `.unwrap_or(fallback)` plus an
+unconditional `window.focus`, so the "moved focus nowhere" outcome is now unrepresentable. All 11
+call sites pass it. Behaviour changes only in the case that was already broken: with a captured
+target or a live agent, the chain resolves exactly as before.
+
+**Tests.** New `root::focus::tabless_window_keybinding_tests` - four `#[gpui::test]`s driving the
+real `crate::default_key_bindings` `secondary-p` binding through `simulate_keystrokes` (never a
+direct `dispatch_action`, which is precisely what cannot see this bug class), one per reproduction
+above plus the already-green "nothing open anywhere" baseline. Each asserts its own zero-tab setup
+before pressing anything so it can't go vacuous, and the file-tab one additionally asserts the
+mechanism rather than only the symptom: real focus must land on `rail_focus_handle`. Reverting
+just the `.unwrap_or(fallback)` line fails exactly the three reproduction tests and leaves the
+baseline green.
+
+**Not reproduced live, and why.** The real app was launched against a scratch repo and captured
+per-window (`XGetImage`), but scripted keystroke delivery into the GPUI window is unreliable in
+this sandbox - synthetic XTEST keys reached the app once and then stopped landing at all - so a
+keyboard-driven end-to-end repro could not be run honestly. The evidence above is the GPUI test
+harness's own real window, real dispatch tree and real key bindings instead. Worth knowing for the
+next person: the status bar's `⌘P commands` hint calls `open_palette` directly from its `on_click`
+rather than dispatching an action, so clicking it kept working throughout - a mouse-only user would
+never have seen this bug.
+
+**Verification**: `cargo build --workspace`, `cargo fmt --all -- --check`, `cargo clippy
+--workspace --all-targets` - all clean. `cargo test -p wt-core`: 290 passed, 0 failed. `cargo test
+-p app --lib`: **2784 passed, 16 failed** - every failure is the known inotify-exhaustion class
+(`rail::worktree_watch`, `sidebar::file_tree_watch`, `root::state::file_tree_watch_integration_
+tests`, `root::repo_list_tests`) plus the known `rust_analyzer_tracks_a_real_live_unsaved_edit_...`
+LSP wiring test, on a host measured at 124/128 `max_user_instances` with several other worktrees'
+suites running concurrently. Nothing in `root::focus`, `code_surface`, `graph_view`, `review`,
+`sidebar::render` or `work_surface::render` failed; the 36 tests in this crate's five
+focus/keybinding modules all pass, new ones included.

--- a/crates/app/src/code_surface/tabs.rs
+++ b/crates/app/src/code_surface/tabs.rs
@@ -529,7 +529,8 @@ impl AdeApp {
                     self.refresh_open_diff_file_cache();
                     self.dismiss_hover();
                     self.dismiss_completions();
-                    restore_focus(&self.agents, &mut self.code_focus, window, cx);
+                    let fallback = self.focus_fallback_handle();
+                    restore_focus(&self.agents, &mut self.code_focus, fallback, window, cx);
                 }
             }
         }

--- a/crates/app/src/graph_view/render.rs
+++ b/crates/app/src/graph_view/render.rs
@@ -91,7 +91,8 @@ impl AdeApp {
         self.tree_context_menu = None;
         self.tree_inline_edit = None;
         if self.tree_focus_handle.is_focused(window) {
-            restore_focus(&self.agents, &mut self.code_focus, window, cx);
+            let fallback = self.focus_fallback_handle();
+            restore_focus(&self.agents, &mut self.code_focus, fallback, window, cx);
         }
         self.palette_focus.forget_target(&self.tree_focus_handle);
         self.settings_focus.forget_target(&self.tree_focus_handle);
@@ -103,7 +104,8 @@ impl AdeApp {
         // left `code_focus_handle` captured as this tab's own return target, a handle that stops
         // being rendered the moment `open_change` clears.
         if self.code_focus_handle.is_focused(window) {
-            restore_focus(&self.agents, &mut self.code_focus, window, cx);
+            let fallback = self.focus_fallback_handle();
+            restore_focus(&self.agents, &mut self.code_focus, fallback, window, cx);
         }
         self.palette_focus.forget_target(&self.code_focus_handle);
         self.settings_focus.forget_target(&self.code_focus_handle);
@@ -217,7 +219,8 @@ impl AdeApp {
                 .branches_filter_focus_handle
                 .is_focused(window)
         {
-            restore_focus(&self.agents, &mut self.graph_focus, window, cx);
+            let fallback = self.focus_fallback_handle();
+            restore_focus(&self.agents, &mut self.graph_focus, fallback, window, cx);
         }
         self.palette_focus.forget_target(&self.graph_focus_handle);
         self.settings_focus.forget_target(&self.graph_focus_handle);

--- a/crates/app/src/review/render.rs
+++ b/crates/app/src/review/render.rs
@@ -68,14 +68,16 @@ impl AdeApp {
         self.tree_context_menu = None;
         self.tree_inline_edit = None;
         if self.tree_focus_handle.is_focused(window) {
-            restore_focus(&self.agents, &mut self.code_focus, window, cx);
+            let fallback = self.focus_fallback_handle();
+            restore_focus(&self.agents, &mut self.code_focus, fallback, window, cx);
         }
         self.palette_focus.forget_target(&self.tree_focus_handle);
         self.settings_focus.forget_target(&self.tree_focus_handle);
         self.code_focus.forget_target(&self.tree_focus_handle);
 
         if self.code_focus_handle.is_focused(window) {
-            restore_focus(&self.agents, &mut self.code_focus, window, cx);
+            let fallback = self.focus_fallback_handle();
+            restore_focus(&self.agents, &mut self.code_focus, fallback, window, cx);
         }
         self.palette_focus.forget_target(&self.code_focus_handle);
         self.settings_focus.forget_target(&self.code_focus_handle);
@@ -142,7 +144,8 @@ impl AdeApp {
         }
         self.review_tab_active = false;
         if self.review_focus_handle.is_focused(window) {
-            restore_focus(&self.agents, &mut self.review_focus, window, cx);
+            let fallback = self.focus_fallback_handle();
+            restore_focus(&self.agents, &mut self.review_focus, fallback, window, cx);
         }
         self.palette_focus.forget_target(&self.review_focus_handle);
         self.settings_focus.forget_target(&self.review_focus_handle);

--- a/crates/app/src/root/focus.rs
+++ b/crates/app/src/root/focus.rs
@@ -10,6 +10,36 @@
 use super::*;
 
 impl AdeApp {
+    /// The one focus target this window is *always* rendering right now - [`restore_focus`]'s
+    /// last-resort landing spot when an overlay closes with nothing real left to hand focus back
+    /// to, and the answer to GitHub issue #255 ("sometimes the command palette can't be opened
+    /// like when there is no tab open").
+    ///
+    /// The three arms mirror [`Render::render`]'s own three-way body branch exactly, because that
+    /// branch is what decides which of these handles is genuinely `track_focus`'d this frame:
+    /// Settings replaces the workspace body (`crate::settings::render::AdeApp::render_settings`
+    /// tracks [`Self::settings_focus_handle`]), a window with no focused repo renders
+    /// [`Self::render_empty_state`] and its own handle instead, and every other state renders the
+    /// workspace body, whose rail root (`crate::rail::render::AdeApp::render_rail`) carries
+    /// [`Self::rail_focus_handle`]. Getting this wrong would be *worse* than no fallback at all -
+    /// focusing a handle nothing draws is precisely the dangling-focus state this exists to
+    /// escape - so it is derived from the same condition rather than assumed.
+    ///
+    /// The rail's *root*, not its filter field: see [`Self::rail_focus_handle`]'s own docs for the
+    /// real keystroke-swallowing bug that distinction fixed, and note that
+    /// [`Self::close_agent`]/[`Self::select_worktree`]/[`Self::cancel_new_file`] already hand-roll
+    /// exactly this fallback for their own non-overlay paths - this method is what lets the shared
+    /// overlay path stop being the one place that lacked it.
+    pub(crate) fn focus_fallback_handle(&self) -> FocusHandle {
+        if self.settings_open {
+            self.settings_focus_handle.clone()
+        } else if self.focused_repo().is_none() {
+            self.empty_state_focus_handle.clone()
+        } else {
+            self.rail_focus_handle.clone()
+        }
+    }
+
     /// Captures the pre-open focus target only on the closed-to-open transition
     /// (`Self::open_change` was `None`) - a second file opened while one is already showing must
     /// not overwrite the real original target with `Self::code_focus_handle` itself (already
@@ -98,7 +128,8 @@ impl AdeApp {
             cx.notify();
             return;
         }
-        restore_focus(&self.agents, &mut self.palette_focus, window, cx);
+        let fallback = self.focus_fallback_handle();
+        restore_focus(&self.agents, &mut self.palette_focus, fallback, window, cx);
         cx.notify();
     }
 
@@ -194,7 +225,8 @@ impl AdeApp {
         // `App::intercept_keystrokes` subscription - it must never survive leaving the Settings
         // surface, or every keystroke in the whole app would keep being silently swallowed.
         self.cancel_keybinding_recording(cx);
-        restore_focus(&self.agents, &mut self.settings_focus, window, cx);
+        let fallback = self.focus_fallback_handle();
+        restore_focus(&self.agents, &mut self.settings_focus, fallback, window, cx);
         cx.notify();
     }
 }
@@ -2150,5 +2182,241 @@ mod palette_result_focus_tests {
             app.update_in(cx, |app, window, cx| app.close_palette(window, cx));
             cx.run_until_parked();
         }
+    }
+}
+
+/// GitHub issue #255 ("sometimes the command palette can't be opened like when there is no tab
+/// open"): real, keystroke-driven coverage for a window that has genuinely run out of tabs.
+///
+/// The bug was [`restore_focus`]' fallback chain ending at the active agent's terminal pane. With
+/// no agent left there was nothing to end it *with*, so closing a focus-owning surface simply did
+/// not move `Window::focus` at all - leaving it on the handle that had just stopped being
+/// rendered, from where GPUI dispatches every keystroke to the dispatch tree's root, above every
+/// `on_action` handler this app registers. See that function's own docs for the full mechanism
+/// and [`AdeApp::focus_fallback_handle`] for the fix.
+///
+/// Every test here drives the real `crate::default_key_bindings` binding through
+/// `simulate_keystrokes` rather than dispatching [`TogglePalette`] directly. A direct dispatch
+/// would in fact see this particular bug (`gpui::VisualTestContext::dispatch_action` routes
+/// through `Window::dispatch_action`, which resolves against the focused node in the rendered
+/// frame exactly as a keystroke does), but it would *not* see the keystroke half - which binding
+/// string the action is actually reachable by - and the issue is a report about pressing a key.
+/// Same choice, for the same reason, as `tab_strip_keybinding_tests`' own
+/// `ctrl_p_still_works_after_...` neighbours. Each test also asserts its own zero-tab setup before
+/// pressing anything, so none of them can go quietly vacuous if a close path ever stops closing
+/// what its name says.
+#[cfg(test)]
+mod tabless_window_keybinding_tests {
+    use super::*;
+    use gpui::{Entity, TestAppContext};
+
+    fn bind_real_keys(cx: &mut gpui::VisualTestContext) {
+        cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
+    }
+
+    /// `crate::default_key_bindings`' own `"secondary-p"`, resolved the same way that list does.
+    const SECONDARY_P: &str = if cfg!(target_os = "macos") {
+        "cmd-p"
+    } else {
+        "ctrl-p"
+    };
+
+    /// A test window over a throwaway repo directory holding one real file, with the initial
+    /// shell agent already spawned (the same `palette_focus_tests::open_test_app` setup every
+    /// other keybinding test in this file uses). The `TempDir` is returned so it outlives the
+    /// test body.
+    fn open_app_with_a_file(
+        cx: &mut TestAppContext,
+    ) -> (
+        Entity<AdeApp>,
+        &mut gpui::VisualTestContext,
+        tempfile::TempDir,
+        PathBuf,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let file_path = repo.path().join("a.txt");
+        std::fs::write(&file_path, "hello\n").expect("write a.txt");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        (app, cx, repo, file_path)
+    }
+
+    /// Closes every open agent through [`AdeApp::close_agent`] - the real entry point the tab
+    /// strip's `×`, middle-click and the Agent menu's Archive row all go through.
+    fn close_every_agent(app: &Entity<AdeApp>, cx: &mut gpui::VisualTestContext) {
+        let ids: Vec<AgentId> = app.read_with(cx, |app, _| {
+            app.agents.iter().map(|agent| agent.id).collect()
+        });
+        app.update_in(cx, |app, window, cx| {
+            for id in ids {
+                app.close_agent(id, window, cx);
+            }
+        });
+        cx.run_until_parked();
+        assert!(
+            app.read_with(cx, |app, _| app.agents.is_empty()),
+            "setup: every agent must really be closed"
+        );
+    }
+
+    fn assert_palette_opened(app: &Entity<AdeApp>, cx: &mut gpui::VisualTestContext, state: &str) {
+        assert!(
+            app.read_with(cx, |app, _| app.palette_open),
+            "a real {SECONDARY_P} keystroke must open the palette {state} - GitHub issue #255: \
+             with no tab left to hand focus back to, restore_focus used to move Window::focus \
+             nowhere at all, leaving it on the surface that had just stopped being rendered and \
+             every global keybinding silently dead until the next click"
+        );
+    }
+
+    /// The plainest reading of the issue: nothing open anywhere. Already green before the fix
+    /// (`AdeApp::close_agent` hand-rolls its own rail fallback for exactly this), and kept as the
+    /// baseline the three real reproductions below are variations on - if this ever breaks, the
+    /// others' evidence about *which* path is at fault stops being readable.
+    #[gpui::test]
+    fn ctrl_p_opens_the_palette_with_no_tab_open_at_all(cx: &mut TestAppContext) {
+        let (app, cx, _repo, _file) = open_app_with_a_file(cx);
+        bind_real_keys(cx);
+
+        close_every_agent(&app, cx);
+
+        cx.simulate_keystrokes(SECONDARY_P);
+        assert_palette_opened(&app, cx, "with no tab open at all");
+    }
+
+    /// Reproduction 1, and the most ordinary of the three: open a file, close the terminal tab,
+    /// close the file tab. `AdeApp::close_agent`'s own rail fallback deliberately stands down
+    /// while a file tab is showing (focus is correctly on the code surface at that point), and the
+    /// file tab's own close then went through [`restore_focus`], whose captured target was the
+    /// agent that no longer exists.
+    #[gpui::test]
+    fn ctrl_p_opens_the_palette_after_the_last_agent_then_the_last_file_tab_are_closed(
+        cx: &mut TestAppContext,
+    ) {
+        let (app, cx, _repo, file_path) = open_app_with_a_file(cx);
+        bind_real_keys(cx);
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_file_view(file_path, window, cx);
+        });
+        cx.run_until_parked();
+        assert!(
+            app.read_with(cx, |app, _| app.open_change.is_some()),
+            "setup: a real file tab must be open"
+        );
+
+        close_every_agent(&app, cx);
+        assert!(
+            app.read_with(cx, |app, _| app.open_change.is_some()),
+            "setup: the file tab must survive closing the agents - the point of this ordering"
+        );
+
+        app.update_in(cx, |app, window, cx| {
+            app.close_change_diff(window, cx);
+        });
+        assert!(
+            app.read_with(cx, |app, _| app.open_change.is_none()),
+            "setup: the file tab must really be closed - zero tabs now"
+        );
+        // The mechanism, not just the symptom: focus has to land on something this frame really
+        // renders. The rail's root container is that thing whenever the workspace body is showing
+        // (`AdeApp::focus_fallback_handle`).
+        assert!(
+            app.update_in(cx, |app, window, _cx| app
+                .rail_focus_handle
+                .is_focused(window)),
+            "closing the last tab must leave real keyboard focus on the rail's own root \
+             container, not dangling on the code surface handle that just stopped rendering"
+        );
+
+        cx.simulate_keystrokes(SECONDARY_P);
+        assert_palette_opened(
+            &app,
+            cx,
+            "after the last agent and then the last file tab closed",
+        );
+    }
+
+    /// Reproduction 2: Settings open, the last agent archived from the title bar's Agent menu
+    /// (`AdeApp::archive_agent`, reachable while Settings covers the workspace body), Settings
+    /// closed. `close_agent` stands down here too - focus is legitimately on Settings' own handle
+    /// at that moment - so the dangling target was created by `close_settings`' restore.
+    #[gpui::test]
+    fn ctrl_p_opens_the_palette_after_closing_settings_that_outlived_the_last_agent(
+        cx: &mut TestAppContext,
+    ) {
+        let (app, cx, _repo, _file) = open_app_with_a_file(cx);
+        bind_real_keys(cx);
+
+        app.update_in(cx, |app, window, cx| app.open_settings(window, cx));
+        assert!(
+            app.read_with(cx, |app, _| app.settings_open),
+            "setup: Settings must really be open"
+        );
+
+        let ids: Vec<AgentId> = app.read_with(cx, |app, _| {
+            app.agents.iter().map(|agent| agent.id).collect()
+        });
+        app.update_in(cx, |app, window, cx| {
+            for id in ids {
+                app.archive_agent(id, window, cx);
+            }
+        });
+        cx.run_until_parked();
+        assert!(
+            app.read_with(cx, |app, _| app.agents.is_empty()),
+            "setup: every agent must really be archived"
+        );
+
+        app.update_in(cx, |app, window, cx| app.close_settings(window, cx));
+        assert!(
+            app.read_with(cx, |app, _| !app.settings_open
+                && app.open_change.is_none()
+                && app.agents.is_empty()),
+            "setup: Settings closed onto a genuinely tabless workspace"
+        );
+
+        cx.simulate_keystrokes(SECONDARY_P);
+        assert_palette_opened(
+            &app,
+            cx,
+            "after closing Settings that outlived the last agent",
+        );
+    }
+
+    /// Reproduction 3: the git graph tab open, the last agent closed behind it, then the graph tab
+    /// closed. Same shape as the other two through a third surface -
+    /// `crate::graph_view::render::AdeApp::leave_graph_tab`'s own [`restore_focus`] call.
+    #[gpui::test]
+    fn ctrl_p_opens_the_palette_after_closing_a_graph_tab_that_outlived_the_last_agent(
+        cx: &mut TestAppContext,
+    ) {
+        let (app, cx, _repo, _file) = open_app_with_a_file(cx);
+        bind_real_keys(cx);
+
+        app.update_in(cx, |app, window, cx| app.open_git_graph(window, cx));
+        cx.run_until_parked();
+        assert!(
+            app.read_with(cx, |app, _| app.graph_tab_active),
+            "setup: the graph tab must really be showing"
+        );
+
+        close_every_agent(&app, cx);
+
+        app.update_in(cx, |app, window, cx| app.close_git_graph_tab(window, cx));
+        cx.run_until_parked();
+        assert!(
+            app.read_with(cx, |app, _| !app.graph_tab_active
+                && !app.graph_tab_open
+                && app.open_change.is_none()),
+            "setup: the graph tab must really be closed - zero tabs now"
+        );
+
+        cx.simulate_keystrokes(SECONDARY_P);
+        assert_palette_opened(
+            &app,
+            cx,
+            "after closing a graph tab that outlived the last agent",
+        );
     }
 }

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -3621,14 +3621,39 @@ impl OverlayFocus {
 /// If the active agent changed while the surface was open, the captured handle is skipped in
 /// favor of the *current* active agent's terminal pane (a handle from a no-longer-active
 /// agent would be just as dangling as the overlay's own). Otherwise the captured handle is
-/// restored, falling back to the active agent's pane if nothing was focused before. A free
-/// function, not an `AdeApp` method, since every caller already holds `&mut self` and needs to
-/// pass `&mut self.some_field` alongside it. Deliberately doesn't call `cx.notify()` - every
-/// caller has its own surface-specific state change around this call and issues its own single
-/// `cx.notify()` once everything, this restore included, is done.
+/// restored, falling back to the active agent's pane if nothing was focused before, and finally
+/// to `fallback` if there is no agent either. A free function, not an `AdeApp` method, since
+/// every caller already holds `&mut self` and needs to pass `&mut self.some_field` alongside it.
+/// Deliberately doesn't call `cx.notify()` - every caller has its own surface-specific state
+/// change around this call and issues its own single `cx.notify()` once everything, this restore
+/// included, is done.
+///
+/// `fallback` ([`AdeApp::focus_fallback_handle`], which every caller passes) is GitHub issue
+/// #255's fix, and it closes a real, reproduced hole rather than padding an unreachable one: this
+/// function used to end its chain at the active agent's pane and simply *not move focus at all*
+/// when there wasn't one, which is the whole bug. A window with no agents left is an ordinary,
+/// fully-supported state (`crate::work_surface::render::AdeApp::render_center_pane`'s own "no
+/// agents open in this worktree" arm), and closing any focus-owning surface in it - a file tab,
+/// the git graph tab, the review tab, Settings, the palette - left `Window::focus` pointing at
+/// the handle that had just stopped being rendered. From there GPUI resolves every subsequent
+/// keystroke against the dispatch tree's *root* node (see this module's [`OverlayFocus`] docs and
+/// `focus_node_id_in_rendered_frame`), which sits above every `on_action` handler `AdeApp` has -
+/// so ⌘P, ⌘,, and every other global binding silently did nothing until the user happened to
+/// click something focusable. Three real reproductions, each now a test in
+/// `crate::root::focus::tabless_window_keybinding_tests`:
+///
+/// 1. Open a file, close the last agent tab, close the file tab.
+/// 2. Open Settings, archive the last agent from the title bar's Agent menu, close Settings.
+/// 3. Open the git graph tab, close the last agent tab, close the graph tab.
+///
+/// Each ends with zero tabs open, which is exactly the state the issue names. The `agent_changed`
+/// branch above is what all three route through: the pre-open target *was* the agent that has
+/// since been closed, so it is (correctly) discarded, and before this parameter existed there was
+/// then nothing left to fall back to.
 pub(crate) fn restore_focus(
     agents: &Agents,
     overlay_focus: &mut OverlayFocus,
+    fallback: FocusHandle,
     window: &mut Window,
     cx: &mut App,
 ) {
@@ -3638,11 +3663,10 @@ pub(crate) fn restore_focus(
     } else {
         overlay_focus.return_focus.take()
     };
-    let focus_target =
-        restore_target.or_else(|| agents.active().map(|agent| agent.pane.focus_handle(cx)));
-    if let Some(handle) = focus_target {
-        window.focus(&handle, cx);
-    }
+    let focus_target = restore_target
+        .or_else(|| agents.active().map(|agent| agent.pane.focus_handle(cx)))
+        .unwrap_or(fallback);
+    window.focus(&focus_target, cx);
     overlay_focus.clear();
 }
 

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -58,7 +58,8 @@ impl AdeApp {
             self.tree_context_menu = None;
             self.tree_inline_edit = None;
             if self.tree_focus_handle.is_focused(window) {
-                restore_focus(&self.agents, &mut self.code_focus, window, cx);
+                let fallback = self.focus_fallback_handle();
+                restore_focus(&self.agents, &mut self.code_focus, fallback, window, cx);
             }
             // 1 again, one level removed, and invisible to the check above: an *overlay* can be
             // holding the tree's handle as its own return target while the overlay itself has

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -291,7 +291,8 @@ impl AdeApp {
                 // (`self.palette_focus.clear()`).
                 self.code_focus.clear();
             } else {
-                restore_focus(&self.agents, &mut self.code_focus, window, cx);
+                let fallback = self.focus_fallback_handle();
+                restore_focus(&self.agents, &mut self.code_focus, fallback, window, cx);
             }
         }
         let cwd = self


### PR DESCRIPTION
Closes #255.

The report, verbatim: *"Sometimes the command palette can't be opened like when there is no tab
open."* No steps and no trace, so the first job was working out which zero-tab states actually
break. Nine candidate paths were written as real `simulate_keystrokes` tests against unmodified
`master`; six passed and three failed:

1. Open a file, close the last agent tab, close the file tab.
2. Open Settings, archive the last agent from the title bar's Agent menu, close Settings.
3. Open the git graph tab, close the last agent tab, close the graph tab.

Each ends with **zero tabs open** - exactly the state the issue names - and in each one `Ctrl+P`
(and `Ctrl+,`, and every other global binding) then does nothing at all until the user clicks
something focusable.

## Root cause

`restore_focus` (`crates/app/src/root/mod.rs`) - the shared "an overlay closed, put keyboard focus
back somewhere real" step every focus-owning surface routes through - ended its fallback chain at
*the active agent's terminal pane*:

```rust
let focus_target = restore_target.or_else(|| agents.active().map(..));
if let Some(handle) = focus_target { window.focus(&handle, cx); }
```

With no agent left, the `if let` simply did nothing, so `Window::focus` stayed on the handle of the
surface that had just stopped being rendered. GPUI resolves a dispatched action against whichever
node the focused `FocusId` maps to in the last rendered frame and falls back to the dispatch
tree's **root** when it isn't there (`focus_node_id_in_rendered_frame`) - above every `on_action`
handler `AdeApp` registers.

A window with no agents at all is an ordinary, fully-supported state (`render_center_pane` has a
real "no agents open in this worktree" arm), and three call sites (`close_agent`,
`reset_repo_scoped_state`, `cancel_new_file`) already hand-roll the right fallback for their own
non-overlay paths - which is why the plainest reading of the issue ("close the only tab, press
⌘P") already worked while the three orderings above did not. In all three, the captured pre-open
target *was* the agent that has since been closed, so `restore_focus`' own `agent_changed` guard
correctly discarded it and then had nothing left.

## Fix

- `AdeApp::focus_fallback_handle` returns the one handle this window is definitely rendering right
  now, with its three arms derived from `Render::render`'s own three-way body branch rather than
  assumed: Settings' own handle, the empty state's, or the rail's context-less **root** (never its
  `"text-input"` filter field).
- `restore_focus` takes it as a parameter, ends with `.unwrap_or(fallback)` and an unconditional
  `window.focus`, so "moved focus nowhere" is no longer representable. All 11 call sites pass it.

Behaviour is unchanged whenever there is a captured target or a live agent - only the
already-broken case moves.

## Tests

New `root::focus::tabless_window_keybinding_tests`: four `#[gpui::test]`s driving the real
`default_key_bindings` `secondary-p` binding through `simulate_keystrokes`, one per reproduction
above plus the already-green "nothing open anywhere" baseline. Each asserts its own zero-tab setup
before pressing anything so it cannot go vacuous, and the file-tab one asserts the mechanism as
well as the symptom (focus must land on `rail_focus_handle`). Reverting just the
`.unwrap_or(fallback)` line fails exactly the three reproduction tests and leaves the baseline
green.

## Verification

`cargo build --workspace`, `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets`
- all clean. `cargo test -p wt-core`: 290 passed, 0 failed. `cargo test -p app --lib`: **2784 passed, 16
failed** - every failure is the known inotify-exhaustion class (`rail::worktree_watch`,
`sidebar::file_tree_watch`, `root::state::file_tree_watch_integration_tests`,
`root::repo_list_tests`) plus the known `rust_analyzer_tracks_a_real_live_unsaved_edit_...` LSP
wiring test, on a host measured at 124/128 `max_user_instances` with several other worktrees'
suites running concurrently. Nothing in `root::focus`, `code_surface`, `graph_view`, `review`,
`sidebar::render` or `work_surface::render` failed, and the 36 tests across this crate's five
focus/keybinding modules all pass (new ones included), re-run after rebasing onto current
`master`.

Not reproduced against the running binary: the app launches and can be captured per-window here,
but scripted keystroke delivery into the GPUI window is unreliable in this sandbox (synthetic
XTEST keys landed once and then stopped arriving), so a keyboard-driven end-to-end repro could not
be run honestly. The evidence is the GPUI test harness's own real window, dispatch tree and key
bindings instead. Worth knowing: the status bar's `⌘P commands` hint calls `open_palette` straight
from its `on_click` rather than dispatching an action, so clicking it kept working throughout - a
mouse-only user would never have hit this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
