### PR TITLE
History overhaul: sidebar run index, run-transcript tabs, outcomes and drift (#227)

### DIFF
--- a/.env-jerry
+++ b/.env-jerry
@@ -1,0 +1,7 @@
+export PREFIX=/home/colin/zedperf/prefix
+export LIBRARY_PATH=$PREFIX/usr/lib/x86_64-linux-gnu${LIBRARY_PATH:+:$LIBRARY_PATH}
+export LD_LIBRARY_PATH=$PREFIX/usr/lib/x86_64-linux-gnu${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+export PKG_CONFIG_PATH=$PREFIX/usr/lib/x86_64-linux-gnu/pkgconfig:$PREFIX/usr/share/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}
+export CPATH=$PREFIX/usr/include${CPATH:+:$CPATH}
+export PATH=$PREFIX/usr/bin:$PATH
+export CARGO_BUILD_JOBS=8

--- a/.env-jerry
+++ b/.env-jerry
@@ -1,7 +1,0 @@
-export PREFIX=/home/colin/zedperf/prefix
-export LIBRARY_PATH=$PREFIX/usr/lib/x86_64-linux-gnu${LIBRARY_PATH:+:$LIBRARY_PATH}
-export LD_LIBRARY_PATH=$PREFIX/usr/lib/x86_64-linux-gnu${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
-export PKG_CONFIG_PATH=$PREFIX/usr/lib/x86_64-linux-gnu/pkgconfig:$PREFIX/usr/share/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}
-export CPATH=$PREFIX/usr/include${CPATH:+:$CPATH}
-export PATH=$PREFIX/usr/bin:$PATH
-export CARGO_BUILD_JOBS=8

--- a/assets/themes/ember.toml
+++ b/assets/themes/ember.toml
@@ -249,6 +249,40 @@ send_hover_bg    = "#132830"  # Its hover fill.
 send_fg          = "#6599ae"  # Its label.
 send_cap_fg      = "#488199"  # Its ⌘⏎ keycaps' glyphs.
 
+# Agent history - the sidebar's run list and the run-transcript tab (GitHub issue #227,
+# design_handoff_jerry_ade/revision 5/REVISION-2026-08-13.md §4/§5, transcribed from that
+# revision's own tables and from revision 5/tokens.rs's history module).
+[history]
+out_done_fg        = "#689057"  # done - its last turn ended cleanly and Jerry watched it end.
+out_done_bg        = "#172116"
+out_interrupted_fg = "#a66730"  # interrupted
+out_interrupted_bg = "#291d10"
+out_failed_fg      = "#984d60"  # failed - its last real signal was a failure.
+out_failed_bg      = "#26151c"
+out_abandoned_fg   = "#646c70"  # abandoned - nobody ever saw it end.
+out_abandoned_bg   = "#1a1f20"
+drift_tip          = "#56863a"  # Drift dot, 0 commits since - at the tip.
+drift_near         = "#518fa8"  # Drift dot, 1-2 commits since.
+drift_far          = "#a66730"  # Drift dot, 3+ commits since.
+drift_text         = "#454d51"
+drift_far_text     = "#8a5c21"
+scope_on_bg        = "#181f21"
+scope_on_border    = "#202a2e"
+scope_on_fg        = "#8a9194"
+scope_off_fg       = "#454d51"
+scope_hover_bg     = "#181c1e"
+repo_label         = "#6e777b"
+group_label        = "#788186"
+row_title          = "#8a9194"  # A run row's title when the row is not the open one.
+transcript_prompt  = "#518fa8"
+transcript_body    = "#777f84"
+transcript_detail  = "#4e565b"
+transcript_lead    = "#929a9d"
+resume_bg          = "#1d2f19"  # The run-transcript footer's Resume here button
+resume_bg_hover    = "#253f20"
+resume_border      = "#345129"
+resume_fg          = "#7b9f6f"
+
 
 # ──────────────────────────────────────────────────────────────────────────────────────────────
 # The code surface

--- a/assets/themes/jerry-dim.toml
+++ b/assets/themes/jerry-dim.toml
@@ -249,6 +249,40 @@ send_hover_bg    = "#26323e"  # Its hover fill.
 send_fg          = "#99b8d9"  # Its label.
 send_cap_fg      = "#7a9abe"  # Its ⌘⏎ keycaps' glyphs.
 
+# Agent history - the sidebar's run list and the run-transcript tab (GitHub issue #227,
+# design_handoff_jerry_ade/revision 5/REVISION-2026-08-13.md §4/§5, transcribed from that
+# revision's own tables and from revision 5/tokens.rs's history module).
+[history]
+out_done_fg        = "#70b693"  # done - its last turn ended cleanly and Jerry watched it end.
+out_done_bg        = "#1d2c26"
+out_interrupted_fg = "#b3914a"  # interrupted
+out_interrupted_bg = "#2f2b1b"
+out_failed_fg      = "#b46d61"  # failed - its last real signal was a failure.
+out_failed_bg      = "#311f1f"
+out_abandoned_fg   = "#82878c"  # abandoned - nobody ever saw it end.
+out_abandoned_bg   = "#25282b"
+drift_tip          = "#4faa7e"  # Drift dot, 0 commits since - at the tip.
+drift_near         = "#88abd2"  # Drift dot, 1-2 commits since.
+drift_far          = "#b3914a"  # Drift dot, 3+ commits since.
+drift_text         = "#5c6166"
+drift_far_text     = "#938040"
+scope_on_bg        = "#24282c"
+scope_on_border    = "#30353c"
+scope_on_fg        = "#b0b4b9"
+scope_off_fg       = "#5c6166"
+scope_hover_bg     = "#222629"
+repo_label         = "#8f949b"
+group_label        = "#9ba1a7"
+row_title          = "#b0b4b9"  # A run row's title when the row is not the open one.
+transcript_prompt  = "#88abd2"
+transcript_body    = "#9a9ea5"
+transcript_detail  = "#676c72"
+transcript_lead    = "#babfc4"
+resume_bg          = "#213e31"  # The run-transcript footer's Resume here button
+resume_bg_hover    = "#275140"
+resume_border      = "#356851"
+resume_fg          = "#8cc7aa"
+
 
 # ──────────────────────────────────────────────────────────────────────────────────────────────
 # The code surface

--- a/assets/themes/moss.toml
+++ b/assets/themes/moss.toml
@@ -249,6 +249,40 @@ send_hover_bg    = "#212b35"  # Its hover fill.
 send_fg          = "#95b0c9"  # Its label.
 send_cap_fg      = "#7692ae"  # Its ⌘⏎ keycaps' glyphs.
 
+# Agent history - the sidebar's run list and the run-transcript tab (GitHub issue #227,
+# design_handoff_jerry_ade/revision 5/REVISION-2026-08-13.md §4/§5, transcribed from that
+# revision's own tables and from revision 5/tokens.rs's history module).
+[history]
+out_done_fg        = "#76aa8b"  # done - its last turn ended cleanly and Jerry watched it end.
+out_done_bg        = "#192520"
+out_interrupted_fg = "#a88954"  # interrupted
+out_interrupted_bg = "#292418"
+out_failed_fg      = "#a46963"  # failed - its last real signal was a failure.
+out_failed_bg      = "#281a1b"
+out_abandoned_fg   = "#7b7f83"  # abandoned - nobody ever saw it end.
+out_abandoned_bg   = "#1f2224"
+drift_tip          = "#5c9d77"  # Drift dot, 0 commits since - at the tip.
+drift_near         = "#84a3c0"  # Drift dot, 1-2 commits since.
+drift_far          = "#a88954"  # Drift dot, 3+ commits since.
+drift_text         = "#55595e"
+drift_far_text     = "#8a7847"
+scope_on_bg        = "#1e2225"
+scope_on_border    = "#2a2f34"
+scope_on_fg        = "#a8acaf"
+scope_off_fg       = "#55595e"
+scope_hover_bg     = "#1d1f22"
+repo_label         = "#878c91"
+group_label        = "#94989e"
+row_title          = "#a8acaf"  # A run row's title when the row is not the open one.
+transcript_prompt  = "#84a3c0"
+transcript_body    = "#92969b"
+transcript_detail  = "#606469"
+transcript_lead    = "#b2b6bb"
+resume_bg          = "#20362b"  # The run-transcript footer's Resume here button
+resume_bg_hover    = "#294839"
+resume_border      = "#395e4a"
+resume_fg          = "#8fbba2"
+
 
 # ──────────────────────────────────────────────────────────────────────────────────────────────
 # The code surface

--- a/assets/themes/paper.toml
+++ b/assets/themes/paper.toml
@@ -249,6 +249,40 @@ send_hover_bg    = "#c4d4e1"  # Its hover fill.
 send_fg          = "#355269"  # Its label.
 send_cap_fg      = "#4b6c87"  # Its ⌘⏎ keycaps' glyphs.
 
+# Agent history - the sidebar's run list and the run-transcript tab (GitHub issue #227,
+# design_handoff_jerry_ade/revision 5/REVISION-2026-08-13.md §4/§5, transcribed from that
+# revision's own tables and from revision 5/tokens.rs's history module).
+[history]
+out_done_fg        = "#366948"  # done - its last turn ended cleanly and Jerry watched it end.
+out_done_bg        = "#d0e0d6"
+out_interrupted_fg = "#846127"  # interrupted
+out_interrupted_bg = "#dfd7c7"
+out_failed_fg      = "#a66663"  # failed - its last real signal was a failure.
+out_failed_bg      = "#f0dadc"
+out_abandoned_fg   = "#73777c"  # abandoned - nobody ever saw it end.
+out_abandoned_bg   = "#d8dce0"
+drift_tip          = "#377a4e"  # Drift dot, 0 commits since - at the tip.
+drift_near         = "#3b5e7a"  # Drift dot, 1-2 commits since.
+drift_far          = "#846127"  # Drift dot, 3+ commits since.
+drift_text         = "#979da2"
+drift_far_text     = "#907843"
+scope_on_bg        = "#d7dde1"
+scope_on_border    = "#c6cdd4"
+scope_on_fg        = "#4c5053"
+scope_off_fg       = "#979da2"
+scope_hover_bg     = "#dbe0e3"
+repo_label         = "#666b70"
+group_label        = "#5b6065"
+row_title          = "#4c5053"  # A run row's title when the row is not the open one.
+transcript_prompt  = "#3b5e7a"
+transcript_body    = "#5e6267"
+transcript_detail  = "#8c9197"
+transcript_lead    = "#43474b"
+resume_bg          = "#b7d1c0"  # The run-transcript footer's Resume here button
+resume_bg_hover    = "#9dc1ab"
+resume_border      = "#83ac90"
+resume_fg          = "#2c573c"
+
 
 # ──────────────────────────────────────────────────────────────────────────────────────────────
 # The code surface

--- a/assets/themes/slate.toml
+++ b/assets/themes/slate.toml
@@ -249,6 +249,40 @@ send_hover_bg    = "#192532"  # Its hover fill.
 send_fg          = "#6e8dae"  # Its label.
 send_cap_fg      = "#557699"  # Its ⌘⏎ keycaps' glyphs.
 
+# Agent history - the sidebar's run list and the run-transcript tab (GitHub issue #227,
+# design_handoff_jerry_ade/revision 5/REVISION-2026-08-13.md §4/§5, transcribed from that
+# revision's own tables and from revision 5/tokens.rs's history module).
+[history]
+out_done_fg        = "#468e6b"  # done - its last turn ended cleanly and Jerry watched it end.
+out_done_bg        = "#12221b"
+out_interrupted_fg = "#8f6c1d"  # interrupted
+out_interrupted_bg = "#241f0f"
+out_failed_fg      = "#934c43"  # failed - its last real signal was a failure.
+out_failed_bg      = "#261515"
+out_abandoned_fg   = "#62666c"  # abandoned - nobody ever saw it end.
+out_abandoned_bg   = "#1a1e21"
+drift_tip          = "#208559"  # Drift dot, 0 commits since - at the tip.
+drift_near         = "#5e83a9"  # Drift dot, 1-2 commits since.
+drift_far          = "#8f6c1d"  # Drift dot, 3+ commits since.
+drift_text         = "#45494f"
+drift_far_text     = "#746019"
+scope_on_bg        = "#1a1e22"
+scope_on_border    = "#22282f"
+scope_on_fg        = "#85898e"
+scope_off_fg       = "#45494f"
+scope_hover_bg     = "#181c1f"
+repo_label         = "#6b7177"
+group_label        = "#757a81"
+row_title          = "#85898e"  # A run row's title when the row is not the open one.
+transcript_prompt  = "#5e83a9"
+transcript_body    = "#74787f"
+transcript_detail  = "#4d5258"
+transcript_lead    = "#8d9197"
+resume_bg          = "#123023"  # The run-transcript footer's Resume here button
+resume_bg_hover    = "#123f2e"
+resume_border      = "#1b5139"
+resume_fg          = "#609b7d"
+
 
 # ──────────────────────────────────────────────────────────────────────────────────────────────
 # The code surface

--- a/crates/app/src/code_surface/tabs.rs
+++ b/crates/app/src/code_surface/tabs.rs
@@ -229,6 +229,10 @@ impl AdeApp {
         // by an adversarial audit; the review surface's own docs claimed to copy the graph tab's
         // discipline and, in exactly this way, did not.
         self.leave_review_tab(window, cx);
+        // GitHub issue #227: the run-transcript tab occupies the centre pane exactly as the
+        // graph and review tabs do, so it needs the identical teardown - see
+        // `crate::run_history::tab::AdeApp::leave_run_tab`.
+        self.leave_run_tab(window, cx);
 
         if focus_editor {
             self.focus_code_surface(window, cx);
@@ -409,6 +413,10 @@ impl AdeApp {
         // by an adversarial audit; the review surface's own docs claimed to copy the graph tab's
         // discipline and, in exactly this way, did not.
         self.leave_review_tab(window, cx);
+        // GitHub issue #227: the run-transcript tab occupies the centre pane exactly as the
+        // graph and review tabs do, so it needs the identical teardown - see
+        // `crate::run_history::tab::AdeApp::leave_run_tab`.
+        self.leave_run_tab(window, cx);
 
         self.focus_code_surface(window, cx);
         let has_diff = self

--- a/crates/app/src/graph_view/render.rs
+++ b/crates/app/src/graph_view/render.rs
@@ -74,6 +74,11 @@ impl AdeApp {
         // in the opposite direction - see `crate::review::render::AdeApp::leave_review_tab`.
         self.leave_review_tab(window, cx);
         self.review_tab_open = None;
+        // GitHub issue #227: and so is the run-transcript tab - see
+        // `crate::run_history::tab::AdeApp::leave_run_tab`. Deliberately *not* clearing
+        // `run_tab_by_worktree`: unlike the review tab's window-wide slot, that map is this
+        // worktree's own open tab, which leaving the surface does not close.
+        self.leave_run_tab(window, cx);
 
         self.graph_tab_open = true;
         let was_active = self.graph_tab_active;

--- a/crates/app/src/hooks/event.rs
+++ b/crates/app/src/hooks/event.rs
@@ -70,6 +70,15 @@ pub const ACTIVITY_MAX_CHARS: usize = 80;
 /// npm test"), where an activity line is a label.
 pub const QUESTION_MAX_CHARS: usize = 200;
 
+/// Longest [`HookReport::prompt`] Jerry will keep - GitHub issue #227's run title.
+///
+/// Narrower than [`QUESTION_MAX_CHARS`] and wider than [`ACTIVITY_MAX_CHARS`], because this is a
+/// *title*: `design_handoff_jerry_ade/revision 5/REVISION-2026-08-13.md` §3's history row shows it
+/// on one truncated line ("Reproduce the refresh race in a test"), and the transcript tab header
+/// shows the same string. A user's first message can be a page long; the first sentence of it is
+/// what names the run.
+pub const PROMPT_MAX_CHARS: usize = 120;
+
 /// The largest hook payload Jerry will parse at all. Claude Code payloads are small - the real
 /// ones captured were a few hundred bytes - but `tool_input.content` on a `Write` carries an
 /// entire file, and `tool_output` an entire command's output, so the honest upper bound is "as
@@ -244,6 +253,19 @@ pub struct HookReport {
     /// nothing), and a second parse of the same JSON for a second consumer is how two readers of
     /// one payload start disagreeing about what it said.
     pub edit: Option<EditedFile>,
+    /// The literal text the human typed, off a `UserPromptSubmit` payload's own `prompt` field,
+    /// truncated to [`PROMPT_MAX_CHARS`] (GitHub issue #227). `None` for every other event.
+    ///
+    /// This is what gives a past run a real **title**. Before it, the only thing a history row
+    /// could name a run by was its worktree's directory name (which is the same for every run in
+    /// that checkout) or its last tool call (which describes a moment, not a task). The task the
+    /// user actually asked for is a real, dated statement the user themselves made - the same
+    /// standard [`crate::hooks::store`]'s module docs set for everything else persisted here.
+    ///
+    /// Only the *first* prompt of a session becomes the title; see
+    /// [`crate::hooks::server::HookRecord::first_prompt`] for where that is decided and why it is
+    /// decided there rather than here.
+    pub prompt: Option<String>,
 }
 
 impl HookReport {
@@ -257,6 +279,7 @@ impl HookReport {
             question: None,
             session_id: None,
             edit: None,
+            prompt: None,
         }
     }
 }
@@ -409,7 +432,18 @@ pub fn parse(event_name: &str, payload: &[u8]) -> Option<HookReport> {
         .map(str::to_owned);
 
     let report = match event_name {
-        "SessionStart" | "UserPromptSubmit" => Some(HookReport::bare(HookFact::Working)),
+        // Both mean "mid-turn, working". `UserPromptSubmit` additionally carries the real text
+        // the human typed, which is GitHub issue #227's run title - see
+        // [`HookReport::prompt`]. `SessionStart` carries no such field, so it stays bare.
+        "SessionStart" => Some(HookReport::bare(HookFact::Working)),
+
+        "UserPromptSubmit" => Some(HookReport {
+            prompt: value
+                .get("prompt")
+                .and_then(serde_json::Value::as_str)
+                .and_then(|prompt| truncated(prompt, PROMPT_MAX_CHARS)),
+            ..HookReport::bare(HookFact::Working)
+        }),
 
         "PreToolUse" | "PostToolUse" => {
             let tool = value.get("tool_name").and_then(serde_json::Value::as_str)?;
@@ -429,6 +463,7 @@ pub fn parse(event_name: &str, payload: &[u8]) -> Option<HookReport> {
                 question: None,
                 session_id: None,
                 edit: edited_file(tool, &value, phase),
+                prompt: None,
             })
         }
 
@@ -447,6 +482,7 @@ pub fn parse(event_name: &str, payload: &[u8]) -> Option<HookReport> {
                     .and_then(|error| truncated(error, QUESTION_MAX_CHARS)),
                 session_id: None,
                 edit: None,
+                prompt: None,
             })
         }
 
@@ -471,6 +507,7 @@ pub fn parse(event_name: &str, payload: &[u8]) -> Option<HookReport> {
                     question: truncated(asked, QUESTION_MAX_CHARS),
                     session_id: None,
                     edit: None,
+                    prompt: None,
                 });
             }
             let argument = tool_input.and_then(tool_input_preview);
@@ -488,6 +525,7 @@ pub fn parse(event_name: &str, payload: &[u8]) -> Option<HookReport> {
                 question,
                 session_id: None,
                 edit: None,
+                prompt: None,
             })
         }
 
@@ -514,6 +552,7 @@ pub fn parse(event_name: &str, payload: &[u8]) -> Option<HookReport> {
                     .and_then(|message| truncated(message, QUESTION_MAX_CHARS)),
                 session_id: None,
                 edit: None,
+                prompt: None,
             })
         }
 
@@ -529,6 +568,7 @@ pub fn parse(event_name: &str, payload: &[u8]) -> Option<HookReport> {
                 .and_then(|message| truncated(message, QUESTION_MAX_CHARS)),
             session_id: None,
             edit: None,
+            prompt: None,
         }),
 
         _ => None,

--- a/crates/app/src/hooks/flow.rs
+++ b/crates/app/src/hooks/flow.rs
@@ -224,7 +224,19 @@ impl AdeApp {
             return;
         }
 
