### PR TITLE
Provider rate-limit budget: real per-provider reads and the agent-pane readout (#294)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,6 +303,7 @@ dependencies = [
  "pty-core",
  "rand 0.9.5",
  "regex",
+ "reqwest",
  "rodio",
  "self_update",
  "serde",

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -217,6 +217,28 @@ tree-sitter-css = "0.25.0"
 # decoder pairs the settings page's sound-library importer accepts alongside WAV). `cpal` is what
 # actually reintroduces `libasound2-dev` on Linux (see this crate's own README/CI comments next to
 # that package) - `rodio` itself has no system dependency beyond what `cpal` already requires.
+# GitHub issue #294's per-provider rate-limit budget (`crate::budget::fetch`): one plain
+# `GET` per provider against its own usage endpoint, authorised with the credential that
+# provider's own CLI already stored on this machine. `reqwest` rather than a new HTTP crate
+# because it is *already compiled into this binary* - `self_update` above depends on exactly
+# this version with exactly these features (`blocking`, `rustls`, verified against the
+# published `self_update` 0.44.0 manifest's own `[dependencies.reqwest]` section and this
+# workspace's `Cargo.lock`), so naming it here promotes an already-built crate to a direct
+# dependency and adds no new build surface at all - the same call `rand`/`imara-diff`/
+# `streaming-iterator` already made. Pinned to the version `Cargo.lock` already resolves.
+#
+# `blocking`, not the async client: every background call in this crate is a blocking function
+# handed to `cx.background_executor()` (see `crate::updater::flow`, `crate::review::flow`),
+# and reaching for the async client would mean introducing a tokio runtime this app does not
+# otherwise have. `rustls`, not `default-tls`, matching the `self_update` entry above so this
+# binary keeps exactly one TLS stack. `default-features = false` because the real default
+# (`default-tls`, `charset`, `http2`, `system-proxy`) would add OpenSSL beside that rustls.
+# `json` is deliberately *not* enabled: the parsers here take a `&str` so they can be unit
+# tested against real captured payloads, and `serde_json` is already a direct dependency.
+reqwest = { version = "0.13", default-features = false, features = [
+    "blocking",
+    "rustls",
+] }
 rodio = { version = "0.22.2", default-features = false, features = [
     "playback",
     "wav",

--- a/crates/app/src/budget/fetch.rs
+++ b/crates/app/src/budget/fetch.rs
@@ -58,12 +58,29 @@ pub enum ProviderRead {
 }
 
 /// One provider's stored credential.
-#[derive(Debug, Clone, PartialEq)]
+///
+/// The `Debug` below is hand-written rather than derived, and that is the point of it - see its
+/// own docs.
+#[derive(Clone, PartialEq)]
 pub struct Credential {
     pub token: String,
     /// Codex's `tokens.account_id`, sent as `ChatGPT-Account-Id`. `None` for Claude, which needs
     /// no equivalent.
     pub account_id: Option<String>,
+}
+
+/// Redacting, on purpose. This struct holds a live OAuth bearer token belonging to the user, and a
+/// `#[derive(Debug)]` would put it verbatim into *any* `{:?}` - a stray `log::debug!`, a panic
+/// message, a future error report. Nothing in this app has a reason to want the token's characters
+/// in a diagnostic, so nothing is given the chance: the presence of each field is reported, and its
+/// value never is.
+impl std::fmt::Debug for Credential {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Credential")
+            .field("token", &"<redacted>")
+            .field("account_id", &self.account_id.is_some())
+            .finish()
+    }
 }
 
 /// The directory a provider's CLI keeps its credential in, honouring the same environment
@@ -549,7 +566,11 @@ mod budget_fetch_tests {
             "primary_window": {"used_percent": 50, "limit_window_seconds": 3600,
                                "reset_after_seconds": 600, "reset_at": 0}}}"#;
         let snapshot = parse_codex_usage(body).expect("parses");
-        assert_eq!(snapshot.windows.len(), 1, "one window is a real payload too");
+        assert_eq!(
+            snapshot.windows.len(),
+            1,
+            "one window is a real payload too"
+        );
         assert_eq!(snapshot.windows[0].label, "1h");
         assert!(
             snapshot.windows[0].resets_at.is_some(),
@@ -599,12 +620,40 @@ mod budget_fetch_tests {
             None
         );
         assert_eq!(
-            parse_credential(Provider::Claude, r#"{"claudeAiOauth": {"accessToken": ""}}"#),
+            parse_credential(
+                Provider::Claude,
+                r#"{"claudeAiOauth": {"accessToken": ""}}"#
+            ),
             None,
             "an empty token is not a token"
         );
         assert_eq!(parse_credential(Provider::Claude, "{}"), None);
         assert_eq!(parse_credential(Provider::Claude, "broken"), None);
+    }
+
+    /// A live bearer token must never be printable. The one place a credential could plausibly
+    /// escape into a log or a panic message is `{:?}`, so that is the hole this closes - and this
+    /// test is what stops a later `#[derive(Debug)]` from quietly reopening it.
+    #[test]
+    fn a_credential_never_prints_its_own_token() {
+        let credential = Credential {
+            token: "sk-ant-oat01-super-secret".to_string(),
+            account_id: Some("acc-secret-1".to_string()),
+        };
+        let printed = format!("{credential:?}");
+        assert!(
+            !printed.contains("super-secret"),
+            "the token must never reach a `{{:?}}`, got {printed}"
+        );
+        assert!(
+            !printed.contains("acc-secret-1"),
+            "nor the account id, got {printed}"
+        );
+        assert!(
+            printed.contains("<redacted>") && printed.contains("account_id: true"),
+            "but a diagnostic must still be able to say a credential was there and complete, got \
+             {printed}"
+        );
     }
 
     #[test]
@@ -614,7 +663,10 @@ mod budget_fetch_tests {
         assert_eq!(utc, zulu, "`Z` and `+00:00` are the same instant");
 
         let fractional = parse_rfc3339("2026-08-15T20:00:00.123456Z").expect("fractional form");
-        assert_eq!(fractional, zulu, "sub-second precision is discarded, not fatal");
+        assert_eq!(
+            fractional, zulu,
+            "sub-second precision is discarded, not fatal"
+        );
 
         let offset = parse_rfc3339("2026-08-15T15:00:00-05:00").expect("negative offset");
         assert_eq!(offset, zulu, "a -05:00 wall clock at 15:00 is 20:00 UTC");
@@ -634,9 +686,17 @@ mod budget_fetch_tests {
             Some(SystemTime::UNIX_EPOCH)
         );
 
-        assert_eq!(parse_rfc3339("2026-08-15T20:00:00"), None, "no zone is not a valid instant");
+        assert_eq!(
+            parse_rfc3339("2026-08-15T20:00:00"),
+            None,
+            "no zone is not a valid instant"
+        );
         assert_eq!(parse_rfc3339("nonsense"), None);
-        assert_eq!(parse_rfc3339("2026-13-15T20:00:00Z"), None, "month 13 is not a date");
+        assert_eq!(
+            parse_rfc3339("2026-13-15T20:00:00Z"),
+            None,
+            "month 13 is not a date"
+        );
     }
 
     /// The credential path really is the file each CLI writes, and really does follow that CLI's

--- a/crates/app/src/budget/fetch.rs
+++ b/crates/app/src/budget/fetch.rs
@@ -1,0 +1,677 @@
+//! Where the numbers actually come from: each provider's own credential on disk, its own usage
+//! endpoint, and a parser for its own response shape.
+//!
+//! # Why an out-of-band HTTP read rather than scraping the CLI
+//!
+//! Jerry spawns `claude` and `codex` as interactive TUIs in a PTY with no arguments
+//! (`crate::work_surface::agents::AgentKind::binary_name`). There is no structured event stream to
+//! read, so the in-band routes those CLIs use internally - Claude's stream events, Codex's
+//! `token_count` event and `x-codex-*` response headers - are not available to us at all. Neither
+//! CLI has a `usage` subcommand. What is available is that both store an OAuth credential in a
+//! well-known file, and both talk to a plain `GET` usage endpoint with it. That is what this
+//! module does, and it is the *same* endpoint each CLI reads for its own `/status` display, so the
+//! numbers agree with what the agent itself would tell you.
+//!
+//! # What is verified, and what is not
+//!
+//! The Claude path was verified live against a real account (issue #294's Phase 0 comment records
+//! the captured 200 payload, which is this module's own test fixture). The Codex path is
+//! *source*-verified against `openai/codex` - the URL
+//! (`codex-rs/backend-client/src/client/rate_limit_resets.rs`, `{base}/wham/usage`), the auth file
+//! (`codex-rs/login/src/auth/storage.rs`'s `AuthDotJson` -> `tokens.access_token`), the
+//! `ChatGPT-Account-Id` header (`codex-rs/backend-client/src/client.rs`'s `headers()`), and the
+//! payload shape (`codex-rs/codex-backend-openapi-models/src/models/rate_limit_status_*.rs`) -
+//! but **not** executed, because there was no `codex` install or ChatGPT credential on the machine
+//! this was written on. It therefore reads `not connected` there rather than inventing anything,
+//! and its parser is tested against a fixture built from those published model definitions.
+//!
+//! # Credentials are read, never written or refreshed
+//!
+//! An expired token is reported as a failed poll, not silently refreshed. The refresh token lives
+//! in the CLI's own credential file and racing that CLI for it risks clobbering the user's login -
+//! re-authentication belongs to the CLI that owns the file. Nothing here ever writes to disk.
+//!
+//! On macOS the Claude CLI may keep its credential in the Keychain instead of the file, and Codex
+//! may use a keyring backend; Jerry does not read either. Those installs read as `not connected`,
+//! which is the honest statement: we have nothing, and nothing is broken.
+
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime};
+
+use super::state::{window_label, BudgetWindow, Provider, ProviderSnapshot};
+
+/// How long a single usage request may take before it is a failure. Short on purpose - this is a
+/// background readout, and the Claude CLI's own call to the same endpoint uses a 5s timeout.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// The result of one real attempt to read one provider.
+///
+/// Three outcomes, matching the three states the UI keeps distinct: no credential at all, a real
+/// snapshot, and a real failure with a real reason.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ProviderRead {
+    /// No credential for this provider on this machine - nothing was sent anywhere.
+    NotConnected,
+    Ok(ProviderSnapshot),
+    /// The reason, for the popover's tooltip and the log. Never rendered as a number.
+    Failed(String),
+}
+
+/// One provider's stored credential.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Credential {
+    pub token: String,
+    /// Codex's `tokens.account_id`, sent as `ChatGPT-Account-Id`. `None` for Claude, which needs
+    /// no equivalent.
+    pub account_id: Option<String>,
+}
+
+/// The directory a provider's CLI keeps its credential in, honouring the same environment
+/// overrides that CLI itself honours (`CLAUDE_CONFIG_DIR`, `CODEX_HOME`) so a relocated config
+/// directory is found rather than reported as "not connected".
+pub fn credential_dir(provider: Provider) -> Option<PathBuf> {
+    let env_key = match provider {
+        Provider::Claude => "CLAUDE_CONFIG_DIR",
+        Provider::Codex => "CODEX_HOME",
+    };
+    credential_dir_from(
+        provider,
+        std::env::var_os(env_key).map(PathBuf::from),
+        home_dir(),
+    )
+}
+
+/// The pure half of [`credential_dir`], so the override rule is tested without mutating the
+/// process-global environment (`std::env::set_var` is unsound to race in a threaded test binary).
+pub fn credential_dir_from(
+    provider: Provider,
+    env_override: Option<PathBuf>,
+    home: Option<PathBuf>,
+) -> Option<PathBuf> {
+    if let Some(dir) = env_override.filter(|value| !value.as_os_str().is_empty()) {
+        return Some(dir);
+    }
+    let default_dir = match provider {
+        Provider::Claude => ".claude",
+        Provider::Codex => ".codex",
+    };
+    Some(home?.join(default_dir))
+}
+
+/// This user's home directory. `$HOME` on unix, `%USERPROFILE%` on Windows - the same pair
+/// `crate::settings::store` already resolves its own config path from.
+fn home_dir() -> Option<PathBuf> {
+    let key = if cfg!(windows) { "USERPROFILE" } else { "HOME" };
+    std::env::var_os(key)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
+/// The credential file for a provider - `~/.claude/.credentials.json`, `~/.codex/auth.json`.
+pub fn credential_path(provider: Provider) -> Option<PathBuf> {
+    let file = match provider {
+        Provider::Claude => ".credentials.json",
+        Provider::Codex => "auth.json",
+    };
+    Some(credential_dir(provider)?.join(file))
+}
+
+/// Reads a provider's credential off disk, or `None` when there is genuinely none to read.
+///
+/// A file that exists but carries no OAuth token (an API-key-only Codex `auth.json`, a
+/// half-written file) is `None` too: there is no token to send, which is the same fact as having
+/// no file, and both are `not connected` rather than a failure.
+pub fn read_credential(provider: Provider) -> Option<Credential> {
+    let path = credential_path(provider)?;
+    let raw = std::fs::read_to_string(path).ok()?;
+    parse_credential(provider, &raw)
+}
+
+/// The pure half of [`read_credential`] - so both file shapes are tested without a home
+/// directory.
+pub fn parse_credential(provider: Provider, raw: &str) -> Option<Credential> {
+    let json: serde_json::Value = serde_json::from_str(raw).ok()?;
+    match provider {
+        Provider::Claude => {
+            let token = json
+                .get("claudeAiOauth")?
+                .get("accessToken")?
+                .as_str()
+                .filter(|token| !token.is_empty())?;
+            Some(Credential {
+                token: token.to_string(),
+                account_id: None,
+            })
+        }
+        Provider::Codex => {
+            let tokens = json.get("tokens")?;
+            let token = tokens
+                .get("access_token")?
+                .as_str()
+                .filter(|token| !token.is_empty())?;
+            Some(Credential {
+                token: token.to_string(),
+                account_id: tokens
+                    .get("account_id")
+                    .and_then(|value| value.as_str())
+                    .filter(|id| !id.is_empty())
+                    .map(|id| id.to_string()),
+            })
+        }
+    }
+}
+
+/// The usage endpoint for a provider.
+fn usage_url(provider: Provider) -> &'static str {
+    match provider {
+        // Read from the `claude` CLI's own call site: `GET /api/oauth/usage` against
+        // `api.anthropic.com`, with the stored OAuth access token.
+        Provider::Claude => "https://api.anthropic.com/api/oauth/usage",
+        // `codex-rs/backend-client/src/client.rs` appends `/backend-api` to a `chatgpt.com` base
+        // URL, and `rate_limit_resets.rs` appends `/wham/usage` to that for the ChatGPT path
+        // style.
+        Provider::Codex => "https://chatgpt.com/backend-api/wham/usage",
+    }
+}
+
+/// One real, blocking read of one provider. **Never call this on the UI thread** - the whole of
+/// `crate::budget::flow` runs it on `cx.background_executor()`.
+///
+/// Returns [`ProviderRead::NotConnected`] without touching the network when there is no
+/// credential, which is what makes "a provider you have not logged into costs nothing" true
+/// rather than aspirational.
+pub fn read_provider(provider: Provider) -> ProviderRead {
+    let Some(credential) = read_credential(provider) else {
+        return ProviderRead::NotConnected;
+    };
+    match http_get_usage(provider, &credential) {
+        Ok(body) => match parse_usage(provider, &body) {
+            Ok(snapshot) => ProviderRead::Ok(snapshot),
+            Err(reason) => ProviderRead::Failed(reason),
+        },
+        Err(reason) => ProviderRead::Failed(reason),
+    }
+}
+
+/// The real HTTP call, with each provider's own required headers.
+fn http_get_usage(provider: Provider, credential: &Credential) -> Result<String, String> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .build()
+        .map_err(|err| format!("could not build an HTTP client: {err}"))?;
+
+    let mut request = client
+        .get(usage_url(provider))
+        .header("Authorization", format!("Bearer {}", credential.token))
+        .header("Content-Type", "application/json");
+    request = match provider {
+        // The OAuth beta header the CLI's own OAuth-authorised calls carry.
+        Provider::Claude => request.header("anthropic-beta", "oauth-2025-04-20"),
+        // `codex-rs/backend-client/src/client.rs`'s `headers()`: a `codex-cli` user agent, plus
+        // the account id when one is stored.
+        Provider::Codex => {
+            let request = request.header("User-Agent", "codex-cli");
+            match &credential.account_id {
+                Some(account_id) => request.header("ChatGPT-Account-Id", account_id.as_str()),
+                None => request,
+            }
+        }
+    };
+
+    let response = request
+        .send()
+        .map_err(|err| format!("the request failed: {err}"))?;
+    let status = response.status();
+    if !status.is_success() {
+        // Every non-2xx is one failure state with a real reason attached, including the two that
+        // matter most here: a 401 (the CLI's stored token expired - re-authentication belongs to
+        // that CLI, not to Jerry) and a 429 (the usage endpoint's own limiter, which is real and
+        // is exactly why `POLL_INTERVAL` is as slow as it is).
+        return Err(format!("the provider answered {}", status.as_u16()));
+    }
+    response
+        .text()
+        .map_err(|err| format!("the response could not be read: {err}"))
+}
+
+/// Parses one provider's usage payload into windows of *headroom*.
+pub fn parse_usage(provider: Provider, body: &str) -> Result<ProviderSnapshot, String> {
+    match provider {
+        Provider::Claude => parse_claude_usage(body),
+        Provider::Codex => parse_codex_usage(body),
+    }
+}
+
+/// Percent used -> percent left, clamped to the real 0-100 range an over-quota account can
+/// otherwise leave (a `utilization` above 100 is possible and would otherwise render as a
+/// negative meter).
+fn headroom_from_utilization(utilization: f64) -> f32 {
+    (100.0 - utilization).clamp(0.0, 100.0) as f32
+}
+
+/// Anthropic's `GET /api/oauth/usage`.
+///
+/// ```json
+/// {"five_hour": {"utilization": 19.0, "resets_at": "2026-08-15T20:00:00+00:00"},
+///  "seven_day": {"utilization": 60.0, "resets_at": "2026-08-18T06:00:00+00:00"},
+///  "limits": [ ... ]}
+/// ```
+///
+/// The two named windows are what this reads: they are the two the CLI's own status display uses,
+/// they carry their own reset instants, and their names fix their durations at 5h and 7d. The
+/// `limits` array beside them carries the same two figures plus per-model scoped rows
+/// (`weekly_scoped`), which are a *breakdown of* the weekly window rather than a third limit - so
+/// reading them too would double-count the same budget under two labels.
+pub fn parse_claude_usage(body: &str) -> Result<ProviderSnapshot, String> {
+    let json: serde_json::Value =
+        serde_json::from_str(body).map_err(|err| format!("the response was not JSON: {err}"))?;
+
+    let mut windows = Vec::new();
+    for (key, label) in [("five_hour", "5h"), ("seven_day", "7d")] {
+        let Some(entry) = json.get(key) else {
+            continue;
+        };
+        let Some(utilization) = entry.get("utilization").and_then(|v| v.as_f64()) else {
+            continue;
+        };
+        windows.push(BudgetWindow {
+            label: label.to_string(),
+            headroom_percent: headroom_from_utilization(utilization),
+            resets_at: entry
+                .get("resets_at")
+                .and_then(|value| value.as_str())
+                .and_then(parse_rfc3339),
+        });
+    }
+
+    if windows.is_empty() {
+        return Err("the response carried no usage windows".to_string());
+    }
+    Ok(ProviderSnapshot { windows })
+}
+
+/// ChatGPT's `GET /backend-api/wham/usage`, as `openai/codex`'s own generated models define it:
+///
+/// ```json
+/// {"plan_type": "pro",
+///  "rate_limit": {"allowed": true, "limit_reached": false,
+///                 "primary_window":   {"used_percent": 12, "limit_window_seconds": 18000,
+///                                      "reset_after_seconds": 900, "reset_at": 1786930000},
+///                 "secondary_window": {"used_percent": 34, "limit_window_seconds": 604800,
+///                                      "reset_after_seconds": 200000, "reset_at": 1787130000}}}
+/// ```
+///
+/// Both window labels are formatted from the server's own `limit_window_seconds` rather than
+/// assumed to be 5h/7d: unlike Claude's, these are numbers the API sends, and a plan whose primary
+/// window is not five hours must not be labelled as though it were.
+pub fn parse_codex_usage(body: &str) -> Result<ProviderSnapshot, String> {
+    let json: serde_json::Value =
+        serde_json::from_str(body).map_err(|err| format!("the response was not JSON: {err}"))?;
+
+    let rate_limit = json
+        .get("rate_limit")
+        .filter(|value| !value.is_null())
+        .ok_or_else(|| "the response carried no rate_limit block".to_string())?;
+
+    let mut windows = Vec::new();
+    for key in ["primary_window", "secondary_window"] {
+        let Some(entry) = rate_limit.get(key).filter(|value| !value.is_null()) else {
+            continue;
+        };
+        let Some(used) = entry.get("used_percent").and_then(|v| v.as_f64()) else {
+            continue;
+        };
+        let seconds = entry
+            .get("limit_window_seconds")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
+        windows.push(BudgetWindow {
+            label: window_label(seconds),
+            headroom_percent: headroom_from_utilization(used),
+            resets_at: codex_reset_instant(entry),
+        });
+    }
+
+    if windows.is_empty() {
+        return Err("the response carried no usage windows".to_string());
+    }
+    Ok(ProviderSnapshot { windows })
+}
+
+/// Codex sends both an absolute `reset_at` and a relative `reset_after_seconds`. The absolute one
+/// wins when it is genuinely an epoch timestamp; otherwise the relative one is added to the
+/// current clock, so a payload that only carries the relative form still produces a real
+/// countdown instead of none.
+fn codex_reset_instant(entry: &serde_json::Value) -> Option<SystemTime> {
+    // Anything below this is not a plausible epoch second (it would be 2001), so it is a
+    // relative value in a field named as though it were absolute.
+    const PLAUSIBLE_EPOCH_FLOOR: i64 = 1_000_000_000;
+
+    if let Some(reset_at) = entry.get("reset_at").and_then(|v| v.as_i64()) {
+        if reset_at >= PLAUSIBLE_EPOCH_FLOOR {
+            return Some(SystemTime::UNIX_EPOCH + Duration::from_secs(reset_at as u64));
+        }
+    }
+    let after = entry
+        .get("reset_after_seconds")
+        .and_then(|v| v.as_i64())
+        .filter(|seconds| *seconds >= 0)?;
+    Some(SystemTime::now() + Duration::from_secs(after as u64))
+}
+
+/// The narrow slice of RFC 3339 the Anthropic payload actually uses:
+/// `2026-08-15T20:00:00+00:00`, `...Z`, and offsets like `-05:00`.
+///
+/// Hand-written rather than reached for as a dependency: this crate has no date/time crate today,
+/// and pulling `chrono` (or `time`) plus its own transitive stack in to read one field of one
+/// response would be a large amount of new build surface for a fixed-shape timestamp. Fractional
+/// seconds are accepted and discarded - a reset instant is not a sub-second fact.
+pub fn parse_rfc3339(raw: &str) -> Option<SystemTime> {
+    let bytes = raw.as_bytes();
+    if bytes.len() < 19 || bytes[4] != b'-' || bytes[7] != b'-' {
+        return None;
+    }
+    let year: i64 = raw.get(0..4)?.parse().ok()?;
+    let month: i64 = raw.get(5..7)?.parse().ok()?;
+    let day: i64 = raw.get(8..10)?.parse().ok()?;
+    if !matches!(bytes[10], b'T' | b't' | b' ') {
+        return None;
+    }
+    let hour: i64 = raw.get(11..13)?.parse().ok()?;
+    let minute: i64 = raw.get(14..16)?.parse().ok()?;
+    let second: i64 = raw.get(17..19)?.parse().ok()?;
+    if !(1..=12).contains(&month) || !(1..=31).contains(&day) || hour > 23 || minute > 59 {
+        return None;
+    }
+
+    // Everything after the seconds is an optional fractional part followed by the zone.
+    let rest = &raw[19..];
+    let zone = match rest.find(['+', '-', 'Z', 'z']) {
+        Some(index) => &rest[index..],
+        // No zone at all: RFC 3339 requires one, and guessing UTC would silently shift a
+        // countdown by hours.
+        None => return None,
+    };
+    let offset_seconds = match zone.as_bytes()[0] {
+        b'Z' | b'z' => 0,
+        sign => {
+            let offset_hour: i64 = zone.get(1..3)?.parse().ok()?;
+            let offset_minute: i64 = zone.get(4..6)?.parse().ok()?;
+            let magnitude = offset_hour * 3600 + offset_minute * 60;
+            if sign == b'-' {
+                -magnitude
+            } else {
+                magnitude
+            }
+        }
+    };
+
+    let epoch_seconds =
+        days_from_civil(year, month, day) * 86_400 + hour * 3600 + minute * 60 + second
+            - offset_seconds;
+    if epoch_seconds < 0 {
+        return None;
+    }
+    Some(SystemTime::UNIX_EPOCH + Duration::from_secs(epoch_seconds as u64))
+}
+
+/// Days since 1970-01-01 for a proleptic Gregorian date - Howard Hinnant's `days_from_civil`, the
+/// same algorithm every date library uses. Exact integer arithmetic, no floating point, correct
+/// across leap years and century rules.
+fn days_from_civil(year: i64, month: i64, day: i64) -> i64 {
+    let year = if month <= 2 { year - 1 } else { year };
+    let era = if year >= 0 { year } else { year - 399 } / 400;
+    let year_of_era = year - era * 400;
+    let day_of_year = (153 * (if month > 2 { month - 3 } else { month + 9 }) + 2) / 5 + day - 1;
+    let day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
+    era * 146_097 + day_of_era - 719_468
+}
+
+/// Real coverage for the two parsers and the credential readers, against real payload shapes.
+#[cfg(test)]
+mod budget_fetch_tests {
+    use super::*;
+
+    /// The genuine 200 body captured from `GET https://api.anthropic.com/api/oauth/usage` on a
+    /// real Claude Max account (issue #294's Phase 0 comment records the capture). Trimmed to the
+    /// fields this parser reads plus the neighbouring ones it must ignore.
+    const CLAUDE_LIVE_PAYLOAD: &str = r#"{
+      "five_hour": {"utilization": 19.0, "resets_at": "2026-08-15T20:00:00+00:00"},
+      "seven_day": {"utilization": 60.0, "resets_at": "2026-08-18T06:00:00+00:00"},
+      "limits": [
+        {"kind": "session", "group": "session", "percent": 19, "severity": "normal",
+         "resets_at": "2026-08-15T20:00:00+00:00", "scope": null, "is_active": false},
+        {"kind": "weekly_all", "group": "weekly", "percent": 60, "severity": "normal",
+         "resets_at": "2026-08-18T06:00:00+00:00", "scope": null, "is_active": true},
+        {"kind": "weekly_scoped", "group": "weekly", "percent": 27, "severity": "normal",
+         "resets_at": "2026-08-18T06:00:00+00:00",
+         "scope": {"model": {"display_name": "Fable"}}, "is_active": false}
+      ],
+      "extra_usage": {},
+      "spend": {}
+    }"#;
+
+    /// Built from `openai/codex`'s own published models - `RateLimitStatusPayload`,
+    /// `RateLimitStatusDetails` and `RateLimitWindowSnapshot` - not from a live capture. See this
+    /// module's docs for why the Codex side is source-verified rather than executed.
+    const CODEX_SPEC_PAYLOAD: &str = r#"{
+      "plan_type": "pro",
+      "rate_limit": {
+        "allowed": true,
+        "limit_reached": false,
+        "primary_window": {"used_percent": 1, "limit_window_seconds": 18000,
+                           "reset_after_seconds": 7200, "reset_at": 1786940000},
+        "secondary_window": {"used_percent": 12, "limit_window_seconds": 604800,
+                             "reset_after_seconds": 400000, "reset_at": 1787240000}
+      }
+    }"#;
+
+    /// The one direction rule the whole feature rests on: the API reports *used*, every value in
+    /// Jerry is *left*. `19% used` must become `81% left`, never `19%`.
+    #[test]
+    fn the_claude_payload_parses_into_two_windows_of_headroom_not_spend() {
+        let snapshot = parse_claude_usage(CLAUDE_LIVE_PAYLOAD).expect("a real payload parses");
+        assert_eq!(
+            snapshot.windows.len(),
+            2,
+            "two independent windows - the finding that settled the two-bar meter shape"
+        );
+        assert_eq!(snapshot.windows[0].label, "5h");
+        assert_eq!(
+            snapshot.windows[0].headroom_percent, 81.0,
+            "19% used is 81% left - the popover's footnote promises headroom, not spend"
+        );
+        assert_eq!(snapshot.windows[1].label, "7d");
+        assert_eq!(snapshot.windows[1].headroom_percent, 40.0);
+        assert_eq!(
+            snapshot.tightest().map(|w| w.label.clone()),
+            Some("7d".to_string()),
+            "on this real account the *week* is the tight window while the session is healthy - \
+             the exact case a single bar would have misreported"
+        );
+    }
+
+    /// The two reset instants are independent, and both are real absolute times rather than the
+    /// same value repeated.
+    #[test]
+    fn each_claude_window_carries_its_own_reset_instant() {
+        let snapshot = parse_claude_usage(CLAUDE_LIVE_PAYLOAD).expect("parses");
+        let five_hour = snapshot.windows[0].resets_at.expect("a 5h reset instant");
+        let seven_day = snapshot.windows[1].resets_at.expect("a 7d reset instant");
+        assert!(
+            seven_day > five_hour,
+            "the weekly window resets later than the session one - two windows, two clocks"
+        );
+        assert_eq!(
+            five_hour
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .expect("after the epoch")
+                .as_secs(),
+            // 2026-08-15T20:00:00Z
+            1_786_824_000,
+            "the timestamp must parse to the exact instant, not an approximation"
+        );
+    }
+
+    #[test]
+    fn a_claude_payload_with_no_windows_at_all_is_a_failure_not_an_empty_meter() {
+        let err = parse_claude_usage(r#"{"limits": []}"#).expect_err("no windows is not a read");
+        assert!(err.contains("no usage windows"), "got {err}");
+        assert!(
+            parse_claude_usage("not json at all").is_err(),
+            "a non-JSON body is a failure with a reason, never a silent zero"
+        );
+    }
+
+    #[test]
+    fn the_codex_payload_parses_into_two_windows_labelled_from_the_server() {
+        let snapshot = parse_codex_usage(CODEX_SPEC_PAYLOAD).expect("the documented shape parses");
+        assert_eq!(snapshot.windows.len(), 2);
+        assert_eq!(
+            snapshot.windows[0].label, "5h",
+            "the label comes from `limit_window_seconds`, not from an assumption"
+        );
+        assert_eq!(snapshot.windows[0].headroom_percent, 99.0);
+        assert_eq!(snapshot.windows[1].label, "7d");
+        assert_eq!(snapshot.windows[1].headroom_percent, 88.0);
+        assert_eq!(
+            snapshot.summary_label(),
+            "5h 99%  \u{b7}  7d 88%",
+            "window label before the value, on this provider too"
+        );
+    }
+
+    /// A plan whose primary window is not five hours must label itself honestly - the whole reason
+    /// the label is formatted from the payload.
+    #[test]
+    fn a_codex_window_of_an_unusual_length_is_labelled_as_what_it_is() {
+        let body = r#"{"rate_limit": {"allowed": true, "limit_reached": false,
+            "primary_window": {"used_percent": 50, "limit_window_seconds": 3600,
+                               "reset_after_seconds": 600, "reset_at": 0}}}"#;
+        let snapshot = parse_codex_usage(body).expect("parses");
+        assert_eq!(snapshot.windows.len(), 1, "one window is a real payload too");
+        assert_eq!(snapshot.windows[0].label, "1h");
+        assert!(
+            snapshot.windows[0].resets_at.is_some(),
+            "a `reset_at` of 0 is not an epoch instant, so the relative `reset_after_seconds` must \
+             be used instead of dropping the countdown"
+        );
+    }
+
+    #[test]
+    fn a_codex_payload_with_a_null_rate_limit_is_a_failure_with_a_reason() {
+        let err = parse_codex_usage(r#"{"plan_type": "free", "rate_limit": null}"#)
+            .expect_err("null is not a snapshot");
+        assert!(err.contains("no rate_limit"), "got {err}");
+    }
+
+    #[test]
+    fn both_credential_shapes_are_read_from_their_real_file_layouts() {
+        let claude = parse_credential(
+            Provider::Claude,
+            r#"{"claudeAiOauth": {"accessToken": "sk-ant-oat01-x", "subscriptionType": "max"}}"#,
+        )
+        .expect("a real .credentials.json shape");
+        assert_eq!(claude.token, "sk-ant-oat01-x");
+        assert_eq!(claude.account_id, None);
+
+        let codex = parse_credential(
+            Provider::Codex,
+            r#"{"OPENAI_API_KEY": null,
+                "tokens": {"access_token": "jwt", "refresh_token": "r", "account_id": "acc-1"}}"#,
+        )
+        .expect("a real auth.json shape");
+        assert_eq!(codex.token, "jwt");
+        assert_eq!(
+            codex.account_id.as_deref(),
+            Some("acc-1"),
+            "the account id is a real header the endpoint needs, not decoration"
+        );
+    }
+
+    /// An API-key-only Codex login, and a Claude file with no OAuth block, both have no token to
+    /// send - which is the same fact as having no file at all, and must read as `not connected`
+    /// rather than as a failure.
+    #[test]
+    fn a_credential_file_with_no_oauth_token_is_not_connected_rather_than_broken() {
+        assert_eq!(
+            parse_credential(Provider::Codex, r#"{"OPENAI_API_KEY": "sk-proj-x"}"#),
+            None
+        );
+        assert_eq!(
+            parse_credential(Provider::Claude, r#"{"claudeAiOauth": {"accessToken": ""}}"#),
+            None,
+            "an empty token is not a token"
+        );
+        assert_eq!(parse_credential(Provider::Claude, "{}"), None);
+        assert_eq!(parse_credential(Provider::Claude, "broken"), None);
+    }
+
+    #[test]
+    fn the_timestamp_parser_handles_every_form_the_payload_uses() {
+        let utc = parse_rfc3339("2026-08-15T20:00:00+00:00").expect("offset form");
+        let zulu = parse_rfc3339("2026-08-15T20:00:00Z").expect("Z form");
+        assert_eq!(utc, zulu, "`Z` and `+00:00` are the same instant");
+
+        let fractional = parse_rfc3339("2026-08-15T20:00:00.123456Z").expect("fractional form");
+        assert_eq!(fractional, zulu, "sub-second precision is discarded, not fatal");
+
+        let offset = parse_rfc3339("2026-08-15T15:00:00-05:00").expect("negative offset");
+        assert_eq!(offset, zulu, "a -05:00 wall clock at 15:00 is 20:00 UTC");
+
+        // A leap day, and a century that is not a leap year - the two cases a hand-rolled
+        // conversion gets wrong.
+        assert_eq!(
+            parse_rfc3339("2024-02-29T00:00:00Z")
+                .expect("a real leap day")
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .expect("after the epoch")
+                .as_secs(),
+            1_709_164_800
+        );
+        assert_eq!(
+            parse_rfc3339("1970-01-01T00:00:00Z"),
+            Some(SystemTime::UNIX_EPOCH)
+        );
+
+        assert_eq!(parse_rfc3339("2026-08-15T20:00:00"), None, "no zone is not a valid instant");
+        assert_eq!(parse_rfc3339("nonsense"), None);
+        assert_eq!(parse_rfc3339("2026-13-15T20:00:00Z"), None, "month 13 is not a date");
+    }
+
+    /// The credential path really is the file each CLI writes, and really does follow that CLI's
+    /// own environment override.
+    #[test]
+    fn the_credential_directory_follows_each_clis_own_environment_override() {
+        let home = Some(PathBuf::from("/home/someone"));
+        assert_eq!(
+            credential_dir_from(Provider::Claude, None, home.clone()),
+            Some(PathBuf::from("/home/someone/.claude")),
+            "the default is the directory the `claude` CLI really writes"
+        );
+        assert_eq!(
+            credential_dir_from(Provider::Codex, None, home.clone()),
+            Some(PathBuf::from("/home/someone/.codex"))
+        );
+        assert_eq!(
+            credential_dir_from(
+                Provider::Claude,
+                Some(PathBuf::from("/elsewhere/claude")),
+                home.clone()
+            ),
+            Some(PathBuf::from("/elsewhere/claude")),
+            "`CLAUDE_CONFIG_DIR` is honoured, so a relocated config directory is found rather \
+             than reported as `not connected`"
+        );
+        assert_eq!(
+            credential_dir_from(Provider::Codex, Some(PathBuf::new()), home),
+            Some(PathBuf::from("/home/someone/.codex")),
+            "an empty override is not an override"
+        );
+        assert_eq!(
+            credential_dir_from(Provider::Claude, None, None),
+            None,
+            "no home directory at all means there is nothing to read, not a guessed path"
+        );
+    }
+}

--- a/crates/app/src/budget/flow.rs
+++ b/crates/app/src/budget/flow.rs
@@ -1,0 +1,277 @@
+//! The poll: when Jerry reads a provider's budget, what stops it reading too often, and how a
+//! real result becomes state.
+//!
+//! Every network call here runs on `cx.background_executor()` and mutates [`AdeApp`] only
+//! afterwards, from inside the `this.update(...)` closure - the same discipline
+//! `crate::review::flow` and `crate::updater::flow` already follow.
+
+use std::time::Instant;
+
+use super::fetch::{self, ProviderRead};
+use super::state::{Provider, POLLING_ENABLED, POLL_INTERVAL};
+use super::*;
+
+/// How often the loop wakes up to *consider* polling. Much shorter than
+/// [`super::state::POLL_INTERVAL`], which is the real cadence a single provider is read at, and
+/// deliberately so: the heartbeat is what makes "you just opened the first agent of the session"
+/// and "you just logged into a provider's CLI" show up in seconds rather than in minutes, without
+/// this module having to reach into every code path that spawns an agent. A wake that finds
+/// nothing due does no I/O at all.
+const POLL_HEARTBEAT: std::time::Duration = std::time::Duration::from_secs(15);
+
+impl AdeApp {
+    /// Starts the background budget poll - called once, from `Self::new_with_settings`, next to
+    /// the update-check loop it is modelled on.
+    ///
+    /// Does nothing at all under `cfg(test)` ([`POLLING_ENABLED`]); see that constant's docs for
+    /// why a test suite must never spend a real person's rate-limit allowance.
+    pub(crate) fn start_budget_poll_loop(&mut self, cx: &mut Context<Self>) {
+        if !POLLING_ENABLED {
+            return;
+        }
+        self.poll_budgets_if_due(cx);
+        let task = cx.spawn(async move |this, cx| loop {
+            cx.background_executor().timer(POLL_HEARTBEAT).await;
+            let alive = this.update(cx, |this, cx| {
+                this.poll_budgets_if_due(cx);
+            });
+            if alive.is_err() {
+                break;
+            }
+        });
+        self._budget_poll_task = Some(task);
+    }
+
+    /// One heartbeat: read every provider whose turn it is.
+    ///
+    /// **Nothing is polled while no agent session is open at all.** The readout lives in an agent
+    /// pane and the popover is reachable only from one (§4u′'s accepted trade-off), so a window
+    /// showing only shell tabs has nowhere to display a budget - and a background HTTP request
+    /// whose result cannot be seen is exactly the "telemetry about telemetry" §2 rejects. It also
+    /// means the common case of Jerry sitting open on a terminal costs a provider nothing.
+    pub(crate) fn poll_budgets_if_due(&mut self, cx: &mut Context<Self>) {
+        if !self
+            .agents
+            .iter()
+            .any(|agent| agent.kind.is_agent_session())
+        {
+            return;
+        }
+        let now = Instant::now();
+        for provider in Provider::ALL {
+            let budget = self.budget.get(provider);
+            let due = match budget.last_attempt {
+                Some(at) => now.saturating_duration_since(at) >= POLL_INTERVAL,
+                None => true,
+            };
+            if due {
+                self.refresh_provider_budget(provider, false, cx);
+            }
+        }
+    }
+
+    /// The popover's `Refresh`: a real, manual read of every provider, held to
+    /// [`super::state::MANUAL_REFRESH_FLOOR`] per provider.
+    pub(crate) fn refresh_all_budgets(&mut self, cx: &mut Context<Self>) {
+        for provider in Provider::ALL {
+            self.refresh_provider_budget(provider, true, cx);
+        }
+    }
+
+    /// One provider's read. `manual` marks a click (`Refresh`, or a failed provider's `Retry`),
+    /// which is the only kind held to the manual floor.
+    ///
+    /// Silently does nothing when this provider may not be polled right now - a click inside the
+    /// floor, or a second click while a request is already open. Dropping it is deliberate:
+    /// queueing would turn an impatient double-click into two requests against an endpoint whose
+    /// own limiter is the reason this cadence exists.
+    pub(crate) fn refresh_provider_budget(
+        &mut self,
+        provider: Provider,
+        manual: bool,
+        cx: &mut Context<Self>,
+    ) {
+        let now = Instant::now();
+        if !self.budget.get(provider).may_poll_now(manual, now) {
+            return;
+        }
+        {
+            let budget = self.budget.get_mut(provider);
+            budget.in_flight = true;
+            budget.last_attempt = Some(now);
+        }
+        cx.notify();
+
+        cx.spawn(async move |this, cx| {
+            let read = cx
+                .background_executor()
+                .spawn(async move { fetch::read_provider(provider) })
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                this.apply_budget_poll_result(provider, read, Instant::now());
+                cx.notify();
+            });
+        })
+        .detach();
+    }
+
+    /// Folds one real read into one provider's state. The whole state machine, in one place and
+    /// with no `Context` - so every transition is directly testable without a window or a network.
+    ///
+    /// The three outcomes are kept genuinely distinct (rev 6 §7 rule 6):
+    ///
+    /// - **not connected** clears everything, including any numbers from before. A provider whose
+    ///   credential has gone (a logout while Jerry was running) is not a provider with stale
+    ///   numbers - the data is not ours to show any more.
+    /// - **ok** replaces the numbers and clears the failure.
+    /// - **failed** records the reason and *keeps* the previous numbers. They are still the last
+    ///   true reading; §2's `last read <age>` takes over once they age past
+    ///   [`super::state::STALE_AFTER`], and the failure itself surfaces as the `Retry`.
+    pub(crate) fn apply_budget_poll_result(
+        &mut self,
+        provider: Provider,
+        read: ProviderRead,
+        now: Instant,
+    ) {
+        let budget = self.budget.get_mut(provider);
+        budget.in_flight = false;
+        match read {
+            ProviderRead::NotConnected => {
+                budget.connected = false;
+                budget.last_ok = None;
+                budget.last_error = None;
+            }
+            ProviderRead::Ok(snapshot) => {
+                budget.connected = true;
+                budget.last_ok = Some((snapshot, now));
+                budget.last_error = None;
+            }
+            ProviderRead::Failed(reason) => {
+                budget.connected = true;
+                log::warn!("{} rate-limit read failed: {reason}", provider.id());
+                budget.last_error = Some(reason);
+            }
+        }
+    }
+}
+
+/// Real coverage for the state machine the poll drives, without touching the network.
+#[cfg(test)]
+mod budget_flow_tests {
+    use super::super::state::{ProviderReadout, ProviderSnapshot, STALE_AFTER};
+    use super::*;
+    use crate::budget::state::BudgetWindow;
+    use crate::root::focus::palette_focus_tests::open_test_app;
+    use gpui::TestAppContext;
+
+    fn snapshot(headroom: f32) -> ProviderSnapshot {
+        ProviderSnapshot {
+            windows: vec![BudgetWindow {
+                label: "5h".to_string(),
+                headroom_percent: headroom,
+                resets_at: None,
+            }],
+        }
+    }
+
+    /// The poll must never run itself in a test build - it reads a real credential off the
+    /// developer's disk and sends it to a real provider. This is the guard, asserted rather than
+    /// assumed.
+    #[test]
+    fn polling_is_off_in_a_test_build() {
+        assert!(
+            !POLLING_ENABLED,
+            "a test run must never spend a real person's provider budget"
+        );
+    }
+
+    #[gpui::test]
+    fn a_real_read_becomes_state_and_a_failure_keeps_the_numbers_it_had(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
+
+        app.update(cx, |app, _cx| {
+            let now = Instant::now();
+
+            app.apply_budget_poll_result(Provider::Claude, ProviderRead::NotConnected, now);
+            assert_eq!(
+                app.budget.get(Provider::Claude).readout(now),
+                ProviderReadout::NotConnected,
+                "no credential is `not connected`, and nothing was sent anywhere"
+            );
+
+            let good = snapshot(81.0);
+            app.apply_budget_poll_result(Provider::Claude, ProviderRead::Ok(good.clone()), now);
+            assert_eq!(
+                app.budget.get(Provider::Claude).readout(now),
+                ProviderReadout::Numbers(&good)
+            );
+            assert!(
+                !app.budget.get(Provider::Claude).in_flight,
+                "a landed result always clears the single-flight guard"
+            );
+
+            app.apply_budget_poll_result(
+                Provider::Claude,
+                ProviderRead::Failed("the provider answered 429".to_string()),
+                now,
+            );
+            assert_eq!(
+                app.budget.get(Provider::Claude).readout(now),
+                ProviderReadout::Numbers(&good),
+                "a failed refresh does not erase numbers that are still true"
+            );
+            assert!(
+                app.budget.get(Provider::Claude).can_retry(),
+                "but it does earn the `Retry` \u{a7}4c puts beside a failure"
+            );
+
+            let stale = now + STALE_AFTER + std::time::Duration::from_secs(1);
+            assert!(
+                matches!(
+                    app.budget.get(Provider::Claude).readout(stale),
+                    ProviderReadout::LastRead(_)
+                ),
+                "\u{a7}2: once they go stale the numbers give way to `last read <age>`"
+            );
+
+            // A logout mid-session: the credential is gone, and so are the numbers.
+            app.apply_budget_poll_result(Provider::Claude, ProviderRead::NotConnected, now);
+            assert_eq!(
+                app.budget.get(Provider::Claude).readout(now),
+                ProviderReadout::NotConnected
+            );
+            assert!(
+                app.budget.get(Provider::Claude).last_ok.is_none(),
+                "numbers from a provider we are no longer logged into are not ours to show"
+            );
+        });
+    }
+
+    /// The heartbeat must not touch the network for a window that has no agent at all - there is
+    /// nowhere to render a budget, and a request whose result cannot be seen is exactly the
+    /// telemetry §2 rejects.
+    #[gpui::test]
+    fn a_window_with_no_agent_session_polls_nothing(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        app.update(cx, |app, cx| {
+            assert!(
+                !app.agents
+                    .iter()
+                    .any(|agent| agent.kind.is_agent_session()),
+                "premise: the startup pane is a shell, not an agent session"
+            );
+            app.poll_budgets_if_due(cx);
+            for provider in Provider::ALL {
+                assert_eq!(
+                    app.budget.get(provider).last_attempt,
+                    None,
+                    "{provider:?} must not have been polled - nothing on screen could show it"
+                );
+            }
+        });
+    }
+}

