### PR TITLE
fix(rail): make agent and history-run selection mutually exclusive

### DIFF
--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -1874,7 +1874,11 @@ impl AdeApp {
         trailing_pb: bool,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        let is_selected = self.agents.active_id() == Some(agent.id);
+        // See `crate::work_surface::render::AdeApp::active_agent_pane_id`'s own docs: reading
+        // `Agents::active_id` straight here would leave this row drawn as selected even while
+        // the centre pane is genuinely showing the review/run/graph tab instead - the live user
+        // report ("agent rows and history rows weren't unselected when switching between them").
+        let is_selected = self.active_agent_pane_id() == Some(agent.id);
         let status = agent.status;
         let chip_icon = self.render_agent_chip_icon(agent.kind, px(15.0), self.ui_text_size(9.0));
         let state_color: gpui::Rgba = match status {

--- a/crates/app/src/run_history/render.rs
+++ b/crates/app/src/run_history/render.rs
@@ -316,7 +316,13 @@ impl AdeApp {
         let outcome = entry.outcome();
         let key = run.key.clone();
         let worktree = run.worktree.clone();
-        let is_open = self.run_tab_by_worktree.get(&worktree) == Some(&key);
+        // `run_tab_active` too, not just the map: `run_tab_by_worktree` remembers which run a
+        // worktree's tab would *reopen to* (so `render_run_tab` can still find it - see
+        // `Self::leave_run_tab`, which clears `run_tab_active` but deliberately leaves this entry
+        // alone), not whether that tab is the centre pane's current occupant. Reading the map
+        // alone left this row highlighted after switching away to an agent (or the review/graph
+        // tab) - a live user report ("history rows weren't unselected when switching away").
+        let is_open = self.run_tab_active && self.run_tab_by_worktree.get(&worktree) == Some(&key);
 
         let element_id = gpui::SharedString::from(format!("history-run-{key}"));
         let body_id = gpui::SharedString::from(format!("history-run-body-{key}"));
@@ -639,6 +645,106 @@ mod history_surface_tests {
                  `{selector}` is missing"
             );
         }
+    }
+
+    /// Live user report: "agents and agents history rows were not unselected when switching
+    /// between them when needed." An agent row and a history run row both derived their own
+    /// "am I the selected one" from a piece of state nothing ever cleared the *other* row's own
+    /// state for, so switching from one to the other could leave both reading as selected at
+    /// once - two rail rows (and two tab-strip tabs) both drawn as active.
+    ///
+    /// Asserted the same way `nothing_selected_means_nothing_shown_anywhere` (`crate::rail::
+    /// render`) already asserts single-selection consistency: by reading the exact fields the
+    /// render code itself branches on - `AdeApp::active_agent_pane_id` (what
+    /// `crate::rail::render::AdeApp::render_agent_row` and `Self::render_agent_tab` both call for
+    /// their own `is_selected`/`is_active`) and the `run_tab_active` + `run_tab_by_worktree`
+    /// pair (`crate::run_history::render::AdeApp::render_history_run_row`'s own `is_open`) -
+    /// rather than trying to read painted colour back out of a window, which this codebase's own
+    /// `gpui::TestAppContext` has no way to do (only `debug_bounds`, a geometry lookup).
+    #[gpui::test]
+    fn switching_between_an_agent_and_a_history_run_leaves_exactly_one_selected(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = init_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        // A real second agent (the startup shell is `Agents`' first entry) so this exercises a
+        // genuine "agent row" rather than the guaranteed startup shell.
+        app.update_in(cx, |app, window, cx| {
+            app.new_agent(ProcessKind::Agent(AgentKind::Claude), window, cx)
+        });
+        cx.run_until_parked();
+        let agent_id = app.read_with(cx, |app, _| {
+            app.agents.iter().last().expect("a spawned agent").id
+        });
+        assert_eq!(
+            app.read_with(cx, |app, _| app.active_agent_pane_id()),
+            Some(agent_id),
+            "premise: the freshly spawned agent is the one genuinely selected right now"
+        );
+
+        let key = record_finished_run(&app, cx, repo.path(), 1_700_000_000, "an earlier run");
+
+        // The real click path: open the History sidebar, then open the run's own transcript tab
+        // - exactly what `render_history_run_row`'s `on_click` does.
+        app.update_in(cx, |app, window, cx| {
+            app.open_history_view(cx);
+            app.open_run_tab(repo.path().to_path_buf(), key.clone(), window, cx);
+        });
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert!(app.run_tab_active, "the run tab must now be the active one");
+            let history_row_selected =
+                app.run_tab_active && app.run_tab_by_worktree.get(repo.path()) == Some(&key);
+            assert!(
+                history_row_selected,
+                "and the history row for the run just opened must read as selected"
+            );
+            assert_eq!(
+                app.active_agent_pane_id(),
+                None,
+                "the agent row/tab must no longer read as selected - the centre pane is showing \
+                 the run transcript, not that agent's pane. Before the fix this was still \
+                 `Some(agent_id)`, because both the rail row and the tab strip read \
+                 `Agents::active_id` straight, which `open_run_tab` never touches"
+            );
+            assert_eq!(
+                app.agents.active_id(),
+                Some(agent_id),
+                "the *underlying* remembered agent must be untouched, though - it's what \
+                 `select_agent` returns to, not something `open_run_tab` should ever clear"
+            );
+        });
+
+        // Switch back to the agent - the real click path (`render_agent_row`'s/`render_agent_tab`'s
+        // own `on_click`, both of which call `select_agent`).
+        app.update_in(cx, |app, window, cx| {
+            app.select_agent(agent_id, window, cx);
+        });
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.active_agent_pane_id(),
+                Some(agent_id),
+                "the agent row/tab must read as selected again"
+            );
+            assert!(
+                !app.run_tab_active,
+                "and the run tab must no longer be the centre pane's active occupant"
+            );
+            let history_row_selected =
+                app.run_tab_active && app.run_tab_by_worktree.get(repo.path()) == Some(&key);
+            assert!(
+                !history_row_selected,
+                "so the history row must read as unselected too - even though \
+                 `run_tab_by_worktree` still remembers this run for this worktree (that's what \
+                 lets the run tab in the strip still resolve to it if re-activated), the row's own \
+                 selection reads `run_tab_active` first and that is genuinely `false` now"
+            );
+        });
     }
 
     /// §3: "One run tab per worktree; opening another replaces it." The replacement is a

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -1819,7 +1819,7 @@ impl AdeApp {
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
         let id = agent.id;
-        let is_active = self.agents.active_id() == Some(id);
+        let is_active = self.active_agent_pane_id() == Some(id);
         let chip_kind = work_surface::tab_chip_kind(agent.kind);
         let is_mono = matches!(chip_kind, work_surface::TabChipKind::Cli);
         let colors = work_surface::tab_colors(is_active);
@@ -2681,6 +2681,34 @@ impl AdeApp {
             None => surface.child(self.render_no_agents_empty_state(cx)),
         }
         .into_any_element()
+    }
+
+    /// Whether `id` is genuinely the agent the centre pane is showing right now - the exact same
+    /// cascade [`Self::render_center_pane`] itself follows, mirrored here so that nothing which
+    /// draws a "this is the selected one" edge from [`Agents::active_id`] - the rail's own agent
+    /// row (`crate::rail::render::AdeApp::render_agent_row`) and this tab strip's own agent tab
+    /// ([`Self::render_agent_tab`]) - can disagree with what the centre pane is actually showing.
+    ///
+    /// [`Agents::active_id`]'s own docs are explicit that it is "read directly by the centre pane
+    /// with no repo-scoping of its own": every *other* centre-pane occupant - the review tab, the
+    /// run tab, the graph tab - is a separate `bool` layered on top precisely because `Agents`
+    /// itself has no way to know about them ([`Self::review_tab_active`]/[`Self::run_tab_active`]/
+    /// [`Self::graph_tab_active`]), so any caller that wants "is the agent pane really what's on
+    /// screen" has to apply the same layering [`Self::render_center_pane`] does, rather than
+    /// reading [`Agents::active_id`] straight.
+    ///
+    /// Before this existed, both call sites above did exactly that - read [`Agents::active_id`]
+    /// straight - so opening a history run (GitHub issue #227) left whichever agent had been
+    /// active still drawn as the selected rail row *and* the active tab, alongside the run's own
+    /// now-correctly-selected row: two rows/tabs reading as selected at once, a live user report.
+    /// The review and graph tabs share the identical shape and were silently carrying the same
+    /// bug; this closes it for all three at the one root, rather than teaching each caller a
+    /// fourth flag to check.
+    pub(crate) fn active_agent_pane_id(&self) -> Option<AgentId> {
+        if self.review_tab_active || self.run_tab_active || self.graph_tab_active {
+            return None;
+        }
+        self.agents.active_id()
     }
 
     /// The centre pane with no agent open in this worktree at all.


