### PR TITLE
fix(ui): delete the tab strip's content-less trailing spacer, put the + button back

### DIFF
--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -985,9 +985,10 @@ impl AdeApp {
     /// which ones repeat - but two tabs genuinely showing the same thing now honestly render the
     /// same label, exactly as any real terminal emulator's tabs do.
     ///
-    /// GitHub issue #354: the tabs themselves are wrapped in their own `#tab-strip-scroll` child,
-    /// `.flex_initial().min_w_0().overflow_x_scroll()`, tracked by
-    /// [`Self::tab_strip_scroll_handle`], rather than laid out directly in `#tab-strip` itself.
+    /// GitHub issue #354: the tabs themselves (plus the `+` button right after them) are wrapped
+    /// in their own `#tab-strip-scroll` child - `.flex_1().min_w_0().overflow_x_scroll()`,
+    /// tracked by [`Self::tab_strip_scroll_handle`] - rather than laid out directly in
+    /// `#tab-strip` itself.
     /// Before this, the outer row carried no `overflow_x_scroll()`/clip of any kind, so once the
     /// real tabs (each `flex_none`, i.e. sized to its own content) outgrew the strip's available
     /// width, the excess simply painted past the pane's own right edge with no way to reach it -
@@ -1004,24 +1005,32 @@ impl AdeApp {
     /// own intrinsic size, so the scroll region would just grow to fit every tab instead of
     /// staying clipped to the space actually available.
     ///
-    /// GitHub issue #399: the scroller is deliberately `.flex_initial()` (shrink, never grow),
-    /// not `.flex_1()`, since a flex-1 scroller consumed every leftover pixel of the strip even
-    /// when its own tabs didn't need it, leaving a wide dead gap of bare, unpainted chrome
-    /// between the last tab and the strip's real right edge (see [`Self::render_tab_strip`]'s own
-    /// top docs for the live repro this was filed against). The `+` button now rides just after
-    /// the scroller, not inside it - see the growing pusher between them, immediately below.
+    /// The `+` button rides inside the same scrollable region, immediately after the last tab
+    /// (exactly where `Jerry.dc.html`'s own tab row puts it: `sc-for tabs`, then the `+` cell,
+    /// then a `flex:1` filler, then the trailing hint cluster), so reaching it when tabs overflow
+    /// is the same one scroll gesture that reaches the last tab - not a second, independently
+    /// reachable control pinned somewhere else.
     ///
-    /// A trailing chrome spacer stays **outside** the scrollable region, as `#tab-strip`'s own
-    /// direct child alongside the scroller: always visible/pinned, not part of what can be
-    /// scrolled through. It used to carry a real right-aligned agent-jump keycap hint, removed
-    /// per a direct product-owner request (see [`Self::render_tab_strip`]'s own top docs) - a
-    /// bare 12px bordered spacer is kept in its place, to give the strip's trailing edge the same
-    /// breathing room every other 12px chrome margin in this bar gets, and to keep carrying its
-    /// own slice of §4v's bottom rule (`.border_b_1()`) exactly as it did with the hint still in
-    /// it. What actually pins that spacer (and the `+` button before it) flush against the
-    /// strip's real right edge, rather than leaving them wherever the tabs happen to end, is the
-    /// growing pusher between the scroller and the `+` button - see its own docs, right where
-    /// it's built, for why that job could not simply stay the scroller's.
+    /// GitHub issue #405: there is deliberately **no** trailing chrome spacer after the scroller
+    /// any more. The mock's `flex:1` filler and the 12px of padding after it belong to the
+    /// trailing agent-jump keycap cluster - real content, flush against the strip's real right
+    /// edge. GitHub issue #397 (PR #398) deleted that cluster's content but kept a bare
+    /// `w(px(12))` bordered div in its place "for breathing room", which is exactly the live
+    /// report that followed: "the tab strip does not go all the way, there is a strange margin
+    /// right". Padding exists to keep real content off an edge; with the content gone it is just
+    /// 12px of dead chrome, and the tabs (which the scroller clips) stopped 12px short of the
+    /// pane's own right edge instead of running flush into it. The `flex_1()` scroller is what
+    /// owns the strip's leftover width now - filler and clip region in one - and it carries §4v's
+    /// bottom rule itself all the way to that real edge, exactly as the spacer used to.
+    ///
+    /// PR #403 (GitHub issue #402) tried to fix that same report by making the scroller
+    /// `.flex_initial()` and moving the `+` button out behind a new growing pusher, which pinned
+    /// the `+` to the far right of the strip. That mis-read a plain tab row (a `+` immediately
+    /// after the last tab, bare strip after it - what `Jerry.dc.html` itself draws, and what
+    /// every other tabbed editor draws) as a layout bug, and left the actual 12px spacer
+    /// untouched. The product owner's verdict on the result was immediate: "you fixed the plus
+    /// button on the right, why? And the padding is still here." Both halves of that change are
+    /// reverted here.
     pub(in crate::work_surface) fn render_tab_strip(
         &self,
         cx: &mut Context<Self>,
@@ -1034,9 +1043,9 @@ impl AdeApp {
         // the pane below) was defeated by the container's line drawing straight through beneath
         // it. ... A child cannot paint over its parent's border - the parent's border sits outside
         // the child's box - so the container cannot own the edge if any child needs to cut it.
-        // **The tabs own it.**" Every child below therefore carries the rule itself, the `+`, the
-        // growing pusher and the trailing spacer included, "without which the rule stopped at the
-        // last tab and 398px of the window's top edge was simply missing".
+        // **The tabs own it.**" Every child below therefore carries the rule itself, the `+` and
+        // the scroller included, "without which the rule stopped at the last tab and 398px of the
+        // window's top edge was simply missing".
         let bar = div()
             .id("tab-strip")
             // Lets a real test measure this column header's own painted box - §4v's
@@ -1052,28 +1061,21 @@ impl AdeApp {
         let order = self.combined_tab_order();
 
         // GitHub issue #354: the real scrollable region - see this method's own top docs. It is
-        // `.flex_initial().min_w_0()` - shrinks (and clips/scrolls) when the tabs are wider than
-        // the strip has room for, exactly as `flex_1()` did before it, but - unlike `flex_1()` -
-        // never *grows* past its own tabs' real content width when they don't fill the strip.
+        // `flex_1().min_w_0()` (bounded to whatever width the strip actually has left, never
+        // grown past it by its children's own content) and carries the column rule itself
+        // (`.border_b_1()`) so that rule still reaches this region's own right edge when the
+        // tabs don't fill it.
         //
-        // GitHub issue #399: `flex_1()` here used to mean "always consume every leftover pixel
-        // of the strip's width," so a handful of short tab labels left a wide, dead stretch of
-        // bare chrome between the last tab and the `+` button, with nothing painted in it - the
-        // scroller grew to the strip's full width regardless of whether its children needed it.
-        // That dead stretch used to be visually masked by the real content the trailing
-        // agent-jump cluster still carried past it (see `Self::render_tab_strip`'s own docs);
-        // once GitHub issue #397 deleted that cluster's content, the same pre-existing dead
-        // stretch became the strip's *entire* trailing edge - "the tab strip does not go all the
-        // way, there is a strange margin right" is this scroller quietly reserving pixels its
-        // own children never asked for, not the trailing spacer (which is still just 12px and
-        // always was). [`Self::render_tab_strip`]'s own trailing flex spacer, immediately below,
-        // is what now actually owns that leftover width - and pushes the `+` button flush
-        // against it, rather than leaving the leftover as a dead gap nothing else claims.
+        // GitHub issue #405: `flex_1()` is also what makes this region the strip's *last* child,
+        // ending exactly at the strip's real right edge, so the tabs it clips run flush into
+        // that edge instead of stopping 12px short of it behind a bare, content-less spacer -
+        // see this method's own top docs for the full report and for why PR #403's `flex_initial`
+        // + pusher answer to the same report was the wrong one.
         let mut scroller = div()
             .id("tab-strip-scroll")
             .debug_selector(|| "tab-strip-scroll".to_string())
             .flex()
-            .flex_initial()
+            .flex_1()
             .min_w_0()
             .items_stretch()
             .overflow_x_scroll()
@@ -1115,34 +1117,9 @@ impl AdeApp {
             }
         }
 
-        // GitHub issue #399: the growing pusher between the (now shrink-only) scroller and the
-        // `+` button - the strip's real "leftover space" owner. When the tabs fill the strip,
-        // this collapses to zero width and the `+` sits directly after the last tab, exactly as
-        // it always visually has. When they don't, this - not the scroller above, and not the
-        // fixed 12px spacer below - is what expands to soak up the difference, so the `+` (and
-        // its own trailing breathing room) stays pinned to the strip's real right edge instead of
-        // floating in the middle of a dead gap. Carries the column rule itself for the same
-        // reason every other child in this row does (`Self::render_tab_strip`'s own top docs,
-        // §4v: "an edge has one owner - if anything needs to cut it, the owner is the children").
-        let pusher = div()
-            .id("tab-strip-pusher")
-            .debug_selector(|| "tab-strip-pusher".to_string())
-            .flex_1()
-            .border_b_1()
-            .border_color(theme::border::RAIL_INNER);
+        scroller = scroller.child(self.render_tab_strip_plus(cx));
 
         bar.child(scroller)
-            .child(pusher)
-            .child(self.render_tab_strip_plus(cx))
-            .child(
-                div()
-                    .id("tab-strip-trailing-spacer")
-                    .debug_selector(|| "tab-strip-trailing-spacer".to_string())
-                    .flex_none()
-                    .w(px(12.0))
-                    .border_b_1()
-                    .border_color(theme::border::RAIL_INNER),
-            )
     }
 
     /// Every tab kind's own `×` close hit box - identical id-suffixing, size, hover, and styling
@@ -6597,110 +6574,172 @@ mod tab_strip_trailing_margin_tests {
     use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
 
-    /// GitHub issue #399: a handful of short file tabs - real, live user report, screenshotted -
-    /// left "a strange margin right": the tab strip visibly stopped short of the pane's own right
-    /// edge, with nothing painted in the gap. Traced to PR #398 (GitHub issue #397): `#tab-strip-
-    /// scroll` was `.flex_1()`, which unconditionally grows to consume every leftover pixel of
-    /// the strip's width regardless of whether its own tabs need it, so the `+` button (the
-    /// scroller's last child, back then) ended up stranded wherever the tabs happened to stop,
-    /// with the leftover width as a dead, unpainted gap *after* it and before the strip's real
-    /// edge - a gap #398's own trailing agent-jump keycap hint used to visually paper over by
-    /// sitting flush against that same real edge. Deleting that hint's content (the issue #397
-    /// fix) didn't create the underlying gap; it just stopped masking it.
+    /// Opens `names` as real file tabs in a real window, then selects the app's own initial shell
+    /// tab again so the centre pane is showing the agent surface (and therefore the agent context
+    /// bar) rather than a file's Surface C - exactly the state both live screenshots of this
+    /// report were taken in: several file tabs open in the strip, the shell tab active underneath
+    /// them, and the bare worktree's `Idle` / `Start an agent` cluster on the context bar below.
+    fn open_files_then_return_to_the_shell_tab<'a>(
+        cx: &'a mut TestAppContext,
+        repo: &std::path::Path,
+        names: &[&str],
+        window_size: gpui::Size<gpui::Pixels>,
+    ) -> (gpui::Entity<AdeApp>, &'a mut gpui::VisualTestContext) {
+        for name in names {
+            std::fs::write(repo.join(name), "// x\n").expect("write");
+        }
+        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.to_path_buf());
+        cx.simulate_resize(window_size);
+        let shell_id = app
+            .read_with(cx, |app, _| app.active_agent_pane_id())
+            .expect("premise: the app opens with a real shell tab already active");
+        app.update_in(cx, |app, window, cx| {
+            for name in names {
+                app.open_file_view(repo.join(name), window, cx);
+            }
+            // Back to the shell tab: `open_file_view` leaves `open_change` set, and
+            // `Self::render_center_pane` returns Surface C - no context bar - while it is.
+            app.select_agent(shell_id, window, cx);
+        });
+        cx.run_until_parked();
+        (app, cx)
+    }
+
+    /// GitHub issue #405, a live product-owner report, screenshotted twice: "the tab strip does
+    /// not go all the way, there is a strange margin right."
     ///
-    /// The real, measured regression: before the fix (`app.plus_button_bounds` reflects
-    /// `#tab-strip-scroll`'s pre-fix `flex_1()`), six short tabs in a comfortably wide strip left
-    /// well over 100px of dead space between the `+` button and the strip's right edge. After the
-    /// fix, the `+` button ends within the trailing 12px chrome margin's own width of that edge -
-    /// the same "breathing room, not a void" every other 12px chrome margin in this bar gets,
-    /// which is the explicit design intent PR #398's own docs already stated but never actually
-    /// achieved (`Self::render_tab_strip`'s own top docs, and the growing pusher's own docs where
-    /// it's built, cover why `#tab-strip-scroll` alone could never deliver that).
+    /// The real, measured cause: `#tab-strip` ended in a bare `w(px(12))` bordered spacer left
+    /// behind by PR #398 (GitHub issue #397) when it deleted the trailing agent-jump keycap
+    /// cluster's *content* but kept its padding. `Jerry.dc.html`'s own tab row has no such thing:
+    /// the 12px there is that cluster's own `padding:0 12px`, and padding with no content in it
+    /// is not breathing room, it is 12px of dead chrome. With the scroller sitting behind it, the
+    /// tabs it clips stopped 12px short of the pane's real right edge instead of running flush
+    /// into it - which is exactly the margin both screenshots show, and exactly what survived
+    /// PR #403 ("the padding is still here").
     ///
-    /// Asserted against `Self::plus_button_bounds` and `"tab-strip"`'s own painted bounds - both
-    /// existed before PR #398 too - so this genuinely fails against the pre-fix tree rather than
-    /// merely asserting today's implementation detail back at itself.
+    /// Asserted against real painted bounds, in the real reported state: enough real file tabs to
+    /// genuinely overflow the strip, with the shell tab active so the bare worktree's context bar
+    /// (`#agent-context-bar`, the `Idle` / `Start an agent` row) is on screen below it. The
+    /// context bar is measured alongside deliberately - it is `#work-surface`'s own sibling of
+    /// the tab strip and carries the design's real `px(12)` padding, so it pins down that the two
+    /// rows genuinely share one pane width and that the discrepancy was the tab strip's alone.
     #[gpui::test]
-    fn a_few_short_tabs_leave_the_plus_button_flush_against_the_strips_real_edge(
-        cx: &mut TestAppContext,
-    ) {
+    fn the_tab_strips_tabs_run_flush_into_the_panes_real_right_edge(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
-        // Six short-ish file names, matching the live report's own screenshot closely enough to
-        // reproduce it: nowhere near enough real content to fill a default test window's tab
-        // strip, which is exactly the precondition the bug needs.
+        // The live screenshots' own tabs, plus enough more of the same to genuinely overflow a
+        // deliberately narrow window rather than a maximized one (the same 900px
+        // `simulate_resize` `tab_strip_overflow_scroll_tests` uses, and for the same reason: real
+        // overflow without paying for dozens of real spawned processes).
         let names = [
-            "a.rs",
             "state.rs",
             "tab_order_state.rs",
             "keymap_overrides.rs",
             "lib.rs",
-            "persisted_state_lots_of_chars.rs",
+            "persisted_state_load.rs",
+            "worktree_history_store.rs",
         ];
-        for name in names {
-            std::fs::write(repo.path().join(name), "// x\n").expect("write");
-        }
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        app.update_in(cx, |app, window, cx| {
-            for name in names {
-                app.open_file_view(repo.path().join(name), window, cx);
-            }
-        });
-        cx.run_until_parked();
+        let (app, cx) = open_files_then_return_to_the_shell_tab(
+            cx,
+            repo.path(),
+            &names,
+            gpui::size(px(900.0), px(700.0)),
+        );
 
         let bar = cx
             .debug_bounds("tab-strip")
             .expect("the tab strip must paint");
-        let plus = app.read_with(cx, |app, _| app.plus_button_bounds);
+        let scroller = cx
+            .debug_bounds("tab-strip-scroll")
+            .expect("the scrollable tab region must paint");
+        let context_bar = cx.debug_bounds("agent-context-bar").expect(
+            "premise: the bare worktree's `Idle` / `Start an agent` context bar must be \
+                     on screen - the exact state the live screenshot was taken in",
+        );
+        let max_offset = app.read_with(cx, |app, _| app.tab_strip_scroll_handle.max_offset());
+        assert!(
+            max_offset.x > px(0.0),
+            "premise: the tabs must genuinely overflow the strip, as they do in both live \
+             screenshots - got max_offset.x = {:?}",
+            max_offset.x
+        );
+
         let bar_right = f32::from(bar.origin.x) + f32::from(bar.size.width);
-        let plus_right = f32::from(plus.origin.x) + f32::from(plus.size.width);
+        let scroller_right = f32::from(scroller.origin.x) + f32::from(scroller.size.width);
+        let context_bar_right = f32::from(context_bar.origin.x) + f32::from(context_bar.size.width);
 
         assert!(
-            plus.size.width > gpui::px(0.0),
-            "premise: the `+` button must have really painted"
+            (bar_right - context_bar_right).abs() <= 0.5,
+            "premise: the tab strip and the context bar are both `#work-surface`'s own full-width \
+             children, so they must already agree on where the pane's right edge is - tab strip \
+             ends at {bar_right}, context bar at {context_bar_right}"
         );
-        // 12px is the trailing spacer's own deliberate width (`Self::render_tab_strip`'s own
-        // docs); a couple more px of slack absorbs the `+` button's own internal padding without
-        // hard-coding its layout. Anything past that is exactly the unaccounted dead gap the live
-        // report shows: on the pre-fix tree this was well over 150px, not a rounding error.
+        // The whole report, in one number. Pre-fix this was `bar_right - scroller_right == 12.0`:
+        // the bare trailing spacer, clipping every tab 12px short of the pane's real edge.
         assert!(
-            bar_right - plus_right <= 15.0,
-            "the `+` button must end within the strip's own trailing 12px breathing room of the \
-             real right edge, not stranded with a dead gap after it - strip ends at {bar_right}, \
-             `+` ends at {plus_right}, a gap of {}",
-            bar_right - plus_right
+            (bar_right - scroller_right).abs() <= 0.5,
+            "the tabs' own clip region must end exactly at the strip's real right edge, with no \
+             dead trailing spacer after it - strip ends at {bar_right}, the tabs' region ends at \
+             {scroller_right}, a dead margin of {}",
+            bar_right - scroller_right
         );
     }
 
-    /// The mirror image of the assertion above, proven directly against the scroller rather than
-    /// inferred from the `+` button: `#tab-strip-scroll` must never grow past what its own tabs
-    /// need. `.flex_1()` (the pre-fix behaviour) would make this fail identically to the test
-    /// above; `.flex_initial()` (the fix) shrinks-or-fits instead of always consuming every
-    /// leftover pixel.
+    /// The other half of the same report: "you fixed the plus button on the right, why?"
+    ///
+    /// PR #403 moved the `+` out of the scroller and put a growing `#tab-strip-pusher` in front of
+    /// it, which pinned it to the far right of the strip whether the tabs filled it or not. That
+    /// is not what `Jerry.dc.html` draws - its tab row is `sc-for tabs`, then the `+` cell, then a
+    /// `flex:1` filler - nor what any other tabbed editor draws, and it was rejected on sight by
+    /// the product owner. The `+` belongs immediately after the last tab; the bare strip after it
+    /// is the design, not a gap in need of filling.
     #[gpui::test]
-    fn the_scroller_never_grows_past_its_own_tabs_real_content_width(cx: &mut TestAppContext) {
+    fn the_plus_button_sits_immediately_after_the_last_tab(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
-        std::fs::write(repo.path().join("a.rs"), "// a\n").expect("write");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        let a_ref = work_surface::TabRef::File(PathBuf::from("a.rs"));
-        app.update_in(cx, |app, window, cx| {
-            app.open_file_view(repo.path().join("a.rs"), window, cx);
-        });
-        cx.run_until_parked();
+        let names = ["state.rs", "lib.rs"];
+        // Maximized (the default 1920x1080 `TestDisplay`), so two short tabs come nowhere near
+        // filling the strip - the precondition under which PR #403's pusher relocated the `+`.
+        let (app, cx) = open_files_then_return_to_the_shell_tab(
+            cx,
+            repo.path(),
+            &names,
+            gpui::size(px(1920.0), px(1080.0)),
+        );
 
-        let scroller = cx
-            .debug_bounds("tab-strip-scroll")
-            .expect("the scroller must paint");
-        let last_tab = app
-            .read_with(cx, |app, _| app.tab_bounds.get(&a_ref).copied())
-            .expect("a.rs must have painted a tab");
-        let scroller_right = f32::from(scroller.origin.x) + f32::from(scroller.size.width);
-        let last_tab_right = f32::from(last_tab.origin.x) + f32::from(last_tab.size.width);
+        let bar = cx
+            .debug_bounds("tab-strip")
+            .expect("the tab strip must paint");
+        let (last_tab, plus) = app.read_with(cx, |app, _| {
+            let last = app
+                .combined_tab_order()
+                .last()
+                .and_then(|tab_ref| app.tab_bounds.get(tab_ref).copied());
+            (last, app.plus_button_bounds)
+        });
+        let last_tab = last_tab.expect("the last tab in the combined order must have painted");
 
         assert!(
-            scroller_right - last_tab_right <= 2.0,
-            "with only one real tab open (a shell tab plus a.rs), `#tab-strip-scroll` must end \
-             right where its own content does, not grow to consume the strip's whole remaining \
-             width - scroller ends at {scroller_right}, last real tab ends at {last_tab_right}"
+            plus.size.width > px(0.0),
+            "premise: the `+` button must have really painted"
+        );
+        let last_tab_right = f32::from(last_tab.origin.x) + f32::from(last_tab.size.width);
+        let plus_left = f32::from(plus.origin.x);
+        let plus_right = plus_left + f32::from(plus.size.width);
+        let bar_right = f32::from(bar.origin.x) + f32::from(bar.size.width);
+
+        // `plus_button_bounds` is captured by an `.absolute().size_full()` canvas *inside* the
+        // `+` cell, so it reports that cell's content box - its own `px(px(10.0))` left padding
+        // (plus the last tab's own 1px right border) sits between the two numbers below, and
+        // nothing else may.
+        assert!(
+            (0.0..=12.0).contains(&(plus_left - last_tab_right)),
+            "the `+` button must start right where the last tab ends, within its own 10px left \
+             padding - it was at {plus_left}, the last tab ends at {last_tab_right}"
+        );
+        assert!(
+            bar_right - plus_right > 100.0,
+            "premise, and the point of the assertion above: with only two short tabs open in a \
+             maximized window the `+` must be nowhere near the strip's right edge - strip ends at \
+             {bar_right}, `+` ends at {plus_right}"
         );
     }
 }


### PR DESCRIPTION
## What the two reports actually were

> *"The tab strip does not go all the way, there is a strange margin right."*

then, after PR #403 shipped as the fix for it:

> *"the tab fix is wrong, you fixed the plus button on the right, why? And the padding is still here."*

Both halves of that second sentence are right.

## Real root cause

PR #398 (issue #397) deleted the tab strip's trailing agent-jump keycap cluster's **content** but kept its **padding** - `div().flex_none().w(px(12.0)).border_b_1()` as `#tab-strip`'s last child.

`Jerry.dc.html`'s own tab row is `sc-for tabs` → the `+` cell → `<div style="flex:1;border-bottom:…">` → the keycap cluster with `padding:0 12px`. That 12px is the *cluster's* padding, keeping real content off the pane's edge. With the content gone it is 12px of dead chrome - and because `#tab-strip-scroll` (which *clips* the tabs) sat behind it, every tab was clipped 12px short of the pane's real right edge instead of running flush into it.

Measured against real painted bounds (`debug_bounds`), six real file tabs overflowing a 900px window with the bare worktree's context bar showing:

| build | `#tab-strip` right | `#tab-strip-scroll` right | dead margin |
|---|---|---|---|
| 0568739 (#398 - the first screenshot's build) | 580 | 568 | **12px** |
| e09e86e (#403 - the second screenshot's build) | 580 | 540 | **40px** |
| this PR | 580 | 580 | **0px** |

## Where #403 went wrong

#403 never touched the spacer. It read an ordinary tab bar with few tabs open - `+` immediately after the last tab, bare strip after it, which is exactly what the mock draws and what every other tabbed editor draws - as a "dead gap bug", made `#tab-strip-scroll` `.flex_initial()`, and moved the `+` out of the scroller behind a new growing `#tab-strip-pusher`. That pinned the `+` to the far right (measured: `+` starting at x=1570 while the last tab ends at 611, two short tabs in a maximized window) **and** widened the actual reported inset from 12px to 40px, since the relocated `+` is 28px the scroller no longer gets either.

## This PR

- Reverts #403 in full: `.flex_1()` scroller, `#tab-strip-pusher` deleted, `+` back inside the scroller right after the last tab (keeping issue #354's "one scroll gesture reaches the last tab and the `+`" contract).
- Deletes #398's bare 12px spacer. The `flex_1()` scroller is the strip's last child again - it owns the leftover width, carries §4v's bottom rule to the pane's real right edge, and clips the tabs flush into it.

## Verification

`tab_strip_trailing_margin_tests` rewritten around the **real** reported state, not #403's synthetic one: six real file tabs genuinely overflowing the strip, with the app's own shell tab reselected so the bare worktree's `Idle`/`Start an agent` context bar is on screen underneath - exactly what both screenshots show. It measures `#tab-strip`, `#tab-strip-scroll` and `#agent-context-bar`'s real painted bounds (the context bar deliberately included, to pin down that the two rows genuinely share one pane width and the discrepancy was the tab strip's alone). Both tests were run against 0568739 and e09e86e directly and genuinely fail there.

Real X11 captures of both builds, same seeded six-tab session, same 1440x928 window, measured pixel-wise: **before, 23px of unpainted chrome between the last painted pixel and the pane divider; after, 0px.**

`cargo build --workspace`, `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets` all clean. `cargo test -p app --lib work_surface::` green (140/140). The full `cargo test -p app --lib` run shows 17 failures, all the known inotify `max_user_instances` (128) exhaustion flake under heavy parallel load (`worktree_watch`/`file_tree_watch`/rust-analyzer) - every one of them passes in isolation on this branch, and none of them touch layout. `sidebar::render::commit_composer_tests::opening_the_commit_menu_closes_an_already_open_plus_menu` was re-run 5x in isolation on this branch: green every time.

Closes #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)
