### PR TITLE
fix(search): real gitignore-aware walk, fix line off-by-one on navigate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,13 @@
 target/
+# A shared `CARGO_TARGET_DIR` some worktrees point at to avoid recompiling the whole workspace
+# per worktree - a real build directory exactly like `target/` above, just outside it. Missing
+# here is the same class of bug `wt_core::review::MAX_UNTRACKED_SNAPSHOT_BYTES` documents hitting
+# once already (a 19 GB, 21,471-file untracked-and-unignored build directory) and that
+# `search::engine`'s own worktree walk hit again for the same reason: any tool that trusts
+# `.gitignore` to mean "not real content" - `git add -A`, this repo's own review-baseline
+# snapshot, and now the Search panel's `git ls-files --exclude-standard` walk - silently treats
+# an unignored build directory as real, searchable/stageable content instead.
+.shared-target/
 .claude/scratch/
 # Windows/WSL alternate-data-stream marker files left behind by files downloaded/copied
 # from a Windows filesystem.

--- a/crates/app/src/search/engine.rs
+++ b/crates/app/src/search/engine.rs
@@ -21,11 +21,15 @@
 //!
 //! ## Bounded, because a worktree is not bounded
 //!
-//! `target/` alone can hold hundreds of thousands of files, and this walk runs against whatever
-//! the active worktree really contains. Four real limits, each reported honestly rather than
-//! silently applied: [`MAX_MATCHES`], [`MAX_SCANNED_FILES`], [`MAX_FILE_BYTES`] and a binary-file
-//! check. [`SearchOutcome::truncated`] is what the panel's count row turns into a real truncation
-//! notice - the issue's own "results cap with an honest truncation notice".
+//! A `target/`- or `node_modules`-style build/dependency directory can hold hundreds of thousands
+//! of files, and (see "Scoped to real content" below) this walk no longer even opens one -
+//! but the caps here are kept regardless, as real defense in depth against whatever the active
+//! worktree really contains once it *is* real, trackable content: an enormous monorepo, a
+//! generated-and-committed directory, or the fallback walk's own non-git path. Four real limits,
+//! each reported honestly rather than silently applied: [`MAX_MATCHES`], [`MAX_SCANNED_FILES`],
+//! [`MAX_FILE_BYTES`] and a binary-file check. [`SearchOutcome::truncated`] is what the panel's
+//! count row turns into a real truncation notice - the issue's own "results cap with an honest
+//! truncation notice".
 //!
 //! ## Parallel, because a directory walk is not one file
 //!
@@ -58,6 +62,37 @@
 //! outcome (its own generation guard already discards it), so this is a pure CPU-saving early
 //! exit, not a correctness-affecting one. [`search_worktree`] is the non-cancellable convenience
 //! wrapper every existing (and every non-panel) caller keeps using.
+//!
+//! ## Scoped to real content, not to every byte on disk
+//!
+//! A second live report, against a real repository rather than a fixture: "it is very slow still
+//! ... it can take 10 seconds", plus its own corroborating clue - "the perf of the search seems
+//! faster after the first query". Both are explained by the same real defect, and neither the
+//! rayon batching above nor the cancellation below touch it, because it sits one step earlier:
+//! candidate *discovery*. The walk that fed both of those fixes candidates
+//! ([`collect_files_by_walking`], now the fallback path below) skipped only `.git` - every other
+//! directory, including a `.gitignore`d build or dependency directory, was opened and `stat`-ed
+//! like any other. Measured directly against this application's *own* checkout: 125,242 files on
+//! disk, of which 99,250 (79%) sit under its own `target/` - 31 GB of `.gitignore`d Rust build
+//! output. [`MAX_SCANNED_FILES`] (20,000) is smaller than `target/` alone, so the old walk hit
+//! that cap, and reported itself truncated, entirely inside `target/` - before a single real
+//! source file was ever read. That is a real, on-disk directory walk (`read_dir` plus a `stat`
+//! per entry across however much of `target/`'s tree it reached before the cap), which costs real
+//! wall-clock time proportional to how much of that metadata the OS has to fetch from storage
+//! rather than serve from its own dentry/page cache - explaining both reports at once: slow
+//! (real, uncached I/O across tens of thousands of build-output entries) the first time, and
+//! faster on every query after (the same metadata, now warm in the OS cache).
+//!
+//! The real fix is [`wt_core::worktree_files::list_worktree_files`]: `git ls-files --cached
+//! --others --exclude-standard`, the same "what does this worktree really contain" question
+//! `wt_core::review::measure_untracked` already answers for the git-snapshot side of this
+//! codebase (see that module's own docs for the near-identical 19 GB untracked-directory incident
+//! this project has already hit once). Unlike a raw walk, `ls-files` never opens a directory once
+//! its own exclude rule matches it - so a build/dependency directory costs one `stat` on the
+//! directory itself, not one per file inside it. Measured directly against this repository: all
+//! 25,992 real files, in 73ms. [`collect_files_by_walking`] stays as the fallback for the one
+//! case `git` cannot answer - `worktree_path` is not (or is no longer) a real git worktree - so
+//! search still functions there; it is no longer the common path.
 
 use std::collections::HashSet;
 use std::fs;
