### PR TITLE
Budget: fix a provider-controlled panic, a permanent poll wedge, a crate-boundary test gate and per-window rate limits; show % used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,14 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: "1"
+  # GitHub issue #294's provider rate-limit poll reads an OAuth credential off disk and sends it
+  # to a real provider usage endpoint. `crate::budget::state::POLLING_ENABLED` already turns that
+  # off for `cargo test -p app --lib` (where `cfg(test)` is true of the `app` crate itself), but a
+  # `cfg` does not survive a crate boundary: an integration test under `crates/app/tests/` would
+  # link `app` as an ordinary dependency with the gate re-armed. Set here, for every job, so that
+  # holds for whatever this workflow grows to run - see
+  # `crate::budget::state::DISABLE_PROVIDER_POLL_ENV`.
+  JERRY_DISABLE_PROVIDER_POLL: "1"
 
 jobs:
   # Build-only signal on Linux, matching macOS/Windows below - deliberately narrowed

--- a/crates/app/src/budget/fetch.rs
+++ b/crates/app/src/budget/fetch.rs
@@ -333,7 +333,8 @@ fn http_get_usage(provider: Provider, credential: &Credential) -> Result<String,
         .map_err(|err| format!("the response could not be read: {err}"))
 }
 
-/// Parses one provider's usage payload into windows of *headroom*.
+/// Parses one provider's usage payload into windows of *usage* - the figure each API already
+/// reports, carried through unconverted (`crate::budget::state`'s "Used, not left").
 pub fn parse_usage(provider: Provider, body: &str) -> Result<ProviderSnapshot, String> {
     match provider {
         Provider::Claude => parse_claude_usage(body),
@@ -341,11 +342,15 @@ pub fn parse_usage(provider: Provider, body: &str) -> Result<ProviderSnapshot, S
     }
 }
 
