### PR TITLE
fix(search): layer an always-on explicit exclude list under a toggleable gitignore layer

### DIFF
--- a/crates/app/src/search/engine.rs
+++ b/crates/app/src/search/engine.rs
@@ -24,8 +24,8 @@
 //! A `target/`- or `node_modules`-style build/dependency directory can hold hundreds of thousands
 //! of files, and (see "Scoped to real content" below) this walk no longer even opens one -
 //! but the caps here are kept regardless, as real defense in depth against whatever the active
-//! worktree really contains once it *is* real, trackable content: an enormous monorepo, a
-//! generated-and-committed directory, or the fallback walk's own non-git path. Four real limits,
+//! worktree really contains once it *is* real, trackable content: an enormous monorepo, or a
+//! generated-and-committed directory not on the explicit exclude list. Four real limits,
 //! each reported honestly rather than silently applied: [`MAX_MATCHES`], [`MAX_SCANNED_FILES`],
 //! [`MAX_FILE_BYTES`] and a binary-file check. [`SearchOutcome::truncated`] is what the panel's
 //! count row turns into a real truncation notice - the issue's own "results cap with an honest
@@ -69,30 +69,32 @@
 //! ... it can take 10 seconds", plus its own corroborating clue - "the perf of the search seems
 //! faster after the first query". Both are explained by the same real defect, and neither the
 //! rayon batching above nor the cancellation below touch it, because it sits one step earlier:
-//! candidate *discovery*. The walk that fed both of those fixes candidates
-//! ([`collect_files_by_walking`], now the fallback path below) skipped only `.git` - every other
-//! directory, including a `.gitignore`d build or dependency directory, was opened and `stat`-ed
-//! like any other. Measured directly against this application's *own* checkout: 125,242 files on
-//! disk, of which 99,250 (79%) sit under its own `target/` - 31 GB of `.gitignore`d Rust build
-//! output. [`MAX_SCANNED_FILES`] (20,000) is smaller than `target/` alone, so the old walk hit
-//! that cap, and reported itself truncated, entirely inside `target/` - before a single real
-//! source file was ever read. That is a real, on-disk directory walk (`read_dir` plus a `stat`
-//! per entry across however much of `target/`'s tree it reached before the cap), which costs real
-//! wall-clock time proportional to how much of that metadata the OS has to fetch from storage
-//! rather than serve from its own dentry/page cache - explaining both reports at once: slow
-//! (real, uncached I/O across tens of thousands of build-output entries) the first time, and
-//! faster on every query after (the same metadata, now warm in the OS cache).
+//! candidate *discovery*. The walk that fed both of those fixes candidates skipped only `.git` -
+//! every other directory, including a `.gitignore`d build or dependency directory, was opened and
+//! `stat`-ed like any other. Measured directly against this application's *own* checkout: 125,242
+//! files on disk, of which 99,250 (79%) sit under its own `target/` - 31 GB of Rust build output.
+//! [`MAX_SCANNED_FILES`] (20,000) is smaller than `target/` alone, so the old walk hit that cap,
+//! and reported itself truncated, entirely inside `target/` - before a single real source file
+//! was ever read.
 //!
-//! The real fix is [`wt_core::worktree_files::list_worktree_files`]: `git ls-files --cached
-//! --others --exclude-standard`, the same "what does this worktree really contain" question
-//! `wt_core::review::measure_untracked` already answers for the git-snapshot side of this
-//! codebase (see that module's own docs for the near-identical 19 GB untracked-directory incident
-//! this project has already hit once). Unlike a raw walk, `ls-files` never opens a directory once
-//! its own exclude rule matches it - so a build/dependency directory costs one `stat` on the
-//! directory itself, not one per file inside it. Measured directly against this repository: all
-//! 25,992 real files, in 73ms. [`collect_files_by_walking`] stays as the fallback for the one
-//! case `git` cannot answer - `worktree_path` is not (or is no longer) a real git worktree - so
-//! search still functions there; it is no longer the common path.
+//! The first fix here (#387/#388) made [`wt_core::worktree_files::list_worktree_files`] (`git
+//! ls-files --cached --others --exclude-standard`) the *sole* candidate source, which fixed the
+//! real regression but, as a direct, immediate live pushback put it: "Wait what you made the
+//! search respect gitignore? This should have nothing to do with git?" - correct: a search whose
+//! entire notion of "don't walk into `target/`" was defined by `.gitignore`, and which stopped
+//! excluding anything at all outside a real git worktree, was never the intended fix.
+//!
+//! GitHub issue #394 reworked this into the two-layer model [`crate::search::exclude`]'s own
+//! module docs describe in full (VS Code's own `files.exclude`/`search.exclude` +
+//! `search.useIgnoreFiles` split, collapsed into Jerry's one combined always-on list since there
+//! is no separate file-explorer walk to share the distinction with): [`collect_candidate_files`]
+//! below now runs [`crate::search::exclude::collect_files_excluding`] - a real, rayon-parallelized
+//! filesystem walk pruned by [`crate::search::exclude::DEFAULT_EXCLUDES`] - as the one, always-on,
+//! git-independent primary discovery mechanism, and layers `list_worktree_files` on top of it as
+//! an *additive*, independently toggleable filter
+//! ([`crate::settings::store::EditorSettings::respect_gitignore`], default `true`) rather than the
+//! sole file source. Measured directly against this repository, in both toggle states: see
+//! [`collect_candidate_files`]'s own docs.
 
 use std::collections::HashSet;
 use std::fs;
@@ -102,6 +104,7 @@ use std::path::{Path, PathBuf};
 
 use rayon::prelude::*;
 
+use crate::search::exclude;
 use crate::search::glob::GlobList;
 use wt_core::worktree_files::list_worktree_files;
 
@@ -358,6 +361,10 @@ pub struct SearchRequest {
     pub root: PathBuf,
     pub matcher: Matcher,
     pub filter: PathFilter,
+    /// The gitignore layer's own toggle - `crate::settings::store::EditorSettings::
+    /// respect_gitignore`, `true` by default. See [`collect_candidate_files`]'s own docs for
+    /// exactly how this composes with the always-on explicit exclude list underneath it.
+    pub respect_gitignore: bool,
 }
 
 /// Runs a real content search over `request.root`.