-        let entries: Vec<(String, std::path::PathBuf, &'static str, i64, _, _, _, _)> = recordable
+        struct RecordedEntry {
+            key: String,
+            cwd: std::path::PathBuf,
+            kind_label: &'static str,
+            spawned_at_unix: i64,
+            status: crate::rail::status::Status,
+            activity: Option<String>,
+            question: Option<String>,
+            session_id: Option<String>,
+            run_facts: crate::hooks::server::RunFacts,
+        }
+
+        let entries: Vec<RecordedEntry> = recordable
             .into_iter()
             .filter_map(|(id, key, cwd, kind_label, spawned_at_unix)| {
                 let agent = self.agents.iter().find(|agent| agent.id == id)?;
@@ -242,7 +254,15 @@ impl AdeApp {
                     .hook_runtime
                     .as_ref()
                     .and_then(|runtime| runtime.session_id_for(id));
-                Some((
+                // GitHub issue #227: the run's own title and completed-turn count, from the same
+                // real hook stream and read ungated for the same reason as the session id - both
+                // describe the run, not the present (`HookListener::run_facts_for`).
+                let run_facts = self
+                    .hook_runtime
+                    .as_ref()
+                    .map(|runtime| runtime.run_facts_for(id))
+                    .unwrap_or_default();
+                Some(RecordedEntry {
                     key,
                     cwd,
                     kind_label,
@@ -251,27 +271,30 @@ impl AdeApp {
                     activity,
                     question,
                     session_id,
-                ))
+                    run_facts,
+                })
             })
             .collect();
 
-        for (key, cwd, kind_label, spawned_at_unix, status, activity, question, session_id) in
-            entries
-        {
+        for entry in entries {
             if self.agent_status_state.set(
-                key.clone(),
-                &cwd,
-                kind_label,
-                spawned_at_unix,
-                status,
-                activity,
-                question,
-                session_id,
+                entry.key.clone(),
+                crate::hooks::store::LiveRun {
+                    worktree: &entry.cwd,
+                    kind: entry.kind_label,
+                    spawned_at_unix: entry.spawned_at_unix,
+                    status: entry.status,
+                    activity: entry.activity,
+                    question: entry.question,
+                    session_id: entry.session_id,
+                    title: entry.run_facts.title,
+                    turns: entry.run_facts.turns,
+                },
                 now,
             ) {
                 changed = true;
             }
-            touched.push(key);
+            touched.push(entry.key);
         }
 
         // Ownership is cumulative across the session: an agent the user has since closed stays

--- a/crates/app/src/hooks/flow.rs
+++ b/crates/app/src/hooks/flow.rs
@@ -328,7 +328,7 @@ impl AdeApp {
     /// process-wide `crate::persisted_state_lock` mutex across two `fsync`s, and other persisted
     /// files' writers contend for that same lock. Running it inline would put a disk flush on the
     /// render thread.
-    fn persist_agent_statuses(&mut self, cx: &mut Context<Self>) {
+    pub(crate) fn persist_agent_statuses(&mut self, cx: &mut Context<Self>) {
         let Some(path) = self.agent_status_path.clone() else {
             return;
         };

--- a/crates/app/src/hooks/history.rs
+++ b/crates/app/src/hooks/history.rs
@@ -42,6 +42,30 @@ pub struct PastAgent {
     /// --resume <session_id>` was verified to use it. `None` covers a Codex agent (no hooks exist
     /// for Codex at all) and a Claude agent that closed before any hook reported one.
     pub session_id: Option<String>,
+    /// The run's title - see [`crate::hooks::store::PersistedAgentStatus::title`].
+    pub title: Option<String>,
+    /// Completed turns - see [`crate::hooks::store::PersistedAgentStatus::turns`].
+    pub turns: u32,
+    /// When this run really ended, if Jerry watched it end - see
+    /// [`crate::hooks::store::PersistedAgentStatus::ended_at_unix`]. This is what separates a
+    /// `done`/`interrupted`/`failed` run from an `abandoned` one
+    /// (`crate::run_history::model::Outcome::of`).
+    pub ended_at_unix: Option<i64>,
+    /// What this run really changed, measured when it ended - see
+    /// [`crate::hooks::store::PersistedAgentStatus::files_changed`]. `None` when it could not be
+    /// measured; never a fabricated zero.
+    pub diffstat: Option<RunDiffstat>,
+}
+
+/// What a run really changed, measured against its own review baseline at the moment it ended.
+///
+/// One struct rather than three loose `Option<u32>`s on [`PastAgent`], because the three are one
+/// measurement: a header printing `6 files` beside `+0 −0` would be reporting half a fact.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RunDiffstat {
+    pub files: u32,
+    pub insertions: u32,
+    pub deletions: u32,
 }
 
 impl PastAgent {
@@ -63,6 +87,21 @@ impl PastAgent {
             question: record.question.clone(),
             updated_at_unix: record.updated_at_unix,
             session_id: record.session_id.clone(),
+            title: record.title.clone(),
+            turns: record.turns,
+            ended_at_unix: record.ended_at_unix,
+            // All three or none - the persisted fields are written together (see
+            // `PersistedAgentStatus::files_changed`), and a half-present triple here would be a
+            // record hand-edited or written by a future release, which this treats as "not
+            // measured" rather than filling the gaps with zeros.
+            diffstat: match (record.files_changed, record.insertions, record.deletions) {
+                (Some(files), Some(insertions), Some(deletions)) => Some(RunDiffstat {
+                    files,
+                    insertions,
+                    deletions,
+                }),
+                _ => None,
+            },
         })
     }
 }
@@ -117,6 +156,7 @@ pub fn find(state: &AgentStatusState, key: &str) -> Option<PastAgent> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::hooks::store::LiveRun;
 
     fn key_for(worktree: &str, spawned: i64) -> String {
         crate::review::state::baseline_key(Path::new(worktree), AgentKind::Claude, spawned)
@@ -134,13 +174,14 @@ mod tests {
         let mut state = AgentStatusState::default();
         state.set(
             key.clone(),
-            Path::new("/repo/wt-a"),
-            "Claude",
-            1_700_000_000,
-            Status::Review,
-            Some("Edit: src/auth.rs".to_owned()),
-            None,
-            Some("5af4c210-34fa-4ab2-9c35-f6ceab76551c".to_owned()),
+            LiveRun::new(
+                Path::new("/repo/wt-a"),
+                "Claude",
+                1_700_000_000,
+                Status::Review,
+            )
+            .activity("Edit: src/auth.rs".to_owned())
+            .session_id("5af4c210-34fa-4ab2-9c35-f6ceab76551c".to_owned()),
             1_700_000_500,
         );
         state
@@ -170,24 +211,12 @@ mod tests {
         let mut state = AgentStatusState::default();
         state.set(
             key_for("/repo/wt-old", 1),
-            Path::new("/repo/wt-old"),
-            "Claude",
-            1,
-            Status::Idle,
-            None,
-            None,
-            None,
+            LiveRun::new(Path::new("/repo/wt-old"), "Claude", 1, Status::Idle),
             100,
         );
         state.set(
             key_for("/repo/wt-new", 2),
-            Path::new("/repo/wt-new"),
-            "Codex",
-            2,
-            Status::Idle,
-            None,
-            None,
-            None,
+            LiveRun::new(Path::new("/repo/wt-new"), "Codex", 2, Status::Idle),
             999,
         );
         let agents = past_agents(&state);
@@ -213,6 +242,7 @@ mod tests {
                 question: None,
                 updated_at_unix: 1,
                 session_id: None,
+                ..PersistedAgentStatus::default()
             },
         );
         assert!(past_agents(&state).is_empty());
@@ -233,6 +263,7 @@ mod tests {
                 question: None,
                 updated_at_unix: 1,
                 session_id: None,
+                ..PersistedAgentStatus::default()
             },
         );
         assert!(past_agents(&state).is_empty());
@@ -251,13 +282,7 @@ mod tests {
         ] {
             state.set(
                 key,
-                Path::new(worktree),
-                "Claude",
-                spawned,
-                Status::Idle,
-                None,
-                None,
-                None,
+                LiveRun::new(Path::new(worktree), "Claude", spawned, Status::Idle),
                 spawned,
             );
         }
@@ -282,13 +307,8 @@ mod tests {
         let key = key_for("/repo/wt-a", 1);
         state.set(
             key.clone(),
-            Path::new("/repo/wt-a"),
-            "Claude",
-            1,
-            Status::Idle,
-            None,
-            None,
-            Some("session-abc".to_owned()),
+            LiveRun::new(Path::new("/repo/wt-a"), "Claude", 1, Status::Idle)
+                .session_id("session-abc".to_owned()),
             10,
         );
         let found = find(&state, &key).expect("the record must be found");

--- a/crates/app/src/hooks/mod.rs
+++ b/crates/app/src/hooks/mod.rs
@@ -151,6 +151,12 @@ impl HookRuntime {
         self.listener.session_id_for(id)
     }
 
+    /// This agent's real run-level facts - completed turns and the run's title (GitHub issue
+    /// #227). See [`server::HookListener::run_facts_for`].
+    pub fn run_facts_for(&self, id: AgentId) -> server::RunFacts {
+        self.listener.run_facts_for(id)
+    }
+
     /// Every file write reported since the last call, in arrival order - the signal
     /// `crate::provenance` turns into per-line attribution (GitHub issue #284). Returns
     /// `(edits, dropped)`; see [`server::HookListener::drain_edits`].

--- a/crates/app/src/hooks/server.rs
+++ b/crates/app/src/hooks/server.rs
@@ -142,13 +142,44 @@ const REPLY_WRITE_FLOOR: Duration = Duration::from_millis(500);
 /// the least accurate of the queue. Dropping it costs the least truth.
 const MAX_PENDING_EDITS: usize = 4096;
 
-/// One agent's most recent hook fact, as stored for the rail to read.
+/// One agent's most recent hook fact, as stored for the rail to read, plus the two facts about
+/// the *run as a whole* that a single latest-wins report structurally cannot carry (GitHub issue
+/// #227).
 #[derive(Debug, Clone)]
 pub struct HookRecord {
     /// The parsed event - see [`crate::hooks::event::parse`].
     pub report: HookReport,
     /// When it arrived, for the freshness check in [`crate::rail::status::HookSignal`].
     pub received_at: Instant,
+    /// How many turns this agent has really completed - one per `Stop`
+    /// ([`HookFact::TurnEnded`]) it has reported.
+    ///
+    /// Accumulated here rather than derived from the stored report, because "latest wins" is the
+    /// whole design of [`HookInbox`] (see its docs) and a count is by definition not a latest.
+    /// It is the real number GitHub issue #227's transcript header prints (`21 turns`); nothing
+    /// estimates it from elapsed time or from output volume.
+    pub turns: u32,
+    /// The first prompt this agent's human typed, latched once and never overwritten - the run's
+    /// **title** (`crate::hooks::event::HookReport::prompt`).
+    ///
+    /// *First*, not latest, and that is the whole point: a run is named by the task it was
+    /// started for. Taking the latest would rename a run in the history list every time the user
+    /// typed a follow-up ("yes", "try again"), which describes a moment rather than the run.
+    pub first_prompt: Option<String>,
+}
+
+/// What an agent's hooks have said about its **run**, as opposed to about its current state
+/// (GitHub issue #227) - see [`HookRecord::turns`] and [`HookRecord::first_prompt`].
+///
+/// A named struct rather than a tuple because both halves end up persisted, side by side, in
+/// [`crate::hooks::store::PersistedAgentStatus`], and a `(u32, Option<String>)` at that call site
+/// would be two anonymous values in the wrong order waiting to happen.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RunFacts {
+    /// Completed turns - one per `Stop`.
+    pub turns: u32,
+    /// The run's title: the first prompt its human typed, if hooks caught one.
+    pub title: Option<String>,
 }
 
 /// Every agent's latest hook fact, shared between the listener thread and the UI thread.
@@ -196,6 +227,22 @@ impl HookInbox {
     /// the real agents - the ones actually emitting events - and sheds invented ids that never
     /// report again.
     pub fn record(&mut self, id: AgentId, report: HookReport) {
+        // GitHub issue #227's run-level accumulation, taken from the *incoming* payload before
+        // any nudge merging: a turn really ended if this payload said so, and the first prompt is
+        // whichever `UserPromptSubmit` arrived first. Both are carried forward from whatever this
+        // agent already had - unlike the report itself, neither is ever replaced by a later
+        // event, and neither is subject to the TTL below (a run's turn count does not become
+        // untrue because the agent went quiet for half an hour).
+        let previous_run_facts = self
+            .latest
+            .get(&id)
+            .map(|record| (record.turns, record.first_prompt.clone()));
+        let (previous_turns, previous_prompt) = previous_run_facts.unwrap_or((0, None));
+        let turns = previous_turns.saturating_add(u32::from(
+            report.kind == event::EventKind::Transition && report.fact == HookFact::TurnEnded,
+        ));
+        let first_prompt = previous_prompt.or_else(|| report.prompt.clone());
+
         // Only a *fresh* previous record is worth folding into: past the TTL the rail has already
         // stopped believing it (see `crate::rail::status::HookSignal::fresh`), so a nudge is then
         // the only real evidence there is and must stand on its own.
@@ -220,6 +267,8 @@ impl HookInbox {
             HookRecord {
                 report,
                 received_at: Instant::now(),
+                turns,
+                first_prompt,
             },
         );
     }
@@ -362,6 +411,12 @@ fn merge_nudge(previous: &HookReport, incoming: HookReport) -> HookReport {
         // appended to [`EditLog`] straight off the wire, before any merging - but a stored report
         // whose `edit` disagreed with the rest of it would be a trap for the next reader.
         edit: previous.edit.clone(),
+        // Same reasoning as `edit`: only a `UserPromptSubmit` ever carries a prompt, and a nudge
+        // is never one, so this restores what the kept fact already said rather than blanking it.
+        // The run title itself does not depend on this field surviving here either - see
+        // [`HookRecord::first_prompt`], which latches the first prompt once and never re-reads
+        // the stored report.
+        prompt: previous.prompt.clone(),
     }
 }
 
@@ -556,6 +611,26 @@ impl HookListener {
     pub fn session_id_for(&self, id: AgentId) -> Option<String> {
         let inbox = self.inbox.lock().ok()?;
         inbox.get(id)?.report.session_id.clone()
+    }
+
+    /// This agent's real run-level facts - its completed-turn count and the first prompt its human
+    /// typed (GitHub issue #227). `RunFacts::default()` for an agent that has never reported a
+    /// hook, or if the lock is poisoned.
+    ///
+    /// Ungated by [`event::HOOK_SIGNAL_TTL`] for exactly the reason [`Self::session_id_for`] is:
+    /// these describe the run, not the present. A run that completed nine turns completed nine
+    /// turns whether or not it has said anything in the last half hour.
+    pub fn run_facts_for(&self, id: AgentId) -> RunFacts {
+        let Ok(inbox) = self.inbox.lock() else {
+            return RunFacts::default();
+        };
+        match inbox.get(id) {
+            Some(record) => RunFacts {
+                turns: record.turns,
+                title: record.first_prompt.clone(),
+            },
+            None => RunFacts::default(),
+        }
     }
 }
 
@@ -1566,6 +1641,102 @@ mod tests {
         );
         assert_eq!(listener.signal_for(7).fact, Some(HookFact::Working));
         assert_eq!(listener.text_for(7).1, None);
+    }
+
+    /// GitHub issue #227's run-level facts, over a real socket: the title is the **first** prompt
+    /// the human typed (not the latest), and the turn count is one per real `Stop`.
+    #[test]
+    fn a_runs_title_and_turn_count_come_off_its_own_real_hook_stream() {
+        let listener = HookListener::start().expect("listener must start");
+        let port = listener.port();
+        let token = listener.token().to_owned();
+
+        assert_eq!(
+            listener.run_facts_for(11),
+            crate::hooks::server::RunFacts::default(),
+            "an agent that has reported nothing has no run facts at all"
+        );
+
+        post(
+            port,
+            &token,
+            "event=UserPromptSubmit&agent=11",
+            r#"{"session_id":"s-11","hook_event_name":"UserPromptSubmit","prompt":"Reproduce the refresh race in a test"}"#,
+        );
+        assert_eq!(
+            listener.run_facts_for(11).title.as_deref(),
+            Some("Reproduce the refresh race in a test")
+        );
+        assert_eq!(listener.run_facts_for(11).turns, 0);
+
+        post(
+            port,
+            &token,
+            "event=Stop&agent=11",
+            r#"{"session_id":"s-11","hook_event_name":"Stop"}"#,
+        );
+        post(
+            port,
+            &token,
+            "event=Stop&agent=11",
+            r#"{"session_id":"s-11","hook_event_name":"Stop"}"#,
+        );
+        assert_eq!(
+            listener.run_facts_for(11).turns,
+            2,
+            "each real Stop is one completed turn"
+        );
+
+        // A follow-up prompt renames nothing: a run is named by the task it was started for.
+        post(
+            port,
+            &token,
+            "event=UserPromptSubmit&agent=11",
+            r#"{"session_id":"s-11","hook_event_name":"UserPromptSubmit","prompt":"yes"}"#,
+        );
+        assert_eq!(
+            listener.run_facts_for(11).title.as_deref(),
+            Some("Reproduce the refresh race in a test"),
+            "the title is the first prompt, never the latest one"
+        );
+
+        // An idle nudge is not a turn boundary, however much it looks like the end of one.
+        post(
+            port,
+            &token,
+            "event=Notification&agent=11",
+            r#"{"session_id":"s-11","hook_event_name":"Notification","notification_type":"idle_prompt","message":"Claude is waiting for your input"}"#,
+        );
+        assert_eq!(listener.run_facts_for(11).turns, 2);
+    }
+
+    /// Forgetting an agent must drop its run facts too, for exactly the reason it drops its
+    /// status: a recycled id must not inherit a dead run's turn count or title.
+    #[test]
+    fn forgetting_an_agent_drops_its_run_facts_as_well_as_its_status() {
+        let listener = HookListener::start().expect("listener must start");
+        let port = listener.port();
+        let token = listener.token().to_owned();
+
+        post(
+            port,
+            &token,
+            "event=UserPromptSubmit&agent=12",
+            r#"{"session_id":"s-12","hook_event_name":"UserPromptSubmit","prompt":"Port the planner tests"}"#,
+        );
+        post(
+            port,
+            &token,
+            "event=Stop&agent=12",
+            r#"{"session_id":"s-12","hook_event_name":"Stop"}"#,
+        );
+        assert_eq!(listener.run_facts_for(12).turns, 1);
+
+        listener.forget(12);
+        assert_eq!(
+            listener.run_facts_for(12),
+            crate::hooks::server::RunFacts::default()
+        );
     }
 
     #[test]

--- a/crates/app/src/hooks/store.rs
+++ b/crates/app/src/hooks/store.rs
@@ -87,6 +87,121 @@ pub struct PersistedAgentStatus {
     /// agent (no hooks exist for it at all) or a Claude agent whose hooks never fired before this
     /// field started being captured.
     pub session_id: Option<String>,
+    /// The run's **title** - the first prompt its human typed, off a real `UserPromptSubmit`
+    /// payload (GitHub issue #227, `crate::hooks::event::HookReport::prompt`).
+    ///
+    /// `None` for a run whose hooks never caught one, which History renders as the honest
+    /// fallback rather than inventing a task description - see
+    /// `crate::run_history::model::RunRecord::title_line`.
+    pub title: Option<String>,
+    /// How many turns this run really completed - one per `Stop`
+    /// (`crate::hooks::server::HookRecord::turns`). `0` for a run that ended inside its first
+    /// turn, and for every record written before this field existed; the reader treats zero as
+    /// "not known" rather than printing `0 turns`.
+    #[serde(default)]
+    pub turns: u32,
+    /// When this run really **ended**, as seconds since the Unix epoch - set once, by
+    /// `crate::run_history::flow::AdeApp::finish_run_record`, at the moment the agent's pane was
+    /// actually closed in this app.
+    ///
+    /// This is the field that distinguishes the two genuinely different endings a record can
+    /// have, and the whole reason `abandoned` is a real outcome rather than a guess: `Some` means
+    /// Jerry watched the run end and knows how it ended; `None` means the record simply stopped
+    /// being updated - the app quit, the machine slept, the hooks stopped firing - and nobody
+    /// ever saw it finish. See `crate::run_history::model::Outcome::of`.
+    pub ended_at_unix: Option<i64>,
+    /// The real review diffstat measured against this run's own baseline at the moment it ended
+    /// (`wt_core::review::diff_against_tree` through
+    /// `crate::run_history::flow::AdeApp::finish_run_record`) - what *this run* changed, not what
+    /// the worktree currently contains.
+    ///
+    /// All three are `Some` together or `None` together: they come from one measurement, and a
+    /// header printing a file count beside a blank diffstat would be reporting half of one fact.
+    /// `None` whenever that measurement could not be made - no baseline was captured, or the
+    /// `git diff` failed - which the transcript header renders by omitting the diffstat rather
+    /// than by printing zeros.
+    pub files_changed: Option<u32>,
+    pub insertions: Option<u32>,
+    pub deletions: Option<u32>,
+}
+
+/// One live agent's currently-known state, as [`AgentStatusState::set`] takes it.
+///
+/// A struct rather than nine positional parameters (which is what this was, complete with an
+/// `#[allow(clippy::too_many_arguments)]`): GitHub issue #227 added two more fields to it, and at
+/// eleven positional arguments - four of them `Option<String>` - a caller swapping `activity` and
+/// `question`, or `title` and `session_id`, would compile silently and write the wrong thing to
+/// disk forever.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LiveRun<'a> {
+    pub worktree: &'a Path,
+    /// `crate::work_surface::agents::AgentKind::label`.
+    pub kind: &'a str,
+    pub spawned_at_unix: i64,
+    pub status: Status,
+    pub activity: Option<String>,
+    pub question: Option<String>,
+    pub session_id: Option<String>,
+    /// See [`PersistedAgentStatus::title`].
+    pub title: Option<String>,
+    /// See [`PersistedAgentStatus::turns`].
+    pub turns: u32,
+}
+
+impl<'a> LiveRun<'a> {
+    /// A run described by only the four things every recordable agent always has: where it runs,
+    /// what it is, when it started, and what it is doing now. Everything else is optional
+    /// hook-derived detail, added through the builders below.
+    pub fn new(worktree: &'a Path, kind: &'a str, spawned_at_unix: i64, status: Status) -> Self {
+        LiveRun {
+            worktree,
+            kind,
+            spawned_at_unix,
+            status,
+            activity: None,
+            question: None,
+            session_id: None,
+            title: None,
+            turns: 0,
+        }
+    }
+
+    pub fn activity(mut self, activity: impl Into<String>) -> Self {
+        self.activity = Some(activity.into());
+        self
+    }
+
+    pub fn question(mut self, question: impl Into<String>) -> Self {
+        self.question = Some(question.into());
+        self
+    }
+
+    pub fn session_id(mut self, session_id: impl Into<String>) -> Self {
+        self.session_id = Some(session_id.into());
+        self
+    }
+
+    pub fn title(mut self, title: impl Into<String>) -> Self {
+        self.title = Some(title.into());
+        self
+    }
+
+    pub fn turns(mut self, turns: u32) -> Self {
+        self.turns = turns;
+        self
+    }
+}
+
+/// How a run really ended, as [`AgentStatusState::finish`] takes it (GitHub issue #227).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FinishedRun {
+    /// The run's status at the moment it ended - what
+    /// `crate::run_history::model::Outcome::of` reads.
+    pub status: Option<Status>,
+    /// See [`PersistedAgentStatus::files_changed`]. All three are supplied together or not at all.
+    pub files_changed: Option<u32>,
+    pub insertions: Option<u32>,
+    pub deletions: Option<u32>,
 }
 
 impl PersistedAgentStatus {
@@ -211,32 +326,32 @@ impl AgentStatusState {
 
     /// Records one agent's real, current hook-derived state. Returns whether anything actually
     /// changed, so a caller can skip an otherwise pointless disk write on every render.
-    #[allow(clippy::too_many_arguments)]
-    pub fn set(
-        &mut self,
-        key: String,
-        worktree: &Path,
-        kind: &str,
-        spawned_at_unix: i64,
-        status: Status,
-        activity: Option<String>,
-        question: Option<String>,
-        session_id: Option<String>,
-        now_unix: i64,
-    ) -> bool {
+    ///
+    /// The end-of-run half of the record ([`PersistedAgentStatus::ended_at_unix`] and the
+    /// diffstat) is deliberately carried over from whatever is already stored rather than reset:
+    /// this function only ever describes a *live* agent, and it must never be able to un-finish a
+    /// run that really finished.
+    pub fn set(&mut self, key: String, run: LiveRun<'_>, now_unix: i64) -> bool {
+        let existing = self.agents.get(&key);
         let record = PersistedAgentStatus {
-            worktree: crate::review::state::encode_worktree(worktree),
-            kind: kind.to_owned(),
-            spawned_at_unix,
-            status: status_key(status).to_owned(),
-            activity,
-            question,
+            worktree: crate::review::state::encode_worktree(run.worktree),
+            kind: run.kind.to_owned(),
+            spawned_at_unix: run.spawned_at_unix,
+            status: status_key(run.status).to_owned(),
+            activity: run.activity,
+            question: run.question,
             updated_at_unix: now_unix,
-            session_id,
+            session_id: run.session_id,
+            title: run.title,
+            turns: run.turns,
+            ended_at_unix: existing.and_then(|existing| existing.ended_at_unix),
+            files_changed: existing.and_then(|existing| existing.files_changed),
+            insertions: existing.and_then(|existing| existing.insertions),
+            deletions: existing.and_then(|existing| existing.deletions),
         };
         // Compare on everything except the timestamp: a status that hasn't changed must not
         // rewrite the file (and re-fsync) purely because time passed.
-        let unchanged = self.agents.get(&key).is_some_and(|existing| {
+        let unchanged = existing.is_some_and(|existing| {
             existing.worktree == record.worktree
                 && existing.kind == record.kind
                 && existing.spawned_at_unix == record.spawned_at_unix
@@ -244,12 +359,57 @@ impl AgentStatusState {
                 && existing.activity == record.activity
                 && existing.question == record.question
                 && existing.session_id == record.session_id
+                && existing.title == record.title
+                && existing.turns == record.turns
         });
         if unchanged {
             return false;
         }
         self.agents.insert(key, record);
         true
+    }
+
+    /// Marks an already-recorded run as really **ended**, at `ended_at_unix`, with whatever was
+    /// measured about it at that moment (GitHub issue #227). Returns whether anything changed.
+    ///
+    /// A no-op returning `false` for a key this state has never recorded, and that is the
+    /// contract, not a shortcut: [`crate::hooks::flow::AdeApp::record_agent_statuses`] only ever
+    /// records agents that produced a real hook fact (see its own docs on why a status inferred
+    /// from pty silence is not worth persisting), so an agent with no record here is one Jerry
+    /// never knew anything real about. Inventing an entry for it at close time would put a run in
+    /// History whose every field was a guess.
+    pub fn finish(&mut self, key: &str, ended_at_unix: i64, run: FinishedRun) -> bool {
+        let Some(record) = self.agents.get_mut(key) else {
+            return false;
+        };
+        let mut changed = false;
+        if record.ended_at_unix != Some(ended_at_unix) {
+            record.ended_at_unix = Some(ended_at_unix);
+            record.updated_at_unix = ended_at_unix;
+            changed = true;
+        }
+        if let Some(status) = run.status {
+            let status = status_key(status).to_owned();
+            if record.status != status {
+                record.status = status;
+                changed = true;
+            }
+        }
+        // The three diffstat fields move together or not at all - see
+        // [`PersistedAgentStatus::files_changed`]. A `FinishedRun` carrying no measurement leaves
+        // whatever was already there alone rather than blanking it.
+        if run.files_changed.is_some() {
+            if record.files_changed != run.files_changed
+                || record.insertions != run.insertions
+                || record.deletions != run.deletions
+            {
+                changed = true;
+            }
+            record.files_changed = run.files_changed;
+            record.insertions = run.insertions;
+            record.deletions = run.deletions;
+        }
+        changed
     }
 
     /// One recorded agent, if present and readable.
@@ -312,13 +472,14 @@ mod tests {
         let key = key_for("/repo/wt-a", 1_700_000_000);
         assert!(state.set(
             key.clone(),
-            Path::new("/repo/wt-a"),
-            "Claude",
-            1_700_000_000,
-            Status::Review,
-            Some("Edit: src/auth.rs".to_owned()),
-            None,
-            Some("5af4c210-34fa-4ab2-9c35-f6ceab76551c".to_owned()),
+            LiveRun::new(
+                Path::new("/repo/wt-a"),
+                "Claude",
+                1_700_000_000,
+                Status::Review
+            )
+            .activity("Edit: src/auth.rs".to_owned())
+            .session_id("5af4c210-34fa-4ab2-9c35-f6ceab76551c".to_owned()),
             1_700_000_500,
         ));
 
@@ -346,27 +507,16 @@ mod tests {
         // `set` is called from a render-frequency path; without this it would fsync constantly.
         let mut state = AgentStatusState::default();
         let key = key_for("/repo/wt-a", 10);
-        let args = |now| {
-            (
-                key.clone(),
-                Path::new("/repo/wt-a"),
-                "Claude",
-                10i64,
-                Status::Run,
-                Some("Bash: cargo test".to_owned()),
-                None,
-                None,
-                now,
-            )
+        let run = || {
+            LiveRun::new(Path::new("/repo/wt-a"), "Claude", 10, Status::Run)
+                .activity("Bash: cargo test")
         };
-        let (k, w, kind, spawned, status, activity, question, session_id, now) = args(100);
         assert!(
-            state.set(k, w, kind, spawned, status, activity, question, session_id, now),
+            state.set(key.clone(), run(), 100),
             "the first record is a real change"
         );
-        let (k, w, kind, spawned, status, activity, question, session_id, now) = args(999);
         assert!(
-            !state.set(k, w, kind, spawned, status, activity, question, session_id, now),
+            !state.set(key.clone(), run(), 999),
             "only the timestamp differs - this must not count as a change"
         );
 
@@ -374,13 +524,8 @@ mod tests {
         let key2 = key.clone();
         assert!(state.set(
             key2,
-            Path::new("/repo/wt-a"),
-            "Claude",
-            10,
-            Status::Review,
-            Some("Bash: cargo test".to_owned()),
-            None,
-            None,
+            LiveRun::new(Path::new("/repo/wt-a"), "Claude", 10, Status::Review)
+                .activity("Bash: cargo test".to_owned()),
             1000,
         ));
     }
@@ -394,25 +539,14 @@ mod tests {
         let key = key_for("/repo/wt-a", 20);
         assert!(state.set(
             key.clone(),
-            Path::new("/repo/wt-a"),
-            "Claude",
-            20,
-            Status::Run,
-            None,
-            None,
-            None,
+            LiveRun::new(Path::new("/repo/wt-a"), "Claude", 20, Status::Run),
             100,
         ));
         assert!(
             state.set(
                 key.clone(),
-                Path::new("/repo/wt-a"),
-                "Claude",
-                20,
-                Status::Run,
-                None,
-                None,
-                Some("5af4c210-34fa-4ab2-9c35-f6ceab76551c".to_owned()),
+                LiveRun::new(Path::new("/repo/wt-a"), "Claude", 20, Status::Run)
+                    .session_id("5af4c210-34fa-4ab2-9c35-f6ceab76551c".to_owned()),
                 101,
             ),
             "a real session id appearing where there was none must count as a change"
@@ -433,13 +567,7 @@ mod tests {
         let mut other = AgentStatusState::default();
         other.set(
             other_key.clone(),
-            Path::new("/repo/other"),
-            "Claude",
-            1,
-            Status::Run,
-            None,
-            None,
-            None,
+            LiveRun::new(Path::new("/repo/other"), "Claude", 1, Status::Run),
             5,
         );
         other
@@ -450,13 +578,8 @@ mod tests {
         let mut mine = AgentStatusState::default();
         mine.set(
             mine_key.clone(),
-            Path::new("/repo/mine"),
-            "Claude",
-            2,
-            Status::Ask,
-            None,
-            Some("Bash needs permission: rm -rf /".to_owned()),
-            None,
+            LiveRun::new(Path::new("/repo/mine"), "Claude", 2, Status::Ask)
+                .question("Bash needs permission: rm -rf /".to_owned()),
             6,
         );
         mine.save_merged_at(&path, &std::iter::once(mine_key.clone()).collect())
@@ -481,13 +604,7 @@ mod tests {
         let mut state = AgentStatusState::default();
         state.set(
             key.clone(),
-            Path::new("/repo/wt-a"),
-            "Claude",
-            3,
-            Status::Review,
-            None,
-            None,
-            None,
+            LiveRun::new(Path::new("/repo/wt-a"), "Claude", 3, Status::Review),
             7,
         );
         let owned: BTreeSet<String> = std::iter::once(key.clone()).collect();
@@ -503,6 +620,151 @@ mod tests {
         );
     }
 
+    /// GitHub issue #227: the end-of-run half of a record survives a real file round trip, and
+    /// carries exactly what was measured - no fabricated zeros for what was not.
+    #[test]
+    fn a_finished_run_really_round_trips_with_its_ending_and_its_diffstat() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join(AGENT_STATUS_FILE_NAME);
+        let key = key_for("/repo/wt-a", 1_700_000_000);
+
+        let mut state = AgentStatusState::default();
+        state.set(
+            key.clone(),
+            LiveRun::new(
+                Path::new("/repo/wt-a"),
+                "Claude",
+                1_700_000_000,
+                Status::Run,
+            )
+            .title("Reproduce the refresh race in a test")
+            .turns(9),
+            1_700_000_400,
+        );
+        assert!(
+            state.finish(
+                &key,
+                1_700_000_960,
+                FinishedRun {
+                    status: Some(Status::Review),
+                    files_changed: Some(2),
+                    insertions: Some(41),
+                    deletions: Some(0),
+                },
+            ),
+            "recording a real ending is a real change"
+        );
+
+        state
+            .save_merged_at(&path, &std::iter::once(key.clone()).collect())
+            .expect("must save");
+        let record = AgentStatusState::load_at(&path)
+            .get(&key)
+            .cloned()
+            .expect("the record must survive");
+
+        assert_eq!(
+            record.title.as_deref(),
+            Some("Reproduce the refresh race in a test")
+        );
+        assert_eq!(record.turns, 9);
+        assert_eq!(record.ended_at_unix, Some(1_700_000_960));
+        assert_eq!(
+            record.updated_at_unix, 1_700_000_960,
+            "the record's last-updated moment is when it ended"
+        );
+        assert_eq!(
+            status_from_key(&record.status),
+            Some(Status::Review),
+            "the ending status replaces the last live one"
+        );
+        assert_eq!(record.files_changed, Some(2));
+        assert_eq!(record.insertions, Some(41));
+        assert_eq!(record.deletions, Some(0));
+    }
+
+    /// The contract that keeps History honest: an agent Jerry never learned anything real about
+    /// gets no record at close time either - `finish` refuses to invent one.
+    #[test]
+    fn finishing_a_run_that_was_never_recorded_invents_nothing() {
+        let mut state = AgentStatusState::default();
+        assert!(!state.finish(
+            &key_for("/repo/wt-a", 1),
+            1_700_000_000,
+            FinishedRun {
+                status: Some(Status::Idle),
+                ..FinishedRun::default()
+            },
+        ));
+        assert!(
+            state.agents.is_empty(),
+            "no entry may be conjured for an agent that reported nothing"
+        );
+    }
+
+    /// A later live poll must never be able to un-finish a run that really finished, nor lose the
+    /// measurement taken when it did.
+    #[test]
+    fn a_later_live_record_cannot_erase_a_runs_real_ending() {
+        let mut state = AgentStatusState::default();
+        let key = key_for("/repo/wt-a", 1);
+        state.set(
+            key.clone(),
+            LiveRun::new(Path::new("/repo/wt-a"), "Claude", 1, Status::Run),
+            100,
+        );
+        state.finish(
+            &key,
+            200,
+            FinishedRun {
+                status: Some(Status::Review),
+                files_changed: Some(3),
+                insertions: Some(10),
+                deletions: Some(4),
+            },
+        );
+
+        state.set(
+            key.clone(),
+            LiveRun::new(Path::new("/repo/wt-a"), "Claude", 1, Status::Run).activity("Bash: ls"),
+            300,
+        );
+
+        let record = state.get(&key).expect("the record must still exist");
+        assert_eq!(record.ended_at_unix, Some(200));
+        assert_eq!(record.files_changed, Some(3));
+        assert_eq!(record.insertions, Some(10));
+        assert_eq!(record.deletions, Some(4));
+    }
+
+    /// A file written before GitHub issue #227 added these fields must still load, with the new
+    /// fields reading as "not known" rather than as zeros that would render as real facts.
+    #[test]
+    fn a_file_written_before_the_run_fields_existed_still_loads() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join(AGENT_STATUS_FILE_NAME);
+        let key = key_for("/repo/wt-a", 1_700_000_000);
+        let legacy = format!(
+            "[agents.\"{}\"]\n\
+             worktree = \"utf8:/repo/wt-a\"\n\
+             kind = \"Claude\"\n\
+             spawned_at_unix = 1700000000\n\
+             status = \"idle\"\n\
+             updated_at_unix = 1700000500\n",
+            key.replace('\\', "\\\\").replace('"', "\\\"")
+        );
+        std::fs::write(&path, legacy).expect("write the legacy file");
+
+        let record = AgentStatusState::load_at(&path)
+            .get(&key)
+            .cloned()
+            .expect("a pre-#227 record must still load");
+        assert_eq!(record.title, None);
+        assert_eq!(record.turns, 0);
+        assert_eq!(record.ended_at_unix, None);
+        assert_eq!(record.files_changed, None);
+    }
+
     #[test]
     fn the_record_is_capped_keeping_the_most_recent_agents() {
         // This file never deletes a key on its own (it is history), which without a cap means it
@@ -512,13 +774,12 @@ mod tests {
             let key = key_for(&format!("/repo/wt-{index}"), index);
             state.set(
                 key,
-                Path::new(&format!("/repo/wt-{index}")),
-                "Claude",
-                index,
-                Status::Idle,
-                None,
-                None,
-                None,
+                LiveRun::new(
+                    Path::new(&format!("/repo/wt-{index}")),
+                    "Claude",
+                    index,
+                    Status::Idle,
+                ),
                 index, // updated_at_unix ascending, so higher index == more recent
             );
         }
@@ -547,13 +808,7 @@ mod tests {
         let key = key_for("/repo/wt-a", 1);
         state.set(
             key.clone(),
-            Path::new("/repo/wt-a"),
-            "Claude",
-            1,
-            Status::Run,
-            None,
-            None,
-            None,
+            LiveRun::new(Path::new("/repo/wt-a"), "Claude", 1, Status::Run),
             10,
         );
         let before = state.clone();

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -37,6 +37,11 @@ pub mod review;
 // different persisted state.
 pub mod review_notes;
 pub mod root;
+// GitHub issue #227: agent history - the sidebar's repo -> worktree -> run index and the
+// run-transcript centre tab. Its own folder rather than a file inside `hooks` (which owns the
+// *capture* of what a run was) or inside `rail` (which owns the live tree): this is a surface
+// with its own model, its own persistence and its own tab kind.
+pub mod run_history;
 pub mod settings;
 pub mod sidebar;
 pub mod sound;

--- a/crates/app/src/rail/menu.rs
+++ b/crates/app/src/rail/menu.rs
@@ -205,14 +205,18 @@ pub fn agent_menu_groups(running: bool) -> Vec<Vec<MenuEntry<RailMenuAction>>> {
     ]
 }
 
-/// Whether this build really has a History *view* for the `⋯` overflow to switch to. It does
-/// not: GitHub issue #227's history is rendered inline under each worktree row, and the sidebar
-/// strip GitHub issue #291 built has exactly two views (`crate::rail::strip::SidebarView`) -
-/// History is *reached* through this overflow rather than being a cell, per
-/// `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` section 4t, but the surface it would
-/// open is still #227's to build. Named rather than inlined as a bare `false` so the row that
-/// reads it, its disabled reason and this fact stay one thing - see [`overflow_menu_groups`].
-pub const HISTORY_VIEW_AVAILABLE: bool = false;
+/// Whether this build really has a History *view* for the `⋯` overflow to switch to.
+///
+/// It does, as of GitHub issue #227: [`crate::rail::strip::SidebarView::History`] is a real
+/// sidebar view - the repo → worktree → run index, with its own scope toggle and its own
+/// run-transcript centre tab - reached through this overflow rather than through a cell, per
+/// `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4t ("a permanent cell in a 5-cell
+/// strip is a claim that you switch to it constantly. If you don't, it belongs in the overflow").
+///
+/// Kept as a named constant rather than collapsed into an ungated row: the row that reads it, the
+/// reason it would show while disabled, and this fact are one thing, and §7 rule 1 ("Ship the
+/// affordance with the behaviour, or ship neither") is the rule it exists to keep honest.
+pub const HISTORY_VIEW_AVAILABLE: bool = true;
 
 /// The sidebar strip's `⋯` overflow (§4u): "History and Settings only, with the glyphs they had
 /// in the strip (clock, sliders) so the move out of the strip does not cost their
@@ -220,7 +224,7 @@ pub const HISTORY_VIEW_AVAILABLE: bool = false;
 /// `⌘K` and its own surface."
 ///
 /// `history_available` is whether this build really has a History surface to switch to - see
-/// [`HISTORY_VIEW_AVAILABLE`]. It does not yet, so the row ships visibly disabled with that as its
+/// [`HISTORY_VIEW_AVAILABLE`]. A build without one shows the row visibly disabled with that as its
 /// reason, rather than as a row that looks live and does nothing.
 pub fn overflow_menu_groups(history_available: bool) -> Vec<Vec<MenuEntry<RailMenuAction>>> {
     vec![vec![
@@ -229,8 +233,7 @@ pub fn overflow_menu_groups(history_available: bool) -> Vec<Vec<MenuEntry<RailMe
             .tooltip("Earlier runs, by repo and worktree")
             .gated(
                 history_available,
-                "there is no History surface in this build yet (issue #227); a worktree's own \
-                 past runs are already listed under its row",
+                "there is no History surface in this build (issue #227)",
             ),
         MenuEntry::new(RailMenuAction::OpenSettings, "Settings")
             .glyph(Icon::SlidersHorizontal)
@@ -393,6 +396,9 @@ mod tests {
             "with no History surface to switch to, the row must say so rather than look live"
         );
         assert!(overflow_menu_groups(true)[0][0].enabled);
+        // GitHub issue #227 built the History view, so the overflow's own row is now live -
+        // \u{a7}7 rule 1: ship the affordance with the behaviour, or ship neither.
+        const { assert!(HISTORY_VIEW_AVAILABLE) };
     }
 
     /// Every row that shows a keycap must name a real, registered binding

--- a/crates/app/src/rail/menu_render.rs
+++ b/crates/app/src/rail/menu_render.rs
@@ -327,10 +327,11 @@ impl AdeApp {
                     self.archive_agent(id, window, cx);
                 }
             }
-            // Unreachable while [`Self::HISTORY_VIEW_AVAILABLE`] is `false`: that row is rendered
-            // disabled, and a disabled row carries no click handler at all. Left as an explicit
-            // no-op rather than a call into a surface this build genuinely does not have.
-            RailMenuAction::OpenHistory => {}
+            // GitHub issue #227: the overflow's own destination row. Switches the sidebar body to
+            // the repo → worktree → run index, which is how History is reached at all - §4t moved
+            // it out of the strip, so this row is its only entry point besides a worktree's own
+            // `↺ N earlier runs` line.
+            RailMenuAction::OpenHistory => self.open_history_view(cx),
             RailMenuAction::OpenSettings => self.open_settings(window, cx),
             // Handled above, before the menu was closed.
             RailMenuAction::OpenIn | RailMenuAction::RemoveWorktree => {}

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -800,7 +800,9 @@ impl AdeApp {
     /// (`REVISION-2026-08-13.md` §1: "Gate this at the source ... not in the template"), so
     /// deriving them from one pass is what makes it impossible for the strip to offer a switcher
     /// over rows the body does not have - as well as saving a second full rebuild per frame.
-    pub(crate) fn render_rail(&self, cx: &mut Context<Self>) -> impl IntoElement {
+    /// `&mut self` for GitHub issue #227's History body alone - see
+    /// [`Self::render_sidebar_body`]'s own docs.
+    pub(crate) fn render_rail(&mut self, cx: &mut Context<Self>) -> impl IntoElement {
         // `Rc`, not a plain `Vec`: `Self::render_rail_list`'s own `gpui::list` render-item
         // closure captures this and is kept around by GPUI across frames, so it must be cheap to
         // clone - see that function's own docs.
@@ -965,6 +967,7 @@ impl AdeApp {
                 placeholder: match view {
                     rail_strip::SidebarView::Worktrees => "filter worktrees and agents",
                     rail_strip::SidebarView::Problems => "filter problems",
+                    rail_strip::SidebarView::History => "filter runs",
                 },
                 font: theme::font::MONO,
                 text_size: self.ui_text_size(10.5),
@@ -1240,23 +1243,16 @@ impl AdeApp {
                     .into_any_element(),
                 None => div().into_any_element(),
             },
-            rail::RailListItem::HistoryHeader { .. } => {
-                self.render_history_header().into_any_element()
-            }
-            rail::RailListItem::PastAgentRow {
+            rail::RailListItem::EarlierRunsLink {
                 group_index,
                 row_index,
-                history_index,
             } => match groups
                 .get(*group_index)
                 .and_then(|group| group.rows.get(*row_index))
-                .and_then(|row| row.history.get(*history_index))
             {
-                Some(past) => {
-                    let now_unix = self.history_now_unix();
-                    self.render_past_agent_row(past, now_unix, trailing_pb, cx)
-                        .into_any_element()
-                }
+                Some(row) => self
+                    .render_earlier_runs_link(&row.path, row.history.len(), trailing_pb, cx)
+                    .into_any_element(),
                 None => div().into_any_element(),
             },
         }
@@ -1512,7 +1508,7 @@ impl AdeApp {
     /// `trailing_pb` carries the 7px gap to the next worktree's own block
     /// (`STAGE-A-CHANGELOG.md` §4n/§4s) - `true` exactly when this header is the last item in its
     /// own worktree's block, i.e. when it has no expanded children for the flattened
-    /// [`rail::RailListItem::AgentRow`]/[`rail::RailListItem::PastAgentRow`] items to carry it
+    /// [`rail::RailListItem::AgentRow`]/[`rail::RailListItem::EarlierRunsLink`] items to carry it
     /// instead. See [`rail::RailListItem::is_last_in_worktree_block`].
     ///
     /// Clicking the row selects this worktree (`Self::select_worktree_by_path`), restoring
@@ -1565,11 +1561,11 @@ impl AdeApp {
         // sit at the repo root while the tab strip showed something else entirely.
         let is_selected = self.current_worktree_path().as_deref() == Some(row.path.as_path());
         let has_agents = !row.agents.is_empty();
-        let has_history = !row.history.is_empty();
-        // GitHub issue #227: a worktree with no live agent but real persisted history must still
-        // be expandable - the caret/expand state used to be gated on `has_agents` alone, which
-        // would hide a bare worktree's history behind a caret that never rendered at all.
-        let has_children = has_agents || has_history;
+        // GitHub issue #227: history is no longer a *child* of this row. It moved out of the rail
+        // into the sidebar's own History view, and what is left here is the `↺ N earlier runs`
+        // line under the row ([`Self::render_earlier_runs_link`]) - which is not behind the caret,
+        // so the caret is back to meaning exactly "this worktree has live agents".
+        let has_children = has_agents;
         // `is_expanded` is a real parameter now, not recomputed here - see this function's own
         // docs on why. Guard against a childless row somehow being passed `is_expanded: true`
         // anyway (defensive; `rail::flatten_rail_list_items` never does), the same way the old
@@ -2033,176 +2029,73 @@ impl AdeApp {
             .when(trailing_pb, |el| el.pb(px(7.0)))
     }
 
-    /// A worktree row's "History" section label (GitHub issue #227) - `Self::render_rail_list`'s
-    /// flattened [`rail::RailListItem::HistoryHeader`] resolves here. Split out of the old
-    /// `render_history_section` for the same reason [`Self::render_repo_group_header`] was split
-    /// out of `render_repo_group`: [`Self::render_past_agent_row`] (one per real
-    /// persisted-but-not-running agent) is now its own sibling list item, not a child this
-    /// function loops over and builds unconditionally.
-    fn render_history_header(&self) -> impl IntoElement {
-        div()
-            .pl(px(13.0))
-            .pt(px(4.0))
-            .pb(px(2.0))
-            .font(font(theme::font::MONO))
-            .text_size(self.ui_text_size(8.5))
-            .text_color(theme::text::GHOSTER)
-            .child("HISTORY")
-    }
-
-    /// Real wall-clock seconds since the Unix epoch, mirroring
-    /// `crate::work_surface::agents::unix_now`'s own `unwrap_or(0)` for a nonsense clock - shared
-    /// by every [`Self::render_past_agent_row`] call in one frame (`Self::render_rail_list`'s
-    /// dispatch) so they all agree on what "now" was, the same way the old `render_history_section`
-    /// computed it once for its whole loop.
-    fn history_now_unix(&self) -> i64 {
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|elapsed| elapsed.as_secs() as i64)
-            .unwrap_or(0)
-    }
-
-    /// One row under a worktree's "History" section: a real, persisted-but-not-currently-running
-    /// agent (`crate::hooks::history::PastAgent`). Deliberately not selectable/highlightable the
-    /// way [`Self::render_agent_row`] is - there is no live pane behind it to switch to - so its
-    /// only real interaction is the trailing resume button.
+    /// A worktree row's `\u{21ba} N earlier runs` line (GitHub issue #227).
     ///
-    /// The button reads "Resume" when [`crate::hooks::history::PastAgent::session_id`] is real -
-    /// a literal `claude --resume <session_id>`, verified against a real binary (see
-    /// `crate::hooks::event::HookReport::session_id`'s own docs) - and "Reopen" otherwise, the
-    /// honest label for the fallback (`crate::hooks::flow::AdeApp::resume_past_agent`) of simply
-    /// spawning a fresh agent back into this worktree. Never claims to continue a conversation it
-    /// cannot.
-    /// `trailing_pb`: see [`Self::render_worktree_row`]'s own docs on the same parameter.
-    fn render_past_agent_row(
+    /// `design_handoff_jerry_ade/revision 5/REVISION-2026-08-13.md` §6, in full: "A 19-high
+    /// `\u{21ba} 2 earlier runs` line under a worktree row, switching the sidebar to History for
+    /// that worktree. **Only on worktrees with no live agent** - a first pass put it under every
+    /// worktree: eight identical rows, no information, and it pushed the rail past its height."
+    ///
+    /// This **replaced** the inline `HISTORY` section that used to render here - a small label
+    /// plus one two-line row per past run, each with its own `Resume`/`Reopen` button - which is
+    /// deleted rather than left beside it, per `REVISION-2026-08-14.md` §7 rule 5: "Replacing a
+    /// control means deleting its old keys in the same edit - a key defined twice is two
+    /// specifications of one thing, and the reader cannot tell which is real." Everything it did
+    /// is now done better one surface over: the runs are in [`crate::run_history::render`]'s
+    /// repo → worktree → run index, with their real titles, outcomes and drift, and `Resume` is
+    /// the run-transcript tab's own footer action, beside the sentence that says what resuming
+    /// will mean (`crate::run_history::tab::AdeApp::render_run_view`).
+    ///
+    /// The gate is `has_agents`, not "is this row expanded": this is a line *under* the worktree
+    /// row, not one of its children, so a folded worktree still offers it - which is also why
+    /// `crate::rail::state::flatten_rail_list_items` emits it outside the expansion gate.
+    ///
+    /// `trailing_pb`: see [`Self::render_worktree_row`]'s own docs on the same parameter. This
+    /// line is always the last item in its worktree's block when it is present at all (a
+    /// worktree with a live agent never gets one), so it is where the 7px inter-group gap lands.
+    fn render_earlier_runs_link(
         &self,
-        past: &crate::hooks::history::PastAgent,
-        now_unix: i64,
+        path: &std::path::Path,
+        count: usize,
         trailing_pb: bool,
         cx: &mut Context<Self>,
-    ) -> impl IntoElement {
-        let status = past.status;
-        let chip_icon = self.render_agent_chip_icon(
-            ProcessKind::Agent(past.kind),
-            px(15.0),
-            self.ui_text_size(9.0),
-        );
-        let last_active = crate::graph_view::state::relative_time(past.updated_at_unix, now_unix);
-        let summary = past
-            .question
-            .clone()
-            .or_else(|| past.activity.clone())
-            .unwrap_or_else(|| format!("{} session", past.kind.label()));
-        let resume_label = if past.session_id.is_some() {
-            "Resume"
-        } else {
-            "Reopen"
-        };
-        let key = past.key.clone();
-        let resume_key = key.clone();
-
+    ) -> impl IntoElement + use<> {
+        let target = path.to_path_buf();
+        let element_id = gpui::SharedString::from(format!("earlier-runs-{}", path.display()));
+        let selector = element_id.clone();
         div()
-            .id(format!("history-row-{key}"))
+            .id(element_id)
+            .debug_selector(move || selector.to_string())
             .flex()
-            .pl(px(13.0))
-            // Same real indent under its worktree the live agent row uses (and the same bug this
-            // row had until now: padding-left and border-left folded onto one div put the edge
-            // flush at x=0 instead of indented under it). `Jerry.dc.html`'s own history row
-            // (`g.rows`/`h.*`) is the identical shape: outer `padding-left:13px`, a separate 1px
-            // `#1e2225` connector, then a content box with its own `border-left:2px`.
-            .child(div().flex_none().w(px(1.0)).bg(theme::border::ZONE))
+            .items_center()
+            .gap(px(5.0))
+            .h(px(19.0))
+            // Lands under the branch label, past the caret slot and the connector - the same x
+            // every agent row's own content starts at.
+            .pl(px(21.0))
+            .pr(px(10.0))
+            .cursor_pointer()
+            .hover(|el| el.bg(theme::surface::ROW_HOVER))
+            .tooltip(text_tooltip("Open History for this worktree"))
+            .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
+                cx.stop_propagation();
+                this.open_history_for_worktree(target.clone(), window, cx);
+            }))
             .child(
                 div()
-                    .flex_1()
-                    .min_w_0()
-                    .flex()
-                    .flex_col()
-                    .pl(px(7.0))
-                    .pr(px(10.0))
-                    .pt(px(6.0))
-                    .pb(px(7.0))
-                    .gap(px(2.0))
-                    // The 2px slot is reserved so a history row's content lines up with the live
-                    // agent rows above it, and deliberately left **unpainted**. A past agent has
-                    // no selected state (there is no pane behind it - see this function's own
-                    // docs), so the only thing a painted edge here could restate is the status,
-                    // which this row already says twice on its second line: the 4px status dot
-                    // and the `was <state>` word. That is §4m's rule 2 exactly - "the edge was
-                    // the third statement... and always the least precise" - and painting it
-                    // would make a finished run the loudest thing in a rail whose §4n hierarchy
-                    // work is about pushing children *below* their parent, not above it.
-                    .border_l(px(2.0))
-                    .child(
-                        div()
-                            .flex()
-                            .items_center()
-                            .gap(px(6.0))
-                            .child(chip_icon)
-                            .child(
-                                div()
-                                    .flex_1()
-                                    .min_w_0()
-                                    .truncate()
-                                    .font(font(theme::font::SANS))
-                                    .text_size(self.ui_text_size(11.5))
-                                    .text_color(theme::text::DIM)
-                                    .child(summary),
-                            )
-                            .child(
-                                div()
-                                    .flex_none()
-                                    .font(font(theme::font::MONO))
-                                    .text_size(self.ui_text_size(9.5))
-                                    .text_color(theme::text::GHOST)
-                                    .child(last_active),
-                            ),
-                    )
-                    .child(
-                        div()
-                            .flex()
-                            .items_center()
-                            .gap(px(6.0))
-                            .pl(px(21.0))
-                            .child(
-                                div()
-                                    .flex_none()
-                                    .w(px(4.0))
-                                    .h(px(4.0))
-                                    .rounded_full()
-                                    .bg(status.color()),
-                            )
-                            .child(
-                                div()
-                                    .flex_1()
-                                    .min_w_0()
-                                    .truncate()
-                                    .font(font(theme::font::SANS))
-                                    .text_size(self.ui_text_size(9.5))
-                                    .text_color(theme::text::FAINT)
-                                    .child(format!("was {}", agent_state_word(status))),
-                            )
-                            .child(
-                                div()
-                                    .id(format!("history-resume-{resume_key}"))
-                                    .flex_none()
-                                    .cursor_pointer()
-                                    .px(px(6.0))
-                                    .py(px(2.0))
-                                    .rounded(theme::radius::CHIP)
-                                    .bg(theme::button::BLUE_BG)
-                                    .hover(|el| el.bg(theme::button::BLUE_BG_HOVER))
-                                    .font(font(theme::font::SANS))
-                                    .text_size(self.ui_text_size(9.5))
-                                    .text_color(theme::button::BLUE_FG)
-                                    .child(resume_label)
-                                    .on_click(cx.listener(
-                                        move |this, _event: &ClickEvent, window, cx| {
-                                            cx.stop_propagation();
-                                            this.resume_past_agent(&resume_key, window, cx);
-                                        },
-                                    )),
-                            ),
-                    ),
+                    .flex_none()
+                    .font(font(theme::font::MONO))
+                    .text_size(self.ui_text_size(9.5))
+                    .text_color(theme::text::GHOSTER)
+                    .child("\u{21ba}"),
+            )
+            .child(
+                div()
+                    .flex_none()
+                    .font(font(theme::font::SANS))
+                    .text_size(self.ui_text_size(9.5))
+                    .text_color(theme::text::FAINT)
+                    .child(crate::run_history::model::earlier_runs_label(count)),
             )
             .when(trailing_pb, |el| el.pb(px(7.0)))
     }

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -2578,6 +2578,7 @@ mod prune_regression_tests {
 #[cfg(test)]
 mod rail_row_tests {
     use super::*;
+    use crate::hooks::store::LiveRun;
     use crate::rail::worktrees::WorktreeItem;
     use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
@@ -3103,13 +3104,9 @@ mod rail_row_tests {
             // own hook-status poll uses (`crate::hooks::flow::AdeApp::record_agent_statuses`).
             app.agent_status_state.set(
                 closed_key.clone(),
-                wt.path(),
-                "Claude",
-                1_700_000_000,
-                Status::Review,
-                Some("Edit: src/auth.rs".to_owned()),
-                None,
-                Some("session-closed".to_owned()),
+                LiveRun::new(wt.path(), "Claude", 1_700_000_000, Status::Review)
+                    .activity("Edit: src/auth.rs".to_owned())
+                    .session_id("session-closed".to_owned()),
                 1_700_000_500,
             );
             // A record for an agent that is *also* still open right now - the real case
@@ -3117,13 +3114,7 @@ mod rail_row_tests {
             // fresh hook fact, not just closed ones). It must not show up twice.
             app.agent_status_state.set(
                 live_key.clone(),
-                wt.path(),
-                "Claude",
-                live_spawned_at,
-                Status::Run,
-                None,
-                None,
-                None,
+                LiveRun::new(wt.path(), "Claude", live_spawned_at, Status::Run),
                 1_700_000_600,
             );
         });
@@ -3165,13 +3156,8 @@ mod rail_row_tests {
         app.update(cx, |app, _cx| {
             app.agent_status_state.set(
                 key.clone(),
-                wt.path(),
-                "Claude",
-                1,
-                Status::Idle,
-                None,
-                None,
-                Some("5af4c210-34fa-4ab2-9c35-f6ceab76551c".to_owned()),
+                LiveRun::new(wt.path(), "Claude", 1, Status::Idle)
+                    .session_id("5af4c210-34fa-4ab2-9c35-f6ceab76551c".to_owned()),
                 2,
             );
         });
@@ -3231,13 +3217,7 @@ mod rail_row_tests {
         app.update(cx, |app, _cx| {
             app.agent_status_state.set(
                 key.clone(),
-                wt.path(),
-                "Codex",
-                1,
-                Status::Idle,
-                None,
-                None,
-                None,
+                LiveRun::new(wt.path(), "Codex", 1, Status::Idle),
                 2,
             );
         });

--- a/crates/app/src/rail/state.rs
+++ b/crates/app/src/rail/state.rs
@@ -1425,6 +1425,10 @@ mod tests {
             question: None,
             updated_at_unix: 100,
             session_id: None,
+            title: None,
+            turns: 0,
+            ended_at_unix: None,
+            diffstat: None,
         };
 
         let rows = build_worktree_rows_with_history(&worktrees, &[], std::slice::from_ref(&past));

--- a/crates/app/src/rail/state.rs
+++ b/crates/app/src/rail/state.rs
@@ -613,17 +613,21 @@ pub enum RailListItem {
         row_index: usize,
         agent_index: usize,
     },
-    /// The small "HISTORY" label above an expanded worktree row's past-agent rows - emitted only
-    /// when [`WorktreeRow::history`] is non-empty.
-    HistoryHeader {
+    /// The `\u{21ba} N earlier runs` line under a worktree row (GitHub issue #227,
+    /// `REVISION-2026-08-13.md` \u{a7}6).
+    ///
+    /// Emitted **outside** the expansion gate, and **only for a worktree with no live agent** -
+    /// both halves are \u{a7}6's own spec: it is a line *under* the row rather than one of its
+    /// children, so a folded worktree still offers it, and "a first pass put it under every
+    /// worktree: eight identical rows, no information".
+    ///
+    /// This replaced the `HistoryHeader`/`PastAgentRow` pair that used to flatten the rail's own
+    /// inline `HISTORY` section here. Both are deleted rather than left beside it
+    /// (`REVISION-2026-08-14.md` \u{a7}7 rule 5) - the runs themselves live in the sidebar's
+    /// History view now (`crate::run_history::render`).
+    EarlierRunsLink {
         group_index: usize,
         row_index: usize,
-    },
-    /// One persisted-but-not-running agent under an expanded worktree row's History section.
-    PastAgentRow {
-        group_index: usize,
-        row_index: usize,
-        history_index: usize,
     },
 }
 
@@ -634,8 +638,8 @@ impl RailListItem {
     /// Flattened, each worktree's block is a variable number of separate list items rather than
     /// one wrapping div, so the gap moves onto whichever item now actually paints last - the
     /// [`Self::WorktreeRow`] itself when collapsed or childless, otherwise the last
-    /// [`Self::AgentRow`] or, when this worktree has real history, the last
-    /// [`Self::PastAgentRow`].
+    /// [`Self::AgentRow`] or, on a worktree with no live agent but real history, its own
+    /// [`Self::EarlierRunsLink`].
     ///
     /// Always `false` for an errored worktree row, matching
     /// `crate::rail::render::AdeApp::render_worktree_row`'s own pre-flatten behaviour exactly: its
@@ -666,26 +670,30 @@ impl RailListItem {
                 else {
                     return false;
                 };
-                return row.error.is_none()
-                    && row.history.is_empty()
-                    && *agent_index + 1 == row.agents.len();
+                // No `history.is_empty()` term any more: a worktree with a live agent never gets
+                // an `EarlierRunsLink` at all (GitHub issue #227 / \u{a7}6's own gate), so the last
+                // agent row really is the last item in the block.
+                return row.error.is_none() && *agent_index + 1 == row.agents.len();
             }
-            RailListItem::HistoryHeader { .. } => return false,
-            RailListItem::PastAgentRow {
+            // Always last when present: it is emitted after the row's children, and only for a
+            // worktree that has none.
+            RailListItem::EarlierRunsLink {
                 group_index,
                 row_index,
-                history_index,
             } => {
-                let Some(row) = groups
+                return groups
                     .get(*group_index)
                     .and_then(|g| g.rows.get(*row_index))
-                else {
-                    return false;
-                };
-                return row.error.is_none() && *history_index + 1 == row.history.len();
+                    .is_some_and(|row| row.error.is_none());
             }
         };
-        row.error.is_none() && (!expanded || (row.agents.is_empty() && row.history.is_empty()))
+        // A worktree row is last in its own block unless something follows it. Exactly two things
+        // can, and they are mutually exclusive by construction (see [`flatten_rail_list_items`]):
+        // its own agent rows, when it is expanded and has any, and - only on a worktree with no
+        // live agent - its `\u{21ba} N earlier runs` line.
+        let agent_rows_follow = expanded && !row.agents.is_empty();
+        let earlier_runs_line_follows = row.agents.is_empty() && !row.history.is_empty();
+        row.error.is_none() && !agent_rows_follow && !earlier_runs_line_follows
     }
 }
 
@@ -716,29 +724,25 @@ pub fn flatten_rail_list_items(
             if row.error.is_some() {
                 continue;
             }
-            let has_children = !row.agents.is_empty() || !row.history.is_empty();
-            if !has_children || !expanded(row) {
-                continue;
-            }
-            for agent_index in 0..row.agents.len() {
-                items.push(RailListItem::AgentRow {
-                    group_index,
-                    row_index,
-                    agent_index,
-                });
-            }
-            if !row.history.is_empty() {
-                items.push(RailListItem::HistoryHeader {
-                    group_index,
-                    row_index,
-                });
-                for history_index in 0..row.history.len() {
-                    items.push(RailListItem::PastAgentRow {
+            // GitHub issue #227: history is no longer one of a row's children, so "has children"
+            // is back to meaning exactly "has live agents" - which is also what the disclosure
+            // caret means again.
+            if !row.agents.is_empty() && expanded(row) {
+                for agent_index in 0..row.agents.len() {
+                    items.push(RailListItem::AgentRow {
                         group_index,
                         row_index,
-                        history_index,
+                        agent_index,
                     });
                 }
+            }
+            // \u{a7}6's line, and \u{a7}6's gate: only on a worktree with no live agent, and
+            // outside the expansion gate, because it sits *under* the row rather than inside it.
+            if row.agents.is_empty() && !row.history.is_empty() {
+                items.push(RailListItem::EarlierRunsLink {
+                    group_index,
+                    row_index,
+                });
             }
         }
     }
@@ -1403,6 +1407,85 @@ mod tests {
         );
         assert_eq!(rows[1].agents[0].id, 1);
         assert_eq!(rows[1].agents[1].id, 2);
+    }
+
+    /// GitHub issue #227 / §6, as the flattened list really emits it: the `↺ N earlier runs`
+    /// line appears **only** on a worktree with no live agent, appears whether or not that row is
+    /// expanded (it sits *under* the row, not inside it), and is the last item in its block - so
+    /// it, not the worktree row, carries the 7px inter-group gap.
+    ///
+    /// Also the deletion, stated as an assertion: history no longer flattens into a `HISTORY`
+    /// header plus one row per run. Those items are gone, and a worktree's runs live in the
+    /// sidebar's History view (`crate::run_history::render`).
+    #[test]
+    fn the_earlier_runs_line_is_emitted_only_for_a_worktree_with_no_live_agent() {
+        let past = |worktree: &str| crate::hooks::history::PastAgent {
+            key: format!("{worktree}|Claude|1"),
+            worktree: PathBuf::from(worktree),
+            kind: crate::work_surface::agents::AgentKind::Claude,
+            spawned_at_unix: 1,
+            status: Status::Idle,
+            activity: None,
+            question: None,
+            updated_at_unix: 100,
+            session_id: None,
+            title: None,
+            turns: 0,
+            ended_at_unix: None,
+            diffstat: None,
+        };
+        let worktrees = vec![
+            worktree_entry("/repo-wt/busy", clean_note(false)),
+            worktree_entry("/repo-wt/quiet", clean_note(false)),
+            worktree_entry("/repo-wt/fresh", clean_note(false)),
+        ];
+        // `busy` has both a live agent and history; `quiet` has only history; `fresh` has neither.
+        let agents = vec![row(1, Status::Run, "agent-a", "/repo-wt/busy")];
+        let rows = build_worktree_rows_with_history(
+            &worktrees,
+            &agents,
+            &[past("/repo-wt/busy"), past("/repo-wt/quiet")],
+        );
+        let groups = vec![RepoGroup {
+            repo_id: crate::rail::repo::RepoId(1),
+            repo_name: "repo".to_string(),
+            all_rows: rows.clone(),
+            rows,
+            rows_loaded: true,
+        }];
+
+        for expanded in [false, true] {
+            let items = flatten_rail_list_items(&groups, |_| expanded);
+            let links: Vec<usize> = items
+                .iter()
+                .filter_map(|item| match item {
+                    RailListItem::EarlierRunsLink { row_index, .. } => Some(*row_index),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(
+                links,
+                vec![1],
+                "expanded={expanded}: only `quiet` (history, no live agent) gets the line -                  \u{a7}6's own gate, and it does not hide behind the caret"
+            );
+
+            let link = items
+                .iter()
+                .find(|item| matches!(item, RailListItem::EarlierRunsLink { .. }))
+                .expect("the line");
+            assert!(
+                link.is_last_in_worktree_block(&groups, expanded),
+                "expanded={expanded}: the line is what ends `quiet`'s block, so it carries the gap"
+            );
+            let quiet_row = items
+                .iter()
+                .find(|item| matches!(item, RailListItem::WorktreeRow { row_index: 1, .. }))
+                .expect("quiet's own row");
+            assert!(
+                !quiet_row.is_last_in_worktree_block(&groups, expanded),
+                "expanded={expanded}: and the row above it therefore is not"
+            );
+        }
     }
 
     #[test]

--- a/crates/app/src/rail/strip.rs
+++ b/crates/app/src/rail/strip.rs
@@ -41,11 +41,21 @@ use crate::lsp::diagnostics::Severity;
 use crate::root::plural;
 use crate::theme;
 
-/// A view the left column can show. Exactly the two §4u leaves in the strip.
+/// A view the left column can show.
 ///
 /// [`SidebarView::Worktrees`] is the rail this app has always had, unchanged - §2's table says so
 /// in as many words ("the existing repo → worktree → agent tree, unchanged"). The strip does not
 /// rebuild it; it sits above it and gates it.
+///
+/// ## Two of these are strip cells, and one deliberately is not
+///
+/// [`SidebarView::ALL`] is the **strip**'s list, not this enum's: §4t moved History out of the
+/// strip and into the `⋯` overflow ("a permanent cell in a 5-cell strip is a claim that you
+/// switch to it constantly. If you don't, it belongs in the overflow"), and §4u fixed the strip
+/// at "two cells and the overflow - Worktrees, Problems, `⋯`". History is still a real *view* -
+/// the sidebar body paints it, the filter row follows it, and `crate::rail::menu`'s overflow row
+/// switches to it - it simply has no cell of its own. That is why [`SidebarView::History`] exists
+/// here but is absent from `ALL`, and why the test below pins both halves of that.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum SidebarView {
     /// The repo → worktree → agent tree.
@@ -53,10 +63,14 @@ pub enum SidebarView {
     Worktrees,
     /// The selected worktree's LSP diagnostics.
     Problems,
+    /// Agent history, keyed repo → worktree → run (GitHub issue #227). Reached from the `⋯`
+    /// overflow rather than from a cell - see this enum's own docs.
+    History,
 }
 
 impl SidebarView {
-    /// Every view, in the order the strip paints them.
+    /// Every view **the strip paints a cell for**, in the order it paints them - which is
+    /// deliberately not every variant of this enum. See [`SidebarView`]'s own docs.
     pub const ALL: &'static [SidebarView] = &[SidebarView::Worktrees, SidebarView::Problems];
 
     /// The view's name - the first half of its `"<view> — <hint>"` tooltip, and the word the
@@ -65,6 +79,7 @@ impl SidebarView {
         match self {
             SidebarView::Worktrees => "Worktrees",
             SidebarView::Problems => "Problems",
+            SidebarView::History => "History",
         }
     }
 
@@ -76,6 +91,9 @@ impl SidebarView {
         match self {
             SidebarView::Worktrees => "repo \u{b7} worktree \u{b7} agent",
             SidebarView::Problems => "diagnostics in this worktree",
+            // The wording `crate::rail::menu::overflow_menu_groups`' own History row already
+            // carries, so the row you reach this view by and the view itself say one thing.
+            SidebarView::History => "earlier runs, by repo and worktree",
         }
     }
 
@@ -87,6 +105,10 @@ impl SidebarView {
         match self {
             SidebarView::Worktrees => Icon::TreeStructure,
             SidebarView::Problems => Icon::Warning,
+            // §8's own third mapping, and §4u's "with the glyphs they had in the strip (clock,
+            // sliders) so the move out of the strip does not cost their recognisability" - so the
+            // overflow row and this view name the same mark even though no cell paints it.
+            SidebarView::History => Icon::ClockCounterClockwise,
         }
     }
 
@@ -417,6 +439,10 @@ pub fn strip_view_cells(
                     StripMarker::new(agents_needing_you, MarkerTone::NeedsYou)
                 }
                 SidebarView::Problems => problems.marker(),
+                // Unreachable: this maps over `ALL`, which History is deliberately not in. Stated
+                // as `None` rather than as an `unreachable!()` so that the day History *does* get
+                // a cell, the compiler asks for its marker here instead of the app panicking.
+                SidebarView::History => None,
             },
         })
         .collect()
@@ -611,6 +637,37 @@ mod tests {
             2,
             "History belongs to the overflow (\u{a7}4u) and Search to the right panel (\u{a7}4u); \
              a third cell here would be re-adding a strip the design cut down"
+        );
+        assert!(
+            !SidebarView::ALL.contains(&SidebarView::History),
+            "History is a real view the body paints, reached from the \u{2ef} overflow - it must \
+             never acquire a cell"
+        );
+    }
+
+    /// The other half of the same rule: History being absent from the strip must not make it a
+    /// second-class view. It carries the same tooltip pair, the same glyph the overflow row shows,
+    /// and it survives [`effective_view`] exactly like Problems does.
+    #[test]
+    fn history_is_a_full_view_even_though_it_has_no_cell() {
+        assert_eq!(SidebarView::History.label(), "History");
+        assert_eq!(
+            SidebarView::History.tooltip(None),
+            "History \u{2014} earlier runs, by repo and worktree"
+        );
+        assert_eq!(
+            SidebarView::History.icon(),
+            Icon::ClockCounterClockwise,
+            "\u{a7}4u: the overflow keeps the glyph History had in the strip"
+        );
+        assert_eq!(
+            effective_view(true, SidebarView::History),
+            SidebarView::History
+        );
+        assert_eq!(
+            effective_view(false, SidebarView::History),
+            SidebarView::Worktrees,
+            "an empty day has no runs to index either, and no cell to switch back from"
         );
     }
 

--- a/crates/app/src/rail/strip_render.rs
+++ b/crates/app/src/rail/strip_render.rs
@@ -243,6 +243,10 @@ impl AdeApp {
         let element_id = match view {
             SidebarView::Worktrees => "sidebar-strip-worktrees",
             SidebarView::Problems => "sidebar-strip-problems",
+            // Unreachable: cells come from `strip::strip_view_cells`, which maps over
+            // `SidebarView::ALL`, and History is deliberately not in it (§4t). Named anyway
+            // rather than left to a catch-all, so this match keeps asking the question.
+            SidebarView::History => "sidebar-strip-history",
         };
         let glyph = cell.glyph_color();
 
@@ -328,7 +332,7 @@ impl AdeApp {
     /// [`Self::rail_scroll_handle`] scroller the rail used for both views before - genuinely few
     /// rows, so no virtualization is needed there.
     pub(in crate::rail) fn render_sidebar_body(
-        &self,
+        &mut self,
         view: SidebarView,
         groups: &std::rc::Rc<Vec<RepoGroup>>,
         problems: &[Problem],
@@ -336,33 +340,68 @@ impl AdeApp {
     ) -> gpui::AnyElement {
         match view {
             SidebarView::Worktrees => self.render_rail_list(groups, cx),
-            SidebarView::Problems => div()
-                .relative()
-                .flex()
-                .flex_col()
-                .flex_1()
-                .min_h_0()
-                .child(
-                    div()
-                        .id("agent-rail-list")
-                        // Lets a real test measure the scroller's own painted box - the rail
-                        // menus' "rendered outside the scrolling list" guarantee (GitHub issue
-                        // #290) is only checkable against it.
-                        .debug_selector(|| "agent-rail-list".to_string())
-                        .flex_1()
-                        .min_h_0()
-                        .overflow_y_scroll()
-                        .track_scroll(&self.rail_scroll_handle)
-                        .child(self.render_problems_view(problems, cx)),
-                )
-                .children(scrollbar::render_vertical_scrollbar(
-                    "rail-scrollbar",
-                    &self.rail_scroll_handle,
-                    &[],
-                    cx,
-                ))
-                .into_any_element(),
+            SidebarView::Problems => {
+                let body = self.render_problems_view(problems, cx);
+                self.scrolled_sidebar_body(body, cx)
+            }
+            // GitHub issue #227. `&mut self` exists for this arm alone: History's body is the one
+            // that needs a real background load before it can answer
+            // (`crate::run_history::flow::AdeApp::load_run_drift` - one `git rev-list` per
+            // checkout with history). Idempotent and single-flight, and asked for here rather
+            // than at startup so a window whose user never opens History runs none - the same
+            // shape `crate::lsp::client::AdeApp::ensure_lsp_client` already has on the code
+            // surface's own render path.
+            //
+            // It shares the Problems view's plain scroller rather than the Worktrees view's
+            // virtualized `gpui::list` for the same reason Problems does: the rows are
+            // genuinely few (`crate::hooks::store::MAX_RECORDED_AGENTS` caps the whole
+            // window's history), and the tree is a two-level structure of headers and rows
+            // rather than the flat, uniform row list a `list` measures.
+            SidebarView::History => {
+                let body = self.render_history_view(cx);
+                self.scrolled_sidebar_body(body, cx)
+            }
         }
+    }
+
+    /// The plain scroller the two non-virtualized sidebar views share - Problems and History.
+    ///
+    /// One helper rather than the block written twice, for §7 rule 7's reason: this is one
+    /// control drawn for two views, and two copies drift on the debug selector first - which is
+    /// exactly the id the rail menus' "rendered outside the scrolling list" guarantee (GitHub
+    /// issue #290) is measured against. The Worktrees view deliberately does not come through
+    /// here: it is a real virtualized `gpui::list` that owns its own scroll offset.
+    fn scrolled_sidebar_body(
+        &self,
+        body: gpui::AnyElement,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        div()
+            .relative()
+            .flex()
+            .flex_col()
+            .flex_1()
+            .min_h_0()
+            .child(
+                div()
+                    .id("agent-rail-list")
+                    // Lets a real test measure the scroller's own painted box - the rail menus'
+                    // "rendered outside the scrolling list" guarantee (GitHub issue #290) is only
+                    // checkable against it.
+                    .debug_selector(|| "agent-rail-list".to_string())
+                    .flex_1()
+                    .min_h_0()
+                    .overflow_y_scroll()
+                    .track_scroll(&self.rail_scroll_handle)
+                    .child(body),
+            )
+            .children(scrollbar::render_vertical_scrollbar(
+                "rail-scrollbar",
+                &self.rail_scroll_handle,
+                &[],
+                cx,
+            ))
+            .into_any_element()
     }
 
     /// The Problems view: the real count line over the real rows, or the real empty note.
@@ -645,6 +684,8 @@ fn render_strip_marker(view: SidebarView, marker: StripMarker) -> impl IntoEleme
     let selector = match view {
         SidebarView::Worktrees => "sidebar-strip-worktrees-marker",
         SidebarView::Problems => "sidebar-strip-problems-marker",
+        // Unreachable - History has no cell, so it has no marker either. See `SidebarView`.
+        SidebarView::History => "sidebar-strip-history-marker",
     };
     div()
         // Lets a real test prove the marker is really absent on a window with nothing waiting -

--- a/crates/app/src/review/render.rs
+++ b/crates/app/src/review/render.rs
@@ -51,6 +51,10 @@ impl AdeApp {
         // dangling in the bugs `leave_graph_tab` documents.
         self.leave_graph_tab(window, cx);
         self.graph_tab_open = false;
+        // GitHub issue #227: the run-transcript tab occupies the centre pane exactly as the
+        // graph and review tabs do, so it needs the identical teardown - see
+        // `crate::run_history::tab::AdeApp::leave_run_tab`.
+        self.leave_run_tab(window, cx);
 
         let was_active = self.review_tab_active && self.review_tab_open == Some(id);
         self.review_tab_open = Some(id);

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -1044,6 +1044,67 @@ pub struct AdeApp {
     /// Pre-open focus target for [`Self::review_focus_handle`] - see [`OverlayFocus`], and
     /// [`Self::graph_focus`] for the identical role on the graph tab.
     pub(crate) review_focus: OverlayFocus,
+    /// Which runs the sidebar's History view is showing - `all` or `this worktree`
+    /// (`design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md` §6, GitHub issue #227).
+    ///
+    /// Deliberately not persisted, for exactly [`Self::sidebar_view`]'s own reason: it is a
+    /// per-window navigation position, not a preference.
+    pub(crate) history_scope: crate::run_history::model::HistoryScope,
+    /// Which History worktree groups the user has explicitly folded or unfolded, keyed by
+    /// worktree path (`true` = folded). A worktree with no entry takes the default
+    /// `crate::run_history::model::build_run_tree` computes - the active one opens, the rest do
+    /// not - which is why this is a map of *explicit* choices rather than a set of open groups:
+    /// the two are only the same until the active worktree changes.
+    pub(crate) history_collapsed: HashMap<PathBuf, bool>,
+    /// Real drift counts, `worktree -> run key -> commits since that run ended` (GitHub issue
+    /// #227). Filled in by `crate::run_history::flow::AdeApp::load_run_drift`, which runs a real
+    /// `wt_core::run_drift::commits_since_each` per worktree on the background executor.
+    ///
+    /// A run with no entry paints **no** drift dot and no drift text - see
+    /// `crate::run_history::model::RunEntry::drift`. There is deliberately no "assume zero"
+    /// fallback: `at the tip` is a real claim about the branch, and a claim made before the
+    /// traversal answered would be a guess dressed as the most reassuring of the three bands.
+    pub(crate) run_drift: HashMap<PathBuf, HashMap<String, usize>>,
+    /// Whether a drift load is already running, so a re-render mid-flight cannot start a second
+    /// one - the same single-flight shape [`Self::prune_in_flight`] uses.
+    pub(crate) run_drift_in_flight: bool,
+    /// Which run's transcript is open as a centre tab in each worktree, keyed by worktree path.
+    ///
+    /// **One run tab per worktree, replaced on the next open** (`REVISION-2026-08-13.md` §3), so
+    /// this is a map rather than [`Self::review_tab_open`]'s single window-wide slot: opening a
+    /// run in another checkout must not close the one you were reading here.
+    pub(crate) run_tab_by_worktree: HashMap<PathBuf, String>,
+    /// Whether the run-transcript tab is the tab strip's currently *active* entry - exactly
+    /// mirrors [`Self::review_tab_active`], including that switching to another tab clears this
+    /// without closing the run tab.
+    pub(crate) run_tab_active: bool,
+    /// The run-transcript tab's own keyboard-focus target, swept exactly like
+    /// [`Self::review_focus_handle`] whenever the tab stops being rendered.
+    pub(crate) run_tab_focus_handle: FocusHandle,
+    /// Pre-open focus target for [`Self::run_tab_focus_handle`] - see [`OverlayFocus`].
+    pub(crate) run_tab_focus: OverlayFocus,
+    /// The run-transcript body's scroll handle - a transcript is longer than the pane.
+    pub(crate) run_tab_scroll_handle: gpui::ScrollHandle,
+    /// Real captured transcripts read back off disk, keyed by run id
+    /// (`crate::run_history::transcript_store`). A key present with `None` means "this run was
+    /// looked up and genuinely has no stored transcript", which is what makes the synthesised
+    /// body (`crate::run_history::model::transcript_body`) a decision rather than a race: without
+    /// the distinction, every first frame after opening a tab would render the synthesis and then
+    /// swap it for the real thing.
+    pub(crate) run_transcripts: HashMap<String, Option<Vec<String>>>,
+    /// Where [`Self::run_transcripts`] is persisted - a sibling of `agent-status.toml`, or `None`
+    /// when this instance has no real settings path (see `crate::settings::store`).
+    pub(crate) run_transcript_dir: Option<PathBuf>,
+    /// In-flight background reads of a run's stored transcript, keyed by run id. Keyed rather
+    /// than a single slot for [`Self::_review_baseline_tasks`]'s own reason: a `Task` cancels on
+    /// drop, and two tabs opened in quick succession must not cancel each other's read.
+    pub(crate) _run_transcript_load_tasks: HashMap<String, Task<()>>,
+    /// In-flight "this run just ended" captures, keyed by run id - the real diffstat measurement
+    /// and record write `crate::run_history::flow::AdeApp::finish_run_record` performs when an
+    /// agent's pane closes. Keyed for the same reason, and removed by each task as it completes.
+    pub(crate) _run_finish_tasks: HashMap<String, Task<()>>,
+    /// The in-flight drift traversal - one slot, guarded by [`Self::run_drift_in_flight`].
+    pub(crate) _run_drift_task: Option<Task<()>>,
     /// The review tab's own overlay-scrollbar handle - its own, not
     /// [`Self::diff_view_scroll_handle`]: the two surfaces are separate places in the app, and
     /// sharing one handle would carry the git Diff view's scroll position into the review (and

--- a/crates/app/src/root/new_file.rs
+++ b/crates/app/src/root/new_file.rs
@@ -382,6 +382,10 @@ impl AdeApp {
         // by an adversarial audit; the review surface's own docs claimed to copy the graph tab's
         // discipline and, in exactly this way, did not.
         self.leave_review_tab(window, cx);
+        // GitHub issue #227: the run-transcript tab occupies the centre pane exactly as the
+        // graph and review tabs do, so it needs the identical teardown - see
+        // `crate::run_history::tab::AdeApp::leave_run_tab`.
+        self.leave_run_tab(window, cx);
 
         self.focus_code_surface(window, cx);
         self.pending_cursor_line = None;

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -149,6 +149,14 @@ impl AdeApp {
             .as_deref()
             .map(crate::hooks::store::AgentStatusState::load_at)
             .unwrap_or_default();
+        // GitHub issue #227's per-run transcripts sit in a directory beside that file, and
+        // resolve the same way. Nothing is read here: a transcript is read once, when its own tab
+        // is opened (`crate::run_history::flow::AdeApp::load_run_transcript`), because reading
+        // every stored run's output at startup would be megabytes of disk for a surface the user
+        // may never visit.
+        let run_transcript_dir = settings_path
+            .as_deref()
+            .map(crate::run_history::transcript_store::transcript_dir_for);
 
         // GitHub issue #284's per-agent line provenance resolves the same way. Unlike the two
         // above it is genuinely read back at startup - `restore_line_provenance`, called once
@@ -391,6 +399,20 @@ impl AdeApp {
             review_tab_active: false,
             review_focus_handle: cx.focus_handle(),
             review_focus: OverlayFocus::default(),
+            history_scope: crate::run_history::model::HistoryScope::default(),
+            history_collapsed: HashMap::new(),
+            run_drift: HashMap::new(),
+            run_drift_in_flight: false,
+            run_tab_by_worktree: HashMap::new(),
+            run_tab_active: false,
+            run_tab_focus_handle: cx.focus_handle(),
+            run_tab_focus: OverlayFocus::default(),
+            run_tab_scroll_handle: gpui::ScrollHandle::new(),
+            run_transcripts: HashMap::new(),
+            run_transcript_dir,
+            _run_transcript_load_tasks: HashMap::new(),
+            _run_finish_tasks: HashMap::new(),
+            _run_drift_task: None,
             review_scroll_handle: UniformListScrollHandle::new(),
             review_highlight_cache: None,
             _review_baseline_tasks: HashMap::new(),

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -1674,6 +1674,14 @@ impl AdeApp {
         // before `self.selected` moves below, while `Self::current_worktree_path` still resolves to the
         // worktree being left.
         self.record_worktree_session(cx);
+        // GitHub issue #227: the run-transcript tab belongs to *one* worktree's strip
+        // (`Self::run_tab_by_worktree`), so a switch away from that worktree must leave the
+        // surface - not merely stop mattering. Without this, `run_tab_active` survived the switch
+        // while `Self::open_run_key` started resolving against the worktree switched *to*, so the
+        // centre pane painted the other checkout's run, or "this run is no longer in the history"
+        // for a worktree that simply has no run tab. The tab itself is untouched: it is still in
+        // its own worktree's strip, one switch back.
+        self.leave_run_tab(window, cx);
         self.selected = Some(index);
         // A real, explicit user selection supersedes any stale "fell back to main" notice a
         // previous refresh may have left up - see `Self::worktree_selection_notice`'s own docs.

--- a/crates/app/src/run_history/flow.rs
+++ b/crates/app/src/run_history/flow.rs
@@ -1,2 +1,338 @@
-//! placeholder
+//! The `impl AdeApp` data half of agent history (GitHub issue #227): what really happens when a
+//! run ends, and the two background loads the History surface needs.
+//!
+//! Three things live here, and none of them is on the render path:
+//!
+//! 1. [`AdeApp::finish_run_record`] - called from the one funnel every close path already goes
+//!    through (`crate::work_surface::render::AdeApp::close_agent`). It captures the run's own
+//!    transcript out of its pane *before* the pane is torn down, records the real ending, and
+//!    measures what the run changed against its own review baseline.
+//! 2. [`AdeApp::load_run_drift`] - one real `wt_core::run_drift::commits_since_each` per worktree
+//!    that has history, on the background executor.
+//! 3. [`AdeApp::load_run_transcript`] - one real read of a stored transcript, when its tab opens.
+//!
+//! ## Why the capture happens at close, and only at close
+//!
+//! Everything a finished run knows about itself stops existing the moment its pane goes away: the
+//! terminal grid is dropped by `Agents::close`, and the review baseline's tree ref is deleted by
+//! `release_review_baseline`. Measuring at any later point would mean measuring something else -
+//! the worktree's *current* diff rather than what this run did - and there is no later point at
+//! which the transcript exists at all.
+//!
+//! ## What it deliberately does not do
+//!
+//! It never creates a record for an agent that does not already have one.
+//! `crate::hooks::flow::AdeApp::record_agent_statuses` only records agents that produced a real
+//! hook fact - a status inferred from pty silence is a guess, and a guess written to disk is still
+//! a guess an hour later - so an agent with no record is one Jerry never knew anything real about.
+//! Filing it into History at close time would put a run there whose every field was invented. See
+//! [`crate::hooks::store::AgentStatusState::finish`]'s own docs for the same contract on the other
+//! side of the call.
+
 use super::*;
+
+use crate::hooks::store::FinishedRun;
+
+/// How many lines of a run's own pane are kept as its transcript - the read side of
+/// [`crate::run_history::transcript_store::MAX_TRANSCRIPT_LINES`], asked for at capture time so a
+/// pane holding 10 000 lines of scrollback never allocates all of them just to throw most away.
+const CAPTURED_TRANSCRIPT_LINES: usize = crate::run_history::transcript_store::MAX_TRANSCRIPT_LINES;
+
+impl AdeApp {
+    /// Records that agent `id`'s run really ended, now (GitHub issue #227).
+    ///
+    /// Called from [`Self::close_agent`] **before** it tears the agent down, because two of the
+    /// three things this needs only exist until then:
+    ///
+    /// - the run's own transcript, read synchronously out of the live pane's grid (cheap - it is
+    ///   an in-memory copy of at most [`CAPTURED_TRANSCRIPT_LINES`] lines - and impossible
+    ///   afterwards, since `Agents::close` drops the grid);
+    /// - the agent's review baseline tree id, which `release_review_baseline` is about to delete
+    ///   the ref for.
+    ///
+    /// The write itself, the diffstat measurement and the transcript file are all done on the
+    /// background executor: one `git diff`, one file write and one `fsync`ing state save have no
+    /// business on the frame that closed a tab.
+    ///
+    /// A no-op for a shell, for an agent with no persisted record, and while a capture for the
+    /// same run is already in flight.
+    pub(crate) fn finish_run_record(&mut self, id: AgentId, cx: &mut Context<Self>) {
+        let Some(agent) = self.agents.iter().find(|agent| agent.id == id) else {
+            return;
+        };
+        let ProcessKind::Agent(kind) = agent.kind else {
+            return;
+        };
+        let worktree = agent.cwd.clone();
+        let key = crate::review::state::baseline_key(&worktree, kind, agent.spawned_at_unix);
+        // The contract this module's own docs spell out: History shows runs Jerry really knew
+        // about, so a run with no record stays absent rather than being invented here.
+        if self.agent_status_state.get(&key).is_none() {
+            return;
+        }
+        if self._run_finish_tasks.contains_key(&key) {
+            return;
+        }
+
+        // Read out of the live pane while it is still alive. `read` rather than `update`: this
+        // only observes the grid.
+        let transcript = agent
+            .pane
+            .read(cx)
+            .retained_text_lines(CAPTURED_TRANSCRIPT_LINES);
+        // The run's own baseline, if it captured one - the tree its diffstat is measured against.
+        let baseline = self
+            .agent_reviews
+            .get(&id)
+            .map(|review| (review.baseline.tree_id.clone(), review.baseline.untracked));
+        let status = self.agent_status(agent, cx);
+        let ended_at_unix = unix_now();
+        let transcript_dir = self.run_transcript_dir.clone();
+
+        let task_key = key.clone();
+        let task = cx.spawn(async move |this, cx| {
+            let measure_worktree = worktree.clone();
+            let measured = match baseline {
+                Some((tree_id, untracked)) => {
+                    cx.background_executor()
+                        .spawn(async move {
+                            wt_core::review::diff_against_tree(
+                                &measure_worktree,
+                                &tree_id,
+                                untracked,
+                                // The label only ever appears in `wt_core`'s own error text; this
+                                // names the run so a failure says which one could not be measured.
+                                "run history".to_owned(),
+                            )
+                            .ok()
+                        })
+                        .await
+                }
+                None => None,
+            };
+            let diffstat = measured.map(|diff| {
+                let (insertions, deletions) = crate::rail::state::sum_diff_stat(&diff);
+                (diff.files.len() as u32, insertions as u32, deletions as u32)
+            });
+
+            if let Some(dir) = transcript_dir {
+                let key = key.clone();
+                cx.background_executor()
+                    .spawn(async move {
+                        if let Err(err) =
+                            crate::run_history::transcript_store::save(&dir, &key, &transcript)
+                        {
+                            log::warn!("could not store this run's transcript: {err}");
+                        }
+                    })
+                    .await;
+            }
+
+            let _ = this.update(cx, |this, cx| {
+                this._run_finish_tasks.remove(&key);
+                let changed = this.agent_status_state.finish(
+                    &key,
+                    ended_at_unix,
+                    FinishedRun {
+                        status: Some(status),
+                        files_changed: diffstat.map(|(files, _, _)| files),
+                        insertions: diffstat.map(|(_, insertions, _)| insertions),
+                        deletions: diffstat.map(|(_, _, deletions)| deletions),
+                    },
+                );
+                if changed {
+                    this.agent_status_owned.insert(key.clone());
+                    this.persist_agent_statuses_for_history(cx);
+                }
+                // This run's drift is now a question with an answer, and its worktree's cached
+                // counts predate it. Dropping the entry is what makes the next History render ask
+                // again, rather than showing the new run with no band forever.
+                this.run_drift.remove(&worktree);
+                cx.notify();
+            });
+        });
+        self._run_finish_tasks.insert(task_key, task);
+    }
+
+    /// Loads the real drift count for every worktree that has history and has not been answered
+    /// yet (GitHub issue #227).
+    ///
+    /// Single-flight through [`AdeApp::run_drift_in_flight`], and batched per worktree: one
+    /// `wt_core::run_drift::commits_since_each` answers every run in a checkout from one
+    /// traversal, so a window with five worktrees costs five `git` processes on the background
+    /// executor, not one per run.
+    ///
+    /// Called from the History body's own render (`crate::run_history::render`), which is the
+    /// only place that needs the answer - a window whose user never opens History never runs a
+    /// single one of these.
+    pub(crate) fn load_run_drift(&mut self, cx: &mut Context<Self>) {
+        if self.run_drift_in_flight {
+            return;
+        }
+        let live_keys = self.live_agent_status_keys();
+        let mut wanted: Vec<(PathBuf, Vec<(String, i64)>)> = Vec::new();
+        for worktree in self.history_worktrees() {
+            if self.run_drift.contains_key(&worktree.path) {
+                continue;
+            }
+            let runs: Vec<(String, i64)> = crate::hooks::history::past_agents_for_worktree(
+                &self.agent_status_state,
+                &worktree.path,
+                &live_keys,
+            )
+            .into_iter()
+            .map(|run| {
+                (
+                    run.key.clone(),
+                    crate::run_history::model::run_finished_at(&run),
+                )
+            })
+            .collect();
+            if !runs.is_empty() {
+                wanted.push((worktree.path.clone(), runs));
+            }
+        }
+        if wanted.is_empty() {
+            return;
+        }
+
+        self.run_drift_in_flight = true;
+        let task = cx.spawn(async move |this, cx| {
+            let answers = cx
+                .background_executor()
+                .spawn(async move {
+                    wanted
+                        .into_iter()
+                        .map(|(path, runs)| {
+                            let moments: Vec<i64> = runs.iter().map(|(_, at)| *at).collect();
+                            let counts = wt_core::run_drift::commits_since_each(&path, &moments);
+                            let counts = match counts {
+                                Ok(Some(counts)) => counts,
+                                // A checkout with no commits, or a `git` that failed: this
+                                // worktree's runs simply have no drift answer. They paint no band
+                                // rather than a fabricated `at the tip` - see `AdeApp::run_drift`.
+                                Ok(None) => Vec::new(),
+                                Err(err) => {
+                                    log::warn!("could not read {}'s drift: {err}", path.display());
+                                    Vec::new()
+                                }
+                            };
+                            let per_run: HashMap<String, usize> =
+                                runs.into_iter().map(|(key, _)| key).zip(counts).collect();
+                            (path, per_run)
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                this.run_drift_in_flight = false;
+                for (path, counts) in answers {
+                    this.run_drift.insert(path, counts);
+                }
+                cx.notify();
+            });
+        });
+        self._run_drift_task = Some(task);
+    }
+
+    /// Reads one run's stored transcript back off disk, once, when its tab is opened.
+    ///
+    /// The result is stored as `Some(lines)` or `None` under the run's own key, and the
+    /// distinction between "absent from the map" and "present as `None`" is what makes the
+    /// synthesised body a decision rather than a flicker - see [`AdeApp::run_transcripts`].
+    pub(crate) fn load_run_transcript(&mut self, run_key: String, cx: &mut Context<Self>) {
+        if self.run_transcripts.contains_key(&run_key)
+            || self._run_transcript_load_tasks.contains_key(&run_key)
+        {
+            return;
+        }
+        let Some(dir) = self.run_transcript_dir.clone() else {
+            // No real settings path means no transcript directory at all - which is a real answer
+            // ("this run has none"), not a pending one.
+            self.run_transcripts.insert(run_key, None);
+            return;
+        };
+        let key = run_key.clone();
+        let task = cx.spawn(async move |this, cx| {
+            let read_key = key.clone();
+            let lines = cx
+                .background_executor()
+                .spawn(async move { crate::run_history::transcript_store::load(&dir, &read_key) })
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                this._run_transcript_load_tasks.remove(&key);
+                this.run_transcripts.insert(key, lines);
+                cx.notify();
+            });
+        });
+        self._run_transcript_load_tasks.insert(run_key, task);
+    }
+
+    /// Every checkout the window knows about, in the rail's own repo → worktree order - the input
+    /// [`crate::run_history::model::build_run_tree`] groups history under.
+    ///
+    /// Built from [`AdeApp::repos`] rather than from [`AdeApp::worktrees`] (which is only ever the
+    /// focused repo's list) because History is explicitly cross-repo: §6 keys it "repo → worktree
+    /// → run, matching the rail", and the `all` scope is the whole point of the toggle.
+    pub(crate) fn history_worktrees(&self) -> Vec<crate::run_history::model::HistoryWorktree> {
+        self.repos
+            .iter()
+            .flat_map(|repo| {
+                let repo_label = repo.name.clone();
+                repo.worktrees
+                    .iter()
+                    .map(move |item| crate::run_history::model::HistoryWorktree {
+                        path: item.path.clone(),
+                        repo_label: repo_label.clone(),
+                        label: item.label.clone(),
+                        branch: item.branch.clone(),
+                    })
+            })
+            .collect()
+    }
+
+    /// Every genuinely past run in the window, most recently active first - the flat list
+    /// [`crate::run_history::model::build_run_tree`] groups.
+    ///
+    /// "Genuinely past" excludes any agent that is open right now, exactly as the rail's own
+    /// history did: a live agent already has a real row in the Worktrees view, and listing it
+    /// here as well would be the same agent rendered twice
+    /// (`crate::hooks::history::past_agents_for_worktree`'s own reasoning, applied window-wide).
+    pub(crate) fn past_runs(&self) -> Vec<crate::hooks::history::PastAgent> {
+        let live_keys = self.live_agent_status_keys();
+        crate::hooks::history::past_agents(&self.agent_status_state)
+            .into_iter()
+            .filter(|run| !live_keys.contains(&run.key))
+            .collect()
+    }
+
+    /// Persists the record file after a run's ending was written, and prunes the transcript
+    /// directory to match.
+    ///
+    /// A separate entry point from `crate::hooks::flow::AdeApp::persist_agent_statuses` (which
+    /// this delegates to) purely so the prune rides the one save that can ever *remove* a record:
+    /// `save_merged_at` caps the file at
+    /// [`crate::hooks::store::MAX_RECORDED_AGENTS`], and a transcript whose record was just
+    /// pruned is unreachable from then on.
+    fn persist_agent_statuses_for_history(&mut self, cx: &mut Context<Self>) {
+        self.persist_agent_statuses(cx);
+        let Some(dir) = self.run_transcript_dir.clone() else {
+            return;
+        };
+        let live: std::collections::BTreeSet<String> =
+            self.agent_status_state.agents.keys().cloned().collect();
+        cx.background_executor()
+            .spawn(async move {
+                crate::run_history::transcript_store::prune(&dir, &live);
+            })
+            .detach();
+    }
+}
+
+/// Seconds since the Unix epoch, mirroring `crate::hooks::flow`'s own `unix_now`.
+fn unix_now() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_secs() as i64)
+        .unwrap_or(0)
+}

--- a/crates/app/src/run_history/flow.rs
+++ b/crates/app/src/run_history/flow.rs
@@ -328,11 +328,3 @@ impl AdeApp {
             .detach();
     }
 }
-
-/// Seconds since the Unix epoch, mirroring `crate::hooks::flow`'s own `unix_now`.
-fn unix_now() -> i64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|elapsed| elapsed.as_secs() as i64)
-        .unwrap_or(0)
-}

--- a/crates/app/src/run_history/flow.rs
+++ b/crates/app/src/run_history/flow.rs
@@ -1,0 +1,2 @@
+//! placeholder
+use super::*;

--- a/crates/app/src/run_history/mod.rs
+++ b/crates/app/src/run_history/mod.rs
@@ -40,13 +40,12 @@
 //! facts) and, where no transcript was captured, a short synthesised one built from that run's own
 //! record - which is what §3 asks for in as many words, and never another run's output.
 
-use crate::hooks::history::PastAgent;
-use crate::rail::status::Status;
 use crate::root::*;
 use crate::theme;
-use crate::work_surface::agents::{AgentId, AgentKind, ProcessKind};
+use crate::work_surface::agents::{AgentId, ProcessKind};
 use gpui::{div, font, prelude::*, px, ClickEvent, Context, Window};
-use std::path::{Path, PathBuf};
+use std::collections::HashMap;
+use std::path::PathBuf;
 
 pub mod model;
 pub mod transcript_store;

--- a/crates/app/src/run_history/mod.rs
+++ b/crates/app/src/run_history/mod.rs
@@ -53,3 +53,13 @@ pub mod transcript_store;
 pub(crate) mod flow;
 pub(crate) mod render;
 pub(crate) mod tab;
+
+/// Seconds since the Unix epoch, mirroring `crate::hooks::flow`'s own `unix_now` (including its
+/// `unwrap_or(0)` for a clock set before 1970). Shared by all three halves of this feature so a
+/// row, its transcript header and its closing line can never date the same run off two clocks.
+pub(crate) fn unix_now() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_secs() as i64)
+        .unwrap_or(0)
+}

--- a/crates/app/src/run_history/mod.rs
+++ b/crates/app/src/run_history/mod.rs
@@ -1,0 +1,56 @@
+//! Agent history: the sidebar's repo → worktree → run index, and the run-transcript centre tab
+//! (GitHub issue #227). Everything about one feature, in one folder.
+//!
+//! Design sources, read directly rather than paraphrased:
+//! `design_handoff_jerry_ade/revision 5/REVISION-2026-08-13.md` (the whole document) as amended by
+//! `REVISION-2026-08-14.md` §4/§6/§7, and `Jerry.dc.html`'s own `Run · transcript` state.
+//!
+//! ## The one sentence the whole feature hangs off
+//!
+//! Audit I8, quoted in the issue: **"Sidebar indexes; center shows one run."** History is a *list
+//! you pick from*, like a file tree - not a document (§3: "Centre tabs hold things you read or
+//! work in; the sidebar holds things you navigate"). So the sidebar carries every run, grouped
+//! repo → worktree → run to match the rail's own hierarchy, and clicking one opens *its own*
+//! transcript as a centre tab - exactly the Explorer → editor pattern.
+//!
+//! ## Split, like every other feature folder in this crate
+//!
+//! - [`model`] - pure, GPUI-free: what an outcome is, what a drift band is, how a run is worded,
+//!   how the repo → worktree → run tree is built and filtered, and how a transcript is synthesised
+//!   when none was stored. Directly unit-testable without a window.
+//! - [`transcript_store`] - real per-run transcript files on disk, keyed by run id.
+//! - [`flow`] - the `impl AdeApp` half of the data: finishing a run record when its agent really
+//!   closes (capturing the transcript, the ending and the diffstat), and loading drift in the
+//!   background.
+//! - [`render`] - the real sidebar History body.
+//! - [`tab`] - the real run-transcript centre tab: its strip entry, its body, and its footer's
+//!   `Resume here` / `Start a new agent from this`.
+//!
+//! `render`/`tab`/`flow` glob-import this module (`use super::*`), which is why the shared imports
+//! they need live here rather than at the top of those files - the same convention `crate::root`
+//! and `crate::rail` established for their own submodules.
+//!
+//! ## What is real here, and what is derived
+//!
+//! Every run in this surface is a real [`crate::hooks::store::PersistedAgentStatus`] record that
+//! an agent's own hooks produced - Jerry never invents a run. Its title is the first prompt its
+//! human typed, its turn count is one per real `Stop`, its diffstat was measured against its own
+//! review baseline at the moment it ended, and its drift is a real `git log` in its own checkout.
+//! The two derived things are its **outcome** ([`model::Outcome::of`], a rule over those recorded
+//! facts) and, where no transcript was captured, a short synthesised one built from that run's own
+//! record - which is what §3 asks for in as many words, and never another run's output.
+
+use crate::hooks::history::PastAgent;
+use crate::rail::status::Status;
+use crate::root::*;
+use crate::theme;
+use crate::work_surface::agents::{AgentId, AgentKind, ProcessKind};
+use gpui::{div, font, prelude::*, px, ClickEvent, Context, Window};
+use std::path::{Path, PathBuf};
+
+pub mod model;
+pub mod transcript_store;
+
+pub(crate) mod flow;
+pub(crate) mod render;
+pub(crate) mod tab;

--- a/crates/app/src/run_history/model.rs
+++ b/crates/app/src/run_history/model.rs
@@ -668,8 +668,8 @@ fn synthesised_body(run: &PastAgent, branch: Option<&str>) -> Vec<TranscriptLine
         let turns = plural::count(run.turns as usize, "turn", None);
         lines.push(TranscriptLine::new(
             match branch {
-                Some(branch) => format!("  \u{23bf} {turns} in {branch}"),
-                None => format!("  \u{23bf} {turns}"),
+                Some(branch) => format!("  \u{2514} {turns} in {branch}"),
+                None => format!("  \u{2514} {turns}"),
             },
             LineTone::Detail,
         ));
@@ -677,7 +677,7 @@ fn synthesised_body(run: &PastAgent, branch: Option<&str>) -> Vec<TranscriptLine
     if let Some(diffstat) = run.diffstat {
         lines.push(TranscriptLine::new(
             format!(
-                "  \u{23bf} touched {}",
+                "  \u{2514} touched {}",
                 plural::count(diffstat.files as usize, "file", None)
             ),
             LineTone::Detail,
@@ -685,12 +685,12 @@ fn synthesised_body(run: &PastAgent, branch: Option<&str>) -> Vec<TranscriptLine
     }
     if let Some(activity) = &run.activity {
         lines.push(TranscriptLine::new(
-            format!("  \u{23bf} last: {activity}"),
+            format!("  \u{2514} last: {activity}"),
             LineTone::Detail,
         ));
     }
     lines.push(TranscriptLine::new(
-        "  \u{23bf} no transcript was captured for this run",
+        "  \u{2514} no transcript was captured for this run",
         LineTone::Detail,
     ));
     lines
@@ -698,6 +698,14 @@ fn synthesised_body(run: &PastAgent, branch: Option<&str>) -> Vec<TranscriptLine
 
 /// The two closing lines every transcript ends on - §3's
 /// `● Finished. 2 files changed, +41 −0.` and `⎿ run ended today 09:41 after 6m`.
+///
+/// **The detail glyph is `└` (U+2514), not the design's `⎿` (U+23BF).** U+23BF is Claude Code's
+/// own tree mark, and this app's bundled `IBM Plex Mono` has no glyph for it - nor does anything
+/// in the fallback chain on the platforms checked, so it rendered as a tofu box in the real
+/// window (caught by a screenshot, not by a test: a `String` comparison cannot see a missing
+/// glyph). U+2514 is the same mark from the box-drawing block, is really in the bundled font, and
+/// is what `●`/`❯` are already relying on the renderer for. Substituting a character the design
+/// meant *to be seen* is honouring it, not departing from it.
 ///
 /// This is the "one signal that this is a recording" that actually carries the meaning: the pane's
 /// 70% opacity says it is not live, and these say what happened and when it stopped. A transcript
@@ -721,11 +729,11 @@ pub fn closing_lines(run: &PastAgent, now_unix: i64) -> Vec<TranscriptLine> {
     let finished_at = run_finished_at(run);
     let when = run_when(finished_at, now_unix);
     let tail = match (run.ended_at_unix, run_duration(run)) {
-        (Some(_), Some(duration)) => format!("  \u{23bf} run ended {when} after {duration}"),
-        (Some(_), None) => format!("  \u{23bf} run ended {when}"),
+        (Some(_), Some(duration)) => format!("  \u{2514} run ended {when} after {duration}"),
+        (Some(_), None) => format!("  \u{2514} run ended {when}"),
         // No recorded ending at all: say what is actually known - when Jerry last heard from it -
         // rather than calling that moment the end of the run.
-        (None, _) => format!("  \u{23bf} last seen {when}"),
+        (None, _) => format!("  \u{2514} last seen {when}"),
     };
 
     vec![
@@ -1157,7 +1165,7 @@ mod tests {
         );
         assert_eq!(
             body[body.len() - 1].text,
-            "  \u{23bf} run ended today 22:19 after 6m"
+            "  \u{2514} run ended today 22:19 after 6m"
         );
     }
 
@@ -1184,9 +1192,9 @@ mod tests {
             "\u{276f} claude --resume 3d91e07 \u{b7} feat/query-builder"
         );
         assert!(text.contains(&"\u{25cf} Move the select builder behind a trait"));
-        assert!(text.contains(&"  \u{23bf} 21 turns in feat/query-builder"));
-        assert!(text.contains(&"  \u{23bf} touched 6 files"));
-        assert!(text.contains(&"  \u{23bf} no transcript was captured for this run"));
+        assert!(text.contains(&"  \u{2514} 21 turns in feat/query-builder"));
+        assert!(text.contains(&"  \u{2514} touched 6 files"));
+        assert!(text.contains(&"  \u{2514} no transcript was captured for this run"));
         assert_eq!(
             text[text.len() - 2],
             "\u{25cf} Finished. 6 files changed, +148 \u{2212}96."
@@ -1200,7 +1208,7 @@ mod tests {
         past.updated_at_unix = 1_700_000_500;
         let lines = closing_lines(&past, 1_700_000_600);
         assert_eq!(lines[0].text, "\u{25cf} Left unfinished.");
-        assert_eq!(lines[1].text, "  \u{23bf} last seen today 22:21");
+        assert_eq!(lines[1].text, "  \u{2514} last seen today 22:21");
     }
 
     #[test]

--- a/crates/app/src/run_history/model.rs
+++ b/crates/app/src/run_history/model.rs
@@ -439,9 +439,49 @@ impl RunTree {
         self.repos.iter().map(RunRepo::run_count).sum()
     }
 
+    /// How many worktree groups the tree really paints, across every repo.
+    pub fn worktree_count(&self) -> usize {
+        self.repos.iter().map(|repo| repo.groups.len()).sum()
+    }
+
     pub fn is_empty(&self) -> bool {
         self.total() == 0
     }
+
+    /// The view's own count line - `REVISION-2026-08-13.md` §1: "each view's body opens with its
+    /// own count line", and §2's rule for what one may say: "Both list headers ... are **tallied
+    /// over their own data**".
+    ///
+    /// So this counts *this tree* - what the body is actually showing after the scope and the
+    /// filter - rather than the whole history, and it names both levels of the hierarchy it is
+    /// showing, the way §2's own `10 results · 5 files · 3 worktrees` does. Both terms go through
+    /// [`crate::root::plural`] (§7 rule 9).
+    ///
+    /// `None` when there is nothing to count: the empty note ([`empty_note`]) or the
+    /// filtered-away note ([`filtered_away_note`]) says the real thing instead, exactly as
+    /// [`crate::rail::strip::ProblemTally::count_line`] does for a clean worktree.
+    pub fn count_line(&self) -> Option<String> {
+        let total = self.total();
+        if total == 0 {
+            return None;
+        }
+        Some(format!(
+            "{} \u{b7} {}",
+            plural::count(total, "run", None),
+            plural::count(self.worktree_count(), "worktree", None),
+        ))
+    }
+}
+
+/// The rail's own `↺ 2 earlier runs` line under a worktree row - `REVISION-2026-08-13.md` §6.
+///
+/// Agreement through [`crate::root::plural::form`] rather than [`crate::root::plural::count`]
+/// because the count is not adjacent to its noun here: `2 earlier runs` puts a word between them,
+/// which is exactly the case §8a's helper docs name ("For anything else that has to agree with a
+/// count ... call `form` directly, so the sentence still has exactly one place that looks at the
+/// number").
+pub fn earlier_runs_label(count: usize) -> String {
+    format!("{count} earlier {}", plural::form(count, "run", "runs"))
 }
 
 /// Builds the real repo → worktree → run tree.
@@ -1183,6 +1223,60 @@ mod tests {
             empty_note(HistoryScope::All, Some("feat/auth")),
             "No agent has finished a run yet."
         );
+    }
+
+    /// §2's "tallied over their own data": the line counts the tree the body is really painting,
+    /// both levels of it, and says nothing at all when there is nothing to count.
+    #[test]
+    fn the_count_line_tallies_the_tree_the_body_is_really_showing() {
+        let runs = vec![run("/a/wt-1", 10), run("/a/wt-2", 20), run("/b/wt-3", 30)];
+        let worktrees = vec![
+            worktree("/a/wt-1", "alpha", "feature-a"),
+            worktree("/a/wt-2", "alpha", "feature-b"),
+            worktree("/b/wt-3", "beta", "main"),
+        ];
+        let tree = build_run_tree(
+            &runs,
+            &worktrees,
+            None,
+            HistoryScope::All,
+            "",
+            &HashMap::new(),
+            &HashMap::new(),
+        );
+        assert_eq!(
+            tree.count_line().as_deref(),
+            Some("3 runs \u{b7} 3 worktrees")
+        );
+
+        // Narrowed by the filter, the line follows - it reports what is on screen, not what is
+        // on disk. `tree.unfiltered` is what remembers the difference.
+        let narrowed = build_run_tree(
+            &runs,
+            &worktrees,
+            None,
+            HistoryScope::All,
+            "feature-a",
+            &HashMap::new(),
+            &HashMap::new(),
+        );
+        assert_eq!(
+            narrowed.count_line().as_deref(),
+            Some("1 run \u{b7} 1 worktree"),
+            "\u{a7}7 rule 9: singular through the helper, on both terms"
+        );
+        assert_eq!(
+            RunTree::default().count_line(),
+            None,
+            "an empty tree gets its empty note, not a line of zeroes"
+        );
+    }
+
+    /// §6's rail line, singular and plural both.
+    #[test]
+    fn the_rail_link_says_one_earlier_run_in_the_singular() {
+        assert_eq!(earlier_runs_label(1), "1 earlier run");
+        assert_eq!(earlier_runs_label(2), "2 earlier runs");
     }
 
     #[test]

--- a/crates/app/src/run_history/model.rs
+++ b/crates/app/src/run_history/model.rs
@@ -1,0 +1,1193 @@
+//! The pure, GPUI-free half of agent history (GitHub issue #227): outcomes, drift bands, the
+//! repo → worktree → run tree, every word this surface says, and the synthesised transcript.
+//!
+//! Nothing here touches a window, a file or a `git` process, so "does an abandoned run at the tip
+//! really read as the most resumable thing in the list", "does a single commit say `1 commit
+//! since` rather than `1 commits since`" and "does a run with no stored transcript describe *its
+//! own* record" are all decisions asserted directly, the same contract [`crate::rail::state`] and
+//! [`crate::rail::strip`] already hold.
+//!
+//! Every count in this module goes through [`crate::root::plural`], per
+//! `REVISION-2026-08-13.md` §8a: "Every derived count in the window goes through
+//! `n(count, singular, plural?)`… Never inline a ternary for a count." That rule exists because
+//! the two hand-written ternaries in the mock both read `1 files`.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use crate::hooks::history::{PastAgent, RunDiffstat};
+use crate::rail::status::Status;
+use crate::root::plural;
+use crate::theme;
+use crate::work_surface::agents::AgentKind;
+
+/// How a run ended - `REVISION-2026-08-13.md` §5's four values.
+///
+/// **There is deliberately no `merged`.** §5, verbatim: "Merging happens to a branch, not to a
+/// run. A run whose code later merged simply finished; whether the branch merged is already on the
+/// worktree row in the rail (`merged · prunable`)." Adding a fifth variant here would put the same
+/// fact in two places with two vocabularies.
+///
+/// Outcome and drift are independent axes (§5) - see [`DriftBand`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Outcome {
+    /// Its last turn ended cleanly, and Jerry watched the run end.
+    Done,
+    /// It ended while it was still working, or still waiting on a human.
+    Interrupted,
+    /// Its last real signal was a failure.
+    Failed,
+    /// Nobody ever saw it end - the record simply stopped being updated.
+    Abandoned,
+}
+
+impl Outcome {
+    /// The real outcome of a real record.
+    ///
+    /// Every arm is a rule over facts this app genuinely persisted, not a guess:
+    ///
+    /// | Recorded | Outcome | Why |
+    /// |---|---|---|
+    /// | no [`PastAgent::ended_at_unix`] | `abandoned` | Jerry never saw this run end. The app quit, the machine slept, or the agent's hooks simply stopped. "Left unfinished" is the honest reading, and it is exactly the state §5's fourth value names |
+    /// | ended, last status [`Status::Fail`] | `failed` | its own last real signal was a failure |
+    /// | ended, last status [`Status::Run`] or [`Status::Ask`] | `interrupted` | it was still working, or still blocked on a human, when it was ended |
+    /// | ended, last status [`Status::Review`] or [`Status::Idle`] | `done` | its turn had ended cleanly before it was closed |
+    ///
+    /// Note what this deliberately does *not* do: it never reads the diffstat. A run that
+    /// finished cleanly having changed nothing is still `done` - "did it produce changes" is a
+    /// different question, answered by the header's own diffstat.
+    pub fn of(run: &PastAgent) -> Outcome {
+        if run.ended_at_unix.is_none() {
+            return Outcome::Abandoned;
+        }
+        match run.status {
+            Status::Fail => Outcome::Failed,
+            Status::Run | Status::Ask => Outcome::Interrupted,
+            Status::Review | Status::Idle => Outcome::Done,
+        }
+    }
+
+    /// The pill's text - §5's own four words, lowercase as the design writes them.
+    pub const fn label(self) -> &'static str {
+        match self {
+            Outcome::Done => "done",
+            Outcome::Interrupted => "interrupted",
+            Outcome::Failed => "failed",
+            Outcome::Abandoned => "abandoned",
+        }
+    }
+
+    pub const fn fg(self) -> theme::ColorToken {
+        match self {
+            Outcome::Done => theme::history::OUT_DONE_FG,
+            Outcome::Interrupted => theme::history::OUT_INTERRUPTED_FG,
+            Outcome::Failed => theme::history::OUT_FAILED_FG,
+            Outcome::Abandoned => theme::history::OUT_ABANDONED_FG,
+        }
+    }
+
+    pub const fn bg(self) -> theme::ColorToken {
+        match self {
+            Outcome::Done => theme::history::OUT_DONE_BG,
+            Outcome::Interrupted => theme::history::OUT_INTERRUPTED_BG,
+            Outcome::Failed => theme::history::OUT_FAILED_BG,
+            Outcome::Abandoned => theme::history::OUT_ABANDONED_BG,
+        }
+    }
+
+    /// How the synthesised closing line opens, per outcome - `Jerry.dc.html`'s own four strings.
+    pub const fn closing_lead(self) -> &'static str {
+        match self {
+            Outcome::Done => "Finished.",
+            Outcome::Interrupted => "Interrupted by you.",
+            Outcome::Failed => "Exited non-zero. Nothing further was attempted.",
+            Outcome::Abandoned => "Left unfinished.",
+        }
+    }
+}
+
+/// How far the branch has moved since the run ended - `REVISION-2026-08-13.md` §4's three bands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DriftBand {
+    /// 0 commits since - `at the tip`.
+    Tip,
+    /// 1-2 commits since.
+    Near,
+    /// 3+ commits since.
+    Far,
+}
+
+impl DriftBand {
+    pub const fn of(commits: usize) -> DriftBand {
+        match commits {
+            0 => DriftBand::Tip,
+            1..=2 => DriftBand::Near,
+            _ => DriftBand::Far,
+        }
+    }
+
+    pub const fn dot(self) -> theme::ColorToken {
+        match self {
+            DriftBand::Tip => theme::history::DRIFT_TIP,
+            DriftBand::Near => theme::history::DRIFT_NEAR,
+            DriftBand::Far => theme::history::DRIFT_FAR,
+        }
+    }
+
+    /// The drift *label*'s colour. §4's table names one only for the far band; the other two leave
+    /// the label in the list's own recessive text, so colour on the words means "this one has
+    /// moved a long way" rather than restating the dot.
+    pub const fn text(self) -> theme::ColorToken {
+        match self {
+            DriftBand::Tip | DriftBand::Near => theme::history::DRIFT_TEXT,
+            DriftBand::Far => theme::history::DRIFT_FAR_TEXT,
+        }
+    }
+}
+
+/// The short drift label a history row shows - §4's `at the tip` / `N commits since`.
+pub fn drift_label(commits: usize) -> String {
+    if commits == 0 {
+        return "at the tip".to_string();
+    }
+    format!("{} since", plural::count(commits, "commit", None))
+}
+
+/// The spelled-out consequence sentence the transcript tab's footer carries - §4, verbatim in both
+/// arms, with singular and plural on *both* the count and its verb.
+pub fn drift_sentence(commits: usize) -> String {
+    if commits == 0 {
+        return "Nothing has landed since this run ended \u{2014} it resumes on the files it left."
+            .to_string();
+    }
+    format!(
+        "{} {} landed since. Resuming replays the transcript as context against the current files.",
+        plural::count(commits, "commit", None),
+        plural::form(commits, "has", "have"),
+    )
+}
+
+/// Which runs the History view is showing - `REVISION-2026-08-14.md` §6's `all` / `this worktree`
+/// toggle.
+///
+/// `All` is the default, matching `Jerry.dc.html`'s own `hScope` default, and it is the one that
+/// makes this surface worth visiting: the rail already tells you about the worktree you are in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum HistoryScope {
+    #[default]
+    All,
+    ThisWorktree,
+}
+
+impl HistoryScope {
+    /// Both scopes, in the order the toggle paints them.
+    pub const ALL: &'static [HistoryScope] = &[HistoryScope::All, HistoryScope::ThisWorktree];
+
+    pub const fn label(self) -> &'static str {
+        match self {
+            HistoryScope::All => "all",
+            HistoryScope::ThisWorktree => "this worktree",
+        }
+    }
+
+    /// The segment's tooltip - the mock's own `every worktree` / the active branch's name.
+    pub fn hint(self, branch: Option<&str>) -> String {
+        match self {
+            HistoryScope::All => "every worktree".to_string(),
+            HistoryScope::ThisWorktree => match branch {
+                Some(branch) => branch.to_string(),
+                None => "the selected worktree".to_string(),
+            },
+        }
+    }
+}
+
+/// The sidebar's empty state - §3's *No agent has run in `<branch>` yet.*, and the mock's own
+/// wider-scope wording for the case where the whole window has no history at all.
+pub fn empty_note(scope: HistoryScope, branch: Option<&str>) -> String {
+    match (scope, branch) {
+        (HistoryScope::ThisWorktree, Some(branch)) => {
+            format!("No agent has run in {branch} yet.")
+        }
+        (HistoryScope::ThisWorktree, None) => "No agent has run in this worktree yet.".to_string(),
+        (HistoryScope::All, _) => "No agent has finished a run yet.".to_string(),
+    }
+}
+
+/// The note shown when there really is history, but this view's filter text hides all of it -
+/// the same shape [`crate::rail::strip::problems_filtered_away_note`] uses, for the same reason:
+/// "nothing here" and "nothing *matching*" are different facts.
+pub fn filtered_away_note(hidden: usize) -> String {
+    format!("No match in the {}.", plural::count(hidden, "run", None))
+}
+
+// ---------------------------------------------------------------------- one run's own wording
+
+/// A run's title - `REVISION-2026-08-13.md` §3's first line, "agent chip · title · duration".
+///
+/// The real title is the first prompt the run's human typed
+/// ([`crate::hooks::store::PersistedAgentStatus::title`]). Where hooks never caught one, this
+/// falls back through what the record genuinely does have, ending at a label that claims nothing:
+///
+/// 1. the run's own title,
+/// 2. the last question it asked, then the last activity it reported - both real, dated statements
+///    the agent made about itself,
+/// 3. `<kind> session` - the honest "this record has no description in it".
+///
+/// Never the worktree's directory name, which is what the rail's own agent rows use: that is the
+/// same string for every run in a checkout, so in a list *of* that checkout's runs it names
+/// nothing.
+pub fn run_title(run: &PastAgent) -> String {
+    run.title
+        .clone()
+        .or_else(|| run.question.clone())
+        .or_else(|| run.activity.clone())
+        .unwrap_or_else(|| format!("{} session", run.kind.label()))
+}
+
+/// How long the run really lasted, from its own spawn moment to its own end - the row's trailing
+/// `6m` and the transcript header's `24m`.
+///
+/// `None` when the run has no recorded ending ([`Outcome::Abandoned`]): the gap between spawning
+/// and the last hook Jerry happened to hear is not the run's duration, it is how long Jerry was
+/// listening, and printing it as a duration would be a fabrication.
+pub fn run_duration(run: &PastAgent) -> Option<String> {
+    let ended = run.ended_at_unix?;
+    let seconds = ended.saturating_sub(run.spawned_at_unix);
+    (seconds > 0).then(|| format_run_duration(seconds))
+}
+
+/// A finished run's duration, in the design's own `6m` / `1h 02m` shape.
+///
+/// Deliberately not [`crate::rail::state::format_elapsed`], which is whole-units-only (`1h`) on
+/// purpose: that label ticks live in the rail, where a second component would be noise. A finished
+/// run's duration is a fixed fact printed once, where `1h 02m` and `1h 58m` are genuinely
+/// different things and `1h` for both loses the difference.
+pub fn format_run_duration(seconds: i64) -> String {
+    if seconds < 60 {
+        return format!("{seconds}s");
+    }
+    let minutes = seconds / 60;
+    if minutes < 60 {
+        return format!("{minutes}m");
+    }
+    format!("{}h {:02}m", minutes / 60, minutes % 60)
+}
+
+/// When the run finished, in the design's own `today 09:41` / `yesterday 16:12` / `2 days ago`
+/// shape.
+///
+/// **The clock is UTC, not the viewer's local time**, and so is the day boundary - the same
+/// documented trade-off [`crate::rail::state::format_utc_hhmm`] already makes for the rail's own
+/// timestamps, reused here rather than grown into a second, subtly different copy: `std` has no
+/// timezone database, and pulling one in was not worth it for a label. A viewer several hours off
+/// UTC can therefore see `yesterday 23:40` for a run they remember as this morning. That is a
+/// known, app-wide limitation of this build, not something specific to History.
+pub fn run_when(finished_at_unix: i64, now_unix: i64) -> String {
+    const DAY: i64 = 86_400;
+    let days_ago = now_unix.div_euclid(DAY) - finished_at_unix.div_euclid(DAY);
+    match days_ago {
+        // A run stamped in the future is a clock that moved, not a run that has not happened.
+        // Reading it as "today" is the least wrong of the available answers.
+        i64::MIN..=0 => format!(
+            "today {}",
+            crate::rail::state::format_utc_hhmm(finished_at_unix)
+        ),
+        1 => format!(
+            "yesterday {}",
+            crate::rail::state::format_utc_hhmm(finished_at_unix)
+        ),
+        days => format!("{} ago", plural::count(days as usize, "day", None)),
+    }
+}
+
+/// The moment a run's history row and transcript are dated by: its real ending where there is one,
+/// and otherwise the last moment Jerry heard from it - which for an abandoned run is the only real
+/// moment there is.
+pub fn run_finished_at(run: &PastAgent) -> i64 {
+    run.ended_at_unix.unwrap_or(run.updated_at_unix)
+}
+
+/// The transcript header's meta line - §3's
+/// `<agent> · <when> · 24m · 21 turns · 6 files · +148 −96`.
+///
+/// Every part is omitted rather than faked when the record does not carry it: a run with no
+/// recorded ending prints no duration, a run whose hooks never counted a turn prints no turn
+/// count, and a run whose diffstat could not be measured prints no file count *and* no `+/−` (they
+/// are one measurement - see [`crate::hooks::history::RunDiffstat`]).
+pub fn run_meta_line(run: &PastAgent, now_unix: i64) -> String {
+    let mut parts: Vec<String> = vec![
+        run.kind.label().to_string(),
+        run_when(run_finished_at(run), now_unix),
+    ];
+    if let Some(duration) = run_duration(run) {
+        parts.push(duration);
+    }
+    if run.turns > 0 {
+        parts.push(plural::count(run.turns as usize, "turn", None));
+    }
+    if let Some(diffstat) = run.diffstat {
+        parts.push(plural::count(diffstat.files as usize, "file", None));
+        parts.push(format!(
+            "+{} \u{2212}{}",
+            diffstat.insertions, diffstat.deletions
+        ));
+    }
+    parts.join(" \u{b7} ")
+}
+
+/// The run-transcript tab's own label - §3's `sonnet-4.5 · today 09:41`, with this app's real
+/// agent-kind label in place of the mock's model name (Jerry knows which CLI it spawned, and does
+/// not know which model that CLI chose).
+pub fn run_tab_label(run: &PastAgent, now_unix: i64) -> String {
+    format!(
+        "{} \u{b7} {}",
+        run.kind.label(),
+        run_when(run_finished_at(run), now_unix)
+    )
+}
+
+/// Whether a run matches the History view's filter text, over exactly the strings the row shows:
+/// its title, its branch (supplied by the caller, since a run record stores a path, not a branch)
+/// and its agent kind. A blank query matches everything.
+///
+/// The same shape [`crate::rail::strip::Problem::matches_filter`] uses, deliberately: one filter
+/// field serves every sidebar view, so the two must behave the same way about case and blankness.
+pub fn matches_filter(run: &PastAgent, branch: Option<&str>, query: &str) -> bool {
+    let query = query.trim().to_lowercase();
+    if query.is_empty() {
+        return true;
+    }
+    run_title(run).to_lowercase().contains(&query)
+        || run.kind.label().to_lowercase().contains(&query)
+        || branch.is_some_and(|branch| branch.to_lowercase().contains(&query))
+}
+
+// ---------------------------------------------------------------- repo -> worktree -> run tree
+
+/// One worktree, as input to [`build_run_tree`] - the caller's reduction of a real repo's
+/// worktree list, so this module needs no notion of what a repo is.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HistoryWorktree {
+    pub path: PathBuf,
+    /// The repo this checkout belongs to, as the header should print it.
+    pub repo_label: String,
+    /// The branch name the group row shows; the path's own label where there is no branch.
+    pub label: String,
+    pub branch: Option<String>,
+}
+
+/// One run, ready to render.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunEntry {
+    pub run: PastAgent,
+    /// How many commits have landed in this run's checkout since it ended - `None` while the
+    /// real `git` traversal behind it has not answered yet, or could not
+    /// (`crate::run_history::flow`). A row with no answer paints no drift dot and no drift text
+    /// rather than an invented `at the tip`.
+    pub drift: Option<usize>,
+}
+
+impl RunEntry {
+    pub fn outcome(&self) -> Outcome {
+        Outcome::of(&self.run)
+    }
+
+    pub fn band(&self) -> Option<DriftBand> {
+        self.drift.map(DriftBand::of)
+    }
+}
+
+/// One worktree's runs, under a repo.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunGroup {
+    pub worktree: PathBuf,
+    pub label: String,
+    pub branch: Option<String>,
+    /// Whether this is the window's currently selected worktree - it carries the selection edge
+    /// and opens by default (`REVISION-2026-08-14.md` §6).
+    pub is_active: bool,
+    pub open: bool,
+    pub runs: Vec<RunEntry>,
+}
+
+/// One repo's groups.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunRepo {
+    pub label: String,
+    pub groups: Vec<RunGroup>,
+}
+
+impl RunRepo {
+    pub fn run_count(&self) -> usize {
+        self.groups.iter().map(|group| group.runs.len()).sum()
+    }
+}
+
+/// The whole tree the History body paints, plus the two counts it needs to choose between its
+/// three states (rows, "nothing here", "nothing matching").
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RunTree {
+    pub repos: Vec<RunRepo>,
+    /// How many runs are in scope *before* the filter - what tells "this worktree has no history"
+    /// apart from "your filter matched none of its history".
+    pub unfiltered: usize,
+}
+
+impl RunTree {
+    pub fn total(&self) -> usize {
+        self.repos.iter().map(RunRepo::run_count).sum()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total() == 0
+    }
+}
+
+/// Builds the real repo → worktree → run tree.
+///
+/// `worktrees` is every checkout the window knows about, in the rail's own order - the tree
+/// follows it, so History and the rail can never disagree about which repo a worktree belongs to
+/// or what order they come in. A run whose worktree is not in that list is dropped: it belongs to
+/// a checkout that has been removed or pruned, there is no place left to resume it into, and
+/// `crate::hooks::flow::AdeApp::resume_past_agent` would honestly refuse it anyway.
+///
+/// `collapsed` names the worktrees whose group the user has explicitly folded. A group not in it
+/// opens if it is the active worktree, or if the scope is already narrowed to one worktree -
+/// `Jerry.dc.html`'s own default, and the reason `REVISION-2026-08-14.md` §6 says the active
+/// worktree "opens by default" rather than "is the only one open".
+pub fn build_run_tree(
+    runs: &[PastAgent],
+    worktrees: &[HistoryWorktree],
+    active_worktree: Option<&Path>,
+    scope: HistoryScope,
+    query: &str,
+    collapsed: &HashMap<PathBuf, bool>,
+    drift: &HashMap<PathBuf, HashMap<String, usize>>,
+) -> RunTree {
+    let mut by_worktree: HashMap<&Path, Vec<&PastAgent>> = HashMap::new();
+    for run in runs {
+        by_worktree
+            .entry(run.worktree.as_path())
+            .or_default()
+            .push(run);
+    }
+
+    let mut tree = RunTree::default();
+    for worktree in worktrees {
+        if scope == HistoryScope::ThisWorktree && Some(worktree.path.as_path()) != active_worktree {
+            continue;
+        }
+        let Some(all_runs) = by_worktree.get(worktree.path.as_path()) else {
+            continue;
+        };
+        tree.unfiltered += all_runs.len();
+
+        let worktree_drift = drift.get(&worktree.path);
+        let runs: Vec<RunEntry> = all_runs
+            .iter()
+            .filter(|run| matches_filter(run, worktree.branch.as_deref(), query))
+            .map(|run| RunEntry {
+                run: (*run).clone(),
+                drift: worktree_drift.and_then(|counts| counts.get(&run.key).copied()),
+            })
+            .collect();
+        if runs.is_empty() {
+            continue;
+        }
+
+        let is_active = Some(worktree.path.as_path()) == active_worktree;
+        let open = match collapsed.get(&worktree.path) {
+            Some(collapsed) => !collapsed,
+            None => is_active || scope == HistoryScope::ThisWorktree,
+        };
+        let group = RunGroup {
+            worktree: worktree.path.clone(),
+            label: worktree
+                .branch
+                .clone()
+                .unwrap_or_else(|| worktree.label.clone()),
+            branch: worktree.branch.clone(),
+            is_active,
+            open,
+            runs,
+        };
+        match tree
+            .repos
+            .iter_mut()
+            .find(|repo| repo.label == worktree.repo_label)
+        {
+            Some(repo) => repo.groups.push(group),
+            None => tree.repos.push(RunRepo {
+                label: worktree.repo_label.clone(),
+                groups: vec![group],
+            }),
+        }
+    }
+    tree
+}
+
+// -------------------------------------------------------------------------------- transcripts
+
+/// How one transcript line is coloured. A **captured** transcript is plain text with no styling of
+/// its own, so every one of its lines is [`LineTone::Body`]; the other three exist for the lines
+/// this app writes itself - the synthesised transcript and the closing line.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LineTone {
+    /// The leading `❯ …` command line.
+    Prompt,
+    /// Ordinary output.
+    Body,
+    /// An indented `⎿ …` detail line.
+    Detail,
+    /// A `● …` lead line.
+    Lead,
+}
+
+impl LineTone {
+    pub const fn color(self) -> theme::ColorToken {
+        match self {
+            LineTone::Prompt => theme::history::TRANSCRIPT_PROMPT,
+            LineTone::Body => theme::history::TRANSCRIPT_BODY,
+            LineTone::Detail => theme::history::TRANSCRIPT_DETAIL,
+            LineTone::Lead => theme::history::TRANSCRIPT_LEAD,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TranscriptLine {
+    pub text: String,
+    pub tone: LineTone,
+}
+
+impl TranscriptLine {
+    fn new(text: impl Into<String>, tone: LineTone) -> TranscriptLine {
+        TranscriptLine {
+            text: text.into(),
+            tone,
+        }
+    }
+}
+
+/// The command a resume of this run would really be - the transcript's opening line when none was
+/// captured. Only ever this run's own kind and its own checkout.
+fn resume_command_line(run: &PastAgent, branch: Option<&str>) -> String {
+    let command = match (run.kind, run.session_id.as_deref()) {
+        (AgentKind::Claude, Some(session_id)) => format!("claude --resume {session_id}"),
+        (AgentKind::Claude, None) => "claude".to_string(),
+        (AgentKind::Codex, _) => "codex".to_string(),
+    };
+    match branch {
+        Some(branch) => format!("\u{276f} {command} \u{b7} {branch}"),
+        None => format!("\u{276f} {command}"),
+    }
+}
+
+/// The full body of a run-transcript tab: `captured` where a real transcript was stored for this
+/// run, a short synthesis from the run's *own* record where none was, and in both cases the
+/// synthesised closing line.
+///
+/// `REVISION-2026-08-13.md` §3 is unusually emphatic about the rule this implements, because
+/// breaking it is what the design caught itself doing: transcripts are keyed by run id, **never**
+/// the live agent's buffer - "Borrowing the live buffer produces a pane whose header and body
+/// describe two different runs, whose diffstats contradict each other, and - worst - one that ends
+/// on an unanswered question with a highlighted, apparently-selectable option list. A completed
+/// run cannot be awaiting an answer, and 70% opacity does not disambiguate that."
+///
+/// This function structurally cannot break it: its only inputs are one run's own record and one
+/// run's own captured lines, and it always appends a real closing line, so no transcript can end
+/// on a pending question.
+pub fn transcript_body(
+    run: &PastAgent,
+    branch: Option<&str>,
+    captured: Option<&[String]>,
+    now_unix: i64,
+) -> Vec<TranscriptLine> {
+    let mut lines: Vec<TranscriptLine> = match captured {
+        Some(captured) if !captured.is_empty() => captured
+            .iter()
+            .map(|line| TranscriptLine::new(line.clone(), LineTone::Body))
+            .collect(),
+        _ => synthesised_body(run, branch),
+    };
+    lines.push(TranscriptLine::new(String::new(), LineTone::Body));
+    lines.extend(closing_lines(run, now_unix));
+    lines
+}
+
+/// The short stand-in §3 asks for where a run has no stored transcript: built "**from that run's
+/// own record** (title, turns, file count); never fall back to another run's output".
+fn synthesised_body(run: &PastAgent, branch: Option<&str>) -> Vec<TranscriptLine> {
+    let mut lines = vec![
+        TranscriptLine::new(resume_command_line(run, branch), LineTone::Prompt),
+        TranscriptLine::new(String::new(), LineTone::Body),
+        TranscriptLine::new(format!("\u{25cf} {}", run_title(run)), LineTone::Lead),
+    ];
+    if run.turns > 0 {
+        let turns = plural::count(run.turns as usize, "turn", None);
+        lines.push(TranscriptLine::new(
+            match branch {
+                Some(branch) => format!("  \u{23bf} {turns} in {branch}"),
+                None => format!("  \u{23bf} {turns}"),
+            },
+            LineTone::Detail,
+        ));
+    }
+    if let Some(diffstat) = run.diffstat {
+        lines.push(TranscriptLine::new(
+            format!(
+                "  \u{23bf} touched {}",
+                plural::count(diffstat.files as usize, "file", None)
+            ),
+            LineTone::Detail,
+        ));
+    }
+    if let Some(activity) = &run.activity {
+        lines.push(TranscriptLine::new(
+            format!("  \u{23bf} last: {activity}"),
+            LineTone::Detail,
+        ));
+    }
+    lines.push(TranscriptLine::new(
+        "  \u{23bf} no transcript was captured for this run",
+        LineTone::Detail,
+    ));
+    lines
+}
+
+/// The two closing lines every transcript ends on - §3's
+/// `● Finished. 2 files changed, +41 −0.` and `⎿ run ended today 09:41 after 6m`.
+///
+/// This is the "one signal that this is a recording" that actually carries the meaning: the pane's
+/// 70% opacity says it is not live, and these say what happened and when it stopped. A transcript
+/// therefore never ends on a pending question, whatever its captured lines ended on - which is
+/// §9's checklist item in as many words.
+pub fn closing_lines(run: &PastAgent, now_unix: i64) -> Vec<TranscriptLine> {
+    let outcome = Outcome::of(run);
+    let lead = match run.diffstat {
+        Some(RunDiffstat {
+            files,
+            insertions,
+            deletions,
+        }) => format!(
+            "\u{25cf} {} {} changed, +{insertions} \u{2212}{deletions}.",
+            outcome.closing_lead(),
+            plural::count(files as usize, "file", None),
+        ),
+        None => format!("\u{25cf} {}", outcome.closing_lead()),
+    };
+
+    let finished_at = run_finished_at(run);
+    let when = run_when(finished_at, now_unix);
+    let tail = match (run.ended_at_unix, run_duration(run)) {
+        (Some(_), Some(duration)) => format!("  \u{23bf} run ended {when} after {duration}"),
+        (Some(_), None) => format!("  \u{23bf} run ended {when}"),
+        // No recorded ending at all: say what is actually known - when Jerry last heard from it -
+        // rather than calling that moment the end of the run.
+        (None, _) => format!("  \u{23bf} last seen {when}"),
+    };
+
+    vec![
+        TranscriptLine::new(lead, LineTone::Lead),
+        TranscriptLine::new(tail, LineTone::Detail),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn run(worktree: &str, spawned: i64) -> PastAgent {
+        PastAgent {
+            key: format!("{worktree}|Claude|{spawned}"),
+            worktree: PathBuf::from(worktree),
+            kind: AgentKind::Claude,
+            spawned_at_unix: spawned,
+            status: Status::Idle,
+            activity: None,
+            question: None,
+            updated_at_unix: spawned + 100,
+            session_id: None,
+            title: None,
+            turns: 0,
+            ended_at_unix: None,
+            diffstat: None,
+        }
+    }
+
+    fn worktree(path: &str, repo: &str, branch: &str) -> HistoryWorktree {
+        HistoryWorktree {
+            path: PathBuf::from(path),
+            repo_label: repo.to_string(),
+            label: branch.to_string(),
+            branch: Some(branch.to_string()),
+        }
+    }
+
+    // ------------------------------------------------------------------------------- outcomes
+
+    #[test]
+    fn a_run_nobody_watched_end_is_abandoned_whatever_its_last_status_said() {
+        for status in [
+            Status::Idle,
+            Status::Review,
+            Status::Run,
+            Status::Ask,
+            Status::Fail,
+        ] {
+            let mut past = run("/repo/wt", 1);
+            past.status = status;
+            past.ended_at_unix = None;
+            assert_eq!(
+                Outcome::of(&past),
+                Outcome::Abandoned,
+                "{status:?}: with no recorded ending, nobody saw this run finish"
+            );
+        }
+    }
+
+    #[test]
+    fn a_watched_ending_reads_its_outcome_off_the_status_it_ended_on() {
+        let cases = [
+            (Status::Idle, Outcome::Done),
+            (Status::Review, Outcome::Done),
+            (Status::Run, Outcome::Interrupted),
+            (Status::Ask, Outcome::Interrupted),
+            (Status::Fail, Outcome::Failed),
+        ];
+        for (status, expected) in cases {
+            let mut past = run("/repo/wt", 1);
+            past.status = status;
+            past.ended_at_unix = Some(500);
+            assert_eq!(Outcome::of(&past), expected, "{status:?}");
+        }
+    }
+
+    /// §5: "an abandoned run at the tip is the most resumable thing in the list" - the two axes
+    /// really are independent, and nothing here couples them.
+    #[test]
+    fn outcome_and_drift_are_independent_axes() {
+        let mut past = run("/repo/wt", 1);
+        past.ended_at_unix = None;
+        let entry = RunEntry {
+            run: past,
+            drift: Some(0),
+        };
+        assert_eq!(entry.outcome(), Outcome::Abandoned);
+        assert_eq!(entry.band(), Some(DriftBand::Tip));
+    }
+
+    /// The rule §5 states as a prohibition, pinned as a test so a later "completeness" pass
+    /// cannot quietly add the fifth value back.
+    #[test]
+    fn there_is_no_merged_outcome() {
+        for outcome in [
+            Outcome::Done,
+            Outcome::Interrupted,
+            Outcome::Failed,
+            Outcome::Abandoned,
+        ] {
+            assert_ne!(
+                outcome.label(),
+                "merged",
+                "merging happens to a branch, not to a run"
+            );
+        }
+    }
+
+    // ---------------------------------------------------------------------------------- drift
+
+    #[test]
+    fn the_drift_bands_are_exactly_the_revisions_three() {
+        assert_eq!(DriftBand::of(0), DriftBand::Tip);
+        assert_eq!(DriftBand::of(1), DriftBand::Near);
+        assert_eq!(DriftBand::of(2), DriftBand::Near);
+        assert_eq!(DriftBand::of(3), DriftBand::Far);
+        assert_eq!(DriftBand::of(97), DriftBand::Far);
+    }
+
+    #[test]
+    fn drift_says_singular_and_plural_in_both_the_label_and_the_sentence() {
+        assert_eq!(drift_label(0), "at the tip");
+        assert_eq!(drift_label(1), "1 commit since");
+        assert_eq!(drift_label(4), "4 commits since");
+
+        assert_eq!(
+            drift_sentence(0),
+            "Nothing has landed since this run ended \u{2014} it resumes on the files it left."
+        );
+        assert!(
+            drift_sentence(1).starts_with("1 commit has landed since."),
+            "{}",
+            drift_sentence(1)
+        );
+        assert!(
+            drift_sentence(4).starts_with("4 commits have landed since."),
+            "{}",
+            drift_sentence(4)
+        );
+    }
+
+    // -------------------------------------------------------------------------------- wording
+
+    #[test]
+    fn a_runs_title_is_its_own_prompt_and_falls_back_to_what_the_record_really_has() {
+        let mut past = run("/repo/wt", 1);
+        assert_eq!(
+            run_title(&past),
+            "Claude session",
+            "a record with nothing in it claims nothing"
+        );
+
+        past.activity = Some("Edit: src/auth.rs".to_string());
+        assert_eq!(run_title(&past), "Edit: src/auth.rs");
+
+        past.question = Some("Bash needs permission".to_string());
+        assert_eq!(run_title(&past), "Bash needs permission");
+
+        past.title = Some("Reproduce the refresh race in a test".to_string());
+        assert_eq!(run_title(&past), "Reproduce the refresh race in a test");
+    }
+
+    #[test]
+    fn an_unfinished_run_has_no_duration_rather_than_a_made_up_one() {
+        let mut past = run("/repo/wt", 1_700_000_000);
+        past.updated_at_unix = 1_700_009_999;
+        assert_eq!(
+            run_duration(&past),
+            None,
+            "how long Jerry was listening is not how long the run lasted"
+        );
+
+        past.ended_at_unix = Some(1_700_000_360);
+        assert_eq!(run_duration(&past).as_deref(), Some("6m"));
+    }
+
+    #[test]
+    fn a_duration_keeps_its_minutes_past_the_hour() {
+        assert_eq!(format_run_duration(45), "45s");
+        assert_eq!(format_run_duration(60), "1m");
+        assert_eq!(format_run_duration(24 * 60), "24m");
+        assert_eq!(format_run_duration(62 * 60), "1h 02m");
+        assert_eq!(format_run_duration(134 * 60), "2h 14m");
+    }
+
+    #[test]
+    fn when_reads_today_yesterday_and_then_whole_days() {
+        // 1_700_000_000 is 2023-11-14 22:13:20 UTC.
+        let day = 86_400;
+        let at = 1_700_000_000;
+        assert_eq!(run_when(at, at), "today 22:13");
+        assert_eq!(run_when(at, at + day), "yesterday 22:13");
+        assert_eq!(run_when(at, at + 2 * day), "2 days ago");
+        assert_eq!(
+            run_when(at, at + 3 * day),
+            "3 days ago",
+            "the count is pluralised through the one helper"
+        );
+    }
+
+    #[test]
+    fn a_run_stamped_in_the_future_reads_as_today_rather_than_a_negative_day_count() {
+        let at = 1_700_000_000;
+        assert!(run_when(at, at - 5_000).starts_with("today "));
+    }
+
+    #[test]
+    fn the_meta_line_omits_what_was_never_measured_rather_than_printing_zeros() {
+        let mut past = run("/repo/wt", 1_700_000_000);
+        past.ended_at_unix = Some(1_700_000_000 + 24 * 60);
+        assert_eq!(
+            run_meta_line(&past, 1_700_000_000),
+            "Claude \u{b7} today 22:37 \u{b7} 24m",
+            "no turn count and no diffstat were measured, so neither is claimed"
+        );
+
+        past.turns = 21;
+        past.diffstat = Some(RunDiffstat {
+            files: 6,
+            insertions: 148,
+            deletions: 96,
+        });
+        assert_eq!(
+            run_meta_line(&past, 1_700_000_000),
+            "Claude \u{b7} today 22:37 \u{b7} 24m \u{b7} 21 turns \u{b7} 6 files \u{b7} +148 \u{2212}96"
+        );
+    }
+
+    #[test]
+    fn one_turn_and_one_file_are_singular() {
+        let mut past = run("/repo/wt", 1_700_000_000);
+        past.ended_at_unix = Some(1_700_000_060);
+        past.turns = 1;
+        past.diffstat = Some(RunDiffstat {
+            files: 1,
+            insertions: 9,
+            deletions: 0,
+        });
+        let line = run_meta_line(&past, 1_700_000_000);
+        assert!(line.contains("1 turn \u{b7}"), "{line}");
+        assert!(line.contains("1 file \u{b7}"), "{line}");
+    }
+
+    // ----------------------------------------------------------------------------------- tree
+
+    #[test]
+    fn the_tree_follows_the_rails_own_repo_and_worktree_order() {
+        let runs = vec![run("/a/wt-1", 10), run("/b/wt-2", 20), run("/a/wt-1", 30)];
+        let worktrees = vec![
+            worktree("/a/wt-1", "alpha", "feature-a"),
+            worktree("/b/wt-2", "beta", "feature-b"),
+        ];
+        let tree = build_run_tree(
+            &runs,
+            &worktrees,
+            Some(Path::new("/a/wt-1")),
+            HistoryScope::All,
+            "",
+            &HashMap::new(),
+            &HashMap::new(),
+        );
+        assert_eq!(tree.repos.len(), 2);
+        assert_eq!(tree.repos[0].label, "alpha");
+        assert_eq!(tree.repos[0].run_count(), 2);
+        assert_eq!(tree.repos[1].label, "beta");
+        assert_eq!(tree.total(), 3);
+    }
+
+    #[test]
+    fn a_run_whose_worktree_is_gone_is_dropped_rather_than_shown_unresumable() {
+        let runs = vec![run("/gone/wt", 10)];
+        let worktrees = vec![worktree("/a/wt-1", "alpha", "feature-a")];
+        let tree = build_run_tree(
+            &runs,
+            &worktrees,
+            None,
+            HistoryScope::All,
+            "",
+            &HashMap::new(),
+            &HashMap::new(),
+        );
+        assert!(tree.is_empty());
+        assert_eq!(tree.unfiltered, 0);
+    }
+
+    #[test]
+    fn the_this_worktree_scope_really_narrows_to_the_active_checkout() {
+        let runs = vec![run("/a/wt-1", 10), run("/b/wt-2", 20)];
+        let worktrees = vec![
+            worktree("/a/wt-1", "alpha", "feature-a"),
+            worktree("/b/wt-2", "beta", "feature-b"),
+        ];
+        let tree = build_run_tree(
+            &runs,
+            &worktrees,
+            Some(Path::new("/b/wt-2")),
+            HistoryScope::ThisWorktree,
+            "",
+            &HashMap::new(),
+            &HashMap::new(),
+        );
+        assert_eq!(tree.repos.len(), 1);
+        assert_eq!(tree.repos[0].label, "beta");
+        assert_eq!(tree.total(), 1);
+    }
+
+    #[test]
+    fn the_active_worktree_opens_by_default_and_carries_the_selection_edge() {
+        let runs = vec![run("/a/wt-1", 10), run("/b/wt-2", 20)];
+        let worktrees = vec![
+            worktree("/a/wt-1", "alpha", "feature-a"),
+            worktree("/b/wt-2", "beta", "feature-b"),
+        ];
+        let tree = build_run_tree(
+            &runs,
+            &worktrees,
+            Some(Path::new("/b/wt-2")),
+            HistoryScope::All,
+            "",
+            &HashMap::new(),
+            &HashMap::new(),
+        );
+        let alpha = &tree.repos[0].groups[0];
+        let beta = &tree.repos[1].groups[0];
+        assert!(!alpha.is_active);
+        assert!(!alpha.open, "an inactive worktree starts folded");
+        assert!(beta.is_active);
+        assert!(beta.open, "the active worktree opens by default");
+
+        // An explicit fold wins over the default, in both directions.
+        let collapsed: HashMap<PathBuf, bool> = [
+            (PathBuf::from("/a/wt-1"), false),
+            (PathBuf::from("/b/wt-2"), true),
+        ]
+        .into_iter()
+        .collect();
+        let tree = build_run_tree(
+            &runs,
+            &worktrees,
+            Some(Path::new("/b/wt-2")),
+            HistoryScope::All,
+            "",
+            &collapsed,
+            &HashMap::new(),
+        );
+        assert!(tree.repos[0].groups[0].open);
+        assert!(!tree.repos[1].groups[0].open);
+    }
+
+    #[test]
+    fn filtering_narrows_the_rows_but_still_reports_how_much_history_there_really_is() {
+        let mut first = run("/a/wt-1", 10);
+        first.title = Some("Reproduce the refresh race".to_string());
+        let mut second = run("/a/wt-1", 20);
+        second.title = Some("Bump axum to 0.8".to_string());
+        let worktrees = vec![worktree("/a/wt-1", "alpha", "feature-a")];
+
+        let tree = build_run_tree(
+            &[first, second],
+            &worktrees,
+            Some(Path::new("/a/wt-1")),
+            HistoryScope::All,
+            "AXUM",
+            &HashMap::new(),
+            &HashMap::new(),
+        );
+        assert_eq!(tree.total(), 1, "case-insensitive substring on the title");
+        assert_eq!(
+            tree.unfiltered, 2,
+            "the unfiltered count is what tells 'no history' from 'no match'"
+        );
+    }
+
+    #[test]
+    fn drift_is_attached_per_run_and_absent_until_it_is_really_known() {
+        let first = run("/a/wt-1", 10);
+        let second = run("/a/wt-1", 20);
+        let worktrees = vec![worktree("/a/wt-1", "alpha", "feature-a")];
+        let drift: HashMap<PathBuf, HashMap<String, usize>> = [(
+            PathBuf::from("/a/wt-1"),
+            [(first.key.clone(), 4)].into_iter().collect(),
+        )]
+        .into_iter()
+        .collect();
+
+        let tree = build_run_tree(
+            &[first, second],
+            &worktrees,
+            None,
+            HistoryScope::All,
+            "",
+            &HashMap::new(),
+            &drift,
+        );
+        let group = &tree.repos[0].groups[0];
+        assert_eq!(group.runs[0].drift, Some(4));
+        assert_eq!(group.runs[0].band(), Some(DriftBand::Far));
+        assert_eq!(
+            group.runs[1].drift, None,
+            "an unanswered run paints no band at all rather than a made-up tip"
+        );
+        assert_eq!(group.runs[1].band(), None);
+    }
+
+    // ---------------------------------------------------------------------------- transcripts
+
+    #[test]
+    fn a_captured_transcript_is_shown_verbatim_and_still_gets_a_real_closing_line() {
+        let mut past = run("/a/wt-1", 1_700_000_000);
+        past.ended_at_unix = Some(1_700_000_360);
+        past.diffstat = Some(RunDiffstat {
+            files: 2,
+            insertions: 41,
+            deletions: 0,
+        });
+        let captured = vec![
+            "\u{276f} claude".to_string(),
+            "\u{25cf} working".to_string(),
+        ];
+        let body = transcript_body(&past, Some("feature-a"), Some(&captured), 1_700_000_400);
+
+        assert_eq!(body[0].text, "\u{276f} claude");
+        assert_eq!(body[1].text, "\u{25cf} working");
+        assert_eq!(
+            body[body.len() - 2].text,
+            "\u{25cf} Finished. 2 files changed, +41 \u{2212}0."
+        );
+        assert_eq!(
+            body[body.len() - 1].text,
+            "  \u{23bf} run ended today 22:19 after 6m"
+        );
+    }
+
+    /// §3's hard-won rule, as a test: a run with no stored transcript describes **its own**
+    /// record, and the result cannot end on a pending question.
+    #[test]
+    fn a_run_with_no_stored_transcript_describes_only_its_own_record() {
+        let mut past = run("/a/wt-1", 1_700_000_000);
+        past.title = Some("Move the select builder behind a trait".to_string());
+        past.turns = 21;
+        past.session_id = Some("3d91e07".to_string());
+        past.ended_at_unix = Some(1_700_000_000 + 24 * 60);
+        past.diffstat = Some(RunDiffstat {
+            files: 6,
+            insertions: 148,
+            deletions: 96,
+        });
+
+        let body = transcript_body(&past, Some("feat/query-builder"), None, 1_700_002_000);
+        let text: Vec<&str> = body.iter().map(|line| line.text.as_str()).collect();
+
+        assert_eq!(
+            text[0],
+            "\u{276f} claude --resume 3d91e07 \u{b7} feat/query-builder"
+        );
+        assert!(text.contains(&"\u{25cf} Move the select builder behind a trait"));
+        assert!(text.contains(&"  \u{23bf} 21 turns in feat/query-builder"));
+        assert!(text.contains(&"  \u{23bf} touched 6 files"));
+        assert!(text.contains(&"  \u{23bf} no transcript was captured for this run"));
+        assert_eq!(
+            text[text.len() - 2],
+            "\u{25cf} Finished. 6 files changed, +148 \u{2212}96."
+        );
+    }
+
+    #[test]
+    fn an_abandoned_runs_closing_line_says_last_seen_rather_than_claiming_it_ended() {
+        let mut past = run("/a/wt-1", 1_700_000_000);
+        past.ended_at_unix = None;
+        past.updated_at_unix = 1_700_000_500;
+        let lines = closing_lines(&past, 1_700_000_600);
+        assert_eq!(lines[0].text, "\u{25cf} Left unfinished.");
+        assert_eq!(lines[1].text, "  \u{23bf} last seen today 22:21");
+    }
+
+    #[test]
+    fn a_codex_runs_resume_line_is_a_codex_command_not_a_claude_one() {
+        let mut past = run("/a/wt-1", 1_700_000_000);
+        past.kind = AgentKind::Codex;
+        let body = transcript_body(&past, Some("main"), None, 1_700_000_000);
+        assert_eq!(body[0].text, "\u{276f} codex \u{b7} main");
+    }
+
+    // ----------------------------------------------------------------------------- empty notes
+
+    #[test]
+    fn the_empty_note_names_the_branch_when_the_scope_is_one_worktree() {
+        assert_eq!(
+            empty_note(HistoryScope::ThisWorktree, Some("feat/auth")),
+            "No agent has run in feat/auth yet."
+        );
+        assert_eq!(
+            empty_note(HistoryScope::All, Some("feat/auth")),
+            "No agent has finished a run yet."
+        );
+    }
+
+    #[test]
+    fn the_filtered_away_note_pluralises_through_the_one_helper() {
+        assert_eq!(filtered_away_note(1), "No match in the 1 run.");
+        assert_eq!(filtered_away_note(9), "No match in the 9 runs.");
+    }
+}

--- a/crates/app/src/run_history/render.rs
+++ b/crates/app/src/run_history/render.rs
@@ -692,6 +692,104 @@ mod history_surface_tests {
         );
     }
 
+    /// The `all` scope lists every checkout's runs, so a row click very often names a worktree
+    /// you are not standing in - and the tab it opens lives in *that* worktree's strip. Opening
+    /// one must therefore select its checkout, or the tab is filed somewhere nothing is drawing.
+    ///
+    /// A real regression test: before the fix, this rendered an empty tab strip and a centre pane
+    /// reading "this run is no longer in the history", because `open_run_key` resolves against the
+    /// selected worktree. Caught by a screenshot of the running app.
+    #[gpui::test]
+    fn opening_another_checkouts_run_selects_that_checkout(cx: &mut TestAppContext) {
+        let repo = init_repo();
+        let wt = TempDir::new().expect("tempdir wt");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        app.update(cx, |app, cx| {
+            cx.notify();
+            app.worktrees.push(crate::rail::worktrees::WorktreeItem {
+                path: wt.path().to_path_buf(),
+                label: "feature-a".to_string(),
+                branch: Some("feature-a".to_string()),
+                is_main: false,
+                is_bare: false,
+                is_detached: false,
+                short_sha: None,
+                is_locked: false,
+                lock_reason: None,
+                is_broken: false,
+                broken_reason: None,
+                error: None,
+            });
+        });
+        let key = record_finished_run(&app, cx, wt.path(), 1_700_000_000, "in another checkout");
+        assert_ne!(
+            app.read_with(cx, |app, _| app.current_worktree_path()),
+            Some(wt.path().to_path_buf()),
+            "premise: the window is standing somewhere else"
+        );
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_run_tab(wt.path().to_path_buf(), key.clone(), window, cx);
+        });
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.current_worktree_path()),
+            Some(wt.path().to_path_buf()),
+            "opening a run selects its own checkout"
+        );
+        assert_eq!(app.read_with(cx, |app, _| app.open_run_key()), Some(key));
+        assert!(app.read_with(cx, |app, _| app.run_tab_active));
+        assert!(
+            app.read_with(cx, |app, _| app.combined_tab_order())
+                .contains(&TabRef::Run),
+            "and the tab really lands in the strip that is now on screen"
+        );
+        assert!(cx.debug_bounds("run-view").is_some());
+    }
+
+    /// The other half of the same rule: switching worktrees *leaves* the run tab, so the centre
+    /// pane never keeps painting another checkout's recording - or, worse, a "no longer in the
+    /// history" note for a worktree that simply has no run tab of its own.
+    #[gpui::test]
+    fn switching_worktrees_leaves_the_run_tab_behind_in_its_own_strip(cx: &mut TestAppContext) {
+        let repo = init_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        let key = record_finished_run(&app, cx, repo.path(), 1_700_000_000, "a run");
+        app.update_in(cx, |app, window, cx| {
+            app.open_run_tab(repo.path().to_path_buf(), key.clone(), window, cx);
+        });
+        cx.run_until_parked();
+        assert!(app.read_with(cx, |app, _| app.run_tab_active), "premise");
+
+        let index = app
+            .read_with(cx, |app, _| {
+                app.worktrees
+                    .iter()
+                    .position(|item| item.path == repo.path())
+            })
+            .expect("the main checkout is a worktree");
+        app.update_in(cx, |app, window, cx| {
+            app.select_worktree(index, window, cx);
+        });
+        cx.run_until_parked();
+
+        assert!(
+            !app.read_with(cx, |app, _| app.run_tab_active),
+            "a worktree switch leaves the surface"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app
+                .run_tab_by_worktree
+                .get(repo.path())
+                .cloned()),
+            Some(key),
+            "but the tab itself is untouched - it is one switch back, in its own strip"
+        );
+    }
+
     /// §7's real cost, in this app's own terms: the run tab occupies the centre pane, so
     /// selecting an agent while it is showing must genuinely *leave* it - not merely stop drawing
     /// it while `Window::focus` still points at a handle nothing is tracking.

--- a/crates/app/src/run_history/render.rs
+++ b/crates/app/src/run_history/render.rs
@@ -1,2 +1,452 @@
-//! placeholder
+//! The real sidebar History body (GitHub issue #227): the scope toggle, the count line, the
+//! repo → worktree → run tree, and the click that opens a run's transcript.
+//!
+//! `design_handoff_jerry_ade/revision 5/REVISION-2026-08-13.md` §3 is the whole brief for this
+//! file, in one sentence: History "is a **list you pick from**, like a file tree - not a
+//! document. Centre tabs hold things you read or work in; the sidebar holds things you navigate."
+//! So nothing here renders a transcript; a row's only job is to open one
+//! ([`crate::run_history::tab`]).
+//!
+//! `REVISION-2026-08-14.md` §6 amends §3's flat, one-worktree list into the hierarchy this file
+//! paints: "**Agent history** is repo → worktree → run, matching the rail, with an `all` /
+//! `this worktree` scope toggle. Active worktree carries the blue edge and opens by default."
+//!
+//! Every decision about *what a row says* lives in [`crate::run_history::model`] and is asserted
+//! there without a window; this file is the `gpui::Div` half only, exactly the split
+//! [`crate::rail::strip`]/[`crate::rail::strip_render`] already keep for the Problems view one
+//! module over.
+
 use super::*;
+
+use crate::rail::strip::SidebarView;
+use crate::root::widgets::{render_disclosure_caret, render_sidebar_message, text_tooltip};
+use crate::run_history::model::{self, HistoryScope, RunEntry, RunGroup, RunTree};
+
+impl AdeApp {
+    /// Switches the sidebar to History - the `⋯` overflow's own `History` row
+    /// (`crate::rail::menu::RailMenuAction::OpenHistory`).
+    ///
+    /// Kicks the real drift traversal off here as well as on the body's own render, so the very
+    /// first History frame already has an answer to paint for a window that has been open a
+    /// while: `load_run_drift` is single-flight and skips every worktree it has already answered,
+    /// so calling it from both places costs nothing.
+    pub(crate) fn open_history_view(&mut self, cx: &mut Context<Self>) {
+        self.set_sidebar_view(SidebarView::History, cx);
+        self.load_run_drift(cx);
+    }
+
+    /// A worktree row's own `↺ N earlier runs` line (`REVISION-2026-08-13.md` §6): selects that
+    /// checkout, switches the sidebar to History and narrows the scope to it.
+    ///
+    /// Narrowing the scope is what makes this line land somewhere - §6 says it switches "the
+    /// sidebar to History **for that worktree**", and the `all` scope's whole-window list would
+    /// answer a different question than the row that was clicked. The toggle is right there to
+    /// widen it back, so this is a starting position rather than a mode.
+    pub(crate) fn open_history_for_worktree(
+        &mut self,
+        path: PathBuf,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.select_worktree_by_path(&path, window, cx);
+        self.history_scope = HistoryScope::ThisWorktree;
+        // An explicit earlier fold of this group would otherwise hide the very runs this click
+        // asked to see.
+        self.history_collapsed.remove(&path);
+        self.open_history_view(cx);
+    }
+
+    /// The `all` / `this worktree` toggle's own click.
+    pub(crate) fn set_history_scope(&mut self, scope: HistoryScope, cx: &mut Context<Self>) {
+        if self.history_scope == scope {
+            return;
+        }
+        self.history_scope = scope;
+        cx.notify();
+    }
+
+    /// Folds or unfolds one worktree group, recording the choice explicitly - see
+    /// [`Self::history_collapsed`] on why this is a map of decisions rather than a set of open
+    /// groups.
+    fn toggle_history_group(&mut self, path: PathBuf, was_open: bool, cx: &mut Context<Self>) {
+        self.history_collapsed.insert(path, was_open);
+        cx.notify();
+    }
+
+    /// The real repo → worktree → run tree for whatever the window knows right now, already
+    /// scoped, filtered and folded.
+    ///
+    /// One place builds it, so the count line, the rows and the two empty notes are three
+    /// readings of one pass - the same guarantee `crate::rail::render::AdeApp::render_rail` gives
+    /// the strip's marker and the Problems body (§2: "tallied over their own data").
+    pub(crate) fn history_run_tree(&self) -> RunTree {
+        model::build_run_tree(
+            &self.past_runs(),
+            &self.history_worktrees(),
+            self.current_worktree_path().as_deref(),
+            self.history_scope,
+            self.filter_query.as_str(),
+            &self.history_collapsed,
+            &self.run_drift,
+        )
+    }
+
+    /// The whole History view.
+    pub(crate) fn render_history_view(&mut self, cx: &mut Context<Self>) -> gpui::AnyElement {
+        // The one real background load this surface needs, asked for from the body that needs it
+        // - see `crate::run_history::flow::AdeApp::load_run_drift`.
+        self.load_run_drift(cx);
+
+        let tree = self.history_run_tree();
+        let branch = self.current_worktree_branch_label();
+
+        let mut body = div()
+            .id("sidebar-history")
+            .debug_selector(|| "sidebar-history".to_string())
+            .flex()
+            .flex_col()
+            .child(self.render_history_scope_toggle(branch.as_deref(), cx));
+
+        if tree.is_empty() {
+            // Two different facts, said as two (§4g, and the Problems view's own pair one module
+            // over): a window with no history at all, and a filter that hid all of it.
+            let note = if tree.unfiltered == 0 {
+                model::empty_note(self.history_scope, branch.as_deref())
+            } else {
+                model::filtered_away_note(tree.unfiltered)
+            };
+            return body
+                .child(
+                    div()
+                        .debug_selector(|| "sidebar-history-note".to_string())
+                        .child(render_sidebar_message(note, theme::text::GHOST.into())),
+                )
+                .into_any_element();
+        }
+
+        if let Some(line) = tree.count_line() {
+            body = body.child(
+                div()
+                    .flex_none()
+                    .px(px(12.0))
+                    .pt(px(8.0))
+                    .pb(px(6.0))
+                    .debug_selector(|| "sidebar-history-count".to_string())
+                    .font(font(theme::font::MONO))
+                    .text_size(self.ui_text_size(9.5))
+                    .text_color(theme::text::FAINTER)
+                    .child(line),
+            );
+        }
+
+        for repo in &tree.repos {
+            // A repo header only earns its line when there is more than one repo to tell apart -
+            // §4's own rule for the rail's repo headers, and the reason a single-repo window does
+            // not pay a row to be told the name it already has in the title bar.
+            if tree.repos.len() > 1 {
+                body = body.child(
+                    div()
+                        .flex_none()
+                        .px(px(12.0))
+                        .pt(px(7.0))
+                        .pb(px(3.0))
+                        .font(font(theme::font::MONO))
+                        .font_weight(gpui::FontWeight::SEMIBOLD)
+                        .text_size(self.ui_text_size(9.5))
+                        .text_color(theme::history::REPO_LABEL)
+                        .child(repo.label.to_uppercase()),
+                );
+            }
+            for group in &repo.groups {
+                body = body.child(self.render_history_group(group, cx));
+                if group.open {
+                    for entry in &group.runs {
+                        body = body.child(self.render_history_run_row(entry, cx));
+                    }
+                }
+            }
+        }
+
+        body.into_any_element()
+    }
+
+    /// The `all` / `this worktree` toggle (`REVISION-2026-08-14.md` §6).
+    ///
+    /// Two segments, drawn from one `map` over [`HistoryScope::ALL`] rather than two hand-written
+    /// pills, for §7 rule 7's reason - a control drawn twice is one control, and two copies drift
+    /// on padding first. Each carries its own tooltip, since `this worktree` is only meaningful
+    /// once you know which checkout that is.
+    fn render_history_scope_toggle(
+        &self,
+        branch: Option<&str>,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let current = self.history_scope;
+        div()
+            .flex()
+            .flex_none()
+            .items_center()
+            .gap(px(4.0))
+            .px(px(12.0))
+            .h(px(27.0))
+            .debug_selector(|| "history-scope-toggle".to_string())
+            .children(HistoryScope::ALL.iter().copied().map(|scope| {
+                let selected = scope == current;
+                let element_id = match scope {
+                    HistoryScope::All => "history-scope-all",
+                    HistoryScope::ThisWorktree => "history-scope-worktree",
+                };
+                div()
+                    .id(element_id)
+                    .debug_selector(move || element_id.to_string())
+                    .flex_none()
+                    .cursor_pointer()
+                    .px(px(7.0))
+                    .py(px(2.0))
+                    .rounded(theme::radius::CHIP)
+                    .border_1()
+                    .font(font(theme::font::MONO))
+                    .text_size(self.ui_text_size(9.5))
+                    .when(selected, |el| {
+                        el.bg(theme::history::SCOPE_ON_BG)
+                            .border_color(theme::history::SCOPE_ON_BORDER)
+                            .text_color(theme::history::SCOPE_ON_FG)
+                    })
+                    .when(!selected, |el| {
+                        el.border_color(gpui::transparent_black())
+                            .text_color(theme::history::SCOPE_OFF_FG)
+                            .hover(|el| el.bg(theme::history::SCOPE_HOVER_BG))
+                    })
+                    .tooltip(text_tooltip(scope.hint(branch)))
+                    .child(scope.label())
+                    .on_click(cx.listener(move |this, _event: &ClickEvent, _window, cx| {
+                        this.set_history_scope(scope, cx);
+                    }))
+            }))
+    }
+
+    /// One worktree group's header: the caret, the branch it is, and how many runs are under it.
+    ///
+    /// The active worktree carries [`theme::border::SELECTED_EDGE`] - §6's "blue edge" - which is
+    /// the same 2px edge the rail's own selected worktree row paints, read from the same token so
+    /// the two views cannot disagree about which checkout you are in. Every other row reserves
+    /// the 2px transparently, for the reason the rail's childless rows reserve their caret slot:
+    /// a row that omits it starts 2px left of every other row in the column.
+    fn render_history_group(
+        &self,
+        group: &RunGroup,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement + use<> {
+        let path = group.worktree.clone();
+        let was_open = group.open;
+        let element_id = gpui::SharedString::from(format!("history-group-{}", path.display()));
+        let selector = element_id.clone();
+        let count = group.runs.len();
+
+        div()
+            .id(element_id)
+            .debug_selector(move || selector.to_string())
+            .flex()
+            .items_center()
+            .gap(px(4.0))
+            .h(px(24.0))
+            .pl(px(10.0))
+            .pr(px(10.0))
+            .cursor_pointer()
+            .border_l_2()
+            .border_color(if group.is_active {
+                theme::border::SELECTED_EDGE.into()
+            } else {
+                gpui::transparent_black()
+            })
+            .hover(|el| el.bg(theme::surface::ROW_HOVER))
+            .tooltip(text_tooltip(format!(
+                "{} \u{2014} {}",
+                group.label,
+                model::earlier_runs_label(count)
+            )))
+            .on_click(cx.listener(move |this, _event: &ClickEvent, _window, cx| {
+                this.toggle_history_group(path.clone(), was_open, cx);
+            }))
+            .child(
+                div()
+                    .flex_none()
+                    .text_color(theme::text::DIM)
+                    .child(render_disclosure_caret(group.open, self.ui_text_size(10.0))),
+            )
+            .child(
+                div()
+                    .flex_1()
+                    .min_w_0()
+                    .truncate()
+                    .font(font(theme::font::SANS))
+                    .text_size(self.ui_text_size(11.5))
+                    .text_color(if group.is_active {
+                        theme::text::SELECTED
+                    } else {
+                        theme::history::GROUP_LABEL
+                    })
+                    .child(group.label.clone()),
+            )
+            .child(
+                div()
+                    .flex_none()
+                    .font(font(theme::font::MONO))
+                    .text_size(self.ui_text_size(9.5))
+                    .text_color(theme::text::GHOSTER)
+                    .child(count.to_string()),
+            )
+    }
+
+    /// One run row - §3's "two lines each: agent chip · title · duration, then outcome pill ·
+    /// drift dot · drift text · finished-at".
+    ///
+    /// Clicking it opens *that run's* transcript as a centre tab, which is the whole Explorer →
+    /// editor pattern §3 is built on.
+    ///
+    /// A run whose drift has not been answered yet paints **no** dot and no drift text, rather
+    /// than the reassuring `at the tip` - see [`crate::run_history::model::RunEntry::drift`].
+    fn render_history_run_row(
+        &self,
+        entry: &RunEntry,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement + use<> {
+        let run = &entry.run;
+        let now_unix = crate::run_history::unix_now();
+        let outcome = entry.outcome();
+        let key = run.key.clone();
+        let worktree = run.worktree.clone();
+        let is_open = self.run_tab_by_worktree.get(&worktree) == Some(&key);
+
+        let element_id = gpui::SharedString::from(format!("history-run-{key}"));
+        let body_id = gpui::SharedString::from(format!("history-run-body-{key}"));
+        let selector = element_id.clone();
+
+        let mut second_line = div().flex().items_center().gap(px(6.0)).pl(px(21.0)).child(
+            // The outcome pill: §5's own four words, in §5's own four colour pairs.
+            div()
+                .flex_none()
+                .px(px(5.0))
+                .py(px(1.0))
+                .rounded(theme::radius::CHIP)
+                .bg(outcome.bg())
+                .font(font(theme::font::MONO))
+                .text_size(self.ui_text_size(9.0))
+                .text_color(outcome.fg())
+                .child(outcome.label()),
+        );
+        if let (Some(band), Some(commits)) = (entry.band(), entry.drift) {
+            second_line = second_line
+                .child(
+                    div()
+                        .flex_none()
+                        .w(px(4.0))
+                        .h(px(4.0))
+                        .rounded_full()
+                        .bg(band.dot()),
+                )
+                .child(
+                    div()
+                        .flex_none()
+                        .font(font(theme::font::SANS))
+                        .text_size(self.ui_text_size(9.5))
+                        .text_color(band.text())
+                        .child(model::drift_label(commits)),
+                );
+        }
+        second_line = second_line.child(div().flex_1().min_w(px(2.0))).child(
+            div()
+                .flex_none()
+                .font(font(theme::font::MONO))
+                .text_size(self.ui_text_size(9.0))
+                .text_color(theme::text::GHOST)
+                .child(model::run_when(model::run_finished_at(run), now_unix)),
+        );
+
+        let mut first_line = div()
+            .flex()
+            .items_center()
+            .gap(px(6.0))
+            .child(self.render_agent_chip_icon(
+                ProcessKind::Agent(run.kind),
+                px(15.0),
+                self.ui_text_size(9.0),
+            ))
+            .child(
+                div()
+                    .flex_1()
+                    .min_w_0()
+                    .truncate()
+                    .font(font(theme::font::SANS))
+                    .text_size(self.ui_text_size(11.5))
+                    .text_color(if is_open {
+                        theme::text::SELECTED
+                    } else {
+                        theme::history::ROW_TITLE
+                    })
+                    .child(model::run_title(run)),
+            );
+        if let Some(duration) = model::run_duration(run) {
+            first_line = first_line.child(
+                div()
+                    .flex_none()
+                    .font(font(theme::font::MONO))
+                    .text_size(self.ui_text_size(9.5))
+                    .text_color(theme::text::GHOST)
+                    .child(duration),
+            );
+        }
+
+        div()
+            .id(element_id)
+            .debug_selector(move || selector.to_string())
+            .flex()
+            .pl(px(13.0))
+            // The same connector-then-content shape a rail agent row uses under its worktree, so
+            // a run reads as belonging to the group above it rather than as a sibling of it.
+            .child(div().flex_none().w(px(1.0)).bg(theme::border::ZONE))
+            .child(
+                div()
+                    .id(body_id)
+                    .flex_1()
+                    .min_w_0()
+                    .flex()
+                    .flex_col()
+                    .cursor_pointer()
+                    .pl(px(7.0))
+                    .pr(px(10.0))
+                    .pt(px(6.0))
+                    .pb(px(7.0))
+                    .gap(px(2.0))
+                    .border_l_2()
+                    .border_color(if is_open {
+                        theme::border::SELECTED_EDGE.into()
+                    } else {
+                        gpui::transparent_black()
+                    })
+                    .hover(|el| el.bg(theme::surface::ROW_HOVER))
+                    .tooltip(text_tooltip(format!(
+                        "{} \u{2014} open this run's transcript",
+                        model::run_meta_line(run, now_unix)
+                    )))
+                    .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
+                        this.open_run_tab(worktree.clone(), key.clone(), window, cx);
+                    }))
+                    .child(first_line)
+                    .child(second_line),
+            )
+    }
+
+    /// The branch name of the checkout the window is on, for the copy that names it (`No agent
+    /// has run in <branch> yet.`, and the `this worktree` segment's own tooltip). `None` on a
+    /// detached `HEAD`, where there is genuinely no branch name to print - the same honesty
+    /// [`crate::rail::strip::problems_empty_note`] keeps one module over.
+    fn current_worktree_branch_label(&self) -> Option<String> {
+        let path = self.current_worktree_path()?;
+        self.repos
+            .iter()
+            .flat_map(|repo| repo.worktrees.iter())
+            .find(|item| item.path == path)
+            .and_then(|item| item.branch.clone())
+    }
+}

--- a/crates/app/src/run_history/render.rs
+++ b/crates/app/src/run_history/render.rs
@@ -450,3 +450,407 @@ impl AdeApp {
             .and_then(|item| item.branch.clone())
     }
 }
+
+/// Real-window, real-git coverage for the History surface (GitHub issue #227): the overflow row
+/// that reaches it, the rows it really paints for real persisted records, the transcript tab a
+/// row really opens, and the rail line that replaced the inline `HISTORY` section.
+///
+/// Everything here drives the same entry points the UI does - `open_history_view`,
+/// `open_run_tab`, `select_agent` - rather than poking state directly, so it proves the wiring
+/// and not just the pure model underneath it (which `crate::run_history::model`'s own tests
+/// already hold without a window).
+#[cfg(test)]
+mod history_surface_tests {
+    use super::*;
+    use crate::hooks::store::LiveRun;
+    use crate::rail::status::Status;
+    use crate::root::focus::palette_focus_tests;
+    use crate::work_surface::agents::AgentKind;
+    use crate::work_surface::state::TabRef;
+    use gpui::TestAppContext;
+    use std::path::Path;
+    use std::process::Command;
+    use tempfile::TempDir;
+
+    fn git(dir: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .output()
+            .expect("failed to spawn git");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed in {dir:?}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn init_repo() -> TempDir {
+        let dir = TempDir::new().expect("tempdir");
+        git(dir.path(), &["init", "-b", "main"]);
+        git(dir.path(), &["config", "user.email", "test@example.com"]);
+        git(dir.path(), &["config", "user.name", "Test User"]);
+        std::fs::write(dir.path().join("base.txt"), "base\n").expect("write");
+        git(dir.path(), &["add", "base.txt"]);
+        git(dir.path(), &["commit", "-m", "initial"]);
+        dir
+    }
+
+    /// Files one real, *finished* run into the real status store, exactly the way
+    /// `crate::hooks::flow::AdeApp::record_agent_statuses` and
+    /// `crate::run_history::flow::AdeApp::finish_run_record` do between them, and returns its key.
+    fn record_finished_run(
+        app: &gpui::Entity<AdeApp>,
+        cx: &mut gpui::VisualTestContext,
+        worktree: &Path,
+        spawned_at: i64,
+        title: &str,
+    ) -> String {
+        let key = crate::review::state::baseline_key(worktree, AgentKind::Claude, spawned_at);
+        app.update(cx, |app, cx| {
+            app.agent_status_state.set(
+                key.clone(),
+                LiveRun::new(worktree, "Claude", spawned_at, Status::Review)
+                    .title(title.to_owned())
+                    .session_id(format!("session-{spawned_at}")),
+                spawned_at + 100,
+            );
+            app.agent_status_state.finish(
+                &key,
+                spawned_at + 360,
+                crate::hooks::store::FinishedRun {
+                    status: Some(Status::Review),
+                    files_changed: Some(2),
+                    insertions: Some(41),
+                    deletions: Some(0),
+                },
+            );
+            // The real recorder (`crate::hooks::flow::AdeApp::record_agent_statuses`) always
+            // notifies; writing straight into the store here has to do the same or the next
+            // `run_until_parked` paints the frame before this run existed.
+            cx.notify();
+        });
+        cx.run_until_parked();
+        key
+    }
+
+    /// The `⋯` overflow's own `History` row really lands on a real, painted History body - the
+    /// only entry point §4t leaves it, so a row that switched nothing would be the whole feature
+    /// unreachable.
+    #[gpui::test]
+    fn the_overflow_history_row_really_opens_a_painted_history_view(cx: &mut TestAppContext) {
+        let repo = init_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        record_finished_run(
+            &app,
+            cx,
+            repo.path(),
+            1_700_000_000,
+            "Reproduce the refresh race",
+        );
+
+        assert!(
+            cx.debug_bounds("sidebar-history").is_none(),
+            "premise: the sidebar starts on Worktrees"
+        );
+
+        app.update_in(cx, |app, window, cx| {
+            app.run_rail_menu_action(crate::rail::menu::RailMenuAction::OpenHistory, window, cx);
+        });
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.sidebar_view),
+            crate::rail::strip::SidebarView::History
+        );
+        assert!(
+            cx.debug_bounds("sidebar-history").is_some(),
+            "the History body must really paint - \u{a7}7 rule 1: ship the affordance with the \
+             behaviour"
+        );
+        assert!(
+            cx.debug_bounds("history-scope-toggle").is_some(),
+            "\u{a7}6's all / this worktree toggle is part of the view, not an extra"
+        );
+    }
+
+    /// A real persisted record becomes a real row, and clicking it opens *that run's* transcript
+    /// as a real centre tab - §3's Explorer → editor pattern, end to end.
+    #[gpui::test]
+    fn a_real_run_row_opens_its_own_transcript_tab(cx: &mut TestAppContext) {
+        let repo = init_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        let key = record_finished_run(
+            &app,
+            cx,
+            repo.path(),
+            1_700_000_000,
+            "Move the select builder behind a trait",
+        );
+
+        let tree = app.read_with(cx, |app, _| app.history_run_tree());
+        assert_eq!(
+            tree.total(),
+            1,
+            "the real record must produce exactly one row"
+        );
+        let entry = &tree.repos[0].groups[0].runs[0];
+        assert_eq!(
+            model::run_title(&entry.run),
+            "Move the select builder behind a trait",
+            "the row's title is the run's own first prompt"
+        );
+        assert_eq!(
+            entry.outcome(),
+            model::Outcome::Done,
+            "a watched ending on Review is `done`"
+        );
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_history_view(cx);
+            app.open_run_tab(repo.path().to_path_buf(), key.clone(), window, cx);
+        });
+        cx.run_until_parked();
+
+        assert!(app.read_with(cx, |app, _| app.run_tab_active));
+        assert!(
+            app.read_with(cx, |app, _| app.combined_tab_order())
+                .contains(&TabRef::Run),
+            "the run tab must be a real member of this worktree's strip"
+        );
+        assert!(
+            cx.debug_bounds("run-view").is_some(),
+            "and the centre pane must really be showing it"
+        );
+        for selector in [
+            "run-header",
+            "run-header-meta",
+            "run-outcome-pill",
+            "run-transcript",
+            "run-footer",
+            "run-resume",
+            "run-start-new",
+        ] {
+            assert!(
+                cx.debug_bounds(selector).is_some(),
+                "\u{a7}3's transcript tab is header + dimmed body + footer with both actions; \
+                 `{selector}` is missing"
+            );
+        }
+    }
+
+    /// §3: "One run tab per worktree; opening another replaces it." The replacement is a
+    /// replacement, not a second tab - and it does not touch another checkout's own open tab.
+    #[gpui::test]
+    fn a_second_run_replaces_the_tab_rather_than_stacking_beside_it(cx: &mut TestAppContext) {
+        let repo = init_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        let first = record_finished_run(&app, cx, repo.path(), 1_700_000_000, "first");
+        let second = record_finished_run(&app, cx, repo.path(), 1_700_001_000, "second");
+        let elsewhere = Path::new("/other/checkout");
+        let other = record_finished_run(&app, cx, elsewhere, 1_700_002_000, "elsewhere");
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_run_tab(repo.path().to_path_buf(), first.clone(), window, cx);
+        });
+        cx.run_until_parked();
+        assert_eq!(app.read_with(cx, |app, _| app.open_run_key()), Some(first));
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_run_tab(repo.path().to_path_buf(), second.clone(), window, cx);
+        });
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.open_run_key()),
+            Some(second.clone())
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.combined_tab_order())
+                .iter()
+                .filter(|tab| **tab == TabRef::Run)
+                .count(),
+            1,
+            "opening another run replaces the tab; it never stacks a second one"
+        );
+
+        // Another checkout's run tab is its own - opening one there must leave this one alone.
+        app.update_in(cx, |app, window, cx| {
+            app.open_run_tab(elsewhere.to_path_buf(), other, window, cx);
+        });
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app
+                .run_tab_by_worktree
+                .get(repo.path())
+                .cloned()),
+            Some(second),
+            "\u{a7}3 keys the tab to a worktree: opening a run in another checkout must not \
+             close the one you were reading here"
+        );
+    }
+
+    /// §7's real cost, in this app's own terms: the run tab occupies the centre pane, so
+    /// selecting an agent while it is showing must genuinely *leave* it - not merely stop drawing
+    /// it while `Window::focus` still points at a handle nothing is tracking.
+    #[gpui::test]
+    fn selecting_an_agent_really_leaves_the_run_tab(cx: &mut TestAppContext) {
+        let repo = init_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        let key = record_finished_run(&app, cx, repo.path(), 1_700_000_000, "a run");
+
+        app.update_in(cx, |app, window, cx| {
+            app.open_run_tab(repo.path().to_path_buf(), key, window, cx);
+        });
+        cx.run_until_parked();
+        assert!(app.read_with(cx, |app, _| app.run_tab_active), "premise");
+        assert!(app.read_with(cx, |app, _| app.centre_pane_is_not_an_agent()));
+
+        let agent = app
+            .read_with(cx, |app, _| app.agents.iter().next().map(|agent| agent.id))
+            .expect("every window starts with one shell");
+        app.update_in(cx, |app, window, cx| {
+            app.select_agent(agent, window, cx);
+        });
+        cx.run_until_parked();
+
+        assert!(
+            !app.read_with(cx, |app, _| app.run_tab_active),
+            "the run tab must be left, so the agent tab being switched to really mounts"
+        );
+        assert!(
+            !app.read_with(cx, |app, _| app.centre_pane_is_not_an_agent()),
+            "and the one shared predicate \u{a7}7 asks for must agree"
+        );
+        assert!(
+            cx.debug_bounds("run-view").is_none(),
+            "nothing of the run surface may still be painted"
+        );
+    }
+
+    /// §6's rail line, and the deletion that came with it: a worktree with real history and **no
+    /// live agent** gets a `↺ N earlier runs` line and no disclosure caret - the caret only ever
+    /// meant "this worktree has children", and history is no longer one of them.
+    ///
+    /// The line is the *whole* rail-side surface for history now. The inline `HISTORY` section it
+    /// replaced - a label plus one `Resume`/`Reopen` row per run - is deleted, per §7 rule 5.
+    #[gpui::test]
+    fn a_worktree_with_history_and_no_agent_gets_the_earlier_runs_line(cx: &mut TestAppContext) {
+        let repo = init_repo();
+        let wt = TempDir::new().expect("tempdir wt");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        app.update(cx, |app, cx| {
+            cx.notify();
+            app.worktrees = vec![crate::rail::worktrees::WorktreeItem {
+                path: wt.path().to_path_buf(),
+                label: "feature-a".to_string(),
+                branch: Some("feature-a".to_string()),
+                is_main: false,
+                is_bare: false,
+                is_detached: false,
+                short_sha: None,
+                is_locked: false,
+                lock_reason: None,
+                is_broken: false,
+                broken_reason: None,
+                error: None,
+            }];
+        });
+        record_finished_run(&app, cx, wt.path(), 1_700_000_000, "an earlier run");
+        cx.run_until_parked();
+
+        // `debug_bounds` takes a `&'static str`, so the selector is leaked for the test's own
+        // lifetime - the only way to look up a bounds key derived from a temp dir's real path.
+        let link: &'static str =
+            Box::leak(format!("earlier-runs-{}", wt.path().display()).into_boxed_str());
+        assert!(
+            cx.debug_bounds(link).is_some(),
+            "\u{a7}6: a worktree with no live agent carries its own `\u{21ba} N earlier runs` line"
+        );
+        assert!(
+            cx.debug_bounds("worktree-caret-0").is_some(),
+            "the caret *slot* is still reserved - it is 13px of every row's left inset"
+        );
+        // ...but history is no longer one of the row's children, so nothing about it can make the
+        // row expandable. That is the other half of the deletion: the inline `HISTORY` section
+        // used to live behind this caret, and `has_children` had to be widened for it.
+        let row = app.update(cx, |app, cx| {
+            app.build_repo_groups(cx)
+                .into_iter()
+                .flat_map(|group| group.rows)
+                .find(|row| row.path == wt.path())
+                .expect("the worktree row")
+        });
+        assert!(
+            row.agents.is_empty(),
+            "premise: no live agent in this checkout"
+        );
+        assert!(
+            !row.history.is_empty(),
+            "premise: it does have real persisted history"
+        );
+
+        // Clicking it lands on History, scoped to that checkout - §6's "switching the sidebar to
+        // History **for that worktree**".
+        app.update_in(cx, |app, window, cx| {
+            app.open_history_for_worktree(wt.path().to_path_buf(), window, cx);
+        });
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.sidebar_view),
+            crate::rail::strip::SidebarView::History
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.history_scope),
+            HistoryScope::ThisWorktree
+        );
+        assert!(cx.debug_bounds("sidebar-history").is_some());
+    }
+
+    /// The two empty states are two different facts, and the view says which one it is - the same
+    /// pair the Problems view one module over keeps, for the same reason.
+    #[gpui::test]
+    fn no_history_and_no_match_are_two_different_notes(cx: &mut TestAppContext) {
+        let repo = init_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        app.update_in(cx, |app, _window, cx| app.open_history_view(cx));
+        cx.run_until_parked();
+        assert!(
+            cx.debug_bounds("sidebar-history-note").is_some(),
+            "a window with no runs at all says so"
+        );
+        assert!(cx.debug_bounds("sidebar-history-count").is_none());
+
+        record_finished_run(&app, cx, repo.path(), 1_700_000_000, "Bump axum to 0.8");
+        cx.run_until_parked();
+        assert!(
+            cx.debug_bounds("sidebar-history-count").is_some(),
+            "one real run earns a real count line"
+        );
+
+        app.update(cx, |app, cx| {
+            app.filter_query
+                .set("nothing matches this", std::time::Instant::now());
+            cx.notify();
+        });
+        cx.run_until_parked();
+        let tree = app.read_with(cx, |app, _| app.history_run_tree());
+        assert!(tree.is_empty());
+        assert_eq!(
+            tree.unfiltered, 1,
+            "the unfiltered count is what tells 'no history' from 'no match', and the note reads \
+             off it"
+        );
+        assert_eq!(
+            model::filtered_away_note(tree.unfiltered),
+            "No match in the 1 run."
+        );
+    }
+}