--- a/crates/app/src/budget/flow.rs
+++ b/crates/app/src/budget/flow.rs
@@ -85,12 +85,26 @@ impl AdeApp {
     /// floor, or a second click while a request is already open. Dropping it is deliberate:
     /// queueing would turn an impatient double-click into two requests against an endpoint whose
     /// own limiter is the reason this cadence exists.
+    ///
+    /// # The `cfg(test)` guard lives here, not only on the timer
+    ///
+    /// This is the single choke point every read passes through: the background loop, the
+    /// popover's `Refresh` and a failed row's `Retry` all arrive here, and only the first of the
+    /// three goes anywhere near [`AdeApp::start_budget_poll_loop`]'s own [`POLLING_ENABLED`]
+    /// check. A test that drove either control - a click test on the popover, a render test that
+    /// happened to fire the handler - would otherwise read the developer's own OAuth credential
+    /// off disk and send it to a real provider, which is precisely what that constant exists to
+    /// prevent. Gating the loop alone made the promise true by accident of what the suite happens
+    /// to call today; gating here makes it true by construction.
     pub(crate) fn refresh_provider_budget(
         &mut self,
         provider: Provider,
         manual: bool,
         cx: &mut Context<Self>,
     ) {
+        if !POLLING_ENABLED {
+            return;
+        }
         let now = Instant::now();
         if !self.budget.get(provider).may_poll_now(manual, now) {
             return;
@@ -175,14 +189,40 @@ mod budget_flow_tests {
     }
 
     /// The poll must never run itself in a test build - it reads a real credential off the
-    /// developer's disk and sends it to a real provider. This is the guard, asserted rather than
-    /// assumed.
-    #[test]
-    fn polling_is_off_in_a_test_build() {
-        assert!(
-            !POLLING_ENABLED,
-            "a test run must never spend a real person's provider budget"
-        );
+    /// developer's disk and sends it to a real provider. Asserted at *compile* time rather than in
+    /// a `#[test]` body: a run-time assertion can only fail after the suite has already had the
+    /// chance to make the call it is guarding against, whereas this one refuses to build a test
+    /// binary in which polling is on.
+    const _: () = assert!(
+        !POLLING_ENABLED,
+        "a test run must never spend a real person's provider budget"
+    );
+
+    /// And the guard as *behaviour*, on the path a click really takes: the popover's `Refresh`
+    /// reaches [`AdeApp::refresh_provider_budget`] without going near the background loop, so the
+    /// constant above would not save a click test on its own. Nothing is even attempted here -
+    /// `last_attempt` staying `None` is the proof no request was started.
+    #[gpui::test]
+    fn a_manual_refresh_starts_no_request_at_all_in_a_test_build(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
+
+        app.update(cx, |app, cx| {
+            app.refresh_all_budgets(cx);
+            app.refresh_provider_budget(Provider::Claude, true, cx);
+            for provider in Provider::ALL {
+                assert_eq!(
+                    app.budget.get(provider).last_attempt,
+                    None,
+                    "{provider:?} must not have been read - a test must never send a real \
+                     developer's OAuth credential to a real endpoint"
+                );
+                assert!(
+                    !app.budget.get(provider).in_flight,
+                    "{provider:?} must not have a request open either"
+                );
+            }
+        });
     }
 
     #[gpui::test]
@@ -259,9 +299,7 @@ mod budget_flow_tests {
 
         app.update(cx, |app, cx| {
             assert!(
-                !app.agents
-                    .iter()
-                    .any(|agent| agent.kind.is_agent_session()),
+                !app.agents.iter().any(|agent| agent.kind.is_agent_session()),
                 "premise: the startup pane is a shell, not an agent session"
             );
             app.poll_budgets_if_due(cx);

--- a/crates/app/src/budget/mod.rs
+++ b/crates/app/src/budget/mod.rs
@@ -1,0 +1,61 @@
+//! Per-provider rate-limit budget: the agent pane's `claude 5h ▓▓▓▓▓▓░ 81% 7d ▓▓▓▓░░░ 40%`
+//! readout and the popover behind it (GitHub issue #294,
+//! `design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md` §2,
+//! `STAGE-A-CHANGELOG.md` §4c/§4t/§4u′).
+//!
+//! Split the way every feature folder in this crate is split - pure, GPUI-window-free logic
+//! apart from the `gpui::Div`-building code that draws it:
+//!
+//! - [`state`] - the provider set, the agent → provider mapping, the window/headroom model, the
+//!   three-step hue thresholds and every string the two surfaces print. No `gpui::Window`, so
+//!   the whole "which state is this provider really in" question is directly `#[test]`-able.
+//! - [`fetch`] - real credential discovery on disk and the real HTTP read of each provider's own
+//!   usage endpoint, plus the two response parsers. The parsers are pure functions over a
+//!   `&str`, so they are tested against real captured/spec-derived payloads rather than against
+//!   a live network.
+//! - [`flow`] - the background poll loop, the manual `Refresh`/`Retry` path and the single-flight
+//!   guards, as `impl AdeApp` methods.
+//! - [`render`] - the pane strip's readout and the popover, as `impl AdeApp` methods.
+//!
+//! # Why this is per agent and not in the footer
+//!
+//! §4u′ is the last word in a four-pass argument: budget is a per-provider fact, a provider
+//! belongs to an agent, and a fixed-width global bar cannot carry a readout whose count grows
+//! with configuration. The pane is scoped to exactly one agent, which spends exactly one
+//! provider - and it is also the right *moment*, because the pane is where you decide whether to
+//! spend another turn. The footer's aggregate slot §4t kept was deleted outright by §4u′; the
+//! accepted trade-off is that the popover is reachable only from an agent pane.
+//!
+//! # Two bars, not one - decided by what the payloads actually contain
+//!
+//! The design bundle disagreed with itself here (`REVISION-2026-08-14.md` §2 describes one meter
+//! "filled to the tighter of the two windows"; `Jerry.dc.html` and §4u′ draw one bar per window),
+//! and issue #294's Phase 0 spike resolved it against the real data rather than by picking a
+//! document. **Both** supported providers expose two genuinely independent windows with their
+//! own utilisation *and their own reset instant*: Claude's `five_hour`/`seven_day`, Codex's
+//! `primary_window`/`secondary_window`. They do not move together - a session window refills in
+//! hours, a week does not - so a single bar filled to the tighter one answers the reader's only
+//! actionable question ("can I spend another turn right now?") with the wrong number whenever the
+//! long window is the tight one. One bar per limit, each hued on its own value.
+//!
+//! # Nothing here is ever fabricated
+//!
+//! Every value on screen comes from a real HTTP read of a real provider endpoint, authorised with
+//! the credential that provider's own CLI already stored on this machine. There is no synthetic
+//! fallback: a provider with no credential reads `not connected`, one that has never been polled
+//! says so, and a failed poll says `refresh failed` next to its `Retry` (rev 6 §7 rule 6 -
+//! "converting a static span to a real input adds an empty state to everything derived from it").
+//! A shell pane, which spends no provider at all, shows nothing.
+
+use crate::root::menus;
+use crate::root::*;
+use crate::theme;
+use gpui::{div, font, prelude::*, px, ClickEvent, Context, Window};
+
+pub mod fetch;
+
+pub mod state;
+
+pub(crate) mod flow;
+
+pub(crate) mod render;

--- a/crates/app/src/budget/render.rs
+++ b/crates/app/src/budget/render.rs
@@ -259,7 +259,8 @@ impl AdeApp {
         // Opens upwards from the readout's own top edge. `right: -8px` in the mock is measured
         // from the readout, so the panel's right edge sits 8px past it; both edges are then
         // clamped into the window so a readout near either edge cannot push the panel off screen.
-        let right_edge = (anchor.origin.x + anchor.size.width + px(8.0)).min(viewport.width - px(6.0));
+        let right_edge =
+            (anchor.origin.x + anchor.size.width + px(8.0)).min(viewport.width - px(6.0));
         let left = (right_edge - width).max(px(6.0));
         let bottom = (viewport.height - anchor.origin.y + px(4.0)).max(px(6.0));
 
@@ -304,6 +305,16 @@ impl AdeApp {
             )
     }
 
+    /// `RATE LIMITS` and the `Refresh` control.
+    ///
+    /// **`Refresh` sits in the header, not next to `Updated N ago` in the foot.** §4c's prose runs
+    /// the two together in one sentence ("`Updated 3m ago` and a `Refresh` that sets `Updated just
+    /// now`"), but `Jerry.dc.html` - the newest state of the bundle, and the build §4u′ describes -
+    /// puts `Refresh` at the head opposite the title and leaves the foot to `Updated N ago` and the
+    /// `counts headroom, not spend` footnote. That is also the better reading of the same sentence:
+    /// it fixes what `Refresh` *does* to the foot line, not where it is drawn. The mock wins on
+    /// placement; the prose's actual claim - that the foot line is derived from a real read - is
+    /// what [`Self::render_budget_popover_footer`] implements.
     fn render_budget_popover_header(&self, cx: &mut Context<Self>) -> impl IntoElement {
         div()
             .flex()

--- a/crates/app/src/budget/render.rs
+++ b/crates/app/src/budget/render.rs
@@ -1,0 +1,635 @@
+//! The two surfaces: the agent pane strip's budget cluster, and the popover it opens.
+//!
+//! Both are `impl AdeApp` methods, like every other rendered surface in this crate, and both read
+//! the same [`super::state::BudgetState`] - there is one derivation of "what does this provider
+//! say right now" ([`super::state::ProviderBudget::readout`]) and two renderings of it, never two
+//! derivations that could disagree.
+
+use std::time::{Instant, SystemTime};
+
+use super::state::{
+    compact_age, BudgetLevel, BudgetWindow, Provider, ProviderReadout, ProviderSnapshot,
+};
+use super::*;
+use crate::root::widgets::{menu_popover_chrome, text_tooltip};
+use crate::status_bar::render::StatusTier;
+use crate::status_bar::resources;
+use crate::work_surface::agents::ProcessKind;
+
+/// §4c: "Click opens a popover (292 wide, above the bar)".
+const POPOVER_WIDTH: f32 = 292.0;
+
+/// The pane strip's meter: `Jerry.dc.html`'s own `30x3` track, one per window.
+const METER_WIDTH: f32 = 30.0;
+const METER_HEIGHT: f32 = 3.0;
+
+impl AdeApp {
+    /// §4t's per-agent provider budget, right-aligned in the pane's readout strip:
+    /// `claude 5h ▓▓▓▓▓▓░ 81% 7d ▓▓▓▓░░░ 40%`, for **this** agent's provider.
+    ///
+    /// `None` - nothing at all, not a dimmed placeholder - for a pane that spends no provider.
+    /// §4t words that as "a local model shows nothing, correctly"; in this build the pane that
+    /// spends nothing is the shell ([`super::state::provider_of`]).
+    ///
+    /// # One bar per window
+    ///
+    /// §4u′, and issue #294's Phase 0 finding: both providers expose two independent windows with
+    /// their own reset instants, so each bar is hued on **its own** value
+    /// ([`super::state::budget_level`] -> `crate::theme::budget`'s tokens, which #279 landed). A
+    /// single bar filled to the tighter window hides *which* limit is tight - and on the live
+    /// account this was verified against, a healthy 5-hour window sat next to a 7-day window on
+    /// the amber boundary, so the single bar would have reported the session as constrained when
+    /// it was not.
+    ///
+    /// # Window label before the value
+    ///
+    /// §4c, verbatim: "`92% 5h` parsed as '92% for 5 hours'; `5h 92%` parses as '5-hour window,
+    /// 92% left'". Every string and every element order here puts the label first.
+    ///
+    /// # Why a not-connected provider still renders a (bare) cluster
+    ///
+    /// §4b's rule that unconnected providers "never appear" was written for the footer's
+    /// *per-provider list*, where each extra row was pure cost. This strip is scoped to one agent
+    /// that is literally running that provider's CLI, and §4t's own correction applies instead:
+    /// hiding the slot "took the popover's only trigger with it, so ... a failed provider's
+    /// `Retry` became unreachable". With §4u′ deleting the footer anchor, this strip is the *only*
+    /// route to the popover - so a connected-or-not agent pane keeps a trigger, and the cluster
+    /// says plainly which state it is in rather than fabricating numbers for it.
+    pub(crate) fn render_agent_budget_readout(
+        &self,
+        kind: ProcessKind,
+        cx: &mut Context<Self>,
+    ) -> Option<gpui::AnyElement> {
+        let provider = super::state::provider_of(kind)?;
+        let now = Instant::now();
+        let budget = self.budget.get(provider);
+
+        let mut cluster = div()
+            .id("pty-footer-budget")
+            .debug_selector(|| "pty-footer-budget".to_string())
+            .flex()
+            .flex_none()
+            .items_center()
+            .gap(px(7.0))
+            .h(px(18.0))
+            .px(px(4.0))
+            .rounded(theme::radius::CHIP)
+            .cursor_pointer()
+            .hover(|el| el.bg(theme::surface::ROW_HOVER_ALT))
+            .when(self.budget_popover_open, |el| {
+                el.bg(theme::surface::ROW_HOVER_ALT)
+            })
+            .tooltip(text_tooltip(match budget.readout(now) {
+                ProviderReadout::Numbers(_) => format!(
+                    "How much of {}'s rate limit is left - click for every window and provider",
+                    provider.label()
+                ),
+                _ => format!("{}'s rate limit - click for details", provider.label()),
+            }))
+            // §4c's secondary tier is "provider names", verbatim - so the name is the one part of
+            // this cluster that never carries a hue.
+            .child(
+                div()
+                    .flex_none()
+                    .font(font(theme::font::MONO))
+                    .font_weight(StatusTier::Secondary.weight())
+                    .text_size(self.ui_text_size(StatusTier::Secondary.text_size()))
+                    .text_color(StatusTier::Secondary.color())
+                    .child(provider.id()),
+            );
+
+        match budget.readout(now) {
+            ProviderReadout::Numbers(snapshot) => {
+                for (index, window) in snapshot.windows.iter().enumerate() {
+                    cluster = cluster.child(self.render_budget_meter(index, window));
+                }
+            }
+            ProviderReadout::LastRead(age) => {
+                cluster = cluster.child(self.render_budget_state_text(
+                    "pty-footer-budget-state",
+                    format!("last read {} ago", compact_age(age)),
+                    theme::budget::STALE,
+                ));
+            }
+            ProviderReadout::RefreshFailed => {
+                cluster = cluster.child(self.render_budget_state_text(
+                    "pty-footer-budget-state",
+                    "refresh failed".to_string(),
+                    theme::budget::WARN,
+                ));
+            }
+            ProviderReadout::NotConnected => {
+                cluster = cluster.child(self.render_budget_state_text(
+                    "pty-footer-budget-state",
+                    "not connected".to_string(),
+                    theme::budget::STALE,
+                ));
+            }
+            ProviderReadout::Checking => {
+                cluster = cluster.child(self.render_budget_state_text(
+                    "pty-footer-budget-state",
+                    "checking\u{2026}".to_string(),
+                    theme::budget::STALE,
+                ));
+            }
+        }
+
+        Some(
+            cluster
+                .child({
+                    let this = cx.entity();
+                    gpui::canvas(
+                        move |bounds, _window, cx| {
+                            this.update(cx, |this, _cx| {
+                                this.budget_readout_bounds = bounds;
+                            });
+                        },
+                        |_, _, _, _| {},
+                    )
+                    .absolute()
+                    .size_full()
+                })
+                .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
+                    let opening = !this.budget_popover_open;
+                    // GitHub issue #176's shared invariant: opening this popover closes whatever
+                    // else was open. Read before the sweep and applied after it, because the sweep
+                    // clears `budget_popover_open` itself.
+                    let _ = this.close_menu_surfaces_except(Some(menus::MenuSurface::Budget));
+                    this.budget_popover_open = opening;
+                    cx.notify();
+                }))
+                .into_any_element(),
+        )
+    }
+
+    /// One window's `5h ▓▓▓▓▓▓░ 81%` - label, then meter, then value, in that painted order.
+    fn render_budget_meter(&self, index: usize, window: &BudgetWindow) -> impl IntoElement {
+        let level = window.level();
+        let label = window.label.clone();
+        // The percentage only joins the attention family when it deserves to (§2) - a healthy
+        // budget's number stays on the bar's own primary tier and spends no colour. Exactly the
+        // rule `render_status_resources_readout` already applies to load.
+        let value_color = if level == BudgetLevel::Ok {
+            StatusTier::Primary.color()
+        } else {
+            level.color()
+        };
+
+        div()
+            .flex()
+            .flex_none()
+            .items_center()
+            .gap(px(5.0))
+            .child(
+                div()
+                    .id(("budget-window-label", index))
+                    .debug_selector(move || format!("budget-window-{index}-label"))
+                    .flex_none()
+                    .font(font(theme::font::MONO))
+                    .text_size(self.ui_text_size(9.5))
+                    .text_color(theme::text::GHOST)
+                    .child(label),
+            )
+            .child(
+                div()
+                    .flex_none()
+                    .w(px(METER_WIDTH))
+                    .h(px(METER_HEIGHT))
+                    .rounded(px(2.0))
+                    .bg(theme::budget::TRACK)
+                    .child(
+                        div()
+                            .h(px(METER_HEIGHT))
+                            .w(gpui::relative(window.fill_fraction()))
+                            .rounded(px(2.0))
+                            .bg(level.color()),
+                    ),
+            )
+            .child(
+                div()
+                    .id(("budget-window-value", index))
+                    .debug_selector(move || format!("budget-window-{index}-value"))
+                    .flex_none()
+                    .font(font(theme::font::MONO))
+                    .font_weight(gpui::FontWeight::MEDIUM)
+                    .text_size(self.ui_text_size(10.5))
+                    .text_color(value_color)
+                    .child(window.value_label()),
+            )
+    }
+
+    /// The strip's non-numeric states - `not connected`, `checking…`, `refresh failed`,
+    /// `last read 3m ago`. One helper, so no state can quietly pick a different size or tier.
+    fn render_budget_state_text(
+        &self,
+        selector: &'static str,
+        text: String,
+        color: theme::ColorToken,
+    ) -> impl IntoElement {
+        div()
+            .id(selector)
+            .debug_selector(move || selector.to_string())
+            .flex_none()
+            .font(font(theme::font::MONO))
+            .text_size(self.ui_text_size(10.0))
+            .text_color(color)
+            .child(text)
+    }
+
+    /// §4c/§4u′'s popover: the tightest provider on top with each window as a labelled meter and
+    /// a reset countdown, the other providers with their own windows or their own failure state,
+    /// and `Updated N ago · Refresh` at the foot.
+    ///
+    /// Anchored **directly above the readout that opened it** (§4u′: "it is now
+    /// `position:absolute; right:-8px; bottom:22px` inside the pane readout itself, opening
+    /// directly above the thing you clicked"). Positioned off the readout's real painted bounds,
+    /// which is why it is a direct child of the root element rather than of the strip: those
+    /// bounds are window-space, so `.absolute()` positioning built from them is only correct
+    /// there - the same shape `render_resources_popover` and `render_plus_menu` use.
+    pub(crate) fn render_budget_popover(
+        &self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let now = Instant::now();
+        let anchor = self.budget_readout_bounds;
+        let viewport = window.viewport_size();
+        let width = px(POPOVER_WIDTH);
+
+        // Opens upwards from the readout's own top edge. `right: -8px` in the mock is measured
+        // from the readout, so the panel's right edge sits 8px past it; both edges are then
+        // clamped into the window so a readout near either edge cannot push the panel off screen.
+        let right_edge = (anchor.origin.x + anchor.size.width + px(8.0)).min(viewport.width - px(6.0));
+        let left = (right_edge - width).max(px(6.0));
+        let bottom = (viewport.height - anchor.origin.y + px(4.0)).max(px(6.0));
+
+        let lead = self.budget.lead_provider(now);
+
+        div()
+            .id("budget-popover-scrim")
+            .absolute()
+            .top(px(0.0))
+            .left(px(0.0))
+            .right(px(0.0))
+            .bottom(px(0.0))
+            .bg(crate::work_surface::state::TRANSPARENT)
+            .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
+                // `stop_propagation` is what makes this a scrim rather than a transparent sheet -
+                // see `render_resources_popover`'s own note: without it, clicking the readout to
+                // dismiss would close here and immediately reopen there.
+                cx.stop_propagation();
+                this.budget_popover_open = false;
+                cx.notify();
+            }))
+            .child(
+                menu_popover_chrome(
+                    div()
+                        .id("budget-popover")
+                        .debug_selector(|| "budget-popover".to_string())
+                        .absolute()
+                        .left(left)
+                        .bottom(bottom)
+                        .w(width)
+                        .flex()
+                        .flex_col(),
+                    theme::shadow::MENU,
+                )
+                .on_click(cx.listener(|_this, _event: &ClickEvent, _window, cx| {
+                    cx.stop_propagation();
+                }))
+                .child(self.render_budget_popover_header(cx))
+                .children(lead.map(|provider| self.render_budget_lead_section(provider, now)))
+                .child(self.render_budget_other_providers(lead, now, cx))
+                .child(self.render_budget_popover_footer()),
+            )
+    }
+
+    fn render_budget_popover_header(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .flex()
+            .items_center()
+            .gap(px(8.0))
+            .px(px(11.0))
+            .pt(px(8.0))
+            .pb(px(7.0))
+            .border_b_1()
+            .border_color(theme::border::INNER)
+            .child(
+                div()
+                    .flex_1()
+                    .font(font(theme::font::SANS))
+                    .font_weight(gpui::FontWeight::SEMIBOLD)
+                    .text_size(self.ui_text_size(9.5))
+                    .text_color(theme::text::MUTED)
+                    .child("RATE LIMITS"),
+            )
+            .child(
+                div()
+                    .id("budget-popover-refresh")
+                    .debug_selector(|| "budget-popover-refresh".to_string())
+                    .flex_none()
+                    .cursor_pointer()
+                    .font(font(theme::font::SANS))
+                    .font_weight(gpui::FontWeight::MEDIUM)
+                    .text_size(self.ui_text_size(10.0))
+                    .text_color(theme::button::BLUE_FG)
+                    .hover(|el| el.text_color(theme::text::SELECTED))
+                    .child("Refresh")
+                    .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
+                        cx.stop_propagation();
+                        // A real read of every provider, not a label swap: §4c's `Refresh` "sets
+                        // `Updated just now`", and here that line is derived from the instant a
+                        // real result lands, so it can only say so once one has.
+                        this.refresh_all_budgets(cx);
+                    })),
+            )
+    }
+
+    /// The lead provider's own block: its chip and name, then one labelled meter per window with
+    /// its own reset countdown.
+    fn render_budget_lead_section(&self, provider: Provider, now: Instant) -> gpui::AnyElement {
+        let budget = self.budget.get(provider);
+        let (chip_fg, chip_bg) = crate::work_surface::state::agent_tint(match provider {
+            Provider::Claude => ProcessKind::claude(),
+            Provider::Codex => ProcessKind::codex(),
+        });
+
+        let mut section = div()
+            .px(px(11.0))
+            .pt(px(9.0))
+            .pb(px(10.0))
+            .border_b_1()
+            .border_color(theme::border::INNER)
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .gap(px(7.0))
+                    .pb(px(7.0))
+                    .child(
+                        div()
+                            .flex_none()
+                            .w(px(13.0))
+                            .h(px(13.0))
+                            .rounded(theme::radius::CHIP)
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .bg(chip_bg)
+                            .font(font(theme::font::MONO))
+                            .font_weight(gpui::FontWeight::MEDIUM)
+                            .text_size(self.ui_text_size(8.0))
+                            .text_color(chip_fg)
+                            .child(provider.chip()),
+                    )
+                    .child(
+                        div()
+                            .font(font(theme::font::SANS))
+                            .font_weight(gpui::FontWeight::MEDIUM)
+                            .text_size(self.ui_text_size(11.5))
+                            .text_color(theme::text::SELECTED)
+                            .child(provider.label()),
+                    ),
+            );
+
+        if let ProviderReadout::Numbers(snapshot) = budget.readout(now) {
+            for window in &snapshot.windows {
+                section = section.child(self.render_budget_lead_row(window));
+            }
+        }
+        section.into_any_element()
+    }
+
+    /// One window inside the lead block: `5h · 92% left · resets in 4h 53m`, over its own meter.
+    ///
+    /// The window label leads here too (§4c), and it is a real duration token (`5h`/`7d`) rather
+    /// than a word, so the two rows read as a series.
+    fn render_budget_lead_row(&self, window: &BudgetWindow) -> impl IntoElement {
+        let level = window.level();
+        let value_color = if level == BudgetLevel::Ok {
+            theme::status_bar::PRIMARY
+        } else {
+            level.color()
+        };
+
+        div()
+            .pt(px(5.0))
+            .child(
+                div()
+                    .flex()
+                    .items_baseline()
+                    .gap(px(6.0))
+                    .child(
+                        div()
+                            .flex_none()
+                            .w(px(30.0))
+                            .font(font(theme::font::MONO))
+                            .text_size(self.ui_text_size(10.0))
+                            .text_color(theme::text::DIM)
+                            .child(window.label.clone()),
+                    )
+                    .child(
+                        div()
+                            .flex_1()
+                            .font(font(theme::font::MONO))
+                            .font_weight(gpui::FontWeight::MEDIUM)
+                            .text_size(self.ui_text_size(10.5))
+                            .text_color(value_color)
+                            .child(window.popover_value_label()),
+                    )
+                    .children(window.reset_label(SystemTime::now()).map(|reset| {
+                        div()
+                            .flex_none()
+                            .font(font(theme::font::MONO))
+                            .text_size(self.ui_text_size(10.0))
+                            .text_color(theme::text::FAINTER)
+                            .child(reset)
+                    })),
+            )
+            .child(
+                div()
+                    .mt(px(4.0))
+                    .h(px(4.0))
+                    .w_full()
+                    .rounded(px(2.0))
+                    .bg(theme::budget::TRACK)
+                    .child(
+                        div()
+                            .h(px(4.0))
+                            .w(gpui::relative(window.fill_fraction()))
+                            .rounded(px(2.0))
+                            .bg(level.color()),
+                    ),
+            )
+    }
+
+    /// Every provider that is not the lead, each in whichever state it is really in - its own
+    /// windows, `not connected`, `refresh failed` + `Retry`, or `last read <age>`.
+    ///
+    /// **No aggregate `⚠ N` anywhere**, and nothing is summed across these rows (§2, verbatim:
+    /// "Amber means *your work is affected*. A provider you do not use failing to poll is
+    /// telemetry about telemetry"). A failure states itself, in its own row, next to the control
+    /// that acts on it.
+    ///
+    /// This build has two providers, so this section holds at most one row - it is deliberately
+    /// **not** padded out to the mock's four (`claude`/`codex`/`copilot`/`grok`), which would mean
+    /// listing providers no agent kind here can spend.
+    fn render_budget_other_providers(
+        &self,
+        lead: Option<Provider>,
+        now: Instant,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let others: Vec<Provider> = Provider::ALL
+            .into_iter()
+            .filter(|provider| Some(*provider) != lead)
+            .collect();
+
+        div()
+            .px(px(11.0))
+            .pt(px(7.0))
+            .pb(px(8.0))
+            .border_b_1()
+            .border_color(theme::border::INNER)
+            .child(
+                div().pb(px(3.0)).child(
+                    div()
+                        .font(font(theme::font::SANS))
+                        .font_weight(gpui::FontWeight::SEMIBOLD)
+                        .text_size(self.ui_text_size(9.0))
+                        .text_color(theme::status_bar::SECTION_LABEL)
+                        // With no lead there is no "other" to be other *than* - the same rows
+                        // under an honest label rather than one that presupposes a section that
+                        // is not on screen.
+                        .child(if lead.is_some() {
+                            "OTHER PROVIDERS"
+                        } else {
+                            "PROVIDERS"
+                        }),
+                ),
+            )
+            .children(
+                others
+                    .into_iter()
+                    .map(|provider| self.render_budget_other_row(provider, now, cx)),
+            )
+    }
+
+    fn render_budget_other_row(
+        &self,
+        provider: Provider,
+        now: Instant,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let budget = self.budget.get(provider);
+        let readout = budget.readout(now);
+        let (state_text, state_color) = match &readout {
+            ProviderReadout::Numbers(snapshot) => (
+                snapshot.summary_label(),
+                Self::budget_summary_color(snapshot),
+            ),
+            ProviderReadout::LastRead(age) => (
+                format!("last read {} ago", compact_age(*age)),
+                theme::budget::STALE,
+            ),
+            ProviderReadout::RefreshFailed => ("refresh failed".to_string(), theme::budget::WARN),
+            ProviderReadout::NotConnected => ("not connected".to_string(), theme::text::GHOST),
+            ProviderReadout::Checking => ("checking\u{2026}".to_string(), theme::budget::STALE),
+        };
+        let name_color = match &readout {
+            ProviderReadout::Numbers(_) => theme::text::STRONG,
+            _ => theme::text::DIM,
+        };
+        let can_retry = budget.can_retry();
+
+        div()
+            .flex()
+            .items_center()
+            .gap(px(8.0))
+            .h(px(20.0))
+            .child(
+                div()
+                    .flex_1()
+                    .min_w_0()
+                    .truncate()
+                    .font(font(theme::font::SANS))
+                    .font_weight(gpui::FontWeight::MEDIUM)
+                    .text_size(self.ui_text_size(10.5))
+                    .text_color(name_color)
+                    .child(provider.label()),
+            )
+            .child(
+                div()
+                    .flex_none()
+                    .font(font(theme::font::MONO))
+                    .text_size(self.ui_text_size(10.0))
+                    .text_color(state_color)
+                    .child(state_text),
+            )
+            .when(can_retry, |el| {
+                el.child(
+                    div()
+                        .id(match provider {
+                            Provider::Claude => "budget-popover-retry-claude",
+                            Provider::Codex => "budget-popover-retry-codex",
+                        })
+                        .debug_selector(move || format!("budget-popover-retry-{}", provider.id()))
+                        .flex_none()
+                        .cursor_pointer()
+                        .font(font(theme::font::SANS))
+                        .font_weight(gpui::FontWeight::MEDIUM)
+                        .text_size(self.ui_text_size(10.0))
+                        .text_color(theme::button::BLUE_FG)
+                        .hover(|el| el.text_color(theme::text::SELECTED))
+                        .child("Retry")
+                        .on_click(cx.listener(move |this, _event: &ClickEvent, _window, cx| {
+                            cx.stop_propagation();
+                            this.refresh_provider_budget(provider, true, cx);
+                        })),
+                )
+            })
+    }
+
+    /// A summary row's hue: its own tightest window's, so a provider one divider away from the
+    /// lead still reports honestly - and stays neutral while it is healthy.
+    fn budget_summary_color(snapshot: &ProviderSnapshot) -> theme::ColorToken {
+        match snapshot.tightest().map(|window| window.level()) {
+            Some(BudgetLevel::Ok) | None => theme::text::DIM,
+            Some(level) => level.color(),
+        }
+    }
+
+    /// §4c's foot: `Updated 3m ago` and the footnote `counts headroom, not spend`.
+    ///
+    /// The age comes from the real instant a real result last landed
+    /// ([`super::state::BudgetState::last_read_at`]), through the *same* formatter the Resources
+    /// popover's own foot line uses - two popovers stating the same kind of fact in two different
+    /// vocabularies would be exactly the drift `resources::agent_readout` exists to prevent.
+    fn render_budget_popover_footer(&self) -> impl IntoElement {
+        let since = self
+            .budget
+            .last_read_at()
+            .map(|at| Instant::now().saturating_duration_since(at));
+        div()
+            .flex()
+            .items_center()
+            .px(px(11.0))
+            .pt(px(7.0))
+            .pb(px(8.0))
+            .child(
+                div()
+                    .flex_1()
+                    .font(font(theme::font::MONO))
+                    .text_size(self.ui_text_size(10.0))
+                    .text_color(theme::status_bar::RECESSIVE)
+                    .child(resources::updated_ago_label(since)),
+            )
+            .child(
+                div()
+                    .font(font(theme::font::SANS))
+                    .text_size(self.ui_text_size(10.0))
+                    .text_color(theme::text::HINT)
+                    .child("counts headroom, not spend"),
+            )
+    }
+}