@@ -386,7 +393,8 @@ pub fn search_worktree_cancellable(
     is_stale: &dyn Fn() -> bool,
 ) -> SearchOutcome {
     let mut outcome = SearchOutcome::default();
-    let mut candidates = collect_candidate_files(&request.root, &mut outcome);
+    let mut candidates =
+        collect_candidate_files(&request.root, request.respect_gitignore, &mut outcome);
     // A stable, predictable order: the tree is read top to bottom and a search re-run after a
     // keystroke must not shuffle rows the user was reading. Neither `git ls-files`' own order nor
     // `read_dir`'s is defined to be that.
@@ -477,95 +485,55 @@ fn scan_file(path: &Path, matcher: &Matcher) -> Option<Vec<LineMatch>> {
 }
 
 /// Every real candidate file under `request.root`, as an absolute path paired with its
-/// worktree-relative, `/`-separated form - see this module's own "Scoped to real content" docs
-/// for why this asks `git`, not the filesystem, and what that actually fixed.
+/// worktree-relative, `/`-separated form - the two-layer model [`crate::search::exclude`]'s own
+/// module docs describe in full, and what GitHub issue #394 reworked #387/#388's gitignore-only
+/// fix into.
 ///
-/// `git ls-files --cached --others --exclude-standard` (via
-/// [`wt_core::worktree_files::list_worktree_files`]) is tried first: it is both the correct
-/// definition of "this worktree's real content" (tracked files, plus untracked files `git` itself
-/// would offer to stage - the same [`wt_core::review::measure_untracked`] already trusts) and,
-/// because it never opens a directory once its own exclude rule matches it, dramatically cheaper
-/// against a real repository with a `target/`- or `node_modules`-style build/dependency directory
-/// than any walk that has to visit one to find out it should be skipped.
+/// **Layer one, always on:** [`crate::search::exclude::collect_files_excluding`] - a real,
+/// `rayon`-parallelized filesystem walk pruned by [`crate::search::exclude::DEFAULT_EXCLUDES`]
+/// (`target`, `node_modules`, `.git`, and a handful of other common build/dependency directory
+/// names) *before* a directory is ever opened. This is the primary discovery mechanism now, not a
+/// fallback: it runs identically whether or not `root` is a real git worktree, which is the literal
+/// answer to the live pushback this issue exists for - "this should have nothing to do with git".
 ///
-/// [`collect_files_by_walking`] is the fallback for the one case `git` cannot answer -
-/// `request.root` is not (or is no longer) a real git worktree, or `git` itself could not be run
-/// at all - so search still functions there, exactly as it always has.
-fn collect_candidate_files(root: &Path, outcome: &mut SearchOutcome) -> Vec<(PathBuf, String)> {
-    match list_worktree_files(root) {
-        Ok(listing) => {
+/// **Layer two, toggleable:** when `request.respect_gitignore` is `true` (the default -
+/// `crate::settings::store::EditorSettings::respect_gitignore`), [`list_worktree_files`] (`git
+/// ls-files --cached --others --exclude-standard`, #388's own real fix) is additionally consulted
+/// and the layer-one candidates are narrowed to exactly the paths it lists - i.e. gitignored files
+/// are removed **on top of** whatever layer one already pruned, never instead of it. Outside a
+/// real git worktree (or wherever `git` itself can't run), [`list_worktree_files`] returns `Err`
+/// and this layer is a no-op: layer one alone is already a complete, honest answer there. When
+/// `respect_gitignore` is `false`, this layer is skipped entirely - a search deliberately scoped
+/// independently of git, which is the literal behaviour the pushback asked for.
+///
+/// Measured directly against this repository's own real checkout (31 GB `target/` + 28 GB
+/// `.shared-target/`, neither one walked by layer one regardless of `respect_gitignore`): both
+/// toggle states stay fast - see this crate's own `PR #394` real functional verification for exact
+/// numbers, not asserted here as a flaky wall-clock unit test.
+fn collect_candidate_files(
+    root: &Path,
+    respect_gitignore: bool,
+    outcome: &mut SearchOutcome,
+) -> Vec<(PathBuf, String)> {
+    let (mut candidates, walk_truncated) =
+        exclude::collect_files_excluding(root, &exclude::default_exclude_list(), MAX_SCANNED_FILES);
+    if walk_truncated {
+        outcome.truncated = true;
+    }
+
+    if respect_gitignore {
+        if let Ok(listing) = list_worktree_files(root) {
             if listing.truncated {
                 outcome.truncated = true;
             }
-            listing
-                .files
-                .into_iter()
-                .map(|relative| (root.join(&relative), relative))
-                .collect()
+            let allowed: HashSet<String> = listing.files.into_iter().collect();
+            candidates.retain(|(_path, relative)| allowed.contains(relative));
         }
-        Err(_) => {
-            let mut paths = Vec::new();
-            collect_files_by_walking(root, &mut paths, outcome);
-            paths
-                .into_iter()
-                .filter_map(|path| {
-                    let relative = relative_slash_path(root, &path)?;
-                    Some((path, relative))
-                })
-                .collect()
-        }
+        // `Err` (not a real git worktree, or `git` couldn't be run at all): layer one's own
+        // output is already the complete, honest answer - see this function's own docs.
     }
-}
 
-/// Every regular file under `dir`, recursively - the fallback walk [`collect_candidate_files`]
-/// uses when `dir` is not a real git worktree `git ls-files` can answer for.
-///
-/// `.git` is the one thing skipped unconditionally, and it is skipped for a reason no filter
-/// should have to restate: it is this app's own bookkeeping, it is mostly binary, and a search of
-/// it can only ever return things the user cannot act on. **Every other dotfile is searchable** -
-/// a deliberate divergence from `crate::sidebar::file_tree::build_file_tree`, which hides them
-/// from the tree. A tree that hides `.github/workflows/ci.yml` is a browsing choice; a search that
-/// silently cannot find text in it is the "an index, not a result" failure `STAGE-A-CHANGELOG.md`
-/// §4v names, one level up.
-///
-/// Unlike the `git`-backed primary path above, this walk has no way to know which directories a
-/// `.gitignore` would exclude - it is only ever reached outside a real git worktree, where there
-/// is no `.gitignore` to ask in the first place. [`MAX_SCANNED_FILES`] is what keeps it bounded.
-///
-/// Symlinks are not followed (`DirEntry::file_type` does not follow them), so a worktree
-/// containing a link to `/` cannot make this walk unbounded.
-fn collect_files_by_walking(dir: &Path, out: &mut Vec<PathBuf>, outcome: &mut SearchOutcome) {
-    if out.len() >= MAX_SCANNED_FILES {
-        outcome.truncated = true;
-        return;
-    }
-    let Ok(entries) = fs::read_dir(dir) else {
-        return;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        let Ok(file_type) = entry.file_type() else {
-            continue;
-        };
-        if file_type.is_symlink() {
-            continue;
-        }
-        if file_type.is_dir() {
-            if path.file_name().is_some_and(|name| name == ".git") {
-                continue;
-            }
-            collect_files_by_walking(&path, out, outcome);
-            if outcome.truncated {
-                return;
-            }
-        } else if file_type.is_file() {
-            if out.len() >= MAX_SCANNED_FILES {
-                outcome.truncated = true;
-                return;
-            }
-            out.push(path);
-        }
-    }
+    candidates
 }
 
 /// `path`'s text, or `None` when it is not something to search: too large
@@ -585,19 +553,6 @@ pub fn read_searchable(path: &Path) -> Option<String> {
         return None;
     }
     String::from_utf8(bytes).ok()
-}
-
-/// `path` relative to `root`, with `/` separators - `None` when it is not under `root` at all.
-fn relative_slash_path(root: &Path, path: &Path) -> Option<String> {
-    let relative = path.strip_prefix(root).ok()?;
-    let mut out = String::new();
-    for component in relative.components() {
-        if !out.is_empty() {
-            out.push('/');
-        }
-        out.push_str(&component.as_os_str().to_string_lossy());
-    }
-    Some(out)
 }
 
 /// One file's real, on-disk replace: reads it, replaces every match, writes it back only if
@@ -1048,6 +1003,7 @@ mod perf_tests {
             .expect("compiles")
             .expect("a query"),
             filter: PathFilter::new("", ""),
+            respect_gitignore: true,
         }
     }
 
@@ -1181,6 +1137,7 @@ mod worktree_tests {
             root: root.to_path_buf(),
             matcher,
             filter: PathFilter::new(include, exclude),
+            respect_gitignore: true,
         })
     }
 
