### PR TITLE
feat(search): make the exclude pattern list itself real, user-editable settings

### DIFF
--- a/crates/app/src/keymap_overrides.rs
+++ b/crates/app/src/keymap_overrides.rs
@@ -757,16 +757,17 @@ mod tests {
         let sites = key_context_call_sites();
         let call_sites: usize = sites.iter().map(|(_, count)| count).sum();
         assert_eq!(
-            call_sites, 20,
-            "real_context_stacks() is hand-derived from exactly twenty .key_context(..) call \
-             sites (thirteen of which emit the same bare \"text-input\": the palette, the rail \
+            call_sites, 21,
+            "real_context_stacks() is hand-derived from exactly twenty-one .key_context(..) call \
+             sites (fourteen of which emit the same bare \"text-input\": the palette, the rail \
              filter, the new-file prompt, the Branches filter, the Keybindings filter, the \
              Themes page's \"Generate from colour\" seed input, the General page's \"Shell\" \
              field (GitHub issue #213), GitHub issue #241's git graph row menu's \"Create \
              branch here\" prompt, GitHub issue #242 phase B's interactive-rebase plan row's own \
              reword message field, GitHub issue #285's Changes panel commit message field, and - \
-             GitHub issue #288's pinned review-note card, and - newest - GitHub issue #162's \
-             Search panel row and its in-file find bar - plus GitHub issue #304's own \
+             GitHub issue #288's pinned review-note card, and - GitHub issue #162's \
+             Search panel row and its in-file find bar, and - newest - GitHub issue #401's \
+             Editor > Search page's \"add a pattern\" row - plus GitHub issue #304's own \
              \"rebase-plan\" and issue #288's own \"diff-view\") - a new one means \
              that list, and every disjointness answer built on \
              it, needs updating. Real sites found: {sites:?}"

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -2207,6 +2207,14 @@ pub struct AdeApp {
     /// [`Self::filter_query`], and the same real per-widget undo history (GitHub issue #17).
     pub(crate) settings_keymap_filter: text_history::TextField,
     pub(crate) settings_keymap_filter_focus_handle: FocusHandle,
+    /// GitHub issue #401: the Editor > Search page's "add a pattern" row - a real, focusable
+    /// text input (same minimal append/backspace/`Esc`-clears/`Enter`-submits shape as
+    /// [`Self::new_file_input`]'s own name field, and the same real per-widget undo history,
+    /// GitHub issue #17) that appends a real, persisted entry to
+    /// [`settings_store::EditorSettings::search_excludes`] on `Enter`, then clears itself for the
+    /// next pattern - see `crate::settings::render::AdeApp::add_search_exclude_pattern`.
+    pub(crate) search_exclude_input: text_history::TextField,
+    pub(crate) search_exclude_input_focus_handle: FocusHandle,
     /// GitHub issue #141: the Themes page's "Generate from colour" seed - a real, focusable hex
     /// input (`#rrggbb`), same minimal append/backspace/`Esc`-clears shape as
     /// [`Self::settings_keymap_filter`] and the same real per-widget undo history (GitHub issue

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -265,6 +265,12 @@ impl AdeApp {
         let settings_keymap_filter_focus_handle = cx.focus_handle();
         let theme_seed_focus_handle = cx.focus_handle();
         let shell_focus_handle = cx.focus_handle();
+        // GitHub issue #401: a real hand-rolled `text_history::TextField` input built alongside
+        // the others in this pre-`this` cluster - see `Self::wire_caret_blink`'s own docs for why
+        // these are all built here rather than inline in the literal below, and GitHub issue #45
+        // for why joining this call (rather than being left out, the recurring live bug this app
+        // keeps re-finding) is not optional.
+        let search_exclude_input_focus_handle = cx.focus_handle();
         let (caret_blink_subscriptions, caret_blink_handles) = AdeApp::wire_caret_blink(
             &[
                 &code_focus_handle,
@@ -275,6 +281,7 @@ impl AdeApp {
                 &settings_keymap_filter_focus_handle,
                 &theme_seed_focus_handle,
                 &shell_focus_handle,
+                &search_exclude_input_focus_handle,
             ],
             window,
             cx,
@@ -670,6 +677,8 @@ impl AdeApp {
             _lsp_rows_task: None,
             settings_keymap_filter: text_history::TextField::new(),
             settings_keymap_filter_focus_handle,
+            search_exclude_input: text_history::TextField::new(),
+            search_exclude_input_focus_handle,
             theme_seed_input: text_history::TextField::new(),
             theme_seed_focus_handle,
             shell_input,

--- a/crates/app/src/search/engine.rs
+++ b/crates/app/src/search/engine.rs
@@ -89,12 +89,18 @@
 //! `search.useIgnoreFiles` split, collapsed into Jerry's one combined always-on list since there
 //! is no separate file-explorer walk to share the distinction with): [`collect_candidate_files`]
 //! below now runs [`crate::search::exclude::collect_files_excluding`] - a real, rayon-parallelized
-//! filesystem walk pruned by [`crate::search::exclude::DEFAULT_EXCLUDES`] - as the one, always-on,
+//! filesystem walk pruned by [`SearchRequest::search_excludes`] - as the one, always-on,
 //! git-independent primary discovery mechanism, and layers `list_worktree_files` on top of it as
 //! an *additive*, independently toggleable filter
 //! ([`crate::settings::store::EditorSettings::respect_gitignore`], default `true`) rather than the
 //! sole file source. Measured directly against this repository, in both toggle states: see
 //! [`collect_candidate_files`]'s own docs.
+//!
+//! GitHub issue #401 made that pruning list itself real, persisted, user-editable settings state
+//! ([`crate::settings::store::EditorSettings::search_excludes`]) rather than the compiled-in
+//! [`crate::search::exclude::DEFAULT_EXCLUDES`] constant alone - see [`SearchRequest::
+//! search_excludes`]'s own docs for exactly what's threaded through, and `crate::search::exclude`'s
+//! own "GitHub issue #401" docs for the full replace-vs-additive design decision.
 
 use std::collections::HashSet;
 use std::fs;
@@ -361,6 +367,15 @@ pub struct SearchRequest {
     pub root: PathBuf,
     pub matcher: Matcher,
     pub filter: PathFilter,
+    /// Layer one's own real, persisted pattern list - `crate::settings::store::EditorSettings::
+    /// search_excludes` (GitHub issue #401), compiled by [`collect_candidate_files`] via
+    /// [`crate::search::exclude::exclude_list_from`] into the [`crate::search::glob::GlobList`]
+    /// [`crate::search::exclude::collect_files_excluding`] prunes the walk against, before layer
+    /// two (below) is ever consulted. `crate::search::render::AdeApp::start_search` is the one
+    /// real call site that populates this, straight from the live setting, so an edit in Settings
+    /// takes effect on the very next query with no restart needed - the same guarantee
+    /// `respect_gitignore` already makes.
+    pub search_excludes: Vec<String>,
     /// The gitignore layer's own toggle - `crate::settings::store::EditorSettings::
     /// respect_gitignore`, `true` by default. See [`collect_candidate_files`]'s own docs for
     /// exactly how this composes with the always-on explicit exclude list underneath it.
@@ -393,8 +408,12 @@ pub fn search_worktree_cancellable(
     is_stale: &dyn Fn() -> bool,
 ) -> SearchOutcome {
     let mut outcome = SearchOutcome::default();
-    let mut candidates =
-        collect_candidate_files(&request.root, request.respect_gitignore, &mut outcome);
+    let mut candidates = collect_candidate_files(
+        &request.root,
+        &request.search_excludes,
+        request.respect_gitignore,
+        &mut outcome,
+    );
     // A stable, predictable order: the tree is read top to bottom and a search re-run after a
     // keystroke must not shuffle rows the user was reading. Neither `git ls-files`' own order nor
     // `read_dir`'s is defined to be that.
@@ -490,11 +509,14 @@ fn scan_file(path: &Path, matcher: &Matcher) -> Option<Vec<LineMatch>> {
 /// fix into.
 ///
 /// **Layer one, always on:** [`crate::search::exclude::collect_files_excluding`] - a real,
-/// `rayon`-parallelized filesystem walk pruned by [`crate::search::exclude::DEFAULT_EXCLUDES`]
-/// (`target`, `node_modules`, `.git`, and a handful of other common build/dependency directory
-/// names) *before* a directory is ever opened. This is the primary discovery mechanism now, not a
-/// fallback: it runs identically whether or not `root` is a real git worktree, which is the literal
-/// answer to the live pushback this issue exists for - "this should have nothing to do with git".
+/// `rayon`-parallelized filesystem walk pruned by `search_excludes`, compiled via
+/// [`crate::search::exclude::exclude_list_from`] (GitHub issue #401's real, persisted
+/// `crate::settings::store::EditorSettings::search_excludes` - `target`, `node_modules`, `.git`,
+/// and a handful of other common build/dependency directory names *by default*, and genuinely
+/// user-editable from there) *before* a directory is ever opened. This is the primary discovery
+/// mechanism now, not a fallback: it runs identically whether or not `root` is a real git
+/// worktree, which is the literal answer to the live pushback this issue exists for - "this should
+/// have nothing to do with git".
 ///
 /// **Layer two, toggleable:** when `request.respect_gitignore` is `true` (the default -
 /// `crate::settings::store::EditorSettings::respect_gitignore`), [`list_worktree_files`] (`git
@@ -512,11 +534,13 @@ fn scan_file(path: &Path, matcher: &Matcher) -> Option<Vec<LineMatch>> {
 /// numbers, not asserted here as a flaky wall-clock unit test.
 fn collect_candidate_files(
     root: &Path,
+    search_excludes: &[String],
     respect_gitignore: bool,
     outcome: &mut SearchOutcome,
 ) -> Vec<(PathBuf, String)> {
+    let excludes = exclude::exclude_list_from(search_excludes);
     let (mut candidates, walk_truncated) =
-        exclude::collect_files_excluding(root, &exclude::default_exclude_list(), MAX_SCANNED_FILES);
+        exclude::collect_files_excluding(root, &excludes, MAX_SCANNED_FILES);
     if walk_truncated {
         outcome.truncated = true;
     }
@@ -1003,6 +1027,7 @@ mod perf_tests {
             .expect("compiles")
             .expect("a query"),
             filter: PathFilter::new("", ""),
+            search_excludes: exclude::default_search_excludes(),
             respect_gitignore: true,
         }
     }
@@ -1137,6 +1162,7 @@ mod worktree_tests {
             root: root.to_path_buf(),
             matcher,
             filter: PathFilter::new(include, exclude),
+            search_excludes: exclude::default_search_excludes(),
             respect_gitignore: true,
         })
     }
@@ -1571,6 +1597,7 @@ mod layered_exclude_tests {
             root: root.to_path_buf(),
             matcher,
             filter: PathFilter::new("", ""),
+            search_excludes: exclude::default_search_excludes(),
             respect_gitignore,
         })
     }
@@ -1723,5 +1750,105 @@ mod layered_exclude_tests {
             .iter()
             .map(|file| file.relative.as_str())
             .collect()
+    }
+}
+
+/// Real, end-to-end coverage for GitHub issue #401: `SearchRequest::search_excludes` is a real,
+/// user-editable list (`crate::settings::store::EditorSettings::search_excludes`), not just the
+/// compiled-in `crate::search::exclude::DEFAULT_EXCLUDES` constant. `crate::search::exclude`'s own
+/// unit tests already prove `exclude_list_from`'s compilation in isolation; this module proves the
+/// *whole* `search_worktree` path - request in, real result out - actually threads a caller's list
+/// through rather than silently falling back to the built-in one somewhere along the way.
+#[cfg(test)]
+mod configurable_exclude_tests {
+    use super::*;
+
+    fn write(root: &Path, relative: &str, content: &str) {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().expect("a parent")).expect("mkdir");
+        fs::write(&path, content).expect("write");
+    }
+
+    fn run(root: &Path, search_excludes: Vec<String>) -> SearchOutcome {
+        let matcher = Matcher::compile("needle", SearchOptions::default())
+            .expect("compiles")
+            .expect("a non-empty query");
+        search_worktree(&SearchRequest {
+            root: root.to_path_buf(),
+            matcher,
+            filter: PathFilter::new("", ""),
+            search_excludes,
+            // No real git worktree in this fixture - irrelevant to what's under test here, same
+            // as every plain-tempdir fixture above `layered_exclude_tests`.
+            respect_gitignore: true,
+        })
+    }
+
+    fn relatives(outcome: &SearchOutcome) -> Vec<&str> {
+        outcome
+            .files
+            .iter()
+            .map(|file| file.relative.as_str())
+            .collect()
+    }
+
+    /// A pattern the user typed into the Settings > Editor > Search "add a pattern" row - not on
+    /// `DEFAULT_EXCLUDES` at all - really prunes the walk, proving the request's own list, not the
+    /// compiled-in constant, is what layer one actually excludes against.
+    #[test]
+    fn a_real_custom_pattern_from_settings_excludes_matching_files() {
+        let dir = tempfile::tempdir().expect("a temp worktree");
+        let root = dir.path();
+        write(root, "src/lib.rs", "needle\n");
+        write(root, "vendor/thirdparty/lib.rs", "needle\n");
+
+        let mut patterns = exclude::default_search_excludes();
+        patterns.push("vendor".to_string());
+        let outcome = run(root, patterns);
+
+        assert_eq!(
+            relatives(&outcome),
+            vec!["src/lib.rs"],
+            "the user's own added `vendor` pattern must exclude it just like a built-in entry"
+        );
+    }
+
+    /// The user removed `node_modules` from their own copy of the list in Settings (the row's
+    /// remove affordance, `crate::settings::render::AdeApp::remove_search_exclude_pattern`) -
+    /// a real search must now find matches inside it again, proving the removal really reaches
+    /// the walk rather than only updating what Settings displays.
+    #[test]
+    fn removing_a_default_pattern_in_settings_re_includes_it_in_a_real_search() {
+        let dir = tempfile::tempdir().expect("a temp worktree");
+        let root = dir.path();
+        write(root, "src/lib.rs", "needle\n");
+        write(root, "node_modules/pkg/index.js", "needle\n");
+
+        let mut patterns = exclude::default_search_excludes();
+        patterns.retain(|pattern| pattern != "node_modules");
+        let outcome = run(root, patterns);
+
+        assert_eq!(
+            relatives(&outcome),
+            vec!["node_modules/pkg/index.js", "src/lib.rs"],
+            "removing node_modules from the user's own list must really re-include it: {:?}",
+            relatives(&outcome)
+        );
+    }
+
+    /// The default request (what every fresh install effectively sends, before any Settings edit)
+    /// still excludes `target/` - the same core #387 guarantee, now proven through the
+    /// user-editable field's own real default rather than only through the old hardcoded-constant
+    /// call path.
+    #[test]
+    fn the_real_default_search_excludes_still_excludes_target() {
+        let dir = tempfile::tempdir().expect("a temp worktree");
+        let root = dir.path();
+        write(root, "src/lib.rs", "needle\n");
+        write(root, "target/debug/deps/needle.d", "needle\n");
+
+        let outcome = run(root, exclude::default_search_excludes());
+
+        assert_eq!(relatives(&outcome), vec!["src/lib.rs"]);
     }
 }

--- a/crates/app/src/search/exclude.rs
+++ b/crates/app/src/search/exclude.rs
@@ -24,6 +24,27 @@
 //! filter checked on top of this module's walk, not as the sole file source #388 originally made
 //! it - see that function's own docs for exactly how the two compose.
 //!
+//! ## GitHub issue #401: the list itself is now real, user-editable settings state
+//!
+//! [`DEFAULT_EXCLUDES`] below is still the real, compiled-in list, but as of #401 it is no longer
+//! the list layer one's own walk actually prunes against in production. That list now lives at
+//! [`crate::settings::store::EditorSettings::search_excludes`] - a real, persisted `Vec<String>`
+//! the Editor settings page's own Search section lets the user add a pattern to or remove a
+//! pattern from - and [`exclude_list_from`] is what compiles *that* list into the same
+//! [`GlobList`] [`default_exclude_list`] used to build from the constant alone.
+//!
+//! [`EditorSettings::search_excludes`]'s own default is [`default_search_excludes`], i.e.
+//! [`DEFAULT_EXCLUDES`] copied into an owned, editable `Vec<String>` - so [`DEFAULT_EXCLUDES`]
+//! survives as this module's real floor for a *fresh install with no settings file yet* (and as
+//! the value every existing test in this module below still exercises directly), while a user who
+//! has actually opened Settings is editing their own real copy of it, not a second list layered on
+//! top of an invisible one they can't see or change. This is the deliberate "seed, don't hide"
+//! answer to the replace-vs-additive question: VS Code's own `search.exclude` is the editable,
+//! visible source of truth, seeded with real defaults, not a hidden base plus an add-on - see
+//! `EditorSettings::search_excludes`'s own docs for the full reasoning, including why this
+//! repository's own checkout (`target`/`.shared-target`) is the concrete case that reasoning has to
+//! hold up against if a user ever trims their own copy of the list too far.
+//!
 //! ## Why `target` and `.shared-target` are both in the default list
 //!
 //! This repository's own checkout is the real, live case [`DEFAULT_EXCLUDES`] has to hold up
@@ -87,6 +108,31 @@ pub const DEFAULT_EXCLUDES: &[&str] = &[
 /// more than that for the walk itself.
 pub fn default_exclude_list() -> GlobList {
     GlobList::parse(&DEFAULT_EXCLUDES.join(","))
+}
+
+/// [`DEFAULT_EXCLUDES`] as an owned, editable `Vec<String>` - the real seed value
+/// [`crate::settings::store::EditorSettings::search_excludes`]'s own `Default` impl uses, and what
+/// every real fresh install starts out with in Settings > Editor > Search before the user ever
+/// touches it. See this module's own "GitHub issue #401" docs for why the persisted setting is
+/// seeded from this rather than layered additively on top of it.
+pub fn default_search_excludes() -> Vec<String> {
+    DEFAULT_EXCLUDES.iter().map(|s| s.to_string()).collect()
+}
+
+/// Compiles a real, user-editable pattern list (`EditorSettings::search_excludes`, or a test's own
+/// stand-in for it) into the same [`GlobList`] [`default_exclude_list`] builds from the constant -
+/// one real compilation path for "whatever list of bare/glob directory patterns is currently in
+/// force," whether that list is the compiled-in default or the user's own edited copy of it.
+///
+/// Reuses [`GlobList::parse`]'s own comma-joined-list parsing rather than a `Vec`-specific one:
+/// each pattern is validated and normalized exactly the way a single pattern typed into the
+/// panel's own include/exclude fields already is (bare name -> basename-anywhere, blank entries
+/// dropped) - see [`crate::search::glob`]'s own module docs for the full rule set. An empty
+/// `patterns` slice (a user who has genuinely deleted every entry) compiles to an empty
+/// [`GlobList`], which [`GlobList::is_empty`]/[`GlobList::matches`] already treat as "never
+/// excludes anything" - a real, honest state this function does not second-guess.
+pub fn exclude_list_from(patterns: &[String]) -> GlobList {
+    GlobList::parse(&patterns.join(","))
 }
 
 /// Every real file under `root`, as an absolute path paired with its worktree-relative,
@@ -294,6 +340,86 @@ mod tests {
             assert_eq!(relatives(&files), vec!["src/lib.rs"]);
             assert!(!truncated);
         }
+    }
+
+    #[test]
+    fn default_search_excludes_is_an_owned_copy_of_default_excludes() {
+        assert_eq!(
+            default_search_excludes(),
+            DEFAULT_EXCLUDES
+                .iter()
+                .map(|s| s.to_string())
+                .collect::<Vec<_>>(),
+            "the real settings default must seed from exactly the compiled-in list, not a \
+             hand-copied second one that could drift from it"
+        );
+    }
+
+    #[test]
+    fn exclude_list_from_a_custom_pattern_excludes_matching_directories() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        write(root, "src/lib.rs", "fn main() {}\n");
+        write(root, "coverage/report.html", "<html></html>\n");
+
+        // Not on the built-in list at all - only real once the user has actually added it.
+        let excludes = exclude_list_from(&["coverage".to_string()]);
+        let (files, _truncated) = collect_files_excluding(root, &excludes, 20_000);
+        assert_eq!(
+            relatives(&files),
+            vec!["src/lib.rs"],
+            "a user-added pattern must be pruned by the walk exactly like a built-in one"
+        );
+    }
+
+    #[test]
+    fn exclude_list_from_with_a_default_entry_removed_re_includes_it() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        write(root, "src/lib.rs", "fn main() {}\n");
+        for i in 0..5 {
+            write(root, &format!("target/debug/deps/artifact-{i}.o"), "junk");
+        }
+        write(
+            root,
+            "node_modules/left-pad/index.js",
+            "module.exports = 1;\n",
+        );
+
+        // The user's own edited copy of the default list with `target` deleted from it - the
+        // real shape `EditorSettings::search_excludes` takes once a row's remove affordance is
+        // clicked (`crate::settings::render::AdeApp::remove_search_exclude_pattern`).
+        let mut patterns = default_search_excludes();
+        patterns.retain(|pattern| pattern != "target");
+        let excludes = exclude_list_from(&patterns);
+
+        let (files, _truncated) = collect_files_excluding(root, &excludes, 20_000);
+        let found = relatives(&files);
+        assert!(
+            found.iter().any(|path| path.starts_with("target/")),
+            "removing `target` from the user's own list must really re-include it: {found:?}"
+        );
+        assert!(
+            !found.iter().any(|path| path.starts_with("node_modules/")),
+            "every other still-present default entry must keep excluding: {found:?}"
+        );
+        assert!(found.contains(&"src/lib.rs"));
+    }
+
+    #[test]
+    fn exclude_list_from_an_empty_list_excludes_nothing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        write(root, "src/lib.rs", "fn main() {}\n");
+        write(root, "target/debug/x.o", "junk");
+
+        let excludes = exclude_list_from(&[]);
+        let (files, _truncated) = collect_files_excluding(root, &excludes, 20_000);
+        assert_eq!(
+            relatives(&files),
+            vec!["src/lib.rs", "target/debug/x.o"],
+            "a user who has genuinely deleted every entry gets an honest, unfiltered walk"
+        );
     }
 
     #[test]

--- a/crates/app/src/search/render.rs
+++ b/crates/app/src/search/render.rs
@@ -1148,6 +1148,9 @@ impl AdeApp {
             root: self.file_tree_root.clone(),
             matcher,
             filter: PathFilter::new(self.search.include.as_str(), self.search.exclude.as_str()),
+            // GitHub issue #401: the real, persisted, user-editable list - see
+            // `crate::settings::store::EditorSettings::search_excludes`'s own docs.
+            search_excludes: self.settings.editor.search_excludes.clone(),
             respect_gitignore: self.settings.editor.respect_gitignore,
         };
         // Captured now rather than re-read after the awaits below: a search that resolves against

--- a/crates/app/src/settings/render.rs
+++ b/crates/app/src/settings/render.rs
@@ -2,8 +2,8 @@ use super::*;
 use crate::root::plural;
 use crate::root::scrollbar;
 use crate::root::widgets::{
-    self, hover_keycap_row, menu_popover_chrome, render_env_chip, render_keycap_row, KeycapSize,
-    SimpleInput, TextFieldHandle,
+    self, hover_keycap_row, menu_popover_chrome, render_env_chip, render_keycap_row, text_tooltip,
+    KeycapSize, SimpleInput, TextFieldHandle,
 };
 use crate::settings::widgets::ChoiceOption;
 use crate::sound::SoundEventKind;
@@ -3301,10 +3301,10 @@ impl AdeApp {
         );
         let respect_gitignore_row = self.render_settings_row(
             "Use .gitignore in search",
-            "The Search panel always skips target/, node_modules/, .git and a handful of other \
-             common build/dependency directories by name, regardless of this setting. On top of \
-             that, additionally hide whatever the active worktree's own .gitignore hides. Off \
-             scopes search independently of git entirely - only the built-in list above applies.",
+            "The Search panel always skips whatever is on the exclude list below, regardless of \
+             this setting. On top of that, additionally hide whatever the active worktree's own \
+             .gitignore hides. Off scopes search independently of git entirely - only the list \
+             below applies.",
             self.render_toggle_control(
                 "settings-editor-respect-gitignore",
                 self.settings.editor.respect_gitignore,
@@ -3312,6 +3312,7 @@ impl AdeApp {
                 |this, cx| this.toggle_respect_gitignore(cx),
             ),
         );
+        let search_exclude_list = self.render_search_exclude_list(cx);
 
         div()
             .flex()
@@ -3352,7 +3353,306 @@ impl AdeApp {
                     .child("Search"),
             )
             .child(respect_gitignore_row)
+            .child(
+                div()
+                    .pt(px(14.0))
+                    .pb(px(6.0))
+                    .font(font(theme::font::SANS))
+                    .text_size(px(12.0))
+                    .text_color(theme::text::HEADING)
+                    .child("Exclude patterns"),
+            )
+            .child(
+                div()
+                    .pb(px(2.0))
+                    .font(font(theme::font::SANS))
+                    .text_size(px(11.0))
+                    .line_height(px(16.0))
+                    .text_color(theme::text::FAINT)
+                    .child(
+                        "Directories and files search never descends into, by real glob pattern \
+                         (GitHub issue #401). Seeded from Jerry's own defaults - remove one you \
+                         don't want, or add your own below.",
+                    ),
+            )
+            .child(search_exclude_list)
             .child(self.render_snippet_block(settings_store::ConfigPage::Editor))
+    }
+
+    /// GitHub issue #401's real, editable exclude-pattern list: a bordered card holding one
+    /// [`Self::render_search_exclude_pattern_row`] per real entry in
+    /// `settings.editor.search_excludes`, followed by [`Self::render_search_exclude_add_row`] as
+    /// the card's own final row - the same "filter/action row lives inside the same card as the
+    /// rows it acts on" shape [`Self::render_settings_keymap_page`] already established for the
+    /// Keybindings page's filter field, applied here to an add-row instead of a filter.
+    ///
+    /// A genuinely empty list (every entry removed) renders the card with nothing in it but the
+    /// add row - a real, honest state, not specially called out, since
+    /// `EditorSettings::search_excludes`'s own docs already say plainly what an empty list means.
+    fn render_search_exclude_list(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let patterns = self.settings.editor.search_excludes.clone();
+        let has_patterns = !patterns.is_empty();
+        div()
+            .rounded(theme::radius::CARD)
+            .border_1()
+            .border_color(theme::border::CARD)
+            .overflow_hidden()
+            .children(
+                patterns
+                    .iter()
+                    .map(|pattern| self.render_search_exclude_pattern_row(pattern, cx)),
+            )
+            .child(self.render_search_exclude_add_row(has_patterns, cx))
+    }
+
+    /// One real pattern's own row: the pattern text, monospaced (it's a real glob, not prose), and
+    /// a single-click remove affordance. Deliberately **not**
+    /// [`Self::request_remove_custom_theme`]'s two-click arm/confirm: that guards a real,
+    /// irreversible disk delete, while removing one entry here is trivially reversible (retype
+    /// it, or reload Settings without having saved) - the same "don't add friction a real action
+    /// doesn't need" call [`Self::render_theme_card`]'s own docs make for *keeping* its two-click
+    /// guard, applied in the opposite direction here.
+    fn render_search_exclude_pattern_row(
+        &self,
+        pattern: &str,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let label = pattern.to_string();
+        let selector_pattern = pattern.to_string();
+        let remove_button_selector_pattern = pattern.to_string();
+        let remove_pattern = pattern.to_string();
+        div()
+            .id(gpui::ElementId::from(format!(
+                "settings-search-exclude-row-{pattern}"
+            )))
+            // Test-only, no-op in release builds - lets a real interaction test confirm exactly
+            // which patterns rendered, the same convention `Self::render_theme_card`'s own
+            // `debug_selector` follows.
+            .debug_selector(move || format!("search-exclude-row-{selector_pattern}"))
+            .flex()
+            .items_center()
+            .justify_between()
+            .gap(px(10.0))
+            .px(px(11.0))
+            .py(px(7.0))
+            .bg(theme::surface::CARD)
+            .border_b_1()
+            .border_color(theme::settings::CARD_ROW_SEP)
+            .child(
+                div()
+                    .flex_1()
+                    .min_w_0()
+                    .truncate()
+                    .font(font(theme::font::MONO))
+                    .text_size(px(11.0))
+                    .text_color(theme::text::BODY)
+                    .child(label),
+            )
+            .child(
+                div()
+                    .id(gpui::ElementId::from(format!(
+                        "settings-search-exclude-remove-{pattern}"
+                    )))
+                    // Test-only, no-op in release builds - `Self::render_theme_card`'s own
+                    // remove button follows the identical convention (a real, own `debug_selector`
+                    // distinct from the row's), so a real interaction test can find and click
+                    // *this* control specifically rather than only the row around it.
+                    .debug_selector(move || {
+                        format!("settings-search-exclude-remove-{remove_button_selector_pattern}")
+                    })
+                    .cursor_pointer()
+                    .flex_none()
+                    .w(px(20.0))
+                    .h(px(20.0))
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .rounded(theme::radius::CHIP)
+                    .hover(|el| el.bg(theme::surface::ROW_HOVER_ALT))
+                    .tooltip(text_tooltip(format!("Remove \"{pattern}\"")))
+                    .child(
+                        crate::icons::IconRow::new(
+                            &self.settings.icon_pack,
+                            crate::icons::IconSize::Control,
+                        )
+                        .draw(crate::icons::Icon::Trash, theme::text::FAINT),
+                    )
+                    .on_click(cx.listener(move |this, _event: &ClickEvent, _window, cx| {
+                        this.remove_search_exclude_pattern(&remove_pattern, cx);
+                    })),
+            )
+    }
+
+    /// The list's own final row: a real text input (the same [`widgets::SimpleInput`]/
+    /// [`Self::render_simple_input_row`] shape [`Self::render_settings_keymap_filter_row`] already
+    /// uses) that appends a pattern to `settings.editor.search_excludes` on `Enter` - see
+    /// [`Self::handle_search_exclude_input_key_down`]/[`Self::add_search_exclude_pattern`].
+    /// `has_patterns` only controls whether a separating top border is drawn - with zero real rows
+    /// above it, this is the card's only content and needs no divider under a rounded top edge
+    /// that's already its own.
+    fn render_search_exclude_add_row(
+        &self,
+        has_patterns: bool,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        self.wire_text_input_actions(
+            div()
+                .id("settings-search-exclude-add")
+                .track_focus(&self.search_exclude_input_focus_handle)
+                // See `crate::default_key_bindings`' `TextUndo`/`TextRedo` docs for why the tag
+                // and the listener both live on this exact node.
+                .key_context("text-input")
+                .on_action(cx.listener(Self::handle_search_exclude_input_text_undo))
+                .on_action(cx.listener(Self::handle_search_exclude_input_text_redo))
+                .on_key_down(cx.listener(Self::handle_search_exclude_input_key_down)),
+            search_exclude_input_handle(),
+            cx,
+        )
+        .on_click(cx.listener(|this, _event: &ClickEvent, window, cx| {
+            window.focus(&this.search_exclude_input_focus_handle, cx);
+        }))
+        .when(has_patterns, |el| {
+            el.border_t_1().border_color(theme::settings::CARD_ROW_SEP)
+        })
+        .flex()
+        .items_center()
+        .gap(px(7.0))
+        .px(px(11.0))
+        .py(px(7.0))
+        .bg(theme::surface::CARD_SUNK)
+        .child(
+            div()
+                .flex_none()
+                .font(font(theme::font::MONO))
+                .text_size(px(11.0))
+                .text_color(theme::text::GHOSTER)
+                .child("+"),
+        )
+        .child(
+            div()
+                .flex_1()
+                .min_w_0()
+                .flex()
+                .items_center()
+                .child(self.render_simple_input_row(
+                    SimpleInput {
+                        caret_selector: "settings-search-exclude-add-caret".into(),
+                        text_selector: "settings-search-exclude-add-text".into(),
+                        focus_handle: Some(&self.search_exclude_input_focus_handle),
+                        text: self.search_exclude_input.as_str(),
+                        caret_offset: self.search_exclude_input.caret(),
+                        selection: self.search_exclude_input.selection(),
+                        placeholder: "add a pattern, e.g. coverage or *.map, then press Enter",
+                        font: theme::font::SANS,
+                        text_size: px(11.0),
+                        text_color: theme::text::DIM,
+                        placeholder_color: theme::text::GHOST,
+                        caret: widgets::SimpleInputCaret::default(),
+                        field: Some(search_exclude_input_handle()),
+                    },
+                    cx,
+                )),
+        )
+    }
+
+    /// The add row's key handler - append/backspace (ordinary typing), `Enter`
+    /// ([`Self::add_search_exclude_pattern`]), `Esc` (clears whatever's typed so far, mirroring
+    /// [`Self::handle_settings_keymap_filter_key_down`]'s identical `Esc` behaviour for its own
+    /// field). `Enter` always counts as a real change (the field always ends up cleared, whatever
+    /// state the pattern list ends up in - see [`Self::add_search_exclude_pattern`]'s own docs),
+    /// so `changed` is unconditionally `true` on that branch rather than threaded through from a
+    /// `bool` return.
+    pub(in crate::settings) fn handle_search_exclude_input_key_down(
+        &mut self,
+        event: &KeyDownEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let keystroke = &event.keystroke;
+        let Some(modifiers) = widgets::text_editing_modifiers(&keystroke.key, &keystroke.modifiers)
+        else {
+            return;
+        };
+        self.reset_caret_blink(cx);
+        let changed = match keystroke.key.as_str() {
+            "escape" => self.search_exclude_input.clear(Instant::now()),
+            "enter" => {
+                self.add_search_exclude_pattern(cx);
+                true
+            }
+            key => self.search_exclude_input.handle_editing_key(
+                key,
+                keystroke.key_char.as_deref(),
+                modifiers,
+                Instant::now(),
+            ),
+        };
+        if changed {
+            cx.notify();
+            cx.stop_propagation();
+        }
+    }
+
+    pub(in crate::settings) fn handle_search_exclude_input_text_undo(
+        &mut self,
+        _: &TextUndo,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.search_exclude_input.undo() {
+            cx.notify();
+        }
+    }
+
+    pub(in crate::settings) fn handle_search_exclude_input_text_redo(
+        &mut self,
+        _: &TextRedo,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.search_exclude_input.redo() {
+            cx.notify();
+        }
+    }
+
+    /// The real "add a pattern" action (GitHub issue #401): the input's current text, trimmed, is
+    /// appended to `settings.editor.search_excludes` and persisted - unless it's blank or already
+    /// on the list, in which case there's nothing to add. Either way the field is cleared
+    /// afterwards: a blank `Enter` had nothing to clear, and a duplicate's already-desired end
+    /// state (that pattern being excluded) already holds, so leaving the just-submitted text
+    /// sitting in the field would read as "did that not work?" for no reason.
+    ///
+    /// No `sanitize()` call here - trimming and de-duplicating this one insertion inline is
+    /// simpler and exactly as correct as calling the whole-list `EditorSettings::sanitize` for a
+    /// single append would be, and avoids re-normalizing (and potentially reordering) every other
+    /// entry on every keystroke's `Enter`.
+    fn add_search_exclude_pattern(&mut self, cx: &mut Context<Self>) {
+        let pattern = self.search_exclude_input.as_str().trim().to_string();
+        if !pattern.is_empty()
+            && !self
+                .settings
+                .editor
+                .search_excludes
+                .iter()
+                .any(|existing| existing == &pattern)
+        {
+            self.settings.editor.search_excludes.push(pattern);
+            self.persist_settings(cx);
+        }
+        self.search_exclude_input.clear(Instant::now());
+    }
+
+    /// The real "remove this pattern" action (GitHub issue #401) - a single click, see
+    /// [`Self::render_search_exclude_pattern_row`]'s own docs for why this has no two-click
+    /// confirm. A `pattern` no longer on the list (a stale click racing a second removal) is a
+    /// harmless no-op, matching every other by-value list mutation in this module.
+    fn remove_search_exclude_pattern(&mut self, pattern: &str, cx: &mut Context<Self>) {
+        self.settings
+            .editor
+            .search_excludes
+            .retain(|existing| existing != pattern);
+        self.persist_settings(cx);
+        cx.notify();
     }
 
     /// *Notifications* (GitHub issue #226): the sound design module. Master switch, one row per
@@ -4823,6 +5123,15 @@ fn settings_keymap_filter_handle() -> TextFieldHandle {
     TextFieldHandle::new(|app: &mut AdeApp| Some(&mut app.settings_keymap_filter))
 }
 
+/// The Editor > Search "add a pattern" field's own handle (GitHub issue #401). No `on_changed`:
+/// unlike a filter field, ordinary typing here has no live follow-up work at all - the real
+/// action only happens on `Enter`, which `Self::handle_search_exclude_input_key_down` already
+/// calls `Self::add_search_exclude_pattern` from directly rather than through this handle's
+/// `on_changed` hook.
+fn search_exclude_input_handle() -> TextFieldHandle {
+    TextFieldHandle::new(|app: &mut AdeApp| Some(&mut app.search_exclude_input))
+}
+
 /// The "Generate from colour" seed field's own handle. No `on_changed` for the same reason
 /// [`settings_keymap_filter_handle`] has none: the live colour swatch beside the field is derived
 /// from it at render time, so `cx.notify()` is all the follow-up there is.
@@ -5083,6 +5392,194 @@ mod settings_keymap_filter_tests {
         assert!(
             cx.debug_bounds("keybinding-row-Command palette").is_some(),
             "clearing the real filter should render every row again"
+        );
+    }
+}
+
+/// Interactive regression coverage for GitHub issue #401's real, editable exclude-pattern list -
+/// like `settings_keymap_filter_tests` above, this drives the actually rendered UI (a focused
+/// field receiving simulated keystrokes, a real click on a rendered button), checked through
+/// `VisualTestContext::debug_bounds`/the live `settings.editor.search_excludes` field and a real
+/// on-disk `settings.toml`, not just the pure `add`/`remove` methods called directly.
+#[cfg(test)]
+mod search_exclude_settings_tests {
+    use super::*;
+    use crate::root::focus::palette_focus_tests;
+    use gpui::TestAppContext;
+
+    fn open_test_app_with_real_settings_path(
+        cx: &mut TestAppContext,
+        repo_path: PathBuf,
+        settings: settings_store::Settings,
+        settings_path: PathBuf,
+    ) -> (gpui::Entity<AdeApp>, &mut gpui::VisualTestContext) {
+        cx.add_window_view(|window, cx| {
+            AdeApp::new_with_settings(
+                Some(repo_path),
+                true,
+                settings,
+                Some(settings_path),
+                window,
+                cx,
+            )
+        })
+    }
+
+    /// Typing a real pattern into the add row and pressing `Enter` must both update the live
+    /// setting (so the very next search picks it up - `crate::search::render::AdeApp::
+    /// start_search` reads `settings.editor.search_excludes` fresh every time) and clear the
+    /// field for the next entry, exactly like `crate::root::new_file`'s own Enter-submits-and-
+    /// prompt-closes shape.
+    #[gpui::test]
+    fn typing_a_pattern_and_pressing_enter_adds_it_and_clears_the_field(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+
+        cx.dispatch_action(ToggleSettings);
+        app.update_in(cx, |app, window, cx| {
+            app.select_settings_page(SettingsPage::Editor, window, cx);
+        });
+        cx.run_until_parked();
+
+        assert!(
+            cx.debug_bounds("search-exclude-row-target").is_some(),
+            "the real default list must already be rendered, one row per entry"
+        );
+        assert!(
+            cx.debug_bounds("search-exclude-row-coverage").is_none(),
+            "sanity check: nothing named `coverage` yet"
+        );
+
+        app.update_in(cx, |app, window, cx| {
+            window.focus(&app.search_exclude_input_focus_handle, cx);
+        });
+        cx.simulate_input("coverage");
+        cx.simulate_keystrokes("enter");
+        cx.run_until_parked();
+
+        assert!(
+            app.read_with(cx, |app, _| app
+                .settings
+                .editor
+                .search_excludes
+                .iter()
+                .any(|p| p == "coverage")),
+            "the real, live setting must now hold the just-typed pattern"
+        );
+        assert!(
+            cx.debug_bounds("search-exclude-row-coverage").is_some(),
+            "the newly added pattern must actually render as its own row"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.search_exclude_input.as_str().to_string()),
+            "",
+            "the field must clear itself after a real successful submit"
+        );
+    }
+
+    /// Pressing `Enter` on a blank field, or on a pattern that's already on the list, must not
+    /// grow the list with a blank/duplicate entry - see `Self::add_search_exclude_pattern`'s own
+    /// docs for why both are silent no-ops rather than errors.
+    #[gpui::test]
+    fn enter_on_a_blank_or_duplicate_pattern_is_a_silent_no_op(cx: &mut TestAppContext) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+
+        cx.dispatch_action(ToggleSettings);
+        app.update_in(cx, |app, window, cx| {
+            app.select_settings_page(SettingsPage::Editor, window, cx);
+        });
+        cx.run_until_parked();
+
+        let before = app.read_with(cx, |app, _| app.settings.editor.search_excludes.clone());
+
+        app.update_in(cx, |app, window, cx| {
+            window.focus(&app.search_exclude_input_focus_handle, cx);
+        });
+        cx.simulate_keystrokes("enter");
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.settings.editor.search_excludes.clone()),
+            before,
+            "Enter on a genuinely blank field must add nothing"
+        );
+
+        cx.simulate_input("target");
+        cx.simulate_keystrokes("enter");
+        cx.run_until_parked();
+        assert_eq!(
+            app.read_with(cx, |app, _| app.settings.editor.search_excludes.clone()),
+            before,
+            "Enter on a pattern already on the list must not add a second, duplicate entry"
+        );
+    }
+
+    /// Clicking a pattern row's own remove affordance must remove exactly that pattern from the
+    /// real, live setting, leave every other default entry alone, and persist the removal to a
+    /// real `settings.toml` on disk - the same "click really reaches the file" bar
+    /// `custom_theme_settings_tests::clicking_the_real_remove_button_deletes_the_theme_without_
+    /// selecting_its_card` already sets for a theme card's own remove button.
+    #[gpui::test]
+    fn clicking_the_remove_button_removes_exactly_that_pattern_and_persists(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let settings_path = settings_dir.path().join("settings.toml");
+        let (app, cx) = open_test_app_with_real_settings_path(
+            cx,
+            repo.path().to_path_buf(),
+            settings_store::Settings::default(),
+            settings_path.clone(),
+        );
+        cx.dispatch_action(ToggleSettings);
+        app.update_in(cx, |app, window, cx| {
+            app.select_settings_page(SettingsPage::Editor, window, cx);
+        });
+        cx.run_until_parked();
+
+        let remove_bounds = cx
+            .debug_bounds("settings-search-exclude-remove-node_modules")
+            .expect("the remove affordance must have painted on the node_modules row");
+        cx.simulate_click(remove_bounds.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        app.read_with(cx, |app, _| {
+            assert!(
+                !app.settings
+                    .editor
+                    .search_excludes
+                    .iter()
+                    .any(|p| p == "node_modules"),
+                "a single real click must really remove the pattern from the live setting"
+            );
+            assert!(
+                app.settings
+                    .editor
+                    .search_excludes
+                    .iter()
+                    .any(|p| p == "target"),
+                "every other default entry must be untouched by removing a different one"
+            );
+        });
+        assert!(
+            cx.debug_bounds("search-exclude-row-node_modules").is_none(),
+            "the removed pattern's own row must no longer render"
+        );
+
+        // The write is queued onto the background executor's serial writer loop - see
+        // `Self::persist_settings`'s own docs - so it has to be let run before the file is real.
+        cx.run_until_parked();
+
+        let on_disk = settings_store::Settings::load_or_init_at(&settings_path);
+        assert!(
+            !on_disk
+                .editor
+                .search_excludes
+                .iter()
+                .any(|p| p == "node_modules"),
+            "the removal must round-trip through a real save to settings.toml: {:?}",
+            on_disk.editor.search_excludes
         );
     }
 }

