### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,7 +288,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "app"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -4773,7 +4773,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lsp-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "dunce",
  "log",
@@ -6144,7 +6144,7 @@ dependencies = [
 
 [[package]]
 name = "pty-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "filedescriptor",
@@ -9885,7 +9885,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wt-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "gix",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 [workspace.package]
 # Single source of truth for the release version - crates inherit via `version = { workspace =
 # true }` rather than pinning their own.
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 publish = false
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Patch bump for the v0.1.1 release tag. Version lives in one place
(`[workspace.package].version`); `release.yml`'s `version-check` job refuses the
release unless the pushed tag equals it.

## What's in 0.1.1

Since `v0.1.0`, both fixes:

- `88cd9c7` — resolve the home directory on Windows so settings load and save.
  `settings_toml_path` read `$HOME` only; Windows sets `%USERPROFILE%`, so the
  path resolved to `None` and every caller took its fallback — saves silently
  no-opped, loads returned an in-memory default, and *Open file* logged a
  warning. Launching from Git Bash/WSL2 masked it, since those do set `HOME`.
- `d819eff` — scope the symlink-walk test fixture to the `#[cfg(unix)]` branch
  that uses it, so it isn't an unused binding tripping `-D warnings` on Windows.

Plus two docs-only commits (`e3a60e7`, `6e45760`) that were already on `master`.

## Verification

`cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets -- -D
warnings` clean; `cargo build --workspace` resolves the lockfile at the bumped
version; `.claude/hooks/check-release-version.sh v0.1.1` reports OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)