### PR TITLE
Text inputs: real selection, clipboard and mouse editing (#336)

### DIFF
--- a/crates/app/src/code_surface/edit_buffer.rs
+++ b/crates/app/src/code_surface/edit_buffer.rs
@@ -186,32 +186,7 @@ use crate::code_surface::fold;
 use crate::code_surface::indent;
 use crate::code_surface::symbols;
 use crate::language::HighlighterFn;
-use crate::text_history::{self, EditKind, SelectionSnapshot, TextEdit, TextHistory};
-
-/// A character's real class for word-wise caret movement/selection (GitHub issue #27) - see
-/// [`EditBuffer::previous_word_boundary`]'s own docs for why this app hand-classifies rather
-/// than using `unicode_segmentation`'s UAX #29 word boundaries for this.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum WordClass {
-    Whitespace,
-    /// A letter, digit, or underscore - grouped together so `foo_bar123` is one real word, not
-    /// three.
-    Word,
-    /// Anything else (`.`, `(`, `)`, `-`, ...) - a real code editor's own word-navigation stops
-    /// at these individually from surrounding word text, but groups a *run* of them together
-    /// (`()` is one hop, not two), matching this app's own real test coverage.
-    Punctuation,
-}
-
-fn word_class(ch: char) -> WordClass {
-    if ch.is_whitespace() {
-        WordClass::Whitespace
-    } else if ch.is_alphanumeric() || ch == '_' {
-        WordClass::Word
-    } else {
-        WordClass::Punctuation
-    }
-}
+use crate::text_history::{self, word_class, EditKind, SelectionSnapshot, TextEdit, TextHistory, WordClass};
 
 /// Longest common byte prefix of `a`/`b`, clamped to a real UTF-8 char boundary in both -
 /// `EditBuffer::stale_spans_for_region`'s own real "which text didn't change" test (GitHub issue

--- a/crates/app/src/code_surface/edit_buffer.rs
+++ b/crates/app/src/code_surface/edit_buffer.rs
@@ -186,7 +186,9 @@ use crate::code_surface::fold;
 use crate::code_surface::indent;
 use crate::code_surface::symbols;
 use crate::language::HighlighterFn;
-use crate::text_history::{self, word_class, EditKind, SelectionSnapshot, TextEdit, TextHistory, WordClass};
+use crate::text_history::{
+    self, word_class, EditKind, SelectionSnapshot, TextEdit, TextHistory, WordClass,
+};
 
 /// Longest common byte prefix of `a`/`b`, clamped to a real UTF-8 char boundary in both -
 /// `EditBuffer::stale_spans_for_region`'s own real "which text didn't change" test (GitHub issue

