### PR TITLE
Git graph: gate the branch menu's merge with the reason on the row (#241)

### DIFF
--- a/crates/app/src/graph_view/mod.rs
+++ b/crates/app/src/graph_view/mod.rs
@@ -76,6 +76,9 @@ pub(crate) mod render;
 pub(crate) mod state;
 
 pub(crate) use state::{
+    graph_branch_merge_gate, GraphBranchMenu, GraphBranchMergeFacts, GraphLoadState,
+    GraphRightPanel, GraphRowMenu,
+};
+pub(crate) use state::{
     graph_lane_canvas_width, lane_color, lane_x, local_branch_dim_bg, relative_time,
 };
-pub(crate) use state::{GraphBranchMenu, GraphLoadState, GraphRightPanel, GraphRowMenu};

--- a/crates/app/src/graph_view/render.rs
+++ b/crates/app/src/graph_view/render.rs
@@ -941,6 +941,61 @@ impl AdeApp {
         });
     }
 
+    /// Everything [`graph_branch_merge_gate`] needs for the branch menu's "Merge into current
+    /// branch…" row, read off real app state for the **focused worktree** - never the repository's
+    /// main checkout (the branch menu's own footer rule; see [`Self::run_graph_remote_op`] for the
+    /// same `diff_root` discipline every other graph mutation already follows).
+    ///
+    /// Every field is a fact this app has already loaded for that worktree, so this performs no
+    /// blocking I/O and is safe to call from a render path: the current branch comes from
+    /// [`AdeApp::worktrees`] (`wt_core::list_worktrees`), the uncommitted count from
+    /// [`AdeApp::dirty_files`] (`wt_core::stage::dirty_paths`), and the agent counts from the live
+    /// [`AdeApp::agents`] plus [`Self::agent_status`] - the single status source the rail and the
+    /// work surface already share, so this can never disagree with them about which agents are
+    /// working.
+    ///
+    /// A `dirty_files` that hasn't landed yet reads as zero rather than as "blocked": `None` there
+    /// means *unknown*, and blocking a real merge on an answer that simply hasn't arrived would be
+    /// a reason the user cannot act on. `wt_core::merge::attempt_merge_into_current` re-checks
+    /// dirtiness against git itself immediately before merging, so an unknown-then-dirty worktree
+    /// costs an honest `MergeTargetDirty` refusal in the resolver, never a merge onto dirty state.
+    pub(crate) fn graph_branch_merge_facts(
+        &self,
+        source_branch: String,
+        cx: &gpui::App,
+    ) -> GraphBranchMergeFacts {
+        let current_branch = self
+            .worktrees
+            .iter()
+            .find(|item| item.path == self.diff_root)
+            .and_then(|item| item.branch.clone());
+        let uncommitted_files = self
+            .dirty_files
+            .as_ref()
+            .map(|files| files.len())
+            .unwrap_or(0);
+        let worktree_agents: Vec<&crate::work_surface::agents::Agent> =
+            self.agents.iter_for_cwd(self.diff_root.clone()).collect();
+        let live_agents = worktree_agents
+            .iter()
+            .filter(|agent| agent.kind.is_agent_session())
+            .filter(|agent| {
+                matches!(
+                    self.agent_status(agent, cx),
+                    crate::rail::status::Status::Run | crate::rail::status::Status::Ask
+                )
+            })
+            .count();
+        GraphBranchMergeFacts {
+            current_branch,
+            source_branch,
+            uncommitted_files,
+            live_agents,
+            has_agent_tab: !worktree_agents.is_empty(),
+            merge_already_running: self.merge_flow.is_some(),
+        }
+    }
+
     /// The branch menu's "Push Branch…" action (GitHub issue #241) - a plain, never-forced push
     /// of that specific branch (`wt_core::remote::push_branch`), regardless of what is checked
     /// out in the focused worktree.
