### PR TITLE
fix(icons): stop stretching the search/rail icon glyphs to fill their 17px hit box

### DIFF
--- a/crates/app/src/icons.rs
+++ b/crates/app/src/icons.rs
@@ -253,9 +253,23 @@ pub enum IconSize {
     /// 15px - the sidebar strip's buttons (`Jerry.dc.html`: each strip glyph sits in a
     /// `position:relative;width:15px;height:15px` wrapper inside a 38px-wide cell).
     Strip,
-    /// 17px - the icon buttons: the search panel's count row (replace / filter / fold-all) and
-    /// the rail footer's prune button, all `width:17px;height:17px` in `Jerry.dc.html`.
-    /// §4w records fold-all being lifted 15 -> 17 for exactly the reason rule 7 states.
+    /// 12px - the icon buttons: the search panel's count row (replace / filter) and the rail
+    /// footer's prune button. `Jerry.dc.html`'s `width:17px;height:17px` on these controls is the
+    /// **hit box** (`theme::band::ICON_BUTTON_HIT`), not the glyph's own optical size - a
+    /// distinction this size got wrong the first time round (GitHub issue filed 2026-08-16,
+    /// screenshot-reported: "icons in buttons are too big"). The hand-drawn stand-ins actually
+    /// painted well inside that box:
+    ///
+    /// - funnel (`onClick="{{ onFindGlob }}"`): three bars at `left:3/5/7 width:11/7/3`, `top:5/8/11
+    ///   height:1` each - bounding box x 3-14 (11 wide), y 5-12 (7 tall).
+    /// - trash (rail prune): lid + nub + body at `left:4/7/5 top:4.5/2.5/6.5` - bounding box x
+    ///   4-13 (9 wide), y 2.5-14.5 (12 tall).
+    /// - `⇄` (replace) and the fold-all caret were plain text at `font-size:11px`.
+    ///
+    /// 12 is the largest real dimension in that set (the trash glyph's height) - the same
+    /// "the square box is the larger dimension" reading [`IconSize::PanelTab`]'s own doc comment
+    /// uses, so nothing here clips. Fold-all stays a text caret (`crate::search::render_search_caret`),
+    /// not an `Icon`, so it is unaffected by this box.
     Control,
 }
 
@@ -276,7 +290,7 @@ impl IconSize {
             IconSize::MenuRow => px(13.0),
             IconSize::TabChip => px(14.0),
             IconSize::Strip => px(15.0),
-            IconSize::Control => px(17.0),
+            IconSize::Control => px(12.0),
         }
     }
 }
