### PR TITLE
fix(sidebar): stop blanking the Changes panel on every switch into it

### DIFF
--- a/crates/app/src/code_surface/tabs.rs
+++ b/crates/app/src/code_surface/tabs.rs
@@ -35,6 +35,13 @@ impl AdeApp {
     /// see [`Self::dirty_files`]' own docs). It is reset to `None` ("not known yet") synchronously
     /// here rather than left holding the outgoing diff's answer, so a stale set can never outlive
     /// the diff it described.
+    ///
+    /// This is the entry point for every caller whose `root` is a worktree being switched **to**
+    /// (a new window, `Self::select_worktree`, a vanished-worktree recovery). A caller that wants
+    /// the exact same real reload for the worktree *already* showing - `crate::sidebar::render::
+    /// AdeApp::set_right_sidebar_view`'s "switching into Changes always recomputes" - wants
+    /// [`Self::refresh_diff`] instead: see its own docs for why blanking the screen first is
+    /// correct here and wrong there.
     pub(crate) fn load_diff(&mut self, root: PathBuf, cx: &mut Context<Self>) {
         self.diff_root = root.clone();
         self.diff_state = DiffLoadState::Loading;
@@ -51,7 +58,47 @@ impl AdeApp {
         self.diff_totals = None;
         self.dirty_files = None;
         cx.notify();
-        let task = cx.spawn(async move |this, cx| {
+        self._load_diff_task = Some(self.spawn_diff_reload(root, cx));
+    }
+
+    /// Re-runs exactly the same real git reload [`Self::load_diff`] does, for the *same* worktree
+    /// [`Self::diff_root`] already names - GitHub issue #399. The one difference is what it does
+    /// **not** do: unlike `load_diff`, this never blanks [`Self::diff_state`]/
+    /// [`Self::uncommitted_diff`]/[`Self::branch_commits`] to `Loading` first, so whatever the
+    /// Changes panel is already showing keeps rendering, undisturbed, for the real duration of the
+    /// reload - only flipping once the fresh answer actually lands.
+    ///
+    /// That is safe here in a way it is *not* safe for `load_diff`'s own callers: every one of
+    /// those names a worktree that is being switched **to**, so whatever was on screen before
+    /// belongs to a different checkout and showing it a frame longer would be the real cross-
+    /// worktree leak `Self::reset_repo_scoped_state`'s own docs guard against. This method's one
+    /// caller (`crate::sidebar::render::AdeApp::set_right_sidebar_view`) never changes
+    /// `Self::diff_root` at all - it re-reads the *same* worktree that was already showing, so the
+    /// stale-but-still-displayed data is, at worst, a few seconds old for the checkout genuinely on
+    /// screen, never another one's.
+    ///
+    /// This is the same "don't blank a still-good cache while a refresh is in flight" idiom
+    /// `crate::code_surface::state::FileLoadState`'s own docs describe for [`Self::file_view_cache`],
+    /// applied to an always-unconditional refresh rather than a freshness-gated skip, since (unlike
+    /// a single file's mtime) there is no cheap way to tell in advance whether any of these five git
+    /// queries would actually come back different. The live report this fixes: "when going to the
+    /// changes pane it is first empty and then fills up" - `set_right_sidebar_view`'s docs already
+    /// explain *why* every switch into Changes must recompute rather than trust a snapshot (an agent
+    /// may have changed files while the panel wasn't showing); recomputing was never the defect,
+    /// unconditionally blanking the screen to do it was.
+    pub(crate) fn refresh_diff(&mut self, cx: &mut Context<Self>) {
+        let root = self.diff_root.clone();
+        self._load_diff_task = Some(self.spawn_diff_reload(root, cx));
+    }
+
+    /// The real background git reload both [`Self::load_diff`] and [`Self::refresh_diff`] run -
+    /// the five real `wt_core` queries (`diff_against_base`, `staged_paths`, `dirty_paths`,
+    /// `diff_against_head`, `commits_since_base`), off the foreground thread, folded into exactly
+    /// the same completion write-back either caller wants. The two callers differ only in what
+    /// they do *before* this runs (see [`Self::refresh_diff`]'s own docs), never in what happens
+    /// once the real answer comes back.
+    fn spawn_diff_reload(&mut self, root: PathBuf, cx: &mut Context<Self>) -> gpui::Task<()> {
+        cx.spawn(async move |this, cx| {
             let (diff_result, staged_result, dirty_result, uncommitted_result, commits_result) = cx
                 .background_executor()
                 .spawn({
@@ -106,10 +153,12 @@ impl AdeApp {
                 if let Ok(staged) = staged_result {
                     this.staged_files = staged;
                 }
-                // A failed `dirty_paths` query leaves `dirty_files` at the `None` this method
-                // already set synchronously - "not known", so every Changes row falls back to the
-                // ordinary stageable presentation rather than silently declaring every file
-                // committed-clean off the back of an answer git never actually gave.
+                // A failed `dirty_paths` query leaves `dirty_files` exactly as it was - `None`
+                // ("not known") for a `Self::load_diff` caller, which reset it synchronously
+                // before this task started, or the last real answer for a `Self::refresh_diff`
+                // caller, which did not. Either way every Changes row falls back to the ordinary
+                // stageable presentation (or the last real one) rather than silently declaring
+                // every file committed-clean off the back of an answer git never actually gave.
                 if let Ok(dirty) = dirty_result {
                     this.dirty_files = Some(dirty);
                 }
@@ -139,8 +188,7 @@ impl AdeApp {
                 this.rebuild_change_set();
                 cx.notify();
             });
-        });
-        self._load_diff_task = Some(task);
+        })
     }
 
     /// Appends `path` to [`Self::open_files`] if not already present. The shared entry point for

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -49,9 +49,18 @@ fn short_sha(sha: &str) -> String {
 
 impl AdeApp {
     /// Switches which data source the right sidebar shows. Switching *to* the Changes view
-    /// always recomputes the diff (`load_diff`, not just `cx.notify()`) rather than showing
-    /// whatever was last loaded - a stale snapshot from when the worktree was first selected
-    /// would silently hide changes an agent just made.
+    /// always recomputes the diff (`Self::refresh_diff`, not just `cx.notify()`) rather than
+    /// showing whatever was last loaded - a stale snapshot from when the worktree was first
+    /// selected would silently hide changes an agent just made.
+    ///
+    /// `refresh_diff`, not `load_diff`: a live report ("when going to the changes pane it is
+    /// first empty and then fills up") traced to exactly this call unconditionally resetting
+    /// `Self::diff_state`/`Self::uncommitted_diff`/`Self::branch_commits` to `Loading` before
+    /// every single switch into Changes, even when the worktree hadn't changed and the panel's
+    /// last real answer was still perfectly good to keep showing while a fresh one loaded.
+    /// `refresh_diff` runs the identical real background reload without that synchronous blank -
+    /// see its own docs for why that is safe specifically because this call site never changes
+    /// `Self::diff_root`.
     pub(crate) fn set_right_sidebar_view(
         &mut self,
         view: RightSidebarView,
@@ -124,10 +133,16 @@ impl AdeApp {
         }
         self.right_sidebar_view = view;
         if view == RightSidebarView::Changes {
-            self.load_diff(self.diff_root.clone(), cx);
-        } else {
-            cx.notify();
+            self.refresh_diff(cx);
         }
+        // `refresh_diff` (unlike `load_diff`) never touches any field the render path reads
+        // synchronously - it only writes once its background task lands, so it never calls
+        // `cx.notify()` itself. `self.right_sidebar_view` above did change, though, and every
+        // other branch this function takes (the `Files`/`Search` unrender blocks, the `else`
+        // this used to be) needs the same repaint - so this now unconditionally notifies once,
+        // rather than one call in the `Changes` arm (via `load_diff`) and a second, separate one
+        // in every other arm.
+        cx.notify();
     }
 
     /// Toggles a directory's expanded state - `crate::sidebar::file_tree::visible_entries` does
@@ -7175,6 +7190,127 @@ mod commit_composer_tests {
             cx.debug_bounds("commit-menu-popover").is_none(),
             "returning to Changes must not resurrect a popover the user never reopened"
         );
+    }
+
+    /// Live report ("when going to the changes pane it is first empty and then fills up"), traced
+    /// to `set_right_sidebar_view` unconditionally resetting `Self::uncommitted_diff`/
+    /// `Self::branch_commits`/`Self::diff_state` to `Loading` on **every** switch into Changes -
+    /// even a second switch to a worktree that never changed, whose diff was already fully
+    /// loaded. GitHub issue #399's fix: `Self::refresh_diff` reruns the same real background
+    /// reload without that synchronous blank, so a re-entry into an already-loaded Changes view
+    /// keeps showing the real data it already had, undisturbed, for the whole real duration of
+    /// the (still genuinely unconditional) background refresh.
+    ///
+    /// This is a synchronous check, deliberately made *before* `cx.run_until_parked()` drains the
+    /// refresh - the exact window the live report is about. A test that only asserted the
+    /// post-`run_until_parked` state would pass whether or not the blank ever happened in
+    /// between, since the refresh always lands on the same real data either way.
+    #[gpui::test]
+    fn returning_to_an_already_loaded_changes_view_never_blanks_it(cx: &mut TestAppContext) {
+        let repo = changes_test_repo();
+        let (app, cx) = open_changes_view(cx, &repo);
+
+        // Premise: the first load already landed, so every scope really is `Loaded`.
+        app.read_with(cx, |app, _| {
+            assert!(
+                matches!(
+                    app.diff_state,
+                    crate::code_surface::state::DiffLoadState::Loaded(_)
+                ),
+                "premise: diff_state must already be Loaded before this test's real assertion"
+            );
+            assert!(
+                app.uncommitted_diff.loaded().is_some(),
+                "premise: uncommitted_diff must already be Loaded"
+            );
+            assert!(
+                app.branch_commits.loaded().is_some(),
+                "premise: branch_commits must already be Loaded"
+            );
+        });
+
+        // Leave Changes, then switch back into it - the exact gesture the live report names.
+        app.update_in(cx, |app, window, cx| {
+            app.set_right_sidebar_view(RightSidebarView::Files, window, cx);
+        });
+        cx.run_until_parked();
+        app.update_in(cx, |app, window, cx| {
+            app.set_right_sidebar_view(RightSidebarView::Changes, window, cx);
+        });
+
+        // Right here - synchronously, before the refresh this call just dispatched has had any
+        // chance to run - every scope must still read as the real, already-loaded data it was a
+        // moment ago, not `Loading`/empty.
+        app.read_with(cx, |app, _| {
+            assert!(
+                matches!(
+                    app.diff_state,
+                    crate::code_surface::state::DiffLoadState::Loaded(_)
+                ),
+                "diff_state must not be reset to Loading just for re-entering an already-loaded \
+                 Changes view - that is the exact empty-then-fills-up flash the live report \
+                 named"
+            );
+            assert!(
+                app.uncommitted_diff.loaded().is_some(),
+                "uncommitted_diff must keep showing its last real answer through the refresh, \
+                 not blank to Loading first"
+            );
+            assert!(
+                app.branch_commits.loaded().is_some(),
+                "branch_commits must keep showing its last real answer through the refresh, not \
+                 blank to Loading first"
+            );
+        });
+
+        // The refresh itself still genuinely ran (freshness is preserved, not abandoned) - once
+        // it lands, every scope is still Loaded, just from the fresh query rather than the stale
+        // one skipped ahead of it.
+        cx.run_until_parked();
+        app.read_with(cx, |app, _| {
+            assert!(matches!(
+                app.diff_state,
+                crate::code_surface::state::DiffLoadState::Loaded(_)
+            ));
+            assert!(app.uncommitted_diff.loaded().is_some());
+            assert!(app.branch_commits.loaded().is_some());
+        });
+    }
+
+    /// The mirror image of the test above: a real worktree switch (as opposed to a same-worktree
+    /// re-entry into the Changes view) is a genuinely different checkout, so `Self::load_diff`
+    /// must keep blanking every scope to `Loading` synchronously - showing the *previous*
+    /// worktree's already-loaded diff a frame longer would be the real cross-worktree data leak
+    /// `Self::reset_repo_scoped_state`'s own docs guard against, not a flash worth avoiding.
+    #[gpui::test]
+    fn switching_worktrees_still_blanks_the_changes_view_synchronously(cx: &mut TestAppContext) {
+        let repo_a = changes_test_repo();
+        let repo_b = changes_test_repo();
+        let (app, cx) = open_changes_view(cx, &repo_a);
+
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.uncommitted_diff.loaded().is_some(),
+                "premise: the first worktree's diff must already be loaded"
+            );
+        });
+
+        app.update_in(cx, |app, window, cx| {
+            app.load_diff(repo_b.path().to_path_buf(), cx);
+            let _ = window;
+        });
+
+        // Synchronously - before the new worktree's own background reload has run at all - the
+        // panel must not still be showing the *previous* worktree's data.
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.uncommitted_diff.loaded().is_none(),
+                "a real worktree switch must blank the previous worktree's diff synchronously, \
+                 rather than leaving it on screen while the new worktree's own answer loads"
+            );
+        });
+
+        cx.run_until_parked();
     }
 
     /// The reported "2 context menus open at the same time", for this pair, end to end through a


