### PR TITLE
Terminals are not agents: the jump keycaps, the review gate, Next Agent, and the palette (#381)

### DIFF
--- a/crates/app/src/palette/state.rs
+++ b/crates/app/src/palette/state.rs
@@ -617,10 +617,20 @@ pub fn build_language_server_groups(
 }
 
 /// Builds the palette's result groups for the current `scope`/`query`. Group order is always
-/// Agents, Commands, Files; a group with zero matches is omitted entirely rather than shown as
-/// an empty header.
+/// Agents, Terminals, Commands, Files; a group with zero matches is omitted entirely rather than
+/// shown as an empty header.
 ///
-/// Agents only appear in [`PaletteScope::All`] - there is no dedicated Agents segment in the
+/// **`Agents` and `Terminals` are two groups, not one** (GitHub issue #381). Both are open panes
+/// and both are worth switching to by name, but a plain `ProcessKind::Shell` is not an agent -
+/// `Jerry.dc.html` has never counted the terminal among a worktree's `agents`, and filing a shell
+/// under a heading that reads `Agents` told the user the opposite of what the rest of the app
+/// (the rail, which gives a shell no agent row at all; the pane chrome, which draws a shell a
+/// different bottom bar) tells them. Splitting rather than filtering is deliberate: the palette
+/// is the keyboard route to a pane, and dropping shells out of it would have made a terminal tab
+/// mouse-reachable only - a real loss, and an unnecessary one, since the honest fix is just to
+/// stop calling it an agent.
+///
+/// Both groups only appear in [`PaletteScope::All`] - there is no dedicated Agents segment in the
 /// scope control. For an empty query in a scope that shows files, the file candidates are first
 /// narrowed to changed files (`FileCandidate::changed.is_some()`) under a `"Recent Files"`
 /// label: this app has no file-access/mtime history to rank true recency by, so "recent" is
@@ -637,10 +647,23 @@ pub fn build_groups(
     let mut groups = Vec::new();
 
     if scope == PaletteScope::All {
-        let entries = filter_agents(agents, query);
+        let (sessions, shells): (Vec<_>, Vec<_>) = agents
+            .iter()
+            .cloned()
+            .partition(|candidate| candidate.kind.is_agent_session());
+
+        let entries = filter_agents(&sessions, query);
         if !entries.is_empty() {
             groups.push(PaletteGroup {
                 label: "Agents",
+                entries,
+            });
+        }
+
+        let entries = filter_agents(&shells, query);
+        if !entries.is_empty() {
+            groups.push(PaletteGroup {
+                label: "Terminals",
                 entries,
             });
         }
@@ -1157,6 +1180,65 @@ mod tests {
         assert_eq!(
             flat[1].target,
             EntryTarget::Command(PaletteCommand::NewShell)
+        );
+    }
+
+    /// GitHub issue #381: a plain [`ProcessKind::Shell`] is not an agent, so it does not appear
+    /// under a heading that says `Agents` - it gets its own `Terminals` group instead, in the
+    /// same palette, so it stays fully keyboard-reachable while being named honestly.
+    #[test]
+    fn a_shell_is_listed_under_terminals_never_under_agents() {
+        let candidates = vec![
+            agent(1, "Fix rate limiter", Some("fix/rl"), Status::Run),
+            AgentCandidate {
+                id: 2,
+                kind: ProcessKind::Shell,
+                title: "scratch".to_string(),
+                branch: Some("fix/rl".to_string()),
+                status: Status::Idle,
+            },
+        ];
+
+        let groups = build_groups(PaletteScope::All, "", &candidates, &[], &[]);
+
+        let labels: Vec<&str> = groups.iter().map(|g| g.label).collect();
+        assert_eq!(
+            labels,
+            vec!["Agents", "Terminals"],
+            "two separate groups, agents first"
+        );
+        let agents_group = groups.iter().find(|g| g.label == "Agents").unwrap();
+        assert_eq!(
+            agents_group
+                .entries
+                .iter()
+                .map(|entry| entry.target.clone())
+                .collect::<Vec<_>>(),
+            vec![EntryTarget::Agent(1)],
+            "only the real agent session may be filed under `Agents`"
+        );
+        let terminals_group = groups.iter().find(|g| g.label == "Terminals").unwrap();
+        assert_eq!(
+            terminals_group
+                .entries
+                .iter()
+                .map(|entry| entry.target.clone())
+                .collect::<Vec<_>>(),
+            vec![EntryTarget::Agent(2)],
+            "the shell is still a real, selectable row - just not an agent"
+        );
+    }
+
+    /// A group with no members is omitted entirely, exactly like every other palette group -
+    /// splitting agents from terminals must not add a permanently-empty `Terminals` header to
+    /// every window that has no shell open.
+    #[test]
+    fn the_terminals_group_is_absent_when_no_shell_is_open() {
+        let candidates = vec![agent(1, "Fix rate limiter", Some("fix/rl"), Status::Run)];
+        let groups = build_groups(PaletteScope::All, "", &candidates, &[], &[]);
+        assert_eq!(
+            groups.iter().map(|g| g.label).collect::<Vec<_>>(),
+            vec!["Agents"]
         );
     }
 

--- a/crates/app/src/review/flow.rs
+++ b/crates/app/src/review/flow.rs
@@ -47,12 +47,20 @@ impl AdeApp {
     /// its worktree, anchored under its own `refs/jerry/review/*` ref, recorded in memory and
     /// persisted.
     ///
-    /// Called from `crate::work_surface::render::AdeApp::new_agent` - the caller of
-    /// `Agents::spawn`, not `Agents::spawn` itself, mirroring how `load_diff` is triggered by a
-    /// caller rather than baked into a lower-level type. `Agents` has no business knowing about
-    /// git snapshots. Called unconditionally after every spawn, [`ProcessKind::Shell`] included -
-    /// the kind check below is what makes that safe rather than something every caller has to
-    /// remember.
+    /// Called from the *callers* of `Agents::spawn`, not from `Agents::spawn` itself, mirroring
+    /// how `load_diff` is triggered by a caller rather than baked into a lower-level type -
+    /// `Agents` has no business knowing about git snapshots. Called unconditionally after every
+    /// spawn, [`ProcessKind::Shell`] included - the kind check below is what makes that safe
+    /// rather than something every caller has to remember.
+    ///
+    /// **Every** real spawn door must call it, and that is the one thing this arrangement cannot
+    /// enforce for itself. The full set: `crate::work_surface::render::AdeApp::new_agent`,
+    /// `::new_agent_pane` and `::respawn_agent`, `crate::work_surface::session::AdeApp::
+    /// restore_worktree_session`'s two arms, `crate::hooks::flow::AdeApp::resume_past_agent`, and
+    /// `crate::root::AdeApp::select_worktree`'s startup tab. The middle two were missing it until
+    /// GitHub issue #381 - `new_agent_pane` in particular is `ctrl-shift-N`, the title bar's
+    /// `New Agent Pane` row and the empty pane's own `Start an agent` CTA, i.e. how most agents
+    /// in this app are really started, and none of them could ever open a review surface.
     ///
     /// ## The accepted race
     ///

--- a/crates/app/src/review/render.rs
+++ b/crates/app/src/review/render.rs
@@ -1187,6 +1187,79 @@ mod review_flow_tests {
         });
     }
 
+    /// **Every real spawn door captures a baseline**, not just `new_agent`.
+    ///
+    /// Found by driving the running app while verifying GitHub issue #381: `new_agent_pane`
+    /// (`ctrl-shift-N`, the title bar's `New Agent Pane` row, and the empty pane's own
+    /// `Start an agent` CTA) and `respawn_agent` (`Retry`/`Resume`) both spawned a real agent and
+    /// never captured one, so no agent started through them could ever open a review surface -
+    /// and `new_agent_pane` is how most agents in this app are actually started. `respawn_agent`
+    /// is the worse of the two: its own `close_agent` has already *released* the previous
+    /// agent's ref, so a retried agent was left with neither.
+    ///
+    /// Asserted through `AdeApp::agent_reviews` (a real captured baseline with a real
+    /// `refs/jerry/review/*` ref behind it), not merely through `review_available_for`, so this
+    /// can't pass on the single-agent gate alone.
+    #[gpui::test]
+    fn every_spawn_door_captures_a_review_baseline(cx: &mut TestAppContext) {
+        let repo = diverged_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        // `new_agent_pane` resolves the first agent CLI really installed on `$PATH` in the
+        // background before it spawns, so this needs a real parked run to land.
+        app.update(cx, |app, cx| app.new_agent_pane(cx));
+        cx.run_until_parked();
+        let from_pane_door = app.read_with(cx, |app, _| {
+            app.agents
+                .active_id()
+                .expect("new_agent_pane spawned a tab")
+        });
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.agents
+                    .iter()
+                    .find(|agent| agent.id == from_pane_door)
+                    .is_some_and(|agent| agent.kind.is_agent_session()),
+                "sanity check: this door spawns a real agent session, not a shell"
+            );
+            let review = app
+                .agent_reviews
+                .get(&from_pane_door)
+                .expect("`New Agent Pane` must capture a review baseline like every other door");
+            assert!(
+                !review.baseline.tree_id.is_empty(),
+                "and a real snapshot behind it, not an empty placeholder"
+            );
+            assert_eq!(
+                git_stdout(repo.path(), &["rev-parse", &review.baseline.ref_name]).trim(),
+                review.baseline.tree_id,
+                "the real ref must point at that snapshot"
+            );
+        });
+
+        // `Retry`/`Resume`: closes the tab (releasing its ref) and spawns a fresh agent.
+        app.update_in(cx, |app, window, cx| {
+            app.respawn_agent(from_pane_door, window, cx)
+        });
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| {
+            let respawned = app.agents.active_id().expect("respawn_agent spawned a tab");
+            assert_ne!(
+                respawned, from_pane_door,
+                "sanity check: a respawn is a genuinely new agent, not the old one revived"
+            );
+            let review = app.agent_reviews.get(&respawned).expect(
+                "a retried agent must get its own baseline - its predecessor's ref was just \
+                 released, so without one it has nothing at all to review against",
+            );
+            assert_eq!(
+                git_stdout(repo.path(), &["rev-parse", &review.baseline.ref_name]).trim(),
+                review.baseline.tree_id
+            );
+        });
+    }
+
     /// Closing an agent releases its baseline ref (so `git gc` can reclaim the objects) but
     /// deliberately keeps the persisted metadata entry - the groundwork GitHub issue #227 needs.
     #[gpui::test]