@@ -619,7 +633,10 @@ mod tests {
         assert_eq!(IconSize::PanelTab.box_size(), px(11.0));
         assert_eq!(IconSize::TabChip.box_size(), px(14.0));
         assert_eq!(IconSize::Strip.box_size(), px(15.0));
-        assert_eq!(IconSize::Control.box_size(), px(17.0));
+        // 12, not 17 - `Jerry.dc.html`'s 17px on these controls is the surrounding hit box
+        // (`theme::band::ICON_BUTTON_HIT`); the funnel/trash hand-drawn glyphs inside it only
+        // really occupy up to 11x7 and 9x12 respectively. See `IconSize::Control`'s doc comment.
+        assert_eq!(IconSize::Control.box_size(), px(12.0));
     }
 
     /// §8's weight rule, checked against what `assets/icons/` really holds. This is the guard

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -2168,8 +2168,11 @@ impl AdeApp {
     /// The two-click arm/confirm is unchanged, only restated: an armed control turns
     /// [`theme::button::DANGER_FG`] and its tooltip becomes [`rail::prune_armed_tooltip`]. The
     /// glyph is `crate::icons::Icon::Trash`, drawn through the shared `crate::icons::IconRow` at
-    /// `crate::icons::IconSize::Control` - the 17px box §7 rule 7 exists to keep every icon
-    /// button in the app sharing.
+    /// `crate::icons::IconSize::Control` (12px) - §7 rule 7's shared optical box. That is
+    /// deliberately smaller than this control's own 17px hit box
+    /// ([`theme::band::ICON_BUTTON_HIT`]): the mock's hand-drawn bin glyph only ever painted a
+    /// 9x12 mark inset in the 17px square, and the first Phosphor migration wrongly stretched the
+    /// vendored SVG to fill the whole hit box (screenshot-reported "icons too big").
     pub(in crate::rail) fn render_rail_footer(&self, cx: &mut Context<Self>) -> impl IntoElement {
         // Includes error'd entries - the count should match what `wt_core::list_worktrees`
         // reported, problems included, not silently shrink.
@@ -2207,8 +2210,8 @@ impl AdeApp {
             .flex()
             .items_center()
             .justify_center()
-            .w(crate::icons::IconSize::Control.box_size())
-            .h(crate::icons::IconSize::Control.box_size())
+            .w(theme::band::ICON_BUTTON_HIT)
+            .h(theme::band::ICON_BUTTON_HIT)
             .rounded(theme::radius::CHIP)
             .tooltip(text_tooltip(tooltip_text))
             .child(
@@ -5109,12 +5112,37 @@ mod rail_rev6_render_tests {
         assert_eq!(
             button.size.height,
             px(17.0),
-            "the shared 17px icon-button box (`icons::IconSize::Control`), not a text button's \
-             own intrinsic size"
+            "the shared 17px icon-button hit box (`theme::band::ICON_BUTTON_HIT`), not a text \
+             button's own intrinsic size"
         );
-        assert!(
-            cx.debug_bounds("icon-trash").is_some(),
-            "and the real vendored Phosphor `trash` SVG must be what paints inside it"
+
+        // Regression for the screenshot-reported "icons in buttons are too big" bug: the SVG
+        // glyph itself must paint at `IconSize::Control`'s real 12px optical box, not stretched
+        // to fill the 17px hit box around it.
+        let icon = cx
+            .debug_bounds("icon-trash")
+            .expect("the real vendored Phosphor `trash` SVG must paint inside it");
+        assert_eq!(
+            icon.size.width,
+            px(12.0),
+            "the trash glyph must paint at `icons::IconSize::Control`'s real optical box (12px), \
+             not the 17px hit box it sits inside"
+        );
+        assert_eq!(icon.size.height, px(12.0));
+
+        // And it must be centred in the hit box, not pinned to a corner.
+        let left_gap = icon.origin.x - button.origin.x;
+        let right_gap = (button.origin.x + button.size.width) - (icon.origin.x + icon.size.width);
+        let top_gap = icon.origin.y - button.origin.y;
+        let bottom_gap =
+            (button.origin.y + button.size.height) - (icon.origin.y + icon.size.height);
+        assert_eq!(
+            left_gap, right_gap,
+            "the smaller glyph must be horizontally centred in the 17px hit box"
+        );
+        assert_eq!(
+            top_gap, bottom_gap,
+            "the smaller glyph must be vertically centred in the 17px hit box"
         );
     }
 

--- a/crates/app/src/search/render.rs
+++ b/crates/app/src/search/render.rs
@@ -258,8 +258,8 @@ impl AdeApp {
             .id(SharedString::from(format!("search-modifier-{key}")))
             .debug_selector(move || format!("search-modifier-{key}"))
             .flex_none()
-            .w(theme::band::SEARCH_ICON_BUTTON)
-            .h(theme::band::SEARCH_ICON_BUTTON)
+            .w(theme::band::ICON_BUTTON_HIT)
+            .h(theme::band::ICON_BUTTON_HIT)
             .rounded(theme::radius::CHIP)
             .flex()
             .items_center()
@@ -430,8 +430,8 @@ impl AdeApp {
                     .id("search-fold-all")
                     .debug_selector(|| "search-fold-all".to_string())
                     .flex_none()
-                    .w(theme::band::SEARCH_ICON_BUTTON)
-                    .h(theme::band::SEARCH_ICON_BUTTON)
+                    .w(theme::band::ICON_BUTTON_HIT)
+                    .h(theme::band::ICON_BUTTON_HIT)
                     .rounded(theme::radius::CHIP)
                     .flex()
                     .items_center()
@@ -454,8 +454,12 @@ impl AdeApp {
             }))
     }
 
-    /// One 17x17 toggle in the count row - `⇄` or the funnel, both drawn in the active pair
-    /// `REVISION-2026-08-14.md` §5 gives the modifier buttons.
+    /// One toggle in the count row - `⇄` or the funnel, both drawn in the active pair
+    /// `REVISION-2026-08-14.md` §5 gives the modifier buttons. The button itself is the shared
+    /// 17x17 hit box (`theme::band::ICON_BUTTON_HIT`); the glyph `icons` draws inside it is the
+    /// smaller `icons::IconSize::Control` optical box (12px), centred by this row's own
+    /// `items_center`/`justify_center` - see `IconSize::Control`'s doc comment for why those two
+    /// numbers are not the same.
     #[allow(clippy::too_many_arguments)]
     fn render_search_toggle_button(
         &self,
@@ -471,8 +475,8 @@ impl AdeApp {
             .id(id)
             .debug_selector(move || id.to_string())
             .flex_none()
-            .w(theme::band::SEARCH_ICON_BUTTON)
-            .h(theme::band::SEARCH_ICON_BUTTON)
+            .w(theme::band::ICON_BUTTON_HIT)
+            .h(theme::band::ICON_BUTTON_HIT)
             .rounded(theme::radius::CHIP)
             .flex()
             .items_center()
@@ -1363,6 +1367,55 @@ mod panel_tests {
         cx.run_until_parked();
     }
 
+    /// Regression for the screenshot-reported "icons in buttons are too big" bug: the count row's
+    /// `⇄`/funnel toggle buttons kept their real 17px hit box, but the SVG glyph inside each one
+    /// was wrongly stretched to fill that whole box instead of painting at
+    /// `icons::IconSize::Control`'s real 12px optical box (`icons.rs`'s doc comment has the
+    /// bounding-box measurements off `Jerry.dc.html` this 12 comes from).
+    #[gpui::test]
+    fn the_count_row_toggle_icons_paint_smaller_than_their_hit_box(cx: &mut TestAppContext) {
+        let repo = fixture_repo();
+        let (_app, cx) = open_search(cx, &repo);
+
+        for (button_selector, icon_selector) in [
+            ("search-toggle-replace", "icon-arrows-left-right"),
+            ("search-toggle-globs", "icon-funnel"),
+        ] {
+            let button = cx
+                .debug_bounds(button_selector)
+                .unwrap_or_else(|| panic!("`{button_selector}` must really paint"));
+            assert_eq!(button.size.width, px(17.0), "{button_selector}'s hit box");
+            assert_eq!(button.size.height, px(17.0), "{button_selector}'s hit box");
+
+            let icon = cx
+                .debug_bounds(icon_selector)
+                .unwrap_or_else(|| panic!("`{icon_selector}` must paint inside {button_selector}"));
+            assert_eq!(
+                icon.size.width,
+                px(12.0),
+                "{icon_selector} must paint at IconSize::Control's real optical box (12px), not \
+                 stretched to fill the 17px hit box"
+            );
+            assert_eq!(icon.size.height, px(12.0));
+
+            // Centred, not pinned to a corner of the larger hit box.
+            let left_gap = icon.origin.x - button.origin.x;
+            let right_gap =
+                (button.origin.x + button.size.width) - (icon.origin.x + icon.size.width);
+            let top_gap = icon.origin.y - button.origin.y;
+            let bottom_gap =
+                (button.origin.y + button.size.height) - (icon.origin.y + icon.size.height);
+            assert_eq!(
+                left_gap, right_gap,
+                "{icon_selector} must be horizontally centred in {button_selector}"
+            );
+            assert_eq!(
+                top_gap, bottom_gap,
+                "{icon_selector} must be vertically centred in {button_selector}"
+            );
+        }
+    }
+
     #[gpui::test]
     fn mod_shift_f_opens_the_panel_with_the_query_focused(cx: &mut TestAppContext) {
         let repo = fixture_repo();
@@ -2173,8 +2226,8 @@ impl AdeApp {
                         .id("find-bar-close")
                         .debug_selector(|| "find-bar-close".to_string())
                         .flex_none()
-                        .w(theme::band::SEARCH_ICON_BUTTON)
-                        .h(theme::band::SEARCH_ICON_BUTTON)
+                        .w(theme::band::ICON_BUTTON_HIT)
+                        .h(theme::band::ICON_BUTTON_HIT)
                         .rounded(theme::radius::CHIP)
                         .flex()
                         .items_center()
@@ -2217,8 +2270,8 @@ impl AdeApp {
             .id(SharedString::from(format!("find-bar-modifier-{key}")))
             .debug_selector(move || format!("find-bar-modifier-{key}"))
             .flex_none()
-            .w(theme::band::SEARCH_ICON_BUTTON)
-            .h(theme::band::SEARCH_ICON_BUTTON)
+            .w(theme::band::ICON_BUTTON_HIT)
+            .h(theme::band::ICON_BUTTON_HIT)
             .rounded(theme::radius::CHIP)
             .flex()
             .items_center()
@@ -2267,8 +2320,8 @@ impl AdeApp {
             .id(id)
             .debug_selector(move || id.to_string())
             .flex_none()
-            .w(theme::band::SEARCH_ICON_BUTTON)
-            .h(theme::band::SEARCH_ICON_BUTTON)
+            .w(theme::band::ICON_BUTTON_HIT)
+            .h(theme::band::ICON_BUTTON_HIT)
             .rounded(theme::radius::CHIP)
             .flex()
             .items_center()

--- a/crates/app/src/theme.rs
+++ b/crates/app/src/theme.rs
@@ -3620,10 +3620,15 @@ pub mod band {
     pub const SEARCH_FILE_ROW: Pixels = px(24.0);
     /// One match row under it - line number, then the line with its hit highlighted.
     pub const SEARCH_MATCH_ROW: Pixels = px(19.0);
-    /// The square hit box every 17x17 icon button in the search panel's count row uses, matching
-    /// `crate::icons::IconSize::Control`'s own optical box (`STAGE-A-CHANGELOG.md` §4w raised
-    /// fold-all 15 -> 17 to land exactly here).
-    pub const SEARCH_ICON_BUTTON: Pixels = px(17.0);
+    /// The square hit box every 17x17 icon-only control button uses - the search panel's count
+    /// row and find bar, and the rail footer's prune button (`STAGE-A-CHANGELOG.md` §4w: "Same
+    /// 17px hit box as the other icon buttons"). **Not** the icon's own optical size - that is
+    /// `crate::icons::IconSize::Control` (12px), a real measurement off the mock's actual glyph
+    /// geometry, which sits inset and centred inside this box rather than filling it. The two
+    /// were wrongly conflated when this constant was first named after `IconSize::Control`'s
+    /// (then-incorrect) 17px value; GitHub issue filed 2026-08-16 for the "icons too big"
+    /// screenshot report this caused.
+    pub const ICON_BUTTON_HIT: Pixels = px(17.0);
 }
 
 pub mod zone {


### PR DESCRIPTION
## Summary

- Screenshot-reported bug: the search panel's count-row toggle icons (swap/replace `⇄`, funnel path filter) and the rail footer's prune/trash icon all read as visually oversized relative to their surrounding text/row height.
- Root cause: `icons::IconSize::Control` was `17px`, which is the mock's real **hit-box** measurement for these buttons (`Jerry.dc.html`'s own `width:17px;height:17px` div, and both design docs explicitly call it a "hit box"), not the icon glyph's own optical size. The hand-drawn glyphs these Phosphor SVGs replaced were much smaller and centred inside that box (funnel 11×7, trash 9×12, real bounding boxes measured off the mock). The Phosphor migration (#282/#308) conflated the two and stretched the SVG to fill the whole 17px box edge to edge.
- `rail/render.rs`'s prune button additionally reused the same `IconSize::Control.box_size()` for *both* its outer hit-box wrapper and its inner icon glyph, coupling them to the same wrong number.

## Fix

- `IconSize::Control` corrected to `px(12.0)` - the real optical box, derived the same way `IconSize::PanelTab`'s own doc comment already resolves a non-square mock reading ("the square box is the larger dimension").
- `theme::band::SEARCH_ICON_BUTTON` renamed to `theme::band::ICON_BUTTON_HIT` (still `17px`) - it is the shared hit box every icon-only control button (search panel, find bar, rail prune) uses, not an icon's own size. Doc comment corrected; it previously (incorrectly) claimed to match `IconSize::Control`'s "own optical box".
- `rail/render.rs`'s prune button now uses `ICON_BUTTON_HIT` for its 17px hit box and `IconSize::Control` only for the 12px icon glyph - decoupled.
- Audited every other `IconSize::Control` call site and every other named `IconSize` (`PanelTab`, `MenuRow`, `TabChip`, `Strip`): `Control` was the only one where the mock's hit box and optical box had been conflated - no other genuinely-isolated outliers found.

Closes #385

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets` (warning-free)
- [x] `cargo test -p app --lib search::` (105 passed, including new `the_count_row_toggle_icons_paint_smaller_than_their_hit_box`)
- [x] `cargo test -p app --lib rail::` (232 passed, including updated `the_prune_control_is_a_bin_icon_in_a_seventeen_pixel_box`)
- [x] `cargo test -p app --lib icons::` (19 passed, including updated `named_sizes_match_the_mocks_own_boxes`)
- [x] Real before/after screenshots over X11 (per-window `XGetImage`) of both reported locations, confirming the icons now paint at the smaller, centred 12px box instead of stretched to the full 17px hit box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)