@@ -68,6 +103,7 @@ use std::path::{Path, PathBuf};
 use rayon::prelude::*;
 
 use crate::search::glob::GlobList;
+use wt_core::worktree_files::list_worktree_files;
 
 /// The largest file this search will read. The same ceiling
 /// `crate::code_surface::code_view::MAX_FILE_BYTES` puts on opening a file in the editor, for the
@@ -350,10 +386,10 @@ pub fn search_worktree_cancellable(
     is_stale: &dyn Fn() -> bool,
 ) -> SearchOutcome {
     let mut outcome = SearchOutcome::default();
-    let mut candidates = Vec::new();
-    collect_files(&request.root, &mut candidates, &mut outcome);
+    let mut candidates = collect_candidate_files(&request.root, &mut outcome);
     // A stable, predictable order: the tree is read top to bottom and a search re-run after a
-    // keystroke must not shuffle rows the user was reading. `read_dir` order is not defined.
+    // keystroke must not shuffle rows the user was reading. Neither `git ls-files`' own order nor
+    // `read_dir`'s is defined to be that.
     candidates.sort();
 
     // The include/exclude filter is real path-string work, not file IO, so it stays sequential -
@@ -361,10 +397,7 @@ pub fn search_worktree_cancellable(
     // batch below holding only real candidates to read.
     let filtered: Vec<(PathBuf, String)> = candidates
         .into_iter()
-        .filter_map(|path| {
-            let relative = relative_slash_path(&request.root, &path)?;
-            request.filter.allows(&relative).then_some((path, relative))
-        })
+        .filter(|(_path, relative)| request.filter.allows(relative))
         .collect();
 
     for batch in filtered.chunks(SEARCH_SCAN_BATCH) {
@@ -443,7 +476,49 @@ fn scan_file(path: &Path, matcher: &Matcher) -> Option<Vec<LineMatch>> {
     )
 }
 
-/// Every regular file under `dir`, recursively.
+/// Every real candidate file under `request.root`, as an absolute path paired with its
+/// worktree-relative, `/`-separated form - see this module's own "Scoped to real content" docs
+/// for why this asks `git`, not the filesystem, and what that actually fixed.
+///
+/// `git ls-files --cached --others --exclude-standard` (via
+/// [`wt_core::worktree_files::list_worktree_files`]) is tried first: it is both the correct
+/// definition of "this worktree's real content" (tracked files, plus untracked files `git` itself
+/// would offer to stage - the same [`wt_core::review::measure_untracked`] already trusts) and,
+/// because it never opens a directory once its own exclude rule matches it, dramatically cheaper
+/// against a real repository with a `target/`- or `node_modules`-style build/dependency directory
+/// than any walk that has to visit one to find out it should be skipped.
+///
+/// [`collect_files_by_walking`] is the fallback for the one case `git` cannot answer -
+/// `request.root` is not (or is no longer) a real git worktree, or `git` itself could not be run
+/// at all - so search still functions there, exactly as it always has.
+fn collect_candidate_files(root: &Path, outcome: &mut SearchOutcome) -> Vec<(PathBuf, String)> {
+    match list_worktree_files(root) {
+        Ok(listing) => {
+            if listing.truncated {
+                outcome.truncated = true;
+            }
+            listing
+                .files
+                .into_iter()
+                .map(|relative| (root.join(&relative), relative))
+                .collect()
+        }
+        Err(_) => {
+            let mut paths = Vec::new();
+            collect_files_by_walking(root, &mut paths, outcome);
+            paths
+                .into_iter()
+                .filter_map(|path| {
+                    let relative = relative_slash_path(root, &path)?;
+                    Some((path, relative))
+                })
+                .collect()
+        }
+    }
+}
+
+/// Every regular file under `dir`, recursively - the fallback walk [`collect_candidate_files`]
+/// uses when `dir` is not a real git worktree `git ls-files` can answer for.
 ///
 /// `.git` is the one thing skipped unconditionally, and it is skipped for a reason no filter
 /// should have to restate: it is this app's own bookkeeping, it is mostly binary, and a search of
@@ -453,9 +528,13 @@ fn scan_file(path: &Path, matcher: &Matcher) -> Option<Vec<LineMatch>> {
 /// silently cannot find text in it is the "an index, not a result" failure `STAGE-A-CHANGELOG.md`
 /// §4v names, one level up.
 ///
+/// Unlike the `git`-backed primary path above, this walk has no way to know which directories a
+/// `.gitignore` would exclude - it is only ever reached outside a real git worktree, where there
+/// is no `.gitignore` to ask in the first place. [`MAX_SCANNED_FILES`] is what keeps it bounded.
+///
 /// Symlinks are not followed (`DirEntry::file_type` does not follow them), so a worktree
 /// containing a link to `/` cannot make this walk unbounded.
-fn collect_files(dir: &Path, out: &mut Vec<PathBuf>, outcome: &mut SearchOutcome) {
+fn collect_files_by_walking(dir: &Path, out: &mut Vec<PathBuf>, outcome: &mut SearchOutcome) {
     if out.len() >= MAX_SCANNED_FILES {
         outcome.truncated = true;
         return;
@@ -475,7 +554,7 @@ fn collect_files(dir: &Path, out: &mut Vec<PathBuf>, outcome: &mut SearchOutcome
             if path.file_name().is_some_and(|name| name == ".git") {
                 continue;
             }
-            collect_files(&path, out, outcome);
+            collect_files_by_walking(&path, out, outcome);
             if outcome.truncated {
                 return;
             }
@@ -1460,5 +1539,134 @@ mod worktree_tests {
             );
             assert!(!outcome.truncated);
         }
+    }
+}
+
+/// Real coverage for the live "search is very slow on my real repo" regression: every test above
+/// this module runs against a plain, non-git [`tempfile::tempdir`], which only ever exercises
+/// [`collect_files_by_walking`] (the fallback). None of it proves the *primary*,
+/// `git`-ls-files-backed path actually excludes a `.gitignore`d build directory the way this
+/// module's own "Scoped to real content" docs claim - that only happens inside a real git
+/// worktree, which is what every test here sets up.
+#[cfg(test)]
+mod git_backed_worktree_tests {
+    use super::*;
+    use std::process::Command;
+
+    fn git(dir: &Path, args: &[&str]) {
+        let status = Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .status()
+            .expect("git runs");
+        assert!(status.success(), "git {args:?} failed");
+    }
+
+    /// A real git worktree with real tracked source, a real `.gitignore`d build directory sized
+    /// enough that including it would matter, and a real untracked-but-not-ignored file - so a
+    /// single search proves all three: gitignored content is never scanned, tracked content is,
+    /// and untracked-non-ignored content is too.
+    fn fixture() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("a temp worktree");
+        let root = dir.path();
+        git(root, &["init", "-q"]);
+        git(root, &["config", "user.email", "t@example.com"]);
+        git(root, &["config", "user.name", "Test"]);
+
+        let write = |relative: &str, content: &str| {
+            let path = root.join(relative);
+            fs::create_dir_all(path.parent().expect("a parent")).expect("mkdir");
+            fs::write(&path, content).expect("write");
+        };
+        write(".gitignore", "target/\n");
+        write(
+            "src/auth/session.rs",
+            "let refresh_token = store.issue(&sid)?;\n",
+        );
+        git(root, &["add", ".gitignore", "src/auth/session.rs"]);
+        // A real `target/`-shaped build directory: several hundred files, every one of them
+        // mentioning the query, so a walk that fails to exclude it would not just be slow - it
+        // would visibly change the result set this test asserts on.
+        for i in 0..300 {
+            write(
+                &format!("target/debug/deps/refresh_token-{i}.d"),
+                "refresh_token\n",
+            );
+        }
+        write("src/new_untracked.rs", "refresh_token again\n");
+        dir
+    }
+
+    fn run(root: &Path, query: &str) -> SearchOutcome {
+        let matcher = Matcher::compile(query, SearchOptions::default())
+            .expect("compiles")
+            .expect("a non-empty query");
+        search_worktree(&SearchRequest {
+            root: root.to_path_buf(),
+            matcher,
+            filter: PathFilter::new("", ""),
+        })
+    }
+
+    #[test]
+    fn a_gitignored_build_directory_is_never_scanned_in_a_real_git_worktree() {
+        let dir = fixture();
+        let outcome = run(dir.path(), "refresh_token");
+
+        assert!(
+            !outcome
+                .files
+                .iter()
+                .any(|file| file.relative.starts_with("target/")),
+            "a real .gitignore'd build directory must never appear in results: {:?}",
+            outcome
+                .files
+                .iter()
+                .map(|f| f.relative.as_str())
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            outcome
+                .files
+                .iter()
+                .any(|file| file.relative == "src/auth/session.rs"),
+            "a real tracked file must still be found"
+        );
+        assert!(
+            outcome
+                .files
+                .iter()
+                .any(|file| file.relative == "src/new_untracked.rs"),
+            "a real untracked-but-not-ignored file must still be found"
+        );
+        assert!(
+            !outcome.truncated,
+            "300 gitignored files must not consume any of MAX_SCANNED_FILES's budget - a walk \
+             that has to burn its cap on a build directory before ever reaching real content is \
+             exactly the regression this proves fixed"
+        );
+        assert_eq!(
+            outcome.scanned_files, 3,
+            "only the three real files (.gitignore, session.rs, new_untracked.rs) should ever \
+             have been opened and read - not the 300 gitignored ones"
+        );
+    }
+
+    #[test]
+    fn an_explicitly_tracked_file_under_a_later_gitignore_rule_is_still_searched() {
+        let dir = fixture();
+        let root = dir.path();
+        // `session.rs` is already tracked (see `fixture`); now ignore its own directory too.
+        fs::write(root.join(".gitignore"), "target/\nsrc/auth/\n").expect("write");
+
+        let outcome = run(root, "refresh_token");
+        assert!(
+            outcome
+                .files
+                .iter()
+                .any(|file| file.relative == "src/auth/session.rs"),
+            "git status does not hide an explicitly tracked file just because a later ignore \
+             rule would otherwise cover it, and neither should search"
+        );
     }
 }

--- a/crates/app/src/search/render.rs
+++ b/crates/app/src/search/render.rs
@@ -1201,6 +1201,18 @@ impl AdeApp {
     }
 
     /// Opens the file a match row points at, in the editor, scrolled to that line.
+    ///
+    /// `line_number` is [`engine::LineMatch::line_number`], already 1-based - the exact number the
+    /// row itself prints (see this row's own leading `line_number.to_string()` label and its
+    /// `"{path}:{line_number}"` tooltip above). [`Self::open_file_at_line`] (`crate::code_surface::
+    /// lsp_ui`) already takes a 1-based line and does its own internal conversion for the editor's
+    /// 0-based scroll target - every other real caller (`Self::trigger_goto_definition`'s own
+    /// `target_range.start.line as usize + 1`, the Problems row's `problem.line`, a terminal
+    /// `path:line` link's parsed `line`) passes it a real 1-based line number for exactly that
+    /// reason. A live report ("result is line 482 but when clicking it goes to line 481") was this
+    /// function subtracting 1 *again* before handing off an already-1-based number to a callee
+    /// that subtracts its own 1 - the real fix is passing `line_number` straight through, not
+    /// re-adding a compensating `+1` here to paper over the double subtraction.
     fn open_search_match(
         &mut self,
         path: PathBuf,
@@ -1208,9 +1220,7 @@ impl AdeApp {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        // 1-based on screen, 0-based in the editor - converted here, once, rather than at either
-        // end where it would be one more place to get wrong.
-        self.open_file_at_line(path, line_number.saturating_sub(1), window, cx);
+        self.open_file_at_line(path, line_number, window, cx);
     }
 }
 
@@ -1603,6 +1613,99 @@ mod panel_tests {
             cx.debug_bounds("search-fold-all").is_some(),
             "one file closed still leaves results, so fold-all still exists"
         );
+    }
+
+    /// Real coverage for a live report: "no loading indicator either so it is weird" - typing a
+    /// query with a real, in-flight search still running (behind `SEARCH_DEBOUNCE`, then the
+    /// background walk itself) must visibly say so, not silently keep showing whatever the panel
+    /// last painted. `BodyState::Searching` and its own count-row/body text already exist
+    /// (`SearchPanel::body_state`/`count_label`/`body_message`) - this proves the *render* layer
+    /// really reaches them while a search is genuinely still in flight, not only once it has
+    /// already settled, which is all `type_and_settle`'s own helper (used by every other panel
+    /// test) ever exercises.
+    #[gpui::test]
+    fn a_real_in_flight_search_shows_the_searching_state_not_a_stale_or_blank_one(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = fixture_repo();
+        let (app, cx) = open_search(cx, &repo);
+
+        // First, a real completed search - so the second one below has real, different-looking
+        // stale results it could wrongly keep showing if `body_state` were not actually driving
+        // the render.
+        type_and_settle(cx, "refresh_token");
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.search.body_state(), BodyState::Results);
+        });
+        assert!(cx.debug_bounds("search-match-0-1-0").is_some());
+
+        // A second keystroke starts a new generation. Only `simulate_input` +
+        // `run_until_parked` runs here - deliberately not `type_and_settle`'s own extra
+        // `advance_clock(SEARCH_DEBOUNCE * 2)` - so this really is mid-`SEARCH_DEBOUNCE`, before
+        // the background walk has even started, the way every real keystroke's first frame is.
+        cx.simulate_input("2");
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.search.body_state(),
+                BodyState::Searching,
+                "a real in-flight search must report itself as searching, not silently keep the \
+                 previous query's completed state"
+            );
+            assert_eq!(
+                app.search.count_label(),
+                "searching\u{2026}",
+                "the count row must say so, not show the previous query's stale count"
+            );
+        });
+        assert!(
+            cx.debug_bounds("search-message").is_some(),
+            "the body must really paint the searching sentence"
+        );
+        assert!(
+            cx.debug_bounds("search-match-0-1-0").is_none(),
+            "the previous query's result tree must not still be on screen while a newer, \
+             different query is in flight - that would look identical to the search having \
+             silently hung rather than started"
+        );
+    }
+
+    /// Real regression coverage for a live report: "when we click on a search result the line we
+    /// go to is one line less than what we select (result is line 482 but when clicking it goes
+    /// to line 481)". `Self::open_search_match` used to subtract 1 from the row's own, already
+    /// 1-based `line_number` before handing it to `Self::open_file_at_line` - which itself already
+    /// expects (and converts) a 1-based line, exactly as `Self::trigger_goto_definition` and the
+    /// Problems row both already pass it. The fixture below deliberately puts its one match well
+    /// past line 1, so a real off-by-one lands on visibly the wrong line rather than accidentally
+    /// clamping to a valid one.
+    #[gpui::test]
+    fn clicking_a_match_row_opens_the_file_on_exactly_the_line_it_reports(cx: &mut TestAppContext) {
+        let repo = TempDir::new().expect("tempdir");
+        let mut content = String::new();
+        for line in 1..=41 {
+            content.push_str(&format!("// padding line {line}\n"));
+        }
+        content.push_str("let refresh_token = store.issue(&sid)?;\n"); // real line 42
+        std::fs::write(repo.path().join("deep.rs"), &content).expect("write");
+
+        let (app, cx) = open_search(cx, &repo);
+        type_and_settle(cx, "refresh_token");
+        assert!(
+            cx.debug_bounds("search-match-0-42-0").is_some(),
+            "the row must really report line 42, matching the fixture's own real line"
+        );
+
+        click(cx, "search-match-0-42-0");
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.code_cursor,
+                Some(42),
+                "a result reported as line 42 must open on real line 42, not 41"
+            );
+        });
     }
 
     #[gpui::test]