--- a/crates/app/src/budget/state.rs
+++ b/crates/app/src/budget/state.rs
@@ -569,7 +569,11 @@ mod budget_state_tests {
             "a window that is not a whole number of hours must not round to one that isn't real"
         );
         assert_eq!(window_label(30), "30s");
-        assert_eq!(window_label(-5), "0s", "a negative duration is not a window");
+        assert_eq!(
+            window_label(-5),
+            "0s",
+            "a negative duration is not a window"
+        );
     }
 
     #[test]
@@ -616,7 +620,10 @@ mod budget_state_tests {
             ProviderReadout::NotConnected,
             "no credential on disk is `not connected`, and nothing about it is broken"
         );
-        assert!(!budget.can_retry(), "there is nothing to retry when there is no credential");
+        assert!(
+            !budget.can_retry(),
+            "there is nothing to retry when there is no credential"
+        );
 
         budget.connected = true;
         assert_eq!(
@@ -631,7 +638,10 @@ mod budget_state_tests {
             ProviderReadout::RefreshFailed,
             "a failure with no earlier numbers has nothing to go stale"
         );
-        assert!(budget.can_retry(), "and it earns the `Retry` \u{a7}4c puts beside it");
+        assert!(
+            budget.can_retry(),
+            "and it earns the `Retry` \u{a7}4c puts beside it"
+        );
 
         let fresh = snapshot(81.0, 40.0);
         budget.last_ok = Some((fresh.clone(), now));
@@ -740,7 +750,11 @@ mod budget_state_tests {
     fn the_last_read_instant_is_the_newest_across_providers() {
         let now = Instant::now();
         let mut state = BudgetState::default();
-        assert_eq!(state.last_read_at(), None, "not sampled yet is its own state");
+        assert_eq!(
+            state.last_read_at(),
+            None,
+            "not sampled yet is its own state"
+        );
 
         let older = now - Duration::from_secs(120);
         state.get_mut(Provider::Claude).last_ok = Some((snapshot(50.0, 50.0), older));

--- a/crates/app/src/budget/state.rs
+++ b/crates/app/src/budget/state.rs
@@ -1,0 +1,750 @@
+//! The budget model: which providers exist, which agent spends which one, what a window's
+//! headroom means, and every string the pane strip and the popover print.
+//!
+//! Pure and GPUI-free, like `crate::status_bar::resources` - so "a connected provider that goes
+//! stale shows `last read <age>` in place of its own numbers" is a property that can be tested
+//! directly against a state value, without a window.
+//!
+//! # Headroom, not spend
+//!
+//! Both providers report a *utilisation* (percent **used**). Every number this module carries and
+//! prints is the complement of that - percent **left** - which is what the popover's own footnote
+//! (`counts headroom, not spend`) promises the reader. The conversion happens once, in
+//! [`crate::budget::fetch`]'s parsers, so nothing downstream can hold a value whose direction is
+//! ambiguous.
+
+use std::time::{Duration, Instant, SystemTime};
+
+use crate::work_surface::agents::{AgentKind, ProcessKind};
+
+/// How often the background loop re-reads every connected provider
+/// (`crate::budget::flow::AdeApp::start_budget_poll_loop`).
+///
+/// Deliberately slow. The windows themselves are 5 hours and 7 days long, so a percentage that
+/// moves visibly inside five minutes does not exist; and the usage endpoints are themselves
+/// rate-limited (a real, observed `429` with a `retry-after` header from Anthropic's own usage
+/// endpoint while an ordinary authenticated `GET /api/oauth/profile` against the same token
+/// returned `200` - the limiter is on the usage route specifically). A budget readout that spent
+/// budget to fetch itself would be the worst possible failure mode here.
+pub const POLL_INTERVAL: Duration = Duration::from_secs(300);
+
+/// The floor between two *manual* reads of one provider (the popover's `Refresh`, and a failed
+/// provider's `Retry`). A click inside this window is dropped rather than queued - see
+/// [`ProviderBudget::may_poll_now`].
+pub const MANUAL_REFRESH_FLOOR: Duration = Duration::from_secs(15);
+
+/// How old a successful read may be before its numbers are replaced by `last read <age>`.
+///
+/// §2: "A **connected** provider that goes stale shows `last read <age>` in place of its own
+/// numbers, so the signal attaches to what is broken." Staleness - not a failed attempt - is what
+/// triggers that swap: a poll that failed seconds after a good read has numbers that are still
+/// true, and hiding them would be less honest, not more. The failed attempt surfaces as the
+/// `Retry` affordance instead ([`ProviderBudget::can_retry`]).
+///
+/// Three poll intervals: one missed tick is a hiccup, three in a row is a provider that has
+/// stopped answering.
+pub const STALE_AFTER: Duration = Duration::from_secs(15 * 60);
+
+/// Whether the background poll loop runs at all in this build.
+///
+/// **Off under `cfg(test)`, deliberately and non-negotiably.** The poll reads the *developer's
+/// own* OAuth credential off disk and sends it to a real provider endpoint; a test suite that did
+/// that would spend a real person's real rate-limit allowance (and hammer a limiter that is
+/// already tight) every time anyone ran `cargo test`. Everything the loop does *around* the
+/// network call - the single-flight guard, the manual-refresh floor, applying a result to state,
+/// every derived readout - is tested directly against
+/// `crate::budget::flow::AdeApp::apply_budget_poll_result`, and the two response parsers are
+/// tested against real payloads. The one thing not covered by a test is "does the timer fire",
+/// which is the same line the updater's own periodic loop draws.
+pub const POLLING_ENABLED: bool = !cfg!(test);
+
+/// A provider Jerry can read a rate-limit budget from.
+///
+/// Exactly the set this build can *spend*: `crate::work_surface::agents::AgentKind` has two
+/// variants and each maps to one of these. This is not a wish list - a provider with no agent
+/// kind has nothing in this app that could consume it, and a row for it in the popover would be
+/// telemetry about a thing you cannot use.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum Provider {
+    Claude,
+    Codex,
+}
+
+impl Provider {
+    /// Every provider, in the order `Other providers` lists them.
+    pub const ALL: [Provider; 2] = [Provider::Claude, Provider::Codex];
+
+    /// The lowercase name the pane strip prints (`Jerry.dc.html`'s `paneBudgetName` is
+    /// `budgetDefs[].id`, lowercase).
+    pub fn id(self) -> &'static str {
+        match self {
+            Provider::Claude => "claude",
+            Provider::Codex => "codex",
+        }
+    }
+
+    /// The capitalised name the popover's rows and lead header print
+    /// (`budgetDefs[].label`).
+    pub fn label(self) -> &'static str {
+        match self {
+            Provider::Claude => "Claude",
+            Provider::Codex => "Codex",
+        }
+    }
+
+    /// The two-letter chip in the popover's lead header (`budgetLeadChip`:
+    /// `label.slice(0, 2).toLowerCase()`).
+    pub fn chip(self) -> &'static str {
+        match self {
+            Provider::Claude => "cl",
+            Provider::Codex => "co",
+        }
+    }
+}
+
+/// §4t's `provOf(agent)`: which provider an agent spends, or `None` for a pane that spends none.
+///
+/// A total function over [`ProcessKind`], not a lookup that can miss: the `match` is exhaustive,
+/// so a third pane kind cannot be added without deciding what it spends. [`ProcessKind::Shell`] is
+/// the `None` - §4t's "a local model shows nothing, correctly" lands in this build as "a shell
+/// pane shows nothing", and for the same underlying reason: a surface that spends no provider has
+/// no budget to attribute to it. That is a correct terminal state, not a gap waiting on a
+/// provider-less agent kind.
+pub fn provider_of(kind: ProcessKind) -> Option<Provider> {
+    match kind {
+        ProcessKind::Shell => None,
+        ProcessKind::Agent(AgentKind::Claude) => Some(Provider::Claude),
+        ProcessKind::Agent(AgentKind::Codex) => Some(Provider::Codex),
+    }
+}
+
+/// The three-step hue rev 6 puts on a budget, on *remaining* budget rather than on consumption
+/// (§2: "Hue `#7fc79a` above 40%, `#c99b4e` 15-40%, `#c4726d` below").
+///
+/// An enum rather than a colour directly, exactly like `crate::status_bar::resources::LoadLevel`:
+/// the thresholds are then testable without a theme, and the render side reads the tokens back
+/// (`crate::theme::budget::{OK, WARN, CRITICAL}`, which #279 already landed) rather than
+/// inventing colour literals.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BudgetLevel {
+    /// Above 40% left - healthy. §2's rule for the whole attention family applies: "a budget only
+    /// joins the attention family when it deserves to".
+    Ok,
+    /// 15-40% left.
+    Warn,
+    /// Below 15% left.
+    Critical,
+}
+
+impl BudgetLevel {
+    /// The real, resolved token for this step.
+    pub fn color(self) -> crate::theme::ColorToken {
+        use crate::theme::budget;
+        match self {
+            BudgetLevel::Ok => budget::OK,
+            BudgetLevel::Warn => budget::WARN,
+            BudgetLevel::Critical => budget::CRITICAL,
+        }
+    }
+}
+
+/// The step a real headroom percentage falls in. Boundaries follow §2's own wording exactly:
+/// *above* 40 is healthy, 15-40 inclusive is amber, *below* 15 is red.
+pub fn budget_level(headroom_percent: f32) -> BudgetLevel {
+    if headroom_percent > 40.0 {
+        BudgetLevel::Ok
+    } else if headroom_percent >= 15.0 {
+        BudgetLevel::Warn
+    } else {
+        BudgetLevel::Critical
+    }
+}
+
+/// One rate-limit window of one provider: how much of it is left, when it resets, and what to
+/// call it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BudgetWindow {
+    /// The window's own duration, as the strip prints it - `5h`, `7d`. Owned rather than
+    /// `&'static str` because it is **not** a constant on the Codex side: that API sends
+    /// `limit_window_seconds` and the label is formatted from it ([`window_label`]), so a plan
+    /// whose primary window is not five hours labels itself correctly instead of lying.
+    pub label: String,
+    /// Percent **left**, 0-100 - already the complement of the API's own "used" figure. See this
+    /// module's docs.
+    pub headroom_percent: f32,
+    /// When this window rolls over, as an absolute instant, so the popover's countdown really
+    /// counts down while it is open instead of freezing at whatever it read at poll time. `None`
+    /// when the provider did not send one.
+    pub resets_at: Option<SystemTime>,
+}
+
+impl BudgetWindow {
+    pub fn level(&self) -> BudgetLevel {
+        budget_level(self.headroom_percent)
+    }
+
+    /// `"92%"` - the value half of the readout. Rounded to whole percent: both APIs report whole
+    /// or near-whole numbers, and a decimal place on a five-hour window is precision this fact
+    /// does not have.
+    pub fn value_label(&self) -> String {
+        format!("{}%", self.headroom_percent.round() as i64)
+    }
+
+    /// `"92% left"` - the popover's own longer form, which has the room to remove the
+    /// left/used ambiguity inline rather than only in the footnote.
+    pub fn popover_value_label(&self) -> String {
+        format!("{} left", self.value_label())
+    }
+
+    /// The meter's fill as a real 0.0-1.0 fraction.
+    pub fn fill_fraction(&self) -> f32 {
+        (self.headroom_percent / 100.0).clamp(0.0, 1.0)
+    }
+
+    /// `"resets in 4h 53m"`, or `None` when the provider sent no reset instant at all - which the
+    /// render side draws as nothing rather than as a fabricated countdown.
+    ///
+    /// A window whose reset is already in the past reads `resets now`: the rollover is due and
+    /// the next read will show it, which is a different (and more useful) statement than a
+    /// negative duration or a stuck `0m`.
+    pub fn reset_label(&self, now: SystemTime) -> Option<String> {
+        let resets_at = self.resets_at?;
+        let Ok(remaining) = resets_at.duration_since(now) else {
+            return Some("resets now".to_string());
+        };
+        Some(format!("resets in {}", coarse_duration(remaining)))
+    }
+}
+
+/// `"4h 53m"` / `"3d 6h"` / `"12m"` - two units at most, largest first, the shape §2's own
+/// `resets 3d 6h` uses. Under a minute reads `<1m` rather than `0m`, which would look stuck.
+pub fn coarse_duration(remaining: Duration) -> String {
+    let total_minutes = remaining.as_secs() / 60;
+    if total_minutes == 0 {
+        return "<1m".to_string();
+    }
+    let days = total_minutes / (60 * 24);
+    let hours = (total_minutes / 60) % 24;
+    let minutes = total_minutes % 60;
+    if days > 0 {
+        return format!("{days}d {hours}h");
+    }
+    if hours > 0 {
+        return format!("{hours}h {minutes}m");
+    }
+    format!("{minutes}m")
+}
+
+/// A window's own label from its real duration in seconds - `18000 -> "5h"`, `604800 -> "7d"`.
+///
+/// Exact units only: a window that is not a whole number of days or hours labels itself in the
+/// next unit down (`90m`) rather than rounding, because the label's whole job is to say *which*
+/// limit this bar is, and `2h` printed on a 150-minute window would name a window that does not
+/// exist.
+pub fn window_label(seconds: i64) -> String {
+    let seconds = seconds.max(0);
+    let day = 60 * 60 * 24;
+    if seconds >= day && seconds % day == 0 {
+        return format!("{}d", seconds / day);
+    }
+    if seconds >= 3600 && seconds % 3600 == 0 {
+        return format!("{}h", seconds / 3600);
+    }
+    if seconds >= 60 {
+        return format!("{}m", seconds / 60);
+    }
+    format!("{seconds}s")
+}
+
+/// `"12s"` / `"3m"` / `"2h"` / `"4d"` - the compact age in `last read <age> ago`.
+///
+/// A second, shorter vocabulary than `crate::status_bar::resources::updated_ago_label`'s
+/// spelled-out `"Updated 3 minutes ago"` on purpose, and only for this one string: it renders
+/// *inside* the pane strip, in place of two meters and two percentages, where a spelled-out unit
+/// would push the readout past the width it is replacing. The popover's own foot line - which has
+/// the room - goes through the shared formatter, so the two surfaces still agree on the one fact
+/// they both state.
+pub fn compact_age(age: Duration) -> String {
+    let seconds = age.as_secs();
+    if seconds < 60 {
+        return format!("{seconds}s");
+    }
+    let minutes = seconds / 60;
+    if minutes < 60 {
+        return format!("{minutes}m");
+    }
+    let hours = minutes / 60;
+    if hours < 24 {
+        return format!("{hours}h");
+    }
+    format!("{}d", hours / 24)
+}
+
+/// One provider's real, current windows - two of them for both providers this build supports, in
+/// short-window-first order.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProviderSnapshot {
+    pub windows: Vec<BudgetWindow>,
+}
+
+impl ProviderSnapshot {
+    /// The window with the least headroom - what ranks providers in the popover ("the tightest
+    /// provider on top"). `None` for a provider that reported no windows at all, which is a real
+    /// possibility for an account with no limits attached and is deliberately not coerced to
+    /// `Some(100)`.
+    pub fn tightest(&self) -> Option<&BudgetWindow> {
+        self.windows.iter().min_by(|a, b| {
+            a.headroom_percent
+                .partial_cmp(&b.headroom_percent)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+    }
+
+    /// The `Other providers` row's one-line summary: `"5h 92%  ·  7d 65%"`.
+    ///
+    /// **Window label before the value**, like every other budget string in this app - §4c,
+    /// verbatim: "`92% 5h` parsed as '92% for 5 hours'; `5h 92%` parses as '5-hour window, 92%
+    /// left'".
+    pub fn summary_label(&self) -> String {
+        self.windows
+            .iter()
+            .map(|window| format!("{} {}", window.label, window.value_label()))
+            .collect::<Vec<_>>()
+            .join("  \u{b7}  ")
+    }
+}
+
+/// What one provider's cluster - in the pane strip or in a popover row - should actually say
+/// right now.
+///
+/// Five distinct states, not one nullable number. Rev 6 §7 rule 6, quoted in issue #294: "every
+/// derived value must handle not-yet-polled, polled-ok, and poll-failed distinctly". `Checking`
+/// and `NotConnected` are the two that a `Option<Snapshot>` would have collapsed into each other,
+/// and they mean opposite things: one is "wait a moment", the other is "there is nothing here and
+/// nothing is broken".
+#[derive(Debug, Clone, PartialEq)]
+pub enum ProviderReadout<'a> {
+    /// No credential for this provider on this machine. §4b's rule applies in the strip: a
+    /// provider that is not connected never appears there at all.
+    NotConnected,
+    /// A credential exists but no poll has landed yet.
+    Checking,
+    /// A real, fresh read.
+    Numbers(&'a ProviderSnapshot),
+    /// Connected, but the last successful read is older than [`STALE_AFTER`] - §2's `last read
+    /// <age>`, in place of the numbers themselves.
+    LastRead(Duration),
+    /// Connected, and no read has ever succeeded - so there is nothing to go stale, only a
+    /// failure to report next to its `Retry`.
+    RefreshFailed,
+}
+
+/// One provider's whole live state: whether it is connected at all, its most recent successful
+/// read, whether the most recent *attempt* failed, and the poll bookkeeping.
+///
+/// Deliberately not an enum. The four facts are independent - a provider can hold good numbers
+/// *and* a failed newest attempt at the same time, which is exactly the state §2's `last read
+/// <age>` and §4c's `refresh failed · Retry` describe between them - and an enum would have to
+/// duplicate the snapshot into several variants to say it.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ProviderBudget {
+    /// Whether this provider's credential was found on disk at the last look. Re-checked on every
+    /// poll, so logging into a provider's CLI while Jerry is running really does connect it.
+    pub connected: bool,
+    /// The most recent *successful* read, with the real instant it landed.
+    pub last_ok: Option<(ProviderSnapshot, Instant)>,
+    /// `Some` when the most recent attempt failed - the message is the popover's tooltip, and its
+    /// presence is what earns the `Retry`. Cleared by a successful read.
+    pub last_error: Option<String>,
+    /// A poll is in flight for this provider right now. Single-flight per provider: a manual
+    /// `Refresh` during the background poll's own request cannot start a second, racing one.
+    pub in_flight: bool,
+    /// The last time a poll was *started* for this provider, successful or not - the floor a
+    /// manual refresh is measured against.
+    pub last_attempt: Option<Instant>,
+}
+
+impl ProviderBudget {
+    /// What this provider's cluster should print, given the clock.
+    pub fn readout(&self, now: Instant) -> ProviderReadout<'_> {
+        if !self.connected {
+            return ProviderReadout::NotConnected;
+        }
+        match &self.last_ok {
+            Some((snapshot, read_at)) => {
+                let age = now.saturating_duration_since(*read_at);
+                if age > STALE_AFTER {
+                    ProviderReadout::LastRead(age)
+                } else {
+                    ProviderReadout::Numbers(snapshot)
+                }
+            }
+            None if self.last_error.is_some() => ProviderReadout::RefreshFailed,
+            None => ProviderReadout::Checking,
+        }
+    }
+
+    /// Whether this provider's row earns a `Retry` - §4c puts one next to `refresh failed`, and
+    /// the same affordance belongs to a provider whose numbers went stale *because* its polls
+    /// started failing. A provider that is simply not connected has nothing to retry: Jerry does
+    /// not log anyone in.
+    pub fn can_retry(&self) -> bool {
+        self.connected && self.last_error.is_some()
+    }
+
+    /// Whether a poll may start right now. `manual` clicks are additionally held to
+    /// [`MANUAL_REFRESH_FLOOR`] since the last attempt; the background loop's own cadence is
+    /// [`POLL_INTERVAL`], so it needs no second floor.
+    pub fn may_poll_now(&self, manual: bool, now: Instant) -> bool {
+        if self.in_flight {
+            return false;
+        }
+        if !manual {
+            return true;
+        }
+        match self.last_attempt {
+            Some(at) => now.saturating_duration_since(at) >= MANUAL_REFRESH_FLOOR,
+            None => true,
+        }
+    }
+
+    /// How tight this provider is, for ranking - its own tightest window's headroom. `None` for
+    /// anything with no usable numbers, which sorts after every provider that has some.
+    pub fn tightest_headroom(&self, now: Instant) -> Option<f32> {
+        match self.readout(now) {
+            ProviderReadout::Numbers(snapshot) => {
+                snapshot.tightest().map(|window| window.headroom_percent)
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Every provider's state, keyed by provider - the whole feature's live data.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct BudgetState {
+    claude: ProviderBudget,
+    codex: ProviderBudget,
+}
+
+impl BudgetState {
+    pub fn get(&self, provider: Provider) -> &ProviderBudget {
+        match provider {
+            Provider::Claude => &self.claude,
+            Provider::Codex => &self.codex,
+        }
+    }
+
+    pub fn get_mut(&mut self, provider: Provider) -> &mut ProviderBudget {
+        match provider {
+            Provider::Claude => &mut self.claude,
+            Provider::Codex => &mut self.codex,
+        }
+    }
+
+    /// The most recent successful read across all providers - the popover's `Updated N ago` foot
+    /// line. `None` until the very first read of any provider lands, which that line prints as an
+    /// honest "not sampled yet" rather than as "just now".
+    pub fn last_read_at(&self) -> Option<Instant> {
+        Provider::ALL
+            .iter()
+            .filter_map(|provider| self.get(*provider).last_ok.as_ref().map(|(_, at)| *at))
+            .max()
+    }
+
+    /// §4c's "the tightest provider at the top": the connected provider with the least headroom
+    /// in any of its windows. Only a provider with real, fresh numbers can lead - a `not
+    /// connected` or never-polled provider has no tightness to compare.
+    pub fn lead_provider(&self, now: Instant) -> Option<Provider> {
+        Provider::ALL
+            .iter()
+            .copied()
+            .filter_map(|provider| {
+                self.get(provider)
+                    .tightest_headroom(now)
+                    .map(|headroom| (provider, headroom))
+            })
+            .min_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+            .map(|(provider, _)| provider)
+    }
+}
+
+/// Real coverage for the model itself - the thresholds, the state machine, and every string.
+#[cfg(test)]
+mod budget_state_tests {
+    use super::*;
+
+    fn window(label: &str, headroom: f32) -> BudgetWindow {
+        BudgetWindow {
+            label: label.to_string(),
+            headroom_percent: headroom,
+            resets_at: None,
+        }
+    }
+
+    fn snapshot(a: f32, b: f32) -> ProviderSnapshot {
+        ProviderSnapshot {
+            windows: vec![window("5h", a), window("7d", b)],
+        }
+    }
+
+    /// §4t's mapping, including the case the issue is most explicit about: a pane that spends no
+    /// provider shows nothing.
+    #[test]
+    fn every_pane_kind_maps_to_the_provider_it_actually_spends() {
+        assert_eq!(
+            provider_of(ProcessKind::claude()),
+            Some(Provider::Claude),
+            "a Claude agent spends Claude"
+        );
+        assert_eq!(
+            provider_of(ProcessKind::codex()),
+            Some(Provider::Codex),
+            "a Codex agent spends Codex"
+        );
+        assert_eq!(
+            provider_of(ProcessKind::Shell),
+            None,
+            "a shell pane spends no provider at all - \u{a7}4t's `a local model shows nothing, \
+             correctly`, which in this build is the shell"
+        );
+    }
+
+    /// §2's boundaries, at the exact numbers rather than near them - `40` is amber (only *above*
+    /// 40 is healthy) and `15` is amber (only *below* 15 is red).
+    #[test]
+    fn the_hue_thresholds_sit_exactly_where_the_design_puts_them() {
+        assert_eq!(budget_level(100.0), BudgetLevel::Ok);
+        assert_eq!(budget_level(40.1), BudgetLevel::Ok);
+        assert_eq!(
+            budget_level(40.0),
+            BudgetLevel::Warn,
+            "\u{a7}2 says healthy is *above* 40%, so 40 itself is amber"
+        );
+        assert_eq!(budget_level(15.0), BudgetLevel::Warn);
+        assert_eq!(
+            budget_level(14.9),
+            BudgetLevel::Critical,
+            "\u{a7}2 says red is *below* 15%"
+        );
+        assert_eq!(budget_level(0.0), BudgetLevel::Critical);
+    }
+
+    /// The rendering decision issue #294's Phase 0 spike locked: two independent windows, hued
+    /// **separately**. This is the exact live reading that settled it - a healthy 5h next to a 7d
+    /// sitting on the amber boundary. One bar filled to the tighter window would paint the whole
+    /// readout amber and say the session is constrained when it is not.
+    #[test]
+    fn each_window_takes_its_own_hue_rather_than_the_tighter_ones() {
+        let snapshot = snapshot(81.0, 40.0);
+        assert_eq!(snapshot.windows[0].level(), BudgetLevel::Ok);
+        assert_eq!(snapshot.windows[1].level(), BudgetLevel::Warn);
+        assert_eq!(
+            snapshot.tightest().map(|w| w.label.clone()),
+            Some("7d".to_string()),
+            "the week is the tight one here - and a single bar would have shown only that"
+        );
+    }
+
+    /// §4c, verbatim: "`92% 5h` parsed as '92% for 5 hours'; `5h 92%` parses as '5-hour window,
+    /// 92% left'". The label leads.
+    #[test]
+    fn every_window_string_puts_the_window_label_before_the_value() {
+        let snapshot = snapshot(92.0, 65.0);
+        assert_eq!(snapshot.summary_label(), "5h 92%  \u{b7}  7d 65%");
+        assert!(
+            snapshot.summary_label().starts_with("5h "),
+            "the window label must lead - `92% 5h` reads as `92% for 5 hours`"
+        );
+    }
+
+    #[test]
+    fn a_window_label_is_formatted_from_its_real_duration() {
+        assert_eq!(window_label(5 * 3600), "5h");
+        assert_eq!(window_label(7 * 86400), "7d");
+        assert_eq!(window_label(86400), "1d");
+        assert_eq!(
+            window_label(150 * 60),
+            "150m",
+            "a window that is not a whole number of hours must not round to one that isn't real"
+        );
+        assert_eq!(window_label(30), "30s");
+        assert_eq!(window_label(-5), "0s", "a negative duration is not a window");
+    }
+
+    #[test]
+    fn a_reset_countdown_reads_largest_unit_first_and_never_goes_negative() {
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+        let mut window = window("5h", 92.0);
+
+        window.resets_at = Some(now + Duration::from_secs(4 * 3600 + 53 * 60));
+        assert_eq!(window.reset_label(now).as_deref(), Some("resets in 4h 53m"));
+
+        window.resets_at = Some(now + Duration::from_secs(3 * 86400 + 6 * 3600));
+        assert_eq!(window.reset_label(now).as_deref(), Some("resets in 3d 6h"));
+
+        window.resets_at = Some(now + Duration::from_secs(30));
+        assert_eq!(
+            window.reset_label(now).as_deref(),
+            Some("resets in <1m"),
+            "under a minute must not read as a stuck `0m`"
+        );
+
+        window.resets_at = Some(now - Duration::from_secs(60));
+        assert_eq!(
+            window.reset_label(now).as_deref(),
+            Some("resets now"),
+            "a rollover that is already due is a real statement, not a negative duration"
+        );
+
+        window.resets_at = None;
+        assert_eq!(
+            window.reset_label(now),
+            None,
+            "a provider that sent no reset instant gets no fabricated countdown"
+        );
+    }
+
+    /// The five states rev 6 §7 rule 6 insists stay distinct, walked in order.
+    #[test]
+    fn the_five_provider_states_are_all_genuinely_distinct() {
+        let now = Instant::now();
+
+        let mut budget = ProviderBudget::default();
+        assert_eq!(
+            budget.readout(now),
+            ProviderReadout::NotConnected,
+            "no credential on disk is `not connected`, and nothing about it is broken"
+        );
+        assert!(!budget.can_retry(), "there is nothing to retry when there is no credential");
+
+        budget.connected = true;
+        assert_eq!(
+            budget.readout(now),
+            ProviderReadout::Checking,
+            "connected but never polled is its own state, not a fake 100%"
+        );
+
+        budget.last_error = Some("boom".to_string());
+        assert_eq!(
+            budget.readout(now),
+            ProviderReadout::RefreshFailed,
+            "a failure with no earlier numbers has nothing to go stale"
+        );
+        assert!(budget.can_retry(), "and it earns the `Retry` \u{a7}4c puts beside it");
+
+        let fresh = snapshot(81.0, 40.0);
+        budget.last_ok = Some((fresh.clone(), now));
+        budget.last_error = None;
+        assert_eq!(
+            budget.readout(now),
+            ProviderReadout::Numbers(&fresh),
+            "a fresh read shows its real numbers"
+        );
+
+        // A failed attempt on top of *fresh* numbers keeps the numbers - they are still true -
+        // and only adds the retry.
+        budget.last_error = Some("boom".to_string());
+        assert_eq!(
+            budget.readout(now),
+            ProviderReadout::Numbers(&fresh),
+            "numbers seconds old are still true; the failed attempt shows up as the `Retry`, not \
+             by hiding a fact we really have"
+        );
+        assert!(budget.can_retry());
+
+        let stale_now = now + STALE_AFTER + Duration::from_secs(1);
+        match budget.readout(stale_now) {
+            ProviderReadout::LastRead(age) => assert!(
+                age > STALE_AFTER,
+                "\u{a7}2: a connected provider that goes stale shows `last read <age>` in place \
+                 of its own numbers"
+            ),
+            other => panic!("expected `last read <age>`, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_manual_refresh_is_floored_but_the_background_poll_is_not() {
+        let now = Instant::now();
+        let mut budget = ProviderBudget {
+            connected: true,
+            ..Default::default()
+        };
+
+        assert!(
+            budget.may_poll_now(true, now),
+            "a provider that has never been polled may always be refreshed"
+        );
+
+        budget.last_attempt = Some(now);
+        assert!(
+            !budget.may_poll_now(true, now + Duration::from_secs(1)),
+            "a second manual click a second later must be dropped, not queued - the endpoint \
+             behind it is itself rate-limited"
+        );
+        assert!(
+            budget.may_poll_now(true, now + MANUAL_REFRESH_FLOOR),
+            "and allowed again once the floor has passed"
+        );
+        assert!(
+            budget.may_poll_now(false, now + Duration::from_secs(1)),
+            "the background loop has its own cadence and is not held to the manual floor"
+        );
+
+        budget.in_flight = true;
+        assert!(
+            !budget.may_poll_now(false, now + POLL_INTERVAL),
+            "single-flight per provider: nothing starts a second request while one is open"
+        );
+    }
+
+    /// §4c: "the tightest provider at the top".
+    #[test]
+    fn the_lead_provider_is_the_tightest_one_with_real_numbers() {
+        let now = Instant::now();
+        let mut state = BudgetState::default();
+        assert_eq!(
+            state.lead_provider(now),
+            None,
+            "nothing connected means nothing leads"
+        );
+
+        state.get_mut(Provider::Claude).connected = true;
+        state.get_mut(Provider::Claude).last_ok = Some((snapshot(81.0, 40.0), now));
+        assert_eq!(state.lead_provider(now), Some(Provider::Claude));
+
+        state.get_mut(Provider::Codex).connected = true;
+        state.get_mut(Provider::Codex).last_ok = Some((snapshot(99.0, 12.0), now));
+        assert_eq!(
+            state.lead_provider(now),
+            Some(Provider::Codex),
+            "codex's 12% weekly is tighter than claude's 40%, even though its session window is \
+             the healthier of the two"
+        );
+
+        // A provider whose numbers went stale cannot lead on numbers nobody can see.
+        let stale_now = now + STALE_AFTER + Duration::from_secs(1);
+        assert_eq!(state.lead_provider(stale_now), None);
+    }
+
+    #[test]
+    fn the_compact_age_steps_through_every_unit() {
+        assert_eq!(compact_age(Duration::from_secs(12)), "12s");
+        assert_eq!(compact_age(Duration::from_secs(180)), "3m");
+        assert_eq!(compact_age(Duration::from_secs(7200)), "2h");
+        assert_eq!(compact_age(Duration::from_secs(4 * 86400)), "4d");
+    }
+
+    #[test]
+    fn the_last_read_instant_is_the_newest_across_providers() {
+        let now = Instant::now();
+        let mut state = BudgetState::default();
+        assert_eq!(state.last_read_at(), None, "not sampled yet is its own state");
+
+        let older = now - Duration::from_secs(120);
+        state.get_mut(Provider::Claude).last_ok = Some((snapshot(50.0, 50.0), older));
+        state.get_mut(Provider::Codex).last_ok = Some((snapshot(50.0, 50.0), now));
+        assert_eq!(state.last_read_at(), Some(now));
+    }
+}

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -8,6 +8,7 @@
 //! and `crate::terminal::grid` for the interesting design decisions (entity/state model,
 //! blocking-call offloading, terminal grid rendering).
 
+pub mod budget;
 pub mod code_surface;
 pub mod env_info;
 pub mod fonts;

--- a/crates/app/src/root/menus.rs
+++ b/crates/app/src/root/menus.rs
@@ -23,7 +23,7 @@
 
 use super::*;
 
-/// Every real floating menu/dropdown surface in the app - the twelve built on
+/// Every real floating menu/dropdown surface in the app - the thirteen built on
 /// [`crate::root::widgets::menu_popover_chrome`].
 ///
 /// Deliberately *not* including the command palette, the "New file" prompt, or the Settings
@@ -86,6 +86,12 @@ pub(crate) enum MenuSurface {
     /// [`crate::root::widgets::menu_popover_chrome`] like all the others, so it belongs to the
     /// same one-at-a-time invariant rather than owning a second dismissal rule of its own.
     Resources,
+    /// The agent pane strip's rate-limit budget popover (GitHub issue #294) -
+    /// [`AdeApp::budget_popover_open`]. Anchored to a readout *inside the workspace body* rather
+    /// than to window chrome, but it is the same click-away popover built on
+    /// [`crate::root::widgets::menu_popover_chrome`], so it belongs to the same one-at-a-time
+    /// invariant.
+    Budget,
 }
 
 impl MenuSurface {
@@ -93,7 +99,7 @@ impl MenuSurface {
     /// [`AdeApp::close_menu_surface`] are exhaustive, so a new variant added here cannot compile
     /// until it is really wired to real state - that pairing is what stops a new menu from
     /// quietly opting out of the invariant.
-    pub(crate) const ALL: [MenuSurface; 12] = [
+    pub(crate) const ALL: [MenuSurface; 13] = [
         MenuSurface::Plus,
         MenuSurface::Title,
         MenuSurface::TreeContext,
@@ -106,6 +112,7 @@ impl MenuSurface {
         MenuSurface::RailRow,
         MenuSurface::RailOverflow,
         MenuSurface::Resources,
+        MenuSurface::Budget,
     ];
 }
 
@@ -126,6 +133,7 @@ impl AdeApp {
             MenuSurface::RailRow => self.rail_row_menu.is_some(),
             MenuSurface::RailOverflow => self.rail_overflow_menu.is_some(),
             MenuSurface::Resources => self.resources_popover_open,
+            MenuSurface::Budget => self.budget_popover_open,
         }
     }
 
@@ -165,6 +173,7 @@ impl AdeApp {
             }
             MenuSurface::RailOverflow => self.rail_overflow_menu = None,
             MenuSurface::Resources => self.resources_popover_open = false,
+            MenuSurface::Budget => self.budget_popover_open = false,
         }
     }
 
@@ -249,6 +258,7 @@ mod menu_surface_tests {
             origin_y: 4.0,
         });
         app.resources_popover_open = true;
+        app.budget_popover_open = true;
     }
 
     #[gpui::test]

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -1434,6 +1434,17 @@ pub struct AdeApp {
     /// `gpui::canvas` idiom [`Self::plus_button_bounds`] uses, so the Resources popover can be
     /// positioned off the control that opens it.
     pub(crate) resources_readout_bounds: gpui::Bounds<Pixels>,
+    /// Every provider's real rate-limit budget (GitHub issue #294) - what the agent pane strip's
+    /// cluster and the budget popover both read. Written only by
+    /// `crate::budget::flow::AdeApp::apply_budget_poll_result`, from real poll results.
+    pub(crate) budget: crate::budget::state::BudgetState,
+    /// Whether the agent pane's rate-limit budget popover is open (GitHub issue #294) - one of
+    /// the [`menus::MenuSurface`]s, so it obeys the app's one-menu-at-a-time invariant.
+    pub(crate) budget_popover_open: bool,
+    /// The pane strip's budget cluster's real painted bounds, captured through the same
+    /// `gpui::canvas` idiom [`Self::resources_readout_bounds`] uses, so the popover opens
+    /// directly above the control that opened it (§4u′).
+    pub(crate) budget_readout_bounds: gpui::Bounds<Pixels>,
     /// Real, bounded disk-usage total across every listed worktree (see
     /// `crate::rail::state::disk_usage_bytes`'s docs for the real `std::fs` walk and its cap),
     /// recomputed whenever the worktree list reloads. `None` while the very first
@@ -1674,6 +1685,12 @@ pub struct AdeApp {
     /// docs), keyed off [`Self::update_state`] itself rather than a separate bool, since
     /// `Downloading` already is that "one is in flight" signal.
     pub(crate) _update_download_task: Option<Task<()>>,
+    /// The per-provider rate-limit budget poll loop (GitHub issue #294,
+    /// `crate::budget::flow::AdeApp::start_budget_poll_loop`) - kept alive here for the same
+    /// reason [`Self::_update_check_task`] is, and reserved to the loop alone: an individual
+    /// provider read detaches its own task rather than reassigning this field, so a manual
+    /// `Refresh` can never cancel the loop out from under itself.
+    pub(crate) _budget_poll_task: Option<Task<()>>,
     pub(crate) _agent_rows_task: Option<Task<()>>,
     pub(crate) _merge_task: Option<Task<()>>,
     /// `Self::clear_merge_flow_for_closed_agent`'s best-effort abort - kept separate from
@@ -3249,6 +3266,15 @@ impl Render for AdeApp {
             // must stay reachable there too.
             .when(self.resources_popover_open, |el| {
                 el.child(self.render_resources_popover(cx))
+            })
+            // The agent pane strip's rate-limit budget popover (GitHub issue #294) - a
+            // window-positioned overlay for exactly the same reason the Resources one above it
+            // is: it is placed off its readout's `gpui::canvas`-captured *window-space* bounds,
+            // so `.absolute()` positioning built from them is only correct as a direct child of
+            // this root element. Nesting it inside the pane strip would additionally clip it to
+            // an 18px-high row.
+            .when(self.budget_popover_open, |el| {
+                el.child(self.render_budget_popover(window, cx))
             })
             // The git graph tab's Push `▾` menu and row `⋯` menu (GitHub issue #1, phase (a)) -
             // window-positioned overlays for the same reason `render_plus_menu` is a sibling here

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -517,6 +517,9 @@ impl AdeApp {
             process_stats_sampled_at: None,
             resources_popover_open: false,
             resources_readout_bounds: gpui::Bounds::default(),
+            budget: crate::budget::state::BudgetState::default(),
+            budget_popover_open: false,
+            budget_readout_bounds: gpui::Bounds::default(),
             disk_usage: None,
             worktree_disk_usage: HashMap::new(),
             prune_status: None,
@@ -567,6 +570,7 @@ impl AdeApp {
             _prune_task: None,
             _worktree_history_task: None,
             _update_check_task: None,
+            _budget_poll_task: None,
             _update_download_task: None,
             _agent_rows_task: None,
             _merge_task: None,
@@ -888,6 +892,11 @@ impl AdeApp {
         // start_update_check_loop`'s own docs. Unconditional for the same reason the keybindings/
         // theme setup above is: it has nothing to do with which (if any) repo is focused.
         this.start_update_check_loop(cx);
+        // GitHub issue #294: the per-provider rate-limit budget poll. Unconditional like the
+        // update check above, and for the same reason - it has nothing to do with which (if any)
+        // repo is focused. It polls nothing at all until there is a real agent session to show a
+        // budget for; see `crate::budget::flow::AdeApp::poll_budgets_if_due`.
+        this.start_budget_poll_loop(cx);
         // GitHub issue #226: the app-start sound. `crate::sound::claim_app_start_sound` is the
         // real "once per process" gate - a second window (`File > New Window`,
         // `crate::title_bar::menu`) constructs a second `AdeApp` and reaches this same line, but

--- a/crates/app/src/status_bar/render.rs
+++ b/crates/app/src/status_bar/render.rs
@@ -40,9 +40,11 @@ pub(crate) enum StatusTier {
     /// §3: `main ↑2 ↓0`'s branch, `4 agents running` - "the readouts you are meant to find
     /// first".
     Primary,
-    /// §3: provider budgets. Nothing in the bar carries this tier until GitHub issue #294 lands
-    /// its per-provider rate-limit clusters; the token itself is live today in the Resources
-    /// popover's memory column (see `crate::theme::status_bar::SECONDARY`).
+    /// §3: provider budgets - carried by the agent pane strip's rate-limit cluster's provider
+    /// name (`crate::budget::render::AdeApp::render_agent_budget_readout`, GitHub issue #294),
+    /// and by the Resources popover's memory column (see `crate::theme::status_bar::SECONDARY`).
+    /// Nothing in the window *footer* itself carries it: §4u′ deleted the footer's aggregate
+    /// budget slot outright, so the tier's own readout lives one surface in.
     Secondary,
     /// §3: `41% cpu · 3.4 GB`, and the tail of every split readout (`↑2 ↓0`).
     Recessive,

--- a/crates/app/src/theme.rs
+++ b/crates/app/src/theme.rs
@@ -2596,9 +2596,13 @@ pub mod scrollbar {
 /// (`design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md` §2).
 ///
 /// Rev 6 moved budget from a single global footer readout to **one meter per agent**, because a
-/// budget is per-provider and a provider belongs to an agent. The meter fills to the tighter of
-/// the two windows (`5h` / `7d`), and its fill hue is the one place in the readout where colour
-/// carries meaning:
+/// budget is per-provider and a provider belongs to an agent. There is then **one bar per window**
+/// (`5h` / `7d`), each hued on its own value - §4u′, and GitHub issue #294's Phase 0 spike, which
+/// found that both supported providers really do report two independent windows with their own
+/// utilisations and their own reset instants. (§2's older "the meter fills to the tighter of the
+/// two windows" is the superseded shape: a single bar hides *which* limit is tight, and on the
+/// live account the spike measured, a healthy 5-hour window sat next to a 7-day one on the amber
+/// boundary.) The fill hue is the one place in the readout where colour carries meaning:
 ///
 /// > Hue `#7fc79a` above 40%, `#c99b4e` 15-40%, `#c4726d` below.
 ///

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -2306,8 +2306,27 @@ impl AdeApp {
         }
 
         footer = footer.child(div().flex_1());
-        match self.render_agent_cost_readout(is_running, pid) {
-            Some(readout) => footer.child(readout),
+        // GitHub issue #294: this agent's provider budget, to the right of its cost (§4t).
+        let budget = self.render_agent_budget_readout(agent.kind, cx);
+        if let Some(cost) = self.render_agent_cost_readout(is_running, pid) {
+            footer = footer.child(cost);
+            // §4t's own grouping: the two readouts are separate facts (what this agent costs
+            // *this machine*, and what it costs *its provider*), so they get the footer's own 1px
+            // divider between them rather than running together as one string. No divider when
+            // only one of the two is there - the same "never a hairline separating nothing from
+            // nothing" rule §4t applied when it deleted the footer's own budget slot.
+            if budget.is_some() {
+                footer = footer.child(
+                    div()
+                        .flex_none()
+                        .w(px(1.0))
+                        .h(px(13.0))
+                        .bg(theme::status_bar::DIVIDER),
+                );
+            }
+        }
+        match budget {
+            Some(budget) => footer.child(budget),
             None => footer,
         }
     }


### PR DESCRIPTION
Builds issue #294's Phase 0 finding. The spike's research comments are on the issue; this is the code, plus a landing-review pass that fixed four things before shipping.

## What this is

Both supported providers expose **two genuinely independent rate-limit windows** — separate utilisations *and* separate reset instants, which do not move together. So the readout is **one bar per window**, each hued on its own value (`STAGE-A-CHANGELOG.md` §4u′, `Jerry.dc.html`), not one bar filled to the tighter of the two (`REVISION-2026-08-14.md` §2, which the bundle's own edit trail supersedes — §4t's footer bullet is prefixed *"Superseded — see below."* in place).

The live account this was verified against is the concrete argument for that: **5h healthy while 7d sat in amber.** A single bar would have painted the whole readout amber and told you your *session* was constrained when it was not.

- `budget::state` — the provider set, `provider_of` (a shell spends nothing, so it shows nothing), the headroom/window model, §2's 40/15 thresholds on #279's already-landed `theme::budget` tokens, and the five distinct provider states.
- `budget::fetch` — real credential discovery (`$CLAUDE_CONFIG_DIR‖~/.claude/.credentials.json`, `$CODEX_HOME‖~/.codex/auth.json`) and a real `GET` of each provider's own usage endpoint, with pure `&str` parsers tested against a captured live payload and against `openai/codex`'s published backend models.
- `budget::flow` — the poll: **nothing at all until an agent session exists**, 300 s per provider, single-flight, a 15 s floor on manual reads, **nothing at all under `cfg(test)`**.
- `budget::render` — the pane strip cluster (window label before the value, §4c) and the 292-wide popover anchored directly above it (§4u′).

**No fabricated numbers anywhere.** No credential → `not connected`. Never polled → `checking…`. 401/429/5xx/transport → `refresh failed` + `Retry`. Previously OK, now failing → keeps the numbers while they are still true, then §2's `last read <age>`.

## Credentials and network, specifically

- Credential files are **read only**, never written. We deliberately never refresh the token ourselves — the refresh token belongs to the CLI that owns the file, and racing it risks clobbering the user's login. An expired token is a reported failure with a `Retry`, not a silent refresh.
- macOS Keychain / API-key-only installs read as `not connected` rather than as a failure, which is the honest statement: we have nothing, and nothing is broken.
- `Credential` no longer derives `Debug` — it prints `<redacted>`, with a test that fails if a later `#[derive(Debug)]` reopens it.
- A budget readout must not spend budget to fetch itself. Anthropic's usage route has its own limiter (a real, observed `429` while `GET /api/oauth/profile` on the same token returned `200` in the same second), hence 300 s and the manual floor.

## Landing-review fixes (second commit)

- **`cargo fmt` had never been run** over the new module.
- **The `cfg(test)` no-polling promise was true only by accident.** The guard sat on the poll loop, but the popover's `Refresh` and a row's `Retry` reach `refresh_provider_budget` without going near the loop — any future click test would have read the developer's own OAuth credential off disk and sent it to a real provider. The guard now sits on that single choke point, asserted at *compile* time, with a `#[gpui::test]` proving a manual `Refresh` starts nothing.
- **`Credential` derived `Debug`**, which would have put a live bearer token verbatim into any `{:?}`.
- The two stale doc comments Phase 0 itself flagged: `theme::budget` still described the superseded single meter; `StatusTier::Secondary` still said nothing carried it "until #294 lands".

## Verification

- `cargo build --workspace`, `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets` — all clean, clippy warning-free.
- `cargo test -p app --lib`: **2833 passed**, 26 of them the new budget tests. The only failures are the known pre-existing inotify-contention family (`worktree_watch` / `file_tree_watch` / `repo_list_tests`, `max_user_instances = 128`), which all pass in isolation and are untouched by this branch.
- **No test touches the network or reads a real credential**, verified empirically rather than by reading: the budget + app-startup test set run under `strace -f -e trace=connect,openat`, on a machine that *does* have a real `~/.claude/.credentials.json`, opens that file **zero** times and makes zero connections to any provider. The only `:443`s in the trace are git's own, to GitHub.
- **Real visual check on the running app over X11**, against a real Claude account: the pane strip renders `claude  5h ▬ 45%  7d ▬ 33%` — window label before the value, two bars, the 5h bar green with a neutral number and the 7d bar amber with an amber number, behind the footer's own 1px divider. A shell pane's footer ends at `0.0% cpu · 5.4 MB` with no cluster at all. The popover renders `RATE LIMITS` + `Refresh`, the `cl Claude` lead with `5h 45% left · resets in 34m` and `7d 33% left · resets in 2d 10h` over their own meters, `OTHER PROVIDERS → Codex  not connected`, and `Updated 14 seconds ago · counts headroom, not spend` — anchored directly above the readout, no aggregate `⚠ N` anywhere.

## Deliberately not closing #294

Two honest gaps remain, both recorded in the Phase 0 comment:

- **Codex is source-verified end to end but never executed** — there is no `codex` install or ChatGPT credential on the machine this was built on, so it ships on the same code path and reads `not connected` until someone logged into Codex confirms it. Its parser is tested against a fixture built from `openai/codex`'s published models, not from a live capture.
- Consequently, "switching focus between agents on *different* providers swaps the readout" is verified in code but not demonstrated live.

Everything else on the issue's checklist is built and verified. Leaving #294 open for that live Codex confirmation rather than claiming it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)