--- a/crates/app/src/review/render.rs
+++ b/crates/app/src/review/render.rs
@@ -1101,6 +1101,92 @@ mod review_flow_tests {
         });
     }
 
+    /// **A plain terminal sharing the worktree does not gate anything** (GitHub issue #381).
+    ///
+    /// The single-agent gate exists so one agent's review can't claim another agent's changes;
+    /// a [`ProcessKind::Shell`] is not a party it can ever be confused with - no baseline is
+    /// captured for one, it has no turns, and it can never open a review surface of its own. It
+    /// used to be counted anyway, and the consequence was not a corner case: `select_worktree`
+    /// opens a startup shell in every worktree that has no tab yet, so the *first* agent started
+    /// anywhere already shared its worktree with that shell and the gate never opened for it. The
+    /// review surface was effectively dead in the default configuration - `crate::sound::flow`'s
+    /// module docs describe exactly this and route around it.
+    ///
+    /// Deliberately does **not** use [`sole_agent`], whose whole job is to close the startup
+    /// shell first: keeping that shell open is the entire point of this test.
+    #[gpui::test]
+    fn a_plain_shell_in_the_same_worktree_does_not_gate_the_review_surface(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = diverged_repo();
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        let shell = app.read_with(cx, |app, _| {
+            let ids: Vec<AgentId> = app.agents.iter().map(|agent| agent.id).collect();
+            assert_eq!(ids.len(), 1, "the window's own startup shell");
+            ids[0]
+        });
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.agents
+                    .iter()
+                    .find(|agent| agent.id == shell)
+                    .map(|agent| agent.kind),
+                Some(ProcessKind::Shell),
+                "sanity check: the startup tab really is a shell, not an agent session"
+            );
+        });
+
+        // A real agent alongside it - the shell stays open, exactly as it does in the app.
+        app.update_in(cx, |app, window, cx| {
+            app.new_agent(ProcessKind::claude(), window, cx);
+        });
+        cx.run_until_parked();
+        let agent = app.read_with(cx, |app, _| {
+            app.agents.active_id().expect("the agent just spawned")
+        });
+        std::fs::write(repo.path().join("agent_work.rs"), "fn main() {}\n").expect("write");
+        app.update(cx, |app, cx| app.load_agent_review(agent, cx));
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.agents.iter().count(),
+                2,
+                "sanity check: the shell and the agent really are both open in this worktree"
+            );
+            assert!(
+                app.agents.is_sole_agent_in_worktree(agent),
+                "a terminal is not an agent - the agent is still the only *agent session* here"
+            );
+            assert!(
+                app.review_available_for(agent),
+                "an open terminal must not hold back the whole review surface"
+            );
+            assert_eq!(app.agent_review_file_count(agent), Some(1));
+            assert!(
+                !app.agents.is_sole_agent_in_worktree(shell),
+                "and the shell itself is never the subject of this gate - it has no baseline and \
+                 nothing to review"
+            );
+            assert!(
+                !app.review_available_for(shell),
+                "a shell must never get a review surface of its own"
+            );
+        });
+
+        // The tab really opens, not just the predicate.
+        app.update_in(cx, |app, window, cx| app.open_review_tab(agent, window, cx));
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.review_tab_open, Some(agent));
+            assert!(app
+                .combined_tab_order()
+                .contains(&work_surface::TabRef::Review(agent)));
+        });
+    }
+
     /// Closing an agent releases its baseline ref (so `git gc` can reclaim the objects) but
     /// deliberately keeps the persisted metadata entry - the groundwork GitHub issue #227 needs.
     #[gpui::test]