@@ -1542,14 +1499,17 @@ mod worktree_tests {
     }
 }
 
-/// Real coverage for the live "search is very slow on my real repo" regression: every test above
-/// this module runs against a plain, non-git [`tempfile::tempdir`], which only ever exercises
-/// [`collect_files_by_walking`] (the fallback). None of it proves the *primary*,
-/// `git`-ls-files-backed path actually excludes a `.gitignore`d build directory the way this
-/// module's own "Scoped to real content" docs claim - that only happens inside a real git
-/// worktree, which is what every test here sets up.
+/// Real coverage for GitHub issue #394's two-layer rework (superseding #387/#388's own
+/// gitignore-only fix - see this module's own "Scoped to real content" docs). Every test above
+/// this module runs against a plain, non-git [`tempfile::tempdir`], which only ever exercises the
+/// always-on explicit-exclude layer ([`crate::search::exclude`]) - with no real git repo there,
+/// the toggleable gitignore layer is a no-op regardless of `respect_gitignore`. This module is
+/// what proves the real *composition* of the two layers inside a real git worktree: the explicit
+/// list always applies and cannot be turned off, the gitignore layer is genuinely additive and
+/// genuinely toggleable on top of it, and both keep holding when the fixture is exactly the shape
+/// the original #387 bug was (a sizeable build directory that isn't even in `.gitignore`).
 #[cfg(test)]