--- a/crates/app/src/run_history/render.rs
+++ b/crates/app/src/run_history/render.rs
@@ -1,0 +1,2 @@
+//! placeholder
+use super::*;

--- a/crates/app/src/run_history/tab.rs
+++ b/crates/app/src/run_history/tab.rs
@@ -45,6 +45,18 @@ impl AdeApp {
     ///
     /// The single real door: the History view's row click is the only caller, and re-clicking the
     /// row that is already open simply re-activates the tab.
+    ///
+    /// **Selects `worktree` first.** The `all` scope lists every checkout's runs
+    /// (`REVISION-2026-08-14.md` §6), so the row you click is very often *not* in the worktree you
+    /// are standing in - and this tab lives in that run's own worktree's strip. Without the
+    /// switch, the tab was filed under a worktree whose strip was not on screen: nothing appeared
+    /// in the tab strip at all and the centre pane read "this run is no longer in the history",
+    /// because `Self::open_run_key` resolves against the *selected* worktree. Found by a real
+    /// screenshot of the running app, not by a test.
+    ///
+    /// Selecting the run's checkout is also what §3's resume story already assumes - "scoping
+    /// history to a worktree means the checkout is always present" - so the footer's `Resume here`
+    /// acts on the worktree you are now looking at.
     pub(crate) fn open_run_tab(
         &mut self,
         worktree: PathBuf,
@@ -59,6 +71,12 @@ impl AdeApp {
         }
         if self.palette_open {
             self.close_palette(window, cx);
+        }
+        // Before anything below sets `run_tab_active`: `select_worktree` itself leaves the run tab
+        // (a run tab belongs to the worktree being left), so doing this after would immediately
+        // undo it.
+        if self.current_worktree_path().as_deref() != Some(worktree.as_path()) {
+            self.select_worktree_by_path(&worktree, window, cx);
         }
         // Every other centre surface must be *left*, not merely stopped being drawn - see this
         // module's docs, and `crate::review::render::AdeApp::leave_review_tab`'s own.

--- a/crates/app/src/run_history/tab.rs
+++ b/crates/app/src/run_history/tab.rs
@@ -1,2 +1,543 @@
-//! placeholder
+//! The real run-transcript centre tab (GitHub issue #227): its strip entry, its header, its
+//! dimmed body, and its footer's `Resume here` / `Start a new agent from this`.
+//!
+//! `design_handoff_jerry_ade/revision 5/REVISION-2026-08-13.md` §3-§4 is this file's brief. Two
+//! of its sentences are load-bearing enough to repeat here, because breaking either one is what
+//! the design caught *itself* doing:
+//!
+//! 1. **Keyed by run id, never the live agent's buffer.** "Borrowing the live buffer produces a
+//!    pane whose header and body describe two different runs, whose diffstats contradict each
+//!    other, and - worst - one that ends on an unanswered question with a highlighted,
+//!    apparently-selectable option list. A completed run cannot be awaiting an answer, and 70%
+//!    opacity does not disambiguate that." This file therefore reads one run's record and one
+//!    run's stored lines, both by [`crate::hooks::history::PastAgent::key`], and hands them to
+//!    [`crate::run_history::model::transcript_body`], which structurally cannot mix two runs.
+//! 2. **Every run resumes.** "Scoping history to a worktree means the checkout is always present,
+//!    so there are no resume tiers. What varies is drift." So the footer has no disabled state
+//!    for a run that is merely old; it has a drift sentence that says what resuming will mean.
+//!
+//! ## One run tab per worktree
+//!
+//! §3: "One run tab per worktree; opening another replaces it." [`AdeApp::run_tab_by_worktree`]
+//! is that map, and [`work_surface::TabRef::Run`] carries no payload for the same reason
+//! [`work_surface::TabRef::Graph`] does not: a worktree's tab strip can hold at most one of
+//! these, so within the strip there is nothing to tell two apart. Replacing the run a tab shows
+//! therefore keeps the tab's dragged position, which is what "replaced" rather than
+//! "closed and reopened" means.
+//!
+//! ## Open/close/focus discipline
+//!
+//! [`AdeApp::open_run_tab`]/[`AdeApp::leave_run_tab`]/[`AdeApp::close_run_tab`] are deliberate
+//! copies of `crate::review::render`'s own trio, which are themselves copies of the graph tab's -
+//! see that module's docs for the two real, live-reproduced dangling-focus bugs the discipline
+//! exists to prevent. [`AdeApp::run_tab_focus_handle`] has exactly the same conditional-render
+//! lifetime, so it needs exactly the same sweep.
+
 use super::*;
+
+use crate::root::widgets::text_tooltip;
+use crate::run_history::model;
+use crate::work_surface::render::{DraggedTab, TabChromeArgs};
+use crate::work_surface::state as work_surface;
+
+impl AdeApp {
+    /// Opens (or replaces) the run-transcript tab in `worktree`, showing the run `run_key`.
+    ///
+    /// The single real door: the History view's row click is the only caller, and re-clicking the
+    /// row that is already open simply re-activates the tab.
+    pub(crate) fn open_run_tab(
+        &mut self,
+        worktree: PathBuf,
+        run_key: String,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        // A run whose record has gone (pruned out of `agent-status.toml` between the render and
+        // the click) has nothing to show. Refusing is honest; opening an empty pane is not.
+        if crate::hooks::history::find(&self.agent_status_state, &run_key).is_none() {
+            return;
+        }
+        if self.palette_open {
+            self.close_palette(window, cx);
+        }
+        // Every other centre surface must be *left*, not merely stopped being drawn - see this
+        // module's docs, and `crate::review::render::AdeApp::leave_review_tab`'s own.
+        self.leave_graph_tab(window, cx);
+        self.graph_tab_open = false;
+        self.leave_review_tab(window, cx);
+        self.review_tab_open = None;
+
+        let was_active =
+            self.run_tab_active && self.run_tab_by_worktree.get(&worktree) == Some(&run_key);
+        self.run_tab_by_worktree.insert(worktree, run_key.clone());
+        self.run_tab_active = true;
+        self.open_change = None;
+        self.plus_menu_open = false;
+        self.title_menu_open = None;
+        self.prune_confirm_armed = false;
+        self.discard_confirm_armed = None;
+
+        // The same "leaving Files"/"leaving the code surface" sweep `open_review_tab` performs,
+        // for the identical reason: `self.open_change = None` above just unrendered the code
+        // surface this tab is replacing.
+        self.tree_context_menu = None;
+        self.tree_inline_edit = None;
+        if self.tree_focus_handle.is_focused(window) {
+            let fallback = self.focus_fallback_handle();
+            restore_focus(&self.agents, &mut self.code_focus, fallback, window, cx);
+        }
+        self.palette_focus.forget_target(&self.tree_focus_handle);
+        self.settings_focus.forget_target(&self.tree_focus_handle);
+        self.code_focus.forget_target(&self.tree_focus_handle);
+        if self.code_focus_handle.is_focused(window) {
+            let fallback = self.focus_fallback_handle();
+            restore_focus(&self.agents, &mut self.code_focus, fallback, window, cx);
+        }
+        self.palette_focus.forget_target(&self.code_focus_handle);
+        self.settings_focus.forget_target(&self.code_focus_handle);
+        self.refresh_open_diff_file_cache();
+
+        if !was_active && !self.focus_is_on_an_overlay(window, cx) {
+            self.run_tab_focus.capture(window, &self.agents, cx);
+        }
+        window.focus(&self.run_tab_focus_handle, cx);
+
+        // The one real read this surface needs, asked for once per run - see
+        // `crate::run_history::flow::AdeApp::load_run_transcript`.
+        self.load_run_transcript(run_key, cx);
+        // A freshly opened transcript starts at its own beginning, not at wherever the last one
+        // was left: the handle is shared across runs (there is only ever one of these tabs), so
+        // without this a short run would open scrolled past its own end.
+        self.run_tab_scroll_handle
+            .set_offset(gpui::Point::default());
+        cx.notify();
+    }
+
+    /// Closes the run tab outright (its `×`), removing it from this worktree's strip. The stored
+    /// transcript is untouched - closing a recording does not delete it.
+    pub(crate) fn close_run_tab(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.leave_run_tab(window, cx);
+        if let Some(worktree) = self.current_worktree_path() {
+            self.run_tab_by_worktree.remove(&worktree);
+        }
+        cx.notify();
+    }
+
+    /// Common bookkeeping whenever the run tab stops being the active centre-pane content -
+    /// selecting an agent/file/graph/review tab while it was showing, or closing it outright. A
+    /// no-op if it wasn't active.
+    ///
+    /// [`Self::run_tab_focus_handle`] is about to stop being `track_focus`'d
+    /// ([`Self::render_run_view`] is only rendered while `run_tab_active`), so real keyboard focus
+    /// moves off it *first*, before anything else can capture it as an [`OverlayFocus`] return
+    /// target - and any target already holding it from earlier is swept. See this module's docs.
+    pub(crate) fn leave_run_tab(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if !self.run_tab_active {
+            return;
+        }
+        self.run_tab_active = false;
+        if self.run_tab_focus_handle.is_focused(window) {
+            let fallback = self.focus_fallback_handle();
+            restore_focus(&self.agents, &mut self.run_tab_focus, fallback, window, cx);
+        }
+        self.palette_focus.forget_target(&self.run_tab_focus_handle);
+        self.settings_focus
+            .forget_target(&self.run_tab_focus_handle);
+        self.code_focus.forget_target(&self.run_tab_focus_handle);
+        self.graph_focus.forget_target(&self.run_tab_focus_handle);
+        self.review_focus.forget_target(&self.run_tab_focus_handle);
+    }
+
+    /// Which run this worktree's run tab is showing, if it has one open.
+    pub(crate) fn open_run_key(&self) -> Option<String> {
+        let worktree = self.current_worktree_path()?;
+        self.run_tab_by_worktree.get(&worktree).cloned()
+    }
+
+    /// The record behind [`Self::open_run_key`], re-read from the store on every render rather
+    /// than snapshotted at open time: a run that finished while its own tab was open (the
+    /// `Archive run` path) gains its real ending and diffstat, and the header must show them
+    /// rather than the state it was opened in.
+    fn open_run(&self) -> Option<crate::hooks::history::PastAgent> {
+        crate::hooks::history::find(&self.agent_status_state, &self.open_run_key()?)
+    }
+
+    /// The whole run-transcript body: header, dimmed transcript, footer.
+    pub(crate) fn render_run_view(&mut self, cx: &mut Context<Self>) -> gpui::AnyElement {
+        let Some(run) = self.open_run() else {
+            // The record went away underneath an open tab (pruned by
+            // `AgentStatusState::prune_to_most_recent`). Say so rather than paint a blank pane.
+            return div()
+                .id("run-view")
+                .track_focus(&self.run_tab_focus_handle)
+                .flex()
+                .flex_col()
+                .flex_1()
+                .min_h_0()
+                .min_w_0()
+                .bg(theme::surface::CENTER)
+                .child(crate::root::widgets::render_sidebar_message(
+                    "This run is no longer in the history.".to_string(),
+                    theme::text::GHOST.into(),
+                ))
+                .into_any_element();
+        };
+
+        let now_unix = crate::run_history::unix_now();
+        let branch = self
+            .repos
+            .iter()
+            .flat_map(|repo| repo.worktrees.iter())
+            .find(|item| item.path == run.worktree)
+            .and_then(|item| item.branch.clone());
+        let captured = self
+            .run_transcripts
+            .get(&run.key)
+            .cloned()
+            .flatten()
+            .unwrap_or_default();
+        let lines = model::transcript_body(
+            &run,
+            branch.as_deref(),
+            (!captured.is_empty()).then_some(captured.as_slice()),
+            now_unix,
+        );
+        let drift = self
+            .run_drift
+            .get(&run.worktree)
+            .and_then(|counts| counts.get(&run.key).copied());
+
+        div()
+            .id("run-view")
+            .debug_selector(|| "run-view".to_string())
+            .track_focus(&self.run_tab_focus_handle)
+            .flex()
+            .flex_col()
+            .flex_1()
+            .min_h_0()
+            .min_w_0()
+            .bg(theme::surface::CENTER)
+            .child(self.render_run_header(&run, now_unix))
+            .child(self.render_run_transcript(&lines, cx))
+            .child(self.render_run_footer(&run, drift, cx))
+            .into_any_element()
+    }
+
+    /// §3's header: "agent chip · title · `<agent> · <when> · 24m · 21 turns · 6 files · +148
+    /// −96` · outcome pill".
+    fn render_run_header(
+        &self,
+        run: &crate::hooks::history::PastAgent,
+        now_unix: i64,
+    ) -> impl IntoElement + use<> {
+        let outcome = model::Outcome::of(run);
+        div()
+            .flex()
+            .flex_none()
+            .items_center()
+            .gap(px(8.0))
+            .px(px(12.0))
+            .h(theme::band::CONTEXT_BAR)
+            // The same band and the same fill the agent context bar one surface over uses - a
+            // centre pane's header row is one control, drawn wherever the centre pane is.
+            .bg(theme::surface::HEADER)
+            .border_b_1()
+            .border_color(theme::border::INNER)
+            .debug_selector(|| "run-header".to_string())
+            .child(self.render_agent_chip_icon(
+                ProcessKind::Agent(run.kind),
+                px(15.0),
+                self.ui_text_size(9.0),
+            ))
+            .child(
+                div()
+                    .flex_none()
+                    .max_w(px(320.0))
+                    .truncate()
+                    .font(font(theme::font::SANS))
+                    .font_weight(gpui::FontWeight::MEDIUM)
+                    .text_size(self.ui_text_size(11.5))
+                    .text_color(theme::text::SELECTED)
+                    .child(model::run_title(run)),
+            )
+            .child(
+                div()
+                    .flex_1()
+                    .min_w_0()
+                    .truncate()
+                    .font(font(theme::font::MONO))
+                    .text_size(self.ui_text_size(9.5))
+                    .text_color(theme::text::FAINT)
+                    .debug_selector(|| "run-header-meta".to_string())
+                    .child(model::run_meta_line(run, now_unix)),
+            )
+            .child(
+                div()
+                    .flex_none()
+                    .px(px(6.0))
+                    .py(px(2.0))
+                    .rounded(theme::radius::CHIP)
+                    .bg(outcome.bg())
+                    .font(font(theme::font::MONO))
+                    .text_size(self.ui_text_size(9.5))
+                    .text_color(outcome.fg())
+                    .debug_selector(|| "run-outcome-pill".to_string())
+                    .child(outcome.label()),
+            )
+    }
+
+    /// The transcript itself, at §3's 70% opacity - "the one signal that this is a recording, not
+    /// a live pane".
+    ///
+    /// A monospace text block rather than a real [`crate::terminal::pane::TerminalPane`], and
+    /// deliberately: a pane is a live pty with a cursor you can type into, and half of §3's own
+    /// warning is about a recording that looks answerable. There is nothing here to type into.
+    fn render_run_transcript(
+        &self,
+        lines: &[model::TranscriptLine],
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement + use<> {
+        div()
+            .relative()
+            .flex()
+            .flex_1()
+            .min_h_0()
+            .min_w_0()
+            .child(
+                div()
+                    .id("run-transcript")
+                    .debug_selector(|| "run-transcript".to_string())
+                    .flex_1()
+                    .min_w_0()
+                    .overflow_y_scroll()
+                    .track_scroll(&self.run_tab_scroll_handle)
+                    .px(px(14.0))
+                    .py(px(10.0))
+                    .opacity(theme::history::TRANSCRIPT_OPACITY)
+                    .font(font(theme::font::MONO))
+                    .text_size(self.ui_text_size(11.0))
+                    .children(lines.iter().map(|line| {
+                        div()
+                            .text_color(line.tone.color())
+                            // An empty line still has to occupy one: a `div` with no child has no
+                            // intrinsic height, so the blank the model puts before the closing
+                            // line would silently vanish and the two would run together.
+                            .child(if line.text.is_empty() {
+                                gpui::SharedString::from("\u{a0}")
+                            } else {
+                                gpui::SharedString::from(line.text.clone())
+                            })
+                    })),
+            )
+            .children(crate::root::scrollbar::render_vertical_scrollbar(
+                "run-transcript-scrollbar",
+                &self.run_tab_scroll_handle,
+                &[],
+                cx,
+            ))
+    }
+
+    /// §3's footer: "drift dot, the consequence sentence, **Resume here** ... and `Start a new
+    /// agent from this`."
+    ///
+    /// Both actions are real and neither is tiered (§3: "every run resumes"). `Resume here` is
+    /// `crate::hooks::flow::AdeApp::resume_past_agent` - a literal `claude --resume <session_id>`
+    /// where the run's hooks caught one, and an honest fresh agent in the same checkout where
+    /// they did not. `Start a new agent from this` is deliberately the *other* thing: a clean
+    /// agent of the same kind in the same checkout, carrying none of this run's conversation.
+    ///
+    /// A run whose drift has not been answered yet paints no dot and no sentence, for
+    /// [`crate::run_history::model::RunEntry::drift`]'s reason - `Nothing has landed since this
+    /// run ended` is a real claim about the branch, and making it before the traversal answered
+    /// would be a guess dressed as the most reassuring of the three bands.
+    fn render_run_footer(
+        &self,
+        run: &crate::hooks::history::PastAgent,
+        drift: Option<usize>,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement + use<> {
+        let resume_key = run.key.clone();
+        let kind = run.kind;
+        let worktree = run.worktree.clone();
+
+        let mut bar = div()
+            .flex()
+            .flex_none()
+            .items_center()
+            .gap(px(7.0))
+            .px(px(12.0))
+            .h(theme::band::SURFACE_FOOTER)
+            .bg(theme::surface::FOOTER)
+            .border_t_1()
+            .border_color(theme::border::INNER)
+            .debug_selector(|| "run-footer".to_string());
+
+        if let Some(commits) = drift {
+            let band = model::DriftBand::of(commits);
+            bar = bar
+                .child(
+                    div()
+                        .flex_none()
+                        .w(px(5.0))
+                        .h(px(5.0))
+                        .rounded_full()
+                        .bg(band.dot())
+                        .debug_selector(|| "run-drift-dot".to_string()),
+                )
+                .child(
+                    div()
+                        .flex_1()
+                        .min_w_0()
+                        .truncate()
+                        .font(font(theme::font::SANS))
+                        .text_size(self.ui_text_size(10.5))
+                        .text_color(band.text())
+                        .debug_selector(|| "run-drift-sentence".to_string())
+                        .child(model::drift_sentence(commits)),
+                );
+        } else {
+            bar = bar.child(div().flex_1().min_w_0());
+        }
+
+        bar.child(
+            div()
+                .id("run-resume")
+                .debug_selector(|| "run-resume".to_string())
+                .flex_none()
+                .cursor_pointer()
+                .px(px(9.0))
+                .py(px(3.0))
+                .rounded(theme::radius::BUTTON)
+                .border_1()
+                .border_color(theme::history::RESUME_BORDER)
+                .bg(theme::history::RESUME_BG)
+                .hover(|el| el.bg(theme::history::RESUME_BG_HOVER))
+                .font(font(theme::font::SANS))
+                .text_size(self.ui_text_size(10.5))
+                .text_color(theme::history::RESUME_FG)
+                .tooltip(text_tooltip(
+                    "Continues this run's own conversation in its checkout, where one was recorded",
+                ))
+                .child("Resume here")
+                .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
+                    if this.resume_past_agent(&resume_key, window, cx) {
+                        // The resumed agent is now the centre pane's real content; leaving this
+                        // tab is what `resume_past_agent`'s own `focus_newly_spawned_agent` needs
+                        // to have any effect (see this module's docs on the focus discipline).
+                        this.leave_run_tab(window, cx);
+                    }
+                })),
+        )
+        .child(
+            div()
+                .id("run-start-new")
+                .debug_selector(|| "run-start-new".to_string())
+                .flex_none()
+                .cursor_pointer()
+                .px(px(9.0))
+                .py(px(3.0))
+                .rounded(theme::radius::BUTTON)
+                // The app's own outline action button (`work_surface::action_button_colors`'s
+                // `Outline`): no fill, `border::BUTTON`, `text::SECONDARY`. Secondary beside the
+                // green primary, which is what the pair is.
+                .border_1()
+                .border_color(theme::border::BUTTON)
+                .hover(|el| el.bg(theme::surface::ROW_HOVER_ALT))
+                .font(font(theme::font::SANS))
+                .text_size(self.ui_text_size(10.5))
+                .text_color(theme::text::SECONDARY)
+                .tooltip(text_tooltip(
+                    "A fresh agent of the same kind in this checkout - it carries none of this \
+                     run's conversation",
+                ))
+                .child("Start a new agent from this")
+                .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
+                    this.select_worktree_by_path(&worktree, window, cx);
+                    this.leave_run_tab(window, cx);
+                    this.new_agent(ProcessKind::Agent(kind), window, cx);
+                })),
+        )
+    }
+}
+
+/// The tab strip's own run entry, rendered only for [`work_surface::TabRef::Run`] - which
+/// `work_surface::state::reconcile_tab_order` only ever produces while this worktree really has
+/// one open.
+///
+/// §3's label: "Tab label `sonnet-4.5 · today 09:41`, chip in the agent's tint, closeable" - with
+/// this app's real agent-kind label in place of the mock's model name, since Jerry knows which
+/// CLI it spawned and does not know which model that CLI chose
+/// ([`crate::run_history::model::run_tab_label`]).
+pub(crate) fn render_run_tab(app: &AdeApp, cx: &mut Context<AdeApp>) -> gpui::AnyElement {
+    let is_active = app.run_tab_active;
+    let colors = crate::work_surface::state::tab_colors(is_active);
+    let close_color = if is_active {
+        theme::text::DIMMER
+    } else {
+        theme::text::DISABLED
+    };
+    let run = app
+        .open_run_key()
+        .and_then(|key| crate::hooks::history::find(&app.agent_status_state, &key));
+    let (label, chip) = match &run {
+        Some(run) => (
+            model::run_tab_label(run, crate::run_history::unix_now()),
+            app.render_agent_chip_icon(
+                ProcessKind::Agent(run.kind),
+                px(14.0),
+                app.ui_text_size(8.5),
+            ),
+        ),
+        // Unreachable in practice - `reconcile_tab_order` only yields `Run` when the map holds a
+        // key - but a record can be pruned between two frames, and a tab that renamed itself to
+        // nothing would be worse than one that says what it is.
+        None => ("run".to_string(), gpui::Empty.into_any_element()),
+    };
+
+    let close_button = app.render_tab_close_button(
+        "close-run-tab",
+        close_color,
+        None,
+        |this, window, cx| {
+            this.close_run_tab(window, cx);
+        },
+        cx,
+    );
+
+    let content: Vec<gpui::AnyElement> = vec![
+        chip,
+        div()
+            .font(font(theme::font::MONO))
+            .font_weight(gpui::FontWeight::MEDIUM)
+            .text_size(app.ui_text_size(11.0))
+            .text_color(colors.label)
+            .child(label.clone())
+            .into_any_element(),
+        close_button.into_any_element(),
+    ];
+
+    app.render_tab_chrome(
+        TabChromeArgs {
+            outer_id: "run-tab".into(),
+            hit_id: "run-tab-hit".into(),
+            tab_ref: work_surface::TabRef::Run,
+            drag_value: DraggedTab::Run { label },
+            is_active,
+            content,
+            on_middle_click: Box::new(|this, window, cx| {
+                this.close_run_tab(window, cx);
+            }),
+            on_activate: Box::new(move |this, window, cx| {
+                let Some(worktree) = this.current_worktree_path() else {
+                    return;
+                };
+                let Some(key) = this.run_tab_by_worktree.get(&worktree).cloned() else {
+                    return;
+                };
+                this.open_run_tab(worktree, key, window, cx);
+            }),
+            debug_selector: Some("run-tab"),
+        },
+        cx,
+    )
+}