--- a/crates/app/src/settings/store.rs
+++ b/crates/app/src/settings/store.rs
@@ -605,7 +605,7 @@ impl SoundEventSettings {
 /// `Shift+Tab`'s own dedent" - `crate::code_surface::indent::indent_settings_for_path` overrides
 /// either field from a real `.editorconfig` file when one applies to the file being edited; these
 /// are only the fallback once no `.editorconfig` sets a given property.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct EditorSettings {
     pub minimap_enabled: bool,
@@ -651,6 +651,45 @@ pub struct EditorSettings {
     /// from this field), and toggled by the Editor settings page's own row
     /// (`crate::settings::render::AdeApp::toggle_respect_gitignore`).
     pub respect_gitignore: bool,
+    /// Layer one's own real, persisted, user-editable pattern list (GitHub issue #401, a direct
+    /// live follow-up to #394/#396: "The things you changed for the search are not configurable?
+    /// They are not in settings or something?"). Read by
+    /// `crate::search::engine::search_worktree_cancellable` via
+    /// `crate::search::engine::SearchRequest::search_excludes`
+    /// (`crate::search::render::AdeApp::start_search` populates it fresh from this field on every
+    /// real search, same as [`Self::respect_gitignore`]), and edited from the Editor settings
+    /// page's own Search section - one row per pattern with a remove affordance
+    /// (`crate::settings::render::AdeApp::remove_search_exclude_pattern`), plus a real text input
+    /// to add a new one (`crate::settings::render::AdeApp::add_search_exclude_pattern`).
+    ///
+    /// ## Replace, not additive - and why
+    ///
+    /// This field is compiled directly into the [`crate::search::glob::GlobList`]
+    /// [`crate::search::exclude::collect_files_excluding`]'s walk prunes against
+    /// (`crate::search::exclude::exclude_list_from`) - it **replaces**
+    /// `crate::search::exclude::DEFAULT_EXCLUDES` as the walk's real input, rather than being an
+    /// *additional* list layered on top of that constant. [`Self::default`] seeds this field from
+    /// [`crate::search::exclude::default_search_excludes`] (i.e. `DEFAULT_EXCLUDES` copied into an
+    /// owned, editable `Vec<String>`), so a fresh install starts out excluding exactly what it
+    /// always did - but the value the user actually sees and edits in Settings *is* the real,
+    /// complete, walk-time list, not a second one shadowing an invisible base they cannot change.
+    ///
+    /// This matches how VS Code's own `search.exclude` genuinely works: it is the editable,
+    /// visible source of truth, pre-populated with sensible defaults, not a hidden built-in list
+    /// plus a user-only add-on layered silently over it. The alternative (an always-on hidden
+    /// floor plus this field purely additive on top) would mean a user could never actually
+    /// *remove* `target` from what gets excluded even if they had a real reason to (say, a
+    /// worktree named `target/` that legitimately holds source, however unlikely) - "visible and
+    /// editable" has to include being able to shrink it, not just grow it.
+    ///
+    /// The one real risk that design choice accepts, stated plainly: unlike the old two-layer
+    /// model's `DEFAULT_EXCLUDES`, this list is not an unconditional floor - a user who explicitly
+    /// deletes `target` (or every entry) from their own copy really does get an unfiltered walk,
+    /// on *this* repository's own real ~59 GB `target/` + `.shared-target/` included. That is the
+    /// same tradeoff VS Code itself accepts for `search.exclude`, and is judged the right one here:
+    /// a setting the user cannot actually edit down to what they want is not the real, editable
+    /// setting issue #401 asked for.
+    pub search_excludes: Vec<String>,
 }
 
 impl Default for EditorSettings {
@@ -663,6 +702,7 @@ impl Default for EditorSettings {
             auto_import: true,
             suggest_auto_imports: true,
             respect_gitignore: true,
+            search_excludes: crate::search::exclude::default_search_excludes(),
         }
     }
 }