-mod git_backed_worktree_tests {
+mod layered_exclude_tests {
     use super::*;
     use std::process::Command;
 
@@ -1562,10 +1522,15 @@ mod git_backed_worktree_tests {
         assert!(status.success(), "git {args:?} failed");
     }
 
-    /// A real git worktree with real tracked source, a real `.gitignore`d build directory sized
-    /// enough that including it would matter, and a real untracked-but-not-ignored file - so a
-    /// single search proves all three: gitignored content is never scanned, tracked content is,
-    /// and untracked-non-ignored content is too.
+    /// A real git worktree with:
+    /// - `target/`, a real `.gitignore`d build directory sized enough that including it would
+    ///   matter, and also on [`crate::search::exclude::DEFAULT_EXCLUDES`] - excluded by *either*
+    ///   layer alone.
+    /// - `secret/`, also real and `.gitignore`d, but deliberately **not** on the explicit default
+    ///   list - the one directory only the toggleable layer can hide, which is what makes the
+    ///   two layers' composition provable rather than merely both-excluding-the-same-thing.
+    /// - a real tracked file and a real untracked-but-not-ignored file, so "still finds real
+    ///   content" is asserted alongside "excludes the right things", never assumed.
     fn fixture() -> tempfile::TempDir {
         let dir = tempfile::tempdir().expect("a temp worktree");
         let root = dir.path();
@@ -1578,7 +1543,7 @@ mod git_backed_worktree_tests {
             fs::create_dir_all(path.parent().expect("a parent")).expect("mkdir");
             fs::write(&path, content).expect("write");
         };
-        write(".gitignore", "target/\n");
+        write(".gitignore", "target/\nsecret/\n");
         write(
             "src/auth/session.rs",
             "let refresh_token = store.issue(&sid)?;\n",
@@ -1593,11 +1558,12 @@ mod git_backed_worktree_tests {
                 "refresh_token\n",
             );
         }
+        write("secret/refresh_token_notes.md", "refresh_token\n");
         write("src/new_untracked.rs", "refresh_token again\n");
         dir
     }
 
-    fn run(root: &Path, query: &str) -> SearchOutcome {
+    fn run(root: &Path, query: &str, respect_gitignore: bool) -> SearchOutcome {
         let matcher = Matcher::compile(query, SearchOptions::default())
             .expect("compiles")
             .expect("a non-empty query");
@@ -1605,61 +1571,93 @@ mod git_backed_worktree_tests {
             root: root.to_path_buf(),
             matcher,
             filter: PathFilter::new("", ""),
+            respect_gitignore,
         })
     }
 
+    /// Gitignore mode on (the real default) hides both the explicitly-excluded directory and the
+    /// gitignore-only one, on top of finding every real file.
     #[test]
-    fn a_gitignored_build_directory_is_never_scanned_in_a_real_git_worktree() {
+    fn gitignore_mode_on_hides_both_the_explicit_and_the_gitignore_only_directory() {
         let dir = fixture();
-        let outcome = run(dir.path(), "refresh_token");
+        let outcome = run(dir.path(), "refresh_token", true);
 
         assert!(
             !outcome
                 .files
                 .iter()
                 .any(|file| file.relative.starts_with("target/")),
-            "a real .gitignore'd build directory must never appear in results: {:?}",
-            outcome
-                .files
-                .iter()
-                .map(|f| f.relative.as_str())
-                .collect::<Vec<_>>()
+            "the always-on explicit list must exclude target/: {:?}",
+            relatives(&outcome)
         );
         assert!(
-            outcome
+            !outcome
                 .files
                 .iter()
-                .any(|file| file.relative == "src/auth/session.rs"),
-            "a real tracked file must still be found"
+                .any(|file| file.relative.starts_with("secret/")),
+            "the gitignore layer, additive on top, must exclude secret/: {:?}",
+            relatives(&outcome)
         );
-        assert!(
-            outcome
-                .files
-                .iter()
-                .any(|file| file.relative == "src/new_untracked.rs"),
-            "a real untracked-but-not-ignored file must still be found"
-        );
+        assert!(outcome
+            .files
+            .iter()
+            .any(|file| file.relative == "src/auth/session.rs"));
+        assert!(outcome
+            .files
+            .iter()
+            .any(|file| file.relative == "src/new_untracked.rs"));
         assert!(
             !outcome.truncated,
-            "300 gitignored files must not consume any of MAX_SCANNED_FILES's budget - a walk \
-             that has to burn its cap on a build directory before ever reaching real content is \
-             exactly the regression this proves fixed"
+            "300 excluded files must not consume any of MAX_SCANNED_FILES's budget"
         );
         assert_eq!(
             outcome.scanned_files, 3,
             "only the three real files (.gitignore, session.rs, new_untracked.rs) should ever \
-             have been opened and read - not the 300 gitignored ones"
+             have been opened and read"
         );
     }
 
+    /// Gitignore mode off: the explicit list still applies (it cannot be turned off), but
+    /// `secret/` - gitignored, and only gitignored - is found. This is the literal answer to
+    /// "this should have nothing to do with git": a search deliberately scoped independently of
+    /// git still excludes real build/dependency directories by name, and nothing else.
     #[test]
-    fn an_explicitly_tracked_file_under_a_later_gitignore_rule_is_still_searched() {
+    fn gitignore_mode_off_still_applies_the_explicit_list_but_finds_the_gitignore_only_file() {
+        let dir = fixture();
+        let outcome = run(dir.path(), "refresh_token", false);
+
+        assert!(
+            !outcome
+                .files
+                .iter()
+                .any(|file| file.relative.starts_with("target/")),
+            "the explicit list is always on, regardless of respect_gitignore: {:?}",
+            relatives(&outcome)
+        );
+        assert!(
+            outcome
+                .files
+                .iter()
+                .any(|file| file.relative == "secret/refresh_token_notes.md"),
+            "a file only .gitignore would hide, and that isn't on the explicit denylist, must be \
+             found with the gitignore layer off: {:?}",
+            relatives(&outcome)
+        );
+        assert!(outcome
+            .files
+            .iter()
+            .any(|file| file.relative == "src/auth/session.rs"));
+    }
+
+    #[test]
+    fn an_explicitly_tracked_file_under_a_later_gitignore_rule_is_still_searched_with_the_layer_on()
+    {
         let dir = fixture();
         let root = dir.path();
         // `session.rs` is already tracked (see `fixture`); now ignore its own directory too.
-        fs::write(root.join(".gitignore"), "target/\nsrc/auth/\n").expect("write");
+        fs::write(root.join(".gitignore"), "target/\nsecret/\nsrc/auth/\n").expect("write");
 
-        let outcome = run(root, "refresh_token");
+        let outcome = run(root, "refresh_token", true);
         assert!(
             outcome
                 .files
@@ -1668,5 +1666,62 @@ mod git_backed_worktree_tests {
             "git status does not hide an explicitly tracked file just because a later ignore \
              rule would otherwise cover it, and neither should search"
         );
+    }
+
+    /// The core bug-fix guarantee (#387): a real, sizeable build/dependency directory that isn't
+    /// even listed in `.gitignore` - this repository's own real `.shared-target/` before #388
+    /// added it, the exact incident - must never be walked, in **either** toggle state. Proves
+    /// the always-on explicit list, not `.gitignore`, is what the fix's real guarantee rests on.
+    #[test]
+    fn an_ungitignored_build_directory_is_excluded_in_both_toggle_states() {
+        let dir = tempfile::tempdir().expect("a temp worktree");
+        let root = dir.path();
+        git(root, &["init", "-q"]);
+        git(root, &["config", "user.email", "t@example.com"]);
+        git(root, &["config", "user.name", "Test"]);
+        let write = |relative: &str, content: &str| {
+            let path = root.join(relative);
+            fs::create_dir_all(path.parent().expect("a parent")).expect("mkdir");
+            fs::write(&path, content).expect("write");
+        };
+        write("src/lib.rs", "refresh_token\n");
+        git(root, &["add", "src/lib.rs"]);
+        // Deliberately no `.gitignore` at all.
+        for i in 0..300 {
+            write(&format!("node_modules/pkg/dist-{i}.js"), "refresh_token\n");
+        }
+
+        for respect_gitignore in [true, false] {
+            let outcome = run(root, "refresh_token", respect_gitignore);
+            assert!(
+                !outcome
+                    .files
+                    .iter()
+                    .any(|file| file.relative.starts_with("node_modules/")),
+                "respect_gitignore={respect_gitignore}: an ungitignored build/dependency \
+                 directory must still be excluded by the always-on explicit list: {:?}",
+                relatives(&outcome)
+            );
+            assert!(
+                outcome
+                    .files
+                    .iter()
+                    .any(|file| file.relative == "src/lib.rs"),
+                "respect_gitignore={respect_gitignore}"
+            );
+            assert!(!outcome.truncated, "respect_gitignore={respect_gitignore}");
+            assert_eq!(
+                outcome.scanned_files, 1,
+                "respect_gitignore={respect_gitignore}"
+            );
+        }
+    }
+
+    fn relatives(outcome: &SearchOutcome) -> Vec<&str> {
+        outcome
+            .files
+            .iter()
+            .map(|file| file.relative.as_str())
+            .collect()
     }
 }

--- a/crates/app/src/search/exclude.rs
+++ b/crates/app/src/search/exclude.rs
@@ -1,0 +1,315 @@
+//! The always-on, explicit exclude layer search's file discovery walk applies before it ever asks
+//! `.gitignore` anything - the first of the two layers GitHub issue #394 reworked
+//! [`crate::search::engine`]'s file source into, after a direct live pushback on #387/#388's own
+//! fix: "Wait what you made the search respect gitignore? This should have nothing to do with
+//! git?"
+//!
+//! ## Two layers, composed like VS Code's are
+//!
+//! VS Code's search layers three independent things: `files.exclude` (a glob denylist),
+//! `search.exclude` (a second, additive glob denylist just for search) and
+//! `search.useIgnoreFiles` (default `true`) - an independently toggleable setting that
+//! *additionally* consults `.gitignore`/`.ignore` on top of the two glob lists, never instead of
+//! them. Jerry doesn't need the `files.exclude`/`search.exclude` split (there is no separate
+//! file-explorer walk to share it with), so this module is the combined equivalent of both: one
+//! small, real, always-on glob denylist ([`DEFAULT_EXCLUDES`]), checked per-directory during a
+//! real filesystem walk so an excluded directory is never even descended into - which is what
+//! makes a `target/`-sized directory genuinely cheap to skip rather than walked and its results
+//! discarded.
+//!
+//! [`crate::settings::store::EditorSettings::respect_gitignore`] is the second, independently
+//! toggleable layer - the direct descendant of #387/#388's own fix. `crate::search::engine::
+//! collect_candidate_files` reuses [`wt_core::worktree_files::list_worktree_files`] (the exact
+//! `git ls-files --cached --others --exclude-standard` idiom #388 introduced) as an *additive*
+//! filter checked on top of this module's walk, not as the sole file source #388 originally made
+//! it - see that function's own docs for exactly how the two compose.
+//!
+//! ## Why `target` and `.shared-target` are both in the default list
+//!
+//! This repository's own checkout is the real, live case [`DEFAULT_EXCLUDES`] has to hold up
+//! against without depending on `.gitignore` at all: a real `target/` (31 GB, Rust's own build
+//! output) and a real, sibling `.shared-target/` (28 GB - this project's own second build-cache
+//! directory, previously only kept out of search by being added to `.gitignore` in #388). With
+//! `respect_gitignore` off, only this list stands between search and re-walking 59 GB of build
+//! output on every query - the exact regression #387 reported - so both must be real entries
+//! here, not merely relying on either one being `.gitignore`d.
+//!
+//! ## Why a real walk, not a shell-out to `find`/`fd`
+//!
+//! Each directory's own worktree-relative path is checked against [`DEFAULT_EXCLUDES`] with the
+//! same [`crate::search::glob::GlobList`] the panel's own include/exclude fields already use -
+//! reusing the pattern language rather than inventing a second one, and keeping the "a bare
+//! pattern matches the basename at any depth" rule (`target` reads as `**/target`) identical
+//! between the two. The walk itself parallelizes sibling subdirectories across `rayon`'s global
+//! thread pool - the same pool `crate::search::engine::search_worktree_cancellable`'s own batched
+//! scan already uses (see that module's own "Parallel" docs) - so pruning a big excluded
+//! directory at one worker never blocks the walk from making progress on every other real
+//! directory at the same time.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use rayon::prelude::*;
+
+use crate::search::glob::GlobList;
+
+/// The always-on denylist - real, small, and not exhaustive by design (see this module's own
+/// docs). Every entry is a bare name, which [`crate::search::glob::Glob::parse`]'s own basename
+/// rule turns into `**/<name>`, matching that directory at any depth - `target` excludes both
+/// `./target` and `crates/app/target`, the same way the panel's own `*.lock` exclude field
+/// already matches a lockfile at any depth.
+///
+/// - `target` - Rust's own build output.
+/// - `.shared-target` - this repository's own second, sibling build-cache directory - see this
+///   module's own "Why `target` and `.shared-target` are both in the default list" docs.
+/// - `node_modules` - JS/TS dependencies.
+/// - `.git` - this app's own VCS bookkeeping; mostly binary, and a hit in it is never actionable.
+/// - `dist`, `build`, `.next` - common JS/TS build output directory names.
+/// - `__pycache__`, `venv`, `.venv` - common Python build/dependency directory names.
+pub const DEFAULT_EXCLUDES: &[&str] = &[
+    "target",
+    ".shared-target",
+    "node_modules",
+    ".git",
+    "dist",
+    "build",
+    ".next",
+    "__pycache__",
+    "venv",
+    ".venv",
+];
+
+/// [`DEFAULT_EXCLUDES`], compiled once into the same [`GlobList`] the panel's own path filter
+/// fields use. A fresh list per call rather than a `once_cell`/`lazy_static`: parsing ten short,
+/// static, always-valid patterns is microseconds, and every real caller (one worktree walk per
+/// keystroke, well downstream of [`crate::search::engine::SEARCH_DEBOUNCE`]) already pays far
+/// more than that for the walk itself.
+pub fn default_exclude_list() -> GlobList {
+    GlobList::parse(&DEFAULT_EXCLUDES.join(","))
+}
+
+/// Every real file under `root`, as an absolute path paired with its worktree-relative,
+/// `/`-separated form, skipping any directory [`excludes`] matches **before** it is ever opened -
+/// see this module's own docs for why that, not a filter applied after the fact, is what makes an
+/// excluded directory genuinely cheap.
+///
+/// `cap` bounds the same way [`crate::search::engine::MAX_SCANNED_FILES`] always has: once the
+/// running file count reaches it, every worker still in flight finishes its own current directory
+/// (so no directory is left half-read) and no new subdirectory is descended into. The count is
+/// only approximately exact under concurrent workers (an `AtomicUsize` racing several `fetch_add`s
+/// at once) - acceptable for a defense-in-depth bound that was never meant to be a precise cutoff,
+/// the same way the old single-threaded walk's own cap was a real limit rather than a guarantee
+/// about exactly which file it landed on.
+///
+/// Symlinks are not followed (`DirEntry::file_type` does not follow them), so a worktree
+/// containing a link back to its own root cannot make this walk unbounded - the same real
+/// property `crate::search::engine`'s own retired `collect_files_by_walking` had.
+///
+/// Returns `(files, truncated)` - `truncated` is `true` only when `cap` was actually reached, and
+/// the caller (`crate::search::engine::collect_candidate_files`) is what turns that into
+/// [`crate::search::engine::SearchOutcome::truncated`].
+pub fn collect_files_excluding(
+    root: &Path,
+    excludes: &GlobList,
+    cap: usize,
+) -> (Vec<(PathBuf, String)>, bool) {
+    let count = AtomicUsize::new(0);
+    let truncated = AtomicBool::new(false);
+    let files = walk(root, root, excludes, &count, cap, &truncated);
+    (files, truncated.load(Ordering::Relaxed))
+}
+
+/// The recursive worker behind [`collect_files_excluding`]. Reads `dir`, splits its entries into
+/// real files (kept, subject to `cap`) and real subdirectories (kept only when [`excludes`]
+/// doesn't match their own worktree-relative path), then recurses into the surviving
+/// subdirectories in parallel via `rayon`'s `par_iter` - the standard parallel-recursive-walk
+/// shape, and what lets pruning one enormous excluded sibling (`target/`) never hold up progress
+/// on every other real directory being walked at the same time.
+fn walk(
+    dir: &Path,
+    root: &Path,
+    excludes: &GlobList,
+    count: &AtomicUsize,
+    cap: usize,
+    truncated: &AtomicBool,
+) -> Vec<(PathBuf, String)> {
+    if truncated.load(Ordering::Relaxed) {
+        return Vec::new();
+    }
+    let Ok(entries) = fs::read_dir(dir) else {
+        return Vec::new();
+    };
+
+    let mut files = Vec::new();
+    let mut subdirs = Vec::new();
+    for entry in entries.flatten() {
+        // Checked per-entry, not only once per directory: a single real directory can itself
+        // hold tens of thousands of flat files (a `target/debug/deps/`-shaped directory not on
+        // the exclude list, say), and the cap has to stop a walk mid-directory in that case, not
+        // only between directories.
+        if truncated.load(Ordering::Relaxed) {
+            break;
+        }
+        let path = entry.path();
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_symlink() {
+            continue;
+        }
+        let Some(relative) = relative_slash_path(root, &path) else {
+            continue;
+        };
+        if file_type.is_dir() {
+            if excludes.matches(&relative) {
+                // Never descended into - the whole point of checking here rather than filtering
+                // the walk's own output afterwards.
+                continue;
+            }
+            subdirs.push(path);
+        } else if file_type.is_file() {
+            if count.fetch_add(1, Ordering::Relaxed) + 1 >= cap {
+                truncated.store(true, Ordering::Relaxed);
+            }
+            files.push((path, relative));
+        }
+    }
+
+    let nested: Vec<Vec<(PathBuf, String)>> = subdirs
+        .par_iter()
+        .map(|subdir| walk(subdir, root, excludes, count, cap, truncated))
+        .collect();
+    for batch in nested {
+        files.extend(batch);
+    }
+    files
+}
+
+/// `path` relative to `root`, with `/` separators - `None` when it is not under `root` at all.
+/// Shared with `crate::search::engine`'s own fallback formatting so the two walks can never
+/// disagree about what "worktree-relative" means.
+pub(crate) fn relative_slash_path(root: &Path, path: &Path) -> Option<String> {
+    let relative = path.strip_prefix(root).ok()?;
+    let mut out = String::new();
+    for component in relative.components() {
+        if !out.is_empty() {
+            out.push('/');
+        }
+        out.push_str(&component.as_os_str().to_string_lossy());
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(root: &Path, relative: &str, content: &str) {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().expect("a parent")).expect("mkdir");
+        fs::write(&path, content).expect("write");
+    }
+
+    fn relatives(files: &[(PathBuf, String)]) -> Vec<&str> {
+        let mut out: Vec<&str> = files
+            .iter()
+            .map(|(_, relative)| relative.as_str())
+            .collect();
+        out.sort_unstable();
+        out
+    }
+
+    #[test]
+    fn a_default_excluded_directory_is_never_descended_into() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        write(root, "src/lib.rs", "fn main() {}\n");
+        for i in 0..50 {
+            write(root, &format!("target/debug/deps/artifact-{i}.o"), "junk");
+        }
+        write(
+            root,
+            "node_modules/left-pad/index.js",
+            "module.exports = 1;\n",
+        );
+        write(root, ".git/COMMIT_EDITMSG", "wip\n");
+
+        let (files, truncated) = collect_files_excluding(root, &default_exclude_list(), 20_000);
+        assert!(!truncated);
+        assert_eq!(
+            relatives(&files),
+            vec!["src/lib.rs"],
+            "target/, node_modules/ and .git/ must all be pruned before being opened"
+        );
+    }
+
+    #[test]
+    fn a_nested_default_excluded_directory_is_pruned_at_any_depth() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        write(root, "crates/app/src/lib.rs", "fn main() {}\n");
+        write(root, "crates/app/target/debug/x.o", "junk");
+
+        let (files, _truncated) = collect_files_excluding(root, &default_exclude_list(), 20_000);
+        assert_eq!(relatives(&files), vec!["crates/app/src/lib.rs"]);
+    }
+
+    #[test]
+    fn a_real_second_build_cache_directory_is_excluded_by_name_alone() {
+        // This repository's own real second build-cache directory (#387/#388,
+        // this module's own docs) - excluded here even with no `.gitignore` involved at all,
+        // which is the whole point of it being a real, explicit entry rather than left to the
+        // gitignore layer.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        write(root, "README.md", "hi\n");
+        for i in 0..50 {
+            write(root, &format!(".shared-target/deps/artifact-{i}.o"), "junk");
+        }
+
+        let (files, _truncated) = collect_files_excluding(root, &default_exclude_list(), 20_000);
+        assert_eq!(relatives(&files), vec!["README.md"]);
+    }
+
+    #[test]
+    fn a_directory_not_on_the_default_list_is_walked_normally() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        write(root, "vendor/lib.rs", "// not excluded by default\n");
+
+        let (files, _truncated) = collect_files_excluding(root, &default_exclude_list(), 20_000);
+        assert_eq!(relatives(&files), vec!["vendor/lib.rs"]);
+    }
+
+    #[test]
+    fn a_symlink_is_never_followed_so_a_loop_cannot_make_the_walk_unbounded() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        write(root, "src/lib.rs", "fn main() {}\n");
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(root, root.join("loop")).expect("a real symlink");
+            let (files, truncated) = collect_files_excluding(root, &default_exclude_list(), 20_000);
+            assert_eq!(relatives(&files), vec!["src/lib.rs"]);
+            assert!(!truncated);
+        }
+    }
+
+    #[test]
+    fn the_cap_stops_the_walk_and_reports_itself_truncated() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        for i in 0..30 {
+            write(root, &format!("src/file_{i}.rs"), "content\n");
+        }
+
+        let (files, truncated) = collect_files_excluding(root, &default_exclude_list(), 10);
+        assert!(truncated);
+        assert!(
+            !files.is_empty() && files.len() < 30,
+            "the cap must actually bound the walk: got {} of 30",
+            files.len()
+        );
+    }
+}

