### PR TITLE
fix: unify crate versions with release tags

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,29 @@
+---
+description: Bump the workspace version, tag, and push a Jerry release
+---
+
+Cut a release following `docs/development-workflow.md`'s "Releasing" section. Jerry has exactly
+one version number (`[workspace.package].version` in the root `Cargo.toml`), and the pushed tag
+must equal it or `release.yml`'s `version-check` job refuses the release.
+
+1. Confirm the working tree is clean and on `master` (`git status --short`, `git branch
+   --show-current`); stop and report if not.
+
+2. Get the current version from `Cargo.toml` and the commit log since the last tag
+   (`git describe --tags --abbrev=0`, then `git log <tag>..HEAD --oneline`). Suggest the next
+   version from that log (patch for fixes, minor for features, major for breaking changes) and
+   confirm it with the user before doing anything else — never bump or tag without confirmation.
+
+3. Update `version` in `Cargo.toml`'s `[workspace.package]` to the confirmed version. Run
+   `.claude/hooks/check-release-version.sh v<version>` to confirm it now matches, and `cargo build
+   --workspace` to confirm the lockfile still resolves.
+
+4. Commit (`chore: bump version to <version>`), tag (`git tag v<version>`), and push both
+   (`git push && git push origin v<version>`).
+
+5. Watch the release run: `gh run list --branch v<version> --limit 1 --json status,conclusion,url`,
+   polling until it completes. Report the result — link the run on failure, link the release
+   (`gh release view v<version> --json url -q .url`) on success.
+
+Don't write a changelog or touch Linear here — this is the fast path (version bump → tag → push →
+watch CI).