-/// Percent used -> percent left, clamped to the real 0-100 range an over-quota account can
-/// otherwise leave (a `utilization` above 100 is possible and would otherwise render as a
-/// negative meter).
-fn headroom_from_utilization(utilization: f64) -> f32 {
-    (100.0 - utilization).clamp(0.0, 100.0) as f32
+/// A provider's own "percent used" figure, clamped to the real 0-100 range an over-quota account
+/// can otherwise leave (a `utilization` above 100 is possible, and would otherwise render as a
+/// meter overflowing its own track).
+///
+/// Clamped but **not** converted: the number every surface prints is the one the API sent - see
+/// `crate::budget::state`'s own docs for why this build shows `% used` rather than the design
+/// bundle's `% left`.
+fn used_percent_from(utilization: f64) -> f32 {
+    utilization.clamp(0.0, 100.0) as f32
 }
 
 /// Anthropic's `GET /api/oauth/usage`.
@@ -375,7 +380,7 @@ pub fn parse_claude_usage(body: &str) -> Result<ProviderSnapshot, String> {
         };
         windows.push(BudgetWindow {
             label: label.to_string(),
-            headroom_percent: headroom_from_utilization(utilization),
+            used_percent: used_percent_from(utilization),
             resets_at: entry
                 .get("resets_at")
                 .and_then(|value| value.as_str())
@@ -426,7 +431,7 @@ pub fn parse_codex_usage(body: &str) -> Result<ProviderSnapshot, String> {
             .unwrap_or(0);
         windows.push(BudgetWindow {
             label: window_label(seconds),
-            headroom_percent: headroom_from_utilization(used),
+            used_percent: used_percent_from(used),
             resets_at: codex_reset_instant(entry),
         });
     }
@@ -598,10 +603,11 @@ mod budget_fetch_tests {
       }
     }"#;
 
-    /// The one direction rule the whole feature rests on: the API reports *used*, every value in
-    /// Jerry is *left*. `19% used` must become `81% left`, never `19%`.
+    /// The one direction rule the whole feature rests on: the API reports *used*, and so does
+    /// every value in Jerry. `19% used` stays `19%`, and is never quietly flipped to the `81%
+    /// left` this build shipped first.
     #[test]
-    fn the_claude_payload_parses_into_two_windows_of_headroom_not_spend() {
+    fn the_claude_payload_parses_into_two_windows_of_usage_not_headroom() {
         let snapshot = parse_claude_usage(CLAUDE_LIVE_PAYLOAD).expect("a real payload parses");
         assert_eq!(
             snapshot.windows.len(),
@@ -610,11 +616,16 @@ mod budget_fetch_tests {
         );
         assert_eq!(snapshot.windows[0].label, "5h");
         assert_eq!(
-            snapshot.windows[0].headroom_percent, 81.0,
-            "19% used is 81% left - the popover's footnote promises headroom, not spend"
+            snapshot.windows[0].used_percent, 19.0,
+            "the payload's own `utilization: 19.0`, carried through rather than converted"
+        );
+        assert_eq!(
+            snapshot.windows[0].headroom_percent(),
+            81.0,
+            "and its complement is still derivable, because that is what the hue keys off"
         );
         assert_eq!(snapshot.windows[1].label, "7d");
-        assert_eq!(snapshot.windows[1].headroom_percent, 40.0);
+        assert_eq!(snapshot.windows[1].used_percent, 60.0);
         assert_eq!(
             snapshot.tightest().map(|w| w.label.clone()),
             Some("7d".to_string()),
@@ -663,13 +674,17 @@ mod budget_fetch_tests {
             snapshot.windows[0].label, "5h",
             "the label comes from `limit_window_seconds`, not from an assumption"
         );
-        assert_eq!(snapshot.windows[0].headroom_percent, 99.0);
+        assert_eq!(
+            snapshot.windows[0].used_percent, 1.0,
+            "the payload's own `used_percent: 1`, printed as the 1% it is"
+        );
         assert_eq!(snapshot.windows[1].label, "7d");
-        assert_eq!(snapshot.windows[1].headroom_percent, 88.0);
+        assert_eq!(snapshot.windows[1].used_percent, 12.0);
         assert_eq!(
             snapshot.summary_label(),
-            "5h 99%  \u{b7}  7d 88%",
-            "window label before the value, on this provider too"
+            "5h 1%  \u{b7}  7d 12%",
+            "window label before the value, on this provider too - and the value is what has been \
+             spent, not what is left"
         );
     }
 
@@ -710,7 +725,7 @@ mod budget_fetch_tests {
     /// before the read starts, to wedge every subsequent poll *and* every `Refresh`/`Retry` click
     /// for the rest of the session with it.
     ///
-    /// The contract asserted here is the whole fix: the window still parses, its headroom - the
+    /// The contract asserted here is the whole fix: the window still parses, its percentage - the
     /// number the reader actually came for - is still real, and only the unusable reset instant is
     /// dropped.
     #[test]
@@ -732,9 +747,8 @@ mod budget_fetch_tests {
             let snapshot = parse_codex_usage(&codex_window_with(&hostile))
                 .unwrap_or_else(|err| panic!("{hostile} must still parse a window, got {err}"));
             assert_eq!(
-                snapshot.windows[0].headroom_percent, 75.0,
-                "{hostile}: the headroom is still a real number - only the reset instant is \
-                 unusable"
+                snapshot.windows[0].used_percent, 25.0,
+                "{hostile}: the usage is still a real number - only the reset instant is unusable"
             );
             assert_eq!(
                 snapshot.windows[0].resets_at, None,

--- a/crates/app/src/budget/fetch.rs
+++ b/crates/app/src/budget/fetch.rs
@@ -36,13 +36,24 @@
 //! which is the honest statement: we have nothing, and nothing is broken.
 
 use std::path::PathBuf;
+use std::sync::OnceLock;
 use std::time::{Duration, SystemTime};
 
 use super::state::{window_label, BudgetWindow, Provider, ProviderSnapshot};
 
 /// How long a single usage request may take before it is a failure. Short on purpose - this is a
 /// background readout, and the Claude CLI's own call to the same endpoint uses a 5s timeout.
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// The single-flight guard's own age-out ([`super::state::IN_FLIGHT_STALE_AFTER`]) is only
+/// meaningful if it is comfortably longer than a request that is merely slow - otherwise a poll
+/// that is still legitimately running would be declared stale and raced by a second one. Asserted
+/// at compile time rather than left as a comment, because the two constants live in different
+/// modules and nothing else would notice one of them moving.
+const _: () = assert!(
+    super::state::IN_FLIGHT_STALE_AFTER.as_secs() >= REQUEST_TIMEOUT.as_secs() * 3,
+    "the in-flight age-out must be several request timeouts long, or a slow poll gets raced"
+);
 
 /// The result of one real attempt to read one provider.
 ///
@@ -53,7 +64,9 @@ pub enum ProviderRead {
     /// No credential for this provider on this machine - nothing was sent anywhere.
     NotConnected,
     Ok(ProviderSnapshot),
-    /// The reason, for the popover's tooltip and the log. Never rendered as a number.
+    /// The reason, for the popover's own tooltip
+    /// (`crate::budget::render::AdeApp::render_budget_other_row` hangs it off the failing row's
+    /// state text) and the log. Never rendered as a number.
     Failed(String),
 }
 
@@ -210,12 +223,81 @@ pub fn read_provider(provider: Provider) -> ProviderRead {
     }
 }
 
+/// The message a panicked read reports. Deliberately fixed text rather than the panic payload:
+/// this whole module runs with a live OAuth bearer token in scope, and a payload is arbitrary
+/// text formatted by whatever code panicked - the same reasoning that made [`Credential`]'s
+/// `Debug` redacting applies to a string that is about to be written into a log line and a
+/// tooltip. The real panic (message, location and backtrace) still reaches stderr through the
+/// process's own panic hook, which is where a developer looks for it anyway.
+pub const PANICKED_READ_REASON: &str = "the read failed unexpectedly";
+
+/// Runs one provider read so that a panic inside it becomes a reported failure instead of a
+/// silently wedged poll.
+///
+/// # Why this exists at all
+///
+/// [`super::state::ProviderBudget::in_flight`] is set before the read starts and cleared when its
+/// result lands. A panic on the way - and everything this parses is a *remote* server's
+/// choice of bytes - would leave that guard set with nothing to clear it, and
+/// [`super::state::ProviderBudget::may_poll_now`] then refuses the background loop **and** every
+/// `Refresh`/`Retry` click for the rest of the process's life: the popover sticks on `checking…`
+/// with dead buttons and no error to show. That is a strictly worse outcome than the panic
+/// itself, and it is not hypothetical - a hostile `reset_after_seconds` really did panic
+/// [`codex_reset_instant`] before that function learned to check its arithmetic.
+///
+/// Catching the unwind here, on the background thread that runs the read, is deliberate rather
+/// than relying on a `Drop` guard: this closure is handed to `cx.background_executor()`, and a
+/// future that panics inside an executor does not necessarily unwind back through the awaiting
+/// task at all - the awaited result may simply never arrive. A value that is *returned* always
+/// arrives.
+///
+/// Nothing captured here is state a panic could leave half-written: [`Provider`] is a `Copy` tag
+/// and the read owns everything else it touches, so the unwind-safety this asserts nothing about
+/// is genuinely trivial rather than papered over.
+pub fn read_provider_catching_panics(provider: Provider) -> ProviderRead {
+    catching_panics(move || read_provider(provider))
+}
+
+/// The pure half of [`read_provider_catching_panics`], so the "a panic becomes a failure" rule is
+/// testable without a provider, a credential or a network.
+pub fn catching_panics(
+    read: impl FnOnce() -> ProviderRead + std::panic::UnwindSafe,
+) -> ProviderRead {
+    std::panic::catch_unwind(read)
+        .unwrap_or_else(|_| ProviderRead::Failed(PANICKED_READ_REASON.to_string()))
+}
+
+/// The one HTTP client this module uses, built once for the life of the process.
+///
+/// Built once rather than per request because a fresh `reqwest::blocking::Client` builds a whole
+/// new connection pool and TLS configuration each time, and this module makes the same two
+/// requests against the same two hosts forever.
+///
+/// # Redirects are refused outright
+///
+/// `reqwest` strips `Authorization` when a redirect crosses to another host, but it has no way to
+/// know that Codex's `ChatGPT-Account-Id` is equally sensitive - a custom header follows the
+/// redirect verbatim. A *usage* endpoint has no legitimate reason to redirect anywhere, so the
+/// policy is `none`: a 3xx becomes an ordinary non-2xx failure with its status in the reason,
+/// which is both the honest report and the one that cannot leak a header to a host we never
+/// chose to talk to.
+fn usage_client() -> Result<&'static reqwest::blocking::Client, String> {
+    static CLIENT: OnceLock<Result<reqwest::blocking::Client, String>> = OnceLock::new();
+    CLIENT
+        .get_or_init(|| {
+            reqwest::blocking::Client::builder()
+                .timeout(REQUEST_TIMEOUT)
+                .redirect(reqwest::redirect::Policy::none())
+                .build()
+                .map_err(|err| format!("could not build an HTTP client: {err}"))
+        })
+        .as_ref()
+        .map_err(|err| err.clone())
+}
+
 /// The real HTTP call, with each provider's own required headers.
 fn http_get_usage(provider: Provider, credential: &Credential) -> Result<String, String> {
-    let client = reqwest::blocking::Client::builder()
-        .timeout(REQUEST_TIMEOUT)
-        .build()
-        .map_err(|err| format!("could not build an HTTP client: {err}"))?;
+    let client = usage_client()?;
 
     let mut request = client
         .get(usage_url(provider))
@@ -359,21 +441,49 @@ pub fn parse_codex_usage(body: &str) -> Result<ProviderSnapshot, String> {
 /// wins when it is genuinely an epoch timestamp; otherwise the relative one is added to the
 /// current clock, so a payload that only carries the relative form still produces a real
 /// countdown instead of none.
+///
+/// # Both numbers are a remote server's choice, and are treated as one
+///
+/// Every value here arrives from the network, so neither is trusted to be sane before it is used
+/// in arithmetic:
+///
+/// - **Range first.** A reset instant outside [`PLAUSIBLE_EPOCH_FLOOR`]..=[`PLAUSIBLE_EPOCH_CEILING`],
+///   or a countdown longer than [`MAX_RESET_AFTER_SECONDS`], is not a rate-limit window - it is a
+///   malformed field, and it is dropped for the same reason a `used_percent` that is not a number
+///   is dropped. Without this a technically-addable value (say 10<sup>12</sup> seconds) would
+///   render a perfectly confident `resets in 11574074d 0h`.
+/// - **Then checked arithmetic.** `SystemTime + Duration` *panics* on overflow, and near
+///   `i64::MAX` both of these additions really do overflow - a provider (or anything able to
+///   answer as one) could otherwise crash the poll with a single JSON number. Reproduced before
+///   this guard existed; see this module's `a_hostile_reset_field_cannot_panic_the_poll` test.
+///
+/// Either rejection lands as `None`, which is the same "the provider did not send a usable reset
+/// instant" the parser already reports for a missing field, and which the render side draws as no
+/// countdown at all rather than as a fabricated one. The window's *headroom* - the number the
+/// reader actually came for - is unaffected either way.
 fn codex_reset_instant(entry: &serde_json::Value) -> Option<SystemTime> {
-    // Anything below this is not a plausible epoch second (it would be 2001), so it is a
-    // relative value in a field named as though it were absolute.
+    /// Anything below this is not a plausible epoch second (it would be 2001), so it is a
+    /// relative value in a field named as though it were absolute.
     const PLAUSIBLE_EPOCH_FLOOR: i64 = 1_000_000_000;
+    /// And anything above it is not one either: 2100-01-01, well past the lifetime of any rate
+    /// limit window, and far enough below `i64::MAX` that the addition below cannot overflow.
+    const PLAUSIBLE_EPOCH_CEILING: i64 = 4_102_444_800;
+    /// Roughly 400 days - longer than any rate-limit window either provider documents (the
+    /// longest is a week) by a wide enough margin to be a sanity ceiling rather than a policy.
+    const MAX_RESET_AFTER_SECONDS: i64 = 60 * 60 * 24 * 400;
 
-    if let Some(reset_at) = entry.get("reset_at").and_then(|v| v.as_i64()) {
-        if reset_at >= PLAUSIBLE_EPOCH_FLOOR {
-            return Some(SystemTime::UNIX_EPOCH + Duration::from_secs(reset_at as u64));
-        }
+    let absolute = entry
+        .get("reset_at")
+        .and_then(|value| value.as_i64())
+        .filter(|at| (PLAUSIBLE_EPOCH_FLOOR..=PLAUSIBLE_EPOCH_CEILING).contains(at));
+    if let Some(reset_at) = absolute {
+        return SystemTime::UNIX_EPOCH.checked_add(Duration::from_secs(reset_at as u64));
     }
     let after = entry
         .get("reset_after_seconds")
-        .and_then(|v| v.as_i64())
-        .filter(|seconds| *seconds >= 0)?;
-    Some(SystemTime::now() + Duration::from_secs(after as u64))
+        .and_then(|value| value.as_i64())
+        .filter(|seconds| (0..=MAX_RESET_AFTER_SECONDS).contains(seconds))?;
+    SystemTime::now().checked_add(Duration::from_secs(after as u64))
 }
 
 /// The narrow slice of RFC 3339 the Anthropic payload actually uses:
@@ -429,7 +539,12 @@ pub fn parse_rfc3339(raw: &str) -> Option<SystemTime> {
     if epoch_seconds < 0 {
         return None;
     }
-    Some(SystemTime::UNIX_EPOCH + Duration::from_secs(epoch_seconds as u64))
+    // `checked_add` for the same reason `codex_reset_instant` uses it: a plain `+` on a
+    // `SystemTime` panics on overflow, and every digit that reaches this line came off the
+    // network. A four-digit year cannot reach that far today, which is exactly why this is
+    // written as arithmetic that cannot panic if the shape of the input ever changes rather
+    // than as a comment asserting that it will not.
+    SystemTime::UNIX_EPOCH.checked_add(Duration::from_secs(epoch_seconds as u64))
 }
 
 /// Days since 1970-01-01 for a proleptic Gregorian date - Howard Hinnant's `days_from_civil`, the
@@ -576,6 +691,131 @@ mod budget_fetch_tests {
             snapshot.windows[0].resets_at.is_some(),
             "a `reset_at` of 0 is not an epoch instant, so the relative `reset_after_seconds` must \
              be used instead of dropping the countdown"
+        );
+    }
+
+    /// One `codex` window, with whatever reset fields the caller wants to put in it.
+    fn codex_window_with(reset_fields: &str) -> String {
+        format!(
+            r#"{{"rate_limit": {{"allowed": true, "limit_reached": false,
+                "primary_window": {{"used_percent": 25, "limit_window_seconds": 18000,
+                                    {reset_fields}}}}}}}"#
+        )
+    }
+
+    /// **The panic this test exists for was real, not theoretical.** `SystemTime + Duration`
+    /// panics on overflow ("overflow when adding duration to instant"), and both reset fields are
+    /// a remote server's free choice of `i64`, filtered only for a sign before this fix. A single
+    /// JSON number was enough to bring down the poll - and, because the single-flight guard is set
+    /// before the read starts, to wedge every subsequent poll *and* every `Refresh`/`Retry` click
+    /// for the rest of the session with it.
+    ///
+    /// The contract asserted here is the whole fix: the window still parses, its headroom - the
+    /// number the reader actually came for - is still real, and only the unusable reset instant is
+    /// dropped.
+    #[test]
+    fn a_hostile_reset_field_cannot_panic_the_poll() {
+        for hostile in [
+            // The exact input the adversarial review reproduced a panic with, in both fields and
+            // in each of them alone.
+            format!(r#""reset_after_seconds": {}"#, i64::MAX),
+            format!(r#""reset_at": {}"#, i64::MAX),
+            format!(
+                r#""reset_at": {}, "reset_after_seconds": {}"#,
+                i64::MAX,
+                i64::MAX
+            ),
+            format!(r#""reset_after_seconds": {}"#, i64::MIN),
+            format!(r#""reset_at": {}"#, i64::MIN),
+            format!(r#""reset_at": {}, "reset_after_seconds": -1"#, i64::MAX),
+        ] {
+            let snapshot = parse_codex_usage(&codex_window_with(&hostile))
+                .unwrap_or_else(|err| panic!("{hostile} must still parse a window, got {err}"));
+            assert_eq!(
+                snapshot.windows[0].headroom_percent, 75.0,
+                "{hostile}: the headroom is still a real number - only the reset instant is \
+                 unusable"
+            );
+            assert_eq!(
+                snapshot.windows[0].resets_at, None,
+                "{hostile}: an unusable reset field must fall back to `no countdown`, the same \
+                 way a missing one already did"
+            );
+        }
+
+        // And an overflowing *absolute* field still lets the relative one answer, rather than
+        // taking the whole countdown down with it: the two fields are checked independently.
+        let mixed = parse_codex_usage(&codex_window_with(&format!(
+            r#""reset_at": {}, "reset_after_seconds": 600"#,
+            i64::MAX
+        )))
+        .expect("parses");
+        assert!(
+            mixed.windows[0].resets_at.is_some(),
+            "a usable `reset_after_seconds` beside a hostile `reset_at` is still a real countdown"
+        );
+    }
+
+    /// The other half of the same guard: a value that would *not* overflow but is still not a
+    /// rate-limit window. Left unbounded, `reset_after_seconds` of ten billion renders a
+    /// confident `resets in 115740d 17h` - a fabricated fact dressed as a measured one, which is
+    /// the one thing this whole module refuses to do.
+    #[test]
+    fn an_implausible_but_addable_reset_is_rejected_rather_than_rendered() {
+        let nonsense = parse_codex_usage(&codex_window_with(
+            r#""reset_after_seconds": 10000000000, "reset_at": 0"#,
+        ))
+        .expect("parses");
+        assert_eq!(nonsense.windows[0].resets_at, None);
+
+        let far_future_absolute =
+            parse_codex_usage(&codex_window_with(r#""reset_at": 99999999999"#)).expect("parses");
+        assert_eq!(
+            far_future_absolute.windows[0].resets_at, None,
+            "an epoch second in the year 5138 is not a rate limit resetting"
+        );
+
+        // And the boundary from the other side: a long-but-real countdown is still honoured, so
+        // the ceiling is a sanity check rather than a new limit on what a provider may say.
+        let plausible = parse_codex_usage(&codex_window_with(
+            r#""reset_after_seconds": 604800, "reset_at": 0"#,
+        ))
+        .expect("parses");
+        let resets_at = plausible.windows[0]
+            .resets_at
+            .expect("a one-week countdown is a real reset instant");
+        let remaining = resets_at
+            .duration_since(SystemTime::now())
+            .expect("in the future");
+        assert!(
+            remaining.as_secs() > 604_700 && remaining.as_secs() <= 604_800,
+            "a real relative reset still counts down from now, got {remaining:?}"
+        );
+    }
+
+    /// A panic anywhere under a read must come back as a *reported* failure. Without this the
+    /// single-flight guard would never be cleared and the provider's polling would be wedged for
+    /// the rest of the process's life - see [`read_provider_catching_panics`]'s own docs.
+    #[test]
+    fn a_panicking_read_becomes_a_reported_failure_rather_than_a_lost_result() {
+        let read = catching_panics(|| panic!("overflow when adding duration to instant"));
+        assert_eq!(read, ProviderRead::Failed(PANICKED_READ_REASON.to_string()));
+
+        // A credential could be anywhere in scope when something panics, so the payload itself is
+        // never what gets reported.
+        let read = catching_panics(|| panic!("sk-ant-oat01-super-secret"));
+        match read {
+            ProviderRead::Failed(reason) => assert!(
+                !reason.contains("super-secret"),
+                "a panic payload must never become the user-visible reason, got {reason}"
+            ),
+            other => panic!("expected a failure, got {other:?}"),
+        }
+
+        // And the ordinary path is untouched - the wrapper only catches, it never invents.
+        assert_eq!(
+            catching_panics(|| ProviderRead::NotConnected),
+            ProviderRead::NotConnected
         );
     }
 

--- a/crates/app/src/budget/flow.rs
+++ b/crates/app/src/budget/flow.rs
@@ -190,11 +190,12 @@ mod budget_flow_tests {
     use crate::root::focus::palette_focus_tests::open_test_app;
     use gpui::TestAppContext;
 
-    fn snapshot(headroom: f32) -> ProviderSnapshot {
+    /// One window of `used` percent - the direction every budget number runs in.
+    fn snapshot(used: f32) -> ProviderSnapshot {
         ProviderSnapshot {
             windows: vec![BudgetWindow {
                 label: "5h".to_string(),
-                headroom_percent: headroom,
+                used_percent: used,
                 resets_at: None,
             }],
         }
@@ -287,7 +288,7 @@ mod budget_flow_tests {
         // Exactly what the first window's poll does: claim the process-wide right to read, then
         // land the result on the shared state.
         let landed = Instant::now();
-        let fetched = snapshot(81.0);
+        let fetched = snapshot(19.0);
         {
             let mut shared = lock_shared_budget();
             assert!(

--- a/crates/app/src/budget/flow.rs
+++ b/crates/app/src/budget/flow.rs
@@ -7,8 +7,8 @@
 
 use std::time::Instant;
 
-use super::fetch::{self, ProviderRead};
-use super::state::{Provider, POLLING_ENABLED, POLL_INTERVAL};
+use super::fetch;
+use super::state::{lock_shared_budget, polling_enabled, Provider};
 use super::*;
 
 /// How often the loop wakes up to *consider* polling. Much shorter than
@@ -21,12 +21,19 @@ const POLL_HEARTBEAT: std::time::Duration = std::time::Duration::from_secs(15);
 
 impl AdeApp {
     /// Starts the background budget poll - called once, from `Self::new_with_settings`, next to
-    /// the update-check loop it is modelled on.
+    /// the update-check loop it sits beside.
     ///
-    /// Does nothing at all under `cfg(test)` ([`POLLING_ENABLED`]); see that constant's docs for
-    /// why a test suite must never spend a real person's rate-limit allowance.
+    /// Does nothing at all when [`polling_enabled`] says so - under `cfg(test)`, or with
+    /// `JERRY_DISABLE_PROVIDER_POLL` set; see [`super::state::DISABLE_PROVIDER_POLL_ENV`] for why
+    /// a test suite must never spend a real person's rate-limit allowance and why the `cfg` alone
+    /// is not enough to promise that.
+    ///
+    /// Every window starts one of these, and that is safe *because* the state it polls against is
+    /// process-global ([`super::state::shared_budget`]): the second window's heartbeat finds the
+    /// first window's poll already recent and does nothing but copy the result onto its own
+    /// screen. The loop is per window; the requests are per process.
     pub(crate) fn start_budget_poll_loop(&mut self, cx: &mut Context<Self>) {
-        if !POLLING_ENABLED {
+        if !polling_enabled() {
             return;
         }
         self.poll_budgets_if_due(cx);
@@ -34,6 +41,9 @@ impl AdeApp {
             cx.background_executor().timer(POLL_HEARTBEAT).await;
             let alive = this.update(cx, |this, cx| {
                 this.poll_budgets_if_due(cx);
+                // Whatever *another* window's poll landed since the last heartbeat belongs on
+                // this window's screen too - it is the same account's budget, read once.
+                this.sync_budget_from_shared(cx);
             });
             if alive.is_err() {
                 break;
@@ -44,29 +54,57 @@ impl AdeApp {
 
     /// One heartbeat: read every provider whose turn it is.
     ///
-    /// **Nothing is polled while no agent session is open at all.** The readout lives in an agent
-    /// pane and the popover is reachable only from one (§4u′'s accepted trade-off), so a window
-    /// showing only shell tabs has nowhere to display a budget - and a background HTTP request
-    /// whose result cannot be seen is exactly the "telemetry about telemetry" §2 rejects. It also
-    /// means the common case of Jerry sitting open on a terminal costs a provider nothing.
+    /// **Nothing is polled unless a budget readout is actually on screen in this window.** The
+    /// readout lives in an agent pane and the popover is reachable only from one (§4u′'s accepted
+    /// trade-off), so the test is the pane that is *selected right now*
+    /// ([`crate::work_surface::agents::Agents::active`]) rather than merely one existing
+    /// somewhere among this window's tabs: a window sitting on a shell tab has nowhere to display
+    /// a budget even if a Claude tab is open behind it, and a background HTTP request whose
+    /// result cannot be seen is exactly the "telemetry about telemetry" §2 rejects. It also means
+    /// the common case of Jerry sitting open on a terminal costs a provider nothing.
+    ///
+    /// Both providers are polled once any agent pane is selected, not only the one that pane
+    /// spends: the popover that pane opens lists every provider, and a row that reads `checking…`
+    /// because nothing had ever fetched it would be a worse answer than the real one.
+    ///
+    /// OS window activation is deliberately **not** part of this test. It is a real signal this
+    /// app already tracks (`crate::root::AdeApp::window_active`), but it is delivered by an
+    /// event that can be missed - a window that saw a deactivate and never the matching activate
+    /// would stop polling for the rest of the session with nothing on screen to explain it. The
+    /// selected tab is in-app state that only a real user action changes, so it cannot get stuck.
     pub(crate) fn poll_budgets_if_due(&mut self, cx: &mut Context<Self>) {
-        if !self
-            .agents
-            .iter()
-            .any(|agent| agent.kind.is_agent_session())
-        {
+        if !self.a_budget_readout_is_on_screen() {
             return;
         }
-        let now = Instant::now();
         for provider in Provider::ALL {
-            let budget = self.budget.get(provider);
-            let due = match budget.last_attempt {
-                Some(at) => now.saturating_duration_since(at) >= POLL_INTERVAL,
-                None => true,
-            };
-            if due {
-                self.refresh_provider_budget(provider, false, cx);
-            }
+            // Whether this provider is actually *due* is [`super::state::ProviderBudget::
+            // may_poll_now`]'s question, asked against the process-global state with its lock
+            // held - a second copy of the cadence rule here would be a second place for it to
+            // drift, and one that could not see another window's poll anyway.
+            self.refresh_provider_budget(provider, false, cx);
+        }
+    }
+
+    /// Whether this window currently shows a surface a budget can be read from - the selected
+    /// pane spends a provider. See [`Self::poll_budgets_if_due`] for why this is the selected
+    /// pane rather than any open one.
+    fn a_budget_readout_is_on_screen(&self) -> bool {
+        self.agents
+            .active()
+            .is_some_and(|agent| super::state::provider_of(agent.kind).is_some())
+    }
+
+    /// Copies the process-global budget onto this window, and redraws only if it really changed.
+    ///
+    /// This is how a window that did not fire the request still shows its result: one poll per
+    /// process, N windows rendering it. The `notify` is conditional because this runs on every
+    /// heartbeat of every window, and an unconditional one would repaint the whole window every
+    /// 15 seconds for nothing.
+    pub(crate) fn sync_budget_from_shared(&mut self, cx: &mut Context<Self>) {
+        let shared = lock_shared_budget().clone();
+        if shared != self.budget {
+            self.budget = shared;
+            cx.notify();
         }
     }
 
@@ -86,94 +124,68 @@ impl AdeApp {
     /// queueing would turn an impatient double-click into two requests against an endpoint whose
     /// own limiter is the reason this cadence exists.
     ///
-    /// # The `cfg(test)` guard lives here, not only on the timer
+    /// # The test guard lives here, not only on the timer
     ///
     /// This is the single choke point every read passes through: the background loop, the
     /// popover's `Refresh` and a failed row's `Retry` all arrive here, and only the first of the
-    /// three goes anywhere near [`AdeApp::start_budget_poll_loop`]'s own [`POLLING_ENABLED`]
+    /// three goes anywhere near [`AdeApp::start_budget_poll_loop`]'s own [`polling_enabled`]
     /// check. A test that drove either control - a click test on the popover, a render test that
     /// happened to fire the handler - would otherwise read the developer's own OAuth credential
-    /// off disk and send it to a real provider, which is precisely what that constant exists to
+    /// off disk and send it to a real provider, which is precisely what that gate exists to
     /// prevent. Gating the loop alone made the promise true by accident of what the suite happens
     /// to call today; gating here makes it true by construction.
+    ///
+    /// # The claim is against the process, not against this window
+    ///
+    /// [`super::state::BudgetState::claim_poll`] runs on the process-global
+    /// [`super::state::shared_budget`], so the interval, the manual floor and the single-flight
+    /// guard hold across every open window rather than once per window - see that function's own
+    /// docs for why an endpoint that has already answered `429` makes that the difference between
+    /// a rule and a suggestion.
     pub(crate) fn refresh_provider_budget(
         &mut self,
         provider: Provider,
         manual: bool,
         cx: &mut Context<Self>,
     ) {
-        if !POLLING_ENABLED {
+        if !polling_enabled() {
             return;
         }
         let now = Instant::now();
-        if !self.budget.get(provider).may_poll_now(manual, now) {
-            return;
-        }
         {
-            let budget = self.budget.get_mut(provider);
-            budget.in_flight = true;
-            budget.last_attempt = Some(now);
+            let mut shared = lock_shared_budget();
+            if !shared.claim_poll(provider, manual, now) {
+                return;
+            }
+            self.budget = shared.clone();
         }
         cx.notify();
 
         cx.spawn(async move |this, cx| {
             let read = cx
                 .background_executor()
-                .spawn(async move { fetch::read_provider(provider) })
+                .spawn(async move { fetch::read_provider_catching_panics(provider) })
                 .await;
+            // Landed in the process-global state *first*, and outside the window update: this
+            // window may be gone by now (closed mid-request), and a result that never reaches
+            // the shared state would leave its single-flight guard set for every *other*
+            // window too. The state that decides whether anyone may poll again must not depend
+            // on the survival of whichever window happened to fire this one.
+            lock_shared_budget().apply_read(provider, read, Instant::now());
             let _ = this.update(cx, |this, cx| {
-                this.apply_budget_poll_result(provider, read, Instant::now());
-                cx.notify();
+                this.sync_budget_from_shared(cx);
             });
         })
         .detach();
-    }
-
-    /// Folds one real read into one provider's state. The whole state machine, in one place and
-    /// with no `Context` - so every transition is directly testable without a window or a network.
-    ///
-    /// The three outcomes are kept genuinely distinct (rev 6 §7 rule 6):
-    ///
-    /// - **not connected** clears everything, including any numbers from before. A provider whose
-    ///   credential has gone (a logout while Jerry was running) is not a provider with stale
-    ///   numbers - the data is not ours to show any more.
-    /// - **ok** replaces the numbers and clears the failure.
-    /// - **failed** records the reason and *keeps* the previous numbers. They are still the last
-    ///   true reading; §2's `last read <age>` takes over once they age past
-    ///   [`super::state::STALE_AFTER`], and the failure itself surfaces as the `Retry`.
-    pub(crate) fn apply_budget_poll_result(
-        &mut self,
-        provider: Provider,
-        read: ProviderRead,
-        now: Instant,
-    ) {
-        let budget = self.budget.get_mut(provider);
-        budget.in_flight = false;
-        match read {
-            ProviderRead::NotConnected => {
-                budget.connected = false;
-                budget.last_ok = None;
-                budget.last_error = None;
-            }
-            ProviderRead::Ok(snapshot) => {
-                budget.connected = true;
-                budget.last_ok = Some((snapshot, now));
-                budget.last_error = None;
-            }
-            ProviderRead::Failed(reason) => {
-                budget.connected = true;
-                log::warn!("{} rate-limit read failed: {reason}", provider.id());
-                budget.last_error = Some(reason);
-            }
-        }
     }
 }
 
 /// Real coverage for the state machine the poll drives, without touching the network.
 #[cfg(test)]
 mod budget_flow_tests {
-    use super::super::state::{ProviderReadout, ProviderSnapshot, STALE_AFTER};
+    use super::super::state::{shared_budget, ProviderSnapshot, POLLING_ENABLED};
     use super::*;
+    use crate::budget::fetch::ProviderRead;
     use crate::budget::state::BudgetWindow;
     use crate::root::focus::palette_focus_tests::open_test_app;
     use gpui::TestAppContext;
@@ -193,6 +205,10 @@ mod budget_flow_tests {
     /// a `#[test]` body: a run-time assertion can only fail after the suite has already had the
     /// chance to make the call it is guarding against, whereas this one refuses to build a test
     /// binary in which polling is on.
+    ///
+    /// This covers *this* crate's test targets only, which is exactly why
+    /// [`super::state::DISABLE_PROVIDER_POLL_ENV`] exists beside it - see
+    /// `the_environment_kill_switch_disables_polling_in_any_build` in `crate::budget::state`.
     const _: () = assert!(
         !POLLING_ENABLED,
         "a test run must never spend a real person's provider budget"
@@ -225,74 +241,11 @@ mod budget_flow_tests {
         });
     }
 
+    /// The heartbeat must not touch the network for a window whose selected pane is a shell -
+    /// there is nowhere to render a budget, and a request whose result cannot be seen is exactly
+    /// the telemetry §2 rejects.
     #[gpui::test]
-    fn a_real_read_becomes_state_and_a_failure_keeps_the_numbers_it_had(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
-
-        app.update(cx, |app, _cx| {
-            let now = Instant::now();
-
-            app.apply_budget_poll_result(Provider::Claude, ProviderRead::NotConnected, now);
-            assert_eq!(
-                app.budget.get(Provider::Claude).readout(now),
-                ProviderReadout::NotConnected,
-                "no credential is `not connected`, and nothing was sent anywhere"
-            );
-
-            let good = snapshot(81.0);
-            app.apply_budget_poll_result(Provider::Claude, ProviderRead::Ok(good.clone()), now);
-            assert_eq!(
-                app.budget.get(Provider::Claude).readout(now),
-                ProviderReadout::Numbers(&good)
-            );
-            assert!(
-                !app.budget.get(Provider::Claude).in_flight,
-                "a landed result always clears the single-flight guard"
-            );
-
-            app.apply_budget_poll_result(
-                Provider::Claude,
-                ProviderRead::Failed("the provider answered 429".to_string()),
-                now,
-            );
-            assert_eq!(
-                app.budget.get(Provider::Claude).readout(now),
-                ProviderReadout::Numbers(&good),
-                "a failed refresh does not erase numbers that are still true"
-            );
-            assert!(
-                app.budget.get(Provider::Claude).can_retry(),
-                "but it does earn the `Retry` \u{a7}4c puts beside a failure"
-            );
-
-            let stale = now + STALE_AFTER + std::time::Duration::from_secs(1);
-            assert!(
-                matches!(
-                    app.budget.get(Provider::Claude).readout(stale),
-                    ProviderReadout::LastRead(_)
-                ),
-                "\u{a7}2: once they go stale the numbers give way to `last read <age>`"
-            );
-
-            // A logout mid-session: the credential is gone, and so are the numbers.
-            app.apply_budget_poll_result(Provider::Claude, ProviderRead::NotConnected, now);
-            assert_eq!(
-                app.budget.get(Provider::Claude).readout(now),
-                ProviderReadout::NotConnected
-            );
-            assert!(
-                app.budget.get(Provider::Claude).last_ok.is_none(),
-                "numbers from a provider we are no longer logged into are not ours to show"
-            );
-        });
-    }
-
-    /// The heartbeat must not touch the network for a window that has no agent at all - there is
-    /// nowhere to render a budget, and a request whose result cannot be seen is exactly the
-    /// telemetry §2 rejects.
-    #[gpui::test]
-    fn a_window_with_no_agent_session_polls_nothing(cx: &mut TestAppContext) {
+    fn a_window_showing_no_agent_pane_polls_nothing(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
         let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
@@ -301,6 +254,10 @@ mod budget_flow_tests {
             assert!(
                 !app.agents.iter().any(|agent| agent.kind.is_agent_session()),
                 "premise: the startup pane is a shell, not an agent session"
+            );
+            assert!(
+                !app.a_budget_readout_is_on_screen(),
+                "so nothing on screen could show a budget"
             );
             app.poll_budgets_if_due(cx);
             for provider in Provider::ALL {
@@ -311,5 +268,59 @@ mod budget_flow_tests {
                 );
             }
         });
+    }
+
+    /// The one shared budget really does reach a second window's own screen. Without this, making
+    /// the poll process-global would have fixed the request rate by leaving every window but one
+    /// permanently on `checking…`, which is a worse readout than the one it replaced.
+    ///
+    /// Writes the process-global state directly, which is safe precisely because polling is off
+    /// in this build: nothing else in the suite reads or writes it (every other test drives a
+    /// local [`super::super::state::BudgetState`]), so there is no other test for this one to
+    /// race.
+    #[gpui::test]
+    fn a_second_window_renders_the_budget_the_first_ones_poll_fetched(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (first, cx) = open_test_app(cx, repo.path().to_path_buf());
+        let (second, cx) = open_test_app(cx, repo.path().to_path_buf());
+
+        // Exactly what the first window's poll does: claim the process-wide right to read, then
+        // land the result on the shared state.
+        let landed = Instant::now();
+        let fetched = snapshot(81.0);
+        {
+            let mut shared = lock_shared_budget();
+            assert!(
+                shared.claim_poll(Provider::Claude, false, landed),
+                "nothing has polled yet in this process, so the claim must succeed"
+            );
+            shared.apply_read(Provider::Claude, ProviderRead::Ok(fetched.clone()), landed);
+        }
+
+        for (label, app) in [("first", &first), ("second", &second)] {
+            app.update(cx, |app, cx| {
+                app.sync_budget_from_shared(cx);
+                assert_eq!(
+                    app.budget
+                        .get(Provider::Claude)
+                        .last_ok
+                        .clone()
+                        .map(|(snapshot, _)| snapshot),
+                    Some(fetched.clone()),
+                    "the {label} window must render the numbers the single shared poll fetched, \
+                     whichever window happened to fire it"
+                );
+            });
+        }
+
+        // And the guard the two windows share is the same one, so neither can start a second
+        // read while the other's is open.
+        assert!(
+            !shared_budget()
+                .lock()
+                .expect("the shared budget is not poisoned")
+                .claim_poll(Provider::Claude, false, landed),
+            "a read that has just landed holds the whole process to POLL_INTERVAL, not one window"
+        );
     }
 }

--- a/crates/app/src/budget/mod.rs
+++ b/crates/app/src/budget/mod.rs
@@ -1,4 +1,4 @@
-//! Per-provider rate-limit budget: the agent pane's `claude 5h ▓▓▓▓▓▓░ 81% 7d ▓▓▓▓░░░ 40%`
+//! Per-provider rate-limit budget: the agent pane's `claude 5h ▓░░░░░░ 19% 7d ▓▓▓▓░░░ 60%`
 //! readout and the popover behind it (GitHub issue #294,
 //! `design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md` §2,
 //! `STAGE-A-CHANGELOG.md` §4c/§4t/§4u′).
@@ -6,7 +6,7 @@
 //! Split the way every feature folder in this crate is split - pure, GPUI-window-free logic
 //! apart from the `gpui::Div`-building code that draws it:
 //!
-//! - [`state`] - the provider set, the agent → provider mapping, the window/headroom model, the
+//! - [`state`] - the provider set, the agent → provider mapping, the window/usage model, the
 //!   three-step hue thresholds and every string the two surfaces print. No `gpui::Window`, so
 //!   the whole "which state is this provider really in" question is directly `#[test]`-able.
 //! - [`fetch`] - real credential discovery on disk and the real HTTP read of each provider's own

--- a/crates/app/src/budget/render.rs
+++ b/crates/app/src/budget/render.rs
@@ -526,6 +526,17 @@ impl AdeApp {
             )
     }
 
+    /// One provider's row. The `refresh failed` / `last read <age>` text carries the **real
+    /// reason** the last attempt failed as its tooltip.
+    ///
+    /// `refresh failed` on its own says only that something went wrong; the difference between
+    /// "the provider answered 401" (the CLI's stored token has expired - re-authenticate *there*,
+    /// Jerry does not log anyone in) and "the provider answered 429" (the endpoint's own limiter -
+    /// wait, do not keep clicking `Retry`) is the whole of what a reader can act on, and it was
+    /// already being carried all the way here in [`super::state::ProviderBudget::last_error`] only
+    /// to be dropped one line short of the screen. It hangs off the state text rather than the
+    /// whole row so it points at the thing it explains, and it sits beside the `Retry` the same
+    /// failure earns.
     fn render_budget_other_row(
         &self,
         provider: Provider,
@@ -534,6 +545,15 @@ impl AdeApp {
     ) -> impl IntoElement {
         let budget = self.budget.get(provider);
         let readout = budget.readout(now);
+        // Only for a state the failure actually explains: a provider showing real, fresh numbers
+        // may still hold a `last_error` from a newer attempt that failed, and hanging "the
+        // provider answered 429" off numbers that are correct would read as though they were not.
+        let failure_reason = match &readout {
+            ProviderReadout::RefreshFailed | ProviderReadout::LastRead(_) => {
+                budget.last_error.clone()
+            }
+            _ => None,
+        };
         let (state_text, state_color) = match &readout {
             ProviderReadout::Numbers(snapshot) => (
                 snapshot.summary_label(),
@@ -571,11 +591,19 @@ impl AdeApp {
             )
             .child(
                 div()
+                    .id(match provider {
+                        Provider::Claude => "budget-popover-state-claude",
+                        Provider::Codex => "budget-popover-state-codex",
+                    })
+                    .debug_selector(move || format!("budget-popover-state-{}", provider.id()))
                     .flex_none()
                     .font(font(theme::font::MONO))
                     .text_size(self.ui_text_size(10.0))
                     .text_color(state_color)
-                    .child(state_text),
+                    .child(state_text)
+                    .when_some(failure_reason, |el, reason| {
+                        el.tooltip(text_tooltip(reason))
+                    }),
             )
             .when(can_retry, |el| {
                 el.child(

--- a/crates/app/src/budget/render.rs
+++ b/crates/app/src/budget/render.rs
@@ -25,7 +25,8 @@ const METER_HEIGHT: f32 = 3.0;
 
 impl AdeApp {
     /// §4t's per-agent provider budget, right-aligned in the pane's readout strip:
-    /// `claude 5h ▓▓▓▓▓▓░ 81% 7d ▓▓▓▓░░░ 40%`, for **this** agent's provider.
+    /// `claude 5h ▓░░░░░░ 19% 7d ▓▓▓▓░░░ 60%`, for **this** agent's provider - each meter filling
+    /// with what has been *spent* (`super::state`'s "Used, not left").
     ///
     /// `None` - nothing at all, not a dimmed placeholder - for a pane that spends no provider.
     /// §4t words that as "a local model shows nothing, correctly"; in this build the pane that
@@ -44,7 +45,9 @@ impl AdeApp {
     /// # Window label before the value
     ///
     /// §4c, verbatim: "`92% 5h` parsed as '92% for 5 hours'; `5h 92%` parses as '5-hour window,
-    /// 92% left'". Every string and every element order here puts the label first.
+    /// 92% left'". Every string and every element order here puts the label first - an argument
+    /// about which half of the pair leads, which the flip from `% left` to `% used`
+    /// (`super::state`'s "Used, not left") leaves exactly as it was.
     ///
     /// # Why a not-connected provider still renders a (bare) cluster
     ///
@@ -81,7 +84,7 @@ impl AdeApp {
             })
             .tooltip(text_tooltip(match budget.readout(now) {
                 ProviderReadout::Numbers(_) => format!(
-                    "How much of {}'s rate limit is left - click for every window and provider",
+                    "How much of {}'s rate limit is used - click for every window and provider",
                     provider.label()
                 ),
                 _ => format!("{}'s rate limit - click for details", provider.label()),
@@ -311,7 +314,7 @@ impl AdeApp {
     /// the two together in one sentence ("`Updated 3m ago` and a `Refresh` that sets `Updated just
     /// now`"), but `Jerry.dc.html` - the newest state of the bundle, and the build §4u′ describes -
     /// puts `Refresh` at the head opposite the title and leaves the foot to `Updated N ago` and the
-    /// `counts headroom, not spend` footnote. That is also the better reading of the same sentence:
+    /// `counts spend, not headroom` footnote. That is also the better reading of the same sentence:
     /// it fixes what `Refresh` *does* to the foot line, not where it is drawn. The mock wins on
     /// placement; the prose's actual claim - that the foot line is derived from a real read - is
     /// what [`Self::render_budget_popover_footer`] implements.
@@ -411,7 +414,7 @@ impl AdeApp {
         section.into_any_element()
     }
 
-    /// One window inside the lead block: `5h · 92% left · resets in 4h 53m`, over its own meter.
+    /// One window inside the lead block: `5h · 8% used · resets in 4h 53m`, over its own meter.
     ///
     /// The window label leads here too (§4c), and it is a real duration token (`5h`/`7d`) rather
     /// than a word, so the two rows read as a series.
@@ -638,7 +641,9 @@ impl AdeApp {
         }
     }
 
-    /// §4c's foot: `Updated 3m ago` and the footnote `counts headroom, not spend`.
+    /// §4c's foot: `Updated 3m ago` and the footnote `counts spend, not headroom` - the design
+    /// bundle's own `counts headroom, not spend`, inverted along with the numbers it describes
+    /// (`super::state`'s "Used, not left").
     ///
     /// The age comes from the real instant a real result last landed
     /// ([`super::state::BudgetState::last_read_at`]), through the *same* formatter the Resources
@@ -668,7 +673,7 @@ impl AdeApp {
                     .font(font(theme::font::SANS))
                     .text_size(self.ui_text_size(10.0))
                     .text_color(theme::text::HINT)
-                    .child("counts headroom, not spend"),
+                    .child("counts spend, not headroom"),
             )
     }
 }

--- a/crates/app/src/budget/state.rs
+++ b/crates/app/src/budget/state.rs
@@ -1,17 +1,30 @@
 //! The budget model: which providers exist, which agent spends which one, what a window's
-//! headroom means, and every string the pane strip and the popover print.
+//! usage means, and every string the pane strip and the popover print.
 //!
 //! Pure and GPUI-free, like `crate::status_bar::resources` - so "a connected provider that goes
 //! stale shows `last read <age>` in place of its own numbers" is a property that can be tested
 //! directly against a state value, without a window.
 //!
-//! # Headroom, not spend
+//! # Used, not left
 //!
-//! Both providers report a *utilisation* (percent **used**). Every number this module carries and
-//! prints is the complement of that - percent **left** - which is what the popover's own footnote
-//! (`counts headroom, not spend`) promises the reader. The conversion happens once, in
-//! [`crate::budget::fetch`]'s parsers, so nothing downstream can hold a value whose direction is
-//! ambiguous.
+//! Both providers report a *utilisation* (percent **used**), and that is the number this module
+//! carries and prints, unconverted: `61% used`, on a meter that fills as it is spent. The design
+//! bundle specified the complement (`65% left`, on a meter where full is good), and this build
+//! shipped that first; it was overruled by the product owner after seeing it, and the reason is
+//! worth recording, because it is the sort of thing that gets "corrected" back by whoever next
+//! reads the bundle. `% used` is the figure both providers' own APIs report, the figure both
+//! CLIs' own `/status` displays show, and the one a reader already has in their head from every
+//! other quota they have ever seen - and a meter that empties as you work reads as a *drain* even
+//! when the number beside it is fine.
+//!
+//! Two consequences worth stating plainly, because getting either backwards would be a real bug
+//! rather than a matter of taste:
+//!
+//! - **The bar and the number tell the same story.** [`BudgetWindow::fill_fraction`] is the
+//!   *usage*, so a nearly-full bar sits beside a high `% used` and both mean "nearly spent".
+//! - **The hue still keys off what is left.** [`budget_level`] takes *headroom*
+//!   ([`BudgetWindow::headroom_percent`]), because "amber below 40% left" is a statement about
+//!   remaining budget and stays true however the number is printed. `95% used` is red, not green.
 
 use std::sync::{Mutex, MutexGuard, OnceLock};
 use std::time::{Duration, Instant, SystemTime};
@@ -201,6 +214,11 @@ impl BudgetLevel {
 
 /// The step a real headroom percentage falls in. Boundaries follow §2's own wording exactly:
 /// *above* 40 is healthy, 15-40 inclusive is amber, *below* 15 is red.
+///
+/// **Takes headroom, not usage**, even though usage is what every surface now prints - the
+/// thresholds are a statement about how much budget is left, and passing a `% used` figure in
+/// here would silently invert every colour on screen (a spent window would read green). The one
+/// conversion lives in [`BudgetWindow::headroom_percent`], so no caller has to remember it.
 pub fn budget_level(headroom_percent: f32) -> BudgetLevel {
     if headroom_percent > 40.0 {
         BudgetLevel::Ok
@@ -211,8 +229,8 @@ pub fn budget_level(headroom_percent: f32) -> BudgetLevel {
     }
 }
 
-/// One rate-limit window of one provider: how much of it is left, when it resets, and what to
-/// call it.
+/// One rate-limit window of one provider: how much of it has been spent, when it resets, and what
+/// to call it.
 #[derive(Debug, Clone, PartialEq)]
 pub struct BudgetWindow {
     /// The window's own duration, as the strip prints it - `5h`, `7d`. Owned rather than
@@ -220,9 +238,10 @@ pub struct BudgetWindow {
     /// `limit_window_seconds` and the label is formatted from it ([`window_label`]), so a plan
     /// whose primary window is not five hours labels itself correctly instead of lying.
     pub label: String,
-    /// Percent **left**, 0-100 - already the complement of the API's own "used" figure. See this
-    /// module's docs.
-    pub headroom_percent: f32,
+    /// Percent **used**, 0-100 - exactly the figure both providers report (Claude's
+    /// `utilization`, Codex's `used_percent`), clamped but not converted. See this module's docs
+    /// for why this is stored the way the API sends it rather than as its complement.
+    pub used_percent: f32,
     /// When this window rolls over, as an absolute instant, so the popover's countdown really
     /// counts down while it is open instead of freezing at whatever it read at poll time. `None`
     /// when the provider did not send one.
@@ -230,26 +249,36 @@ pub struct BudgetWindow {
 }
 
 impl BudgetWindow {
+    /// Percent **left** - the complement of [`Self::used_percent`], and the only thing that reads
+    /// it. Nothing on screen prints this; it exists because the hue thresholds are defined on
+    /// remaining budget ([`budget_level`]) and must stay that way whatever the printed number
+    /// says.
+    pub fn headroom_percent(&self) -> f32 {
+        (100.0 - self.used_percent).clamp(0.0, 100.0)
+    }
+
     pub fn level(&self) -> BudgetLevel {
-        budget_level(self.headroom_percent)
+        budget_level(self.headroom_percent())
     }
 
-    /// `"92%"` - the value half of the readout. Rounded to whole percent: both APIs report whole
-    /// or near-whole numbers, and a decimal place on a five-hour window is precision this fact
-    /// does not have.
+    /// `"61%"` - the value half of the readout, as percent **used**. Rounded to whole percent:
+    /// both APIs report whole or near-whole numbers, and a decimal place on a five-hour window is
+    /// precision this fact does not have.
     pub fn value_label(&self) -> String {
-        format!("{}%", self.headroom_percent.round() as i64)
+        format!("{}%", self.used_percent.round() as i64)
     }
 
-    /// `"92% left"` - the popover's own longer form, which has the room to remove the
-    /// left/used ambiguity inline rather than only in the footnote.
+    /// `"61% used"` - the popover's own longer form, which has the room to say which direction
+    /// the number runs in inline rather than only in the footnote.
     pub fn popover_value_label(&self) -> String {
-        format!("{} left", self.value_label())
+        format!("{} used", self.value_label())
     }
 
-    /// The meter's fill as a real 0.0-1.0 fraction.
+    /// The meter's fill as a real 0.0-1.0 fraction: the **usage**, so the bar fills up as the
+    /// window is spent and a nearly-full red bar sits beside a high `% used`. See this module's
+    /// docs - the bar and the number have to tell one story, and this is which one.
     pub fn fill_fraction(&self) -> f32 {
-        (self.headroom_percent / 100.0).clamp(0.0, 1.0)
+        (self.used_percent / 100.0).clamp(0.0, 1.0)
     }
 
     /// `"resets in 4h 53m"`, or `None` when the provider sent no reset instant at all - which the
@@ -339,23 +368,24 @@ pub struct ProviderSnapshot {
 }
 
 impl ProviderSnapshot {
-    /// The window with the least headroom - what ranks providers in the popover ("the tightest
-    /// provider on top"). `None` for a provider that reported no windows at all, which is a real
-    /// possibility for an account with no limits attached and is deliberately not coerced to
-    /// `Some(100)`.
+    /// The tightest window - the most spent, equivalently the one with the least headroom - which
+    /// is what ranks providers in the popover ("the tightest provider on top"). `None` for a
+    /// provider that reported no windows at all, which is a real possibility for an account with
+    /// no limits attached and is deliberately not coerced to `Some(0)`.
     pub fn tightest(&self) -> Option<&BudgetWindow> {
         self.windows.iter().min_by(|a, b| {
-            a.headroom_percent
-                .partial_cmp(&b.headroom_percent)
+            a.headroom_percent()
+                .partial_cmp(&b.headroom_percent())
                 .unwrap_or(std::cmp::Ordering::Equal)
         })
     }
 
-    /// The `Other providers` row's one-line summary: `"5h 92%  ·  7d 65%"`.
+    /// The `Other providers` row's one-line summary: `"5h 8%  ·  7d 35%"`.
     ///
     /// **Window label before the value**, like every other budget string in this app - §4c,
-    /// verbatim: "`92% 5h` parsed as '92% for 5 hours'; `5h 92%` parses as '5-hour window, 92%
-    /// left'".
+    /// verbatim: "`92% 5h` parsed as '92% for 5 hours'; `5h 92%` parses as '5-hour window, 92%'".
+    /// That argument is about which half of the pair leads, and is untouched by the direction the
+    /// number itself runs in.
     pub fn summary_label(&self) -> String {
         self.windows
             .iter()
@@ -486,7 +516,7 @@ impl ProviderBudget {
     pub fn tightest_headroom(&self, now: Instant) -> Option<f32> {
         match self.readout(now) {
             ProviderReadout::Numbers(snapshot) => {
-                snapshot.tightest().map(|window| window.headroom_percent)
+                snapshot.tightest().map(|window| window.headroom_percent())
             }
             _ => None,
         }
@@ -648,10 +678,12 @@ pub fn lock_shared_budget() -> MutexGuard<'static, BudgetState> {
 mod budget_state_tests {
     use super::*;
 
-    fn window(label: &str, headroom: f32) -> BudgetWindow {
+    /// A window of `used` percent - the direction every one of these numbers runs in, so a test
+    /// that reads `19.0` means "19% spent, 81% left" and never the other way round.
+    fn window(label: &str, used: f32) -> BudgetWindow {
         BudgetWindow {
             label: label.to_string(),
-            headroom_percent: headroom,
+            used_percent: used,
             resets_at: None,
         }
     }
@@ -710,7 +742,7 @@ mod budget_state_tests {
     /// readout amber and say the session is constrained when it is not.
     #[test]
     fn each_window_takes_its_own_hue_rather_than_the_tighter_ones() {
-        let snapshot = snapshot(81.0, 40.0);
+        let snapshot = snapshot(19.0, 60.0);
         assert_eq!(snapshot.windows[0].level(), BudgetLevel::Ok);
         assert_eq!(snapshot.windows[1].level(), BudgetLevel::Warn);
         assert_eq!(
@@ -721,15 +753,54 @@ mod budget_state_tests {
     }
 
     /// §4c, verbatim: "`92% 5h` parsed as '92% for 5 hours'; `5h 92%` parses as '5-hour window,
-    /// 92% left'". The label leads.
+    /// 92%'". The label leads - an argument about ordering that the direction of the number
+    /// itself does not touch.
     #[test]
     fn every_window_string_puts_the_window_label_before_the_value() {
-        let snapshot = snapshot(92.0, 65.0);
-        assert_eq!(snapshot.summary_label(), "5h 92%  \u{b7}  7d 65%");
+        let snapshot = snapshot(8.0, 35.0);
+        assert_eq!(snapshot.summary_label(), "5h 8%  \u{b7}  7d 35%");
         assert!(
             snapshot.summary_label().starts_with("5h "),
-            "the window label must lead - `92% 5h` reads as `92% for 5 hours`"
+            "the window label must lead - `8% 5h` reads as `8% for 5 hours`"
         );
+    }
+
+    /// **Every number on screen is percent used, and the bar agrees with it.** The design bundle
+    /// specified the complement (`92% left`, on a meter where full is good) and this build shipped
+    /// that first; the product owner overruled it after seeing it. Pinned here in one place so the
+    /// flip cannot drift back a field at a time - and so the *hue*, which still keys off what is
+    /// left, cannot be flipped along with the number by accident.
+    #[test]
+    fn every_printed_percentage_is_usage_and_the_meter_fills_with_it() {
+        let nearly_spent = window("5h", 95.0);
+        assert_eq!(
+            nearly_spent.value_label(),
+            "95%",
+            "the strip prints what has been spent, not what is left"
+        );
+        assert_eq!(nearly_spent.popover_value_label(), "95% used");
+        assert!(
+            (nearly_spent.fill_fraction() - 0.95).abs() < f32::EPSILON,
+            "and the meter is nearly full, because the bar and the number have to tell one story"
+        );
+        assert_eq!(
+            nearly_spent.level(),
+            BudgetLevel::Critical,
+            "95% used is 5% left, which is red - the hue keys off headroom however the number is \
+             printed, and inverting it along with the display would paint a spent window green"
+        );
+
+        let untouched = window("7d", 0.0);
+        assert_eq!(untouched.value_label(), "0%");
+        assert_eq!(untouched.fill_fraction(), 0.0, "an unspent window is empty");
+        assert_eq!(untouched.level(), BudgetLevel::Ok);
+
+        // An over-quota account can report past 100; the meter must not overflow its own track,
+        // and the number must not read as a percentage that cannot exist.
+        let over_quota = window("5h", 130.0);
+        assert_eq!(over_quota.fill_fraction(), 1.0);
+        assert_eq!(over_quota.headroom_percent(), 0.0);
+        assert_eq!(over_quota.level(), BudgetLevel::Critical);
     }
 
     #[test]
@@ -753,7 +824,7 @@ mod budget_state_tests {
     #[test]
     fn a_reset_countdown_reads_largest_unit_first_and_never_goes_negative() {
         let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
-        let mut window = window("5h", 92.0);
+        let mut window = window("5h", 8.0);
 
         window.resets_at = Some(now + Duration::from_secs(4 * 3600 + 53 * 60));
         assert_eq!(window.reset_label(now).as_deref(), Some("resets in 4h 53m"));
@@ -817,7 +888,7 @@ mod budget_state_tests {
             "and it earns the `Retry` \u{a7}4c puts beside it"
         );
 
-        let fresh = snapshot(81.0, 40.0);
+        let fresh = snapshot(19.0, 60.0);
         budget.last_ok = Some((fresh.clone(), now));
         budget.last_error = None;
         assert_eq!(
@@ -939,7 +1010,7 @@ mod budget_state_tests {
         let now = Instant::now();
         for read in [
             ProviderRead::NotConnected,
-            ProviderRead::Ok(snapshot(81.0, 40.0)),
+            ProviderRead::Ok(snapshot(19.0, 60.0)),
             ProviderRead::Failed("the provider answered 429".to_string()),
         ] {
             let mut state = BudgetState::default();
@@ -970,7 +1041,7 @@ mod budget_state_tests {
             "no credential is `not connected`, and nothing was sent anywhere"
         );
 
-        let good = snapshot(81.0, 40.0);
+        let good = snapshot(19.0, 60.0);
         state.apply_read(Provider::Claude, ProviderRead::Ok(good.clone()), now);
         assert_eq!(
             state.get(Provider::Claude).readout(now),
@@ -1034,7 +1105,7 @@ mod budget_state_tests {
 
         shared.apply_read(
             Provider::Claude,
-            ProviderRead::Ok(snapshot(81.0, 40.0)),
+            ProviderRead::Ok(snapshot(19.0, 60.0)),
             now,
         );
         assert!(
@@ -1095,16 +1166,16 @@ mod budget_state_tests {
         );
 
         state.get_mut(Provider::Claude).connected = true;
-        state.get_mut(Provider::Claude).last_ok = Some((snapshot(81.0, 40.0), now));
+        state.get_mut(Provider::Claude).last_ok = Some((snapshot(19.0, 60.0), now));
         assert_eq!(state.lead_provider(now), Some(Provider::Claude));
 
         state.get_mut(Provider::Codex).connected = true;
-        state.get_mut(Provider::Codex).last_ok = Some((snapshot(99.0, 12.0), now));
+        state.get_mut(Provider::Codex).last_ok = Some((snapshot(1.0, 88.0), now));
         assert_eq!(
             state.lead_provider(now),
             Some(Provider::Codex),
-            "codex's 12% weekly is tighter than claude's 40%, even though its session window is \
-             the healthier of the two"
+            "codex's 88%-spent week is tighter than claude's 60%, even though its session window \
+             is the healthier of the two"
         );
 
         // A provider whose numbers went stale cannot lead on numbers nobody can see.

--- a/crates/app/src/budget/state.rs
+++ b/crates/app/src/budget/state.rs
@@ -13,8 +13,10 @@
 //! [`crate::budget::fetch`]'s parsers, so nothing downstream can hold a value whose direction is
 //! ambiguous.
 
+use std::sync::{Mutex, MutexGuard, OnceLock};
 use std::time::{Duration, Instant, SystemTime};
 
+use super::fetch::ProviderRead;
 use crate::work_surface::agents::{AgentKind, ProcessKind};
 
 /// How often the background loop re-reads every connected provider
@@ -45,18 +47,67 @@ pub const MANUAL_REFRESH_FLOOR: Duration = Duration::from_secs(15);
 /// stopped answering.
 pub const STALE_AFTER: Duration = Duration::from_secs(15 * 60);
 
-/// Whether the background poll loop runs at all in this build.
+/// How long [`ProviderBudget::in_flight`] may stay set before it is treated as a lost poll rather
+/// than as a running one.
+///
+/// The guard is cleared by a landing result, and [`crate::budget::fetch::read_provider_catching_panics`]
+/// plus `crate::budget::flow`'s own "apply to the shared state before touching the window"
+/// ordering are what make a result land on every ordinary path, panic included. This constant is
+/// what covers the paths *nobody* can enumerate - an executor thread that dies, a future that is
+/// dropped mid-await, a bug not yet written. Without it a single lost result silently disables
+/// the background poll **and** every `Refresh`/`Retry` click for the rest of the process's life,
+/// with the popover stuck on `checking…`: a failure mode with no error message and no way back.
+///
+/// Six [`crate::budget::fetch::REQUEST_TIMEOUT`]s (asserted against it at compile time, in that
+/// module), so a request that is merely slow is never raced by a second one.
+pub const IN_FLIGHT_STALE_AFTER: Duration = Duration::from_secs(60);
+
+/// Whether this *build* compiles the provider poll in at all - `false` under `cfg(test)`.
 ///
 /// **Off under `cfg(test)`, deliberately and non-negotiably.** The poll reads the *developer's
 /// own* OAuth credential off disk and sends it to a real provider endpoint; a test suite that did
 /// that would spend a real person's real rate-limit allowance (and hammer a limiter that is
 /// already tight) every time anyone ran `cargo test`. Everything the loop does *around* the
 /// network call - the single-flight guard, the manual-refresh floor, applying a result to state,
-/// every derived readout - is tested directly against
-/// `crate::budget::flow::AdeApp::apply_budget_poll_result`, and the two response parsers are
-/// tested against real payloads. The one thing not covered by a test is "does the timer fire",
-/// which is the same line the updater's own periodic loop draws.
+/// every derived readout - is tested directly against [`BudgetState::apply_read`], and the two
+/// response parsers are tested against real payloads. The one thing not covered by a test is
+/// "does the timer fire".
+///
+/// **This constant alone is not the guarantee** - see [`polling_enabled`], which is what every
+/// caller actually asks. `cfg!(test)` is true only while the `app` crate is itself being compiled
+/// *as* a test target; an integration test under `crates/app/tests/` links `app` as an ordinary
+/// dependency, where this is `true` and the guard silently disarms.
 pub const POLLING_ENABLED: bool = !cfg!(test);
+
+/// Set this to anything (`JERRY_DISABLE_PROVIDER_POLL=1`) and no provider is ever read, in any
+/// build.
+///
+/// The kill switch [`POLLING_ENABLED`] cannot be, because a compile-time `cfg` does not survive a
+/// crate boundary. Any test harness that drives this app's UI - today's `#[gpui::test]`s already
+/// get [`POLLING_ENABLED`], a future `crates/app/tests/` integration test would not - must set
+/// this in its environment, and this repo's CI sets it for every job so a suite added there is
+/// covered whether or not whoever adds it remembers. It is also the switch to reach for when
+/// running the real app against a rate-limited account, or offline.
+///
+/// A `JERRY_`-prefixed environment variable rather than a Cargo feature for the same reason
+/// `JERRY_REQUIRE_REAL_CLAUDE` (`crate::hooks::integration_tests`) is one: it works for a test
+/// binary, a `cargo run`, a packaged build and a CI job identically, and needs no cooperation
+/// from Cargo's feature resolution to reach a crate compiled as a plain dependency.
+pub const DISABLE_PROVIDER_POLL_ENV: &str = "JERRY_DISABLE_PROVIDER_POLL";
+
+/// Whether a real provider read may happen in this process, right now. The single question every
+/// caller in `crate::budget::flow` asks before touching a credential or the network.
+pub fn polling_enabled() -> bool {
+    polling_enabled_from(POLLING_ENABLED, std::env::var_os(DISABLE_PROVIDER_POLL_ENV))
+}
+
+/// The pure half of [`polling_enabled`] - so the rule is tested without mutating the
+/// process-global environment (`std::env::set_var` is unsound to race in a threaded test binary),
+/// the same split [`crate::budget::fetch::credential_dir_from`] already uses for its own
+/// environment override.
+pub fn polling_enabled_from(compiled_in: bool, disable_env: Option<std::ffi::OsString>) -> bool {
+    compiled_in && disable_env.is_none()
+}
 
 /// A provider Jerry can read a rate-limit budget from.
 ///
@@ -353,7 +404,8 @@ pub struct ProviderBudget {
     pub connected: bool,
     /// The most recent *successful* read, with the real instant it landed.
     pub last_ok: Option<(ProviderSnapshot, Instant)>,
-    /// `Some` when the most recent attempt failed - the message is the popover's tooltip, and its
+    /// `Some` when the most recent attempt failed - the message is the tooltip on that provider's
+    /// own popover row (`crate::budget::render::AdeApp::render_budget_other_row`), and its
     /// presence is what earns the `Retry`. Cleared by a successful read.
     pub last_error: Option<String>,
     /// A poll is in flight for this provider right now. Single-flight per provider: a manual
@@ -392,19 +444,40 @@ impl ProviderBudget {
         self.connected && self.last_error.is_some()
     }
 
-    /// Whether a poll may start right now. `manual` clicks are additionally held to
-    /// [`MANUAL_REFRESH_FLOOR`] since the last attempt; the background loop's own cadence is
-    /// [`POLL_INTERVAL`], so it needs no second floor.
+    /// Whether a poll may start right now: nothing already open, and long enough since the last
+    /// attempt - [`MANUAL_REFRESH_FLOOR`] for a click, the full [`POLL_INTERVAL`] for the
+    /// background loop.
+    ///
+    /// **Both floors live here, not in the caller.** The heartbeat used to hold its own cadence
+    /// and ask this only about single-flight, which meant the rule that actually protects the
+    /// provider's limiter was enforced by whichever code path happened to remember it. Every real
+    /// read now passes one gate that knows both.
+    ///
+    /// The single-flight guard ages out after [`IN_FLIGHT_STALE_AFTER`] rather than being trusted
+    /// forever - see that constant for the failure mode that buys.
     pub fn may_poll_now(&self, manual: bool, now: Instant) -> bool {
-        if self.in_flight {
+        if self.in_flight && !self.in_flight_is_stale(now) {
             return false;
         }
-        if !manual {
-            return true;
-        }
+        let floor = if manual {
+            MANUAL_REFRESH_FLOOR
+        } else {
+            POLL_INTERVAL
+        };
         match self.last_attempt {
-            Some(at) => now.saturating_duration_since(at) >= MANUAL_REFRESH_FLOOR,
+            Some(at) => now.saturating_duration_since(at) >= floor,
             None => true,
+        }
+    }
+
+    /// Whether an open request has been open so long that it is better explained as lost than as
+    /// running. A guard with no `last_attempt` behind it cannot be aged (nothing says when it was
+    /// set) and is left alone - that combination is not reachable, because the two are written
+    /// together in [`BudgetState::claim_poll`].
+    fn in_flight_is_stale(&self, now: Instant) -> bool {
+        match self.last_attempt {
+            Some(at) => now.saturating_duration_since(at) >= IN_FLIGHT_STALE_AFTER,
+            None => false,
         }
     }
 
@@ -421,6 +494,10 @@ impl ProviderBudget {
 }
 
 /// Every provider's state, keyed by provider - the whole feature's live data.
+///
+/// One of these is the process's real budget ([`shared_budget`]); every window holds a *copy* of
+/// it to render from. See that function for why the truth is process-global rather than per
+/// window.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct BudgetState {
     claude: ProviderBudget,
@@ -428,6 +505,63 @@ pub struct BudgetState {
 }
 
 impl BudgetState {
+    /// Takes the right to start exactly one real read of `provider`, marking it in flight, or
+    /// answers `false` because something else already holds that right (or because a click came
+    /// inside [`MANUAL_REFRESH_FLOOR`]).
+    ///
+    /// Deliberately a claim rather than a question followed by a write: this runs against the
+    /// process-global [`shared_budget`] with its lock held, so the check and the flag it sets are
+    /// one indivisible step. Two windows waking their heartbeats at the same instant is the
+    /// ordinary case, not a rare race.
+    pub fn claim_poll(&mut self, provider: Provider, manual: bool, now: Instant) -> bool {
+        if !self.get(provider).may_poll_now(manual, now) {
+            return false;
+        }
+        let budget = self.get_mut(provider);
+        budget.in_flight = true;
+        budget.last_attempt = Some(now);
+        true
+    }
+
+    /// Folds one real read into one provider's state. The whole state machine, in one place and
+    /// with no `Context` and no window - so every transition is directly testable without either.
+    ///
+    /// The three outcomes are kept genuinely distinct (rev 6 §7 rule 6):
+    ///
+    /// - **not connected** clears everything, including any numbers from before. A provider whose
+    ///   credential has gone (a logout while Jerry was running) is not a provider with stale
+    ///   numbers - the data is not ours to show any more.
+    /// - **ok** replaces the numbers and clears the failure.
+    /// - **failed** records the reason and *keeps* the previous numbers. They are still the last
+    ///   true reading; §2's `last read <age>` takes over once they age past [`STALE_AFTER`], and
+    ///   the failure itself surfaces as the `Retry` and as that row's tooltip.
+    ///
+    /// Every path clears [`ProviderBudget::in_flight`], including the failure one - that is the
+    /// other half of [`claim_poll`], and the reason a panicked read is converted into a
+    /// [`ProviderRead::Failed`] rather than allowed to swallow the result
+    /// ([`crate::budget::fetch::read_provider_catching_panics`]).
+    pub fn apply_read(&mut self, provider: Provider, read: ProviderRead, now: Instant) {
+        let budget = self.get_mut(provider);
+        budget.in_flight = false;
+        match read {
+            ProviderRead::NotConnected => {
+                budget.connected = false;
+                budget.last_ok = None;
+                budget.last_error = None;
+            }
+            ProviderRead::Ok(snapshot) => {
+                budget.connected = true;
+                budget.last_ok = Some((snapshot, now));
+                budget.last_error = None;
+            }
+            ProviderRead::Failed(reason) => {
+                budget.connected = true;
+                log::warn!("{} rate-limit read failed: {reason}", provider.id());
+                budget.last_error = Some(reason);
+            }
+        }
+    }
+
     pub fn get(&self, provider: Provider) -> &ProviderBudget {
         match provider {
             Provider::Claude => &self.claude,
@@ -467,6 +601,46 @@ impl BudgetState {
             .min_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
             .map(|(provider, _)| provider)
     }
+}
+
+/// The one budget this **process** has, shared by every window in it.
+///
+/// # Why this is global rather than a field on each window
+///
+/// `File > New Window` (`crate::title_bar::menu`) builds a second, wholly independent `AdeApp`.
+/// With the poll bookkeeping on that struct, every rate-limit rule this module has - the
+/// [`POLL_INTERVAL`] cadence, the [`MANUAL_REFRESH_FLOOR`] on clicks, the single-flight guard -
+/// would be per *window*, so N windows would read every provider N times as often. The endpoint
+/// on the other end is the one that already answered a real `429` during issue #294's Phase 0
+/// research (see [`POLL_INTERVAL`]'s own docs); multiplying its traffic by the number of windows
+/// somebody happens to have open is exactly the "a budget readout that spent budget to fetch
+/// itself" failure that constant exists to prevent.
+///
+/// The same shape `crate::sound::claim_app_start_sound` already uses for "once per process, not
+/// once per window", for the same underlying reason: a process-wide fact cannot live in a
+/// per-window struct.
+///
+/// Sharing the *results* too - rather than only claiming the right to poll and leaving other
+/// windows blank - is what keeps every window's readout real: a second window renders the same
+/// numbers the single shared poll fetched, refreshed onto its own copy by
+/// `crate::budget::flow::AdeApp::sync_budget_from_shared`, instead of sitting on a permanent
+/// `checking…` it is not allowed to resolve.
+pub fn shared_budget() -> &'static Mutex<BudgetState> {
+    static SHARED: OnceLock<Mutex<BudgetState>> = OnceLock::new();
+    SHARED.get_or_init(|| Mutex::new(BudgetState::default()))
+}
+
+/// [`shared_budget`], locked, recovering rather than propagating if a previous holder panicked.
+///
+/// Poison is deliberately ignored: the data behind this lock is a readout, every field of it is
+/// overwritten wholesale by the next poll, and there is no invariant a half-finished write could
+/// break. Answering `unwrap()` here would turn one panic anywhere near the budget into a panic in
+/// *every* window on every heartbeat afterwards - the same permanently-wedged failure mode
+/// [`IN_FLIGHT_STALE_AFTER`] and the poll's own `catch_unwind` exist to rule out.
+pub fn lock_shared_budget() -> MutexGuard<'static, BudgetState> {
+    shared_budget()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
 /// Real coverage for the model itself - the thresholds, the state machine, and every string.
@@ -675,7 +849,7 @@ mod budget_state_tests {
     }
 
     #[test]
-    fn a_manual_refresh_is_floored_but_the_background_poll_is_not() {
+    fn a_manual_refresh_is_floored_and_the_background_poll_holds_the_full_interval() {
         let now = Instant::now();
         let mut budget = ProviderBudget {
             connected: true,
@@ -698,14 +872,214 @@ mod budget_state_tests {
             "and allowed again once the floor has passed"
         );
         assert!(
-            budget.may_poll_now(false, now + Duration::from_secs(1)),
-            "the background loop has its own cadence and is not held to the manual floor"
+            !budget.may_poll_now(false, now + MANUAL_REFRESH_FLOOR),
+            "the background loop is held to its own, much longer cadence - a click may jump the \
+             queue, a timer may not"
+        );
+        assert!(
+            budget.may_poll_now(false, now + POLL_INTERVAL),
+            "and takes its turn once a full interval has passed"
         );
 
         budget.in_flight = true;
         assert!(
-            !budget.may_poll_now(false, now + POLL_INTERVAL),
+            !budget.may_poll_now(false, now + IN_FLIGHT_STALE_AFTER / 2),
             "single-flight per provider: nothing starts a second request while one is open"
+        );
+        assert!(
+            budget.may_poll_now(false, now + POLL_INTERVAL),
+            "but the guard is not trusted past the point where the request must be lost - see \
+             `a_lost_poll_ages_out_instead_of_wedging_the_provider_forever`"
+        );
+    }
+
+    /// The wedge this guards against was real: `in_flight` is set before a read starts and
+    /// cleared when its result lands, so a result that never lands - a panicked parse, a dead
+    /// executor thread - left it set forever, and [`ProviderBudget::may_poll_now`] then refused
+    /// the background loop *and* every `Refresh`/`Retry` click for the rest of the session, with
+    /// the popover stuck on `checking…` and no error anywhere.
+    #[test]
+    fn a_lost_poll_ages_out_instead_of_wedging_the_provider_forever() {
+        let started = Instant::now();
+        let budget = ProviderBudget {
+            connected: true,
+            in_flight: true,
+            last_attempt: Some(started),
+            ..Default::default()
+        };
+
+        assert!(
+            !budget.may_poll_now(false, started + Duration::from_secs(1)),
+            "single-flight still holds while the request is plausibly still running"
+        );
+        assert!(
+            !budget.may_poll_now(
+                true,
+                started + IN_FLIGHT_STALE_AFTER - Duration::from_secs(1)
+            ),
+            "and right up to the age-out, for a click as much as for the loop"
+        );
+        assert!(
+            budget.may_poll_now(true, started + IN_FLIGHT_STALE_AFTER),
+            "past it the request is better explained as lost than as running: the `Retry` button \
+             must come back to life rather than stay dead for the session, since it is the \
+             control a user reaches for when the readout looks stuck"
+        );
+        assert!(
+            budget.may_poll_now(false, started + POLL_INTERVAL),
+            "and the background loop takes the provider back over at its own next turn - the \
+             age-out lifts the guard, it does not shorten the cadence"
+        );
+    }
+
+    /// A landed result always clears the guard, on every one of the three outcomes - the ordinary
+    /// half of the same contract.
+    #[test]
+    fn every_landed_result_clears_the_single_flight_guard() {
+        let now = Instant::now();
+        for read in [
+            ProviderRead::NotConnected,
+            ProviderRead::Ok(snapshot(81.0, 40.0)),
+            ProviderRead::Failed("the provider answered 429".to_string()),
+        ] {
+            let mut state = BudgetState::default();
+            assert!(
+                state.claim_poll(Provider::Claude, false, now),
+                "a fresh provider may always be claimed"
+            );
+            assert!(state.get(Provider::Claude).in_flight);
+            state.apply_read(Provider::Claude, read.clone(), now);
+            assert!(
+                !state.get(Provider::Claude).in_flight,
+                "{read:?} must clear the guard - a result that lands and leaves it set is the \
+                 wedge in another costume"
+            );
+        }
+    }
+
+    /// The whole of §4c's state machine, driven through the same entry point a real poll uses.
+    #[test]
+    fn a_real_read_becomes_state_and_a_failure_keeps_the_numbers_it_had() {
+        let now = Instant::now();
+        let mut state = BudgetState::default();
+
+        state.apply_read(Provider::Claude, ProviderRead::NotConnected, now);
+        assert_eq!(
+            state.get(Provider::Claude).readout(now),
+            ProviderReadout::NotConnected,
+            "no credential is `not connected`, and nothing was sent anywhere"
+        );
+
+        let good = snapshot(81.0, 40.0);
+        state.apply_read(Provider::Claude, ProviderRead::Ok(good.clone()), now);
+        assert_eq!(
+            state.get(Provider::Claude).readout(now),
+            ProviderReadout::Numbers(&good)
+        );
+
+        state.apply_read(
+            Provider::Claude,
+            ProviderRead::Failed("the provider answered 429".to_string()),
+            now,
+        );
+        assert_eq!(
+            state.get(Provider::Claude).readout(now),
+            ProviderReadout::Numbers(&good),
+            "a failed refresh does not erase numbers that are still true"
+        );
+        assert!(
+            state.get(Provider::Claude).can_retry(),
+            "but it does earn the `Retry` \u{a7}4c puts beside a failure"
+        );
+        assert_eq!(
+            state.get(Provider::Claude).last_error.as_deref(),
+            Some("the provider answered 429"),
+            "and the real reason is kept, for the row's tooltip"
+        );
+
+        // A logout mid-session: the credential is gone, and so are the numbers.
+        state.apply_read(Provider::Claude, ProviderRead::NotConnected, now);
+        assert_eq!(
+            state.get(Provider::Claude).readout(now),
+            ProviderReadout::NotConnected
+        );
+        assert!(
+            state.get(Provider::Claude).last_ok.is_none(),
+            "numbers from a provider we are no longer logged into are not ours to show"
+        );
+    }
+
+    /// §4c's rate-limit discipline is a rule about this *process*, not about one window: two
+    /// windows sharing one [`BudgetState`] get one poll between them, not one each. Driven here
+    /// against a local state standing in for [`shared_budget`], which is the same value the real
+    /// windows claim against.
+    #[test]
+    fn two_windows_claiming_the_same_budget_get_one_poll_between_them() {
+        let now = Instant::now();
+        let mut shared = BudgetState::default();
+
+        assert!(
+            shared.claim_poll(Provider::Claude, false, now),
+            "the first window's heartbeat starts the read"
+        );
+        assert!(
+            !shared.claim_poll(Provider::Claude, false, now),
+            "the second window's heartbeat, a moment later, must find the read already open - \
+             not open a competing one against an endpoint that answers 429"
+        );
+        assert!(
+            !shared.claim_poll(Provider::Claude, true, now),
+            "and a `Refresh` clicked in that second window is held to the same shared guard"
+        );
+
+        shared.apply_read(
+            Provider::Claude,
+            ProviderRead::Ok(snapshot(81.0, 40.0)),
+            now,
+        );
+        assert!(
+            !shared.claim_poll(Provider::Claude, false, now + POLL_INTERVAL / 2),
+            "the cadence is shared too: half an interval later neither window may poll"
+        );
+        assert!(
+            shared.claim_poll(Provider::Claude, false, now + POLL_INTERVAL),
+            "and whichever window's heartbeat gets there first takes the next one"
+        );
+    }
+
+    /// The shared budget really is one value for the whole process - the property the paragraph
+    /// above rests on, checked rather than assumed.
+    #[test]
+    fn the_shared_budget_is_a_single_process_wide_value() {
+        assert!(
+            std::ptr::eq(shared_budget(), shared_budget()),
+            "every window must claim against the same state, or none of the rate-limit rules \
+             mean anything across windows"
+        );
+    }
+
+    /// The `cfg(test)` gate only covers this crate's *own* test targets. Anything else that drives
+    /// this app - a future `crates/app/tests/` integration test, where `app` is compiled as a
+    /// plain dependency with `cfg(test)` off - needs a switch that survives the crate boundary.
+    #[test]
+    fn the_environment_kill_switch_disables_polling_in_any_build() {
+        assert!(
+            polling_enabled_from(true, None),
+            "a real build with no switch set polls, or the feature does not exist"
+        );
+        assert!(
+            !polling_enabled_from(true, Some(std::ffi::OsString::from("1"))),
+            "and the switch turns it off even in a build that compiled it in - the case an \
+             integration-test crate would otherwise walk straight into, reading the developer's \
+             own OAuth credential and spending their real allowance"
+        );
+        assert!(
+            !polling_enabled_from(true, Some(std::ffi::OsString::from(""))),
+            "set-but-empty is still set: a harness that exports it without a value means it"
+        );
+        assert!(
+            !polling_enabled_from(false, None),
+            "and this crate's own test targets stay off with or without it"
         );
     }
 

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -1435,8 +1435,14 @@ pub struct AdeApp {
     /// positioned off the control that opens it.
     pub(crate) resources_readout_bounds: gpui::Bounds<Pixels>,
     /// Every provider's real rate-limit budget (GitHub issue #294) - what the agent pane strip's
-    /// cluster and the budget popover both read. Written only by
-    /// `crate::budget::flow::AdeApp::apply_budget_poll_result`, from real poll results.
+    /// cluster and the budget popover both read.
+    ///
+    /// **This window's copy of a process-wide fact**, not the fact itself: the budget one poll
+    /// fetched belongs to every window, and so do the rate-limit rules that decide when the next
+    /// poll may run, so the truth lives in `crate::budget::state::shared_budget` and this is
+    /// refreshed from it by `crate::budget::flow::AdeApp::sync_budget_from_shared`. Written only
+    /// from there, and only from real poll results - see that module for why a per-window budget
+    /// meant N windows read every provider N times as often.
     pub(crate) budget: crate::budget::state::BudgetState,
     /// Whether the agent pane's rate-limit budget popover is open (GitHub issue #294) - one of
     /// the [`menus::MenuSurface`]s, so it obeys the app's one-menu-at-a-time invariant.


### PR DESCRIPTION
Follow-up to #294 / #352. An independent adversarial security review of the provider rate-limit budget merged in #352 **confirmed** its three core claims with real verification (credentials read-only and never written; never logged or `Debug`-exposed; no network under `cfg(test)`, checked with an strace positive control) and found four real bugs behind them. All four are fixed here, each with a regression test. Does **not** close #294 - that issue still has its own remaining gap about live Codex testing.

## C1 - a provider-controlled panic (critical, reproduced)

`codex_reset_instant` fed `reset_after_seconds` straight from the response into `SystemTime::now() + Duration`, filtered only for a sign. A value near `i64::MAX` overflows and panics (`overflow when adding duration to instant`); the reviewer reproduced it with a standalone binary.

Both reset fields are now range-checked against what a rate-limit window can plausibly be (a 2001..2100 epoch window for the absolute one, 400 days for the relative one) *and* added with `checked_add`, so an unusable field falls back to "no countdown" - the same fallback a missing field already had - while the window's percentage still parses. `parse_rfc3339` gets the same treatment. The bound matters on its own: an un-panicking but absurd `10000000000` would otherwise have rendered a confident `resets in 115740d 17h`.

`a_hostile_reset_field_cannot_panic_the_poll` drives the exact input the reviewer used, in both fields and each alone.

## C2 - one panic wedged the provider for the rest of the session (critical)

`in_flight` is set before the read and cleared when its result lands, so a panicked read left it set forever: `may_poll_now` then silently refused the background loop **and** every Refresh/Retry click, with the popover stuck on `checking…`, dead buttons and no error anywhere - strictly worse than the panic.

Three independent fixes, because no one of them covers every path:

- The read runs under `catch_unwind` on the background thread. A *returned* value always arrives; a panicked future's result may not, which is why this is not a `Drop` guard.
- The result is applied to the shared state **before** the window update, so a window closed mid-request cannot swallow it.
- The guard ages out after `IN_FLIGHT_STALE_AFTER` (6× the request timeout, asserted against it at compile time) for the failure paths nobody can enumerate - a dead executor thread, a dropped future, a bug not yet written.

The panic's payload is deliberately *not* propagated into the reported reason: a live OAuth token is in scope, and that string goes to a log and a tooltip.

## C3 - the test gate did not survive a crate boundary (critical)

`POLLING_ENABLED = !cfg!(test)` is only false while `app` compiles as its own test target. The moment a `crates/app/tests/` integration test exists, `app` links as an ordinary dependency, the gate re-arms, and a UI test that clicks Refresh reads the developer's real OAuth token and hits a real endpoint.

Adds `JERRY_DISABLE_PROVIDER_POLL`, checked at runtime beside the `cfg` (the `JERRY_`-prefixed env idiom this repo already uses for `JERRY_REQUIRE_REAL_CLAUDE`, chosen over a Cargo feature because it reaches a crate compiled as a plain dependency without help from feature resolution), and sets it for every CI job so a suite added there is covered whether or not whoever adds it remembers.

## C4 - rate-limit discipline was per window, not per process

`File > New Window` builds a second `AdeApp`, so `POLL_INTERVAL`, `MANUAL_REFRESH_FLOOR` and single-flight were all per window: N windows, N× the request rate against an endpoint that already answered a real 429 during Phase 0 research.

The budget is now process-global (`shared_budget()`, the shape `sound::claim_app_start_sound` already uses), claimed atomically under its lock, with each window rendering a copy synced from it. Sharing the *results* rather than only the right to poll is what keeps the second window honest - it shows the shared poll's real numbers instead of a permanent `checking…` it is not allowed to resolve. The cadence moved into `may_poll_now` alongside the manual floor, so one gate knows both rules and no caller can forget one.

## Lower-severity, from the same review

- **The failure reason reaches the screen.** `last_error` was carried all the way to the popover and dropped one line short of it; the row's state text now carries it as a tooltip, as its own doc comment always claimed. "the provider answered 401" (re-authenticate in the CLI) and "429" (stop clicking Retry) are the whole of what a reader can act on.
- **"No polling when no agent session is visible" is now true**: the test is the *selected* pane, not merely one existing among this window's tabs. OS window activation is deliberately not part of it - a missed activate event would stop polling for the session with nothing on screen to explain it.
- **`Policy::none()` on the HTTP client**, so a cross-host redirect cannot carry Codex's `ChatGPT-Account-Id` (which, unlike `Authorization`, reqwest has no reason to strip) to a host we never chose.
- **One `reqwest::blocking::Client` behind a `OnceLock`** instead of a fresh connection pool and TLS config per request.
- Drops the doc comment citing the updater's poll loop as a test-safe precedent - it has no `cfg(test)` guard at all, and this branch's own strace run shows it connecting to GitHub during a test. Filed separately rather than fixed here.

## Also: percent used, not percent left

Separate from the review, at the product owner's direction: the readout now prints `% used` on a meter that fills as the window is spent, rather than the bundle's `% left` on a meter where full is good. `% used` is what both providers' APIs report and what both CLIs' own `/status` displays show. The hue still keys off *headroom* (`95% used` is red, not green - pinned by a test), and the bar fills with usage so the bar and the number tell one story. §4c's window-label-before-value ordering is untouched, being an argument about which half leads.

## Verification

- `cargo build --workspace`, `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets` all clean.
- `cargo test -p app --lib budget::` - 35 passed.
- `cargo test -p app --lib` - 2860 passed; the 16 failures are the known inotify `max_user_instances` contention flakes (worktree/file-tree watchers) and all pass in isolation, none in budget code.
- Re-ran the reviewer's strace positive control: real credential files planted in a probe `HOME`, budget suite run under `strace -f -e trace=connect,openat,open`. **Zero** opens of either credential file and **zero** connections to `api.anthropic.com` or `chatgpt.com`. The only traffic in the log is the updater's own GitHub check, which is the finding above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)