--- a/crates/app/src/root/focus.rs
+++ b/crates/app/src/root/focus.rs
@@ -828,9 +828,17 @@ mod tab_strip_keybinding_tests {
         );
     }
 
-    /// Spawns four extra real shell agents (five total, including the one `AdeApp::new` starts)
-    /// and confirms `secondary-3` really jumps to the third one in real agent order - not just
-    /// that `AdeApp::jump_to_agent_at(3, ..)` does when called directly.
+    /// Spawns a genuinely **mixed** strip - shells and real agent sessions interleaved - and
+    /// confirms `secondary-3` really jumps to the third *agent session*, not to the third tab.
+    /// Real keystroke coverage, not just that `AdeApp::jump_to_agent_at(3, ..)` does the right
+    /// thing when called directly.
+    ///
+    /// GitHub issue #381, the user's own report: shells used to take numbers. The startup shell
+    /// `AdeApp::new` opens sits at tab position 1 in every worktree, so with the old behaviour
+    /// every real agent was one position further along than the keycap beside it said, and
+    /// `secondary-1` selected a terminal. The fixture below is built so tab order and agent order
+    /// genuinely disagree: `[shell, claude, shell, codex, claude]`, where the third *agent* is
+    /// tab 5.
     #[gpui::test]
     fn secondary_3_jumps_to_the_third_real_agent_through_the_real_key_bindings(
         cx: &mut TestAppContext,
@@ -839,24 +847,42 @@ mod tab_strip_keybinding_tests {
         let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
 
+        // Tab 1 is `open_test_app`'s own startup shell. Four more, then retagged so the strip
+        // reads `[shell, claude, shell, codex, claude]` - every process is a real spawned shell,
+        // `set_kind_for_test` only changes what this app *calls* each one, which is exactly the
+        // discriminator under test.
         for _ in 0..4 {
             app.update_in(cx, |app, window, cx| {
                 app.new_agent(ProcessKind::Shell, window, cx);
             });
         }
-        let third_id = app.read_with(cx, |app, _| {
-            app.agents
-                .iter()
-                .nth(2)
-                .map(|agent| agent.id)
-                .expect("five real agents should exist by now")
+        let tab_ids: Vec<crate::work_surface::agents::AgentId> = app.read_with(cx, |app, _| {
+            app.agents.iter().map(|agent| agent.id).collect()
         });
-        assert_ne!(
-            app.read_with(cx, |app, _| app.agents.active_id()),
-            Some(third_id),
-            "sanity check: the most recently spawned agent (the fifth), not the third, should \
-             be active before the jump"
+        assert_eq!(tab_ids.len(), 5, "five real tabs should exist by now");
+        app.update(cx, |app, _cx| {
+            app.agents
+                .set_kind_for_test(tab_ids[1], ProcessKind::claude());
+            app.agents
+                .set_kind_for_test(tab_ids[3], ProcessKind::codex());
+            app.agents
+                .set_kind_for_test(tab_ids[4], ProcessKind::claude());
+        });
+        // The third real agent session: tab 5, two shells having been skipped on the way.
+        let third_agent_id = tab_ids[4];
+        let third_tab_id = tab_ids[2];
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.agent_jump_keys()),
+            vec!["1".to_string(), "2".to_string(), "3".to_string()],
+            "the keycap row must advertise one number per real agent session (three), not one \
+             per tab (five)"
         );
+
+        // Start from a tab that is neither answer, so the assertion below can't pass by accident.
+        app.update_in(cx, |app, window, cx| {
+            app.select_agent(tab_ids[0], window, cx);
+        });
 
         let secondary_3 = if cfg!(target_os = "macos") {
             "cmd-3"
@@ -867,15 +893,25 @@ mod tab_strip_keybinding_tests {
 
         assert_eq!(
             app.read_with(cx, |app, _| app.agents.active_id()),
-            Some(third_id),
-            "a real, simulated {secondary_3} keystroke must activate the agent at position 3 \
+            Some(third_agent_id),
+            "a real, simulated {secondary_3} keystroke must activate the *third agent session* \
              through crate::default_key_bindings' real secondary-3 -> JumpToAgent3 binding"
+        );
+        assert_ne!(
+            app.read_with(cx, |app, _| app.agents.active_id()),
+            Some(third_tab_id),
+            "it must not activate the third *tab*, which is a plain shell - a terminal is not an \
+             agent and takes no jump number (GitHub issue #381)"
         );
     }
 
     /// [`AdeApp::jump_to_agent_at`]'s own direct-call coverage (as opposed to the keystroke
     /// simulation above) for every position 1..=8, plus the real "fewer agents than the
     /// position" no-op.
+    ///
+    /// Every tab here is retagged to a real agent session, so positions 1..=4 are genuinely
+    /// occupied - GitHub issue #381 stopped shells taking a number, and the interleaved-fixture
+    /// case is covered by the keystroke test above.
     #[gpui::test]
     fn jump_to_agent_at_activates_the_right_agent_by_position(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
@@ -899,6 +935,11 @@ mod tab_strip_keybinding_tests {
             ids.push(id);
         }
         // Four real agents now exist, in spawn order `ids[0..4]`.
+        app.update(cx, |app, _cx| {
+            for id in &ids {
+                app.agents.set_kind_for_test(*id, ProcessKind::claude());
+            }
+        });
 
         for (position, expected_id) in ids.iter().enumerate() {
             let position = position + 1;

--- a/crates/app/src/root/menu_commands.rs
+++ b/crates/app/src/root/menu_commands.rs
@@ -74,8 +74,25 @@ impl AdeApp {
             // GitHub issue #90: a genuinely empty window has no real repo root to spawn an agent
             // into - see `crate::work_surface::render::AdeApp::new_agent`'s own docs.
             MenuCommand::NewTerminal | MenuCommand::NewAgentPane => self.focused_repo().is_some(),
+            // Exactly what `select_relative_agent` can actually do, so the row is never enabled
+            // over a no-op: with the active tab already *being* the worktree's only agent
+            // session there is nowhere to cycle to, but from a shell tab (or any other non-agent
+            // pane) a single agent session is a real destination - see that method's own docs
+            // for the entry-from-outside-the-cycle case, and GitHub issue #381 for why a shell
+            // stopped counting as a stop on it.
             MenuCommand::NextAgent | MenuCommand::PreviousAgent => {
-                self.current_worktree_agents().count() > 1
+                let ids: Vec<_> = self
+                    .current_worktree_agent_sessions()
+                    .map(|agent| agent.id)
+                    .collect();
+                match self.agents.active_id() {
+                    None => false,
+                    // Already sitting on the cycle: it has to have somewhere else to go.
+                    Some(active) if ids.contains(&active) => ids.len() > 1,
+                    // Entering it from outside (a shell tab is the common one): any single
+                    // agent session is a real destination.
+                    Some(_) => !ids.is_empty(),
+                }
             }
             MenuCommand::ArchiveAgent => self.agents.active_id().is_some(),
             // GitHub issue #295 moved the agent review door here from the pane footer, which §4r

--- a/crates/app/src/title_bar/menu.rs
+++ b/crates/app/src/title_bar/menu.rs
@@ -1283,6 +1283,18 @@ mod title_menu_tests {
                 cx,
             );
         });
+        // Retagged to a real agent kind: `select_relative_agent` only ever stops on a real agent
+        // session (GitHub issue #381 - a row that says "Next Agent" must not land on a terminal),
+        // so a cycle built out of plain shells would have nothing to cycle through at all. The
+        // second worktree's agent is retagged too, so it stays a genuine candidate for the
+        // cross-worktree leak this test's own docs are about - filtering by kind must not be what
+        // keeps cycling inside worktree A.
+        app.update(cx, |app, _cx| {
+            let ids: Vec<AgentId> = app.agents.iter().map(|agent| agent.id).collect();
+            for id in ids {
+                app.agents.set_kind_for_test(id, ProcessKind::claude());
+            }
+        });
         // Spawning into the second worktree above made its own agent globally active - re-
         // select the first worktree to restore it as the one under test (its own last-active tab
         // via `Agents::activate_for_worktree`).
@@ -1359,5 +1371,102 @@ mod title_menu_tests {
                  find nothing"
             );
         });
+    }
+
+    /// GitHub issue #381: `Next Agent`/`Previous Agent` skip plain terminals, and - because the
+    /// active tab being a terminal is the *normal* state, not an edge case - stepping from one
+    /// enters the agent cycle at its near end rather than doing nothing.
+    ///
+    /// The strip here is `[shell, claude, codex]`, which is what a worktree looks like the moment
+    /// a user starts two agents in it: the startup shell `select_worktree` opened, then their
+    /// agents. Before this fix the cycle had three stops and half of every user's presses landed
+    /// them back on the terminal they were trying to leave.
+    #[gpui::test]
+    fn next_agent_skips_shells_and_enters_the_cycle_from_one(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        for _ in 0..2 {
+            app.update_in(cx, |app, window, cx| {
+                app.new_agent(ProcessKind::Shell, window, cx);
+            });
+        }
+        cx.run_until_parked();
+        let ids: Vec<AgentId> = app.read_with(cx, |app, _| {
+            app.agents.iter().map(|agent| agent.id).collect()
+        });
+        assert_eq!(ids.len(), 3, "the startup shell plus two more tabs");
+        app.update(cx, |app, _cx| {
+            app.agents.set_kind_for_test(ids[1], ProcessKind::claude());
+            app.agents.set_kind_for_test(ids[2], ProcessKind::codex());
+        });
+
+        // Sitting on the shell: `Next Agent` must be offered, and must go somewhere.
+        app.update_in(cx, |app, window, cx| app.select_agent(ids[0], window, cx));
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.menu_command_enabled(MenuCommand::NextAgent),
+                "with real agents open, `Next Agent` from a terminal is a real action"
+            );
+        });
+        app.update_in(cx, |app, window, cx| {
+            app.select_relative_agent(1, window, cx)
+        });
+        assert_eq!(
+            app.read_with(cx, |app, _| app.agents.active_id()),
+            Some(ids[1]),
+            "stepping forward off a terminal must enter the agent cycle at its first agent, \
+             never be a silent no-op"
+        );
+
+        // Forward again wraps across the two agents - the shell is not a stop.
+        app.update_in(cx, |app, window, cx| {
+            app.select_relative_agent(1, window, cx)
+        });
+        assert_eq!(
+            app.read_with(cx, |app, _| app.agents.active_id()),
+            Some(ids[2])
+        );
+        app.update_in(cx, |app, window, cx| {
+            app.select_relative_agent(1, window, cx)
+        });
+        assert_eq!(
+            app.read_with(cx, |app, _| app.agents.active_id()),
+            Some(ids[1]),
+            "the cycle wraps between the two real agents and never lands on the shell"
+        );
+
+        // Backwards off a terminal enters at the far end instead.
+        app.update_in(cx, |app, window, cx| app.select_agent(ids[0], window, cx));
+        app.update_in(cx, |app, window, cx| {
+            app.select_relative_agent(-1, window, cx)
+        });
+        assert_eq!(
+            app.read_with(cx, |app, _| app.agents.active_id()),
+            Some(ids[2]),
+            "stepping backward off a terminal must enter at the last agent"
+        );
+
+        // And with no agent session at all there is genuinely nothing to offer.
+        app.update_in(cx, |app, window, cx| {
+            app.agents.set_kind_for_test(ids[1], ProcessKind::Shell);
+            app.agents.set_kind_for_test(ids[2], ProcessKind::Shell);
+            app.select_agent(ids[0], window, cx);
+        });
+        app.read_with(cx, |app, _| {
+            assert!(
+                !app.menu_command_enabled(MenuCommand::NextAgent),
+                "a worktree of nothing but terminals has no agent to cycle to"
+            );
+        });
+        app.update_in(cx, |app, window, cx| {
+            app.select_relative_agent(1, window, cx)
+        });
+        assert_eq!(
+            app.read_with(cx, |app, _| app.agents.active_id()),
+            Some(ids[0]),
+            "and the action itself is a real no-op there, not a jump to a terminal"
+        );
     }
 }

