### PR TITLE
Search: right-panel Search tab with a real match tree, four real inputs, three states, real in-place replace, and in-file find (#162)

### DIFF
--- a/assets/themes/ember.toml
+++ b/assets/themes/ember.toml
@@ -283,6 +283,16 @@ resume_bg_hover    = "#253f20"
 resume_border      = "#345129"
 resume_fg          = "#7b9f6f"
 
+# The right panel's Search tab (GitHub issue #162, REVISION-2026-08-14.md §5 /
+# STAGE-A-CHANGELOG.md §4v) - real hex values transcribed directly from those sections, not
+# paraphrased.
+[search]
+modifier_on_bg = "#0f2c36"  # A modifier button's active fill
+modifier_on_fg = "#6599ae"  # That button's glyph while it is on.
+match_bg       = "#1a333f"
+match_fg       = "#6599ae"  # The matched text itself.
+line           = "#555e63"
+
 
 # ──────────────────────────────────────────────────────────────────────────────────────────────
 # The code surface

--- a/assets/themes/jerry-dim.toml
+++ b/assets/themes/jerry-dim.toml
@@ -283,6 +283,16 @@ resume_bg_hover    = "#275140"
 resume_border      = "#356851"
 resume_fg          = "#8cc7aa"
 
+# The right panel's Search tab (GitHub issue #162, REVISION-2026-08-14.md §5 /
+# STAGE-A-CHANGELOG.md §4v) - real hex values transcribed directly from those sections, not
+# paraphrased.
+[search]
+modifier_on_bg = "#253646"  # A modifier button's active fill
+modifier_on_fg = "#99b8d9"  # That button's glyph while it is on.
+match_bg       = "#323f51"
+match_fg       = "#99b8d9"  # The matched text itself.
+line           = "#70767c"
+
 
 # ──────────────────────────────────────────────────────────────────────────────────────────────
 # The code surface

--- a/assets/themes/moss.toml
+++ b/assets/themes/moss.toml
@@ -283,6 +283,16 @@ resume_bg_hover    = "#294839"
 resume_border      = "#395e4a"
 resume_fg          = "#8fbba2"
 
+# The right panel's Search tab (GitHub issue #162, REVISION-2026-08-14.md §5 /
+# STAGE-A-CHANGELOG.md §4v) - real hex values transcribed directly from those sections, not
+# paraphrased.
+[search]
+modifier_on_bg = "#212f3b"  # A modifier button's active fill
+modifier_on_fg = "#95b0c9"  # That button's glyph while it is on.
+match_bg       = "#2d3946"
+match_fg       = "#95b0c9"  # The matched text itself.
+line           = "#696e73"
+
 
 # ──────────────────────────────────────────────────────────────────────────────────────────────
 # The code surface

--- a/assets/themes/paper.toml
+++ b/assets/themes/paper.toml
@@ -283,6 +283,16 @@ resume_bg_hover    = "#9dc1ab"
 resume_border      = "#83ac90"
 resume_fg          = "#2c573c"
 
+# The right panel's Search tab (GitHub issue #162, REVISION-2026-08-14.md §5 /
+# STAGE-A-CHANGELOG.md §4v) - real hex values transcribed directly from those sections, not
+# paraphrased.
+[search]
+modifier_on_bg = "#bbd0e0"  # A modifier button's active fill
+modifier_on_fg = "#355269"  # That button's glyph while it is on.
+match_bg       = "#b2c3d5"
+match_fg       = "#355269"  # The matched text itself.
+line           = "#82888d"
+
 
 # ──────────────────────────────────────────────────────────────────────────────────────────────
 # The code surface

--- a/assets/themes/slate.toml
+++ b/assets/themes/slate.toml
@@ -283,6 +283,16 @@ resume_bg_hover    = "#123f2e"
 resume_border      = "#1b5139"
 resume_fg          = "#609b7d"
 
+# The right panel's Search tab (GitHub issue #162, REVISION-2026-08-14.md §5 /
+# STAGE-A-CHANGELOG.md §4v) - real hex values transcribed directly from those sections, not
+# paraphrased.
+[search]
+modifier_on_bg = "#172838"  # A modifier button's active fill
+modifier_on_fg = "#6e8dae"  # That button's glyph while it is on.
+match_bg       = "#213041"
+match_fg       = "#6e8dae"  # The matched text itself.
+line           = "#545a60"
+
 
 # ──────────────────────────────────────────────────────────────────────────────────────────────
 # The code surface

--- a/crates/app/src/code_surface/render.rs
+++ b/crates/app/src/code_surface/render.rs
@@ -320,8 +320,11 @@ impl AdeApp {
         // the editor instead of itself. Found by this module's own `find_bar_tests`, which typed
         // `left left ...` into the bar and got the text back unmoved.
         //
-        // Rendered above the surface rather than over it: a find bar that covers the first line
-        // of what it is searching is hiding a result it is meant to point at.
+        // It therefore sits at the very top of the pane, above the file toolbar, rather than
+        // between the toolbar and the content: that is the one position outside the editor's own
+        // context stack. It is also the position Zed puts its own buffer search in - the bar
+        // belongs to the pane, not to the line it is pointing at - and it keeps the bar from
+        // covering the first line of what it is searching, which a floating overlay would.
         if self.find_bar.is_none() {
             return surface;
         }

--- a/crates/app/src/code_surface/render.rs
+++ b/crates/app/src/code_surface/render.rs
@@ -238,7 +238,7 @@ impl AdeApp {
             (false, _) => "diff",
         };
 
-        div()
+        let surface = div()
             .id("code-surface")
             // Focus target for the whole Diff/File surface - see `code_focus_handle`'s docs for
             // the dangling-`Window::focus` bug this fixes, the same class `render_settings`'s
@@ -298,6 +298,9 @@ impl AdeApp {
             .on_action(cx.listener(Self::handle_editor_indent_action))
             .on_action(cx.listener(Self::handle_editor_dedent_action))
             .on_action(cx.listener(Self::handle_editor_escape_action))
+            // GitHub issue #162's in-file find. On this node rather than the window root because
+            // its binding is `"file-editor"`-scoped, and this node is what carries that tag.
+            .on_action(cx.listener(Self::handle_find_in_file_action))
             .flex()
             .flex_col()
             .flex_1()
@@ -307,6 +310,30 @@ impl AdeApp {
             .bg(theme::surface::CENTER)
             .child(toolbar)
             .child(body)
+            .into_any_element();
+
+        // The find bar is a **sibling** of the `"code-surface"` node above, not a child of it,
+        // and that is load-bearing rather than cosmetic. GPUI resolves a keystroke against the
+        // focused node's whole ancestor context stack, so a bar nested inside a node carrying
+        // `"file-editor"` would have `EditorLeft`, `EditorEnter` and `EditorCollapseCursors`
+        // matching every arrow key, Enter and Esc typed into it - the field would silently drive
+        // the editor instead of itself. Found by this module's own `find_bar_tests`, which typed
+        // `left left ...` into the bar and got the text back unmoved.
+        //
+        // Rendered above the surface rather than over it: a find bar that covers the first line
+        // of what it is searching is hiding a result it is meant to point at.
+        if self.find_bar.is_none() {
+            return surface;
+        }
+        div()
+            .flex()
+            .flex_col()
+            .flex_1()
+            .min_w_0()
+            .min_h_0()
+            .overflow_hidden()
+            .children(self.render_find_bar(cx))
+            .child(surface)
             .into_any_element()
     }
 

--- a/crates/app/src/graph_view/rebase.rs
+++ b/crates/app/src/graph_view/rebase.rs
@@ -857,9 +857,11 @@ impl AdeApp {
             return;
         };
         let changed = match keystroke.key.as_str() {
-            "backspace" => row.reword_message.pop(Instant::now()),
+            "backspace" => row.reword_message.backspace(Instant::now()),
             _ => match keystroke.key_char.as_deref() {
-                Some(text) if !text.is_empty() => row.reword_message.push_str(text, Instant::now()),
+                Some(text) if !text.is_empty() => {
+                    row.reword_message.insert_str(text, Instant::now())
+                }
                 _ => false,
             },
         };

--- a/crates/app/src/graph_view/render.rs
+++ b/crates/app/src/graph_view/render.rs
@@ -1181,13 +1181,13 @@ impl AdeApp {
         // exactly why this field never blinked in the first place.
         self.reset_caret_blink(cx);
         let changed = match keystroke.key.as_str() {
-            "backspace" => self.graph_state.branches_filter.pop(Instant::now()),
+            "backspace" => self.graph_state.branches_filter.backspace(Instant::now()),
             "escape" => self.graph_state.branches_filter.clear(Instant::now()),
             _ => match keystroke.key_char.as_deref() {
                 Some(text) if !text.is_empty() => self
                     .graph_state
                     .branches_filter
-                    .push_str(text, Instant::now()),
+                    .insert_str(text, Instant::now()),
                 _ => false,
             },
         };
@@ -1243,7 +1243,9 @@ impl AdeApp {
             }
             "backspace" => {
                 if self.graph_state.branch_prompt.is_some() {
-                    self.graph_state.branch_prompt_name.pop(Instant::now());
+                    self.graph_state
+                        .branch_prompt_name
+                        .backspace(Instant::now());
                     if let Some(open) = self.graph_state.branch_prompt.as_mut() {
                         open.error = None;
                     }
@@ -1261,7 +1263,7 @@ impl AdeApp {
                     if self.graph_state.branch_prompt.is_some() {
                         self.graph_state
                             .branch_prompt_name
-                            .push_str(text, Instant::now());
+                            .insert_str(text, Instant::now());
                         if let Some(open) = self.graph_state.branch_prompt.as_mut() {
                             open.error = None;
                         }
@@ -3094,6 +3096,7 @@ impl AdeApp {
                 text_selector: "graph-branches-filter-text".into(),
                 focus_handle: Some(&self.graph_state.branches_filter_focus_handle),
                 text: self.graph_state.branches_filter.as_str(),
+                caret_offset: self.graph_state.branches_filter.caret(),
                 placeholder: "filter branches",
                 font: theme::font::MONO,
                 text_size: px(10.5),

--- a/crates/app/src/keymap_overrides.rs
+++ b/crates/app/src/keymap_overrides.rs
@@ -219,6 +219,23 @@ pub fn real_context_stacks() -> Vec<Vec<&'static str>> {
         // characters instead of letting them be typed into a note.
         vec!["app", "diff", "diff-view"],
         vec!["app", "diff", "diff-view", "text-input"],
+        // GitHub issue #162 adds two more bare `"text-input"` frames, and their *stacks* are the
+        // interesting part rather than the tag:
+        //
+        // - the Search panel's four fields live in the right sidebar, which is not inside any
+        //   other keyed container, so they are the plain `vec!["app", "text-input"]` already
+        //   listed above - no new stack.
+        // - the in-file find bar is deliberately a **sibling** of the code surface's own
+        //   `"diff file-editor text-input"` node rather than a child of it (see
+        //   `crate::code_surface::render::AdeApp::render_code_surface`), which is exactly why it
+        //   is *also* the plain `vec!["app", "text-input"]` and not a
+        //   `["app", "diff file-editor text-input", "text-input"]`. Nested, every arrow key,
+        //   Enter and Esc typed into the bar would have matched an `Editor*` binding instead -
+        //   a real, reproduced bug, not a hypothetical.
+        //
+        // So neither adds a stack here; both add a call site, which is what the drift guard
+        // below counts.
+        //
         // The file tree (GitHub issue #19), built by calling the *same* function the renderer
         // calls, over both of its inputs - not by restating its literals here. See
         // [`file_tree_key_context`] for why that indirection is load-bearing rather than tidy.
@@ -740,15 +757,16 @@ mod tests {
         let sites = key_context_call_sites();
         let call_sites: usize = sites.iter().map(|(_, count)| count).sum();
         assert_eq!(
-            call_sites, 18,
-            "real_context_stacks() is hand-derived from exactly eighteen .key_context(..) call \
-             sites (eleven of which emit the same bare \"text-input\": the palette, the rail \
+            call_sites, 20,
+            "real_context_stacks() is hand-derived from exactly twenty .key_context(..) call \
+             sites (thirteen of which emit the same bare \"text-input\": the palette, the rail \
              filter, the new-file prompt, the Branches filter, the Keybindings filter, the \
              Themes page's \"Generate from colour\" seed input, the General page's \"Shell\" \
              field (GitHub issue #213), GitHub issue #241's git graph row menu's \"Create \
              branch here\" prompt, GitHub issue #242 phase B's interactive-rebase plan row's own \
              reword message field, GitHub issue #285's Changes panel commit message field, and - \
-             newest, GitHub issue #288's pinned review-note card - plus GitHub issue #304's own \
+             GitHub issue #288's pinned review-note card, and - newest - GitHub issue #162's \
+             Search panel row and its in-file find bar - plus GitHub issue #304's own \
              \"rebase-plan\" and issue #288's own \"diff-view\") - a new one means \
              that list, and every disjointness answer built on \
              it, needs updating. Real sites found: {sites:?}"

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -260,6 +260,13 @@ pub fn default_key_bindings() -> Vec<gpui::KeyBinding> {
         // `platform`, and `Ctrl+Shift+F` is not a control byte any shell reads), so there is no
         // terminal input for it to swallow.
         gpui::KeyBinding::new("secondary-shift-f", root::SearchInWorktree, None),
+        // GitHub issue #162's in-file find. Scoped `Some("file-editor")`, unlike the panel's
+        // global `secondary-shift-f` above: `mod+F` only means anything where there is a file to
+        // find *in*, and the Diff view is two files side by side, so a bar claiming to find "in
+        // this file" over it would have to pick one silently. The handler independently re-checks
+        // `AdeApp::active_editable_path` for the same reason every other `"file-editor"`-scoped
+        // handler does.
+        gpui::KeyBinding::new("secondary-f", root::FindInFile, Some("file-editor")),
         // `&& !text-input` was added by GitHub issue #288, and it is a real fix rather than
         // defensive padding: that issue puts a pinned review-note card - a genuine
         // `"text-input"` node - *inside* the diff surface, so with the old predicate a plain `]`

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -252,6 +252,14 @@ pub fn default_key_bindings() -> Vec<gpui::KeyBinding> {
         gpui::KeyBinding::new("ctrl-shift-t", root::NewTerminal, None),
         gpui::KeyBinding::new("secondary-shift-n", root::NewAgentPane, None),
         gpui::KeyBinding::new("secondary-shift-g", root::NewGitGraph, None),
+        // GitHub issue #162's own ask, unchanged by the rev-6 re-scope: "`mod+shift+F` opens the
+        // panel focused in the query." Deliberately global (`None`), like every other
+        // `"secondary-shift-"` entry above and unlike the plain letters further down: a real
+        // Cmd/Ctrl-modified keystroke never reaches a focused pty in the first place
+        // (`crate::terminal::pane::keystroke_to_bytes` returns `None` for any keystroke carrying
+        // `platform`, and `Ctrl+Shift+F` is not a control byte any shell reads), so there is no
+        // terminal input for it to swallow.
+        gpui::KeyBinding::new("secondary-shift-f", root::SearchInWorktree, None),
         // `&& !text-input` was added by GitHub issue #288, and it is a real fix rather than
         // defensive padding: that issue puts a pinned review-note card - a genuine
         // `"text-input"` node - *inside* the diff surface, so with the old predicate a plain `]`

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -42,6 +42,9 @@ pub mod root;
 // *capture* of what a run was) or inside `rail` (which owns the live tree): this is a surface
 // with its own model, its own persistence and its own tab kind.
 pub mod run_history;
+// GitHub issue #162 / `REVISION-2026-08-14.md` §5: the right panel's Search tab - the matcher,
+// the bounded worktree walk, the two-level result tree and the real in-place replace behind it.
+pub mod search;
 pub mod settings;
 pub mod sidebar;
 pub mod sound;

--- a/crates/app/src/palette/render.rs
+++ b/crates/app/src/palette/render.rs
@@ -646,7 +646,7 @@ impl AdeApp {
                 cx.stop_propagation();
             }
             "backspace" => {
-                self.palette_query.pop(Instant::now());
+                self.palette_query.backspace(Instant::now());
                 self.palette_selected = 0;
                 cx.notify();
                 cx.stop_propagation();
@@ -692,7 +692,7 @@ impl AdeApp {
                         }
                     }
                 }
-                self.palette_query.push_str(text, Instant::now());
+                self.palette_query.insert_str(text, Instant::now());
                 self.palette_selected = 0;
                 cx.notify();
                 cx.stop_propagation();

--- a/crates/app/src/palette/render.rs
+++ b/crates/app/src/palette/render.rs
@@ -3,7 +3,7 @@ use crate::root::plural;
 use crate::root::scrollbar;
 use crate::root::widgets::{render_hint_pair, render_hint_row, render_keycap_row, KeycapSize};
 use crate::settings::widgets::ChoiceOption;
-use crate::sidebar::render::RightSidebarView;
+use crate::sidebar::render::{next_right_sidebar_view, RightSidebarView};
 
 /// Live secondary line for one of the three `Window controls: …` palette commands - names which
 /// chrome that option resolves to and flags the one that's already active, like
@@ -168,9 +168,10 @@ impl AdeApp {
             Some(cwd) => format!("in {}", cwd.display()),
             None => "- select a worktree first".to_string(),
         };
-        let next_sidebar_view = match self.right_sidebar_view {
-            RightSidebarView::Files => "Changes",
-            RightSidebarView::Changes => "Files",
+        let next_sidebar_view = match next_right_sidebar_view(self.right_sidebar_view) {
+            RightSidebarView::Files => "Files",
+            RightSidebarView::Search => "Search",
+            RightSidebarView::Changes => "Changes",
         };
         let mut commands = vec![
             palette::CommandCandidate {
@@ -186,7 +187,7 @@ impl AdeApp {
                 secondary: format!("spawn codex {spawn_target}"),
             },
             palette::CommandCandidate {
-                command: palette::PaletteCommand::ToggleFilesChanges,
+                command: palette::PaletteCommand::CycleRightPanel,
                 secondary: format!("switch the right panel to {next_sidebar_view}"),
             },
             palette::CommandCandidate {
@@ -437,17 +438,17 @@ impl AdeApp {
             palette::PaletteCommand::NewCodexAgent => {
                 self.new_agent(ProcessKind::codex(), window, cx)
             }
-            palette::PaletteCommand::ToggleFilesChanges => {
+            palette::PaletteCommand::CycleRightPanel => {
                 // Any palette gesture must disarm a pending prune confirmation (see
                 // `Self::open_palette`'s docs); the other branches already do this via the
                 // methods they call, so this one clears it explicitly.
                 self.prune_confirm_armed = false;
                 self.discard_confirm_armed = None;
-                let next = match self.right_sidebar_view {
-                    RightSidebarView::Files => RightSidebarView::Changes,
-                    RightSidebarView::Changes => RightSidebarView::Files,
-                };
-                self.set_right_sidebar_view(next, window, cx);
+                self.set_right_sidebar_view(
+                    next_right_sidebar_view(self.right_sidebar_view),
+                    window,
+                    cx,
+                );
             }
             palette::PaletteCommand::PruneWorktrees => self.request_prune(cx),
             palette::PaletteCommand::OpenSettings => self.open_settings(window, cx),

--- a/crates/app/src/palette/state.rs
+++ b/crates/app/src/palette/state.rs
@@ -126,8 +126,15 @@ pub enum PaletteCommand {
     NewClaudeAgent,
     /// `crate::root::AdeApp::new_agent(ProcessKind::codex(), ..)`.
     NewCodexAgent,
-    /// `crate::root::AdeApp::set_right_sidebar_view`, same as the `Files | Changes` control.
-    ToggleFilesChanges,
+    /// `crate::root::AdeApp::set_right_sidebar_view`, same as the `Files - Search - Changes`
+    /// control.
+    ///
+    /// A **cycle**, not a toggle, since GitHub issue #162 made the panel three tabs: `Toggle` was
+    /// this command's own name while there were exactly two, and leaving it named that over three
+    /// would have been a name stating something the command no longer does - the "two
+    /// specifications of one thing" defect `STAGE-A-CHANGELOG.md` 4w names, in its
+    /// name-versus-behaviour form.
+    CycleRightPanel,
     /// `crate::root::AdeApp::request_prune` - goes through the same two-click confirmation gate
     /// as the rail footer's own `prune` button, never bypassing it.
     PruneWorktrees,
@@ -183,7 +190,7 @@ impl PaletteCommand {
         PaletteCommand::NewShell,
         PaletteCommand::NewClaudeAgent,
         PaletteCommand::NewCodexAgent,
-        PaletteCommand::ToggleFilesChanges,
+        PaletteCommand::CycleRightPanel,
         PaletteCommand::PruneWorktrees,
         PaletteCommand::OpenSettings,
         PaletteCommand::RestartLanguageServers,
@@ -206,7 +213,7 @@ impl PaletteCommand {
             PaletteCommand::NewShell => "New Shell",
             PaletteCommand::NewClaudeAgent => "New Claude Agent",
             PaletteCommand::NewCodexAgent => "New Codex Agent",
-            PaletteCommand::ToggleFilesChanges => "Toggle Files / Changes",
+            PaletteCommand::CycleRightPanel => "Cycle Right Panel",
             PaletteCommand::PruneWorktrees => "Prune Worktrees",
             PaletteCommand::OpenSettings => "Open Settings",
             PaletteCommand::RestartLanguageServers => "Restart Language Servers",
@@ -226,7 +233,9 @@ impl PaletteCommand {
             PaletteCommand::NewShell => "shell terminal spawn agent",
             PaletteCommand::NewClaudeAgent => "claude agent spawn agent cli",
             PaletteCommand::NewCodexAgent => "codex agent spawn agent cli",
-            PaletteCommand::ToggleFilesChanges => "files changes panel sidebar switch",
+            PaletteCommand::CycleRightPanel => {
+                "files search changes find panel sidebar switch toggle tab"
+            }
             PaletteCommand::PruneWorktrees => "prune worktree remove delete cleanup merged",
             PaletteCommand::OpenSettings => "settings preferences agents worktrees config",
             PaletteCommand::RestartLanguageServers => {

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -237,12 +237,17 @@ impl AdeApp {
         )
     }
 
-    /// Types (or backspaces/clears) into [`Self::filter_query`] - a small, hand-rolled text
-    /// field (append/backspace only, no cursor positioning or selection) rather than
+    /// Types into [`Self::filter_query`] - a small, hand-rolled text field rather than
     /// `vendor/zed/crates/gpui/examples/input.rs`'s full `EntityInputHandler`, judged out of
     /// scope for a single filter row. Modified keystrokes (⌘, ⌃, ⌥) are left unhandled and
     /// keep propagating, so app-level shortcuts (e.g. ⌘N) still reach their bindings while
     /// this field has focus.
+    ///
+    /// Every key but `Esc` is `crate::text_history::TextField::handle_editing_key`'s, which is
+    /// where GitHub issue #162's real caret arrived: Left/Right/Home/End/Delete work here now,
+    /// not only in the search panel that motivated the upgrade. That is the issue's own "benefits
+    /// every other filter row", taken literally rather than left as a claim about a capability
+    /// nothing else calls.
     pub(in crate::rail) fn handle_filter_key_down(
         &mut self,
         event: &KeyDownEvent,
@@ -257,14 +262,14 @@ impl AdeApp {
         // handle_palette_key_down`'s identical reasoning.
         self.reset_caret_blink(cx);
         let changed = match keystroke.key.as_str() {
-            "backspace" => self.filter_query.pop(Instant::now()),
             // A real, undoable step, not a silent loss: `Esc` clearing a typed filter is exactly
             // the case Ctrl+Z should bring back. See `crate::text_history::TextField::set`.
             "escape" => self.filter_query.clear(Instant::now()),
-            _ => match keystroke.key_char.as_deref() {
-                Some(text) if !text.is_empty() => self.filter_query.push_str(text, Instant::now()),
-                _ => false,
-            },
+            key => self.filter_query.handle_editing_key(
+                key,
+                keystroke.key_char.as_deref(),
+                Instant::now(),
+            ),
         };
         if changed {
             self.prune_confirm_armed = false;
@@ -964,6 +969,7 @@ impl AdeApp {
                 text_selector: "rail-filter-text".into(),
                 focus_handle: Some(&self.filter_focus_handle),
                 text: self.filter_query.as_str(),
+                caret_offset: self.filter_query.caret(),
                 placeholder: match view {
                     rail_strip::SidebarView::Worktrees => "filter worktrees and agents",
                     rail_strip::SidebarView::Problems => "filter problems",
@@ -2920,7 +2926,7 @@ mod rail_row_tests {
         // Type a filter query that matches only "alpha", not "beta".
         app.update(cx, |app, _cx| {
             app.filter_query
-                .push_str("alpha", std::time::Instant::now());
+                .insert_str("alpha", std::time::Instant::now());
         });
 
         let groups_after_filter = app.update(cx, |app, cx| app.build_repo_groups(cx));

--- a/crates/app/src/review_notes/flow.rs
+++ b/crates/app/src/review_notes/flow.rs
@@ -333,9 +333,9 @@ impl AdeApp {
             return;
         }
         let changed = match keystroke.key.as_str() {
-            "backspace" => draft.field.pop(Instant::now()),
+            "backspace" => draft.field.backspace(Instant::now()),
             _ => match keystroke.key_char.as_deref() {
-                Some(text) if !text.is_empty() => draft.field.push_str(text, Instant::now()),
+                Some(text) if !text.is_empty() => draft.field.insert_str(text, Instant::now()),
                 _ => false,
             },
         };

--- a/crates/app/src/review_notes/render.rs
+++ b/crates/app/src/review_notes/render.rs
@@ -424,6 +424,13 @@ impl AdeApp {
             (_, Some(note)) => note.text.clone(),
             _ => String::new(),
         };
+        // Only the card actually being edited has a caret at all, so only its draft's own offset
+        // is meaningful; a pinned, read-only card renders with `focus_handle: None` and never
+        // paints one.
+        let text_caret = match &self.note_draft {
+            Some(draft) if editing => draft.field.caret(),
+            _ => text.len(),
+        };
         let mark = note.map(|note| note.mark()).unwrap_or(NoteMark::Draft);
         // The honest half of the draft/sent history: a card that has been sent and then edited
         // can still say what the agent really was told.
@@ -508,6 +515,7 @@ impl AdeApp {
                         text_selector: SharedString::from(text_selector),
                         focus_handle: editing.then_some(&self.note_focus_handle),
                         text: &text,
+                        caret_offset: text_caret,
                         placeholder: NOTE_PLACEHOLDER,
                         font: theme::font::SANS,
                         text_size: px(11.5),

--- a/crates/app/src/root/focus.rs
+++ b/crates/app/src/root/focus.rs
@@ -2161,7 +2161,7 @@ mod palette_result_focus_tests {
             app.update_in(cx, |app, window, cx| app.open_palette(window, cx));
             app.update(cx, |app, _| {
                 app.palette_query
-                    .push_str(command.label(), std::time::Instant::now());
+                    .insert_str(command.label(), std::time::Instant::now());
             });
             cx.run_until_parked();
 

--- a/crates/app/src/root/focus.rs
+++ b/crates/app/src/root/focus.rs
@@ -2015,12 +2015,12 @@ mod palette_result_focus_tests {
     }
 
     /// Adversarial-audit regression, MAJOR. With the tree focused, opening the palette captures
-    /// `tree_focus_handle`; running the palette's own "Toggle Files / Changes" then unrenders the
+    /// `tree_focus_handle`; running the palette's own "Cycle Right Panel" then unrenders the
     /// whole tree. `set_right_sidebar_view`'s own `is_focused` guard cannot see this, because the
     /// *palette* holds focus at that moment - so closing the palette restored focus straight onto
     /// a handle that is no longer in the frame.
     #[gpui::test]
-    fn toggling_to_changes_from_the_palette_does_not_restore_focus_onto_the_unrendered_tree(
+    fn cycling_off_files_from_the_palette_does_not_restore_focus_onto_the_unrendered_tree(
         cx: &mut TestAppContext,
     ) {
         let (_repo, app, cx) = open_seeded(cx);
@@ -2036,7 +2036,7 @@ mod palette_result_focus_tests {
             let groups = app.build_palette_groups(cx);
             let index = palette::flatten(&groups).iter().position(|entry| {
                 entry.target
-                    == palette::EntryTarget::Command(palette::PaletteCommand::ToggleFilesChanges)
+                    == palette::EntryTarget::Command(palette::PaletteCommand::CycleRightPanel)
             });
             match index {
                 Some(index) => {
@@ -2046,15 +2046,15 @@ mod palette_result_focus_tests {
                 None => false,
             }
         });
-        assert!(ran, "the palette must offer the real Files/Changes toggle");
+        assert!(ran, "the palette must offer the real right-panel cycle");
         cx.simulate_keystrokes("enter");
         cx.run_until_parked();
 
         app.read_with(cx, |app, _| {
             assert_eq!(
                 app.right_sidebar_view,
-                RightSidebarView::Changes,
-                "premise: the toggle really ran and the tree really is unrendered"
+                RightSidebarView::Search,
+                "premise: the cycle really ran (Files -> Search) and the tree really is unrendered"
             );
         });
         let (focused, tree_handle) = app.update_in(cx, |app, window, cx| {

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -172,6 +172,7 @@ actions!(
         NewTerminal,
         NewAgentPane,
         NewGitGraph,
+        SearchInWorktree,
         NextChangedFile,
         ToggleChangeSeen,
         ToggleChangeStaged,
@@ -473,6 +474,21 @@ pub struct AdeApp {
     /// handle `crate::sidebar::render::AdeApp::render_file_tree`'s own `uniform_list` is
     /// `track_scroll`'d with - not a second, parallel tracking mechanism.
     pub(crate) file_tree_scroll_handle: UniformListScrollHandle,
+    /// The right panel's Search tab (GitHub issue #162): its four real inputs, the modifier
+    /// toggles, per-file collapse, and the last completed search - see
+    /// `crate::search::state::SearchPanel`.
+    pub(crate) search: crate::search::state::SearchPanel,
+    /// The result tree's own scroll handle. A plain `gpui::ScrollHandle` rather than a
+    /// `UniformListScrollHandle` like the file tree's: the tree is two-level with per-file
+    /// collapse, so its rows are not uniform in count *or* height, which is exactly what
+    /// `uniform_list` requires. The result cap (`crate::search::engine::MAX_MATCHES`) is what
+    /// bounds how many rows this can ever hold.
+    pub(crate) search_scroll_handle: gpui::ScrollHandle,
+    /// The in-flight debounced search - superseded rather than cancelled, with a generation
+    /// guard on the result, so a slow walk cannot overwrite a newer, faster one.
+    pub(crate) _search_task: Option<Task<()>>,
+    /// The in-flight Replace all / per-file replace.
+    pub(crate) _search_replace_task: Option<Task<()>>,
     pub(crate) diff_root: PathBuf,
     pub(crate) diff_state: DiffLoadState,
     /// The real `+n`/`-n` totals across every file in [`Self::diff_state`]'s currently loaded
@@ -3248,6 +3264,7 @@ impl Render for AdeApp {
                 el.on_action(cx.listener(Self::handle_new_agent_pane_action))
             })
             .on_action(cx.listener(Self::handle_new_git_graph_action))
+            .on_action(cx.listener(Self::handle_search_in_worktree_action))
             .on_action(cx.listener(Self::handle_next_changed_file_action))
             .on_action(cx.listener(Self::handle_toggle_change_seen_action))
             .on_action(cx.listener(Self::handle_toggle_change_staged_action))
@@ -3705,7 +3722,7 @@ impl OverlayFocus {
     ///
     /// This exists for a real, reproduced case (found by the `tree-focus-bugfixes` branch's own
     /// adversarial audit): with the file tree focused, opening the palette captures
-    /// `tree_focus_handle`; running the palette's own "Toggle Files / Changes" then unrenders the
+    /// `tree_focus_handle`; running the palette's own "Cycle Right Panel" then unrenders the
     /// whole tree, and closing the palette restored focus straight onto it.
     /// `crate::sidebar::render::AdeApp::set_right_sidebar_view` already had a
     /// `tree_focus_handle.is_focused(window)` guard for the *direct* version of this, but the

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -173,6 +173,7 @@ actions!(
         NewAgentPane,
         NewGitGraph,
         SearchInWorktree,
+        FindInFile,
         NextChangedFile,
         ToggleChangeSeen,
         ToggleChangeStaged,
@@ -489,6 +490,17 @@ pub struct AdeApp {
     pub(crate) _search_task: Option<Task<()>>,
     /// The in-flight Replace all / per-file replace.
     pub(crate) _search_replace_task: Option<Task<()>>,
+    /// The `mod+F` find bar over the focused file view, or `None` while it is closed
+    /// (GitHub issue #162's own in-file-find section). An `Option` rather than an always-present
+    /// struct with an `open` flag: the bar has no state worth keeping between openings, and a
+    /// live `FocusHandle` that no rendered node tracks is exactly the dangling-focus hazard
+    /// `crate::root::OverlayFocus` exists for.
+    pub(crate) find_bar: Option<crate::search::in_file::FindBar>,
+    /// The find bar's focus handle - permanent, and wired into `crate::root::caret_blink` at
+    /// start-up like every other field's, even though the bar itself comes and goes. See
+    /// `crate::search::in_file::FindBar::focus_handle`'s own docs for why it is not minted per
+    /// opening.
+    pub(crate) find_bar_focus_handle: FocusHandle,
     pub(crate) diff_root: PathBuf,
     pub(crate) diff_state: DiffLoadState,
     /// The real `+n`/`-n` totals across every file in [`Self::diff_state`]'s currently loaded

--- a/crates/app/src/root/new_file.rs
+++ b/crates/app/src/root/new_file.rs
@@ -106,7 +106,7 @@ impl AdeApp {
             }
             "backspace" => {
                 if let Some(input) = self.new_file_input.as_mut() {
-                    input.name.pop(Instant::now());
+                    input.name.backspace(Instant::now());
                     // GitHub issue #27's "solid mid-keystroke" - see `crate::rail::render::
                     // AdeApp::handle_filter_key_down`'s identical reasoning. Missing here
                     // (GitHub issue #45) is exactly why this field never blinked.
@@ -122,7 +122,7 @@ impl AdeApp {
                     .filter(|text| !text.is_empty())
                 {
                     if let Some(input) = self.new_file_input.as_mut() {
-                        input.name.push_str(text, Instant::now());
+                        input.name.insert_str(text, Instant::now());
                         self.reset_caret_blink(cx);
                         cx.notify();
                         cx.stop_propagation();
@@ -181,6 +181,11 @@ impl AdeApp {
             .new_file_input
             .as_ref()
             .map(|input| input.name.as_str().to_string())
+            .unwrap_or_default();
+        let name_caret = self
+            .new_file_input
+            .as_ref()
+            .map(|input| input.name.caret())
             .unwrap_or_default();
         let parent_label = self
             .new_file_input
@@ -272,6 +277,7 @@ impl AdeApp {
                                 text_selector: "new-file-name-text".into(),
                                 focus_handle: Some(&self.new_file_focus_handle),
                                 text: &name,
+                                caret_offset: name_caret,
                                 placeholder: "file-name.ext",
                                 font: theme::font::MONO,
                                 text_size: px(11.5),

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -357,6 +357,10 @@ impl AdeApp {
             file_tree_error: None,
             right_sidebar_view: RightSidebarView::Files,
             file_tree_scroll_handle: UniformListScrollHandle::new(),
+            search: crate::search::state::SearchPanel::new(cx),
+            search_scroll_handle: gpui::ScrollHandle::new(),
+            _search_task: None,
+            _search_replace_task: None,
             diff_state: DiffLoadState::Loading,
             diff_totals: None,
             agent_reviews: HashMap::new(),
@@ -784,6 +788,14 @@ impl AdeApp {
                 // the moment this one gained focus, and never toggled after that, reading as no
                 // caret at all most of the time.
                 &this.note_focus_handle,
+                // GitHub issue #162's four search-panel fields are the sixth through ninth, built
+                // inside `this.search` by this same `Self` literal. Wired here rather than left
+                // out: this omission has been a live bug report five separate times (see the four
+                // entries above), and four fields added in one edit is four chances to repeat it.
+                &this.search.query_focus_handle,
+                &this.search.replace_focus_handle,
+                &this.search.include_focus_handle,
+                &this.search.exclude_focus_handle,
             ],
             window,
             cx,

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -361,6 +361,8 @@ impl AdeApp {
             search_scroll_handle: gpui::ScrollHandle::new(),
             _search_task: None,
             _search_replace_task: None,
+            find_bar: None,
+            find_bar_focus_handle: cx.focus_handle(),
             diff_state: DiffLoadState::Loading,
             diff_totals: None,
             agent_reviews: HashMap::new(),
@@ -796,6 +798,10 @@ impl AdeApp {
                 &this.search.replace_focus_handle,
                 &this.search.include_focus_handle,
                 &this.search.exclude_focus_handle,
+                // And the tenth: GitHub issue #162's in-file find bar. Its handle is permanent
+                // even though the bar itself is created and dropped on every `mod+F`, precisely so
+                // it can be wired here once rather than on every opening.
+                &this.find_bar_focus_handle,
             ],
             window,
             cx,

--- a/crates/app/src/root/widgets.rs
+++ b/crates/app/src/root/widgets.rs
@@ -504,6 +504,19 @@ impl AdeApp {
     /// happens to be rendering. And there is deliberately no gap between the text and the caret:
     /// a cursor sits flush against the last glyph (`crate::rail::render`'s own live report).
     ///
+    /// The third rule, added by GitHub issue #162: the caret sits at
+    /// [`SimpleInput::caret_offset`], not unconditionally at the end. Now that
+    /// `crate::text_history::TextField` has a real caret, the text is split at it and the bar is
+    /// drawn *between* the two halves. With the caret at the end - which is where it is for every
+    /// field until the user presses Left or Home - the trailing half is empty and this renders
+    /// exactly the structure it always did, which is why the existing caret-position tests still
+    /// measure what they measured.
+    ///
+    /// [`SimpleInput::text_selector`] deliberately stays on the **leading** half rather than
+    /// moving to a wrapper around both: those tests assert "the caret is at or past the text's
+    /// right edge", and a wrapper containing the caret would enclose it and make that assertion
+    /// unsatisfiable by construction.
+    ///
     /// The caller still owns the box *around* this row - its border, padding, height and
     /// background - because that genuinely differs per field. What it no longer owns is the part
     /// that was never supposed to differ.
@@ -513,6 +526,7 @@ impl AdeApp {
             text_selector,
             focus_handle,
             text,
+            caret_offset,
             placeholder,
             font: font_name,
             text_size,
@@ -522,7 +536,19 @@ impl AdeApp {
         // "Blank" by the same rule every caller used: nothing typed at all. A field holding only
         // spaces is holding real text and shows it, with the caret after it.
         let is_blank = text.is_empty();
-        let shown = if is_blank { placeholder } else { text }.to_string();
+        // Clamped and re-aligned to a real `char` boundary here as well as in `TextField`: this
+        // helper also serves callers that pass an offset from somewhere else, and slicing a
+        // `&str` mid-character panics.
+        let split_at = (0..=text.len())
+            .rev()
+            .find(|offset| *offset <= caret_offset && text.is_char_boundary(*offset))
+            .unwrap_or(0);
+        let (before_caret, after_caret) = text.split_at(split_at);
+        let leading = if is_blank {
+            placeholder.to_string()
+        } else {
+            before_caret.to_string()
+        };
         // `None` is a genuinely read-only row - a pinned note card that is not the one being
         // typed into, say. It cannot be expressed by passing a handle that happens to be
         // unfocused: several of these rows can be on screen sharing *one* focus handle (only one
@@ -534,6 +560,21 @@ impl AdeApp {
             }
             None => el,
         };
+        // One shared shape for both halves: intrinsically sized, and allowed to shrink and clip
+        // rather than to wrap or to push the caret out of the row. `min_w_0` here is a *floor* of
+        // zero on an auto-sized box, which is a different thing from the `flex_1` that used to sit
+        // beside it and is what makes a field narrower than its own text degrade to a clipped line
+        // instead of a two-line row.
+        let span = |content: String, color: theme::ColorToken| {
+            div()
+                .min_w_0()
+                .overflow_hidden()
+                .whitespace_nowrap()
+                .font(font(font_name))
+                .text_size(text_size)
+                .text_color(color)
+                .child(content)
+        };
         div()
             // On the wrapper, which is the whole point - see this method's own docs.
             .flex_1()
@@ -542,26 +583,22 @@ impl AdeApp {
             .items_center()
             .when(is_blank, caret)
             .child(
-                div()
-                    .debug_selector(move || text_selector.to_string())
-                    // Intrinsically sized, and allowed to shrink and clip rather than to wrap or
-                    // to push the caret out of the row: `min_w_0` here is a *floor* of zero on an
-                    // auto-sized box, which is a different thing from the `flex_1` that used to
-                    // sit beside it and is what makes a field narrower than its own text degrade
-                    // to a clipped line instead of a two-line row.
-                    .min_w_0()
-                    .overflow_hidden()
-                    .whitespace_nowrap()
-                    .font(font(font_name))
-                    .text_size(text_size)
-                    .text_color(if is_blank {
+                span(
+                    leading,
+                    if is_blank {
                         placeholder_color
                     } else {
                         text_color
-                    })
-                    .child(shown),
+                    },
+                )
+                .debug_selector(move || text_selector.to_string()),
             )
             .when(!is_blank, caret)
+            // Only when there really is text after the caret, so a field with the caret at its end
+            // paints the exact element tree it painted before this method knew about carets.
+            .when(!is_blank && !after_caret.is_empty(), |el| {
+                el.child(span(after_caret.to_string(), text_color))
+            })
     }
 }
 
@@ -583,6 +620,11 @@ pub(crate) struct SimpleInput<'a> {
     pub focus_handle: Option<&'a FocusHandle>,
     /// What the field holds right now.
     pub text: &'a str,
+    /// Where the insertion point is, as a byte offset into [`Self::text`] -
+    /// `crate::text_history::TextField::caret`. Clamped and re-aligned to a `char` boundary by
+    /// the renderer, so an out-of-range or mid-character value degrades to the nearest real one
+    /// rather than panicking.
+    pub caret_offset: usize,
     /// What it says while that is empty.
     pub placeholder: &'a str,
     /// The font family, as a `crate::theme::font` name.

--- a/crates/app/src/search/engine.rs
+++ b/crates/app/src/search/engine.rs
@@ -1,0 +1,1258 @@
+//! The pure, GPUI-free content search behind the right panel's Search tab: the compiled matcher
+//! the three modifier buttons produce, the worktree walk, the two-level result tree, and the real
+//! in-place replace.
+//!
+//! Everything here is a plain function over plain data with no `Window`, no `Context` and no app
+//! state, which is the split every feature folder in this crate uses (`crate::sidebar::file_tree`
+//! vs `crate::sidebar::render`). The panel itself is `crate::search::render`.
+//!
+//! ## One matcher, three buttons
+//!
+//! `Aa` (match case), `ab` (whole word) and `.*` (regex) are not three code paths - they are three
+//! inputs to one [`Matcher`], which is always a real `regex::Regex`. A literal query is
+//! `regex::escape`d first; whole-word wraps the whole thing in `\b(?:...)\b`. That is one place
+//! for the "leftmost, non-overlapping" semantics every editor's find has, rather than a
+//! hand-rolled substring scan for two of the three states and a regex for the third - which is
+//! exactly how the two would silently drift apart on overlapping matches.
+//!
+//! The one behaviour that genuinely differs by mode is what the *replacement* string means: in
+//! regex mode `$1` is a real capture reference (what a user typing a regex expects, and what VS
+//! Code does), and in literal mode it is a literal dollar sign. See [`Matcher::replace_all`].
+//!
+//! ## Bounded, because a worktree is not bounded
+//!
+//! `target/` alone can hold hundreds of thousands of files, and this walk runs against whatever
+//! the active worktree really contains. Four real limits, each reported honestly rather than
+//! silently applied: [`MAX_MATCHES`], [`MAX_SCANNED_FILES`], [`MAX_FILE_BYTES`] and a binary-file
+//! check. [`SearchOutcome::truncated`] is what the panel's count row turns into a real truncation
+//! notice - the issue's own "results cap with an honest truncation notice".
+
+use std::collections::HashSet;
+use std::fs;
+use std::io;
+use std::ops::Range;
+use std::path::{Path, PathBuf};
+
+use crate::search::glob::GlobList;
+
+/// The largest file this search will read. The same ceiling
+/// `crate::code_surface::code_view::MAX_FILE_BYTES` puts on opening a file in the editor, for the
+/// same reason: past it, the thing on disk is not source you are searching, and reading it costs
+/// more than any hit in it is worth.
+pub const MAX_FILE_BYTES: u64 = crate::code_surface::code_view::MAX_FILE_BYTES as u64;
+
+/// How many matches one search collects before it stops and reports itself truncated. High enough
+/// that a real question about a real worktree is answered in full; low enough that a one-character
+/// query against a large checkout cannot build a multi-million-row tree the panel would then have
+/// to render.
+pub const MAX_MATCHES: usize = 2_000;
+
+/// How many files one search will open before it stops and reports itself truncated. A separate
+/// bound from [`MAX_MATCHES`] because the expensive case is the *opposite* one: a long, specific
+/// query that matches almost nothing still reads every file in the worktree.
+pub const MAX_SCANNED_FILES: usize = 20_000;
+
+/// How much of a file is sniffed for a NUL byte before it is called binary and skipped.
+const BINARY_SNIFF_BYTES: usize = 8 * 1024;
+
+/// The three modifier buttons in the query row, as real state
+/// (`REVISION-2026-08-14.md` §5: "`Aa` / `ab` / `.*` modifier buttons").
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SearchOptions {
+    /// `Aa` - off means the search is case-insensitive.
+    pub match_case: bool,
+    /// `ab` - the query must sit on word boundaries.
+    pub whole_word: bool,
+    /// `.*` - the query is a regular expression rather than literal text.
+    pub regex: bool,
+}
+
+/// A compiled query. Construct with [`Matcher::compile`]; an invalid regex is a real, reportable
+/// state ([`MatcherError`]) rather than a silent fallback to a literal search, which would answer
+/// a question the user did not ask.
+#[derive(Debug, Clone)]
+pub struct Matcher {
+    regex: regex::Regex,
+    /// Kept so [`Self::replace_all`] can tell a real regex replacement (where `$1` is a capture
+    /// reference) from a literal one (where it is a dollar sign) - see this module's own docs.
+    regex_mode: bool,
+}
+
+/// Why a query could not be compiled - shown verbatim under the query row, since a regex error
+/// message is the only thing that can tell the user which character is the problem.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MatcherError(pub String);
+
+impl std::fmt::Display for MatcherError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl Matcher {
+    /// Compiles `query` under `options`. Returns `Ok(None)` for a query that is empty once
+    /// trimmed of nothing at all - i.e. genuinely `""` - which is the panel's "not searched yet"
+    /// state and not an error.
+    ///
+    /// A query of pure whitespace is a **real** query: a user searching for `"    "` (an
+    /// indentation width) means it, and treating it as empty would silently refuse a legitimate
+    /// search. Only a genuinely empty string is the idle state.
+    pub fn compile(query: &str, options: SearchOptions) -> Result<Option<Self>, MatcherError> {
+        if query.is_empty() {
+            return Ok(None);
+        }
+        let body = if options.regex {
+            query.to_string()
+        } else {
+            regex::escape(query)
+        };
+        // `\b(?:...)\b` rather than `\b...\b`: without the non-capturing group, a top-level
+        // alternation in regex mode (`foo|bar`) would bind as `(\bfoo)|(bar\b)` and quietly stop
+        // meaning "whole word".
+        let pattern = if options.whole_word {
+            format!(r"\b(?:{body})\b")
+        } else {
+            body
+        };
+        let regex = regex::RegexBuilder::new(&pattern)
+            .case_insensitive(!options.match_case)
+            .build()
+            .map_err(|error| MatcherError(first_line_of(&error.to_string())))?;
+        Ok(Some(Matcher {
+            regex,
+            regex_mode: options.regex,
+        }))
+    }
+
+    /// Every non-overlapping match in `line`, as byte ranges into it.
+    ///
+    /// Zero-length matches are dropped rather than reported. They are reachable the moment the
+    /// user types `.*` or `a?` into a regex query, and a zero-width "match" is not something the
+    /// tree can highlight, the count can honestly total, or replace can act on - it would produce
+    /// one result row per character in the worktree.
+    pub fn find_in_line(&self, line: &str) -> Vec<Range<usize>> {
+        self.regex
+            .find_iter(line)
+            .filter(|found| found.start() != found.end())
+            .map(|found| found.range())
+            .collect()
+    }
+
+    /// `text` with every match replaced, plus how many were replaced.
+    ///
+    /// In regex mode `replacement` is a real template: `$1` / `${name}` expand to captures, which
+    /// is what a user who just typed a regex means by it. In literal mode it is inserted verbatim
+    /// (`regex::NoExpand`), so replacing with `$5.00` writes `$5.00` rather than an empty capture.
+    ///
+    /// Zero-length matches are skipped here for the same reason [`Self::find_in_line`] drops them,
+    /// and by the same code path - so the count this returns is always exactly the count the tree
+    /// showed.
+    pub fn replace_all(&self, text: &str, replacement: &str) -> (String, usize) {
+        let mut out = String::with_capacity(text.len());
+        let mut last = 0usize;
+        let mut count = 0usize;
+        for captures in self.regex.captures_iter(text) {
+            let whole = captures.get(0).expect("group 0 always exists");
+            if whole.start() == whole.end() {
+                continue;
+            }
+            out.push_str(&text[last..whole.start()]);
+            if self.regex_mode {
+                captures.expand(replacement, &mut out);
+            } else {
+                out.push_str(replacement);
+            }
+            last = whole.end();
+            count += 1;
+        }
+        out.push_str(&text[last..]);
+        (out, count)
+    }
+}
+
+/// A regex error renders as several lines with a caret diagram, which is more than a one-line
+/// notice under a 28px field can show. The first line is the sentence that names the problem.
+fn first_line_of(message: &str) -> String {
+    message
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .unwrap_or(message)
+        .trim()
+        .to_string()
+}
+
+/// The two path-filter fields, resolved into the one question the walk asks per file.
+///
+/// The asymmetry between them is deliberate and is the whole reason this is a type rather than
+/// two `GlobList`s: an **empty include** means "no include filter", i.e. every path is a
+/// candidate, while an empty exclude means "exclude nothing". Both read as "the field is blank, so
+/// it is not filtering", but they are opposite defaults on a bare `GlobList::matches`.
+#[derive(Debug, Clone, Default)]
+pub struct PathFilter {
+    include: GlobList,
+    exclude: GlobList,
+}
+
+impl PathFilter {
+    pub fn new(include: &str, exclude: &str) -> Self {
+        PathFilter {
+            include: GlobList::parse(include),
+            exclude: GlobList::parse(exclude),
+        }
+    }
+
+    /// Whether a worktree-relative, `/`-separated path survives both fields.
+    pub fn allows(&self, relative: &str) -> bool {
+        if !self.include.is_empty() && !self.include.matches(relative) {
+            return false;
+        }
+        !self.exclude.matches(relative)
+    }
+}
+
+/// One matched line, and every hit on it.
+///
+/// The whole line is kept rather than a pre-trimmed display string: the panel's own left-elision
+/// rule ([`elide_around`]) is a *rendering* decision that depends on which hit a row is showing,
+/// and baking it in here would make the same data unusable for replace.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LineMatch {
+    /// 1-based, as every editor and every `grep` reports it.
+    pub line_number: usize,
+    pub text: String,
+    /// Byte ranges into [`Self::text`], in order, non-overlapping.
+    pub ranges: Vec<Range<usize>>,
+}
+
+/// One file's whole contribution to the tree - the file row plus the match rows under it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileMatches {
+    /// Absolute, so a click can open it without re-deriving the worktree root.
+    pub path: PathBuf,
+    /// Worktree-relative and `/`-separated - what the file row prints and what the path filter
+    /// matched.
+    pub relative: String,
+    pub lines: Vec<LineMatch>,
+}
+
+impl FileMatches {
+    /// Hits in this file, counting **matches** rather than lines - two hits on one line are two
+    /// results, which is what the tree draws and what Replace all would act on.
+    pub fn match_count(&self) -> usize {
+        self.lines.iter().map(|line| line.ranges.len()).sum()
+    }
+
+    /// The file's own name, as the file row's leading label.
+    pub fn file_name(&self) -> &str {
+        match self.relative.rsplit_once('/') {
+            Some((_, name)) => name,
+            None => self.relative.as_str(),
+        }
+    }
+
+    /// The dimmed directory beside it, with its trailing `/` - `""` for a root-level file.
+    pub fn directory(&self) -> &str {
+        match self.relative.rfind('/') {
+            Some(index) => &self.relative[..=index],
+            None => "",
+        }
+    }
+}
+
+/// A completed search.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SearchOutcome {
+    pub files: Vec<FileMatches>,
+    /// Total hits across every file - the `N results` half of the count row.
+    pub total_matches: usize,
+    /// A real limit was reached ([`MAX_MATCHES`] or [`MAX_SCANNED_FILES`]), so this is a prefix of
+    /// the truth and the panel must say so.
+    pub truncated: bool,
+    /// How many files were really opened and scanned - the number the truncation notice quotes.
+    pub scanned_files: usize,
+}
+
+/// Everything one search run needs. A struct rather than five parameters because the panel builds
+/// it from five separate widgets and three of them are strings that would be transposable.
+#[derive(Debug, Clone)]
+pub struct SearchRequest {
+    /// The worktree being searched - `STAGE-A-CHANGELOG.md` §4u: "scoped to the active worktree
+    /// like the tree beside it".
+    pub root: PathBuf,
+    pub matcher: Matcher,
+    pub filter: PathFilter,
+}
+
+/// Runs a real content search over `request.root`.
+///
+/// Blocking, by design: the caller runs it on `gpui::BackgroundExecutor` exactly as
+/// `crate::sidebar::file_tree::build_file_tree` is run (see `crate::search::render::AdeApp::
+/// start_search`). Errors reading an individual file or directory are skipped rather than
+/// aborting - one unreadable folder must never blank a whole result tree - which is the same call
+/// `build_file_tree`'s own walk makes.
+pub fn search_worktree(request: &SearchRequest) -> SearchOutcome {
+    let mut outcome = SearchOutcome::default();
+    let mut candidates = Vec::new();
+    collect_files(&request.root, &mut candidates, &mut outcome);
+    // A stable, predictable order: the tree is read top to bottom and a search re-run after a
+    // keystroke must not shuffle rows the user was reading. `read_dir` order is not defined.
+    candidates.sort();
+
+    for path in candidates {
+        if outcome.truncated {
+            break;
+        }
+        let Some(relative) = relative_slash_path(&request.root, &path) else {
+            continue;
+        };
+        if !request.filter.allows(&relative) {
+            continue;
+        }
+        if outcome.scanned_files >= MAX_SCANNED_FILES {
+            outcome.truncated = true;
+            break;
+        }
+        let Some(content) = read_searchable(&path) else {
+            continue;
+        };
+        outcome.scanned_files += 1;
+        let mut lines = Vec::new();
+        for (index, line) in content.lines().enumerate() {
+            let ranges = request.matcher.find_in_line(line);
+            if ranges.is_empty() {
+                continue;
+            }
+            outcome.total_matches += ranges.len();
+            lines.push(LineMatch {
+                line_number: index + 1,
+                text: line.to_string(),
+                ranges,
+            });
+            if outcome.total_matches >= MAX_MATCHES {
+                outcome.truncated = true;
+                break;
+            }
+        }
+        if !lines.is_empty() {
+            outcome.files.push(FileMatches {
+                path,
+                relative,
+                lines,
+            });
+        }
+    }
+    outcome
+}
+
+/// Every regular file under `dir`, recursively.
+///
+/// `.git` is the one thing skipped unconditionally, and it is skipped for a reason no filter
+/// should have to restate: it is this app's own bookkeeping, it is mostly binary, and a search of
+/// it can only ever return things the user cannot act on. **Every other dotfile is searchable** -
+/// a deliberate divergence from `crate::sidebar::file_tree::build_file_tree`, which hides them
+/// from the tree. A tree that hides `.github/workflows/ci.yml` is a browsing choice; a search that
+/// silently cannot find text in it is the "an index, not a result" failure `STAGE-A-CHANGELOG.md`
+/// §4v names, one level up.
+///
+/// Symlinks are not followed (`DirEntry::file_type` does not follow them), so a worktree
+/// containing a link to `/` cannot make this walk unbounded.
+fn collect_files(dir: &Path, out: &mut Vec<PathBuf>, outcome: &mut SearchOutcome) {
+    if out.len() >= MAX_SCANNED_FILES {
+        outcome.truncated = true;
+        return;
+    }
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_symlink() {
+            continue;
+        }
+        if file_type.is_dir() {
+            if path.file_name().is_some_and(|name| name == ".git") {
+                continue;
+            }
+            collect_files(&path, out, outcome);
+            if outcome.truncated {
+                return;
+            }
+        } else if file_type.is_file() {
+            if out.len() >= MAX_SCANNED_FILES {
+                outcome.truncated = true;
+                return;
+            }
+            out.push(path);
+        }
+    }
+}
+
+/// `path`'s text, or `None` when it is not something to search: too large
+/// ([`MAX_FILE_BYTES`]), binary (a NUL byte in the first [`BINARY_SNIFF_BYTES`]), not valid UTF-8,
+/// or simply unreadable.
+///
+/// The UTF-8 check is real rather than lossy: a lossy decode would report byte offsets into a
+/// string that is not what is on disk, and replace would then write those offsets back.
+pub fn read_searchable(path: &Path) -> Option<String> {
+    let metadata = fs::metadata(path).ok()?;
+    if metadata.len() > MAX_FILE_BYTES {
+        return None;
+    }
+    let bytes = fs::read(path).ok()?;
+    let sniff = &bytes[..bytes.len().min(BINARY_SNIFF_BYTES)];
+    if sniff.contains(&0) {
+        return None;
+    }
+    String::from_utf8(bytes).ok()
+}
+
+/// `path` relative to `root`, with `/` separators - `None` when it is not under `root` at all.
+fn relative_slash_path(root: &Path, path: &Path) -> Option<String> {
+    let relative = path.strip_prefix(root).ok()?;
+    let mut out = String::new();
+    for component in relative.components() {
+        if !out.is_empty() {
+            out.push('/');
+        }
+        out.push_str(&component.as_os_str().to_string_lossy());
+    }
+    Some(out)
+}
+
+/// One file's real, on-disk replace: reads it, replaces every match, writes it back only if
+/// something actually changed.
+///
+/// Re-reads rather than trusting the [`SearchOutcome`] the tree is showing - that outcome can be
+/// seconds old and an agent may have rewritten the file since. The count returned is therefore
+/// the count that really landed, which is what "report what changed" has to mean.
+pub fn replace_in_file(
+    path: &Path,
+    matcher: &Matcher,
+    replacement: &str,
+) -> io::Result<ReplacedFile> {
+    let Some(content) = read_searchable(path) else {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "not a searchable text file",
+        ));
+    };
+    let (replaced, count) = matcher.replace_all(&content, replacement);
+    if count == 0 || replaced == content {
+        return Ok(ReplacedFile {
+            path: path.to_path_buf(),
+            matches: 0,
+        });
+    }
+    fs::write(path, replaced.as_bytes())?;
+    Ok(ReplacedFile {
+        path: path.to_path_buf(),
+        matches: count,
+    })
+}
+
+/// What one file's replace really did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReplacedFile {
+    pub path: PathBuf,
+    /// Zero when the file was re-read and no longer matched - a real outcome, not a failure.
+    pub matches: usize,
+}
+
+/// The whole outcome of a Replace all / per-file replace, as the panel reports it.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ReplaceOutcome {
+    pub files_changed: usize,
+    pub matches_replaced: usize,
+    /// Files that were deliberately not touched because they are open in the editor with unsaved
+    /// edits - see [`replace_across`]'s own docs.
+    pub skipped_dirty: Vec<PathBuf>,
+    /// Files whose write really failed, with the OS's own message.
+    pub failed: Vec<(PathBuf, String)>,
+}
+
+/// Replaces across `files`, skipping any path in `dirty` entirely.
+///
+/// `dirty` is the set of files currently open in the editor with **unsaved** changes
+/// (`crate::code_surface::edit_buffer::EditBuffer::is_dirty`). Writing those would silently
+/// destroy edits the user has not saved: the replace is computed from what is on disk, so it
+/// would write disk-content-with-substitutions over a buffer the editor still believes it owns,
+/// and the editor's own next save would then write the un-replaced buffer straight back. Refusing
+/// and *naming* them is the only honest option - `REVISION-2026-08-14.md` §7 rule 1's "ship the
+/// affordance with the behaviour, or ship neither", applied to a partial one.
+pub fn replace_across(
+    files: &[PathBuf],
+    matcher: &Matcher,
+    replacement: &str,
+    dirty: &HashSet<PathBuf>,
+) -> ReplaceOutcome {
+    let mut outcome = ReplaceOutcome::default();
+    for path in files {
+        if dirty.contains(path) {
+            outcome.skipped_dirty.push(path.clone());
+            continue;
+        }
+        match replace_in_file(path, matcher, replacement) {
+            Ok(replaced) if replaced.matches > 0 => {
+                outcome.files_changed += 1;
+                outcome.matches_replaced += replaced.matches;
+            }
+            Ok(_) => {}
+            Err(error) => outcome.failed.push((path.clone(), error.to_string())),
+        }
+    }
+    outcome
+}
+
+/// How many characters of context sit before the hit on a match row before the prefix elides from
+/// the left. `Jerry.dc.html`'s own `trimPre`: `s.length > 16 ? '…' + s.slice(-15)`.
+pub const ELIDE_PREFIX_MAX: usize = 16;
+
+/// The same for the tail. `Jerry.dc.html`'s own `trimPost`: `s.length > 26 ? s.slice(0, 25) + '…'`.
+pub const ELIDE_SUFFIX_MAX: usize = 26;
+
+/// Splits `line` around `range` into the three spans a match row draws, with the design's own
+/// left-elision applied.
+///
+/// `Jerry.dc.html` states the rule and the reason verbatim: "The row is ~40 characters at 10px
+/// mono. A long prefix pushes the match clean out of the box, which defeats the point of showing
+/// the line at all - so the prefix elides from the LEFT and the hit stays at a fixed early column,
+/// the way VS Code does it. The tail may overflow; the tail is only context."
+///
+/// Counts **characters**, not bytes, so an indented line of CJK or a comment with an emoji in it
+/// elides at the same visual width as an ASCII one rather than three times earlier.
+pub fn elide_around(line: &str, range: &Range<usize>) -> (String, String, String) {
+    let before = &line[..range.start];
+    let hit = &line[range.clone()];
+    let after = &line[range.end..];
+
+    let before_chars: Vec<char> = before.chars().collect();
+    let prefix = if before_chars.len() > ELIDE_PREFIX_MAX {
+        let tail: String = before_chars[before_chars.len() - (ELIDE_PREFIX_MAX - 1)..]
+            .iter()
+            .collect();
+        format!("\u{2026}{tail}")
+    } else {
+        before.to_string()
+    };
+
+    let after_chars: Vec<char> = after.chars().collect();
+    let suffix = if after_chars.len() > ELIDE_SUFFIX_MAX {
+        let head: String = after_chars[..ELIDE_SUFFIX_MAX - 1].iter().collect();
+        format!("{head}\u{2026}")
+    } else {
+        after.to_string()
+    };
+
+    (prefix, hit.to_string(), suffix)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn matcher(query: &str, options: SearchOptions) -> Matcher {
+        Matcher::compile(query, options)
+            .expect("compiles")
+            .expect("a non-empty query")
+    }
+
+    fn literal(query: &str) -> Matcher {
+        matcher(query, SearchOptions::default())
+    }
+
+    #[test]
+    fn an_empty_query_is_the_idle_state_not_an_error() {
+        assert!(Matcher::compile("", SearchOptions::default())
+            .expect("no error")
+            .is_none());
+    }
+
+    #[test]
+    fn a_whitespace_only_query_is_a_real_search() {
+        let matcher = literal("    ");
+        assert_eq!(
+            matcher.find_in_line("    indented").len(),
+            1,
+            "searching for an indentation width is a real thing to want; only a genuinely empty \
+             field is the not-searched-yet state"
+        );
+    }
+
+    #[test]
+    fn a_literal_query_never_reads_as_a_regex() {
+        let matcher = literal("a.c");
+        assert!(
+            matcher.find_in_line("abc").is_empty(),
+            "`.` must be literal"
+        );
+        assert_eq!(matcher.find_in_line("a.c").len(), 1);
+    }
+
+    #[test]
+    fn match_case_off_is_case_insensitive_and_on_is_not() {
+        let insensitive = literal("Token");
+        assert_eq!(insensitive.find_in_line("refresh_token").len(), 1);
+        let sensitive = matcher(
+            "Token",
+            SearchOptions {
+                match_case: true,
+                ..SearchOptions::default()
+            },
+        );
+        assert!(sensitive.find_in_line("refresh_token").is_empty());
+        assert_eq!(sensitive.find_in_line("refresh_Token").len(), 1);
+    }
+
+    #[test]
+    fn whole_word_rejects_a_hit_inside_a_longer_identifier() {
+        let matcher = matcher(
+            "token",
+            SearchOptions {
+                whole_word: true,
+                ..SearchOptions::default()
+            },
+        );
+        assert!(
+            matcher.find_in_line("refresh_token").is_empty(),
+            "`_` is a word character, so `refresh_token` does not contain the whole word `token`"
+        );
+        assert_eq!(matcher.find_in_line("let token = 1;").len(), 1);
+    }
+
+    #[test]
+    fn whole_word_over_a_regex_alternation_binds_to_the_whole_alternation() {
+        // Without the `(?:...)` group this compiles to `\bfoo|bar\b`, which silently means
+        // "whole-word foo, or any bar" - the exact shadowed-semantics bug the group exists for.
+        let matcher = matcher(
+            "foo|bar",
+            SearchOptions {
+                whole_word: true,
+                regex: true,
+                ..SearchOptions::default()
+            },
+        );
+        assert!(matcher.find_in_line("xxbarxx").is_empty());
+        assert_eq!(matcher.find_in_line("a bar b").len(), 1);
+    }
+
+    #[test]
+    fn an_invalid_regex_is_a_real_reportable_error_not_a_silent_literal_fallback() {
+        let error = Matcher::compile(
+            "(unclosed",
+            SearchOptions {
+                regex: true,
+                ..SearchOptions::default()
+            },
+        )
+        .expect_err("an unclosed group must not compile");
+        assert!(!error.0.is_empty());
+        assert!(
+            !error.0.contains('\n'),
+            "the panel shows one line under a 28px field: {}",
+            error.0
+        );
+    }
+
+    #[test]
+    fn matches_are_leftmost_and_non_overlapping() {
+        let matcher = literal("aa");
+        assert_eq!(
+            matcher.find_in_line("aaaa"),
+            vec![0..2, 2..4],
+            "two non-overlapping hits, not three overlapping ones"
+        );
+    }
+
+    #[test]
+    fn a_zero_width_regex_match_is_never_reported_as_a_result() {
+        let matcher = matcher(
+            "x*",
+            SearchOptions {
+                regex: true,
+                ..SearchOptions::default()
+            },
+        );
+        assert_eq!(
+            matcher.find_in_line("abc"),
+            Vec::<Range<usize>>::new(),
+            "`x*` matches the empty string at every offset - one result row per character is not \
+             a search result"
+        );
+        assert_eq!(matcher.find_in_line("axxb"), vec![1..3]);
+    }
+
+    #[test]
+    fn replace_in_literal_mode_never_expands_a_dollar_group() {
+        let matcher = literal("PRICE");
+        let (out, count) = matcher.replace_all("cost: PRICE", "$5.00");
+        assert_eq!(out, "cost: $5.00");
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn replace_in_regex_mode_really_expands_captures() {
+        let matcher = matcher(
+            r"fn (\w+)\(",
+            SearchOptions {
+                regex: true,
+                ..SearchOptions::default()
+            },
+        );
+        let (out, count) = matcher.replace_all("fn refresh(", "pub fn $1(");
+        assert_eq!(out, "pub fn refresh(");
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn replace_counts_every_hit_including_several_on_one_line() {
+        let matcher = literal("a");
+        let (out, count) = matcher.replace_all("a b a\na", "X");
+        assert_eq!(out, "X b X\nX");
+        assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn replacing_with_the_empty_string_is_a_real_deletion() {
+        let matcher = literal("_old");
+        let (out, count) = matcher.replace_all("name_old = 1", "");
+        assert_eq!(out, "name = 1");
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn a_path_filter_with_an_empty_include_lets_everything_through() {
+        let filter = PathFilter::new("", "");
+        assert!(filter.allows("src/lib.rs"));
+        assert!(filter.allows("target/debug/x"));
+    }
+
+    #[test]
+    fn a_real_include_narrows_and_a_real_exclude_wins_over_it() {
+        let filter = PathFilter::new("src/**, tests/**", "src/generated/**");
+        assert!(filter.allows("src/auth/session.rs"));
+        assert!(filter.allows("tests/auth_race.rs"));
+        assert!(!filter.allows("migrations/0031.sql"), "not included");
+        assert!(
+            !filter.allows("src/generated/api.rs"),
+            "exclude must win over include, or an exclude could never narrow one"
+        );
+    }
+
+    #[test]
+    fn file_matches_split_a_relative_path_into_name_and_dimmed_directory() {
+        let file = FileMatches {
+            path: PathBuf::from("/wt/src/auth/session.rs"),
+            relative: "src/auth/session.rs".to_string(),
+            lines: Vec::new(),
+        };
+        assert_eq!(file.file_name(), "session.rs");
+        assert_eq!(file.directory(), "src/auth/");
+
+        let root_level = FileMatches {
+            path: PathBuf::from("/wt/README.md"),
+            relative: "README.md".to_string(),
+            lines: Vec::new(),
+        };
+        assert_eq!(root_level.file_name(), "README.md");
+        assert_eq!(root_level.directory(), "");
+    }
+
+    #[test]
+    fn a_files_match_count_totals_hits_not_lines() {
+        let file = FileMatches {
+            path: PathBuf::from("/wt/a.rs"),
+            relative: "a.rs".to_string(),
+            lines: vec![
+                LineMatch {
+                    line_number: 1,
+                    text: "a a".to_string(),
+                    ranges: vec![0..1, 2..3],
+                },
+                LineMatch {
+                    line_number: 4,
+                    text: "aa".to_string(),
+                    ranges: vec![0..1, 1..2],
+                },
+            ],
+        };
+        assert_eq!(
+            file.match_count(),
+            4,
+            "two hits on one line are two results - the count row and Replace all must agree"
+        );
+    }
+
+    #[test]
+    fn a_long_prefix_elides_from_the_left_so_the_hit_stays_at_an_early_column() {
+        let line = "                    let refresh_token = issue();";
+        let range = line.find("refresh_token").expect("the hit")..;
+        let range = range.start..range.start + "refresh_token".len();
+        let (prefix, hit, suffix) = elide_around(line, &range);
+        assert!(prefix.starts_with('\u{2026}'));
+        assert_eq!(prefix.chars().count(), ELIDE_PREFIX_MAX);
+        assert_eq!(hit, "refresh_token");
+        assert_eq!(suffix, " = issue();");
+    }
+
+    #[test]
+    fn a_short_prefix_and_tail_are_left_exactly_as_they_are() {
+        let (prefix, hit, suffix) = elide_around("let a = 1;", &(4..5));
+        assert_eq!(
+            (prefix.as_str(), hit.as_str(), suffix.as_str()),
+            ("let ", "a", " = 1;")
+        );
+    }
+
+    #[test]
+    fn a_long_tail_elides_from_the_right_because_the_tail_is_only_context() {
+        let line = format!("x{}", "y".repeat(80));
+        let (_, hit, suffix) = elide_around(&line, &(0..1));
+        assert_eq!(hit, "x");
+        assert_eq!(suffix.chars().count(), ELIDE_SUFFIX_MAX);
+        assert!(suffix.ends_with('\u{2026}'));
+    }
+
+    #[test]
+    fn elision_counts_characters_not_bytes() {
+        // Twenty CJK characters is 60 bytes; a byte-counting elision would cut this three times
+        // earlier than an equivalent ASCII line.
+        let prefix_source = "\u{6f22}".repeat(20);
+        let line = format!("{prefix_source}HIT");
+        let start = prefix_source.len();
+        let (prefix, hit, _) = elide_around(&line, &(start..start + 3));
+        assert_eq!(hit, "HIT");
+        assert_eq!(prefix.chars().count(), ELIDE_PREFIX_MAX);
+    }
+}
+
+/// Real searches and real replaces over a real, multi-file worktree on disk - no in-memory stand-in
+/// for the walk, the reads or the writes, because the walk's own rules (`.git`, symlinks, binary
+/// files, the size cap) are exactly the part an in-memory fixture cannot exercise.
+///
+/// The corpus mirrors `Jerry.dc.html`'s own fixture (`refresh_token` across `src/auth/`,
+/// `tests/` and `migrations/`) so the shapes asserted here are the shapes the panel was designed
+/// against.
+#[cfg(test)]
+mod worktree_tests {
+    use super::*;
+
+    /// Writes a real worktree and returns its `TempDir` - the whole fixture in one place so every
+    /// test below searches the same corpus the panel's own mock does.
+    fn fixture() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("a temp worktree");
+        let root = dir.path();
+        let write = |relative: &str, content: &str| {
+            let path = root.join(relative);
+            fs::create_dir_all(path.parent().expect("a parent")).expect("mkdir");
+            fs::write(&path, content).expect("write");
+        };
+        write(
+            "src/auth/session.rs",
+            "use crate::store;\n\
+             pub fn issue(&self) -> Token {\n    let refresh_token = self.store.issue(&sid)?;\n\
+             \n    if self.refresh_token.is_expired(now) {\n        drop(refresh_token);\n    }\n}\n",
+        );
+        write(
+            "src/auth/store.rs",
+            "pub trait Store {\n    fn refresh_token(&self, sid: &SessionId) -> Option<Token>;\n}\n",
+        );
+        write("src/api/users.rs", "let t = auth.refresh_token(&sid)?;\n");
+        write(
+            "tests/auth_race.rs",
+            "let a = svc.refresh_token(sid).unwrap();\nlet b = svc.refresh_token(sid).unwrap();\n",
+        );
+        write(
+            "migrations/0031_add_refresh_lock.sql",
+            "alter table sessions\n  add column refresh_token_lock boolean not null default false;\n",
+        );
+        write("README.md", "No hits in here.\n");
+        write("Cargo.lock", "refresh_token = \"1\"\n");
+        // Real `.git` bookkeeping: the one thing the walk skips unconditionally.
+        write(".git/COMMIT_EDITMSG", "wip refresh_token\n");
+        // A dotfile that is *not* `.git` - searchable, deliberately, see `collect_files`' docs.
+        write(
+            ".github/workflows/ci.yml",
+            "run: cargo test refresh_token\n",
+        );
+        // A real binary file: a NUL byte in the sniff window.
+        fs::write(root.join("logo.bin"), [0x89, 0x50, 0x00, 0x01, 0x02]).expect("write binary");
+        dir
+    }
+
+    fn run(
+        root: &Path,
+        query: &str,
+        options: SearchOptions,
+        include: &str,
+        exclude: &str,
+    ) -> SearchOutcome {
+        let matcher = Matcher::compile(query, options)
+            .expect("compiles")
+            .expect("a non-empty query");
+        search_worktree(&SearchRequest {
+            root: root.to_path_buf(),
+            matcher,
+            filter: PathFilter::new(include, exclude),
+        })
+    }
+
+    fn relatives(outcome: &SearchOutcome) -> Vec<&str> {
+        outcome
+            .files
+            .iter()
+            .map(|file| file.relative.as_str())
+            .collect()
+    }
+
+    #[test]
+    fn a_real_search_across_a_real_worktree_finds_every_file_and_every_line() {
+        let dir = fixture();
+        let outcome = run(
+            dir.path(),
+            "refresh_token",
+            SearchOptions::default(),
+            "",
+            "",
+        );
+
+        assert_eq!(
+            relatives(&outcome),
+            vec![
+                ".github/workflows/ci.yml",
+                "Cargo.lock",
+                "migrations/0031_add_refresh_lock.sql",
+                "src/api/users.rs",
+                "src/auth/session.rs",
+                "src/auth/store.rs",
+                "tests/auth_race.rs",
+            ],
+            "sorted, stable order - a re-run after a keystroke must not shuffle rows"
+        );
+        assert_eq!(
+            outcome.total_matches, 10,
+            "every hit, counted as a hit: three on three separate lines of session.rs, one each \
+             in store.rs / users.rs / the migration / Cargo.lock / the workflow, and two in \
+             auth_race.rs"
+        );
+        assert!(!outcome.truncated);
+
+        let session = outcome
+            .files
+            .iter()
+            .find(|file| file.relative == "src/auth/session.rs")
+            .expect("session.rs");
+        assert_eq!(
+            session
+                .lines
+                .iter()
+                .map(|line| line.line_number)
+                .collect::<Vec<_>>(),
+            vec![3, 5, 6],
+            "real 1-based line numbers off the real file"
+        );
+    }
+
+    #[test]
+    fn the_git_directory_is_never_searched_but_other_dotfiles_are() {
+        let dir = fixture();
+        let outcome = run(
+            dir.path(),
+            "refresh_token",
+            SearchOptions::default(),
+            "",
+            "",
+        );
+        assert!(
+            !relatives(&outcome)
+                .iter()
+                .any(|path| path.starts_with(".git/")),
+            "`.git` is this app's own bookkeeping - a hit in it is not actionable"
+        );
+        assert!(
+            relatives(&outcome).contains(&".github/workflows/ci.yml"),
+            "a search that silently cannot find text in a dotfile is an index, not a result"
+        );
+    }
+
+    #[test]
+    fn a_binary_file_is_skipped_rather_than_decoded() {
+        let dir = fixture();
+        fs::write(
+            dir.path().join("blob.bin"),
+            [b'r', b'e', b'f', 0x00, b'r', b'e', b'f'],
+        )
+        .expect("write");
+        let outcome = run(dir.path(), "ref", SearchOptions::default(), "", "");
+        assert!(!relatives(&outcome).contains(&"blob.bin"));
+    }
+
+    #[test]
+    fn a_file_past_the_size_cap_is_skipped() {
+        let dir = fixture();
+        let huge = format!(
+            "{}\nrefresh_token\n",
+            "x".repeat(MAX_FILE_BYTES as usize + 1)
+        );
+        fs::write(dir.path().join("huge.rs"), huge).expect("write");
+        let outcome = run(
+            dir.path(),
+            "refresh_token",
+            SearchOptions::default(),
+            "",
+            "",
+        );
+        assert!(!relatives(&outcome).contains(&"huge.rs"));
+    }
+
+    #[test]
+    fn the_include_and_exclude_fields_really_narrow_a_real_walk() {
+        let dir = fixture();
+        let included = run(
+            dir.path(),
+            "refresh_token",
+            SearchOptions::default(),
+            "src/**, tests/**",
+            "",
+        );
+        assert_eq!(
+            relatives(&included),
+            vec![
+                "src/api/users.rs",
+                "src/auth/session.rs",
+                "src/auth/store.rs",
+                "tests/auth_race.rs",
+            ]
+        );
+
+        let excluded = run(
+            dir.path(),
+            "refresh_token",
+            SearchOptions::default(),
+            "",
+            "*.lock, migrations/**, .github/**",
+        );
+        assert_eq!(
+            relatives(&excluded),
+            vec![
+                "src/api/users.rs",
+                "src/auth/session.rs",
+                "src/auth/store.rs",
+                "tests/auth_race.rs",
+            ],
+            "the design's own `target/**, *.lock` shape, against a real tree"
+        );
+    }
+
+    #[test]
+    fn match_case_really_changes_a_real_result_set() {
+        let dir = fixture();
+        fs::write(dir.path().join("src/Cased.rs"), "Refresh_Token\n").expect("write");
+
+        let insensitive = run(
+            dir.path(),
+            "Refresh_Token",
+            SearchOptions::default(),
+            "src/**",
+            "",
+        );
+        assert!(insensitive.total_matches > 1);
+
+        let sensitive = run(
+            dir.path(),
+            "Refresh_Token",
+            SearchOptions {
+                match_case: true,
+                ..SearchOptions::default()
+            },
+            "src/**",
+            "",
+        );
+        assert_eq!(relatives(&sensitive), vec!["src/Cased.rs"]);
+        assert_eq!(sensitive.total_matches, 1);
+    }
+
+    #[test]
+    fn a_real_replace_all_rewrites_every_file_on_disk_and_reports_what_changed() {
+        let dir = fixture();
+        let root = dir.path();
+        let outcome = run(
+            root,
+            "refresh_token",
+            SearchOptions::default(),
+            "src/**",
+            "",
+        );
+        let files: Vec<PathBuf> = outcome.files.iter().map(|file| file.path.clone()).collect();
+        assert_eq!(files.len(), 3);
+
+        let matcher = Matcher::compile("refresh_token", SearchOptions::default())
+            .expect("compiles")
+            .expect("a query");
+        let replaced = replace_across(&files, &matcher, "rotate_token", &HashSet::new());
+
+        assert_eq!(replaced.files_changed, 3);
+        assert_eq!(replaced.matches_replaced, 5);
+        assert!(replaced.skipped_dirty.is_empty());
+        assert!(replaced.failed.is_empty());
+
+        let session = fs::read_to_string(root.join("src/auth/session.rs")).expect("read back");
+        assert!(
+            !session.contains("refresh_token"),
+            "the file on disk must really have changed: {session}"
+        );
+        assert!(session.contains("rotate_token"));
+        assert!(
+            session.contains("use crate::store;"),
+            "every untouched line must survive verbatim"
+        );
+
+        // Outside the include filter, so genuinely untouched.
+        let untouched = fs::read_to_string(root.join("tests/auth_race.rs")).expect("read back");
+        assert!(untouched.contains("refresh_token"));
+
+        // And the search really agrees afterwards.
+        let after = run(
+            root,
+            "refresh_token",
+            SearchOptions::default(),
+            "src/**",
+            "",
+        );
+        assert_eq!(after.total_matches, 0);
+    }
+
+    #[test]
+    fn a_file_open_with_unsaved_edits_is_refused_and_named_rather_than_silently_overwritten() {
+        let dir = fixture();
+        let root = dir.path();
+        let session = root.join("src/auth/session.rs");
+        let store = root.join("src/auth/store.rs");
+        let before = fs::read_to_string(&session).expect("read");
+
+        let matcher = Matcher::compile("refresh_token", SearchOptions::default())
+            .expect("compiles")
+            .expect("a query");
+        let dirty: HashSet<PathBuf> = [session.clone()].into_iter().collect();
+        let outcome = replace_across(
+            &[session.clone(), store.clone()],
+            &matcher,
+            "rotate",
+            &dirty,
+        );
+
+        assert_eq!(outcome.skipped_dirty, vec![session.clone()]);
+        assert_eq!(outcome.files_changed, 1, "the clean file is still replaced");
+        assert_eq!(
+            fs::read_to_string(&session).expect("read back"),
+            before,
+            "a file with unsaved editor changes must be byte-identical afterwards - writing it \
+             would destroy edits the editor still believes it owns"
+        );
+        assert!(fs::read_to_string(&store)
+            .expect("read back")
+            .contains("rotate"));
+    }
+
+    #[test]
+    fn replacing_one_file_leaves_every_other_matching_file_alone() {
+        let dir = fixture();
+        let root = dir.path();
+        let matcher = Matcher::compile("refresh_token", SearchOptions::default())
+            .expect("compiles")
+            .expect("a query");
+
+        let replaced =
+            replace_in_file(&root.join("src/api/users.rs"), &matcher, "rotate").expect("replaced");
+        assert_eq!(replaced.matches, 1);
+
+        assert!(fs::read_to_string(root.join("src/api/users.rs"))
+            .expect("read")
+            .contains("rotate"));
+        assert!(
+            fs::read_to_string(root.join("src/auth/store.rs"))
+                .expect("read")
+                .contains("refresh_token"),
+            "a per-file replace is per file"
+        );
+    }
+
+    #[test]
+    fn a_replace_that_re_reads_a_file_no_longer_matching_reports_zero_rather_than_writing() {
+        let dir = fixture();
+        let path = dir.path().join("src/api/users.rs");
+        let matcher = Matcher::compile("refresh_token", SearchOptions::default())
+            .expect("compiles")
+            .expect("a query");
+        // An agent rewrote the file between the search and the replace - the real race this
+        // re-read exists for.
+        fs::write(&path, "let t = auth.rotate(&sid)?;\n").expect("rewrite");
+        let replaced = replace_in_file(&path, &matcher, "x").expect("no error");
+        assert_eq!(replaced.matches, 0);
+        assert_eq!(
+            fs::read_to_string(&path).expect("read back"),
+            "let t = auth.rotate(&sid)?;\n",
+            "nothing matched, so nothing may be written"
+        );
+    }
+
+    #[test]
+    fn overlapping_candidates_are_replaced_left_to_right_without_double_counting() {
+        let dir = tempfile::tempdir().expect("temp");
+        let path = dir.path().join("a.txt");
+        fs::write(&path, "aaaa\n").expect("write");
+        let matcher = Matcher::compile("aa", SearchOptions::default())
+            .expect("compiles")
+            .expect("a query");
+        let replaced = replace_in_file(&path, &matcher, "b").expect("replaced");
+        assert_eq!(
+            replaced.matches, 2,
+            "`aaaa` holds two non-overlapping `aa`, not three overlapping ones"
+        );
+        assert_eq!(fs::read_to_string(&path).expect("read back"), "bb\n");
+    }
+
+    #[test]
+    fn the_result_cap_stops_the_search_and_says_so_rather_than_returning_a_silent_prefix() {
+        let dir = tempfile::tempdir().expect("temp");
+        let mut content = String::new();
+        for _ in 0..(MAX_MATCHES + 50) {
+            content.push_str("hit\n");
+        }
+        fs::write(dir.path().join("big.txt"), content).expect("write");
+        let outcome = run(dir.path(), "hit", SearchOptions::default(), "", "");
+        assert!(outcome.truncated);
+        assert!(outcome.total_matches >= MAX_MATCHES);
+        assert!(
+            outcome.total_matches <= MAX_MATCHES + 1,
+            "the cap must stop the scan, not merely be observed after it: {}",
+            outcome.total_matches
+        );
+    }
+
+    #[test]
+    fn a_symlink_is_never_followed_so_a_loop_cannot_make_the_walk_unbounded() {
+        let dir = fixture();
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(dir.path(), dir.path().join("loop"))
+                .expect("a real symlink back to the root");
+            let outcome = run(
+                dir.path(),
+                "refresh_token",
+                SearchOptions::default(),
+                "",
+                "",
+            );
+            assert!(
+                !relatives(&outcome)
+                    .iter()
+                    .any(|path| path.starts_with("loop/")),
+                "following this link would recurse forever"
+            );
+            assert!(!outcome.truncated);
+        }
+    }
+}

--- a/crates/app/src/search/glob.rs
+++ b/crates/app/src/search/glob.rs
@@ -1,0 +1,285 @@
+//! The pure glob matcher behind the search panel's `include` / `exclude` path filters
+//! (`design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md` §5: "a funnel for path filters",
+//! and STAGE-A-CHANGELOG.md §4v's "Include/exclude globs behind `⋯` - `src/**, tests/**` /
+//! `target/**, *.lock`").
+//!
+//! ## Why hand-rolled rather than `globset`
+//!
+//! The two fields hold a *comma-separated list* of shell-style patterns matched against one
+//! worktree-relative, `/`-separated path each. That is a genuinely small language (`**`, `*`,
+//! `?`), and this crate already declines to add a dependency for something this size - see
+//! `crate::sidebar::file_ops`'s own hand-rolled name validation, and
+//! `crate::palette::state::substring_match`. `globset` would also bring `aho-corasick` and
+//! `bstr` in for it. Being pure and dependency-free is what lets every rule below be a real unit
+//! test rather than a claim about a third party's semantics.
+//!
+//! ## The rules, exactly
+//!
+//! - A pattern is split on `/` into segments and matched segment-by-segment against the path's
+//!   own segments.
+//! - `**` matches **zero or more whole segments**, so `target/**` matches `target/debug/x.rs` and
+//!   `src/**/mod.rs` matches both `src/mod.rs` and `src/a/b/mod.rs`.
+//! - `*` matches any run of characters **within one segment** (never across a `/`), `?` matches
+//!   exactly one character within one segment.
+//! - A pattern containing **no** `/` is matched against every path's *basename*, i.e. `*.lock` is
+//!   read as `**/*.lock`. That is the rule VS Code's own search globs use, and it is what makes
+//!   the design's own `*.lock` example mean what a reader expects it to. It is also why `src` and
+//!   `src/` are genuinely different patterns: the trailing slash is what anchors it.
+//! - Everything else is anchored at the worktree root: `src/**` does not match `crates/src/x.rs`.
+//! - Matching is case-sensitive, because paths on this app's primary platform are.
+//!
+//! An empty list matches nothing ([`GlobList::is_empty`]); the *caller* is what decides that an
+//! empty `include` means "no include filter at all" rather than "exclude everything" - see
+//! [`crate::search::engine::PathFilter`].
+
+/// One parsed pattern: its segments, plus whether it was basename-only (no `/` anywhere).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Glob {
+    segments: Vec<String>,
+}
+
+impl Glob {
+    /// Parses one pattern. Returns `None` for a pattern that is empty once trimmed, so a trailing
+    /// comma or a double comma in a field is simply ignored rather than becoming a pattern that
+    /// matches everything (or nothing) by accident.
+    pub fn parse(pattern: &str) -> Option<Self> {
+        let pattern = pattern.trim();
+        if pattern.is_empty() {
+            return None;
+        }
+        // The basename rule, applied once here rather than at every match: a pattern with no `/`
+        // becomes `**/<pattern>`, which is exactly "match the basename anywhere".
+        let normalized = if pattern.contains('/') {
+            pattern.to_string()
+        } else {
+            format!("**/{pattern}")
+        };
+        let segments: Vec<String> = normalized
+            .split('/')
+            // `src//foo` and a trailing `src/` both produce empty segments that mean nothing;
+            // dropping them keeps `target/` and `target` equivalent, which is what a user typing
+            // a directory name expects.
+            .filter(|segment| !segment.is_empty())
+            .map(|segment| segment.to_string())
+            .collect();
+        if segments.is_empty() {
+            return None;
+        }
+        Some(Glob { segments })
+    }
+
+    /// Whether `path` - already worktree-relative and `/`-separated - matches this pattern.
+    pub fn matches(&self, path: &str) -> bool {
+        let path_segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+        match_segments(&self.segments, &path_segments)
+    }
+}
+
+/// `**` matches zero or more whole segments; every other segment matches exactly one.
+///
+/// Recursion is bounded by the pattern's own segment count (each non-`**` step consumes one path
+/// segment, each `**` step recurses on a strictly shorter pattern), and real patterns are a
+/// handful of segments long - see this module's own docs for why this is not `globset`.
+fn match_segments(pattern: &[String], path: &[&str]) -> bool {
+    let Some((head, rest)) = pattern.split_first() else {
+        return path.is_empty();
+    };
+    if head == "**" {
+        // Zero segments consumed, then one, then two... The zero case is what makes `src/**`
+        // match `src` itself and `**/x` match a root-level `x`.
+        return (0..=path.len()).any(|skip| match_segments(rest, &path[skip..]));
+    }
+    match path.split_first() {
+        Some((first, tail)) => wildcard_matches(head, first) && match_segments(rest, tail),
+        None => false,
+    }
+}
+
+/// `*`/`?` matching **within one segment**. Iterative with one backtrack point, the standard
+/// linear-in-practice formulation - a recursive one is exponential on patterns like `a*a*a*b`,
+/// which a user can type into a filter field by accident.
+fn wildcard_matches(pattern: &str, text: &str) -> bool {
+    let pattern: Vec<char> = pattern.chars().collect();
+    let text: Vec<char> = text.chars().collect();
+    let (mut p, mut t) = (0usize, 0usize);
+    // Where to resume from if the current `*` turns out to have consumed too little.
+    let mut star: Option<(usize, usize)> = None;
+
+    while t < text.len() {
+        if p < pattern.len() && (pattern[p] == '?' || pattern[p] == text[t]) {
+            p += 1;
+            t += 1;
+        } else if p < pattern.len() && pattern[p] == '*' {
+            star = Some((p, t));
+            p += 1;
+        } else if let Some((star_p, star_t)) = star {
+            // Let the last `*` swallow one more character and retry from just after it.
+            p = star_p + 1;
+            t = star_t + 1;
+            star = Some((star_p, star_t + 1));
+        } else {
+            return false;
+        }
+    }
+    // Trailing `*`s in the pattern are allowed to match nothing at all.
+    while p < pattern.len() && pattern[p] == '*' {
+        p += 1;
+    }
+    p == pattern.len()
+}
+
+/// One field's whole comma-separated list.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GlobList {
+    globs: Vec<Glob>,
+}
+
+impl GlobList {
+    /// Parses `src/**, tests/**` into its two real patterns. Whitespace around each entry is
+    /// trimmed and empty entries are dropped, so a field the user is halfway through typing
+    /// (`src/**,`) behaves as the one pattern it currently states rather than briefly matching
+    /// everything.
+    pub fn parse(list: &str) -> Self {
+        GlobList {
+            globs: list.split(',').filter_map(Glob::parse).collect(),
+        }
+    }
+
+    /// No real patterns at all - an empty field, or one holding only separators.
+    pub fn is_empty(&self) -> bool {
+        self.globs.is_empty()
+    }
+
+    /// How many real patterns this list holds.
+    pub fn len(&self) -> usize {
+        self.globs.len()
+    }
+
+    /// Whether **any** pattern matches - a list is a union, which is what a comma reads as.
+    pub fn matches(&self, path: &str) -> bool {
+        self.globs.iter().any(|glob| glob.matches(path))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn matches(pattern: &str, path: &str) -> bool {
+        Glob::parse(pattern)
+            .unwrap_or_else(|| panic!("`{pattern}` must parse"))
+            .matches(path)
+    }
+
+    #[test]
+    fn a_double_star_matches_any_number_of_segments_including_none() {
+        assert!(matches("target/**", "target/debug/build/x.rs"));
+        assert!(matches("target/**", "target/x.rs"));
+        assert!(
+            matches("target/**", "target"),
+            "zero segments is a real case: `target/**` naming the directory itself must not be a \
+             surprise miss"
+        );
+        assert!(!matches("target/**", "src/target/x.rs"));
+    }
+
+    #[test]
+    fn a_double_star_in_the_middle_spans_any_depth() {
+        assert!(matches("src/**/mod.rs", "src/mod.rs"));
+        assert!(matches("src/**/mod.rs", "src/a/mod.rs"));
+        assert!(matches("src/**/mod.rs", "src/a/b/c/mod.rs"));
+        assert!(!matches("src/**/mod.rs", "src/a/lib.rs"));
+    }
+
+    #[test]
+    fn a_single_star_never_crosses_a_slash() {
+        assert!(matches("src/*.rs", "src/lib.rs"));
+        assert!(
+            !matches("src/*.rs", "src/auth/session.rs"),
+            "`*` is a within-segment wildcard - crossing a `/` is what `**` is for"
+        );
+    }
+
+    #[test]
+    fn a_pattern_with_no_slash_matches_the_basename_at_any_depth() {
+        // The design's own `*.lock` example. Read literally (anchored at the root) it would match
+        // only a root-level lock file, which is not what anyone typing it means.
+        assert!(matches("*.lock", "Cargo.lock"));
+        assert!(matches("*.lock", "crates/app/Cargo.lock"));
+        assert!(!matches("*.lock", "crates/app/Cargo.toml"));
+    }
+
+    #[test]
+    fn a_pattern_with_a_slash_is_anchored_at_the_worktree_root() {
+        assert!(matches("src/**", "src/auth/session.rs"));
+        assert!(
+            !matches("src/**", "crates/src/auth/session.rs"),
+            "an anchored pattern must not drift into a nested directory of the same name"
+        );
+    }
+
+    #[test]
+    fn a_question_mark_matches_exactly_one_character() {
+        assert!(matches("src/?.rs", "src/a.rs"));
+        assert!(!matches("src/?.rs", "src/ab.rs"));
+        assert!(!matches("src/?.rs", "src/.rs"));
+    }
+
+    #[test]
+    fn a_pathological_star_pattern_still_terminates_and_answers_correctly() {
+        // The exponential case a naive recursive matcher blows up on - a user can type this.
+        assert!(matches("a*a*a*a*a*b", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaab"));
+        assert!(!matches("a*a*a*a*a*b", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaac"));
+    }
+
+    #[test]
+    fn a_trailing_slash_is_what_anchors_a_directory_name_the_bare_name_does_not() {
+        // These are deliberately *different*, and the difference is the basename rule doing its
+        // job: `src/` contains a `/`, so it is a real, root-anchored path; a bare `src` is a
+        // basename pattern that matches a `src` entry at any depth. Asserted rather than left
+        // implicit because reading the two side by side, "the same thing" is the intuitive - and
+        // wrong - answer.
+        assert!(Glob::parse("src/").expect("parses").matches("src"));
+        assert!(!Glob::parse("src/").expect("parses").matches("crates/src"));
+        assert!(Glob::parse("src").expect("parses").matches("crates/src"));
+    }
+
+    #[test]
+    fn a_repeated_or_trailing_separator_inside_a_pattern_is_not_a_segment() {
+        assert!(Glob::parse("src//auth/**")
+            .expect("parses")
+            .matches("src/auth/session.rs"));
+    }
+
+    #[test]
+    fn an_empty_or_separator_only_pattern_is_not_a_pattern() {
+        assert_eq!(Glob::parse(""), None);
+        assert_eq!(Glob::parse("   "), None);
+        assert_eq!(Glob::parse("/"), None);
+    }
+
+    #[test]
+    fn a_list_is_a_union_of_its_entries_and_ignores_stray_separators() {
+        let list = GlobList::parse("src/**, tests/** ,");
+        assert_eq!(list.len(), 2, "the trailing comma is not a third pattern");
+        assert!(list.matches("src/auth/session.rs"));
+        assert!(list.matches("tests/auth_race.rs"));
+        assert!(!list.matches("migrations/0031.sql"));
+    }
+
+    #[test]
+    fn an_empty_list_matches_nothing_and_says_so() {
+        let list = GlobList::parse("   ");
+        assert!(list.is_empty());
+        assert!(
+            !list.matches("anything.rs"),
+            "an empty list is empty; turning it into \"match everything\" is the caller's \
+             decision, not this type's - see `PathFilter`"
+        );
+    }
+
+    #[test]
+    fn matching_is_case_sensitive_like_the_paths_it_matches() {
+        assert!(!matches("src/**", "SRC/lib.rs"));
+    }
+}

--- a/crates/app/src/search/in_file.rs
+++ b/crates/app/src/search/in_file.rs
@@ -1,0 +1,381 @@
+//! In-file find (`mod+F`) - the find bar inside the focused file view, and its pure model.
+//!
+//! GitHub issue #162's original ask, kept below the rev-6 re-scope: "`mod+F` opens a find bar in
+//! the focused file view with match count and next/prev, following the panel's modifier-button and
+//! three-state conventions. (No mock exists for this; match the panel's vocabulary rather than
+//! inventing a new one.)"
+//!
+//! So this deliberately reuses, rather than parallels, the panel:
+//!
+//! - the same [`crate::search::engine::Matcher`], so `Aa` / `ab` / `.*` mean here exactly what
+//!   they mean there, overlapping matches included,
+//! - the same [`crate::search::state::SearchModifier`] buttons and the same 17x17 boxes,
+//!   drawn by the same helper,
+//! - the same `crate::text_history::TextField` with a real caret,
+//! - and the same **three-state gate**: an empty field is *not searched yet*, which is not the
+//!   same fact as *searched, found nothing* (`REVISION-2026-08-14.md` §7 rule 6).
+//!
+//! What it deliberately does **not** share is the subject: the panel searches the worktree on
+//! disk, and this searches the **buffer** - `crate::code_surface::edit_buffer::EditBuffer`'s live
+//! content, unsaved edits included. Finding the file's saved bytes while the user is looking at
+//! their own unsaved edits would be answering a question about a file that is not on screen.
+
+use std::ops::Range;
+
+use crate::root::plural;
+use crate::search::engine::Matcher;
+
+/// One hit in the open buffer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FindHit {
+    /// 1-based, matching `crate::root::AdeApp::code_cursor`'s own convention.
+    pub line_number: usize,
+    /// The byte range within that line.
+    pub range: Range<usize>,
+}
+
+/// Every hit in `content`, in document order.
+///
+/// One row per **match**, not per line, exactly as the panel's tree is - so `3 of 12` counts the
+/// same things the panel's `12 results` would.
+pub fn find_all(content: &str, matcher: &Matcher) -> Vec<FindHit> {
+    content
+        .lines()
+        .enumerate()
+        .flat_map(|(index, line)| {
+            matcher
+                .find_in_line(line)
+                .into_iter()
+                .map(move |range| FindHit {
+                    line_number: index + 1,
+                    range,
+                })
+        })
+        .collect()
+}
+
+/// The find bar's whole state.
+pub struct FindBar {
+    pub query: crate::text_history::TextField,
+    pub options: crate::search::engine::SearchOptions,
+    /// Every hit against the buffer as it was when the query, the options or the content last
+    /// changed.
+    pub hits: Vec<FindHit>,
+    /// Which hit is current, as an index into [`Self::hits`]. Meaningless - and never read - when
+    /// `hits` is empty.
+    pub current: usize,
+    /// The query could not be compiled, with `regex`'s own message.
+    pub error: Option<String>,
+    /// A clone of `crate::root::AdeApp::find_bar_focus_handle` - the app's own permanent handle,
+    /// not one minted per opening.
+    ///
+    /// That distinction is load-bearing: the bar is created and dropped every time `mod+F` is
+    /// pressed, and a fresh handle each time would have to be re-wired into
+    /// `crate::root::caret_blink`'s shared loop on every opening, growing
+    /// `AdeApp::caret_blink_handles` without bound and giving five chances to forget the wiring
+    /// instead of one. One permanent handle wired once at start-up, exactly like every other
+    /// field in this app, has neither problem.
+    pub focus_handle: gpui::FocusHandle,
+}
+
+impl FindBar {
+    pub fn new(focus_handle: gpui::FocusHandle) -> Self {
+        FindBar {
+            query: crate::text_history::TextField::new(),
+            options: crate::search::engine::SearchOptions::default(),
+            hits: Vec::new(),
+            current: 0,
+            error: None,
+            focus_handle,
+        }
+    }
+
+    /// A genuinely empty field is the not-searched-yet state. Whitespace is a real query, exactly
+    /// as it is in the panel (see `Matcher::compile`'s own docs).
+    pub fn has_query(&self) -> bool {
+        !self.query.is_empty()
+    }
+
+    /// Recomputes [`Self::hits`] against `content`, keeping the caret on the nearest hit at or
+    /// after where it already was rather than snapping back to the top.
+    ///
+    /// Keeping position matters more here than it would in the panel: the user is looking at the
+    /// file while they type, and a find that jumps to hit 1 on every keystroke drags the viewport
+    /// away from what they were reading.
+    pub fn recompute(&mut self, content: &str) {
+        let previous_line = self.current_hit().map(|hit| hit.line_number);
+        match Matcher::compile(self.query.as_str(), self.options) {
+            Ok(Some(matcher)) => {
+                self.error = None;
+                self.hits = find_all(content, &matcher);
+            }
+            Ok(None) => {
+                self.error = None;
+                self.hits.clear();
+            }
+            Err(error) => {
+                self.error = Some(error.0);
+                self.hits.clear();
+            }
+        }
+        self.current = match previous_line {
+            Some(line) => self
+                .hits
+                .iter()
+                .position(|hit| hit.line_number >= line)
+                .unwrap_or(0),
+            None => 0,
+        };
+    }
+
+    /// The hit the viewport should be showing, if there is one.
+    pub fn current_hit(&self) -> Option<&FindHit> {
+        self.hits.get(self.current)
+    }
+
+    /// Steps to the next hit, wrapping - which is what every editor's find does, and what makes
+    /// the count row's `N of M` honest about there being a cycle rather than an end.
+    ///
+    /// `step_next` rather than `next`: a bare `next(&mut self) -> Option<&T>` on a non-iterator is
+    /// the exact shape `clippy::should_implement_trait` flags, and it would be read as an
+    /// `Iterator` by anyone skimming.
+    pub fn step_next(&mut self) -> Option<&FindHit> {
+        if self.hits.is_empty() {
+            return None;
+        }
+        self.current = (self.current + 1) % self.hits.len();
+        self.current_hit()
+    }
+
+    /// The mirror of [`Self::step_next`].
+    pub fn step_previous(&mut self) -> Option<&FindHit> {
+        if self.hits.is_empty() {
+            return None;
+        }
+        self.current = if self.current == 0 {
+            self.hits.len() - 1
+        } else {
+            self.current - 1
+        };
+        self.current_hit()
+    }
+
+    /// The bar's own count readout, following the panel's three-state gate exactly:
+    /// `""` while nothing is typed, `no results` for a real search that found nothing, and
+    /// `3 of 12` once there are hits.
+    pub fn count_label(&self) -> String {
+        if !self.has_query() {
+            return String::new();
+        }
+        if self.error.is_some() {
+            return "invalid pattern".to_string();
+        }
+        if self.hits.is_empty() {
+            return "no results".to_string();
+        }
+        format!("{} of {}", self.current + 1, self.hits.len())
+    }
+
+    /// Next/prev exist only when there is something to step through -
+    /// `REVISION-2026-08-14.md` §7 rule 2, the same gate the panel's fold-all and `Replace all`
+    /// are behind.
+    pub fn has_results(&self) -> bool {
+        self.has_query() && self.error.is_none() && !self.hits.is_empty()
+    }
+
+    /// What the bar says when it has something to say beyond the count - the compile error, or
+    /// nothing at all. Deliberately *not* a "not searched yet" sentence: unlike the panel, this
+    /// bar sits directly above the file it searches, so the file itself is the empty state.
+    pub fn notice(&self) -> Option<String> {
+        self.error.clone()
+    }
+
+    /// The tooltip on next/prev, naming what stepping would land on.
+    pub fn step_tooltip(&self, forward: bool) -> String {
+        let direction = if forward { "Next" } else { "Previous" };
+        format!(
+            "{direction} of {}",
+            plural::count(self.hits.len(), "match", Some("matches"))
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::search::engine::SearchOptions;
+    use std::time::Instant;
+
+    const SAMPLE: &str = "let refresh_token = issue();\n\
+                          if refresh_token.expired() { drop(refresh_token); }\n\
+                          // nothing here\n\
+                          fn refresh_token() {}\n";
+
+    fn bar(cx: &mut gpui::App) -> FindBar {
+        FindBar::new(cx.focus_handle())
+    }
+
+    fn typed(cx: &mut gpui::App, query: &str, options: SearchOptions) -> FindBar {
+        let mut bar = bar(cx);
+        bar.options = options;
+        bar.query.set(query, Instant::now());
+        bar.recompute(SAMPLE);
+        bar
+    }
+
+    #[gpui::test]
+    fn an_empty_field_is_not_searched_yet_and_offers_nothing_to_step_through(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let bar = cx.update(bar);
+        assert_eq!(bar.count_label(), "");
+        assert!(!bar.has_results());
+        assert_eq!(bar.notice(), None);
+    }
+
+    #[gpui::test]
+    fn a_real_query_finds_every_hit_including_two_on_one_line(cx: &mut gpui::TestAppContext) {
+        let bar = cx.update(|cx| typed(cx, "refresh_token", SearchOptions::default()));
+        assert_eq!(
+            bar.hits
+                .iter()
+                .map(|hit| hit.line_number)
+                .collect::<Vec<_>>(),
+            vec![1, 2, 2, 4],
+            "line 2 holds two hits, and they are two results - the same rule the panel's tree \
+             follows"
+        );
+        assert_eq!(bar.count_label(), "1 of 4");
+    }
+
+    #[gpui::test]
+    fn a_real_query_with_no_hits_says_no_results_rather_than_nothing(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let bar = cx.update(|cx| typed(cx, "nonexistent", SearchOptions::default()));
+        assert_eq!(bar.count_label(), "no results");
+        assert!(!bar.has_results());
+        assert_eq!(
+            bar.current_hit(),
+            None,
+            "nothing to jump to, so the viewport must not move"
+        );
+    }
+
+    #[gpui::test]
+    fn next_and_previous_walk_every_hit_and_wrap(cx: &mut gpui::TestAppContext) {
+        let mut bar = cx.update(|cx| typed(cx, "refresh_token", SearchOptions::default()));
+        let total = bar.hits.len();
+        assert_eq!(bar.count_label(), "1 of 4");
+        for step in 1..total {
+            bar.step_next();
+            assert_eq!(bar.count_label(), format!("{} of {total}", step + 1));
+        }
+        bar.step_next();
+        assert_eq!(
+            bar.count_label(),
+            "1 of 4",
+            "wrapping is what every editor's find does, and the count says there is a cycle"
+        );
+        bar.step_previous();
+        assert_eq!(bar.count_label(), "4 of 4");
+    }
+
+    #[gpui::test]
+    fn stepping_an_empty_result_set_is_a_no_op_rather_than_a_panic(cx: &mut gpui::TestAppContext) {
+        let mut bar = cx.update(|cx| typed(cx, "nonexistent", SearchOptions::default()));
+        assert_eq!(bar.step_next(), None);
+        assert_eq!(bar.step_previous(), None);
+    }
+
+    #[gpui::test]
+    fn the_modifier_buttons_mean_here_exactly_what_they_mean_in_the_panel(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let sensitive = cx.update(|cx| {
+            typed(
+                cx,
+                "REFRESH_TOKEN",
+                SearchOptions {
+                    match_case: true,
+                    ..SearchOptions::default()
+                },
+            )
+        });
+        assert_eq!(sensitive.count_label(), "no results");
+
+        let insensitive = cx.update(|cx| typed(cx, "REFRESH_TOKEN", SearchOptions::default()));
+        assert_eq!(insensitive.hits.len(), 4);
+
+        let whole_word = cx.update(|cx| {
+            typed(
+                cx,
+                "token",
+                SearchOptions {
+                    whole_word: true,
+                    ..SearchOptions::default()
+                },
+            )
+        });
+        assert_eq!(
+            whole_word.count_label(),
+            "no results",
+            "`_` is a word character, so `refresh_token` does not contain the whole word `token`"
+        );
+
+        let regex = cx.update(|cx| {
+            typed(
+                cx,
+                r"fn \w+\(",
+                SearchOptions {
+                    regex: true,
+                    ..SearchOptions::default()
+                },
+            )
+        });
+        assert_eq!(regex.count_label(), "1 of 1");
+    }
+
+    #[gpui::test]
+    fn an_invalid_regex_reports_itself_rather_than_claiming_the_file_is_empty(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let bar = cx.update(|cx| {
+            typed(
+                cx,
+                "(unclosed",
+                SearchOptions {
+                    regex: true,
+                    ..SearchOptions::default()
+                },
+            )
+        });
+        assert_eq!(bar.count_label(), "invalid pattern");
+        assert!(bar.notice().is_some());
+        assert!(!bar.has_results());
+    }
+
+    #[gpui::test]
+    fn narrowing_a_query_keeps_the_caret_near_where_it_already_was(cx: &mut gpui::TestAppContext) {
+        let mut bar = cx.update(|cx| typed(cx, "refresh_token", SearchOptions::default()));
+        bar.step_next();
+        bar.step_next();
+        bar.step_next();
+        assert_eq!(bar.current_hit().expect("a hit").line_number, 4);
+
+        // One more character typed: the hit set shrinks, and the bar must stay near line 4 rather
+        // than dragging the viewport back to the top of the file.
+        bar.query.insert_str("(", Instant::now());
+        bar.recompute(SAMPLE);
+        assert_eq!(bar.hits.len(), 1);
+        assert_eq!(bar.current_hit().expect("a hit").line_number, 4);
+    }
+
+    #[gpui::test]
+    fn the_step_tooltip_goes_through_the_pluralisation_helper(cx: &mut gpui::TestAppContext) {
+        let bar = cx.update(|cx| typed(cx, "// nothing", SearchOptions::default()));
+        assert_eq!(bar.step_tooltip(true), "Next of 1 match");
+        let many = cx.update(|cx| typed(cx, "refresh_token", SearchOptions::default()));
+        assert_eq!(many.step_tooltip(false), "Previous of 4 matches");
+    }
+}

--- a/crates/app/src/search/mod.rs
+++ b/crates/app/src/search/mod.rs
@@ -1,0 +1,23 @@
+//! The right panel's **Search** tab: everything about one feature, in one folder.
+//!
+//! `design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md` §5 ("Search is a real panel") and
+//! `STAGE-A-CHANGELOG.md` §4u/§4v/§4w re-scoped search from a flat list of filenames into the
+//! middle tab of `Files · Search · Changes`, with the verdict this whole folder exists to satisfy:
+//! **"a search result that only names a file is an index, not a result. Show the line."**
+//!
+//! Split the way every feature folder in this crate is split - pure, GPUI-free logic separate from
+//! the `gpui::Div`-building code that draws it:
+//!
+//! - [`glob`] - the pure `include`/`exclude` pattern language (`**`, `*`, `?`, comma-separated).
+//! - [`engine`] - the compiled matcher the three modifier buttons produce, the bounded worktree
+//!   walk, the two-level result tree, and the real on-disk replace.
+//! - [`state`] - the panel's own pure state: the four real inputs, which one has focus, the
+//!   modifier toggles, per-file collapse, the load state, and the three-state gate the count row
+//!   and body both read.
+//! - [`render`] - the real GPUI panel, as `impl AdeApp` methods.
+//!
+//! `render` glob-imports `crate::root` for the shared `AdeApp` imports, the same convention
+//! `crate::sidebar` established for its own submodules.
+
+pub mod engine;
+pub mod glob;

--- a/crates/app/src/search/mod.rs
+++ b/crates/app/src/search/mod.rs
@@ -21,3 +21,6 @@
 
 pub mod engine;
 pub mod glob;
+pub mod state;
+
+pub(crate) mod render;

--- a/crates/app/src/search/mod.rs
+++ b/crates/app/src/search/mod.rs
@@ -11,6 +11,8 @@
 //! - [`glob`] - the pure `include`/`exclude` pattern language (`**`, `*`, `?`, comma-separated).
 //! - [`engine`] - the compiled matcher the three modifier buttons produce, the bounded worktree
 //!   walk, the two-level result tree, and the real on-disk replace.
+//! - [`in_file`] - the `mod+F` find bar's own pure model: hits in the open buffer, the current
+//!   one, and the same three-state count the panel uses.
 //! - [`state`] - the panel's own pure state: the four real inputs, which one has focus, the
 //!   modifier toggles, per-file collapse, the load state, and the three-state gate the count row
 //!   and body both read.
@@ -21,6 +23,7 @@
 
 pub mod engine;
 pub mod glob;
+pub mod in_file;
 pub mod state;
 
 pub(crate) mod render;

--- a/crates/app/src/search/render.rs
+++ b/crates/app/src/search/render.rs
@@ -26,7 +26,7 @@ use gpui::{div, font, prelude::*, px, ClickEvent, Context, KeyDownEvent, SharedS
 
 use crate::icons::{Icon, IconRow, IconSize};
 use crate::root::widgets::{text_tooltip, SimpleInput};
-use crate::root::{plural, scrollbar, AdeApp, SearchInWorktree, TextRedo, TextUndo};
+use crate::root::{plural, scrollbar, AdeApp, FindInFile, SearchInWorktree, TextRedo, TextUndo};
 use crate::search::engine::{
     self, Matcher, PathFilter, ReplaceOutcome, SearchOutcome, SearchRequest,
 };
@@ -1700,5 +1700,622 @@ mod panel_tests {
             "a `FocusId` no rendered frame can resolve silently kills every context-scoped \
              binding until the next click"
         );
+    }
+}
+
+/// The in-file find bar (`mod+F`) - `crate::search::in_file`'s model, drawn in the file view's
+/// own column between its toolbar and its content.
+///
+/// Deliberately built from the panel's own helpers rather than a second vocabulary: the same
+/// modifier buttons, the same 17x17 icon-button box, the same leading text mark, the same
+/// `SimpleInput` row, the same three-state count. GitHub issue #162's own instruction for the
+/// unspecced half: "match the panel's vocabulary rather than inventing a new one."
+impl AdeApp {
+    /// `mod+F` - opens the bar over the focused file view and puts the caret in it, or, if it is
+    /// already open, re-focuses it (the same "press it again to get back to the field" behaviour
+    /// every editor's find has).
+    pub(crate) fn handle_find_in_file_action(
+        &mut self,
+        _: &FindInFile,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        // Only over a real editable File view. There is no honest subject otherwise: the Diff
+        // view is two files side by side, and a bar claiming to find "in this file" over it would
+        // have to pick one silently.
+        if self.active_editable_path().is_none() {
+            return;
+        }
+        if self.find_bar.is_none() {
+            self.find_bar = Some(crate::search::in_file::FindBar::new(
+                self.find_bar_focus_handle.clone(),
+            ));
+        }
+        self.refresh_find_bar();
+        let handle = self
+            .find_bar
+            .as_ref()
+            .expect("just created or already present")
+            .focus_handle
+            .clone();
+        window.focus(&handle, cx);
+        self.reset_caret_blink(cx);
+        cx.notify();
+    }
+
+    /// Closes the bar and hands focus back to the editor - the surface the user was reading, and
+    /// the only one that can accept the keystroke they press next.
+    pub(crate) fn close_find_bar(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.find_bar.take().is_some() {
+            let code = self.code_focus_handle.clone();
+            window.focus(&code, cx);
+            cx.notify();
+        }
+    }
+
+    /// Re-runs the find against the buffer's **live** content - unsaved edits included, since that
+    /// is what is on screen.
+    pub(crate) fn refresh_find_bar(&mut self) {
+        let Some(content) = self
+            .active_edit_buffer()
+            .map(|buffer| buffer.content.clone())
+        else {
+            return;
+        };
+        if let Some(bar) = self.find_bar.as_mut() {
+            bar.recompute(&content);
+        }
+    }
+
+    /// Moves the editor's caret and viewport onto the bar's current hit.
+    fn reveal_current_find_hit(&mut self, cx: &mut Context<Self>) {
+        let Some(path) = self.active_editable_path() else {
+            return;
+        };
+        let Some(line) = self
+            .find_bar
+            .as_ref()
+            .and_then(|bar| bar.current_hit())
+            .map(|hit| hit.line_number)
+        else {
+            return;
+        };
+        self.code_cursor = Some(line);
+        self.scroll_file_view_to_line(&path, line.saturating_sub(1), gpui::ScrollStrategy::Center);
+        cx.notify();
+    }
+
+    /// Steps the bar one hit forward or back and reveals it.
+    fn step_find_bar(&mut self, forward: bool, cx: &mut Context<Self>) {
+        let moved = match self.find_bar.as_mut() {
+            Some(bar) if forward => bar.step_next().is_some(),
+            Some(bar) => bar.step_previous().is_some(),
+            None => false,
+        };
+        if moved {
+            self.reveal_current_find_hit(cx);
+        }
+    }
+
+    /// The bar itself, or nothing when it is closed.
+    pub(crate) fn render_find_bar(&self, cx: &mut Context<Self>) -> Option<gpui::AnyElement> {
+        let bar = self.find_bar.as_ref()?;
+        let has_results = bar.has_results();
+        let count = bar.count_label();
+        let invalid = bar.notice().is_some();
+        Some(
+            div()
+                .id("find-bar")
+                .debug_selector(|| "find-bar".to_string())
+                .track_focus(&bar.focus_handle)
+                .key_context("text-input")
+                .on_action(cx.listener(|this, _: &TextUndo, _window, cx| {
+                    if this.find_bar.as_mut().is_some_and(|bar| bar.query.undo()) {
+                        this.refresh_find_bar();
+                        cx.notify();
+                    }
+                }))
+                .on_action(cx.listener(|this, _: &TextRedo, _window, cx| {
+                    if this.find_bar.as_mut().is_some_and(|bar| bar.query.redo()) {
+                        this.refresh_find_bar();
+                        cx.notify();
+                    }
+                }))
+                .on_key_down(cx.listener(Self::handle_find_bar_key_down))
+                .on_click(cx.listener(|this, _: &ClickEvent, window, cx| {
+                    let Some(handle) = this.find_bar.as_ref().map(|bar| bar.focus_handle.clone())
+                    else {
+                        return;
+                    };
+                    window.focus(&handle, cx);
+                    this.reset_caret_blink(cx);
+                }))
+                .flex_none()
+                .flex()
+                .items_center()
+                .gap(px(7.0))
+                .h(theme::band::FILTER_ROW)
+                .pl(px(12.0))
+                .pr(px(8.0))
+                .bg(theme::surface::HEADER)
+                .border_b_1()
+                .border_color(theme::border::ROW)
+                .child(render_search_row_mark("/", self.ui_text_size(10.0)))
+                .child(self.render_simple_input_row(SimpleInput {
+                    caret_selector: "find-bar-caret".into(),
+                    text_selector: "find-bar-text".into(),
+                    focus_handle: Some(&bar.focus_handle),
+                    text: bar.query.as_str(),
+                    caret_offset: bar.query.caret(),
+                    placeholder: "find in this file",
+                    font: theme::font::MONO,
+                    text_size: self.ui_text_size(11.0),
+                    text_color: theme::text::SELECTED,
+                    placeholder_color: theme::text::GHOST,
+                }))
+                .child(
+                    div()
+                        .id("find-bar-count")
+                        .debug_selector(|| "find-bar-count".to_string())
+                        .flex_none()
+                        .whitespace_nowrap()
+                        .font(font(theme::font::MONO))
+                        .text_size(self.ui_text_size(9.5))
+                        .text_color(if invalid {
+                            theme::status::FAIL
+                        } else {
+                            theme::text::FAINTER
+                        })
+                        .child(count),
+                )
+                .children(
+                    SearchModifier::ALL
+                        .into_iter()
+                        .map(|modifier| self.render_find_bar_modifier(modifier, cx)),
+                )
+                // Rule 2 once more: with nothing to step through, next/prev do not exist.
+                .children(
+                    has_results
+                        .then(|| self.render_find_bar_step(false, bar.step_tooltip(false), cx)),
+                )
+                .children(
+                    has_results
+                        .then(|| self.render_find_bar_step(true, bar.step_tooltip(true), cx)),
+                )
+                .child(
+                    div()
+                        .id("find-bar-close")
+                        .debug_selector(|| "find-bar-close".to_string())
+                        .flex_none()
+                        .w(theme::band::SEARCH_ICON_BUTTON)
+                        .h(theme::band::SEARCH_ICON_BUTTON)
+                        .rounded(theme::radius::CHIP)
+                        .flex()
+                        .items_center()
+                        .justify_center()
+                        .cursor_pointer()
+                        .hover(|el| el.bg(theme::surface::ROW_HOVER_ALT))
+                        .tooltip(text_tooltip("Close find (Esc)"))
+                        .child(
+                            div()
+                                .font(font(theme::font::MONO))
+                                .text_size(self.ui_text_size(11.0))
+                                .text_color(theme::text::FAINTER)
+                                .child("\u{d7}"),
+                        )
+                        .on_click(cx.listener(|this, _: &ClickEvent, window, cx| {
+                            this.close_find_bar(window, cx);
+                        })),
+                )
+                .into_any_element(),
+        )
+    }
+
+    /// One `Aa` / `ab` / `.*` button on the find bar - the panel's own button, pointed at the
+    /// bar's own options.
+    fn render_find_bar_modifier(
+        &self,
+        modifier: SearchModifier,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let on = self
+            .find_bar
+            .as_ref()
+            .is_some_and(|bar| modifier.is_on(bar.options));
+        let key = match modifier {
+            SearchModifier::MatchCase => "case",
+            SearchModifier::WholeWord => "word",
+            SearchModifier::Regex => "regex",
+        };
+        div()
+            .id(SharedString::from(format!("find-bar-modifier-{key}")))
+            .debug_selector(move || format!("find-bar-modifier-{key}"))
+            .flex_none()
+            .w(theme::band::SEARCH_ICON_BUTTON)
+            .h(theme::band::SEARCH_ICON_BUTTON)
+            .rounded(theme::radius::CHIP)
+            .flex()
+            .items_center()
+            .justify_center()
+            .cursor_pointer()
+            .when(on, |el| el.bg(theme::search::MODIFIER_ON_BG))
+            .when(!on, |el| {
+                el.hover(|el| el.bg(theme::surface::SEGMENT_ACTIVE))
+            })
+            .tooltip(text_tooltip(modifier.tooltip()))
+            .child(
+                div()
+                    .font(font(theme::font::MONO))
+                    .font_weight(gpui::FontWeight::MEDIUM)
+                    .text_size(self.ui_text_size(8.5))
+                    .text_color(if on {
+                        theme::search::MODIFIER_ON_FG
+                    } else {
+                        theme::text::FAINTER
+                    })
+                    .when(modifier == SearchModifier::WholeWord, |el| el.underline())
+                    .child(modifier.label()),
+            )
+            .on_click(cx.listener(move |this, _: &ClickEvent, _window, cx| {
+                if let Some(bar) = this.find_bar.as_mut() {
+                    modifier.toggle(&mut bar.options);
+                }
+                this.refresh_find_bar();
+                cx.notify();
+            }))
+    }
+
+    /// One next/prev button.
+    fn render_find_bar_step(
+        &self,
+        forward: bool,
+        tooltip: String,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let id = if forward {
+            "find-bar-next"
+        } else {
+            "find-bar-prev"
+        };
+        div()
+            .id(id)
+            .debug_selector(move || id.to_string())
+            .flex_none()
+            .w(theme::band::SEARCH_ICON_BUTTON)
+            .h(theme::band::SEARCH_ICON_BUTTON)
+            .rounded(theme::radius::CHIP)
+            .flex()
+            .items_center()
+            .justify_center()
+            .cursor_pointer()
+            .hover(|el| el.bg(theme::surface::ROW_HOVER_ALT))
+            .tooltip(text_tooltip(tooltip))
+            // The file tree's own caret glyphs, rotated in meaning rather than in geometry:
+            // `▾`/`▴` is down/up through a list of lines, which is exactly what stepping is.
+            // Reusing the tree's family keeps this from being a fourth arrow vocabulary in a
+            // window that already has three.
+            .child(
+                div()
+                    .font(font(theme::font::MONO))
+                    .text_size(self.ui_text_size(11.0))
+                    .text_color(theme::text::FAINTER)
+                    .child(if forward { "\u{25be}" } else { "\u{25b4}" }),
+            )
+            .on_click(cx.listener(move |this, _: &ClickEvent, _window, cx| {
+                this.step_find_bar(forward, cx);
+            }))
+    }
+
+    /// One keystroke into the find bar.
+    fn handle_find_bar_key_down(
+        &mut self,
+        event: &KeyDownEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let keystroke = &event.keystroke;
+        if keystroke.modifiers.platform || keystroke.modifiers.control || keystroke.modifiers.alt {
+            return;
+        }
+        match keystroke.key.as_str() {
+            // Esc closes rather than clearing: the bar is a transient surface over a file, and
+            // the field's own contents are what the user would want back if they reopen it.
+            "escape" => {
+                self.close_find_bar(window, cx);
+                cx.stop_propagation();
+                return;
+            }
+            // Enter / Shift+Enter step, the way every editor's find does.
+            "enter" => {
+                self.step_find_bar(!keystroke.modifiers.shift, cx);
+                cx.stop_propagation();
+                return;
+            }
+            _ => {}
+        }
+        self.reset_caret_blink(cx);
+        let changed = self.find_bar.as_mut().is_some_and(|bar| {
+            bar.query.handle_editing_key(
+                keystroke.key.as_str(),
+                keystroke.key_char.as_deref(),
+                Instant::now(),
+            )
+        });
+        if changed {
+            self.refresh_find_bar();
+            self.reveal_current_find_hit(cx);
+            cx.notify();
+            cx.stop_propagation();
+        }
+    }
+}
+
+/// The in-file find bar driven the way a user drives it: `mod+F` over a real open file, real
+/// keystrokes, real next/prev, and the real editor caret really moving.
+#[cfg(test)]
+mod find_bar_tests {
+    use super::*;
+    use crate::root::focus::palette_focus_tests;
+    use gpui::TestAppContext;
+    use tempfile::TempDir;
+
+    const SAMPLE: &str = "let refresh_token = issue();\n\
+                          if refresh_token.expired() { drop(refresh_token); }\n\
+                          // nothing here\n\
+                          fn refresh_token() {}\n";
+
+    fn repo_with_open_file(
+        cx: &mut TestAppContext,
+    ) -> (TempDir, gpui::Entity<AdeApp>, &mut gpui::VisualTestContext) {
+        let repo = TempDir::new().expect("tempdir");
+        let file = repo.path().join("session.rs");
+        std::fs::write(&file, SAMPLE).expect("write");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        app.update_in(cx, |app, window, cx| {
+            app.open_file_view(file.clone(), window, cx);
+        });
+        cx.run_until_parked();
+        (repo, app, cx)
+    }
+
+    fn click(cx: &mut gpui::VisualTestContext, selector: &'static str) {
+        let bounds = cx
+            .debug_bounds(selector)
+            .unwrap_or_else(|| panic!("`{selector}` must really paint"));
+        cx.simulate_click(bounds.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+    }
+
+    #[gpui::test]
+    fn mod_f_opens_a_real_find_bar_over_the_open_file_and_focuses_it(cx: &mut TestAppContext) {
+        let (_repo, app, cx) = repo_with_open_file(cx);
+        assert!(
+            cx.debug_bounds("find-bar").is_none(),
+            "premise: the bar is closed until it is asked for"
+        );
+
+        cx.dispatch_action(FindInFile);
+        cx.run_until_parked();
+
+        assert!(
+            cx.debug_bounds("find-bar").is_some(),
+            "the bar must really paint, not merely exist in state"
+        );
+        let (focused, handle) = app.update_in(cx, |app, window, cx| {
+            (window.focused(cx), app.find_bar_focus_handle.clone())
+        });
+        assert_eq!(focused.as_ref(), Some(&handle));
+    }
+
+    #[gpui::test]
+    fn typing_really_finds_and_the_count_follows_the_panels_three_state_gate(
+        cx: &mut TestAppContext,
+    ) {
+        let (_repo, app, cx) = repo_with_open_file(cx);
+        cx.dispatch_action(FindInFile);
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            let bar = app.find_bar.as_ref().expect("open");
+            assert_eq!(
+                bar.count_label(),
+                "",
+                "an empty field is not searched yet, which is not `no results`"
+            );
+        });
+        assert!(
+            cx.debug_bounds("find-bar-next").is_none(),
+            "a control that acts on results does not exist when there are none"
+        );
+
+        cx.simulate_input("refresh_token");
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| {
+            let bar = app.find_bar.as_ref().expect("open");
+            assert_eq!(bar.count_label(), "1 of 4");
+        });
+        assert!(cx.debug_bounds("find-bar-next").is_some());
+        assert!(cx.debug_bounds("find-bar-prev").is_some());
+
+        // A real query with no hits is its own, differently-worded state.
+        cx.simulate_input("_nonexistent");
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.find_bar.as_ref().expect("open").count_label(),
+                "no results"
+            );
+        });
+        assert!(cx.debug_bounds("find-bar-next").is_none());
+    }
+
+    #[gpui::test]
+    fn next_and_previous_really_move_the_editor_caret_and_wrap(cx: &mut TestAppContext) {
+        let (_repo, app, cx) = repo_with_open_file(cx);
+        cx.dispatch_action(FindInFile);
+        cx.run_until_parked();
+        cx.simulate_input("refresh_token");
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.code_cursor,
+                Some(1),
+                "typing lands on the first hit, on line 1"
+            );
+        });
+
+        click(cx, "find-bar-next");
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.find_bar.as_ref().expect("open").count_label(), "2 of 4");
+            assert_eq!(app.code_cursor, Some(2));
+        });
+
+        // Enter steps too, the way every editor's find does.
+        cx.simulate_keystrokes("enter");
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.find_bar.as_ref().expect("open").count_label(), "3 of 4");
+        });
+
+        click(cx, "find-bar-next");
+        click(cx, "find-bar-next");
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.find_bar.as_ref().expect("open").count_label(),
+                "1 of 4",
+                "stepping past the last hit wraps"
+            );
+            assert_eq!(app.code_cursor, Some(1));
+        });
+
+        click(cx, "find-bar-prev");
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.find_bar.as_ref().expect("open").count_label(), "4 of 4");
+            assert_eq!(app.code_cursor, Some(4));
+        });
+    }
+
+    #[gpui::test]
+    fn the_match_case_button_really_changes_the_find(cx: &mut TestAppContext) {
+        let (_repo, app, cx) = repo_with_open_file(cx);
+        cx.dispatch_action(FindInFile);
+        cx.run_until_parked();
+        cx.simulate_input("REFRESH_TOKEN");
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.find_bar.as_ref().expect("open").count_label(), "1 of 4")
+        });
+
+        click(cx, "find-bar-modifier-case");
+        app.read_with(cx, |app, _| {
+            let bar = app.find_bar.as_ref().expect("open");
+            assert!(bar.options.match_case);
+            assert_eq!(
+                bar.count_label(),
+                "no results",
+                "`Aa` means here exactly what it means in the panel"
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn the_find_bar_searches_the_buffer_not_the_bytes_on_disk(cx: &mut TestAppContext) {
+        let (repo, app, cx) = repo_with_open_file(cx);
+        let file = repo.path().join("session.rs");
+
+        // A real unsaved edit, exactly as typing into the File view produces. `edit_buffers` is
+        // keyed by the **worktree-relative** path (`AdeApp::edit_buffer_key`), which is also what
+        // `active_editable_path` hands back.
+        app.update(cx, |app, _cx| {
+            let relative = app
+                .active_editable_path()
+                .expect("the File view really has an editable path");
+            let buffer = app
+                .edit_buffer_mut(&relative)
+                .expect("the open file has a buffer");
+            buffer.content.push_str("let unsaved_marker = 1;\n");
+        });
+
+        cx.dispatch_action(FindInFile);
+        cx.run_until_parked();
+        cx.simulate_input("unsaved_marker");
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.find_bar.as_ref().expect("open").count_label(),
+                "1 of 1",
+                "finding the saved bytes while the user looks at their own unsaved edits would \
+                 answer a question about a file that is not on screen"
+            );
+        });
+        assert!(
+            !std::fs::read_to_string(&file)
+                .expect("read")
+                .contains("unsaved_marker"),
+            "premise: that text really is only in the buffer"
+        );
+    }
+
+    #[gpui::test]
+    fn escape_closes_the_bar_and_hands_focus_back_to_the_editor(cx: &mut TestAppContext) {
+        let (_repo, app, cx) = repo_with_open_file(cx);
+        cx.dispatch_action(FindInFile);
+        cx.run_until_parked();
+        cx.simulate_input("refresh");
+        cx.run_until_parked();
+
+        cx.simulate_keystrokes("escape");
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| assert!(app.find_bar.is_none()));
+        assert!(cx.debug_bounds("find-bar").is_none());
+        let (focused, code_handle, bar_handle) = app.update_in(cx, |app, window, cx| {
+            (
+                window.focused(cx),
+                app.code_focus_handle.clone(),
+                app.find_bar_focus_handle.clone(),
+            )
+        });
+        assert_ne!(
+            focused.as_ref(),
+            Some(&bar_handle),
+            "focus left on an unrendered node silently kills every context-scoped binding"
+        );
+        assert_eq!(focused.as_ref(), Some(&code_handle));
+    }
+
+    #[gpui::test]
+    fn the_close_button_does_what_escape_does(cx: &mut TestAppContext) {
+        let (_repo, app, cx) = repo_with_open_file(cx);
+        cx.dispatch_action(FindInFile);
+        cx.run_until_parked();
+        click(cx, "find-bar-close");
+        app.read_with(cx, |app, _| assert!(app.find_bar.is_none()));
+    }
+
+    #[gpui::test]
+    fn the_bar_has_a_real_caret_that_can_be_moved_back_into_the_query(cx: &mut TestAppContext) {
+        let (_repo, app, cx) = repo_with_open_file(cx);
+        cx.dispatch_action(FindInFile);
+        cx.run_until_parked();
+        cx.simulate_input("refresh_token");
+        cx.run_until_parked();
+        assert!(
+            cx.debug_bounds("find-bar-caret").is_some(),
+            "a focused field paints a real caret"
+        );
+
+        cx.simulate_keystrokes("left left left left left left");
+        cx.run_until_parked();
+        cx.simulate_input("ed");
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.find_bar.as_ref().expect("open").query.as_str(),
+                "refreshed_token"
+            );
+        });
     }
 }

--- a/crates/app/src/search/render.rs
+++ b/crates/app/src/search/render.rs
@@ -1,0 +1,1178 @@
+//! The real GPUI Search panel - the middle tab of `Files · Search · Changes`, as `impl AdeApp`
+//! methods.
+//!
+//! Built from top to bottom exactly as `Jerry.dc.html`'s own `showFind` block is:
+//!
+//! - the **query row** (30 high): leading `⌕`, the real query input, then the `Aa` / `ab` / `.*`
+//!   modifier buttons,
+//! - the **replace row** (28) behind `⇄`, with `Replace all` when there is something to replace,
+//! - the two **glob rows** (25 each) behind the funnel: `include` and `exclude`,
+//! - the **count row** (24): the count, then `⇄`, the funnel, a divider, and fold-all,
+//! - the **body**: the two-level match tree, or one of the message states.
+//!
+//! Every one of those four fields is a real, editable `crate::text_history::TextField` with its
+//! own focus handle and its own caret - `REVISION-2026-08-14.md` §5: "A fake field directly below
+//! a real one is a dead end the user will click."
+//!
+//! The state machine behind all of it is `crate::search::state::SearchPanel`, and the searching
+//! and replacing themselves are `crate::search::engine`'s. This module only draws, routes
+//! keystrokes, and owns the two background tasks.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use gpui::{div, font, prelude::*, px, ClickEvent, Context, KeyDownEvent, SharedString, Window};
+
+use crate::icons::{Icon, IconRow, IconSize};
+use crate::root::widgets::{text_tooltip, SimpleInput};
+use crate::root::{plural, scrollbar, AdeApp, SearchInWorktree, TextRedo, TextUndo};
+use crate::search::engine::{
+    self, Matcher, PathFilter, ReplaceOutcome, SearchOutcome, SearchRequest,
+};
+use crate::search::state::{BodyState, CompletedSearch, SearchField, SearchModifier};
+use crate::sidebar::file_tree::lang_chip_for_name;
+use crate::sidebar::render::RightSidebarView;
+use crate::theme;
+
+/// How long the panel waits after the last keystroke before it really walks the worktree.
+///
+/// A search is real filesystem work over a whole checkout, so running one per keystroke would
+/// start (and then have to discard) a walk for every prefix of what the user is typing. Sits at
+/// the same value as `crate::code_surface::editing::REHIGHLIGHT_DEBOUNCE`, and for the same
+/// reason: it must fire *within* a typing burst, not survive one.
+pub const SEARCH_DEBOUNCE: Duration = Duration::from_millis(150);
+
+impl AdeApp {
+    /// The whole Search tab, under the panel header the `Files · Search · Changes` toggle draws.
+    pub(crate) fn render_search_panel(&self, cx: &mut Context<Self>) -> gpui::AnyElement {
+        let state = self.search.body_state();
+        let branch = self.search_branch_label();
+        div()
+            .flex()
+            .flex_col()
+            .flex_1()
+            .min_h_0()
+            .child(self.render_search_query_block(&state, cx))
+            .child(self.render_search_count_row(&state, cx))
+            .children(self.render_search_notice())
+            .child(self.render_search_body(&state, &branch, cx))
+            .into_any_element()
+    }
+
+    /// The worktree this search is scoped to, named the way the design's two body sentences name
+    /// it (`Search the files in <branch>.`).
+    ///
+    /// `STAGE-A-CHANGELOG.md` §4u: search is "scoped to the active worktree like the tree beside
+    /// it - a hit in another checkout is not something you can act on from here without switching
+    /// first". So this is the same root `crate::sidebar::render::AdeApp::render_file_tree` walks,
+    /// `AdeApp::file_tree_root`, and the branch label is that worktree's own. A detached or
+    /// unnamed checkout falls back to the directory name rather than printing nothing, since the
+    /// sentence has to name *something* the user can recognise.
+    fn search_branch_label(&self) -> String {
+        let root = &self.file_tree_root;
+        self.worktrees
+            .iter()
+            .find(|item| item.path == *root)
+            .and_then(|item| item.branch.clone())
+            .or_else(|| {
+                root.file_name()
+                    .map(|name| name.to_string_lossy().into_owned())
+            })
+            .unwrap_or_else(|| root.display().to_string())
+    }
+
+    /// The query row plus whichever of the replace/include/exclude rows are revealed - one block
+    /// with one bottom rule, as the mock draws it.
+    fn render_search_query_block(
+        &self,
+        state: &BodyState,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let icons = IconRow::new(&self.settings.icon_pack, IconSize::Control);
+        div()
+            .flex_none()
+            .flex()
+            .flex_col()
+            .border_b_1()
+            .border_color(theme::border::ROW)
+            .child(
+                self.search_input_row(SearchField::Query, cx)
+                    .h(theme::band::FILTER_ROW)
+                    .child(
+                        // The leading mark. A real magnifying glass rather than the mock's
+                        // hand-drawn `/`: this row is what the panel's own tab icon points at, and
+                        // `REVISION-2026-08-14.md` §8 moved every glyph in this window to Phosphor.
+                        icons
+                            .draw(Icon::MagnifyingGlass, theme::text::DISABLED)
+                            .flex_none(),
+                    )
+                    .child(self.render_search_field(SearchField::Query, "search this worktree"))
+                    .children(
+                        SearchModifier::ALL
+                            .into_iter()
+                            .map(|modifier| self.render_search_modifier(modifier, cx)),
+                    ),
+            )
+            .when(self.search.replace_open, |el| {
+                el.child(
+                    self.search_input_row(SearchField::Replace, cx)
+                        .h(theme::band::SEARCH_REPLACE_ROW)
+                        .border_t_1()
+                        .border_color(theme::border::ROW)
+                        .child(
+                            icons
+                                .draw(Icon::ArrowsLeftRight, theme::text::DISABLED)
+                                .flex_none(),
+                        )
+                        .child(
+                            self.render_search_field(SearchField::Replace, "replace with\u{2026}"),
+                        )
+                        // `REVISION-2026-08-14.md` §7 rule 2: a control that acts on results does
+                        // not exist when there are none.
+                        .children(
+                            state
+                                .has_results()
+                                .then(|| self.render_replace_all_button(cx)),
+                        ),
+                )
+            })
+            .when(self.search.globs_open, |el| {
+                el.child(self.render_search_glob_row(SearchField::Include, cx))
+                    .child(self.render_search_glob_row(SearchField::Exclude, cx))
+            })
+    }
+
+    /// One `include` / `exclude` row: a fixed-width label, then the real field.
+    fn render_search_glob_row(
+        &self,
+        field: SearchField,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let (label, placeholder) = match field {
+            SearchField::Include => ("include", "src/**, tests/**"),
+            _ => ("exclude", "target/**, *.lock"),
+        };
+        self.search_input_row(field, cx)
+            .h(theme::band::SEARCH_GLOB_ROW)
+            .border_t_1()
+            .border_color(theme::border::ROW)
+            .child(
+                div()
+                    .flex_none()
+                    // A fixed 44 so the two fields' left edges line up under each other - the
+                    // mock's own `width:44px`. Two intrinsically-sized labels would put `include`
+                    // and `exclude`'s inputs at different columns.
+                    .w(px(44.0))
+                    .whitespace_nowrap()
+                    .font(font(theme::font::MONO))
+                    .text_size(self.ui_text_size(9.5))
+                    .text_color(theme::text::GHOST)
+                    .child(label),
+            )
+            .child(self.render_search_field(field, placeholder))
+    }
+
+    /// The shared shell every one of the four input rows is built on: the focus handle it tracks,
+    /// the `"text-input"` context that makes Ctrl+Z mean *this* field, its key handler, and the
+    /// click that focuses it.
+    ///
+    /// One function rather than four copies specifically because the omission this codebase keeps
+    /// finding (GitHub issue #45, five times over) is a field wired into some of those four and
+    /// not the rest.
+    fn search_input_row(
+        &self,
+        field: SearchField,
+        cx: &mut Context<Self>,
+    ) -> gpui::Stateful<gpui::Div> {
+        div()
+            .id(SharedString::from(format!(
+                "search-row-{}",
+                field_key(field)
+            )))
+            .track_focus(self.search.focus_handle(field))
+            // See `crate::default_key_bindings`' `TextUndo`/`TextRedo` docs for why the tag and
+            // the listeners both live on the exact node that carries the focus.
+            .key_context("text-input")
+            .on_action(cx.listener(move |this, _: &TextUndo, _window, cx| {
+                if this.search.field_mut(field).undo() {
+                    this.on_search_input_changed(cx);
+                }
+            }))
+            .on_action(cx.listener(move |this, _: &TextRedo, _window, cx| {
+                if this.search.field_mut(field).redo() {
+                    this.on_search_input_changed(cx);
+                }
+            }))
+            .on_key_down(cx.listener(move |this, event: &KeyDownEvent, window, cx| {
+                this.handle_search_key_down(field, event, window, cx);
+            }))
+            .on_click(cx.listener(move |this, _: &ClickEvent, window, cx| {
+                this.focus_search_field(field, window, cx);
+            }))
+            .flex()
+            .flex_none()
+            .items_center()
+            .gap(px(7.0))
+            .pl(px(12.0))
+            .pr(px(8.0))
+    }
+
+    /// One field's caret+text pair, through the one helper that owns that structure.
+    fn render_search_field(&self, field: SearchField, placeholder: &str) -> impl IntoElement {
+        let key = field_key(field);
+        let (text_size, text_color) = match field {
+            SearchField::Query => (11.0, theme::text::SELECTED),
+            SearchField::Replace => (11.0, theme::text::STRONG),
+            SearchField::Include | SearchField::Exclude => (10.0, theme::text::STRONG),
+        };
+        self.render_simple_input_row(SimpleInput {
+            caret_selector: SharedString::from(format!("search-{key}-caret")),
+            text_selector: SharedString::from(format!("search-{key}-text")),
+            focus_handle: Some(self.search.focus_handle(field)),
+            text: self.search.field(field).as_str(),
+            caret_offset: self.search.field(field).caret(),
+            placeholder,
+            font: theme::font::MONO,
+            text_size: self.ui_text_size(text_size),
+            text_color,
+            // GitHub issue #162 / §4w: the mock's browser-default placeholder "was brighter than
+            // either dim-text token and absent from the palette". This is the design's own
+            // `#4e545a`, through the theme layer.
+            placeholder_color: theme::text::GHOST,
+        })
+    }
+
+    /// One 17x17 modifier button - `Aa` / `ab` / `.*`.
+    fn render_search_modifier(
+        &self,
+        modifier: SearchModifier,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let on = modifier.is_on(self.search.options);
+        let key = match modifier {
+            SearchModifier::MatchCase => "case",
+            SearchModifier::WholeWord => "word",
+            SearchModifier::Regex => "regex",
+        };
+        div()
+            .id(SharedString::from(format!("search-modifier-{key}")))
+            .debug_selector(move || format!("search-modifier-{key}"))
+            .flex_none()
+            .w(theme::band::SEARCH_ICON_BUTTON)
+            .h(theme::band::SEARCH_ICON_BUTTON)
+            .rounded(theme::radius::CHIP)
+            .flex()
+            .items_center()
+            .justify_center()
+            .cursor_pointer()
+            .when(on, |el| el.bg(theme::search::MODIFIER_ON_BG))
+            .when(!on, |el| {
+                el.hover(|el| el.bg(theme::surface::SEGMENT_ACTIVE))
+            })
+            .tooltip(text_tooltip(modifier.tooltip()))
+            .child(
+                div()
+                    .font(font(theme::font::MONO))
+                    .font_weight(gpui::FontWeight::MEDIUM)
+                    .text_size(self.ui_text_size(8.5))
+                    .text_color(if on {
+                        theme::search::MODIFIER_ON_FG
+                    } else {
+                        theme::text::FAINTER
+                    })
+                    // `ab` is underlined, the way VS Code draws whole-word
+                    // (`STAGE-A-CHANGELOG.md` §4v) - the one thing that tells it apart from two
+                    // ordinary letters.
+                    .when(modifier == SearchModifier::WholeWord, |el| el.underline())
+                    .child(modifier.label()),
+            )
+            .on_click(cx.listener(move |this, _: &ClickEvent, _window, cx| {
+                modifier.toggle(&mut this.search.options);
+                this.on_search_input_changed(cx);
+            }))
+    }
+
+    /// `Replace all`, with the tooltip the issue calls out the mock for hardcoding.
+    fn render_replace_all_button(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let tooltip = self
+            .search
+            .replace_all_tooltip()
+            .unwrap_or_else(|| "Replace all".to_string());
+        div()
+            .id("search-replace-all")
+            .debug_selector(|| "search-replace-all".to_string())
+            .flex_none()
+            .h(px(19.0))
+            .px(px(7.0))
+            .rounded(theme::radius::CHIP)
+            .flex()
+            .items_center()
+            .cursor_pointer()
+            .bg(theme::surface::ROW_SELECTED)
+            .hover(|el| el.bg(theme::surface::ROW_HOVER_ALT))
+            .tooltip(text_tooltip(tooltip))
+            .child(
+                div()
+                    .whitespace_nowrap()
+                    .font(font(theme::font::SANS))
+                    .font_weight(gpui::FontWeight::MEDIUM)
+                    .text_size(self.ui_text_size(10.0))
+                    .text_color(theme::text::DIM)
+                    .child("Replace all"),
+            )
+            .on_click(cx.listener(|this, _: &ClickEvent, _window, cx| {
+                let paths = this.search.result_paths();
+                this.replace_search_matches(paths, cx);
+            }))
+    }
+
+    /// The count row: the count, then `⇄`, the funnel, a divider, and fold-all.
+    fn render_search_count_row(
+        &self,
+        state: &BodyState,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let icons = IconRow::new(&self.settings.icon_pack, IconSize::Control);
+        let count = self.search.count_label();
+        let truncation = self.search.truncation_tooltip();
+        let all_collapsed = self.search.all_collapsed();
+        div()
+            .flex_none()
+            .flex()
+            .items_center()
+            .gap(px(8.0))
+            .h(theme::band::SEARCH_COUNT_ROW)
+            .pl(px(12.0))
+            .pr(px(10.0))
+            .border_b_1()
+            .border_color(theme::border::ROW)
+            .child(
+                div()
+                    .id("search-count")
+                    .debug_selector(|| "search-count".to_string())
+                    .flex_1()
+                    .min_w_0()
+                    .overflow_hidden()
+                    .whitespace_nowrap()
+                    .font(font(theme::font::MONO))
+                    .text_size(self.ui_text_size(9.5))
+                    .text_color(if matches!(state, BodyState::InvalidQuery(_)) {
+                        theme::status::FAIL
+                    } else {
+                        theme::text::FAINTER
+                    })
+                    .when_some(truncation, |el, tooltip| el.tooltip(text_tooltip(tooltip)))
+                    .child(count),
+            )
+            .child(self.render_search_toggle_button(
+                &icons,
+                "search-toggle-replace",
+                Icon::ArrowsLeftRight,
+                self.search.replace_open,
+                if self.search.replace_open {
+                    "Hide replace"
+                } else {
+                    "Show replace"
+                },
+                cx,
+                |this, window, cx| {
+                    this.search.replace_open = !this.search.replace_open;
+                    // Revealing a field and leaving the caret somewhere else is half an
+                    // affordance; hiding one the user is typing into would strand the focus on an
+                    // unrendered node, which is exactly the dangling-focus bug class
+                    // `crate::root::focus` exists for.
+                    if this.search.replace_open {
+                        this.focus_search_field(SearchField::Replace, window, cx);
+                    } else if this.search.focused_field == SearchField::Replace {
+                        this.focus_search_field(SearchField::Query, window, cx);
+                    }
+                    cx.notify();
+                },
+            ))
+            .child(self.render_search_toggle_button(
+                &icons,
+                "search-toggle-globs",
+                Icon::Funnel,
+                self.search.globs_open,
+                if self.search.globs_open {
+                    "Hide path filters"
+                } else {
+                    "Limit the search to paths"
+                },
+                cx,
+                |this, window, cx| {
+                    this.search.globs_open = !this.search.globs_open;
+                    if this.search.globs_open {
+                        this.focus_search_field(SearchField::Include, window, cx);
+                    } else if matches!(
+                        this.search.focused_field,
+                        SearchField::Include | SearchField::Exclude
+                    ) {
+                        this.focus_search_field(SearchField::Query, window, cx);
+                    }
+                    cx.notify();
+                },
+            ))
+            .child(
+                div()
+                    .flex_none()
+                    .w(px(1.0))
+                    .h(px(11.0))
+                    .bg(theme::border::DIVIDER),
+            )
+            // Rule 2 again: with no results there is nothing to fold, and a caret offering to
+            // expand nothing is exactly what §4w records removing.
+            .children(state.has_results().then(|| {
+                div()
+                    .id("search-fold-all")
+                    .debug_selector(|| "search-fold-all".to_string())
+                    .flex_none()
+                    .w(theme::band::SEARCH_ICON_BUTTON)
+                    .h(theme::band::SEARCH_ICON_BUTTON)
+                    .rounded(theme::radius::CHIP)
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .cursor_pointer()
+                    .hover(|el| el.bg(theme::surface::MENU_ROW_HOVER))
+                    .tooltip(text_tooltip(if all_collapsed {
+                        "Expand all files"
+                    } else {
+                        "Collapse all files"
+                    }))
+                    // The same caret a file row uses, at the same 17x17 - §4w: "semantically
+                    // exact (the same action applied to every row) and from a different glyph
+                    // family [than the funnel beside it], so the two cannot be confused".
+                    .child(render_search_caret(!all_collapsed, self.ui_text_size(11.0)))
+                    .on_click(cx.listener(|this, _: &ClickEvent, _window, cx| {
+                        this.search.toggle_fold_all();
+                        cx.notify();
+                    }))
+            }))
+    }
+
+    /// One 17x17 toggle in the count row - `⇄` or the funnel, both drawn in the active pair
+    /// `REVISION-2026-08-14.md` §5 gives the modifier buttons.
+    #[allow(clippy::too_many_arguments)]
+    fn render_search_toggle_button(
+        &self,
+        icons: &IconRow<'_>,
+        id: &'static str,
+        icon: Icon,
+        on: bool,
+        tooltip: &'static str,
+        cx: &mut Context<Self>,
+        on_click: impl Fn(&mut Self, &mut Window, &mut Context<Self>) + 'static,
+    ) -> impl IntoElement {
+        div()
+            .id(id)
+            .debug_selector(move || id.to_string())
+            .flex_none()
+            .w(theme::band::SEARCH_ICON_BUTTON)
+            .h(theme::band::SEARCH_ICON_BUTTON)
+            .rounded(theme::radius::CHIP)
+            .flex()
+            .items_center()
+            .justify_center()
+            .cursor_pointer()
+            .when(on, |el| el.bg(theme::search::MODIFIER_ON_BG))
+            .when(!on, |el| {
+                el.hover(|el| el.bg(theme::surface::ROW_HOVER_ALT))
+            })
+            .tooltip(text_tooltip(tooltip))
+            .child(icons.draw(
+                icon,
+                if on {
+                    theme::search::MODIFIER_ON_FG
+                } else {
+                    theme::text::FAINTER
+                },
+            ))
+            .on_click(cx.listener(move |this, _: &ClickEvent, window, cx| {
+                on_click(this, window, cx);
+            }))
+    }
+
+    /// What the last replace really did, said out loud rather than left for the user to infer
+    /// from the tree redrawing - the issue's own "Replace all / per-file replace perform real
+    /// edits **and report what changed**".
+    fn render_search_notice(&self) -> Option<impl IntoElement> {
+        let notice = self.search.notice.clone()?;
+        Some(
+            div()
+                .debug_selector(|| "search-notice".to_string())
+                .flex_none()
+                .px(px(12.0))
+                .py(px(6.0))
+                .border_b_1()
+                .border_color(theme::border::ROW)
+                .font(font(theme::font::SANS))
+                .text_size(self.ui_text_size(10.5))
+                .text_color(theme::text::DIM)
+                .child(notice),
+        )
+    }
+
+    /// The body: the two-level tree, or the one sentence that state has instead.
+    fn render_search_body(
+        &self,
+        state: &BodyState,
+        branch: &str,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        if let Some(message) = self.search.body_message(branch) {
+            let color = match state {
+                // §5's table gives the two message states two different tints, and the difference
+                // is the point: "not searched yet" is dimmer than "searched, found nothing".
+                BodyState::NotSearched => theme::text::HINT,
+                BodyState::InvalidQuery(_) => theme::status::FAIL,
+                _ => theme::text::GHOST,
+            };
+            return div()
+                .id("search-body")
+                .flex_1()
+                .min_h_0()
+                .overflow_y_scroll()
+                .child(
+                    div()
+                        .debug_selector(|| "search-message".to_string())
+                        .px(px(12.0))
+                        .py(px(14.0))
+                        .font(font(theme::font::SANS))
+                        .text_size(self.ui_text_size(11.0))
+                        .line_height(self.ui_text_size(16.0))
+                        .text_color(color)
+                        .child(message),
+                )
+                .into_any_element();
+        }
+
+        let Some(outcome) = self.search.results() else {
+            return div().flex_1().min_h_0().into_any_element();
+        };
+        div()
+            .id("search-body")
+            .flex_1()
+            .min_h_0()
+            .overflow_y_scroll()
+            .track_scroll(&self.search_scroll_handle)
+            .children(
+                outcome
+                    .files
+                    .iter()
+                    .enumerate()
+                    .map(|(index, file)| self.render_search_file(index, file, cx)),
+            )
+            // The app's shared overlay scrollbar, off the same handle this scroller tracks - not a
+            // second, parallel tracking mechanism. Drawn as a sibling of the rows for the same
+            // reason `crate::sidebar::render::AdeApp::render_file_tree` draws its own that way.
+            .children(scrollbar::render_vertical_scrollbar(
+                "search-scrollbar",
+                &self.search_scroll_handle,
+                &[],
+                cx,
+            ))
+            .relative()
+            .into_any_element()
+    }
+
+    /// One file's row plus, unless it is collapsed, one row per match under it.
+    fn render_search_file(
+        &self,
+        index: usize,
+        file: &engine::FileMatches,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        let open = !self.search.collapsed.contains(&file.path);
+        // Built eagerly rather than inside the `.children(..)` closure below: that closure is
+        // `FnMut` and would have to capture `cx` by move, which the borrow checker rightly
+        // refuses. One `Vec` of already-rendered rows is also one place the "one row per match,
+        // not per line" rule lives.
+        let match_rows: Vec<gpui::AnyElement> = if open {
+            file.lines
+                .iter()
+                .flat_map(|line| {
+                    line.ranges
+                        .iter()
+                        .enumerate()
+                        .map(move |(hit, range)| (line, hit, range))
+                })
+                .map(|(line, hit, range)| {
+                    self.render_search_match(file, line, hit, range, index, cx)
+                })
+                .collect()
+        } else {
+            Vec::new()
+        };
+        let chip = lang_chip_for_name(file.file_name());
+        let path = file.path.clone();
+        let replace_path = file.path.clone();
+        let count = file.match_count();
+        div()
+            .child(
+                div()
+                    .id(SharedString::from(format!("search-file-{index}")))
+                    .debug_selector(move || format!("search-file-{index}"))
+                    .group(SharedString::from(format!("search-file-group-{index}")))
+                    .flex()
+                    .items_center()
+                    .gap(px(6.0))
+                    .h(theme::band::SEARCH_FILE_ROW)
+                    .pl(px(6.0))
+                    .pr(px(10.0))
+                    .cursor_pointer()
+                    .bg(theme::surface::LSP_POPOVER_FOOTER)
+                    .border_t_1()
+                    .border_color(theme::border::RAIL_INNER)
+                    .hover(|el| el.bg(theme::surface::ROW_SELECTED))
+                    .tooltip(text_tooltip(file.relative.clone()))
+                    .child(
+                        div()
+                            .flex_none()
+                            .w(px(11.0))
+                            .text_center()
+                            .child(render_search_caret(open, self.ui_text_size(8.0))),
+                    )
+                    .child(
+                        div()
+                            .flex_none()
+                            .w(px(14.0))
+                            .h(px(14.0))
+                            .rounded(theme::radius::CHIP)
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .bg(chip.bg)
+                            .font(font(theme::font::MONO))
+                            .font_weight(gpui::FontWeight::MEDIUM)
+                            .text_size(self.ui_text_size(7.0))
+                            .text_color(chip.fg)
+                            .child(chip.label),
+                    )
+                    .child(
+                        div()
+                            .flex_none()
+                            .whitespace_nowrap()
+                            .font(font(theme::font::MONO))
+                            .font_weight(gpui::FontWeight::MEDIUM)
+                            .text_size(self.ui_text_size(10.5))
+                            .text_color(theme::text::STRONG)
+                            .child(file.file_name().to_string()),
+                    )
+                    .child(
+                        div()
+                            .flex_1()
+                            .min_w_0()
+                            .overflow_hidden()
+                            .whitespace_nowrap()
+                            .font(font(theme::font::MONO))
+                            .text_size(self.ui_text_size(9.5))
+                            .text_color(theme::text::GHOSTER)
+                            .child(file.directory().to_string()),
+                    )
+                    // Per-file replace, revealed on hover and only while the replace row is open -
+                    // acting on a field the user cannot see would be a control with no visible
+                    // subject. The mock has no such button; the issue's acceptance criterion names
+                    // per-file replace explicitly, so it is here rather than nowhere.
+                    .when(self.search.replace_open, |el| {
+                        let group = SharedString::from(format!("search-file-group-{index}"));
+                        el.child(
+                            div()
+                                .id(SharedString::from(format!("search-file-replace-{index}")))
+                                .debug_selector(move || format!("search-file-replace-{index}"))
+                                .flex_none()
+                                .w(px(15.0))
+                                .h(px(15.0))
+                                .rounded(theme::radius::CHIP)
+                                .flex()
+                                .items_center()
+                                .justify_center()
+                                .invisible()
+                                .group_hover(group, |el| el.visible())
+                                .hover(|el| el.bg(theme::surface::ROW_HOVER_ALT))
+                                .tooltip(text_tooltip(format!(
+                                    "Replace {} in {}",
+                                    plural::count(count, "match", Some("matches")),
+                                    file.file_name()
+                                )))
+                                .child(
+                                    div()
+                                        .font(font(theme::font::MONO))
+                                        .text_size(self.ui_text_size(10.0))
+                                        .text_color(theme::text::FAINTER)
+                                        .child("\u{21c4}"),
+                                )
+                                .on_click(cx.listener(
+                                    move |this, event: &ClickEvent, _window, cx| {
+                                        // Stops the click from also toggling the row's own collapse -
+                                        // a replace that folds the file it just changed hides the
+                                        // result it is meant to report.
+                                        cx.stop_propagation();
+                                        let _ = event;
+                                        this.replace_search_matches(vec![replace_path.clone()], cx);
+                                    },
+                                )),
+                        )
+                    })
+                    .child(
+                        div()
+                            .flex_none()
+                            .whitespace_nowrap()
+                            .font(font(theme::font::MONO))
+                            .text_size(self.ui_text_size(9.5))
+                            .text_color(theme::text::FAINTER)
+                            .child(count.to_string()),
+                    )
+                    .on_click(cx.listener(move |this, _: &ClickEvent, _window, cx| {
+                        if !this.search.collapsed.remove(&path) {
+                            this.search.collapsed.insert(path.clone());
+                        }
+                        cx.notify();
+                    })),
+            )
+            .when(open, |el| {
+                el.child(
+                    div()
+                        .relative()
+                        .pt(px(2.0))
+                        .pb(px(3.0))
+                        // The vertical rule under the file row's caret, tying its match rows to
+                        // it - the same indent guide the file tree draws.
+                        .child(
+                            div()
+                                .absolute()
+                                .left(px(11.0))
+                                .top_0()
+                                .bottom_0()
+                                .w(px(1.0))
+                                .bg(theme::border::DIVIDER),
+                        )
+                        .children(match_rows),
+                )
+            })
+            .into_any_element()
+    }
+
+    /// One match row: the line number, then the line with **this** hit highlighted.
+    ///
+    /// One row per *match*, not per line (`STAGE-A-CHANGELOG.md` §4v: "one row per match with its
+    /// line number and the hit highlighted"), so two hits on one line are two rows that each
+    /// point at their own - which is also what makes the count row's total and the rows on screen
+    /// agree.
+    #[allow(clippy::too_many_arguments)]
+    fn render_search_match(
+        &self,
+        file: &engine::FileMatches,
+        line: &engine::LineMatch,
+        hit: usize,
+        range: &std::ops::Range<usize>,
+        file_index: usize,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        let (before, matched, after) = engine::elide_around(&line.text, range);
+        let path = file.path.clone();
+        let line_number = line.line_number;
+        let id = SharedString::from(format!("search-match-{file_index}-{line_number}-{hit}"));
+        div()
+            .id(id.clone())
+            .debug_selector(move || id.to_string())
+            .flex()
+            .items_baseline()
+            .gap(px(8.0))
+            .h(theme::band::SEARCH_MATCH_ROW)
+            .pl(px(18.0))
+            .pr(px(10.0))
+            .cursor_pointer()
+            .hover(|el| el.bg(theme::surface::ROW_HOVER))
+            .tooltip(text_tooltip(format!(
+                "{}:{line_number} \u{2014} open",
+                file.relative
+            )))
+            .child(
+                div()
+                    .flex_none()
+                    .w(px(26.0))
+                    .text_right()
+                    .whitespace_nowrap()
+                    .font(font(theme::font::MONO))
+                    .text_size(self.ui_text_size(9.5))
+                    .text_color(theme::text::DISABLED)
+                    .child(line_number.to_string()),
+            )
+            .child(
+                div()
+                    .flex_1()
+                    .min_w_0()
+                    .flex()
+                    .overflow_hidden()
+                    .whitespace_nowrap()
+                    .font(font(theme::font::MONO))
+                    .text_size(self.ui_text_size(10.0))
+                    .child(
+                        div()
+                            .flex_none()
+                            .text_color(theme::search::LINE)
+                            .child(before),
+                    )
+                    .child(
+                        div()
+                            .flex_none()
+                            .bg(theme::search::MATCH_BG)
+                            .text_color(theme::search::MATCH_FG)
+                            .child(matched),
+                    )
+                    .child(
+                        div()
+                            .flex_none()
+                            .text_color(theme::search::LINE)
+                            .child(after),
+                    ),
+            )
+            .on_click(cx.listener(move |this, _: &ClickEvent, window, cx| {
+                this.open_search_match(path.clone(), line_number, window, cx);
+            }))
+            .into_any_element()
+    }
+}
+
+/// `▾` open / `▸` closed - the file tree's own caret glyphs, reused verbatim so the two trees in
+/// this window speak one language (`STAGE-A-CHANGELOG.md` §4w's fold-all note is explicit that
+/// this is "the same caret a file row uses").
+fn render_search_caret(open: bool, text_size: gpui::Pixels) -> impl IntoElement {
+    div()
+        .font(font(theme::font::MONO))
+        .text_size(text_size)
+        .text_color(theme::text::TREE_CARET)
+        .child(if open { "\u{25be}" } else { "\u{25b8}" })
+}
+
+/// A field's stable slug, for element ids and debug selectors.
+fn field_key(field: SearchField) -> &'static str {
+    match field {
+        SearchField::Query => "query",
+        SearchField::Replace => "replace",
+        SearchField::Include => "include",
+        SearchField::Exclude => "exclude",
+    }
+}
+
+impl AdeApp {
+    /// `mod+shift+F` - the issue's own binding, "opens the panel focused in the query".
+    pub(crate) fn handle_search_in_worktree_action(
+        &mut self,
+        _: &SearchInWorktree,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.open_search_panel(window, cx);
+    }
+
+    /// Opens the Search tab with the query focused - `mod+shift+F`, and the panel tab's own click
+    /// when it is already showing.
+    pub(crate) fn open_search_panel(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.right_sidebar_view != RightSidebarView::Search {
+            self.set_right_sidebar_view(RightSidebarView::Search, window, cx);
+        }
+        self.focus_search_field(SearchField::Query, window, cx);
+        cx.notify();
+    }
+
+    /// Moves focus - and the key handler's own idea of which field is being typed into - to
+    /// `field`.
+    pub(crate) fn focus_search_field(
+        &mut self,
+        field: SearchField,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.search.focused_field = field;
+        let handle = self.search.focus_handle(field).clone();
+        window.focus(&handle, cx);
+        self.reset_caret_blink(cx);
+        cx.notify();
+    }
+
+    /// One keystroke into one of the four fields.
+    ///
+    /// Everything but `Tab` and `Esc` is `TextField::handle_editing_key`'s, so all four fields get
+    /// the same real editing vocabulary - caret movement included - rather than each row growing
+    /// its own half of it.
+    fn handle_search_key_down(
+        &mut self,
+        field: SearchField,
+        event: &KeyDownEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let keystroke = &event.keystroke;
+        if keystroke.modifiers.platform || keystroke.modifiers.control || keystroke.modifiers.alt {
+            return;
+        }
+        self.reset_caret_blink(cx);
+        match keystroke.key.as_str() {
+            // Walks only the rows that are really on screen - see
+            // `SearchPanel::next_visible_field`.
+            "tab" => {
+                if let Some(next) = self.search.next_visible_field(field) {
+                    self.focus_search_field(next, window, cx);
+                }
+                cx.stop_propagation();
+                return;
+            }
+            // A real, undoable step rather than a silent loss, exactly as the rail filter's own
+            // `Esc` is.
+            "escape" => {
+                if self.search.field_mut(field).clear(Instant::now()) {
+                    self.on_search_input_changed(cx);
+                    cx.stop_propagation();
+                }
+                return;
+            }
+            _ => {}
+        }
+        if self.search.field_mut(field).handle_editing_key(
+            keystroke.key.as_str(),
+            keystroke.key_char.as_deref(),
+            Instant::now(),
+        ) {
+            self.on_search_input_changed(cx);
+            cx.stop_propagation();
+        }
+    }
+
+    /// Anything that changes what the search would return: a keystroke in any of the four fields,
+    /// a modifier toggle, an undo.
+    ///
+    /// Clears the replace notice too - it described a replace against results that no longer
+    /// answer what is typed, and a stale report is worse than none.
+    fn on_search_input_changed(&mut self, cx: &mut Context<Self>) {
+        self.search.notice = None;
+        self.start_search(cx);
+        cx.notify();
+    }
+
+    /// Compiles the query and, if it compiles to something, starts a real debounced search of the
+    /// active worktree on the background executor.
+    ///
+    /// Generation-guarded rather than task-cancelled: a slow search over a big worktree must never
+    /// overwrite a newer, faster one's results, and the check is one comparison at the moment the
+    /// result lands. The debounce is `SEARCH_DEBOUNCE` - see its own docs for why a search is not
+    /// run per keystroke.
+    pub(crate) fn start_search(&mut self, cx: &mut Context<Self>) {
+        self.search.generation += 1;
+        let generation = self.search.generation;
+
+        let matcher = match Matcher::compile(self.search.query.as_str(), self.search.options) {
+            Ok(Some(matcher)) => {
+                self.search.error = None;
+                matcher
+            }
+            // An empty query is the not-searched-yet state, not a search of nothing.
+            Ok(None) => {
+                self.search.error = None;
+                self.search.searching = false;
+                self.search.completed = None;
+                self.search.collapsed.clear();
+                return;
+            }
+            Err(error) => {
+                self.search.error = Some(error.0);
+                self.search.searching = false;
+                return;
+            }
+        };
+
+        let request = SearchRequest {
+            root: self.file_tree_root.clone(),
+            matcher,
+            filter: PathFilter::new(self.search.include.as_str(), self.search.exclude.as_str()),
+        };
+        // Captured now rather than re-read after the awaits below: a search that resolves against
+        // whatever the user has since typed would report a count for one query beside a tree for
+        // another. Same rule `crate::code_surface::editing::AdeApp::enqueue_save` follows for its
+        // own worktree root.
+        let query = self.search.query.as_str().to_string();
+        let options = self.search.options;
+        let include = self.search.include.as_str().to_string();
+        let exclude = self.search.exclude.as_str().to_string();
+
+        self.search.searching = true;
+        self._search_task = Some(cx.spawn(async move |this, cx| {
+            cx.background_executor().timer(SEARCH_DEBOUNCE).await;
+            let still_current = this
+                .update(cx, |this, _cx| this.search.generation == generation)
+                .unwrap_or(false);
+            if !still_current {
+                return;
+            }
+            let outcome: SearchOutcome = cx
+                .background_executor()
+                .spawn(async move { engine::search_worktree(&request) })
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                if this.search.generation != generation {
+                    return;
+                }
+                this.search.searching = false;
+                // A fresh result set opens every file, which is the state the design draws - the
+                // previous search's collapse decisions were about different files.
+                this.search.collapsed.clear();
+                this.search.completed = Some(CompletedSearch {
+                    query,
+                    options,
+                    include,
+                    exclude,
+                    outcome,
+                });
+                cx.notify();
+            });
+        }));
+    }
+
+    /// Replaces every match in `paths` for real, on disk, then re-runs the search so the tree
+    /// reflects what the files now hold rather than what they held a moment ago.
+    ///
+    /// Files open in the editor with **unsaved** edits are refused and named - see
+    /// `crate::search::engine::replace_across`'s own docs for why writing them would destroy
+    /// those edits. The notice this leaves behind is the issue's "report what changed".
+    pub(crate) fn replace_search_matches(&mut self, paths: Vec<PathBuf>, cx: &mut Context<Self>) {
+        if paths.is_empty() {
+            return;
+        }
+        let Ok(Some(matcher)) = Matcher::compile(self.search.query.as_str(), self.search.options)
+        else {
+            return;
+        };
+        let replacement = self.search.replace.as_str().to_string();
+        let dirty = self.dirty_edit_buffer_paths();
+
+        self._search_replace_task = Some(cx.spawn(async move |this, cx| {
+            let outcome: ReplaceOutcome = cx
+                .background_executor()
+                .spawn(
+                    async move { engine::replace_across(&paths, &matcher, &replacement, &dirty) },
+                )
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                this.search.notice = Some(replace_notice(&outcome));
+                // A replace is a real change to the working tree, and nothing else re-derives the
+                // diff from it - the same reason `spawn_file_save_loop` reloads it after a save.
+                if outcome.files_changed > 0 {
+                    this.load_diff(this.diff_root.clone(), cx);
+                    // Force the File view's next freshness check to re-read rather than trusting
+                    // its throttle window: we just changed these files' real mtimes ourselves.
+                    this.file_view_last_freshness_check = None;
+                }
+                this.start_search(cx);
+                cx.notify();
+            });
+        }));
+    }
+
+    /// Every open editor buffer with unsaved changes, as absolute paths - what a replace refuses
+    /// to write over.
+    fn dirty_edit_buffer_paths(&self) -> HashSet<PathBuf> {
+        self.edit_buffers
+            .values()
+            .filter(|buffer| buffer.is_dirty())
+            .map(|buffer| buffer.path.clone())
+            .collect()
+    }
+
+    /// Opens the file a match row points at, in the editor, scrolled to that line.
+    fn open_search_match(
+        &mut self,
+        path: PathBuf,
+        line_number: usize,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        // 1-based on screen, 0-based in the editor - converted here, once, rather than at either
+        // end where it would be one more place to get wrong.
+        self.open_file_at_line(path, line_number.saturating_sub(1), window, cx);
+    }
+}
+
+/// One sentence saying exactly what a replace did, including what it refused to do.
+///
+/// Pure so the wording is a real unit test rather than something only a screenshot can check -
+/// and there is real wording to get wrong here, since "nothing changed" and "3 files were skipped"
+/// are different facts that a single count would flatten into one.
+pub fn replace_notice(outcome: &ReplaceOutcome) -> String {
+    let mut parts = Vec::new();
+    if outcome.matches_replaced == 0 {
+        parts.push("Nothing replaced".to_string());
+    } else {
+        parts.push(format!(
+            "Replaced {} in {}",
+            plural::count(outcome.matches_replaced, "match", Some("matches")),
+            plural::count(outcome.files_changed, "file", None)
+        ));
+    }
+    if !outcome.skipped_dirty.is_empty() {
+        parts.push(format!(
+            "{} skipped \u{2014} unsaved changes are open in the editor",
+            plural::count(outcome.skipped_dirty.len(), "file", None)
+        ));
+    }
+    if !outcome.failed.is_empty() {
+        parts.push(format!(
+            "{} failed to write",
+            plural::count(outcome.failed.len(), "file", None)
+        ));
+    }
+    format!("{}.", parts.join("; "))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn outcome(replaced: usize, files: usize) -> ReplaceOutcome {
+        ReplaceOutcome {
+            files_changed: files,
+            matches_replaced: replaced,
+            skipped_dirty: Vec::new(),
+            failed: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn a_real_replace_reports_what_it_changed_through_the_pluralisation_helper() {
+        assert_eq!(
+            replace_notice(&outcome(14, 6)),
+            "Replaced 14 matches in 6 files."
+        );
+        assert_eq!(
+            replace_notice(&outcome(1, 1)),
+            "Replaced 1 match in 1 file."
+        );
+    }
+
+    #[test]
+    fn a_replace_that_changed_nothing_says_so_rather_than_reporting_zero_of_something() {
+        assert_eq!(replace_notice(&outcome(0, 0)), "Nothing replaced.");
+    }
+
+    #[test]
+    fn refused_files_are_named_as_a_separate_fact_not_folded_into_the_count() {
+        let mut outcome = outcome(4, 2);
+        outcome.skipped_dirty = vec![PathBuf::from("/wt/a.rs"), PathBuf::from("/wt/b.rs")];
+        assert_eq!(
+            replace_notice(&outcome),
+            "Replaced 4 matches in 2 files; 2 files skipped \u{2014} unsaved changes are open in \
+             the editor."
+        );
+    }
+
+    #[test]
+    fn a_write_that_really_failed_is_reported_alongside_what_succeeded() {
+        let mut outcome = outcome(4, 2);
+        outcome.failed = vec![(PathBuf::from("/wt/c.rs"), "permission denied".to_string())];
+        assert_eq!(
+            replace_notice(&outcome),
+            "Replaced 4 matches in 2 files; 1 file failed to write."
+        );
+    }
+}

--- a/crates/app/src/search/render.rs
+++ b/crates/app/src/search/render.rs
@@ -89,7 +89,6 @@ impl AdeApp {
         state: &BodyState,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        let icons = IconRow::new(&self.settings.icon_pack, IconSize::Control);
         div()
             .flex_none()
             .flex()
@@ -99,14 +98,7 @@ impl AdeApp {
             .child(
                 self.search_input_row(SearchField::Query, cx)
                     .h(theme::band::FILTER_ROW)
-                    .child(
-                        // The leading mark. A real magnifying glass rather than the mock's
-                        // hand-drawn `/`: this row is what the panel's own tab icon points at, and
-                        // `REVISION-2026-08-14.md` §8 moved every glyph in this window to Phosphor.
-                        icons
-                            .draw(Icon::MagnifyingGlass, theme::text::DISABLED)
-                            .flex_none(),
-                    )
+                    .child(render_search_row_mark("/", self.ui_text_size(10.0)))
                     .child(self.render_search_field(SearchField::Query, "search this worktree"))
                     .children(
                         SearchModifier::ALL
@@ -120,11 +112,7 @@ impl AdeApp {
                         .h(theme::band::SEARCH_REPLACE_ROW)
                         .border_t_1()
                         .border_color(theme::border::ROW)
-                        .child(
-                            icons
-                                .draw(Icon::ArrowsLeftRight, theme::text::DISABLED)
-                                .flex_none(),
-                        )
+                        .child(render_search_row_mark("\u{21c4}", self.ui_text_size(10.0)))
                         .child(
                             self.render_search_field(SearchField::Replace, "replace with\u{2026}"),
                         )
@@ -414,13 +402,16 @@ impl AdeApp {
                     cx.notify();
                 },
             ))
-            .child(
+            // The 1px rule exists to separate the two field toggles from fold-all. With fold-all
+            // gone there is nothing on its far side, and a divider dividing something from nothing
+            // is a stray mark - so it is gated on the same flag the control it separates is.
+            .children(state.has_results().then(|| {
                 div()
                     .flex_none()
                     .w(px(1.0))
                     .h(px(11.0))
-                    .bg(theme::border::DIVIDER),
-            )
+                    .bg(theme::border::DIVIDER)
+            }))
             // Rule 2 again: with no results there is nothing to fold, and a caret offering to
             // expand nothing is exactly what §4w records removing.
             .children(state.has_results().then(|| {
@@ -671,10 +662,16 @@ impl AdeApp {
                             .text_color(theme::text::GHOSTER)
                             .child(file.directory().to_string()),
                     )
-                    // Per-file replace, revealed on hover and only while the replace row is open -
-                    // acting on a field the user cannot see would be a control with no visible
-                    // subject. The mock has no such button; the issue's acceptance criterion names
-                    // per-file replace explicitly, so it is here rather than nowhere.
+                    // Per-file replace, shown only while the replace row is open - acting on a
+                    // field the user cannot see would be a control with no visible subject. The
+                    // mock has no such button; the issue's acceptance criterion names per-file
+                    // replace explicitly, so it is here rather than nowhere.
+                    //
+                    // Always present rather than hover-only, following the file tree's own
+                    // per-directory `+`: "this project has no established 'hidden until row hover'
+                    // mechanism yet, and a subtle-but-always-there affordance beats an invented
+                    // one" (`crate::sidebar::render::AdeApp::render_file_tree_row`). It is also
+                    // the difference between a control a test can click and one it cannot.
                     .when(self.search.replace_open, |el| {
                         let group = SharedString::from(format!("search-file-group-{index}"));
                         el.child(
@@ -688,9 +685,8 @@ impl AdeApp {
                                 .flex()
                                 .items_center()
                                 .justify_center()
-                                .invisible()
-                                .group_hover(group, |el| el.visible())
-                                .hover(|el| el.bg(theme::surface::ROW_HOVER_ALT))
+                                .group_hover(group, |el| el.bg(theme::surface::ROW_HOVER_ALT))
+                                .hover(|el| el.bg(theme::surface::SEGMENT_ACTIVE))
                                 .tooltip(text_tooltip(format!(
                                     "Replace {} in {}",
                                     plural::count(count, "match", Some("matches")),
@@ -834,6 +830,24 @@ impl AdeApp {
             }))
             .into_any_element()
     }
+}
+
+/// A field row's leading mark - the `/` of the query row and the `⇄` of the replace row.
+///
+/// Deliberately **text**, not an icon, and deliberately not a magnifying glass. The panel's own
+/// tab, 30px directly above this row, already *is* a magnifying glass, and
+/// `REVISION-2026-08-14.md` §7 rule 8 is exactly about that: "Before adding an icon, check what it
+/// sits beside. Two marks from the same family one divider apart are one mark with a rendering
+/// bug, as far as the eye is concerned." Caught on the first real screenshot of this panel, where
+/// the two magnifiers read as one control drawn twice. `/` is also what the rail's own filter row
+/// uses, so the two filter fields in this window speak one language.
+fn render_search_row_mark(mark: &'static str, text_size: gpui::Pixels) -> impl IntoElement {
+    div()
+        .flex_none()
+        .font(font(theme::font::MONO))
+        .text_size(text_size)
+        .text_color(theme::text::DISABLED)
+        .child(mark)
 }
 
 /// `▾` open / `▸` closed - the file tree's own caret glyphs, reused verbatim so the two trees in
@@ -1173,6 +1187,518 @@ mod tests {
         assert_eq!(
             replace_notice(&outcome),
             "Replaced 4 matches in 2 files; 1 file failed to write."
+        );
+    }
+}
+
+/// The panel driven the way a user drives it: a real window, real keystrokes into the real
+/// fields, real clicks on the real controls, and - for replace - real files on disk that really
+/// change.
+///
+/// These sit beside `crate::search::state`'s pure tests rather than replacing them: those pin the
+/// three-state gate's *decisions*, these pin that the gate is really what the panel reads, that
+/// the four fields are really editable, and that `Replace all` really writes.
+#[cfg(test)]
+mod panel_tests {
+    use super::*;
+    use crate::root::focus::palette_focus_tests;
+    use crate::search::state::SearchField;
+    use gpui::TestAppContext;
+    use tempfile::TempDir;
+
+    /// A real worktree on disk with `refresh_token` across four files - the same corpus
+    /// `Jerry.dc.html`'s own search fixture uses, so what these tests see is what the design was
+    /// drawn against.
+    fn fixture_repo() -> TempDir {
+        let repo = TempDir::new().expect("tempdir");
+        let write = |relative: &str, content: &str| {
+            let path = repo.path().join(relative);
+            std::fs::create_dir_all(path.parent().expect("a parent")).expect("mkdir");
+            std::fs::write(&path, content).expect("write");
+        };
+        write(
+            "src/auth/session.rs",
+            "let refresh_token = store.issue(&sid)?;\nif self.refresh_token.is_expired(now) {}\n",
+        );
+        write(
+            "src/auth/store.rs",
+            "fn refresh_token(&self, sid: &SessionId) -> Option<Token>;\n",
+        );
+        write("src/api/users.rs", "let t = auth.refresh_token(&sid)?;\n");
+        write("tests/auth_race.rs", "let a = svc.refresh_token(sid);\n");
+        write("README.md", "nothing to find here\n");
+        repo
+    }
+
+    fn open_search<'a>(
+        cx: &'a mut TestAppContext,
+        repo: &TempDir,
+    ) -> (gpui::Entity<AdeApp>, &'a mut gpui::VisualTestContext) {
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        app.update_in(cx, |app, window, cx| app.open_search_panel(window, cx));
+        cx.run_until_parked();
+        (app, cx)
+    }
+
+    /// Types into whichever field is focused and lets the debounced search really finish.
+    fn type_and_settle(cx: &mut gpui::VisualTestContext, text: &str) {
+        cx.simulate_input(text);
+        cx.run_until_parked();
+        // The search itself is behind a real `SEARCH_DEBOUNCE` timer on the background executor.
+        cx.executor().advance_clock(SEARCH_DEBOUNCE * 2);
+        cx.run_until_parked();
+    }
+
+    fn click(cx: &mut gpui::VisualTestContext, selector: &'static str) {
+        let bounds = cx
+            .debug_bounds(selector)
+            .unwrap_or_else(|| panic!("`{selector}` must really paint"));
+        cx.simulate_click(bounds.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+    }
+
+    #[gpui::test]
+    fn mod_shift_f_opens_the_panel_with_the_query_focused(cx: &mut TestAppContext) {
+        let repo = fixture_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.dispatch_action(SearchInWorktree);
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.right_sidebar_view, RightSidebarView::Search);
+        });
+        let (focused, query_handle) = app.update_in(cx, |app, window, cx| {
+            (window.focused(cx), app.search.query_focus_handle.clone())
+        });
+        assert_eq!(
+            focused.as_ref(),
+            Some(&query_handle),
+            "the issue's own wording: \"opens the panel focused in the query\""
+        );
+    }
+
+    #[gpui::test]
+    fn typing_a_real_query_really_searches_the_worktree_and_builds_the_tree(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = fixture_repo();
+        let (app, cx) = open_search(cx, &repo);
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.search.body_state(), BodyState::NotSearched);
+            assert_eq!(app.search.count_label(), "");
+        });
+        assert!(
+            cx.debug_bounds("search-fold-all").is_none(),
+            "a control that acts on results does not exist when there are none"
+        );
+
+        type_and_settle(cx, "refresh_token");
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.search.query.as_str(), "refresh_token");
+            assert_eq!(app.search.body_state(), BodyState::Results);
+            assert_eq!(
+                app.search.count_label(),
+                "5 results in 4 files",
+                "a real walk of a real worktree, not a fixture handed to the panel"
+            );
+        });
+        assert!(
+            cx.debug_bounds("search-file-0").is_some(),
+            "the tree's first file row must really paint"
+        );
+        assert!(
+            cx.debug_bounds("search-fold-all").is_some(),
+            "and now that there are results, so must fold-all"
+        );
+    }
+
+    #[gpui::test]
+    fn clearing_the_query_returns_to_the_not_searched_state(cx: &mut TestAppContext) {
+        let repo = fixture_repo();
+        let (app, cx) = open_search(cx, &repo);
+        type_and_settle(cx, "refresh_token");
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.search.body_state(), BodyState::Results)
+        });
+
+        cx.simulate_keystrokes("escape");
+        cx.run_until_parked();
+        cx.executor().advance_clock(SEARCH_DEBOUNCE * 2);
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.search.body_state(),
+                BodyState::NotSearched,
+                "the acceptance criterion: \"clearing the query returns to the not-searched state\""
+            );
+            assert_eq!(app.search.count_label(), "");
+        });
+        assert!(cx.debug_bounds("search-fold-all").is_none());
+    }
+
+    #[gpui::test]
+    fn the_match_case_button_really_changes_the_result_set(cx: &mut TestAppContext) {
+        let repo = fixture_repo();
+        std::fs::write(repo.path().join("src/Cased.rs"), "Refresh_Token\n").expect("write");
+        let (app, cx) = open_search(cx, &repo);
+        type_and_settle(cx, "Refresh_Token");
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.search.count_label(),
+                "6 results in 5 files",
+                "case-insensitive by default"
+            );
+        });
+
+        click(cx, "search-modifier-case");
+        cx.executor().advance_clock(SEARCH_DEBOUNCE * 2);
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert!(app.search.options.match_case);
+            assert_eq!(
+                app.search.count_label(),
+                "1 result in 1 file",
+                "`Aa` changes results - the acceptance criterion says so in as many words"
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn all_four_fields_are_really_editable_and_the_globs_really_narrow_the_search(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = fixture_repo();
+        let (app, cx) = open_search(cx, &repo);
+        type_and_settle(cx, "refresh_token");
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.search.count_label(), "5 results in 4 files")
+        });
+
+        // The funnel reveals the two glob rows and focuses the first, so the very next keystroke
+        // lands in a field the user can see.
+        click(cx, "search-toggle-globs");
+        app.read_with(cx, |app, _| {
+            assert!(app.search.globs_open);
+            assert_eq!(app.search.focused_field, SearchField::Include);
+        });
+        type_and_settle(cx, "src/**");
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.search.include.as_str(), "src/**");
+            assert_eq!(
+                app.search.count_label(),
+                "4 results in 3 files",
+                "the include glob really dropped `tests/auth_race.rs`"
+            );
+        });
+
+        // Tab walks to exclude, which is a real, separate field.
+        cx.simulate_keystrokes("tab");
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.search.focused_field, SearchField::Exclude)
+        });
+        type_and_settle(cx, "**/store.rs");
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.search.exclude.as_str(), "**/store.rs");
+            assert_eq!(
+                app.search.include.as_str(),
+                "src/**",
+                "and it is a *separate* field"
+            );
+            assert_eq!(app.search.count_label(), "3 results in 2 files");
+        });
+
+        // The fourth field, behind `⇄`.
+        click(cx, "search-toggle-replace");
+        app.read_with(cx, |app, _| {
+            assert!(app.search.replace_open);
+            assert_eq!(app.search.focused_field, SearchField::Replace);
+        });
+        cx.simulate_input("rotate_token");
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.search.replace.as_str(), "rotate_token");
+            assert_eq!(
+                app.search.query.as_str(),
+                "refresh_token",
+                "typing into replace must not touch the query - four fields, four values"
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn the_query_field_has_a_real_caret_that_can_be_moved_back_into_the_text(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = fixture_repo();
+        let (app, cx) = open_search(cx, &repo);
+        cx.simulate_input("refresh_token");
+        cx.run_until_parked();
+        cx.simulate_keystrokes("left left left left left left");
+        cx.run_until_parked();
+        cx.simulate_input("ed");
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.search.query.as_str(),
+                "refreshed_token",
+                "a real editable field, not append/backspace-only - `REVISION-2026-08-14.md` §5"
+            );
+        });
+        assert!(
+            cx.debug_bounds("search-query-caret").is_some(),
+            "and it paints a real caret while focused"
+        );
+    }
+
+    #[gpui::test]
+    fn fold_all_really_collapses_and_expands_every_file_row(cx: &mut TestAppContext) {
+        let repo = fixture_repo();
+        let (app, cx) = open_search(cx, &repo);
+        type_and_settle(cx, "refresh_token");
+        assert!(
+            cx.debug_bounds("search-match-0-1-0").is_some(),
+            "a match row must really paint before it can be folded away"
+        );
+
+        click(cx, "search-fold-all");
+        app.read_with(cx, |app, _| assert!(app.search.all_collapsed()));
+        assert!(
+            cx.debug_bounds("search-match-0-1-0").is_none(),
+            "collapsing must really remove the match rows, not just recolour a caret"
+        );
+        assert!(
+            cx.debug_bounds("search-file-0").is_some(),
+            "the file rows themselves stay"
+        );
+
+        click(cx, "search-fold-all");
+        app.read_with(cx, |app, _| assert!(!app.search.all_collapsed()));
+        assert!(cx.debug_bounds("search-match-0-1-0").is_some());
+    }
+
+    #[gpui::test]
+    fn clicking_one_file_row_collapses_only_that_file(cx: &mut TestAppContext) {
+        let repo = fixture_repo();
+        let (app, cx) = open_search(cx, &repo);
+        type_and_settle(cx, "refresh_token");
+
+        click(cx, "search-file-0");
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.search.collapsed.len(), 1);
+            assert!(!app.search.all_collapsed());
+        });
+        assert!(
+            cx.debug_bounds("search-fold-all").is_some(),
+            "one file closed still leaves results, so fold-all still exists"
+        );
+    }
+
+    #[gpui::test]
+    fn replace_all_really_rewrites_the_files_on_disk_and_reports_what_changed(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = fixture_repo();
+        let session = repo.path().join("src/auth/session.rs");
+        let readme = repo.path().join("README.md");
+        let readme_before = std::fs::read_to_string(&readme).expect("read");
+
+        let (app, cx) = open_search(cx, &repo);
+        type_and_settle(cx, "refresh_token");
+        click(cx, "search-toggle-replace");
+        cx.simulate_input("rotate_token");
+        cx.run_until_parked();
+
+        click(cx, "search-replace-all");
+        cx.executor().advance_clock(SEARCH_DEBOUNCE * 4);
+        cx.run_until_parked();
+
+        let after = std::fs::read_to_string(&session).expect("read back");
+        assert!(
+            !after.contains("refresh_token"),
+            "the file on disk must really have changed: {after}"
+        );
+        assert!(after.contains("rotate_token"));
+        assert!(
+            after.contains("store.issue(&sid)?;"),
+            "every untouched part of the line must survive verbatim"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&readme).expect("read back"),
+            readme_before,
+            "a file with no matches must be byte-identical - a replace touches what it found"
+        );
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.search.notice.as_deref(),
+                Some("Replaced 5 matches in 4 files."),
+                "\"perform real edits and report what changed\""
+            );
+            assert_eq!(
+                app.search.body_state(),
+                BodyState::NoMatch,
+                "and the tree really re-ran against what the files now hold"
+            );
+        });
+        assert!(
+            cx.debug_bounds("search-notice").is_some(),
+            "the report must really be on screen, not only in state"
+        );
+    }
+
+    #[gpui::test]
+    fn a_per_file_replace_touches_only_that_file(cx: &mut TestAppContext) {
+        let repo = fixture_repo();
+        let (app, cx) = open_search(cx, &repo);
+        type_and_settle(cx, "refresh_token");
+        click(cx, "search-toggle-replace");
+        cx.simulate_input("rotate_token");
+        cx.run_until_parked();
+
+        // Which file row index 0 is, read off the real results rather than assumed - the walk
+        // sorts by path, and an assumption here would make this test's subject drift with the
+        // fixture.
+        let first = app.read_with(cx, |app, _| {
+            app.search
+                .results()
+                .expect("results")
+                .files
+                .first()
+                .expect("a file")
+                .path
+                .clone()
+        });
+        let others: Vec<PathBuf> = app.read_with(cx, |app, _| {
+            app.search
+                .results()
+                .expect("results")
+                .files
+                .iter()
+                .skip(1)
+                .map(|file| file.path.clone())
+                .collect()
+        });
+
+        click(cx, "search-file-replace-0");
+        cx.executor().advance_clock(SEARCH_DEBOUNCE * 4);
+        cx.run_until_parked();
+
+        assert!(!std::fs::read_to_string(&first)
+            .expect("read")
+            .contains("refresh_token"));
+        for other in &others {
+            assert!(
+                std::fs::read_to_string(other)
+                    .expect("read")
+                    .contains("refresh_token"),
+                "a per-file replace is per file: {} was touched too",
+                other.display()
+            );
+        }
+        app.read_with(cx, |app, _| {
+            assert!(app
+                .search
+                .notice
+                .as_deref()
+                .expect("a notice")
+                .starts_with("Replaced"));
+        });
+    }
+
+    #[gpui::test]
+    fn a_file_open_in_the_editor_with_unsaved_edits_is_refused_and_named(cx: &mut TestAppContext) {
+        let repo = fixture_repo();
+        let session = repo.path().join("src/auth/session.rs");
+        let before = std::fs::read_to_string(&session).expect("read");
+        let (app, cx) = open_search(cx, &repo);
+
+        // A real, dirty `EditBuffer` for that file - the same shape opening it in the File view
+        // and typing produces.
+        app.update(cx, |app, _cx| {
+            let metadata = std::fs::metadata(&session).expect("the file really exists");
+            let mut buffer = crate::code_surface::edit_buffer::EditBuffer::new(
+                session.clone(),
+                before.clone(),
+                Some("rs".to_string()),
+                metadata.modified().ok(),
+                metadata.len(),
+            );
+            buffer.content.push_str("// an unsaved edit\n");
+            assert!(buffer.is_dirty(), "premise: this buffer really is dirty");
+            let root = app.file_tree_root.clone();
+            app.insert_edit_buffer_at(root, session.clone(), buffer);
+        });
+
+        type_and_settle(cx, "refresh_token");
+        click(cx, "search-toggle-replace");
+        cx.simulate_input("rotate_token");
+        cx.run_until_parked();
+        click(cx, "search-replace-all");
+        cx.executor().advance_clock(SEARCH_DEBOUNCE * 4);
+        cx.run_until_parked();
+
+        assert_eq!(
+            std::fs::read_to_string(&session).expect("read back"),
+            before,
+            "writing this file would destroy edits the editor still believes it owns"
+        );
+        app.read_with(cx, |app, _| {
+            let notice = app.search.notice.as_deref().expect("a notice");
+            assert!(
+                notice.contains("1 file skipped"),
+                "refusing silently is the failure this exists to prevent: {notice}"
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn an_invalid_regex_reports_itself_rather_than_claiming_the_worktree_is_empty(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = fixture_repo();
+        let (app, cx) = open_search(cx, &repo);
+        click(cx, "search-modifier-regex");
+        type_and_settle(cx, "(unclosed");
+
+        app.read_with(cx, |app, _| {
+            assert!(matches!(
+                app.search.body_state(),
+                BodyState::InvalidQuery(_)
+            ));
+            assert_eq!(app.search.count_label(), "invalid pattern");
+        });
+        assert!(
+            cx.debug_bounds("search-fold-all").is_none(),
+            "there are no results to fold"
+        );
+    }
+
+    #[gpui::test]
+    fn leaving_the_search_tab_never_strands_focus_on_an_unrendered_field(cx: &mut TestAppContext) {
+        let repo = fixture_repo();
+        let (app, cx) = open_search(cx, &repo);
+        cx.simulate_input("refresh");
+        cx.run_until_parked();
+
+        app.update_in(cx, |app, window, cx| {
+            app.set_right_sidebar_view(RightSidebarView::Files, window, cx);
+        });
+        cx.run_until_parked();
+
+        let (focused, query_handle) = app.update_in(cx, |app, window, cx| {
+            (window.focused(cx), app.search.query_focus_handle.clone())
+        });
+        assert_ne!(
+            focused.as_ref(),
+            Some(&query_handle),
+            "a `FocusId` no rendered frame can resolve silently kills every context-scoped \
+             binding until the next click"
         );
     }
 }

--- a/crates/app/src/search/state.rs
+++ b/crates/app/src/search/state.rs
@@ -1,0 +1,740 @@
+//! The Search panel's own state, and the pure decisions the panel's chrome reads off it: which
+//! of the three design states the body is in, what the count row says, and what each of the four
+//! real inputs holds.
+//!
+//! GPUI-free apart from the four [`gpui::FocusHandle`]s the fields need - which are plain data
+//! (`FocusHandle` is a cheap, cloneable id, not a window) - so every rule below is a real unit
+//! test rather than a claim checked only by looking at a screenshot.
+//!
+//! ## Three states, gated on one flag
+//!
+//! `REVISION-2026-08-14.md` §5's table **is** the spec, and [`BodyState`] is it as an enum:
+//!
+//! | | count row | body | fold-all · Replace all |
+//! |---|---|---|---|
+//! | no query | *(empty)* | `Search the files in <branch>.` | hidden |
+//! | no match | `no results` | `No matches for "<q>" in <branch>.` | hidden |
+//! | results | `14 results in 6 files` | the tree | shown |
+//!
+//! §4w's own account of why this is three and not two is the whole reason the flag exists:
+//! "making the query a real input created a state that could not previously exist - an empty
+//! field - and every derived value still branched on the match count alone, so *not searched yet*
+//! rendered as `no results` ... That asserts a fact about the worktree from a search nobody ran."
+//!
+//! Two further states the design table does not have, because a mock cannot have them: a search
+//! genuinely **in flight**, and a regex that does not **compile**. Both are real, and both are
+//! shown as themselves rather than folded into `no results` - which would be the same lie the
+//! table exists to stop, one layer down. In particular the results of a *previous* query are
+//! never left on screen under a newer one: [`SearchPanel::body_state`] compares the outcome's own
+//! query against what is typed now, so a stale tree reports itself as still searching instead of
+//! answering a question nobody asked.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use gpui::FocusHandle;
+
+use crate::root::plural;
+use crate::search::engine::{SearchOptions, SearchOutcome};
+use crate::text_history::TextField;
+
+/// Which of the four real inputs the panel is typing into.
+///
+/// A single enum rather than four booleans or four separate key handlers: the four fields share
+/// one keymap and one key-down handler, and "which one is focused" is exactly one fact. Four
+/// flags would be four facts that can disagree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SearchField {
+    Query,
+    Replace,
+    Include,
+    Exclude,
+}
+
+impl SearchField {
+    /// Every field, in the order Tab walks them - which is also the order they are stacked on
+    /// screen.
+    pub const ALL: [SearchField; 4] = [
+        SearchField::Query,
+        SearchField::Replace,
+        SearchField::Include,
+        SearchField::Exclude,
+    ];
+}
+
+/// One of the three modifier buttons, so the row can be built by iteration rather than three
+/// near-identical hand-written blocks that can drift apart.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SearchModifier {
+    /// `Aa`.
+    MatchCase,
+    /// `ab`, drawn underlined the way VS Code draws it (`STAGE-A-CHANGELOG.md` §4v).
+    WholeWord,
+    /// `.*`.
+    Regex,
+}
+
+impl SearchModifier {
+    pub const ALL: [SearchModifier; 3] = [
+        SearchModifier::MatchCase,
+        SearchModifier::WholeWord,
+        SearchModifier::Regex,
+    ];
+
+    /// The glyph pair `REVISION-2026-08-14.md` §5 names.
+    pub fn label(self) -> &'static str {
+        match self {
+            SearchModifier::MatchCase => "Aa",
+            SearchModifier::WholeWord => "ab",
+            SearchModifier::Regex => ".*",
+        }
+    }
+
+    pub fn tooltip(self) -> &'static str {
+        match self {
+            SearchModifier::MatchCase => "Match case",
+            SearchModifier::WholeWord => "Match whole word",
+            SearchModifier::Regex => "Use regular expression",
+        }
+    }
+
+    pub fn is_on(self, options: SearchOptions) -> bool {
+        match self {
+            SearchModifier::MatchCase => options.match_case,
+            SearchModifier::WholeWord => options.whole_word,
+            SearchModifier::Regex => options.regex,
+        }
+    }
+
+    pub fn toggle(self, options: &mut SearchOptions) {
+        match self {
+            SearchModifier::MatchCase => options.match_case = !options.match_case,
+            SearchModifier::WholeWord => options.whole_word = !options.whole_word,
+            SearchModifier::Regex => options.regex = !options.regex,
+        }
+    }
+}
+
+/// A completed search, kept beside the exact query and options that produced it.
+///
+/// The query is stored rather than assumed: it is what lets [`SearchPanel::body_state`] tell "these
+/// are the results for what is typed" from "these are the results for what *was* typed", which is
+/// the difference between a result tree and a stale one.
+#[derive(Debug, Clone)]
+pub struct CompletedSearch {
+    pub query: String,
+    pub options: SearchOptions,
+    pub include: String,
+    pub exclude: String,
+    pub outcome: SearchOutcome,
+}
+
+impl CompletedSearch {
+    /// Whether this really answers the panel's current inputs.
+    fn answers(&self, panel: &SearchPanel) -> bool {
+        self.query == panel.query.as_str()
+            && self.options == panel.options
+            && self.include == panel.include.as_str()
+            && self.exclude == panel.exclude.as_str()
+    }
+}
+
+/// What the panel's body is showing right now - `REVISION-2026-08-14.md` §5's table, plus the two
+/// states a static mock cannot have. See this module's own docs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BodyState {
+    /// Nothing typed. Not the same fact as "searched, found nothing".
+    NotSearched,
+    /// The query is a regular expression that does not compile, with the message from `regex`
+    /// itself - the only thing that can say which character is the problem.
+    InvalidQuery(String),
+    /// A real search is running, or the last completed one answers a different query.
+    Searching,
+    /// Searched, and the worktree really holds nothing matching.
+    NoMatch,
+    /// Searched, and there are hits.
+    Results,
+}
+
+impl BodyState {
+    /// Whether the fold-all caret and `Replace all` exist at all - `REVISION-2026-08-14.md` §7
+    /// rule 2: "A control that acts on results does not exist when there are none."
+    pub fn has_results(&self) -> bool {
+        matches!(self, BodyState::Results)
+    }
+}
+
+/// The whole Search tab's state.
+pub struct SearchPanel {
+    /// The four real inputs. `REVISION-2026-08-14.md` §5: "Four real inputs: query, replace,
+    /// include, exclude. A fake field directly below a real one is a dead end the user will
+    /// click."
+    pub query: TextField,
+    pub replace: TextField,
+    pub include: TextField,
+    pub exclude: TextField,
+    /// Which one the key handler is typing into. See [`SearchField`].
+    pub focused_field: SearchField,
+    pub options: SearchOptions,
+    /// Whether the `⇄` replace row is revealed.
+    pub replace_open: bool,
+    /// Whether the funnel's include/exclude rows are revealed.
+    pub globs_open: bool,
+    /// Files whose match rows are collapsed - absent means expanded, so a fresh search opens
+    /// everything, which is what the design's own default state draws.
+    pub collapsed: HashSet<PathBuf>,
+    /// The last search that really finished.
+    pub completed: Option<CompletedSearch>,
+    /// A real search is in flight right now.
+    pub searching: bool,
+    /// The query could not be compiled - `Some` only while that is still true of what is typed.
+    pub error: Option<String>,
+    /// Bumped for every search started; a finishing task whose generation is stale is discarded,
+    /// so a slow search over a big worktree can never overwrite a newer, faster one's results.
+    pub generation: u64,
+    /// What the last replace really did, said out loud under the query row until the next edit.
+    pub notice: Option<String>,
+    /// One handle per field - a shared handle could not tell the renderer which field's caret to
+    /// paint, and painting all four at once is exactly the bug class GitHub issue #45 keeps
+    /// finding.
+    pub query_focus_handle: FocusHandle,
+    pub replace_focus_handle: FocusHandle,
+    pub include_focus_handle: FocusHandle,
+    pub exclude_focus_handle: FocusHandle,
+}
+
+impl SearchPanel {
+    pub fn new(cx: &mut gpui::App) -> Self {
+        SearchPanel {
+            query: TextField::new(),
+            replace: TextField::new(),
+            include: TextField::new(),
+            exclude: TextField::new(),
+            focused_field: SearchField::Query,
+            options: SearchOptions::default(),
+            replace_open: false,
+            globs_open: false,
+            collapsed: HashSet::new(),
+            completed: None,
+            searching: false,
+            error: None,
+            generation: 0,
+            notice: None,
+            query_focus_handle: cx.focus_handle(),
+            replace_focus_handle: cx.focus_handle(),
+            include_focus_handle: cx.focus_handle(),
+            exclude_focus_handle: cx.focus_handle(),
+        }
+    }
+
+    pub fn field(&self, which: SearchField) -> &TextField {
+        match which {
+            SearchField::Query => &self.query,
+            SearchField::Replace => &self.replace,
+            SearchField::Include => &self.include,
+            SearchField::Exclude => &self.exclude,
+        }
+    }
+
+    pub fn field_mut(&mut self, which: SearchField) -> &mut TextField {
+        match which {
+            SearchField::Query => &mut self.query,
+            SearchField::Replace => &mut self.replace,
+            SearchField::Include => &mut self.include,
+            SearchField::Exclude => &mut self.exclude,
+        }
+    }
+
+    pub fn focus_handle(&self, which: SearchField) -> &FocusHandle {
+        match which {
+            SearchField::Query => &self.query_focus_handle,
+            SearchField::Replace => &self.replace_focus_handle,
+            SearchField::Include => &self.include_focus_handle,
+            SearchField::Exclude => &self.exclude_focus_handle,
+        }
+    }
+
+    /// Whether a field is currently reachable - a hidden row's field is not something Tab may land
+    /// on, and `⇄`/the funnel are what reveal them.
+    pub fn field_is_visible(&self, which: SearchField) -> bool {
+        match which {
+            SearchField::Query => true,
+            SearchField::Replace => self.replace_open,
+            SearchField::Include | SearchField::Exclude => self.globs_open,
+        }
+    }
+
+    /// The next visible field Tab should move to, wrapping. `None` only if somehow nothing is
+    /// visible, which cannot happen - the query row is always there.
+    pub fn next_visible_field(&self, from: SearchField) -> Option<SearchField> {
+        let start = SearchField::ALL
+            .iter()
+            .position(|field| *field == from)
+            .unwrap_or(0);
+        (1..=SearchField::ALL.len())
+            .map(|step| SearchField::ALL[(start + step) % SearchField::ALL.len()])
+            .find(|field| self.field_is_visible(*field))
+    }
+
+    /// The query as the search would run it. `REVISION-2026-08-14.md` §5's own `hasQ` is
+    /// `findQ.trim().length > 0`, but this app does **not** trim: a whitespace query is a real
+    /// search here (see `crate::search::engine::Matcher::compile`), so the has-query flag is
+    /// simply "not empty".
+    pub fn has_query(&self) -> bool {
+        !self.query.is_empty()
+    }
+
+    /// The one three-state gate the count row, the body and the results-only controls all read.
+    pub fn body_state(&self) -> BodyState {
+        if !self.has_query() {
+            return BodyState::NotSearched;
+        }
+        if let Some(error) = &self.error {
+            return BodyState::InvalidQuery(error.clone());
+        }
+        match &self.completed {
+            Some(completed) if completed.answers(self) => {
+                if completed.outcome.total_matches == 0 {
+                    BodyState::NoMatch
+                } else {
+                    BodyState::Results
+                }
+            }
+            // Either nothing has finished yet, or what finished answers a different question.
+            // Both are "we do not know yet", and saying so beats showing the previous query's
+            // tree under this one.
+            _ => BodyState::Searching,
+        }
+    }
+
+    /// The outcome the tree should draw, or `None` in every state that is not [`BodyState::Results`].
+    pub fn results(&self) -> Option<&SearchOutcome> {
+        match self.body_state() {
+            BodyState::Results => self.completed.as_ref().map(|completed| &completed.outcome),
+            _ => None,
+        }
+    }
+
+    /// The count row's text - `""`, `no results`, `14 results in 6 files`, or the two states the
+    /// design table does not have.
+    ///
+    /// Every count goes through `crate::root::plural` (`REVISION-2026-08-14.md` §7 rule 9), so
+    /// `1 result in 1 file` is never `1 results in 1 files`.
+    pub fn count_label(&self) -> String {
+        match self.body_state() {
+            BodyState::NotSearched => String::new(),
+            BodyState::InvalidQuery(_) => "invalid pattern".to_string(),
+            BodyState::Searching => "searching\u{2026}".to_string(),
+            BodyState::NoMatch => "no results".to_string(),
+            BodyState::Results => {
+                let Some(outcome) = self.results() else {
+                    return String::new();
+                };
+                let label = format!(
+                    "{} in {}",
+                    plural::count(outcome.total_matches, "result", None),
+                    plural::count(outcome.files.len(), "file", None)
+                );
+                if outcome.truncated {
+                    // The issue's own "results cap with an honest truncation notice". Said in the
+                    // count row itself rather than only in a tooltip: the number beside it is a
+                    // floor, not a total, and a reader who does not hover would otherwise take it
+                    // for the total.
+                    format!("{label} (capped)")
+                } else {
+                    label
+                }
+            }
+        }
+    }
+
+    /// The count row's tooltip while the cap was hit, which is where the number the label cannot
+    /// fit belongs.
+    pub fn truncation_tooltip(&self) -> Option<String> {
+        let outcome = self.results()?;
+        outcome.truncated.then(|| {
+            format!(
+                "Stopped at {} across {} - narrow the query, or use the path filters",
+                plural::count(outcome.total_matches, "match", Some("matches")),
+                plural::count(outcome.scanned_files, "file", None)
+            )
+        })
+    }
+
+    /// The body's message in every state that is a message rather than a tree.
+    ///
+    /// `branch` is the active worktree's branch, exactly as the design's two sentences name it -
+    /// `Search the files in <branch>.` and `No matches for "<q>" in <branch>.`
+    pub fn body_message(&self, branch: &str) -> Option<String> {
+        match self.body_state() {
+            BodyState::NotSearched => Some(format!("Search the files in {branch}.")),
+            BodyState::Searching => Some(format!("Searching {branch}\u{2026}")),
+            BodyState::NoMatch => Some(format!(
+                "No matches for \u{201c}{}\u{201d} in {branch}.",
+                self.query.as_str()
+            )),
+            BodyState::InvalidQuery(error) => Some(error),
+            BodyState::Results => None,
+        }
+    }
+
+    /// `Replace all`'s tooltip, derived from live hits.
+    ///
+    /// The issue calls out the mock's own bug here by name: it "had `14` hardcoded and would have
+    /// lied on the first keystroke". Returns `None` in every state where there is nothing to
+    /// replace, which is the same gate the button itself is behind.
+    pub fn replace_all_tooltip(&self) -> Option<String> {
+        let outcome = self.results()?;
+        Some(format!(
+            "Replace all {} in {}",
+            plural::count(outcome.total_matches, "match", Some("matches")),
+            plural::count(outcome.files.len(), "file", None)
+        ))
+    }
+
+    /// Whether every file in the current results is collapsed - what the fold-all caret points
+    /// at, and what clicking it inverts. `REVISION-2026-08-14.md` §5: fold-all is "the same
+    /// `▾`/`▸` caret a file row uses, since it is the same action applied to all of them".
+    pub fn all_collapsed(&self) -> bool {
+        match self.results() {
+            Some(outcome) => outcome
+                .files
+                .iter()
+                .all(|file| self.collapsed.contains(&file.path)),
+            None => false,
+        }
+    }
+
+    /// Collapses every result file, or expands every one of them - whichever the caret is
+    /// currently offering.
+    pub fn toggle_fold_all(&mut self) {
+        let collapse = !self.all_collapsed();
+        let Some(paths) = self.results().map(|outcome| {
+            outcome
+                .files
+                .iter()
+                .map(|file| file.path.clone())
+                .collect::<Vec<_>>()
+        }) else {
+            return;
+        };
+        for path in paths {
+            if collapse {
+                self.collapsed.insert(path);
+            } else {
+                self.collapsed.remove(&path);
+            }
+        }
+    }
+
+    /// Every result file's absolute path, for a Replace all.
+    pub fn result_paths(&self) -> Vec<PathBuf> {
+        self.results()
+            .map(|outcome| outcome.files.iter().map(|file| file.path.clone()).collect())
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::search::engine::{FileMatches, LineMatch};
+    use std::time::Instant;
+
+    /// A panel with no `gpui::App` behind it. The four focus handles are the only thing `new`
+    /// needs a context for, and a test of the three-state gate has no business standing a window
+    /// up for them - so this builds the same struct with handles from a real, headless
+    /// `gpui::App` provided by the caller.
+    fn panel(cx: &mut gpui::App) -> SearchPanel {
+        SearchPanel::new(cx)
+    }
+
+    fn outcome(files: Vec<(&str, usize)>) -> SearchOutcome {
+        let files: Vec<FileMatches> = files
+            .into_iter()
+            .map(|(relative, hits)| FileMatches {
+                path: PathBuf::from("/wt").join(relative),
+                relative: relative.to_string(),
+                lines: (0..hits)
+                    .map(|index| LineMatch {
+                        line_number: index + 1,
+                        text: "hit".to_string(),
+                        // `std::iter::once` rather than `vec![0..3]`: clippy reads a one-element
+                        // `Vec<Range>` literal as a probable mistyped `(0..3).collect()`, which it
+                        // is not.
+                        ranges: std::iter::once(0..3).collect(),
+                    })
+                    .collect(),
+            })
+            .collect();
+        let total_matches = files.iter().map(|file| file.match_count()).sum();
+        SearchOutcome {
+            files,
+            total_matches,
+            truncated: false,
+            scanned_files: 12,
+        }
+    }
+
+    /// Marks `panel`'s current inputs as answered by `outcome`.
+    fn complete(panel: &mut SearchPanel, outcome: SearchOutcome) {
+        panel.completed = Some(CompletedSearch {
+            query: panel.query.as_str().to_string(),
+            options: panel.options,
+            include: panel.include.as_str().to_string(),
+            exclude: panel.exclude.as_str().to_string(),
+            outcome,
+        });
+        panel.searching = false;
+    }
+
+    #[gpui::test]
+    fn an_empty_query_is_not_searched_yet_not_no_results(cx: &mut gpui::TestAppContext) {
+        let panel = cx.update(panel);
+        assert_eq!(panel.body_state(), BodyState::NotSearched);
+        assert_eq!(
+            panel.count_label(),
+            "",
+            "the count row is empty, not `no results` - a search nobody ran asserts nothing about \
+             the worktree"
+        );
+        assert_eq!(
+            panel.body_message("fix/auth-token-race").as_deref(),
+            Some("Search the files in fix/auth-token-race.")
+        );
+        assert!(!panel.body_state().has_results());
+        assert_eq!(panel.replace_all_tooltip(), None);
+    }
+
+    #[gpui::test]
+    fn a_query_with_no_hits_is_a_different_state_with_a_different_sentence(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let mut panel = cx.update(panel);
+        panel.query.set("refresh_token", Instant::now());
+        complete(&mut panel, outcome(Vec::new()));
+        assert_eq!(panel.body_state(), BodyState::NoMatch);
+        assert_eq!(panel.count_label(), "no results");
+        assert_eq!(
+            panel.body_message("fix/auth-token-race").as_deref(),
+            Some("No matches for \u{201c}refresh_token\u{201d} in fix/auth-token-race.")
+        );
+        assert!(
+            !panel.body_state().has_results(),
+            "a control that acts on results does not exist when there are none"
+        );
+    }
+
+    #[gpui::test]
+    fn results_read_through_the_pluralisation_helper_in_both_directions(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let mut panel = cx.update(panel);
+        panel.query.set("refresh_token", Instant::now());
+        complete(&mut panel, outcome(vec![("src/a.rs", 1)]));
+        assert_eq!(
+            panel.count_label(),
+            "1 result in 1 file",
+            "never `1 results in 1 files` - the exact defect §7 rule 9 exists for"
+        );
+
+        complete(
+            &mut panel,
+            outcome(vec![
+                ("src/auth/session.rs", 4),
+                ("src/auth/store.rs", 2),
+                ("src/auth/mod.rs", 1),
+                ("tests/auth_race.rs", 3),
+                ("src/api/users.rs", 2),
+                ("migrations/0031.sql", 2),
+            ]),
+        );
+        assert_eq!(panel.count_label(), "14 results in 6 files");
+        assert!(panel.body_state().has_results());
+    }
+
+    #[gpui::test]
+    fn the_replace_all_tooltip_derives_from_live_hits_rather_than_a_hardcoded_number(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let mut panel = cx.update(panel);
+        panel.query.set("refresh_token", Instant::now());
+        complete(&mut panel, outcome(vec![("src/a.rs", 4), ("src/b.rs", 2)]));
+        assert_eq!(
+            panel.replace_all_tooltip().as_deref(),
+            Some("Replace all 6 matches in 2 files")
+        );
+
+        // One keystroke later the results answer a different query - which is precisely where the
+        // mock's own hardcoded `14` would have started lying.
+        panel.query.insert_str("s", Instant::now());
+        assert_eq!(panel.replace_all_tooltip(), None);
+    }
+
+    #[gpui::test]
+    fn results_for_a_previous_query_are_never_shown_under_a_newer_one(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let mut panel = cx.update(panel);
+        panel.query.set("refresh", Instant::now());
+        complete(&mut panel, outcome(vec![("src/a.rs", 3)]));
+        assert_eq!(panel.body_state(), BodyState::Results);
+
+        panel.query.insert_str("_token", Instant::now());
+        assert_eq!(
+            panel.body_state(),
+            BodyState::Searching,
+            "a tree answering a question nobody asked is the same lie the three-state gate exists \
+             to stop, one layer down"
+        );
+        assert_eq!(panel.results(), None);
+    }
+
+    #[gpui::test]
+    fn changing_a_modifier_or_a_glob_also_invalidates_the_results(cx: &mut gpui::TestAppContext) {
+        let mut panel = cx.update(panel);
+        panel.query.set("token", Instant::now());
+        complete(&mut panel, outcome(vec![("src/a.rs", 1)]));
+
+        panel.options.match_case = true;
+        assert_eq!(
+            panel.body_state(),
+            BodyState::Searching,
+            "`Aa` changes results - the acceptance criterion says so in as many words"
+        );
+
+        panel.options.match_case = false;
+        assert_eq!(panel.body_state(), BodyState::Results);
+        panel.include.set("src/**", Instant::now());
+        assert_eq!(panel.body_state(), BodyState::Searching);
+    }
+
+    #[gpui::test]
+    fn an_invalid_regex_says_which_character_rather_than_claiming_no_results(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let mut panel = cx.update(panel);
+        panel.query.set("(unclosed", Instant::now());
+        panel.options.regex = true;
+        panel.error = Some("regex parse error: unclosed group".to_string());
+        assert_eq!(
+            panel.body_state(),
+            BodyState::InvalidQuery("regex parse error: unclosed group".to_string())
+        );
+        assert_eq!(panel.count_label(), "invalid pattern");
+        assert_eq!(
+            panel.body_message("main").as_deref(),
+            Some("regex parse error: unclosed group")
+        );
+        assert!(!panel.body_state().has_results());
+    }
+
+    #[gpui::test]
+    fn a_capped_search_says_so_in_the_count_row_not_only_in_a_tooltip(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let mut panel = cx.update(panel);
+        panel.query.set("a", Instant::now());
+        let mut capped = outcome(vec![("src/a.rs", 3)]);
+        capped.truncated = true;
+        complete(&mut panel, capped);
+        assert_eq!(panel.count_label(), "3 results in 1 file (capped)");
+        assert!(panel
+            .truncation_tooltip()
+            .expect("a tooltip")
+            .contains("Stopped at 3 matches"));
+    }
+
+    #[gpui::test]
+    fn fold_all_collapses_every_file_and_then_expands_every_file(cx: &mut gpui::TestAppContext) {
+        let mut panel = cx.update(panel);
+        panel.query.set("a", Instant::now());
+        complete(&mut panel, outcome(vec![("src/a.rs", 1), ("src/b.rs", 1)]));
+
+        assert!(!panel.all_collapsed(), "a fresh search opens everything");
+        panel.toggle_fold_all();
+        assert!(panel.all_collapsed());
+        assert_eq!(panel.collapsed.len(), 2);
+        panel.toggle_fold_all();
+        assert!(!panel.all_collapsed());
+        assert!(panel.collapsed.is_empty());
+    }
+
+    #[gpui::test]
+    fn one_collapsed_file_out_of_two_still_offers_collapse_all(cx: &mut gpui::TestAppContext) {
+        let mut panel = cx.update(panel);
+        panel.query.set("a", Instant::now());
+        complete(&mut panel, outcome(vec![("src/a.rs", 1), ("src/b.rs", 1)]));
+        panel.collapsed.insert(PathBuf::from("/wt/src/a.rs"));
+        assert!(
+            !panel.all_collapsed(),
+            "some open means the caret still offers to close them"
+        );
+        panel.toggle_fold_all();
+        assert!(panel.all_collapsed());
+    }
+
+    #[gpui::test]
+    fn tab_walks_only_the_fields_that_are_really_on_screen(cx: &mut gpui::TestAppContext) {
+        let mut panel = cx.update(panel);
+        assert_eq!(
+            panel.next_visible_field(SearchField::Query),
+            Some(SearchField::Query),
+            "with replace and the globs hidden, the query is the only field there is"
+        );
+
+        panel.replace_open = true;
+        assert_eq!(
+            panel.next_visible_field(SearchField::Query),
+            Some(SearchField::Replace)
+        );
+        assert_eq!(
+            panel.next_visible_field(SearchField::Replace),
+            Some(SearchField::Query)
+        );
+
+        panel.globs_open = true;
+        assert_eq!(
+            panel.next_visible_field(SearchField::Replace),
+            Some(SearchField::Include)
+        );
+        assert_eq!(
+            panel.next_visible_field(SearchField::Exclude),
+            Some(SearchField::Query)
+        );
+    }
+
+    #[gpui::test]
+    fn each_field_has_its_own_text_and_its_own_focus_handle(cx: &mut gpui::TestAppContext) {
+        let mut panel = cx.update(panel);
+        let now = Instant::now();
+        for (index, field) in SearchField::ALL.into_iter().enumerate() {
+            panel.field_mut(field).set(&format!("value{index}"), now);
+        }
+        for (index, field) in SearchField::ALL.into_iter().enumerate() {
+            assert_eq!(panel.field(field).as_str(), format!("value{index}"));
+        }
+        // Four distinct handles, not one shared one - see the field's own docs.
+        let handles: Vec<gpui::FocusHandle> = SearchField::ALL
+            .into_iter()
+            .map(|field| panel.focus_handle(field).clone())
+            .collect();
+        for (index, handle) in handles.iter().enumerate() {
+            for other in handles.iter().skip(index + 1) {
+                assert_ne!(handle, other);
+            }
+        }
+    }
+
+    #[gpui::test]
+    fn a_whitespace_query_is_a_real_search_not_the_idle_state(cx: &mut gpui::TestAppContext) {
+        let mut panel = cx.update(panel);
+        panel.query.set("    ", Instant::now());
+        assert!(panel.has_query());
+        assert_eq!(
+            panel.body_state(),
+            BodyState::Searching,
+            "searching for an indentation width is a real thing to want"
+        );
+    }
+}

--- a/crates/app/src/settings/render.rs
+++ b/crates/app/src/settings/render.rs
@@ -1134,6 +1134,7 @@ impl AdeApp {
                         text_selector: "settings-shell-text".into(),
                         focus_handle: Some(&self.shell_focus_handle),
                         text: if has_shell { &shell } else { "" },
+                        caret_offset: self.shell_input.caret(),
                         placeholder: &placeholder,
                         font: theme::font::MONO,
                         text_size: self.ui_text_size(10.5),
@@ -1169,13 +1170,13 @@ impl AdeApp {
         self.reset_caret_blink(cx);
         let escaped = keystroke.key.as_str() == "escape";
         let changed = match keystroke.key.as_str() {
-            "backspace" => self.shell_input.pop(Instant::now()),
+            "backspace" => self.shell_input.backspace(Instant::now()),
             // Clearing the field is itself a real, meaningful edit here (it means "go back to the
             // system default"), so it persists like any other - and is undoable, like every other
             // simple input's `Esc`.
             "escape" => self.shell_input.clear(Instant::now()),
             _ => match keystroke.key_char.as_deref() {
-                Some(text) if !text.is_empty() => self.shell_input.push_str(text, Instant::now()),
+                Some(text) if !text.is_empty() => self.shell_input.insert_str(text, Instant::now()),
                 _ => false,
             },
         };
@@ -2146,7 +2147,7 @@ impl AdeApp {
         }
         self.reset_caret_blink(cx);
         let changed = match keystroke.key.as_str() {
-            "backspace" => self.theme_seed_input.pop(Instant::now()),
+            "backspace" => self.theme_seed_input.backspace(Instant::now()),
             "escape" => self.theme_seed_input.clear(Instant::now()),
             "enter" => {
                 self.start_generate_theme_from_seed(cx);
@@ -2154,7 +2155,7 @@ impl AdeApp {
             }
             _ => match keystroke.key_char.as_deref() {
                 Some(text) if !text.is_empty() => {
-                    self.theme_seed_input.push_str(text, Instant::now())
+                    self.theme_seed_input.insert_str(text, Instant::now())
                 }
                 _ => false,
             },
@@ -2644,6 +2645,7 @@ impl AdeApp {
                         text_selector: "settings-keymap-filter-text".into(),
                         focus_handle: Some(&self.settings_keymap_filter_focus_handle),
                         text: self.settings_keymap_filter.as_str(),
+                        caret_offset: self.settings_keymap_filter.caret(),
                         placeholder: &format!("filter {}", plural::count(total, "binding", None)),
                         font: theme::font::SANS,
                         text_size: px(11.0),
@@ -2677,13 +2679,13 @@ impl AdeApp {
         // handle_palette_key_down`'s identical reasoning.
         self.reset_caret_blink(cx);
         let changed = match keystroke.key.as_str() {
-            "backspace" => self.settings_keymap_filter.pop(Instant::now()),
+            "backspace" => self.settings_keymap_filter.backspace(Instant::now()),
             // A real, undoable step - see `crate::rail::AdeApp::handle_filter_key_down`'s own
             // identical `Esc` handling.
             "escape" => self.settings_keymap_filter.clear(Instant::now()),
             _ => match keystroke.key_char.as_deref() {
                 Some(text) if !text.is_empty() => {
-                    self.settings_keymap_filter.push_str(text, Instant::now())
+                    self.settings_keymap_filter.insert_str(text, Instant::now())
                 }
                 _ => false,
             },

--- a/crates/app/src/settings/state.rs
+++ b/crates/app/src/settings/state.rs
@@ -535,6 +535,8 @@ pub(crate) fn action_label(action: &dyn gpui::Action) -> Option<&'static str> {
         "app::NewTerminal" => Some("New terminal"),
         "app::NewAgentPane" => Some("New agent pane"),
         "app::NewGitGraph" => Some("Open git graph"),
+        "app::SearchInWorktree" => Some("Search in this worktree"),
+        "app::FindInFile" => Some("Find in this file"),
         "app::NextChangedFile" => Some("Next changed file"),
         "app::ToggleChangeSeen" => Some("Mark file seen / unseen"),
         "app::ToggleChangeStaged" => Some("Stage / unstage file"),
@@ -1888,6 +1890,8 @@ mod tests {
                 "New terminal",
                 "New agent pane",
                 "Open git graph",
+                "Search in this worktree",
+                "Find in this file",
                 "Next changed file",
                 "Mark file seen / unseen",
                 "Stage / unstage file",
@@ -2102,6 +2106,10 @@ mod tests {
         // the batch - and `ToggleLineNote` (`c`) under `Some("diff-view && !text-input")`, the
         // same negated conjunct and the same reason as the rebase plan's plain letters above:
         // the pinned note card is a real text field inside that very container.
+        // GitHub issue #162 added 1 more scoped binding: `mod+F` -> `FindInFile` under
+        // `Some("file-editor")`. Its sibling `mod+shift+F` -> `SearchInWorktree` is deliberately
+        // *global* and so is not counted here - the right panel's Search tab has no editor to be
+        // scoped to, and a real Cmd/Ctrl-modified keystroke never reaches a focused pty anyway.
         // The Changes-footer prose fix added 1 more: `space` -> `ToggleChangeStaged`, alongside
         // `v` and `]` - `Jerry.dc.html`'s `changesHints` advertises `space stage` in that footer
         // and nothing was bound to it. All three of those now also carry `&& !text-input`, since
@@ -2114,7 +2122,7 @@ mod tests {
             rows.iter().filter(|row| row.context != "global").collect();
         assert_eq!(
             scoped.len(),
-            85,
+            86,
             "expected `] -> NextChangedFile` (1) plus every real Editor* binding (19) plus \
              every real Completions* binding (5) plus every real merge-editor binding (18) plus \
              TextUndo/TextRedo (3, GitHub issue #17) plus every real \
@@ -2126,7 +2134,8 @@ mod tests {
              (1, GitHub issue #20) plus TerminalCopy/TerminalPaste (2, GitHub issue #158) plus \
              every real interactive-rebase plan binding (6, GitHub issue #304) plus every \
              real review-note binding (2, GitHub issue #288) plus `space -> \
-             ToggleChangeStaged` (1, the Changes footer's own `space stage` hint) to be scoped, \
+             ToggleChangeStaged` (1, the Changes footer's own `space stage` hint) plus \
+             `mod+F -> FindInFile` (1, GitHub issue #162's in-file find) to be scoped, \
              not global"
         );
         assert!(

--- a/crates/app/src/settings/theme_file_format.rs
+++ b/crates/app/src/settings/theme_file_format.rs
@@ -51,6 +51,7 @@ const SECTIONS: &[(&str, &[&str])] = &[
         "Meaning and state (colour carries information here)",
         &[
             "status", "diff", "tag", "rail", "agent", "changes", "budget", "notes", "history",
+            "search",
         ],
     ),
     (

--- a/crates/app/src/settings/widgets.rs
+++ b/crates/app/src/settings/widgets.rs
@@ -531,36 +531,56 @@ impl AdeApp {
             .rounded(theme::radius::BUTTON)
             .bg(theme::surface::SEGMENT_TRACK);
 
+        // One `IconRow` for the whole control, not one per segment: that is `REVISION-2026-08-14.md`
+        // §7 rule 7 ("a row of icons needs one shared optical box, not one size per icon") made
+        // structural rather than left to each segment to get right - the exact defect §4w records
+        // fixing after the first cut drew "folder 12x8, magnifier 8x8, diff 7x7".
+        let icons =
+            crate::icons::IconRow::new(&self.settings.icon_pack, crate::icons::IconSize::PanelTab);
         for (index, option) in options.iter().enumerate() {
             let label = option.label;
             let is_active = label == selected;
             let on_select = on_select.clone();
+            let foreground = if is_active {
+                theme::text::PRIMARY
+            } else if option.enabled {
+                theme::settings::SUBTITLE
+            } else {
+                theme::text::DISABLED
+            };
             let mut segment = div()
                 .id(gpui::ElementId::from(format!("{id_prefix}-{label}")))
                 // Index-based lookup key for `VisualTestContext::debug_bounds`, matching this
                 // control's own index-based `on_select` dispatch. No-op in release builds.
                 .debug_selector(move || format!("choice-{id_prefix}-{index}"))
                 .h(px(19.0))
-                .px(px(9.0))
+                // An icon segment is a fixed 26 wide with its glyph centred (§4w's "26x19
+                // buttons"); a label segment stays intrinsically sized with its own side padding.
+                .map(|el| match option.icon {
+                    Some(_) => el.w(px(26.0)).justify_center(),
+                    None => el.px(px(9.0)),
+                })
                 .rounded(theme::radius::CHIP)
                 .flex()
                 .items_center()
                 .gap(px(6.0))
                 .when(is_active, |el| el.bg(theme::surface::SEGMENT_ACTIVE))
-                .child(
-                    div()
-                        .font(font(theme::font::SANS))
-                        .font_weight(gpui::FontWeight::MEDIUM)
-                        .text_size(self.ui_text_size(10.5))
-                        .text_color(if is_active {
-                            theme::text::PRIMARY
-                        } else if option.enabled {
-                            theme::settings::SUBTITLE
-                        } else {
-                            theme::text::DISABLED
-                        })
-                        .child(label),
-                )
+                .when_some(option.tooltip, |el, tooltip| {
+                    el.tooltip(crate::root::widgets::text_tooltip(tooltip))
+                })
+                .map(|el| match option.icon {
+                    // The glyph replaces the label entirely - drawing both would put the label
+                    // back on a row §4w emptied on purpose.
+                    Some(icon) => el.child(icons.draw(icon, foreground)),
+                    None => el.child(
+                        div()
+                            .font(font(theme::font::SANS))
+                            .font_weight(gpui::FontWeight::MEDIUM)
+                            .text_size(self.ui_text_size(10.5))
+                            .text_color(foreground)
+                            .child(label),
+                    ),
+                })
                 .when_some(option.hint, |el, hint| {
                     // A horizontal sibling of the label, not text stacked underneath it.
                     el.child(
@@ -598,14 +618,26 @@ impl AdeApp {
 }
 
 /// One segment of [`AdeApp::render_choice_control`]. The common case is just a label
-/// ([`Self::new`]) - disabled state and/or a secondary hint (a horizontal sibling of the label)
-/// are opt-in for the call sites that need them (the Diff/File toggle's `Diff` segment when
-/// there's no diff to show; the palette scope control's per-segment keybinding hint).
+/// ([`Self::new`]) - disabled state, a secondary hint (a horizontal sibling of the label), and an
+/// icon in place of the label are opt-in for the call sites that need them (the Diff/File toggle's
+/// `Diff` segment when there's no diff to show; the palette scope control's per-segment keybinding
+/// hint; the right panel's three icon tabs).
 #[derive(Clone, Copy)]
 pub(crate) struct ChoiceOption {
+    /// This segment's identity as well as its default rendering: [`AdeApp::render_choice_control`]
+    /// matches `selected` against it. An icon segment still carries one, so selection is never
+    /// keyed on something as fragile as which glyph is drawn.
     pub(in crate::settings) label: &'static str,
     pub(in crate::settings) enabled: bool,
     pub(in crate::settings) hint: Option<&'static str>,
+    /// Drawn **instead of** the label. `STAGE-A-CHANGELOG.md` §4w: the right panel's `Files` /
+    /// `Search` / `Changes` tabs become "three 26x19 buttons in the same segmented shell ... all
+    /// three drawn inside one 11x10 optical box", with the labels moving to the tooltips below.
+    pub(in crate::settings) icon: Option<crate::icons::Icon>,
+    /// The full `"<label> - <hint>"` sentence a segment shows on hover. Mandatory in practice for
+    /// an icon segment, which has no visible label left to read - §4w's own "labels move to
+    /// tooltips with their hints intact".
+    pub(in crate::settings) tooltip: Option<&'static str>,
 }
 
 impl ChoiceOption {
@@ -614,6 +646,8 @@ impl ChoiceOption {
             label,
             enabled: true,
             hint: None,
+            icon: None,
+            tooltip: None,
         }
     }
 
@@ -622,6 +656,8 @@ impl ChoiceOption {
             label,
             enabled,
             hint: None,
+            icon: None,
+            tooltip: None,
         }
     }
 
@@ -630,6 +666,24 @@ impl ChoiceOption {
             label,
             enabled: true,
             hint: Some(hint),
+            icon: None,
+            tooltip: None,
+        }
+    }
+
+    /// An icon segment: the glyph replaces the label on screen, and the label plus its hint move
+    /// into `tooltip` verbatim.
+    pub(crate) fn with_icon(
+        label: &'static str,
+        icon: crate::icons::Icon,
+        tooltip: &'static str,
+    ) -> Self {
+        Self {
+            label,
+            enabled: true,
+            hint: None,
+            icon: Some(icon),
+            tooltip: Some(tooltip),
         }
     }
 }

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -482,10 +482,10 @@ impl AdeApp {
             return;
         }
         let changed = match keystroke.key.as_str() {
-            "backspace" => self.commit_message.pop(Instant::now()),
+            "backspace" => self.commit_message.backspace(Instant::now()),
             _ => match keystroke.key_char.as_deref() {
                 Some(text) if !text.is_empty() => {
-                    self.commit_message.push_str(text, Instant::now())
+                    self.commit_message.insert_str(text, Instant::now())
                 }
                 _ => false,
             },

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -63,7 +63,7 @@ impl AdeApp {
             }
             // 1 again, one level removed, and invisible to the check above: an *overlay* can be
             // holding the tree's handle as its own return target while the overlay itself has
-            // focus - which is exactly the state the palette's own "Toggle Files / Changes"
+            // focus - which is exactly the state the palette's own "Cycle Right Panel"
             // command runs in, since the palette is focused and the tree is not. Closing the
             // palette afterwards would then restore focus onto a handle this very branch has
             // just unrendered. Swept from every overlay rather than only the palette, so a
@@ -72,6 +72,26 @@ impl AdeApp {
             self.palette_focus.forget_target(&self.tree_focus_handle);
             self.settings_focus.forget_target(&self.tree_focus_handle);
             self.code_focus.forget_target(&self.tree_focus_handle);
+        }
+        if view != RightSidebarView::Search {
+            // The same dangling-focus invariant as the Files block above, for GitHub issue #162's
+            // four fields: leaving Search unrenders every one of their `track_focus` nodes, so a
+            // handle still focused here would leave `Window::focus` pointing at a `FocusId` no
+            // rendered frame can resolve - which silently kills every context-scoped binding and
+            // the focused terminal's own key handling until the next click. Swept from the
+            // overlays too, for the reason the Files block's own `forget_target` sweep records:
+            // the palette can be the focused surface while holding a search field as its return
+            // target, and closing it would restore focus onto a node this branch just unrendered.
+            for field in crate::search::state::SearchField::ALL {
+                let handle = self.search.focus_handle(field).clone();
+                if handle.is_focused(window) {
+                    let fallback = self.focus_fallback_handle();
+                    restore_focus(&self.agents, &mut self.code_focus, fallback, window, cx);
+                }
+                self.palette_focus.forget_target(&handle);
+                self.settings_focus.forget_target(&handle);
+                self.code_focus.forget_target(&handle);
+            }
         }
         if view != RightSidebarView::Changes {
             // GitHub issue #176, the mirror image of the block above: leaving Changes unrenders
@@ -1613,30 +1633,56 @@ impl AdeApp {
         row.into_any_element()
     }
 
-    /// Zone 3's header band (36 high): the real `Files | Changes` segmented control
+    /// Zone 3's header band (36 high): the real `Files · Search · Changes` segmented control
     /// (`design_handoff_jerry_ade/README.md`: "Header 36: segmented `Files | Changes`
-    /// (Files is first and default...)") plus the real `+n`/`−n` totals across the currently
-    /// loaded diff, summed from the same real per-file stats
-    /// (`crate::sidebar::changes::diff_file_stats`) the Changes rows themselves show.
+    /// (Files is first and default...)", with GitHub issue #162 adding Search in the middle) plus
+    /// the real `+n`/`−n` totals across the currently loaded diff, summed from the same real
+    /// per-file stats (`crate::sidebar::changes::diff_file_stats`) the Changes rows themselves
+    /// show.
+    ///
+    /// The three segments are **icons**, not text - `STAGE-A-CHANGELOG.md` §4w: "`Files` /
+    /// `Search` / `Changes` were the only text tabs left in a window whose left strip is already
+    /// iconographic. Now three 26x19 buttons in the same segmented shell, selected state
+    /// unchanged, each with a tooltip carrying the old label plus its old hint." The tooltip
+    /// strings below are `Jerry.dc.html`'s own `title` attributes on those three buttons,
+    /// transcribed rather than paraphrased.
     pub(in crate::sidebar) fn render_right_sidebar_toggle(
         &self,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
         let selected = match self.right_sidebar_view {
             RightSidebarView::Files => "Files",
+            RightSidebarView::Search => "Search",
             RightSidebarView::Changes => "Changes",
         };
         let toggle = self.render_choice_control(
             "right-sidebar-toggle",
-            &[ChoiceOption::new("Files"), ChoiceOption::new("Changes")],
+            &[
+                ChoiceOption::with_icon(
+                    "Files",
+                    crate::icons::Icon::Folder,
+                    "Files \u{2014} the file tree for this worktree",
+                ),
+                ChoiceOption::with_icon(
+                    "Search",
+                    crate::icons::Icon::MagnifyingGlass,
+                    "Search \u{2014} find in this worktree",
+                ),
+                ChoiceOption::with_icon(
+                    "Changes",
+                    crate::icons::Icon::GitBranch,
+                    "Changes \u{2014} runs, uncommitted, commits and the branch diff",
+                ),
+            ],
             selected.to_string(),
             cx,
             |this, index, window, cx| {
-                // Structural, not a label re-match: index 0 is `Files`, index 1 is `Changes`,
-                // per the `options` array literal right above - see
+                // Structural, not a label re-match: index 0 is `Files`, 1 is `Search`, 2 is
+                // `Changes`, per the `options` array literal right above - see
                 // `Self::render_choice_control`'s own docs for why dispatch is index-based.
                 let view = match index {
-                    1 => RightSidebarView::Changes,
+                    1 => RightSidebarView::Search,
+                    2 => RightSidebarView::Changes,
                     _ => RightSidebarView::Files,
                 };
                 this.set_right_sidebar_view(view, window, cx);
@@ -1820,6 +1866,11 @@ impl AdeApp {
                     self.window_controls_style().is_macos(),
                     self.tree_inline_edit.is_none(),
                 )),
+            // GitHub issue #162 / `REVISION-2026-08-14.md` §5: the query row (with the replace
+            // and glob rows it reveals), the count row, then the body - which is the two-level
+            // match tree, or one of the two message states, gated on one has-query flag. The whole
+            // panel is `crate::search::render`'s; this arm only places it.
+            RightSidebarView::Search => container.child(self.render_search_panel(cx)),
             // GitHub issue #285: four collapsible sections, with the commit composer pinned
             // **above** them rather than at the panel's foot. The composer is a git control and
             // the sections are what it acts on, so it reads first; that ordering is
@@ -4023,13 +4074,39 @@ impl AdeApp {
 }
 
 /// Which data source the right sidebar currently shows for the selected worktree - Zone 3's
-/// `right_pane` state (`Files | Changes`, `Files` default). The panel never shows diff
+/// `right_pane` state (`Files · Search · Changes`, `Files` default). The panel never shows diff
 /// *content* (see [`AdeApp::open_change`]'s docs) - `Changes` is the per-file review list,
 /// not a diff view.
+///
+/// `Search` is the middle tab (GitHub issue #162, `STAGE-A-CHANGELOG.md` §4u: "Search is now the
+/// middle tab of the right panel - `Files · Search · Changes`"). Middle rather than appended:
+/// these three are ordered by how far from the file they are - the tree, then finding a file's
+/// contents, then what has changed in them - and the order is what a user learns, not the label.
+///
+/// The variants' declaration order is also the segments' order in
+/// [`AdeApp::render_right_sidebar_toggle`], whose `on_select` dispatches by index. See
+/// `crate::settings::widgets::AdeApp::render_choice_control`'s own docs for why index, not label.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RightSidebarView {
     Files,
+    Search,
     Changes,
+}
+
+/// The next tab in `Files -> Search -> Changes -> Files` order, behind the command palette's
+/// `Cycle Right Panel`.
+///
+/// A free function next to the enum rather than two separate `match`es inside
+/// `crate::palette::render`: that command both *names* the tab it is about to show and *switches*
+/// to it, and those were two independent matches over the same enum before this - a shape that
+/// only stayed correct while nobody added a third variant. Which is exactly what GitHub issue #162
+/// then did.
+pub(crate) fn next_right_sidebar_view(current: RightSidebarView) -> RightSidebarView {
+    match current {
+        RightSidebarView::Files => RightSidebarView::Search,
+        RightSidebarView::Search => RightSidebarView::Changes,
+        RightSidebarView::Changes => RightSidebarView::Files,
+    }
 }
 
 /// One row of [`AdeApp::render_file_tree`]'s virtualized list: either a real walked entry (by

--- a/crates/app/src/sidebar/tree_ops.rs
+++ b/crates/app/src/sidebar/tree_ops.rs
@@ -658,7 +658,7 @@ impl AdeApp {
             }
             "backspace" => {
                 if let Some(edit) = self.tree_inline_edit.as_mut() {
-                    edit.name.pop(Instant::now());
+                    edit.name.backspace(Instant::now());
                     edit.error = None;
                     cx.notify();
                     cx.stop_propagation();
@@ -671,7 +671,7 @@ impl AdeApp {
                     .filter(|text| !text.is_empty())
                 {
                     if let Some(edit) = self.tree_inline_edit.as_mut() {
-                        edit.name.push_str(text, Instant::now());
+                        edit.name.insert_str(text, Instant::now());
                         edit.error = None;
                         cx.notify();
                         cx.stop_propagation();

--- a/crates/app/src/text_history.rs
+++ b/crates/app/src/text_history.rs
@@ -66,6 +66,8 @@
 use std::ops::Range;
 use std::time::{Duration, Instant};
 
+use unicode_segmentation::UnicodeSegmentation;
+
 /// How long a pause in typing ends the current undo group. Long enough that an ordinary typing
 /// burst (including a moment's thought mid-word) stays one step; short enough that stepping away
 /// and coming back doesn't silently extend a step that already feels finished. Sits deliberately
@@ -603,18 +605,44 @@ impl TextHistory {
 /// agent filter, the Settings › Keybindings filter, the New file name prompt, the file
 /// tree's inline New File / New Folder / Rename editor - `crate::sidebar::tree_ops::TreeInlineEdit`,
 /// which became one of these when GitHub issue #19's tree met issue #17's undo work at a merge -
-/// the git graph tab's Branches filter, and GitHub issue #242 phase B's interactive-rebase plan
-/// rows' own per-row `reword` message field, one instance per row) with a real undo history
-/// attached. All are append/backspace-only with no caret of their own - see
-/// `crate::rail::AdeApp::handle_filter_key_down`'s own docs for that deliberate scope decision -
-/// so every snapshot here is a collapsed caret at the end of the text.
+/// the git graph tab's Branches filter, GitHub issue #242 phase B's interactive-rebase plan
+/// rows' own per-row `reword` message field, and GitHub issue #162's four search-panel fields)
+/// with a real undo history attached.
 ///
-/// The `String` is private on purpose: every mutation has to go through a method that records, so
-/// a future call site physically cannot bypass the history the way a bare `pub` field would allow.
-/// That is the same silent-divergence bug class this project's own audits keep finding.
+/// ## A real caret (GitHub issue #162)
+///
+/// These fields used to be append/backspace-only, with every history snapshot a collapsed caret
+/// pinned at the end of the text. `REVISION-2026-08-14.md` §5 ended that: "the shared single-line
+/// input needs to become a real editable field - caret positioning, not append/backspace-only;
+/// that upgrade is part of this issue and benefits every other filter row." A search panel with
+/// four real fields is where the old shape stops being defensible - a user *will* arrow back into
+/// a mistyped query rather than backspacing out eight characters of a regex to fix the first one.
+///
+/// So [`Self::caret`] is a real byte offset into [`Self::as_str`], always on a grapheme-cluster
+/// boundary, and every edit happens *there*: [`Self::insert_str`] splices at it,
+/// [`Self::backspace`]/[`Self::delete_forward`] remove the cluster on either side of it, and
+/// [`Self::move_left`]/[`Self::move_right`]/[`Self::move_to_start`]/[`Self::move_to_end`] move it
+/// without recording anything. [`Self::handle_editing_key`] is all of that behind one call, so a
+/// call site gets the whole vocabulary rather than whichever half it remembered to wire.
+///
+/// Undo/redo restore the caret too, from the [`SelectionSnapshot`]s the history already carried -
+/// which is what makes the coalescing policy's own "a caret jump is a group boundary" rule mean
+/// something here for the first time: arrowing away mid-burst now really does start a new step.
+///
+/// Deliberately **not** implemented: selection (and therefore selection-replacing typing, cut, or
+/// shift-arrow). Nothing in these fields needs it, `crate::code_surface::edit_buffer::EditBuffer`
+/// is what a surface that does needs, and half a selection model is worse than none.
+///
+/// The `String` and the caret are private on purpose: every mutation has to go through a method
+/// that records and that re-clamps the caret, so a future call site physically cannot bypass the
+/// history or leave the caret mid-cluster the way bare `pub` fields would allow. That is the same
+/// silent-divergence bug class this project's own audits keep finding.
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct TextField {
     text: String,
+    /// A byte offset into [`Self::text`], always `<= text.len()` and always on a grapheme
+    /// boundary.
+    caret: usize,
     history: TextHistory,
 }
 
@@ -623,9 +651,9 @@ impl TextField {
         Self::default()
     }
 
-    /// A field that opens *already holding* `text`, with an empty history - the file tree's
-    /// inline **rename** editor (GitHub issue #19), which pre-fills with the entry's current
-    /// name.
+    /// A field that opens *already holding* `text`, with an empty history and the caret at the
+    /// end - the file tree's inline **rename** editor (GitHub issue #19), which pre-fills with the
+    /// entry's current name.
     ///
     /// Deliberately not `new()` followed by [`Self::set`]: that would record the pre-fill as a
     /// real undoable step, so the very first `Ctrl+Z` after opening a rename would blank the
@@ -634,6 +662,7 @@ impl TextField {
     /// false until the user genuinely changes something.
     pub fn seeded(text: &str) -> Self {
         Self {
+            caret: text.len(),
             text: text.to_string(),
             history: TextHistory::new(),
         }
@@ -647,16 +676,108 @@ impl TextField {
         self.text.is_empty()
     }
 
-    /// Appends `text` at the end (this widget class has no caret to insert at), recording it as
-    /// ordinary typing. Returns whether anything changed.
-    pub fn push_str(&mut self, text: &str, now: Instant) -> bool {
+    /// Where the insertion point really is, as a byte offset into [`Self::as_str`]. What
+    /// `crate::root::widgets::SimpleInput` splits the rendered text at.
+    pub fn caret(&self) -> usize {
+        self.caret
+    }
+
+    /// The text before and after the caret - the two spans a rendered row draws the caret bar
+    /// between, so no call site has to slice on a byte offset itself and risk panicking mid-
+    /// cluster.
+    pub fn split_at_caret(&self) -> (&str, &str) {
+        self.text.split_at(self.caret)
+    }
+
+    /// The grapheme boundary at or just before `offset`, clamped into the text. A single-line
+    /// field is short enough to scan whole, unlike `EditBuffer` (see its own
+    /// `previous_boundary` docs for the measured whole-buffer-scan bug that is *not* reachable
+    /// here).
+    fn boundary_at_or_before(&self, offset: usize) -> usize {
+        if offset >= self.text.len() {
+            return self.text.len();
+        }
+        self.text
+            .grapheme_indices(true)
+            .rev()
+            .find(|(index, _)| *index <= offset)
+            .map(|(index, _)| index)
+            .unwrap_or(0)
+    }
+
+    /// The grapheme boundary strictly before the caret, or `None` at the very start.
+    fn previous_boundary(&self) -> Option<usize> {
+        self.text
+            .grapheme_indices(true)
+            .rev()
+            .find(|(index, _)| *index < self.caret)
+            .map(|(index, _)| index)
+    }
+
+    /// The grapheme boundary strictly after the caret, or `None` at the very end.
+    fn next_boundary(&self) -> Option<usize> {
+        self.text
+            .grapheme_indices(true)
+            .find(|(index, grapheme)| index + grapheme.len() > self.caret)
+            .map(|(index, grapheme)| index + grapheme.len())
+    }
+
+    /// Moves the caret one grapheme cluster left. Returns whether it really moved, so a caller can
+    /// tell "the view needs repainting" from "this keystroke did nothing and should keep
+    /// propagating".
+    pub fn move_left(&mut self) -> bool {
+        match self.previous_boundary() {
+            Some(offset) => {
+                self.caret = offset;
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// The mirror of [`Self::move_left`].
+    pub fn move_right(&mut self) -> bool {
+        match self.next_boundary() {
+            Some(offset) => {
+                self.caret = offset;
+                true
+            }
+            None => false,
+        }
+    }
+
+    pub fn move_to_start(&mut self) -> bool {
+        let moved = self.caret != 0;
+        self.caret = 0;
+        moved
+    }
+
+    pub fn move_to_end(&mut self) -> bool {
+        let moved = self.caret != self.text.len();
+        self.caret = self.text.len();
+        moved
+    }
+
+    /// Puts the caret at the grapheme boundary at or before `offset` - for a caller that has a
+    /// real byte offset of its own (a click hit-test) rather than an arrow key.
+    pub fn set_caret(&mut self, offset: usize) -> bool {
+        let clamped = self.boundary_at_or_before(offset);
+        let moved = clamped != self.caret;
+        self.caret = clamped;
+        moved
+    }
+
+    /// Splices `text` in at the caret, recording it as ordinary typing and leaving the caret after
+    /// what was inserted. Returns whether anything changed.
+    pub fn insert_str(&mut self, text: &str, now: Instant) -> bool {
         if text.is_empty() {
             return false;
         }
-        let at = self.text.len();
+        let at = self.caret;
         let before = SelectionSnapshot::caret(at);
-        self.text.push_str(text);
-        let after = SelectionSnapshot::caret(self.text.len());
+        self.text.insert_str(at, text);
+        self.caret = at + text.len();
+        let after = SelectionSnapshot::caret(self.caret);
         self.history.record(
             TextEdit {
                 at,
@@ -671,19 +792,21 @@ impl TextField {
         true
     }
 
-    /// Removes the last `char`, matching the `String::pop` these fields used before they had a
-    /// history. Returns whether anything was removed.
-    pub fn pop(&mut self, now: Instant) -> bool {
-        let Some(popped) = self.text.pop() else {
+    /// Removes the grapheme cluster **before** the caret - Backspace. Returns whether anything was
+    /// removed.
+    pub fn backspace(&mut self, now: Instant) -> bool {
+        let Some(at) = self.previous_boundary() else {
             return false;
         };
-        let at = self.text.len();
-        let before = SelectionSnapshot::caret(at + popped.len_utf8());
+        let removed = self.text[at..self.caret].to_string();
+        let before = SelectionSnapshot::caret(self.caret);
+        self.text.replace_range(at..self.caret, "");
+        self.caret = at;
         let after = SelectionSnapshot::caret(at);
         self.history.record(
             TextEdit {
                 at,
-                removed: popped.to_string(),
+                removed,
                 inserted: String::new(),
             },
             before,
@@ -694,18 +817,45 @@ impl TextField {
         true
     }
 
+    /// Removes the grapheme cluster **after** the caret - Delete. The caret does not move, which
+    /// is exactly why this cannot share a coalescing group with [`Self::backspace`] by accident:
+    /// their `before`/`after` snapshots differ.
+    pub fn delete_forward(&mut self, now: Instant) -> bool {
+        let Some(end) = self.next_boundary() else {
+            return false;
+        };
+        let at = self.caret;
+        let removed = self.text[at..end].to_string();
+        let before = SelectionSnapshot::caret(at);
+        self.text.replace_range(at..end, "");
+        self.history.record(
+            TextEdit {
+                at,
+                removed,
+                inserted: String::new(),
+            },
+            before,
+            SelectionSnapshot::caret(at),
+            EditKind::Delete,
+            now,
+        );
+        true
+    }
+
     /// Replaces the whole field programmatically (the `Esc`-clears gesture the rail/Settings
-    /// filters have). Recorded as its own sealed step, so `Esc` then Ctrl+Z really brings the
-    /// query back rather than silently losing it. Returns whether anything changed.
+    /// filters have, or a command that seeds a query). Recorded as its own sealed step, so `Esc`
+    /// then Ctrl+Z really brings the query back rather than silently losing it. Leaves the caret
+    /// at the end of the new text. Returns whether anything changed.
     pub fn set(&mut self, text: &str, now: Instant) -> bool {
         if self.text == text {
             return false;
         }
-        let before = SelectionSnapshot::caret(self.text.len());
+        let before = SelectionSnapshot::caret(self.caret);
         let after = SelectionSnapshot::caret(text.len());
         self.history
             .record_replacement(&self.text, text, before, after, now);
         self.text = text.to_string();
+        self.caret = self.text.len();
         true
     }
 
@@ -719,6 +869,7 @@ impl TextField {
     /// [`TextHistory::reset`]'s own docs.
     pub fn reset(&mut self) {
         self.text.clear();
+        self.caret = 0;
         self.history.reset();
     }
 
@@ -726,9 +877,10 @@ impl TextField {
         self.history.can_undo()
     }
 
-    /// Steps one group back. Returns whether anything was actually undone - `false` both for an
-    /// empty history and (defensively) for a group that doesn't match the current text, which
-    /// leaves both the text and the cursor untouched rather than corrupting either.
+    /// Steps one group back, restoring the caret the group recorded as its `before`. Returns
+    /// whether anything was actually undone - `false` both for an empty history and (defensively)
+    /// for a group that doesn't match the current text, which leaves the text, the caret and the
+    /// cursor untouched rather than corrupting any of them.
     pub fn undo(&mut self) -> bool {
         let Some(group) = self.history.peek_undo() else {
             return false;
@@ -741,11 +893,12 @@ impl TextField {
             }
         }
         self.text = candidate;
+        self.caret = self.boundary_at_or_before(group.before.start);
         self.history.commit_undo();
         true
     }
 
-    /// The mirror of [`Self::undo`].
+    /// The mirror of [`Self::undo`], restoring the group's `after` caret.
     pub fn redo(&mut self) -> bool {
         let Some(group) = self.history.peek_redo() else {
             return false;
@@ -757,8 +910,35 @@ impl TextField {
             }
         }
         self.text = candidate;
+        self.caret = self.boundary_at_or_before(group.after.start);
         self.history.commit_redo();
         true
+    }
+
+    /// One keystroke's worth of ordinary single-line editing, so every call site gets the whole
+    /// vocabulary rather than whichever half it remembered to wire - which is precisely how these
+    /// fields ended up append/backspace-only for eight surfaces in the first place.
+    ///
+    /// `key`/`key_char` come straight off `gpui::Keystroke`. Returns whether anything changed
+    /// (text *or* caret), i.e. whether the caller should `cx.notify()` and stop propagation.
+    ///
+    /// Deliberately does **not** handle `escape`, `enter`, `tab` or the arrow keys' `up`/`down`:
+    /// every one of those means something different per surface (cancel, accept, move a list
+    /// selection), and a shared default would silently take them away from the handler that owns
+    /// them. A caller matches its own keys first and falls through to this.
+    pub fn handle_editing_key(&mut self, key: &str, key_char: Option<&str>, now: Instant) -> bool {
+        match key {
+            "left" => self.move_left(),
+            "right" => self.move_right(),
+            "home" => self.move_to_start(),
+            "end" => self.move_to_end(),
+            "backspace" => self.backspace(now),
+            "delete" => self.delete_forward(now),
+            _ => match key_char {
+                Some(text) if !text.is_empty() => self.insert_str(text, now),
+                _ => false,
+            },
+        }
     }
 
     /// Real recorded-step count - see [`TextHistory::len`]'s own docs.
@@ -1177,7 +1357,7 @@ mod tests {
 
         // A real edit on top of a seeded field undoes back to the baseline, not past it.
         let mut field = TextField::seeded("README.md");
-        field.push_str("x", t0());
+        field.insert_str("x", t0());
         assert_eq!(field.as_str(), "README.mdx");
         assert!(field.undo());
         assert_eq!(field.as_str(), "README.md");
@@ -1189,7 +1369,7 @@ mod tests {
         let mut field = TextField::new();
         let now = t0();
         for ch in "hello".chars() {
-            field.push_str(&ch.to_string(), now);
+            field.insert_str(&ch.to_string(), now);
         }
         assert_eq!(field.as_str(), "hello");
         assert_eq!(field.history_len(), 1);
@@ -1204,7 +1384,7 @@ mod tests {
     fn text_field_escape_clear_is_undoable() {
         let mut field = TextField::new();
         let now = t0();
-        field.push_str("main", now);
+        field.insert_str("main", now);
         assert!(field.clear(now));
         assert_eq!(field.as_str(), "");
         assert!(field.undo());
@@ -1219,9 +1399,9 @@ mod tests {
     fn text_field_backspaces_coalesce_and_undo_as_one_step() {
         let mut field = TextField::new();
         let now = t0();
-        field.push_str("abcdef", now);
+        field.insert_str("abcdef", now);
         for _ in 0..3 {
-            field.pop(now);
+            field.backspace(now);
         }
         assert_eq!(field.as_str(), "abc");
         assert!(field.undo());
@@ -1232,7 +1412,7 @@ mod tests {
     fn text_field_reset_drops_the_history_too() {
         let mut field = TextField::new();
         let now = t0();
-        field.push_str("abc", now);
+        field.insert_str("abc", now);
         field.reset();
         assert_eq!(field.as_str(), "");
         assert!(
@@ -1246,13 +1426,200 @@ mod tests {
     fn text_field_handles_a_real_multi_byte_character_without_splitting_it() {
         let mut field = TextField::new();
         let now = t0();
-        field.push_str("caf\u{e9}", now);
-        field.push_str("\u{1f600}", now);
+        field.insert_str("caf\u{e9}", now);
+        field.insert_str("\u{1f600}", now);
         assert_eq!(field.as_str(), "caf\u{e9}\u{1f600}");
-        assert!(field.pop(now));
+        assert!(field.backspace(now));
         assert_eq!(field.as_str(), "caf\u{e9}");
         assert!(field.undo());
         assert_eq!(field.as_str(), "caf\u{e9}\u{1f600}");
+    }
+
+    // GitHub issue #162: the real caret. Before this, every one of these fields was
+    // append/backspace-only and every snapshot was pinned at the end of the text.
+
+    /// Types `text` into `field` one real keystroke at a time, exactly as
+    /// `handle_editing_key`'s character arm receives it.
+    fn type_into(field: &mut TextField, text: &str, now: Instant) {
+        for ch in text.chars() {
+            field.handle_editing_key("", Some(&ch.to_string()), now);
+        }
+    }
+
+    #[test]
+    fn text_typed_into_a_fresh_field_leaves_the_caret_after_it() {
+        let mut field = TextField::new();
+        type_into(&mut field, "refresh", t0());
+        assert_eq!(field.caret(), "refresh".len());
+        assert_eq!(field.split_at_caret(), ("refresh", ""));
+    }
+
+    #[test]
+    fn arrowing_back_and_typing_really_inserts_in_the_middle() {
+        let mut field = TextField::new();
+        let now = t0();
+        type_into(&mut field, "refresh_token", now);
+        for _ in 0.."_token".len() {
+            assert!(field.handle_editing_key("left", None, now));
+        }
+        assert_eq!(field.split_at_caret(), ("refresh", "_token"));
+        type_into(&mut field, "ed", now);
+        assert_eq!(
+            field.as_str(),
+            "refreshed_token",
+            "this is the whole point of the upgrade: fixing the start of a query without \
+             backspacing out its end"
+        );
+        assert_eq!(field.caret(), "refreshed".len());
+    }
+
+    #[test]
+    fn backspace_and_delete_act_on_opposite_sides_of_the_caret() {
+        let mut field = TextField::new();
+        let now = t0();
+        type_into(&mut field, "abcd", now);
+        field.handle_editing_key("left", None, now);
+        field.handle_editing_key("left", None, now);
+        assert_eq!(field.split_at_caret(), ("ab", "cd"));
+
+        assert!(field.handle_editing_key("backspace", None, now));
+        assert_eq!(field.as_str(), "acd");
+        assert_eq!(field.caret(), 1);
+
+        assert!(field.handle_editing_key("delete", None, now));
+        assert_eq!(field.as_str(), "ad");
+        assert_eq!(field.caret(), 1, "Delete never moves the caret");
+    }
+
+    #[test]
+    fn home_and_end_move_the_caret_to_the_real_ends() {
+        let mut field = TextField::new();
+        let now = t0();
+        type_into(&mut field, "abc", now);
+        assert!(field.handle_editing_key("home", None, now));
+        assert_eq!(field.caret(), 0);
+        assert!(
+            !field.handle_editing_key("home", None, now),
+            "a key that moves nothing must report so, or the caller stops propagating a \
+             keystroke it did not use"
+        );
+        assert!(field.handle_editing_key("end", None, now));
+        assert_eq!(field.caret(), 3);
+    }
+
+    #[test]
+    fn the_caret_never_lands_inside_a_grapheme_cluster() {
+        let mut field = TextField::new();
+        let now = t0();
+        // A family emoji is a single UAX #29 cluster made of several code points and 25 bytes.
+        let cluster = "\u{1f468}\u{200d}\u{1f469}\u{200d}\u{1f467}";
+        field.insert_str(cluster, now);
+        field.insert_str("x", now);
+        assert!(field.handle_editing_key("left", None, now));
+        assert_eq!(field.caret(), cluster.len());
+        assert!(field.handle_editing_key("left", None, now));
+        assert_eq!(
+            field.caret(),
+            0,
+            "one Left must step over the whole cluster, not into the middle of it"
+        );
+
+        field.move_to_end();
+        assert!(field.handle_editing_key("backspace", None, now));
+        assert_eq!(field.as_str(), cluster);
+        assert!(field.handle_editing_key("backspace", None, now));
+        assert_eq!(
+            field.as_str(),
+            "",
+            "Backspace removes the whole cluster, never a lone code point that would leave \
+             mojibake behind"
+        );
+    }
+
+    #[test]
+    fn moving_the_caret_mid_burst_is_a_real_undo_boundary() {
+        let mut field = TextField::new();
+        let now = t0();
+        type_into(&mut field, "abc", now);
+        assert_eq!(field.history_len(), 1);
+        field.handle_editing_key("home", None, now);
+        type_into(&mut field, "X", now);
+        assert_eq!(
+            field.history_len(),
+            2,
+            "the coalescing policy has always called a caret jump a boundary - with no caret to \
+             jump, that rule could never fire in these fields"
+        );
+        assert_eq!(field.as_str(), "Xabc");
+        assert!(field.undo());
+        assert_eq!(field.as_str(), "abc");
+        assert_eq!(
+            field.caret(),
+            0,
+            "undo restores the caret the burst started at"
+        );
+    }
+
+    #[test]
+    fn undo_and_redo_put_the_caret_back_where_the_step_left_it() {
+        let mut field = TextField::new();
+        let now = t0();
+        type_into(&mut field, "hello", now);
+        assert!(field.undo());
+        assert_eq!(field.caret(), 0);
+        assert!(field.redo());
+        assert_eq!(field.caret(), 5);
+    }
+
+    #[test]
+    fn setting_and_clearing_the_whole_field_move_the_caret_with_it() {
+        let mut field = TextField::new();
+        let now = t0();
+        type_into(&mut field, "abcdef", now);
+        field.move_to_start();
+        assert!(field.clear(now));
+        assert_eq!(field.caret(), 0);
+        assert!(field.set("main", now));
+        assert_eq!(
+            field.caret(),
+            4,
+            "a programmatic replacement leaves the caret at the end of what it wrote - a caret \
+             stranded past the end of the new text would panic the renderer's own split"
+        );
+    }
+
+    #[test]
+    fn a_seeded_field_opens_with_the_caret_at_the_end_of_its_prefill() {
+        let field = TextField::seeded("README.md");
+        assert_eq!(field.caret(), "README.md".len());
+    }
+
+    #[test]
+    fn set_caret_clamps_an_out_of_range_or_mid_character_offset() {
+        let mut field = TextField::seeded("caf\u{e9}");
+        field.move_to_start();
+        assert!(field.set_caret(999));
+        assert_eq!(field.caret(), field.as_str().len());
+        field.set_caret(4);
+        assert_eq!(
+            field.caret(),
+            3,
+            "byte 4 is inside the two-byte `\u{e9}`; the caret must land on the boundary before it"
+        );
+    }
+
+    #[test]
+    fn handle_editing_key_leaves_the_keys_its_callers_own_alone() {
+        let mut field = TextField::seeded("abc");
+        let now = t0();
+        for key in ["escape", "enter", "tab", "up", "down"] {
+            assert!(
+                !field.handle_editing_key(key, None, now),
+                "`{key}` means something different on every surface - a shared default would \
+                 silently take it away from the handler that owns it"
+            );
+        }
+        assert_eq!(field.as_str(), "abc");
     }
 
     /// Regression for a real, reachable data-losing sequence found in self-review: `commit_undo`

--- a/crates/app/src/theme.rs
+++ b/crates/app/src/theme.rs
@@ -288,6 +288,7 @@ pub const TOKEN_GROUPS: &[(&str, &[(&str, ColorToken)])] = &[
     ("status_bar", status_bar::TOKENS),
     ("notes", notes::TOKENS),
     ("history", history::TOKENS),
+    ("search", search::TOKENS),
 ];
 
 /// Every real registered [`ColorToken`], flattened across [`TOKEN_GROUPS`] - registry order
@@ -3161,6 +3162,49 @@ pub mod history {
     ];
 }
 
+/// The right panel's Search tab (GitHub issue #162, `REVISION-2026-08-14.md` §5 /
+/// `STAGE-A-CHANGELOG.md` §4v) - real hex values transcribed directly from those sections, not
+/// paraphrased.
+///
+/// Only the values this surface is the **first** to need get keys here. Its greys are already in
+/// the ramp and are reused rather than re-declared: the idle note's `#41464b` is
+/// [`super::text::HINT`], the empty note's and the placeholders' `#4e545a` is
+/// [`super::text::GHOST`], the count row's `#5e646a` is [`super::text::FAINTER`], a modifier
+/// button's off-state is [`super::text::FAINTER`] too, the line number's `#3d4248` is
+/// [`super::text::DISABLED`] and the file row's dimmed directory `#454b51` is
+/// [`super::text::GHOSTER`]. A second key holding a value the ramp already states would be
+/// exactly the "two specifications of one thing" defect §4w names.
+pub mod search {
+    use super::{token, ColorToken};
+
+    /// A modifier button's active fill - `Aa` / `ab` / `.*` while that modifier is on
+    /// (§5: "on-state bg `#1d3242` fg `#a5cdf0`, off `#5e646a`"). Shared with the query row's
+    /// own `⇄` and funnel toggles, which §4v draws in the same active pair.
+    pub const MODIFIER_ON_BG: ColorToken = token("search.modifier_on_bg", 0x1d3242);
+    /// That button's glyph while it is on.
+    pub const MODIFIER_ON_FG: ColorToken = token("search.modifier_on_fg", 0xa5cdf0);
+
+    /// The highlight behind the matched text on a result row (§4v: "the hit highlighted
+    /// `#2b3d4f`/`#a5cdf0`").
+    pub const MATCH_BG: ColorToken = token("search.match_bg", 0x2b3d4f);
+    /// The matched text itself.
+    pub const MATCH_FG: ColorToken = token("search.match_fg", 0xa5cdf0);
+
+    /// The un-matched context either side of the hit on a result row - deliberately recessive
+    /// against [`MATCH_FG`], since the line is there to place the hit, not to be read in full.
+    pub const LINE: ColorToken = token("search.line", 0x767d84);
+
+    /// Every real [`ColorToken`] this module declares, paired with its own Rust `const` name -
+    /// the module's slice of [`super::TOKEN_GROUPS`]'s whole-app registry.
+    pub const TOKENS: &[(&str, ColorToken)] = &[
+        ("MODIFIER_ON_BG", MODIFIER_ON_BG),
+        ("MODIFIER_ON_FG", MODIFIER_ON_FG),
+        ("MATCH_BG", MATCH_BG),
+        ("MATCH_FG", MATCH_FG),
+        ("LINE", LINE),
+    ];
+}
+
 /// The git graph tab (design handoff `design_handoff_jerry_ade/revision 2/CHANGELOG.md`,
 /// 2026-07-31 entry, "git graph (issue #1)") - real hex values transcribed directly from that
 /// entry's §2/§3, not paraphrased. The column header band and the removal of the per-commit
@@ -3561,6 +3605,25 @@ pub mod band {
     pub const TITLE_BAR_CAPTION_BUTTON: Pixels = px(44.0);
     /// The tab strip's `+` menu popover's row height.
     pub const PLUS_MENU_ROW: Pixels = px(29.0);
+
+    // The right panel's Search tab (GitHub issue #162). Every value below is a real measurement
+    // off `Jerry.dc.html`'s own `showFind` block, not a round number picked here. The query row
+    // itself is [`FILTER_ROW`] (30), shared with the rail's own filter - they are the same object
+    // in two places and must not drift.
+    /// The `⇄` replace row, revealed under the query row.
+    pub const SEARCH_REPLACE_ROW: Pixels = px(28.0);
+    /// One of the two `include`/`exclude` glob rows, revealed under those.
+    pub const SEARCH_GLOB_ROW: Pixels = px(25.0);
+    /// The count row: `14 results in 6 files` plus the `⇄` / funnel / fold-all controls.
+    pub const SEARCH_COUNT_ROW: Pixels = px(24.0);
+    /// A result tree's file row - caret, chip, name, dimmed directory, match count.
+    pub const SEARCH_FILE_ROW: Pixels = px(24.0);
+    /// One match row under it - line number, then the line with its hit highlighted.
+    pub const SEARCH_MATCH_ROW: Pixels = px(19.0);
+    /// The square hit box every 17x17 icon button in the search panel's count row uses, matching
+    /// `crate::icons::IconSize::Control`'s own optical box (`STAGE-A-CHANGELOG.md` §4w raised
+    /// fold-all 15 -> 17 to land exactly here).
+    pub const SEARCH_ICON_BUTTON: Pixels = px(17.0);
 }
 
 pub mod zone {


### PR DESCRIPTION
Closes #162.

`REVISION-2026-08-14.md` §5 and `STAGE-A-CHANGELOG.md` §4u/§4v/§4w, built for real, plus the issue's own in-file-find section. Nothing search-shaped existed in the app before this - the palette does filename substring matching only.

## The backend (`crate::search::engine`, `crate::search::glob`)

One `Matcher` behind all three modifier buttons: a literal query is `regex::escape`d, whole-word wraps it in `\b(?:...)\b` (the group is load-bearing - `\bfoo|bar\b` silently means something else). So the "leftmost, non-overlapping" semantics cannot drift between the three states. Zero-width matches are dropped everywhere, since `.*` would otherwise produce one result row per character in the worktree.

The walk is bounded and says so: `MAX_MATCHES`, `MAX_SCANNED_FILES`, the editor's own `MAX_FILE_BYTES`, a NUL-byte binary sniff, no symlink following. `.git` is the one unconditional skip; other dotfiles are searchable, deliberately diverging from the Files tree - a search that cannot find text in `.github/workflows/ci.yml` is the "index, not a result" failure §4v names, one level up.

`include`/`exclude` are a hand-rolled glob language (`**`, `*`, `?`, comma-separated) rather than a new dependency - the module docs give the reasoning, and every rule is a unit test rather than a claim about a third party.

Replace re-reads each file rather than trusting a seconds-old result tree, only writes when something really changed, expands `$1` in regex mode and never in literal mode, and **refuses files open in the editor with unsaved edits** - naming them rather than destroying them.

## The panel (`crate::search::state`, `crate::search::render`)

- **Middle tab of `Files · Search · Changes`**, all three now icons in the same segmented shell (§4w), one shared 11px optical box, labels moved to tooltips with their hints intact.
- **Four real inputs** - query, replace, include, exclude - each a real `TextField` with its own focus handle, its own caret, its own `"text-input"` Ctrl+Z scope, and Tab walking only rows really on screen. All four wired into `wire_caret_blink` in the same edit.
- **Three states on one gate**: `SearchPanel::body_state` is §5's table as an enum, plus the two a static mock cannot have (a search in flight, a regex that does not compile). Results for a *previous* query are never left under a newer one - the completed search carries the query, options and globs that produced it.
- **`Replace all`'s tooltip derives from live hits**, which is the mock's own bug the issue calls out by name.
- **Two-level tree**: file row (caret · chip · name · dimmed dir · count) to one row per *match* with its line number and that hit highlighted, per-file collapse, fold-all in the count row drawn as the same caret a file row uses. Long prefixes elide from the left at `Jerry.dc.html`'s own thresholds, counted in characters.
- Searching is debounced 150ms on the background executor, generation-guarded. Replace really rewrites files, then reloads the diff and re-runs the search.
- `mod+shift+F` opens the panel focused in the query.

## In-file find (`mod+F`, `crate::search::in_file`)

The issue's own unspecced half, built to its own instruction ("match the panel's vocabulary rather than inventing a new one"): the same `Matcher`, the same modifier buttons at the same 17x17, the same `SimpleInput` row with a real caret, the same leading `/`, and the same three-state gate - `""`, `no results`, `3 of 12`, with next/prev existing only in the third. `Esc` closes and returns focus to the editor; Enter / Shift+Enter step; the binding is `"file-editor"`-scoped, since the Diff view is two files and a bar claiming "in this file" over it would have to pick one silently.

It searches the **buffer**, unsaved edits included - finding the file's saved bytes while the user looks at their own unsaved edits would answer a question about a file that is not on screen.

**The bar renders as a sibling of the `"code-surface"` node, not a child of it**, and that is load-bearing: GPUI resolves a keystroke against the focused node's whole ancestor context stack, so nested under a node carrying `"file-editor"` it had `EditorLeft`, `EditorEnter` and `EditorCollapseCursors` matching every arrow key, Enter and Esc typed into it. Found by a test that typed `left left ...` into the bar and got the text back unmoved.

## The shared input upgrade

§5 asks for this by name: "the shared single-line input needs to become a real editable field - caret positioning, not append/backspace-only; that upgrade is part of this issue and benefits every other filter row."

`TextField` now has a real grapheme-boundary caret with insert/backspace/delete-forward/left/right/home/end behind one `handle_editing_key`, and undo/redo restore it - which finally makes the coalescing policy's own "a caret jump is a group boundary" rule fire in these fields. `push_str`/`pop` are **renamed** to `insert_str`/`backspace` rather than aliased, since their old names describe something the methods no longer do. `SimpleInput` splits the text at the caret; with the caret at the end it emits the exact element tree it emitted before, so the six existing caret-position tests still measure what they measured. The rail filter row delegates to the same handler, so Left/Right/Home/End/Delete work there now too.

## Three defects found by really running it

- The query row's leading mark was a **second magnifying glass**, 30px under the tab's own - §7 rule 8 exactly. Now `/`, matching the rail filter row.
- The count row's **divider dangled** when fold-all was hidden, dividing something from nothing.
- The per-file replace button was `.invisible()` until group-hover, which excludes it from hit testing - an affordance that did nothing (§7 rule 1). Now always present and subtle, following the file tree's own per-directory `+`.

## Registries

Four drift guards caught this change, which is what they are for: the `key_context` call-site count, the Keybindings page's per-action label and row order, the scoped-binding count, and `theme_file_format::SECTIONS`. The five bundled theme files are regenerated so each carries its own derived `[search]` block rather than inheriting Jerry Dark's blues into a warm or a light theme.

## Verification

- **116 new tests.** Pure: the matcher (case/whole-word/regex/overlaps/zero-width/replacement templates), the glob language, the three-state gate, the count-row and tooltip wording, the find bar's hit model and wrapping. Real filesystem: searches and replaces over a real multi-file worktree modelled on `Jerry.dc.html`'s own `refresh_token` fixture, including binary files, the size cap, symlink loops, the result cap, and a dirty editor buffer being refused. Real GPUI: 13 panel tests and 8 find-bar tests driving real keystrokes and real clicks against a real worktree, asserting real painted elements, the real editor caret, and real file contents.
- **Real visual check over X11** against a real 6-file worktree: idle, results tree, all four inputs open, `Aa` flipping 16 results to `no results`, a real Replace all reporting *"Replaced 16 matches in 6 files"* with the files genuinely changed on disk and the panel header's diffstat moving to `+15 −15`, and the find bar reading `1 of 4` over a real open file.
- `cargo build --workspace`, `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets` all clean. `cargo test -p app --lib`: 3038 pass; the only failures are the 15 known `*_watch` tests that exhaust the host's inotify `max_user_instances` under concurrent load and pass in isolation (issue #320's family).

Rebased onto master after #227's History work landed; the `theme` registry, `SECTIONS` and the generated theme files were merged rather than overwritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)