### PR TITLE
docs: add docs/design/, a design doc set that can absorb a change (1/3)

### DIFF
--- a/.claude/conventions-baseline.json
+++ b/.claude/conventions-baseline.json
@@ -1,5 +1,6 @@
 {
   "_comment": "Ratchet baseline for .claude/hooks/check-conventions.sh - these numbers may only go down, never up. Recount with the exact commands in that script's comments after fixing a batch of violations, and lower the number in the same commit.",
   "glob_imports_app_src": 304,
-  "render_adapter_calls": 222
+  "render_adapter_calls": 222,
+  "design_handoff_citations": 364
 }

--- a/.claude/hooks/check-conventions.sh
+++ b/.claude/hooks/check-conventions.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
-# Deterministic ratchet check for the two structural rules in CLAUDE.md that clippy can't
-# express without the glob-import cleanup first (docs/architecture/decisions.md, entry 3):
-# no new `use super::*` glob, no new adapter call from a render.rs file. This does not rely on
-# an LLM following instructions - it's a real grep run by a real script, wired to three points
-# so drift is caught as early as possible rather than only at the end:
+# Deterministic ratchet check for three rules this repo enforces by counting rather than by
+# review. Two are the structural rules in CLAUDE.md that clippy can't express without the
+# glob-import cleanup first (docs/architecture/decisions.md, entry 3): no new `use super::*`
+# glob, no new adapter call from a render.rs file. The third is design_handoff_jerry_ade/
+# citations in source comments (docs/design/decisions.md, entry 14): the bundle is being
+# replaced by docs/design/, roughly a third of the existing citations already point at
+# `revision N/` paths that were never committed, and CLAUDE.md's comment rule excludes exactly
+# this material - design history, revision IDs, issue archaeology - from source comments anyway.
+# This does not rely on an LLM following instructions - it's a real grep run by a real script,
+# wired to three points so drift is caught as early as possible rather than only at the end:
 #   1. PostToolUse:Edit|Write (settings.json) - fires right after every file edit, for the
 #      fastest possible feedback. Can't block the edit that already happened, but the failing
 #      exit code and message surface immediately instead of waiting for a commit attempt.
@@ -36,9 +41,11 @@ fi
 
 glob_baseline=$(jq -r '.glob_imports_app_src' "$BASELINE_FILE")
 adapter_baseline=$(jq -r '.render_adapter_calls' "$BASELINE_FILE")
+handoff_baseline=$(jq -r '.design_handoff_citations' "$BASELINE_FILE")
 
 glob_current=$(grep -rE "use super::\*;" crates/app/src 2>/dev/null | wc -l | tr -d ' ')
 adapter_current=$(grep -rE "wt_core::|pty_core::|lsp_core::|process::Command::new" crates/app/src --include='render.rs' 2>/dev/null | wc -l | tr -d ' ')
+handoff_current=$(grep -rE "design_handoff|Jerry\.dc\.html" crates 2>/dev/null | wc -l | tr -d ' ')
 
 fail=0
 
@@ -54,8 +61,14 @@ if [ "$adapter_current" -gt "$adapter_baseline" ]; then
   fail=1
 fi
 
+if [ "$handoff_current" -gt "$handoff_baseline" ]; then
+  echo "check-conventions: FAIL - design_handoff_jerry_ade/ citations in crates/ rose from $handoff_baseline to $handoff_current." >&2
+  echo "  That bundle is being replaced by docs/design/ (docs/design/decisions.md, entry 14) and many of its paths were never committed. Cite docs/design/<file>.md, or drop the reference - CLAUDE.md's comment rule excludes design history from source comments." >&2
+  fail=1
+fi
+
 if [ "$fail" -eq 0 ]; then
-  echo "check-conventions: OK (glob imports: $glob_current/$glob_baseline, render adapter calls: $adapter_current/$adapter_baseline)"
+  echo "check-conventions: OK (glob imports: $glob_current/$glob_baseline, render adapter calls: $adapter_current/$adapter_baseline, handoff citations: $handoff_current/$handoff_baseline)"
 fi
 
 exit $fail

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -43,7 +43,8 @@ Every surface doc uses one skeleton, so the set reads as a single document:
 ```markdown
 # Session rail
 
-**Code:** `crates/app/src/rail/`  ·  **Tokens:** `theme::{status, rail}`
+- **Code:** `crates/app/src/rail/`
+- **Tokens:** `theme::{status, rail}`
 
 ## What it's for       — one paragraph, the job this surface does
 ## Structure           — the parts, and what each is
@@ -60,8 +61,8 @@ code, applied to the docs.
 A UI change **updates the relevant page in the same PR** — that is the entire difference between
 this and what it replaced. Concretely:
 
-- Changed how a surface behaves or what it's composed of → edit that surface's `Structure` or
-  `Rules that matter`.
+- Changed how a surface behaves or what it's composed of → edit that surface's `Structure` or `Rules
+  that matter`.
 - Built something the page lists under `Not built yet` → delete the line.
 - Made a call that a future contributor would otherwise re-litigate, or reversed one already
   recorded → add a **new numbered entry** to [`decisions.md`](./decisions.md). Never edit an old
@@ -73,10 +74,10 @@ this and what it replaced. Concretely:
 
 Until #414, the design authority was `design_handoff_jerry_ade/` — a one-shot handoff bundle
 containing a 4,266-line interactive HTML mockup, a transcribed `tokens.rs`, and a README written as
-a build brief. It did its job: essentially all of Jerry's chrome was built from it. But it was frozen
-by construction, so every design change after it was recorded as another `revision N/` folder that
-was never committed, and roughly a third of the 364 source comments citing it pointed at paths that
-did not exist in the repository.
+a build brief. It did its job: essentially all of Jerry's chrome was built from it. But it was
+frozen by construction, so every design change after it was recorded as another `revision N/` folder
+that was never committed, and roughly a third of the 364 source comments citing it pointed at paths
+that did not exist in the repository.
 
 The bundle is preserved by git history alone — no tag, no release asset. To recover it:
 
@@ -86,5 +87,5 @@ git show <that-sha>^:design_handoff_jerry_ade/README.md                 # any fi
 ```
 
 Read it as the historical artefact it is. Where it and the shipped app disagree, **the app wins**,
-and the delta is either an entry in [`decisions.md`](./decisions.md) or a line under a
-`Not built yet` heading here.
+and the delta is either an entry in [`decisions.md`](./decisions.md) or a line under a `Not built
+yet` heading here.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,90 @@
+# Design documentation
+
+What Jerry's UI is *for*, surface by surface — the intent, the structure, the vocabulary and the
+invariants a change must not break. Its counterpart is
+[`docs/architecture/`](../architecture/overview.md), which covers where code lives; this set covers
+what the code draws and why.
+
+## The one rule that keeps this current
+
+**These documents never reprint a value.** No hex codes, no pixel literals, no font sizes. Every
+value in Jerry's UI already lives in `crates/app/src/theme.rs` as a named
+[`ColorToken`](../../crates/app/src/theme.rs) or a `Pixels` constant, with its own doc comment, and
+`theme.rs` is what the themes in `assets/themes/` and [`docs/themes.md`](../themes.md) are generated
+against. These docs name the token; the token carries the number.
+
+That is the whole reason the set can stay honest. A document that duplicates `#e2a336` goes stale
+the first time somebody retunes the amber. A document that says *"the needs-input amber
+(`theme::status::ASK`)"* cannot.
+
+The same applies to structure: a surface doc names the module that draws it and describes the rules
+that module has to hold, rather than re-deriving its layout.
+
+## How to read it
+
+Start with [`principles.md`](./principles.md) — six rules that constrain every other page — then
+[`vocabulary.md`](./vocabulary.md) for the shared visual language (status, agent tints, chips,
+keycaps, icons). After that, read the surface you're changing.
+
+| File | Covers | Code it maps to |
+|---|---|---|
+| [`principles.md`](./principles.md) | The durable visual rules that constrain every UI change | — |
+| [`vocabulary.md`](./vocabulary.md) | Status vocabulary, agent tints, chips, pills, keycaps, icons | `theme.rs`, `rail/status.rs`, `keymap.rs`, `icons.rs` |
+| [`layout.md`](./layout.md) | Window bands, the three zones, the work-surface stack | `root/`, `title_bar/`, `status_bar/` |
+| [`rail.md`](./rail.md) | Zone 1 — the agent rail, its strip, grouping and rows | `rail/` |
+| [`work-surface.md`](./work-surface.md) | Zone 2 — tab strip, context bar, and every centre surface | `work_surface/`, `terminal/`, `code_surface/`, `lsp/`, `merge/`, `graph_view/`, `review/`, `run_history/` |
+| [`sidebar.md`](./sidebar.md) | Zone 3 — Files · Search · Changes | `sidebar/`, `search/` |
+| [`settings.md`](./settings.md) | The Settings surface, its nav, cards and row controls | `settings/` |
+| [`command-palette.md`](./command-palette.md) | The ⌘P overlay, scopes and result rows | `palette/` |
+| [`decisions.md`](./decisions.md) | Numbered design decisions log | — |
+
+Every surface doc uses one skeleton, so the set reads as a single document:
+
+```markdown
+# Session rail
+
+**Code:** `crates/app/src/rail/`  ·  **Tokens:** `theme::{status, rail}`
+
+## What it's for       — one paragraph, the job this surface does
+## Structure           — the parts, and what each is
+## Rules that matter   — the non-obvious invariants a change must not break
+## Not built yet       — honest gaps, linked to their issues
+```
+
+`Not built yet` is the section that turns this from a description into a contribution map. It is the
+same honesty [`CLAUDE.md`](../../CLAUDE.md)'s "no fake functionality" rule already demands of the
+code, applied to the docs.
+
+## How to change it
+
+A UI change **updates the relevant page in the same PR** — that is the entire difference between
+this and what it replaced. Concretely:
+
+- Changed how a surface behaves or what it's composed of → edit that surface's `Structure` or
+  `Rules that matter`.
+- Built something the page lists under `Not built yet` → delete the line.
+- Made a call that a future contributor would otherwise re-litigate, or reversed one already
+  recorded → add a **new numbered entry** to [`decisions.md`](./decisions.md). Never edit an old
+  entry back to "current"; mark it superseded and point at the new one.
+- Retuned a colour or a dimension → that is a `theme.rs` change, and these docs should need no edit
+  at all. If one is needed, the doc was reprinting a value it shouldn't have.
+
+## What this replaced
+
+Until #414, the design authority was `design_handoff_jerry_ade/` — a one-shot handoff bundle
+containing a 4,266-line interactive HTML mockup, a transcribed `tokens.rs`, and a README written as
+a build brief. It did its job: essentially all of Jerry's chrome was built from it. But it was frozen
+by construction, so every design change after it was recorded as another `revision N/` folder that
+was never committed, and roughly a third of the 364 source comments citing it pointed at paths that
+did not exist in the repository.
+
+The bundle is preserved by git history alone — no tag, no release asset. To recover it:
+
+```sh
+git log --diff-filter=D --format='%H' -1 -- design_handoff_jerry_ade/   # the deleting commit
+git show <that-sha>^:design_handoff_jerry_ade/README.md                 # any file, as it was
+```
+
+Read it as the historical artefact it is. Where it and the shipped app disagree, **the app wins**,
+and the delta is either an entry in [`decisions.md`](./decisions.md) or a line under a
+`Not built yet` heading here.

--- a/docs/design/command-palette.md
+++ b/docs/design/command-palette.md
@@ -1,0 +1,86 @@
+# Command palette
+
+**Code:** `crates/app/src/palette/`
+**Tokens:** `theme::palette`, `theme::{band::PALETTE_*, zone::PALETTE_WIDTH, shadow::PALETTE}`
+
+## What it's for
+
+One overlay that is both the command list **and** the way you get to a pane or a file without
+touching the mouse. It is the keyboard route to everything, which is why an agent, a shell, a file
+and a command are all rows in the same list rather than four separate finders.
+
+An **overlay, not a page**: a flat scrim over everything below the title bar (a plain alpha fill, not
+a blur — see [`principles.md`](./principles.md) rule 3), and a panel pinned near the top. Clicking
+the scrim or pressing `esc` dismisses it. There is nothing here you can leave the app parked in.
+
+## Structure
+
+Bound to `mod+P`, deliberately not `mod+K`. `mod+K` was the original binding, but the file editor's
+real `ctrl-k ctrl-d` chord registers `ctrl-k` as a chord *prefix* in that context, so a lone press
+waited out GPUI's ~1s prefix timeout before reaching the palette — a real, noticeable delay. `mod+P`
+also matches the VS Code / Sublime convention directly. The tradeoff is explicit: a focused
+terminal's own readline `Ctrl+P` is shadowed by this binding.
+
+### Scopes
+
+`palette::state::PaletteScope` — `All` (default), `Commands`, `Files`. Reachable three ways, all
+equivalent: clicking the segmented control, cycling with `⇥`, or typing the scope's own prefix
+character (`›` or `@`) into an empty query (`typed_scope_prefix`).
+
+### Steps are not a fourth scope
+
+`PaletteStep` is the palette's one drill-down shape, entered by running a command that needs an
+argument — today, "which language server?" for a restart. The distinction from a scope is
+load-bearing and the code states it: **a scope is a user-switchable filter over the same candidates
+and is reachable at any time; a step lists something else entirely and is left with `esc`, which
+there means "back", not "close".**
+
+### Groups
+
+Built by `build_groups`, in order:
+
+| Group | Scope | Notes |
+|---|---|---|
+| Agents | `All` | Real agent sessions only |
+| Terminals | `All` | Shells, **split out rather than filtered out** |
+| Commands | `All`, `Commands` | |
+| Git | `All`, `Commands` | A dedicated group, not folded into Commands |
+| Recent Files / Files | `All`, `Files` | Label depends on the query — see below |
+
+The Agents/Terminals split is a good example of the honesty rule applied to a label. A shell is not
+an agent: the rail gives it no agent row, and the pane chrome draws it a different bottom bar. Filing
+it under a heading reading `Agents` would tell the user the opposite of what the rest of the app
+tells them. Filtering shells out entirely would have been the other easy answer, and it was rejected
+— the palette is the keyboard route to a pane, so that would make terminal tabs mouse-reachable only.
+Splitting is the fix; renaming is the whole fix.
+
+**"Recent Files" means "currently has uncommitted changes."** Jerry has no file-access or mtime
+history to rank true recency by, so an empty query narrows to changed files under that label rather
+than inventing an ordering. A non-empty query searches the whole tree under a plain `Files` label.
+
+### Rows
+
+A 15px kind chip — the `›` command chip, the file's language chip, or the agent's tint badge, so the
+palette inherits the rail's colour coding — then the label with the **matched substring highlighted**
+(three spans: pre, match, post), a dim secondary line (branch for an agent, `dir · +n −n` for a file,
+a one-line description for a command), an optional status dot, and a keycap for the bound shortcut.
+
+Selected rows carry the same left-edge treatment used elsewhere for selection.
+
+## Rules that matter
+
+- **Every `PaletteCommand` maps one-to-one to a real `AdeApp` method.** Never a stub, never a row
+  that opens a "coming soon". `PaletteCommand::ALL` is the closed list.
+- **A label must be true.** If a group's name would misdescribe half its rows, split the group; do
+  not filter the rows away to make the name fit.
+- **Scope ≠ step.** A new filter over the same candidates is a scope. A new list reached by running a
+  command is a step. Getting this wrong makes `esc` mean two things.
+- **The palette inherits existing chips**; it does not define its own row iconography.
+- **No blur.** The scrim is a flat alpha fill.
+
+## Not built yet
+
+- **No fuzzy ranking across kinds.** Matching is a substring match per group; there is no unified
+  relevance score that would let a file outrank a command.
+- **No true recency.** See above — there is no access history to rank by, and the label is honest
+  about the proxy it uses instead.