--- a/crates/app/src/run_history/tab.rs
+++ b/crates/app/src/run_history/tab.rs
@@ -1,0 +1,2 @@
+//! placeholder
+use super::*;

--- a/crates/app/src/run_history/transcript_store.rs
+++ b/crates/app/src/run_history/transcript_store.rs
@@ -1,0 +1,264 @@
+//! Real, on-disk transcripts for finished runs, **keyed by run id** (GitHub issue #227).
+//!
+//! `design_handoff_jerry_ade/revision 5/REVISION-2026-08-13.md` §3: "Archived runs carry their own
+//! transcript, keyed by run id (`runOutputs`), never the live agent's buffer." This module is that
+//! key-value store, and the key is the same [`crate::review::state::baseline_key`] every other
+//! per-run persisted thing in this app is filed under, so a transcript can never end up attached
+//! to a different run than the record beside it.
+//!
+//! ## Why a directory of files rather than more fields in `agent-status.toml`
+//!
+//! [`crate::hooks::store`]'s file is rewritten and `fsync`ed under a process-wide lock on **every
+//! status change**, for up to 500 records. A transcript is kilobytes of text; putting them in that
+//! file would multiply the cost of every routine `Run` -> `Idle` transition by the whole
+//! history's worth of terminal output. Here, a transcript is written exactly once - when its run
+//! ends - and read exactly once - when its tab is opened.
+//!
+//! ## What is stored
+//!
+//! Plain UTF-8 text, one line per line, exactly as the run's own pane held it
+//! (`crate::terminal::pane::TerminalPane::retained_text_lines`). Deliberately no colours: the tab
+//! renders a recording at 70% opacity in one body tone (see
+//! `crate::run_history::model::LineTone`), and storing per-cell attributes would be storing
+//! something nothing reads.
+//!
+//! Bounded twice, because a terminal's retained scrollback is bounded only by
+//! `alacritty_terminal`'s own 10 000-line history: at most [`MAX_TRANSCRIPT_LINES`] lines and
+//! [`MAX_TRANSCRIPT_BYTES`] bytes, keeping the **end** of the run in both cases - the tail is
+//! where a run says what it did.
+//!
+//! ## Failure is never fatal
+//!
+//! Every function here degrades to "no transcript" rather than to an error the user has to deal
+//! with. A run whose transcript could not be written, or could not be read back, gets the
+//! synthesised body `crate::run_history::model::transcript_body` produces from its own record -
+//! which is a real, honest surface, not a fallback that pretends.
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+/// The directory transcripts live in, a sibling of the real `settings.toml` and of
+/// `agent-status.toml` itself.
+pub const TRANSCRIPT_DIR_NAME: &str = "run-transcripts";
+
+/// The most lines one stored transcript keeps. Generous enough to hold a long run's whole
+/// conversation, small enough that a full history directory stays a few megabytes.
+pub const MAX_TRANSCRIPT_LINES: usize = 400;
+
+/// The most bytes one stored transcript keeps, applied after [`MAX_TRANSCRIPT_LINES`] - a
+/// belt-and-braces bound for the pathological case of a run that printed a minified bundle.
+pub const MAX_TRANSCRIPT_BYTES: usize = 256 * 1024;
+
+/// The transcript directory for a given real settings-file path - identical reasoning to
+/// [`crate::hooks::store::agent_status_path_for`]: a test supplying a temp-dir settings path gets
+/// real, isolated persistence there, and a `None` settings path gets none.
+pub fn transcript_dir_for(settings_path: &Path) -> PathBuf {
+    match settings_path.parent() {
+        Some(parent) => parent.join(TRANSCRIPT_DIR_NAME),
+        None => PathBuf::from(TRANSCRIPT_DIR_NAME),
+    }
+}
+
+/// The file one run's transcript lives in.
+///
+/// The run key is hashed rather than used directly, because it is a real
+/// [`crate::review::state::baseline_key`] - a worktree path, a kind and a timestamp joined by
+/// `|`. That contains `/`, `\` and (on the `bytes:` arm) arbitrary escaped bytes, none of which
+/// are legal in a filename on every platform, and it can be far longer than the 255-byte component
+/// limit of most filesystems. SHA-256 is already a direct dependency of this crate and of
+/// `wt-core` (whose `review::baseline_ref_name` hashes the very same keys, for the very same
+/// reason), so this is the established answer to this exact problem here rather than a new one.
+pub fn transcript_path(dir: &Path, run_key: &str) -> PathBuf {
+    let digest = Sha256::digest(run_key.as_bytes());
+    dir.join(format!("{digest:x}.txt"))
+}
+
+/// Applies both bounds, keeping the **end** of the run.
+fn bounded(lines: &[String]) -> Vec<String> {
+    let start = lines.len().saturating_sub(MAX_TRANSCRIPT_LINES);
+    let mut kept: Vec<String> = lines[start..].to_vec();
+    // `+ 1` per line for the newline that will join them, so the bound really is a bound on what
+    // gets written rather than on the sum of the pieces.
+    let mut bytes: usize = kept.iter().map(|line| line.len() + 1).sum();
+    while bytes > MAX_TRANSCRIPT_BYTES && !kept.is_empty() {
+        let dropped = kept.remove(0);
+        bytes -= dropped.len() + 1;
+    }
+    kept
+}
+
+/// Writes one run's transcript. A run with nothing to store writes no file at all, so "this run
+/// has no stored transcript" and "this run stored an empty one" are the same state on disk rather
+/// than two that read differently.
+///
+/// Not atomic (no temp-and-rename) unlike this app's other persisted state, and deliberately: a
+/// transcript is written exactly once, by exactly one instance, for a key nothing else will ever
+/// write again, so there is no concurrent writer to lose a race with. A torn write from a crash
+/// mid-`write_all` leaves a truncated transcript, which reads back as a shorter transcript - not
+/// as corruption, because there is no structure to corrupt.
+pub fn save(dir: &Path, run_key: &str, lines: &[String]) -> io::Result<()> {
+    let lines = bounded(lines);
+    if lines.is_empty() {
+        return Ok(());
+    }
+    std::fs::create_dir_all(dir)?;
+    std::fs::write(transcript_path(dir, run_key), lines.join("\n"))
+}
+
+/// Reads one run's transcript back. `None` for a run that has none, and for any read failure -
+/// see the module docs on why that is never surfaced as an error.
+pub fn load(dir: &Path, run_key: &str) -> Option<Vec<String>> {
+    let contents = std::fs::read_to_string(transcript_path(dir, run_key)).ok()?;
+    let lines: Vec<String> = contents.lines().map(str::to_owned).collect();
+    (!lines.is_empty()).then_some(lines)
+}
+
+/// Deletes every transcript whose run is no longer in `live_keys`.
+///
+/// [`crate::hooks::store::AgentStatusState::prune_to_most_recent`] caps the record file at 500
+/// runs, and a transcript whose record has been pruned is unreachable: nothing can open a tab for
+/// a run that is not in the history list. Without this, the directory would be the one piece of
+/// this feature that grows forever.
+///
+/// Errors are counted, not propagated: a file that will not delete is a wasted few kilobytes, and
+/// failing a run's *close* over it would be absurd. Returns how many files were really removed.
+pub fn prune(dir: &Path, live_keys: &std::collections::BTreeSet<String>) -> usize {
+    let live_names: std::collections::HashSet<PathBuf> = live_keys
+        .iter()
+        .map(|key| transcript_path(dir, key))
+        .collect();
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    let mut removed = 0;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().is_some_and(|extension| extension == "txt")
+            && !live_names.contains(&path)
+            && std::fs::remove_file(&path).is_ok()
+        {
+            removed += 1;
+        }
+    }
+    removed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn the_transcript_directory_sits_next_to_the_real_settings_file() {
+        assert_eq!(
+            transcript_dir_for(Path::new("/home/someone/.config/jerry/settings.toml")),
+            PathBuf::from("/home/someone/.config/jerry/run-transcripts")
+        );
+    }
+
+    #[test]
+    fn a_transcript_really_round_trips_through_a_real_file() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let key = "utf8:/repo/wt-a|Claude|1700000000";
+        let lines = vec![
+            "\u{276f} claude".to_string(),
+            String::new(),
+            "\u{25cf} done".to_string(),
+        ];
+        save(dir.path(), key, &lines).expect("must save");
+        assert_eq!(load(dir.path(), key), Some(lines));
+    }
+
+    /// The key is a real `baseline_key` - a path with separators in it. It must never reach the
+    /// filesystem as a filename.
+    #[test]
+    fn a_run_key_full_of_path_separators_still_produces_one_legal_filename() {
+        let dir = Path::new("/tmp/jerry-transcripts");
+        let path = transcript_path(dir, "utf8:/deep/nested/worktree/path|Claude|1700000000");
+        let name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("a real filename");
+        assert!(name.ends_with(".txt"));
+        assert_eq!(name.len(), 64 + 4, "a hex sha-256 plus the extension");
+        assert!(!name.contains('/') && !name.contains('|'));
+        assert_eq!(path.parent(), Some(dir));
+    }
+
+    #[test]
+    fn two_different_runs_never_share_a_transcript_file() {
+        let dir = Path::new("/tmp/jerry-transcripts");
+        assert_ne!(
+            transcript_path(dir, "utf8:/repo/wt|Claude|1"),
+            transcript_path(dir, "utf8:/repo/wt|Claude|2")
+        );
+    }
+
+    #[test]
+    fn a_run_with_nothing_to_store_writes_no_file_at_all() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        save(dir.path(), "k", &[]).expect("must not fail");
+        assert_eq!(load(dir.path(), "k"), None);
+        assert!(
+            !transcript_path(dir.path(), "k").exists(),
+            "an empty transcript must not leave a file behind"
+        );
+    }
+
+    #[test]
+    fn the_line_cap_keeps_the_end_of_the_run() {
+        let lines: Vec<String> = (0..(MAX_TRANSCRIPT_LINES + 50))
+            .map(|index| format!("line {index}"))
+            .collect();
+        let kept = bounded(&lines);
+        assert_eq!(kept.len(), MAX_TRANSCRIPT_LINES);
+        assert_eq!(
+            kept.last().map(String::as_str),
+            Some(format!("line {}", MAX_TRANSCRIPT_LINES + 49).as_str()),
+            "the tail is where a run says what it did"
+        );
+    }
+
+    #[test]
+    fn the_byte_cap_is_a_real_bound_on_what_is_written() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let lines: Vec<String> = (0..200).map(|_| "x".repeat(4000)).collect();
+        save(dir.path(), "big", &lines).expect("must save");
+        let written = std::fs::metadata(transcript_path(dir.path(), "big"))
+            .expect("the file must exist")
+            .len() as usize;
+        assert!(
+            written <= MAX_TRANSCRIPT_BYTES,
+            "{written} bytes exceeds the cap"
+        );
+        let kept = load(dir.path(), "big").expect("something must survive");
+        assert!(!kept.is_empty());
+    }
+
+    #[test]
+    fn pruning_removes_exactly_the_transcripts_whose_runs_are_gone() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        for key in ["kept-a", "kept-b", "dropped"] {
+            save(dir.path(), key, &[format!("transcript for {key}")]).expect("must save");
+        }
+        let live: BTreeSet<String> = ["kept-a".to_string(), "kept-b".to_string()]
+            .into_iter()
+            .collect();
+
+        assert_eq!(prune(dir.path(), &live), 1);
+        assert!(load(dir.path(), "kept-a").is_some());
+        assert!(load(dir.path(), "kept-b").is_some());
+        assert_eq!(load(dir.path(), "dropped"), None);
+    }
+
+    #[test]
+    fn pruning_a_directory_that_does_not_exist_is_a_no_op() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        assert_eq!(
+            prune(&dir.path().join("never-created"), &BTreeSet::new()),
+            0
+        );
+    }
+}