--- a/crates/wt-core/src/lib.rs
+++ b/crates/wt-core/src/lib.rs
@@ -32,6 +32,7 @@ pub mod rewrite;
 pub mod run_drift;
 pub mod stage;
 pub mod undo;
+pub mod worktree_files;
 
 pub use error::{Error, GitExit};
 

--- a/crates/wt-core/src/worktree_files.rs
+++ b/crates/wt-core/src/worktree_files.rs
@@ -1,0 +1,198 @@
+//! Enumerating a worktree's *real* content: what `git` itself would show you, not what a raw
+//! directory walk stumbles into.
+//!
+//! ## Why this exists
+//!
+//! The `app` crate's search panel (GitHub issue #162, `crate::search::engine` there) originally
+//! listed candidate files with its own recursive `fs::read_dir` walk, skipping only `.git`. That
+//! looked reasonable against the small fixture it was built and measured against, and was badly
+//! wrong at real scale: this very repository's own checkout has 125,242 files on disk, of which
+//! 99,250 sit under `target/` - this project's own `.gitignore`d Rust build output, currently
+//! 31 GB. A raw walk has to open every directory in that subtree and `stat` every file in it just
+//! to discover there was nothing there worth searching; `git ls-files --exclude-standard` never
+//! opens a gitignored directory at all, because git's own exclude matching happens *before* it
+//! descends, not after. Measured directly against this repository: `git ls-files --cached
+//! --others --exclude-standard -z` returns all 25,992 real files in **73ms**; the search panel's
+//! own `MAX_SCANNED_FILES` cap (20,000) is smaller than `target/` alone (99,250 files), so the
+//! raw walk it replaces was hitting that cap - and reporting itself truncated - entirely inside
+//! `target/`, before a single real source file was ever read.
+//!
+//! This is also the same failure mode `review::MAX_UNTRACKED_SNAPSHOT_BYTES` already documents
+//! from the git-snapshot side of this codebase - a 19 GB, 21,471-file untracked build directory
+//! that an unconditional `git add -A` would have hashed on every agent spawn. Two different
+//! features, hand-rolled two different times, tripped on the same real directory for the same
+//! real reason. This module is the one place that answers "what does this worktree actually
+//! contain" so a third feature doesn't hand-roll it a third time.
+//!
+//! ## What "real content" means here
+//!
+//! `--cached` (tracked, regardless of what `.gitignore` says now - an explicitly tracked file
+//! stays visible even under a later-added ignore rule, exactly like `git status` treats it) plus
+//! `--others --exclude-standard` (untracked, but only the untracked files git itself would ever
+//! offer to stage - i.e. not `.gitignore`d, not `.git/info/exclude`d, not `core.excludesFile`d).
+//! That is the same list `review::measure_untracked` already trusted for exactly this reason -
+//! this module generalizes it into something a second caller can use directly instead of
+//! re-deriving its own copy of the same two flags.
+//!
+//! Performs blocking I/O; see the crate-level docs.
+
+use std::ffi::OsString;
+use std::path::Path;
+
+use crate::diff::capture_git_stdout;
+use crate::error::Error;
+
+/// How many bytes of `git ls-files -z` stdout this will buffer before giving up on the rest and
+/// reporting [`WorktreeFileList::truncated`] instead.
+///
+/// Generous on purpose: even a real path averaging 100 bytes, this holds well over 300,000
+/// entries - comfortably past `search::engine::MAX_SCANNED_FILES` (20,000), which is the cap a
+/// caller like the search panel applies on top of this one regardless. This cap exists only to
+/// bound memory and read time against a repository with a genuinely enormous tracked file count,
+/// not to be the search panel's own truncation notice.
+pub const MAX_LIST_OUTPUT_BYTES: usize = 32 * 1024 * 1024;
+
+/// The result of [`list_worktree_files`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WorktreeFileList {
+    /// Worktree-relative, `/`-separated paths (`git`'s own path format, and the same format
+    /// `search::engine::FileMatches::relative` already uses) - one entry per real file.
+    pub files: Vec<String>,
+    /// `true` when the real list was longer than [`MAX_LIST_OUTPUT_BYTES`] would hold. The last
+    /// record read is dropped rather than kept when this is set, since a byte cap can only ever
+    /// land mid-path, never reliably on a record boundary.
+    pub truncated: bool,
+}
+
+/// Lists every real file `worktree_path` contains, the way `git` itself would: every tracked
+/// path, plus every untracked path `git` would actually offer to stage - see this module's own
+/// docs for why that, and not a raw filesystem walk, is the right definition of "real content".
+///
+/// Returns `Err` when `worktree_path` is not (or is no longer) inside a real git worktree, or
+/// `git` itself could not be run at all - a caller that must keep working outside a git repo
+/// needs its own fallback for that case, the same way `search::engine::search_worktree_cancellable`
+/// falls back to a plain recursive walk.
+pub fn list_worktree_files(worktree_path: &Path) -> Result<WorktreeFileList, Error> {
+    let args: Vec<OsString> = vec![
+        "ls-files".into(),
+        "--cached".into(),
+        "--others".into(),
+        "--exclude-standard".into(),
+        "-z".into(),
+    ];
+    let (output, truncated) =
+        capture_git_stdout(worktree_path, &args, MAX_LIST_OUTPUT_BYTES, None)?;
+
+    let mut records: Vec<&[u8]> = output.split(|byte| *byte == 0).collect();
+    if truncated {
+        // The very last slice is whatever the child had written up to the byte cap - it may be
+        // a complete path that happened to land on a boundary, but there is no way to tell that
+        // apart from a path sliced in half, so it is dropped rather than risk reporting a
+        // truncated filename as a real one.
+        records.pop();
+    }
+
+    let files = records
+        .into_iter()
+        .filter(|record| !record.is_empty())
+        .map(|record| String::from_utf8_lossy(record).into_owned())
+        .collect();
+
+    Ok(WorktreeFileList { files, truncated })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::process::Command;
+
+    fn git(dir: &Path, args: &[&str]) {
+        let status = Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .status()
+            .expect("git runs");
+        assert!(status.success(), "git {args:?} failed");
+    }
+
+    fn init_repo() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        git(dir.path(), &["init", "-q"]);
+        git(dir.path(), &["config", "user.email", "t@example.com"]);
+        git(dir.path(), &["config", "user.name", "Test"]);
+        dir
+    }
+
+    #[test]
+    fn lists_tracked_and_untracked_but_never_a_gitignored_build_directory() {
+        let dir = init_repo();
+        let root = dir.path();
+        fs::write(root.join(".gitignore"), "target/\n").expect("write");
+        fs::create_dir_all(root.join("src")).expect("mkdir");
+        fs::write(root.join("src/lib.rs"), "fn main() {}\n").expect("write");
+        git(root, &["add", ".gitignore", "src/lib.rs"]);
+        git(root, &["commit", "-q", "-m", "init"]);
+
+        // An untracked file that is not ignored - must show up.
+        fs::write(root.join("src/new.rs"), "// new\n").expect("write");
+        // A real, sizeable gitignored build directory - must never show up, and must never even
+        // need to be individually stat-ed by the caller.
+        fs::create_dir_all(root.join("target/debug/deps")).expect("mkdir");
+        for i in 0..50 {
+            fs::write(
+                root.join(format!("target/debug/deps/artifact-{i}.o")),
+                "binary junk",
+            )
+            .expect("write");
+        }
+
+        let listing = list_worktree_files(root).expect("a real git worktree");
+        assert!(!listing.truncated);
+        assert!(
+            listing.files.contains(&"src/lib.rs".to_string()),
+            "tracked files must be listed: {:?}",
+            listing.files
+        );
+        assert!(
+            listing.files.contains(&"src/new.rs".to_string()),
+            "untracked, non-ignored files must be listed: {:?}",
+            listing.files
+        );
+        assert!(
+            !listing.files.iter().any(|f| f.starts_with("target/")),
+            "a gitignored build directory must never appear: {:?}",
+            listing.files
+        );
+    }
+
+    #[test]
+    fn an_explicitly_tracked_file_stays_listed_even_under_a_later_ignore_rule() {
+        let dir = init_repo();
+        let root = dir.path();
+        fs::create_dir_all(root.join("generated")).expect("mkdir");
+        fs::write(root.join("generated/schema.rs"), "// generated\n").expect("write");
+        git(root, &["add", "generated/schema.rs"]);
+        git(root, &["commit", "-q", "-m", "track generated file"]);
+
+        fs::write(root.join(".gitignore"), "generated/\n").expect("write");
+
+        let listing = list_worktree_files(root).expect("a real git worktree");
+        assert!(
+            listing.files.contains(&"generated/schema.rs".to_string()),
+            "an explicitly tracked path must not disappear just because a later .gitignore rule \
+             would otherwise hide it - `git status` does not hide it either: {:?}",
+            listing.files
+        );
+    }
+
+    #[test]
+    fn a_directory_that_is_not_a_git_worktree_is_a_real_error_not_an_empty_list() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let result = list_worktree_files(dir.path());
+        assert!(
+            result.is_err(),
+            "a non-repo must be a real error a caller can fall back on, not a silent empty result"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Three live reports against a real repository (#387) on top of the already-shipped search perf fix (#374):

1. **Real 10s+ search latency**, root-caused: the worktree walk (`search::engine::collect_files`) only ever skipped `.git`. Any real `.gitignore`d build/dependency directory (`target/`, and this repo's own second, *unignored* `.shared-target/`, 28GB/25,715 files) got opened and `stat`-ed like real content, hitting `MAX_SCANNED_FILES` (20,000, smaller than `target/` alone) entirely inside it before a single real source file was ever read. New `wt_core::worktree_files::list_worktree_files` (`git ls-files --cached --others --exclude-standard`, the same idiom `wt_core::review::measure_untracked` already established for exactly this "what does this worktree really contain" question) is now the primary candidate source; the old recursive walk is kept only as a fallback outside a real git worktree. `.shared-target/` is also added to `.gitignore` - the second, real half of the root cause. Measured directly against this repo: full real-content listing in ~73ms; an actual `refresh_token` search over the repo's own real files went from truncated-empty-inside-`target/` to ~190ms warm / ~700ms cold.
2. **"No loading indicator"** - investigated, no rendering bug found. `BodyState::Searching` already has real count-row/body text, and a new render-level test proves it actually paints while a search is genuinely in flight (not just after `type_and_settle`, which every other panel test uses and which skips straight past the in-flight window). The design doc (`REVISION-2026-08-14.md` §5) has no in-flight spec at all, and every other async state in this codebase (`HoverStatus::Loading` -> "loading hover...") is plain text too, so no new spinner/widget was invented. Most of the felt "hang" is explained by #1.
3. **Off-by-one on result navigation** - real double-subtraction bug. `open_search_match` subtracted 1 from the match row's already-1-based `line_number` before calling `open_file_at_line`, which itself already expects (and internally converts) a real 1-based line - exactly as goto-definition (`target_range.start.line as usize + 1`), the Problems row, and a terminal `path:line` link all already pass it. A result reported as line N opened the editor on line N-1. Fixed by passing the line straight through, confirmed with a test that fails at `Some(41)` without the fix and passes at `Some(42)` with it.

Closes #387

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets` (warning-free)
- [x] `cargo test -p app --lib search::` (108 passed, including 4 new tests)
- [x] `cargo test -p wt-core` (302 passed, including 3 new `worktree_files` tests)
- [x] `cargo test -p app --lib` (3071 passed; 15 pre-existing, unrelated `file_tree_watch`/`worktree_watch` inotify-contention flakes reproduced as failing under full concurrent load and passing cleanly in isolation - known issue, untouched by this change)
- [x] Real functional verification: measured wall-clock search time before/after against this repo's own real checkout (10s+/truncated-empty -> ~190-700ms with real results), confirmed the in-flight state renders via a real GPUI test, confirmed a match reported as line 42 opens the editor on real line 42

🤖 Generated with [Claude Code](https://claude.com/claude-code)