### PR DESCRIPTION
## Summary

Live user report: "also another bug I saw was that agents and agents history rows where not unselected when switching between them when needed."

Root cause (three independent trackers, none mutually exclusive):
- The rail's agent row and the tab strip's own agent tab both read `Agents::active_id()` straight, with no awareness that the review/run/graph tab might currently occupy the centre pane instead.
- The history run row's own selected state read only `run_tab_by_worktree` (which run a worktree's tab would *reopen to*), not `run_tab_active` (whether that tab is genuinely the centre pane's current occupant right now) - `leave_run_tab` clears `run_tab_active` but deliberately leaves the map entry alone.

Fix:
- Added `AdeApp::active_agent_pane_id()`, mirroring the exact cascade `render_center_pane` already uses (review, then run, then graph tab, else the agent pane) - now the one place both the rail's agent row and the tab strip's agent tab read instead of `Agents::active_id()` directly.
- `render_history_run_row`'s `is_open` now requires `run_tab_active` too, not just the map lookup.

Closes #376

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets` (warning-free)
- [x] `cargo test -p app --lib rail::` (232 passed)
- [x] `cargo test -p app --lib run_history::` (45 passed, including the new end-to-end regression test `switching_between_an_agent_and_a_history_run_leaves_exactly_one_selected`, which fails on a revert of the fix)
- [x] Real visual verification against a running instance (per-window X11 screenshot capture): spawned a real agent, seeded a real finished run, opened its history transcript tab, confirmed the agent row/tab un-highlighted and the run row/tab highlighted; switched back via the tab strip, confirmed the reverse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)