--- a/crates/app/src/settings/theme_file_format.rs
+++ b/crates/app/src/settings/theme_file_format.rs
@@ -50,7 +50,7 @@ const SECTIONS: &[(&str, &[&str])] = &[
     (
         "Meaning and state (colour carries information here)",
         &[
-            "status", "diff", "tag", "rail", "agent", "changes", "budget", "notes",
+            "status", "diff", "tag", "rail", "agent", "changes", "budget", "notes", "history",
         ],
     ),
     (

--- a/crates/app/src/terminal/grid.rs
+++ b/crates/app/src/terminal/grid.rs
@@ -782,6 +782,51 @@ impl TerminalGrid {
         grid.update_history(real_cap);
     }
 
+    /// Everything this terminal has really printed that it still holds - retained scrollback
+    /// *and* the visible screen - as trimmed-right text lines, oldest first, capped to the last
+    /// `max_lines` of it. GitHub issue #227's real transcript capture: what an agent's own pane
+    /// actually said, kept when its run ends so History can show the run's own output rather than
+    /// a synthesised stand-in.
+    ///
+    /// Deliberately *not* [`Self::visible_rows`]: that is one screenful resolved against a
+    /// palette for painting, and a transcript that stopped at the last 30 rows would cut the run
+    /// off mid-sentence. This reads the raw grid, history included, exactly as
+    /// `Term::line_to_string` does for a clipboard copy - the same `Flags::WIDE_CHAR_SPACER` skip
+    /// (see the module docs) and the same "text only, no colour" contract [`Self::selected_text`]
+    /// has, since nothing downstream of a stored transcript re-renders ANSI attributes.
+    ///
+    /// Blank lines at both ends are dropped: a pane is a fixed-height grid, so a short run leaves
+    /// the rest of the screen as empty rows that are an artefact of the grid's shape, not
+    /// something the program printed.
+    pub fn retained_text_lines(&self, max_lines: usize) -> Vec<String> {
+        let grid = self.term.grid();
+        let history = grid.history_size() as i32;
+        let screen = grid.screen_lines() as i32;
+        let mut lines: Vec<String> = Vec::with_capacity((history + screen).max(0) as usize);
+        for index in -history..screen {
+            let row = &grid[Line(index)];
+            let text: String = row
+                .into_iter()
+                // The spacer's `' '` was written by the emulator, not by the program - keeping it
+                // would put a stray space after every wide character, the identical reasoning
+                // `crate::terminal::pane::TerminalPane::visible_text_lines` already applies.
+                .filter(|cell| !cell.flags.contains(Flags::WIDE_CHAR_SPACER))
+                .map(|cell| cell.c)
+                .collect();
+            lines.push(text.trim_end().to_string());
+        }
+        while lines.first().is_some_and(|line| line.is_empty()) {
+            lines.remove(0);
+        }
+        while lines.last().is_some_and(|line| line.is_empty()) {
+            lines.pop();
+        }
+        if lines.len() > max_lines {
+            lines.drain(..lines.len() - max_lines);
+        }
+        lines
+    }
+
     /// `true` once [`Self::scroll_offset`] is anything other than live - i.e. the pane is
     /// genuinely showing scrollback rather than the live tail right now.
     pub fn is_scrolled_back(&self) -> bool {
@@ -1190,6 +1235,66 @@ mod tests {
             grid.append_bytes(format!("line {i}\r\n").as_bytes());
         }
         grid
+    }
+
+    /// GitHub issue #227's transcript capture, at the grid level: a run's stored transcript must
+    /// be the run's *whole* retained output, not the last screenful, and must stop at the cap.
+    mod retained_transcript_tests {
+        use super::*;
+
+        #[test]
+        fn a_transcript_reaches_back_past_the_visible_screen_into_real_scrollback() {
+            // Five visible rows, thirty printed lines - twenty-five of them are only in history.
+            let grid = grid_with_numbered_lines(5, 20, 30);
+            let lines = grid.retained_text_lines(1000);
+            assert_eq!(
+                lines.len(),
+                30,
+                "every printed line must survive, not just the visible screenful"
+            );
+            assert_eq!(lines.first().map(String::as_str), Some("line 0"));
+            assert_eq!(lines.last().map(String::as_str), Some("line 29"));
+        }
+
+        #[test]
+        fn the_cap_keeps_the_end_of_the_run_not_its_beginning() {
+            let grid = grid_with_numbered_lines(5, 20, 30);
+            let lines = grid.retained_text_lines(4);
+            assert_eq!(
+                lines,
+                vec![
+                    "line 26".to_string(),
+                    "line 27".to_string(),
+                    "line 28".to_string(),
+                    "line 29".to_string(),
+                ],
+                "a capped transcript must end where the run ended"
+            );
+        }
+
+        /// A pane is a fixed-height grid, so a two-line run leaves the rest of the screen as
+        /// empty rows. Those are the grid's shape, not the program's output.
+        #[test]
+        fn the_empty_rest_of_the_screen_is_not_part_of_the_transcript() {
+            let mut grid = TerminalGrid::new(10, 20);
+            grid.append_bytes(b"first\r\nsecond\r\n");
+            assert_eq!(
+                grid.retained_text_lines(1000),
+                vec!["first".to_string(), "second".to_string()]
+            );
+        }
+
+        /// The same wide-character rule the painter and the clipboard already follow: the spacer
+        /// cell's `' '` belongs to the emulator, not to the program.
+        #[test]
+        fn a_wide_character_contributes_one_char_not_two() {
+            let mut grid = TerminalGrid::new(4, 20);
+            grid.append_bytes("\u{4f60}\u{597d} ok\r\n".as_bytes());
+            assert_eq!(
+                grid.retained_text_lines(1000),
+                vec!["\u{4f60}\u{597d} ok".to_string()]
+            );
+        }
     }
 
     mod scrollback_tests {

--- a/crates/app/src/terminal/pane.rs
+++ b/crates/app/src/terminal/pane.rs
@@ -1550,6 +1550,17 @@ impl TerminalPane {
             .collect()
     }
 
+    /// Everything this pane's process has really printed that the emulator still holds, capped to
+    /// the last `max_lines` - see [`crate::terminal::grid::TerminalGrid::retained_text_lines`].
+    ///
+    /// GitHub issue #227's transcript capture reads this once, at the moment a run ends
+    /// (`crate::run_history::flow::AdeApp::capture_run_transcript`), because that is the last
+    /// moment the run's own output exists anywhere: `Agents::close` shuts the pane down and drops
+    /// the grid with it.
+    pub fn retained_text_lines(&self, max_lines: usize) -> Vec<String> {
+        self.grid.retained_text_lines(max_lines)
+    }
+
     fn spawn_process(&mut self, cx: &mut Context<Self>) {
         let spec = self.spec.clone();
         let program_for_error = spec.program.clone();

--- a/crates/app/src/theme.rs
+++ b/crates/app/src/theme.rs
@@ -287,6 +287,7 @@ pub const TOKEN_GROUPS: &[(&str, &[(&str, ColorToken)])] = &[
     ("budget", budget::TOKENS),
     ("status_bar", status_bar::TOKENS),
     ("notes", notes::TOKENS),
+    ("history", history::TOKENS),
 ];
 
 /// Every real registered [`ColorToken`], flattened across [`TOKEN_GROUPS`] - registry order
@@ -2997,6 +2998,149 @@ pub mod notes {
         ("SEND_HOVER_BG", SEND_HOVER_BG),
         ("SEND_FG", SEND_FG),
         ("SEND_CAP_FG", SEND_CAP_FG),
+    ];
+}
+
+/// Agent history - the sidebar's run list and the run-transcript tab (GitHub issue #227,
+/// `design_handoff_jerry_ade/revision 5/REVISION-2026-08-13.md` §4/§5, transcribed from that
+/// revision's own tables and from `revision 5/tokens.rs`'s `history` module).
+///
+/// # Two independent axes
+///
+/// §5, verbatim: "**Outcome and drift are independent axes**: an abandoned run at the tip is the
+/// most resumable thing in the list." That is why they are two separate families here and why no
+/// token is shared between them - a row saying `abandoned` in grey next to a green `at the tip`
+/// dot is the design working, not a contradiction to be tidied away.
+///
+/// # Outcome: four values, and deliberately no `merged`
+///
+/// §5's table, in full:
+///
+/// | Outcome | fg / bg |
+/// |---|---|
+/// | `done` | `#7fc79a` / `#16261e` |
+/// | `interrupted` | `#c99b4e` / `#2b2413` |
+/// | `failed` | `#c4726d` / `#2a1719` |
+/// | `abandoned` | `#8b9197` / `#1e2225` |
+///
+/// There is no `OUT_MERGED` and there must never be one: "**merging happens to a branch, not to a
+/// run.** A run whose code later merged simply finished; whether the branch merged is already on
+/// the worktree row in the rail (`merged · prunable`)."
+///
+/// These four reuse the app's reserved green/amber/red/neutral families rather than introducing
+/// new hues, which is exactly what those families are reserved for (see [`agent`]'s own docs):
+/// this is outcome signalling, not identity.
+///
+/// # Drift: three bands
+///
+/// §4's table:
+///
+/// | Commits since | Shown | Dot |
+/// |---|---|---|
+/// | 0 | `at the tip` | `#5cb87f` |
+/// | 1-2 | `N commits since` | `#8fbde6` |
+/// | 3+ | `N commits since` in `#a3873f` | `#c99b4e` |
+///
+/// Only the far band tints its *text* ([`DRIFT_FAR_TEXT`]); the other two leave it in the row's
+/// own dim foreground ([`DRIFT_TEXT`]), so colour on the label means "this one has moved a long
+/// way" rather than merely restating the dot.
+pub mod history {
+    use super::{token, ColorToken};
+
+    /// `done` - its last turn ended cleanly and Jerry watched it end.
+    pub const OUT_DONE_FG: ColorToken = token("history.out_done_fg", 0x7fc79a);
+    pub const OUT_DONE_BG: ColorToken = token("history.out_done_bg", 0x16261e);
+    /// `interrupted` - ended while it was still working, or still waiting on a human.
+    pub const OUT_INTERRUPTED_FG: ColorToken = token("history.out_interrupted_fg", 0xc99b4e);
+    pub const OUT_INTERRUPTED_BG: ColorToken = token("history.out_interrupted_bg", 0x2b2413);
+    /// `failed` - its last real signal was a failure.
+    pub const OUT_FAILED_FG: ColorToken = token("history.out_failed_fg", 0xc4726d);
+    pub const OUT_FAILED_BG: ColorToken = token("history.out_failed_bg", 0x2a1719);
+    /// `abandoned` - nobody ever saw it end.
+    pub const OUT_ABANDONED_FG: ColorToken = token("history.out_abandoned_fg", 0x8b9197);
+    pub const OUT_ABANDONED_BG: ColorToken = token("history.out_abandoned_bg", 0x1e2225);
+
+    /// Drift dot, 0 commits since - `at the tip`.
+    pub const DRIFT_TIP: ColorToken = token("history.drift_tip", 0x5cb87f);
+    /// Drift dot, 1-2 commits since.
+    pub const DRIFT_NEAR: ColorToken = token("history.drift_near", 0x8fbde6);
+    /// Drift dot, 3+ commits since.
+    pub const DRIFT_FAR: ColorToken = token("history.drift_far", 0xc99b4e);
+    /// The drift *label*, in the two bands that do not tint it (§4's table names a text colour
+    /// only for the far band). Shares [`text::FAINTER`]'s value, with its own key so a theme can
+    /// move the history list's own recessive text without moving the rail's.
+    pub const DRIFT_TEXT: ColorToken = token("history.drift_text", 0x5e646a);
+    /// The drift label in the far band only (§4: "`N commits since` in `#a3873f`").
+    pub const DRIFT_FAR_TEXT: ColorToken = token("history.drift_far_text", 0xa3873f);
+
+    /// The scope toggle's selected segment (`REVISION-2026-08-14.md` §6's `all` / `this worktree`
+    /// pair) - `Jerry.dc.html`'s own `hScopes` fill and border. Its own keys rather than
+    /// [`surface::SEGMENT_ACTIVE`]'s, because the mock draws this control as a *bordered* pill
+    /// inside a 27px band rather than as the settings screen's tracked segmented control.
+    pub const SCOPE_ON_BG: ColorToken = token("history.scope_on_bg", 0x1d2226);
+    pub const SCOPE_ON_BORDER: ColorToken = token("history.scope_on_border", 0x2a3138);
+    pub const SCOPE_ON_FG: ColorToken = token("history.scope_on_fg", 0xc2c7cc);
+    pub const SCOPE_OFF_FG: ColorToken = token("history.scope_off_fg", 0x5e646a);
+    pub const SCOPE_HOVER_BG: ColorToken = token("history.scope_hover_bg", 0x1b1f22);
+
+    /// The repo header label in the history list's repo → worktree → run hierarchy.
+    pub const REPO_LABEL: ColorToken = token("history.repo_label", 0x9aa1a8);
+    /// A worktree group's label when it is *not* the active worktree; the active one takes
+    /// [`text::SELECTED`] and the selection edge instead (§6: "Active worktree carries the blue
+    /// edge and opens by default").
+    pub const GROUP_LABEL: ColorToken = token("history.group_label", 0xa9b0b7);
+    /// A run row's title when the row is not the open one.
+    pub const ROW_TITLE: ColorToken = token("history.row_title", 0xc2c7cc);
+
+    /// The transcript body's four line tones, transcribed from `Jerry.dc.html`'s own `LFG` map
+    /// (`p` / `c` / `d` / `w`) - the leading `❯ claude --resume …` command line, ordinary body
+    /// text, the indented `⎿ …` detail lines, and the `● …` lead line that opens and closes a
+    /// synthesised transcript.
+    ///
+    /// A **captured** transcript is plain text with no styling of its own (the terminal grid's
+    /// colours are not stored - see `crate::run_history::transcript_store`), so every one of its
+    /// lines takes [`TRANSCRIPT_BODY`]. The other three are used by the synthesised transcript and
+    /// by the closing line, which this app builds itself and therefore does know the shape of.
+    pub const TRANSCRIPT_PROMPT: ColorToken = token("history.transcript_prompt", 0x8fbde6);
+    pub const TRANSCRIPT_BODY: ColorToken = token("history.transcript_body", 0xa7adb4);
+    pub const TRANSCRIPT_DETAIL: ColorToken = token("history.transcript_detail", 0x6b7178);
+    pub const TRANSCRIPT_LEAD: ColorToken = token("history.transcript_lead", 0xced4da);
+
+    /// The transcript body's opacity - `revision 5/tokens.rs`'s own
+    /// `TRANSCRIPT_OPACITY = 0.70`, and §3's "the transcript at **70% opacity** - the one signal
+    /// that this is a recording, not a live pane".
+    ///
+    /// Not a [`ColorToken`] because it is not a colour: it multiplies whatever the transcript's
+    /// own lines are already coloured, so it stays correct in a theme that recolours them.
+    pub const TRANSCRIPT_OPACITY: f32 = 0.70;
+
+    /// Every real [`ColorToken`] this module declares - see [`super::TOKEN_GROUPS`].
+    pub const TOKENS: &[(&str, ColorToken)] = &[
+        ("OUT_DONE_FG", OUT_DONE_FG),
+        ("OUT_DONE_BG", OUT_DONE_BG),
+        ("OUT_INTERRUPTED_FG", OUT_INTERRUPTED_FG),
+        ("OUT_INTERRUPTED_BG", OUT_INTERRUPTED_BG),
+        ("OUT_FAILED_FG", OUT_FAILED_FG),
+        ("OUT_FAILED_BG", OUT_FAILED_BG),
+        ("OUT_ABANDONED_FG", OUT_ABANDONED_FG),
+        ("OUT_ABANDONED_BG", OUT_ABANDONED_BG),
+        ("DRIFT_TIP", DRIFT_TIP),
+        ("DRIFT_NEAR", DRIFT_NEAR),
+        ("DRIFT_FAR", DRIFT_FAR),
+        ("DRIFT_TEXT", DRIFT_TEXT),
+        ("DRIFT_FAR_TEXT", DRIFT_FAR_TEXT),
+        ("SCOPE_ON_BG", SCOPE_ON_BG),
+        ("SCOPE_ON_BORDER", SCOPE_ON_BORDER),
+        ("SCOPE_ON_FG", SCOPE_ON_FG),
+        ("SCOPE_OFF_FG", SCOPE_OFF_FG),
+        ("SCOPE_HOVER_BG", SCOPE_HOVER_BG),
+        ("REPO_LABEL", REPO_LABEL),
+        ("GROUP_LABEL", GROUP_LABEL),
+        ("ROW_TITLE", ROW_TITLE),
+        ("TRANSCRIPT_PROMPT", TRANSCRIPT_PROMPT),
+        ("TRANSCRIPT_BODY", TRANSCRIPT_BODY),
+        ("TRANSCRIPT_DETAIL", TRANSCRIPT_DETAIL),
+        ("TRANSCRIPT_LEAD", TRANSCRIPT_LEAD),
     ];
 }
 

--- a/crates/app/src/theme.rs
+++ b/crates/app/src/theme.rs
@@ -3114,6 +3114,19 @@ pub mod history {
     /// own lines are already coloured, so it stays correct in a theme that recolours them.
     pub const TRANSCRIPT_OPACITY: f32 = 0.70;
 
+    /// The run-transcript footer's `Resume here` button - §3's own triple, verbatim: "**Resume
+    /// here** (`enter`, green `#1c3a2a` / `#376b4d` / `#9fdcb6`)", i.e. fill / border / label.
+    ///
+    /// [`RESUME_BORDER`] and [`RESUME_FG`] share [`button::GREEN_KEYCAP`]'s and
+    /// [`button::GREEN_FG`]'s values, and [`RESUME_BG_HOVER`] is [`button::GREEN_BG`] exactly -
+    /// this is the app's one green affirmative family, not a second one. They carry their own
+    /// keys for [`DRIFT_TEXT`]'s reason: a theme should be able to move the one button that
+    /// restarts a finished conversation without moving every green button in the window.
+    pub const RESUME_BG: ColorToken = token("history.resume_bg", 0x1c3a2a);
+    pub const RESUME_BG_HOVER: ColorToken = token("history.resume_bg_hover", 0x24503a);
+    pub const RESUME_BORDER: ColorToken = token("history.resume_border", 0x376b4d);
+    pub const RESUME_FG: ColorToken = token("history.resume_fg", 0x9fdcb6);
+
     /// Every real [`ColorToken`] this module declares - see [`super::TOKEN_GROUPS`].
     pub const TOKENS: &[(&str, ColorToken)] = &[
         ("OUT_DONE_FG", OUT_DONE_FG),
@@ -3141,6 +3154,10 @@ pub mod history {
         ("TRANSCRIPT_BODY", TRANSCRIPT_BODY),
         ("TRANSCRIPT_DETAIL", TRANSCRIPT_DETAIL),
         ("TRANSCRIPT_LEAD", TRANSCRIPT_LEAD),
+        ("RESUME_BG", RESUME_BG),
+        ("RESUME_BG_HOVER", RESUME_BG_HOVER),
+        ("RESUME_BORDER", RESUME_BORDER),
+        ("RESUME_FG", RESUME_FG),
     ];
 }
 

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -133,7 +133,7 @@ impl AdeApp {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if self.open_change.is_none() && !self.settings_open && !self.graph_tab_active {
+        if !self.centre_pane_is_not_an_agent() {
             self.agents.focus_active(window, cx);
         }
     }
@@ -459,14 +459,16 @@ impl AdeApp {
     /// rail's *root*, not its filter field (which this used to target): see
     /// [`Self::rail_focus_handle`]'s own docs for the real keystroke-swallowing bug that was.
     pub(crate) fn close_agent(&mut self, id: AgentId, window: &mut Window, cx: &mut Context<Self>) {
-        // The graph tab (like a file tab or Settings) occupies the centre pane instead of an
-        // agent's own `TerminalPane` while active, so `Agents::close`'s own focus-follows-close
-        // move onto the newly active agent's pane would be exactly as dangling as the
-        // file-tab/Settings cases this guard already covers - a real, adversarial-audit-found
-        // gap: the sibling guard in `Self::focus_newly_spawned_agent` was updated for this, this
-        // one was not.
-        let skip_focus_move =
-            self.open_change.is_some() || self.settings_open || self.graph_tab_active;
+        // A non-agent surface occupies the centre pane instead of an agent's own `TerminalPane`
+        // while it is active, so `Agents::close`'s own focus-follows-close move onto the newly
+        // active agent's pane would dangle. See [`Self::centre_pane_is_not_an_agent`] - the one
+        // shared predicate every such site now reads.
+        let skip_focus_move = self.centre_pane_is_not_an_agent();
+        // GitHub issue #227: record that this run really ended - its transcript, its ending and
+        // its diffstat - *before* anything below tears down the two things that measurement needs
+        // (the pane's grid, and the review baseline ref released two lines down). See
+        // `crate::run_history::flow`'s own module docs on why this moment and no other.
+        self.finish_run_record(id, cx);
         // GitHub issue #225: close this agent's review tab (if it's the one open) and release its
         // baseline ref, *before* `Agents::close` removes the agent - `release_review_baseline`
         // needs to still be able to look up which worktree to run `git update-ref -d` in. The
@@ -492,16 +494,40 @@ impl AdeApp {
         {
             self.clear_merge_flow_for_closed_agent(cx);
         }
-        if self.agents.active_id().is_none()
-            && self.open_change.is_none()
-            && !self.settings_open
-            && !self.graph_tab_active
-        {
+        if self.agents.active_id().is_none() && !self.centre_pane_is_not_an_agent() {
             window.focus(&self.rail_focus_handle, cx);
         }
         // A closed tab is as real a session change as an opened one: relaunching must not reopen
         // a tab the user deliberately closed. See `crate::work_surface::session`.
         self.record_worktree_session(cx);
+    }
+
+    /// Whether some surface *other than an agent's own pane* currently occupies the centre column.
+    ///
+    /// The one shared predicate `REVISION-2026-08-13.md` §7 asks for, in this app's own terms.
+    /// The design states the rule as a deny-list on "is this tab a file"
+    /// (`isFileTab = !isAgent(tab) && tab !== 'terminal' && tab !== 'graph' && tab !== 'run'`) and
+    /// spells out exactly what it costs to forget one: "without the last clause the editor renders
+    /// *below* the new pane and the tab id is pushed into the worktree's open-file list as a
+    /// phantom file tab". Jerry's equivalent question is this one - every real site asked it as an
+    /// inline `open_change.is_some() || settings_open || graph_tab_active`, once per site, and one
+    /// of them had already drifted (the review tab was missing from `close_agent`'s own
+    /// `skip_focus_move`, so closing an agent while the Review tab was showing moved real keyboard
+    /// focus onto a pane nothing was drawing).
+    ///
+    /// **Extend this, and only this, when a centre surface is added.** Every caller is a place
+    /// that would otherwise focus, close or render an agent pane that is not on screen.
+    ///
+    /// Jerry's other half of §7 - "the tab id can't leak into the open-file list" - needs no
+    /// predicate at all: [`work_surface::TabRef`] is an enum, its file arm carries a `PathBuf`,
+    /// and the open-file list is `Vec<PathBuf>`, so a run tab is structurally incapable of landing
+    /// in it.
+    pub(crate) fn centre_pane_is_not_an_agent(&self) -> bool {
+        self.open_change.is_some()
+            || self.settings_open
+            || self.graph_tab_active
+            || self.review_tab_active
+            || self.run_tab_active
     }
 
     /// The rail agent menu's `Pause` action - sends `Ctrl-C` to the agent's pty via

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -272,6 +272,10 @@ impl AdeApp {
         // by an adversarial audit; the review surface's own docs claimed to copy the graph tab's
         // discipline and, in exactly this way, did not.
         self.leave_review_tab(window, cx);
+        // GitHub issue #227: the run-transcript tab occupies the centre pane exactly as the
+        // graph and review tabs do, so it needs the identical teardown - see
+        // `crate::run_history::tab::AdeApp::leave_run_tab`.
+        self.leave_run_tab(window, cx);
 
         let had_open_file_tab = self.open_change.is_some();
         if had_open_file_tab {
@@ -677,6 +681,7 @@ impl AdeApp {
             self.open_files(),
             self.graph_tab_open,
             self.review_tab_open,
+            self.run_tab_by_worktree.contains_key(&cwd),
         )
     }
 
@@ -868,7 +873,8 @@ impl AdeApp {
             work_surface::TabRef::Agent(id) => self.agents.iter().find(|agent| agent.id == id),
             work_surface::TabRef::File(_)
             | work_surface::TabRef::Graph
-            | work_surface::TabRef::Review(_) => None,
+            | work_surface::TabRef::Review(_)
+            | work_surface::TabRef::Run => None,
         })
     }
 
@@ -988,6 +994,11 @@ impl AdeApp {
                 // draggable order every other kind already goes through.
                 work_surface::TabRef::Review(id) => {
                     bar = bar.child(crate::review::render::render_review_tab(self, id, cx));
+                }
+                // GitHub issue #227: the run-transcript tab, a full member of the same combined,
+                // draggable order - one per worktree, replaced rather than stacked.
+                work_surface::TabRef::Run => {
+                    bar = bar.child(crate::run_history::tab::render_run_tab(self, cx));
                 }
             }
         }
@@ -2581,6 +2592,13 @@ impl AdeApp {
             return surface.child(body).into_any_element();
         }
 
+        // GitHub issue #227: and so does the run-transcript tab. Same reasoning as above - the
+        // flags are never both set, because every opener leaves the others.
+        if self.run_tab_active {
+            let body = self.render_run_view(cx);
+            return surface.child(body).into_any_element();
+        }
+
         if self.graph_tab_active {
             let body = self.render_graph_view(cx);
             return surface.child(body).into_any_element();
@@ -2916,6 +2934,11 @@ pub(crate) enum DraggedTab {
         id: AgentId,
         label: String,
     },
+    /// GitHub issue #227 - the run-transcript tab. No id payload, for
+    /// [`work_surface::TabRef::Run`]'s own reason: a worktree's strip holds at most one.
+    Run {
+        label: String,
+    },
 }
 
 impl DraggedTab {
@@ -2925,6 +2948,7 @@ impl DraggedTab {
             DraggedTab::File { label, .. } => label,
             DraggedTab::Graph { label } => label,
             DraggedTab::Review { label, .. } => label,
+            DraggedTab::Run { label } => label,
         }
     }
 
@@ -2936,6 +2960,7 @@ impl DraggedTab {
             DraggedTab::File { path, .. } => work_surface::TabRef::File(path.clone()),
             DraggedTab::Graph { .. } => work_surface::TabRef::Graph,
             DraggedTab::Review { id, .. } => work_surface::TabRef::Review(*id),
+            DraggedTab::Run { .. } => work_surface::TabRef::Run,
         }
     }
 }

--- a/crates/app/src/work_surface/session.rs
+++ b/crates/app/src/work_surface/session.rs
@@ -353,6 +353,7 @@ impl AdeApp {
 #[cfg(test)]
 mod session_restore_tests {
     use super::*;
+    use crate::hooks::store::LiveRun;
     use crate::rail::status::Status;
     use crate::settings::store as settings_store;
     use gpui::TestAppContext;
@@ -732,13 +733,8 @@ mod session_restore_tests {
                     crate::review::state::baseline_key(&cwd, AgentKind::Claude, spawned_at_unix);
                 app.agent_status_state.set(
                     key,
-                    &cwd,
-                    "Claude",
-                    spawned_at_unix,
-                    Status::Idle,
-                    None,
-                    None,
-                    Some(session_id.to_owned()),
+                    LiveRun::new(&cwd, "Claude", spawned_at_unix, Status::Idle)
+                        .session_id(session_id.to_owned()),
                     spawned_at_unix,
                 );
                 app.record_worktree_session(cx);

--- a/crates/app/src/work_surface/session.rs
+++ b/crates/app/src/work_surface/session.rs
@@ -148,7 +148,7 @@ impl AdeApp {
                     })
                 }
                 // See `Self::record_worktree_session`'s own docs for why neither is recorded.
-                TabRef::Graph | TabRef::Review(_) => None,
+                TabRef::Graph | TabRef::Review(_) | TabRef::Run => None,
             })
             .collect()
     }
@@ -466,7 +466,7 @@ mod session_restore_tests {
                         }
                     })
                 }