--- a/.claude/hooks/check-release-version.sh
+++ b/.claude/hooks/check-release-version.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Guards against crate versions drifting from the release tag (issue #317), which silently
+# broke the in-app updater's version comparison. Checks that every crates/*/Cargo.toml inherits
+# `version` from the workspace, and - if $1 is set to a tag - that the tag matches it.
+#
+# Usage:
+#   .claude/hooks/check-release-version.sh          (run from the repo root; inheritance only)
+#   .claude/hooks/check-release-version.sh v0.1.0    (also checks the tag against the version)
+
+set -u
+
+cd "${CLAUDE_PROJECT_DIR:-.}" || exit 1
+
+ROOT_MANIFEST="Cargo.toml"
+fail=0
+
+workspace_version=$(grep -A20 '^\[workspace.package\]' "$ROOT_MANIFEST" | grep -m1 '^version' | sed -E 's/version = "([^"]+)".*/\1/')
+if [ -z "$workspace_version" ]; then
+  echo "check-release-version: FAIL - could not find a version in $ROOT_MANIFEST's [workspace.package]." >&2
+  exit 1
+fi
+
+offenders=$(grep -lE '^version = "[^"]+"' crates/*/Cargo.toml 2>/dev/null)
+if [ -n "$offenders" ]; then
+  echo "check-release-version: FAIL - these crate manifests pin their own version instead of inheriting from the workspace:" >&2
+  echo "$offenders" | sed 's/^/  /' >&2
+  echo "  Use version = { workspace = true }, matching edition/publish/license in the same file." >&2
+  fail=1
+fi
+
+tag="${1:-}"
+if [ -n "$tag" ]; then
+  tag_version="${tag#v}"
+  tag_version="${tag_version#V}"
+  if [ "$tag_version" != "$workspace_version" ]; then
+    echo "check-release-version: FAIL - tag '$tag' (version $tag_version) does not match the workspace version '$workspace_version' in $ROOT_MANIFEST." >&2
+    echo "  Bump [workspace.package] version to match before tagging, or fix the tag." >&2
+    fail=1
+  fi
+fi
+
+if [ "$fail" -eq 0 ]; then
+  if [ -n "$tag" ]; then
+    echo "check-release-version: OK (workspace version $workspace_version matches tag $tag)"
+  else
+    echo "check-release-version: OK (all crates inherit workspace version $workspace_version)"
+  fi
+fi
+
+exit $fail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,10 @@ jobs:
       - name: Convention ratchet
         run: .claude/hooks/check-conventions.sh
 
+      # Catches a crate manifest that regresses to a hardcoded version (issue #317).
+      - name: Crate version inheritance
+        run: .claude/hooks/check-release-version.sh
+
       - name: cargo fmt --all -- --check
         run: cargo fmt --all -- --check
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,20 @@ env:
   RUST_BACKTRACE: "1"
 
 jobs:
+  # Fails fast if the pushed tag doesn't match the workspace version (issue #317). Skipped on
+  # workflow_dispatch, which has no real tag and only ever publishes a draft.
+  version-check:
+    name: Tag matches crate version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - name: Check tag against workspace version
+        if: github.event_name == 'push'
+        run: .claude/hooks/check-release-version.sh "${GITHUB_REF_NAME}"
+
   # Build-only signal per platform before packaging, deliberately matching ci.yml's own
   # "build, test, clippy, fmt" -> build-only narrowing on this exact workspace: a real
   # `v0.0.1-test` tag run of a fuller `cargo test --workspace` step here hit the same
@@ -26,6 +40,7 @@ jobs:
   # fuller CI as follow-up rather than something to take on inside this release
   # workflow.
   build:
+    needs: version-check
     strategy:
       fail-fast: false
       matrix:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ members = [
 ]
 
 [workspace.package]
+# Single source of truth for the release version - crates inherit via `version = { workspace =
+# true }` rather than pinning their own.
+version = "0.1.0"
 edition = "2021"
 publish = false
 license = "MIT OR Apache-2.0"

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.1.0"
+version = { workspace = true }
 edition = { workspace = true }
 publish = { workspace = true }
 license = { workspace = true }

--- a/crates/lsp-core/Cargo.toml
+++ b/crates/lsp-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lsp-core"
-version = "0.1.0"
+version = { workspace = true }
 edition = { workspace = true }
 publish = { workspace = true }
 license = { workspace = true }

--- a/crates/pty-core/Cargo.toml
+++ b/crates/pty-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pty-core"
-version = "0.1.0"
+version = { workspace = true }
 edition = { workspace = true }
 publish = { workspace = true }
 license = { workspace = true }

--- a/crates/wt-core/Cargo.toml
+++ b/crates/wt-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wt-core"
-version = "0.1.0"
+version = { workspace = true }
 edition = { workspace = true }
 publish = { workspace = true }
 license = { workspace = true }

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -59,6 +59,22 @@ process that applies them.
 9. **Keep the tracker usable — `triage`.** A periodic batch pass, not part of any single change's
    flow: labels, catches duplicates, flags stale issues.
 
+## Releasing
+
+There is exactly one version number for the whole workspace: `version` in the root `Cargo.toml`'s
+`[workspace.package]`. Every crate inherits it (`version = { workspace = true }`); nothing pins its
+own. To cut a release:
+
+1. Bump that one `version` field and commit.
+2. Tag the commit `v<same number>` (e.g. version `0.1.1` → tag `v0.1.1`) and push the tag.
+3. `.github/workflows/release.yml` takes it from there — its `version-check` job runs
+   `.claude/hooks/check-release-version.sh` against the pushed tag and refuses the release outright
+   if the tag doesn't match the workspace version, before any of the per-OS builds run.
+
+This tag/version equality is what the in-app updater (`crates/app/src/updater/`) actually depends
+on — it compares `env!("CARGO_PKG_VERSION")` against the latest release tag, so any drift between
+the two silently breaks update detection (GitHub issue #317).
+
 ## Commands vs. skills
 
 `/check` and `/setup` are commands — deterministic, cheap, no judgment involved (`/check` just runs


### PR DESCRIPTION
<!-- Closes #317 -->

## What

Every crate (`app`, `wt-core`, `pty-core`, `lsp-core`) carried its own hardcoded `version =
"0.1.0"`, while the three shipped releases are tagged `v0.0.1`/`v0.0.2`/`v0.0.3`. Nothing ever
checked the two against each other. Concretely, that meant `env!("CARGO_PKG_VERSION")` (`0.1.0`)
compared as *older* than every real release tag, so the in-app updater's
`is_remote_version_newer` (`crates/app/src/updater/state.rs`) has never once been able to detect
an update — it silently concluded "up to date" on every check.

- Crates now inherit `version` from `[workspace.package]` in the root `Cargo.toml` instead of
  pinning their own — one number to bump, not four.
- New `.claude/hooks/check-release-version.sh`: fails if a crate manifest regresses to a literal
  version (wired into `ci.yml`, every push), and fails if a pushed release tag doesn't match the
  workspace version (wired into `release.yml`'s new `version-check` job, which `build` now
  depends on — so a mismatched tag is caught in seconds, before any per-OS build runs).
- `docs/development-workflow.md` gets a short "Releasing" section — there was no written release
  procedure anywhere in the repo before this.
- New `/release` command for the actual bump → tag → push → watch-CI flow, matching the
  single-version convention this PR establishes.

## Why

The next release is planned as `v0.1.0` (crates stay at `0.1.0`, matching what's already there).
Existing `v0.0.3` installs carry `0.1.0` internally already, so they won't be prompted for
`v0.1.0` itself, but will update normally from `v0.1.1` onward. Full reasoning posted to the issue
before implementation: https://github.com/ColinEspinas/jerry/issues/317#issuecomment-5307823302

## Testing

- [x] `/check` (conventions + fmt + clippy `-D warnings`) passes locally
- [ ] `verify` capture attached below, if this touches `render.rs`/`theme.rs`/layout — N/A, no
      render/UI code touched
- [x] New/changed behavior has a real test, run manually and confirmed passing:
  - `.claude/hooks/check-release-version.sh` run against no argument, `v0.1.0`, `v0.2.0`, `v0.0.3`,
    and a hand-reintroduced literal crate version — all four cases behave correctly.
  - `cargo build --workspace` and `cargo build -p app -v` confirm version inheritance resolves
    (`app v0.1.0`).
  - `cargo test -p app --lib updater::` — the 7 existing tests (including
    `version_comparison_tests`) still pass unchanged.

## Architecture notes

No crate-boundary or Command/Query changes — this is workspace manifest config, a new CI/release
guard script, and docs.