@@ -693,6 +733,27 @@ impl EditorSettings {
         self.tab_width = self
             .tab_width
             .clamp(EDITOR_TAB_WIDTH_MIN, EDITOR_TAB_WIDTH_MAX);
+        // A hand-edited `search_excludes` gets trimmed/deduped, not rejected - the same "hand-edit
+        // gets normalized" discipline [`SoundEventSettings::sanitize`]'s own docs describe for a
+        // blank `sound`. Blank entries (`""`, or whitespace-only after a stray trailing comma-style
+        // hand-edit) are dropped outright rather than kept as a pattern
+        // [`crate::search::glob::Glob::parse`] would silently treat as "no pattern" anyway - a
+        // Settings-page row rendering an entirely blank line would be a real, visible bug, not a
+        // faithful mirror of the file. Order is preserved and exact duplicates are collapsed to
+        // their first occurrence, so a hand-edited `["target", "target"]` shows one row, not two
+        // identical, independently-removable ones.
+        let mut seen = std::collections::HashSet::new();
+        self.search_excludes = std::mem::take(&mut self.search_excludes)
+            .into_iter()
+            .filter_map(|pattern| {
+                let trimmed = pattern.trim().to_string();
+                if trimmed.is_empty() || !seen.insert(trimmed.clone()) {
+                    None
+                } else {
+                    Some(trimmed)
+                }
+            })
+            .collect();
     }
 }
 