--- a/crates/app/src/graph_view/rebase.rs
+++ b/crates/app/src/graph_view/rebase.rs
@@ -846,9 +846,13 @@ impl AdeApp {
         cx: &mut Context<Self>,
     ) {
         let keystroke = &event.keystroke;
-        if keystroke.modifiers.platform || keystroke.modifiers.control || keystroke.modifiers.alt {
+        // GitHub issue #336: `widgets::text_editing_modifiers` rather than a flat "any modifier
+        // means not ours" - see `crate::rail::render::AdeApp::handle_filter_key_down`'s own note.
+        let Some(modifiers) =
+            crate::root::widgets::text_editing_modifiers(&keystroke.key, &keystroke.modifiers)
+        else {
             return;
-        }
+        };
         self.reset_caret_blink(cx);
         let Some(rebase_state) = self.graph_state.rebase.as_mut() else {
             return;
@@ -856,15 +860,12 @@ impl AdeApp {
         let Some(row) = rebase_state.plan.get_mut(row_index) else {
             return;
         };
-        let changed = match keystroke.key.as_str() {
-            "backspace" => row.reword_message.backspace(Instant::now()),
-            _ => match keystroke.key_char.as_deref() {
-                Some(text) if !text.is_empty() => {
-                    row.reword_message.insert_str(text, Instant::now())
-                }
-                _ => false,
-            },
-        };
+        let changed = row.reword_message.handle_editing_key(
+            &keystroke.key,
+            keystroke.key_char.as_deref(),
+            modifiers,
+            Instant::now(),
+        );
         if changed {
             cx.notify();
             cx.stop_propagation();

--- a/crates/app/src/graph_view/rebase_render.rs
+++ b/crates/app/src/graph_view/rebase_render.rs
@@ -10,7 +10,22 @@ use super::rebase::{
 };
 use super::*;
 use crate::root::plural;
-use gpui::{DragMoveEvent, KeyDownEvent};
+use crate::root::widgets::{SimpleInput, SimpleInputCaret, TextFieldHandle};
+use gpui::{DragMoveEvent, KeyDownEvent, SharedString};
+
+/// One interactive-rebase plan row's `reword` message field handle - what click/drag selection
+/// and GitHub issue #336's four clipboard/select-all actions act on. `None` whenever the plan no
+/// longer has a row at `index`, which is exactly the case [`TextFieldHandle`]'s own `Option`
+/// exists for.
+fn rebase_reword_handle(index: usize) -> TextFieldHandle {
+    TextFieldHandle::new(move |app: &mut AdeApp| {
+        app.graph_state
+            .rebase
+            .as_mut()
+            .and_then(|state| state.plan.get_mut(index))
+            .map(|row| &mut row.reword_message)
+    })
+}
 use wt_core::rebase::RebaseOutcome;
 
 /// The dragged payload for a plan row's own drag handle (design spec §1.4) - mirrors
@@ -933,7 +948,8 @@ impl AdeApp {
         let text = row.reword_message.as_str().to_string();
         let focus_handle = row.reword_focus_handle.clone();
         let supplied = row.has_supplied_reword_message();
-        div()
+        let field = rebase_reword_handle(index);
+        let row_node = div()
             .id(("rebase-reword-field", index))
             .flex_1()
             .min_w_0()
@@ -942,7 +958,10 @@ impl AdeApp {
             .key_context("text-input")
             .on_key_down(cx.listener(move |this, event: &KeyDownEvent, window, cx| {
                 this.handle_rebase_reword_key_down(index, event, window, cx);
-            }))
+            }));
+        // GitHub issue #336's four clipboard/select-all actions, on the same node that carries
+        // this row's `"text-input"` word.
+        self.wire_text_input_actions(row_node, field.clone(), cx)
             // §1.4: "Its click must stop propagating, so placing the caret does not fight row
             // selection" - but the row still becomes the selected one, since that is visibly the
             // row being worked on and is what §1.4's keyboard actions then act upon.
@@ -966,12 +985,28 @@ impl AdeApp {
             })
             .flex()
             .items_center()
-            .gap(px(1.0))
-            .font(font(theme::font::SANS))
-            .text_size(px(11.5))
-            .text_color(theme::text::SELECTED)
-            .child(text)
-            .child(self.render_simple_input_caret("rebase-reword-caret", &focus_handle))
+            // GitHub issue #336: through the one helper that owns this structure, like every
+            // other simple input in the app. Before this, the caret was pinned after the text
+            // whatever the row's own `TextField::caret` said, and there was no selection
+            // highlight or click hit-testing at all.
+            .child(self.render_simple_input_row(
+                SimpleInput {
+                    caret_selector: SharedString::from(format!("rebase-reword-caret-{index}")),
+                    text_selector: SharedString::from(format!("rebase-reword-text-{index}")),
+                    focus_handle: Some(&focus_handle),
+                    text: &text,
+                    caret_offset: row.reword_message.caret(),
+                    selection: row.reword_message.selection(),
+                    placeholder: "",
+                    font: theme::font::SANS,
+                    text_size: px(11.5),
+                    text_color: theme::text::SELECTED,
+                    placeholder_color: theme::text::GHOST,
+                    caret: SimpleInputCaret::default(),
+                    field: Some(field),
+                },
+                cx,
+            ))
             .into_any_element()
     }
 

--- a/crates/app/src/graph_view/render.rs
+++ b/crates/app/src/graph_view/render.rs
@@ -1464,10 +1464,11 @@ fn branches_filter_handle() -> TextFieldHandle {
 /// as much right to clear "that name already exists" as a typed one.
 fn branch_prompt_name_handle() -> TextFieldHandle {
     TextFieldHandle::new(|app: &mut AdeApp| {
-        app.graph_state
-            .branch_prompt
-            .is_some()
-            .then(|| &mut app.graph_state.branch_prompt_name)
+        if app.graph_state.branch_prompt.is_some() {
+            Some(&mut app.graph_state.branch_prompt_name)
+        } else {
+            None
+        }
     })
     .on_changed(|app: &mut AdeApp, _cx| {
         if let Some(open) = app.graph_state.branch_prompt.as_mut() {

--- a/crates/app/src/graph_view/render.rs
+++ b/crates/app/src/graph_view/render.rs
@@ -7,6 +7,7 @@ use super::*;
 use crate::root::scrollbar;
 use crate::root::widgets::{
     menu_popover_chrome, modal_scrim_bg, render_sidebar_message, render_status_letter, SimpleInput,
+    TextFieldHandle,
 };
 use crate::settings::widgets;
 use crate::sidebar::changes;
@@ -1173,23 +1174,25 @@ impl AdeApp {
         cx: &mut Context<Self>,
     ) {
         let keystroke = &event.keystroke;
-        if keystroke.modifiers.platform || keystroke.modifiers.control || keystroke.modifiers.alt {
+        // GitHub issue #336: `widgets::text_editing_modifiers` rather than a flat "any modifier
+        // means not ours" - see `crate::rail::render::AdeApp::handle_filter_key_down`'s own note.
+        let Some(modifiers) =
+            crate::root::widgets::text_editing_modifiers(&keystroke.key, &keystroke.modifiers)
+        else {
             return;
-        }
+        };
         // GitHub issue #27's "solid mid-keystroke" - see `crate::rail::render::AdeApp::
         // handle_filter_key_down`'s identical reasoning. Missing here (GitHub issue #45) is
         // exactly why this field never blinked in the first place.
         self.reset_caret_blink(cx);
         let changed = match keystroke.key.as_str() {
-            "backspace" => self.graph_state.branches_filter.backspace(Instant::now()),
             "escape" => self.graph_state.branches_filter.clear(Instant::now()),
-            _ => match keystroke.key_char.as_deref() {
-                Some(text) if !text.is_empty() => self
-                    .graph_state
-                    .branches_filter
-                    .insert_str(text, Instant::now()),
-                _ => false,
-            },
+            key => self.graph_state.branches_filter.handle_editing_key(
+                key,
+                keystroke.key_char.as_deref(),
+                modifiers,
+                Instant::now(),
+            ),
         };
         if changed {
             cx.notify();
@@ -1229,50 +1232,43 @@ impl AdeApp {
         cx: &mut Context<Self>,
     ) {
         let keystroke = &event.keystroke;
-        if keystroke.modifiers.platform || keystroke.modifiers.control || keystroke.modifiers.alt {
+        // GitHub issue #336: `widgets::text_editing_modifiers` rather than a flat "any modifier
+        // means not ours" - see `crate::rail::render::AdeApp::handle_filter_key_down`'s own note.
+        let Some(modifiers) =
+            crate::root::widgets::text_editing_modifiers(&keystroke.key, &keystroke.modifiers)
+        else {
             return;
-        }
+        };
         match keystroke.key.as_str() {
             "escape" => {
                 self.cancel_graph_branch_prompt(window, cx);
                 cx.stop_propagation();
+                return;
             }
             "enter" => {
                 self.commit_graph_branch_prompt(window, cx);
                 cx.stop_propagation();
+                return;
             }
-            "backspace" => {
-                if self.graph_state.branch_prompt.is_some() {
-                    self.graph_state
-                        .branch_prompt_name
-                        .backspace(Instant::now());
-                    if let Some(open) = self.graph_state.branch_prompt.as_mut() {
-                        open.error = None;
-                    }
-                    self.reset_caret_blink(cx);
-                    cx.notify();
-                    cx.stop_propagation();
-                }
+            _ => {}
+        }
+        if self.graph_state.branch_prompt.is_none() {
+            return;
+        }
+        // GitHub issue #336: the whole `TextField` vocabulary through the one shared entry point,
+        // rather than the backspace/insert pair this prompt used to hand-roll.
+        if self.graph_state.branch_prompt_name.handle_editing_key(
+            &keystroke.key,
+            keystroke.key_char.as_deref(),
+            modifiers,
+            Instant::now(),
+        ) {
+            if let Some(open) = self.graph_state.branch_prompt.as_mut() {
+                open.error = None;
             }
-            _ => {
-                if let Some(text) = keystroke
-                    .key_char
-                    .as_deref()
-                    .filter(|text| !text.is_empty())
-                {
-                    if self.graph_state.branch_prompt.is_some() {
-                        self.graph_state
-                            .branch_prompt_name
-                            .insert_str(text, Instant::now());
-                        if let Some(open) = self.graph_state.branch_prompt.as_mut() {
-                            open.error = None;
-                        }
-                        self.reset_caret_blink(cx);
-                        cx.notify();
-                        cx.stop_propagation();
-                    }
-                }
-            }
+            self.reset_caret_blink(cx);
+            cx.notify();
+            cx.stop_propagation();
         }
     }
 
@@ -1360,13 +1356,17 @@ impl AdeApp {
                 this.cancel_graph_branch_prompt(window, cx);
             }))
             .child(
-                div()
-                    .id("graph-branch-prompt-panel")
-                    .track_focus(&self.graph_state.branch_prompt_focus_handle)
-                    .key_context("text-input")
-                    .on_action(cx.listener(Self::handle_graph_branch_prompt_text_undo))
-                    .on_action(cx.listener(Self::handle_graph_branch_prompt_text_redo))
-                    .on_key_down(cx.listener(Self::handle_graph_branch_prompt_key_down))
+                self.wire_text_input_actions(
+                    div()
+                        .id("graph-branch-prompt-panel")
+                        .track_focus(&self.graph_state.branch_prompt_focus_handle)
+                        .key_context("text-input")
+                        .on_action(cx.listener(Self::handle_graph_branch_prompt_text_undo))
+                        .on_action(cx.listener(Self::handle_graph_branch_prompt_text_redo))
+                        .on_key_down(cx.listener(Self::handle_graph_branch_prompt_key_down)),
+                    branch_prompt_name_handle(),
+                    cx,
+                )
                     .on_click(cx.listener(|_this, _event: &ClickEvent, _window, cx| {
                         cx.stop_propagation();
                     }))
@@ -1403,30 +1403,29 @@ impl AdeApp {
                             .bg(theme::surface::SEGMENT_TRACK)
                             .flex()
                             .items_center()
-                            // No decorative gap before the caret - see
-                            // `crate::rail::render::AdeApp::render_rail_filter_row`'s own
-                            // comment for why (live report: it read as a gap between the
-                            // typed text and where it's actually being typed).
-                            .font(font(theme::font::MONO))
-                            .text_size(px(11.5))
-                            .text_color(theme::text::BODY)
-                            .when(!has_name, |el| {
-                                el.child(self.render_simple_input_caret(
-                                    "graph-branch-prompt-caret",
-                                    &self.graph_state.branch_prompt_focus_handle,
-                                ))
-                            })
-                            .child(if has_name {
-                                name
-                            } else {
-                                "branch-name".to_string()
-                            })
-                            .when(has_name, |el| {
-                                el.child(self.render_simple_input_caret(
-                                    "graph-branch-prompt-caret",
-                                    &self.graph_state.branch_prompt_focus_handle,
-                                ))
-                            }),
+                            // GitHub issue #336: through the one helper that owns this structure,
+                            // like every other simple input in the app - which is also what gives
+                            // this prompt a selection highlight and real click-to-position for the
+                            // first time.
+                            .child(self.render_simple_input_row(
+                                SimpleInput {
+                                    caret_selector: "graph-branch-prompt-caret".into(),
+                                    text_selector: "graph-branch-prompt-text".into(),
+                                    focus_handle: Some(
+                                        &self.graph_state.branch_prompt_focus_handle,
+                                    ),
+                                    text: if has_name { name.as_str() } else { "" },
+                                    caret_offset: self.graph_state.branch_prompt_name.caret(),
+                                    selection: self.graph_state.branch_prompt_name.selection(),
+                                    placeholder: "branch-name",
+                                    font: theme::font::MONO,
+                                    text_size: px(11.5),
+                                    text_color: theme::text::BODY,
+                                    placeholder_color: theme::text::GHOST,
+                                    field: Some(branch_prompt_name_handle()),
+                                },
+                                cx,
+                            )),
                     )
                     .when_some(prompt.and_then(|prompt| prompt.error), |el, error| {
                         el.child(
@@ -1453,6 +1452,31 @@ impl AdeApp {
 /// two-collection shape rather than unifying into one `Tab` enum (see that function's docs, and
 /// this project's own note that a forced unification wasn't the right call here). Rendered only
 /// while `AdeApp::graph_tab_open` is `true`.
+/// The Branches panel filter's own [`TextFieldHandle`] - what click/drag selection and GitHub
+/// issue #336's four clipboard/select-all actions act on. No `on_changed`: the filtered branch
+/// list is derived from the field at render time.
+fn branches_filter_handle() -> TextFieldHandle {
+    TextFieldHandle::new(|app: &mut AdeApp| Some(&mut app.graph_state.branches_filter))
+}
+
+/// The "Create branch here" / rename prompt's own field handle. `None` whenever the prompt is
+/// closed, and its `on_changed` clears the prompt's stale validation error exactly as
+/// `AdeApp::handle_graph_branch_prompt_key_down` does after a keystroke - a pasted name has just
+/// as much right to clear "that name already exists" as a typed one.
+fn branch_prompt_name_handle() -> TextFieldHandle {
+    TextFieldHandle::new(|app: &mut AdeApp| {
+        app.graph_state
+            .branch_prompt
+            .is_some()
+            .then(|| &mut app.graph_state.branch_prompt_name)
+    })
+    .on_changed(|app: &mut AdeApp, _cx| {
+        if let Some(open) = app.graph_state.branch_prompt.as_mut() {
+            open.error = None;
+        }
+    })
+}
+
 pub(crate) fn render_graph_tab(app: &AdeApp, cx: &mut Context<AdeApp>) -> gpui::AnyElement {
     let is_active = app.graph_tab_active;
     let colors = work_surface::tab_colors(is_active);
@@ -3063,13 +3087,17 @@ impl AdeApp {
         count: usize,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        div()
-            .id("graph-branches-filter")
-            .track_focus(&self.graph_state.branches_filter_focus_handle)
-            .key_context("text-input")
-            .on_action(cx.listener(Self::handle_branches_filter_text_undo))
-            .on_action(cx.listener(Self::handle_branches_filter_text_redo))
-            .on_key_down(cx.listener(Self::handle_branches_filter_key_down))
+        self.wire_text_input_actions(
+            div()
+                .id("graph-branches-filter")
+                .track_focus(&self.graph_state.branches_filter_focus_handle)
+                .key_context("text-input")
+                .on_action(cx.listener(Self::handle_branches_filter_text_undo))
+                .on_action(cx.listener(Self::handle_branches_filter_text_redo))
+                .on_key_down(cx.listener(Self::handle_branches_filter_key_down)),
+            branches_filter_handle(),
+            cx,
+        )
             .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
                 window.focus(&this.graph_state.branches_filter_focus_handle, cx);
             }))
@@ -3091,18 +3119,23 @@ impl AdeApp {
             // Caret placement, the empty/typed ordering and the flex structure around them all
             // through the one helper that owns them - see
             // `AdeApp::render_simple_input_row`'s own docs.
-            .child(self.render_simple_input_row(SimpleInput {
-                caret_selector: "graph-branches-filter-caret".into(),
-                text_selector: "graph-branches-filter-text".into(),
-                focus_handle: Some(&self.graph_state.branches_filter_focus_handle),
-                text: self.graph_state.branches_filter.as_str(),
-                caret_offset: self.graph_state.branches_filter.caret(),
-                placeholder: "filter branches",
-                font: theme::font::MONO,
-                text_size: px(10.5),
-                text_color: theme::text::DIM,
-                placeholder_color: theme::text::GHOST,
-            }))
+            .child(self.render_simple_input_row(
+                SimpleInput {
+                    caret_selector: "graph-branches-filter-caret".into(),
+                    text_selector: "graph-branches-filter-text".into(),
+                    focus_handle: Some(&self.graph_state.branches_filter_focus_handle),
+                    text: self.graph_state.branches_filter.as_str(),
+                    caret_offset: self.graph_state.branches_filter.caret(),
+                    selection: self.graph_state.branches_filter.selection(),
+                    placeholder: "filter branches",
+                    font: theme::font::MONO,
+                    text_size: px(10.5),
+                    text_color: theme::text::DIM,
+                    placeholder_color: theme::text::GHOST,
+                    field: Some(branches_filter_handle()),
+                },
+                cx,
+            ))
             .child(
                 div()
                     .font(font(theme::font::MONO))

--- a/crates/app/src/graph_view/render.rs
+++ b/crates/app/src/graph_view/render.rs
@@ -7,7 +7,7 @@ use super::*;
 use crate::root::scrollbar;
 use crate::root::widgets::{
     menu_popover_chrome, modal_scrim_bg, render_sidebar_message, render_status_letter, SimpleInput,
-    TextFieldHandle,
+    SimpleInputCaret, TextFieldHandle,
 };
 use crate::settings::widgets;
 use crate::sidebar::changes;
@@ -1367,82 +1367,81 @@ impl AdeApp {
                     branch_prompt_name_handle(),
                     cx,
                 )
-                    .on_click(cx.listener(|_this, _event: &ClickEvent, _window, cx| {
-                        cx.stop_propagation();
-                    }))
-                    .flex()
-                    .flex_col()
-                    .gap(px(6.0))
-                    .w(px(320.0))
-                    .p(px(12.0))
-                    .bg(theme::surface::PALETTE)
-                    .border_1()
-                    .border_color(theme::border::POPOVER)
-                    .rounded(theme::radius::CARD)
-                    .child(
+                .on_click(cx.listener(|_this, _event: &ClickEvent, _window, cx| {
+                    cx.stop_propagation();
+                }))
+                .flex()
+                .flex_col()
+                .gap(px(6.0))
+                .w(px(320.0))
+                .p(px(12.0))
+                .bg(theme::surface::PALETTE)
+                .border_1()
+                .border_color(theme::border::POPOVER)
+                .rounded(theme::radius::CARD)
+                .child(
+                    div()
+                        .font(font(theme::font::SANS))
+                        .font_weight(gpui::FontWeight::MEDIUM)
+                        .text_size(px(11.5))
+                        .text_color(theme::text::HEADING)
+                        .child(title),
+                )
+                .child(
+                    div()
+                        .debug_selector(|| "graph-branch-prompt-subtitle".to_string())
+                        .font(font(theme::font::MONO))
+                        .text_size(px(9.5))
+                        .text_color(theme::text::FAINTER)
+                        .child(subtitle),
+                )
+                .child(
+                    div()
+                        .px(px(8.0))
+                        .py(px(5.0))
+                        .rounded(theme::radius::CHIP)
+                        .bg(theme::surface::SEGMENT_TRACK)
+                        .flex()
+                        .items_center()
+                        // GitHub issue #336: through the one helper that owns this structure,
+                        // like every other simple input in the app - which is also what gives
+                        // this prompt a selection highlight and real click-to-position for the
+                        // first time.
+                        .child(self.render_simple_input_row(
+                            SimpleInput {
+                                caret_selector: "graph-branch-prompt-caret".into(),
+                                text_selector: "graph-branch-prompt-text".into(),
+                                focus_handle: Some(&self.graph_state.branch_prompt_focus_handle),
+                                text: if has_name { name.as_str() } else { "" },
+                                caret_offset: self.graph_state.branch_prompt_name.caret(),
+                                selection: self.graph_state.branch_prompt_name.selection(),
+                                placeholder: "branch-name",
+                                font: theme::font::MONO,
+                                text_size: px(11.5),
+                                text_color: theme::text::BODY,
+                                placeholder_color: theme::text::GHOST,
+                                caret: SimpleInputCaret::default(),
+                                field: Some(branch_prompt_name_handle()),
+                            },
+                            cx,
+                        )),
+                )
+                .when_some(prompt.and_then(|prompt| prompt.error), |el, error| {
+                    el.child(
                         div()
                             .font(font(theme::font::SANS))
-                            .font_weight(gpui::FontWeight::MEDIUM)
-                            .text_size(px(11.5))
-                            .text_color(theme::text::HEADING)
-                            .child(title),
+                            .text_size(px(10.5))
+                            .text_color(theme::status::FAIL)
+                            .child(error),
                     )
-                    .child(
-                        div()
-                            .debug_selector(|| "graph-branch-prompt-subtitle".to_string())
-                            .font(font(theme::font::MONO))
-                            .text_size(px(9.5))
-                            .text_color(theme::text::FAINTER)
-                            .child(subtitle),
-                    )
-                    .child(
-                        div()
-                            .px(px(8.0))
-                            .py(px(5.0))
-                            .rounded(theme::radius::CHIP)
-                            .bg(theme::surface::SEGMENT_TRACK)
-                            .flex()
-                            .items_center()
-                            // GitHub issue #336: through the one helper that owns this structure,
-                            // like every other simple input in the app - which is also what gives
-                            // this prompt a selection highlight and real click-to-position for the
-                            // first time.
-                            .child(self.render_simple_input_row(
-                                SimpleInput {
-                                    caret_selector: "graph-branch-prompt-caret".into(),
-                                    text_selector: "graph-branch-prompt-text".into(),
-                                    focus_handle: Some(
-                                        &self.graph_state.branch_prompt_focus_handle,
-                                    ),
-                                    text: if has_name { name.as_str() } else { "" },
-                                    caret_offset: self.graph_state.branch_prompt_name.caret(),
-                                    selection: self.graph_state.branch_prompt_name.selection(),
-                                    placeholder: "branch-name",
-                                    font: theme::font::MONO,
-                                    text_size: px(11.5),
-                                    text_color: theme::text::BODY,
-                                    placeholder_color: theme::text::GHOST,
-                                    field: Some(branch_prompt_name_handle()),
-                                },
-                                cx,
-                            )),
-                    )
-                    .when_some(prompt.and_then(|prompt| prompt.error), |el, error| {
-                        el.child(
-                            div()
-                                .font(font(theme::font::SANS))
-                                .text_size(px(10.5))
-                                .text_color(theme::status::FAIL)
-                                .child(error),
-                        )
-                    })
-                    .child(
-                        div()
-                            .font(font(theme::font::SANS))
-                            .text_size(px(10.0))
-                            .text_color(theme::text::GHOST)
-                            .child(footer),
-                    ),
+                })
+                .child(
+                    div()
+                        .font(font(theme::font::SANS))
+                        .text_size(px(10.0))
+                        .text_color(theme::text::GHOST)
+                        .child(footer),
+                ),
             )
     }
 }
@@ -3098,51 +3097,52 @@ impl AdeApp {
             branches_filter_handle(),
             cx,
         )
-            .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
-                window.focus(&this.graph_state.branches_filter_focus_handle, cx);
-            }))
-            .flex_none()
-            .flex()
-            .items_center()
-            .gap(px(6.0))
-            .px(px(10.0))
-            .h(theme::graph::BRANCHES_FILTER_ROW)
-            .border_b_1()
-            .border_color(theme::border::RAIL_INNER)
-            .child(
-                div()
-                    .font(font(theme::font::MONO))
-                    .text_size(px(10.5))
-                    .text_color(theme::text::GHOST)
-                    .child("/"),
-            )
-            // Caret placement, the empty/typed ordering and the flex structure around them all
-            // through the one helper that owns them - see
-            // `AdeApp::render_simple_input_row`'s own docs.
-            .child(self.render_simple_input_row(
-                SimpleInput {
-                    caret_selector: "graph-branches-filter-caret".into(),
-                    text_selector: "graph-branches-filter-text".into(),
-                    focus_handle: Some(&self.graph_state.branches_filter_focus_handle),
-                    text: self.graph_state.branches_filter.as_str(),
-                    caret_offset: self.graph_state.branches_filter.caret(),
-                    selection: self.graph_state.branches_filter.selection(),
-                    placeholder: "filter branches",
-                    font: theme::font::MONO,
-                    text_size: px(10.5),
-                    text_color: theme::text::DIM,
-                    placeholder_color: theme::text::GHOST,
-                    field: Some(branches_filter_handle()),
-                },
-                cx,
-            ))
-            .child(
-                div()
-                    .font(font(theme::font::MONO))
-                    .text_size(px(10.0))
-                    .text_color(theme::text::GHOST)
-                    .child(format!("{count}")),
-            )
+        .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
+            window.focus(&this.graph_state.branches_filter_focus_handle, cx);
+        }))
+        .flex_none()
+        .flex()
+        .items_center()
+        .gap(px(6.0))
+        .px(px(10.0))
+        .h(theme::graph::BRANCHES_FILTER_ROW)
+        .border_b_1()
+        .border_color(theme::border::RAIL_INNER)
+        .child(
+            div()
+                .font(font(theme::font::MONO))
+                .text_size(px(10.5))
+                .text_color(theme::text::GHOST)
+                .child("/"),
+        )
+        // Caret placement, the empty/typed ordering and the flex structure around them all
+        // through the one helper that owns them - see
+        // `AdeApp::render_simple_input_row`'s own docs.
+        .child(self.render_simple_input_row(
+            SimpleInput {
+                caret_selector: "graph-branches-filter-caret".into(),
+                text_selector: "graph-branches-filter-text".into(),
+                focus_handle: Some(&self.graph_state.branches_filter_focus_handle),
+                text: self.graph_state.branches_filter.as_str(),
+                caret_offset: self.graph_state.branches_filter.caret(),
+                selection: self.graph_state.branches_filter.selection(),
+                placeholder: "filter branches",
+                font: theme::font::MONO,
+                text_size: px(10.5),
+                text_color: theme::text::DIM,
+                placeholder_color: theme::text::GHOST,
+                caret: SimpleInputCaret::default(),
+                field: Some(branches_filter_handle()),
+            },
+            cx,
+        ))
+        .child(
+            div()
+                .font(font(theme::font::MONO))
+                .text_size(px(10.0))
+                .text_color(theme::text::GHOST)
+                .child(format!("{count}")),
+        )
     }
 
     fn current_graph(&self) -> Option<&Graph> {

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -248,6 +248,53 @@ pub fn default_key_bindings() -> Vec<gpui::KeyBinding> {
         gpui::KeyBinding::new("secondary-z", root::TextUndo, Some("text-input")),
         gpui::KeyBinding::new("secondary-shift-z", root::TextRedo, Some("text-input")),
         gpui::KeyBinding::new("ctrl-y", root::TextRedo, Some("text-input")),
+        // GitHub issue #336 ("Text inputs do not have selection and standard copy/paste/cut"),
+        // scoped `Some("text-input")` for exactly the reasons `TextUndo`/`TextRedo` above already
+        // are - the one shared context tag every real single-line input in this app carries, and
+        // nothing else does.
+        //
+        // Deliberately *not* `None`: `secondary-c`/`secondary-x`/`secondary-v` at global scope
+        // would claim the control bytes `crate::terminal::pane::keystroke_to_bytes` hands a
+        // focused shell (Ctrl+C is SIGINT - binding it globally would risk making it impossible to
+        // interrupt a running agent CLI), the exact bug class this list's own file-tree entries
+        // below already document at length.
+        //
+        // `&& !file-editor && !merge-editor` is load-bearing, and is the same `&& !` discipline
+        // `"file-editor && !completions"` and `"diff && !file-editor"` above already established.
+        // The code surface and the merge hand-edit surface both carry `"text-input"` *in the same
+        // context frame* as their own tag (`crate::keymap_overrides::real_context_stacks`'
+        // `"diff file-editor text-input"` and `"merge-editor text-input"`) - deliberately, so
+        // `TextUndo`/`TextRedo` above reach their real `EditBuffer` history. Without these two
+        // exclusions, `secondary-c` on those stacks would match `EditorCopy` *and* `TextCopy` at
+        // exactly the same predicate depth, leaving which one actually fires to registration
+        // order - precisely the "keystroke reaches the wrong handler" bug class this list's own
+        // docs count seven-plus instances of. Those two surfaces already have real, richer
+        // clipboard handling of their own (`crate::code_surface::editing`'s `Editor*` actions over
+        // a full `EditBuffer`), so the exclusion loses nothing.
+        //
+        // `undo_scoping_matrix_tests::secondary_c_reaches_text_copy_in_exactly_the_simple_input_
+        // contexts` asserts that as predicate logic against every real context stack, rather than
+        // leaving it as a claim here.
+        gpui::KeyBinding::new(
+            "secondary-c",
+            root::TextCopy,
+            Some("text-input && !file-editor && !merge-editor"),
+        ),
+        gpui::KeyBinding::new(
+            "secondary-x",
+            root::TextCut,
+            Some("text-input && !file-editor && !merge-editor"),
+        ),
+        gpui::KeyBinding::new(
+            "secondary-v",
+            root::TextPaste,
+            Some("text-input && !file-editor && !merge-editor"),
+        ),
+        gpui::KeyBinding::new(
+            "secondary-a",
+            root::TextSelectAll,
+            Some("text-input && !file-editor && !merge-editor"),
+        ),
         gpui::KeyBinding::new("f12", root::GotoDefinition, None),
         gpui::KeyBinding::new("ctrl-shift-t", root::NewTerminal, None),
         gpui::KeyBinding::new("secondary-shift-n", root::NewAgentPane, None),

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -1387,6 +1387,164 @@ mod undo_scoping_matrix_tests {
         }
     }
 
+    /// GitHub issue #336's own scoping claim, in exactly the same shape as `TextUndo`'s above:
+    /// `TextCopy`/`TextCut`/`TextPaste`/`TextSelectAll` are live in every real *simple* text-input
+    /// context and nowhere else - specifically **not** on the code surface or the merge hand-edit
+    /// surface, where the `Editor*` actions already own `secondary-c`/`x`/`v`/`a` and would
+    /// otherwise tie with these at exactly the same predicate depth.
+    ///
+    /// A live `simulate_keystrokes` test can only ever observe whichever binding won that tie, so
+    /// it would pass just as happily with the ambiguity in place. This asserts the predicate logic
+    /// itself, which is the thing that actually has to hold.
+    #[test]
+    fn the_text_clipboard_actions_are_live_in_exactly_the_simple_input_contexts() {
+        let cases = [
+            (
+                "app::TextCopy",
+                if cfg!(target_os = "macos") {
+                    "cmd-c"
+                } else {
+                    "ctrl-c"
+                },
+            ),
+            (
+                "app::TextCut",
+                if cfg!(target_os = "macos") {
+                    "cmd-x"
+                } else {
+                    "ctrl-x"
+                },
+            ),
+            (
+                "app::TextPaste",
+                if cfg!(target_os = "macos") {
+                    "cmd-v"
+                } else {
+                    "ctrl-v"
+                },
+            ),
+            (
+                "app::TextSelectAll",
+                if cfg!(target_os = "macos") {
+                    "cmd-a"
+                } else {
+                    "ctrl-a"
+                },
+            ),
+        ];
+        // Index-aligned with `real_context_stacks()`/`stack_descriptions()`. Identical to
+        // `TextUndo`'s own expectations above except for the two editor rows, which are `false`
+        // here and `true` there - deliberately, and the whole point of this test.
+        let expectations: Vec<bool> = vec![
+            false, // a dangling focus handle
+            false, // no key context of its own
+            false, // a focused terminal
+            false, // the read-only Diff view
+            false, // the editable File view - `EditorCopy`/`EditorCut`/`EditorPaste` own these
+            false, // ...with completions open
+            false, // the merge hand-edit surface - likewise
+            true,  // a focused single-line text input
+            false, // the rebase plan surface itself
+            true,  // ...with a reword message field focused
+            false, // the review-notes surface itself
+            true,  // ...with a pinned note card focused
+            false, // the file tree with no editor open
+            true,  // ...with its inline name editor open
+        ];
+        assert_eq!(expectations.len(), real_context_stacks().len());
+
+        for (action, keystroke) in cases {
+            let bindings = bindings_for(action, keystroke);
+            assert_eq!(bindings.len(), 1, "exactly one real {action} binding");
+            for ((description, parts), wants) in stack_descriptions()
+                .into_iter()
+                .zip(real_context_stacks())
+                .zip(expectations.iter().copied())
+            {
+                let contexts = stack(&parts);
+                assert_eq!(
+                    enabled(&bindings[0], &contexts),
+                    wants,
+                    "{action} enablement for {description}"
+                );
+            }
+        }
+    }
+
+    /// The other half of the same claim: on the two editor surfaces the `Editor*` actions really
+    /// are still the only live owner of those four keystrokes, so nothing was taken away from them
+    /// by GitHub issue #336's additions.
+    #[test]
+    fn the_editor_surfaces_keep_sole_ownership_of_their_own_clipboard_keystrokes() {
+        let pairs = [
+            (
+                "app::EditorCopy",
+                "app::TextCopy",
+                if cfg!(target_os = "macos") {
+                    "cmd-c"
+                } else {
+                    "ctrl-c"
+                },
+            ),
+            (
+                "app::EditorCut",
+                "app::TextCut",
+                if cfg!(target_os = "macos") {
+                    "cmd-x"
+                } else {
+                    "ctrl-x"
+                },
+            ),
+            (
+                "app::EditorPaste",
+                "app::TextPaste",
+                if cfg!(target_os = "macos") {
+                    "cmd-v"
+                } else {
+                    "ctrl-v"
+                },
+            ),
+            (
+                "app::EditorSelectAll",
+                "app::TextSelectAll",
+                if cfg!(target_os = "macos") {
+                    "cmd-a"
+                } else {
+                    "ctrl-a"
+                },
+            ),
+        ];
+        for parts in real_context_stacks() {
+            let joined = parts.join(" ");
+            if !joined.contains("file-editor") && !joined.contains("merge-editor") {
+                continue;
+            }
+            let contexts = stack(&parts);
+            for (editor_action, text_action, keystroke) in pairs {
+                let editor_live = crate::default_key_bindings()
+                    .into_iter()
+                    .filter(|binding| {
+                        binding.action().name() == editor_action && enabled(binding, &contexts)
+                    })
+                    .count();
+                assert_eq!(
+                    editor_live, 1,
+                    "exactly one real {editor_action} binding must stay live on `{joined}`"
+                );
+                let text_live = bindings_for(text_action, keystroke)
+                    .into_iter()
+                    .filter(|binding| enabled(binding, &contexts))
+                    .count();
+                assert_eq!(
+                    text_live, 0,
+                    "{text_action} must be dead on `{joined}` - two live bindings for \
+                     `{keystroke}` at the same predicate depth is exactly the ambiguity this \
+                     scoping exists to rule out"
+                );
+            }
+        }
+    }
+
     /// GitHub issue #158's root cause, asserted directly: before the fix there was **no**
     /// binding of any kind that reached an action while a terminal had focus for either copy or
     /// paste, so both keystrokes fell through to `crate::terminal::pane::keystroke_to_bytes`

--- a/crates/app/src/palette/render.rs
+++ b/crates/app/src/palette/render.rs
@@ -1,7 +1,9 @@
 use super::*;
 use crate::root::plural;
 use crate::root::scrollbar;
-use crate::root::widgets::{render_hint_pair, render_hint_row, render_keycap_row, KeycapSize};
+use crate::root::widgets::{
+    render_hint_pair, render_hint_row, render_keycap_row, KeycapSize, SimpleInput, SimpleInputCaret,
+};
 use crate::settings::widgets::ChoiceOption;
 use crate::sidebar::render::{next_right_sidebar_view, RightSidebarView};
 
@@ -628,9 +630,13 @@ impl AdeApp {
         cx: &mut Context<Self>,
     ) {
         let keystroke = &event.keystroke;
-        if keystroke.modifiers.platform || keystroke.modifiers.control || keystroke.modifiers.alt {
+        // GitHub issue #336: `widgets::text_editing_modifiers` rather than a flat "any modifier
+        // means not ours" - see `crate::rail::render::AdeApp::handle_filter_key_down`'s own note.
+        let Some(modifiers) =
+            crate::root::widgets::text_editing_modifiers(&keystroke.key, &keystroke.modifiers)
+        else {
             return;
-        }
+        };
         // GitHub issue #27's "solid mid-keystroke" applies to every real caret-bearing input,
         // not only the code editor - reset unconditionally here, before dispatching on which key
         // this actually was, since every branch below is a real, live keystroke this input is
@@ -644,12 +650,6 @@ impl AdeApp {
                 if !self.leave_palette_step(cx) {
                     self.close_palette(window, cx);
                 }
-                cx.stop_propagation();
-            }
-            "backspace" => {
-                self.palette_query.backspace(Instant::now());
-                self.palette_selected = 0;
-                cx.notify();
                 cx.stop_propagation();
             }
             "enter" => {
@@ -674,17 +674,20 @@ impl AdeApp {
                 }
                 cx.stop_propagation();
             }
-            _ => {
-                let Some(text) = keystroke.key_char.as_deref() else {
-                    return;
-                };
-                if text.is_empty() {
-                    return;
-                }
-                if self.palette_query.is_empty() && self.palette_step == palette::PaletteStep::Root
+            key => {
+                // A scope prefix character typed into an *empty* root query switches scope
+                // instead of being inserted - checked before any editing, exactly as before.
+                if let Some(text) = keystroke
+                    .key_char
+                    .as_deref()
+                    .filter(|text| !text.is_empty())
                 {
-                    if let Some(first_char) = text.chars().next() {
-                        if let Some(scope) = palette::typed_scope_prefix(first_char) {
+                    if self.palette_query.is_empty()
+                        && self.palette_step == palette::PaletteStep::Root
+                    {
+                        if let Some(scope) =
+                            text.chars().next().and_then(palette::typed_scope_prefix)
+                        {
                             self.palette_scope = scope;
                             self.palette_selected = 0;
                             cx.notify();
@@ -693,12 +696,31 @@ impl AdeApp {
                         }
                     }
                 }
-                self.palette_query.insert_str(text, Instant::now());
-                self.palette_selected = 0;
-                cx.notify();
-                cx.stop_propagation();
+                // GitHub issue #336: the whole `TextField` vocabulary through one entry point,
+                // rather than the backspace/insert pair this palette used to hand-roll - which is
+                // why its caret could never move off the end of the query.
+                if self.palette_query.handle_editing_key(
+                    key,
+                    keystroke.key_char.as_deref(),
+                    modifiers,
+                    Instant::now(),
+                ) {
+                    self.palette_selected = 0;
+                    cx.notify();
+                    cx.stop_propagation();
+                }
             }
         }
+    }
+
+    /// The palette query's own field handle - what click/drag selection and GitHub issue #336's
+    /// four clipboard/select-all actions act on. Its `on_changed` resets the highlighted row to
+    /// the top exactly as a keystroke into the field does: a pasted query describes a different
+    /// result list, and leaving the old index selected would run whatever now happens to sit
+    /// there.
+    fn palette_query_handle() -> crate::root::widgets::TextFieldHandle {
+        crate::root::widgets::TextFieldHandle::new(|app: &mut AdeApp| Some(&mut app.palette_query))
+            .on_changed(|app: &mut AdeApp, _cx| app.palette_selected = 0)
     }
 
     /// The command palette overlay: an absolutely-positioned scrim + panel painted as the last
@@ -728,43 +750,47 @@ impl AdeApp {
                 this.close_palette(window, cx);
             }))
             .child(
-                div()
-                    .id("palette-panel")
-                    .track_focus(&self.palette_focus_handle)
-                    // The one shared context tag every real text-typing surface in this app
-                    // carries (GitHub issue #17): it routes `secondary-z` to `TextUndo` here.
-                    // Registering the listener on *this* node - the one `palette_focus_handle` is
-                    // tracked on - is what makes the routing structural: GPUI only dispatches an
-                    // action along the focused node's own ancestor path, so a palette query typed
-                    // over an open file editor undoes the query, not the file. See
-                    // `crate::default_key_bindings`' own docs.
-                    .key_context("text-input")
-                    .on_action(cx.listener(Self::handle_palette_text_undo))
-                    .on_action(cx.listener(Self::handle_palette_text_redo))
-                    .on_key_down(cx.listener(Self::handle_palette_key_down))
-                    .on_click(cx.listener(|_this, _event: &ClickEvent, _window, cx| {
-                        // Stops the click from bubbling to the scrim's own `on_click`, which
-                        // would otherwise close the palette on every click inside it.
-                        cx.stop_propagation();
-                    }))
-                    .flex()
-                    .flex_col()
-                    .w(theme::zone::PALETTE_WIDTH)
-                    .max_h(px(480.0))
-                    .bg(theme::surface::PALETTE)
-                    .border_1()
-                    .border_color(theme::border::POPOVER)
-                    .rounded(theme::radius::PANEL)
-                    .overflow_hidden()
-                    .shadow(vec![BoxShadow::new(
-                        shadow_x,
-                        shadow_y,
-                        gpui::black().opacity(0.55),
-                    )
-                    .blur_radius(shadow_blur)])
-                    .child(self.render_palette_input_row(cx))
-                    .child(self.render_palette_groups(&groups, cx))
-                    .child(self.render_palette_footer(total)),
+                self.wire_text_input_actions(
+                    div()
+                        .id("palette-panel")
+                        .track_focus(&self.palette_focus_handle)
+                        // The one shared context tag every real text-typing surface in this app
+                        // carries (GitHub issue #17): it routes `secondary-z` to `TextUndo` here.
+                        // Registering the listener on *this* node - the one
+                        // `palette_focus_handle` is tracked on - is what makes the routing
+                        // structural: GPUI only dispatches an action along the focused node's own
+                        // ancestor path, so a palette query typed over an open file editor undoes
+                        // the query, not the file. See `crate::default_key_bindings`' own docs.
+                        .key_context("text-input")
+                        .on_action(cx.listener(Self::handle_palette_text_undo))
+                        .on_action(cx.listener(Self::handle_palette_text_redo))
+                        .on_key_down(cx.listener(Self::handle_palette_key_down)),
+                    Self::palette_query_handle(),
+                    cx,
+                )
+                .on_click(cx.listener(|_this, _event: &ClickEvent, _window, cx| {
+                    // Stops the click from bubbling to the scrim's own `on_click`, which
+                    // would otherwise close the palette on every click inside it.
+                    cx.stop_propagation();
+                }))
+                .flex()
+                .flex_col()
+                .w(theme::zone::PALETTE_WIDTH)
+                .max_h(px(480.0))
+                .bg(theme::surface::PALETTE)
+                .border_1()
+                .border_color(theme::border::POPOVER)
+                .rounded(theme::radius::PANEL)
+                .overflow_hidden()
+                .shadow(vec![BoxShadow::new(
+                    shadow_x,
+                    shadow_y,
+                    gpui::black().opacity(0.55),
+                )
+                .blur_radius(shadow_blur)])
+                .child(self.render_palette_input_row(cx))
+                .child(self.render_palette_groups(&groups, cx))
+                .child(self.render_palette_footer(total)),
             )
     }
 
@@ -773,35 +799,6 @@ impl AdeApp {
     /// which renders the identical two-position caret rather than a fixed one, so this isn't a
     /// new invention. `margin_right`/`margin_left` place it on whichever side of the text it sits
     /// on: before the placeholder (empty query) or after the real typed text (non-empty).
-    fn render_palette_caret(
-        &self,
-        margin_right: gpui::Pixels,
-        margin_left: gpui::Pixels,
-    ) -> impl IntoElement {
-        // GitHub issue #27's caret blink, applied here too: `Self::palette_focus_handle` is
-        // wired into the same shared blink loop `crate::root::caret_blink` drives for the code
-        // editor (`AdeApp::wire_caret_blink`), and stays genuinely focused for this input's
-        // entire real lifetime - the palette panel's only other interactive children
-        // (`Self::render_palette_scope_control`'s segments) are plain `.on_click()` divs with no
-        // `.track_focus()` of their own, so they never steal keyboard focus away from it. That
-        // means this caret is never actually rendered while unfocused (closing the palette stops
-        // rendering it at all), so unlike the code editor's own caret there's no separate
-        // "hidden while unfocused" case to paint here - `caret_blink_visible` alone is the real,
-        // whole answer for whether to paint it this frame.
-        let visible = self.caret_blink_visible;
-        div()
-            .flex_none()
-            .mr(margin_right)
-            .ml(margin_left)
-            .w(px(1.5))
-            .h(px(16.0))
-            .when(visible, |el| el.bg(theme::term::CURSOR))
-            // `debug_selector` is a no-op outside test builds; lets
-            // `palette_caret_tests::*` measure the caret's real painted x position in both
-            // states and assert it actually moved.
-            .debug_selector(|| "palette-caret".to_string())
-    }
-
     /// The palette's input row: scope-prefix glyph, typed query (or its placeholder), a caret at
     /// the real insertion point, and the clickable segmented scope control.
     ///
@@ -819,7 +816,6 @@ impl AdeApp {
         &self,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        let has_query = !self.palette_query.is_empty();
         let placeholder = match self.palette_step {
             palette::PaletteStep::Root => "Type a command, file or agent\u{2026}",
             palette::PaletteStep::PickLanguageServer => "Which language server?",
@@ -844,35 +840,35 @@ impl AdeApp {
                     .text_color(theme::palette::PREFIX)
                     .child(self.palette_scope.prefix_glyph()),
             )
-            .child(
-                div()
-                    .flex_1()
-                    .min_w_0()
-                    .flex()
-                    .items_center()
-                    .when(!has_query, |el| {
-                        el.child(self.render_palette_caret(px(3.0), px(0.0)))
-                    })
-                    .child(
-                        div()
-                            .font(font(theme::font::SANS))
-                            .text_size(self.ui_text_size(13.0))
-                            .text_color(if has_query {
-                                theme::text::SELECTED
-                            } else {
-                                theme::text::GHOST
-                            })
-                            .child(if has_query {
-                                self.palette_query.as_str().to_string()
-                            } else {
-                                placeholder.to_string()
-                            })
-                            .debug_selector(|| "palette-query-text".to_string()),
-                    )
-                    .when(has_query, |el| {
-                        el.child(self.render_palette_caret(px(0.0), px(2.0)))
-                    }),
-            )
+            // GitHub issue #336: through the one helper that owns this structure, like every
+            // other simple input in the app. The palette keeps its own caret *metrics* (16px
+            // tall, 3px before the placeholder, 2px after the typed text -
+            // `Jerry.dc.html`'s own `paletteEmpty`/`paletteTyped` fixture) through
+            // `SimpleInputCaret`, which is exactly why that type exists. What it gains is a caret
+            // that follows `TextField::caret` instead of sitting at the end of the query
+            // regardless, a real selection highlight, and real click/drag/double-click selection.
+            .child(self.render_simple_input_row(
+                SimpleInput {
+                    caret_selector: "palette-caret".into(),
+                    text_selector: "palette-query-text".into(),
+                    focus_handle: Some(&self.palette_focus_handle),
+                    text: self.palette_query.as_str(),
+                    caret_offset: self.palette_query.caret(),
+                    selection: self.palette_query.selection(),
+                    placeholder,
+                    font: theme::font::SANS,
+                    text_size: self.ui_text_size(13.0),
+                    text_color: theme::text::SELECTED,
+                    placeholder_color: theme::text::GHOST,
+                    caret: SimpleInputCaret {
+                        height: px(16.0),
+                        gap_before_placeholder: px(3.0),
+                        gap_after_text: px(2.0),
+                    },
+                    field: Some(Self::palette_query_handle()),
+                },
+                cx,
+            ))
             .when(self.palette_step == palette::PaletteStep::Root, |el| {
                 el.child(self.render_palette_scope_control(cx))
             })

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -5549,7 +5549,7 @@ mod rail_filter_selection_tests {
         app.read_with(cx, |app, _| {
             let (bounds, shaped) = app
                 .simple_input_layout
-                .get(&gpui::SharedString::from("rail-filter-text"))
+                .get(&gpui::SharedString::from("rail-filter-caret"))
                 .expect("the filter row's own overlay must really have painted");
             gpui::point(
                 bounds.origin.x + shaped.x_for_index(offset),
@@ -5825,7 +5825,7 @@ mod rail_filter_selection_tests {
         cx.simulate_keystrokes(&secondary("a"));
         cx.run_until_parked();
 
-        let key = gpui::SharedString::from("rail-filter-text");
+        let key = gpui::SharedString::from("rail-filter-caret");
         let (start_x, end_x, width) = app.read_with(cx, |app, _| {
             let (_, shaped) = app.simple_input_layout.get(&key).expect(
                 "the filter row's own overlay must really have painted and recorded its \

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -5483,3 +5483,380 @@ mod rail_virtualization_tests {
         );
     }
 }
+
+/// GitHub issue #336 ("Text inputs do not have selection and standard copy/paste/cut"), driven the
+/// way a user drives it: real simulated clicks, drags and keystrokes into a real focused field,
+/// with the real system clipboard on the other end of Ctrl/Cmd+C.
+///
+/// The rail filter is the surface under test because it is the plainest of the app's thirteen
+/// `"text-input"` nodes - one field, one focus handle, no modal, no debounce - so what these
+/// assert is the shared plumbing (`crate::root::widgets::AdeApp::render_simple_input_row`,
+/// `wire_text_input_actions`, `crate::text_history::TextField`) that every one of the other twelve
+/// goes through, not anything the rail owns. The per-surface half - that each field really passes
+/// its own `TextFieldHandle` - is what `crate::keymap_overrides::real_context_stacks`' own
+/// enumeration plus the scoping matrix in `crate::undo_scoping_matrix_tests` covers.
+#[cfg(test)]
+mod rail_filter_selection_tests {
+    use super::*;
+    use crate::root::focus::palette_focus_tests;
+    use gpui::TestAppContext;
+
+    fn secondary(key: &str) -> String {
+        if cfg!(target_os = "macos") {
+            format!("cmd-{key}")
+        } else {
+            format!("ctrl-{key}")
+        }
+    }
+
+    /// A focused rail filter holding `text`, with the real default key bindings live so the
+    /// clipboard actions can be reached by their real keystrokes rather than dispatched directly.
+    fn open_filter_with<'a>(
+        cx: &'a mut TestAppContext,
+        repo: &std::path::Path,
+        text: &str,
+    ) -> (gpui::Entity<AdeApp>, &'a mut gpui::VisualTestContext) {
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.to_path_buf());
+        cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
+        app.update_in(cx, |app, window, cx| {
+            window.focus(&app.filter_focus_handle, cx);
+        });
+        cx.simulate_input(text);
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.filter_query.as_str().to_string()),
+            text,
+            "sanity check: the field really holds what was typed into it"
+        );
+        (app, cx)
+    }
+
+    /// A real window-space point over byte `offset` of the filter's own painted text.
+    ///
+    /// Built from `AdeApp::simple_input_layout` - the `(bounds, ShapedLine)` pair the row's own
+    /// overlay recorded when it last painted - rather than from the text element's `debug_bounds`.
+    /// That matters: `SimpleInput::text_selector` sits on the row's *leading* half (see
+    /// `AdeApp::render_simple_input_row`'s own docs), so once the caret is anywhere but the end,
+    /// that element is only as wide as the text before the caret. The recorded layout always
+    /// describes the whole line, which is also exactly what the click handler itself hit-tests
+    /// against - so a point built here and the offset the app resolves it to cannot disagree by
+    /// construction.
+    fn point_at_offset(
+        app: &gpui::Entity<AdeApp>,
+        cx: &mut gpui::VisualTestContext,
+        offset: usize,
+    ) -> gpui::Point<gpui::Pixels> {
+        app.read_with(cx, |app, _| {
+            let (bounds, shaped) = app
+                .simple_input_layout
+                .get(&gpui::SharedString::from("rail-filter-text"))
+                .expect("the filter row's own overlay must really have painted");
+            gpui::point(
+                bounds.origin.x + shaped.x_for_index(offset),
+                bounds.origin.y + bounds.size.height / 2.0,
+            )
+        })
+    }
+
+    /// A point genuinely *over* the glyph at `offset` - halfway into it, so a hit test resolves to
+    /// that byte rather than to whichever side of the boundary rounding happens to favour.
+    fn point_inside_glyph(
+        app: &gpui::Entity<AdeApp>,
+        cx: &mut gpui::VisualTestContext,
+        offset: usize,
+    ) -> gpui::Point<gpui::Pixels> {
+        let left = point_at_offset(app, cx, offset);
+        let right = point_at_offset(app, cx, offset + 1);
+        gpui::point((left.x + right.x) / 2.0, left.y)
+    }
+
+    #[gpui::test]
+    fn shift_arrow_extends_a_real_selection_and_a_plain_arrow_collapses_it(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = open_filter_with(cx, repo.path(), "origin");
+
+        cx.simulate_keystrokes("home shift-right shift-right shift-right");
+        assert_eq!(
+            app.read_with(cx, |app, _| app.filter_query.selected_text().to_string()),
+            "ori",
+            "three real Shift+Right keystrokes must extend a real three-grapheme selection"
+        );
+
+        cx.simulate_keystrokes("right");
+        assert!(
+            app.read_with(cx, |app, _| !app.filter_query.has_selection()),
+            "a plain arrow key collapses the selection rather than extending it"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.filter_query.caret()),
+            3,
+            "...and collapses to the selection's near edge, not one grapheme past it"
+        );
+    }
+
+    #[gpui::test]
+    fn a_real_click_places_the_caret_and_a_drag_selects_the_range_between(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = open_filter_with(cx, repo.path(), "origin/main");
+
+        // A click at the field's own text origin: byte 0, whatever the glyph metrics are.
+        let start = point_at_offset(&app, cx, 0);
+        cx.simulate_mouse_down(start, gpui::MouseButton::Left, gpui::Modifiers::default());
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.filter_query.caret()),
+            0,
+            "a real click at the text's own origin must place the caret at byte 0 - before this \
+             there was no click handling on these fields at all"
+        );
+
+        // ...then drag far past the field's right edge, which is exactly the gesture a
+        // hover-filtered `on_mouse_move` listener could not see (see
+        // `AdeApp::simple_input_overlay`'s own docs).
+        let far_right = gpui::point(start.x + px(4000.0), start.y);
+        cx.simulate_mouse_move(
+            far_right,
+            gpui::MouseButton::Left,
+            gpui::Modifiers::default(),
+        );
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.filter_query.selected_text().to_string()),
+            "origin/main",
+            "dragging past the right edge selects to the end of the real text"
+        );
+
+        cx.simulate_mouse_up(
+            far_right,
+            gpui::MouseButton::Left,
+            gpui::Modifiers::default(),
+        );
+        cx.run_until_parked();
+        // With the button released, a bare pointer move must no longer touch the selection.
+        cx.simulate_mouse_move(start, None, gpui::Modifiers::default());
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.filter_query.selected_text().to_string()),
+            "origin/main",
+            "the drag ended on mouse-up; moving the pointer afterwards must not keep selecting"
+        );
+    }
+
+    #[gpui::test]
+    fn a_real_double_click_selects_the_word_under_the_pointer(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = open_filter_with(cx, repo.path(), "origin/main");
+        // Over the `a` of `main`, so the pointer is genuinely inside the second word.
+        let inside_second_word = point_inside_glyph(&app, cx, 8);
+        cx.simulate_event(gpui::MouseDownEvent {
+            position: inside_second_word,
+            modifiers: gpui::Modifiers::default(),
+            button: gpui::MouseButton::Left,
+            click_count: 2,
+            first_mouse: false,
+        });
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.filter_query.selected_text().to_string()),
+            "main",
+            "GPUI's own `MouseDownEvent::click_count` is what makes this a double-click - the \
+             field needs no timing of its own"
+        );
+    }
+
+    #[gpui::test]
+    fn a_shift_click_extends_from_the_existing_anchor(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = open_filter_with(cx, repo.path(), "origin/main");
+        let left_edge = point_at_offset(&app, cx, 0);
+        cx.simulate_mouse_down(
+            left_edge,
+            gpui::MouseButton::Left,
+            gpui::Modifiers::default(),
+        );
+        cx.simulate_mouse_up(
+            left_edge,
+            gpui::MouseButton::Left,
+            gpui::Modifiers::default(),
+        );
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.filter_query.caret()),
+            0,
+            "sanity check: the first, unmodified click really moved the caret to byte 0"
+        );
+
+        let text_end = point_at_offset(&app, cx, "origin/main".len());
+        cx.simulate_mouse_down(text_end, gpui::MouseButton::Left, gpui::Modifiers::shift());
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.filter_query.selected_text().to_string()),
+            "origin/main",
+            "a Shift-held click extends from the caret the previous click left behind"
+        );
+    }
+
+    #[gpui::test]
+    fn select_all_then_copy_puts_the_real_text_on_the_real_clipboard(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = open_filter_with(cx, repo.path(), "origin/main");
+        // Seeded with something else first, so a green result cannot come from a clipboard that
+        // simply already said the right thing.
+        cx.update(|_window, cx| {
+            cx.write_to_clipboard(gpui::ClipboardItem::new_string("stale".into()))
+        });
+
+        cx.simulate_keystrokes(&secondary("a"));
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.filter_query.selected_text().to_string()),
+            "origin/main",
+            "a real mod+A keystroke must reach TextSelectAll through the real key bindings"
+        );
+
+        cx.simulate_keystrokes(&secondary("c"));
+        cx.run_until_parked();
+        assert_eq!(
+            cx.update(|_window, cx| cx.read_from_clipboard().and_then(|item| item.text())),
+            Some("origin/main".to_string())
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.filter_query.as_str().to_string()),
+            "origin/main",
+            "a copy never edits the field"
+        );
+    }
+
+    #[gpui::test]
+    fn cut_removes_the_selection_and_paste_puts_it_back_somewhere_else(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = open_filter_with(cx, repo.path(), "origin/main");
+
+        cx.simulate_keystrokes("home shift-right shift-right shift-right");
+        cx.simulate_keystrokes(&secondary("x"));
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.filter_query.as_str().to_string()),
+            "gin/main",
+            "cut removes exactly the selected range"
+        );
+        assert_eq!(
+            cx.update(|_window, cx| cx.read_from_clipboard().and_then(|item| item.text())),
+            Some("ori".to_string())
+        );
+
+        cx.simulate_keystrokes("end");
+        cx.simulate_keystrokes(&secondary("v"));
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.filter_query.as_str().to_string()),
+            "gin/mainori",
+            "paste inserts the real clipboard content at the caret"
+        );
+
+        // ...and the whole cut+paste pair is undoable, one real step at a time.
+        cx.simulate_keystrokes(&secondary("z"));
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.filter_query.as_str().to_string()),
+            "gin/main",
+            "one Ctrl+Z undoes the paste and nothing more"
+        );
+        cx.simulate_keystrokes(&secondary("z"));
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.filter_query.as_str().to_string()),
+            "origin/main",
+            "the next one undoes the cut, selection and all"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.filter_query.selected_text().to_string()),
+            "ori",
+            "undoing a cut restores the selection it removed, not just the text"
+        );
+    }
+
+    #[gpui::test]
+    fn paste_over_a_selection_replaces_it(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = open_filter_with(cx, repo.path(), "origin/main");
+        cx.update(|_window, cx| {
+            cx.write_to_clipboard(gpui::ClipboardItem::new_string("upstream".into()))
+        });
+
+        cx.simulate_keystrokes(
+            "home shift-right shift-right shift-right shift-right shift-right shift-right",
+        );
+        cx.simulate_keystrokes(&secondary("v"));
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.filter_query.as_str().to_string()),
+            "upstream/main",
+            "a paste with a live selection replaces that whole range"
+        );
+    }
+
+    #[gpui::test]
+    fn backspace_over_a_selection_deletes_the_whole_range(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = open_filter_with(cx, repo.path(), "origin/main");
+        cx.simulate_keystrokes(&secondary("a"));
+        cx.simulate_keystrokes("backspace");
+        cx.run_until_parked();
+        assert!(
+            app.read_with(cx, |app, _| app.filter_query.is_empty()),
+            "one Backspace over a whole-field selection empties it, rather than removing one \
+             character from the end"
+        );
+    }
+
+    /// The selected range really is painted behind the glyphs, not merely tracked in state.
+    ///
+    /// Asserted through `AdeApp::simple_input_layout` - the `(bounds, ShapedLine)` pair the row's
+    /// own overlay records every frame, which is the *same* pair the selection quad's own
+    /// `x_for_index` edges are computed from and the same one every click hit-test reads. If the
+    /// overlay never painted, this entry does not exist at all and there is no quad either.
+    #[gpui::test]
+    fn the_selection_is_really_measured_from_the_row_that_painted_it(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = open_filter_with(cx, repo.path(), "origin/main");
+        cx.simulate_keystrokes(&secondary("a"));
+        cx.run_until_parked();
+
+        let key = gpui::SharedString::from("rail-filter-text");
+        let (start_x, end_x, width) = app.read_with(cx, |app, _| {
+            let (_, shaped) = app.simple_input_layout.get(&key).expect(
+                "the filter row's own overlay must really have painted and recorded its \
+                         shaped line - without it there is no selection quad and no hit-testing",
+            );
+            let selection = app.filter_query.selection();
+            (
+                shaped.x_for_index(selection.start),
+                shaped.x_for_index(selection.end),
+                shaped.width,
+            )
+        });
+        assert_eq!(
+            start_x,
+            px(0.0),
+            "a whole-field selection starts at the text origin"
+        );
+        assert!(
+            end_x > px(0.0) && end_x == width,
+            "...and ends at the shaped line's own real right edge - got {end_x:?} vs {width:?}"
+        );
+
+        // The same shaped line is what a click hit-tests against, so the two can never disagree.
+        let hit = app.read_with(cx, |app, _| {
+            let (bounds, _) = app.simple_input_layout.get(&key).expect("still painted");
+            app.simple_input_offset_at(&key, gpui::point(bounds.origin.x + end_x, bounds.origin.y))
+        });
+        assert_eq!(
+            hit,
+            Some("origin/main".len()),
+            "clicking at the selection's own painted right edge hit-tests to the end of the text"
+        );
+    }
+}

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -990,6 +990,7 @@ impl AdeApp {
                     text_size: self.ui_text_size(10.5),
                     text_color: theme::text::DIM,
                     placeholder_color: theme::text::GHOST,
+                    caret: widgets::SimpleInputCaret::default(),
                     field: Some(Self::filter_query_handle()),
                 },
                 cx,

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -255,9 +255,14 @@ impl AdeApp {
         cx: &mut Context<Self>,
     ) {
         let keystroke = &event.keystroke;
-        if keystroke.modifiers.platform || keystroke.modifiers.control || keystroke.modifiers.alt {
+        // GitHub issue #336: the modifier check is `widgets::text_editing_modifiers`' now, not a
+        // flat "any of Ctrl/Alt/Cmd means not ours" - word-wise Ctrl+Left/Right (Alt on macOS) is
+        // real text editing that this used to refuse, and Shift is the extend-selection modifier
+        // rather than something to ignore.
+        let Some(modifiers) = widgets::text_editing_modifiers(&keystroke.key, &keystroke.modifiers)
+        else {
             return;
-        }
+        };
         // GitHub issue #27's "solid mid-keystroke" - see `crate::palette::render::AdeApp::
         // handle_palette_key_down`'s identical reasoning.
         self.reset_caret_blink(cx);
@@ -268,6 +273,7 @@ impl AdeApp {
             key => self.filter_query.handle_editing_key(
                 key,
                 keystroke.key_char.as_deref(),
+                modifiers,
                 Instant::now(),
             ),
         };
@@ -936,7 +942,7 @@ impl AdeApp {
         view: rail_strip::SidebarView,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        div()
+        let row = div()
             .id("rail-filter-row")
             .track_focus(&self.filter_focus_handle)
             // See `crate::default_key_bindings`' `TextUndo`/`TextRedo` docs for why the tag and
@@ -944,7 +950,10 @@ impl AdeApp {
             .key_context("text-input")
             .on_action(cx.listener(Self::handle_filter_text_undo))
             .on_action(cx.listener(Self::handle_filter_text_redo))
-            .on_key_down(cx.listener(Self::handle_filter_key_down))
+            .on_key_down(cx.listener(Self::handle_filter_key_down));
+        // GitHub issue #336's four clipboard/select-all actions, on the same node and for the same
+        // structural-routing reason the two undo actions above are.
+        self.wire_text_input_actions(row, Self::filter_query_handle(), cx)
             .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
                 window.focus(&this.filter_focus_handle, cx);
             }))