### PR DESCRIPTION
## Summary

- Live user report: "when going to the changes pane it is first empty and then fills up." Traced to `AdeApp::set_right_sidebar_view` calling `load_diff` unconditionally on every switch into the Changes view, which synchronously resets `diff_state`/`uncommitted_diff`/`branch_commits`/`change_set`/`dirty_files` to `Loading`/empty before the real background reload lands - even when the worktree hadn't changed and the panel's last answer was already fully loaded and still valid.
- Measured real cost of that reload against a non-trivial repo (~670 commits, 5-commit feature branch, 4 uncommitted files): **~58-65ms sequential** (five real `git` subprocess-backed queries: `diff_against_base`, `staged_paths`, `dirty_paths`, `diff_against_head`, `commits_since_base`). That's genuine, unavoidable git I/O for a first load - but re-paying the *visible blank* for it on every subsequent visit was the actual defect, not the underlying latency.
- Split `AdeApp::load_diff` into two entry points that share one background-reload helper (`spawn_diff_reload`):
  - `load_diff` (unchanged behavior) - every caller whose root is a worktree being switched **to** (new window, `select_worktree`, vanished-worktree recovery). Keeps the synchronous blank: the previous data belongs to a *different* checkout, and showing it a frame longer would be a real cross-worktree leak.
  - `refresh_diff` (new) - `set_right_sidebar_view`'s "switching into Changes always recomputes" call, which never changes `diff_root`. Runs the identical real reload without the synchronous blank, so the panel keeps showing its last real answer, undisturbed, until the fresh one lands - freshness is fully preserved (the reload still genuinely runs every time), only the needless blank is gone.