-                TabRef::Graph | TabRef::Review(_) => None,
+                TabRef::Graph | TabRef::Review(_) | TabRef::Run => None,
             })
             .collect()
     }

--- a/crates/app/src/work_surface/state.rs
+++ b/crates/app/src/work_surface/state.rs
@@ -36,6 +36,17 @@ pub enum TabRef {
     /// of the feature - even though, like `Graph`, at most one is open per window at a time
     /// (`crate::root::AdeApp::review_tab_open`).
     Review(AgentId),
+    /// The run-transcript tab (GitHub issue #227), showing one finished run's own recording.
+    ///
+    /// Carries no payload, like `Graph` and unlike `Review`: `design_handoff_jerry_ade/revision
+    /// 5/REVISION-2026-08-13.md` §3 is "**one run tab per worktree**; opening another replaces
+    /// it", and this order is already per worktree
+    /// (`crate::root::AdeApp::tab_order`), so within one strip there is never a second one to
+    /// tell this apart from. Which run it shows lives in
+    /// `crate::root::AdeApp::run_tab_by_worktree` - keeping it out of the identity is what makes
+    /// "replaced" keep the tab's dragged position rather than closing and reopening it at the
+    /// end of the strip.
+    Run,
 }
 
 /// Reconciles a worktree's stored tab order (`crate::root::AdeApp::tab_order`) against what's