@@ -964,22 +973,39 @@ impl AdeApp {
                     .text_color(theme::text::GHOST)
                     .child("/"),
             )
-            .child(self.render_simple_input_row(SimpleInput {
-                caret_selector: "rail-filter-caret".into(),
-                text_selector: "rail-filter-text".into(),
-                focus_handle: Some(&self.filter_focus_handle),
-                text: self.filter_query.as_str(),
-                caret_offset: self.filter_query.caret(),
-                placeholder: match view {
-                    rail_strip::SidebarView::Worktrees => "filter worktrees and agents",
-                    rail_strip::SidebarView::Problems => "filter problems",
-                    rail_strip::SidebarView::History => "filter runs",
+            .child(self.render_simple_input_row(
+                SimpleInput {
+                    caret_selector: "rail-filter-caret".into(),
+                    text_selector: "rail-filter-text".into(),
+                    focus_handle: Some(&self.filter_focus_handle),
+                    text: self.filter_query.as_str(),
+                    caret_offset: self.filter_query.caret(),
+                    selection: self.filter_query.selection(),
+                    placeholder: match view {
+                        rail_strip::SidebarView::Worktrees => "filter worktrees and agents",
+                        rail_strip::SidebarView::Problems => "filter problems",
+                        rail_strip::SidebarView::History => "filter runs",
+                    },
+                    font: theme::font::MONO,
+                    text_size: self.ui_text_size(10.5),
+                    text_color: theme::text::DIM,
+                    placeholder_color: theme::text::GHOST,
+                    field: Some(Self::filter_query_handle()),
                 },
-                font: theme::font::MONO,
-                text_size: self.ui_text_size(10.5),
-                text_color: theme::text::DIM,
-                placeholder_color: theme::text::GHOST,
-            }))
+                cx,
+            ))
+    }
+
+    /// The rail filter's own field handle - what click/drag selection and the four clipboard
+    /// actions act on, and the same "an edit disarms the pending confirmations" work
+    /// [`Self::handle_filter_key_down`] does for an ordinary keystroke.
+    fn filter_query_handle() -> widgets::TextFieldHandle {
+        widgets::TextFieldHandle::new(|app: &mut AdeApp| Some(&mut app.filter_query)).on_changed(
+            |app: &mut AdeApp, _cx| {
+                app.prune_confirm_armed = false;
+                app.discard_confirm_armed = None;
+            },
+        )
     }
 
     /// Builds this rail's repo groups fresh from live state every render (cheap: no I/O, just