--- a/crates/app/src/search/mod.rs
+++ b/crates/app/src/search/mod.rs
@@ -9,6 +9,9 @@
 //! the `gpui::Div`-building code that draws it:
 //!
 //! - [`glob`] - the pure `include`/`exclude` pattern language (`**`, `*`, `?`, comma-separated).
+//! - [`exclude`] - the always-on, explicit `target`/`node_modules`/`.git`-style exclude list the
+//!   worktree walk applies before it ever asks `.gitignore` anything (GitHub issue #394) - see
+//!   that module's own docs for how it composes with the separate, toggleable gitignore layer.
 //! - [`engine`] - the compiled matcher the three modifier buttons produce, the bounded worktree
 //!   walk, the two-level result tree, and the real on-disk replace.
 //! - [`in_file`] - the `mod+F` find bar's own pure model: hits in the open buffer, the current
@@ -22,6 +25,7 @@
 //! `crate::sidebar` established for its own submodules.
 
 pub mod engine;
+pub mod exclude;
 pub mod glob;
 pub mod in_file;
 pub mod state;

--- a/crates/app/src/search/render.rs
+++ b/crates/app/src/search/render.rs
@@ -1102,6 +1102,7 @@ impl AdeApp {
             root: self.file_tree_root.clone(),
             matcher,
             filter: PathFilter::new(self.search.include.as_str(), self.search.exclude.as_str()),
+            respect_gitignore: self.settings.editor.respect_gitignore,
         };
         // Captured now rather than re-read after the awaits below: a search that resolves against
         // whatever the user has since typed would report a count for one query beside a tree for