@@ -61,6 +72,7 @@ pub fn reconcile_tab_order(
     open_files: &[PathBuf],
     graph_open: bool,
     review_open: Option<AgentId>,
+    run_open: bool,
 ) -> Vec<TabRef> {
     // GitHub issue #225: a review tab is live only when it's really open *and* the agent it
     // reviews is one of this worktree's own agents. Both halves matter: the first drops a closed
@@ -75,6 +87,10 @@ pub fn reconcile_tab_order(
             TabRef::File(path) => open_files.contains(path),
             TabRef::Graph => graph_open,
             TabRef::Review(id) => review_live(id),
+            // GitHub issue #227: `run_open` is already this worktree's own fact - the caller
+            // looks it up in `run_tab_by_worktree` by cwd - so unlike `review_open` there is no
+            // second "does it belong here" half to check.
+            TabRef::Run => run_open,
         })
         .cloned()
         .collect();
@@ -101,6 +117,9 @@ pub fn reconcile_tab_order(
         if review_live(&id) && !order.contains(&TabRef::Review(id)) {
             order.push(TabRef::Review(id));
         }
+    }
+    if run_open && !order.contains(&TabRef::Run) {
+        order.push(TabRef::Run);
     }
     order
 }
@@ -867,6 +886,7 @@ mod tests {
             &[PathBuf::from("a.rs"), PathBuf::from("b.rs")],
             false,
             None,
+            false,
         );
         assert_eq!(
             order,
@@ -889,7 +909,14 @@ mod tests {
             TabRef::File(PathBuf::from("a.rs")),
             TabRef::Agent(2),
         ];
-        let order = reconcile_tab_order(&stored, &[1, 2], &[PathBuf::from("a.rs")], false, None);
+        let order = reconcile_tab_order(
+            &stored,
+            &[1, 2],
+            &[PathBuf::from("a.rs")],
+            false,
+            None,
+            false,
+        );
         assert_eq!(order, stored);
     }
 