@@ -846,7 +907,7 @@ pub fn config_keys_line(page: ConfigPage) -> &'static str {
         }
         ConfigPage::Editor => {
             "editor.minimap_enabled \u{b7} editor.minimap_scale_percent \u{b7} \
-             editor.respect_gitignore"
+             editor.respect_gitignore \u{b7} editor.search_excludes"
         }
         ConfigPage::Notifications => {
             "sound.enabled \u{b7} sound.app_start.sound \u{b7} sound.agent_finished.sound \u{b7} \
@@ -1018,6 +1079,12 @@ mod tests {
             settings.editor.respect_gitignore,
             "matches VS Code's own search.useIgnoreFiles default of true"
         );
+        assert_eq!(
+            settings.editor.search_excludes,
+            crate::search::exclude::default_search_excludes(),
+            "GitHub issue #401: a fresh install's real, editable list must start out identical to \
+             crate::search::exclude::DEFAULT_EXCLUDES, not some independently-maintained copy"
+        );
     }
 
     /// The real toggle a user flips from the Editor settings page - see
@@ -1062,6 +1129,105 @@ mod tests {
         assert!(
             loaded.editor.respect_gitignore,
             "a missing key must fall back to the real default, not an implicit false"
+        );
+        assert_eq!(
+            loaded.editor.search_excludes,
+            crate::search::exclude::default_search_excludes(),
+            "a settings.toml written before GitHub issue #401 has no search_excludes key at all - \
+             it must fall back to the real default list, not an empty (unfiltered) one"
+        );
+    }
+
+    /// GitHub issue #401's real, editable list - proven the same way `respect_gitignore_persists_
+    /// through_a_real_save_and_load_in_both_states` proves its own toggle: a real save + load
+    /// round trip, both adding a custom pattern and removing a default one, since a setting nobody
+    /// can actually edit-and-keep-edited is not a real setting.
+    #[test]
+    fn search_excludes_persists_through_a_real_save_and_load_with_a_custom_edit() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("settings.toml");
+
+        let mut settings = Settings::default();
+        assert_eq!(
+            settings.editor.search_excludes,
+            crate::search::exclude::default_search_excludes(),
+            "the real default"
+        );
+        // The real shape of a Settings-page edit: the user added `coverage` and removed the
+        // default `dist` entry.
+        settings.editor.search_excludes.push("coverage".to_string());
+        settings.editor.search_excludes.retain(|p| p != "dist");
+        settings.save_at(&path).expect("save");
+
+        let reloaded = Settings::load_or_init_at(&path);
+        assert!(
+            reloaded
+                .editor
+                .search_excludes
+                .iter()
+                .any(|p| p == "coverage"),
+            "a real save must round-trip a user-added pattern: {:?}",
+            reloaded.editor.search_excludes
+        );
+        assert!(
+            !reloaded.editor.search_excludes.iter().any(|p| p == "dist"),
+            "a real save must round-trip a user's removal of a default pattern too, not silently \
+             restore it: {:?}",
+            reloaded.editor.search_excludes
+        );
+        assert!(
+            reloaded
+                .editor
+                .search_excludes
+                .iter()
+                .any(|p| p == "target"),
+            "every other untouched default entry must still be there: {:?}",
+            reloaded.editor.search_excludes
+        );
+    }
+
+    /// [`EditorSettings::sanitize`]'s own "hand-edit gets normalized, not rejected" discipline,
+    /// applied to `search_excludes`: blank entries are dropped and exact duplicates are collapsed,
+    /// the same way a hand-edited `settings.toml` full of stray whitespace/repeats is normalized
+    /// rather than rejected outright elsewhere in this module.
+    #[test]
+    fn a_hand_edited_search_excludes_with_blanks_and_duplicates_is_sanitized() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("settings.toml");
+        std::fs::write(
+            &path,
+            "[editor]\nsearch_excludes = [\"target\", \" \", \"target\", \"  coverage  \", \"\"]\n",
+        )
+        .expect("write hand-edited file");
+
+        let loaded = Settings::load_or_init_at(&path);
+        assert_eq!(
+            loaded.editor.search_excludes,
+            vec!["target".to_string(), "coverage".to_string()],
+            "blank entries dropped, duplicates collapsed, real entries trimmed: {:?}",
+            loaded.editor.search_excludes
+        );
+    }
+
+    /// A user who genuinely wants an unfiltered search is allowed to delete every entry - a real,
+    /// honest empty list, not one `sanitize` quietly refills back to the default. See
+    /// `EditorSettings::search_excludes`'s own "one real risk" docs for why this is the accepted
+    /// tradeoff.
+    #[test]
+    fn a_genuinely_empty_search_excludes_list_round_trips_as_empty() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("settings.toml");
+
+        let mut settings = Settings::default();
+        settings.editor.search_excludes.clear();
+        settings.save_at(&path).expect("save");
+
+        let reloaded = Settings::load_or_init_at(&path);
+        assert!(
+            reloaded.editor.search_excludes.is_empty(),
+            "an explicit, deliberate empty list must round-trip as empty, not be re-seeded with \
+             the default: {:?}",
+            reloaded.editor.search_excludes
         );
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #394/#396's layered search-exclude model. #396 built an always-on explicit glob denylist (`crates/app/src/search/exclude.rs`'s `DEFAULT_EXCLUDES`) plus a real, persisted `respect_gitignore` toggle. The user asked directly afterwards: "The things you changed for the search are not configurable? They are not in settings or something?" - only `respect_gitignore` was real; the exclude list itself was a hardcoded constant with no UI to change it.