--- a/crates/app/src/settings/render.rs
+++ b/crates/app/src/settings/render.rs
@@ -3198,10 +3198,12 @@ impl AdeApp {
             })
     }
 
-    /// *Editor* - the one real row on this page is the minimap (GitHub issue #30,
-    /// `crate::code_surface::minimap`) - see `crate::settings::state`'s own module docs on why
-    /// the rest of this page (indentation/soft-wrap/whitespace-display) still has no real
-    /// backing and stays left off entirely, rather than shown as an inert control.
+    /// *Editor* - the minimap (GitHub issue #30, `crate::code_surface::minimap`), completions,
+    /// and now Search's own gitignore toggle (GitHub issue #394 -
+    /// `crate::settings::store::EditorSettings::respect_gitignore`) are this page's real rows -
+    /// see `crate::settings::state`'s own module docs on why the rest of this page
+    /// (indentation/soft-wrap/whitespace-display) still has no real backing and stays left off
+    /// entirely, rather than shown as an inert control.
     pub(in crate::settings) fn render_settings_editor_page(
         &self,
         cx: &mut Context<Self>,
@@ -3266,6 +3268,19 @@ impl AdeApp {
                 },
             ),
         );
+        let respect_gitignore_row = self.render_settings_row(
+            "Use .gitignore in search",
+            "The Search panel always skips target/, node_modules/, .git and a handful of other \
+             common build/dependency directories by name, regardless of this setting. On top of \
+             that, additionally hide whatever the active worktree's own .gitignore hides. Off \
+             scopes search independently of git entirely - only the built-in list above applies.",
+            self.render_toggle_control(
+                "settings-editor-respect-gitignore",
+                self.settings.editor.respect_gitignore,
+                cx,
+                |this, cx| this.toggle_respect_gitignore(cx),
+            ),
+        );
 
         div()
             .flex()