--- a/docs/design/command-palette.md
+++ b/docs/design/command-palette.md
@@ -1,7 +1,7 @@
 # Command palette
 
-**Code:** `crates/app/src/palette/`
-**Tokens:** `theme::palette`, `theme::{band::PALETTE_*, zone::PALETTE_WIDTH, shadow::PALETTE}`
+- **Code:** `crates/app/src/palette/`
+- **Tokens:** `theme::palette`, `theme::{band::PALETTE_*, zone::PALETTE_WIDTH, shadow::PALETTE}`
 
 ## What it's for
 
@@ -9,9 +9,10 @@ One overlay that is both the command list **and** the way you get to a pane or a
 touching the mouse. It is the keyboard route to everything, which is why an agent, a shell, a file
 and a command are all rows in the same list rather than four separate finders.
 
-An **overlay, not a page**: a flat scrim over everything below the title bar (a plain alpha fill, not
-a blur — see [`principles.md`](./principles.md) rule 3), and a panel pinned near the top. Clicking
-the scrim or pressing `esc` dismisses it. There is nothing here you can leave the app parked in.
+An **overlay, not a page**: a flat scrim over everything below the title bar (a plain alpha fill,
+not a blur — see [`principles.md`](./principles.md) rule 3), and a panel pinned near the top.
+Clicking the scrim or pressing `esc` dismisses it. There is nothing here you can leave the app
+parked in.
 
 ## Structure
 
@@ -48,11 +49,11 @@ Built by `build_groups`, in order:
 | Recent Files / Files | `All`, `Files` | Label depends on the query — see below |
 
 The Agents/Terminals split is a good example of the honesty rule applied to a label. A shell is not
-an agent: the rail gives it no agent row, and the pane chrome draws it a different bottom bar. Filing
-it under a heading reading `Agents` would tell the user the opposite of what the rest of the app
-tells them. Filtering shells out entirely would have been the other easy answer, and it was rejected
-— the palette is the keyboard route to a pane, so that would make terminal tabs mouse-reachable only.
-Splitting is the fix; renaming is the whole fix.
+an agent: the rail gives it no agent row, and the pane chrome draws it a different bottom bar.
+Filing it under a heading reading `Agents` would tell the user the opposite of what the rest of the
+app tells them. Filtering shells out entirely would have been the other easy answer, and it was
+rejected — the palette is the keyboard route to a pane, so that would make terminal tabs
+mouse-reachable only. Splitting is the fix; renaming is the whole fix.
 
 **"Recent Files" means "currently has uncommitted changes."** Jerry has no file-access or mtime
 history to rank true recency by, so an empty query narrows to changed files under that label rather
@@ -61,9 +62,10 @@ than inventing an ordering. A non-empty query searches the whole tree under a pl
 ### Rows
 
 A 15px kind chip — the `›` command chip, the file's language chip, or the agent's tint badge, so the
-palette inherits the rail's colour coding — then the label with the **matched substring highlighted**
-(three spans: pre, match, post), a dim secondary line (branch for an agent, `dir · +n −n` for a file,
-a one-line description for a command), an optional status dot, and a keycap for the bound shortcut.
+palette inherits the rail's colour coding — then the label with the **matched substring
+highlighted** (three spans: pre, match, post), a dim secondary line (branch for an agent, `dir · +n
+−n` for a file, a one-line description for a command), an optional status dot, and a keycap for the
+bound shortcut.
 
 Selected rows carry the same left-edge treatment used elsewhere for selection.
 
@@ -73,8 +75,8 @@ Selected rows carry the same left-edge treatment used elsewhere for selection.
   that opens a "coming soon". `PaletteCommand::ALL` is the closed list.
 - **A label must be true.** If a group's name would misdescribe half its rows, split the group; do
   not filter the rows away to make the name fit.
