### PR TITLE
fix(ui): remove the agent-jump keycap hint from the tab strip and status bar

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -121,9 +121,11 @@ use settings::store as settings_store;
 ///   actively being edited, reproduced live by typing `]` into real content. `!`/`&&` are real,
 ///   supported `KeyBindingContextPredicate` syntax (`vendor/zed/crates/gpui/src/keymap/
 ///   context.rs:172-420`'s own `Not`/`And` variants and parser), not invented here.
-/// - `"secondary-1"` through `"secondary-8"` back the tab strip's agent-jump keycaps
+/// - `"secondary-1"` through `"secondary-8"` back agent-jumping
 ///   (`root::AdeApp::jump_to_agent_at`), expanding the design's `mod+1…8` spec into eight
-///   individually bound keystrokes since GPUI has no "N" wildcard keystroke component.
+///   individually bound keystrokes since GPUI has no "N" wildcard keystroke component. No longer
+///   advertised by an on-screen keycap hint (removed per a direct product-owner request), but the
+///   bindings themselves are still real.
 /// - The `Editor*` entries (Revision R8.5a's real File view text editing) are scoped to
 ///   `Some("file-editor")`, a real *additional* context alongside `"diff"` above - both live on
 ///   the *same* focused "code-surface" container (`code_surface::render::AdeApp::

--- a/crates/app/src/root/focus.rs
+++ b/crates/app/src/root/focus.rs
@@ -873,10 +873,10 @@ mod tab_strip_keybinding_tests {
         let third_tab_id = tab_ids[2];
 
         assert_eq!(
-            app.read_with(cx, |app, _| app.agent_jump_keys()),
-            vec!["1".to_string(), "2".to_string(), "3".to_string()],
-            "the keycap row must advertise one number per real agent session (three), not one \
-             per tab (five)"
+            app.read_with(cx, |app, _| app.current_worktree_agent_sessions().count()),
+            3,
+            "premise: exactly three real agent sessions exist (not five tabs) for \
+             secondary-1..secondary-3 to have anything to number"
         );
 
         // Start from a tab that is neither answer, so the assertion below can't pass by accident.

--- a/crates/app/src/status_bar/render.rs
+++ b/crates/app/src/status_bar/render.rs
@@ -215,20 +215,22 @@ impl AdeApp {
         )
     }
 
-    /// The environment chip and the palette/agent keycap hints - all that is left on the right
-    /// after §4b's subtractive pass (the file/editor cluster and the LSP counts were the rest of
-    /// it, and both are gone).
+    /// The environment chip and the palette keycap hint - all that is left on the right after
+    /// §4b's subtractive pass (the file/editor cluster and the LSP counts were the rest of it,
+    /// and both are gone).
+    ///
+    /// This used to also carry a second hint, a `secondary-1`..`secondary-8` agent-jump keycap
+    /// row (`Self::render_status_agent_hint`, mirroring the tab strip's own right-aligned copy -
+    /// `work_surface::render::AdeApp::render_tab_strip`). GitHub issue #397, a direct
+    /// product-owner report: at zero real agent sessions in the current worktree the keycap row
+    /// rendered empty and left the bare word "agent" floating with nothing in front of it, which
+    /// read as clutter rather than a useful hint. The underlying `secondary-1`..`secondary-8`
+    /// jump keybindings (`root::AdeApp::jump_to_agent_at`) are unaffected - only the advertising
+    /// hint is gone.
     fn render_status_bar_right(&self, cx: &mut Context<Self>) -> gpui::AnyElement {
-        let hints = div()
-            .flex()
-            .items_center()
-            .gap(px(16.0))
-            .child(self.render_status_palette_hint(cx))
-            .child(self.render_status_agent_hint());
-
         render_status_segment_row(vec![
             render_env_chip().into_any_element(),
-            hints.into_any_element(),
+            self.render_status_palette_hint(cx).into_any_element(),
         ])
         .into_any_element()
     }
@@ -567,26 +569,6 @@ impl AdeApp {
             .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
                 this.open_palette(window, cx);
             }))