@@ -3295,6 +3310,17 @@ impl AdeApp {
             )
             .child(suggest_auto_imports_row)
             .child(auto_import_row)
+            .child(
+                div()
+                    .pt(px(20.0))
+                    .pb(px(4.0))
+                    .font(font(theme::font::SANS))
+                    .font_weight(gpui::FontWeight::SEMIBOLD)
+                    .text_size(px(9.5))
+                    .text_color(theme::palette::GROUP_HEADER)
+                    .child("Search"),
+            )
+            .child(respect_gitignore_row)
             .child(self.render_snippet_block(settings_store::ConfigPage::Editor))
     }
 
@@ -4084,6 +4110,18 @@ impl AdeApp {
     /// accept. See `settings_store::EditorSettings::auto_import`.
     fn toggle_auto_import(&mut self, cx: &mut Context<Self>) {
         self.settings.editor.auto_import = !self.settings.editor.auto_import;
+        self.persist_settings(cx);
+        cx.notify();
+    }
+
+    /// The Editor page's Search-group "Use .gitignore in search" toggle (GitHub issue #394) -
+    /// `crate::search::render::AdeApp::start_search` reads
+    /// `self.settings.editor.respect_gitignore` fresh on every real search, so a toggle here
+    /// takes effect on the very next query with no restart needed. See
+    /// `settings_store::EditorSettings::respect_gitignore`'s own docs for exactly how this
+    /// composes with the always-on explicit exclude list underneath it.
+    fn toggle_respect_gitignore(&mut self, cx: &mut Context<Self>) {
+        self.settings.editor.respect_gitignore = !self.settings.editor.respect_gitignore;
         self.persist_settings(cx);
         cx.notify();
     }

--- a/crates/app/src/settings/store.rs
+++ b/crates/app/src/settings/store.rs
@@ -634,6 +634,23 @@ pub struct EditorSettings {
     /// `crate::language::auto_import_suppression_options`, which currently means
     /// `typescript-language-server` and no one else.
     pub suggest_auto_imports: bool,
+    /// Whether the search panel's real, always-on explicit exclude list
+    /// (`crate::search::exclude::DEFAULT_EXCLUDES` - `target`, `node_modules`, `.git`, and a
+    /// handful of other common build/dependency directories) is ALSO layered with the worktree's
+    /// real `.gitignore` (GitHub issue #394, which reworked #387/#388's own gitignore-only fix
+    /// into this layered model after a direct "this should have nothing to do with git?"
+    /// pushback - see `crate::search::exclude`'s own module docs for the full story).
+    ///
+    /// Matches VS Code's own `search.useIgnoreFiles`, including its default of `true`: on top of
+    /// the explicit list (which always applies and this toggle cannot turn off), this
+    /// additionally hides gitignored files. Off, only the explicit list applies - a search
+    /// deliberately scoped independently of git, which is what the pushback this setting exists
+    /// to satisfy actually asked for. Read by `crate::search::engine::search_worktree_cancellable`
+    /// via `crate::search::engine::SearchRequest::respect_gitignore`
+    /// (`crate::search::render::AdeApp::start_search` is the one real call site that populates it
+    /// from this field), and toggled by the Editor settings page's own row
+    /// (`crate::settings::render::AdeApp::toggle_respect_gitignore`).
+    pub respect_gitignore: bool,
 }
 
 impl Default for EditorSettings {
@@ -645,6 +662,7 @@ impl Default for EditorSettings {
             tab_width: EDITOR_TAB_WIDTH_DEFAULT,
             auto_import: true,
             suggest_auto_imports: true,
+            respect_gitignore: true,
         }
     }
 }
@@ -826,7 +844,10 @@ pub fn config_keys_line(page: ConfigPage) -> &'static str {
         ConfigPage::Theme => {
             "theme.name \u{b7} theme.follow_system \u{b7} theme.high_contrast_diff"
         }
