### PR TITLE
fix(terminal): a real resize no longer leaves the grid stale on an idle pane

### DIFF
--- a/crates/app/src/terminal/pane.rs
+++ b/crates/app/src/terminal/pane.rs
@@ -2780,12 +2780,51 @@ impl Render for TerminalPane {
         // `.relative()` parent, updating `self.content_bounds` from the `canvas()` prepaint
         // callback via a strong `Entity<Self>` handle, is the same idiom
         // `vendor/zed/crates/workspace/src/workspace.rs` uses for its own dock-sizing bounds.
+        //
+        // **Live report, GitHub issue #375: "the height of the agent terminal is not good"
+        // after a genuinely long real conversation.** This `canvas()` prepaint callback runs on
+        // every real paint pass regardless of whether `Render::render` was actually re-invoked
+        // for this entity - a window resize, a panel opening, a sidebar toggle all re-flow and
+        // re-paint the *existing* element tree even when nothing about this pane's own state
+        // changed, so `self.content_bounds` genuinely does track the real, current window size
+        // the whole time. But nothing used to tell the *next frame* to actually look at that new
+        // measurement: `Entity::update` does not implicitly notify (`gpui::Entity::write` calls
+        // `cx.notify()` itself precisely because plain `update` doesn't), and even a bare
+        // `cx.notify()` called from inside this prepaint callback is silently dropped -
+        // `WindowInvalidator::invalidate_view` only actually marks the window dirty when
+        // `draw_phase == DrawPhase::None` (`vendor/zed/crates/gpui/src/window.rs`), which is
+        // never true while this very prepaint callback is running. Measured directly against
+        // this real app: after a real `simulate_resize` on a long-running pane, `content_bounds`
+        // updated correctly on the very next paint, yet `TerminalPane::grid_dimensions()` stayed
+        // frozen at the *pre-resize* values across several more full `run_until_parked` passes,
+        // and only caught up the moment unrelated new pty output (which *does* call
+        // `cx.notify()` outside any draw phase, from `Self::spawn_process`'s poll loop) forced a
+        // fresh `render()`. A real agent conversation spends real time idle between turns -
+        // exactly when a resize/split/sidebar-toggle is likely to happen - so the grid's own
+        // row/col count (and therefore the real pty size, and therefore how
+        // `alacritty_terminal` itself wraps/paginates the transcript) can silently disagree with
+        // the pane's own real, visibly-correct box for as long as that idle period lasts: the
+        // chrome and even this pane's own measured bounds look right the whole time, but the
+        // grid inside them is still sized for the box that used to be there.
+        //
+        // `Window::defer` runs its callback "at the end of the current effect cycle" - i.e.
+        // after this frame's draw phase has ended - which is exactly the gap `invalidate_view`
+        // needs closed: the deferred callback's own `cx.notify()` runs with `draw_phase ==
+        // DrawPhase::None`, so it genuinely schedules the next real frame, which then picks the
+        // new bounds up in `Self::maybe_resize_pty` like any other real resize does. Comparing
+        // against the previous value first keeps this from scheduling a new frame forever while
+        // nothing is actually moving.
         let measure_bounds = {
             let this = cx.entity();
             canvas(
-                move |bounds, _window, cx| {
-                    this.update(cx, |this, _cx| {
-                        this.content_bounds = Some(bounds);
+                move |bounds, window, cx| {
+                    window.defer(cx, move |_window, cx| {
+                        this.update(cx, |this, cx| {
+                            if this.content_bounds != Some(bounds) {
+                                this.content_bounds = Some(bounds);
+                                cx.notify();
+                            }
+                        });
                     });
                 },
                 |_bounds, _prepaint, _window, _cx| {},
@@ -2796,6 +2835,7 @@ impl Render for TerminalPane {
 
         let mut pane = div()
             .id("terminal-pane")
+            .debug_selector(|| "terminal-pane".to_string())
             .track_focus(&self.focus_handle)
             // Tagged `"terminal"` (Revision R10) so `crate::default_key_bindings`'s global
             // bindings that have no business firing over a focused terminal (e.g.
@@ -5053,6 +5093,14 @@ mod scrollback_pane_tests {
                 cx,
             )
         });
+        // Two passes, not one: the pane's real content-bounds measurement now schedules its own
+        // follow-up render via `Window::defer` (see the measuring `canvas()`'s own docs) rather
+        // than updating synchronously, so a single `run_until_parked` can return with that
+        // deferred callback still pending. A test that then pokes `TerminalPane`'s private state
+        // directly (several in this module simulate a pre-first-paint pane) must start from a
+        // fully-settled pane, or that leftover callback fires later and clobbers the test's own
+        // reset with this constructor's real (large, default test-window-sized) measurement.
+        cx.run_until_parked();
         cx.run_until_parked();
         (pane, cx)
     }
@@ -5530,13 +5578,15 @@ mod scrollback_pane_tests {
             (900.0, 40.0),
             (420.0, 20.0),
         ] {
-            pane.update_in(cx, |pane, window, _cx| {
-                pane.content_bounds = Some(Bounds {
-                    origin: gpui::point(px(0.0), px(0.0)),
-                    size: gpui::size(px(width), px(rows * ROW_LINE_HEIGHT_PX)),
-                });
-                pane.maybe_resize_pty(window);
-            });
+            // A *real* resize of the test window, not a direct `content_bounds` field poke:
+            // `TerminalPane` is this window's root view (`.size_full()`, no ancestor chrome), so
+            // resizing the window to exactly `(width, rows * ROW_LINE_HEIGHT_PX)` makes the
+            // pane's own real, measured padding-box bounds exactly that size too - and, since
+            // the pane's own measuring `canvas()` now actively self-heals any divergence from
+            // the real measurement (see that `canvas()` call's own docs), a direct field poke
+            // here would just be corrected right back by the next real paint anyway.
+            cx.simulate_resize(gpui::size(px(width), px(rows * ROW_LINE_HEIGHT_PX)));
+            cx.run_until_parked();
             cx.run_until_parked();
 
             let dims = pane.read_with(cx, |pane, _| pane.grid_dimensions());
@@ -5673,12 +5723,14 @@ mod scrollback_pane_tests {
     /// than the placeholder's own height - before that correction lands,
     /// `alacritty_terminal`'s own shrink-resize semantics legitimately evict the overflow into
     /// real retained scrollback the instant `TerminalPane::maybe_resize_pty` applies the
-    /// correct, smaller size. This reproduces that exact race deterministically - no GPUI
-    /// layout timing depended on - by resetting a pane back to its pre-first-paint state (a
-    /// placeholder-sized grid, `content_bounds` still unmeasured), printing content that fits
-    /// the placeholder but not the eventual real size, and then driving
-    /// `maybe_resize_pty` with a real, small measurement exactly as the pane's own second render
-    /// would.
+    /// correct, smaller size. This reproduces that exact race deterministically by resetting a
+    /// pane back to its pre-first-paint state (a placeholder-sized grid, `content_bounds` still
+    /// unmeasured), resizing the pane's *real* test window down to the small target size the
+    /// eventual measurement will find, then printing content that fits the placeholder but not
+    /// that real size - the pane's own measuring `canvas()` self-heals toward the real window on
+    /// its own once it renders again (see that `canvas()` call's own docs), so this only has to
+    /// drive real output and let a couple of real frames land, not call `maybe_resize_pty`
+    /// directly the way this test did before that self-healing existed.
     #[gpui::test]
     fn the_placeholder_spawn_races_content_bounds_but_the_first_real_resize_discards_it(
         cx: &mut TestAppContext,
@@ -5703,9 +5755,19 @@ mod scrollback_pane_tests {
             placeholder_rows > real_rows as usize,
             "sanity check: the placeholder must genuinely be taller than the real target"
         );
-        pane.update(cx, |pane, cx| {
+
+        // The child's output lands directly on the grid, bypassing `inject_bytes_for_test`'s own
+        // `cx.notify()` (unlike every other test in this module) - a real pty's bytes arrive on
+        // a background poll tick this test isn't driving, so nothing here may trigger a real
+        // render on its own. That distinction matters more than it used to: the pane's own
+        // measuring `canvas()` now self-heals toward the real window on every real paint it sees
+        // (see that `canvas()` call's own docs) - if injecting *did* trigger a render here, this
+        // pane would discover this test's real (large, default) window mid-loop and settle
+        // against *that*, long before this test ever gets to simulate the real race, which is
+        // exactly the failure mode this distinction avoids.
+        pane.update(cx, |pane, _cx| {
             for i in 0..(placeholder_rows - 5) {
-                pane.inject_bytes_for_test(format!("line {i}\r\n").as_bytes(), cx);
+                pane.grid.append_bytes(format!("line {i}\r\n").as_bytes());
             }
         });
         assert_eq!(
@@ -5716,7 +5778,13 @@ mod scrollback_pane_tests {
         );
 
         // The pane's own content-box measurement settles to a real, much smaller area - what
-        // `render`'s measuring `canvas()` reports once it has actually painted.
+        // `render`'s measuring `canvas()` reports once it has actually painted - driven directly
+        // rather than through a real resize/paint cycle for the same reason the injection above
+        // is: this test's real window is this pane's own default (large) test size, not the
+        // small target below, so a real `cx.simulate_resize` here would just as readily paint an
+        // intermediate frame at the *real* window size first (see `a_fresh_pane_never_becomes_
+        // scrollable_as_its_layout_settles` for that scenario instead - a real resize sequence
+        // on a pane that starts out already settled).
         let small_bounds = Bounds {
             origin: gpui::point(px(0.0), px(0.0)),
             size: gpui::size(px(800.0), px(real_rows as f32 * ROW_LINE_HEIGHT_PX)),

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -2134,6 +2134,7 @@ impl AdeApp {
 
         let header = div()
             .id("pty-header")
+            .debug_selector(|| "pty-header".to_string())
             .flex()
             .flex_none()
             .items_center()
@@ -2631,6 +2632,7 @@ impl AdeApp {
                 } else {
                     div()
                         .id("pty-surface")
+                        .debug_selector(|| "pty-surface".to_string())
                         .flex()
                         .flex_col()
                         .flex_1()
@@ -2641,6 +2643,8 @@ impl AdeApp {
                         .child(self.render_pty_header(agent, cx))
                         .child(
                             div()
+                                .id("pty-surface-content")
+                                .debug_selector(|| "pty-surface-content".to_string())
                                 .flex_1()
                                 .min_h_0()
                                 .min_w_0()
@@ -5777,6 +5781,154 @@ mod agent_pane_readout_tests {
             cx.debug_bounds("pty-header-pid").is_some(),
             "the pid moves to the header rather than being lost with the info footer - \
              `{{ focus.cli }}  pid {{ focus.pid }}` in the mock's `isChat` header"
+        );
+    }
+
+    /// **Live report: "the height of the agent terminal is not good... it get a scrollbar" against
+    /// a genuinely long real Claude agent transcript** - investigated for both of this project's
+    /// two prior sizing-bug classes (#368's fresh-pane grid/pty measurement race, #356's stacked
+    /// header/footer chrome) and a third (a font-fallback-driven row-height blowup); none
+    /// reproduced under real, repeated measurement. This is the real, direct check of the
+    /// remaining candidate root cause `debug_bounds` can answer: does this pane's own real,
+    /// painted geometry - header band + the terminal's own content band + its bottom bar - ever
+    /// stop summing to the pane's real total height, on a pane that has had genuinely long real
+    /// output (well past #356's chrome rebuild and #368's fresh-pane latch, both scoped to a
+    /// pane's very first frames)? A gap here would mean the grid is sized against a region
+    /// different from what is really on screen - exactly the shape "the height is not good" would
+    /// take, independent of whether a scrollbar is also, separately, correct.
+    #[gpui::test]
+    fn header_content_and_footer_bands_sum_to_the_real_pane_height_on_a_long_transcript(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = init_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+        let id = spawn_and_select(&app, cx, repo.path().to_path_buf(), None);
+        app.update(cx, |app, cx| {
+            app.agents.set_kind_for_test(id, ProcessKind::claude());
+            cx.notify();
+        });
+        cx.run_until_parked();
+
+        let pane = app
+            .read_with(cx, |app, _| {
+                app.agents
+                    .iter()
+                    .find(|agent| agent.id == id)
+                    .map(|agent| agent.pane.clone())
+            })
+            .expect("the spawned agent");
+
+        // A genuinely long real transcript - matches the user's own repro (~165 numbered lines),
+        // well past one screen's worth of content, so a scrollbar is *expected*; what this test
+        // checks is whether the pane's own real geometry stays self-consistent, not whether
+        // scrolling exists at all.
+        pane.update(cx, |pane, cx| {
+            for i in 1..=165 {
+                pane.inject_bytes_for_test(format!("line {i}\r\n").as_bytes(), cx);
+            }
+        });
+        cx.run_until_parked();
+
+        // Checked once at the pane's initial size, and again below after a *real* window resize
+        // on this now-long-running pane - hypothesis: does the grid's own row/col count, and the
+        // chrome around it, stay correct across a real resize once a pane has real accumulated
+        // output, or can it drift/go stale the way a fresh, empty pane's once did (#368)?
+        let check = |cx: &mut gpui::VisualTestContext, when: &str| {
+            let surface = cx
+                .debug_bounds("pty-surface")
+                .unwrap_or_else(|| panic!("the pty surface must paint ({when})"));
+            let header = cx
+                .debug_bounds("pty-header")
+                .unwrap_or_else(|| panic!("the header must paint ({when})"));
+            let content = cx
+                .debug_bounds("pty-surface-content")
+                .unwrap_or_else(|| panic!("the content band must paint ({when})"));
+            let footer = cx.debug_bounds("pty-footer").unwrap_or_else(|| {
+                panic!("a real agent tab's own readout strip must paint ({when})")
+            });
+            let terminal = cx
+                .debug_bounds("terminal-pane")
+                .unwrap_or_else(|| panic!("the terminal pane itself must paint ({when})"));
+
+            let summed_height = header.size.height + content.size.height + footer.size.height;
+            assert!(
+                (summed_height.as_f32() - surface.size.height.as_f32()).abs() < 1.0,
+                "{when}: header ({:?}) + content ({:?}) + footer ({:?}) = {summed_height:?} must \
+                 sum to the pane's real total height {:?}, with no unaccounted-for gap or overlap",
+                header.size.height,
+                content.size.height,
+                footer.size.height,
+                surface.size.height,
+            );
+
+            // The terminal itself must exactly fill the content band it was given - not claim
+            // less (dead space) or more (painting over the header/footer).
+            assert_eq!(
+                terminal.size, content.size,
+                "{when}: the terminal pane must exactly fill its own content band, got \
+                 terminal={terminal:?} content={content:?}"
+            );
+        };
+        check(cx, "at initial size, after 165 real lines");
+
+        // The terminal's *own* internally-measured content-area bounds - what
+        // `TerminalPane::maybe_resize_pty` actually sizes the grid from - must match its
+        // externally-measured painted bounds. If these ever disagreed, the grid would be sized
+        // for a region different from what is really on screen.
+        let assert_internal_matches_external = |cx: &mut gpui::VisualTestContext, when: &str| {
+            let terminal = cx.debug_bounds("terminal-pane").expect("checked above");
+            let internal = pane
+                .read_with(cx, |pane, _| pane.content_bounds_for_test())
+                .expect("the pane must have painted at least once");
+            assert!(
+                (internal.size.width.as_f32() - terminal.size.width.as_f32()).abs() < 1.0
+                    && (internal.size.height.as_f32() - terminal.size.height.as_f32()).abs() < 1.0,
+                "{when}: the terminal's own internal measurement {internal:?} must match its \
+                 real, externally painted bounds {terminal:?}"
+            );
+        };
+        assert_internal_matches_external(cx, "at initial size, after 165 real lines");
+
+        // A real resize - a window resize, a panel opening, a sidebar toggle all land here -
+        // happening *after* this pane has real, long-accumulated output, not just at spawn.
+        let initial_size = cx.debug_bounds("pty-surface").expect("checked above").size;
+        let resized = gpui::size(
+            initial_size.width - px(280.0),
+            initial_size.height - px(140.0),
+        );
+        cx.simulate_resize(resized);
+        // A couple of parked passes - matching `maybe_resize_pty`'s own documented one-frame
+        // measurement lag - not the many an unfixed pane would actually need (it never caught up
+        // on its own at all; see the fix this test guards).
+        cx.run_until_parked();
+        cx.run_until_parked();
+
+        check(cx, "after a real resize on a long-running pane");
+        assert_internal_matches_external(cx, "after a real resize on a long-running pane");
+
+        // And the grid itself must have really followed - immediately, without needing any
+        // *unrelated* event (e.g. new pty output) to force a fresh render first: its own
+        // reported column/row count must be consistent with the terminal's newly measured
+        // content area and cell size, not left over from before the resize.
+        let (cell_size, (cols, rows), content_bounds) = pane.update_in(cx, |pane, window, _cx| {
+            (
+                pane.cell_size_for_test(window),
+                pane.grid_dimensions(),
+                pane.content_bounds_for_test()
+                    .expect("the pane must have painted at least once"),
+            )
+        });
+        let expected_cols =
+            ((content_bounds.size.width.as_f32() - 16.0) / cell_size.width.as_f32()) as u16;
+        let expected_rows =
+            ((content_bounds.size.height.as_f32() - 16.0) / cell_size.height.as_f32()) as u16;
+        assert!(
+            cols.abs_diff(expected_cols) <= 1 && rows.abs_diff(expected_rows) <= 1,
+            "after a real resize on a long-running pane, the grid's own dimensions ({cols}x{rows}) \
+             must track its newly measured content area (expected ~{expected_cols}x{expected_rows} \
+             from content_bounds={content_bounds:?}, cell_size={cell_size:?}) - not be stale from \
+             before the resize"
         );
     }
 


### PR DESCRIPTION
## Summary

- Fixes #375 - a real, live-reported bug: "the height of the agent terminal is not good" on a genuinely long real Claude agent conversation.
- Root cause: `TerminalPane`'s content-bounds-measuring `canvas()` updated `self.content_bounds` via a plain `Entity::update`, which doesn't implicitly notify - and a bare `cx.notify()` called from inside that same prepaint callback is silently dropped, since `WindowInvalidator::invalidate_view` only marks the window dirty outside an active draw phase. A real window resize (or a panel opening, a sidebar toggle) on a pane that wasn't otherwise producing new pty output left the grid's own row/col count frozen at the pre-resize values indefinitely - only unrelated new pty output (which does notify outside a draw phase, from the poll loop) would eventually force it to catch up. A real conversation spends real time idle between turns, exactly when a resize is likely to happen.
- Two other candidate root causes (the #368 fresh-pane grid-sizing race, the #356 header/footer chrome rebuild) were investigated with real, repeated measurement and ruled out - see the issue for the full trail, including a font-fallback-glyph-wrap hypothesis that was tested directly against GPUI's real layout engine and disproven.
- Fix: `window.defer` the content-bounds update + `cx.notify()` to the end of the current effect cycle, where `invalidate_view` will actually schedule the next real frame, comparing against the previous value first so this doesn't request a redraw every frame while nothing is moving.

## Test plan

- [x] New regression test (`header_content_and_footer_bands_sum_to_the_real_pane_height_on_a_long_transcript`) proving the header/content/footer bands sum to the pane's real total height, and the grid's own dimensions track a real `cx.simulate_resize` immediately, on a pane with 165 real lines of accumulated output.
- [x] Two existing #368 regression tests updated to drive a real resize / direct grid append instead of a raw `content_bounds` field poke, since the canvas now actively self-heals any divergence from the real window.
- [x] `cargo build --workspace`
- [x] `cargo test -p app --lib terminal::` (184 passed)
- [x] `cargo test -p app --lib work_surface::` (137 passed)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (clean)
- [x] Live before/after in the real running app: a real X11 `ConfigureWindow` resize (no synthetic keyboard/mouse input) on an already-open shell pane. Before the fix, the pty-dimensions footer stayed stuck at the pre-resize `110x36` while the pane was quiet; after the fix it updates to the correct `51x25` on the very next frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)