-    }
-
-    /// The real agent-jump keycap hint (`secondary-1`..`secondary-8`) - reuses
-    /// [`Self::agent_jump_keys`], the exact same computation `Self::render_tab_strip`'s own
-    /// right-aligned cluster uses, not a second copy that could drift from what's really bound.
-    fn render_status_agent_hint(&self) -> impl IntoElement {
-        let jump_keys = self.agent_jump_keys();
-        div()
-            .flex()
-            .items_center()
-            .gap(px(6.0))
-            .child(render_keycap_row(&jump_keys, KeycapSize::Standard))
-            .child(
-                div()
-                    .font(font(theme::font::SANS))
-                    .font_weight(gpui::FontWeight::MEDIUM)
-                    .text_size(self.ui_text_size(10.5))
-                    .text_color(theme::text::FAINT)
-                    .child("agent"),
-            )
     }
 
     /// One status-bar readout, rendered in its assigned [`StatusTier`] - the one place a bar

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -890,10 +890,10 @@ impl AdeApp {
 
     /// [`Self::current_worktree_agents`] narrowed to **real agent sessions**
     /// (`ProcessKind::is_agent_session`) - the list every surface that says the word *agent* to
-    /// the user counts and indexes by: [`Self::agent_jump_keys`]/[`Self::jump_to_agent_at`] (the
-    /// `secondary-1`..`secondary-8` keycaps and the status bar's copy of them),
-    /// [`Self::select_relative_agent`] (the title bar's `Next Agent`/`Previous Agent`), and that
-    /// pair's own menu-enablement predicate.
+    /// the user counts and indexes by: [`Self::jump_to_agent_at`] (the `secondary-1`..
+    /// `secondary-8` bindings - no longer advertised by an on-screen keycap hint, removed per a
+    /// direct product-owner request), [`Self::select_relative_agent`] (the title bar's `Next
+    /// Agent`/`Previous Agent`), and that pair's own menu-enablement predicate.
     ///
     /// Same order as the strip, just with the shells dropped, so `secondary-2` still means "the
     /// second agent you can see, reading left to right" - it simply stops counting the terminal
@@ -968,7 +968,15 @@ impl AdeApp {
     /// [`Self::render_agent_tab`] for a `TabRef::Agent`, [`Self::render_file_tab`] for a
     /// `TabRef::File` - so an agent tab and a file tab can sit side by side in either order
     /// (GitHub issue #16), rather than always "every agent, then every file" - followed by the
-    /// `+` menu button ([`Self::render_tab_strip_plus`]) and right-aligned agent-jump keycaps.
+    /// `+` menu button ([`Self::render_tab_strip_plus`]).
+    ///
+    /// This used to end in a right-aligned `secondary-1`..`secondary-8` agent-jump keycap hint
+    /// (mirrored by the status bar's own copy, `status_bar::render::AdeApp::
+    /// render_status_agent_hint`). GitHub issue #397, a direct product-owner report: at zero
+    /// real agent sessions in the current worktree the keycap row rendered empty and left the
+    /// bare word "agent" floating with nothing in front of it, which read as clutter rather than
+    /// a useful hint. The underlying `secondary-1`..`secondary-8` jump keybindings
+    /// ([`Self::jump_to_agent_at`]) are unaffected - only the advertising hint is gone.
     ///
     /// Each agent tab's label is read per tab, inside the loop below
     /// (`Self::agent_tab_label`): a label is now purely a fact about that one pane's own live
@@ -999,9 +1007,16 @@ impl AdeApp {
     /// The `+` button rides inside the same scrollable region, immediately after the last tab
     /// (exactly where it already sits when nothing overflows), so reaching it when tabs overflow
     /// is the same one scroll gesture that reaches the last tab - not a second, independently
-    /// reachable control. The trailing spacer and the right-aligned agent-jump keycap cluster stay
-    /// **outside** the scrollable region, as `#tab-strip`'s own direct children: they are chrome
-    /// that should always stay visible/pinned, not part of what can be scrolled through.
+    /// reachable control.
+    ///
+    /// A trailing chrome spacer stays **outside** the scrollable region, as `#tab-strip`'s own
+    /// direct child alongside the scroller: always visible/pinned, not part of what can be
+    /// scrolled through. It used to carry a real right-aligned agent-jump keycap hint, removed
+    /// per a direct product-owner request (see [`Self::render_tab_strip`]'s own top docs) - a
+    /// bare 12px bordered spacer is kept in its place, both to give the strip's trailing edge the
+    /// same breathing room every other 12px chrome margin in this bar gets (rather than leaving
+    /// the `+` button flush against the window's edge), and to keep carrying its own slice of
+    /// §4v's bottom rule (`.border_b_1()`) exactly as it did with the hint still in it.
     pub(in crate::work_surface) fn render_tab_strip(
         &self,
         cx: &mut Context<Self>,
@@ -1084,40 +1099,13 @@ impl AdeApp {
 
         scroller = scroller.child(self.render_tab_strip_plus(cx));
 
-        let jump_keys = self.agent_jump_keys();
-
         bar.child(scroller).child(
             div()
                 .flex_none()
-                .flex()
-                .items_center()
-                .gap(px(6.0))
-                .px(px(12.0))
+                .w(px(12.0))
                 .border_b_1()
-                .border_color(theme::border::RAIL_INNER)
-                .child(render_keycap_row(&jump_keys, KeycapSize::Standard))
-                .child(
-                    div()
-                        .font(font(theme::font::SANS))
-                        .text_size(px(10.0))
-                        .text_color(theme::text::PATH)
-                        .child("agent"),
-                ),
+                .border_color(theme::border::RAIL_INNER),
         )
-    }
-
-    /// The real `secondary-1`..`secondary-8` agent-jump keycap labels: one per **real agent
-    /// session** open in the *currently selected* worktree
-    /// ([`Self::current_worktree_agent_sessions`] - a plain shell is not an agent and gets no
-    /// number, see that method's docs), capped at 8 since those are the only ones actually bound
-    /// (`crate::default_key_bindings`) - never a keycap advertising a shortcut that silently does
-    /// nothing, and (GitHub issue #381) never one more keycap than there are agents for them to
-    /// land on. Shared by [`Self::render_tab_strip`]'s own right-aligned cluster and the status
-    /// bar's agent hint (`status_bar::render::render_status_agent_hint`), so the two can never
-    /// independently drift on what's really bound.
-    pub(crate) fn agent_jump_keys(&self) -> Vec<String> {
-        let agent_count = self.current_worktree_agent_sessions().count().min(8);
-        (1..=agent_count).map(|n| n.to_string()).collect()
     }
 
     /// Every tab kind's own `×` close hit box - identical id-suffixing, size, hover, and styling
@@ -1762,10 +1750,10 @@ impl AdeApp {
 
     /// The `+` menu's "Next changed file" action (`]`) - opens the next changed file after the
     /// active file tab as a tab, wrapping around to the first once the last is passed (so a
-    /// repeated `]` press cycles indefinitely, matching how the agent-jump keycaps and palette
-    /// arrow keys already treat "next"/"previous"). If the active file isn't itself a changed
-    /// file, or nothing is active, this opens the first changed file. No-op if there's no loaded
-    /// diff, or it has no changed files.
+    /// repeated `]` press cycles indefinitely, matching how `secondary-1`..`secondary-8` and
+    /// palette arrow keys already treat "next"/"previous"). If the active file isn't itself a
+    /// changed file, or nothing is active, this opens the first changed file. No-op if there's no
+    /// loaded diff, or it has no changed files.
     pub(crate) fn next_changed_file(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let next_path = {
             let Some(diff) = self.current_diff() else {
@@ -1787,10 +1775,13 @@ impl AdeApp {
         self.open_change_diff(next_path, window, cx);
     }
 
-    /// The tab strip's agent-jump keycaps (`secondary-1`..`secondary-8`) - jumps to the **real
-    /// agent session** at 1-indexed `position` in the same order [`Self::render_tab_strip`]
-    /// iterates ([`Self::current_worktree_agent_sessions`]), via [`Self::select_agent`]. No-op if
-    /// fewer than `position` agent sessions are currently open in the selected worktree.
+    /// The real handler behind the `secondary-1`..`secondary-8` keybindings - jumps to the
+    /// **real agent session** at 1-indexed `position` in the same order
+    /// [`Self::render_tab_strip`] iterates ([`Self::current_worktree_agent_sessions`]), via
+    /// [`Self::select_agent`]. No-op if fewer than `position` agent sessions are currently open
+    /// in the selected worktree. No longer advertised by any on-screen keycap hint (removed per
+    /// a direct product-owner request), but the bindings themselves are still real and
+    /// unaffected.
     ///
     /// GitHub issue #381: a plain [`ProcessKind::Shell`] does not take a number. It used to, and
     /// the position it consumed was the user's own live report - the *worktree's startup shell*


### PR DESCRIPTION
## Summary

- Direct product-owner report (screenshot-driven): the `secondary-1`..`secondary-8` agent-jump keycap hint (`[1][2][3] agent`) in both the tab strip and status bar collapses to a bare, floating word "agent" once the current worktree has zero real agent sessions (`render_keycap_row` renders nothing for `&[]`). Removed outright from both locations.
- Deleted `render_status_agent_hint` and `AdeApp::agent_jump_keys` (no production caller left once both hints are gone) rather than leaving dead/hidden code.
- The real `secondary-1`..`secondary-8` jump-to-agent keybindings and `AdeApp::jump_to_agent_at` are untouched - only the advertising UI is gone.
- The tab strip's trailing spacer keeps a bare 12px width + bottom border so the strip's own bottom rule and right-edge breathing room survive the removal (rev 6 §4v: "the children own this column's bottom edge").
- Updated a `root/focus.rs` test that asserted `agent_jump_keys()`'s output to instead assert the same premise directly against `current_worktree_agent_sessions()`.
- Refreshed stale doc comments across `lib.rs`, `work_surface/render.rs`, `status_bar/render.rs`.

Closes #397

## Test plan

- [x] `cargo build --workspace` - clean, no warnings
- [x] `cargo fmt --all -- --check` - clean
- [x] `cargo clippy --workspace --all-targets` - clean, no warnings
- [x] `cargo test -p app --lib work_surface::` - 138 passed
- [x] `cargo test -p app --lib root::focus::` - 52 passed (including the updated `secondary_3_jumps_to_the_third_real_agent_through_the_real_key_bindings`)
- [x] `cargo test -p app --lib status_bar::` - 57 passed
- [x] Real before/after visual verification: launched the built binary against a fresh bare worktree (zero agent sessions) over X11, screenshotted the running window, confirmed both the tab strip's right edge and the status bar's footer no longer show the "agent" hint, with no awkward gap or layout regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)