@@ -977,6 +1032,7 @@ impl AdeApp {
     /// up front keeps the arm intact, so the click the user is about to repeat still counts.
     pub(crate) fn request_graph_delete_branch(&mut self, branch: String, cx: &mut Context<Self>) {
         if self.graph_state.remote_op_in_flight {
+            self.report_graph_op_in_flight(cx);
             return;
         }
         if self.graph_state.delete_branch_confirm_armed.as_deref() != Some(branch.as_str()) {
@@ -1018,6 +1074,7 @@ impl AdeApp {
         // this ordering closes. Soft/Mixed behave exactly as before either way (they arm nothing,
         // and `run_graph_remote_op` would have refused them at the far end regardless).
         if self.graph_state.remote_op_in_flight {
+            self.report_graph_op_in_flight(cx);
             return;
         }
         if mode == ResetMode::Hard
@@ -1040,6 +1097,18 @@ impl AdeApp {
         });
     }
 
+    /// The one refusal every graph action's single-flight guard reports, so a click that lands
+    /// while another graph operation is still running says so instead of doing nothing visible
+    /// (GitHub issue #241). Deliberately does *not* dismiss the menu or disarm any confirmation:
+    /// the click did not count, so the surface it came from must stay exactly as it was for the
+    /// user to repeat it - see [`Self::request_graph_delete_branch`]'s own docs on why disarming
+    /// before this check was a real bug.
+    fn report_graph_op_in_flight(&mut self, cx: &mut Context<Self>) {
+        self.graph_state.status_message =
+            Some("another git operation is still running".to_string());
+        cx.notify();
+    }
+
     /// Shared plumbing behind [`Self::request_graph_fetch`]/[`Self::request_graph_pull`]/
     /// [`Self::request_graph_push`]: guards against a double-click starting a second, overlapping
     /// git subprocess (`GraphTabState::remote_op_in_flight`), runs `op` on the background
@@ -1047,6 +1116,11 @@ impl AdeApp {
     /// real success or a real git error message and reloads the graph either way - a fetch/pull/
     /// push always changes what the graph/ahead-behind counts should show, success or not (a
     /// failed pull can still have fetched new remote-tracking data, for one).
+    ///
+    /// A click that arrives while another graph operation is still in flight is **refused out
+    /// loud**, on the same status line every other outcome uses (GitHub issue #241's own rule for
+    /// this menu: never a silent no-op). It used to return in silence, which read as a dead click:
+    /// nothing happened, nothing was said, and the menu the click came from stayed open.
     fn run_graph_remote_op(
         &mut self,
         action: &'static str,
@@ -1054,6 +1128,7 @@ impl AdeApp {
         op: impl FnOnce(std::path::PathBuf) -> Result<(), wt_core::Error> + Send + 'static,
     ) {
         if self.graph_state.remote_op_in_flight {
+            self.report_graph_op_in_flight(cx);
             return;
         }
         let root = self.diff_root.clone();
@@ -1553,9 +1628,11 @@ impl AdeApp {
     }
 
     /// Toolbar (design spec §4): `HEAD` branch/chip/counts, the `All | Worktrees | Current` scope
-    /// segment, and the Fetch/Pull/Push button group. None of Fetch/Pull/Push perform a real git
-    /// operation yet (see `super`'s module docs) - clicking any of them calls
-    /// [`AdeApp::graph_action_not_yet_wired`], a real, honest, visible response.
+    /// segment, and the Fetch/Pull/Push button group. Fetch and Pull run real `wt_core::remote`
+    /// operations ([`Self::request_graph_fetch`]/[`Self::request_graph_pull`]); `Push ▾` opens
+    /// [`Self::render_graph_push_menu`], whose three rows are real too. (An earlier revision
+    /// shipped all three inert; that is no longer true, and this doc used to say so - see phase
+    /// (c) in `super`'s module docs.)
     fn render_graph_toolbar(&self, cx: &mut Context<Self>) -> impl IntoElement {
         let branch = self
             .worktrees
@@ -1664,8 +1741,10 @@ impl AdeApp {
     }
 
     /// `Push ↑N ▾` - opens the Push menu (design spec §4: 268-wide, Push / Force with lease /
-    /// Force). Every entry mutates the remote, so every entry is disabled - see `super`'s module
-    /// docs.
+    /// Force). All three entries are real `wt_core::remote::push` calls
+    /// ([`Self::request_graph_push`]); the two force postures sit behind the two-click
+    /// confirmation [`state::GraphTabState::push_force_confirm_armed`] documents. (Phase (a)
+    /// shipped them disabled, and this doc used to say so.)
     fn render_graph_push_button(&self, cx: &mut Context<Self>) -> impl IntoElement {
         // `None` (no configured upstream, or still loading) renders as a bare "Push", never a
         // fabricated "↑0" - matching `wt_core::graph::ahead_behind_against_upstream`'s own "no
@@ -2166,7 +2245,9 @@ impl AdeApp {
     }
 
     /// The row `⋯` context menu (design spec §4): grouped Branch / Apply / Reset / Copy. Every
-    /// entry that would perform a real git mutation is disabled - only Copy's entries are wired.
+    /// entry is real (`wt_core::checkout`/`wt_core::rewrite`/the `wt_core::rebase`-backed rebase
+    /// mode/the clipboard), and `Hard` carries its own two-click confirmation. (Phase (a) shipped
+    /// every mutating entry disabled with only Copy wired, and this doc used to say so.)
     /// Anchored to [`GraphRowMenu::origin_x`]/`origin_y` - the real position it was opened at
     /// (either a right-click's own `event.position`, or the `⋯` button's own captured bounds via
     /// `AdeApp::graph_state.row_menu_bounds`, the same `gpui::canvas`-bounds-capture mechanism
@@ -2497,14 +2578,13 @@ impl AdeApp {
         let branch = menu.branch.clone();
         let delete_armed =
             self.graph_state.delete_branch_confirm_armed.as_deref() == Some(branch.as_str());
-        // The branch the merge would land in, read off the same real `wt_core::list_worktrees`
-        // data the rest of the app uses for the focused worktree - never a guess, and honestly
-        // absent (no sub-label at all) when the worktree is on a detached `HEAD`.
-        let current_branch = self
-            .worktrees
-            .iter()
-            .find(|item| item.path == self.diff_root)
-            .and_then(|item| item.branch.clone());
+        // Whether this merge can really run right now, and if not, the real reason - decided by
+        // the one pure gate `AdeApp::start_merge_from_graph_branch` re-checks on the click, so the
+        // row can never look live for a merge the action would refuse (or dead for one it would
+        // run). See `graph_branch_merge_gate`'s own docs for where each precondition comes from.
+        let merge_gate =
+            graph_branch_merge_gate(&self.graph_branch_merge_facts(branch.clone(), cx));
+        let merge_ready = merge_gate.is_ready();
 
         div()
             .id("graph-branch-menu-scrim")
@@ -2600,23 +2680,32 @@ impl AdeApp {
                     })),
                 )
                 .child(render_graph_row_menu_header("Integrate"))
-                .child(
-                    render_dropdown_menu_row(
+                .child({
+                    // A blocked merge renders as a real disabled row carrying its own reason
+                    // (GitHub issue #241: "never a silent no-op"), and gets no `on_click` at all -
+                    // `render_dropdown_menu_row`'s own enabled/disabled contract, which controls
+                    // the row's look but never whether it is wired up.
+                    let row = render_dropdown_menu_row(
                         "\u{2193}",
                         theme::button::BLUE_FG.into(),
                         theme::surface::CHIP_NEUTRAL.into(),
                         "Merge into current branch\u{2026}",
-                        current_branch.clone().unwrap_or_default(),
+                        merge_gate.sub_label(),
                         Vec::new(),
-                        true,
-                    )
-                    .on_click(cx.listener({
-                        let branch = branch.clone();
-                        move |this, _event: &ClickEvent, window, cx| {
-                            this.start_merge_from_graph_branch(branch.clone(), window, cx);
-                        }
-                    })),
-                )
+                        merge_ready,
+                    );
+                    if merge_ready {
+                        row.on_click(cx.listener({
+                            let branch = branch.clone();
+                            move |this, _event: &ClickEvent, window, cx| {
+                                this.start_merge_from_graph_branch(branch.clone(), window, cx);
+                            }
+                        }))
+                        .into_any_element()
+                    } else {
+                        row.into_any_element()
+                    }
+                })
                 .child(
                     render_dropdown_menu_row(
                         "\u{2191}",
@@ -8806,6 +8895,166 @@ mod graph_branch_menu_tests {
             );
         });
     }
+
+    /// The design's own first content precondition (`mergeReady: … && !uncommitted.length`), as a
+    /// real disabled row: a dirty worktree must show the reason *on the row* and the row must
+    /// genuinely have no click handler at all, not one that silently no-ops.
+    ///
+    /// This is also the one precondition that would otherwise only be discovered after the click:
+    /// `wt_core::merge::attempt_merge_into_current` refuses a dirty target with
+    /// `Error::MergeTargetDirty`, which would land in the resolver as a failed merge rather than
+    /// on the control the user is looking at.
+    #[gpui::test]
+    fn merge_row_is_disabled_with_the_designs_own_reason_while_the_worktree_is_dirty(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        seed_three_branches(repo.path());
+        // Two real uncommitted files, present before the app ever opens, so the app's own real
+        // `wt_core::stage::dirty_paths` read is what fills `dirty_files` - never a hand-set field.
+        std::fs::write(repo.path().join("dirty-one.txt"), "uncommitted\n").expect("write");
+        std::fs::write(repo.path().join("dirty-two.txt"), "uncommitted\n").expect("write");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        app.update_in(cx, |app, window, cx| {
+            app.open_git_graph(window, cx);
+        });
+        cx.run_until_parked();
+        app.update_in(cx, |app, _window, cx| {
+            app.set_graph_right_panel(GraphRightPanel::Branches, cx);
+        });
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, cx| {
+            assert_eq!(
+                app.dirty_files.as_ref().map(|files| files.len()),
+                Some(2),
+                "premise: the app's own real dirty-path read must have found both files"
+            );
+            let gate =
+                graph_branch_merge_gate(&app.graph_branch_merge_facts("feature-a".to_string(), cx));
+            assert_eq!(
+                gate.reason(),
+                Some("2 files still uncommitted"),
+                "the reason must be the design's own mergeWhy wording"
+            );
+            assert_eq!(
+                gate.sub_label(),
+                "2 files still uncommitted",
+                "and it must be what the row itself renders, in place of the target branch"
+            );
+        });
+
+        // The real, painted row - clicked for real. A disabled row gets no `on_click` at all, so
+        // this must do nothing whatsoever.
+        open_menu_at(cx, "graph-branch-row-feature-a");
+        click_menu_row(cx, "dropdown-menu-row-Merge into current branch\u{2026}");
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.merge_flow.is_none(),
+                "a blocked merge row must start no merge flow at all"
+            );
+            assert_eq!(
+                app.graph_state.status_message, None,
+                "and must not even reach the action - a disabled row carries no click handler, so \
+                 there is nothing to report"
+            );
+        });
+        assert!(
+            !wt_core::merge::merge_head_exists(repo.path()).expect("merge_head_exists"),
+            "and no real git merge must have been run in the worktree"
+        );
+    }
+
+    /// Merging the branch that is already checked out into itself is a guaranteed no-op
+    /// (`wt_core::Error::MergeSourceIsCurrentBranch`) - refused on the row rather than after the
+    /// click, and phrased as the state it really is rather than as something the user could fix by
+    /// committing.
+    #[gpui::test]
+    fn merge_row_is_disabled_on_the_branch_that_is_already_checked_out(cx: &mut TestAppContext) {
+        let (repo, app, cx) = open_seeded_branches_panel(cx);
+        assert_eq!(
+            git_output(repo.path(), &["rev-parse", "--abbrev-ref", "HEAD"]),
+            "main",
+            "premise: the focused worktree really is on main"
+        );
+
+        app.read_with(cx, |app, cx| {
+            let gate =
+                graph_branch_merge_gate(&app.graph_branch_merge_facts("main".to_string(), cx));
+            assert_eq!(gate.reason(), Some("already on main"));
+        });
+
+        open_menu_at(cx, "graph-branch-row-main");
+        click_menu_row(cx, "dropdown-menu-row-Merge into current branch\u{2026}");
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.merge_flow.is_none(),
+                "merging main into main must not even start"
+            );
+            assert_eq!(
+                app.graph_state.status_message, None,
+                "and the row must genuinely be disabled - a click that reached the action would \
+                 have reported the gate's refusal on the status line instead"
+            );
+        });
+        assert!(
+            !wt_core::merge::merge_head_exists(repo.path()).expect("merge_head_exists"),
+            "and must have run no real git merge"
+        );
+    }
+
+    /// The other half of the gate: the facts it decides from must really be read off this app's
+    /// own loaded state for the **focused worktree**, not from constants. The pure decision itself
+    /// is covered branch-by-branch in `super::state`'s own unit tests; this pins the reading.
+    #[gpui::test]
+    fn merge_facts_are_read_from_the_focused_worktrees_own_real_state(cx: &mut TestAppContext) {
+        let (repo, app, cx) = open_seeded_branches_panel(cx);
+
+        app.read_with(cx, |app, cx| {
+            let facts = app.graph_branch_merge_facts("feature-a".to_string(), cx);
+            assert_eq!(
+                facts.current_branch.as_deref(),
+                Some("main"),
+                "the target branch must come from the real worktree listing"
+            );
+            assert_eq!(facts.source_branch, "feature-a");
+            assert_eq!(
+                facts.uncommitted_files, 0,
+                "premise: this fixture's worktree is really clean"
+            );
+            assert_eq!(
+                facts.live_agents, 0,
+                "the fixture's one tab is a shell, which is not an agent session"
+            );
+            assert!(
+                facts.has_agent_tab,
+                "but it is still a real tab the resolver could render in"
+            );
+            assert!(!facts.merge_already_running);
+            assert!(graph_branch_merge_gate(&facts).is_ready());
+        });
+
+        // A real merge really running is a real fact, read the same way.
+        app.update_in(cx, |app, window, cx| {
+            app.start_merge_from_graph_branch("feature-a".to_string(), window, cx);
+        });
+        cx.run_until_parked();
+        app.read_with(cx, |app, cx| {
+            let facts = app.graph_branch_merge_facts("feature-b".to_string(), cx);
+            assert!(
+                facts.merge_already_running,
+                "premise: the first merge really is live"
+            );
+            assert_eq!(
+                graph_branch_merge_gate(&facts).reason(),
+                Some("a merge is already running")
+            );
+        });
+        assert!(
+            wt_core::merge::merge_head_exists(repo.path()).expect("merge_head_exists"),
+            "and that really was a real git merge, left in progress for the resolver"
+        );
+    }
 }
 
 /// GitHub issue #241: what each of the branch context menu's seven actions really does, end to