--- a/crates/app/src/work_surface/agents.rs
+++ b/crates/app/src/work_surface/agents.rs
@@ -247,8 +247,8 @@ impl Agents {
         self.agents.iter().filter(move |agent| agent.cwd == cwd)
     }
 
-    /// How many agents are currently open in `cwd` - the real signal behind GitHub issue #225's
-    /// **single-agent gate**.
+    /// How many **real agent sessions** are currently open in `cwd` - the real signal behind
+    /// GitHub issue #225's **single-agent gate**.
     ///
     /// The whole review surface (the Review tab, the footer's `Review diff` door, and the rail's
     /// review-ready status) is held back for any worktree with more than one open agent, because
@@ -257,30 +257,49 @@ impl Agents {
     /// would have no way to tell them apart. Presenting that as "this agent's review" would be a
     /// fabrication, so it shows nothing at all until the worktree is back down to one agent.
     ///
+    /// A plain [`ProcessKind::Shell`] is **not** counted (GitHub issue #381). The gate is about
+    /// *which agent gets credited with a diff*, and a shell is never a candidate for that credit:
+    /// no baseline is ever captured for one ([`crate::review::flow::AdeApp::
+    /// capture_review_baseline`] refuses outright), it has no turns to end, and it can never
+    /// itself open a review surface. Counting one was not a conservative choice, it was a
+    /// silently fatal one: `crate::root::AdeApp::select_worktree` spawns a startup shell into
+    /// every worktree that has no tab yet, so the *first* agent started in any worktree already
+    /// shared it with that shell and the gate never opened for it - the review surface was
+    /// effectively dead in the default configuration. `crate::sound::flow`'s module docs had
+    /// already written that consequence down ("Every window starts with a shell already open in
+    /// the repo, so spawning a Claude agent into that same worktree makes two agents there - the
+    /// single-agent gate then never opens for it") and routed around it rather than fixing it
+    /// here.
+    ///
     /// Deliberately a **decision-time** check, not a capture-time one: a baseline is still
     /// captured for every agent regardless of how many share its worktree (it's cheap, and it
     /// means the surface simply starts working - correctly, against a real baseline taken at the
     /// right moment - the instant the others close). Only *display* is gated.
     ///
-    /// Reads through [`Self::iter_for_cwd`] rather than open-coding the filter, so the tab
-    /// strip's own per-worktree scoping and this gate can never disagree about which agents
-    /// belong to a worktree.
+    /// Reads through [`Self::iter_for_cwd`] rather than open-coding the per-worktree filter, so
+    /// the tab strip's own per-worktree scoping and this gate can never disagree about which
+    /// agents belong to a worktree.
     pub fn count_for_cwd(&self, cwd: &Path) -> usize {
-        self.iter_for_cwd(cwd.to_path_buf()).count()
+        self.iter_for_cwd(cwd.to_path_buf())
+            .filter(|agent| agent.kind.is_agent_session())
+            .count()
     }
 
-    /// `true` if `id` names an agent that is the **only** one currently open in its own
-    /// worktree: the review surface's real gate, in the one form every call site wants. `false`
-    /// for an
-    /// unknown id (e.g. a just-closed agent), so a stale click handler can never re-open a review
-    /// surface for an agent that no longer exists.
+    /// `true` if `id` names a **real agent session** that is the only one currently open in its
+    /// own worktree: the review surface's real gate, in the one form every call site wants.
+    /// `false` for an unknown id (e.g. a just-closed agent), so a stale click handler can never
+    /// re-open a review surface for an agent that no longer exists - and `false` for a plain
+    /// [`ProcessKind::Shell`], which is not a session this gate can ever open *for* (it has no
+    /// baseline and nothing to review); without that check a lone shell would satisfy a gate
+    /// whose whole subject is "which agent's changes are these".
     ///
-    /// See [`Self::count_for_cwd`] for why this gate exists at all.
+    /// See [`Self::count_for_cwd`] for why this gate exists at all, and why the count it reads
+    /// leaves shells out.
     pub fn is_sole_agent_in_worktree(&self, id: AgentId) -> bool {
         let Some(agent) = self.agents.iter().find(|agent| agent.id == id) else {
             return false;
         };
-        self.count_for_cwd(&agent.cwd) == 1
+        agent.kind.is_agent_session() && self.count_for_cwd(&agent.cwd) == 1
     }
 
     /// **The worktree's primary agent**: its own last-active tab (see [`Self::active_by_cwd`]),

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -569,7 +569,7 @@ impl AdeApp {
         // real hook injection - otherwise "Retry" would silently produce an agent whose status
         // fell back to the quiescence heuristic.
         let hook_injection = self.hook_injection_for(kind);
-        self.agents.spawn(
+        let respawned = self.agents.spawn(
             kind,
             cwd,
             self.settings.appearance.terminal_font_size,
@@ -578,6 +578,13 @@ impl AdeApp {
             window,
             cx,
         );
+        // ...and a freshly spawned agent's other half: its own review baseline. The close above
+        // has already released the *previous* agent's ref (`release_review_baseline`), so without
+        // this a retried agent could never have a review at all - a real gap found while
+        // verifying GitHub issue #381 against the running app, in the same "an agent-only
+        // capability quietly isn't there" family as that issue's own findings. A no-op for a
+        // `Shell`, like every other call to it.
+        self.capture_review_baseline(respawned, cx);
         self.focus_newly_spawned_agent(window, cx);
         // The close above and the spawn here are two real session changes; both are recorded, so a
         // relaunch reopens the retried agent's slot rather than the one it replaced.
@@ -1685,7 +1692,7 @@ impl AdeApp {
             let _ = this.update_in(cx, |this, window, cx| {
                 let kind = installed.unwrap_or(settings::AGENT_KINDS[0]);
                 let hook_injection = this.hook_injection_for(ProcessKind::Agent(kind));
-                this.agents.spawn(
+                let id = this.agents.spawn(
                     ProcessKind::Agent(kind),
                     cwd,
                     this.settings.appearance.terminal_font_size,
@@ -1694,6 +1701,13 @@ impl AdeApp {
                     window,
                     cx,
                 );
+                // See `Self::new_agent`'s own identical call. Missing here until GitHub issue
+                // #381's live verification tripped over it: this door (`ctrl-shift-N`, the title
+                // bar's `New Agent Pane` row, and the empty pane's own `Start an agent` CTA) is
+                // how most agents in this app are actually started, and every one of them was
+                // spawned without a review baseline - so the whole #225 review surface could
+                // never open for it, no matter how many agents shared the worktree.
+                this.capture_review_baseline(id, cx);
                 this.focus_newly_spawned_agent(window, cx);
                 // See `Self::new_agent`'s own identical call - this is the same real new tab,
                 // reached through the `+` menu's background `$PATH` search instead.

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -864,9 +864,12 @@ impl AdeApp {
     /// the same order [`Self::combined_tab_order`] renders them - never Agents' own raw
     /// creation order once a real drag has interleaved them differently, and never every agent
     /// across every worktree, per this revision's whole point (see `crate::root::mod`'s "One
-    /// rail row per worktree" docs). The real per-worktree tab-strip order both
-    /// [`Self::render_tab_strip`] and [`Self::agent_jump_keys`]/[`Self::jump_to_agent_at`]
-    /// share, so the tabs shown and the tabs a jump keycap can reach can never disagree.
+    /// rail row per worktree" docs). The real per-worktree tab-strip order
+    /// [`Self::render_tab_strip`] draws from, so the tabs shown and this list can never disagree.
+    ///
+    /// **Every** pane tab, shells included - this is "what does the strip show", and a
+    /// [`ProcessKind::Shell`] genuinely gets a tab. Anything that means "a real agent session"
+    /// rather than "a pane" wants [`Self::current_worktree_agent_sessions`] instead.
     pub(crate) fn current_worktree_agents(&self) -> impl Iterator<Item = &Agent> {
         let order = self.combined_tab_order();
         order.into_iter().filter_map(move |tab_ref| match tab_ref {
@@ -876,6 +879,30 @@ impl AdeApp {
             | work_surface::TabRef::Review(_)
             | work_surface::TabRef::Run => None,
         })
+    }
+
+    /// [`Self::current_worktree_agents`] narrowed to **real agent sessions**
+    /// (`ProcessKind::is_agent_session`) - the list every surface that says the word *agent* to
+    /// the user counts and indexes by: [`Self::agent_jump_keys`]/[`Self::jump_to_agent_at`] (the
+    /// `secondary-1`..`secondary-8` keycaps and the status bar's copy of them),
+    /// [`Self::select_relative_agent`] (the title bar's `Next Agent`/`Previous Agent`), and that
+    /// pair's own menu-enablement predicate.
+    ///
+    /// Same order as the strip, just with the shells dropped, so `secondary-2` still means "the
+    /// second agent you can see, reading left to right" - it simply stops counting the terminal
+    /// sitting between them. GitHub issue #381: `Jerry.dc.html` has never treated a terminal as
+    /// an agent (`isAgent = t => activeWt.agents.indexOf(t) >= 0`, with `'terminal'` a separate
+    /// tab id its `isFileTab` test excludes by name), and the design's own keybinding table calls
+    /// this `Jump to session by position`. Counting shells made the keycap row advertise more
+    /// positions than there were agents and pushed every real agent off its own number.
+    ///
+    /// A shell is not made unreachable by this: it still has a real tab to click, and - since
+    /// this same issue stopped the palette filing shells under a heading that reads `Agents` - it
+    /// now has its own `Terminals` group there, which is a full keyboard path to it
+    /// (`crate::palette::state::build_groups`).
+    pub(crate) fn current_worktree_agent_sessions(&self) -> impl Iterator<Item = &Agent> {
+        self.current_worktree_agents()
+            .filter(|agent| agent.kind.is_agent_session())
     }
 
     /// Whether the *currently selected* worktree has zero real agents - at most a default
@@ -1034,15 +1061,17 @@ impl AdeApp {
         )
     }
 
-    /// The real `secondary-1`..`secondary-8` agent-jump keycap labels: one per agent open in
-    /// the *currently selected* worktree (`Self::current_worktree_agents`), capped at 8 since
-    /// those are the only ones actually bound (`crate::default_key_bindings`) - never a keycap
-    /// advertising a shortcut that silently does nothing. Shared by [`Self::render_tab_strip`]'s
-    /// own right-aligned cluster and the status bar's agent hint (`status_bar::render::
-    /// render_status_agent_hint`), so the two can never independently drift on what's really
-    /// bound.
+    /// The real `secondary-1`..`secondary-8` agent-jump keycap labels: one per **real agent
+    /// session** open in the *currently selected* worktree
+    /// ([`Self::current_worktree_agent_sessions`] - a plain shell is not an agent and gets no
+    /// number, see that method's docs), capped at 8 since those are the only ones actually bound
+    /// (`crate::default_key_bindings`) - never a keycap advertising a shortcut that silently does
+    /// nothing, and (GitHub issue #381) never one more keycap than there are agents for them to
+    /// land on. Shared by [`Self::render_tab_strip`]'s own right-aligned cluster and the status
+    /// bar's agent hint (`status_bar::render::render_status_agent_hint`), so the two can never
+    /// independently drift on what's really bound.
     pub(crate) fn agent_jump_keys(&self) -> Vec<String> {
-        let agent_count = self.current_worktree_agents().count().min(8);
+        let agent_count = self.current_worktree_agent_sessions().count().min(8);
         (1..=agent_count).map(|n| n.to_string()).collect()
     }
 
@@ -1706,10 +1735,16 @@ impl AdeApp {
         self.open_change_diff(next_path, window, cx);
     }
 
-    /// The tab strip's agent-jump keycaps (`secondary-1`..`secondary-8`) - jumps to the
-    /// agent at 1-indexed `position` in the same order [`Self::render_tab_strip`] iterates
-    /// (`Self::current_worktree_agents`), via [`Self::select_agent`]. No-op if fewer than
-    /// `position` agents are currently open in the selected worktree.
+    /// The tab strip's agent-jump keycaps (`secondary-1`..`secondary-8`) - jumps to the **real
+    /// agent session** at 1-indexed `position` in the same order [`Self::render_tab_strip`]
+    /// iterates ([`Self::current_worktree_agent_sessions`]), via [`Self::select_agent`]. No-op if
+    /// fewer than `position` agent sessions are currently open in the selected worktree.
+    ///
+    /// GitHub issue #381: a plain [`ProcessKind::Shell`] does not take a number. It used to, and
+    /// the position it consumed was the user's own live report - the *worktree's startup shell*
+    /// occupies position 1 in essentially every worktree, so `secondary-1` selected a terminal
+    /// and every real agent sat one place further along than the keycap beside it claimed. See
+    /// [`Self::current_worktree_agent_sessions`] for why the design agrees.
     pub(crate) fn jump_to_agent_at(
         &mut self,
         position: usize,
@@ -1718,7 +1753,7 @@ impl AdeApp {
     ) {
         let Some(id) = position
             .checked_sub(1)
-            .and_then(|index| self.current_worktree_agents().nth(index))
+            .and_then(|index| self.current_worktree_agent_sessions().nth(index))
             .map(|agent| agent.id)
         else {
             return;
@@ -1728,7 +1763,7 @@ impl AdeApp {
 
     /// The Windows/Linux title bar's Agent menu "Next agent"/"Previous agent" rows
     /// (`crate::title_bar::menu::AdeApp::render_title_menu`) - `delta` is `1`/`-1`. Cycles
-    /// through [`Self::current_worktree_agents`] in the same order
+    /// through [`Self::current_worktree_agent_sessions`] in the same order
     /// [`Self::jump_to_agent_at`] indexes - **never** every agent across every worktree
     /// (a real, live-reproduced bug found in this revision's own self-audit: an earlier version
     /// cycled `self.agents` directly, so "Next Agent" could jump to a *different* worktree's
@@ -1740,27 +1775,52 @@ impl AdeApp {
     /// [`Self::next_changed_file`]'s own cyclic-index convention for "next" over an existing
     /// ordered list), via the same real [`Self::select_agent`] every tab-strip click and jump
     /// keycap already goes through - no separate "next agent" subsystem, just a cyclic index
-    /// over the existing per-worktree list. No-op with fewer than two agents in the selected
-    /// worktree (nothing to cycle to) or no active agent at all (both real, reachable states -
-    /// the latter only while every agent has been closed).
+    /// over the existing per-worktree list. No-op with no agent session in the selected worktree
+    /// at all, or with no active agent at all (both real, reachable states - the latter only
+    /// while every agent has been closed).
+    ///
+    /// GitHub issue #381: a plain [`ProcessKind::Shell`] is not a stop on this cycle. A row that
+    /// says `Next Agent` and lands on a terminal is the same conflation the jump keycaps had, and
+    /// this one bit harder in practice - the startup shell sits in every worktree, so a two-tab
+    /// worktree of `[shell, claude]` made `Next Agent` a toggle that spent half its presses
+    /// leaving the only agent there was.
+    ///
+    /// **The active tab not being an agent session is a first-class case, not a no-op.** It is
+    /// the *normal* state (a focused terminal), and `Next Agent` from it must mean something:
+    /// there is no "current" position on the cycle to step from, so `delta > 0` enters at the
+    /// first agent session and `delta < 0` at the last. Falling out through the old
+    /// `position()?` here would have made the row silently dead in exactly the situation a user
+    /// reaches for it.
     pub(crate) fn select_relative_agent(
         &mut self,
         delta: isize,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let ids: Vec<AgentId> = self.current_worktree_agents().map(|s| s.id).collect();
-        if ids.len() < 2 {
+        let ids: Vec<AgentId> = self
+            .current_worktree_agent_sessions()
+            .map(|s| s.id)
+            .collect();
+        if ids.is_empty() {
             return;
         }
         let Some(active_id) = self.agents.active_id() else {
             return;
         };
-        let Some(current_index) = ids.iter().position(|id| *id == active_id) else {
-            return;
+        let next_index = match ids.iter().position(|id| *id == active_id) {
+            Some(current_index) => {
+                if ids.len() < 2 {
+                    // The one agent session here is already active - cycling has nowhere to go.
+                    return;
+                }
+                let len = ids.len() as isize;
+                (current_index as isize + delta).rem_euclid(len) as usize
+            }
+            // Active on a shell (or on some other pane that isn't an agent session at all):
+            // enter the cycle from whichever end `delta` is heading towards.
+            None if delta >= 0 => 0,
+            None => ids.len() - 1,
         };
-        let len = ids.len() as isize;
-        let next_index = (current_index as isize + delta).rem_euclid(len) as usize;
         self.select_agent(ids[next_index], window, cx);
     }
 


### PR DESCRIPTION
Closes #381.

The user's report, against the shipped build:

> terminals should not be considered agents. This is still the case for a few things like ctrl + number shortcuts. Check the app for other things like this.

Same root cause as #356/#358 — a plain `Shell` tab and a real `Claude`/`Codex` agent are both a `work_surface::agents::Agent`, discriminated only by `ProcessKind::is_agent_session()`. #358 fixed two rendering instances; this is the systemic audit the user asked for. `Jerry.dc.html` has never treated a terminal as an agent (`isAgent = t => activeWt.agents.indexOf(t) >= 0`, with `'terminal'` a separate tab id), and the design's keybinding table calls the numbered shortcut `Jump to session by position`.

Four real bugs, four commits.

### 1. `secondary-1`..`secondary-8` counted and indexed shells — the user's own example

`jump_to_agent_at`/`agent_jump_keys` walked `current_worktree_agents()`, which is the tab strip's list and correctly includes shells. `select_worktree` opens a startup shell in every worktree with no tab yet, so that shell held position 1 essentially everywhere: `secondary-1` selected a terminal, every real agent sat one position further along than the keycap beside it claimed, and the keycap row (in the strip and in the status bar's copy) advertised more numbers than there were agents.

New `current_worktree_agent_sessions()` is what every surface that says *agent* to the user now counts and indexes. `current_worktree_agents()` is unchanged — it answers "what does the strip show", which is right.

### 2. The whole #225 review surface was dead in the default configuration

`Agents::count_for_cwd` — the single-agent gate behind the Review tab, the footer's `Review diff` door, the rail's review-ready status and `agent_has_unreviewed_changes` — counted every tab in the worktree, shells included. Its own docs say the gate exists because two agents sharing a worktree can't be told apart in a diff; a shell is not such a party (no baseline is ever captured for one, it has no turns, it can never open a review surface).

Because of that startup shell, **the first agent started in any worktree already shared it with the shell and the gate never opened for it.** `sound::flow`'s module docs had already written this consequence down verbatim and routed the sound module around it rather than fixing the count; `pause_agents_for_cwd`'s docs already claimed a filter here that did not exist.

### 3. `Next Agent`/`Previous Agent` cycled through terminals

In the `[shell, claude]` strip you get the moment you start your first agent, a row labelled `Next Agent` was a toggle that spent half its presses leaving the only agent there was. Also: the active tab *being* a terminal is the normal state, so stepping off one now enters the agent cycle at its near end instead of falling out through a `position()?` and doing nothing. The menu-enablement predicate mirrors that exactly.

### 4. The palette filed shells under a heading that reads `Agents`

Split into `Agents` and `Terminals` rather than filtered — the palette is the keyboard route to a pane, and dropping shells would have made a terminal tab mouse-reachable only. Empty groups are omitted as usual.

### 5. (found live) No review baseline on two of the real spawn doors

Surfaced by driving the running app to verify #2: with the gate finally opening, `Review Agent` was *still* dead, because `new_agent_pane` and `respawn_agent` spawn a real agent and never call `capture_review_baseline`. `new_agent_pane` is `ctrl-shift-N`, the title bar's `New Agent Pane` row and the empty pane's `Start an agent` CTA — how most agents in this app are actually started. `respawn_agent` is worse: its own `close_agent` has already released the previous ref, so a retried agent had neither. The full set of doors is now enumerated in `capture_review_baseline`'s docs, since that arrangement can't enforce completeness for itself.

## Audited and left alone

Every place the app enumerates/indexes/counts `Agent` structs was checked. Correctly scoped as-is: `build_agent_rows` (and everything downstream of it — rail rows, title-bar chips, `N agents running`, `Archive N agents`, `rail_agent_is_running`); `build_resource_tree` (deliberately all processes — a shell burns real CPU and the readout claims the whole cost); `derive_status`; `sound::flow`; `live_agent_status_keys`/`record_agent_statuses`; `finish_run_record`; `provenance::flow`/`render`; `changes_run_rows`; `capture_review_baseline`'s own kind gate; the rebase pause set; `graph_branch_merge_gate`'s `live_agents`; `review_notes`' send target; `a_budget_readout_is_on_screen`. Genuinely pane-scoped and right to include shells: `primary_for_cwd`, `combined_tab_order`, `session_tabs_for`, the worktree-discard orphan close, `merge::flow`'s result surface, `has_agent_tab`, `ArchiveAgent` ("close the active tab"). Full list in #381.

## Verification

`cargo build --workspace`, `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets` clean. `cargo test -p app --lib`: 3065 pass; the only failures are the known inotify `max_user_instances` contention flakies (#320 family), which pass in isolation on this branch.

New coverage: `secondary-3` through the real key bindings against a mixed `[shell, claude, shell, codex, claude]` strip (lands on the third *agent*, tab 5 — and `agent_jump_keys()` advertises three numbers, not five); a real agent alongside an untouched startup shell getting a working review surface while the shell never gets one; `Next Agent` skipping shells, entering from a terminal at either end, and disabled in an all-terminal worktree; the palette's `Agents`/`Terminals` split and the omitted-when-empty case; every spawn door capturing a real anchored baseline.

Verified live on X11 against a real repo with real `claude` processes: with `[shell, claude, shell, claude]` open the keycap row shows exactly `1 2`; `ctrl+1` lands on tab 2 (first agent, not the shell at tab 1), `ctrl+2` on tab 4 (second agent, skipping the shell at tab 3), `ctrl+3` a real no-op. The palette shows `AGENTS 2` and `TERMINALS 2` as separate groups. With one `ctrl-shift-N` agent beside the startup shell, a real `refs/jerry/review/*` ref lands, `Review Agent` is enabled, and the Review tab really opens on the file written after spawn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