- Mirrors an idiom already established elsewhere in this app: `crate::code_surface::state::FileLoadState`'s own docs describe keeping `AdeApp::file_view_cache` visible while a fresh load is in flight, for the same reason.

Closes #399

## Test plan

- [x] New regression test `returning_to_an_already_loaded_changes_view_never_blanks_it` - proven to fail against the pre-fix code (reverted locally and re-ran to confirm), passes with the fix. Asserts synchronously, before `run_until_parked()`, that re-entering an already-loaded Changes view keeps every scope `Loaded` rather than `Loading`.
- [x] New regression test `switching_worktrees_still_blanks_the_changes_view_synchronously` - confirms `load_diff`'s worktree-switch path is unchanged (still blanks synchronously, so no cross-worktree data leak is introduced).
- [x] `cargo build --workspace`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets` (warning-free)
- [x] `cargo test -p app --lib sidebar::` (278 passed)
- [x] `cargo test -p app --lib code_surface::` (622 passed)
- [x] Real wall-clock timing measured directly against `wt_core::diff` on a real cloned repo (~670 commits, 5-commit feature branch, 4 uncommitted files)
- [x] Real functional check over X11: built and launched the app, clicked into the Changes tab via real XTEST mouse events, confirmed the panel renders correct real data (Uncommitted 4, Commits 5, Against main +9/-0, Runs empty state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)