-        ConfigPage::Editor => "editor.minimap_enabled \u{b7} editor.minimap_scale_percent",
+        ConfigPage::Editor => {
+            "editor.minimap_enabled \u{b7} editor.minimap_scale_percent \u{b7} \
+             editor.respect_gitignore"
+        }
         ConfigPage::Notifications => {
             "sound.enabled \u{b7} sound.app_start.sound \u{b7} sound.agent_finished.sound \u{b7} \
              sound.agent_needs_input.sound"
@@ -993,6 +1014,55 @@ mod tests {
         );
         assert!(settings.editor.insert_spaces);
         assert_eq!(settings.editor.tab_width, EDITOR_TAB_WIDTH_DEFAULT);
+        assert!(
+            settings.editor.respect_gitignore,
+            "matches VS Code's own search.useIgnoreFiles default of true"
+        );
+    }
+
+    /// The real toggle a user flips from the Editor settings page - see
+    /// `crate::settings::render::AdeApp::toggle_respect_gitignore`. Proven here at the file-format
+    /// level (round-trips through a real save + load, and an explicit `false` in a hand-edited
+    /// file is honoured rather than silently reset to the default) rather than only asserted
+    /// in-memory, since a toggle nobody can actually flip-and-keep-flipped is not a real setting.
+    #[test]
+    fn respect_gitignore_persists_through_a_real_save_and_load_in_both_states() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("settings.toml");
+
+        let mut settings = Settings::default();
+        assert!(settings.editor.respect_gitignore, "the real default");
+        settings.editor.respect_gitignore = false;
+        settings.save_at(&path).expect("save");
+
+        let reloaded = Settings::load_or_init_at(&path);
+        assert!(
+            !reloaded.editor.respect_gitignore,
+            "a real save must round-trip an explicit `false`, not silently revert to the default"
+        );
+
+        let mut settings = reloaded;
+        settings.editor.respect_gitignore = true;
+        settings.save_at(&path).expect("save");
+        assert!(Settings::load_or_init_at(&path).editor.respect_gitignore);
+    }
+
+    /// A `settings.toml` written before this setting existed has no `respect_gitignore` key at
+    /// all under `[editor]` - `#[serde(default)]` must fall back to the real default (`true`)
+    /// rather than failing the whole parse, the same fallback already proven for the minimap and
+    /// keymap sections.
+    #[test]
+    fn a_settings_file_missing_respect_gitignore_entirely_still_loads_the_real_default() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("settings.toml");
+        std::fs::write(&path, "[editor]\ntab_width = 2\n").expect("write old file");
+
+        let loaded = Settings::load_or_init_at(&path);
+        assert_eq!(loaded.editor.tab_width, 2);
+        assert!(
+            loaded.editor.respect_gitignore,
+            "a missing key must fall back to the real default, not an implicit false"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

#387/#388 fixed a real, live 10-second search-latency bug by making search's file
discovery use `wt_core::worktree_files::list_worktree_files` (`git ls-files
--cached --others --exclude-standard`) as its *only* candidate source. That fixed
the real regression (an unexcluded `target/` + `.shared-target/`, 59GB combined),
but it also made search's whole notion of "don't walk into `target/`" a function
of `.gitignore` - direct pushback after seeing it land: "Wait what you made the
search respect gitignore? This should have nothing to do with git?"

This reworks file discovery into VS Code's real layered model (`files.exclude` +
`search.exclude` + `search.useIgnoreFiles`, collapsed into one combined list
since Jerry has no separate file-explorer walk to share the split with):

1. **A real, always-on, explicit glob exclude list** (`crates/app/src/search/exclude.rs`)
   - `target`, `.shared-target` (this repo's own second build-cache directory),
   `node_modules`, `.git`, `dist`, `build`, `.next`, `__pycache__`, `venv`, `.venv`.
   Checked per-directory during a real, `rayon`-parallelized filesystem walk, so
   an excluded directory is never even descended into - this is the new primary
   discovery mechanism, and runs identically whether or not the root is a real
   git worktree.
2. **A separate, independently toggleable "respect .gitignore" layer**, default
   **on** (matching VS Code's `search.useIgnoreFiles`). Reuses #388's
   `list_worktree_files` as an *additive* filter checked on top of the explicit
   list, not as the sole file source. Off, only the explicit list applies - a
   search deliberately scoped independently of git.
3. **A real, persisted setting** - `EditorSettings::respect_gitignore`, with a
   row on the Editor settings page's new "Search" group.

Closes #394

## Real measurements

Directly against this repository's own real checkout (31GB `target/` + 28GB
`.shared-target/`):

| `respect_gitignore` | elapsed | scanned files | `target/`+`.shared-target/` files |
|---|---|---|---|
| `true` (default) | ~220-246ms | 255 | 0 |
| `false` | ~895-922ms | 4,173 | 0 |

Both dramatically faster than the original 10s stall, and both toggle states
exclude `target/`/`.shared-target/` - the core bug-fix guarantee holds
regardless of the gitignore toggle.

## Real functional verification

Launched the built binary against a real git worktree over X11 (per-window
`XGetImage` capture): the Editor settings page really shows the new "Search"
group with a live "Use .gitignore in search" toggle; clicking it (real mouse
click, not simulated) flips it and the change round-trips through a real
`settings.toml` save/reload (`respect_gitignore = false` → `true` observed on
disk after each click). Scripted keyboard input into the GPUI window is a
pre-existing, independently-documented limitation of this sandbox (`BUILD-LOG.md`)
unrelated to this change, so the query-typing / result-set-changes half of the
functional check is covered by the real GPUI test harness instead (`search::render::panel_tests`, unaffected and still green) plus the new
engine-level tests below, which exercise the exact same `search_worktree`/
`collect_candidate_files` code path `search::render::AdeApp::start_search` calls.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets` (warning-free)
- [x] `cargo test -p app --lib search::` (117 passed, including new `search::exclude` and `search::engine::layered_exclude_tests` coverage)
- [x] `cargo test -p app --lib settings::` (250 passed, including new `respect_gitignore` persistence tests)
- [x] `cargo test -p wt-core` (302 passed, untouched)
- [x] Explicit-exclude-only mode (gitignore off) still finds a file a hypothetical `.gitignore` would hide but that isn't on the explicit denylist
- [x] Gitignore-mode-on (default) additionally hides gitignored files, on top of the explicit excludes
- [x] Both modes exclude `target/`/`node_modules`-equivalent directories regardless of the gitignore toggle state
- [x] The settings toggle persists and is read back correctly (store-level tests + live round-trip through a real `settings.toml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)