### PR TITLE
Terminal: wire up mouse-wheel/PageUp scrollback

### DIFF
--- a/crates/app/src/code_surface/diff_view.rs
+++ b/crates/app/src/code_surface/diff_view.rs
@@ -7,6 +7,7 @@ use crate::review_notes::{NoteAnchor, NoteMark};
 #[cfg(test)]
 use crate::root::focus::palette_focus_tests;
 use crate::root::plural;
+use crate::root::scrollbar;
 use crate::root::widgets::render_sidebar_message;
 use std::rc::Rc;
 
@@ -656,7 +657,7 @@ impl AdeApp {
             .flex_1()
             .min_h_0()
             .child(content)
-            .children(self.render_vertical_scrollbar(
+            .children(scrollbar::render_vertical_scrollbar(
                 surface.scrollbar_id(),
                 surface.scroll_handle(self),
                 &[],

--- a/crates/app/src/code_surface/file_view.rs
+++ b/crates/app/src/code_surface/file_view.rs
@@ -11,6 +11,7 @@ use crate::lsp::client::{lsp_file_status, LspFileStatus};
 #[cfg(test)]
 use crate::root::focus::palette_focus_tests;
 use crate::root::plural;
+use crate::root::scrollbar;
 use crate::root::widgets::render_sidebar_message;
 use std::collections::HashSet;
 
@@ -867,7 +868,7 @@ impl AdeApp {
             .flex_1()
             .min_h_0()
             .child(code)
-            .children(self.render_vertical_scrollbar(
+            .children(scrollbar::render_vertical_scrollbar(
                 "file-view-scrollbar",
                 &self.file_view_scroll_handle,
                 &marks,

--- a/crates/app/src/code_surface/lsp_ui.rs
+++ b/crates/app/src/code_surface/lsp_ui.rs
@@ -10,6 +10,7 @@ use super::*;
 use crate::lsp::client::LspClientState;
 #[cfg(test)]
 use crate::root::focus::palette_focus_tests;
+use crate::root::scrollbar;
 use crate::root::widgets::render_keycap;
 use std::time::Duration;
 
@@ -1339,7 +1340,7 @@ impl AdeApp {
                         .flex_1()
                         .min_h_0()
                         .child(scroll_body)
-                        .children(self.render_vertical_scrollbar(
+                        .children(scrollbar::render_vertical_scrollbar(
                             "hover-card-scrollbar",
                             &self.hover_card_scroll_handle,
                             &[],

--- a/crates/app/src/code_surface/markdown_preview.rs
+++ b/crates/app/src/code_surface/markdown_preview.rs
@@ -519,6 +519,7 @@ use gpui::{
 
 use super::code_view;
 use super::zoom::zoom_scoped;
+use crate::root::scrollbar;
 use crate::root::AdeApp;
 use crate::theme;
 
@@ -589,7 +590,7 @@ impl AdeApp {
             .min_h_0()
             .bg(theme::surface::CENTER)
             .child(content)
-            .children(self.render_vertical_scrollbar(
+            .children(scrollbar::render_vertical_scrollbar(
                 "markdown-preview-scrollbar",
                 &self.markdown_preview_scroll_handle,
                 &[],

--- a/crates/app/src/graph_view/render.rs
+++ b/crates/app/src/graph_view/render.rs
@@ -4,6 +4,7 @@
 //! docs for scope.
 
 use super::*;
+use crate::root::scrollbar;
 use crate::root::widgets::{
     menu_popover_chrome, modal_scrim_bg, render_sidebar_message, render_status_letter, SimpleInput,
 };
@@ -1995,7 +1996,7 @@ impl AdeApp {
             .flex_1()
             .min_h_0()
             .child(list)
-            .children(self.render_vertical_scrollbar(
+            .children(scrollbar::render_vertical_scrollbar(
                 "graph-rows-scrollbar",
                 &self.graph_state.rows_scroll_handle,
                 &[],
@@ -2972,7 +2973,7 @@ impl AdeApp {
             .flex_1()
             .min_h_0()
             .child(panel)
-            .children(self.render_vertical_scrollbar(
+            .children(scrollbar::render_vertical_scrollbar(
                 "graph-commit-panel-scrollbar",
                 &self.graph_state.commit_panel_scroll_handle,
                 &[],
@@ -3030,7 +3031,7 @@ impl AdeApp {
                             })),
                     )
                     // GitHub issue #142.
-                    .children(self.render_vertical_scrollbar(
+                    .children(scrollbar::render_vertical_scrollbar(
                         "graph-branches-scrollbar",
                         &self.graph_state.branches_scroll_handle,
                         &[],

--- a/crates/app/src/lsp/completion_popup.rs
+++ b/crates/app/src/lsp/completion_popup.rs
@@ -51,6 +51,7 @@ use crate::code_surface::code_view;
 use crate::code_surface::edit_buffer::EditBuffer;
 use crate::keymap;
 use crate::lsp::completion as completion_view;
+use crate::root::scrollbar;
 use crate::root::widgets::{render_hint_pair, render_hint_row};
 use crate::theme;
 use gpui::{BoxShadow, EntityInputHandler};
@@ -836,7 +837,7 @@ impl AdeApp {
                         // regardless of how tall the detail pane makes the row.
                         .flex_1()
                         .child(list)
-                        .children(self.render_vertical_scrollbar(
+                        .children(scrollbar::render_vertical_scrollbar(
                             "completions-scrollbar",
                             &self.completions_scroll_handle,
                             &[],
@@ -1214,7 +1215,7 @@ impl AdeApp {
                 .flex_1()
                 .min_h_0()
                 .child(scroll_body)
-                .children(self.render_vertical_scrollbar(
+                .children(scrollbar::render_vertical_scrollbar(
                     "completions-detail-scrollbar",
                     &self.completions_detail_scroll_handle,
                     &[],

--- a/crates/app/src/merge/editing.rs
+++ b/crates/app/src/merge/editing.rs
@@ -46,6 +46,7 @@ use gpui::{canvas, fill, point, Bounds, ElementInputHandler, Entity, TextRun};
 use super::*;
 use crate::code_surface::editing::split_runs_for_marked_range;
 use crate::code_surface::zoom::zoom_scoped;
+use crate::root::scrollbar;
 use crate::settings::store as settings_store;
 
 impl AdeApp {
@@ -287,7 +288,7 @@ impl AdeApp {
                     .flex_1()
                     .min_h_0()
                     .child(code)
-                    .children(self.render_vertical_scrollbar(
+                    .children(scrollbar::render_vertical_scrollbar(
                         "merge-edit-scrollbar",
                         &self.merge_edit_scroll_handle,
                         &[],

--- a/crates/app/src/palette/render.rs
+++ b/crates/app/src/palette/render.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::root::plural;
+use crate::root::scrollbar;
 use crate::root::widgets::{render_hint_pair, render_hint_row, render_keycap_row, KeycapSize};
 use crate::settings::widgets::ChoiceOption;
 use crate::sidebar::render::RightSidebarView;
@@ -962,7 +963,7 @@ impl AdeApp {
             .flex_1()
             .min_h_0()
             .child(container)
-            .children(self.render_vertical_scrollbar(
+            .children(scrollbar::render_vertical_scrollbar(
                 "palette-results-scrollbar",
                 &self.palette_results_scroll_handle,
                 &[],

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::root::plural;
+use crate::root::scrollbar;
 use crate::root::widgets::{render_disclosure_caret, text_tooltip, SimpleInput};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -851,7 +852,7 @@ impl AdeApp {
                             .track_scroll(&self.rail_scroll_handle)
                             .child(self.render_sidebar_body(view, &groups, &problems, cx)),
                     )
-                    .children(self.render_vertical_scrollbar(
+                    .children(scrollbar::render_vertical_scrollbar(
                         "rail-scrollbar",
                         &self.rail_scroll_handle,
                         &[],

--- a/crates/app/src/root/scrollbar.rs
+++ b/crates/app/src/root/scrollbar.rs
@@ -262,13 +262,14 @@ impl gpui::Render for ScrollbarDrag {
 /// A free function generic over `Context<T>` rather than an `AdeApp` method (GitHub issue
 /// #331): every call site until that issue happened to be a method on `AdeApp` itself, so it
 /// was originally written as one, taking an unused `&self` purely to be callable as
-/// `scrollbar::render_vertical_scrollbar(...)` from those sites. `crate::terminal::pane::
-/// TerminalPane` is a genuinely separate `Entity<TerminalPane>` with its own `Context<TerminalPane>`
-/// - it has no `AdeApp` to call this through - and the body never actually touched `self` (both
-/// `cx.listener` closures below take `_this`, unused), so generalizing the signature is a real
-/// behavior-preserving mechanical change, not a rework: every existing `AdeApp` call site
-/// still type-checks unchanged (`T` is inferred from `cx`'s own type), just spelled as a plain
-/// function call instead of a method call.
+/// `self.render_vertical_scrollbar(...)` from those sites. `crate::terminal::pane::
+/// TerminalPane` is a genuinely separate `Entity<TerminalPane>` with its own
+/// `Context<TerminalPane>`, with no `AdeApp` to call this through, and the body never actually
+/// touched `self` (both `cx.listener` closures below take `_this`, unused), so generalizing the
+/// signature is a real behavior-preserving mechanical change, not a rework: every existing
+/// `AdeApp` call site still type-checks unchanged (`T` is inferred from `cx`'s own type), just
+/// spelled as a plain function call (`scrollbar::render_vertical_scrollbar(...)`) instead of a
+/// method call.
 pub(crate) fn render_vertical_scrollbar<T: 'static, H: ScrollableHandle>(
     id: &'static str,
     handle: &H,

--- a/crates/app/src/root/scrollbar.rs
+++ b/crates/app/src/root/scrollbar.rs
@@ -253,133 +253,141 @@ impl gpui::Render for ScrollbarDrag {
     }
 }
 
-impl AdeApp {
-    /// A real vertical overlay scrollbar for `handle`'s region - `None` when the region doesn't
-    /// currently overflow vertically (nothing to draw, nothing to hit-test). `id` must be a
-    /// literal unique to this call site (see this module's own docs on why `on_drag_move`
-    /// dispatch needs it). `marks` are the editor's real decoration ticks (empty for every other
-    /// region - see [`ScrollbarMark`]'s own docs).
-    pub(crate) fn render_vertical_scrollbar<H: ScrollableHandle>(
-        &self,
-        id: &'static str,
-        handle: &H,
-        marks: &[ScrollbarMark],
-        cx: &mut Context<Self>,
-    ) -> Option<AnyElement> {
-        let bounds = handle.viewport_bounds();
-        let viewport = bounds.size.height.as_f32();
-        let max_offset = handle.max_scroll_offset().y.as_f32();
-        if viewport <= 0.0 || max_offset <= 0.5 {
-            return None;
-        }
-        let scrolled = (-handle.scroll_offset().y.as_f32()).clamp(0.0, max_offset);
-        let thumb_len = geometry::thumb_length(viewport, max_offset);
-        let thumb_top = geometry::thumb_position(viewport, max_offset, scrolled);
-
-        let jump_handle = handle.clone();
-        let drag_handle = handle.clone();
-
-        Some(
-            div()
-                .id(id)
-                // Test-only (a no-op outside test builds, like every other `debug_selector` in
-                // this codebase) - lets a real render test read the track's own painted bounds
-                // back with `VisualTestContext::debug_bounds` to assert genuine geometric
-                // clearance (see `crate::sidebar::render`'s tests), rather than trusting a
-                // padding value's *number* changed without proving what it actually clears.
-                .debug_selector(move || id.to_string())
-                .absolute()
-                .top_0()
-                .right_0()
-                .h_full()
-                .w(px(SCROLLBAR_SIZE))
-                .on_mouse_down(
-                    MouseButton::Left,
-                    cx.listener(move |_this, event: &MouseDownEvent, _window, cx| {
-                        let viewport = jump_handle.viewport_bounds().size.height.as_f32();
-                        let max_offset = jump_handle.max_scroll_offset().y.as_f32();
-                        let track_top = jump_handle.viewport_bounds().origin.y.as_f32();
-                        let new_scrolled = geometry::offset_for_pointer(
-                            viewport,
-                            max_offset,
-                            track_top,
-                            event.position.y.as_f32(),
-                        );
-                        let current = jump_handle.scroll_offset();
-                        jump_handle.set_scroll_offset(gpui::point(current.x, px(-new_scrolled)));
-                        cx.notify();
-                    }),
-                )
-                .children(marks.iter().map(|mark| {
-                    let top = (mark.fraction * viewport).clamp(0.0, (viewport - 2.0).max(0.0));
-                    div()
-                        .absolute()
-                        .top(px(top))
-                        .right_0()
-                        .w(px(SCROLLBAR_SIZE))
-                        .h(px(2.0))
-                        .bg(mark.color)
-                }))
-                .child(
-                    div()
-                        .id(format!("{id}-thumb"))
-                        .absolute()
-                        .top(px(thumb_top + THUMB_INSET))
-                        // STAGE-A-CHANGELOG.md §4p: the thumb carries "a 2px transparent border
-                        // and `background-clip:content-box` so it floats 2px clear of the edge".
-                        // Drawn directly rather than in CSS, that transparent border is simply an
-                        // inset on every edge - so the thumb is `WIDTH - 2 * INSET` wide and sits
-                        // `INSET` in from the track's own edges. The track keeps its full
-                        // `SCROLLBAR_SIZE` width and its own click-to-jump handler, so the region
-                        // the pointer can act on is unchanged; only the painted bar is slimmer.
-                        .right(theme::scrollbar::THUMB_INSET)
-                        .w(px(SCROLLBAR_SIZE - 2.0 * THUMB_INSET))
-                        .h(px(thumb_len - 2.0 * THUMB_INSET))
-                        .rounded(theme::scrollbar::THUMB_RADIUS)
-                        // Painted at full strength: §4p's `#2b3137` is already quieter than the
-                        // greys these values replaced, so the old opacity multiplier would land
-                        // somewhere the spec did not ask for.
-                        .bg(theme::scrollbar::THUMB)
-                        .hover(|el| el.bg(theme::scrollbar::THUMB_HOVER))
-                        .on_mouse_down(
-                            MouseButton::Left,
-                            cx.listener(|_this, _event: &MouseDownEvent, _window, cx| {
-                                // Swallows the mouse-down so it never also bubbles to the
-                                // track's own handler above and jumps the view right before
-                                // the drag below takes over - the same idiom
-                                // `crate::root::resize::AdeApp::render_resize_handle` uses for
-                                // its splitter.
-                                cx.stop_propagation();
-                            }),
-                        )
-                        .on_drag(ScrollbarDrag { id }, move |drag, _offset, _window, cx| {
-                            cx.new(|_| *drag)
-                        })
-                        .on_drag_move(cx.listener(
-                            move |_this, event: &DragMoveEvent<ScrollbarDrag>, _window, cx| {
-                                let drag = event.drag(cx);
-                                if drag.id != id {
-                                    return;
-                                }
-                                let viewport = drag_handle.viewport_bounds().size.height.as_f32();
-                                let max_offset = drag_handle.max_scroll_offset().y.as_f32();
-                                let track_top = drag_handle.viewport_bounds().origin.y.as_f32();
-                                let new_scrolled = geometry::offset_for_pointer(
-                                    viewport,
-                                    max_offset,
-                                    track_top,
-                                    event.event.position.y.as_f32(),
-                                );
-                                let current = drag_handle.scroll_offset();
-                                drag_handle
-                                    .set_scroll_offset(gpui::point(current.x, px(-new_scrolled)));
-                                cx.notify();
-                            },
-                        )),
-                )
-                .into_any_element(),
-        )
+/// A real vertical overlay scrollbar for `handle`'s region - `None` when the region doesn't
+/// currently overflow vertically (nothing to draw, nothing to hit-test). `id` must be a
+/// literal unique to this call site (see this module's own docs on why `on_drag_move`
+/// dispatch needs it). `marks` are the editor's real decoration ticks (empty for every other
+/// region - see [`ScrollbarMark`]'s own docs).
+///
+/// A free function generic over `Context<T>` rather than an `AdeApp` method (GitHub issue
+/// #331): every call site until that issue happened to be a method on `AdeApp` itself, so it
+/// was originally written as one, taking an unused `&self` purely to be callable as
+/// `scrollbar::render_vertical_scrollbar(...)` from those sites. `crate::terminal::pane::
+/// TerminalPane` is a genuinely separate `Entity<TerminalPane>` with its own `Context<TerminalPane>`
+/// - it has no `AdeApp` to call this through - and the body never actually touched `self` (both
+/// `cx.listener` closures below take `_this`, unused), so generalizing the signature is a real
+/// behavior-preserving mechanical change, not a rework: every existing `AdeApp` call site
+/// still type-checks unchanged (`T` is inferred from `cx`'s own type), just spelled as a plain
+/// function call instead of a method call.
+pub(crate) fn render_vertical_scrollbar<T: 'static, H: ScrollableHandle>(
+    id: &'static str,
+    handle: &H,
+    marks: &[ScrollbarMark],
+    cx: &mut Context<T>,
+) -> Option<AnyElement> {
+    let bounds = handle.viewport_bounds();
+    let viewport = bounds.size.height.as_f32();
+    let max_offset = handle.max_scroll_offset().y.as_f32();
+    if viewport <= 0.0 || max_offset <= 0.5 {
+        return None;
     }
+    let scrolled = (-handle.scroll_offset().y.as_f32()).clamp(0.0, max_offset);
+    let thumb_len = geometry::thumb_length(viewport, max_offset);
+    let thumb_top = geometry::thumb_position(viewport, max_offset, scrolled);
+
+    let jump_handle = handle.clone();
+    let drag_handle = handle.clone();
+
+    Some(
+        div()
+            .id(id)
+            // Test-only (a no-op outside test builds, like every other `debug_selector` in
+            // this codebase) - lets a real render test read the track's own painted bounds
+            // back with `VisualTestContext::debug_bounds` to assert genuine geometric
+            // clearance (see `crate::sidebar::render`'s tests), rather than trusting a
+            // padding value's *number* changed without proving what it actually clears.
+            .debug_selector(move || id.to_string())
+            .absolute()
+            .top_0()
+            .right_0()
+            .h_full()
+            .w(px(SCROLLBAR_SIZE))
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(move |_this, event: &MouseDownEvent, _window, cx| {
+                    let viewport = jump_handle.viewport_bounds().size.height.as_f32();
+                    let max_offset = jump_handle.max_scroll_offset().y.as_f32();
+                    let track_top = jump_handle.viewport_bounds().origin.y.as_f32();
+                    let new_scrolled = geometry::offset_for_pointer(
+                        viewport,
+                        max_offset,
+                        track_top,
+                        event.position.y.as_f32(),
+                    );
+                    let current = jump_handle.scroll_offset();
+                    jump_handle.set_scroll_offset(gpui::point(current.x, px(-new_scrolled)));
+                    cx.notify();
+                }),
+            )
+            .children(marks.iter().map(|mark| {
+                let top = (mark.fraction * viewport).clamp(0.0, (viewport - 2.0).max(0.0));
+                div()
+                    .absolute()
+                    .top(px(top))
+                    .right_0()
+                    .w(px(SCROLLBAR_SIZE))
+                    .h(px(2.0))
+                    .bg(mark.color)
+            }))
+            .child(
+                div()
+                    .id(format!("{id}-thumb"))
+                    .absolute()
+                    .top(px(thumb_top + THUMB_INSET))
+                    // STAGE-A-CHANGELOG.md §4p: the thumb carries "a 2px transparent border
+                    // and `background-clip:content-box` so it floats 2px clear of the edge".
+                    // Drawn directly rather than in CSS, that transparent border is simply an
+                    // inset on every edge - so the thumb is `WIDTH - 2 * INSET` wide and sits
+                    // `INSET` in from the track's own edges. The track keeps its full
+                    // `SCROLLBAR_SIZE` width and its own click-to-jump handler, so the region
+                    // the pointer can act on is unchanged; only the painted bar is slimmer.
+                    .right(theme::scrollbar::THUMB_INSET)
+                    .w(px(SCROLLBAR_SIZE - 2.0 * THUMB_INSET))
+                    .h(px(thumb_len - 2.0 * THUMB_INSET))
+                    .rounded(theme::scrollbar::THUMB_RADIUS)
+                    // Painted at full strength: §4p's `#2b3137` is already quieter than the
+                    // greys these values replaced, so the old opacity multiplier would land
+                    // somewhere the spec did not ask for.
+                    .bg(theme::scrollbar::THUMB)
+                    .hover(|el| el.bg(theme::scrollbar::THUMB_HOVER))
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(|_this, _event: &MouseDownEvent, _window, cx| {
+                            // Swallows the mouse-down so it never also bubbles to the
+                            // track's own handler above and jumps the view right before
+                            // the drag below takes over - the same idiom
+                            // `crate::root::resize::AdeApp::render_resize_handle` uses for
+                            // its splitter.
+                            cx.stop_propagation();
+                        }),
+                    )
+                    .on_drag(ScrollbarDrag { id }, move |drag, _offset, _window, cx| {
+                        cx.new(|_| *drag)
+                    })
+                    .on_drag_move(cx.listener(
+                        move |_this, event: &DragMoveEvent<ScrollbarDrag>, _window, cx| {
+                            let drag = event.drag(cx);
+                            if drag.id != id {
+                                return;
+                            }
+                            let viewport = drag_handle.viewport_bounds().size.height.as_f32();
+                            let max_offset = drag_handle.max_scroll_offset().y.as_f32();
+                            let track_top = drag_handle.viewport_bounds().origin.y.as_f32();
+                            let new_scrolled = geometry::offset_for_pointer(
+                                viewport,
+                                max_offset,
+                                track_top,
+                                event.event.position.y.as_f32(),
+                            );
+                            let current = drag_handle.scroll_offset();
+                            drag_handle
+                                .set_scroll_offset(gpui::point(current.x, px(-new_scrolled)));
+                            cx.notify();
+                        },
+                    )),
+            )
+            .into_any_element(),
+    )
 }
 
 /// Pins this module's plain-`f32` geometry constants to the design tokens they mirror.

--- a/crates/app/src/settings/render.rs
+++ b/crates/app/src/settings/render.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::root::plural;
+use crate::root::scrollbar;
 use crate::root::widgets::{
     hover_keycap_row, menu_popover_chrome, render_env_chip, render_keycap_row, KeycapSize,
     SimpleInput,
@@ -263,7 +264,7 @@ impl AdeApp {
                                 )
                             })),
                     )
-                    .children(self.render_vertical_scrollbar(
+                    .children(scrollbar::render_vertical_scrollbar(
                         "settings-nav-scrollbar",
                         &self.settings_nav_scroll_handle,
                         &[],
@@ -508,7 +509,7 @@ impl AdeApp {
                                     }),
                             ),
                     )
-                    .children(self.render_vertical_scrollbar(
+                    .children(scrollbar::render_vertical_scrollbar(
                         "settings-content-scrollbar",
                         &self.settings_content_scroll_handle,
                         &[],

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -912,7 +912,7 @@ impl AdeApp {
             .flex_1()
             .min_h_0()
             .child(list)
-            .children(self.render_vertical_scrollbar(
+            .children(scrollbar::render_vertical_scrollbar(
                 "file-tree-scrollbar",
                 &self.file_tree_scroll_handle,
                 &[],
@@ -2215,7 +2215,7 @@ impl AdeApp {
             .flex_1()
             .min_h_0()
             .child(list)
-            .children(self.render_vertical_scrollbar(
+            .children(scrollbar::render_vertical_scrollbar(
                 "changes-sections-scrollbar",
                 &self.changes_sections_list,
                 &[],

--- a/crates/app/src/terminal/grid.rs
+++ b/crates/app/src/terminal/grid.rs
@@ -35,12 +35,44 @@
 //!   `point.column` ranges `0..columns`) - not the whole scrollback. `Cell`'s real fields are
 //!   `c: char, fg: Color, bg: Color, flags: Flags, extra: ...` (`term/cell.rs:134`).
 //!
-//! ## Scope cut: no scrollback UI
+//! ## Scrollback (GitHub issue #331)
 //!
-//! `Term` retains scrollback history (`Config::scrolling_history`, default 10000 lines), but
-//! `display_iter` at `display_offset == 0` only ever exposes the live viewport -
-//! `Term::scroll_display` (mouse-wheel/PageUp scrolling into history) isn't wired up here. Not
-//! an oversight - a natural following step.
+//! `Term` retains scrollback history (`Config::scrolling_history`, default 10000 lines) - this
+//! used to go entirely unused: `display_iter` was only ever read at `display_offset == 0` (the
+//! live viewport), and nothing here ever called `Term::scroll_display`. [`TerminalGrid::
+//! scroll_display`] is the real fix: a thin wrapper over it, taking this module's own
+//! [`ScrollAmount`] rather than leaking `alacritty_terminal::grid::Scroll` across the module
+//! boundary (the same convention [`CellSide`]/[`CellPosition`] already follow).
+//! `crate::terminal::pane` drives it from a real `on_scroll_wheel` handler and PageUp/PageDown
+//! keys - see that module's own docs for the input side.
+//!
+//! `display_iter` itself needed no change for this: `Grid::display_iter` already yields
+//! `Indexed<Point>`s whose `point.line` is relative to the *viewport*, not the underlying grid -
+//! at `display_offset > 0` those points simply run negative for the (now-visible) history rows
+//! above the live screen. [`Self::visible_rows`] shifts every yielded `point.line` by the real
+//! `display_offset` (`RenderableContent::display_offset`, `Term`'s own field, never a second
+//! copy) before indexing into the row `Vec`, which is the one line that changed there - verified
+//! against the real, pinned rev's source at `grid/mod.rs:422-427`'s own `display_iter` doc
+//! comment ("Iterate over all visible cells").
+//!
+//! **Staying put when new output arrives while scrolled back** needs no bookkeeping here either:
+//! `alacritty_terminal`'s own `Grid::scroll_up` (the internal call every newline past the bottom
+//! row makes) already increments `display_offset` by the same number of lines the screen just
+//! scrolled by, *whenever* `display_offset != 0` (`grid/mod.rs:262-265`, verified against the
+//! pinned rev) - so a caller sitting in history keeps looking at the exact same historical lines
+//! as new output arrives underneath, rather than being yanked back to the live tail. This is the
+//! same convention every real terminal emulator (iTerm2, Alacritty itself, Windows Terminal)
+//! follows, and it falls out of not fighting `Term`'s own state rather than anything this module
+//! added.
+//!
+//! **The alt screen has no scrollback of its own.** `Term::swap_alt` (entering `vim`/`less`/an
+//! agent CLI's full-screen UI) swaps in a second `Grid` constructed with `history_size: 0`
+//! (`Term::new`, `term/mod.rs:412-413` - see this module's own "API surface" section above), so
+//! [`Self::scroll_history_len`] is naturally `0` there and [`Self::scroll_display`] is a
+//! real no-op: a mouse-wheel/PageUp that reaches a full-screen program does nothing to this
+//! app's own view, exactly as if scrollback genuinely didn't exist for the duration of the alt
+//! screen - no special-casing needed, since `alacritty_terminal`'s own `Scroll::Delta`/`PageUp`/
+//! `PageDown` clamp to `history_size()` internally (`grid/mod.rs:163-172`).
 //!
 //! ## Scope cut: no OSC 4/10/11 customization
 //!
@@ -108,7 +140,7 @@
 
 use crate::terminal::osc::{OscWatcher, Progress};
 use alacritty_terminal::event::{Event as AlacEvent, EventListener};
-use alacritty_terminal::grid::Dimensions;
+use alacritty_terminal::grid::{Dimensions, Scroll as AlacScroll};
 use alacritty_terminal::index::{Column, Line, Point as AlacPoint, Side};
 use alacritty_terminal::selection::{Selection, SelectionType};
 use alacritty_terminal::term::cell::{Cell as AlacCell, Flags};
@@ -298,12 +330,40 @@ pub struct CellPosition {
 }
 
 impl CellPosition {
-    /// Valid only while `display_offset == 0`, which is always the case here - this module
-    /// never calls `Term::scroll_display` (see the module docs' "no scrollback UI" scope cut),
-    /// so a viewport row index *is* the grid `Line` index.
-    fn to_alacritty(self) -> AlacPoint {
-        AlacPoint::new(Line(self.row as i32), Column(self.column))
+    /// `display_offset` is `Term`'s own current scroll position (GitHub issue #331 -
+    /// [`TerminalGrid::scroll_display`]'s docs), needed here because a viewport row index is
+    /// only ever the grid `Line` index at `display_offset == 0`: at any other offset the two
+    /// diverge by exactly that many lines, the same shift [`TerminalGrid::visible_rows`] applies
+    /// in the opposite direction when reading cells back out. Selecting text while scrolled back
+    /// therefore still anchors on the real historical line the pointer is over, not on
+    /// whatever's currently live at that same screen row.
+    fn to_alacritty(self, display_offset: usize) -> AlacPoint {
+        AlacPoint::new(
+            Line(self.row as i32 - display_offset as i32),
+            Column(self.column),
+        )
     }
+}
+
+/// How far, and by what unit, to move the viewport into (or back out of) retained scrollback
+/// history (GitHub issue #331) - [`TerminalGrid::scroll_display`]'s argument. Mirrors
+/// `alacritty_terminal::grid::Scroll` rather than re-exporting it, matching this module's
+/// [`CellSide`]/[`CellPosition`] convention of never leaking `alacritty_terminal` types across
+/// its own boundary into `crate::terminal::pane`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScrollAmount {
+    /// A relative move by `count` grid lines: positive scrolls up into history, negative scrolls
+    /// back down toward the live tail. What a mouse-wheel notch or an accumulated trackpad delta
+    /// becomes once `crate::terminal::pane` converts pixels to whole lines.
+    Lines(i32),
+    /// One screenful up into history - a `PageUp` keystroke.
+    PageUp,
+    /// One screenful back down toward the live tail - a `PageDown` keystroke.
+    PageDown,
+    /// All the way back to the oldest retained line.
+    Top,
+    /// All the way back to the live tail - the "jump to bottom" affordance.
+    Bottom,
 }
 
 /// Every real colour a terminal grid resolves against, already reduced to concrete RGB - the whole
@@ -616,18 +676,24 @@ impl TerminalGrid {
         let cursor_point =
             (content.cursor.shape != CursorShape::Hidden).then_some(content.cursor.point);
         let selection = content.selection;
+        // GitHub issue #331: `display_iter`'s own `point.line` is viewport-relative, running
+        // negative for history rows once `display_offset > 0` - see the module docs' scrollback
+        // section for why shifting by `display_offset` here is the one change scrolling needed.
+        let display_offset = content.display_offset as i32;
 
         let mut rows: Vec<Vec<GridCell>> = (0..self.size.rows)
             .map(|_| Vec::with_capacity(self.size.cols))
             .collect();
 
         for indexed in content.display_iter {
-            if indexed.point.line.0 < 0 {
-                // Shouldn't happen at `display_offset == 0` (see the module docs), but guard
-                // defensively rather than panicking on an unexpected negative index.
+            let line = indexed.point.line.0 + display_offset;
+            if line < 0 {
+                // Shouldn't happen - `display_iter` never yields more than `screen_lines` rows
+                // above the viewport top - but guard defensively rather than panicking on an
+                // unexpected negative index.
                 continue;
             }
-            let Some(row) = rows.get_mut(indexed.point.line.0 as usize) else {
+            let Some(row) = rows.get_mut(line as usize) else {
                 continue;
             };
             let is_cursor = cursor_point == Some(indexed.point);
@@ -643,6 +709,60 @@ impl TerminalGrid {
         rows
     }
 
+    // -------------------------------------------------------------- scrollback (issue #331)
+
+    /// Scrolls the viewport into (or back out of) retained scrollback history. A thin wrapper
+    /// over `Term::scroll_display` - see the module docs' scrollback section for why no
+    /// "don't yank the user back to the bottom while new output arrives" bookkeeping is needed
+    /// here: `alacritty_terminal`'s own `Grid::scroll_up` already keeps `display_offset` pinned
+    /// to the same historical lines whenever it isn't `0`.
+    pub fn scroll_display(&mut self, amount: ScrollAmount) {
+        let scroll = match amount {
+            ScrollAmount::Lines(count) => AlacScroll::Delta(count),
+            ScrollAmount::PageUp => AlacScroll::PageUp,
+            ScrollAmount::PageDown => AlacScroll::PageDown,
+            ScrollAmount::Top => AlacScroll::Top,
+            ScrollAmount::Bottom => AlacScroll::Bottom,
+        };
+        self.term.scroll_display(scroll);
+    }
+
+    /// Scrolls directly to an absolute `display_offset` (clamped to
+    /// `0..=Self::scroll_history_len`) - `crate::terminal::pane`'s scrollbar click/drag, which
+    /// already computes a target line count from where the pointer landed on the track rather
+    /// than a relative delta. Implemented as a `Delta` of the difference from
+    /// [`Self::scroll_offset`] so `alacritty_terminal`'s own clamping (`grid/mod.rs:163-172`)
+    /// stays the single place that enforces the valid range, rather than a second copy of it
+    /// here.
+    pub fn set_scroll_offset(&mut self, target: usize) {
+        // `target`/`Self::scroll_offset` are both bounded by real scrollback line counts (at
+        // most `Config::scrolling_history`, 10000, plus a screenful) - nowhere near overflowing
+        // an `i32` delta between them.
+        let delta = target as i32 - self.scroll_offset() as i32;
+        self.scroll_display(ScrollAmount::Lines(delta));
+    }
+
+    /// How many lines back into scrollback the viewport currently is - `0` means live (the
+    /// normal, unscrolled state), matching `Term`'s own `Grid::display_offset`. Read live, never
+    /// mirrored, so it can't drift from what [`Self::visible_rows`] actually painted.
+    pub fn scroll_offset(&self) -> usize {
+        self.term.grid().display_offset()
+    }
+
+    /// How many lines of real scrollback are currently retained - `0` on the alt screen (see the
+    /// module docs' alt-screen note), otherwise growing up to `Config::scrolling_history`
+    /// (10000) as output accumulates. Backs the scrollbar's `max_scroll_offset` and the
+    /// "is there anything to scroll to at all" checks.
+    pub fn scroll_history_len(&self) -> usize {
+        self.term.grid().history_size()
+    }
+
+    /// `true` once [`Self::scroll_offset`] is anything other than live - i.e. the pane is
+    /// genuinely showing scrollback rather than the live tail right now.
+    pub fn is_scrolled_back(&self) -> bool {
+        self.scroll_offset() > 0
+    }
+
     // ------------------------------------------------------------------ selection (issue #158)
 
     /// Anchors a new selection at `position`, discarding any previous one - what a real
@@ -651,9 +771,10 @@ impl TerminalGrid {
     /// `None` for it: a plain click therefore clears the selection rather than selecting one
     /// stray character, without this needing a "was it a drag?" flag of its own.
     pub fn start_selection(&mut self, position: CellPosition) {
+        let display_offset = self.scroll_offset();
         self.term.selection = Some(Selection::new(
             SelectionType::Simple,
-            position.to_alacritty(),
+            position.to_alacritty(display_offset),
             position.side.to_alacritty(),
         ));
     }
@@ -662,8 +783,12 @@ impl TerminalGrid {
     /// `selection.rs:133`) - what a real mouse-drag does. A no-op when nothing is anchored, so
     /// an ordinary hover can never conjure a selection out of nothing.
     pub fn update_selection(&mut self, position: CellPosition) {
+        let display_offset = self.scroll_offset();
         if let Some(selection) = self.term.selection.as_mut() {
-            selection.update(position.to_alacritty(), position.side.to_alacritty());
+            selection.update(
+                position.to_alacritty(display_offset),
+                position.side.to_alacritty(),
+            );
         }
     }
 
@@ -995,6 +1120,208 @@ mod tests {
         assert!(!grid.ended);
         grid.mark_ended();
         assert!(grid.ended);
+    }
+
+    /// Pushes `count` numbered lines (`"line 0\r\n"`, `"line 1\r\n"`, ...) through a real grid -
+    /// the shared fixture the scrollback tests below build on. Each line is short and
+    /// distinguishable by its own number, so a test can assert exactly which lines are on
+    /// screen at a given scroll position rather than just that *something* rendered.
+    fn grid_with_numbered_lines(rows: u16, cols: u16, count: usize) -> TerminalGrid {
+        let mut grid = TerminalGrid::new(rows, cols);
+        for i in 0..count {
+            grid.append_bytes(format!("line {i}\r\n").as_bytes());
+        }
+        grid
+    }
+
+    mod scrollback_tests {
+        use super::*;
+
+        /// The core of GitHub issue #331: scrolling up must actually reveal lines that were
+        /// pushed off the top of the visible screen into history, not just move a cursor over
+        /// the same five lines that were always on screen.
+        #[test]
+        fn scrolling_up_reveals_lines_pushed_into_history() {
+            // A 5-row screen, 30 lines written - the first 25 are pushed into scrollback, and
+            // the live viewport shows lines 25..30.
+            let mut grid = grid_with_numbered_lines(5, 20, 30);
+            assert_eq!(grid.scroll_offset(), 0, "sanity check: starts live");
+            assert_eq!(
+                row_text(&grid.visible_rows(&TerminalPalette::default())[0]).trim(),
+                "line 26"
+            );
+
+            // One page up (5 rows, matching the screen height) must reveal the five lines
+            // immediately above what was on screen.
+            grid.scroll_display(ScrollAmount::PageUp);
+            assert_eq!(grid.scroll_offset(), 5);
+            let rows = grid.visible_rows(&TerminalPalette::default());
+            assert_eq!(row_text(&rows[0]).trim(), "line 21");
+            assert_eq!(row_text(&rows[4]).trim(), "line 25");
+        }
+
+        /// `Scroll::Top`/`Scroll::Bottom` reach the real extremes: the oldest retained line, and
+        /// back to the live tail - proof the whole retained history is really reachable, not
+        /// just the one page `PageUp` moves by.
+        #[test]
+        fn top_and_bottom_reach_the_real_extremes() {
+            let mut grid = grid_with_numbered_lines(5, 20, 30);
+
+            grid.scroll_display(ScrollAmount::Top);
+            assert_eq!(
+                grid.scroll_offset(),
+                grid.scroll_history_len(),
+                "Top must land exactly on the oldest retained line, not short of it"
+            );
+            assert_eq!(
+                row_text(&grid.visible_rows(&TerminalPalette::default())[0]).trim(),
+                "line 0"
+            );
+
+            grid.scroll_display(ScrollAmount::Bottom);
+            assert_eq!(grid.scroll_offset(), 0);
+            assert!(!grid.is_scrolled_back());
+            assert_eq!(
+                row_text(&grid.visible_rows(&TerminalPalette::default())[0]).trim(),
+                "line 26"
+            );
+        }
+
+        /// The real "stay put" behavior GitHub issue #331 asks for: new output arriving while
+        /// scrolled back must not yank the viewport back to the live tail - the same historical
+        /// lines stay on screen, only the retained-history count grows underneath. Exercised
+        /// through the exact same `TerminalGrid::append_bytes` path live pty output takes, not a
+        /// synthetic offset write - see the module docs' scrollback section for why this falls
+        /// out of `alacritty_terminal`'s own `Grid::scroll_up` rather than needing code here.
+        #[test]
+        fn new_output_while_scrolled_back_does_not_move_the_viewport() {
+            let mut grid = grid_with_numbered_lines(5, 20, 30);
+            grid.scroll_display(ScrollAmount::PageUp); // offset 5, viewing lines 20..25
+            let before = grid.visible_rows(&TerminalPalette::default());
+            assert_eq!(row_text(&before[0]).trim(), "line 21");
+
+            // Ten more lines of real output arrive - as if the shell kept printing while the
+            // human was scrolled back reading history.
+            for i in 30..40 {
+                grid.append_bytes(format!("line {i}\r\n").as_bytes());
+            }
+
+            let after = grid.visible_rows(&TerminalPalette::default());
+            assert_eq!(
+                row_text(&after[0]).trim(),
+                "line 21",
+                "new output while scrolled back must not move the viewport off the line the \
+                 user was looking at"
+            );
+            assert_eq!(row_text(&after[4]).trim(), "line 25");
+            assert!(
+                grid.is_scrolled_back(),
+                "must still genuinely be scrolled back, not silently reset to live"
+            );
+            assert!(
+                grid.scroll_history_len() > 30,
+                "the ten new lines must still have landed in real retained history underneath, \
+                 not been dropped: {}",
+                grid.scroll_history_len()
+            );
+        }
+
+        /// [`TerminalGrid::set_scroll_offset`] - the scrollbar's click/drag path, which computes
+        /// an absolute target line count from where the pointer landed rather than a relative
+        /// delta.
+        #[test]
+        fn set_scroll_offset_jumps_directly_to_an_absolute_target() {
+            let mut grid = grid_with_numbered_lines(5, 20, 30);
+            let history_len = grid.scroll_history_len();
+
+            grid.set_scroll_offset(history_len);
+            assert_eq!(grid.scroll_offset(), history_len);
+            assert_eq!(
+                row_text(&grid.visible_rows(&TerminalPalette::default())[0]).trim(),
+                "line 0"
+            );
+
+            grid.set_scroll_offset(0);
+            assert_eq!(grid.scroll_offset(), 0);
+            assert_eq!(
+                row_text(&grid.visible_rows(&TerminalPalette::default())[0]).trim(),
+                "line 26"
+            );
+        }
+
+        /// `ScrollAmount::Lines` must clamp at both ends rather than under/overflowing - `Delta`
+        /// past the top must stop at the oldest retained line, and a `Delta` back down past live
+        /// must stop at `0`, matching `alacritty_terminal`'s own real clamping.
+        #[test]
+        fn scroll_amount_lines_clamps_at_both_ends() {
+            let mut grid = grid_with_numbered_lines(5, 20, 30);
+            let history_len = grid.scroll_history_len();
+
+            grid.scroll_display(ScrollAmount::Lines(history_len as i32 + 1_000));
+            assert_eq!(grid.scroll_offset(), history_len);
+
+            grid.scroll_display(ScrollAmount::Lines(-1_000_000));
+            assert_eq!(grid.scroll_offset(), 0);
+        }
+
+        /// A selection anchored while scrolled back must land on the real historical cell the
+        /// pointer is over - not on whatever is currently live at that same on-screen row (the
+        /// bug the module docs' `CellPosition::to_alacritty` update exists to prevent).
+        #[test]
+        fn a_selection_anchored_while_scrolled_back_selects_the_real_historical_line() {
+            let mut grid = grid_with_numbered_lines(5, 20, 30);
+            grid.scroll_display(ScrollAmount::PageUp); // offset 5, viewing lines 20..25
+            assert_eq!(
+                row_text(&grid.visible_rows(&TerminalPalette::default())[0]).trim(),
+                "line 21"
+            );
+
+            // Select across the whole first on-screen row (viewport row 0 = the real "line 21").
+            grid.start_selection(CellPosition {
+                row: 0,
+                column: 0,
+                side: CellSide::Left,
+            });
+            grid.update_selection(CellPosition {
+                row: 0,
+                column: 6,
+                side: CellSide::Right,
+            });
+
+            assert_eq!(
+                grid.selected_text().as_deref().map(str::trim),
+                Some("line 21"),
+                "the selection must follow the real scrolled-to line, not whatever is live at \
+                 viewport row 0 right now (which is \"line 25\")"
+            );
+        }
+
+        /// The alt screen keeps no scrollback of its own (see the module docs) - entering it
+        /// (`\x1b[?1049h`, real `smcup`, what `vim`/`less`/full-screen agent CLIs send) must make
+        /// [`TerminalGrid::scroll_history_len`] genuinely `0`, and a scroll attempt while inside
+        /// it a real no-op rather than silently doing nothing for some other, wrong reason.
+        #[test]
+        fn the_alt_screen_reports_no_scrollback_and_a_scroll_attempt_is_a_real_no_op() {
+            let mut grid = grid_with_numbered_lines(5, 20, 30);
+            assert!(
+                grid.scroll_history_len() > 0,
+                "sanity check: real history exists first"
+            );
+
+            grid.append_bytes(b"\x1b[?1049h"); // enter the alt screen
+            assert_eq!(
+                grid.scroll_history_len(),
+                0,
+                "the alt screen's own grid must report zero scrollback"
+            );
+
+            grid.scroll_display(ScrollAmount::PageUp);
+            assert_eq!(
+                grid.scroll_offset(),
+                0,
+                "a scroll attempt on the alt screen must not move it into a history it doesn't have"
+            );
+        }
     }
 
     /// End-to-end through a genuinely spawned process on a real pty (via `pty_core::spawn`)

--- a/crates/app/src/terminal/pane.rs
+++ b/crates/app/src/terminal/pane.rs
@@ -79,18 +79,23 @@
 //! anything - and feeds a confirmed exit into the exact same `newly_exited`/`process_ended`
 //! state transition the unix EOF path already uses.
 
+use std::cell::RefCell;
 use std::path::{Path, PathBuf};
+use std::rc::Rc;
 use std::sync::mpsc::TryRecvError;
 use std::time::{Duration, Instant};
 
 use gpui::{
     canvas, div, font, prelude::*, px, rgb, BorderStyle, Bounds, ClickEvent, Context, EventEmitter,
-    FocusHandle, Focusable, FontWeight, KeyDownEvent, Keystroke, Pixels, Size, Task, Window,
+    FocusHandle, Focusable, FontWeight, KeyDownEvent, Keystroke, Pixels, ScrollWheelEvent, Size,
+    Task, Window,
 };
 use pty_core::{ExitStatus, PtyError, PtySession, SpawnOptions};
 
+use crate::root::scrollbar::{self, ScrollableHandle};
+use crate::root::widgets::text_tooltip;
 use crate::terminal::grid::{
-    CellPosition, CellSide, CellWidth, GridCell, TerminalGrid, TerminalPalette,
+    CellPosition, CellSide, CellWidth, GridCell, ScrollAmount, TerminalGrid, TerminalPalette,
 };
 use crate::terminal::links::{self as terminal_links, LinkMatch};
 use crate::terminal::osc::Progress;
@@ -569,6 +574,103 @@ mod shell_program_tests {
     }
 }
 
+/// Real GPUI scroll handle backing the terminal's own scrollback (GitHub issue #331) - the
+/// [`ScrollableHandle`] adapter that lets [`TerminalPane`] reuse the exact same shared overlay
+/// scrollbar every other scrollable region in this app uses
+/// (`crate::root::scrollbar::render_vertical_scrollbar`, see that module's own docs), even
+/// though the terminal's real scroll position is `alacritty_terminal::Term`'s line-based
+/// `display_offset` (`TerminalGrid::scroll_offset`), not a GPUI-native scrollable div's pixel
+/// offset.
+///
+/// `Rc<RefCell<..>>`, not owned data: [`ScrollableHandle::set_scroll_offset`] is called from the
+/// scrollbar's own `on_mouse_down`/`on_drag_move` closures, which only ever get a `.clone()` of
+/// this handle, never `&mut TerminalPane` - so a click/drag has to leave a real record somewhere
+/// the *next* [`TerminalPane::render`] can pick up and turn into a real
+/// `TerminalGrid::set_scroll_offset` call (see [`TerminalScrollState::requested_display_offset`]).
+/// The same `Rc`'d-interior-mutability idiom `crate::terminal::grid::TermEventSink` uses, for the
+/// same "the real callback signature only ever hands out `&self`" reason.
+#[derive(Clone)]
+struct TerminalScrollHandle(Rc<RefCell<TerminalScrollState>>);
+
+#[derive(Default)]
+struct TerminalScrollState {
+    viewport_bounds: Bounds<Pixels>,
+    row_height: Pixels,
+    history_len: usize,
+    display_offset: usize,
+    /// Set by [`ScrollableHandle::set_scroll_offset`] (a scrollbar click/drag); drained by
+    /// [`TerminalPane::render`] at the top of the next render and turned into a real
+    /// `TerminalGrid::set_scroll_offset` call.
+    requested_display_offset: Option<usize>,
+}
+
+impl TerminalScrollHandle {
+    fn new() -> Self {
+        Self(Rc::new(RefCell::new(TerminalScrollState::default())))
+    }
+
+    /// Pushes the grid's real current scroll state into the handle - called once per render,
+    /// before the scrollbar itself is built, so [`ScrollableHandle`]'s geometry methods answer
+    /// with this frame's real numbers rather than a stale previous frame's.
+    fn sync(
+        &self,
+        viewport_bounds: Bounds<Pixels>,
+        row_height: Pixels,
+        history_len: usize,
+        display_offset: usize,
+    ) {
+        let mut state = self.0.borrow_mut();
+        state.viewport_bounds = viewport_bounds;
+        state.row_height = row_height;
+        state.history_len = history_len;
+        state.display_offset = display_offset;
+    }
+
+    /// Drains a scrollbar-driven target display offset, if the user clicked or dragged the
+    /// thumb since the last render.
+    fn take_requested_display_offset(&self) -> Option<usize> {
+        self.0.borrow_mut().requested_display_offset.take()
+    }
+}
+
+impl ScrollableHandle for TerminalScrollHandle {
+    /// Lines-from-top, not `TerminalGrid::scroll_offset`'s own live-relative convention: `0` at
+    /// the *oldest* retained line (the top of the track) and [`TerminalScrollState::history_len`]
+    /// at the live tail (the bottom of the track) - matching `gpui::ScrollHandle`'s own "offset
+    /// grows toward the bottom of the content" convention, and what makes the scrollbar thumb
+    /// sit at the *bottom* of the track while live-following, exactly like every real terminal
+    /// emulator's own scrollbar.
+    fn viewport_bounds(&self) -> Bounds<Pixels> {
+        self.0.borrow().viewport_bounds
+    }
+
+    fn max_scroll_offset(&self) -> gpui::Point<Pixels> {
+        let state = self.0.borrow();
+        gpui::point(
+            px(0.0),
+            px(state.row_height.as_f32() * state.history_len as f32),
+        )
+    }
+
+    fn scroll_offset(&self) -> gpui::Point<Pixels> {
+        let state = self.0.borrow();
+        let lines_from_top = state.history_len.saturating_sub(state.display_offset) as f32;
+        gpui::point(px(0.0), px(-(state.row_height.as_f32() * lines_from_top)))
+    }
+
+    fn set_scroll_offset(&self, offset: gpui::Point<Pixels>) {
+        let mut state = self.0.borrow_mut();
+        let row_height = state.row_height.as_f32();
+        if row_height <= 0.0 {
+            return;
+        }
+        let max_px = row_height * state.history_len as f32;
+        let scrolled_px = (-offset.y.as_f32()).clamp(0.0, max_px);
+        let lines_from_top = (scrolled_px / row_height).round() as usize;
+        state.requested_display_offset = Some(state.history_len.saturating_sub(lines_from_top));
+    }
+}
+
 /// An event [`TerminalPane`] emits (`cx.emit`) for its owner to react to - the same
 /// `EventEmitter`/`cx.subscribe_in` pattern `vendor/zed/crates/terminal/src/terminal.rs`'s own
 /// `Event::Open(MaybeNavigationTarget)` uses for the same "a click resolved to a navigation
@@ -681,6 +783,24 @@ pub struct TerminalPane {
     /// frame and consumed within that frame (see [`theme_terminal_palette`]).
     #[cfg(test)]
     last_painted_palette: Option<TerminalPalette>,
+    /// The scrollback scrollbar's own [`ScrollableHandle`] adapter (GitHub issue #331) - see
+    /// [`TerminalScrollHandle`]'s own docs for why the terminal needs one at all, rather than
+    /// reusing a plain `gpui::ScrollHandle` the way every other scrollable region does.
+    scroll_handle: TerminalScrollHandle,
+    /// Accumulated, not-yet-applied mouse-wheel/trackpad scroll distance, in pixels (GitHub
+    /// issue #331). A mouse-wheel notch (`gpui::ScrollDelta::Lines`) always converts to a whole
+    /// number of grid lines cleanly, but trackpad deltas (`ScrollDelta::Pixels`) essentially
+    /// never divide evenly by [`Self::line_height_px`] - truncating every single event to whole
+    /// lines would silently drop each event's sub-line remainder, and a slow trackpad flick
+    /// would scroll nothing at all. This carries that remainder across events; see
+    /// [`Self::handle_scroll_wheel`].
+    pending_scroll_px: f32,
+    /// `true` once real pty output has arrived while [`Self::grid`] was scrolled back (GitHub
+    /// issue #331) - drives the "jump to bottom" affordance's highlighted "there's new output"
+    /// state. Cleared the moment [`Self::grid`]'s own scroll offset is observed back at live
+    /// (`render`, every frame - self-correcting, since the grid is the single source of truth
+    /// for "are we scrolled back", never mirrored here).
+    new_output_while_scrolled: bool,
 }
 
 impl TerminalPane {
@@ -712,6 +832,9 @@ impl TerminalPane {
             selecting: false,
             #[cfg(test)]
             last_painted_palette: None,
+            scroll_handle: TerminalScrollHandle::new(),
+            pending_scroll_px: 0.0,
+            new_output_while_scrolled: false,
         };
         this.spawn_process(cx);
         this
@@ -1148,6 +1271,118 @@ impl TerminalPane {
         self.selecting = false;
     }
 
+    /// Mouse-wheel/trackpad scrollback (GitHub issue #331) - converts `event.delta` into whole
+    /// grid lines, carrying any sub-line remainder in [`Self::pending_scroll_px`], then drives
+    /// `TerminalGrid::scroll_display` directly.
+    ///
+    /// A real `on_scroll_wheel` handler, not GPUI's built-in `overflow_y_scroll`/`track_scroll`
+    /// mechanism every other scrollable region in this app uses (`crate::root::scrollbar`'s own
+    /// docs): this pane paints its own fixed-size cell grid rather than a tall scrollable div of
+    /// child rows (see the module docs), so there is no GPUI-native scrollable content for that
+    /// mechanism to act on - the grid's real "scroll position" is `alacritty_terminal::Term`'s
+    /// own `display_offset`, and only `TerminalGrid::scroll_display` can move it.
+    ///
+    /// A negative `delta.y` (the platform convention for "scrolling down" - the same sign
+    /// `vendor/zed/crates/gpui/src/elements/div.rs`'s own built-in scroll listener adds straight
+    /// onto a `ScrollHandle`'s offset, whose own docs say "negative when scrolled down") scrolls
+    /// toward the live tail; a positive one scrolls up into history - matching
+    /// [`ScrollAmount::Lines`]'s own sign convention, so the delta needs no inversion here.
+    fn handle_scroll_wheel(
+        &mut self,
+        event: &ScrollWheelEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let row_height = self.line_height_px();
+        if row_height <= 0.0 {
+            return;
+        }
+        let delta_px = event.delta.pixel_delta(px(row_height)).y.as_f32();
+        self.pending_scroll_px += delta_px;
+        let lines = (self.pending_scroll_px / row_height).trunc();
+        if lines == 0.0 {
+            return;
+        }
+        self.pending_scroll_px -= lines * row_height;
+        self.grid.scroll_display(ScrollAmount::Lines(lines as i32));
+        cx.notify();
+    }
+
+    /// Applies a scrollbar click/drag's requested target, if one was recorded since the last
+    /// render (see [`TerminalScrollHandle`]'s own docs for why this is deferred by a frame
+    /// rather than applied immediately). Called at the top of every `render`, before this
+    /// frame's rows are read out of [`Self::grid`], so a click/drag is reflected in the very
+    /// same frame it's applied in rather than lagging an extra one.
+    fn apply_pending_scrollbar_target(&mut self) {
+        if let Some(target) = self.scroll_handle.take_requested_display_offset() {
+            self.grid.set_scroll_offset(target);
+        }
+    }
+
+    /// The "jump to bottom" affordance (GitHub issue #331) - `None` (nothing painted, nothing
+    /// hit-tested) whenever [`TerminalGrid::is_scrolled_back`] is `false`, since there is
+    /// nothing to jump to: this only ever appears while genuinely showing scrollback, matching
+    /// [`crate::root::scrollbar::render_vertical_scrollbar`]'s own "`None` when there's nothing
+    /// to act on" convention.
+    ///
+    /// Highlighted (`theme::status::RUN`, the same blue `theme::terminal::CURSOR` already
+    /// paints this pane's own cursor with) once [`Self::new_output_while_scrolled`] has
+    /// latched - real output arrived underneath while the human was reading history, the same
+    /// "something happened while you were looking elsewhere" idea `crate::rail::status`'s own
+    /// attention signal answers for a whole tab, applied here to a single pane's own scroll
+    /// state instead. A plain `text_tooltip` carries the explanation rather than a keycap: no
+    /// new keyboard shortcut is bound to this action (typing while scrolled back already jumps
+    /// back on its own - see `Self::handle_key_down`), so there is no key combo for a keycap to
+    /// show.
+    fn render_jump_to_bottom_affordance(&self, cx: &mut Context<Self>) -> Option<gpui::AnyElement> {
+        if !self.grid.is_scrolled_back() {
+            return None;
+        }
+        let highlighted = self.new_output_while_scrolled;
+        let (fg, border, label): (gpui::Rgba, gpui::Rgba, &'static str) = if highlighted {
+            (
+                theme::status::RUN.into(),
+                theme::status::RUN.into(),
+                "New output \u{2193}",
+            )
+        } else {
+            (
+                theme::text::SECONDARY.into(),
+                theme::border::POPOVER.into(),
+                "\u{2193} Scrolled",
+            )
+        };
+        Some(
+            div()
+                .id("terminal-jump-to-bottom")
+                .absolute()
+                .bottom(px(10.0))
+                .right(px(scrollbar::CONTENT_CLEARANCE))
+                .flex()
+                .items_center()
+                .gap(px(5.0))
+                .h(px(20.0))
+                .px(px(8.0))
+                .rounded(theme::radius::CARD_SM)
+                .bg(theme::surface::POPOVER)
+                .border_1()
+                .border_color(border)
+                .cursor_pointer()
+                .hover(|el| el.bg(theme::surface::MENU_ROW_HOVER))
+                .font(font(theme::font::SANS))
+                .text_size(px(10.5))
+                .text_color(fg)
+                .child(label)
+                .tooltip(text_tooltip("Jump to the live output"))
+                .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
+                    this.grid.scroll_display(ScrollAmount::Bottom);
+                    this.new_output_while_scrolled = false;
+                    cx.notify();
+                }))
+                .into_any_element(),
+        )
+    }
+
     /// Test-only seam: feeds bytes straight into this pane's grid, exactly as
     /// [`Self::spawn_process`]'s poll loop does for pty output - lets a test put known,
     /// deterministic text on screen without synchronizing against a real child process's
@@ -1373,6 +1608,15 @@ impl TerminalPane {
                                     // unbounded if that ever changes is not a bound.
                                     drained_bytes += chunk.len().max(1);
                                     this.grid.append_bytes(&chunk);
+                                    // GitHub issue #331: real output arrived while the human was
+                                    // looking at scrollback - latch the "new output" indicator
+                                    // for the jump-to-bottom affordance. `Self::grid` already
+                                    // stays pinned to the same historical lines on its own (see
+                                    // `TerminalGrid::scroll_display`'s docs), so this is purely
+                                    // the UI signal, never a scroll-position decision.
+                                    if this.grid.is_scrolled_back() {
+                                        this.new_output_while_scrolled = true;
+                                    }
                                     this.activity_at = Some(Instant::now());
                                     // Consume the grid's one-shot OSC 9 / 777 notification flag
                                     // right where the bytes that could have set it were parsed,
@@ -1489,6 +1733,29 @@ impl TerminalPane {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        // GitHub issue #331: plain (unmodified) PageUp/PageDown scroll real retained
+        // scrollback rather than being forwarded to the pty. Claiming these is safe:
+        // `keystroke_to_bytes` never mapped either key to any byte sequence to begin with (see
+        // its own docs' deliberately small subset), so this app never actually forwarded a
+        // PageUp/PageDown to the child process before now - not taking over a keystroke a
+        // full-screen program (`vim`/`less`/`htop`) might otherwise have received. The alt
+        // screen keeps no scrollback of its own (`TerminalGrid::scroll_display`'s docs), so a
+        // PageUp/PageDown reaching one there is already a real no-op. Modified variants
+        // (Shift/Ctrl/Alt+PageUp, ...) fall through unclaimed, same as before this issue.
+        if !event.keystroke.modifiers.modified() {
+            let scroll = match event.keystroke.key.as_str() {
+                "pageup" => Some(ScrollAmount::PageUp),
+                "pagedown" => Some(ScrollAmount::PageDown),
+                _ => None,
+            };
+            if let Some(scroll) = scroll {
+                self.grid.scroll_display(scroll);
+                cx.notify();
+                cx.stop_propagation();
+                return;
+            }
+        }
+
         let Some(session) = &self.session else {
             return;
         };
@@ -1506,6 +1773,13 @@ impl TerminalPane {
         if let Err(err) = write_result {
             self.spawn_error = Some(format!("failed to write input: {err}"));
             cx.notify();
+        }
+        // GitHub issue #331: typing while scrolled back jumps back to the live tail - the
+        // standard terminal convention (iTerm2, Alacritty, Windows Terminal all do this): a real
+        // keystroke reaching the child process is the human demonstrating they want to interact
+        // with the live process, not keep reading history underneath it.
+        if self.grid.is_scrolled_back() {
+            self.grid.scroll_display(ScrollAmount::Bottom);
         }
         // Consumed as terminal input; don't let it also be interpreted as an app-level
         // keybinding (matches `vendor/zed/crates/terminal_view/src/terminal_view.rs`'s
@@ -2317,6 +2591,18 @@ impl Render for TerminalPane {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         self.maybe_resize_pty(window);
 
+        // GitHub issue #331: apply a scrollbar click/drag from the previous frame before this
+        // frame reads `self.grid`'s scroll state - see `Self::apply_pending_scrollbar_target`'s
+        // own docs for why this can't happen synchronously inside the scrollbar's own handlers.
+        self.apply_pending_scrollbar_target();
+        // The grid's own `display_offset` is the single source of truth for "are we scrolled
+        // back" - self-correcting the moment it's observed back at live, rather than needing an
+        // explicit "the user jumped back" event from every place that can cause that (the
+        // affordance's own click, a keystroke, `Scroll::Bottom` from anywhere else).
+        if !self.grid.is_scrolled_back() {
+            self.new_output_while_scrolled = false;
+        }
+
         // GitHub issue #211: the real measured monospace advance (`Self::cell_size`, cached), so
         // `render_row` can pin a double-width run to exactly the two columns per character it
         // owns instead of trusting whatever advance the font happens to give that glyph.
@@ -2382,6 +2668,10 @@ impl Render for TerminalPane {
             )
             .on_mouse_move(cx.listener(Self::handle_mouse_move))
             .on_mouse_up(gpui::MouseButton::Left, cx.listener(Self::handle_mouse_up))
+            // GitHub issue #331: real mouse-wheel/trackpad scrollback - see
+            // `Self::handle_scroll_wheel`'s own docs for why this is a direct handler rather
+            // than GPUI's built-in scrollable-div mechanism.
+            .on_scroll_wheel(cx.listener(Self::handle_scroll_wheel))
             .relative()
             .flex()
             .flex_col()
@@ -2423,6 +2713,25 @@ impl Render for TerminalPane {
                     .child("[process exited]"),
             );
         }
+
+        // GitHub issue #331: the shared overlay scrollbar (`crate::root::scrollbar`, the same
+        // component the file tree/diff view/completions popup/etc. all reuse - see that
+        // module's own docs) - synced from the grid's real current scroll state right before
+        // it's built, so its geometry reflects this exact frame's numbers, including any
+        // `Self::apply_pending_scrollbar_target` call already applied above.
+        self.scroll_handle.sync(
+            self.content_bounds.unwrap_or_default(),
+            px(self.line_height_px()),
+            self.grid.scroll_history_len(),
+            self.grid.scroll_offset(),
+        );
+        pane = pane.children(scrollbar::render_vertical_scrollbar(
+            "terminal-scrollbar",
+            &self.scroll_handle,
+            &[],
+            cx,
+        ));
+        pane = pane.children(self.render_jump_to_bottom_affordance(cx));
 
         pane
     }

--- a/crates/app/src/terminal/pane.rs
+++ b/crates/app/src/terminal/pane.rs
@@ -4876,3 +4876,369 @@ mod terminal_theme_tests {
         assert_eq!(cell.bg, bundled_rgb("Slate", "terminal.background"));
     }
 }
+
+/// GitHub issue #331, end to end at the pane level: real scroll-wheel/PageUp/PageDown input
+/// through [`TerminalPane::handle_key_down`]/[`TerminalPane::handle_scroll_wheel`], typing
+/// snapping back to the live tail, and - through a real `cat`-backed pty, not the
+/// [`TerminalPane::inject_bytes_for_test`] seam - real output arriving through the real poll
+/// loop while scrolled back neither moving the viewport nor going unnoticed.
+#[cfg(test)]
+mod scrollback_pane_tests {
+    use super::*;
+    use gpui::{Modifiers, TestAppContext};
+
+    fn new_pane(
+        cx: &mut TestAppContext,
+    ) -> (gpui::Entity<TerminalPane>, &mut gpui::VisualTestContext) {
+        let (pane, cx) = cx.add_window_view(|_window, cx| {
+            TerminalPane::new(
+                TerminalSpec::command("cat", Vec::new(), std::env::temp_dir()),
+                ROW_FONT_SIZE_PX,
+                cx,
+            )
+        });
+        cx.run_until_parked();
+        (pane, cx)
+    }
+
+    /// A real, unmodified navigation key with no `key_char` - matches how GPUI reports
+    /// PageUp/PageDown/arrows in practice (see `keystroke_tests`' own `keystroke` helper for the
+    /// printable-character counterpart).
+    fn nav_key(key: &str) -> Keystroke {
+        Keystroke {
+            key: key.to_string(),
+            key_char: None,
+            modifiers: Modifiers::default(),
+        }
+    }
+
+    fn key_event(keystroke: Keystroke) -> KeyDownEvent {
+        KeyDownEvent {
+            keystroke,
+            is_held: false,
+            prefer_character_input: false,
+        }
+    }
+
+    /// Pushes `count` numbered lines directly into the grid - the same
+    /// [`TerminalPane::inject_bytes_for_test`] seam `clipboard_tests`/etc. already use - enough
+    /// to overflow the pane's real current row count into genuine retained scrollback.
+    fn push_numbered_lines(
+        pane: &gpui::Entity<TerminalPane>,
+        cx: &mut gpui::VisualTestContext,
+        count: usize,
+    ) {
+        pane.update(cx, |pane, cx| {
+            for i in 0..count {
+                pane.inject_bytes_for_test(format!("line {i}\r\n").as_bytes(), cx);
+            }
+        });
+    }
+
+    #[gpui::test]
+    fn page_up_and_page_down_scroll_the_real_display_offset(cx: &mut TestAppContext) {
+        let (pane, cx) = new_pane(cx);
+        let rows = pane.read_with(cx, |pane, _| pane.grid_dimensions().1 as usize);
+        push_numbered_lines(&pane, cx, rows * 3);
+        assert_eq!(pane.read_with(cx, |pane, _| pane.grid.scroll_offset()), 0);
+
+        pane.update_in(cx, |pane, window, cx| {
+            pane.handle_key_down(&key_event(nav_key("pageup")), window, cx);
+        });
+        let offset = pane.read_with(cx, |pane, _| pane.grid.scroll_offset());
+        assert!(
+            offset > 0,
+            "PageUp must move the real display_offset into history"
+        );
+
+        pane.update_in(cx, |pane, window, cx| {
+            pane.handle_key_down(&key_event(nav_key("pagedown")), window, cx);
+        });
+        assert_eq!(
+            pane.read_with(cx, |pane, _| pane.grid.scroll_offset()),
+            0,
+            "PageDown by the same one page must land exactly back at live"
+        );
+    }
+
+    /// Real proof PageUp/PageDown are claimed *before* `keystroke_to_bytes`/`PtySession::
+    /// write_input`, not just that the grid's own offset happens to move: a real `cat` process
+    /// echoes back anything it receives on stdin, so if PageUp were (wrongly) also forwarded as
+    /// pty input, the grid would show a stray echoed byte on the next tick.
+    #[gpui::test]
+    fn page_up_never_reaches_the_real_pty(cx: &mut TestAppContext) {
+        let (pane, cx) = new_pane(cx);
+        let rows = pane.read_with(cx, |pane, _| pane.grid_dimensions().1 as usize);
+        push_numbered_lines(&pane, cx, rows * 3);
+
+        pane.update_in(cx, |pane, window, cx| {
+            pane.handle_key_down(&key_event(nav_key("pageup")), window, cx);
+        });
+        let offset_right_after = pane.read_with(cx, |pane, _| pane.grid.scroll_offset());
+        let lines_right_after = pane.read_with(cx, |pane, _| pane.visible_text_lines());
+
+        // `cat` echoes back verbatim anything it receives on stdin - if PageUp had wrongly also
+        // been forwarded as pty input (rather than claimed before `keystroke_to_bytes` runs at
+        // all), a real echoed reply would show up in the grid, and/or the poll loop draining it
+        // could perturb `display_offset`, within a handful of real poll ticks.
+        for _ in 0..20 {
+            cx.background_executor.advance_clock(POLL_INTERVAL);
+            cx.run_until_parked();
+        }
+
+        assert_eq!(
+            pane.read_with(cx, |pane, _| pane.grid.scroll_offset()),
+            offset_right_after,
+            "display_offset must not drift after PageUp once the poll loop has had many real \
+             ticks to run - it would if a stray echoed reply had reached the pty"
+        );
+        assert_eq!(
+            pane.read_with(cx, |pane, _| pane.visible_text_lines()),
+            lines_right_after,
+            "no new content may appear after PageUp with no further input - a real echoed PageUp \
+             byte sequence would show up here"
+        );
+    }
+
+    #[gpui::test]
+    fn typing_while_scrolled_back_snaps_back_to_the_live_tail(cx: &mut TestAppContext) {
+        let (pane, cx) = new_pane(cx);
+        let rows = pane.read_with(cx, |pane, _| pane.grid_dimensions().1 as usize);
+        push_numbered_lines(&pane, cx, rows * 3);
+
+        pane.update_in(cx, |pane, window, cx| {
+            pane.handle_key_down(&key_event(nav_key("pageup")), window, cx);
+        });
+        assert!(pane.read_with(cx, |pane, _| pane.grid.is_scrolled_back()));
+
+        let typed = Keystroke {
+            key: "a".to_string(),
+            key_char: Some("a".to_string()),
+            modifiers: Modifiers::default(),
+        };
+        pane.update_in(cx, |pane, window, cx| {
+            pane.handle_key_down(&key_event(typed), window, cx);
+        });
+
+        assert!(
+            !pane.read_with(cx, |pane, _| pane.grid.is_scrolled_back()),
+            "a real keystroke reaching the pty must jump the view back to live"
+        );
+    }
+
+    fn wheel_event(delta: gpui::ScrollDelta) -> ScrollWheelEvent {
+        ScrollWheelEvent {
+            position: gpui::point(px(0.0), px(0.0)),
+            delta,
+            modifiers: Modifiers::default(),
+            touch_phase: gpui::TouchPhase::Moved,
+        }
+    }
+
+    #[gpui::test]
+    fn mouse_wheel_lines_scroll_by_exactly_that_many_grid_lines(cx: &mut TestAppContext) {
+        let (pane, cx) = new_pane(cx);
+        let rows = pane.read_with(cx, |pane, _| pane.grid_dimensions().1 as usize);
+        push_numbered_lines(&pane, cx, rows * 3);
+
+        pane.update_in(cx, |pane, window, cx| {
+            pane.handle_scroll_wheel(
+                &wheel_event(gpui::ScrollDelta::Lines(gpui::point(0.0, 3.0))),
+                window,
+                cx,
+            );
+        });
+        assert_eq!(pane.read_with(cx, |pane, _| pane.grid.scroll_offset()), 3);
+
+        // Scrolling back down (negative delta) must move back toward live by the same amount.
+        pane.update_in(cx, |pane, window, cx| {
+            pane.handle_scroll_wheel(
+                &wheel_event(gpui::ScrollDelta::Lines(gpui::point(0.0, -3.0))),
+                window,
+                cx,
+            );
+        });
+        assert_eq!(pane.read_with(cx, |pane, _| pane.grid.scroll_offset()), 0);
+    }
+
+    /// Trackpad pixel deltas rarely divide evenly by the row height - two individually-sub-line
+    /// deltas must still accumulate into a real whole-line scroll rather than each being
+    /// truncated to zero and silently dropped (see [`TerminalPane::pending_scroll_px`]'s docs).
+    #[gpui::test]
+    fn sub_line_trackpad_deltas_accumulate_into_a_real_line_scroll(cx: &mut TestAppContext) {
+        let (pane, cx) = new_pane(cx);
+        let rows = pane.read_with(cx, |pane, _| pane.grid_dimensions().1 as usize);
+        push_numbered_lines(&pane, cx, rows * 3);
+
+        let row_height = pane.read_with(cx, |pane, _| pane.line_height_px());
+        let two_thirds_row = row_height * 2.0 / 3.0;
+
+        pane.update_in(cx, |pane, window, cx| {
+            pane.handle_scroll_wheel(
+                &wheel_event(gpui::ScrollDelta::Pixels(gpui::point(
+                    px(0.0),
+                    px(two_thirds_row),
+                ))),
+                window,
+                cx,
+            );
+        });
+        assert_eq!(
+            pane.read_with(cx, |pane, _| pane.grid.scroll_offset()),
+            0,
+            "a single sub-line delta must not itself move a whole line yet"
+        );
+
+        pane.update_in(cx, |pane, window, cx| {
+            pane.handle_scroll_wheel(
+                &wheel_event(gpui::ScrollDelta::Pixels(gpui::point(
+                    px(0.0),
+                    px(two_thirds_row),
+                ))),
+                window,
+                cx,
+            );
+        });
+        assert_eq!(
+            pane.read_with(cx, |pane, _| pane.grid.scroll_offset()),
+            1,
+            "two 2/3-row deltas together exceed one full row and must produce a real one-line \
+             scroll, not be dropped individually"
+        );
+    }
+
+    /// The real integration proof for GitHub issue #331's "stay put" requirement, at the pane
+    /// level: real pty output arriving through the real poll loop while scrolled back must not
+    /// move the viewport, and must latch the jump-to-bottom affordance's own "new output"
+    /// indicator.
+    #[gpui::test]
+    fn new_real_pty_output_while_scrolled_back_does_not_move_the_viewport_and_latches_the_indicator(
+        cx: &mut TestAppContext,
+    ) {
+        let (pane, cx) = new_pane(cx);
+        let rows = pane.read_with(cx, |pane, _| pane.grid_dimensions().1 as usize);
+        let line_count = rows * 3;
+
+        let first_batch: String = (0..line_count).map(|i| format!("line {i}\r\n")).collect();
+        pane.update(cx, |pane, cx| {
+            pane.session
+                .as_ref()
+                .expect("a real cat session must be live")
+                .write_input(first_batch.as_bytes())
+                .expect("writing to a real live pty must succeed");
+            cx.notify();
+        });
+        let last_line = format!("line {}", line_count - 1);
+        let mut echoed = false;
+        for _ in 0..300 {
+            cx.background_executor.advance_clock(POLL_INTERVAL);
+            cx.run_until_parked();
+            if pane.read_with(cx, |pane, _| {
+                pane.visible_text_lines()
+                    .iter()
+                    .any(|line| line.contains(&last_line))
+            }) {
+                echoed = true;
+                break;
+            }
+        }
+        assert!(echoed, "the real pty must echo the first batch back");
+
+        pane.update_in(cx, |pane, window, cx| {
+            pane.handle_key_down(&key_event(nav_key("pageup")), window, cx);
+        });
+        let offset_before = pane.read_with(cx, |pane, _| pane.grid.scroll_offset());
+        assert!(offset_before > 0, "sanity check: genuinely scrolled back");
+        assert!(
+            !pane.read_with(cx, |pane, _| pane.new_output_while_scrolled),
+            "sanity check: no new output has arrived yet"
+        );
+        // The real content on screen right now - what "stay put" promises stays visible. Not
+        // `scroll_offset()` itself: "staying put" means `display_offset` keeps pace with however
+        // many real grid rows the new output consumes (matching `alacritty_terminal`'s own
+        // `Grid::scroll_up` pinning behavior - see `TerminalGrid::scroll_display`'s docs), which
+        // is exactly what makes the *visible lines* the invariant here, not the raw offset
+        // number (a wrapped long line can advance the grid by more than one row per logical
+        // line written).
+        let lines_before = pane.read_with(cx, |pane, _| pane.visible_text_lines());
+
+        pane.update(cx, |pane, cx| {
+            pane.session
+                .as_ref()
+                .expect("a real cat session must still be live")
+                .write_input(b"more output while scrolled back\r\n")
+                .expect("writing to a real live pty must succeed");
+            cx.notify();
+        });
+        let mut saw_new_output_flag = false;
+        for _ in 0..300 {
+            cx.background_executor.advance_clock(POLL_INTERVAL);
+            cx.run_until_parked();
+            if pane.read_with(cx, |pane, _| pane.new_output_while_scrolled) {
+                saw_new_output_flag = true;
+                break;
+            }
+        }
+        assert!(
+            saw_new_output_flag,
+            "real output arriving through the real poll loop while scrolled back must latch \
+             the jump-to-bottom affordance's indicator"
+        );
+        assert_eq!(
+            pane.read_with(cx, |pane, _| pane.visible_text_lines()),
+            lines_before,
+            "must not move the viewport off the lines the user was looking at"
+        );
+        assert!(
+            pane.read_with(cx, |pane, _| pane.grid.scroll_offset()) >= offset_before,
+            "display_offset must have kept pace with (or exceeded, if the new line wrapped) the \
+             real new output, not snapped back toward live"
+        );
+
+        // The jump-to-bottom affordance's own click handler - exercised directly, since it
+        // needs a real painted hitbox to click through GPUI's own event dispatch - clears both.
+        pane.update(cx, |pane, cx| {
+            pane.grid.scroll_display(ScrollAmount::Bottom);
+            pane.new_output_while_scrolled = false;
+            cx.notify();
+        });
+        cx.run_until_parked();
+        assert!(!pane.read_with(cx, |pane, _| pane.grid.is_scrolled_back()));
+        assert!(!pane.read_with(cx, |pane, _| pane.new_output_while_scrolled));
+    }
+
+    /// The scrollbar's own `ScrollableHandle` adapter (GitHub issue #331): synced from real grid
+    /// state, its geometry must answer with the *lines-from-top* convention documented on
+    /// `TerminalScrollHandle::viewport_bounds` - live (`display_offset == 0`) at the bottom of
+    /// the track, fully scrolled back at the top.
+    #[test]
+    fn terminal_scroll_handle_reports_live_at_the_bottom_and_history_at_the_top() {
+        let handle = TerminalScrollHandle::new();
+        let bounds = Bounds {
+            origin: gpui::point(px(0.0), px(0.0)),
+            size: gpui::size(px(200.0), px(500.0)),
+        };
+        handle.sync(bounds, px(20.0), 100, 0);
+
+        assert_eq!(handle.max_scroll_offset(), gpui::point(px(0.0), px(2000.0)));
+        assert_eq!(
+            handle.scroll_offset(),
+            gpui::point(px(0.0), px(-2000.0)),
+            "display_offset == 0 (live) must report the maximum negative offset - the bottom of \
+             the track, matching every real terminal emulator's own scrollbar"
+        );
+
+        handle.sync(bounds, px(20.0), 100, 100);
+        assert_eq!(
+            handle.scroll_offset(),
+            gpui::point(px(0.0), px(0.0)),
+            "fully scrolled back (display_offset == history_len) must report offset zero - the \
+             top of the track"
+        );
+
+        // A click near the bottom of the track must request an offset close to live.
+        handle.sync(bounds, px(20.0), 100, 100);
+        handle.set_scroll_offset(gpui::point(px(0.0), px(-1900.0)));
+        assert_eq!(handle.take_requested_display_offset(), Some(5));
+    }
+}


### PR DESCRIPTION
## Summary

- Wires `alacritty_terminal`'s already-retained scrollback (`Config::scrolling_history`, 10000 lines) to real input: `TerminalGrid::scroll_display`/`set_scroll_offset`/`scroll_offset`/`scroll_history_len`/`is_scrolled_back` (`terminal/grid.rs`), driven by a real `on_scroll_wheel` handler and unmodified PageUp/PageDown in `terminal/pane.rs`.
- "Stay put while scrolled back" falls out of `alacritty_terminal`'s own `Grid::scroll_up` pinning `display_offset` while non-zero - proven with a real, live-pty integration test rather than assumed.
- Typing while scrolled back jumps back to the live tail (iTerm2/Alacritty/Windows Terminal convention).
- A "jump to bottom" affordance appears while scrolled back, highlighted once real output has arrived underneath, with a tooltip (no keycap - no new keyboard shortcut is bound to the click).
- The terminal reuses the exact same shared overlay scrollbar (`crate::root::scrollbar`) every other scrollable region in this app already uses: `render_vertical_scrollbar` was generalized from an `AdeApp` method into a free function generic over `Context<T>`, since the terminal pane is a separate `Entity<TerminalPane>` with no `AdeApp` to call it through. All 11 existing call sites were mechanically updated to the free-function form (verified behavior-preserving; every one still type-checks with `T` inferred from `cx`).
- Real end-to-end tests: PageUp/PageDown moving the real `display_offset` and never reaching the pty (proven via a real `cat` echo staying silent), typing while scrolled back snapping back to live, mouse-wheel `Lines` deltas moving by exactly that many grid lines, sub-line trackpad pixel deltas accumulating rather than being dropped, `TerminalScrollHandle`'s lines-from-top <-> pixel geometry conversion, and real pty output arriving through the real poll loop while scrolled back neither moving the visible content nor going unnoticed by the jump-to-bottom affordance's own indicator flag.

Closes #331

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets` clean, no warnings
- [x] `cargo test -p app --lib`: 2823 passed, 18 failed - all 18 independently re-verified as pre-existing environmental flakiness unrelated to this change (inotify `max_user_instances` contention from concurrent sandbox activity for `worktree_watch`/`file_tree_watch`/`repo_list_tests`; the known ETXTBSY `hooks::settings_file` flake, issue #320; two `text_undo_scoping_tests` that pass cleanly in isolation) - none touch any file this PR changes
- [x] `cargo test -p pty-core`: 19/19 passed
- [x] Real, live app build launched over X11: ran `seq 1 300` in a real shell, scrolled up with the real mouse wheel into genuine retained history, confirmed the shared overlay scrollbar renders and the "Scrolled" jump-to-bottom affordance appears, clicked it and confirmed a clean return to the live tail with both disappearing
- [x] Confirmed the shared scrollbar generalization is safe on another touched surface (the rail's worktree list) via real mouse-wheel scrolling in the same live session

🤖 Generated with [Claude Code](https://claude.com/claude-code)