### PR TITLE
docs: route release version bump and changelog through a PR

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -14,16 +14,24 @@ must equal it or `release.yml`'s `version-check` job refuses the release.
    version from that log (patch for fixes, minor for features, major for breaking changes) and
    confirm it with the user before doing anything else — never bump or tag without confirmation.
 
-3. Update `version` in `Cargo.toml`'s `[workspace.package]` to the confirmed version. Run
-   `.claude/hooks/check-release-version.sh v<version>` to confirm it now matches, and `cargo build
-   --workspace` to confirm the lockfile still resolves.
+3. **Never commit the version bump directly to `master`.** Create a branch
+   (`git checkout -b chore/bump-version-<version>`), update `version` in `Cargo.toml`'s
+   `[workspace.package]` there. Run `.claude/hooks/check-release-version.sh v<version>` to confirm
+   it now matches, and `cargo build --workspace` to confirm the lockfile still resolves.
 
-4. Commit (`chore: bump version to <version>`), tag (`git tag v<version>`), and push both
-   (`git push && git push origin v<version>`).
+4. Commit (`chore: bump version to <version>`), push the branch
+   (`git push -u origin chore/bump-version-<version>`), and open a PR
+   (`gh pr create --title "chore: bump version to <version>" --base master --head
+   chore/bump-version-<version>`). Share the PR link and stop to wait for it to be merged — the
+   tag has to point at the bump commit once it's on `master`, so tagging can't happen until then.
 
-5. Watch the release run: `gh run list --branch v<version> --limit 1 --json status,conclusion,url`,
+5. Once the PR is merged, switch back to `master` and sync
+   (`git checkout master && git pull`). Confirm `Cargo.toml`'s version is now the bumped one, then
+   tag the merge commit (`git tag v<version>`) and push the tag (`git push origin v<version>`).
+
+6. Watch the release run: `gh run list --branch v<version> --limit 1 --json status,conclusion,url`,
    polling until it completes. Report the result — link the run on failure, link the release
    (`gh release view v<version> --json url -q .url`) on success.
 
-Don't write a changelog or touch Linear here — this is the fast path (version bump → tag → push →
-watch CI).
+Don't write a changelog or touch Linear here — this is the fast path (version bump PR → merge →
+tag → push → watch CI).

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -65,11 +65,16 @@ There is exactly one version number for the whole workspace: `version` in the ro
 `[workspace.package]`. Every crate inherits it (`version = { workspace = true }`); nothing pins its
 own. To cut a release:
 
-1. Bump that one `version` field and commit.
-2. Tag the commit `v<same number>` (e.g. version `0.1.1` → tag `v0.1.1`) and push the tag.
+1. Bump that one `version` field on a branch, commit, and open a PR — never commit the bump
+   directly to `master`.
+2. Once the PR is merged, tag the resulting `master` commit `v<same number>` (e.g. version
+   `0.1.1` → tag `v0.1.1`) and push the tag.
 3. `.github/workflows/release.yml` takes it from there — its `version-check` job runs
    `.claude/hooks/check-release-version.sh` against the pushed tag and refuses the release outright
    if the tag doesn't match the workspace version, before any of the per-OS builds run.
+
+The same rule applies to the changelog: `CHANGELOG.md` updates and any other release-adjacent
+commit go through a branch and a PR too, same as any other change to the repo.
 
 This tag/version equality is what the in-app updater (`crates/app/src/updater/`) actually depends
 on — it compares `env!("CARGO_PKG_VERSION")` against the latest release tag, so any drift between


### PR DESCRIPTION
The /release command's version-bump step and the release skill's CHANGELOG.md step both committed straight to master. This requires a branch + PR for both instead, consistent with every other change to the repo.

Also updates `docs/development-workflow.md`'s "Releasing" section to describe the new PR-first flow (tag now happens after the version-bump PR is merged, not before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)