@@ -9163,11 +9412,21 @@ mod graph_branch_action_tests {
         );
         assert_eq!(
             app.read_with(cx, |app, _| app.graph_state.status_message.clone()),
-            Some("Fetch\u{2026}".to_string()),
-            "and must not overwrite the in-flight operation's own status line with a \
-             confirmation prompt it will not honour"
+            Some("another git operation is still running".to_string()),
+            "and must say why the click did nothing, rather than either silently doing nothing \
+             (the dead click GitHub issue #241's sweep found) or posting a confirmation prompt it \
+             will not honour. The in-flight operation's own line is not lost: its completion \
+             handler writes the real result over this a moment later, as the run below proves."
         );
         cx.run_until_parked();
+        let after = app.read_with(cx, |app, _| app.graph_state.status_message.clone());
+        assert!(
+            after
+                .as_deref()
+                .is_some_and(|text| text.starts_with("Fetch")),
+            "the refused click's reason must give way to the real operation's own real outcome \
+             (success or git's own failure) - got {after:?}"
+        );
 
         // The user's next click is, to them, a first click - so it must arm, not delete.
         app.update_in(cx, |app, _window, cx| {
@@ -9490,6 +9749,29 @@ mod graph_branch_action_tests {
                          resolver's own file list"
                     );
                     assert_eq!(files[0].relative_path(), std::path::Path::new("shared.txt"));
+
+                    // The two strings the resolver's own columns are labelled with
+                    // (`crate::merge::render::AdeApp::render_conflict_columns`). The incoming
+                    // column must name the branch that was *merged in*, never the branch the
+                    // worktree is already on: deriving it from the agent's worktree instead of
+                    // git's own marker made both columns read `main` for this merge direction -
+                    // on the one screen whose job is telling the two sides apart.
+                    let wt_core::merge::ConflictedPath::Text(file) = &files[0] else {
+                        panic!("a real text conflict, not an unmergeable path");
+                    };
+                    let hunk = file
+                        .segments
+                        .iter()
+                        .find_map(|segment| match segment {
+                            wt_core::merge::ConflictSegment::Conflict(hunk) => Some(hunk),
+                            _ => None,
+                        })
+                        .expect("a real conflict hunk");
+                    assert_eq!(hunk.ours_label, "HEAD", "the target side is HEAD");
+                    assert_eq!(
+                        hunk.theirs_label, "feature",
+                        "and the incoming side is the branch that was really merged in"
+                    );
                 }
                 other => panic!(
                     "expected a real conflicted merge state, got {}",
@@ -9538,12 +9820,11 @@ mod graph_branch_action_tests {
                 "no merge flow must have been started at all"
             );
             let status = app.graph_state.status_message.clone();
-            assert!(
-                status
-                    .as_deref()
-                    .is_some_and(|text| text.contains("no agent tab")),
-                "and the refusal must say why, rather than looking like a dead click - got \
-                 {status:?}"
+            assert_eq!(
+                status.as_deref(),
+                Some("no agent tab to show the merge"),
+                "and the refusal must say why, in the very words the disabled row itself carries \
+                 (`graph_branch_merge_gate`), rather than looking like a dead click"
             );
         });
         assert!(
@@ -9585,11 +9866,11 @@ mod graph_branch_action_tests {
         cx.run_until_parked();
 
         let status = app.read_with(cx, |app, _| app.graph_state.status_message.clone());
-        assert!(
-            status
-                .as_deref()
-                .is_some_and(|text| text.contains("already in progress")),
-            "a second merge while one is live must be refused with a real reason - got {status:?}"
+        assert_eq!(
+            status.as_deref(),
+            Some("a merge is already running"),
+            "a second merge while one is live must be refused with the very reason the row itself \
+             would have carried (`graph_branch_merge_gate`)"
         );
         assert_eq!(
             app.read_with(cx, |app, _| app

--- a/crates/app/src/graph_view/state.rs
+++ b/crates/app/src/graph_view/state.rs
@@ -1,6 +1,7 @@
 //! Pure state and formatting for the git graph tab - see `super`'s module docs.
 
 use super::rebase::RebaseModeState;
+use crate::root::plural;
 use crate::root::AdeApp;
 use crate::text_history::TextField;
 use crate::theme;
@@ -104,6 +105,140 @@ pub(crate) struct GraphBranchPrompt {
     /// [`GraphTabState::status_message`] instead, git's own real error text, exactly like every
     /// other menu mutation) - cleared on the very next keystroke.
     pub error: Option<String>,
+}
+
+/// Everything [`graph_branch_merge_gate`] is allowed to look at, already resolved into plain
+/// values by its one producer (`crate::graph_view::render::AdeApp::graph_branch_merge_facts`).
+/// Keeping the decision a pure function of these - rather than reaching into `AdeApp` from inside
+/// it - is what makes every precondition below unit-testable without a GPUI window, the same split
+/// `crate::rail::state::prunable_worktree_paths` already uses for the rail's own destructive
+/// action.
+///
+/// Every field describes the **focused worktree** (`AdeApp::diff_root`), never the repository's
+/// main checkout - the branch menu's own footer rule ("check out, merge, rebase, push and delete
+/// all run in the focused worktree, never the main checkout"), and the same `diff_root` discipline
+/// every other graph mutation already follows through
+/// `crate::graph_view::render::AdeApp::run_graph_remote_op`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GraphBranchMergeFacts {
+    /// The branch the merge would land *in*: the focused worktree's own checked-out branch.
+    /// `None` on a detached `HEAD`, which `git merge` has no branch to merge into - the exact
+    /// state `wt_core::merge::attempt_merge_into_current` refuses with `Error::MergeTargetDetached`.
+    pub current_branch: Option<String>,
+    /// The branch the merge would take commits *from*: the one whose row the menu was opened on.
+    pub source_branch: String,
+    /// How many real uncommitted paths the focused worktree has (`wt_core::stage::dirty_paths`,
+    /// via `AdeApp::dirty_files`).
+    pub uncommitted_files: usize,
+    /// How many real agent sessions in the focused worktree are still `Run`ning or `Ask`ing.
+    pub live_agents: usize,
+    /// Whether the focused worktree has any agent tab at all for the existing conflict resolver to
+    /// render in - see [`GraphBranchMergeGate::Blocked`]'s own docs and
+    /// `crate::merge::flow::AdeApp::start_merge_from_graph_branch`.
+    pub has_agent_tab: bool,
+    /// `AdeApp::merge_flow.is_some()` - only one merge runs at a time app-wide.
+    pub merge_already_running: bool,
+}
+
+/// Whether the branch menu's "Merge into current branch…" row is live, and if not, the real
+/// reason - rendered *on the row itself*, dimmed and un-clickable, never a silent no-op (GitHub
+/// issue #241; `design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md` §1 rule 3: "disabled
+/// while anything is uncommitted, with the reason on the button itself").
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum GraphBranchMergeGate {
+    /// Every precondition holds. `current_branch` is the branch the merge would land in - the
+    /// row's own sub-label when it is live, so the row always names its real target.
+    Ready { current_branch: String },
+    /// A real, user-facing reason this merge cannot run right now.
+    Blocked(String),
+}
+
+impl GraphBranchMergeGate {
+    pub(crate) fn is_ready(&self) -> bool {
+        matches!(self, GraphBranchMergeGate::Ready { .. })
+    }
+
+    /// The reason string for a blocked gate - `None` when ready, so a caller can never render a
+    /// reason next to a live control.
+    pub(crate) fn reason(&self) -> Option<&str> {
+        match self {
+            GraphBranchMergeGate::Ready { .. } => None,
+            GraphBranchMergeGate::Blocked(reason) => Some(reason.as_str()),
+        }
+    }
+
+    /// The row's sub-label: the real target branch while live, the real reason while blocked.
+    /// One function so the two can never be rendered together or swapped by accident.
+    pub(crate) fn sub_label(&self) -> String {
+        match self {
+            GraphBranchMergeGate::Ready { current_branch } => current_branch.clone(),
+            GraphBranchMergeGate::Blocked(reason) => reason.clone(),
+        }
+    }
+}
+
+/// The one place the graph decides whether "Merge into current branch…" may run (GitHub issue
+/// #241).
+///
+/// The two *content* preconditions and their exact wording come straight from the design's own
+/// `mergeReady`/`mergeWhy` (`design_handoff_jerry_ade/revision 5/Jerry.dc.html`):
+/// `!uncommitted.length && !liveAgents.length`, reported as `N files still uncommitted` /
+/// `N agents still working`. The structural ones ahead of them are this app's own: they describe
+/// states in which `wt_core::merge::attempt_merge_into_current` could not do anything meaningful
+/// at all, and each mirrors a real `wt_core::Error` variant that function would otherwise return
+/// only *after* the user clicked (`MergeTargetDetached`, `MergeSourceIsCurrentBranch`,
+/// `MergeTargetDirty`) - checked here so the reason is visible on the row instead of arriving as
+/// an error in the resolver.
+///
+/// Order is deliberate: a structurally impossible merge outranks a merely blocked one, because
+/// "3 files still uncommitted" on a detached `HEAD` would imply that committing them is enough to
+/// unblock it, which is false.
+///
+/// Every reason is kept short enough to render *whole* in the row's sub-label at
+/// [`theme::graph::BRANCH_MENU_WIDTH`] - a truncated reason ("2 files still uncom…") is not a
+/// reason. The design's own two are already short; this app's own structural ones were shortened
+/// to match after measuring the real painted row, and that width was widened for the same reason
+/// (see its own docs).
+///
+/// This is a *pre-flight* gate, not the authority: `wt_core::merge` re-checks the detached-`HEAD`,
+/// same-branch and dirty-worktree preconditions against git's own ground truth immediately before
+/// running `git merge`, so a fact that goes stale between the render and the click (a background
+/// `load_diff`, an agent waking up, a file written under the worktree) can only ever cost an
+/// honest refusal in the resolver - never a merge this gate would have blocked.
+pub(crate) fn graph_branch_merge_gate(facts: &GraphBranchMergeFacts) -> GraphBranchMergeGate {
+    let Some(current_branch) = facts.current_branch.clone() else {
+        return GraphBranchMergeGate::Blocked(
+            "detached HEAD \u{2013} no current branch".to_string(),
+        );
+    };
+    if current_branch == facts.source_branch {
+        return GraphBranchMergeGate::Blocked(format!("already on {current_branch}"));
+    }
+    if facts.merge_already_running {
+        return GraphBranchMergeGate::Blocked("a merge is already running".to_string());
+    }
+    if facts.uncommitted_files > 0 {
+        return GraphBranchMergeGate::Blocked(format!(
+            "{} still uncommitted",
+            plural::count(facts.uncommitted_files, "file", None)
+        ));
+    }
+    if facts.live_agents > 0 {
+        return GraphBranchMergeGate::Blocked(format!(
+            "{} still working",
+            plural::count(facts.live_agents, "agent", None)
+        ));
+    }
+    if !facts.has_agent_tab {
+        // The conflict resolver this action hands off to renders inside an agent's own work
+        // surface (`crate::merge::render::AdeApp::render_merge_flow_surface` takes an `&Agent`,
+        // reached only from `crate::work_surface::render`'s active-agent branch), so a worktree
+        // with no agent tab at all has nowhere to show a conflicted merge. Refusing up front is
+        // the honest reading of that: the alternative is starting a merge whose conflicts would be
+        // invisible.
+        return GraphBranchMergeGate::Blocked("no agent tab to show the merge".to_string());
+    }
+    GraphBranchMergeGate::Ready { current_branch }
 }
 
 /// The graph tab's own UI state: what's loaded, which scope/panel is selected, and the row `⋯`/
@@ -359,6 +494,164 @@ pub(crate) fn relative_time(commit_unix_seconds: i64, now_unix_seconds: i64) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A fully-mergeable set of facts - every test below changes exactly one field, so a failure
+    /// names the one precondition it is about rather than a whole hand-built struct.
+    fn ready_merge_facts() -> GraphBranchMergeFacts {
+        GraphBranchMergeFacts {
+            current_branch: Some("main".to_string()),
+            source_branch: "feature".to_string(),
+            uncommitted_files: 0,
+            live_agents: 0,
+            has_agent_tab: true,
+            merge_already_running: false,
+        }
+    }
+
+    #[test]
+    fn merge_gate_is_ready_and_names_the_branch_it_would_merge_into() {
+        let gate = graph_branch_merge_gate(&ready_merge_facts());
+        assert_eq!(
+            gate,
+            GraphBranchMergeGate::Ready {
+                current_branch: "main".to_string()
+            }
+        );
+        assert!(gate.is_ready());
+        assert_eq!(
+            gate.reason(),
+            None,
+            "a live control must never carry a blocked reason"
+        );
+        assert_eq!(
+            gate.sub_label(),
+            "main",
+            "the live row's sub-label names its real target branch"
+        );
+    }
+
+    #[test]
+    fn merge_gate_blocks_a_detached_head_because_there_is_no_branch_to_merge_into() {
+        let facts = GraphBranchMergeFacts {
+            current_branch: None,
+            ..ready_merge_facts()
+        };
+        let gate = graph_branch_merge_gate(&facts);
+        assert!(!gate.is_ready());
+        assert_eq!(
+            gate.reason(),
+            Some("detached HEAD \u{2013} no current branch")
+        );
+        assert_eq!(gate.sub_label(), "detached HEAD \u{2013} no current branch");
+    }
+
+    #[test]
+    fn merge_gate_blocks_merging_a_branch_into_itself() {
+        let facts = GraphBranchMergeFacts {
+            source_branch: "main".to_string(),
+            ..ready_merge_facts()
+        };
+        assert_eq!(
+            graph_branch_merge_gate(&facts).reason(),
+            Some("already on main")
+        );
+    }
+
+    #[test]
+    fn merge_gate_blocks_while_another_merge_is_already_running() {
+        let facts = GraphBranchMergeFacts {
+            merge_already_running: true,
+            ..ready_merge_facts()
+        };
+        assert_eq!(
+            graph_branch_merge_gate(&facts).reason(),
+            Some("a merge is already running")
+        );
+    }
+
+    #[test]
+    fn merge_gate_blocks_on_uncommitted_files_in_the_designs_own_wording() {
+        // The design's own `mergeWhy`: `this.n(uncommitted.length, 'file') + ' still uncommitted'`.
+        let one = GraphBranchMergeFacts {
+            uncommitted_files: 1,
+            ..ready_merge_facts()
+        };
+        assert_eq!(
+            graph_branch_merge_gate(&one).reason(),
+            Some("1 file still uncommitted")
+        );
+        let many = GraphBranchMergeFacts {
+            uncommitted_files: 3,
+            ..ready_merge_facts()
+        };
+        assert_eq!(
+            graph_branch_merge_gate(&many).reason(),
+            Some("3 files still uncommitted")
+        );
+    }
+
+    #[test]
+    fn merge_gate_blocks_on_live_agents_in_the_designs_own_wording() {
+        // The design's own `mergeWhy`: `this.n(liveAgents.length, 'agent') + ' still working'`.
+        let one = GraphBranchMergeFacts {
+            live_agents: 1,
+            ..ready_merge_facts()
+        };
+        assert_eq!(
+            graph_branch_merge_gate(&one).reason(),
+            Some("1 agent still working")
+        );
+        let many = GraphBranchMergeFacts {
+            live_agents: 2,
+            ..ready_merge_facts()
+        };
+        assert_eq!(
+            graph_branch_merge_gate(&many).reason(),
+            Some("2 agents still working")
+        );
+    }
+
+    #[test]
+    fn merge_gate_blocks_when_there_is_no_agent_tab_to_show_a_conflict_in() {
+        let facts = GraphBranchMergeFacts {
+            has_agent_tab: false,
+            ..ready_merge_facts()
+        };
+        assert_eq!(
+            graph_branch_merge_gate(&facts).reason(),
+            Some("no agent tab to show the merge")
+        );
+    }
+
+    #[test]
+    fn merge_gate_reports_the_structural_refusal_first_when_several_hold_at_once() {
+        // A detached HEAD with uncommitted files must not claim that committing them unblocks the
+        // merge - it does not.
+        let facts = GraphBranchMergeFacts {
+            current_branch: None,
+            uncommitted_files: 3,
+            live_agents: 2,
+            has_agent_tab: false,
+            merge_already_running: true,
+            ..ready_merge_facts()
+        };
+        assert_eq!(
+            graph_branch_merge_gate(&facts).reason(),
+            Some("detached HEAD \u{2013} no current branch")
+        );
+
+        // Uncommitted files outrank live agents: committing is the first thing to do, and the
+        // agents may well be what is about to commit them.
+        let dirty_and_busy = GraphBranchMergeFacts {
+            uncommitted_files: 1,
+            live_agents: 1,
+            ..ready_merge_facts()
+        };
+        assert_eq!(
+            graph_branch_merge_gate(&dirty_and_busy).reason(),
+            Some("1 file still uncommitted")
+        );
+    }
 
     #[test]
     fn relative_time_formats_each_bucket() {

--- a/crates/app/src/merge/flow.rs
+++ b/crates/app/src/merge/flow.rs
@@ -163,17 +163,21 @@ impl AdeApp {
     /// is shown in - and every agent this picks between shares that one worktree by construction
     /// (`Agents::iter_for_cwd`).
     ///
-    /// Two real refusals, both reported honestly through the graph tab's own status line rather
-    /// than silently dropped:
-    /// - a merge flow is already in progress (two concurrent `git merge` invocations would race
-    ///   over the same worktree - the same single-flight rule [`Self::start_merge`] applies);
-    /// - the focused worktree has no agent tab at all, so there is genuinely nowhere to show the
-    ///   resolver. Nothing is started in that case; no merge is left half-run.
+    /// Every precondition is [`crate::graph_view::graph_branch_merge_gate`]'s - the *same* pure
+    /// gate the row that was just clicked rendered itself from, so what the row said and what this
+    /// does can never disagree. Re-checked here rather than trusted from that render: the frame
+    /// that drew a live row and the click that lands on it are separate frames, and a background
+    /// `load_diff`, an agent waking up, or another merge starting in between can genuinely
+    /// invalidate it - the same "re-check rather than trust a UI-level belief" discipline
+    /// `wt_core::merge::complete_merge` already applies one layer down. A gate that refuses is
+    /// reported on the graph tab's own status line with the very string the row was showing, never
+    /// silently dropped.
     ///
-    /// Everything else - a detached `HEAD`, a dirty worktree, merging a branch into itself, a
-    /// branch that doesn't exist - is `wt_core::merge`'s own precondition to refuse, and surfaces
-    /// as a real [`merge::MergeFlowState::Error`] in the resolver with git's (or that module's)
-    /// own real message.
+    /// The gate is a pre-flight, not the authority: `wt_core::merge::attempt_merge_into_current`
+    /// re-checks the detached-`HEAD`, same-branch and dirty-worktree preconditions against git's
+    /// own ground truth, and a branch that doesn't exist is git's own refusal. Each surfaces as a
+    /// real [`merge::MergeFlowState::Error`] in the resolver with that module's (or git's) own real
+    /// message.
     pub(crate) fn start_merge_from_graph_branch(
         &mut self,
         source_branch: String,
@@ -182,9 +186,11 @@ impl AdeApp {
     ) {
         self.graph_state.branch_menu_open = None;
         self.graph_state.delete_branch_confirm_armed = None;
-        if self.merge_flow.is_some() {
-            self.graph_state.status_message =
-                Some("a merge is already in progress; finish or abort it first".to_string());
+        let gate = crate::graph_view::graph_branch_merge_gate(
+            &self.graph_branch_merge_facts(source_branch.clone(), cx),
+        );
+        if let Some(reason) = gate.reason() {
+            self.graph_state.status_message = Some(reason.to_string());
             cx.notify();
             return;
         }
@@ -194,10 +200,9 @@ impl AdeApp {
             .map(|agent| agent.id)
             .next()
         else {
-            self.graph_state.status_message = Some(
-                "this worktree has no agent tab to show the merge in; open one first".to_string(),
-            );
-            cx.notify();
+            // Unreachable while the gate above returned `Ready` (its `has_agent_tab` is derived
+            // from this same iterator), handled rather than `expect`ed - never a panic for a state
+            // a background agent-close could genuinely change out from under this.
             return;
         };
 

--- a/crates/app/src/merge/render.rs
+++ b/crates/app/src/merge/render.rs
@@ -418,12 +418,22 @@ impl AdeApp {
         // (the File/Diff views included) instead of a merge-view-specific override, and gets
         // both columns to the same real legibility - neither has text sitting on a color wash.
         let (agent_fg, _) = work_surface::agent_tint(agent.kind);
-        let agent_branch = self
-            .worktrees
-            .iter()
-            .find(|item| item.path == agent.cwd)
-            .and_then(|item| item.branch.clone())
-            .unwrap_or_else(|| hunk.theirs_label.clone());
+        // The incoming side's real branch, taken from git's own conflict marker
+        // (`>>>>>>> <branch>`) rather than from the agent's worktree (GitHub issue #241).
+        //
+        // Looking it up by `agent.cwd` was right only while every merge went the one direction the
+        // context bar's `Merge` button starts - the agent's own branch into the base - where the
+        // agent's worktree branch and git's `theirs` label are the same string. The graph Branches
+        // panel's "Merge into current branch…" merges an arbitrary branch *into* the focused
+        // worktree, so that lookup returned the focused worktree's branch: the **target**, printed
+        // on the **incoming** column. Live-reproduced in a real X11 build merging `conflict-x` into
+        // `main` - both columns read `main`, on the one screen whose whole job is telling the two
+        // sides apart before the user picks one.
+        //
+        // `theirs_label` is git's own answer for both directions (`git merge <branch>` writes
+        // `<branch>` into the marker), so this is strictly more accurate than what it replaces,
+        // never merely different.
+        let incoming_branch = hunk.theirs_label.clone();
 
         let rem_px = self.effective_code_rem_px();
         let (ours_rendered, theirs_rendered): (
@@ -615,7 +625,7 @@ impl AdeApp {
                     .child(column(
                         "theirs",
                         agent.kind.label().to_string(),
-                        agent_branch,
+                        incoming_branch,
                         &hunk.theirs,
                         theirs_rendered,
                         hunk.theirs_start_line,

--- a/crates/app/src/theme.rs
+++ b/crates/app/src/theme.rs
@@ -3203,10 +3203,20 @@ pub mod graph {
     /// degrades safely either way (it still keeps the menu on-screen, just not pixel-perfectly
     /// flush with the edge), so this has been left as a known imprecision rather than a blocker.
     pub const ROW_MENU_HEIGHT: Pixels = px(425.0);
-    /// The Branches panel's own branch right-click context menu width (GitHub issue #241) - the
-    /// same 330 as [`ROW_MENU_WIDTH`], since it is the same kind of popover with the same kind of
-    /// rows, just anchored off a branch row instead of a commit row.
-    pub const BRANCH_MENU_WIDTH: Pixels = px(330.0);
+    /// The Branches panel's own branch right-click context menu width (GitHub issue #241).
+    ///
+    /// Deliberately **wider** than [`ROW_MENU_WIDTH`]'s design-specified 330 (§4's "a 330-wide
+    /// context menu" is that menu's own number, for its own short verbs), because this menu's rows
+    /// genuinely need more room and were measurably losing text at 330 in a real running build:
+    /// its labels are whole sentences (`Rebase current branch on Branch…`) and its sub-labels carry
+    /// real explanations rather than a sha - `Delete Branch…`'s own "refused if it has unmerged
+    /// commits" was already truncating to "…unmerged co…" before anything was added to this menu,
+    /// and `Merge into current branch…`'s blocked reason (`graph_branch_merge_gate`) has to be
+    /// *readable* to do its job at all: a reason clipped to "2 files still uncom…" is a rule
+    /// (REVISION-2026-08-14.md §1 rule 3, "the reason on the button itself") only half kept.
+    /// Measured against the longest real label+reason pair this menu can produce, in a real X11
+    /// build, not calculated from font metrics.
+    pub const BRANCH_MENU_WIDTH: Pixels = px(400.0);
     /// The branch context menu's painted height under the test suite's `gpui::TestAppContext` -
     /// pinned by `crate::graph_view::render::graph_branch_menu_tests::
     /// the_branch_menu_pins_the_real_height_this_edge_clamp_relies_on` for exactly the reasons


### PR DESCRIPTION
Closes #241.

## What was left

The merge scope of #241 landed in PR #310: the Branches panel's branch context menu has a real `Merge into current branch…` that runs `wt_core::merge::attempt_merge_into_current` in the **focused worktree** (the menu's own footer rule), completes a clean merge with the existing "Clean merge into `<base>`" wording, and hands a conflicted one to the **existing** resolver — no second conflict UI (REVISION-2026-08-12.md §1.8).

What it did not do was **say no in advance**. Every refusal arrived after the click: a dirty worktree came back as a `wt_core::Error::MergeTargetDirty` inside the resolver, and "agents still running/asking" was not checked at all. That is the issue's remaining checkbox:

> Preconditions surfaced where the action lives, with the reason on the disabled control (the same gating vocabulary the design used: uncommitted files present; agents still running/asking in that worktree) — never a silent no-op.

## The gate

`graph_branch_merge_gate` is a pure function of `GraphBranchMergeFacts` — the same state/render split `rail::state::prunable_worktree_paths` uses — so every precondition is unit-testable without a GPUI window.

Its two **content** preconditions and their exact wording are the design's own `mergeReady`/`mergeWhy` (revision 5 `Jerry.dc.html`): `!uncommitted.length && !liveAgents.length` → `N files still uncommitted` / `N agents still working`. Ahead of them sit three **structural** refusals, each mirroring a real `attempt_merge_into_current` error the click would otherwise have to discover (`MergeTargetDetached`, `MergeSourceIsCurrentBranch`, merge already running), and after them "no agent tab to show the merge" — the resolver renders inside an agent's work surface.

Order is deliberate: "3 files still uncommitted" on a detached HEAD would imply committing them unblocks the merge, which is false.

The row renders from that gate through `render_dropdown_menu_row`'s existing enabled/disabled contract — dimmed, reason in the sub-label in place of the target branch — and gets **no `on_click` at all** when blocked. `start_merge_from_graph_branch` re-checks the same gate rather than trusting the frame that drew the row, and reports the refusal with the very string the row was showing. It is a pre-flight, not the authority: `wt_core::merge` still re-checks against git itself immediately before merging.

## Three things the running app then showed

1. **The reason was unreadable.** At `BRANCH_MENU_WIDTH`'s 330 it truncated to `2 files still uncom…` — the rule half kept. Widened to 400 (measured in a real X11 build, not calculated) and this app's own structural reasons shortened to match; the design's two are untouched. `Delete Branch…`'s own sub-label, already truncating before this change, now fits too.
2. **The conflict resolver named the wrong branch.** Its incoming column took the branch from the *agent's worktree* — correct only for the direction the context bar's Merge button starts. Merging an arbitrary branch *into* the focused worktree made **both columns read `main`**, on the one screen whose job is telling the two sides apart. It now uses git's own `theirs_label` from the conflict marker, correct for both directions. Live-reproduced before and after.
3. **Silent dead clicks.** Every graph action's single-flight guard returned without a word. They now report it on the same status line every other outcome uses, without dismissing the menu or disarming a confirmation the user still means to repeat.

Also corrects three doc comments still describing phase (a) — the toolbar's Fetch/Pull/Push, the Push menu and the row menu's mutating entries are all real now, and one of them named a function that no longer exists.

## Tests

- 8 unit tests over the gate: every branch, both plural forms, and the precedence between a structural and a content refusal.
- 4 `#[gpui::test]`s against real git repositories: a dirty worktree's row painted and **clicked for real**, proven to start nothing and say nothing; the same for a branch already checked out; the facts read off real app state including a real in-flight merge; and the existing conflict test extended to pin the two strings the resolver's columns carry.
- Both new render tests mutation-tested (forcing the row enabled fails them), as was the action's own re-check.

## Verification

`cargo build --workspace`, `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets` all clean. `cargo test -p wt-core` 290/290. `cargo test -p app --lib` 2791 pass / 16 fail — all 16 the known inotify-contention set (`worktree_watch`, `file_tree_watch`, `repo_list_tests`, the rust-analyzer wiring test), each re-run green in isolation once a parallel agent's test binary released its 107 inotify instances.

Driven end to end in a real X11 build: blocked row with its full reason, live row naming its target, a real clean merge through `Complete merge` to a real merge commit, and a real conflicted merge through the existing resolver's `Take right` to a real merge commit holding the resolved content.

## Issue checkbox status

- Merge action reachable from the graph — #310.
- Preconditions on the disabled control — **this PR**.
- Clean merge with the existing wording; conflict to the existing resolver — #310, verified for real here.
- Runs in the focused worktree, never the main checkout — #310.
- `Start agent from this commit` — removed in #310, per the issue's own "wire it, or remove the row until it works".
- `Rebase onto this commit` — verified and moved onto the #242 engine in #310.
- Sweep for rendered-but-inert entries — done here (the dead clicks and the stale docs); an audit of both menus, the toolbar and the panels found every remaining control really wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)