-- **Scope ≠ step.** A new filter over the same candidates is a scope. A new list reached by running a
-  command is a step. Getting this wrong makes `esc` mean two things.
+- **Scope ≠ step.** A new filter over the same candidates is a scope. A new list reached by running
+  a command is a step. Getting this wrong makes `esc` mean two things.
 - **The palette inherits existing chips**; it does not define its own row iconography.
 - **No blur.** The scrim is a flat alpha fill.
 

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -1,0 +1,269 @@
+# Design decisions
+
+Why Jerry's UI looks and behaves the way it does — the reasoning behind a call, not just the rule.
+[`principles.md`](./principles.md) and the surface pages state each rule in a line or two and point
+here for the argument, deliberately, so they stay short.
+
+This is a **decisions log, not a running narrative**, and it mirrors
+[`docs/architecture/decisions.md`](../architecture/decisions.md)'s format for exactly the reason
+that file gives: a growing chronicle nobody can tell is current is worse than no record. A decision
+here is written once. If a later decision changes an earlier one, it gets its **own new numbered
+entry** at the bottom and the old entry's `Status` line is updated to point at it — never edited
+back to "current".
+
+Add an entry for a real decision: a new rule, a reversal, or a call a future contributor would
+otherwise re-litigate. Not for every routine application of one already recorded.
+
+Entries 1–6 are seeded from calls made during the original design work and recorded until now only
+in handoff prose or in a code comment. They are stated here so they can be argued with.
+
+## 1. The rail answers "who needs me" pre-verbally
+
+**Status:** Accepted.
+
+**Context:** Supervising six-plus agents at once is a triage problem before it is anything else. A
+list of agents with status labels is readable, but reading it is a serial operation: eyes down the
+column, one row at a time, in a UI you are checking every few minutes all day.
+
+**Decision:** The rail is ranked by urgency at every level (`WorktreeRow::urgency_rank`,
+`Status::urgency_rank`) and each row carries a coloured left edge in its status colour. The intended
+interaction is *seeing how tall the amber block at the top is*, not reading labels.
+
+**Consequences:** Colour becomes a scarce resource that has to be protected (entry 2). Any change
+making the answer require reading is a regression however much information it adds — sorting
+alphabetically, colouring rows by agent instead of by status, or replacing the edge with an icon all
+break it. This is [`principles.md`](./principles.md) rule 1.
+
+## 2. Colour is reserved for status and diffs
+
+**Status:** Accepted.
+
+**Context:** Entry 1 only works if amber means exactly one thing everywhere in the product. Every
+decorative accent spends a little of that.
+
+**Decision:** The status palette (`theme::status`), the diff palette (`theme::diff`), agent tints
+(`theme::agent`) and syntax highlighting (`theme::syntax`) are the entire colour budget. Chrome is
+grey.
+
+**Consequences:** New surfaces get grey chrome and borrow an existing semantic colour where they
+need one. Agent tints, being the one non-status use of saturated colour, are constrained by their
+own allocation rule — see entry 9. This is [`principles.md`](./principles.md) rule 2.
+
+## 3. There is no chat UI
+
+**Status:** Accepted.
+
+**Context:** The obvious shape for an app that supervises agent CLIs is a chat client: parse the
+agent's output, render its questions as cards, its answers as bubbles. Every other product in the
+category does some version of this.
+
+**Decision:** The agent runs in a real pty and Jerry renders its output **verbatim**, cell by cell
+(`terminal::grid` over `alacritty_terminal`). The agent's question is *its own* numbered prompt, not
+a card Jerry designed. The pane header shows the real invocation, the real pid and the real pty
+state.
+
+**Consequences:** Jerry works with any agent CLI on day one, including ones that don't exist yet, and
+never lies about what the agent said. Structural information about agent state has to come from real
+side channels — the terminal title (`rail::title_signal`), OSC sequences (`terminal::osc`), and
+Claude Code's own hook system (`hooks/`) — rather than from parsing rendered output. Anything Jerry
+adds around the agent goes in the chrome above and below the pane, never inside it. It also means
+Jerry cannot offer features that require understanding the conversation, and that is accepted.
+
+## 4. Every icon is composed from rects and text glyphs
+
+**Status:** **Superseded by entry 8.**
+
+**Context:** The original design had no image assets at all. Every icon was absolutely-positioned 1px
+`div`s and Unicode glyphs, so nothing needed an SVG pipeline and the whole UI ported cheaply to any
+toolkit.
+
+**Decision:** No icon assets. Compose from rects and glyphs.
+
+**Consequences:** Held for the whole first build. What it cost is recorded in entry 8.
+
+## 5. `Accept file` is always rendered, dimmed
+
+**Status:** Accepted.
+
+**Context:** The code surface's toolbar carries a `Diff | File` segmented toggle and, next to it, an
+`Accept file` button. The natural implementation hides the button when there is nothing to accept.
+
+**Decision:** It is always rendered, dimmed and non-interactive when unavailable.
+
+**Consequences:** Layout under the cursor never moves. Hiding it reflows the toggle sitting beside
+it — under the pointer that was about to click the toggle. Generalised into
+[`principles.md`](./principles.md) rule 6: controls dim, they do not vanish. `FooterAction::implemented`
+applies the same treatment to the agent pane's actions.
+
+## 6. Merge-conflict columns are headed by their agent
+
+**Status:** Accepted.
+
+**Context:** Git presents a conflict as "ours" and "theirs" — a framing anchored on which side ran
+the merge.
+
+**Decision:** Each column in the conflict surface is headed by **the agent whose work it is**: agent
+badge, agent name, branch, commit count, and its own lines tinted with that agent's colour. Never
+"ours"/"theirs".
+
+**Consequences:** In Jerry the two sides of a conflict are two agents you know by name and by tint,
+and the surface reads as *these two agents disagree here* rather than as a git operation. The same
+reasoning makes Jerry propose the resolution where it can — a pre-flight strip states how many files
+auto-resolve because their edits don't overlap, and `Take both` is the primary action when both edits
+can be kept.
+
+## 7. The rail has one structure: repo → worktree → agent
+
+**Status:** Accepted. Supersedes the original `by urgency / by project` grouping toggle.
+
+**Context:** The original rail had two grouping modes behind a header control, plus a sort control.
+"By urgency" grouped agents under status headers; "by project" grouped them under repositories, and
+was the only mode that could show worktrees with no agent in them at all.
+
+**Decision:** One structure, always: **repo group → worktree → agents.** The mode toggle, the sort
+control and their state were deleted, not hidden. Urgency became *ranking within* the fixed structure
+— worktrees ordered by their most urgent agent, repos by their most urgent worktree.
+
+**Consequences:** Entry 1's property is preserved (the most urgent things still float to the top and
+wear a colour) while the rail keeps one shape a user can build spatial memory of. Worktrees with no
+agent are always visible, which was the only real argument for the second mode. Repo headers carry
+**two** urgency counts, red and amber, rather than one merged amber count: merging them said "three
+worktrees want you" when one of the three had actually died. That generalises to a rule stated in
+[`layout.md`](./layout.md#rules-that-matter) — two states distinguished anywhere in the app are never
+summed anywhere in it.
+
+## 8. Shipped icons are Phosphor SVGs; Jerry's own vocabulary stays hand-drawn
+
+**Status:** Accepted. Supersedes entry 4. (GitHub issue #282.)
+
+**Context:** Entry 4's rule held through the first build and produced, in the words of the review
+that ended it: "mismatched optical sizes in a row, two glyphs from one family a divider apart, marks
+that read as nothing at 17px". Hand-composed icons have no shared canvas, so two of them side by side
+have no reason to look like siblings.
+
+**Decision:** Vendor real [Phosphor](https://phosphoricons.com) SVGs (MIT) under `assets/icons/` for
+**actions and views only** — panel tabs, sidebar-strip cells, the overflow menu, the terminal tab,
+the prune button. `icons::Icon` is that closed list. Everything that is Jerry's own semantic
+vocabulary — agent tint chips, status dots, file-extension chips, diff gutter marks, graph lanes and
+merge elbows — **stays hand-drawn**, because a third-party icon family has no opinion about what
+those mean.
+
+The deciding argument for Phosphor specifically was the build target: it ships raw SVGs and GPUI
+renders SVG natively, so each icon is a named asset rather than geometry someone has to reinterpret
+as paths.
+
+**Consequences:** Two mechanical rules came with it, both enforced by tests rather than convention:
+icons draw only through an `IconRow` so a row shares one optical box, and files are vendored at
+`bold` weight because `regular`'s stroke reads thin below 20px. Every vendored file is on the same
+`0 0 256 256` canvas, asserted by a test, which is what makes equal boxes give equal optical weight —
+the property entry 4 could not hold. Moving something off the hand-drawn list needs its own entry
+here.
+
+## 9. Agent tints may not reuse a reserved hue
+
+**Status:** Accepted.
+
+**Context:** Agent tints are the one saturated, non-status use of colour in the product (entry 2). The
+original allocation collided with it: one agent wore the additions green, another wore an amber one
+step from the needs-input amber it sits *beside* in a rail row, and a third wore the exact branch-scope
+violet.
+
+**Decision:** No agent tint may sit in a hue already spent on status or on diffs. The pool is
+enumerable (`theme::agent::TINT_POOL`) and the rule is enforced by a real test
+(`theme::agent_tint_allocation_tests`), not by review.
+
+**Consequences:** The pool was reallocated to copper / teal / periwinkle / steel blue. Adding an agent
+means adding a tint that passes the test, which in practice means the pool is finite and a fifth or
+sixth agent will need a deliberate hue decision rather than the next colour to hand.
+
+## 10. `Status::Review` renders as `Finished`
+
+**Status:** Accepted. (GitHub issue #280.)
+
+**Context:** The status originally rendered as `Review ready`.
+
+**Decision:** The rendered word is `Finished`. The enum variant keeps its `Review` name — it is an
+internal identifier and this is only about the string.
+
+**Consequences:** "Review ready" states a judgement the agent cannot make: the agent knows it exited
+zero with a non-empty diff, not that the work is ready for review. It also collided with the user's
+*own* review progress tracked in the Changes panel, and contradicted the app's own vocabulary.
+`Finished` states the fact, and the file count rendered beside it carries what there is to look at.
+The urgency ordering is unchanged.
+
+## 11. The status bar watches agents; it is not an editor's footer
+
+**Status:** Accepted. (GitHub issue #293.)
+
+**Context:** An audit of the status bar counted thirteen readouts and found eight of them lifted from
+VS Code — cursor position, indent width, line ending, encoding, editor zoom, UI scale among them.
+"VS Code's footer answers *what am I typing into*; Jerry's job is watching agents. Wrong app's
+chrome."
+
+**Decision:** Delete all eight, code paths included. What is left is three groups on three type
+tiers: a transient notice slot, the branch cluster, running agents, and machine load on the left; the
+environment chip and the palette hint on the right.
+
+**Consequences:** Editor zoom survives as `mod+plus`/`mod+minus` — the state and handlers were kept,
+only the readouts went. The urgency dot cluster moved into the title bar. `N worktrees · Y GB` was
+dropped because the rail footer carries it 30px away: the rail owns worktree inventory and its prune
+action, the bar owns activity and cost. This is also where the general rule comes from that replacing
+a control means deleting its old keys in the same edit — a key defined twice is two specifications of
+one thing and the reader cannot tell which is real.
+
+## 12. The agent pane's bottom strip is a readout, not an action bar
+
+**Status:** Accepted. (GitHub issue #295.)
+
+**Context:** The strip below an agent pane originally carried a per-status row of git actions — keep
+all, review diff, open in editor, discard, retry, interrupt, open terminal.
+
+**Decision:** It is a readout. `work_surface::state::ActionKind` went from seven variants to two
+(`Respawn`, `DiscardWorktree`); the other five were **deleted**, not hidden behind a condition.
+
+**Consequences:** The pane reports what the agent is doing rather than competing with it for the
+bottom of the screen, and the actions that survive are the ones the CLI genuinely cannot perform for
+itself. Anything still rendered without backing logic is dimmed and non-interactive
+(`FooterAction::implemented`) — never a clickable-looking no-op.
+
+## 13. The palette binds `mod+P`
+
+**Status:** Accepted.
+
+**Context:** `mod+K` was the original binding. The file editor's real `ctrl-k ctrl-d` chord registers
+`ctrl-k` as a chord *prefix* in that context, so a lone press waited out GPUI's ~1s prefix timeout
+before replaying and reaching the palette.
+
+**Decision:** Bind `mod+P`, unscoped, as a real replacement — not an alias alongside `mod+K`.
+
+**Consequences:** No delay, and the binding matches the VS Code / Sublime convention directly. The
+known tradeoff: a focused terminal's own readline `Ctrl+P` (`previous-history`) is shadowed by this
+binding rather than reaching the shell. A terminal's Up-arrow history navigation is unaffected.
+
+## 14. `docs/design/` replaces the design-handoff bundle
+
+**Status:** Accepted. (GitHub issue #414.)
+
+**Context:** `design_handoff_jerry_ade/` was a one-shot handoff bundle — an interactive HTML mockup, a
+transcribed `tokens.rs`, and a README written as a build brief. It was the de-facto design authority:
+364 doc comments across 81 files in `crates/` cited it, and so did `CONTRIBUTING.md`,
+`docs/development-workflow.md`, two skills and an issue template. `CONTRIBUTING.md` also described it
+honestly as "a one-time handoff artifact, not a living spec".
+
+Three things had gone wrong. Roughly a third of those citations pointed at `revision N/` directories
+that were never committed, so a contributor reading `theme.rs` hit an unresolvable path every other
+screen. The citations were exactly what `CLAUDE.md`'s comment rule forbids — design history, revision
+IDs, issue archaeology — and were the single largest class of violation in the codebase. And a frozen
+mockup cannot absorb a design change: entry 8 silently superseded entry 4 with nothing in the
+repository to record it.
+
+**Decision:** Delete the bundle and replace it with this documentation set. `theme.rs` stays the
+source of truth for **values**; these docs cover **intent, structure, vocabulary and invariants**, and
+name the token rather than reprinting a hex. The bundle is preserved by git history alone — no tag,
+no release asset.
+
+**Consequences:** The docs cannot drift from the code on values, because they never duplicate them. A
+UI change updates the relevant page in the same PR, and a call worth recording gets an entry here
+instead of an uncommitted `revision N/` folder. Where the old mockup and the shipped app disagree,
+**the app wins**, and the delta becomes an entry here or a `Not built yet` line on a surface page —
+entries 7 and 10 through 13 are that reconciliation, written down for the first time.

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -62,9 +62,9 @@ category does some version of this.
 a card Jerry designed. The pane header shows the real invocation, the real pid and the real pty
 state.
 
-**Consequences:** Jerry works with any agent CLI on day one, including ones that don't exist yet, and
-never lies about what the agent said. Structural information about agent state has to come from real
-side channels — the terminal title (`rail::title_signal`), OSC sequences (`terminal::osc`), and
+**Consequences:** Jerry works with any agent CLI on day one, including ones that don't exist yet,
+and never lies about what the agent said. Structural information about agent state has to come from
+real side channels — the terminal title (`rail::title_signal`), OSC sequences (`terminal::osc`), and
 Claude Code's own hook system (`hooks/`) — rather than from parsing rendered output. Anything Jerry
 adds around the agent goes in the chrome above and below the pane, never inside it. It also means
 Jerry cannot offer features that require understanding the conversation, and that is accepted.
@@ -73,9 +73,9 @@ Jerry cannot offer features that require understanding the conversation, and tha
 
 **Status:** **Superseded by entry 8.**
 
-**Context:** The original design had no image assets at all. Every icon was absolutely-positioned 1px
-`div`s and Unicode glyphs, so nothing needed an SVG pipeline and the whole UI ported cheaply to any
-toolkit.
+**Context:** The original design had no image assets at all. Every icon was absolutely-positioned
+1px `div`s and Unicode glyphs, so nothing needed an SVG pipeline and the whole UI ported cheaply to
+any toolkit.
 
 **Decision:** No icon assets. Compose from rects and glyphs.
 
@@ -92,8 +92,8 @@ toolkit.
 
 **Consequences:** Layout under the cursor never moves. Hiding it reflows the toggle sitting beside
 it — under the pointer that was about to click the toggle. Generalised into
-[`principles.md`](./principles.md) rule 6: controls dim, they do not vanish. `FooterAction::implemented`
-applies the same treatment to the agent pane's actions.
+[`principles.md`](./principles.md) rule 6: controls dim, they do not vanish.
+`FooterAction::implemented` applies the same treatment to the agent pane's actions.
 
 ## 6. Merge-conflict columns are headed by their agent
 
@@ -109,8 +109,8 @@ badge, agent name, branch, commit count, and its own lines tinted with that agen
 **Consequences:** In Jerry the two sides of a conflict are two agents you know by name and by tint,
 and the surface reads as *these two agents disagree here* rather than as a git operation. The same
 reasoning makes Jerry propose the resolution where it can — a pre-flight strip states how many files
-auto-resolve because their edits don't overlap, and `Take both` is the primary action when both edits
-can be kept.
+auto-resolve because their edits don't overlap, and `Take both` is the primary action when both
+edits can be kept.
 
 ## 7. The rail has one structure: repo → worktree → agent
 
@@ -121,16 +121,16 @@ can be kept.
 was the only mode that could show worktrees with no agent in them at all.
 
 **Decision:** One structure, always: **repo group → worktree → agents.** The mode toggle, the sort
-control and their state were deleted, not hidden. Urgency became *ranking within* the fixed structure
-— worktrees ordered by their most urgent agent, repos by their most urgent worktree.
+control and their state were deleted, not hidden. Urgency became *ranking within* the fixed
+structure — worktrees ordered by their most urgent agent, repos by their most urgent worktree.
 
 **Consequences:** Entry 1's property is preserved (the most urgent things still float to the top and
 wear a colour) while the rail keeps one shape a user can build spatial memory of. Worktrees with no
 agent are always visible, which was the only real argument for the second mode. Repo headers carry
 **two** urgency counts, red and amber, rather than one merged amber count: merging them said "three
 worktrees want you" when one of the three had actually died. That generalises to a rule stated in
-[`layout.md`](./layout.md#rules-that-matter) — two states distinguished anywhere in the app are never
-summed anywhere in it.
+[`layout.md`](./layout.md#rules-that-matter) — two states distinguished anywhere in the app are
+never summed anywhere in it.
 
 ## 8. Shipped icons are Phosphor SVGs; Jerry's own vocabulary stays hand-drawn
 
@@ -138,8 +138,8 @@ summed anywhere in it.
 
 **Context:** Entry 4's rule held through the first build and produced, in the words of the review
 that ended it: "mismatched optical sizes in a row, two glyphs from one family a divider apart, marks
-that read as nothing at 17px". Hand-composed icons have no shared canvas, so two of them side by side
-have no reason to look like siblings.
+that read as nothing at 17px". Hand-composed icons have no shared canvas, so two of them side by
+side have no reason to look like siblings.
 
 **Decision:** Vendor real [Phosphor](https://phosphoricons.com) SVGs (MIT) under `assets/icons/` for
 **actions and views only** — panel tabs, sidebar-strip cells, the overflow menu, the terminal tab,
@@ -155,26 +155,26 @@ as paths.
 **Consequences:** Two mechanical rules came with it, both enforced by tests rather than convention:
 icons draw only through an `IconRow` so a row shares one optical box, and files are vendored at
 `bold` weight because `regular`'s stroke reads thin below 20px. Every vendored file is on the same
-`0 0 256 256` canvas, asserted by a test, which is what makes equal boxes give equal optical weight —
-the property entry 4 could not hold. Moving something off the hand-drawn list needs its own entry
+`0 0 256 256` canvas, asserted by a test, which is what makes equal boxes give equal optical weight
+— the property entry 4 could not hold. Moving something off the hand-drawn list needs its own entry
 here.
 
 ## 9. Agent tints may not reuse a reserved hue
 
 **Status:** Accepted.
 
-**Context:** Agent tints are the one saturated, non-status use of colour in the product (entry 2). The
-original allocation collided with it: one agent wore the additions green, another wore an amber one
-step from the needs-input amber it sits *beside* in a rail row, and a third wore the exact branch-scope
-violet.
+**Context:** Agent tints are the one saturated, non-status use of colour in the product (entry 2).
+The original allocation collided with it: one agent wore the additions green, another wore an amber
+one step from the needs-input amber it sits *beside* in a rail row, and a third wore the exact
+branch-scope violet.
 
 **Decision:** No agent tint may sit in a hue already spent on status or on diffs. The pool is
 enumerable (`theme::agent::TINT_POOL`) and the rule is enforced by a real test
 (`theme::agent_tint_allocation_tests`), not by review.
 
-**Consequences:** The pool was reallocated to copper / teal / periwinkle / steel blue. Adding an agent
-means adding a tint that passes the test, which in practice means the pool is finite and a fifth or
-sixth agent will need a deliberate hue decision rather than the next colour to hand.
+**Consequences:** The pool was reallocated to copper / teal / periwinkle / steel blue. Adding an
+agent means adding a tint that passes the test, which in practice means the pool is finite and a
+fifth or sixth agent will need a deliberate hue decision rather than the next colour to hand.
 
 ## 10. `Status::Review` renders as `Finished`
 
@@ -195,21 +195,21 @@ The urgency ordering is unchanged.
 
 **Status:** Accepted. (GitHub issue #293.)
 
-**Context:** An audit of the status bar counted thirteen readouts and found eight of them lifted from
-VS Code — cursor position, indent width, line ending, encoding, editor zoom, UI scale among them.
-"VS Code's footer answers *what am I typing into*; Jerry's job is watching agents. Wrong app's
+**Context:** An audit of the status bar counted thirteen readouts and found eight of them lifted
+from VS Code — cursor position, indent width, line ending, encoding, editor zoom, UI scale among
+them. "VS Code's footer answers *what am I typing into*; Jerry's job is watching agents. Wrong app's
 chrome."
 
 **Decision:** Delete all eight, code paths included. What is left is three groups on three type
-tiers: a transient notice slot, the branch cluster, running agents, and machine load on the left; the
-environment chip and the palette hint on the right.
+tiers: a transient notice slot, the branch cluster, running agents, and machine load on the left;
+the environment chip and the palette hint on the right.
 
 **Consequences:** Editor zoom survives as `mod+plus`/`mod+minus` — the state and handlers were kept,
 only the readouts went. The urgency dot cluster moved into the title bar. `N worktrees · Y GB` was
 dropped because the rail footer carries it 30px away: the rail owns worktree inventory and its prune
-action, the bar owns activity and cost. This is also where the general rule comes from that replacing
-a control means deleting its old keys in the same edit — a key defined twice is two specifications of
-one thing and the reader cannot tell which is real.
+action, the bar owns activity and cost. This is also where the general rule comes from that
+replacing a control means deleting its old keys in the same edit — a key defined twice is two
+specifications of one thing and the reader cannot tell which is real.
 
 ## 12. The agent pane's bottom strip is a readout, not an action bar
 
@@ -230,9 +230,9 @@ itself. Anything still rendered without backing logic is dimmed and non-interact
 
 **Status:** Accepted.
 
-**Context:** `mod+K` was the original binding. The file editor's real `ctrl-k ctrl-d` chord registers
-`ctrl-k` as a chord *prefix* in that context, so a lone press waited out GPUI's ~1s prefix timeout
-before replaying and reaching the palette.
+**Context:** `mod+K` was the original binding. The file editor's real `ctrl-k ctrl-d` chord
+registers `ctrl-k` as a chord *prefix* in that context, so a lone press waited out GPUI's ~1s prefix
+timeout before replaying and reaching the palette.
 
 **Decision:** Bind `mod+P`, unscoped, as a real replacement — not an alias alongside `mod+K`.
 
@@ -244,26 +244,26 @@ binding rather than reaching the shell. A terminal's Up-arrow history navigation
 
 **Status:** Accepted. (GitHub issue #414.)
 
-**Context:** `design_handoff_jerry_ade/` was a one-shot handoff bundle — an interactive HTML mockup, a
-transcribed `tokens.rs`, and a README written as a build brief. It was the de-facto design authority:
-364 doc comments across 81 files in `crates/` cited it, and so did `CONTRIBUTING.md`,
-`docs/development-workflow.md`, two skills and an issue template. `CONTRIBUTING.md` also described it
-honestly as "a one-time handoff artifact, not a living spec".
+**Context:** `design_handoff_jerry_ade/` was a one-shot handoff bundle — an interactive HTML mockup,
+a transcribed `tokens.rs`, and a README written as a build brief. It was the de-facto design
+authority: 364 doc comments across 81 files in `crates/` cited it, and so did `CONTRIBUTING.md`,
+`docs/development-workflow.md`, two skills and an issue template. `CONTRIBUTING.md` also described
+it honestly as "a one-time handoff artifact, not a living spec".
 
 Three things had gone wrong. Roughly a third of those citations pointed at `revision N/` directories
 that were never committed, so a contributor reading `theme.rs` hit an unresolvable path every other
-screen. The citations were exactly what `CLAUDE.md`'s comment rule forbids — design history, revision
-IDs, issue archaeology — and were the single largest class of violation in the codebase. And a frozen
-mockup cannot absorb a design change: entry 8 silently superseded entry 4 with nothing in the
-repository to record it.
+screen. The citations were exactly what `CLAUDE.md`'s comment rule forbids — design history,
+revision IDs, issue archaeology — and were the single largest class of violation in the codebase.
+And a frozen mockup cannot absorb a design change: entry 8 silently superseded entry 4 with nothing
+in the repository to record it.
 
 **Decision:** Delete the bundle and replace it with this documentation set. `theme.rs` stays the
-source of truth for **values**; these docs cover **intent, structure, vocabulary and invariants**, and
-name the token rather than reprinting a hex. The bundle is preserved by git history alone — no tag,
-no release asset.
+source of truth for **values**; these docs cover **intent, structure, vocabulary and invariants**,
+and name the token rather than reprinting a hex. The bundle is preserved by git history alone — no
+tag, no release asset.
 
-**Consequences:** The docs cannot drift from the code on values, because they never duplicate them. A
-UI change updates the relevant page in the same PR, and a call worth recording gets an entry here
+**Consequences:** The docs cannot drift from the code on values, because they never duplicate them.
+A UI change updates the relevant page in the same PR, and a call worth recording gets an entry here
 instead of an uncommitted `revision N/` folder. Where the old mockup and the shipped app disagree,
 **the app wins**, and the delta becomes an entry here or a `Not built yet` line on a surface page —
 entries 7 and 10 through 13 are that reconciliation, written down for the first time.

--- a/docs/design/layout.md
+++ b/docs/design/layout.md
@@ -1,0 +1,144 @@
+# Window layout
+
+**Code:** `crates/app/src/root/`, `crates/app/src/title_bar/`, `crates/app/src/status_bar/`
+**Tokens:** `theme::{band, zone, surface, border}`
+
+## What it's for
+
+Jerry is one window with a fixed skeleton: a title bar, three side-by-side zones, and a status bar.
+The skeleton never changes shape. Surfaces swap *inside* Zone 2; panels collapse and resize; but a
+developer who has used the app for a week always knows which third of the window answers which
+question. That predictability is what makes triage fast, and it is why nothing here floats, docks
+elsewhere, or becomes a modal.
+
+## Structure
+
+### Bands, top to bottom
+
+| Band | Height | Notes |
+|---|---|---|
+| Title bar | `theme::band::TITLE_BAR` | Platform-dependent — see below |
+| Body — three zones | fill | |
+| Status bar | `theme::band::STATUS_BAR` | Three type tiers; see below |
+
+### The three zones
+
+| Zone | Width | Owns |
+|---|---|---|
+| 1 — agent rail | `theme::zone::RAIL_WIDTH`, resizable | Which agents exist and which needs you ([`rail.md`](./rail.md)) |
+| 2 — work surface | fill | Whatever you are looking at right now ([`work-surface.md`](./work-surface.md)) |
+| 3 — files / search / changes | `theme::zone::PANEL_WIDTH` | Navigating this worktree ([`sidebar.md`](./sidebar.md)) |
+
+Zones 1 and 3 are drag-resizable. The clamp is pure and window-free, in `root::layout`
+(`RAIL_DEFAULT`/`RAIL_MIN`/`RAIL_MAX` and the panel's equivalents), so the arithmetic is unit-tested
+without a live GPUI window; `root::resize` owns the actual drag. Widths are computed from the drag's
+absolute cursor position each tick rather than from an armed drag-start baseline — which is what
+removes the "drag state left dangling if the mouse is released outside the window" class of bug by
+construction.
+
+### The work-surface stack
+
+Zone 2 is itself a vertical stack, and every layer has a named band height:
+
+```
+tab strip              theme::band::CHROME_HEADER
+agent context bar      theme::band::CONTEXT_BAR
+(conflict banner)      only when another agent has touched a file on this branch
+surface                fill  — the agent pane, a terminal, a file, the graph, a review, a run
+surface footer         theme::band::SURFACE_FOOTER  or  ::PTY_INFO_FOOTER
+```
+
+A pane gets exactly **one** bottom bar, chosen by its `ProcessKind`, never both stacked: the agent
+pane's readout strip (`SURFACE_FOOTER`) or the shell pane's info footer (`PTY_INFO_FOOTER`).
+
+### One header rule across three columns
+
+The work-surface tab strip, the rail's own sidebar strip, and the Zone 3 panel header all sit on one
+y and all read `theme::band::CHROME_HEADER`. This is the canonical instance of
+[`principles.md`](./principles.md) rule 5, and that constant's doc comment records what happened
+when the three drifted: a visible staircase at every column boundary. Their bottom rule shares one
+colour too (`theme::border::RAIL_INNER`), for the same reason.
+
+**Changing any of the three heights changes a line that spans the whole window. Check the other two
+in the same edit.**
+
+### Title bar — two variants
+
+Platform-dependent, driven by one setting (`keymap::WindowControlsStyle`) that also decides which
+glyphs keycaps resolve to. See `keymap.rs`'s own docs for why the two are deliberately one setting
+and not two.
+
+- **macOS** — the OS paints its own traffic lights over the window; `title_bar::render` reserves
+  their cluster width and draws the trailing divider clear of them.
+- **Windows / Linux** — a menu row (`File Edit View Agent Help`, whose dropdowns live in
+  `title_bar::menu`) and three caption buttons pinned to the right edge, outside the band's own
+  padding. The close glyph is two rotated rects; `title_bar::render`'s
+  `CLOSE_GLYPH_HALF_DIAGONAL` is the geometry.
+
+Everything between the two ends — project chip, the compact urgency dot chips, panel toggles — is
+shared.
+
+The override is a **cosmetic preview**, not a rebinding: GPUI resolves `"secondary"` to a physical
+key once, at compile time, so previewing the macOS look on Linux renders `⌘P` while Ctrl+P is still
+the key that works. That mismatch is accepted, and confined to an explicitly opt-in action whose own
+label says "preview". `keymap.rs`'s docs carry the full argument.
+
+### Status bar
+
+**The bar watches agents. It is not a text editor's footer.** That is the whole editorial rule, and
+it was arrived at subtractively: an audit of the previous bar found eight of its thirteen readouts
+lifted straight from VS Code — cursor position, indent width, line ending, encoding, zoom and UI
+scale among them — answering *what am I typing into* rather than *what are my agents doing*. All
+eight were deleted, code paths included, in the rev-6 rebuild (issue #293).
+
+What is left is three groups, one per type tier, separated by a deliberately heavier divider
+(`theme::status_bar::DIVIDER`; at the old weight the groups they separated ran together):
+
+- **Left** — a transient notice slot (an available update from `updater`, or one-off
+  keep-all/discard feedback from `worktree_history::flow`), the branch cluster with ahead/behind,
+  `N agents running`, and the machine's real CPU/memory load.
+- **Right** — the environment chip and the palette keycap hint. That is all of it.
+
+Resource figures are real measurements sampled off the OS (`status_bar::process_stats`,
+`status_bar::resources`), not decoration.
+
+Two removals are worth knowing about because they look like omissions and are not: the **urgency
+dot cluster** moved into the title bar's compact dot chips, and **`N worktrees · Y GB`** was dropped
+because the rail footer already carries it 30px away — the rail owns worktree inventory, the bar
+owns activity. Editor zoom survives as `mod+plus`/`mod+minus`; only its readout is gone.
+
+The status bar is rendered as an unconditional sibling of the workspace/Settings swap, so it stays
+visible while Settings is open — which is why transient feedback lives here rather than in the rail
+footer, where it would vanish exactly when a long operation needed reporting.
+
+## Rules that matter
+
+- **Nothing floats.** Overlays are the command palette, the completion popup, and menus — all of
+  which are dismissible and none of which is a place you can leave the app parked. Settings replaces
+  the three zones rather than opening as a modal; the title bar and status bar stay.
+- **Overlay focus is centrally owned.** `root::focus` and `OverlayFocus` decide who has the keyboard
+  when a palette or popup is up. A new overlay routes through it rather than grabbing focus itself.
+- **Band heights come from `theme::band`.** A surface that needs a new band height adds a named
+  constant with a doc comment saying what it is, rather than a literal at the call site — otherwise
+  rule 5 above has nothing to enforce.
+- **Two states distinguished anywhere in the app are never summed anywhere in it.** This is why the
+  status bar counts *running* agents rather than every open agent: the rail spends its whole design
+  on separating five statuses, and a bar that adds them back into one number contradicts it.
+- **One fact has one home.** If two chrome surfaces would show the same number, the one that owns
+  the action on it keeps it. Worktree inventory belongs to the rail because the rail has the prune
+  button.
+- **Every user-visible count goes through `root::plural`.** `plural::count(n, "file", None)`,
+  `plural::form(n, "needs", "need")`. Zero is plural in English and the helper knows that. This is
+  binding on new code and is stated in [`CLAUDE.md`](../../CLAUDE.md) too.
+- **Text scaling is opt-in per surface.** `theme::ui_scale::scaled_px` is applied where its module
+  docs say it is; the code surface and terminal panes are deliberately excluded because they own
+  their own font-size settings and a second multiplier would compound with them.
+
+## Not built yet
+
+- **Interface scale does not reach padding, icons or fixed chrome.** Retrofitting every literal
+  `Pixels` constant in `theme.rs` to scale is out of scope for the current mechanism, and
+  `theme::ui_scale`'s docs say so explicitly rather than implying full coverage.
+- **Zone 2 is single-pane.** There is no split view within the work surface — tabs replace each
+  other in one region. A vertical/horizontal split would be a real design decision, not an
+  incremental change, and belongs in [`decisions.md`](./decisions.md) first.

--- a/docs/design/layout.md
+++ b/docs/design/layout.md
@@ -1,7 +1,7 @@
 # Window layout
 
-**Code:** `crates/app/src/root/`, `crates/app/src/title_bar/`, `crates/app/src/status_bar/`
-**Tokens:** `theme::{band, zone, surface, border}`
+- **Code:** `crates/app/src/root/`, `crates/app/src/title_bar/`, `crates/app/src/status_bar/`
+- **Tokens:** `theme::{band, zone, surface, border}`
 
 ## What it's for
 
@@ -72,8 +72,8 @@ and not two.
   their cluster width and draws the trailing divider clear of them.
 - **Windows / Linux** — a menu row (`File Edit View Agent Help`, whose dropdowns live in
   `title_bar::menu`) and three caption buttons pinned to the right edge, outside the band's own
-  padding. The close glyph is two rotated rects; `title_bar::render`'s
-  `CLOSE_GLYPH_HALF_DIAGONAL` is the geometry.
+  padding. The close glyph is two rotated rects; `title_bar::render`'s `CLOSE_GLYPH_HALF_DIAGONAL`
+  is the geometry.
 
 Everything between the two ends — project chip, the compact urgency dot chips, panel toggles — is
 shared.
@@ -95,15 +95,15 @@ What is left is three groups, one per type tier, separated by a deliberately hea
 (`theme::status_bar::DIVIDER`; at the old weight the groups they separated ran together):
 
 - **Left** — a transient notice slot (an available update from `updater`, or one-off
-  keep-all/discard feedback from `worktree_history::flow`), the branch cluster with ahead/behind,
-  `N agents running`, and the machine's real CPU/memory load.
+  keep-all/discard feedback from `worktree_history::flow`), the branch cluster with ahead/behind, `N
+  agents running`, and the machine's real CPU/memory load.
 - **Right** — the environment chip and the palette keycap hint. That is all of it.
 
 Resource figures are real measurements sampled off the OS (`status_bar::process_stats`,
 `status_bar::resources`), not decoration.
 
-Two removals are worth knowing about because they look like omissions and are not: the **urgency
-dot cluster** moved into the title bar's compact dot chips, and **`N worktrees · Y GB`** was dropped
+Two removals are worth knowing about because they look like omissions and are not: the **urgency dot
+cluster** moved into the title bar's compact dot chips, and **`N worktrees · Y GB`** was dropped
 because the rail footer already carries it 30px away — the rail owns worktree inventory, the bar
 owns activity. Editor zoom survives as `mod+plus`/`mod+minus`; only its readout is gone.
 

--- a/docs/design/principles.md
+++ b/docs/design/principles.md
@@ -1,0 +1,92 @@
+# Design principles
+
+Six rules. They constrain every other page in this set, and a UI change that breaks one needs an
+entry in [`decisions.md`](./decisions.md) saying so — not a quiet exception.
+
+## 1. The rail answers "who needs me" in under a second
+
+Jerry exists to supervise several agents at once. Everything else in the window is secondary to the
+left rail telling a developer, at a glance, which of six-plus running agents is blocked on them.
+
+The mechanism is deliberately pre-verbal: every level of the rail is ranked by urgency
+(`rail::state::WorktreeRow::urgency_rank`, `rail::status::Status::urgency_rank`) and every row
+carries a coloured left edge in its status colour. The question the eye answers is *how tall is the
+amber block at the top* — not *read the labels*. Any change that makes the answer require reading is
+a regression, however much information it adds.
+
+## 2. Colour is reserved for status and diffs
+
+Nothing decorative is coloured. The status palette (`theme::status`), the diff palette
+(`theme::diff`), the agent tints (`theme::agent`) and syntax highlighting (`theme::syntax`) are the
+whole budget. Chrome is grey.
+
+This is what makes rule 1 work: amber means one thing in this product. Spending amber on a
+non-status accent costs the rail its glanceability everywhere at once. The agent tints are
+constrained by the same logic — `theme::agent`'s own module docs record the reserved-hue rule and
+the reallocation it forced (see [`decisions.md`](./decisions.md) §9).
+
+## 3. Flat surfaces, one shadow
+
+Flat fills, 1px borders, small radii. No blur, no layered transparency, no gradient. Borders carry
+elevation, not shadows.
+
+`theme::shadow` holds the exceptions — the completion popup, the command palette, and the shared
+dropdown/menu shadow — and that module's own docs say to drop them if GPUI makes them awkward,
+because the borders already do the work. The origin of this rule is the build target: the mockup was
+authored inside GPUI's constraints so that nothing in it would need reinterpreting as a CSS effect
+GPUI has no cheap equivalent for.
+
+## 4. No fake functionality, on screen as much as in code
+
+A control that looks clickable does something. A readout shows a real measurement. Sample data never
+ships.
+
+This is [`CLAUDE.md`](../../CLAUDE.md)'s rule applied to pixels, and it has real teeth in the
+codebase: `work_surface::state::FooterAction::implemented` renders an unwired action *dimmed and
+non-interactive* rather than hiding it or letting it no-op, and
+`work_surface::state::ActionKind`'s own docs record five variants being **deleted** rather than left
+as decoration. Where a surface genuinely isn't built, it says so — in the UI, and in the
+`Not built yet` section of its page here.
+
+## 5. One object, one specification
+
+When two places draw the same thing, they read one constant. `theme::band::CHROME_HEADER` is the
+canonical case: the work-surface tab strip, the rail's sidebar strip and the Zone 3 panel header all
+sit on one y, and that constant's own doc comment records what happened when they didn't — "a
+visible staircase at every column boundary". Its rule, kept verbatim in the code:
+
+> Column headers that share a y are one rule, not three. Changing any of their heights changes a
+> line that spans the whole window — check the other two in the same edit.
+
+The corollary is that replacing a control means deleting its old keys in the same edit. A key
+defined twice is two specifications of one thing, and the reader cannot tell which is real.
+
+## 6. Layout must not move under the cursor
+
+Controls do not appear and disappear with view state; they dim. The code surface's `Accept file`
+button is the canonical case — it is always rendered, dimmed when there is nothing to accept,
+because appearing and disappearing reflows the Diff/File toggle sitting next to it, under the
+pointer that was about to click it.
+
+The same reasoning drives the fixed widths in the agent context bar: every child is inflexible
+except the worktree path, which ellipsises, so narrowing the centre zone never causes the bar to
+wrap.
+
+---
+
+## Type, spacing and shape
+
+Not principles so much as the palette these principles are executed in. All of it lives in
+`theme.rs`; none of it is reprinted here.
+
+- **Two font families, nothing else** — IBM Plex Sans for UI, IBM Plex Mono for branches, paths,
+  diffs, terminal and code (`theme::font`, bundled by `crate::fonts`). Both are OFL.
+- **Radii** are a scale in `theme::radius`, from the window corner down to a small mark. The step
+  matters: at 5px across, the difference between `MARK` and `MARK_SM` is the difference
+  between reading as a square and reading as a dot, and this app already uses a real circle for
+  "an agent's status".
+- **Band heights** are named in `theme::band`, **zone widths** in `theme::zone`. A new surface reuses
+  an existing band height wherever it plausibly can, per rule 5.
+- **Interface scale** applies to text size only (`theme::ui_scale`), deliberately not to padding,
+  icons or fixed chrome. That module's docs enumerate exactly which surfaces honour it and why each
+  exclusion exists.

--- a/docs/design/principles.md
+++ b/docs/design/principles.md
@@ -43,10 +43,9 @@ ships.
 
 This is [`CLAUDE.md`](../../CLAUDE.md)'s rule applied to pixels, and it has real teeth in the
 codebase: `work_surface::state::FooterAction::implemented` renders an unwired action *dimmed and
-non-interactive* rather than hiding it or letting it no-op, and
-`work_surface::state::ActionKind`'s own docs record five variants being **deleted** rather than left
-as decoration. Where a surface genuinely isn't built, it says so — in the UI, and in the
-`Not built yet` section of its page here.
+non-interactive* rather than hiding it or letting it no-op, and `work_surface::state::ActionKind`'s
+own docs record five variants being **deleted** rather than left as decoration. Where a surface
+genuinely isn't built, it says so — in the UI, and in the `Not built yet` section of its page here.
 
 ## 5. One object, one specification
 
@@ -82,11 +81,11 @@ Not principles so much as the palette these principles are executed in. All of i
 - **Two font families, nothing else** — IBM Plex Sans for UI, IBM Plex Mono for branches, paths,
   diffs, terminal and code (`theme::font`, bundled by `crate::fonts`). Both are OFL.
 - **Radii** are a scale in `theme::radius`, from the window corner down to a small mark. The step
-  matters: at 5px across, the difference between `MARK` and `MARK_SM` is the difference
-  between reading as a square and reading as a dot, and this app already uses a real circle for
-  "an agent's status".
-- **Band heights** are named in `theme::band`, **zone widths** in `theme::zone`. A new surface reuses
-  an existing band height wherever it plausibly can, per rule 5.
+  matters: at 5px across, the difference between `MARK` and `MARK_SM` is the difference between
+  reading as a square and reading as a dot, and this app already uses a real circle for "an agent's
+  status".
+- **Band heights** are named in `theme::band`, **zone widths** in `theme::zone`. A new surface
+  reuses an existing band height wherever it plausibly can, per rule 5.
 - **Interface scale** applies to text size only (`theme::ui_scale`), deliberately not to padding,
   icons or fixed chrome. That module's docs enumerate exactly which surfaces honour it and why each
   exclusion exists.

--- a/docs/design/rail.md
+++ b/docs/design/rail.md
@@ -1,0 +1,124 @@
+# Zone 1 — the agent rail
+
+**Code:** `crates/app/src/rail/`
+**Tokens:** `theme::{status, rail, band, zone}`
+
+## What it's for
+
+The rail is the product. Everything else in the window is a place you go *after* the rail has told
+you where to go.
+
+Its single job is answering **"who needs me"** in under a second, across every repository you have
+open and every worktree in each of them. The answer is delivered pre-verbally: the most urgent
+things float to the top and wear a colour, so the eye resolves *how much amber is at the top* before
+it reads a single word. See [`principles.md`](./principles.md) rule 1.
+
+## Structure
+
+### Two levels, always
+
+**Repo group → worktree → agents.** There is no grouping-mode toggle. An earlier design had a
+`by urgency / by project` switch in the rail header; the revision that redesigned the rail around
+repo grouping removed it outright, along with its sort control, rather than leaving a second
+structure behind. `rail::state`'s own module docs record this.
+
+Urgency did not disappear — it became **ranking within the fixed structure** rather than an
+alternative to it:
+
+- Worktrees inside a repo are ordered by `WorktreeRow::urgency_rank` — their most urgent agent.
+- Repos are ordered by their own most urgent worktree.
+- A worktree's aggregate status is its most urgent agent's status (`WorktreeRow::aggregate_status`).
+
+That gets the same "amber at the top" property as the old urgency mode while keeping one structure a
+user can build a spatial memory of.
+
+### The parts, top to bottom
+
+| Part | Height | What it is |
+|---|---|---|
+| Sidebar strip | `theme::band::CHROME_HEADER` | View switcher — see below |
+| Filter row | `theme::band::FILTER_ROW` | Filters the rows below; follows the active view |
+| Body | fill | The active view |
+| Footer | — | Worktree inventory and the prune action |
+
+**Repo header** — name, `N wt`, and **two** urgency counts, not one. Red for worktrees holding a
+failed agent, amber for worktrees holding an asking one, each hidden at zero. Merging them into a
+single amber count "said *three worktrees want you* when one of the three had actually died, and
+amber is the wrong colour for that" — see the general rule in
+[`layout.md`](./layout.md#rules-that-matter).
+
+**Worktree row** — always present whether or not it is expanded, carrying its branch, its aggregate
+status, and its diff totals against base.
+
+**Agent row** — one per open agent under an expanded worktree, in the same order the tab strip uses.
+Carries the agent's tint badge, its title, its status, and its own `+n −n`.
+
+**Earlier-runs link** — `↺ N earlier runs`, under a worktree that has **no live agent**. Deliberately
+under the row rather than among its children, so a folded worktree still offers it; and deliberately
+not under every worktree, because a first pass that did produced eight identical rows carrying no
+information. Clicking it goes to the History view.
+
+`rail::state::RailListItem` is the flattened list of all of the above — index-only into the frame's
+own `&[RepoGroup]`, rebuilt each render rather than cached.
+
+### The sidebar strip
+
+A **horizontal** icon strip along the top of Zone 1 (`rail::strip`, `rail::strip_render`), not a
+vertical activity bar: a vertical bar costs permanent width on a window whose entire job is fitting
+three panels side by side.
+
+Two cells — **Worktrees** and **Problems** — plus `+` and `⋯`. `SidebarView` has a third variant,
+**History**, which is a real view with a real body and is deliberately *absent* from
+`SidebarView::ALL`: it lives in the `⋯` overflow instead, because a permanent cell in the strip is a
+claim that you switch to it constantly. Search is not here at all; it is the middle tab of Zone 3.
+
+Cells are `theme::zone::SIDEBAR_STRIP_CELL` wide, full-height, no radius and no gap — the same
+object as the centre tabs, which is what makes the dividing rules read as a tab strip rather than as
+icons scattered on a dark band.
+
+### Status derivation
+
+`rail::status::derive_status` turns already-read process signals into a `Status`. It is pure and
+window-free, so every rule is directly testable.
+
+The signal it refines with is unusual and worth knowing about: `rail::title_signal` reads the agent
+CLI's **own terminal title**. TUI programs have written their state into the terminal title since
+long before agent CLIs existed, and agent CLIs reuse the convention — so a terminal that reads the
+title learns what the agent is doing the moment the agent decides it, instead of inferring it from
+how long the pty has been quiet. That module's docs record what was verified live on which CLI
+versions, including a captured nine-second stretch of real work with zero pty output — exactly the
+false positive the title signal exists to prevent.
+
+A second, structural channel exists for Claude Code specifically: its own hook system
+(`crates/app/src/hooks/`), which fires at named lifecycle events and reports *"blocked on a human"*
+as a fact rather than an inference.
+
+## Rules that matter
+
+- **Colour on a rail row means status, and nothing else.** The left edge, the dot, and the question
+  preview's tint all come from `Status::color`. A decorative accent here costs the rail its
+  glanceability. ([`principles.md`](./principles.md) rule 2.)
+- **The strip empties itself on an empty day**, and it does so *at the source*
+  (`strip::strip_view_cells` returns an empty `Vec`), not with a `when(..)` in the renderer. With no
+  worktrees there are no views to offer, and a switcher with dead views is worse than no switcher.
+  Gating in the renderer once meant the cells were hidden and their badges were not — claiming three
+  agents needed a human on a day the rail, title bar and footer all reported zero.
+- **Two states are never summed.** A repo header shows failed and asking as separate counts.
+- **Header counts read `all_rows`, never the filtered `rows`.** A filter narrows what you see; it
+  must not change what the header claims exists.
+- **An errored worktree row is never interactive and never shows children.** It renders itself and
+  stops.
+- **`rows_loaded` must be consulted before treating an empty list as "zero worktrees".** Not-yet-
+  loaded and genuinely-empty are different states and get different copy.
+- **Worktree inventory and its prune action belong here**, not in the status bar — one fact, one
+  home.
+
+## Not built yet
+
+- **Question previews depend on what the agent exposes.** The rail shows *that* an agent is asking,
+  from the title signal, the hook channel, or quiescence. Reading the tail of the pty to preview the
+  question itself is only as good as the CLI's own output; there is no cross-CLI structured channel
+  for it.
+- **Only Claude Code has the structural hook channel.** Every other CLI is on the title-signal plus
+  quiescence heuristic, which is genuinely coarser. `hooks/` documents the shape a second
+  integration would take.

--- a/docs/design/rail.md
+++ b/docs/design/rail.md
@@ -1,7 +1,7 @@
 # Zone 1 — the agent rail
 
-**Code:** `crates/app/src/rail/`
-**Tokens:** `theme::{status, rail, band, zone}`
+- **Code:** `crates/app/src/rail/`
+- **Tokens:** `theme::{status, rail, band, zone}`
 
 ## What it's for
 
@@ -17,10 +17,10 @@ it reads a single word. See [`principles.md`](./principles.md) rule 1.
 
 ### Two levels, always
 
-**Repo group → worktree → agents.** There is no grouping-mode toggle. An earlier design had a
-`by urgency / by project` switch in the rail header; the revision that redesigned the rail around
-repo grouping removed it outright, along with its sort control, rather than leaving a second
-structure behind. `rail::state`'s own module docs record this.
+**Repo group → worktree → agents.** There is no grouping-mode toggle. An earlier design had a `by
+urgency / by project` switch in the rail header; the revision that redesigned the rail around repo
+grouping removed it outright, along with its sort control, rather than leaving a second structure
+behind. `rail::state`'s own module docs record this.
 
 Urgency did not disappear — it became **ranking within the fixed structure** rather than an
 alternative to it:
@@ -53,10 +53,10 @@ status, and its diff totals against base.
 **Agent row** — one per open agent under an expanded worktree, in the same order the tab strip uses.
 Carries the agent's tint badge, its title, its status, and its own `+n −n`.
 
-**Earlier-runs link** — `↺ N earlier runs`, under a worktree that has **no live agent**. Deliberately
-under the row rather than among its children, so a folded worktree still offers it; and deliberately
-not under every worktree, because a first pass that did produced eight identical rows carrying no
-information. Clicking it goes to the History view.
+**Earlier-runs link** — `↺ N earlier runs`, under a worktree that has **no live agent**.
+Deliberately under the row rather than among its children, so a folded worktree still offers it; and
+deliberately not under every worktree, because a first pass that did produced eight identical rows
+carrying no information. Clicking it goes to the History view.
 
 `rail::state::RailListItem` is the flattened list of all of the above — index-only into the frame's
 own `&[RepoGroup]`, rebuilt each render rather than cached.

--- a/docs/design/settings.md
+++ b/docs/design/settings.md
@@ -1,0 +1,121 @@
+# Settings
+
+**Code:** `crates/app/src/settings/`
+**Tokens:** `theme::{settings, toggle, button, zone::SETTINGS_*}`
+
+## What it's for
+
+Settings is **a view of a config file**, not a database of preferences with a file export. The file
+(`~/.config/jerry/settings.toml`) is the source of truth; this surface reads and writes it, and says
+so on every page.
+
+That framing is deliberate and it shows up in the design: each page names the file, lists the exact
+keys it owns, and prints the real TOML (or JSON) for its own current values at the foot of the page.
+A user who prefers the editor loses nothing, and a user who prefers the UI learns the file's shape
+while using it.
+
+## Structure
+
+A **separate surface, not a modal**: it replaces the three zones while the title bar and status bar
+stay put. `esc` — rendered as a keycap in the nav header — returns to the workspace.
+
+### Nav
+
+`theme::zone::SETTINGS_NAV_WIDTH` wide, four groups:
+
+| Group | Pages |
+|---|---|
+| Workspace | General · Agents · Worktrees |
+| Interface | Appearance & scaling · Themes · Keybindings |
+| Editor | Editor · Language servers |
+| Other | Notifications · Integrations · About |
+
+`settings::state::SettingsPage` is the eleven-variant enum; `SettingsPage::ALL` is the order and
+`SettingsPage::label` the rendered names. Each page also has a stable `id()` written by hand rather
+than derived from the variant name, so renaming a variant cannot silently re-key its elements.
+
+### Content column
+
+Capped at `theme::zone::SETTINGS_CONTENT_MAX_WIDTH` — header block and scrollable body share the cap
+— and left-aligned inside the surface padding. Long lines of prose in a settings page are the fastest
+way to make it unreadable.
+
+Every page is: header block (title, one-line rationale) · **config banner** · sections · **snippet
+block**.
+
+**Config banner** — the file path, the page's own key list, a `TOML | JSON` switch, and an
+`Open file` button. `store::config_keys_line` is the key list, and it is deliberately narrower than
+the mockup's fixture: it names only the `Settings` fields this app really persists, rather than
+inheriting a list that included settings that were never implemented.
+
+**Snippet block** — `In settings.toml`, then the page's real keys with their real current values,
+serialised from the live `Settings` struct by `store::snippet_lines`. It is generated, not
+transcribed, which is why it cannot drift from what the file actually contains.
+
+`store::ConfigPage` is the five pages that have a banner and snippet (General, Appearance, Theme,
+Editor, Notifications) — the ones backed by scalar settings. Agents, Worktrees, Keybindings and
+Language servers are card/list pages over real discovered state, not over a config table.
+
+### Row controls — four kinds, no fifth
+
+One pattern for every scalar setting: label plus hint on the left, control on the right, bottom
+border. The control is one of `toggle`, `stepper`, `choice` (a segmented control matching the code
+surface's Diff/File toggle) or `path` (value plus a `Change…` button). They live in
+`settings::widgets` and are shared by every page.
+
+**Hints carry the reasoning, not a restatement of the label.** *"Past eight the rail stops being
+glanceable"*, *"Costs a cold rebuild when the toolchain changes"*. That tone is part of the design:
+a hint that repeats the label is worse than no hint, because it trains the reader to skip them.
+
+### Card pages
+
+Agents, Worktrees and Language servers share one card shape: a bordered card of rows on a slightly
+lighter surface, separated by hairlines, with a footer carrying totals and the page's one action.
+Rows are fixed-width columns so that the same field lines up down the card.
+
+These pages show **real discovered state** — `settings::state` performs real `$PATH` detection for
+agent binaries and language servers, so a "ready" dot means the binary was actually found.
+
+### Themes
+
+Theme cards over a swatch strip. Six built-ins live as real literal palette files
+(`settings::builtin_themes`, `assets/themes/*.toml`), and a user's own themes load from
+`~/.config/jerry/themes/*.toml` (`settings::custom_theme` — the format, its validation, and
+import/export). `settings::vscode_theme` imports a VS Code theme.
+
+The mechanism underneath is `theme.rs`'s `ColorToken`: every token has a stable key
+(`"surface.window"`, `"syntax.keyword"`) and its own Jerry Dark literal default, a theme file names
+tokens by those keys, and live resolution is a plain hash lookup. Jerry Dark is the identity case —
+no palette installed, so every token resolves to its own compiled default unchanged. See
+[`docs/themes.md`](../themes.md) for the file format from a user's side.
+
+### Keybindings
+
+Rows of command · context · keycaps · source (`base` or `user`). The list is resolved off the **live
+registered** `gpui::KeyBinding`s through `keymap::resolve_keystroke`, not a hand-maintained table —
+which is what stops it from drifting the way a hand-copied list once did (a wrong context label, a
+stale order). Overrides persist through `keymap_overrides`.
+
+## Rules that matter
+
+- **The file is the source of truth.** A setting that the UI can change but the file cannot express
+  is a bug. Every page says where its values live.
+- **The snippet is generated from live state**, never written by hand.
+- **Four row controls, and adding a fifth is a design decision.** The four cover every scalar shape
+  Jerry has needed; a bespoke control on one page is the beginning of two idioms.
+- **Hints explain, they don't restate.**
+- **Detection is real.** A "ready" dot, a resolved binary path, a version string — all read off the
+  real machine. A page that cannot detect something says so rather than showing a plausible default.
+- **Page ids are hand-written**, decoupled from variant names.
+- **Settings replaces the zones; it is not a modal.** The status bar stays visible, which is why
+  long-running feedback is rendered there — see [`layout.md`](./layout.md#status-bar).
+
+## Not built yet
+
+- **Notifications and Integrations are thin.** They exist as pages with real nav entries; the
+  surface area behind them is small compared to Agents/Worktrees/Themes.
+- **Not every page has a config banner.** `store::ConfigPage` covers five; the card pages are over
+  discovered state rather than a config table, and deliberately have neither banner nor snippet.
+- **Window-controls style is a cosmetic preview only.** Overriding it changes the title bar and the
+  keycap glyphs, not which physical key is bound — GPUI resolves that at compile time. See
+  [`layout.md`](./layout.md#title-bar--two-variants).

--- a/docs/design/settings.md
+++ b/docs/design/settings.md
@@ -1,7 +1,7 @@
 # Settings
 
-**Code:** `crates/app/src/settings/`
-**Tokens:** `theme::{settings, toggle, button, zone::SETTINGS_*}`
+- **Code:** `crates/app/src/settings/`
+- **Tokens:** `theme::{settings, toggle, button, zone::SETTINGS_*}`
 
 ## What it's for
 
@@ -37,15 +37,15 @@ than derived from the variant name, so renaming a variant cannot silently re-key
 ### Content column
 
 Capped at `theme::zone::SETTINGS_CONTENT_MAX_WIDTH` — header block and scrollable body share the cap
-— and left-aligned inside the surface padding. Long lines of prose in a settings page are the fastest
-way to make it unreadable.
+— and left-aligned inside the surface padding. Long lines of prose in a settings page are the
+fastest way to make it unreadable.
 
 Every page is: header block (title, one-line rationale) · **config banner** · sections · **snippet
 block**.
 
-**Config banner** — the file path, the page's own key list, a `TOML | JSON` switch, and an
-`Open file` button. `store::config_keys_line` is the key list, and it is deliberately narrower than
-the mockup's fixture: it names only the `Settings` fields this app really persists, rather than
+**Config banner** — the file path, the page's own key list, a `TOML | JSON` switch, and an `Open
+file` button. `store::config_keys_line` is the key list, and it is deliberately narrower than the
+mockup's fixture: it names only the `Settings` fields this app really persists, rather than
 inheriting a list that included settings that were never implemented.
 
 **Snippet block** — `In settings.toml`, then the page's real keys with their real current values,

--- a/docs/design/sidebar.md
+++ b/docs/design/sidebar.md
@@ -1,7 +1,7 @@
 # Zone 3 — files, search and changes
 
-**Code:** `crates/app/src/sidebar/`, `crates/app/src/search/`
-**Tokens:** `theme::{tree, changes, lang, band, zone}`
+- **Code:** `crates/app/src/sidebar/`, `crates/app/src/search/`
+- **Tokens:** `theme::{tree, changes, lang, band, zone}`
 
 ## What it's for
 
@@ -16,18 +16,17 @@ preview would be.
 ## Structure
 
 Header (`theme::band::CHROME_HEADER`, sharing its y with the other two column headers — see
-[`layout.md`](./layout.md#one-header-rule-across-three-columns)) carrying a segmented
-**Files · Search · Changes**. Files is first and the default; the review flow opens straight into
-Changes. Each tab's icon is drawn in one shared optical box (`icons::IconSize::PanelTab`) — a first
-cut that sized each to suit itself put three different weights on one row.
+[`layout.md`](./layout.md#one-header-rule-across-three-columns)) carrying a segmented **Files ·
+Search · Changes**. Files is first and the default; the review flow opens straight into Changes.
+Each tab's icon is drawn in one shared optical box (`icons::IconSize::PanelTab`) — a first cut that
+sized each to suit itself put three different weights on one row.
 
 ### Files
 
 A flattened, indented row list from a real `std::fs::read_dir` walk (`sidebar::file_tree`), rendered
-virtualised. Rows carry the file's language chip (see
-[`vocabulary.md`](./vocabulary.md#chips)) and a mark for changed files. Folder expansion is real,
-per-worktree state persisted to disk (`sidebar::fold_state`), so reopening a worktree restores the
-shape of the tree you left.
+virtualised. Rows carry the file's language chip (see [`vocabulary.md`](./vocabulary.md#chips)) and
+a mark for changed files. Folder expansion is real, per-worktree state persisted to disk
+(`sidebar::fold_state`), so reopening a worktree restores the shape of the tree you left.
 
 Live refresh is a `notify`-backed OS watcher that sets a flag, polled by a GPUI background loop
 (`sidebar::file_tree_watch`) — the same split `rail::worktree_watch` uses, and the reason neither
@@ -52,10 +51,10 @@ count row with the modifier buttons, then a **two-level result tree** — file r
 match rows showing the line with its hit highlighted.
 
 The pure halves are worth knowing about because they carry the semantics: `search::glob` is the
-pattern language, `search::exclude` is the always-on `target`/`node_modules`/`.git` exclusion applied
-*before* `.gitignore` is consulted at all, and `search::engine` is the compiled matcher, the bounded
-walk, and the real on-disk replace. `search::in_file` is the `mod+F` find bar over the open buffer,
-reusing the same three-state count.
+pattern language, `search::exclude` is the always-on `target`/`node_modules`/`.git` exclusion
+applied *before* `.gitignore` is consulted at all, and `search::engine` is the compiled matcher, the
+bounded walk, and the real on-disk replace. `search::in_file` is the `mod+F` find bar over the open
+buffer, reusing the same three-state count.
 
 ### Changes
 

--- a/docs/design/sidebar.md
+++ b/docs/design/sidebar.md
@@ -1,0 +1,104 @@
+# Zone 3 — files, search and changes
+
+**Code:** `crates/app/src/sidebar/`, `crates/app/src/search/`
+**Tokens:** `theme::{tree, changes, lang, band, zone}`
+
+## What it's for
+
+Zone 3 is for **navigating** the focused worktree — finding the thing you want to look at. It never
+shows the thing itself. Clicking a file in the tree, a search hit, or a row in Changes opens it as a
+tab in Zone 2.
+
+That division is the whole design: *centre tabs hold things you read or work in; the sidebar holds
+things you navigate*. It is also why the panel has no diff view of its own, however tempting a
+preview would be.
+
+## Structure
+
+Header (`theme::band::CHROME_HEADER`, sharing its y with the other two column headers — see
+[`layout.md`](./layout.md#one-header-rule-across-three-columns)) carrying a segmented
+**Files · Search · Changes**. Files is first and the default; the review flow opens straight into
+Changes. Each tab's icon is drawn in one shared optical box (`icons::IconSize::PanelTab`) — a first
+cut that sized each to suit itself put three different weights on one row.
+
+### Files
+
+A flattened, indented row list from a real `std::fs::read_dir` walk (`sidebar::file_tree`), rendered
+virtualised. Rows carry the file's language chip (see
+[`vocabulary.md`](./vocabulary.md#chips)) and a mark for changed files. Folder expansion is real,
+per-worktree state persisted to disk (`sidebar::fold_state`), so reopening a worktree restores the
+shape of the tree you left.
+
+Live refresh is a `notify`-backed OS watcher that sets a flag, polled by a GPUI background loop
+(`sidebar::file_tree_watch`) — the same split `rail::worktree_watch` uses, and the reason neither
+one needs a `gpui` dependency.
+
+Right-clicking gives the file operations menu (`sidebar::context_menu` for the pure row model,
+`sidebar::file_ops` for the primitives, `sidebar::tree_ops` for the sequencing). The popover itself
+is the app's one shared menu component (`menu/`) — because right-click actions on a row and an `⋯`
+overflow are both "a list of actions", and two idioms for one thing drift.
+
+Delete goes to the real OS trash where one exists; name validation and collision-free renaming are
+pure functions in `file_ops`, tested without touching a filesystem.
+
+### Search
+
+A real panel, not a filename filter. The verdict it was built to satisfy: **a search result that
+only names a file is an index, not a result — show the line.**
+
+Structure, top to bottom: query row (sharing `theme::band::FILTER_ROW` with the rail's own filter —
+the same object in two places), a revealed replace row, revealed `include`/`exclude` glob rows, a
+count row with the modifier buttons, then a **two-level result tree** — file rows, each expanding to
+match rows showing the line with its hit highlighted.
+
+The pure halves are worth knowing about because they carry the semantics: `search::glob` is the
+pattern language, `search::exclude` is the always-on `target`/`node_modules`/`.git` exclusion applied
+*before* `.gitignore` is consulted at all, and `search::engine` is the compiled matcher, the bounded
+walk, and the real on-disk replace. `search::in_file` is the `mod+F` find bar over the open buffer,
+reusing the same three-state count.
+
+### Changes
+
+Four stacked sections (`sidebar::sections::ChangesSection`), in a fixed render order that
+`ChangesSection::ORDER` is the single place recording:
+
+| Section | Answers |
+|---|---|
+| `UNCOMMITTED` | what is dirty in this worktree right now |
+| `COMMITS` | what has been committed on this branch |
+| `AGAINST <BASE>` | how this worktree differs from the merge-base with its base branch |
+| `RUNS` | the same changes, indexed by which agent produced them |
+
+The first three are **one ladder of git state**, narrowing to widening. Runs is not on that ladder —
+it re-indexes the same changes by author — so it sits after the ladder rather than inside it, which
+also keeps `UNCOMMITTED`'s top edge fixed however many agents have run.
+
+Rows carry a **seen** mark, a directory, a name, a tag pill, `+n −n`, and a stat bar.
+
+`sections::SeenFiles` is deliberately **not** the staged set. A file counts as seen only if it was
+marked *and still has the diffstat it had when marked* — so a file you reviewed and an agent then
+touched again reverts to unseen on its own. Marks are keyed by worktree then by repo-relative path,
+so switching worktrees and back does not lose your progress, and one worktree's counter never leaks
+into another's.
+
+## Rules that matter
+
+- **The panel navigates; the centre displays.** No diff, no file preview, no transcript rendered
+  here. A row click opens a Zone 2 tab.
+- **Files is the default tab.** Changes is where a review flow lands you, not where you start.
+- **`ChangesSection::ORDER` is the only place the section order is written down.** Re-deriving it at
+  a render site is how the two get out of sync.
+- **Seen ≠ staged.** Two different questions; conflating them would make "reviewed" survive an
+  agent's next edit.
+- **Panel-tab icons share one optical box.** Never one size per icon.
+- **The Zone 3 header shares a y with two other headers.** Changing its height is a three-column
+  edit.
+- **Exclusion happens before `.gitignore`.** The always-on list in `search::exclude` is not
+  negotiable by repository config; the gitignore layer is a separate, toggleable one on top.
+
+## Not built yet
+
+- **Search has no cross-worktree scope.** It walks the focused worktree. Searching every open
+  worktree at once is not wired.
+- **Changes is per worktree, not per repo.** The Runs section indexes the focused worktree's
+  provenance union only.

--- a/docs/design/vocabulary.md
+++ b/docs/design/vocabulary.md
@@ -1,7 +1,8 @@
 # Visual vocabulary
 
-**Code:** `crates/app/src/{theme.rs, icons.rs, keymap.rs, language.rs}`, `crates/app/src/rail/status.rs`, `crates/app/src/root/widgets.rs`
-**Tokens:** `theme::{status, agent, lang, tag, button, radius, band}`
+- **Code:** `crates/app/src/{theme.rs, icons.rs, keymap.rs, language.rs}`,
+  `crates/app/src/rail/status.rs`, `crates/app/src/root/widgets.rs`
+- **Tokens:** `theme::{status, agent, lang, tag, button, radius, band}`
 
 ## What it's for
 
@@ -41,8 +42,7 @@ There is no third treatment.
 `theme::agent` holds one `(fg, bg)` pair per agent, and `theme::agent::TINT_POOL` is the enumerable
 list. An agent's tint is its identity across the whole window: the 16px badge in a rail row, the tab
 chip on its CLI tab, the badge in the agent context bar, the session row in the palette, and its own
-side of a merge-conflict view all read the same pair through
-`work_surface::state::agent_tint`.
+side of a merge-conflict view all read the same pair through `work_surface::state::agent_tint`.
 
 The pool obeys a **reserved-hue rule** recorded in that module's own docs: no agent tint may sit in
 a hue already spent on status or on diffs. That rule is enforced by a real test
@@ -56,8 +56,9 @@ glyph. Four kinds exist, and no surface invents a fifth:
 
 - **Agent chip** — the agent tint pair, agent initial. Identity.
 - **Language chip** — derived from the file extension, *never* hand-assigned. One table
-  (`language::EXTENSIONS`, colours in `theme::lang`) feeds the file tree, the code tab, the palette's
-  file results, and the Settings language-server rows. A file's chip is the same object in all four.
+  (`language::EXTENSIONS`, colours in `theme::lang`) feeds the file tree, the code tab, the
+  palette's file results, and the Settings language-server rows. A file's chip is the same object in
+  all four.
 - **Tab chip** — `work_surface::state::TabChipKind`, either the CLI `❯` or the terminal pane glyph,
   tinted with the agent's own colour when active and dimmed to `theme::border::ZONE` /
   `theme::text::FAINTER` when not (`tab_chip_colors`, `file_tab_chip_colors`). The dimmed pair is
@@ -70,23 +71,23 @@ Shortcuts render as keycaps, never as bare glyph runs. One cap per resolved key,
 
 Two sizes, both in `root::widgets::render_keycap_sized` behind `KeycapSize`: `Standard`
 (`theme::band::KEYCAP`) for a control's own binding, and `Hint` (`theme::band::KEYCAP_HINT`) for the
-footer/hint rows that list several. Inside a coloured button the cap goes transparent and borrows the
-button's tint (`theme::button::*_KEYCAP`).
+footer/hint rows that list several. Inside a coloured button the cap goes transparent and borrows
+the button's tint (`theme::button::*_KEYCAP`).
 
 **Every binding in the product is authored as a spec string** — `"mod+shift+K"`, `"ctrl+C"` — and
-rendered through `keymap::resolve_combo`, which maps the eight recognised tokens
-(`mod alt ctrl shift enter esc tab bksp`) onto the macOS or the Windows/Linux table. There is no
-literal `⌘` in calling code anywhere. The Settings › Keybindings page goes one better and resolves
-straight off the live registered `gpui::KeyBinding`s via `keymap::resolve_keystroke`, so it cannot
-drift from what is actually bound.
+rendered through `keymap::resolve_combo`, which maps the eight recognised tokens (`mod alt ctrl
+shift enter esc tab bksp`) onto the macOS or the Windows/Linux table. There is no literal `⌘` in
+calling code anywhere. The Settings › Keybindings page goes one better and resolves straight off the
+live registered `gpui::KeyBinding`s via `keymap::resolve_keystroke`, so it cannot drift from what is
+actually bound.
 
 ### Icons
 
 Two populations, and the split is deliberate.
 
 **Shipped icons** are real [Phosphor](https://phosphoricons.com) SVGs (MIT) vendored under
-`assets/icons/`, drawn through `icons::Icon` — twelve mapped slots, covering *actions and views only*
-(panel tabs, sidebar strip cells, the overflow menu, the terminal tab, the prune button).
+`assets/icons/`, drawn through `icons::Icon` — twelve mapped slots, covering *actions and views
+only* (panel tabs, sidebar strip cells, the overflow menu, the terminal tab, the prune button).
 
 **Jerry's own vocabulary stays hand-drawn**: agent tint chips, status dots, file-extension chips,
 diff gutter marks, and the graph's lanes and merge elbows. Those are shapes that carry meaning
@@ -102,9 +103,9 @@ Two rules the `icons` module enforces mechanically rather than by convention:
 - **`bold` below 20px.** `regular`'s stroke reads thin against Jerry's greys. `weight_for_size` is
   that rule as code, paired against what `assets/icons/` actually holds by a test.
 
-A user-supplied **icon pack** (`icon_pack.rs`) can override a slot with a real file, rendered through
-`gpui::img` so it keeps its own colours — as opposed to the shipped Phosphor icons, which go through
-`gpui::svg` precisely so they tint like text.
+A user-supplied **icon pack** (`icon_pack.rs`) can override a slot with a real file, rendered
+through `gpui::img` so it keeps its own colours — as opposed to the shipped Phosphor icons, which go
+through `gpui::svg` precisely so they tint like text.
 
 ## Rules that matter
 

--- a/docs/design/vocabulary.md
+++ b/docs/design/vocabulary.md
@@ -1,0 +1,129 @@
+# Visual vocabulary
+
+**Code:** `crates/app/src/{theme.rs, icons.rs, keymap.rs, language.rs}`, `crates/app/src/rail/status.rs`, `crates/app/src/root/widgets.rs`
+**Tokens:** `theme::{status, agent, lang, tag, button, radius, band}`
+
+## What it's for
+
+The small set of shapes Jerry reuses everywhere. Every one of them is defined once and drawn from
+one place, which is what lets a status colour mean the same thing in the rail, the tab strip, the
+status bar and the palette without any of those four re-deciding it.
+
+If you are adding a surface, this is the page to read first: almost everything a new surface needs
+already exists here, and reaching for a new shape needs a reason.
+
+## Structure
+
+### Status — five values, used nowhere else
+
+`rail::status::Status` is the whole vocabulary: `Ask`, `Fail`, `Review`, `Run`, `Idle`. It carries
+its own rendered label (`Status::label`), its urgency ordering (`Status::urgency_rank`,
+`Status::ORDER`), its dot/edge colour (`Status::color` → `theme::status`) and its pill background
+(`Status::pill_bg`).
+
+| Variant | Rendered label | Meaning |
+|---|---|---|
+| `Ask` | Needs input | Agent has been quiet past `AGENT_ASK_IDLE_THRESHOLD`, or a hook says it's blocked |
+| `Fail` | Failed | Non-zero exit, or killed by a signal |
+| `Review` | Finished | Exited 0 with a real, non-empty diff against base |
+| `Run` | Running | Alive and producing output, or alive and briefly paused |
+| `Idle` | Idle | No process running, or a shell just sitting there |
+
+The variant name and the rendered word are deliberately allowed to differ — `Review` renders as
+`Finished`. See [`decisions.md`](./decisions.md) §10 for why.
+
+Anywhere a status is shown as a **pill**, it is the dot plus the label in `Status::color` on
+`Status::pill_bg`. Anywhere it is shown as a **row edge** or a **dot**, it is `Status::color` alone.
+There is no third treatment.
+
+### Agent tints
+
+`theme::agent` holds one `(fg, bg)` pair per agent, and `theme::agent::TINT_POOL` is the enumerable
+list. An agent's tint is its identity across the whole window: the 16px badge in a rail row, the tab
+chip on its CLI tab, the badge in the agent context bar, the session row in the palette, and its own
+side of a merge-conflict view all read the same pair through
+`work_surface::state::agent_tint`.
+
+The pool obeys a **reserved-hue rule** recorded in that module's own docs: no agent tint may sit in
+a hue already spent on status or on diffs. That rule is enforced by a real test
+(`theme::agent_tint_allocation_tests`), and forcing a reallocation is what produced today's copper /
+teal / periwinkle / steel-blue set — see [`decisions.md`](./decisions.md) §9.
+
+### Chips
+
+A chip is a small rounded square (`theme::radius::CHIP`) carrying a two-or-three-letter label or a
+glyph. Four kinds exist, and no surface invents a fifth:
+
+- **Agent chip** — the agent tint pair, agent initial. Identity.
+- **Language chip** — derived from the file extension, *never* hand-assigned. One table
+  (`language::EXTENSIONS`, colours in `theme::lang`) feeds the file tree, the code tab, the palette's
+  file results, and the Settings language-server rows. A file's chip is the same object in all four.
+- **Tab chip** — `work_surface::state::TabChipKind`, either the CLI `❯` or the terminal pane glyph,
+  tinted with the agent's own colour when active and dimmed to `theme::border::ZONE` /
+  `theme::text::FAINTER` when not (`tab_chip_colors`, `file_tab_chip_colors`). The dimmed pair is
+  shared, so an inactive agent tab and an inactive file tab dim identically.
+- **Tag pill** — `theme::tag`, for a file's `new` / `del` / `conflict` state.
+
+### Keycaps
+
+Shortcuts render as keycaps, never as bare glyph runs. One cap per resolved key, in a row.
+
+Two sizes, both in `root::widgets::render_keycap_sized` behind `KeycapSize`: `Standard`
+(`theme::band::KEYCAP`) for a control's own binding, and `Hint` (`theme::band::KEYCAP_HINT`) for the
+footer/hint rows that list several. Inside a coloured button the cap goes transparent and borrows the
+button's tint (`theme::button::*_KEYCAP`).
+
+**Every binding in the product is authored as a spec string** — `"mod+shift+K"`, `"ctrl+C"` — and
+rendered through `keymap::resolve_combo`, which maps the eight recognised tokens
+(`mod alt ctrl shift enter esc tab bksp`) onto the macOS or the Windows/Linux table. There is no
+literal `⌘` in calling code anywhere. The Settings › Keybindings page goes one better and resolves
+straight off the live registered `gpui::KeyBinding`s via `keymap::resolve_keystroke`, so it cannot
+drift from what is actually bound.
+
+### Icons
+
+Two populations, and the split is deliberate.
+
+**Shipped icons** are real [Phosphor](https://phosphoricons.com) SVGs (MIT) vendored under
+`assets/icons/`, drawn through `icons::Icon` — twelve mapped slots, covering *actions and views only*
+(panel tabs, sidebar strip cells, the overflow menu, the terminal tab, the prune button).
+
+**Jerry's own vocabulary stays hand-drawn**: agent tint chips, status dots, file-extension chips,
+diff gutter marks, and the graph's lanes and merge elbows. Those are shapes that carry meaning
+defined on this page, not generic action glyphs, and a third-party icon family has no opinion about
+them.
+
+Two rules the `icons` module enforces mechanically rather than by convention:
+
+- **One optical box per row, never one size per icon.** The only way to draw an icon is through an
+  `IconRow`, constructed once with one `IconSize`; a lone icon is a row of one. Every vendored file
+  is on the same `0 0 256 256` canvas, asserted by a test, so equal boxes really do give equal
+  optical weight.
+- **`bold` below 20px.** `regular`'s stroke reads thin against Jerry's greys. `weight_for_size` is
+  that rule as code, paired against what `assets/icons/` actually holds by a test.
+
+A user-supplied **icon pack** (`icon_pack.rs`) can override a slot with a real file, rendered through
+`gpui::img` so it keeps its own colours — as opposed to the shipped Phosphor icons, which go through
+`gpui::svg` precisely so they tint like text.
+
+## Rules that matter
+
+- **The status vocabulary is closed.** A new UI state is one of the five, or it is not a status.
+  Adding a sixth changes the rail's group order, the status bar's counters and the urgency ranking
+  simultaneously — it is a `decisions.md` entry, not a local change.
+- **Language chips are derived, never assigned.** Adding a language means adding a row to
+  `language::EXTENSIONS` and its colours to `theme::lang`; every surface then picks it up for free.
+- **No literal shortcut glyph in calling code.** Author the spec string. A hardcoded `⌘` is a bug on
+  Windows and Linux.
+- **A new icon slot means vendoring the file and extending `Icon`**, not drawing a shape inline. The
+  reverse is also true: something in the hand-drawn list above does not become a Phosphor icon
+  without an entry in `decisions.md`.
+
+## Not built yet
+
+- **Icon packs cover one slot family.** `icon_pack.rs` is wired only to the three process-kind chips
+  (Claude / Codex / Shell). The other ~25 icon concepts fall back to the built-in rendering. Stated
+  follow-up in that module's own docs.
+- **Interface scale is text-only.** `theme::ui_scale` scales font sizes on the surfaces its docs
+  enumerate; padding, chips, badges, keycaps and fixed chrome do not scale, and the code surface and
+  terminal have their own separate font-size mechanisms instead.

--- a/docs/design/work-surface.md
+++ b/docs/design/work-surface.md
@@ -1,0 +1,187 @@
+# Zone 2 — the work surface
+
+**Code:** `crates/app/src/work_surface/`, and the surfaces it hosts — `terminal/`, `code_surface/`, `lsp/`, `merge/`, `graph_view/`, `review/`, `review_notes/`, `run_history/`, `provenance/`, `budget/`
+**Tokens:** `theme::{term, editor, diff, syntax, band, button, completions_popup}`
+
+## What it's for
+
+Zone 2 is where you actually do the thing the rail sent you to do. It is a **tab strip over one
+surface region** — never a split, never a floating pane. Which surface is showing is entirely a
+function of which tab is active, and the chrome above the surface (the tab strip, the agent context
+bar) is constant so that switching between an agent pane and a diff does not move anything you were
+about to click.
+
+## Structure
+
+### The stack
+
+Described in [`layout.md`](./layout.md#the-work-surface-stack): tab strip · agent context bar ·
+optional conflict banner · surface · one footer.
+
+### The tab strip
+
+A **real tab list**, not a three-way pane selector. `work_surface::state::TabRef` is the identity of
+one tab:
+
+| `TabRef` | Payload | Cardinality |
+|---|---|---|
+| `Agent(AgentId)` | the agent | one per open agent (CLI or shell) |
+| `File(PathBuf)` | the file | one per open file, in open order |
+| `Graph` | — | at most one per window |
+| `Review(AgentId)` | the agent reviewed | at most one open, but *per agent* — that's the point of the feature |
+| `Run` | — | one run tab per worktree; opening another replaces it |
+
+The payload rule is worth stating because it is not arbitrary: a variant carries a payload exactly
+when two of it can meaningfully coexist in one strip. `Run` carries none, so that "replaced" keeps
+the tab's dragged position instead of closing and reopening at the end of the strip.
+
+Tab order is per worktree and persisted. `reconcile_tab_order` is pure and idempotent: it drops
+entries that no longer exist and appends anything newly open at the end — which is what lets the
+render path call it fresh every frame instead of maintaining a mutated cache. A real drag is the
+only thing that writes back.
+
+Each tab carries a chip (see [`vocabulary.md`](./vocabulary.md#chips)): the agent's tint for a CLI
+tab, the terminal glyph for a shell, the file's language chip for a file tab — so a tab is always
+colour-coded to *who* or *what* it is.
+
+**Opening a file adds a tab.** It never takes over the centre region. Sources: a row in Changes, a
+file in the tree, a `path:line` reference in terminal output, a palette result, `]` / `[`.
+
+The `+` is a menu button opening a popover of *New terminal · New agent pane · Open file… · Next
+changed file*, each with its own hint keycaps.
+
+### The agent context bar
+
+Agent badge · agent name · divider · branch · worktree path · status pill · actions.
+
+**The layout rule that matters:** every child is inflexible and non-wrapping except the worktree
+path, which is the single flexible item and ellipsises. Without that the bar wraps and overflows the
+moment the centre zone narrows. ([`principles.md`](./principles.md) rule 6.)
+
+### Surface A — the agent pane
+
+**There is no chat UI.** The agent runs in a real pty (`pty-core` + `alacritty_terminal` via
+`terminal::pane` and `terminal::grid`) and Jerry renders its output verbatim, cell by cell. The
+agent's question is *its own* numbered prompt, never a card Jerry designed for it.
+
+That is a product position, not an implementation shortcut, and it is why the pane's header shows
+the real invocation, the real pid and the real pty state (`attached · waiting on stdin`,
+`exited 101`, `detached · resumable`) rather than an abstraction over them.
+
+Its footer band is a **readout, not an action bar** — the strip below an agent pane reports; it does
+not offer git operations the CLI could have done itself. `work_surface::state::ActionKind` is down to
+two variants (`Respawn`, `DiscardWorktree`) and the five it lost were deleted rather than hidden.
+Anything still listed renders honestly disabled when it has no backing logic
+(`FooterAction::implemented`).
+
+The pane also carries the **per-provider rate-limit budget** readout (`budget/`) — the
+`claude 5h ▓░░░░░ 19%` bar and the popover behind it, read from each provider's own usage endpoint
+with real credentials found on disk.
+
+### Surface B — the shell
+
+Same geometry as the agent pane, with its own info footer (`theme::band::PTY_INFO_FOOTER`) carrying
+pid, grid dimensions and the environment chip. A pane gets one footer or the other, never both.
+
+Terminal output is **interactive**: `terminal::links` is a pure `path:line[:col]` scanner over
+already-rendered row text, and a match renders as a link that opens the file as a tab. The link is a
+span *inside* the line, not a whole-line style, so `↳ tests/upload.rs:88:` links only the path.
+
+### Surface C — code (Diff | File)
+
+The largest subsystem in the app; `code_surface/mod.rs`'s own docs are the file-by-file map. One
+tab, two views, toggled in the surface's own toolbar.
+
+**Diff view** — unified, full width. Two line-number gutters, a sign column, then the code.
+Backgrounds and text per line kind come from `theme::diff`. **Folds** are what stop a twelve-file
+change from being a wall: only changed hunks plus context, everything else collapsed behind a
+`⋯ N unchanged lines` marker.
+
+**File view** — a real editable buffer (`edit_buffer`, driven from real keystrokes through
+`editing`'s `EntityInputHandler` wiring), with a breadcrumb, tree-sitter syntax spans from
+`code_view`, a git gutter, bracket folding (`fold`), inline git blame (`blame`, `blame_view`), and a
+syntax-coloured **minimap** with a draggable viewport slider.
+
+Indentation resolves through `indent`, including a real minimal `.editorconfig` reader — Jerry does
+not guess a file's indent style when the repository has stated it.
+
+**The toolbar's `Accept file` is always rendered**, dimmed when there is nothing to accept. See
+[`principles.md`](./principles.md) rule 6 for why this one is load-bearing.
+
+**Zoom** is per editor tab (`zoom`), applied through a rem-scoped subtree (`root::rem_scope`) so the
+diff and file views scale together while gutters and sign columns keep their fixed widths. Its
+readout was removed from the status bar; the keyboard bindings were not.
+
+### Language-server UI
+
+`lsp/` owns the client and the pure response→view-model mappings; `code_surface::lsp_ui` draws hover
+and diagnostics *over* the surface; `lsp::completion_popup` is the completions popup.
+
+Three decorations, at most one at a time: **completions** (a two-column popover — candidates with
+kind chips on the left, signature and doc on the right — carrying the one shadow in the product,
+`theme::shadow::POPOVER`), **diagnostics** (an underline on the offending span, a dim inline message,
+a tinted row, and a card below with the server's own code and any quick fix), and **hover** (an
+underline on the symbol and a card with signature, doc and module path).
+
+The mappings are pure functions over `lsp_types` responses, so their rules are tested against
+fixture responses rather than against a live server.
+
+### Surface D — merge conflict
+
+Reached from the conflict banner. `merge/` holds a pure conflict/segment/choice model (`state`), the
+real `wt_core::merge` calls and the surface's own state machine (`flow`), a whole-file hand-edit
+buffer for conflicts the side-picker can't resolve (`editing`), and the view (`render`).
+
+**Each side is headed by its agent, not by "ours" and "theirs".** That is the single most important
+thing about this surface: in Jerry the two sides of a conflict are two agents you know by name and by
+tint, and each column tints its own lines with that agent's colour. "Ours/theirs" is git's framing
+and it is the wrong one here.
+
+Jerry proposes the answer rather than only presenting the choice — a pre-flight strip states how many
+files it can auto-resolve because their edits don't overlap, and `Take both` is the primary action
+where both edits can be kept.
+
+### Other centre surfaces
+
+- **Graph** (`graph_view/`) — the git graph tab: lane canvas, row list, ref chips, and its own
+  interactive-rebase mode. Lanes and merge elbows are hand-drawn Jerry vocabulary, not icons.
+- **Review** (`review/`) — the agent review tab. The distinction it exists to draw is worth reading
+  in that module's docs: a **git diff** answers *how does this worktree differ from the merge-base*
+  (a property of the branch), while an **agent diff** answers *what did this agent change* (a
+  property of a run). They are separated by base point and lifetime, not by filtering one list.
+- **Review notes** (`review_notes/`) — line-anchored comments on a diff, **batched** into one prompt,
+  delivered to a **named** agent's pty, and **kept pinned** afterwards so the revision can be checked
+  against them. All three properties are the point; sending comments one at a time makes an agent
+  swing back and forth.
+- **Run transcript** (`run_history/`) — one finished run's own recording. The governing sentence is
+  *"the sidebar indexes; the centre shows one run"*: history is a list you navigate from Zone 3, and
+  opening an entry opens its transcript here, exactly the Explorer → editor pattern.
+- **Provenance** (`provenance/`) — per-agent line provenance in a shared worktree: gutter tints,
+  author chips, and the `⚠` shared-file ring. Deliberately not blame — blame answers *which commit*,
+  and collapses every uncommitted line into one bucket; in a worktree with two agents running, the
+  interesting fact about a dirty line is *which agent wrote it*.
+
+## Rules that matter
+
+- **One region, one surface.** Tabs replace each other. There is no split, and adding one is a
+  [`decisions.md`](./decisions.md) entry.
+- **A pane has exactly one bottom bar**, chosen by its kind. Never both stacked.
+- **The agent pane renders the agent, not a rendering of the agent.** No chat bubbles, no synthesised
+  cards around its questions, no reformatting of its output.
+- **A tab's chip identifies it.** Agent tint for agents, language chip for files — derived, never
+  hand-assigned.
+- **Controls dim, they don't vanish.** `Accept file` is the canonical case.
+- **Only the worktree path flexes in the context bar.** Everything else is `flex: none`.
+- **Pure logic stays out of `render.rs`.** Every folder here already splits window-free logic from
+  the `gpui::Div`-building code, and the tests live against the pure half. New work follows the
+  split.
+
+## Not built yet
+
+- **No resumable agent state.** `ActionKind::Respawn` closes the tab and spawns a fresh agent of the
+  same kind and cwd — an approximate stand-in for `Retry`/`Resume`, because there is no saved agent
+  session to actually resume *from*. `pty_state_label` names the same gap.
+- **The render layer still calls adapters directly.** Several `render.rs` files here reach into
+  `wt_core::`/`pty_core::` rather than dispatching a Command/Query. This is a known architectural
+  gap, ratcheted by `.claude/hooks/check-conventions.sh` and tracked in
+  [`docs/architecture/decisions.md`](../architecture/decisions.md) §3 — not a pattern to copy.

--- a/docs/design/work-surface.md
+++ b/docs/design/work-surface.md
@@ -1,7 +1,9 @@
 # Zone 2 — the work surface
 
-**Code:** `crates/app/src/work_surface/`, and the surfaces it hosts — `terminal/`, `code_surface/`, `lsp/`, `merge/`, `graph_view/`, `review/`, `review_notes/`, `run_history/`, `provenance/`, `budget/`
-**Tokens:** `theme::{term, editor, diff, syntax, band, button, completions_popup}`
+- **Code:** `crates/app/src/work_surface/`, and the surfaces it hosts — `terminal/`,
+  `code_surface/`, `lsp/`, `merge/`, `graph_view/`, `review/`, `review_notes/`, `run_history/`,
+  `provenance/`, `budget/`
+- **Tokens:** `theme::{term, editor, diff, syntax, band, button, completions_popup}`
 
 ## What it's for
 
@@ -65,18 +67,18 @@ moment the centre zone narrows. ([`principles.md`](./principles.md) rule 6.)
 agent's question is *its own* numbered prompt, never a card Jerry designed for it.
 
 That is a product position, not an implementation shortcut, and it is why the pane's header shows
-the real invocation, the real pid and the real pty state (`attached · waiting on stdin`,
-`exited 101`, `detached · resumable`) rather than an abstraction over them.
+the real invocation, the real pid and the real pty state (`attached · waiting on stdin`, `exited
+101`, `detached · resumable`) rather than an abstraction over them.
 
 Its footer band is a **readout, not an action bar** — the strip below an agent pane reports; it does
-not offer git operations the CLI could have done itself. `work_surface::state::ActionKind` is down to
-two variants (`Respawn`, `DiscardWorktree`) and the five it lost were deleted rather than hidden.
+not offer git operations the CLI could have done itself. `work_surface::state::ActionKind` is down
+to two variants (`Respawn`, `DiscardWorktree`) and the five it lost were deleted rather than hidden.
 Anything still listed renders honestly disabled when it has no backing logic
 (`FooterAction::implemented`).
 
-The pane also carries the **per-provider rate-limit budget** readout (`budget/`) — the
-`claude 5h ▓░░░░░ 19%` bar and the popover behind it, read from each provider's own usage endpoint
-with real credentials found on disk.
+The pane also carries the **per-provider rate-limit budget** readout (`budget/`) — the `claude 5h
+▓░░░░░ 19%` bar and the popover behind it, read from each provider's own usage endpoint with real
+credentials found on disk.
 
 ### Surface B — the shell
 
@@ -94,8 +96,8 @@ tab, two views, toggled in the surface's own toolbar.
 
 **Diff view** — unified, full width. Two line-number gutters, a sign column, then the code.
 Backgrounds and text per line kind come from `theme::diff`. **Folds** are what stop a twelve-file
-change from being a wall: only changed hunks plus context, everything else collapsed behind a
-`⋯ N unchanged lines` marker.
+change from being a wall: only changed hunks plus context, everything else collapsed behind a `⋯ N
+unchanged lines` marker.
 
 **File view** — a real editable buffer (`edit_buffer`, driven from real keystrokes through
 `editing`'s `EntityInputHandler` wiring), with a breadcrumb, tree-sitter syntax spans from
@@ -119,9 +121,9 @@ and diagnostics *over* the surface; `lsp::completion_popup` is the completions p
 
 Three decorations, at most one at a time: **completions** (a two-column popover — candidates with
 kind chips on the left, signature and doc on the right — carrying the one shadow in the product,
-`theme::shadow::POPOVER`), **diagnostics** (an underline on the offending span, a dim inline message,
-a tinted row, and a card below with the server's own code and any quick fix), and **hover** (an
-underline on the symbol and a card with signature, doc and module path).
+`theme::shadow::POPOVER`), **diagnostics** (an underline on the offending span, a dim inline
+message, a tinted row, and a card below with the server's own code and any quick fix), and **hover**
+(an underline on the symbol and a card with signature, doc and module path).
 
 The mappings are pure functions over `lsp_types` responses, so their rules are tested against
 fixture responses rather than against a live server.
@@ -133,13 +135,13 @@ real `wt_core::merge` calls and the surface's own state machine (`flow`), a whol
 buffer for conflicts the side-picker can't resolve (`editing`), and the view (`render`).
 
 **Each side is headed by its agent, not by "ours" and "theirs".** That is the single most important
-thing about this surface: in Jerry the two sides of a conflict are two agents you know by name and by
-tint, and each column tints its own lines with that agent's colour. "Ours/theirs" is git's framing
-and it is the wrong one here.
+thing about this surface: in Jerry the two sides of a conflict are two agents you know by name and
+by tint, and each column tints its own lines with that agent's colour. "Ours/theirs" is git's
+framing and it is the wrong one here.
 
-Jerry proposes the answer rather than only presenting the choice — a pre-flight strip states how many
-files it can auto-resolve because their edits don't overlap, and `Take both` is the primary action
-where both edits can be kept.
+Jerry proposes the answer rather than only presenting the choice — a pre-flight strip states how
+many files it can auto-resolve because their edits don't overlap, and `Take both` is the primary
+action where both edits can be kept.
 
 ### Other centre surfaces
 
@@ -149,10 +151,10 @@ where both edits can be kept.
   in that module's docs: a **git diff** answers *how does this worktree differ from the merge-base*
   (a property of the branch), while an **agent diff** answers *what did this agent change* (a
   property of a run). They are separated by base point and lifetime, not by filtering one list.
-- **Review notes** (`review_notes/`) — line-anchored comments on a diff, **batched** into one prompt,
-  delivered to a **named** agent's pty, and **kept pinned** afterwards so the revision can be checked
-  against them. All three properties are the point; sending comments one at a time makes an agent
-  swing back and forth.
+- **Review notes** (`review_notes/`) — line-anchored comments on a diff, **batched** into one
+  prompt, delivered to a **named** agent's pty, and **kept pinned** afterwards so the revision can
+  be checked against them. All three properties are the point; sending comments one at a time makes
+  an agent swing back and forth.
 - **Run transcript** (`run_history/`) — one finished run's own recording. The governing sentence is
   *"the sidebar indexes; the centre shows one run"*: history is a list you navigate from Zone 3, and
   opening an entry opens its transcript here, exactly the Explorer → editor pattern.
@@ -166,8 +168,8 @@ where both edits can be kept.
 - **One region, one surface.** Tabs replace each other. There is no split, and adding one is a
   [`decisions.md`](./decisions.md) entry.
 - **A pane has exactly one bottom bar**, chosen by its kind. Never both stacked.
-- **The agent pane renders the agent, not a rendering of the agent.** No chat bubbles, no synthesised
-  cards around its questions, no reformatting of its output.
+- **The agent pane renders the agent, not a rendering of the agent.** No chat bubbles, no
+  synthesised cards around its questions, no reformatting of its output.
 - **A tab's chip identifies it.** Agent tint for agents, language chip for files — derived, never
   hand-assigned.
 - **Controls dim, they don't vanish.** `Accept file` is the canonical case.


### PR DESCRIPTION
Part 1 of 3 for #414. Base is the integration branch **`docs/414-design-docs`**, so the whole set can be reviewed and merged together; #419 and #420 stack on top of this one in that order.

## What

Adds `docs/design/` — ten files, mirroring `docs/architecture/`'s shape rather than inventing a new one, each mapping to a code module and each on one fixed skeleton (*What it's for* / *Structure* / *Rules that matter* / *Not built yet*).

| File | Covers |
|---|---|
| `README.md` | Index, how to read and how to *change* the set, how to recover the deleted bundle |
| `principles.md` | Six rules that constrain every other page |
| `vocabulary.md` | Status, agent tints, chips, keycaps, icons |
| `layout.md` | Bands, the three zones, the work-surface stack, title/status bar |
| `rail.md` | Zone 1 |
| `work-surface.md` | Zone 2, and every surface it hosts |
| `sidebar.md` | Zone 3 — Files · Search · Changes |
| `settings.md` | The Settings surface |
| `command-palette.md` | The ⌘P overlay |
| `decisions.md` | Fourteen numbered design decisions |

Also adds a third ratchet counter to `.claude/hooks/check-conventions.sh` — `design_handoff_citations`, baselined at the current 364 — so part 2's sweep is mechanically enforced rather than hoped for.

Pure addition otherwise. No code changes, nothing removed.

Prose in every page wraps at 100 columns, the measure `CLAUDE.md`, `CONTRIBUTING.md` and `docs/architecture/` already use.

## Why

`design_handoff_jerry_ade/` is a one-shot handoff bundle, and `CONTRIBUTING.md` already says so — *"a one-time handoff artifact, not a living spec."* It became the de-facto design authority anyway: 364 doc comments across 81 files in `crates/` cite it, roughly a third of them at `revision N/` directories that were never committed.

The property the bundle lacked, and the reason this set can stay current: **these docs never reprint a value.** `theme.rs` already owns every colour and dimension, with a doc comment per token, and already generates `assets/themes/`. A page names `theme::status::ASK`; the token carries the number. A document that duplicates `#e2a336` goes stale the first time somebody retunes the amber — one that names the token cannot.

Written against the code **as it is today**, not transcribed. Where the mockup and the shipped app disagree, the app wins and the delta is recorded. `decisions.md` seeds fourteen entries, five of which are reconciliations written down here for the first time:

- **§7** — the rail's `by urgency / by project` toggle was removed in favour of one `repo → worktree → agent` structure; urgency became ranking *within* it.
- **§10** — `Review ready` renders as `Finished` (#280).
- **§9** — the agent-tint reserved-hue rule, and the copper/teal/periwinkle/steel-blue reallocation it forced.
- **§11** — the status bar's subtractive rebuild (#293): eight of thirteen readouts were VS Code's, not Jerry's.
- **§12** — the agent pane's footer became a readout, not an action bar (#295).

And the one that demonstrates what the log is *for*: **§4** (every icon composed from rects and glyphs) is marked **superseded by §8** (Phosphor SVGs, #282). That supersession happened months ago and the frozen bundle had no way to record it.

## Testing

- [x] `/check` (conventions + fmt + clippy `-D warnings`) passes locally
- [x] Every `crates/**.rs` path and every `crates/app/src/*/` directory named in `docs/design/` resolves — checked with the issue's own verification loop, zero misses
- [x] Every relative markdown link and anchor in the set resolves to a real file and a real heading
- [x] `.claude/hooks/check-conventions.sh` passes with the new counter (`handoff citations: 364/364`)
- [ ] `verify` capture — n/a, no UI change
- [ ] New/changed behaviour test — n/a, documentation and one hook counter

## Architecture notes

None. No crate boundary or Command/Query change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