--- a/crates/app/src/review_notes/flow.rs
+++ b/crates/app/src/review_notes/flow.rs
@@ -335,10 +335,9 @@ impl AdeApp {
         // rather than being typed into it - through `widgets::text_editing_modifiers` since
         // GitHub issue #336, so word-wise Ctrl+Left/Right is real editing here rather than a
         // refused keystroke (see `crate::rail::render::AdeApp::handle_filter_key_down`'s note).
-        let Some(modifiers) = crate::root::widgets::text_editing_modifiers(
-            &keystroke.key,
-            &keystroke.modifiers,
-        ) else {
+        let Some(modifiers) =
+            crate::root::widgets::text_editing_modifiers(&keystroke.key, &keystroke.modifiers)
+        else {
             return;
         };
         let changed = draft.field.handle_editing_key(

--- a/crates/app/src/review_notes/flow.rs
+++ b/crates/app/src/review_notes/flow.rs
@@ -174,7 +174,11 @@ impl AdeApp {
     /// `crate::code_surface::editing::AdeApp::schedule_rehighlight` already uses, and the state is
     /// captured *inside* the task after the wait, so a coalesced write is a write of the newest
     /// content rather than of whatever was there when the first keystroke landed.
-    fn schedule_review_notes_persist(&mut self, worktree: &Path, cx: &mut Context<Self>) {
+    pub(in crate::review_notes) fn schedule_review_notes_persist(
+        &mut self,
+        worktree: &Path,
+        cx: &mut Context<Self>,
+    ) {
         self.write_review_notes(worktree, Some(REVIEW_NOTES_PERSIST_DEBOUNCE), cx);
     }
 
@@ -328,17 +332,21 @@ impl AdeApp {
         let keystroke = &event.keystroke;
         // The same guard `crate::sidebar::render::AdeApp::handle_commit_message_key_down` uses,
         // and it is what lets `mod+enter` reach `SendReviewNotes` from inside this very field
-        // rather than being typed into it.
-        if keystroke.modifiers.platform || keystroke.modifiers.control || keystroke.modifiers.alt {
+        // rather than being typed into it - through `widgets::text_editing_modifiers` since
+        // GitHub issue #336, so word-wise Ctrl+Left/Right is real editing here rather than a
+        // refused keystroke (see `crate::rail::render::AdeApp::handle_filter_key_down`'s note).
+        let Some(modifiers) = crate::root::widgets::text_editing_modifiers(
+            &keystroke.key,
+            &keystroke.modifiers,
+        ) else {
             return;
-        }
-        let changed = match keystroke.key.as_str() {
-            "backspace" => draft.field.backspace(Instant::now()),
-            _ => match keystroke.key_char.as_deref() {
-                Some(text) if !text.is_empty() => draft.field.insert_str(text, Instant::now()),
-                _ => false,
-            },
         };
+        let changed = draft.field.handle_editing_key(
+            &keystroke.key,
+            keystroke.key_char.as_deref(),
+            modifiers,
+            Instant::now(),
+        );
         if !changed {
             return;
         }

--- a/crates/app/src/review_notes/render.rs
+++ b/crates/app/src/review_notes/render.rs
@@ -10,7 +10,7 @@ use super::{flow, NoteAnchor, NoteMark};
 use crate::provenance::render::author_style;
 use crate::provenance::Author;
 use crate::root::widgets::{
-    render_keycap_row, text_tooltip, KeycapSize, SimpleInput, TextFieldHandle,
+    render_keycap_row, text_tooltip, KeycapSize, SimpleInput, SimpleInputCaret, TextFieldHandle,
 };
 use crate::root::{plural, AdeApp};
 use crate::theme;
@@ -554,6 +554,7 @@ impl AdeApp {
                             text_size: px(11.5),
                             text_color: theme::notes::CARD_FG,
                             placeholder_color: theme::notes::CARD_PLACEHOLDER,
+                            caret: SimpleInputCaret::default(),
                             // Only the card really being edited is pointer-editable; the pinned
                             // ones around it are read-only text, exactly as their suppressed
                             // caret already says.

--- a/crates/app/src/review_notes/render.rs
+++ b/crates/app/src/review_notes/render.rs
@@ -9,12 +9,34 @@
 use super::{flow, NoteAnchor, NoteMark};
 use crate::provenance::render::author_style;
 use crate::provenance::Author;
-use crate::root::widgets::{render_keycap_row, text_tooltip, KeycapSize, SimpleInput};
+use crate::root::widgets::{
+    render_keycap_row, text_tooltip, KeycapSize, SimpleInput, TextFieldHandle,
+};
 use crate::root::{plural, AdeApp};
 use crate::theme;
 use crate::{keymap, work_surface};
 use gpui::prelude::*;
 use gpui::{div, font, px, rems, ClickEvent, Context, IntoElement, SharedString};
+
+/// The open note card's own [`TextFieldHandle`] - what click/drag selection and GitHub issue
+/// #336's four clipboard/select-all actions act on. `None` whenever no card is open for typing,
+/// and its `on_changed` mirrors `AdeApp::handle_note_key_down`'s own follow-up exactly: the note's
+/// stored text is updated and a persist is scheduled, so a pasted note survives a restart just
+/// like a typed one.
+fn note_draft_handle() -> TextFieldHandle {
+    TextFieldHandle::new(|app: &mut AdeApp| app.note_draft.as_mut().map(|draft| &mut draft.field))
+        .on_changed(|app: &mut AdeApp, cx| {
+            let Some(draft) = app.note_draft.as_ref() else {
+                return;
+            };
+            let worktree = draft.worktree.clone();
+            let at = draft.at.clone();
+            let text = draft.field.as_str().to_string();
+            app.review_notes
+                .set_text(&worktree, &at.path, at.anchor, &text);
+            app.schedule_review_notes_persist(&worktree, cx);
+        })
+}
 
 /// The bar's fixed second line, **verbatim** from `Jerry.dc.html` and from `STAGE-A-CHANGELOG.md`
 /// §1's own row for this feature: *"A notes bar above the hunks: count, the line `one prompt,
@@ -120,18 +142,22 @@ impl AdeApp {
     fn render_note_input_node(&self, cx: &mut Context<Self>) -> Option<gpui::AnyElement> {
         self.note_draft.as_ref()?;
         Some(
-            div()
-                .id("diff-note-input")
-                .debug_selector(|| "diff-note-input".to_string())
-                .flex_none()
-                .w(px(0.0))
-                .h(px(0.0))
-                .track_focus(&self.note_focus_handle)
-                .key_context("text-input")
-                .on_action(cx.listener(Self::handle_note_text_undo))
-                .on_action(cx.listener(Self::handle_note_text_redo))
-                .on_key_down(cx.listener(Self::handle_note_key_down))
-                .into_any_element(),
+            self.wire_text_input_actions(
+                div()
+                    .id("diff-note-input")
+                    .debug_selector(|| "diff-note-input".to_string())
+                    .flex_none()
+                    .w(px(0.0))
+                    .h(px(0.0))
+                    .track_focus(&self.note_focus_handle)
+                    .key_context("text-input")
+                    .on_action(cx.listener(Self::handle_note_text_undo))
+                    .on_action(cx.listener(Self::handle_note_text_redo))
+                    .on_key_down(cx.listener(Self::handle_note_key_down)),
+                note_draft_handle(),
+                cx,
+            )
+            .into_any_element(),
         )
     }
 
@@ -431,6 +457,11 @@ impl AdeApp {
             Some(draft) if editing => draft.field.caret(),
             _ => text.len(),
         };
+        // Same rule as the caret: only the card really being typed into can show a selection.
+        let text_selection = match &self.note_draft {
+            Some(draft) if editing => draft.field.selection(),
+            _ => 0..0,
+        };
         let mark = note.map(|note| note.mark()).unwrap_or(NoteMark::Draft);
         // The honest half of the draft/sent history: a card that has been sent and then edited
         // can still say what the agent really was told.
@@ -510,18 +541,26 @@ impl AdeApp {
                     // Only a card being typed into gets a caret at all; the pinned cards
                     // around it are read-only text, so they render the same row with the
                     // caret suppressed by a focus handle that is not theirs to hold.
-                    .child(self.render_simple_input_row(SimpleInput {
-                        caret_selector: SharedString::from(caret_selector),
-                        text_selector: SharedString::from(text_selector),
-                        focus_handle: editing.then_some(&self.note_focus_handle),
-                        text: &text,
-                        caret_offset: text_caret,
-                        placeholder: NOTE_PLACEHOLDER,
-                        font: theme::font::SANS,
-                        text_size: px(11.5),
-                        text_color: theme::notes::CARD_FG,
-                        placeholder_color: theme::notes::CARD_PLACEHOLDER,
-                    }))
+                    .child(self.render_simple_input_row(
+                        SimpleInput {
+                            caret_selector: SharedString::from(caret_selector),
+                            text_selector: SharedString::from(text_selector),
+                            focus_handle: editing.then_some(&self.note_focus_handle),
+                            text: &text,
+                            caret_offset: text_caret,
+                            selection: text_selection,
+                            placeholder: NOTE_PLACEHOLDER,
+                            font: theme::font::SANS,
+                            text_size: px(11.5),
+                            text_color: theme::notes::CARD_FG,
+                            placeholder_color: theme::notes::CARD_PLACEHOLDER,
+                            // Only the card really being edited is pointer-editable; the pinned
+                            // ones around it are read-only text, exactly as their suppressed
+                            // caret already says.
+                            field: editing.then(note_draft_handle),
+                        },
+                        cx,
+                    ))
                     .child(
                         div()
                             .debug_selector(move || mark_selector)

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -1351,14 +1351,14 @@ pub struct AdeApp {
     /// inputs (GitHub issue #336): every `widgets::render_simple_input_row` captures its own real
     /// painted bounds and shaped line here each frame, and its click/drag handlers read them back
     /// to hit-test a pointer x into a real byte offset (`gpui::LineLayout::closest_index_for_x`).
-    /// Keyed by the row's own `widgets::SimpleInput::text_selector`, which is already unique per
-    /// field (per *row* for the fields that are rows of a list). Transient/best-effort in exactly
+    /// Keyed by the row's own `widgets::SimpleInput::caret_selector` - see that field's own docs
+    /// for why the caret selector rather than the text one. Transient/best-effort in exactly
     /// the same way: an entry for a field no longer on screen is simply never refreshed, and can
     /// never be read because it can't be clicked.
     pub(crate) simple_input_layout:
         HashMap<gpui::SharedString, (gpui::Bounds<Pixels>, gpui::ShapedLine)>,
     /// Which single-line input a real click-drag selection is currently in progress in - the
-    /// `text_selector` key of [`Self::simple_input_layout`], or `None` when no button is down.
+    /// `caret_selector` key of [`Self::simple_input_layout`], or `None` when no button is down.
     ///
     /// Needed because the drag has to keep extending the selection while the pointer is *outside*
     /// the field (dragging past its right edge is how a user selects to the end of a query that

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -222,6 +222,10 @@ actions!(
         EditorEscape,
         TextUndo,
         TextRedo,
+        TextCopy,
+        TextCut,
+        TextPaste,
+        TextSelectAll,
         CloseFocusedTab,
         FileTreeRename,
         FileTreeCopy,
@@ -1343,6 +1347,26 @@ pub struct AdeApp {
     /// only ever read for a row-click hit test, and a scrolled-away row can't be clicked), so this
     /// is cleared wholesale only on a worktree switch, not pruned every frame.
     pub(crate) file_view_row_layout: HashMap<usize, (gpui::Bounds<Pixels>, gpui::ShapedLine)>,
+    /// The same idea as [`Self::file_view_row_layout`], for the app's hand-rolled single-line
+    /// inputs (GitHub issue #336): every `widgets::render_simple_input_row` captures its own real
+    /// painted bounds and shaped line here each frame, and its click/drag handlers read them back
+    /// to hit-test a pointer x into a real byte offset (`gpui::LineLayout::closest_index_for_x`).
+    /// Keyed by the row's own `widgets::SimpleInput::text_selector`, which is already unique per
+    /// field (per *row* for the fields that are rows of a list). Transient/best-effort in exactly
+    /// the same way: an entry for a field no longer on screen is simply never refreshed, and can
+    /// never be read because it can't be clicked.
+    pub(crate) simple_input_layout:
+        HashMap<gpui::SharedString, (gpui::Bounds<Pixels>, gpui::ShapedLine)>,
+    /// Which single-line input a real click-drag selection is currently in progress in - the
+    /// `text_selector` key of [`Self::simple_input_layout`], or `None` when no button is down.
+    ///
+    /// Needed because the drag has to keep extending the selection while the pointer is *outside*
+    /// the field (dragging past its right edge is how a user selects to the end of a query that
+    /// overflows its box), which a hover-filtered `on_mouse_move` listener cannot see - so the
+    /// move/up listeners are registered window-wide (`gpui::Window::on_mouse_event`, the same
+    /// mechanism Zed's own editor element uses for this) and this is what tells them the drag is
+    /// really theirs.
+    pub(crate) simple_input_drag: Option<gpui::SharedString>,
     /// GitHub issue #202: which code blocks the user has currently collapsed, keyed by absolute
     /// path, each value a set of 0-based [`code_surface::fold::FoldRange::start_line`]s.
     ///

--- a/crates/app/src/root/new_file.rs
+++ b/crates/app/src/root/new_file.rs
@@ -92,44 +92,51 @@ impl AdeApp {
         cx: &mut Context<Self>,
     ) {
         let keystroke = &event.keystroke;
-        if keystroke.modifiers.platform || keystroke.modifiers.control || keystroke.modifiers.alt {
+        // GitHub issue #336: `widgets::text_editing_modifiers` rather than a flat "any modifier
+        // means not ours" - see `crate::rail::render::AdeApp::handle_filter_key_down`'s own note.
+        let Some(modifiers) = widgets::text_editing_modifiers(&keystroke.key, &keystroke.modifiers)
+        else {
             return;
-        }
+        };
         match keystroke.key.as_str() {
             "escape" => {
                 self.cancel_new_file(window, cx);
                 cx.stop_propagation();
+                return;
             }
             "enter" => {
                 self.create_new_file(window, cx);
                 cx.stop_propagation();
+                return;
             }
-            "backspace" => {
-                if let Some(input) = self.new_file_input.as_mut() {
-                    input.name.backspace(Instant::now());
-                    // GitHub issue #27's "solid mid-keystroke" - see `crate::rail::render::
-                    // AdeApp::handle_filter_key_down`'s identical reasoning. Missing here
-                    // (GitHub issue #45) is exactly why this field never blinked.
-                    self.reset_caret_blink(cx);
-                    cx.notify();
-                    cx.stop_propagation();
-                }
-            }
-            _ => {
-                if let Some(text) = keystroke
-                    .key_char
-                    .as_deref()
-                    .filter(|text| !text.is_empty())
-                {
-                    if let Some(input) = self.new_file_input.as_mut() {
-                        input.name.insert_str(text, Instant::now());
-                        self.reset_caret_blink(cx);
-                        cx.notify();
-                        cx.stop_propagation();
-                    }
-                }
-            }
+            _ => {}
         }
+        let Some(input) = self.new_file_input.as_mut() else {
+            return;
+        };
+        // GitHub issue #336: the whole `TextField` vocabulary through the one shared entry point,
+        // rather than the backspace/insert pair this prompt used to hand-roll.
+        if input.name.handle_editing_key(
+            &keystroke.key,
+            keystroke.key_char.as_deref(),
+            modifiers,
+            Instant::now(),
+        ) {
+            // GitHub issue #27's "solid mid-keystroke" - see `crate::rail::render::
+            // AdeApp::handle_filter_key_down`'s identical reasoning. Missing here
+            // (GitHub issue #45) is exactly why this field never blinked.
+            self.reset_caret_blink(cx);
+            cx.notify();
+            cx.stop_propagation();
+        }
+    }
+
+    /// The "New file" name prompt's own field handle - what click/drag selection and GitHub issue
+    /// #336's four clipboard/select-all actions act on. `None` whenever the prompt is closed.
+    fn new_file_name_handle() -> widgets::TextFieldHandle {
+        widgets::TextFieldHandle::new(|app: &mut AdeApp| {
+            app.new_file_input.as_mut().map(|input| &mut input.name)
+        })
     }
 
     /// `TextUndo`/`TextRedo` for the "New file" name prompt (GitHub issue #17). Clears the
@@ -187,6 +194,11 @@ impl AdeApp {
             .as_ref()
             .map(|input| input.name.caret())
             .unwrap_or_default();
+        let name_selection = self
+            .new_file_input
+            .as_ref()
+            .map(|input| input.name.selection())
+            .unwrap_or(0..0);
         let parent_label = self
             .new_file_input
             .as_ref()
@@ -221,15 +233,19 @@ impl AdeApp {
                 this.cancel_new_file(window, cx);
             }))
             .child(
-                div()
-                    .id("new-file-panel")
-                    .track_focus(&self.new_file_focus_handle)
-                    // See `crate::default_key_bindings`' `TextUndo`/`TextRedo` docs for why the
-                    // tag and the listeners both live on this exact node.
-                    .key_context("text-input")
-                    .on_action(cx.listener(Self::handle_new_file_text_undo))
-                    .on_action(cx.listener(Self::handle_new_file_text_redo))
-                    .on_key_down(cx.listener(Self::handle_new_file_key_down))
+                self.wire_text_input_actions(
+                    div()
+                        .id("new-file-panel")
+                        .track_focus(&self.new_file_focus_handle)
+                        // See `crate::default_key_bindings`' `TextUndo`/`TextRedo` docs for why
+                        // the tag and the listeners both live on this exact node.
+                        .key_context("text-input")
+                        .on_action(cx.listener(Self::handle_new_file_text_undo))
+                        .on_action(cx.listener(Self::handle_new_file_text_redo))
+                        .on_key_down(cx.listener(Self::handle_new_file_key_down)),
+                    Self::new_file_name_handle(),
+                    cx,
+                )
                     .on_click(cx.listener(|_this, _event: &ClickEvent, _window, cx| {
                         cx.stop_propagation();
                     }))
@@ -272,20 +288,26 @@ impl AdeApp {
                             // `Self::new_with_settings`'s own comment on the fix). The caret and
                             // the text around it now come from the one helper that owns that
                             // structure - see `AdeApp::render_simple_input_row`.
-                            .child(self.render_simple_input_row(widgets::SimpleInput {
-                                caret_selector: "new-file-caret".into(),
-                                text_selector: "new-file-name-text".into(),
-                                focus_handle: Some(&self.new_file_focus_handle),
-                                text: &name,
-                                caret_offset: name_caret,
-                                placeholder: "file-name.ext",
-                                font: theme::font::MONO,
-                                text_size: px(11.5),
-                                // One colour for both: this prompt has never dimmed its
-                                // placeholder, and the migration is not the place to change that.
-                                text_color: theme::text::BODY,
-                                placeholder_color: theme::text::BODY,
-                            })),
+                            .child(self.render_simple_input_row(
+                                widgets::SimpleInput {
+                                    caret_selector: "new-file-caret".into(),
+                                    text_selector: "new-file-name-text".into(),
+                                    focus_handle: Some(&self.new_file_focus_handle),
+                                    text: &name,
+                                    caret_offset: name_caret,
+                                    selection: name_selection.clone(),
+                                    placeholder: "file-name.ext",
+                                    font: theme::font::MONO,
+                                    text_size: px(11.5),
+                                    // One colour for both: this prompt has never dimmed its
+                                    // placeholder, and the migration is not the place to change
+                                    // that.
+                                    text_color: theme::text::BODY,
+                                    placeholder_color: theme::text::BODY,
+                                    field: Some(Self::new_file_name_handle()),
+                                },
+                                cx,
+                            )),
                     )
                     .when_some(self.new_file_error.clone(), |el, error| {
                         el.child(

--- a/crates/app/src/root/new_file.rs
+++ b/crates/app/src/root/new_file.rs
@@ -246,85 +246,86 @@ impl AdeApp {
                     Self::new_file_name_handle(),
                     cx,
                 )
-                    .on_click(cx.listener(|_this, _event: &ClickEvent, _window, cx| {
-                        cx.stop_propagation();
-                    }))
-                    .flex()
-                    .flex_col()
-                    .gap(px(6.0))
-                    .w(px(320.0))
-                    .p(px(12.0))
-                    .bg(theme::surface::PALETTE)
-                    .border_1()
-                    .border_color(theme::border::POPOVER)
-                    .rounded(theme::radius::CARD)
-                    .child(
+                .on_click(cx.listener(|_this, _event: &ClickEvent, _window, cx| {
+                    cx.stop_propagation();
+                }))
+                .flex()
+                .flex_col()
+                .gap(px(6.0))
+                .w(px(320.0))
+                .p(px(12.0))
+                .bg(theme::surface::PALETTE)
+                .border_1()
+                .border_color(theme::border::POPOVER)
+                .rounded(theme::radius::CARD)
+                .child(
+                    div()
+                        .font(font(theme::font::SANS))
+                        .font_weight(gpui::FontWeight::MEDIUM)
+                        .text_size(px(11.5))
+                        .text_color(theme::text::HEADING)
+                        .child("New file"),
+                )
+                .child(
+                    div()
+                        .font(font(theme::font::MONO))
+                        .text_size(px(9.5))
+                        .text_color(theme::text::FAINTER)
+                        .child(parent_label),
+                )
+                .child(
+                    div()
+                        .px(px(8.0))
+                        .py(px(5.0))
+                        .rounded(theme::radius::CHIP)
+                        .bg(theme::surface::SEGMENT_TRACK)
+                        .flex()
+                        .items_center()
+                        // GitHub issue #45 / live report: this prompt had no caret element
+                        // at all before this - just the typed name or its placeholder, no
+                        // insertion-point indicator, and `new_file_focus_handle` was never
+                        // wired into `crate::root::caret_blink` either (see
+                        // `Self::new_with_settings`'s own comment on the fix). The caret and
+                        // the text around it now come from the one helper that owns that
+                        // structure - see `AdeApp::render_simple_input_row`.
+                        .child(self.render_simple_input_row(
+                            widgets::SimpleInput {
+                                caret_selector: "new-file-caret".into(),
+                                text_selector: "new-file-name-text".into(),
+                                focus_handle: Some(&self.new_file_focus_handle),
+                                text: &name,
+                                caret_offset: name_caret,
+                                selection: name_selection.clone(),
+                                placeholder: "file-name.ext",
+                                font: theme::font::MONO,
+                                text_size: px(11.5),
+                                // One colour for both: this prompt has never dimmed its
+                                // placeholder, and the migration is not the place to change
+                                // that.
+                                text_color: theme::text::BODY,
+                                placeholder_color: theme::text::BODY,
+                                caret: widgets::SimpleInputCaret::default(),
+                                field: Some(Self::new_file_name_handle()),
+                            },
+                            cx,
+                        )),
+                )
+                .when_some(self.new_file_error.clone(), |el, error| {
+                    el.child(
                         div()
                             .font(font(theme::font::SANS))
-                            .font_weight(gpui::FontWeight::MEDIUM)
-                            .text_size(px(11.5))
-                            .text_color(theme::text::HEADING)
-                            .child("New file"),
+                            .text_size(px(10.5))
+                            .text_color(theme::status::FAIL)
+                            .child(error),
                     )
-                    .child(
-                        div()
-                            .font(font(theme::font::MONO))
-                            .text_size(px(9.5))
-                            .text_color(theme::text::FAINTER)
-                            .child(parent_label),
-                    )
-                    .child(
-                        div()
-                            .px(px(8.0))
-                            .py(px(5.0))
-                            .rounded(theme::radius::CHIP)
-                            .bg(theme::surface::SEGMENT_TRACK)
-                            .flex()
-                            .items_center()
-                            // GitHub issue #45 / live report: this prompt had no caret element
-                            // at all before this - just the typed name or its placeholder, no
-                            // insertion-point indicator, and `new_file_focus_handle` was never
-                            // wired into `crate::root::caret_blink` either (see
-                            // `Self::new_with_settings`'s own comment on the fix). The caret and
-                            // the text around it now come from the one helper that owns that
-                            // structure - see `AdeApp::render_simple_input_row`.
-                            .child(self.render_simple_input_row(
-                                widgets::SimpleInput {
-                                    caret_selector: "new-file-caret".into(),
-                                    text_selector: "new-file-name-text".into(),
-                                    focus_handle: Some(&self.new_file_focus_handle),
-                                    text: &name,
-                                    caret_offset: name_caret,
-                                    selection: name_selection.clone(),
-                                    placeholder: "file-name.ext",
-                                    font: theme::font::MONO,
-                                    text_size: px(11.5),
-                                    // One colour for both: this prompt has never dimmed its
-                                    // placeholder, and the migration is not the place to change
-                                    // that.
-                                    text_color: theme::text::BODY,
-                                    placeholder_color: theme::text::BODY,
-                                    field: Some(Self::new_file_name_handle()),
-                                },
-                                cx,
-                            )),
-                    )
-                    .when_some(self.new_file_error.clone(), |el, error| {
-                        el.child(
-                            div()
-                                .font(font(theme::font::SANS))
-                                .text_size(px(10.5))
-                                .text_color(theme::status::FAIL)
-                                .child(error),
-                        )
-                    })
-                    .child(
-                        div()
-                            .font(font(theme::font::SANS))
-                            .text_size(px(10.0))
-                            .text_color(theme::text::GHOST)
-                            .child("enter to create \u{b7} esc to cancel"),
-                    ),
+                })
+                .child(
+                    div()
+                        .font(font(theme::font::SANS))
+                        .text_size(px(10.0))
+                        .text_color(theme::text::GHOST)
+                        .child("enter to create \u{b7} esc to cancel"),
+                ),
             )
     }
 

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -526,6 +526,8 @@ impl AdeApp {
             _blame_message_tasks: HashMap::new(),
             edit_buffers: HashMap::new(),
             file_view_row_layout: HashMap::new(),
+            simple_input_layout: HashMap::new(),
+            simple_input_drag: None,
             file_view_folds: HashMap::new(),
             file_view_last_layout: None,
             file_view_last_bounds: None,
@@ -1890,6 +1892,8 @@ impl AdeApp {
         // free-function signature - are reset directly here for the same reason. Dropping the
         // task maps cancels every in-flight debounced re-highlight/save for whatever was left.
         self.file_view_row_layout = HashMap::new();
+        self.simple_input_layout = HashMap::new();
+        self.simple_input_drag = None;
         self.file_view_last_layout = None;
         self.file_view_last_bounds = None;
         self.file_view_last_layout_for = None;

--- a/crates/app/src/root/widgets.rs
+++ b/crates/app/src/root/widgets.rs
@@ -1002,9 +1002,17 @@ impl AdeApp {
 /// box showing stale results.
 #[derive(Clone)]
 pub(crate) struct TextFieldHandle {
-    access: Rc<dyn for<'a> Fn(&'a mut AdeApp) -> Option<&'a mut text_history::TextField>>,
-    on_changed: Option<Rc<dyn Fn(&mut AdeApp, &mut Context<AdeApp>)>>,
+    access: TextFieldAccess,
+    on_changed: Option<TextFieldChanged>,
 }
+
+/// How a [`TextFieldHandle`] reaches its field - see that type's own docs for why this is a
+/// closure rather than an enum of every field in the app.
+type TextFieldAccess =
+    Rc<dyn for<'a> Fn(&'a mut AdeApp) -> Option<&'a mut text_history::TextField>>;
+
+/// The follow-up work a [`TextFieldHandle`]'s own surface runs whenever its field really changes.
+type TextFieldChanged = Rc<dyn Fn(&mut AdeApp, &mut Context<AdeApp>)>;
 
 impl TextFieldHandle {
     pub(crate) fn new(
@@ -1100,8 +1108,8 @@ pub(crate) fn text_editing_modifiers(
 /// field's: `design_handoff_jerry_ade/revision/Jerry.dc.html`'s own `paletteEmpty`/`paletteTyped`
 /// fixture draws it 16px tall with a 3px gap before the placeholder and a 2px gap after the typed
 /// text, while every other input in the app is the plain flush 14px bar this type defaults to. The
-/// alternative to modelling that here was leaving the palette hand-assembling its own row forever
-/// - which is exactly how it ended up the one field whose caret ignored
+/// alternative to modelling that here was leaving the palette hand-assembling its own row
+/// forever, which is exactly how it ended up the one field whose caret ignored
 /// `crate::text_history::TextField::caret` entirely and sat at the end of the text whatever the
 /// user had arrowed back to.
 #[derive(Debug, Clone, Copy)]

--- a/crates/app/src/root/widgets.rs
+++ b/crates/app/src/root/widgets.rs
@@ -1,4 +1,7 @@
 use super::*;
+use std::ops::Range;
+use std::rc::Rc;
+
 use crate::icon_pack;
 use crate::work_surface::agents::ProcessKind;
 
@@ -439,6 +442,17 @@ impl AdeApp {
     /// surrounding `render_*` call chain's own signatures carry. Mirrors `caret_paint_quad`'s own
     /// rule exactly (GitHub issue #107): focused *and* blink-visible paints solid, anything else -
     /// focused-but-blinked-off, or simply unfocused - paints nothing at all.
+    ///
+    /// GitHub issue #336 made the bar **zero-width in flow**: a `w(px(0.))` `relative()` anchor
+    /// holding an `absolute()` 1.5px child. That is a real fix, not a stylistic change. As an
+    /// ordinary `flex_none().w(px(1.5))` flex item between the text before and after it, the bar
+    /// displaced the trailing half of a line 1.5px to the right whenever the caret was in the
+    /// middle of it - visible as the text jittering sideways while arrowing through it, and, once
+    /// #336 added real click-to-position hit-testing, a systematic ~1.5px disagreement between
+    /// where the glyphs are painted and where the `gpui::ShapedLine` the row hit-tests against
+    /// says they are. Out of flow, the text is one contiguous run again, exactly as that shaping
+    /// assumes - and the anchor still sits at precisely the caret's own boundary, so every
+    /// existing `debug_bounds` caret-position test measures the same x it always did.
     pub(crate) fn render_simple_input_caret(
         &self,
         selector: impl Into<gpui::SharedString>,
@@ -454,24 +468,38 @@ impl AdeApp {
         let selector = selector.into();
         div()
             .flex_none()
-            .w(px(1.5))
+            .w(px(0.0))
             .h(px(14.0))
-            .debug_selector(move || selector.to_string())
+            .relative()
             .child(
-                gpui::canvas(
-                    move |bounds, window, _cx| {
-                        let is_focused = focus_handle.is_focused(window);
-                        simple_input_caret_opacity(is_focused, caret_blink_visible).map(|opacity| {
-                            gpui::fill(bounds, theme::term::CURSOR.resolve().opacity(opacity))
-                        })
-                    },
-                    |_bounds, quad, window, _cx| {
-                        if let Some(quad) = quad {
-                            window.paint_quad(quad);
-                        }
-                    },
-                )
-                .size_full(),
+                div()
+                    .absolute()
+                    .top_0()
+                    .left_0()
+                    .w(px(1.5))
+                    .h(px(14.0))
+                    .debug_selector(move || selector.to_string())
+                    .child(
+                        gpui::canvas(
+                            move |bounds, window, _cx| {
+                                let is_focused = focus_handle.is_focused(window);
+                                simple_input_caret_opacity(is_focused, caret_blink_visible).map(
+                                    |opacity| {
+                                        gpui::fill(
+                                            bounds,
+                                            theme::term::CURSOR.resolve().opacity(opacity),
+                                        )
+                                    },
+                                )
+                            },
+                            |_bounds, quad, window, _cx| {
+                                if let Some(quad) = quad {
+                                    window.paint_quad(quad);
+                                }
+                            },
+                        )
+                        .size_full(),
+                    ),
             )
     }
 
@@ -517,38 +545,80 @@ impl AdeApp {
     /// right edge", and a wrapper containing the caret would enclose it and make that assertion
     /// unsatisfiable by construction.
     ///
+    /// ## Selection, and the two shapes this row really has (GitHub issue #336)
+    ///
+    /// With [`SimpleInput::selection`] collapsed - every field's ordinary state - the structure is
+    /// exactly the one described above: a leading span, the caret, a trailing span. With a real,
+    /// non-collapsed selection there is **no caret at all** and the text is **one** span, with the
+    /// selected range painted as a real quad behind it by the same `gpui::canvas` overlay that
+    /// does this row's hit-testing. That is not two ways of doing the same thing, it is what makes
+    /// both correct:
+    ///
+    /// - The selection quad's edges come from `gpui::ShapedLine::x_for_index` over the whole line
+    ///   shaped **once**. That is only pixel-accurate if the visible glyphs really are one
+    ///   contiguous run, which is why the selected state does not split the text into spans -
+    ///   GitHub issue #170's own measured lesson, that independently-shaped adjacent text elements
+    ///   drift, applied to this row.
+    /// - The caret's position, in the collapsed state, comes from real flex layout rather than
+    ///   from that shaping - pixel-exact by construction, and unchanged from the structure every
+    ///   existing caret-position test in this app already measures.
+    ///
+    /// Hiding the caret while a selection is up is also simply what every real text input does,
+    /// and matches both `vendor/zed/crates/gpui/examples/input.rs` (`if selected_range.is_empty()`
+    /// gates its own cursor quad) and this app's own
+    /// `crate::code_surface::edit_buffer::EditBuffer::cursor_within_line`.
+    ///
+    /// ## Mouse
+    ///
+    /// Passing a [`SimpleInput::field`] handle is what turns the row into a really *pointer*-
+    /// editable one: click to place the caret, drag to select, double-click to select the word,
+    /// Shift+click to extend. It is optional because a genuinely read-only row (a pinned note card
+    /// that is not the one being typed into) must not respond to any of that; those pass `None`,
+    /// exactly as they already pass `focus_handle: None` to suppress the caret.
+    ///
     /// The caller still owns the box *around* this row - its border, padding, height and
     /// background - because that genuinely differs per field. What it no longer owns is the part
     /// that was never supposed to differ.
-    pub(crate) fn render_simple_input_row(&self, input: SimpleInput<'_>) -> impl IntoElement {
+    pub(crate) fn render_simple_input_row(
+        &self,
+        input: SimpleInput<'_>,
+        cx: &Context<Self>,
+    ) -> impl IntoElement {
         let SimpleInput {
             caret_selector,
             text_selector,
             focus_handle,
             text,
             caret_offset,
+            selection,
             placeholder,
             font: font_name,
             text_size,
             text_color,
             placeholder_color,
+            field,
         } = input;
         // "Blank" by the same rule every caller used: nothing typed at all. A field holding only
         // spaces is holding real text and shows it, with the caret after it.
         let is_blank = text.is_empty();
-        // Clamped and re-aligned to a real `char` boundary here as well as in `TextField`: this
-        // helper also serves callers that pass an offset from somewhere else, and slicing a
-        // `&str` mid-character panics.
-        let split_at = (0..=text.len())
-            .rev()
-            .find(|offset| *offset <= caret_offset && text.is_char_boundary(*offset))
-            .unwrap_or(0);
-        let (before_caret, after_caret) = text.split_at(split_at);
-        let leading = if is_blank {
-            placeholder.to_string()
-        } else {
-            before_caret.to_string()
+        // Clamped and re-aligned to real `char` boundaries here as well as in `TextField`: this
+        // helper also serves callers that pass offsets from somewhere else, and slicing a `&str`
+        // mid-character panics.
+        let clamp = |offset: usize| -> usize {
+            (0..=text.len())
+                .rev()
+                .find(|candidate| *candidate <= offset && text.is_char_boundary(*candidate))
+                .unwrap_or(0)
         };
+        let selection = clamp(selection.start)..clamp(selection.end);
+        let selection = if selection.start <= selection.end {
+            selection
+        } else {
+            selection.end..selection.start
+        };
+        let has_selection = !selection.is_empty();
+        let split_at = clamp(caret_offset);
+        let (before_caret, after_caret) = text.split_at(split_at);
         // `None` is a genuinely read-only row - a pinned note card that is not the one being
         // typed into, say. It cannot be expressed by passing a handle that happens to be
         // unfocused: several of these rows can be on screen sharing *one* focus handle (only one
@@ -575,31 +645,448 @@ impl AdeApp {
                 .text_color(color)
                 .child(content)
         };
-        div()
-            // On the wrapper, which is the whole point - see this method's own docs.
+        let mut row = div()
+            // On the wrapper, which is the whole point - see this method's own docs. `.relative()`
+            // is what the `.absolute()` hit-test/selection overlay below positions against.
+            .relative()
             .flex_1()
             .min_w_0()
             .flex()
-            .items_center()
-            .when(is_blank, caret)
-            .child(
-                span(
-                    leading,
-                    if is_blank {
-                        placeholder_color
-                    } else {
-                        text_color
-                    },
+            .items_center();
+        if has_selection {
+            // One span, so the shaped line the overlay measures the selection quad from really
+            // does describe the glyphs on screen - see this method's own docs.
+            row = row.child(
+                span(text.to_string(), text_color)
+                    .debug_selector({
+                        let selector = text_selector.clone();
+                        move || selector.to_string()
+                    }),
+            );
+        } else {
+            let leading = if is_blank {
+                placeholder.to_string()
+            } else {
+                before_caret.to_string()
+            };
+            row = row
+                .when(is_blank, caret)
+                .child(
+                    span(
+                        leading,
+                        if is_blank {
+                            placeholder_color
+                        } else {
+                            text_color
+                        },
+                    )
+                    .debug_selector({
+                        let selector = text_selector.clone();
+                        move || selector.to_string()
+                    }),
                 )
-                .debug_selector(move || text_selector.to_string()),
-            )
-            .when(!is_blank, caret)
-            // Only when there really is text after the caret, so a field with the caret at its end
-            // paints the exact element tree it painted before this method knew about carets.
-            .when(!is_blank && !after_caret.is_empty(), |el| {
-                el.child(span(after_caret.to_string(), text_color))
-            })
+                .when(!is_blank, caret)
+                // Only when there really is text after the caret, so a field with the caret at its
+                // end paints the exact element tree it painted before this method knew about
+                // carets.
+                .when(!is_blank && !after_caret.is_empty(), |el| {
+                    el.child(span(after_caret.to_string(), text_color))
+                });
+        }
+        row.child(self.simple_input_overlay(
+            text_selector.clone(),
+            text,
+            &selection,
+            focus_handle,
+            font_name,
+            text_size,
+            text_color,
+            field.clone(),
+            cx,
+        ))
+        .when_some(field, |el, field| {
+            self.wire_simple_input_mouse(el, text_selector, focus_handle.cloned(), field, cx)
+        })
     }
+
+    /// This row's real measurement/paint overlay: shapes the visible line **once**, paints the
+    /// selection quad from it, records `(bounds, ShapedLine)` into
+    /// [`AdeApp::simple_input_layout`] for the click handlers to hit-test against, and (while a
+    /// drag is live) registers the window-wide move/up listeners that keep extending it.
+    ///
+    /// `.absolute().size_full()` inside the `.relative()` row, the same proven idiom
+    /// `crate::code_surface::editing::render_editable_file_view_line`'s own cursor overlay uses: a
+    /// `gpui::canvas` contributes no intrinsic content size to GPUI's layout pass, so it must never
+    /// be the thing that sizes a row - as an absolutely-positioned child it simply fills whatever
+    /// box the real, in-flow text already resolved to.
+    #[allow(clippy::too_many_arguments)]
+    fn simple_input_overlay(
+        &self,
+        layout_key: gpui::SharedString,
+        text: &str,
+        selection: &Range<usize>,
+        focus_handle: Option<&FocusHandle>,
+        font_name: &'static str,
+        text_size: Pixels,
+        text_color: theme::ColorToken,
+        field: Option<TextFieldHandle>,
+        cx: &Context<Self>,
+    ) -> impl IntoElement {
+        let entity = cx.entity();
+        let shaped_text: gpui::SharedString = text.to_string().into();
+        let run_font = font(font_name);
+        let selection = selection.clone();
+        let focus_handle = focus_handle.cloned();
+        let paint_key = layout_key.clone();
+        gpui::canvas(
+            move |bounds, window, _cx| {
+                // One run covering the whole line: these rows paint their text in a single colour
+                // (no syntax highlighting), so a single run is not a simplification - it is
+                // exactly what the visible spans above are. `TextRun::len` must cover every byte
+                // or `shape_line` silently shapes only the prefix and `x_for_index` answers with
+                // the short line's width for everything past it (see
+                // `crate::code_surface::editing::force_runs_to_cover`'s own docs).
+                let run = gpui::TextRun {
+                    len: shaped_text.len(),
+                    font: run_font.clone(),
+                    color: text_color.resolve().into(),
+                    background_color: None,
+                    underline: None,
+                    strikethrough: None,
+                };
+                let shaped =
+                    window
+                        .text_system()
+                        .shape_line(shaped_text.clone(), text_size, &[run], None);
+                // GitHub issue #27's "selection remains visible (dimmed) when the editor loses
+                // focus", read from the same real, live focus check the caret uses - the same two
+                // tokens `crate::code_surface::editing` already paints a selection with, rather
+                // than a second, independently-chosen colour for the same concept.
+                let is_focused = focus_handle
+                    .as_ref()
+                    .is_some_and(|handle| handle.is_focused(window));
+                let quad = (!selection.is_empty()).then(|| {
+                    let opacity = if is_focused {
+                        theme::editor::SELECTION_OPACITY
+                    } else {
+                        theme::editor::SELECTION_INACTIVE_OPACITY
+                    };
+                    gpui::fill(
+                        gpui::Bounds::from_corners(
+                            gpui::point(
+                                bounds.left() + shaped.x_for_index(selection.start),
+                                bounds.top(),
+                            ),
+                            gpui::point(
+                                bounds.left() + shaped.x_for_index(selection.end),
+                                bounds.bottom(),
+                            ),
+                        ),
+                        theme::editor::SELECTION.resolve().opacity(opacity),
+                    )
+                });
+                (shaped, quad)
+            },
+            move |bounds, (shaped, quad), window, cx| {
+                if let Some(quad) = quad {
+                    window.paint_quad(quad);
+                }
+                entity.update(cx, |this, _cx| {
+                    this.simple_input_layout
+                        .insert(paint_key.clone(), (bounds, shaped));
+                });
+                let Some(field) = field else {
+                    return;
+                };
+                // Registered window-wide rather than as `on_mouse_move`/`on_mouse_up` handlers on
+                // the row itself, and this is the whole reason this overlay paints at all rather
+                // than only measuring: GPUI's own `on_mouse_move` listener is gated on
+                // `hitbox.is_hovered(window)` (`vendor/zed/crates/gpui/src/elements/div.rs`), so a
+                // drag would stop extending the moment the pointer left the field - which is
+                // exactly the gesture that matters, since dragging past a field's right edge is
+                // how a user selects to the end of a query that overflows its box. Zed's own
+                // editor element drives its drag selection through this same
+                // `gpui::Window::on_mouse_event` mechanism. `Window::on_mouse_event` may only be
+                // called during paint, which is where this closure runs, and the listeners it
+                // registers are per-frame - so they exist exactly while this field is on screen.
+                let move_entity = entity.clone();
+                let move_key = paint_key.clone();
+                let move_field = field.clone();
+                window.on_mouse_event(
+                    move |event: &gpui::MouseMoveEvent, phase, _window, cx| {
+                        if phase != gpui::DispatchPhase::Bubble
+                            || event.pressed_button != Some(MouseButton::Left)
+                        {
+                            return;
+                        }
+                        move_entity.update(cx, |this, cx| {
+                            if this.simple_input_drag.as_ref() != Some(&move_key) {
+                                return;
+                            }
+                            let Some(offset) = this.simple_input_offset_at(&move_key, event.position)
+                            else {
+                                return;
+                            };
+                            if move_field.with(this, |field| field.select_to(offset)) == Some(true) {
+                                move_field.changed(this, cx);
+                                cx.notify();
+                            }
+                        });
+                    },
+                );
+                let up_entity = entity.clone();
+                let up_key = paint_key.clone();
+                window.on_mouse_event(move |_: &gpui::MouseUpEvent, phase, _window, cx| {
+                    if phase != gpui::DispatchPhase::Bubble {
+                        return;
+                    }
+                    up_entity.update(cx, |this, _cx| {
+                        if this.simple_input_drag.as_ref() == Some(&up_key) {
+                            this.simple_input_drag = None;
+                        }
+                    });
+                });
+            },
+        )
+        .absolute()
+        .size_full()
+    }
+
+    /// The row's own `mouse down`: focus the field, then place/extend/word-select at the real
+    /// hit-tested byte offset, and arm the drag [`Self::simple_input_overlay`]'s window-wide
+    /// listeners extend.
+    ///
+    /// Deliberately does **not** `cx.stop_propagation()`: several of these rows sit inside a
+    /// larger clickable container whose own handler is what focuses the surface, opens the row for
+    /// editing, or selects the list item the field belongs to, and swallowing the click here would
+    /// silently break those. Everything this handler does is idempotent with a parent that also
+    /// focuses the same field.
+    fn wire_simple_input_mouse<E: InteractiveElement>(
+        &self,
+        el: E,
+        layout_key: gpui::SharedString,
+        focus_handle: Option<FocusHandle>,
+        field: TextFieldHandle,
+        cx: &Context<Self>,
+    ) -> E {
+        el.on_mouse_down(
+            MouseButton::Left,
+            cx.listener(move |this, event: &MouseDownEvent, window, cx| {
+                let Some(offset) = this.simple_input_offset_at(&layout_key, event.position) else {
+                    return;
+                };
+                if let Some(handle) = focus_handle.as_ref() {
+                    window.focus(handle, cx);
+                }
+                // GPUI's own `MouseDownEvent::click_count` already counts consecutive same-place
+                // clicks, so this needs no double-click timing of its own - the same real reading
+                // `crate::code_surface::editing`'s own row click handler does. `>= 2` rather than
+                // `== 2` so a third rapid click keeps re-selecting the word (a single-line field
+                // has no "select the line" step above it - `Ctrl/Cmd+A` is that) instead of
+                // dropping back to a plain caret.
+                let changed = field.with(this, |field| {
+                    if event.click_count >= 2 {
+                        field.select_word_at(offset)
+                    } else if event.modifiers.shift {
+                        field.select_to(offset)
+                    } else {
+                        field.move_to(offset)
+                    }
+                });
+                this.simple_input_drag = Some(layout_key.clone());
+                this.reset_caret_blink(cx);
+                if changed == Some(true) {
+                    field.changed(this, cx);
+                }
+                cx.notify();
+            }),
+        )
+    }
+
+    /// Hit-tests a real window-space pointer position into a byte offset in the field keyed by
+    /// `layout_key`, using the [`gpui::ShapedLine`] that field's own overlay recorded when it last
+    /// painted. `None` when the field has never painted (so there is nothing to hit-test against).
+    ///
+    /// `x` is clamped to the field's own left edge rather than rejected: a drag that has travelled
+    /// left of the field means "select to the start", and `gpui::LineLayout::closest_index_for_x`
+    /// already clamps the other end for us by returning the line's real length for any `x` past
+    /// its last glyph.
+    pub(crate) fn simple_input_offset_at(
+        &self,
+        layout_key: &gpui::SharedString,
+        position: gpui::Point<Pixels>,
+    ) -> Option<usize> {
+        let (bounds, shaped) = self.simple_input_layout.get(layout_key)?;
+        let local_x = (position.x - bounds.left()).max(px(0.0));
+        Some(shaped.closest_index_for_x(local_x))
+    }
+
+    /// Registers the four real clipboard/select-all actions (GitHub issue #336) on one input's own
+    /// `key_context("text-input")` node, for the [`TextFieldHandle`] that node's field is behind.
+    ///
+    /// One helper rather than four hand-written handlers per call site for the same reason
+    /// [`Self::render_simple_input_row`] exists at all: this app has thirteen `"text-input"` nodes,
+    /// and fifty-two hand-copied action handlers is fifty-two chances for one of them to
+    /// coalesce an undo group differently or forget to re-run its surface's own
+    /// `on_changed` work.
+    pub(crate) fn wire_text_input_actions<E: InteractiveElement>(
+        &self,
+        el: E,
+        field: TextFieldHandle,
+        cx: &Context<Self>,
+    ) -> E {
+        let copy = field.clone();
+        let cut = field.clone();
+        let paste = field.clone();
+        let select_all = field;
+        el.on_action(cx.listener(
+            move |this, _: &crate::root::TextCopy, _window, cx: &mut Context<Self>| {
+                if let Some(Some(text)) = copy.read(this, |field| field.copy()) {
+                    cx.write_to_clipboard(gpui::ClipboardItem::new_string(text));
+                }
+            },
+        ))
+        .on_action(cx.listener(
+            move |this, _: &crate::root::TextCut, _window, cx: &mut Context<Self>| {
+                let Some(Some(text)) = cut.with(this, |field| field.cut(Instant::now())) else {
+                    return;
+                };
+                cx.write_to_clipboard(gpui::ClipboardItem::new_string(text));
+                cut.changed(this, cx);
+                this.reset_caret_blink(cx);
+                cx.notify();
+            },
+        ))
+        .on_action(cx.listener(
+            move |this, _: &crate::root::TextPaste, _window, cx: &mut Context<Self>| {
+                let Some(text) = cx.read_from_clipboard().and_then(|item| item.text()) else {
+                    return;
+                };
+                if paste.with(this, |field| field.paste(&text, Instant::now())) != Some(true) {
+                    return;
+                }
+                paste.changed(this, cx);
+                this.reset_caret_blink(cx);
+                cx.notify();
+            },
+        ))
+        .on_action(cx.listener(
+            move |this, _: &crate::root::TextSelectAll, _window, cx: &mut Context<Self>| {
+                if select_all.with(this, |field| field.select_all()) == Some(true) {
+                    this.reset_caret_blink(cx);
+                    cx.notify();
+                }
+            },
+        ))
+    }
+}
+
+/// How the shared input plumbing reaches one real [`text_history::TextField`], and what its owning
+/// surface has to re-run once that field changes.
+///
+/// A closure rather than, say, an enum of every field in the app: the fields these rows edit are
+/// not all plain `AdeApp` members. Several live behind an `Option` that may have closed
+/// (`AdeApp::new_file_input`, `AdeApp::tree_inline_edit`), and some are one *row* of a list
+/// (a rebase plan's per-row `reword` message, a review note card), reachable only by looking the
+/// row up by id. Only the call site knows how to get there, so only the call site can say.
+///
+/// [`Self::on_changed`] exists because "the text changed" genuinely means different work per
+/// surface - the Search panel has to restart its debounced worktree search, the rail has to drop
+/// its armed confirmations - and a paste or a cut has to do exactly the same work an ordinary
+/// keystroke into that field already does. Leaving it out is how a pasted query would sit in the
+/// box showing stale results.
+#[derive(Clone)]
+pub(crate) struct TextFieldHandle {
+    access: Rc<dyn for<'a> Fn(&'a mut AdeApp) -> Option<&'a mut text_history::TextField>>,
+    on_changed: Option<Rc<dyn Fn(&mut AdeApp, &mut Context<AdeApp>)>>,
+}
+
+impl TextFieldHandle {
+    pub(crate) fn new(
+        access: impl for<'a> Fn(&'a mut AdeApp) -> Option<&'a mut text_history::TextField> + 'static,
+    ) -> Self {
+        Self {
+            access: Rc::new(access),
+            on_changed: None,
+        }
+    }
+
+    /// The work this field's own surface does whenever its text really changes - the same work its
+    /// key handler already does for an ordinary keystroke.
+    pub(crate) fn on_changed(
+        mut self,
+        on_changed: impl Fn(&mut AdeApp, &mut Context<AdeApp>) + 'static,
+    ) -> Self {
+        self.on_changed = Some(Rc::new(on_changed));
+        self
+    }
+
+    /// Runs `f` against the real field, or returns `None` when it no longer exists (the prompt was
+    /// dismissed, the row was removed) - which every caller treats as "this gesture did nothing",
+    /// never as a reason to panic.
+    pub(crate) fn with<R>(
+        &self,
+        app: &mut AdeApp,
+        f: impl FnOnce(&mut text_history::TextField) -> R,
+    ) -> Option<R> {
+        (self.access)(app).map(f)
+    }
+
+    /// [`Self::with`] for a caller that only reads. Still takes `&mut AdeApp`, since the accessor
+    /// itself is the mutable one - there is no second, read-only accessor to maintain alongside it.
+    pub(crate) fn read<R>(
+        &self,
+        app: &mut AdeApp,
+        f: impl FnOnce(&text_history::TextField) -> R,
+    ) -> Option<R> {
+        (self.access)(app).map(|field| f(field))
+    }
+
+    pub(crate) fn changed(&self, app: &mut AdeApp, cx: &mut Context<AdeApp>) {
+        if let Some(on_changed) = self.on_changed.clone() {
+            on_changed(app, cx);
+        }
+    }
+}
+
+/// Translates one real keystroke's modifier set into [`text_history::EditingModifiers`], or `None`
+/// when this keystroke is not text editing at all and the field must let it keep propagating to
+/// whatever application binding owns it.
+///
+/// The platform decision lives here rather than in `crate::text_history` (which is deliberately
+/// GPUI-free): **word-wise movement is Alt+Arrow on macOS and Ctrl+Arrow everywhere else**, which
+/// is what the platforms' own text fields do, and the *other* of those two modifiers is always an
+/// application shortcut. `platform` (Cmd) is always an application shortcut too - `TextCopy`/
+/// `TextCut`/`TextPaste`/`TextSelectAll` are real bound actions, not keystrokes this function
+/// should be claiming.
+///
+/// Shift is never a reason to refuse: it is either the extend-selection modifier (on a movement
+/// key) or simply how a capital letter is typed, and `gpui::Keystroke::key_char` has already
+/// resolved the latter.
+pub(crate) fn text_editing_modifiers(
+    key: &str,
+    modifiers: &gpui::Modifiers,
+) -> Option<text_history::EditingModifiers> {
+    if modifiers.platform || modifiers.function {
+        return None;
+    }
+    let (word_modifier, foreign_modifier) = if cfg!(target_os = "macos") {
+        (modifiers.alt, modifiers.control)
+    } else {
+        (modifiers.control, modifiers.alt)
+    };
+    if foreign_modifier {
+        return None;
+    }
+    // The word modifier only ever means anything on a horizontal movement key; on anything else
+    // it is a modified keystroke some real binding owns, and claiming it here would swallow it.
+    if word_modifier && !matches!(key, "left" | "right") {
+        return None;
+    }
+    Some(text_history::EditingModifiers {
+        extend: modifiers.shift,
+        word: word_modifier,
+    })
 }
 
 /// One [`AdeApp::render_simple_input_row`] field: what it holds, what it says while empty, and
@@ -614,6 +1101,9 @@ pub(crate) struct SimpleInput<'a> {
     pub caret_selector: gpui::SharedString,
     /// The text element's `debug_selector`, for the same reason. A [`SharedString`] rather than a
     /// `&'static str` because a field that is a *row of a list* has one selector per row.
+    ///
+    /// Doubles as this row's key into `AdeApp::simple_input_layout` (GitHub issue #336), which is
+    /// exactly the uniqueness this field already had to have.
     pub text_selector: gpui::SharedString,
     /// The handle the caret watches - it paints only while this one is really focused. `None`
     /// draws no caret at all, which is what a read-only row of an otherwise-editable list is.
@@ -625,6 +1115,10 @@ pub(crate) struct SimpleInput<'a> {
     /// the renderer, so an out-of-range or mid-character value degrades to the nearest real one
     /// rather than panicking.
     pub caret_offset: usize,
+    /// The really-selected byte range - `crate::text_history::TextField::selection`. Collapsed
+    /// (empty) means "just a caret", which is every field's ordinary state and renders exactly the
+    /// element tree this row rendered before selection existed.
+    pub selection: Range<usize>,
     /// What it says while that is empty.
     pub placeholder: &'a str,
     /// The font family, as a `crate::theme::font` name.
@@ -635,6 +1129,9 @@ pub(crate) struct SimpleInput<'a> {
     pub text_color: theme::ColorToken,
     /// The (usually dimmer) colour of the placeholder.
     pub placeholder_color: theme::ColorToken,
+    /// How to reach the real field behind this row, for click/drag/double-click selection. `None`
+    /// is a genuinely read-only row - see [`AdeApp::render_simple_input_row`]'s own docs.
+    pub field: Option<TextFieldHandle>,
 }
 
 /// [`AdeApp::render_simple_input_caret`]'s paint decision, pulled out as a pure function so it's

--- a/crates/app/src/root/widgets.rs
+++ b/crates/app/src/root/widgets.rs
@@ -457,7 +457,8 @@ impl AdeApp {
         &self,
         selector: impl Into<gpui::SharedString>,
         focus_handle: &FocusHandle,
-    ) -> impl IntoElement {
+        height: Pixels,
+    ) -> gpui::Div {
         let caret_blink_visible = self.caret_blink_visible;
         let focus_handle = focus_handle.clone();
         // `impl Into<SharedString>` rather than `&'static str`: a caret that belongs to a *row of
@@ -466,41 +467,36 @@ impl AdeApp {
         // which is exactly the ambiguity `only_the_card_being_typed_into_paints_a_caret` has to be
         // able to see through.
         let selector = selector.into();
-        div()
-            .flex_none()
-            .w(px(0.0))
-            .h(px(14.0))
-            .relative()
-            .child(
-                div()
-                    .absolute()
-                    .top_0()
-                    .left_0()
-                    .w(px(1.5))
-                    .h(px(14.0))
-                    .debug_selector(move || selector.to_string())
-                    .child(
-                        gpui::canvas(
-                            move |bounds, window, _cx| {
-                                let is_focused = focus_handle.is_focused(window);
-                                simple_input_caret_opacity(is_focused, caret_blink_visible).map(
-                                    |opacity| {
-                                        gpui::fill(
-                                            bounds,
-                                            theme::term::CURSOR.resolve().opacity(opacity),
-                                        )
-                                    },
-                                )
-                            },
-                            |_bounds, quad, window, _cx| {
-                                if let Some(quad) = quad {
-                                    window.paint_quad(quad);
-                                }
-                            },
-                        )
-                        .size_full(),
-                    ),
-            )
+        div().flex_none().w(px(0.0)).h(height).relative().child(
+            div()
+                .absolute()
+                .top_0()
+                .left_0()
+                .w(px(1.5))
+                .h(height)
+                .debug_selector(move || selector.to_string())
+                .child(
+                    gpui::canvas(
+                        move |bounds, window, _cx| {
+                            let is_focused = focus_handle.is_focused(window);
+                            simple_input_caret_opacity(is_focused, caret_blink_visible).map(
+                                |opacity| {
+                                    gpui::fill(
+                                        bounds,
+                                        theme::term::CURSOR.resolve().opacity(opacity),
+                                    )
+                                },
+                            )
+                        },
+                        |_bounds, quad, window, _cx| {
+                            if let Some(quad) = quad {
+                                window.paint_quad(quad);
+                            }
+                        },
+                    )
+                    .size_full(),
+                ),
+        )
     }
 
     /// **The** caret+text row every hand-rolled single-line input in this app should be built
@@ -596,6 +592,7 @@ impl AdeApp {
             text_size,
             text_color,
             placeholder_color,
+            caret: caret_style,
             field,
         } = input;
         // "Blank" by the same rule every caller used: nothing typed at all. A field holding only
@@ -625,9 +622,22 @@ impl AdeApp {
         // draft is ever open), and a caret keyed on that shared handle would paint in every one
         // of them the moment any of them was focused.
         let caret = |el: gpui::Div| match focus_handle {
-            Some(handle) => {
-                el.child(self.render_simple_input_caret(caret_selector.clone(), handle))
-            }
+            Some(handle) => el.child(
+                self.render_simple_input_caret(caret_selector.clone(), handle, caret_style.height)
+                    // The gaps are margins on the *zero-width* anchor, so they really are gaps
+                    // between the bar and its neighbour rather than extra caret width - see
+                    // [`SimpleInputCaret`] for the one field in this app that needs them.
+                    .mr(if is_blank {
+                        caret_style.gap_before_placeholder
+                    } else {
+                        px(0.0)
+                    })
+                    .ml(if is_blank {
+                        px(0.0)
+                    } else {
+                        caret_style.gap_after_text
+                    }),
+            ),
             None => el,
         };
         // One shared shape for both halves: intrinsically sized, and allowed to shrink and clip
@@ -656,13 +666,10 @@ impl AdeApp {
         if has_selection {
             // One span, so the shaped line the overlay measures the selection quad from really
             // does describe the glyphs on screen - see this method's own docs.
-            row = row.child(
-                span(text.to_string(), text_color)
-                    .debug_selector({
-                        let selector = text_selector.clone();
-                        move || selector.to_string()
-                    }),
-            );
+            row = row.child(span(text.to_string(), text_color).debug_selector({
+                let selector = text_selector.clone();
+                move || selector.to_string()
+            }));
         } else {
             let leading = if is_blank {
                 placeholder.to_string()
@@ -812,28 +819,26 @@ impl AdeApp {
                 let move_entity = entity.clone();
                 let move_key = paint_key.clone();
                 let move_field = field.clone();
-                window.on_mouse_event(
-                    move |event: &gpui::MouseMoveEvent, phase, _window, cx| {
-                        if phase != gpui::DispatchPhase::Bubble
-                            || event.pressed_button != Some(MouseButton::Left)
-                        {
+                window.on_mouse_event(move |event: &gpui::MouseMoveEvent, phase, _window, cx| {
+                    if phase != gpui::DispatchPhase::Bubble
+                        || event.pressed_button != Some(MouseButton::Left)
+                    {
+                        return;
+                    }
+                    move_entity.update(cx, |this, cx| {
+                        if this.simple_input_drag.as_ref() != Some(&move_key) {
                             return;
                         }
-                        move_entity.update(cx, |this, cx| {
-                            if this.simple_input_drag.as_ref() != Some(&move_key) {
-                                return;
-                            }
-                            let Some(offset) = this.simple_input_offset_at(&move_key, event.position)
-                            else {
-                                return;
-                            };
-                            if move_field.with(this, |field| field.select_to(offset)) == Some(true) {
-                                move_field.changed(this, cx);
-                                cx.notify();
-                            }
-                        });
-                    },
-                );
+                        let Some(offset) = this.simple_input_offset_at(&move_key, event.position)
+                        else {
+                            return;
+                        };
+                        if move_field.with(this, |field| field.select_to(offset)) == Some(true) {
+                            move_field.changed(this, cx);
+                            cx.notify();
+                        }
+                    });
+                });
                 let up_entity = entity.clone();
                 let up_key = paint_key.clone();
                 window.on_mouse_event(move |_: &gpui::MouseUpEvent, phase, _window, cx| {
@@ -1089,6 +1094,35 @@ pub(crate) fn text_editing_modifiers(
     })
 }
 
+/// One [`SimpleInput`]'s caret metrics.
+///
+/// Exists because the command palette's caret is genuinely a different control from every other
+/// field's: `design_handoff_jerry_ade/revision/Jerry.dc.html`'s own `paletteEmpty`/`paletteTyped`
+/// fixture draws it 16px tall with a 3px gap before the placeholder and a 2px gap after the typed
+/// text, while every other input in the app is the plain flush 14px bar this type defaults to. The
+/// alternative to modelling that here was leaving the palette hand-assembling its own row forever
+/// - which is exactly how it ended up the one field whose caret ignored
+/// `crate::text_history::TextField::caret` entirely and sat at the end of the text whatever the
+/// user had arrowed back to.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SimpleInputCaret {
+    pub height: Pixels,
+    /// Gap between the caret and the placeholder it sits *before*, while the field is blank.
+    pub gap_before_placeholder: Pixels,
+    /// Gap between the real text and the caret that sits *after* it.
+    pub gap_after_text: Pixels,
+}
+
+impl Default for SimpleInputCaret {
+    fn default() -> Self {
+        Self {
+            height: px(14.0),
+            gap_before_placeholder: px(0.0),
+            gap_after_text: px(0.0),
+        }
+    }
+}
+
 /// One [`AdeApp::render_simple_input_row`] field: what it holds, what it says while empty, and
 /// how it is painted.
 ///
@@ -1129,6 +1163,9 @@ pub(crate) struct SimpleInput<'a> {
     pub text_color: theme::ColorToken,
     /// The (usually dimmer) colour of the placeholder.
     pub placeholder_color: theme::ColorToken,
+    /// The caret bar's own metrics. `SimpleInputCaret::default()` for every field but the command
+    /// palette - see that type's own docs.
+    pub caret: SimpleInputCaret,
     /// How to reach the real field behind this row, for click/drag/double-click selection. `None`
     /// is a genuinely read-only row - see [`AdeApp::render_simple_input_row`]'s own docs.
     pub field: Option<TextFieldHandle>,

--- a/crates/app/src/root/widgets.rs
+++ b/crates/app/src/root/widgets.rs
@@ -701,7 +701,7 @@ impl AdeApp {
                 });
         }
         row.child(self.simple_input_overlay(
-            text_selector.clone(),
+            caret_selector.clone(),
             text,
             &selection,
             focus_handle,
@@ -712,7 +712,7 @@ impl AdeApp {
             cx,
         ))
         .when_some(field, |el, field| {
-            self.wire_simple_input_mouse(el, text_selector, focus_handle.cloned(), field, cx)
+            self.wire_simple_input_mouse(el, caret_selector, focus_handle.cloned(), field, cx)
         })
     }
 
@@ -1140,12 +1140,18 @@ impl Default for SimpleInputCaret {
 pub(crate) struct SimpleInput<'a> {
     /// The caret element's own `debug_selector`, so a render test can assert *where* it painted.
     /// A [`SharedString`] for the same reason [`Self::text_selector`] is one.
+    ///
+    /// Doubles as this row's key into `AdeApp::simple_input_layout` (GitHub issue #336) - the
+    /// `(bounds, ShapedLine)` pair its own overlay records every frame for click hit-testing and
+    /// for the selection quad. Keyed off *this* selector rather than [`Self::text_selector`]
+    /// specifically because a caret selector is stable for the life of a field while a text one
+    /// need not be: the commit composer's own text selector embeds the message being typed
+    /// (`commit-composer-message-{message}`, so a render test can read the painted text back),
+    /// which as a map key would add a fresh, immediately-stale entry on every keystroke.
     pub caret_selector: gpui::SharedString,
     /// The text element's `debug_selector`, for the same reason. A [`SharedString`] rather than a
     /// `&'static str` because a field that is a *row of a list* has one selector per row.
     ///
-    /// Doubles as this row's key into `AdeApp::simple_input_layout` (GitHub issue #336), which is
-    /// exactly the uniqueness this field already had to have.
     pub text_selector: gpui::SharedString,
     /// The handle the caret watches - it paints only while this one is really focused. `None`
     /// draws no caret at all, which is what a read-only row of an otherwise-editable list is.

--- a/crates/app/src/root/widgets.rs
+++ b/crates/app/src/root/widgets.rs
@@ -833,8 +833,10 @@ impl AdeApp {
                         else {
                             return;
                         };
+                        // No `TextFieldHandle::changed` here either - see
+                        // `AdeApp::wire_simple_input_mouse`'s own docs: a drag moves the
+                        // selection, it never edits the text.
                         if move_field.with(this, |field| field.select_to(offset)) == Some(true) {
-                            move_field.changed(this, cx);
                             cx.notify();
                         }
                     });
@@ -858,8 +860,14 @@ impl AdeApp {
     }
 
     /// The row's own `mouse down`: focus the field, then place/extend/word-select at the real
-    /// hit-tested byte offset, and arm the drag [`Self::simple_input_overlay`]'s window-wide
-    /// listeners extend.
+    /// hit-tested byte offset, and arm the drag that [`Self::simple_input_overlay`]'s window-wide
+    /// listeners go on to extend.
+    ///
+    /// Deliberately does **not** run [`TextFieldHandle::changed`]: a click moves the selection, it
+    /// never edits the text, and that hook is the owning surface's "the text changed" work (the
+    /// Search panel restarting its debounced worktree walk, a note card scheduling a persist).
+    /// Running it here would restart a real filesystem search every time the user clicked into the
+    /// query box.
     ///
     /// Deliberately does **not** `cx.stop_propagation()`: several of these rows sit inside a
     /// larger clickable container whose own handler is what focuses the surface, opens the row for
@@ -889,7 +897,7 @@ impl AdeApp {
                 // `== 2` so a third rapid click keeps re-selecting the word (a single-line field
                 // has no "select the line" step above it - `Ctrl/Cmd+A` is that) instead of
                 // dropping back to a plain caret.
-                let changed = field.with(this, |field| {
+                field.with(this, |field| {
                     if event.click_count >= 2 {
                         field.select_word_at(offset)
                     } else if event.modifiers.shift {
@@ -900,9 +908,6 @@ impl AdeApp {
                 });
                 this.simple_input_drag = Some(layout_key.clone());
                 this.reset_caret_blink(cx);
-                if changed == Some(true) {
-                    field.changed(this, cx);
-                }
                 cx.notify();
             }),
         )
@@ -1112,6 +1117,15 @@ pub(crate) fn text_editing_modifiers(
 /// forever, which is exactly how it ended up the one field whose caret ignored
 /// `crate::text_history::TextField::caret` entirely and sat at the end of the text whatever the
 /// user had arrowed back to.
+///
+/// One honest consequence, stated rather than hidden: a nonzero [`Self::gap_after_text`] is a real
+/// margin on the caret's own (zero-width) anchor, so it displaces whatever text follows the caret
+/// by that many pixels, while the `gpui::ShapedLine` the row hit-tests against describes an
+/// unbroken line. In the palette that is a ≤2px click inaccuracy, and only while the caret is
+/// genuinely *mid-string* (with the caret at the end - where it is for every field until the user
+/// presses Left or Home - there is no following text to displace). Every other field in this app
+/// leaves both gaps at zero and is exact. The alternative was dropping the design's own
+/// `paletteTyped` spacing, which is not this change's call to make.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct SimpleInputCaret {
     pub height: Pixels,

--- a/crates/app/src/search/render.rs
+++ b/crates/app/src/search/render.rs
@@ -27,7 +27,7 @@ use std::time::{Duration, Instant};
 use gpui::{div, font, prelude::*, px, ClickEvent, Context, KeyDownEvent, SharedString, Window};
 
 use crate::icons::{Icon, IconRow, IconSize};
-use crate::root::widgets::{text_tooltip, SimpleInput};
+use crate::root::widgets::{self, text_tooltip, SimpleInput, TextFieldHandle};
 use crate::root::{plural, scrollbar, AdeApp, FindInFile, SearchInWorktree, TextRedo, TextUndo};
 use crate::search::engine::{
     self, Matcher, PathFilter, ReplaceOutcome, SearchOutcome, SearchRequest,
@@ -110,7 +110,7 @@ impl AdeApp {
                 self.search_input_row(SearchField::Query, cx)
                     .h(theme::band::FILTER_ROW)
                     .child(render_search_row_mark("/", self.ui_text_size(10.0)))
-                    .child(self.render_search_field(SearchField::Query, "search this worktree"))
+                    .child(self.render_search_field(SearchField::Query, "search this worktree", cx))
                     .children(
                         SearchModifier::ALL
                             .into_iter()
@@ -125,7 +125,7 @@ impl AdeApp {
                         .border_color(theme::border::ROW)
                         .child(render_search_row_mark("\u{21c4}", self.ui_text_size(10.0)))
                         .child(
-                            self.render_search_field(SearchField::Replace, "replace with\u{2026}"),
+                            self.render_search_field(SearchField::Replace, "replace with\u{2026}", cx),
                         )
                         // `REVISION-2026-08-14.md` §7 rule 2: a control that acts on results does
                         // not exist when there are none.
@@ -169,7 +169,7 @@ impl AdeApp {
                     .text_color(theme::text::GHOST)
                     .child(label),
             )
-            .child(self.render_search_field(field, placeholder))
+            .child(self.render_search_field(field, placeholder, cx))
     }
 
     /// The shared shell every one of the four input rows is built on: the focus handle it tracks,
@@ -184,7 +184,7 @@ impl AdeApp {
         field: SearchField,
         cx: &mut Context<Self>,
     ) -> gpui::Stateful<gpui::Div> {
-        div()
+        let row = div()
             .id(SharedString::from(format!(
                 "search-row-{}",
                 field_key(field)
@@ -205,7 +205,12 @@ impl AdeApp {
             }))
             .on_key_down(cx.listener(move |this, event: &KeyDownEvent, window, cx| {
                 this.handle_search_key_down(field, event, window, cx);
-            }))
+            }));
+        // GitHub issue #336's four clipboard/select-all actions, on the same node and for the same
+        // structural-routing reason the two undo actions above are - and carrying the same
+        // `on_search_input_changed` follow-up work every other edit to these fields does, so a
+        // pasted or cut query really re-runs the search instead of leaving stale results up.
+        self.wire_text_input_actions(row, search_field_handle(field), cx)
             .on_click(cx.listener(move |this, _: &ClickEvent, window, cx| {
                 this.focus_search_field(field, window, cx);
             }))
@@ -218,28 +223,38 @@ impl AdeApp {
     }
 
     /// One field's caret+text pair, through the one helper that owns that structure.
-    fn render_search_field(&self, field: SearchField, placeholder: &str) -> impl IntoElement {
+    fn render_search_field(
+        &self,
+        field: SearchField,
+        placeholder: &str,
+        cx: &Context<Self>,
+    ) -> impl IntoElement {
         let key = field_key(field);
         let (text_size, text_color) = match field {
             SearchField::Query => (11.0, theme::text::SELECTED),
             SearchField::Replace => (11.0, theme::text::STRONG),
             SearchField::Include | SearchField::Exclude => (10.0, theme::text::STRONG),
         };
-        self.render_simple_input_row(SimpleInput {
-            caret_selector: SharedString::from(format!("search-{key}-caret")),
-            text_selector: SharedString::from(format!("search-{key}-text")),
-            focus_handle: Some(self.search.focus_handle(field)),
-            text: self.search.field(field).as_str(),
-            caret_offset: self.search.field(field).caret(),
-            placeholder,
-            font: theme::font::MONO,
-            text_size: self.ui_text_size(text_size),
-            text_color,
-            // GitHub issue #162 / §4w: the mock's browser-default placeholder "was brighter than
-            // either dim-text token and absent from the palette". This is the design's own
-            // `#4e545a`, through the theme layer.
-            placeholder_color: theme::text::GHOST,
-        })
+        self.render_simple_input_row(
+            SimpleInput {
+                caret_selector: SharedString::from(format!("search-{key}-caret")),
+                text_selector: SharedString::from(format!("search-{key}-text")),
+                focus_handle: Some(self.search.focus_handle(field)),
+                text: self.search.field(field).as_str(),
+                caret_offset: self.search.field(field).caret(),
+                selection: self.search.field(field).selection(),
+                placeholder,
+                font: theme::font::MONO,
+                text_size: self.ui_text_size(text_size),
+                text_color,
+                // GitHub issue #162 / §4w: the mock's browser-default placeholder "was brighter than
+                // either dim-text token and absent from the palette". This is the design's own
+                // `#4e545a`, through the theme layer.
+                placeholder_color: theme::text::GHOST,
+                field: Some(search_field_handle(field)),
+            },
+            cx,
+        )
     }
 
     /// One 17x17 modifier button - `Aa` / `ab` / `.*`.
@@ -956,6 +971,30 @@ fn render_search_caret(open: bool, text_size: gpui::Pixels) -> impl IntoElement 
 }
 
 /// A field's stable slug, for element ids and debug selectors.
+/// One search field's own [`TextFieldHandle`] - what click/drag selection and GitHub issue #336's
+/// four clipboard/select-all actions act on.
+///
+/// Carries [`AdeApp::on_search_input_changed`] as its `on_changed`, which is exactly what
+/// [`AdeApp::handle_search_key_down`] already runs after an ordinary keystroke: a paste or a cut
+/// changes what the search would return just as much as typing does, and without this the panel
+/// would sit showing results for a query that is no longer in the box.
+/// The in-file find bar's own field handle - the same shape [`search_field_handle`] has, with the
+/// bar's own "the query changed, so re-run the match set and reveal the current hit" follow-up
+/// (exactly what `AdeApp::handle_find_bar_key_down` runs after a keystroke). `None` whenever the
+/// bar is closed, which is the case [`TextFieldHandle`]'s own `Option` exists for.
+fn find_bar_query_handle() -> TextFieldHandle {
+    TextFieldHandle::new(|app: &mut AdeApp| app.find_bar.as_mut().map(|bar| &mut bar.query))
+        .on_changed(|app: &mut AdeApp, cx| {
+            app.refresh_find_bar();
+            app.reveal_current_find_hit(cx);
+        })
+}
+
+fn search_field_handle(field: SearchField) -> TextFieldHandle {
+    TextFieldHandle::new(move |app: &mut AdeApp| Some(app.search.field_mut(field)))
+        .on_changed(|app: &mut AdeApp, cx| app.on_search_input_changed(cx))
+}
+
 fn field_key(field: SearchField) -> &'static str {
     match field {
         SearchField::Query => "query",
@@ -1014,9 +1053,12 @@ impl AdeApp {
         cx: &mut Context<Self>,
     ) {
         let keystroke = &event.keystroke;
-        if keystroke.modifiers.platform || keystroke.modifiers.control || keystroke.modifiers.alt {
+        // GitHub issue #336: `widgets::text_editing_modifiers` rather than a flat "any modifier
+        // means not ours" - see `crate::rail::render::AdeApp::handle_filter_key_down`'s own note.
+        let Some(modifiers) = widgets::text_editing_modifiers(&keystroke.key, &keystroke.modifiers)
+        else {
             return;
-        }
+        };
         self.reset_caret_blink(cx);
         match keystroke.key.as_str() {
             // Walks only the rows that are really on screen - see
@@ -1042,6 +1084,7 @@ impl AdeApp {
         if self.search.field_mut(field).handle_editing_key(
             keystroke.key.as_str(),
             keystroke.key_char.as_deref(),
+            modifiers,
             Instant::now(),
         ) {
             self.on_search_input_changed(cx);
@@ -2245,12 +2288,13 @@ impl AdeApp {
         let has_results = bar.has_results();
         let count = bar.count_label();
         let invalid = bar.notice().is_some();
+        let bar_row = div()
+            .id("find-bar")
+            .debug_selector(|| "find-bar".to_string())
+            .track_focus(&bar.focus_handle)
+            .key_context("text-input");
         Some(
-            div()
-                .id("find-bar")
-                .debug_selector(|| "find-bar".to_string())
-                .track_focus(&bar.focus_handle)
-                .key_context("text-input")
+            self.wire_text_input_actions(bar_row, find_bar_query_handle(), cx)
                 .on_action(cx.listener(|this, _: &TextUndo, _window, cx| {
                     if this.find_bar.as_mut().is_some_and(|bar| bar.query.undo()) {
                         this.refresh_find_bar();
@@ -2283,18 +2327,23 @@ impl AdeApp {
                 .border_b_1()
                 .border_color(theme::border::ROW)
                 .child(render_search_row_mark("/", self.ui_text_size(10.0)))
-                .child(self.render_simple_input_row(SimpleInput {
-                    caret_selector: "find-bar-caret".into(),
-                    text_selector: "find-bar-text".into(),
-                    focus_handle: Some(&bar.focus_handle),
-                    text: bar.query.as_str(),
-                    caret_offset: bar.query.caret(),
-                    placeholder: "find in this file",
-                    font: theme::font::MONO,
-                    text_size: self.ui_text_size(11.0),
-                    text_color: theme::text::SELECTED,
-                    placeholder_color: theme::text::GHOST,
-                }))
+                .child(self.render_simple_input_row(
+                    SimpleInput {
+                        caret_selector: "find-bar-caret".into(),
+                        text_selector: "find-bar-text".into(),
+                        focus_handle: Some(&bar.focus_handle),
+                        text: bar.query.as_str(),
+                        caret_offset: bar.query.caret(),
+                        selection: bar.query.selection(),
+                        placeholder: "find in this file",
+                        font: theme::font::MONO,
+                        text_size: self.ui_text_size(11.0),
+                        text_color: theme::text::SELECTED,
+                        placeholder_color: theme::text::GHOST,
+                        field: Some(find_bar_query_handle()),
+                    },
+                    cx,
+                ))
                 .child(
                     div()
                         .id("find-bar-count")
@@ -2473,9 +2522,12 @@ impl AdeApp {
             cx.stop_propagation();
             return;
         }
-        if keystroke.modifiers.platform || keystroke.modifiers.control || keystroke.modifiers.alt {
+        // GitHub issue #336: `widgets::text_editing_modifiers` rather than a flat "any modifier
+        // means not ours" - see `crate::rail::render::AdeApp::handle_filter_key_down`'s own note.
+        let Some(modifiers) = widgets::text_editing_modifiers(&keystroke.key, &keystroke.modifiers)
+        else {
             return;
-        }
+        };
         match keystroke.key.as_str() {
             // Esc closes rather than clearing: the bar is a transient surface over a file, and
             // the field's own contents are what the user would want back if they reopen it.
@@ -2497,6 +2549,7 @@ impl AdeApp {
             bar.query.handle_editing_key(
                 keystroke.key.as_str(),
                 keystroke.key_char.as_deref(),
+                modifiers,
                 Instant::now(),
             )
         });

--- a/crates/app/src/search/render.rs
+++ b/crates/app/src/search/render.rs
@@ -124,9 +124,11 @@ impl AdeApp {
                         .border_t_1()
                         .border_color(theme::border::ROW)
                         .child(render_search_row_mark("\u{21c4}", self.ui_text_size(10.0)))
-                        .child(
-                            self.render_search_field(SearchField::Replace, "replace with\u{2026}", cx),
-                        )
+                        .child(self.render_search_field(
+                            SearchField::Replace,
+                            "replace with\u{2026}",
+                            cx,
+                        ))
                         // `REVISION-2026-08-14.md` §7 rule 2: a control that acts on results does
                         // not exist when there are none.
                         .children(
@@ -251,6 +253,7 @@ impl AdeApp {
                 // either dim-text token and absent from the palette". This is the design's own
                 // `#4e545a`, through the theme layer.
                 placeholder_color: theme::text::GHOST,
+                caret: widgets::SimpleInputCaret::default(),
                 field: Some(search_field_handle(field)),
             },
             cx,
@@ -2340,6 +2343,7 @@ impl AdeApp {
                         text_size: self.ui_text_size(11.0),
                         text_color: theme::text::SELECTED,
                         placeholder_color: theme::text::GHOST,
+                        caret: widgets::SimpleInputCaret::default(),
                         field: Some(find_bar_query_handle()),
                     },
                     cx,

--- a/crates/app/src/settings/render.rs
+++ b/crates/app/src/settings/render.rs
@@ -2,8 +2,8 @@ use super::*;
 use crate::root::plural;
 use crate::root::scrollbar;
 use crate::root::widgets::{
-    hover_keycap_row, menu_popover_chrome, render_env_chip, render_keycap_row, KeycapSize,
-    SimpleInput,
+    self, hover_keycap_row, menu_popover_chrome, render_env_chip, render_keycap_row, KeycapSize,
+    SimpleInput, TextFieldHandle,
 };
 use crate::settings::widgets::ChoiceOption;
 use crate::sound::SoundEventKind;
@@ -1075,16 +1075,20 @@ impl AdeApp {
                     .debug_selector(|| "settings-shell-status".to_string()),
             )
             .child(
-                div()
-                    .id("settings-shell-input")
-                    .debug_selector(|| "settings-shell-input".to_string())
-                    .track_focus(&self.shell_focus_handle)
-                    // See `crate::default_key_bindings`' `TextUndo`/`TextRedo` docs for why the
-                    // tag and the listeners both live on this exact node.
-                    .key_context("text-input")
-                    .on_action(cx.listener(Self::handle_settings_shell_text_undo))
-                    .on_action(cx.listener(Self::handle_settings_shell_text_redo))
-                    .on_key_down(cx.listener(Self::handle_settings_shell_key_down))
+                self.wire_text_input_actions(
+                    div()
+                        .id("settings-shell-input")
+                        .debug_selector(|| "settings-shell-input".to_string())
+                        .track_focus(&self.shell_focus_handle)
+                        // See `crate::default_key_bindings`' `TextUndo`/`TextRedo` docs for why
+                        // the tag and the listeners both live on this exact node.
+                        .key_context("text-input")
+                        .on_action(cx.listener(Self::handle_settings_shell_text_undo))
+                        .on_action(cx.listener(Self::handle_settings_shell_text_redo))
+                        .on_key_down(cx.listener(Self::handle_settings_shell_key_down)),
+                    shell_input_handle(),
+                    cx,
+                )
                     .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
                         window.focus(&this.shell_focus_handle, cx);
                         this.open_shell_suggestions(cx);
@@ -1129,18 +1133,23 @@ impl AdeApp {
                     // the text element, so inside this fixed 168px box the text's layout box
                     // filled the whole field whatever the shell path said, and the caret after it
                     // sat pinned to the right-hand border instead of against the last character.
-                    .child(self.render_simple_input_row(SimpleInput {
-                        caret_selector: "settings-shell-caret".into(),
-                        text_selector: "settings-shell-text".into(),
-                        focus_handle: Some(&self.shell_focus_handle),
-                        text: if has_shell { &shell } else { "" },
-                        caret_offset: self.shell_input.caret(),
-                        placeholder: &placeholder,
-                        font: theme::font::MONO,
-                        text_size: self.ui_text_size(10.5),
-                        text_color: theme::text::BODY,
-                        placeholder_color: theme::text::GHOST,
-                    })),
+                    .child(self.render_simple_input_row(
+                        SimpleInput {
+                            caret_selector: "settings-shell-caret".into(),
+                            text_selector: "settings-shell-text".into(),
+                            focus_handle: Some(&self.shell_focus_handle),
+                            text: if has_shell { &shell } else { "" },
+                            caret_offset: self.shell_input.caret(),
+                            selection: self.shell_input.selection(),
+                            placeholder: &placeholder,
+                            font: theme::font::MONO,
+                            text_size: self.ui_text_size(10.5),
+                            text_color: theme::text::BODY,
+                            placeholder_color: theme::text::GHOST,
+                            field: Some(shell_input_handle()),
+                        },
+                        cx,
+                    )),
             )
     }
 
@@ -1164,21 +1173,27 @@ impl AdeApp {
         cx: &mut Context<Self>,
     ) {
         let keystroke = &event.keystroke;
-        if keystroke.modifiers.platform || keystroke.modifiers.control || keystroke.modifiers.alt {
+        // GitHub issue #336: `widgets::text_editing_modifiers` rather than a flat "any modifier
+        // means not ours" - see `crate::rail::render::AdeApp::handle_filter_key_down`'s own note.
+        let Some(modifiers) = widgets::text_editing_modifiers(&keystroke.key, &keystroke.modifiers)
+        else {
             return;
-        }
+        };
         self.reset_caret_blink(cx);
         let escaped = keystroke.key.as_str() == "escape";
         let changed = match keystroke.key.as_str() {
-            "backspace" => self.shell_input.backspace(Instant::now()),
             // Clearing the field is itself a real, meaningful edit here (it means "go back to the
             // system default"), so it persists like any other - and is undoable, like every other
             // simple input's `Esc`.
             "escape" => self.shell_input.clear(Instant::now()),
-            _ => match keystroke.key_char.as_deref() {
-                Some(text) if !text.is_empty() => self.shell_input.insert_str(text, Instant::now()),
-                _ => false,
-            },
+            // GitHub issue #336: the whole `TextField` vocabulary rather than the
+            // backspace/insert half this used to hand-roll - caret movement, selection extension,
+            // word-wise movement and Delete all arrive here at once, for this field and the two
+            // below it.
+            key => {
+                self.shell_input
+                    .handle_editing_key(key, keystroke.key_char.as_deref(), modifiers, Instant::now())
+            }
         };
         if changed {
             self.apply_shell_input(cx);
@@ -2042,16 +2057,20 @@ impl AdeApp {
                     .child("Generate from colour"),
             )
             .child(
-                div()
-                    .id("settings-theme-seed-input")
-                    .debug_selector(|| "settings-theme-seed-input".to_string())
-                    .track_focus(&self.theme_seed_focus_handle)
-                    // See `crate::default_key_bindings`' `TextUndo`/`TextRedo` docs for why the
-                    // tag and the listeners both live on this exact node.
-                    .key_context("text-input")
-                    .on_action(cx.listener(Self::handle_theme_seed_text_undo))
-                    .on_action(cx.listener(Self::handle_theme_seed_text_redo))
-                    .on_key_down(cx.listener(Self::handle_theme_seed_key_down))
+                self.wire_text_input_actions(
+                    div()
+                        .id("settings-theme-seed-input")
+                        .debug_selector(|| "settings-theme-seed-input".to_string())
+                        .track_focus(&self.theme_seed_focus_handle)
+                        // See `crate::default_key_bindings`' `TextUndo`/`TextRedo` docs for why
+                        // the tag and the listeners both live on this exact node.
+                        .key_context("text-input")
+                        .on_action(cx.listener(Self::handle_theme_seed_text_undo))
+                        .on_action(cx.listener(Self::handle_theme_seed_text_redo))
+                        .on_key_down(cx.listener(Self::handle_theme_seed_key_down)),
+                    theme_seed_input_handle(),
+                    cx,
+                )
                     .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
                         window.focus(&this.theme_seed_focus_handle, cx);
                     }))
@@ -2069,34 +2088,28 @@ impl AdeApp {
                     .border_1()
                     .border_color(theme::border::CARD_FIELD)
                     .bg(theme::surface::CARD_SUNK)
-                    .when(!has_seed, |el| {
-                        el.child(self.render_simple_input_caret(
-                            "settings-theme-seed-caret",
-                            &self.theme_seed_focus_handle,
-                        ))
-                    })
-                    .child(
-                        div()
-                            .font(font(theme::font::MONO))
-                            .text_size(px(10.5))
-                            .text_color(if has_seed {
-                                theme::text::BODY
-                            } else {
-                                theme::text::GHOST
-                            })
-                            .child(if has_seed {
-                                seed.clone()
-                            } else {
-                                "#rrggbb".to_string()
-                            })
-                            .debug_selector(|| "settings-theme-seed-text".to_string()),
-                    )
-                    .when(has_seed, |el| {
-                        el.child(self.render_simple_input_caret(
-                            "settings-theme-seed-caret",
-                            &self.theme_seed_focus_handle,
-                        ))
-                    }),
+                    // GitHub issue #336: through the one helper that owns this structure, like
+                    // every other simple input in the app, rather than the hand-assembled
+                    // caret-before-placeholder / text / caret-after-text trio this row used to
+                    // carry - which is exactly the duplication `render_simple_input_row` exists to
+                    // end, and which had no selection highlight or hit-testing of its own.
+                    .child(self.render_simple_input_row(
+                        SimpleInput {
+                            caret_selector: "settings-theme-seed-caret".into(),
+                            text_selector: "settings-theme-seed-text".into(),
+                            focus_handle: Some(&self.theme_seed_focus_handle),
+                            text: if has_seed { seed.as_str() } else { "" },
+                            caret_offset: self.theme_seed_input.caret(),
+                            selection: self.theme_seed_input.selection(),
+                            placeholder: "#rrggbb",
+                            font: theme::font::MONO,
+                            text_size: px(10.5),
+                            text_color: theme::text::BODY,
+                            placeholder_color: theme::text::GHOST,
+                            field: Some(theme_seed_input_handle()),
+                        },
+                        cx,
+                    )),
             )
             // A real, live preview of the seed itself, so a typo is visible before clicking.
             .when(parse_seed_hex(&seed).is_some(), |el| {
@@ -2142,23 +2155,25 @@ impl AdeApp {
         cx: &mut Context<Self>,
     ) {
         let keystroke = &event.keystroke;
-        if keystroke.modifiers.platform || keystroke.modifiers.control || keystroke.modifiers.alt {
+        // GitHub issue #336: `widgets::text_editing_modifiers` rather than a flat "any modifier
+        // means not ours" - see `crate::rail::render::AdeApp::handle_filter_key_down`'s own note.
+        let Some(modifiers) = widgets::text_editing_modifiers(&keystroke.key, &keystroke.modifiers)
+        else {
             return;
-        }
+        };
         self.reset_caret_blink(cx);
         let changed = match keystroke.key.as_str() {
-            "backspace" => self.theme_seed_input.backspace(Instant::now()),
             "escape" => self.theme_seed_input.clear(Instant::now()),
             "enter" => {
                 self.start_generate_theme_from_seed(cx);
                 return;
             }
-            _ => match keystroke.key_char.as_deref() {
-                Some(text) if !text.is_empty() => {
-                    self.theme_seed_input.insert_str(text, Instant::now())
-                }
-                _ => false,
-            },
+            key => self.theme_seed_input.handle_editing_key(
+                key,
+                keystroke.key_char.as_deref(),
+                modifiers,
+                Instant::now(),
+            ),
         };
         if changed {
             cx.notify();
@@ -2599,15 +2614,19 @@ impl AdeApp {
         total: usize,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        div()
-            .id("settings-keymap-filter")
-            .track_focus(&self.settings_keymap_filter_focus_handle)
-            // See `crate::default_key_bindings`' `TextUndo`/`TextRedo` docs for why the tag and
-            // the listener both live on this exact node.
-            .key_context("text-input")
-            .on_action(cx.listener(Self::handle_settings_keymap_filter_text_undo))
-            .on_action(cx.listener(Self::handle_settings_keymap_filter_text_redo))
-            .on_key_down(cx.listener(Self::handle_settings_keymap_filter_key_down))
+        self.wire_text_input_actions(
+            div()
+                .id("settings-keymap-filter")
+                .track_focus(&self.settings_keymap_filter_focus_handle)
+                // See `crate::default_key_bindings`' `TextUndo`/`TextRedo` docs for why the tag
+                // and the listener both live on this exact node.
+                .key_context("text-input")
+                .on_action(cx.listener(Self::handle_settings_keymap_filter_text_undo))
+                .on_action(cx.listener(Self::handle_settings_keymap_filter_text_redo))
+                .on_key_down(cx.listener(Self::handle_settings_keymap_filter_key_down)),
+            settings_keymap_filter_handle(),
+            cx,
+        )
             .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
                 window.focus(&this.settings_keymap_filter_focus_handle, cx);
             }))
@@ -2640,18 +2659,26 @@ impl AdeApp {
                     // `crate::rail::render::AdeApp::render_rail_filter_row` - the caret sits
                     // before the placeholder (real cursor position 0) while the filter is empty,
                     // never appended after it.
-                    .child(self.render_simple_input_row(SimpleInput {
-                        caret_selector: "settings-keymap-filter-caret".into(),
-                        text_selector: "settings-keymap-filter-text".into(),
-                        focus_handle: Some(&self.settings_keymap_filter_focus_handle),
-                        text: self.settings_keymap_filter.as_str(),
-                        caret_offset: self.settings_keymap_filter.caret(),
-                        placeholder: &format!("filter {}", plural::count(total, "binding", None)),
-                        font: theme::font::SANS,
-                        text_size: px(11.0),
-                        text_color: theme::text::DIM,
-                        placeholder_color: theme::text::GHOST,
-                    })),
+                    .child(self.render_simple_input_row(
+                        SimpleInput {
+                            caret_selector: "settings-keymap-filter-caret".into(),
+                            text_selector: "settings-keymap-filter-text".into(),
+                            focus_handle: Some(&self.settings_keymap_filter_focus_handle),
+                            text: self.settings_keymap_filter.as_str(),
+                            caret_offset: self.settings_keymap_filter.caret(),
+                            selection: self.settings_keymap_filter.selection(),
+                            placeholder: &format!(
+                                "filter {}",
+                                plural::count(total, "binding", None)
+                            ),
+                            font: theme::font::SANS,
+                            text_size: px(11.0),
+                            text_color: theme::text::DIM,
+                            placeholder_color: theme::text::GHOST,
+                            field: Some(settings_keymap_filter_handle()),
+                        },
+                        cx,
+                    )),
             )
             .child(
                 div()
@@ -2672,23 +2699,25 @@ impl AdeApp {
         cx: &mut Context<Self>,
     ) {
         let keystroke = &event.keystroke;
-        if keystroke.modifiers.platform || keystroke.modifiers.control || keystroke.modifiers.alt {
+        // GitHub issue #336: `widgets::text_editing_modifiers` rather than a flat "any modifier
+        // means not ours" - see `crate::rail::render::AdeApp::handle_filter_key_down`'s own note.
+        let Some(modifiers) = widgets::text_editing_modifiers(&keystroke.key, &keystroke.modifiers)
+        else {
             return;
-        }
+        };
         // GitHub issue #27's "solid mid-keystroke" - see `crate::palette::render::AdeApp::
         // handle_palette_key_down`'s identical reasoning.
         self.reset_caret_blink(cx);
         let changed = match keystroke.key.as_str() {
-            "backspace" => self.settings_keymap_filter.backspace(Instant::now()),
             // A real, undoable step - see `crate::rail::AdeApp::handle_filter_key_down`'s own
             // identical `Esc` handling.
             "escape" => self.settings_keymap_filter.clear(Instant::now()),
-            _ => match keystroke.key_char.as_deref() {
-                Some(text) if !text.is_empty() => {
-                    self.settings_keymap_filter.insert_str(text, Instant::now())
-                }
-                _ => false,
-            },
+            key => self.settings_keymap_filter.handle_editing_key(
+                key,
+                keystroke.key_char.as_deref(),
+                modifiers,
+                Instant::now(),
+            ),
         };
         if changed {
             cx.notify();
@@ -4732,6 +4761,33 @@ impl AdeApp {
         self.apply_follow_system_appearance(appearance, cx);
         cx.notify();
     }
+}
+
+/// The Settings › Terminal shell field's own [`TextFieldHandle`] - what click/drag selection and
+/// GitHub issue #336's four clipboard/select-all actions act on, carrying exactly the follow-up
+/// work `AdeApp::handle_settings_shell_key_down` already runs after a keystroke: the new value is
+/// persisted immediately, and the suggestion dropdown is re-opened against it.
+fn shell_input_handle() -> TextFieldHandle {
+    TextFieldHandle::new(|app: &mut AdeApp| Some(&mut app.shell_input)).on_changed(
+        |app: &mut AdeApp, cx| {
+            app.apply_shell_input(cx);
+            app.open_shell_suggestions(cx);
+        },
+    )
+}
+
+/// The Settings › Keybindings filter field's own handle. No `on_changed`: the filtered list is
+/// derived from the field at render time, so a `cx.notify()` - which every caller of this already
+/// does - is the whole of the follow-up work.
+fn settings_keymap_filter_handle() -> TextFieldHandle {
+    TextFieldHandle::new(|app: &mut AdeApp| Some(&mut app.settings_keymap_filter))
+}
+
+/// The "Generate from colour" seed field's own handle. No `on_changed` for the same reason
+/// [`settings_keymap_filter_handle`] has none: the live colour swatch beside the field is derived
+/// from it at render time, so `cx.notify()` is all the follow-up there is.
+fn theme_seed_input_handle() -> TextFieldHandle {
+    TextFieldHandle::new(|app: &mut AdeApp| Some(&mut app.theme_seed_input))
 }
 
 /// Parses the "Generate from colour" seed input's own text into a real `0xrrggbb` value -

--- a/crates/app/src/settings/render.rs
+++ b/crates/app/src/settings/render.rs
@@ -1089,67 +1089,68 @@ impl AdeApp {
                     shell_input_handle(),
                     cx,
                 )
-                    .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
-                        window.focus(&this.shell_focus_handle, cx);
-                        this.open_shell_suggestions(cx);
-                    }))
-                    // The field's real, window-space painted bounds, for positioning the
-                    // suggestion dropdown - the same `gpui::canvas` idiom
-                    // `Self::plus_button_bounds` uses, and for the same reason: the dropdown is a
-                    // top-level sibling in `AdeApp::render`, so it needs the field's position in
-                    // window space, not in this row's own coordinate system.
-                    .child({
-                        let this = cx.entity();
-                        gpui::canvas(
-                            move |bounds, _window, cx| {
-                                this.update(cx, |this, _cx| {
-                                    this.shell_field_bounds = bounds;
-                                });
-                            },
-                            |_, _, _, _| {},
-                        )
-                        .absolute()
-                        .size_full()
-                    })
-                    .cursor_pointer()
-                    .flex_none()
-                    .flex()
-                    .items_center()
-                    // No decorative gap before the caret - see
-                    // `crate::rail::render::AdeApp::render_rail_filter_row`'s own
-                    // comment for why (live report: it read as a gap between the
-                    // typed text and where it's actually being typed).
-                    .h(px(20.0))
-                    .w(px(168.0))
-                    .px(px(7.0))
-                    .rounded(theme::radius::BUTTON)
-                    .border_1()
-                    .border_color(theme::border::CARD_FIELD)
-                    .bg(theme::surface::CARD_SUNK)
-                    // Caret placement and text sizing both through
-                    // `AdeApp::render_simple_input_row`, which owns that structure for every
-                    // simple input in this app. This field was the *second* live instance of the
-                    // bug that helper exists to make unrepeatable: `.flex_1().min_w_0()` sat on
-                    // the text element, so inside this fixed 168px box the text's layout box
-                    // filled the whole field whatever the shell path said, and the caret after it
-                    // sat pinned to the right-hand border instead of against the last character.
-                    .child(self.render_simple_input_row(
-                        SimpleInput {
-                            caret_selector: "settings-shell-caret".into(),
-                            text_selector: "settings-shell-text".into(),
-                            focus_handle: Some(&self.shell_focus_handle),
-                            text: if has_shell { &shell } else { "" },
-                            caret_offset: self.shell_input.caret(),
-                            selection: self.shell_input.selection(),
-                            placeholder: &placeholder,
-                            font: theme::font::MONO,
-                            text_size: self.ui_text_size(10.5),
-                            text_color: theme::text::BODY,
-                            placeholder_color: theme::text::GHOST,
-                            field: Some(shell_input_handle()),
+                .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
+                    window.focus(&this.shell_focus_handle, cx);
+                    this.open_shell_suggestions(cx);
+                }))
+                // The field's real, window-space painted bounds, for positioning the
+                // suggestion dropdown - the same `gpui::canvas` idiom
+                // `Self::plus_button_bounds` uses, and for the same reason: the dropdown is a
+                // top-level sibling in `AdeApp::render`, so it needs the field's position in
+                // window space, not in this row's own coordinate system.
+                .child({
+                    let this = cx.entity();
+                    gpui::canvas(
+                        move |bounds, _window, cx| {
+                            this.update(cx, |this, _cx| {
+                                this.shell_field_bounds = bounds;
+                            });
                         },
-                        cx,
-                    )),
+                        |_, _, _, _| {},
+                    )
+                    .absolute()
+                    .size_full()
+                })
+                .cursor_pointer()
+                .flex_none()
+                .flex()
+                .items_center()
+                // No decorative gap before the caret - see
+                // `crate::rail::render::AdeApp::render_rail_filter_row`'s own
+                // comment for why (live report: it read as a gap between the
+                // typed text and where it's actually being typed).
+                .h(px(20.0))
+                .w(px(168.0))
+                .px(px(7.0))
+                .rounded(theme::radius::BUTTON)
+                .border_1()
+                .border_color(theme::border::CARD_FIELD)
+                .bg(theme::surface::CARD_SUNK)
+                // Caret placement and text sizing both through
+                // `AdeApp::render_simple_input_row`, which owns that structure for every
+                // simple input in this app. This field was the *second* live instance of the
+                // bug that helper exists to make unrepeatable: `.flex_1().min_w_0()` sat on
+                // the text element, so inside this fixed 168px box the text's layout box
+                // filled the whole field whatever the shell path said, and the caret after it
+                // sat pinned to the right-hand border instead of against the last character.
+                .child(self.render_simple_input_row(
+                    SimpleInput {
+                        caret_selector: "settings-shell-caret".into(),
+                        text_selector: "settings-shell-text".into(),
+                        focus_handle: Some(&self.shell_focus_handle),
+                        text: if has_shell { &shell } else { "" },
+                        caret_offset: self.shell_input.caret(),
+                        selection: self.shell_input.selection(),
+                        placeholder: &placeholder,
+                        font: theme::font::MONO,
+                        text_size: self.ui_text_size(10.5),
+                        text_color: theme::text::BODY,
+                        placeholder_color: theme::text::GHOST,
+                        caret: widgets::SimpleInputCaret::default(),
+                        field: Some(shell_input_handle()),
+                    },
+                    cx,
+                )),
             )
     }
 
@@ -1190,10 +1191,12 @@ impl AdeApp {
             // backspace/insert half this used to hand-roll - caret movement, selection extension,
             // word-wise movement and Delete all arrive here at once, for this field and the two
             // below it.
-            key => {
-                self.shell_input
-                    .handle_editing_key(key, keystroke.key_char.as_deref(), modifiers, Instant::now())
-            }
+            key => self.shell_input.handle_editing_key(
+                key,
+                keystroke.key_char.as_deref(),
+                modifiers,
+                Instant::now(),
+            ),
         };
         if changed {
             self.apply_shell_input(cx);
@@ -2071,45 +2074,46 @@ impl AdeApp {
                     theme_seed_input_handle(),
                     cx,
                 )
-                    .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
-                        window.focus(&this.theme_seed_focus_handle, cx);
-                    }))
-                    .cursor_pointer()
-                    .flex()
-                    .items_center()
-                    // No decorative gap before the caret - see
-                    // `crate::rail::render::AdeApp::render_rail_filter_row`'s own
-                    // comment for why (live report: it read as a gap between the
-                    // typed text and where it's actually being typed).
-                    .h(px(20.0))
-                    .w(px(96.0))
-                    .px(px(7.0))
-                    .rounded(theme::radius::BUTTON)
-                    .border_1()
-                    .border_color(theme::border::CARD_FIELD)
-                    .bg(theme::surface::CARD_SUNK)
-                    // GitHub issue #336: through the one helper that owns this structure, like
-                    // every other simple input in the app, rather than the hand-assembled
-                    // caret-before-placeholder / text / caret-after-text trio this row used to
-                    // carry - which is exactly the duplication `render_simple_input_row` exists to
-                    // end, and which had no selection highlight or hit-testing of its own.
-                    .child(self.render_simple_input_row(
-                        SimpleInput {
-                            caret_selector: "settings-theme-seed-caret".into(),
-                            text_selector: "settings-theme-seed-text".into(),
-                            focus_handle: Some(&self.theme_seed_focus_handle),
-                            text: if has_seed { seed.as_str() } else { "" },
-                            caret_offset: self.theme_seed_input.caret(),
-                            selection: self.theme_seed_input.selection(),
-                            placeholder: "#rrggbb",
-                            font: theme::font::MONO,
-                            text_size: px(10.5),
-                            text_color: theme::text::BODY,
-                            placeholder_color: theme::text::GHOST,
-                            field: Some(theme_seed_input_handle()),
-                        },
-                        cx,
-                    )),
+                .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
+                    window.focus(&this.theme_seed_focus_handle, cx);
+                }))
+                .cursor_pointer()
+                .flex()
+                .items_center()
+                // No decorative gap before the caret - see
+                // `crate::rail::render::AdeApp::render_rail_filter_row`'s own
+                // comment for why (live report: it read as a gap between the
+                // typed text and where it's actually being typed).
+                .h(px(20.0))
+                .w(px(96.0))
+                .px(px(7.0))
+                .rounded(theme::radius::BUTTON)
+                .border_1()
+                .border_color(theme::border::CARD_FIELD)
+                .bg(theme::surface::CARD_SUNK)
+                // GitHub issue #336: through the one helper that owns this structure, like
+                // every other simple input in the app, rather than the hand-assembled
+                // caret-before-placeholder / text / caret-after-text trio this row used to
+                // carry - which is exactly the duplication `render_simple_input_row` exists to
+                // end, and which had no selection highlight or hit-testing of its own.
+                .child(self.render_simple_input_row(
+                    SimpleInput {
+                        caret_selector: "settings-theme-seed-caret".into(),
+                        text_selector: "settings-theme-seed-text".into(),
+                        focus_handle: Some(&self.theme_seed_focus_handle),
+                        text: if has_seed { seed.as_str() } else { "" },
+                        caret_offset: self.theme_seed_input.caret(),
+                        selection: self.theme_seed_input.selection(),
+                        placeholder: "#rrggbb",
+                        font: theme::font::MONO,
+                        text_size: px(10.5),
+                        text_color: theme::text::BODY,
+                        placeholder_color: theme::text::GHOST,
+                        caret: widgets::SimpleInputCaret::default(),
+                        field: Some(theme_seed_input_handle()),
+                    },
+                    cx,
+                )),
             )
             // A real, live preview of the seed itself, so a typo is visible before clicking.
             .when(parse_seed_hex(&seed).is_some(), |el| {
@@ -2627,66 +2631,64 @@ impl AdeApp {
             settings_keymap_filter_handle(),
             cx,
         )
-            .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
-                window.focus(&this.settings_keymap_filter_focus_handle, cx);
-            }))
-            .flex()
-            .items_center()
-            .gap(px(7.0))
-            .px(px(11.0))
-            .py(px(7.0))
-            .bg(theme::surface::CARD_SUNK)
-            .border_b_1()
-            .border_color(theme::border::CARD)
-            .child(
-                div()
-                    .font(font(theme::font::MONO))
-                    .text_size(px(11.0))
-                    .text_color(theme::text::GHOSTER)
-                    .child("/"),
-            )
-            .child(
-                div()
-                    .flex_1()
-                    .min_w_0()
-                    .flex()
-                    .items_center()
-                    // No decorative gap before the caret - see
-                    // `crate::rail::render::AdeApp::render_rail_filter_row`'s own
-                    // comment for why (live report: it read as a gap between the
-                    // typed text and where it's actually being typed).
-                    // GitHub issue #45 / live report: same fix as
-                    // `crate::rail::render::AdeApp::render_rail_filter_row` - the caret sits
-                    // before the placeholder (real cursor position 0) while the filter is empty,
-                    // never appended after it.
-                    .child(self.render_simple_input_row(
-                        SimpleInput {
-                            caret_selector: "settings-keymap-filter-caret".into(),
-                            text_selector: "settings-keymap-filter-text".into(),
-                            focus_handle: Some(&self.settings_keymap_filter_focus_handle),
-                            text: self.settings_keymap_filter.as_str(),
-                            caret_offset: self.settings_keymap_filter.caret(),
-                            selection: self.settings_keymap_filter.selection(),
-                            placeholder: &format!(
-                                "filter {}",
-                                plural::count(total, "binding", None)
-                            ),
-                            font: theme::font::SANS,
-                            text_size: px(11.0),
-                            text_color: theme::text::DIM,
-                            placeholder_color: theme::text::GHOST,
-                            field: Some(settings_keymap_filter_handle()),
-                        },
-                        cx,
-                    )),
-            )
-            .child(
-                div()
-                    .font(font(theme::font::MONO))
-                    .text_size(px(10.0))
-                    .text_color(theme::text::GHOST)
-                    .child(format!("{shown} shown")),
-            )
+        .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
+            window.focus(&this.settings_keymap_filter_focus_handle, cx);
+        }))
+        .flex()
+        .items_center()
+        .gap(px(7.0))
+        .px(px(11.0))
+        .py(px(7.0))
+        .bg(theme::surface::CARD_SUNK)
+        .border_b_1()
+        .border_color(theme::border::CARD)
+        .child(
+            div()
+                .font(font(theme::font::MONO))
+                .text_size(px(11.0))
+                .text_color(theme::text::GHOSTER)
+                .child("/"),
+        )
+        .child(
+            div()
+                .flex_1()
+                .min_w_0()
+                .flex()
+                .items_center()
+                // No decorative gap before the caret - see
+                // `crate::rail::render::AdeApp::render_rail_filter_row`'s own
+                // comment for why (live report: it read as a gap between the
+                // typed text and where it's actually being typed).
+                // GitHub issue #45 / live report: same fix as
+                // `crate::rail::render::AdeApp::render_rail_filter_row` - the caret sits
+                // before the placeholder (real cursor position 0) while the filter is empty,
+                // never appended after it.
+                .child(self.render_simple_input_row(
+                    SimpleInput {
+                        caret_selector: "settings-keymap-filter-caret".into(),
+                        text_selector: "settings-keymap-filter-text".into(),
+                        focus_handle: Some(&self.settings_keymap_filter_focus_handle),
+                        text: self.settings_keymap_filter.as_str(),
+                        caret_offset: self.settings_keymap_filter.caret(),
+                        selection: self.settings_keymap_filter.selection(),
+                        placeholder: &format!("filter {}", plural::count(total, "binding", None)),
+                        font: theme::font::SANS,
+                        text_size: px(11.0),
+                        text_color: theme::text::DIM,
+                        placeholder_color: theme::text::GHOST,
+                        caret: widgets::SimpleInputCaret::default(),
+                        field: Some(settings_keymap_filter_handle()),
+                    },
+                    cx,
+                )),
+        )
+        .child(
+            div()
+                .font(font(theme::font::MONO))
+                .text_size(px(10.0))
+                .text_color(theme::text::GHOST)
+                .child(format!("{shown} shown")),
+        )
     }
 
     /// Same minimal append/backspace/escape-clears shape as [`Self::handle_filter_key_down`] -

--- a/crates/app/src/settings/state.rs
+++ b/crates/app/src/settings/state.rs
@@ -587,6 +587,11 @@ pub(crate) fn action_label(action: &dyn gpui::Action) -> Option<&'static str> {
         "app::EditorEscape" => Some("Editor: move focus out"),
         "app::TextUndo" => Some("Text: undo"),
         "app::TextRedo" => Some("Text: redo"),
+        // GitHub issue #336's real clipboard/select-all for every single-line text input.
+        "app::TextCopy" => Some("Text: copy selection"),
+        "app::TextCut" => Some("Text: cut selection"),
+        "app::TextPaste" => Some("Text: paste"),
+        "app::TextSelectAll" => Some("Text: select all"),
         "app::CloseFocusedTab" => Some("Close focused tab"),
         "app::FileTreeRename" => Some("Files tree: rename"),
         "app::FileTreeCopy" => Some("Files tree: copy"),
@@ -1886,6 +1891,10 @@ mod tests {
                 "Text: undo",
                 "Text: redo",
                 "Text: redo",
+                "Text: copy selection",
+                "Text: cut selection",
+                "Text: paste",
+                "Text: select all",
                 "Go to definition",
                 "New terminal",
                 "New agent pane",
@@ -2115,6 +2124,12 @@ mod tests {
         // and nothing was bound to it. All three of those now also carry `&& !text-input`, since
         // issue #288's pinned note card is a real text input *inside* the `"diff"` node that
         // `"file-editor"` does not cover.
+        // GitHub issue #336 added 4 more scoped bindings: `TextCopy`/`TextCut`/`TextPaste`/
+        // `TextSelectAll` (`mod+C`/`mod+X`/`mod+V`/`mod+A`) under
+        // `Some("text-input && !file-editor && !merge-editor")` - the same `"text-input"` tag
+        // `TextUndo`/`TextRedo` above carry, with the two editor surfaces excluded because their
+        // own `Editor*` actions already own those exact keystrokes there at the same predicate
+        // depth (see `crate::default_key_bindings`' own entry).
         let bindings = crate::default_key_bindings();
         let rows = keybinding_rows(&bindings, &[]);
         assert!(!rows.is_empty());
@@ -2122,7 +2137,7 @@ mod tests {
             rows.iter().filter(|row| row.context != "global").collect();
         assert_eq!(
             scoped.len(),
-            86,
+            90,
             "expected `] -> NextChangedFile` (1) plus every real Editor* binding (19) plus \
              every real Completions* binding (5) plus every real merge-editor binding (18) plus \
              TextUndo/TextRedo (3, GitHub issue #17) plus every real \
@@ -2135,7 +2150,8 @@ mod tests {
              every real interactive-rebase plan binding (6, GitHub issue #304) plus every \
              real review-note binding (2, GitHub issue #288) plus `space -> \
              ToggleChangeStaged` (1, the Changes footer's own `space stage` hint) plus \
-             `mod+F -> FindInFile` (1, GitHub issue #162's in-file find) to be scoped, \
+             `mod+F -> FindInFile` (1, GitHub issue #162's in-file find) plus \
+             TextCopy/TextCut/TextPaste/TextSelectAll (4, GitHub issue #336) to be scoped, \
              not global"
         );
         assert!(

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -5,9 +5,11 @@ use crate::root::scrollbar;
 use crate::root::widgets::{
     hover_bg, menu_popover_chrome, render_committed_tag, render_disclosure_caret,
     render_keycap_row, render_sidebar_message, render_status_letter, text_tooltip, KeycapSize,
+    SimpleInput, SimpleInputCaret, TextFieldHandle,
 };
 use crate::settings::widgets::ChoiceOption;
 use crate::worktree_history::flow as worktree_history;
+use gpui::SharedString;
 use std::time::Instant;
 
 /// How much extra the Changes panel's `gpui::list` measures above and below the viewport.
@@ -20,6 +22,27 @@ pub(crate) const CHANGES_LIST_OVERDRAW: gpui::Pixels = px(48.0);
 
 /// git's own conventional short form of a commit id, for a label that only has room for one.
 /// Never a hand-picked width elsewhere in this file - one length, defined once.
+/// The commit composer's own [`TextFieldHandle`] - what click/drag selection and GitHub issue
+/// #336's four clipboard/select-all actions act on. No `on_changed`: the composer's buttons all
+/// read `AdeApp::commit_message` directly at render time.
+fn commit_message_handle() -> TextFieldHandle {
+    TextFieldHandle::new(|app: &mut AdeApp| Some(&mut app.commit_message))
+}
+
+/// The file tree's inline New File / New Folder / Rename name editor's own field handle. `None`
+/// whenever no editor is open, and its `on_changed` clears the stale rejection hint exactly as
+/// `crate::sidebar::tree_ops::AdeApp::handle_tree_key_down` does after a keystroke.
+fn tree_inline_edit_handle() -> TextFieldHandle {
+    TextFieldHandle::new(|app: &mut AdeApp| {
+        app.tree_inline_edit.as_mut().map(|edit| &mut edit.name)
+    })
+    .on_changed(|app: &mut AdeApp, _cx| {
+        if let Some(edit) = app.tree_inline_edit.as_mut() {
+            edit.error = None;
+        }
+    })
+}
+
 fn short_sha(sha: &str) -> String {
     sha.chars().take(7).collect()
 }
@@ -498,19 +521,21 @@ impl AdeApp {
         cx: &mut Context<Self>,
     ) {
         let keystroke = &event.keystroke;
-        if keystroke.modifiers.platform || keystroke.modifiers.control || keystroke.modifiers.alt {
+        // GitHub issue #336: `widgets::text_editing_modifiers` rather than a flat "any modifier
+        // means not ours" - see `crate::rail::render::AdeApp::handle_filter_key_down`'s own note.
+        // This is still what lets `mod+enter` reach the composer's own commit action from inside
+        // the field rather than being typed into it.
+        let Some(modifiers) =
+            crate::root::widgets::text_editing_modifiers(&keystroke.key, &keystroke.modifiers)
+        else {
             return;
-        }
-        let changed = match keystroke.key.as_str() {
-            "backspace" => self.commit_message.backspace(Instant::now()),
-            _ => match keystroke.key_char.as_deref() {
-                Some(text) if !text.is_empty() => {
-                    self.commit_message.insert_str(text, Instant::now())
-                }
-                _ => false,
-            },
         };
-        if changed {
+        if self.commit_message.handle_editing_key(
+            &keystroke.key,
+            keystroke.key_char.as_deref(),
+            modifiers,
+            Instant::now(),
+        ) {
             cx.notify();
             cx.stop_propagation();
         }
@@ -1020,7 +1045,7 @@ impl AdeApp {
         // issue #105).
         let key_context =
             crate::keymap_overrides::file_tree_key_context(self.tree_inline_edit.is_some());
-        div()
+        let shell = div()
             .id("file-tree-shell")
             .key_context(key_context)
             .track_focus(&self.tree_focus_handle)
@@ -1033,7 +1058,14 @@ impl AdeApp {
             .on_action(cx.listener(Self::handle_file_tree_redo_action))
             .on_action(cx.listener(Self::handle_tree_text_undo))
             .on_action(cx.listener(Self::handle_tree_text_redo))
-            .on_key_down(cx.listener(Self::handle_tree_key_down))
+            .on_key_down(cx.listener(Self::handle_tree_key_down));
+        // GitHub issue #336's four clipboard/select-all actions, on the same node the
+        // `"text-input"` word above lives on. They are only ever *reachable* while an inline name
+        // editor is open, since that word only appears then - and `tree_inline_edit_handle`
+        // independently answers `None` when it is not, so a stray dispatch is a real no-op rather
+        // than an edit to a field that isn't there.
+        let shell = self
+            .wire_text_input_actions(shell, tree_inline_edit_handle(), cx)
             .flex()
             .flex_col()
             .flex_1()
@@ -1082,8 +1114,8 @@ impl AdeApp {
                 .absolute()
                 .size_full()
             })
-            .child(body)
-            .into_any_element()
+            .child(body);
+        shell.into_any_element()
     }
 
     /// The rows [`Self::render_file_tree`]'s `uniform_list` will build, and the indent depth the
@@ -1149,7 +1181,7 @@ impl AdeApp {
     fn render_tree_inline_edit_row(
         &self,
         depth: usize,
-        _cx: &mut Context<Self>,
+        cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
         let Some(edit) = self.tree_inline_edit.as_ref() else {
             return div().into_any_element();
@@ -1185,23 +1217,29 @@ impl AdeApp {
                     .child(edit.kind.title()),
             )
             .child(
-                div()
-                    .flex_1()
-                    .min_w_0()
-                    .overflow_hidden()
-                    .text_color(theme::text::STRONG)
-                    // A real caret glyph, so an empty field still reads as "type here" rather
-                    // than as a blank row - blinking (GitHub issue #27), same shared loop
-                    // (`Self::tree_focus_handle` is wired into `crate::root::caret_blink` too) the
-                    // code editor's/palette's own carets use. Same reasoning as the palette's own
-                    // caret for why no separate "unfocused" case is needed here: this row only
-                    // renders while `Self::tree_inline_edit` is genuinely open and
-                    // `tree_focus_handle` is its own real focus target for that whole time.
-                    .child(if self.caret_blink_visible {
-                        format!("{name}\u{2502}")
-                    } else {
-                        name
-                    }),
+                // GitHub issue #336: a real caret *bar* at the real insertion point, through the
+                // one helper that owns that structure - not the `\u{2502}` glyph appended to the
+                // text this row used to draw, which could only ever sit at the end of the name
+                // however far back the user had arrowed, and which no selection highlight or
+                // click hit-testing could be built on.
+                self.render_simple_input_row(
+                    SimpleInput {
+                        caret_selector: "file-tree-inline-edit-caret".into(),
+                        text_selector: "file-tree-inline-edit-text".into(),
+                        focus_handle: Some(&self.tree_focus_handle),
+                        text: &name,
+                        caret_offset: edit.name.caret(),
+                        selection: edit.name.selection(),
+                        placeholder: "",
+                        font: theme::font::MONO,
+                        text_size: self.ui_text_size(11.5),
+                        text_color: theme::text::STRONG,
+                        placeholder_color: theme::text::GHOST,
+                        caret: SimpleInputCaret::default(),
+                        field: Some(tree_inline_edit_handle()),
+                    },
+                    cx,
+                ),
             )
             .when_some(edit.error.clone(), |el, error| {
                 el.child(
@@ -3661,79 +3699,77 @@ impl AdeApp {
             .child(
                 // The message box - a normal text input the user fills in themselves, nothing
                 // pre-drafted (see `Self::staged_commit_message`'s own docs).
-                div()
-                    .id("commit-composer-message")
-                    .debug_selector(|| "commit-composer-message-field".to_string())
-                    .flex_none()
-                    .border_1()
-                    .border_color(theme::border::CARD)
-                    .rounded(theme::radius::CARD_SM)
-                    .bg(theme::surface::CARD_SUNK)
-                    .px(px(9.0))
-                    .py(px(7.0))
-                    .track_focus(&self.commit_message_focus_handle)
-                    .key_context("text-input")
-                    .on_action(cx.listener(Self::handle_commit_message_text_undo))
-                    .on_action(cx.listener(Self::handle_commit_message_text_redo))
-                    .on_key_down(cx.listener(Self::handle_commit_message_key_down))
-                    .cursor_text()
-                    // Live report ("carret is not centered verticaly, when typing it goes to the
-                    // right side of the input"): this row used to be `.items_start()` with
-                    // `.flex_1().min_w_0()` on the *text* div below. `flex_1` stretched the text
-                    // div's layout box across the whole field, so the caret - a `flex_none`
-                    // sibling rendered *after* it in DOM order once the message is non-empty -
-                    // sat pinned at the field's right edge instead of adjacent to the last glyph,
-                    // and `items_start` top-aligned the 14px caret bar against the 17px text
-                    // line. Now the exact structure every working simple input uses
-                    // (`Self::render_rail_filter_row`'s caret+text wrapper, `Self::
-                    // render_new_file_prompt`'s name box): an `items_center` row whose text div is
-                    // intrinsically sized, so the caret sits right next to the real text.
-                    //
-                    // No decorative gap before the caret - see
-                    // `crate::rail::render::AdeApp::render_rail_filter_row`'s own comment for why
-                    // (live report: it read as a gap between the typed text and where it's
-                    // actually being typed). This field was written while that 2px gap was still
-                    // on every other input in the app; it goes here for the same reason it went
-                    // everywhere else.
-                    .flex()
-                    .items_center()
-                    .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
-                        this.focus_commit_message(window, cx);
-                    }))
-                    // Mirrors `Self::render_rail_filter_row`'s own fix exactly (GitHub issue #45):
-                    // a caret pinned unconditionally *after* this child sits glued to the end of
-                    // the placeholder when the field is empty, instead of at the real cursor
-                    // position (0, before any text at all). It belongs before the placeholder
-                    // when empty and after the real message once there is any.
-                    .when(message.is_empty(), |el| {
-                        el.child(self.render_simple_input_caret(
-                            "commit-composer-message-caret",
-                            &self.commit_message_focus_handle,
-                        ))
-                    })
-                    .child(
-                        div()
-                            .debug_selector(move || message_selector)
-                            .font(font(theme::font::SANS))
-                            .text_size(px(11.5))
-                            .line_height(px(17.0))
-                            .text_color(if message.is_empty() {
-                                theme::text::FAINT
-                            } else {
-                                theme::text::STRONG
-                            })
-                            .child(if message.is_empty() {
-                                "commit message".to_string()
-                            } else {
-                                message.clone()
-                            }),
-                    )
-                    .when(!message.is_empty(), |el| {
-                        el.child(self.render_simple_input_caret(
-                            "commit-composer-message-caret",
-                            &self.commit_message_focus_handle,
-                        ))
-                    }),
+                self.wire_text_input_actions(
+                    div()
+                        .id("commit-composer-message")
+                        .debug_selector(|| "commit-composer-message-field".to_string())
+                        .flex_none()
+                        .border_1()
+                        .border_color(theme::border::CARD)
+                        .rounded(theme::radius::CARD_SM)
+                        .bg(theme::surface::CARD_SUNK)
+                        .px(px(9.0))
+                        .py(px(7.0))
+                        .track_focus(&self.commit_message_focus_handle)
+                        .key_context("text-input")
+                        .on_action(cx.listener(Self::handle_commit_message_text_undo))
+                        .on_action(cx.listener(Self::handle_commit_message_text_redo))
+                        .on_key_down(cx.listener(Self::handle_commit_message_key_down)),
+                    commit_message_handle(),
+                    cx,
+                )
+                .cursor_text()
+                // Live report ("carret is not centered verticaly, when typing it goes to the
+                // right side of the input"): this row used to be `.items_start()` with
+                // `.flex_1().min_w_0()` on the *text* div below. `flex_1` stretched the text
+                // div's layout box across the whole field, so the caret - a `flex_none`
+                // sibling rendered *after* it in DOM order once the message is non-empty -
+                // sat pinned at the field's right edge instead of adjacent to the last glyph,
+                // and `items_start` top-aligned the 14px caret bar against the 17px text
+                // line. Now the exact structure every working simple input uses
+                // (`Self::render_rail_filter_row`'s caret+text wrapper, `Self::
+                // render_new_file_prompt`'s name box): an `items_center` row whose text div is
+                // intrinsically sized, so the caret sits right next to the real text.
+                //
+                // No decorative gap before the caret - see
+                // `crate::rail::render::AdeApp::render_rail_filter_row`'s own comment for why
+                // (live report: it read as a gap between the typed text and where it's
+                // actually being typed). This field was written while that 2px gap was still
+                // on every other input in the app; it goes here for the same reason it went
+                // everywhere else.
+                .flex()
+                .items_center()
+                .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
+                    this.focus_commit_message(window, cx);
+                }))
+                // Mirrors `Self::render_rail_filter_row`'s own fix exactly (GitHub issue #45):
+                // a caret pinned unconditionally *after* this child sits glued to the end of
+                // the placeholder when the field is empty, instead of at the real cursor
+                // position (0, before any text at all). It belongs before the placeholder
+                // when empty and after the real message once there is any.
+                // GitHub issue #336: through the one helper that owns this structure, like
+                // every other simple input in the app - which is also what gives the composer
+                // a real caret *position* (it used to pin the bar to the end of the message
+                // whatever the user had arrowed back to), a selection highlight, and real
+                // click-to-position.
+                .child(self.render_simple_input_row(
+                    SimpleInput {
+                        caret_selector: "commit-composer-message-caret".into(),
+                        text_selector: SharedString::from(message_selector),
+                        focus_handle: Some(&self.commit_message_focus_handle),
+                        text: &message,
+                        caret_offset: self.commit_message.caret(),
+                        selection: self.commit_message.selection(),
+                        placeholder: "commit message",
+                        font: theme::font::SANS,
+                        text_size: px(11.5),
+                        text_color: theme::text::STRONG,
+                        placeholder_color: theme::text::FAINT,
+                        caret: SimpleInputCaret::default(),
+                        field: Some(commit_message_handle()),
+                    },
+                    cx,
+                )),
             )
             .child(
                 // Primary action + split-button menu + right-aligned target branch.

--- a/crates/app/src/sidebar/tree_ops.rs
+++ b/crates/app/src/sidebar/tree_ops.rs
@@ -633,10 +633,13 @@ impl AdeApp {
         cx: &mut Context<Self>,
     ) {
         let keystroke = &event.keystroke;
-        if keystroke.modifiers.platform || keystroke.modifiers.control || keystroke.modifiers.alt {
-            return;
-        }
         if self.tree_inline_edit.is_none() {
+            if keystroke.modifiers.platform
+                || keystroke.modifiers.control
+                || keystroke.modifiers.alt
+            {
+                return;
+            }
             if keystroke.key == "escape" && self.tree_context_menu.is_some() {
                 self.close_tree_context_menu(cx);
                 cx.stop_propagation();
@@ -651,33 +654,36 @@ impl AdeApp {
             "escape" => {
                 self.cancel_tree_inline_edit(window, cx);
                 cx.stop_propagation();
+                return;
             }
             "enter" => {
                 self.commit_tree_inline_edit(window, cx);
                 cx.stop_propagation();
+                return;
             }
-            "backspace" => {
-                if let Some(edit) = self.tree_inline_edit.as_mut() {
-                    edit.name.backspace(Instant::now());
-                    edit.error = None;
-                    cx.notify();
-                    cx.stop_propagation();
-                }
-            }
-            _ => {
-                if let Some(text) = keystroke
-                    .key_char
-                    .as_deref()
-                    .filter(|text| !text.is_empty())
-                {
-                    if let Some(edit) = self.tree_inline_edit.as_mut() {
-                        edit.name.insert_str(text, Instant::now());
-                        edit.error = None;
-                        cx.notify();
-                        cx.stop_propagation();
-                    }
-                }
-            }
+            _ => {}
+        }
+        // GitHub issue #336: `widgets::text_editing_modifiers` plus the whole `TextField`
+        // vocabulary through one entry point, rather than the backspace/insert pair this editor
+        // used to hand-roll - see `crate::rail::render::AdeApp::handle_filter_key_down`'s own
+        // note on the modifier translation.
+        let Some(modifiers) =
+            crate::root::widgets::text_editing_modifiers(&keystroke.key, &keystroke.modifiers)
+        else {
+            return;
+        };
+        let Some(edit) = self.tree_inline_edit.as_mut() else {
+            return;
+        };
+        if edit.name.handle_editing_key(
+            &keystroke.key,
+            keystroke.key_char.as_deref(),
+            modifiers,
+            Instant::now(),
+        ) {
+            edit.error = None;
+            cx.notify();
+            cx.stop_propagation();
         }
     }
 

--- a/crates/app/src/text_history.rs
+++ b/crates/app/src/text_history.rs
@@ -601,6 +601,57 @@ impl TextHistory {
     }
 }
 
+/// A character's real class for word-wise caret movement and double-click word selection (GitHub
+/// issue #27, GitHub issue #336) - shared by [`TextField`] and
+/// `crate::code_surface::edit_buffer::EditBuffer`, so the app's simple single-line inputs and its
+/// full code editor agree on where a word starts and ends rather than each hand-classifying its
+/// own way. See [`TextField::previous_word_boundary`]'s own docs for why this app hand-classifies
+/// rather than using `unicode_segmentation`'s UAX #29 word boundaries for this.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WordClass {
+    Whitespace,
+    /// A letter, digit, or underscore - grouped together so `foo_bar123` is one real word, not
+    /// three.
+    Word,
+    /// Anything else (`.`, `(`, `)`, `-`, ...) - a real code editor's own word-navigation stops
+    /// at these individually from surrounding word text, but groups a *run* of them together
+    /// (`()` is one hop, not two), matching this app's own real test coverage.
+    Punctuation,
+}
+
+pub fn word_class(ch: char) -> WordClass {
+    if ch.is_whitespace() {
+        WordClass::Whitespace
+    } else if ch.is_alphanumeric() || ch == '_' {
+        WordClass::Word
+    } else {
+        WordClass::Punctuation
+    }
+}
+
+/// The modifier state one keystroke carries into [`TextField::handle_editing_key`], in this
+/// module's own GPUI-free vocabulary rather than `gpui::Modifiers`.
+///
+/// Two booleans rather than the raw platform modifier set on purpose: *which* physical key means
+/// "word-wise" differs by platform (Alt on macOS, Ctrl everywhere else) and that is a decision
+/// about keyboards, not about text, so it belongs at the GPUI boundary
+/// (`crate::root::widgets::text_editing_modifiers`) and not in here. Everything below this line
+/// only ever needs to know "extend the selection?" and "move by word?".
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct EditingModifiers {
+    /// Shift: extend the selection from its existing anchor rather than collapsing/moving it.
+    pub extend: bool,
+    /// The platform's word-wise modifier: move/extend a whole word at a time.
+    pub word: bool,
+}
+
+impl EditingModifiers {
+    /// No modifiers at all - an ordinary, unmodified keystroke.
+    pub fn none() -> Self {
+        Self::default()
+    }
+}
+
 /// One of the app's hand-rolled single-line text inputs (the command-palette query, the rail
 /// agent filter, the Settings › Keybindings filter, the New file name prompt, the file
 /// tree's inline New File / New Folder / Rename editor - `crate::sidebar::tree_ops::TreeInlineEdit`,
@@ -618,31 +669,57 @@ impl TextHistory {
 /// four real fields is where the old shape stops being defensible - a user *will* arrow back into
 /// a mistyped query rather than backspacing out eight characters of a regex to fix the first one.
 ///
-/// So [`Self::caret`] is a real byte offset into [`Self::as_str`], always on a grapheme-cluster
-/// boundary, and every edit happens *there*: [`Self::insert_str`] splices at it,
-/// [`Self::backspace`]/[`Self::delete_forward`] remove the cluster on either side of it, and
-/// [`Self::move_left`]/[`Self::move_right`]/[`Self::move_to_start`]/[`Self::move_to_end`] move it
-/// without recording anything. [`Self::handle_editing_key`] is all of that behind one call, so a
-/// call site gets the whole vocabulary rather than whichever half it remembered to wire.
+/// ## A real selection (GitHub issue #336)
 ///
-/// Undo/redo restore the caret too, from the [`SelectionSnapshot`]s the history already carried -
-/// which is what makes the coalescing policy's own "a caret jump is a group boundary" rule mean
-/// something here for the first time: arrowing away mid-burst now really does start a new step.
+/// The version of this type that issue #162 left behind carried exactly one `caret: usize` and
+/// said, in this docstring, that selection was "deliberately not implemented". GitHub issue #336
+/// is the live report that ended that: "Text inputs do not have selection and standard
+/// copy/paste/cut."
 ///
-/// Deliberately **not** implemented: selection (and therefore selection-replacing typing, cut, or
-/// shift-arrow). Nothing in these fields needs it, `crate::code_surface::edit_buffer::EditBuffer`
-/// is what a surface that does needs, and half a selection model is worse than none.
+/// So the state below is a real **anchor/head** pair, in exactly the shape
+/// `vendor/zed/crates/gpui/examples/input.rs`'s own `TextInput` and this app's own
+/// `crate::code_surface::edit_buffer::EditBuffer` already use: an ordered
+/// [`Self::selection`] range plus a [`Self::selection_reversed`] flag saying which end the caret
+/// is really sitting on. That is the same information an explicit `(anchor, head)` pair carries -
+/// a selection can be built in either direction - stored so that the common questions ("what is
+/// selected?", "is anything selected?") are answered without a `min`/`max` at every call site,
+/// and so a [`SelectionSnapshot`] round-trips through it with no conversion at all. A *collapsed*
+/// selection (`start == end`) is the ordinary single-caret case, which is why every pre-#336
+/// caller keeps working unchanged.
 ///
-/// The `String` and the caret are private on purpose: every mutation has to go through a method
-/// that records and that re-clamps the caret, so a future call site physically cannot bypass the
-/// history or leave the caret mid-cluster the way bare `pub` fields would allow. That is the same
-/// silent-divergence bug class this project's own audits keep finding.
+/// Everything else follows from that one pair:
+///
+/// - [`Self::insert_str`] **replaces** the selection rather than splicing beside it, and
+///   [`Self::backspace`]/[`Self::delete_forward`] delete the whole selection when there is one -
+///   the standard behaviour of every real text input.
+/// - [`Self::move_left`] and friends **collapse** to the near edge instead of moving, again
+///   standard; [`Self::select_left`] and friends extend from the anchor.
+/// - [`Self::copy`]/[`Self::cut`]/[`Self::paste`] are the pure halves of Ctrl/Cmd+C/X/V; the real
+///   OS clipboard lives at the GPUI boundary (`crate::root::widgets`), so this module stays
+///   GPUI-free and directly unit-testable.
+/// - Undo/redo restore the whole [`SelectionSnapshot`], not just the caret - so undoing a
+///   type-over-a-selection really does put the selection back, which is what makes a second
+///   Ctrl+Z land where the user expects.
+///
+/// Word boundaries come from the shared [`word_class`] above rather than a second, subtly
+/// different classification of this module's own - the same anti-drift discipline that put the
+/// coalescing policy here in the first place.
+///
+/// The `String` and the selection are private on purpose: every mutation has to go through a
+/// method that records and that re-clamps to a real grapheme boundary, so a future call site
+/// physically cannot bypass the history or leave the caret mid-cluster the way bare `pub` fields
+/// would allow. That is the same silent-divergence bug class this project's own audits keep
+/// finding.
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct TextField {
     text: String,
-    /// A byte offset into [`Self::text`], always `<= text.len()` and always on a grapheme
-    /// boundary.
-    caret: usize,
+    /// The selected byte range, always ordered (`start <= end`), always within [`Self::text`], and
+    /// always with both ends on a grapheme boundary. Collapsed (`start == end`) is a plain caret.
+    selection: Range<usize>,
+    /// `true` when the selection was extended leftward from its anchor, i.e. the visible caret
+    /// sits at `selection.start` rather than `selection.end`. Always `false` while the selection
+    /// is collapsed, so two equal selections never compare unequal over an invisible flag.
+    selection_reversed: bool,
     history: TextHistory,
 }
 
@@ -662,7 +739,8 @@ impl TextField {
     /// false until the user genuinely changes something.
     pub fn seeded(text: &str) -> Self {
         Self {
-            caret: text.len(),
+            selection: text.len()..text.len(),
+            selection_reversed: false,
             text: text.to_string(),
             history: TextHistory::new(),
         }
@@ -676,17 +754,53 @@ impl TextField {
         self.text.is_empty()
     }
 
-    /// Where the insertion point really is, as a byte offset into [`Self::as_str`]. What
-    /// `crate::root::widgets::SimpleInput` splits the rendered text at.
+    /// Where the insertion point really is, as a byte offset into [`Self::as_str`] - the *active*
+    /// end of [`Self::selection`], which is its start while the selection was dragged leftward.
+    /// What `crate::root::widgets::SimpleInput` draws the caret bar at.
     pub fn caret(&self) -> usize {
-        self.caret
+        if self.selection_reversed {
+            self.selection.start
+        } else {
+            self.selection.end
+        }
+    }
+
+    /// The real selected byte range - collapsed (empty) when there is only a caret.
+    pub fn selection(&self) -> Range<usize> {
+        self.selection.clone()
+    }
+
+    /// Which end of [`Self::selection`] the caret sits on - see the field's own docs.
+    pub fn selection_reversed(&self) -> bool {
+        self.selection_reversed
+    }
+
+    /// `true` when there is a real, non-collapsed selection - what "copy would copy something"
+    /// and "this Backspace deletes a range, not a character" both mean.
+    pub fn has_selection(&self) -> bool {
+        !self.selection.is_empty()
+    }
+
+    /// The really-selected text, or `""` while the selection is collapsed.
+    pub fn selected_text(&self) -> &str {
+        &self.text[self.selection.clone()]
+    }
+
+    /// The anchor - the end of the selection the caret is *not* on, i.e. where a Shift+click or a
+    /// drag would extend from. Equal to [`Self::caret`] while collapsed.
+    pub fn anchor(&self) -> usize {
+        if self.selection_reversed {
+            self.selection.end
+        } else {
+            self.selection.start
+        }
     }
 
     /// The text before and after the caret - the two spans a rendered row draws the caret bar
     /// between, so no call site has to slice on a byte offset itself and risk panicking mid-
     /// cluster.
     pub fn split_at_caret(&self) -> (&str, &str) {
-        self.text.split_at(self.caret)
+        self.text.split_at(self.caret())
     }
 
     /// The grapheme boundary at or just before `offset`, clamped into the text. A single-line
@@ -705,140 +819,388 @@ impl TextField {
             .unwrap_or(0)
     }
 
-    /// The grapheme boundary strictly before the caret, or `None` at the very start.
-    fn previous_boundary(&self) -> Option<usize> {
+    /// The grapheme boundary strictly before `offset`, or `None` at the very start.
+    fn previous_boundary(&self, offset: usize) -> Option<usize> {
         self.text
             .grapheme_indices(true)
             .rev()
-            .find(|(index, _)| *index < self.caret)
+            .find(|(index, _)| *index < offset)
             .map(|(index, _)| index)
     }
 
-    /// The grapheme boundary strictly after the caret, or `None` at the very end.
-    fn next_boundary(&self) -> Option<usize> {
+    /// The grapheme boundary strictly after `offset`, or `None` at the very end.
+    fn next_boundary(&self, offset: usize) -> Option<usize> {
         self.text
             .grapheme_indices(true)
-            .find(|(index, grapheme)| index + grapheme.len() > self.caret)
+            .find(|(index, grapheme)| index + grapheme.len() > offset)
             .map(|(index, grapheme)| index + grapheme.len())
     }
 
-    /// Moves the caret one grapheme cluster left. Returns whether it really moved, so a caller can
-    /// tell "the view needs repainting" from "this keystroke did nothing and should keep
-    /// propagating".
-    pub fn move_left(&mut self) -> bool {
-        match self.previous_boundary() {
-            Some(offset) => {
-                self.caret = offset;
-                true
+    /// The real word boundary just before `offset` - a maximal run of same-[`WordClass`]
+    /// characters, skipping over runs of whitespace rather than stopping on them. Ported from
+    /// `crate::code_surface::edit_buffer::EditBuffer::previous_word_boundary` minus its
+    /// line-scoping (a single-line field has exactly one line), and sharing that method's own
+    /// [`word_class`] so the two surfaces cannot drift.
+    ///
+    /// Deliberately *not* `unicode_segmentation::UnicodeSegmentation::split_word_bound_indices`
+    /// (this type's own grapheme-boundary methods' crate): UAX #29's word boundaries are designed
+    /// for natural-language prose and keep e.g. `foo.bar` as one unbroken word, which is wrong for
+    /// the paths, branch names, globs and regexes these fields actually hold.
+    fn previous_word_boundary(&self, offset: usize) -> usize {
+        let chars: Vec<(usize, char)> = self.text.char_indices().collect();
+        let mut cursor = chars.iter().rposition(|&(index, _)| index < offset);
+        while let Some(pos) = cursor {
+            if word_class(chars[pos].1) == WordClass::Whitespace {
+                cursor = pos.checked_sub(1);
+            } else {
+                break;
             }
+        }
+        let Some(mut start) = cursor else {
+            return 0;
+        };
+        let class = word_class(chars[start].1);
+        while start > 0 && word_class(chars[start - 1].1) == class {
+            start -= 1;
+        }
+        chars[start].0
+    }
+
+    /// The mirror of [`Self::previous_word_boundary`].
+    fn next_word_boundary(&self, offset: usize) -> usize {
+        let chars: Vec<(usize, char)> = self.text.char_indices().collect();
+        let mut cursor = chars.iter().position(|&(index, _)| index >= offset);
+        while let Some(pos) = cursor {
+            if word_class(chars[pos].1) == WordClass::Whitespace {
+                cursor = (pos + 1 < chars.len()).then_some(pos + 1);
+            } else {
+                break;
+            }
+        }
+        let Some(mut end) = cursor else {
+            return self.text.len();
+        };
+        let class = word_class(chars[end].1);
+        while end + 1 < chars.len() && word_class(chars[end + 1].1) == class {
+            end += 1;
+        }
+        chars[end].0 + chars[end].1.len_utf8()
+    }
+
+    /// The maximal same-[`WordClass`] run touching `offset` - what a real double-click selects.
+    /// `offset` landing on whitespace returns `None` (a plain caret there rather than a fabricated
+    /// "word" that isn't really there), matching
+    /// `crate::code_surface::edit_buffer::EditBuffer::select_word_at`'s own rule.
+    pub fn word_range_at(&self, offset: usize) -> Option<Range<usize>> {
+        let offset = self.boundary_at_or_before(offset.min(self.text.len()));
+        let chars: Vec<(usize, char)> = self.text.char_indices().collect();
+        // The char the click actually landed on/just before - the first char whose byte range
+        // contains `offset`, or (a click right at the text's real end) the last char there is.
+        let pos = chars
+            .iter()
+            .position(|&(index, ch)| offset < index + ch.len_utf8())
+            .or_else(|| chars.len().checked_sub(1))?;
+        let class = word_class(chars[pos].1);
+        if class == WordClass::Whitespace {
+            return None;
+        }
+        let mut start = pos;
+        while start > 0 && word_class(chars[start - 1].1) == class {
+            start -= 1;
+        }
+        let mut end = pos;
+        while end + 1 < chars.len() && word_class(chars[end + 1].1) == class {
+            end += 1;
+        }
+        Some(chars[start].0..chars[end].0 + chars[end].1.len_utf8())
+    }
+
+    /// The real selection right now, as the history's own snapshot shape.
+    fn snapshot(&self) -> SelectionSnapshot {
+        SelectionSnapshot::of(&self.selection, self.selection_reversed)
+    }
+
+    /// Puts the selection back from a history snapshot, re-clamped into the *current* text and
+    /// onto real grapheme boundaries - defensive, since a snapshot describes the text as it was
+    /// when it was taken.
+    fn restore(&mut self, snapshot: SelectionSnapshot) {
+        let mut start = self.boundary_at_or_before(snapshot.start.min(self.text.len()));
+        let mut end = self.boundary_at_or_before(snapshot.end.min(self.text.len()));
+        if start > end {
+            std::mem::swap(&mut start, &mut end);
+        }
+        self.selection = start..end;
+        self.selection_reversed = snapshot.reversed && start != end;
+    }
+
+    /// Collapses the selection to a caret at the grapheme boundary at or before `offset` - the
+    /// real target of a plain click, and of `Left`/`Right`/`Home`/`End` once a selection exists.
+    /// Returns whether anything actually moved.
+    pub fn move_to(&mut self, offset: usize) -> bool {
+        let offset = self.boundary_at_or_before(offset.min(self.text.len()));
+        let changed = self.selection != (offset..offset);
+        self.selection = offset..offset;
+        self.selection_reversed = false;
+        changed
+    }
+
+    /// Extends the selection to `offset` from whichever end is currently anchored, flipping
+    /// [`Self::selection_reversed`] if the selection crosses over itself - the drag/Shift+click/
+    /// Shift+arrow primitive, ported from `vendor/zed/crates/gpui/examples/input.rs`'s own
+    /// `TextInput::select_to` (and identical to
+    /// `crate::code_surface::edit_buffer::EditBuffer::select_to`).
+    pub fn select_to(&mut self, offset: usize) -> bool {
+        let offset = self.boundary_at_or_before(offset.min(self.text.len()));
+        let before = (self.selection.clone(), self.selection_reversed);
+        if self.selection_reversed {
+            self.selection.start = offset;
+        } else {
+            self.selection.end = offset;
+        }
+        if self.selection.end < self.selection.start {
+            self.selection_reversed = !self.selection_reversed;
+            self.selection = self.selection.end..self.selection.start;
+        }
+        if self.selection.is_empty() {
+            self.selection_reversed = false;
+        }
+        before != (self.selection.clone(), self.selection_reversed)
+    }
+
+    /// `Ctrl/Cmd+A`.
+    pub fn select_all(&mut self) -> bool {
+        let whole = 0..self.text.len();
+        let changed = self.selection != whole || self.selection_reversed;
+        self.selection = whole;
+        self.selection_reversed = false;
+        changed
+    }
+
+    /// Double-click: selects the word under `offset` ([`Self::word_range_at`]), or just places a
+    /// caret there when `offset` is on whitespace.
+    pub fn select_word_at(&mut self, offset: usize) -> bool {
+        match self.word_range_at(offset) {
+            Some(range) => {
+                let changed = self.selection != range || self.selection_reversed;
+                self.selection = range;
+                self.selection_reversed = false;
+                changed
+            }
+            None => self.move_to(offset),
+        }
+    }
+
+    /// Moves the caret one grapheme cluster left, **collapsing** an active selection to its left
+    /// edge instead - which is what every real text input does, and why a plain arrow key is not
+    /// just "extend with `shift` unset". Returns whether it really moved, so a caller can tell
+    /// "the view needs repainting" from "this keystroke did nothing and should keep propagating".
+    pub fn move_left(&mut self) -> bool {
+        if self.has_selection() {
+            return self.move_to(self.selection.start);
+        }
+        match self.previous_boundary(self.caret()) {
+            Some(offset) => self.move_to(offset),
             None => false,
         }
     }
 
     /// The mirror of [`Self::move_left`].
     pub fn move_right(&mut self) -> bool {
-        match self.next_boundary() {
-            Some(offset) => {
-                self.caret = offset;
-                true
-            }
+        if self.has_selection() {
+            return self.move_to(self.selection.end);
+        }
+        match self.next_boundary(self.caret()) {
+            Some(offset) => self.move_to(offset),
             None => false,
         }
     }
 
     pub fn move_to_start(&mut self) -> bool {
-        let moved = self.caret != 0;
-        self.caret = 0;
-        moved
+        self.move_to(0)
     }
 
     pub fn move_to_end(&mut self) -> bool {
-        let moved = self.caret != self.text.len();
-        self.caret = self.text.len();
-        moved
+        self.move_to(self.text.len())
+    }
+
+    /// Ctrl/Alt+Left - one whole word left, collapsing any selection.
+    pub fn move_word_left(&mut self) -> bool {
+        let from = if self.has_selection() {
+            self.selection.start
+        } else {
+            self.caret()
+        };
+        self.move_to(self.previous_word_boundary(from))
+    }
+
+    /// Ctrl/Alt+Right - one whole word right, collapsing any selection.
+    pub fn move_word_right(&mut self) -> bool {
+        let from = if self.has_selection() {
+            self.selection.end
+        } else {
+            self.caret()
+        };
+        self.move_to(self.next_word_boundary(from))
+    }
+
+    /// Shift+Left.
+    pub fn select_left(&mut self) -> bool {
+        match self.previous_boundary(self.caret()) {
+            Some(offset) => self.select_to(offset),
+            None => false,
+        }
+    }
+
+    /// Shift+Right.
+    pub fn select_right(&mut self) -> bool {
+        match self.next_boundary(self.caret()) {
+            Some(offset) => self.select_to(offset),
+            None => false,
+        }
+    }
+
+    /// Shift+Home.
+    pub fn select_to_start(&mut self) -> bool {
+        self.select_to(0)
+    }
+
+    /// Shift+End.
+    pub fn select_to_end(&mut self) -> bool {
+        self.select_to(self.text.len())
+    }
+
+    /// Ctrl/Alt+Shift+Left.
+    pub fn select_word_left(&mut self) -> bool {
+        self.select_to(self.previous_word_boundary(self.caret()))
+    }
+
+    /// Ctrl/Alt+Shift+Right.
+    pub fn select_word_right(&mut self) -> bool {
+        self.select_to(self.next_word_boundary(self.caret()))
     }
 
     /// Puts the caret at the grapheme boundary at or before `offset` - for a caller that has a
-    /// real byte offset of its own (a click hit-test) rather than an arrow key.
+    /// real byte offset of its own (a click hit-test) rather than an arrow key. An alias of
+    /// [`Self::move_to`], kept for the pre-#336 name.
     pub fn set_caret(&mut self, offset: usize) -> bool {
-        let clamped = self.boundary_at_or_before(offset);
-        let moved = clamped != self.caret;
-        self.caret = clamped;
-        moved
+        self.move_to(offset)
     }
 
-    /// Splices `text` in at the caret, recording it as ordinary typing and leaving the caret after
-    /// what was inserted. Returns whether anything changed.
+    /// The one splice every edit below goes through: replaces `range` with `inserted`, records it
+    /// with the real selection on either side, and leaves a collapsed caret after what was
+    /// inserted. `range` must already be a real, ordered, in-bounds grapheme-boundary range -
+    /// every caller here derives it from [`Self::selection`] or from a boundary method.
+    fn replace_range_recorded(
+        &mut self,
+        range: Range<usize>,
+        inserted: &str,
+        kind: EditKind,
+        now: Instant,
+    ) {
+        let removed = self.text[range.clone()].to_string();
+        let before = self.snapshot();
+        self.text.replace_range(range.clone(), inserted);
+        let caret = range.start + inserted.len();
+        self.selection = caret..caret;
+        self.selection_reversed = false;
+        let after = self.snapshot();
+        self.history.record(
+            TextEdit {
+                at: range.start,
+                removed,
+                inserted: inserted.to_string(),
+            },
+            before,
+            after,
+            kind,
+            now,
+        );
+    }
+
+    /// Splices `text` in **over the current selection** (or at the caret when collapsed),
+    /// recording it as ordinary typing and leaving the caret after what was inserted. Returns
+    /// whether anything changed.
     pub fn insert_str(&mut self, text: &str, now: Instant) -> bool {
-        if text.is_empty() {
+        if text.is_empty() && !self.has_selection() {
             return false;
         }
-        let at = self.caret;
-        let before = SelectionSnapshot::caret(at);
-        self.text.insert_str(at, text);
-        self.caret = at + text.len();
-        let after = SelectionSnapshot::caret(self.caret);
-        self.history.record(
-            TextEdit {
-                at,
-                removed: String::new(),
-                inserted: text.to_string(),
-            },
-            before,
-            after,
-            EditKind::Type,
-            now,
-        );
+        self.replace_range_recorded(self.selection.clone(), text, EditKind::Type, now);
         true
     }
 
-    /// Removes the grapheme cluster **before** the caret - Backspace. Returns whether anything was
-    /// removed.
+    /// Removes the selection if there is one, else the grapheme cluster **before** the caret -
+    /// Backspace, exactly as every real text input behaves. Returns whether anything was removed.
     pub fn backspace(&mut self, now: Instant) -> bool {
-        let Some(at) = self.previous_boundary() else {
+        if self.has_selection() {
+            self.replace_range_recorded(self.selection.clone(), "", EditKind::Delete, now);
+            return true;
+        }
+        let caret = self.caret();
+        let Some(at) = self.previous_boundary(caret) else {
             return false;
         };
-        let removed = self.text[at..self.caret].to_string();
-        let before = SelectionSnapshot::caret(self.caret);
-        self.text.replace_range(at..self.caret, "");
-        self.caret = at;
-        let after = SelectionSnapshot::caret(at);
-        self.history.record(
-            TextEdit {
-                at,
-                removed,
-                inserted: String::new(),
-            },
-            before,
-            after,
-            EditKind::Delete,
-            now,
-        );
+        self.replace_range_recorded(at..caret, "", EditKind::Delete, now);
         true
     }
 
-    /// Removes the grapheme cluster **after** the caret - Delete. The caret does not move, which
-    /// is exactly why this cannot share a coalescing group with [`Self::backspace`] by accident:
-    /// their `before`/`after` snapshots differ.
+    /// Removes the selection if there is one, else the grapheme cluster **after** the caret -
+    /// Delete. With no selection the caret does not move, which is exactly why this cannot share a
+    /// coalescing group with [`Self::backspace`] by accident: their `before`/`after` snapshots
+    /// differ.
     pub fn delete_forward(&mut self, now: Instant) -> bool {
-        let Some(end) = self.next_boundary() else {
+        if self.has_selection() {
+            self.replace_range_recorded(self.selection.clone(), "", EditKind::Delete, now);
+            return true;
+        }
+        let caret = self.caret();
+        let Some(end) = self.next_boundary(caret) else {
             return false;
         };
-        let at = self.caret;
-        let removed = self.text[at..end].to_string();
-        let before = SelectionSnapshot::caret(at);
-        self.text.replace_range(at..end, "");
-        self.history.record(
-            TextEdit {
-                at,
-                removed,
-                inserted: String::new(),
-            },
-            before,
-            SelectionSnapshot::caret(at),
-            EditKind::Delete,
+        self.replace_range_recorded(caret..end, "", EditKind::Delete, now);
+        true
+    }
+
+    /// The pure half of Ctrl/Cmd+C: the text a copy would put on the real clipboard, or `None`
+    /// with nothing selected. The clipboard itself lives at the GPUI boundary - see this type's
+    /// own docs.
+    pub fn copy(&self) -> Option<String> {
+        self.has_selection()
+            .then(|| self.selected_text().to_string())
+    }
+
+    /// The pure half of Ctrl/Cmd+X: removes the selection and hands back what it held, as one
+    /// sealed undo step on both sides (a cut is a discrete, deliberate action, not part of a
+    /// backspace run on either side of it - the same reasoning
+    /// `crate::code_surface::editing::AdeApp::handle_editor_cut_action` already applies).
+    pub fn cut(&mut self, now: Instant) -> Option<String> {
+        let text = self.copy()?;
+        self.history.seal();
+        self.replace_range_recorded(self.selection.clone(), "", EditKind::Delete, now);
+        self.history.seal();
+        Some(text)
+    }
+
+    /// The pure half of Ctrl/Cmd+V: replaces the selection (or inserts at the caret) with real
+    /// clipboard content, as its own sealed undo step in both directions - a paste is one of
+    /// GitHub issue #17's four named group boundaries.
+    ///
+    /// Newlines are flattened to spaces: these are one-line fields, and a `\n` in one would render
+    /// as an unpaintable box and corrupt every offset the row's own hit-testing derives. The same
+    /// choice `vendor/zed/crates/gpui/examples/input.rs`'s own `TextInput::paste` makes
+    /// (`text.replace("\n", " ")`), and for the same reason.
+    pub fn paste(&mut self, text: &str, now: Instant) -> bool {
+        let flattened = text.replace(['\n', '\r'], " ");
+        if flattened.is_empty() && !self.has_selection() {
+            return false;
+        }
+        self.history.seal();
+        self.replace_range_recorded(
+            self.selection.clone(),
+            &flattened,
+            EditKind::Programmatic,
             now,
         );
+        self.history.seal();
         true
     }
 
@@ -850,12 +1212,13 @@ impl TextField {
         if self.text == text {
             return false;
         }
-        let before = SelectionSnapshot::caret(self.caret);
+        let before = self.snapshot();
         let after = SelectionSnapshot::caret(text.len());
         self.history
             .record_replacement(&self.text, text, before, after, now);
         self.text = text.to_string();
-        self.caret = self.text.len();
+        self.selection = self.text.len()..self.text.len();
+        self.selection_reversed = false;
         true
     }
 
@@ -869,18 +1232,27 @@ impl TextField {
     /// [`TextHistory::reset`]'s own docs.
     pub fn reset(&mut self) {
         self.text.clear();
-        self.caret = 0;
+        self.selection = 0..0;
+        self.selection_reversed = false;
         self.history.reset();
+    }
+
+    /// Closes the current undo group, so the next recorded edit always starts a fresh one - the
+    /// caller-driven half of this module's coalescing policy, for a boundary only the call site
+    /// knows about. See [`TextHistory::seal`].
+    pub fn seal_history(&mut self) {
+        self.history.seal();
     }
 
     pub fn can_undo(&self) -> bool {
         self.history.can_undo()
     }
 
-    /// Steps one group back, restoring the caret the group recorded as its `before`. Returns
-    /// whether anything was actually undone - `false` both for an empty history and (defensively)
-    /// for a group that doesn't match the current text, which leaves the text, the caret and the
-    /// cursor untouched rather than corrupting any of them.
+    /// Steps one group back, restoring the whole selection the group recorded as its `before` -
+    /// not just the caret, so undoing a type-over-a-selection really does put the selection back.
+    /// Returns whether anything was actually undone - `false` both for an empty history and
+    /// (defensively) for a group that doesn't match the current text, which leaves the text, the
+    /// selection and the cursor untouched rather than corrupting any of them.
     pub fn undo(&mut self) -> bool {
         let Some(group) = self.history.peek_undo() else {
             return false;
@@ -893,12 +1265,12 @@ impl TextField {
             }
         }
         self.text = candidate;
-        self.caret = self.boundary_at_or_before(group.before.start);
+        self.restore(group.before);
         self.history.commit_undo();
         true
     }
 
-    /// The mirror of [`Self::undo`], restoring the group's `after` caret.
+    /// The mirror of [`Self::undo`], restoring the group's `after` selection.
     pub fn redo(&mut self) -> bool {
         let Some(group) = self.history.peek_redo() else {
             return false;
@@ -910,7 +1282,7 @@ impl TextField {
             }
         }
         self.text = candidate;
-        self.caret = self.boundary_at_or_before(group.after.start);
+        self.restore(group.after);
         self.history.commit_redo();
         true
     }
@@ -919,21 +1291,59 @@ impl TextField {
     /// vocabulary rather than whichever half it remembered to wire - which is precisely how these
     /// fields ended up append/backspace-only for eight surfaces in the first place.
     ///
-    /// `key`/`key_char` come straight off `gpui::Keystroke`. Returns whether anything changed
-    /// (text *or* caret), i.e. whether the caller should `cx.notify()` and stop propagation.
+    /// `key`/`key_char` come straight off `gpui::Keystroke`; `modifiers` is
+    /// `crate::root::widgets::text_editing_modifiers`' own translation of that keystroke's real
+    /// modifier set (see [`EditingModifiers`] for why the platform decision lives there and not
+    /// here). Returns whether anything changed (text *or* selection), i.e. whether the caller
+    /// should `cx.notify()` and stop propagation.
     ///
     /// Deliberately does **not** handle `escape`, `enter`, `tab` or the arrow keys' `up`/`down`:
     /// every one of those means something different per surface (cancel, accept, move a list
     /// selection), and a shared default would silently take them away from the handler that owns
-    /// them. A caller matches its own keys first and falls through to this.
-    pub fn handle_editing_key(&mut self, key: &str, key_char: Option<&str>, now: Instant) -> bool {
+    /// them. A caller matches its own keys first and falls through to this. Clipboard and
+    /// select-all are not here either - those arrive as real, rebindable
+    /// `crate::root::TextCopy`/`TextCut`/`TextPaste`/`TextSelectAll` actions rather than as
+    /// hard-coded keystrokes, and only the action path can reach the OS clipboard.
+    pub fn handle_editing_key(
+        &mut self,
+        key: &str,
+        key_char: Option<&str>,
+        modifiers: EditingModifiers,
+        now: Instant,
+    ) -> bool {
         match key {
-            "left" => self.move_left(),
-            "right" => self.move_right(),
-            "home" => self.move_to_start(),
-            "end" => self.move_to_end(),
+            "left" => match (modifiers.extend, modifiers.word) {
+                (false, false) => self.move_left(),
+                (false, true) => self.move_word_left(),
+                (true, false) => self.select_left(),
+                (true, true) => self.select_word_left(),
+            },
+            "right" => match (modifiers.extend, modifiers.word) {
+                (false, false) => self.move_right(),
+                (false, true) => self.move_word_right(),
+                (true, false) => self.select_right(),
+                (true, true) => self.select_word_right(),
+            },
+            "home" => {
+                if modifiers.extend {
+                    self.select_to_start()
+                } else {
+                    self.move_to_start()
+                }
+            }
+            "end" => {
+                if modifiers.extend {
+                    self.select_to_end()
+                } else {
+                    self.move_to_end()
+                }
+            }
             "backspace" => self.backspace(now),
             "delete" => self.delete_forward(now),
+            // `modifiers.word` is the platform's Ctrl/Alt: a modified letter is an application
+            // shortcut, never text to insert, even on the platforms where the OS still hands one a
+            // `key_char`.
+            _ if modifiers.word => false,
             _ => match key_char {
                 Some(text) if !text.is_empty() => self.insert_str(text, now),
                 _ => false,

--- a/crates/app/src/text_history.rs
+++ b/crates/app/src/text_history.rs
@@ -1124,7 +1124,17 @@ impl TextField {
         if text.is_empty() && !self.has_selection() {
             return false;
         }
-        self.replace_range_recorded(self.selection.clone(), text, EditKind::Type, now);
+        // [`EditKind::for_replacement`] rather than a flat [`EditKind::Type`]: inserting the empty
+        // string *over a selection* is a deletion, and mislabelling it would let it coalesce with
+        // a typing burst on either side of it. Not reachable from `handle_editing_key` (which
+        // never passes an empty `key_char`), but this is a `pub` primitive and the honest kind
+        // costs nothing.
+        self.replace_range_recorded(
+            self.selection.clone(),
+            text,
+            EditKind::for_replacement(text),
+            now,
+        );
         true
     }
 

--- a/crates/app/src/text_history.rs
+++ b/crates/app/src/text_history.rs
@@ -2437,4 +2437,423 @@ mod tests {
         }
         assert_eq!(text, "one\ntwo\nthree\n");
     }
+
+    // GitHub issue #336: a real selection. Before this, `TextField` carried exactly one
+    // `caret: usize` and its own docs said selection was "deliberately not implemented".
+
+    fn shift() -> EditingModifiers {
+        EditingModifiers {
+            extend: true,
+            word: false,
+        }
+    }
+
+    fn word() -> EditingModifiers {
+        EditingModifiers {
+            extend: false,
+            word: true,
+        }
+    }
+
+    fn word_shift() -> EditingModifiers {
+        EditingModifiers {
+            extend: true,
+            word: true,
+        }
+    }
+
+    #[test]
+    fn a_fresh_field_has_a_collapsed_selection_which_is_just_a_caret() {
+        let mut field = TextField::new();
+        type_into(&mut field, "origin/main", t0());
+        assert!(!field.has_selection());
+        assert_eq!(field.selection(), field.caret()..field.caret());
+        assert_eq!(field.selected_text(), "");
+        assert_eq!(field.copy(), None, "nothing selected means nothing to copy");
+    }
+
+    #[test]
+    fn shift_right_extends_and_shift_left_shrinks_the_same_selection() {
+        let mut field = TextField::new();
+        let now = t0();
+        type_into(&mut field, "origin/main", now);
+        field.move_to_start();
+
+        assert!(field.select_right());
+        assert!(field.select_right());
+        assert!(field.select_right());
+        assert_eq!(field.selected_text(), "ori");
+        assert_eq!(field.caret(), 3, "the caret is the moving end");
+        assert_eq!(
+            field.anchor(),
+            0,
+            "the anchor stayed where the selection began"
+        );
+        assert!(!field.selection_reversed());
+
+        assert!(field.select_left());
+        assert_eq!(
+            field.selected_text(),
+            "or",
+            "shrinking back is the same one primitive, not a separate case"
+        );
+    }
+
+    #[test]
+    fn a_selection_built_leftward_is_really_reversed_and_crosses_over_cleanly() {
+        let mut field = TextField::new();
+        let now = t0();
+        type_into(&mut field, "origin/main", now);
+        field.move_to(6);
+
+        assert!(field.select_left());
+        assert!(field.select_left());
+        assert_eq!(field.selected_text(), "in");
+        assert!(
+            field.selection_reversed(),
+            "extended leftward, so the caret is on the range's start"
+        );
+        assert_eq!(field.caret(), 4);
+        assert_eq!(field.anchor(), 6);
+
+        // ...and dragging back past the anchor flips it rather than producing an inverted range:
+        // the anchor (6) stays put and the caret crosses to the far side of it.
+        field.select_to(9);
+        assert_eq!(field.selected_text(), "/ma");
+        assert!(!field.selection_reversed());
+        assert_eq!(field.caret(), 9);
+        assert_eq!(field.anchor(), 6);
+    }
+
+    #[test]
+    fn a_plain_arrow_key_collapses_a_selection_to_its_near_edge_rather_than_moving() {
+        let mut field = TextField::new();
+        let now = t0();
+        type_into(&mut field, "origin/main", now);
+        field.move_to(2);
+        field.select_to(6);
+        assert_eq!(field.selected_text(), "igin");
+
+        // Left collapses to the *start*, and lands exactly there - not one grapheme further left,
+        // which is what a naive "collapse then move" would do and what no real text input does.
+        assert!(field.move_left());
+        assert!(!field.has_selection());
+        assert_eq!(field.caret(), 2);
+
+        field.select_to(6);
+        assert!(field.move_right());
+        assert!(!field.has_selection());
+        assert_eq!(field.caret(), 6, "Right collapses to the end");
+    }
+
+    #[test]
+    fn select_all_selects_the_whole_field_and_a_plain_key_replaces_it() {
+        let mut field = TextField::new();
+        let now = t0();
+        type_into(&mut field, "origin/main", now);
+        assert!(field.select_all());
+        assert_eq!(field.selected_text(), "origin/main");
+        assert!(
+            !field.select_all(),
+            "selecting all twice is a real no-op, so a caller can stop propagating honestly"
+        );
+
+        assert!(field.insert_str("x", now));
+        assert_eq!(
+            field.as_str(),
+            "x",
+            "typing over a selection replaces it, it does not splice beside it"
+        );
+        assert_eq!(field.caret(), 1);
+        assert!(!field.has_selection());
+    }
+
+    #[test]
+    fn backspace_and_delete_with_a_selection_remove_the_whole_range() {
+        let now = t0();
+        let mut backspaced = TextField::new();
+        type_into(&mut backspaced, "origin/main", now);
+        backspaced.move_to(0);
+        backspaced.select_to(7);
+        assert!(backspaced.backspace(now));
+        assert_eq!(backspaced.as_str(), "main");
+        assert_eq!(backspaced.caret(), 0);
+
+        let mut deleted = TextField::new();
+        type_into(&mut deleted, "origin/main", now);
+        deleted.move_to(0);
+        deleted.select_to(7);
+        assert!(deleted.delete_forward(now));
+        assert_eq!(
+            deleted.as_str(),
+            "main",
+            "Delete with a selection removes the selection, not the character after it"
+        );
+    }
+
+    #[test]
+    fn a_double_click_selects_the_word_under_the_pointer_and_nothing_in_whitespace() {
+        let mut field = TextField::new();
+        let now = t0();
+        type_into(&mut field, "fix the flaky test", now);
+
+        assert!(field.select_word_at(5));
+        assert_eq!(field.selected_text(), "the");
+
+        // `.`/`/` are punctuation, which is its own class - `foo.bar` is two words, matching the
+        // code editor's own `word_class` (this is literally the same function).
+        let mut path = TextField::new();
+        type_into(&mut path, "src/app/main.rs", now);
+        assert!(path.select_word_at(9));
+        assert_eq!(path.selected_text(), "main");
+
+        // A double-click on whitespace selects nothing and just places a caret.
+        assert!(field.select_word_at(3));
+        assert!(!field.has_selection());
+        assert_eq!(field.caret(), 3);
+    }
+
+    #[test]
+    fn word_wise_movement_hops_whole_words_and_shift_extends_over_them() {
+        let mut field = TextField::new();
+        let now = t0();
+        type_into(&mut field, "origin/feature-branch", now);
+        field.move_to_end();
+
+        assert!(field.move_word_left());
+        assert_eq!(field.caret(), "origin/feature-".len(), "back over `branch`");
+        assert!(field.move_word_left());
+        assert_eq!(
+            field.caret(),
+            "origin/feature".len(),
+            "a run of punctuation is its own hop - `word_class`'s own documented rule, shared \
+             verbatim with the code editor"
+        );
+        assert!(field.move_word_left());
+        assert_eq!(field.caret(), "origin/".len(), "back over `feature`");
+
+        field.move_to_start();
+        assert!(field.select_word_right());
+        assert_eq!(
+            field.selected_text(),
+            "origin",
+            "Ctrl+Shift+Right extends over a whole word rather than one grapheme"
+        );
+    }
+
+    #[test]
+    fn copy_leaves_the_field_alone_and_cut_removes_exactly_the_selected_range() {
+        let now = t0();
+        let mut field = TextField::new();
+        type_into(&mut field, "origin/main", now);
+        field.move_to(0);
+        field.select_to(6);
+
+        assert_eq!(field.copy().as_deref(), Some("origin"));
+        assert_eq!(field.as_str(), "origin/main", "copy never edits");
+        assert!(
+            field.has_selection(),
+            "...and never collapses the selection"
+        );
+
+        assert_eq!(field.cut(now).as_deref(), Some("origin"));
+        assert_eq!(field.as_str(), "/main");
+        assert_eq!(field.caret(), 0);
+        assert!(!field.has_selection());
+        assert_eq!(field.cut(now), None, "nothing selected, nothing cut");
+    }
+
+    #[test]
+    fn paste_replaces_a_selection_and_a_copy_then_paste_round_trips_the_same_text() {
+        let now = t0();
+        let mut field = TextField::new();
+        type_into(&mut field, "origin/main", now);
+        field.move_to(0);
+        field.select_to(6);
+        let copied = field.copy().expect("a real selection was copied");
+
+        // Paste over a *different* selection: the whole range goes, the clipboard text lands.
+        field.move_to(7);
+        field.select_to(11);
+        assert!(field.paste(&copied, now));
+        assert_eq!(field.as_str(), "origin/origin");
+        assert_eq!(field.caret(), "origin/origin".len());
+
+        // ...and a collapsed paste inserts at the caret.
+        field.move_to(0);
+        assert!(field.paste("upstream-", now));
+        assert_eq!(field.as_str(), "upstream-origin/origin");
+    }
+
+    #[test]
+    fn a_pasted_newline_becomes_a_space_rather_than_an_unpaintable_line_break() {
+        let mut field = TextField::new();
+        assert!(field.paste("first\nsecond\r\nthird", t0()));
+        assert_eq!(
+            field.as_str(),
+            "first second  third",
+            "these are one-line fields; a real `\\n` in one would corrupt every offset the row's \
+             own hit-testing derives from it"
+        );
+    }
+
+    #[test]
+    fn undo_after_typing_over_a_selection_restores_the_selection_itself_not_just_a_caret() {
+        let now = t0();
+        let mut field = TextField::new();
+        type_into(&mut field, "origin/main", now);
+        field.move_to(0);
+        field.select_to(6);
+        assert!(field.insert_str("upstream", now));
+        assert_eq!(field.as_str(), "upstream/main");
+
+        assert!(field.undo());
+        assert_eq!(field.as_str(), "origin/main");
+        assert_eq!(
+            field.selection(),
+            0..6,
+            "the whole selection comes back, which is what makes a second Ctrl+Z land where the \
+             user expects rather than at a bare caret"
+        );
+        assert_eq!(field.selected_text(), "origin");
+
+        assert!(field.redo());
+        assert_eq!(field.as_str(), "upstream/main");
+        assert_eq!(
+            field.selection(),
+            8..8,
+            "redo restores the collapsed caret the edit really left behind"
+        );
+    }
+
+    #[test]
+    fn undo_after_a_cut_puts_the_cut_text_and_its_selection_back() {
+        let now = t0();
+        let mut field = TextField::new();
+        type_into(&mut field, "origin/main", now);
+        field.move_to(7);
+        field.select_to(11);
+        assert_eq!(field.cut(now).as_deref(), Some("main"));
+        assert_eq!(field.as_str(), "origin/");
+
+        assert!(field.undo());
+        assert_eq!(field.as_str(), "origin/main");
+        assert_eq!(field.selection(), 7..11);
+    }
+
+    #[test]
+    fn a_paste_is_its_own_undo_step_on_both_sides_of_a_typing_burst() {
+        let now = t0();
+        let mut field = TextField::new();
+        type_into(&mut field, "abc", now);
+        assert_eq!(field.history_len(), 1);
+        assert!(field.paste("XY", now));
+        assert_eq!(
+            field.history_len(),
+            2,
+            "a paste never joins the burst before it"
+        );
+        type_into(&mut field, "def", now);
+        assert_eq!(
+            field.history_len(),
+            3,
+            "...and the burst after it never joins the paste"
+        );
+        assert!(field.undo());
+        assert_eq!(field.as_str(), "abcXY");
+        assert!(field.undo());
+        assert_eq!(field.as_str(), "abc");
+    }
+
+    #[test]
+    fn a_selection_change_between_two_keystrokes_starts_a_new_undo_step() {
+        let now = t0();
+        let mut field = TextField::new();
+        type_into(&mut field, "abc", now);
+        assert_eq!(field.history_len(), 1);
+        // No text edit at all here - only the selection moved.
+        assert!(field.select_left());
+        type_into(&mut field, "d", now);
+        assert_eq!(
+            field.history_len(),
+            2,
+            "the module's own 'a caret jump is a group boundary' rule covers selection changes \
+             for free, because the check is full-snapshot equality"
+        );
+    }
+
+    #[test]
+    fn handle_editing_key_routes_shift_and_word_modifiers_to_the_right_primitive() {
+        let now = t0();
+        let mut field = TextField::new();
+        type_into(&mut field, "origin/main", now);
+
+        field.move_to_start();
+        assert!(field.handle_editing_key("right", None, shift(), now));
+        assert_eq!(field.selected_text(), "o");
+        assert!(field.handle_editing_key("end", None, shift(), now));
+        assert_eq!(field.selected_text(), "origin/main");
+        assert!(field.handle_editing_key("home", None, shift(), now));
+        assert!(
+            !field.has_selection(),
+            "Shift+Home from a selection anchored at 0 collapses it back onto that anchor"
+        );
+
+        field.move_to_end();
+        assert!(field.handle_editing_key("left", None, word(), now));
+        assert_eq!(field.caret(), "origin/".len());
+        assert!(field.handle_editing_key("left", None, word_shift(), now));
+        assert_eq!(field.selected_text(), "/");
+
+        // A word-modified letter is an application shortcut, never text to insert.
+        let before = field.as_str().to_string();
+        assert!(!field.handle_editing_key("a", Some("a"), word(), now));
+        assert_eq!(field.as_str(), before);
+    }
+
+    #[test]
+    fn every_selection_edge_lands_on_a_real_grapheme_boundary() {
+        let now = t0();
+        let mut field = TextField::new();
+        // A flag is one grapheme cluster made of two 4-byte scalars.
+        type_into(&mut field, "caf\u{e9}\u{1f1eb}\u{1f1f7}x", now);
+        field.move_to_start();
+        assert!(field.select_right());
+        assert!(field.select_right());
+        assert!(field.select_right());
+        assert!(field.select_right());
+        assert_eq!(field.selected_text(), "caf\u{e9}");
+        assert!(field.select_right());
+        assert_eq!(
+            field.selected_text(),
+            "caf\u{e9}\u{1f1eb}\u{1f1f7}",
+            "one Shift+Right crosses the whole flag cluster, never half of it"
+        );
+
+        // An out-of-range or mid-cluster offset from a click hit-test is clamped, never a panic.
+        field.move_to(usize::MAX);
+        assert_eq!(field.caret(), field.as_str().len());
+        field.move_to(0);
+        field.select_to(5);
+        assert!(field.as_str().is_char_boundary(field.selection().end));
+    }
+
+    #[test]
+    fn seeded_and_set_both_leave_a_collapsed_selection_at_the_end() {
+        let seeded = TextField::seeded("main.rs");
+        assert!(!seeded.has_selection());
+        assert_eq!(seeded.caret(), "main.rs".len());
+
+        let mut field = TextField::new();
+        let now = t0();
+        type_into(&mut field, "abc", now);
+        field.select_all();
+        assert!(field.set("xyz", now));
+        assert!(
+            !field.has_selection(),
+            "a programmatic replacement leaves a caret, not a selection over text the user \
+             never selected"
+        );
+        assert_eq!(field.caret(), 3);
+    }
 }

--- a/crates/app/src/text_history.rs
+++ b/crates/app/src/text_history.rs
@@ -1852,7 +1852,7 @@ mod tests {
     /// `handle_editing_key`'s character arm receives it.
     fn type_into(field: &mut TextField, text: &str, now: Instant) {
         for ch in text.chars() {
-            field.handle_editing_key("", Some(&ch.to_string()), now);
+            field.handle_editing_key("", Some(&ch.to_string()), EditingModifiers::none(), now);
         }
     }
 
@@ -1870,7 +1870,7 @@ mod tests {
         let now = t0();
         type_into(&mut field, "refresh_token", now);
         for _ in 0.."_token".len() {
-            assert!(field.handle_editing_key("left", None, now));
+            assert!(field.handle_editing_key("left", None, EditingModifiers::none(), now));
         }
         assert_eq!(field.split_at_caret(), ("refresh", "_token"));
         type_into(&mut field, "ed", now);
@@ -1888,15 +1888,15 @@ mod tests {
         let mut field = TextField::new();
         let now = t0();
         type_into(&mut field, "abcd", now);
-        field.handle_editing_key("left", None, now);
-        field.handle_editing_key("left", None, now);
+        field.handle_editing_key("left", None, EditingModifiers::none(), now);
+        field.handle_editing_key("left", None, EditingModifiers::none(), now);
         assert_eq!(field.split_at_caret(), ("ab", "cd"));
 
-        assert!(field.handle_editing_key("backspace", None, now));
+        assert!(field.handle_editing_key("backspace", None, EditingModifiers::none(), now));
         assert_eq!(field.as_str(), "acd");
         assert_eq!(field.caret(), 1);
 
-        assert!(field.handle_editing_key("delete", None, now));
+        assert!(field.handle_editing_key("delete", None, EditingModifiers::none(), now));
         assert_eq!(field.as_str(), "ad");
         assert_eq!(field.caret(), 1, "Delete never moves the caret");
     }
@@ -1906,14 +1906,14 @@ mod tests {
         let mut field = TextField::new();
         let now = t0();
         type_into(&mut field, "abc", now);
-        assert!(field.handle_editing_key("home", None, now));
+        assert!(field.handle_editing_key("home", None, EditingModifiers::none(), now));
         assert_eq!(field.caret(), 0);
         assert!(
-            !field.handle_editing_key("home", None, now),
+            !field.handle_editing_key("home", None, EditingModifiers::none(), now),
             "a key that moves nothing must report so, or the caller stops propagating a \
              keystroke it did not use"
         );
-        assert!(field.handle_editing_key("end", None, now));
+        assert!(field.handle_editing_key("end", None, EditingModifiers::none(), now));
         assert_eq!(field.caret(), 3);
     }
 
@@ -1925,9 +1925,9 @@ mod tests {
         let cluster = "\u{1f468}\u{200d}\u{1f469}\u{200d}\u{1f467}";
         field.insert_str(cluster, now);
         field.insert_str("x", now);
-        assert!(field.handle_editing_key("left", None, now));
+        assert!(field.handle_editing_key("left", None, EditingModifiers::none(), now));
         assert_eq!(field.caret(), cluster.len());
-        assert!(field.handle_editing_key("left", None, now));
+        assert!(field.handle_editing_key("left", None, EditingModifiers::none(), now));
         assert_eq!(
             field.caret(),
             0,
@@ -1935,9 +1935,9 @@ mod tests {
         );
 
         field.move_to_end();
-        assert!(field.handle_editing_key("backspace", None, now));
+        assert!(field.handle_editing_key("backspace", None, EditingModifiers::none(), now));
         assert_eq!(field.as_str(), cluster);
-        assert!(field.handle_editing_key("backspace", None, now));
+        assert!(field.handle_editing_key("backspace", None, EditingModifiers::none(), now));
         assert_eq!(
             field.as_str(),
             "",
@@ -1952,7 +1952,7 @@ mod tests {
         let now = t0();
         type_into(&mut field, "abc", now);
         assert_eq!(field.history_len(), 1);
-        field.handle_editing_key("home", None, now);
+        field.handle_editing_key("home", None, EditingModifiers::none(), now);
         type_into(&mut field, "X", now);
         assert_eq!(
             field.history_len(),
@@ -2024,7 +2024,7 @@ mod tests {
         let now = t0();
         for key in ["escape", "enter", "tab", "up", "down"] {
             assert!(
-                !field.handle_editing_key(key, None, now),
+                !field.handle_editing_key(key, None, EditingModifiers::none(), now),
                 "`{key}` means something different on every surface - a shared default would \
                  silently take it away from the handler that owns it"
             );


### PR DESCRIPTION
Closes #336.

> Text inputs do not have selection and standard copy/paste/cut. Look at GPUI and how zed does inputs this could help.

## The data model

`text_history::TextField` carried exactly one `caret: usize`, and its own docs said selection was "deliberately not implemented". It now carries a real **anchor/head** pair, in exactly the shape `vendor/zed/crates/gpui/examples/input.rs`'s own `TextInput` and this app's own `code_surface::edit_buffer::EditBuffer` already use:

```rust
selection: Range<usize>,     // ordered, in-bounds, both ends on a grapheme boundary
selection_reversed: bool,    // true => the caret sits on `start`, not `end`
```

That carries the same information an explicit `(anchor, head)` pair does - a selection really can be built in either direction - while answering "what is selected?" without a `min`/`max` at every call site, and it makes a `SelectionSnapshot` round-trip through it with **no conversion at all**, which is what lets undo/redo restore the whole selection rather than just a caret. A *collapsed* selection is the ordinary single-caret case, so every pre-#336 caller kept working unchanged.

`select_to` is ported verbatim from the GPUI example's own `TextInput::select_to` (flip `selection_reversed` when the range crosses over itself). Word boundaries come from `word_class`, which was **moved out of `edit_buffer` into `text_history`** and is now shared by the code editor and the simple inputs - one classification rule, not two that can drift.

## What is new

- **Selection state**: `selection()`/`selection_reversed()`/`anchor()`/`selected_text()`/`has_selection()`, plus `move_to`/`select_to`/`select_all`/`select_word_at`/`word_range_at`.
- **Keyboard**: `Shift+Left/Right/Home/End`, `Ctrl+Left/Right` (Alt on macOS) word-wise, `Ctrl+Shift+Left/Right` word-wise extension. A **plain** arrow key collapses to the near edge rather than moving - standard behaviour, and not the same thing as "extend with shift unset".
- **Mouse**: click to place the caret, drag to select, double-click to select the word, Shift+click to extend. Hit-testing is `gpui::ShapedLine::closest_index_for_x` over the line shaped once by the row's own overlay - the same `(bounds, ShapedLine)` idiom `code_surface::editing`'s editable rows already use, recorded per field in `AdeApp::simple_input_layout`.
- **Clipboard**: four new real, rebindable actions - `TextCopy`/`TextCut`/`TextPaste`/`TextSelectAll` on `mod+C/X/V/A` - through `gpui::App::write_to_clipboard`/`read_from_clipboard`, the app's own existing clipboard idiom. Copy/cut act on the selection; paste replaces it (or inserts at the caret), flattening newlines to spaces exactly as the GPUI example's own `paste` does.
- **Backspace/Delete** with a selection remove the whole range.
- **Undo/redo** restore the full `SelectionSnapshot`. The coalescing policy needed no change: its boundary check is full-snapshot equality, so a selection change is already a group boundary for free.

## Rendering

The row has two shapes now, and that is what makes both correct:

- **Collapsed** - leading span, caret, trailing span, exactly as before. The caret's position comes from real flex layout, pixel-exact by construction.
- **Selected** - **one** span with no caret at all, and the selected range painted as a real quad by the same `gpui::canvas` overlay that does the hit-testing. The quad's edges are `x_for_index` over the line shaped **once**, which is only accurate if the visible glyphs really are one contiguous run - GitHub issue #170's own measured lesson applied here.

Hiding the caret while a selection is up matches both the GPUI example (`if selected_range.is_empty()` gates its cursor quad) and `EditBuffer::cursor_within_line`. Colours are `theme::editor::SELECTION` + `SELECTION_OPACITY`/`SELECTION_INACTIVE_OPACITY` - the existing tokens the code editor already paints selections with, not new ones.

One real fix fell out: the caret bar is now **zero-width in flow** (a `w(0)` anchor holding an `absolute()` 1.5px child). As an ordinary flex item it displaced the trailing half of a line 1.5px whenever the caret was mid-string - visible as text jittering while arrowing, and a systematic disagreement between painted glyphs and the shaped line the hit test uses.

## Call sites

All **thirteen** `"text-input"` surfaces, not a subset. Six of them - the command palette, the commit composer, the file-tree inline name editor, the rebase `reword` field, the theme-seed field and the git-graph branch prompt - were still hand-assembling their own caret+text row and are now migrated onto `render_simple_input_row`. Three of those had carets pinned to the end of the text whatever `TextField::caret` said; the tree's inline editor didn't have a caret element at all, just a `│` glyph appended to the name.

Nine hand-rolled `"backspace" => …, key_char => insert_str` key handlers are gone, replaced by `TextField::handle_editing_key` - which is what actually gives every one of those fields caret movement, selection and word-wise navigation at once.

Two new shared pieces carry the per-surface half:
- `widgets::TextFieldHandle` - how to reach one real field (several live behind an `Option` that may have closed, or are one *row* of a list) plus the follow-up work its surface runs on change (the Search panel restarts its debounced walk, the rail drops its armed confirmations, a note card persists).
- `widgets::text_editing_modifiers` - the GPUI↔`text_history` boundary, where the platform decision lives (word-wise is Alt on macOS, Ctrl elsewhere). This replaced the flat "any of Ctrl/Alt/Cmd means not ours" guard nine call sites each carried, which is precisely why `Ctrl+Left` did nothing anywhere.

## Scoping

The four new bindings are `Some("text-input && !file-editor && !merge-editor")`. The exclusions are load-bearing: the code surface and the merge editor both carry `"text-input"` *in the same context frame* as their own tag (deliberately, so `TextUndo`/`TextRedo` reach their `EditBuffer` history), and without them `mod+C` would match `EditorCopy` **and** `TextCopy` at the same predicate depth - leaving the winner to registration order, which is the exact bug class this repo's keymap docs count seven-plus instances of. Two new predicate-logic tests assert both halves against every real context stack.

## Tests

- **23** new unit tests over the selection model: anchor/head and cross-over, collapse rules, word selection and the whitespace case, grapheme-cluster edges (a flag is one Shift+Right), clipboard round-trip, cut/paste undo grouping, undo restoring the selection itself.
- **9** new `#[gpui::test]`s driving the real rail filter: real `simulate_mouse_down`/`_move`/`_up` click, drag (including past the field's right edge), double-click via `click_count`, Shift+click, `mod+A`/`C`/`X`/`V` through the real registered key bindings and the real system clipboard, and a check that the selection quad and the click hit test read the same recorded `ShapedLine`.
- Two keymap scoping-matrix tests.

`cargo test -p app --lib`: **3100 passed**. The 16 failures are the known inotify-`max_user_instances` contention flakies (`file_tree_watch`/`worktree_watch`/`hooks`) - all pass in isolation, verified.

## Real functional verification

Driven over X11 against the real app (real clicks/drags/keystrokes, real clipboard), across four call sites:

- **Rail filter** - drag-selected `origin/`, double-clicked `branch`, dragged past the right edge to select everything, `Shift+Left` extension.
- **Command palette** - `Ctrl+Left` word movement (impossible there before), `Ctrl+Shift+Left` word selection, `Ctrl+X` cut, `Ctrl+Z` restoring both text *and* selection. Its 16px/3px/2px caret metrics from `Jerry.dc.html` are preserved through `SimpleInputCaret`.
- **Search panel query** - `Ctrl+C` in the rail filter, `Ctrl+V` here: real cross-field clipboard round-trip, and the search really re-ran against the pasted text.
- **File-tree inline rename** - double-click selected `README`, drag-select, `Ctrl+A`.

## Deliberately out of scope

The **code editor** (`code_surface::edit_buffer::EditBuffer`) is not touched. Checked rather than assumed: it already has a complete, richer selection implementation of its own - `select_to`/`select_word_at`/`select_line_at`, drag, Shift+click, Alt+click multi-cursor, real `Editor*` clipboard actions - and issue #336 is about the one-line inputs. The only thing shared between the two is now `word_class`, moved down into `text_history` so both agree on where a word ends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