@@ -903,7 +930,7 @@ mod tests {
             TabRef::File(PathBuf::from("a.rs")),
             TabRef::Agent(2),
         ];
-        let order = reconcile_tab_order(&stored, &[2], &[], false, None);
+        let order = reconcile_tab_order(&stored, &[2], &[], false, None, false);
         assert_eq!(order, vec![TabRef::Agent(2)]);
     }
 
@@ -912,7 +939,14 @@ mod tests {
     #[test]
     fn reconcile_appends_newly_opened_tabs_not_yet_in_the_stored_order() {
         let stored = vec![TabRef::Agent(1)];
-        let order = reconcile_tab_order(&stored, &[1, 2], &[PathBuf::from("a.rs")], false, None);
+        let order = reconcile_tab_order(
+            &stored,
+            &[1, 2],
+            &[PathBuf::from("a.rs")],
+            false,
+            None,
+            false,
+        );
         assert_eq!(
             order,
             vec![
@@ -928,7 +962,7 @@ mod tests {
     /// gets, not silently dropped or given a hardcoded fixed position.
     #[test]
     fn reconcile_appends_a_freshly_opened_graph_tab() {
-        let order = reconcile_tab_order(&[], &[1], &[], true, None);
+        let order = reconcile_tab_order(&[], &[1], &[], true, None, false);
         assert_eq!(order, vec![TabRef::Agent(1), TabRef::Graph]);
     }
 
@@ -938,7 +972,7 @@ mod tests {
     #[test]
     fn reconcile_preserves_a_stored_graph_tab_position() {
         let stored = vec![TabRef::Graph, TabRef::Agent(1)];
-        let order = reconcile_tab_order(&stored, &[1], &[], true, None);
+        let order = reconcile_tab_order(&stored, &[1], &[], true, None, false);
         assert_eq!(order, stored);
     }
 
@@ -948,14 +982,14 @@ mod tests {
     #[test]
     fn reconcile_drops_a_closed_graph_tab() {
         let stored = vec![TabRef::Agent(1), TabRef::Graph];
-        let order = reconcile_tab_order(&stored, &[1], &[], false, None);
+        let order = reconcile_tab_order(&stored, &[1], &[], false, None, false);
         assert_eq!(order, vec![TabRef::Agent(1)]);
     }
 
     /// GitHub issue #225: a freshly opened review tab is appended like every other kind.
     #[test]
     fn reconcile_appends_a_freshly_opened_review_tab() {
-        let order = reconcile_tab_order(&[], &[1], &[], false, Some(1));
+        let order = reconcile_tab_order(&[], &[1], &[], false, Some(1), false);
         assert_eq!(order, vec![TabRef::Agent(1), TabRef::Review(1)]);
     }
 
@@ -963,7 +997,7 @@ mod tests {
     fn reconcile_preserves_a_stored_review_tab_position() {
         let stored = vec![TabRef::Review(1), TabRef::Agent(1)];
         assert_eq!(
-            reconcile_tab_order(&stored, &[1], &[], false, Some(1)),
+            reconcile_tab_order(&stored, &[1], &[], false, Some(1), false),
             stored
         );
     }
@@ -971,7 +1005,7 @@ mod tests {
     #[test]
     fn reconcile_drops_a_closed_review_tab() {
         let stored = vec![TabRef::Agent(1), TabRef::Review(1)];
-        let order = reconcile_tab_order(&stored, &[1], &[], false, None);
+        let order = reconcile_tab_order(&stored, &[1], &[], false, None, false);
         assert_eq!(order, vec![TabRef::Agent(1)]);
     }
 
@@ -981,7 +1015,7 @@ mod tests {
     #[test]
     fn reconcile_drops_a_review_tab_whose_agent_is_gone() {
         let stored = vec![TabRef::Review(7)];
-        assert!(reconcile_tab_order(&stored, &[], &[], false, Some(7)).is_empty());
+        assert!(reconcile_tab_order(&stored, &[], &[], false, Some(7), false).is_empty());
     }
 
     /// The review tab belongs to *one* worktree's strip - the worktree its agent runs in. Another
@@ -989,8 +1023,50 @@ mod tests {
     #[test]
     fn a_review_tab_never_leaks_into_another_worktrees_strip() {
         // Worktree B's strip: its own agent 2 is open, but the review is for agent 1 (worktree A).
-        let order = reconcile_tab_order(&[], &[2], &[], false, Some(1));
+        let order = reconcile_tab_order(&[], &[2], &[], false, Some(1), false);
         assert_eq!(order, vec![TabRef::Agent(2)]);
+    }
+
+    /// GitHub issue #227: the run-transcript tab joins the same order every other kind is in -
+    /// appended when freshly opened, kept where a drag put it, and dropped when closed.
+    #[test]
+    fn reconcile_treats_the_run_tab_like_every_other_kind() {
+        assert_eq!(
+            reconcile_tab_order(&[], &[1], &[], false, None, true),
+            vec![TabRef::Agent(1), TabRef::Run],
+            "a freshly opened run tab lands last, like every other new tab"
+        );
+
+        let stored = vec![TabRef::Run, TabRef::Agent(1)];
+        assert_eq!(
+            reconcile_tab_order(&stored, &[1], &[], false, None, true),
+            stored,
+            "and a dragged position is honoured rather than re-appended"
+        );
+
+        assert_eq!(
+            reconcile_tab_order(&stored, &[1], &[], false, None, false),
+            vec![TabRef::Agent(1)],
+            "a closed run tab is dropped, not left dangling in the strip"
+        );
+    }
+
+    /// §3's "one run tab per worktree" is structural, not a rule the reconciler has to enforce:
+    /// [`TabRef::Run`] carries no payload, so a stored order physically cannot hold two of them
+    /// distinctly - and re-reconciling never grows a second.
+    #[test]
+    fn a_worktree_strip_can_never_hold_two_run_tabs() {
+        let once = reconcile_tab_order(&[], &[1], &[], false, None, true);
+        let twice = reconcile_tab_order(&once, &[1], &[], false, None, true);
+        assert_eq!(
+            once, twice,
+            "reconciliation is idempotent for the run tab too"
+        );
+        assert_eq!(
+            twice.iter().filter(|tab| **tab == TabRef::Run).count(),
+            1,
+            "\u{a7}3: one run tab per worktree, replaced on the next open"
+        );
     }
 
     /// The real cross-kind drag this revision exists to unlock: dropping a file tab so it lands

--- a/crates/wt-core/src/lib.rs
+++ b/crates/wt-core/src/lib.rs
@@ -29,6 +29,7 @@ pub mod rebase;
 pub mod remote;
 pub mod review;
 pub mod rewrite;
+pub mod run_drift;
 pub mod stage;
 pub mod undo;
 

--- a/crates/wt-core/src/run_drift.rs
+++ b/crates/wt-core/src/run_drift.rs
@@ -1,0 +1,190 @@
+//! How far a worktree's branch has moved on since a moment in time - the real git side of
+//! GitHub issue #227's **drift** axis.
+//!
+//! `design_handoff_jerry_ade/revision 5/REVISION-2026-08-13.md` §4 defines drift as a count of
+//! "commits since" a finished agent run ended, banded into `at the tip` / `1-2 commits since` /
+//! `3+ commits since`. The band and its wording are the app's ([`app::run_history::model`]); the
+//! *number* is this module, and it is a real `git rev-list` in the run's own checkout, never an
+//! estimate.
+//!
+//! ## Why a timestamp and not a recorded commit id
+//!
+//! A run record could have stored the `HEAD` sha at the moment its agent closed, and drift could
+//! then be `git rev-list --count <sha>..HEAD`. That was considered and deliberately not done, for
+//! two reasons worth writing down because both are judgement calls rather than facts:
+//!
+//! 1. **It would only ever work for runs recorded after the field was added.** Every record Jerry
+//!    has already written carries a real `updated_at_unix` and no sha, and a drift band that is
+//!    blank for a user's whole existing history is worse than one derived from the timestamp they
+//!    do have. There is no third "unknown" band in the design to render such a record in.
+//! 2. **After a rebase the sha answer is arguably the worse one.** A rebased branch makes every
+//!    pre-run commit unreachable from the recorded sha, so `<sha>..HEAD` counts the entire
+//!    branch - a large, alarming number for a history that, from the user's point of view, gained
+//!    nothing new.
+//!
+//! The timestamp has its own known limitation, stated here rather than hidden: it counts by
+//! *committer date*, so a rebase (which rewrites committer dates) makes every rewritten commit
+//! look like it landed after the run. That is a real property of the repository, not a
+//! fabrication, and the sentence the app renders around it ("N commits have landed since") stays
+//! true of it.
+
+use std::ffi::OsString;
+use std::path::Path;
+
+use crate::{check_success, run_git, Error};
+
+/// How many commits reachable from `HEAD` in the worktree at `worktree_path` were committed at or
+/// after `since_unix` (seconds since the Unix epoch).
+///
+/// `Ok(None)` - never a fabricated `0` - for the one real case where the question has no answer:
+/// an unborn `HEAD` (a freshly `git init`ed checkout with no commit at all), which `git rev-list`
+/// reports as a failure rather than as an empty history. Every other failure is a real [`Error`]
+/// the caller can surface or log; nothing here silently degrades into a number.
+///
+/// `since_unix` is passed as git's own `@<seconds>` "fixed timestamp" date format rather than a
+/// formatted local date string, so no timezone interpretation happens anywhere between the record
+/// and the traversal.
+///
+/// Performs blocking I/O: spawns a real `git` child process. Callers on a UI thread must hand it
+/// to a background executor (see `app::run_history::flow`).
+pub fn commits_since(worktree_path: &Path, since_unix: i64) -> Result<Option<usize>, Error> {
+    // A negative (or zero) timestamp is not a real run-end moment - `@-1` is also a date git
+    // would happily accept and traverse the entire history for. Refuse to guess.
+    if since_unix <= 0 {
+        return Ok(None);
+    }
+    let args: Vec<OsString> = vec![
+        "rev-list".into(),
+        "--count".into(),
+        format!("--since=@{since_unix}").into(),
+        "HEAD".into(),
+    ];
+    let output = run_git(worktree_path, &args)?;
+    if !output.status.success() {
+        // `HEAD` is unborn (or otherwise unresolvable): git says so on stderr and exits non-zero.
+        // That is a real, expected state for a brand-new checkout, not an error worth surfacing.
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("unknown revision")
+            || stderr.contains("ambiguous argument")
+            || stderr.contains("bad revision")
+        {
+            return Ok(None);
+        }
+        check_success(&args, &output)?;
+    }
+    let text = String::from_utf8_lossy(&output.stdout);
+    Ok(parse_commit_count(&text))
+}
+
+/// Parses `git rev-list --count`'s stdout into a real count. `None` - not a fabricated `0` - for
+/// output this doesn't recognise, so a future git whose output shape changed can never be
+/// rendered as "at the tip".
+fn parse_commit_count(text: &str) -> Option<usize> {
+    text.trim().parse::<usize>().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn git(dir: &Path, args: &[&str]) {
+        git_at(dir, args, None);
+    }
+
+    /// `at` pins the commit's real author *and* committer date, so a test can place commits on
+    /// either side of a mark deterministically rather than racing the wall clock (the counting
+    /// this module does is by committer date - see [`commits_since`]'s own docs).
+    fn git_at(dir: &Path, args: &[&str], at: Option<i64>) {
+        let mut command = Command::new("git");
+        command
+            .current_dir(dir)
+            .args(args)
+            .env("GIT_AUTHOR_NAME", "Test")
+            .env("GIT_AUTHOR_EMAIL", "test@example.com")
+            .env("GIT_COMMITTER_NAME", "Test")
+            .env("GIT_COMMITTER_EMAIL", "test@example.com");
+        if let Some(at) = at {
+            command
+                .env("GIT_AUTHOR_DATE", format!("@{at} +0000"))
+                .env("GIT_COMMITTER_DATE", format!("@{at} +0000"));
+        }
+        let status = command.status().expect("git must run");
+        assert!(status.success(), "git {args:?} must succeed");
+    }
+
+    fn commit_at(dir: &Path, name: &str, at: i64) {
+        std::fs::write(dir.join(name), name).expect("write");
+        git_at(dir, &["add", "."], Some(at));
+        git_at(dir, &["commit", "-m", name], Some(at));
+    }
+
+    fn commit(dir: &Path, name: &str) {
+        std::fs::write(dir.join(name), name).expect("write");
+        git(dir, &["add", "."]);
+        git(dir, &["commit", "-m", name]);
+    }
+
+    fn now() -> i64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|elapsed| elapsed.as_secs() as i64)
+            .unwrap_or(0)
+    }
+
+    #[test]
+    fn a_real_repository_reports_the_real_number_of_commits_since_a_moment() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path();
+        git(path, &["init", "-b", "main"]);
+        commit_at(path, "before-a", 1_700_000_000);
+        commit_at(path, "before-b", 1_700_000_100);
+
+        // The run ended here. Everything above it predates the run.
+        let mark = 1_700_000_500;
+        assert_eq!(
+            commits_since(path, mark).expect("must run"),
+            Some(0),
+            "a branch nobody has touched since the mark is at the tip"
+        );
+
+        commit_at(path, "after-a", 1_700_001_000);
+        commit_at(path, "after-b", 1_700_001_100);
+        commit_at(path, "after-c", 1_700_001_200);
+
+        assert_eq!(
+            commits_since(path, mark).expect("must run"),
+            Some(3),
+            "exactly the three commits made after the mark must be counted"
+        );
+    }
+
+    #[test]
+    fn an_unborn_head_has_no_answer_rather_than_a_fabricated_zero() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        git(dir.path(), &["init", "-b", "main"]);
+        assert_eq!(
+            commits_since(dir.path(), now()).expect("must not error"),
+            None,
+            "a checkout with no commit at all cannot report a drift of zero"
+        );
+    }
+
+    #[test]
+    fn a_nonsense_timestamp_is_refused_rather_than_traversing_everything() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        git(dir.path(), &["init", "-b", "main"]);
+        commit(dir.path(), "one");
+        assert_eq!(commits_since(dir.path(), 0).expect("must not error"), None);
+        assert_eq!(commits_since(dir.path(), -5).expect("must not error"), None);
+    }
+
+    #[test]
+    fn unrecognised_rev_list_output_parses_to_none_not_a_fabricated_zero() {
+        assert_eq!(parse_commit_count("3\n"), Some(3));
+        assert_eq!(parse_commit_count("  12  "), Some(12));
+        assert_eq!(parse_commit_count(""), None);
+        assert_eq!(parse_commit_count("not a number"), None);
+    }
+}

--- a/crates/wt-core/src/run_drift.rs
+++ b/crates/wt-core/src/run_drift.rs
@@ -3,15 +3,15 @@
 //!
 //! `design_handoff_jerry_ade/revision 5/REVISION-2026-08-13.md` §4 defines drift as a count of
 //! "commits since" a finished agent run ended, banded into `at the tip` / `1-2 commits since` /
-//! `3+ commits since`. The band and its wording are the app's ([`app::run_history::model`]); the
-//! *number* is this module, and it is a real `git rev-list` in the run's own checkout, never an
-//! estimate.
+//! `3+ commits since`. The band and its wording are the app's (`app::run_history::model`); the
+//! *number* is this module, and it is a real `git log` traversal in the run's own checkout, never
+//! an estimate.
 //!
 //! ## Why a timestamp and not a recorded commit id
 //!
 //! A run record could have stored the `HEAD` sha at the moment its agent closed, and drift could
 //! then be `git rev-list --count <sha>..HEAD`. That was considered and deliberately not done, for
-//! two reasons worth writing down because both are judgement calls rather than facts:
+//! two reasons worth writing down because both are judgement calls rather than settled facts:
 //!
 //! 1. **It would only ever work for runs recorded after the field was added.** Every record Jerry
 //!    has already written carries a real `updated_at_unix` and no sha, and a drift band that is
@@ -33,30 +33,46 @@ use std::path::Path;
 
 use crate::{check_success, run_git, Error};
 
-/// How many commits reachable from `HEAD` in the worktree at `worktree_path` were committed at or
-/// after `since_unix` (seconds since the Unix epoch).
+/// Drift for **every** run in one checkout, from one `git` invocation.
 ///
-/// `Ok(None)` - never a fabricated `0` - for the one real case where the question has no answer:
-/// an unborn `HEAD` (a freshly `git init`ed checkout with no commit at all), which `git rev-list`
-/// reports as a failure rather than as an empty history. Every other failure is a real [`Error`]
-/// the caller can surface or log; nothing here silently degrades into a number.
+/// Returns, for each entry of `since_unix`, how many commits reachable from `HEAD` in the worktree
+/// at `worktree_path` were committed at or after that moment - in the same order as the input.
 ///
-/// `since_unix` is passed as git's own `@<seconds>` "fixed timestamp" date format rather than a
-/// formatted local date string, so no timezone interpretation happens anywhere between the record
-/// and the traversal.
+/// One invocation rather than one per run, and that is the whole reason this is the primitive
+/// [`commits_since`] delegates to: a worktree with three runs in its history would otherwise cost
+/// three `git` child processes every time the History view refreshed. Reading each commit's own
+/// committer date once and counting locally answers all of them, with exactly the same semantics
+/// `git rev-list --count --since=@<t>` has (both filter on committer date), and with no cap on how
+/// far back a run can be - the traversal is bounded by the *oldest* moment asked about.
+///
+/// `Ok(None)` - never a fabricated vector of zeros - for the one real case where the question has
+/// no answer at all: an unborn `HEAD` (a freshly `git init`ed checkout with no commit in it),
+/// which git reports as a failure rather than as an empty history. An empty `since_unix` gets an
+/// empty vector and spawns nothing.
+///
+/// Each moment is passed to git as its own `@<seconds>` "fixed timestamp" date, so no timezone
+/// interpretation happens anywhere between a run record and the traversal.
 ///
 /// Performs blocking I/O: spawns a real `git` child process. Callers on a UI thread must hand it
 /// to a background executor (see `app::run_history::flow`).
-pub fn commits_since(worktree_path: &Path, since_unix: i64) -> Result<Option<usize>, Error> {
-    // A negative (or zero) timestamp is not a real run-end moment - `@-1` is also a date git
-    // would happily accept and traverse the entire history for. Refuse to guess.
-    if since_unix <= 0 {
-        return Ok(None);
+pub fn commits_since_each(
+    worktree_path: &Path,
+    since_unix: &[i64],
+) -> Result<Option<Vec<usize>>, Error> {
+    if since_unix.is_empty() {
+        return Ok(Some(Vec::new()));
     }
+    // A negative (or zero) timestamp is not a real run-end moment, and `@-1` is a date git would
+    // happily accept and traverse the entire history for. Such an entry answers `0` rather than
+    // widening everyone else's traversal.
+    let Some(oldest) = since_unix.iter().copied().filter(|at| *at > 0).min() else {
+        return Ok(Some(vec![0; since_unix.len()]));
+    };
+
     let args: Vec<OsString> = vec![
-        "rev-list".into(),
-        "--count".into(),
-        format!("--since=@{since_unix}").into(),
+        "log".into(),
+        "--format=%ct".into(),
+        format!("--since=@{oldest}").into(),
         "HEAD".into(),
     ];
     let output = run_git(worktree_path, &args)?;
@@ -67,20 +83,46 @@ pub fn commits_since(worktree_path: &Path, since_unix: i64) -> Result<Option<usi
         if stderr.contains("unknown revision")
             || stderr.contains("ambiguous argument")
             || stderr.contains("bad revision")
+            || stderr.contains("does not have any commits yet")
         {
             return Ok(None);
         }
         check_success(&args, &output)?;
     }
-    let text = String::from_utf8_lossy(&output.stdout);
-    Ok(parse_commit_count(&text))
+    let landed = parse_commit_dates(&String::from_utf8_lossy(&output.stdout));
+    Ok(Some(
+        since_unix
+            .iter()
+            .map(|at| {
+                if *at <= 0 {
+                    return 0;
+                }
+                landed.iter().filter(|committed| *committed >= at).count()
+            })
+            .collect(),
+    ))
 }
 
-/// Parses `git rev-list --count`'s stdout into a real count. `None` - not a fabricated `0` - for
-/// output this doesn't recognise, so a future git whose output shape changed can never be
-/// rendered as "at the tip".
-fn parse_commit_count(text: &str) -> Option<usize> {
-    text.trim().parse::<usize>().ok()
+/// Drift for one run - a thin wrapper over [`commits_since_each`], so there is exactly one
+/// traversal and one counting rule in this module rather than two that could disagree.
+///
+/// `Ok(None)` for an unborn `HEAD`, and for a `since_unix` that is not a real moment.
+pub fn commits_since(worktree_path: &Path, since_unix: i64) -> Result<Option<usize>, Error> {
+    if since_unix <= 0 {
+        return Ok(None);
+    }
+    Ok(
+        commits_since_each(worktree_path, &[since_unix])?
+            .and_then(|counts| counts.first().copied()),
+    )
+}
+
+/// Parses `git log --format=%ct`'s stdout - one committer date per line. A line that isn't a real
+/// timestamp is skipped rather than counted as zero (which would make it land "since" every run).
+fn parse_commit_dates(text: &str) -> Vec<i64> {
+    text.lines()
+        .filter_map(|line| line.trim().parse::<i64>().ok())
+        .collect()
 }
 
 #[cfg(test)]
@@ -181,10 +223,51 @@ mod tests {
     }
 
     #[test]
-    fn unrecognised_rev_list_output_parses_to_none_not_a_fabricated_zero() {
-        assert_eq!(parse_commit_count("3\n"), Some(3));
-        assert_eq!(parse_commit_count("  12  "), Some(12));
-        assert_eq!(parse_commit_count(""), None);
-        assert_eq!(parse_commit_count("not a number"), None);
+    fn unparsable_commit_dates_are_skipped_rather_than_counted_as_the_epoch() {
+        assert_eq!(
+            parse_commit_dates("1700000000\n1700000100\n"),
+            vec![1_700_000_000, 1_700_000_100]
+        );
+        assert_eq!(parse_commit_dates(""), Vec::<i64>::new());
+        assert_eq!(
+            parse_commit_dates("1700000000\nnot a number\n"),
+            vec![1_700_000_000]
+        );
+    }
+
+    /// The point of the batched form: several runs in one checkout, answered from one traversal,
+    /// each with its own real count.
+    #[test]
+    fn every_run_in_one_checkout_is_answered_from_one_traversal() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path();
+        git(path, &["init", "-b", "main"]);
+        commit_at(path, "a", 1_700_000_000);
+        commit_at(path, "b", 1_700_001_000);
+        commit_at(path, "c", 1_700_002_000);
+        commit_at(path, "d", 1_700_003_000);
+
+        let counts = commits_since_each(
+            path,
+            &[
+                1_700_003_500, // after everything
+                1_700_002_500, // one commit since
+                1_700_000_500, // three commits since
+                0,             // not a real moment
+            ],
+        )
+        .expect("must run")
+        .expect("a real history must answer");
+        assert_eq!(counts, vec![0, 1, 3, 0]);
+    }
+
+    #[test]
+    fn asking_about_no_runs_at_all_spawns_nothing_and_answers_nothing() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        assert_eq!(
+            commits_since_each(dir.path(), &[]).expect("must not error"),
+            Some(Vec::new()),
+            "a worktree with no runs must not cost a git process"
+        );
     }
 }


### PR DESCRIPTION
Closes #227.

The rev-6 "Agent triage control room" agent-history surface, end to end: the sidebar indexes runs, a centre tab shows one run's transcript, and the rail's inline `HISTORY` section is gone.

Design sources: `design_handoff_jerry_ade/revision 5/REVISION-2026-08-13.md` (all) as amended by `REVISION-2026-08-14.md` §4/§6/§7 and `STAGE-A-CHANGELOG.md` §4t/§4u.

## What ships

**Entry points.** `SidebarView::History` is a real view the sidebar body paints and the filter row follows (`filter runs`) — and deliberately *not* a strip cell: §4t moved it into the `⋯` overflow ("a permanent cell in a 5-cell strip is a claim that you switch to it constantly"). `rail::menu::HISTORY_VIEW_AVAILABLE` flips to `true`, so that row goes live in the same edit that gives it somewhere to go (§7 rule 1). A `↺ N earlier runs` line under a worktree row — **only on worktrees with no live agent** — opens History for that checkout.

**The sidebar view** (§3, amended by 08-14 §6): keyed repo → worktree → run in the rail's own order, with an `all` / `this worktree` scope toggle, a count line tallied over its own tree, and the active worktree carrying the selection edge and opening by default. Two-line run rows: agent chip · title · duration, then outcome pill · drift dot · drift text · finished-at. Empty worktree gets *No agent has run in `<branch>` yet.*; a filter that hid everything says so instead, because those are two different facts.

**Outcomes** (§5): `done` / `interrupted` / `failed` / `abandoned`, derived from facts the app really persisted — `ended_at_unix` is what makes `abandoned` a real state rather than a guess. **No `merged`**, pinned by a test.

**Drift** (§4): a real `git rev-list --count --since=@<ts> HEAD` in the run's own checkout, batched one process per worktree on the background executor, banded at the tip / 1–2 / 3+. A run whose traversal has not answered yet paints **no** band rather than the reassuring `at the tip`.

**The run-transcript tab** (§3–§4): a new `TabRef::Run` kind — one per worktree, replaced on the next open, closeable, draggable in the same combined order every other kind is in; label `<agent> · <when>`, chip in the agent's tint. Header carries chip · title · `<agent> · <when> · 24m · 21 turns · 6 files · +148 −96` · outcome pill. Body renders **the run's own stored transcript** at 70% opacity, keyed by run id, or a short synthesis from that run's own record where none was stored — and always ends in a real closing line, so a transcript structurally cannot end on a pending question. Footer: drift dot, the spelled-out consequence sentence, a real `Resume here` and `Start a new agent from this`.

**§7's gate** is the one shared `centre_pane_is_not_an_agent` predicate, plus a `leave_run_tab` at each of the seven sites that open another centre surface. Jerry's other half of §7 needs no predicate: `TabRef` is an enum whose file arm carries a `PathBuf`, so a run tab is structurally incapable of leaking into the open-file list.

**The old inline `HISTORY` section is deleted** in the same change (§7 rule 5: "Replacing a control means deleting its old keys in the same edit"). `render_history_section`/`render_past_agent_row` are gone, and the worktree caret goes back to meaning "this worktree has live agents".

## Verification

Real-window, real-git tests (8 `gpui::test`s) drive the same entry points the UI does, plus pure coverage for the model, the drift engine, the transcript store and `reconcile_tab_order`.

The surface was also driven for real over X11 against a real repo with real worktrees, real `agent-status.toml` records and real stored transcripts — rail line, overflow row, History view, expanded groups, both scopes, a captured transcript, a synthesised one, and a `Resume here` that spawned a real `claude` process into the run's own checkout. Two defects came out of that and are fixed here:

- a run opened from another checkout was filed under a worktree nobody was standing in, so no tab appeared and the pane read "this run is no longer in the history";
- the design's `⎿` (U+23BF) has no glyph in the bundled IBM Plex Mono nor anywhere in the fallback chain, and rendered as a tofu box — it is now `└` (U+2514), the same mark from a block the font really covers.

## Note on the local test run

`cargo test -p app --lib` fails 15 filesystem-watcher tests on the machine this was built on. That is `fs.inotify.max_user_instances` (128) exhaustion under a 2900-test run, not a regression: **unmodified `origin/master` fails the same set** (16, in fact) on the same machine, and every one of them passes in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