- `EditorSettings::search_excludes: Vec<String>` is a real, persisted setting, seeded from `DEFAULT_EXCLUDES` (`crate::search::exclude::default_search_excludes`) so a fresh install keeps today's defaults untouched.
- **Replace, not additive**: this field *replaces* `DEFAULT_EXCLUDES` as the walk's real input (`crate::search::exclude::exclude_list_from`), rather than being layered on top of an invisible constant. Matches how VS Code's own `search.exclude` actually works - editable, visible source of truth, not a hidden base plus an add-on. A user can genuinely shrink the list, including to empty (documented tradeoff in `EditorSettings::search_excludes`'s own docs).
- Settings > Editor > Search gets a real "Exclude patterns" list: one row per pattern with a single-click remove affordance (deliberately no two-click confirm - trivially reversible, unlike deleting a theme file off disk), and a real text input to add a new one (`Enter` submits and clears the field, `Esc` clears). The new `FocusHandle` is wired into `wire_caret_blink` (issue #45's recurring gap, hit 5+ times before).
- `SearchRequest::search_excludes` threads the live setting through `collect_candidate_files`, which now compiles the caller's own list via `exclude::exclude_list_from` instead of the hardcoded constant.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets` (clean)
- [x] `cargo test -p app --lib search::` (124 passed, incl. new `configurable_exclude_tests` covering a custom pattern excluding files, a removed default re-including them, and the real default still excluding `target/`)
- [x] `cargo test -p app --lib settings::` (256 passed, incl. new persistence tests - custom edit round-trips, hand-edited blanks/duplicates sanitized, a genuinely empty list stays empty - and new `search_exclude_settings_tests` UI interaction tests: typing+Enter adds and clears the field, blank/duplicate Enter is a no-op, a real click on the remove button removes and persists to a real `settings.toml`)
- [x] Real functional check over X11 against the real running app: opened Settings > Editor > Search, confirmed the real default list renders (target, .shared-target, node_modules, .git, dist, build, .next, __pycache__, venv, .venv) matching a fresh install's real `settings.toml`; searched this repo's own real `target/CACHEDIR.TAG` signature and got "no results" with defaults; removed `target` from the list via a real click + turned off "Use .gitignore in search" (this repo's own `.gitignore` also lists `target/`, so both layers had to agree) and re-ran the same search - got a real "1 result in 1 file" hit inside `target/`, proving live re-inclusion end to end.

Closes #401