### PR TITLE
docs: sweep every design_handoff_jerry_ade citation out of the source (2/3)

### DIFF
--- a/.claude/conventions-baseline.json
+++ b/.claude/conventions-baseline.json
@@ -2,5 +2,5 @@
   "_comment": "Ratchet baseline for .claude/hooks/check-conventions.sh - these numbers may only go down, never up. Recount with the exact commands in that script's comments after fixing a batch of violations, and lower the number in the same commit.",
   "glob_imports_app_src": 304,
   "render_adapter_calls": 222,
-  "design_handoff_citations": 364
+  "design_handoff_citations": 0
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,7 @@ dbg_macro = "warn"
 gpui = { git = "https://github.com/zed-industries/zed", rev = "7b030b500810b04cf5fb4aa5973be99a502d9f36" }
 anyhow = "1"
 thiserror = "1"
-# Real config-file (de)serialization for `crate::settings_store::Settings`
-# (`design_handoff_jerry_ade/revision/CHANGELOG.md`'s 2026-07-29 entry, change 3). Pinned to
+# Real config-file (de)serialization for `crate::settings_store::Settings`. Pinned to
 # the exact major versions `vendor/zed/Cargo.toml` itself pins (`serde = "1.0.221"`,
 # `toml = "0.8"`), matching this project's established "same versions Zed verified against"
 # convention for shared dependencies (see `crates/app/Cargo.toml`'s own `tree-sitter`/

--- a/assets/icons/README.md
+++ b/assets/icons/README.md
@@ -15,8 +15,8 @@ the upstream project's own `assets/bold/` tree.
 
 ## Weight
 
-All twelve files are the **bold** weight. `design_handoff_jerry_ade/revision 5/`'s
-`REVISION-2026-08-14.md` §8 states the rule verbatim:
+All twelve files are the **bold** weight. The design states the rule verbatim
+(`docs/design/decisions.md` §8):
 
 > **Weight:** `bold` at 15–17px (`regular`'s 1.5px stroke reads thin against `#5e646a`);
 > `regular` only at 20px+.

--- a/assets/themes/ember.toml
+++ b/assets/themes/ember.toml
@@ -75,13 +75,13 @@ button_disabled        = "#1a1f22"
 keycap                 = "#1f2629"
 keycap_hint            = "#1d2225"  # The hint-size keycap's own border
 selected_edge          = "#224959"  # 2px left edge on a selected row
-diagnostic_card        = "#321c24"
+diagnostic_card        = "#321c24"  # The Diagnostic popover's own border.
 diagnostic_card_footer = "#251d22"  # The Diagnostic popover's own footer band's top border
 
 # The Files tree's own structural marks (GitHub issue #18 §3).
 [tree]
 indent_guide        = "#1c2124"
-indent_guide_active = "#224959"  # The guide for a level in the selected file's ancestor chain
+indent_guide_active = "#224959"
 
 # The overlay scrollbar (GitHub issue #30).
 [scrollbar]
@@ -165,11 +165,10 @@ status_deleted  = "#894959"  # D
 tree_added      = "#507344"  # "A" mark
 tree_modified   = "#8a5c21"  # "M" mark
 
-# Tokens used only by the Revision R12 rail rewrite (design_handoff_jerry_ade/revision 3/
-# REVISION-2026-07-31.md §2) that have no exact match elsewhere in this module - every other
-# colour that section calls for (the branch/note/model/activity greys, the amber flag, the
-# spine/selection edges) already has one, reused directly at the call site rather than
-# duplicated here under a second name.
+# Tokens the rail needs that have no exact match elsewhere in this module - every other colour
+# it calls for (the branch/note/model/activity greys, the amber flag, the spine/selection edges)
+# already has one, reused directly at the call site rather than duplicated here under a second
+# name.
 [rail]
 repo_header_name   = "#6e777b"  # Repo group header's uppercase name.
 worktree_active_bg = "#151a1c"
@@ -189,9 +188,8 @@ repo_fail_count    = "#984d60"  # The repo header's red urgency **count**
 "local.fg"  = "#4277a3"  # Steel blue - qwen-local.
 "local.bg"  = "#102538"  # Steel blue - qwen-local.
 
-# The Changes panel - four stacked, collapsible sections in one scroller
-# (design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md §1), plus the file row's own
-# seen/unseen and discard states (STAGE-A-CHANGELOG.md §4i).
+# The Changes panel - four stacked, collapsible sections in one scroller, plus the file row's
+# own seen/unseen and discard states.
 [changes]
 edge_uncommitted      = "#224959"  # UNCOMMITTED's 2px left edge - what is dirty in the checkout.
 edge_neutral          = "#1c2124"  # COMMITS' 2px left edge.
@@ -217,8 +215,7 @@ discard_fg            = "#ac586d"  # The armed Discard? pill's label.
 hover_action_hover_bg = "#1c2429"
 discard_hover_bg      = "#2d151e"  # The discard button's hover fill
 
-# Per-provider rate-limit budget - the meter on an agent tab and in the budget popover
-# (design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md §2).
+# Per-provider rate-limit budget - the meter on an agent tab and in the budget popover.
 [budget]
 ok       = "#689057"  # Above 40% remaining.
 warn     = "#a66730"  # 15-40% remaining.
@@ -226,8 +223,8 @@ critical = "#984d60"  # Below 15% remaining.
 track    = "#1c2124"  # The unfilled remainder of the meter
 stale    = "#4e565b"
 
-# Diff-line review notes (GitHub issue #288, STAGE-A-CHANGELOG.md §1's two §6.2 rows and the
-# audit's top-5 #2) - the notes bar above the hunks and the card pinned beneath a line.
+# Diff-line review notes (GitHub issue #288) - the notes bar above the hunks and the card pinned
+# beneath a line.
 [notes]
 edge             = "#00789d"
 card_bg          = "#12191c"  # The pinned card's fill.
@@ -249,9 +246,7 @@ send_hover_bg    = "#132830"  # Its hover fill.
 send_fg          = "#6599ae"  # Its label.
 send_cap_fg      = "#488199"  # Its ⌘⏎ keycaps' glyphs.
 
-# Agent history - the sidebar's run list and the run-transcript tab (GitHub issue #227,
-# design_handoff_jerry_ade/revision 5/REVISION-2026-08-13.md §4/§5, transcribed from that
-# revision's own tables and from revision 5/tokens.rs's history module).
+# Agent history - the sidebar's run list and the run-transcript tab (GitHub issue #227).
 [history]
 out_done_fg        = "#689057"  # done - its last turn ended cleanly and Jerry watched it end.
 out_done_bg        = "#172116"
@@ -266,7 +261,7 @@ drift_near         = "#518fa8"  # Drift dot, 1-2 commits since.
 drift_far          = "#a66730"  # Drift dot, 3+ commits since.
 drift_text         = "#454d51"
 drift_far_text     = "#8a5c21"
-scope_on_bg        = "#181f21"
+scope_on_bg        = "#181f21"  # The scope toggle's selected segment
 scope_on_border    = "#202a2e"
 scope_on_fg        = "#8a9194"
 scope_off_fg       = "#454d51"
@@ -274,7 +269,7 @@ scope_hover_bg     = "#181c1e"
 repo_label         = "#6e777b"
 group_label        = "#788186"
 row_title          = "#8a9194"  # A run row's title when the row is not the open one.
-transcript_prompt  = "#518fa8"
+transcript_prompt  = "#518fa8"  # The transcript body's four line tones
 transcript_body    = "#777f84"
 transcript_detail  = "#4e565b"
 transcript_lead    = "#929a9d"
@@ -348,7 +343,7 @@ error_underline           = "#ca5976"  # 2px dotted
 hover_underline           = "#4786a3"  # 1px solid
 diagnostic_row_bg         = "#181417"
 diagnostic_inline_message = "#af6b7a"
-diagnostic_card_message   = "#b4687a"
+diagnostic_card_message   = "#b4687a"  # The Diagnostic state's card message headline.
 
 # The File view's structural chrome (GitHub issue #31's "editor chrome" checklist item) -
 # selection, the current-line highlight, the caret, and a handful of tokens for editor features
@@ -418,12 +413,12 @@ process_exited = "#d08637"  # The process exited label, once the child is gone.
 "ansi.14"      = "#29b8db"
 "ansi.15"      = "#ffffff"
 
-# Exact colours for Surface C's real Completions popup item rows - read directly from
-# design_handoff_jerry_ade/revision/Jerry.dc.html's own completions/KBG/KFG data (the sel ? ...
+# Exact colours for Surface C's real Completions popup item rows - each its own token rather
+# than a reuse of a nearby-but-not-identical existing one (e.g.
 [completions_popup]
-item_selected_bg   = "#113340"
-item_selected_fg   = "#a1a7aa"
-item_fg            = "#838c90"
+item_selected_bg   = "#113340"  # A selected completion row's background.
+item_selected_fg   = "#a1a7aa"  # A selected completion row's label colour.
+item_fg            = "#838c90"  # An unselected completion row's label colour
 "kind_function.fg" = "#518fa8"
 "kind_function.bg" = "#113340"
 "kind_variable.fg" = "#b36f25"
@@ -443,7 +438,7 @@ green_bg        = "#253f20"
 green_bg_hover  = "#2c4a25"
 green_fg        = "#7b9f6f"
 green_keycap    = "#345129"
-green_keycap_fg = "#6d9262"
+green_keycap_fg = "#6d9262"  # The keycap glyph colour inside a green primary button
 blue_bg         = "#113340"
 blue_bg_hover   = "#123e4d"
 blue_fg         = "#6599ae"
@@ -462,35 +457,29 @@ knob_on        = "#93aa8e"
 knob_off       = "#4e565b"
 checkbox_hover = "#3c5b2b"
 
-# Settings-surface-only colours read directly from Jerry.dc.html's inline literals for the
-# settingsOpen block - real values present in the mockup but missing from tokens.rs's
-# transcription (predates the Settings section).
+# Settings-surface-only colours: the ones that have no equivalent in another module.
 [settings]
-nav_row_hover           = "#151819"
-subtitle                = "#555e63"
-card_row_sep            = "#1a1f22"
+nav_row_hover           = "#151819"  # A nav row's hover background
+subtitle                = "#555e63"  # The content column's page-subtitle text
+card_row_sep            = "#1a1f22"  # A card row's own bottom separator
 agent_ready             = "#56863a"  # A binary-found status dot on the Agents page.
 agent_not_found         = "#af395c"  # A binary-not-found status dot on the Agents page
 worktree_prunable_dot   = "#30383b"  # The Worktrees page's "merged and prunable" row dot
 card_selected_bg        = "#131a1c"
 card_unselected_bg      = "#121618"
-theme_card_hover_border = "#2c3539"
-snippet_section         = "#7e6eba"
+theme_card_hover_border = "#2c3539"  # A Theme card's hover border.
+snippet_section         = "#7e6eba"  # The config snippet block's section-header line colour.
 
-# Palette-only (⌘P) colours read directly from Jerry.dc.html's inline literals for the
-# paletteOpen block - real values missing from tokens.rs's transcription (predates the palette
-# section).
+# Palette-only (⌘P) colours: the ones that have no equivalent in another module.
 [palette]
-prefix            = "#366377"
-group_header      = "#434b4f"
-row_hover         = "#161b1d"
-label_selected    = "#a1a7aa"
-"command_chip.fg" = "#4277a3"
-"command_chip.bg" = "#14222c"
+prefix            = "#366377"  # The input row's scope-prefix glyph.
+group_header      = "#434b4f"  # A result group's uppercase header label
+row_hover         = "#161b1d"  # An unselected result row's hover background
+label_selected    = "#a1a7aa"  # The selected/first row's label colour
+"command_chip.fg" = "#4277a3"  # A command result's kind chip (fg, bg)
+"command_chip.bg" = "#14222c"  # A command result's kind chip (fg, bg)
 
-# The git graph tab (design handoff design_handoff_jerry_ade/revision 2/CHANGELOG.md, 2026-07-31
-# entry, "git graph (issue #1)") - real hex values transcribed directly from that entry's
-# §2/§3, not paraphrased.
+# The git graph tab (GitHub issue #1).
 [graph]
 tab_chip_bg                = "#211d2e"  # The tab chip's own background (§1: "#2a2030 bg").
 tab_chip_fg                = "#8d689f"  # The tab chip's fork-glyph colour (§1: "#c98fbf fork glyph").
@@ -582,8 +571,7 @@ local_border = "#1c2124"  # Defaults to border::DIVIDER's own value.
 "unknown.fg" = "#4e565b"
 "unknown.bg" = "#1d2225"
 
-# The status bar's three type tiers (design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md
-# §3).
+# The status bar's three type tiers - see docs/design/layout.md.
 [status_bar]
 primary       = "#788186"  # Tier 1
 secondary     = "#5a6368"  # Tier 2

--- a/assets/themes/jerry-dim.toml
+++ b/assets/themes/jerry-dim.toml
@@ -75,13 +75,13 @@ button_disabled        = "#26292d"
 keycap                 = "#2d3136"
 keycap_hint            = "#292d31"  # The hint-size keycap's own border
 selected_edge          = "#435971"  # 2px left edge on a selected row
-diagnostic_card        = "#3e2828"
+diagnostic_card        = "#3e2828"  # The Diagnostic popover's own border.
 diagnostic_card_footer = "#312829"  # The Diagnostic popover's own footer band's top border
 
 # The Files tree's own structural marks (GitHub issue #18 §3).
 [tree]
 indent_guide        = "#292c30"
-indent_guide_active = "#435971"  # The guide for a level in the selected file's ancestor chain
+indent_guide_active = "#435971"
 
 # The overlay scrollbar (GitHub issue #30).
 [scrollbar]
@@ -165,11 +165,10 @@ status_deleted  = "#a3665c"  # D
 tree_added      = "#569176"  # "A" mark
 tree_modified   = "#938040"  # "M" mark
 
-# Tokens used only by the Revision R12 rail rewrite (design_handoff_jerry_ade/revision 3/
-# REVISION-2026-07-31.md §2) that have no exact match elsewhere in this module - every other
-# colour that section calls for (the branch/note/model/activity greys, the amber flag, the
-# spine/selection edges) already has one, reused directly at the call site rather than
-# duplicated here under a second name.
+# Tokens the rail needs that have no exact match elsewhere in this module - every other colour
+# it calls for (the branch/note/model/activity greys, the amber flag, the spine/selection edges)
+# already has one, reused directly at the call site rather than duplicated here under a second
+# name.
 [rail]
 repo_header_name   = "#8f949b"  # Repo group header's uppercase name.
 worktree_active_bg = "#202326"
@@ -189,9 +188,8 @@ repo_fail_count    = "#b46d61"  # The repo header's red urgency **count**
 "local.fg"  = "#7c8dc2"  # Steel blue - qwen-local.
 "local.bg"  = "#282e45"  # Steel blue - qwen-local.
 
-# The Changes panel - four stacked, collapsible sections in one scroller
-# (design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md §1), plus the file row's own
-# seen/unseen and discard states (STAGE-A-CHANGELOG.md §4i).
+# The Changes panel - four stacked, collapsible sections in one scroller, plus the file row's
+# own seen/unseen and discard states.
 [changes]
 edge_uncommitted      = "#435971"  # UNCOMMITTED's 2px left edge - what is dirty in the checkout.
 edge_neutral          = "#292c30"  # COMMITS' 2px left edge.
@@ -217,8 +215,7 @@ discard_fg            = "#cc7c6f"  # The armed Discard? pill's label.
 hover_action_hover_bg = "#2a2e35"
 discard_hover_bg      = "#392120"  # The discard button's hover fill
 
-# Per-provider rate-limit budget - the meter on an agent tab and in the budget popover
-# (design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md §2).
+# Per-provider rate-limit budget - the meter on an agent tab and in the budget popover.
 [budget]
 ok       = "#70b693"  # Above 40% remaining.
 warn     = "#b3914a"  # 15-40% remaining.
@@ -226,8 +223,8 @@ critical = "#b46d61"  # Below 15% remaining.
 track    = "#292c30"  # The unfilled remainder of the meter
 stale    = "#676c72"
 
-# Diff-line review notes (GitHub issue #288, STAGE-A-CHANGELOG.md §1's two §6.2 rows and the
-# audit's top-5 #2) - the notes bar above the hunks and the card pinned beneath a line.
+# Diff-line review notes (GitHub issue #288) - the notes bar above the hunks and the card pinned
+# beneath a line.
 [notes]
 edge             = "#5e8dc4"
 card_bg          = "#1d2126"  # The pinned card's fill.
@@ -249,9 +246,7 @@ send_hover_bg    = "#26323e"  # Its hover fill.
 send_fg          = "#99b8d9"  # Its label.
 send_cap_fg      = "#7a9abe"  # Its ⌘⏎ keycaps' glyphs.
 
-# Agent history - the sidebar's run list and the run-transcript tab (GitHub issue #227,
-# design_handoff_jerry_ade/revision 5/REVISION-2026-08-13.md §4/§5, transcribed from that
-# revision's own tables and from revision 5/tokens.rs's history module).
+# Agent history - the sidebar's run list and the run-transcript tab (GitHub issue #227).
 [history]
 out_done_fg        = "#70b693"  # done - its last turn ended cleanly and Jerry watched it end.
 out_done_bg        = "#1d2c26"
@@ -266,7 +261,7 @@ drift_near         = "#88abd2"  # Drift dot, 1-2 commits since.
 drift_far          = "#b3914a"  # Drift dot, 3+ commits since.
 drift_text         = "#5c6166"
 drift_far_text     = "#938040"
-scope_on_bg        = "#24282c"
+scope_on_bg        = "#24282c"  # The scope toggle's selected segment
 scope_on_border    = "#30353c"
 scope_on_fg        = "#b0b4b9"
 scope_off_fg       = "#5c6166"
@@ -274,7 +269,7 @@ scope_hover_bg     = "#222629"
 repo_label         = "#8f949b"
 group_label        = "#9ba1a7"
 row_title          = "#b0b4b9"  # A run row's title when the row is not the open one.
-transcript_prompt  = "#88abd2"
+transcript_prompt  = "#88abd2"  # The transcript body's four line tones
 transcript_body    = "#9a9ea5"
 transcript_detail  = "#676c72"
 transcript_lead    = "#babfc4"
@@ -348,7 +343,7 @@ error_underline           = "#ce6655"  # 2px dotted
 hover_underline           = "#6787b0"  # 1px solid
 diagnostic_row_bg         = "#211c1d"
 diagnostic_inline_message = "#b3746a"
-diagnostic_card_message   = "#ce867b"
+diagnostic_card_message   = "#ce867b"  # The Diagnostic state's card message headline.
 
 # The File view's structural chrome (GitHub issue #31's "editor chrome" checklist item) -
 # selection, the current-line highlight, the caret, and a handful of tokens for editor features
@@ -418,12 +413,12 @@ process_exited = "#dfbb5e"  # The process exited label, once the child is gone.
 "ansi.14"      = "#29b8db"
 "ansi.15"      = "#ffffff"
 
-# Exact colours for Surface C's real Completions popup item rows - read directly from
-# design_handoff_jerry_ade/revision/Jerry.dc.html's own completions/KBG/KFG data (the sel ? ...
+# Exact colours for Surface C's real Completions popup item rows - each its own token rather
+# than a reuse of a nearby-but-not-identical existing one (e.g.
 [completions_popup]
-item_selected_bg   = "#2c3e52"
-item_selected_fg   = "#cccfd4"
-item_fg            = "#a8adb4"
+item_selected_bg   = "#2c3e52"  # A selected completion row's background.
+item_selected_fg   = "#cccfd4"  # A selected completion row's label colour.
+item_fg            = "#a8adb4"  # An unselected completion row's label colour
 "kind_function.fg" = "#88abd2"
 "kind_function.bg" = "#2c3e52"
 "kind_variable.fg" = "#bf9d47"
@@ -443,7 +438,7 @@ green_bg        = "#275140"
 green_bg_hover  = "#2c5f4a"
 green_fg        = "#8cc7aa"
 green_keycap    = "#356851"
-green_keycap_fg = "#7bb79b"
+green_keycap_fg = "#7bb79b"  # The keycap glyph colour inside a green primary button
 blue_bg         = "#2c3e52"
 blue_bg_hover   = "#334a63"
 blue_fg         = "#99b8d9"
@@ -462,35 +457,29 @@ knob_on        = "#b2d4c3"
 knob_off       = "#676c72"
 checkbox_hover = "#3b7558"
 
-# Settings-surface-only colours read directly from Jerry.dc.html's inline literals for the
-# settingsOpen block - real values present in the mockup but missing from tokens.rs's
-# transcription (predates the Settings section).
+# Settings-surface-only colours: the ones that have no equivalent in another module.
 [settings]
-nav_row_hover           = "#1f2022"
-subtitle                = "#70767c"
-card_row_sep            = "#26292d"
+nav_row_hover           = "#1f2022"  # A nav row's hover background
+subtitle                = "#70767c"  # The content column's page-subtitle text
+card_row_sep            = "#26292d"  # A card row's own bottom separator
 agent_ready             = "#4faa7e"  # A binary-found status dot on the Agents page.
 agent_not_found         = "#cd604e"  # A binary-not-found status dot on the Agents page
 worktree_prunable_dot   = "#42464c"  # The Worktrees page's "merged and prunable" row dot
 card_selected_bg        = "#1e2226"
 card_unselected_bg      = "#1b1e21"
-theme_card_hover_border = "#3d434a"
-snippet_section         = "#b687c7"
+theme_card_hover_border = "#3d434a"  # A Theme card's hover border.
+snippet_section         = "#b687c7"  # The config snippet block's section-header line colour.
 
-# Palette-only (⌘P) colours read directly from Jerry.dc.html's inline literals for the
-# paletteOpen block - real values missing from tokens.rs's transcription (predates the palette
-# section).
+# Palette-only (⌘P) colours: the ones that have no equivalent in another module.
 [palette]
-prefix            = "#5f7794"
-group_header      = "#5a5e64"
-row_hover         = "#212427"
-label_selected    = "#cccfd4"
-"command_chip.fg" = "#7c8dc2"
-"command_chip.bg" = "#252b37"
+prefix            = "#5f7794"  # The input row's scope-prefix glyph.
+group_header      = "#5a5e64"  # A result group's uppercase header label
+row_hover         = "#212427"  # An unselected result row's hover background
+label_selected    = "#cccfd4"  # The selected/first row's label colour
+"command_chip.fg" = "#7c8dc2"  # A command result's kind chip (fg, bg)
+"command_chip.bg" = "#252b37"  # A command result's kind chip (fg, bg)
 
-# The git graph tab (design handoff design_handoff_jerry_ade/revision 2/CHANGELOG.md, 2026-07-31
-# entry, "git graph (issue #1)") - real hex values transcribed directly from that entry's
-# §2/§3, not paraphrased.
+# The git graph tab (GitHub issue #1).
 [graph]
 tab_chip_bg                = "#312634"  # The tab chip's own background (§1: "#2a2030 bg").
 tab_chip_fg                = "#bb83aa"  # The tab chip's fork-glyph colour (§1: "#c98fbf fork glyph").
@@ -582,8 +571,7 @@ local_border = "#292c30"  # Defaults to border::DIVIDER's own value.
 "unknown.fg" = "#676c72"
 "unknown.bg" = "#292d31"
 
-# The status bar's three type tiers (design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md
-# §3).
+# The status bar's three type tiers - see docs/design/layout.md.
 [status_bar]
 primary       = "#9ba1a7"  # Tier 1
 secondary     = "#767c82"  # Tier 2

--- a/assets/themes/moss.toml
+++ b/assets/themes/moss.toml
@@ -75,13 +75,13 @@ button_disabled        = "#202326"
 keycap                 = "#272a2e"
 keycap_hint            = "#232629"  # The hint-size keycap's own border
 selected_edge          = "#3f5264"  # 2px left edge on a selected row
-diagnostic_card        = "#352324"
+diagnostic_card        = "#352324"  # The Diagnostic popover's own border.
 diagnostic_card_footer = "#292224"  # The Diagnostic popover's own footer band's top border
 
 # The Files tree's own structural marks (GitHub issue #18 §3).
 [tree]
 indent_guide        = "#232528"
-indent_guide_active = "#3f5264"  # The guide for a level in the selected file's ancestor chain
+indent_guide_active = "#3f5264"
 
 # The overlay scrollbar (GitHub issue #30).
 [scrollbar]
@@ -165,11 +165,10 @@ status_deleted  = "#94625d"  # D
 tree_added      = "#5b876e"  # "A" mark
 tree_modified   = "#8a7847"  # "M" mark
 
-# Tokens used only by the Revision R12 rail rewrite (design_handoff_jerry_ade/revision 3/
-# REVISION-2026-07-31.md §2) that have no exact match elsewhere in this module - every other
-# colour that section calls for (the branch/note/model/activity greys, the amber flag, the
-# spine/selection edges) already has one, reused directly at the call site rather than
-# duplicated here under a second name.
+# Tokens the rail needs that have no exact match elsewhere in this module - every other colour
+# it calls for (the branch/note/model/activity greys, the amber flag, the spine/selection edges)
+# already has one, reused directly at the call site rather than duplicated here under a second
+# name.
 [rail]
 repo_header_name   = "#878c91"  # Repo group header's uppercase name.
 worktree_active_bg = "#1a1d1f"
@@ -189,9 +188,8 @@ repo_fail_count    = "#a46963"  # The repo header's red urgency **count**
 "local.fg"  = "#7586b0"  # Steel blue - qwen-local.
 "local.bg"  = "#22283a"  # Steel blue - qwen-local.
 
-# The Changes panel - four stacked, collapsible sections in one scroller
-# (design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md §1), plus the file row's own
-# seen/unseen and discard states (STAGE-A-CHANGELOG.md §4i).
+# The Changes panel - four stacked, collapsible sections in one scroller, plus the file row's
+# own seen/unseen and discard states.
 [changes]
 edge_uncommitted      = "#3f5264"  # UNCOMMITTED's 2px left edge - what is dirty in the checkout.
 edge_neutral          = "#232528"  # COMMITS' 2px left edge.
@@ -217,8 +215,7 @@ discard_fg            = "#ba7972"  # The armed Discard? pill's label.
 hover_action_hover_bg = "#24282d"
 discard_hover_bg      = "#2f1c1c"  # The discard button's hover fill
 
-# Per-provider rate-limit budget - the meter on an agent tab and in the budget popover
-# (design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md §2).
+# Per-provider rate-limit budget - the meter on an agent tab and in the budget popover.
 [budget]
 ok       = "#76aa8b"  # Above 40% remaining.
 warn     = "#a88954"  # 15-40% remaining.
@@ -226,8 +223,8 @@ critical = "#a46963"  # Below 15% remaining.
 track    = "#232528"  # The unfilled remainder of the meter
 stale    = "#606469"
 
-# Diff-line review notes (GitHub issue #288, STAGE-A-CHANGELOG.md §1's two §6.2 rows and the
-# audit's top-5 #2) - the notes bar above the hunks and the card pinned beneath a line.
+# Diff-line review notes (GitHub issue #288) - the notes bar above the hunks and the card pinned
+# beneath a line.
 [notes]
 edge             = "#5c86b0"
 card_bg          = "#181b1f"  # The pinned card's fill.
@@ -249,9 +246,7 @@ send_hover_bg    = "#212b35"  # Its hover fill.
 send_fg          = "#95b0c9"  # Its label.
 send_cap_fg      = "#7692ae"  # Its ⌘⏎ keycaps' glyphs.
 
-# Agent history - the sidebar's run list and the run-transcript tab (GitHub issue #227,
-# design_handoff_jerry_ade/revision 5/REVISION-2026-08-13.md §4/§5, transcribed from that
-# revision's own tables and from revision 5/tokens.rs's history module).
+# Agent history - the sidebar's run list and the run-transcript tab (GitHub issue #227).
 [history]
 out_done_fg        = "#76aa8b"  # done - its last turn ended cleanly and Jerry watched it end.
 out_done_bg        = "#192520"
@@ -266,7 +261,7 @@ drift_near         = "#84a3c0"  # Drift dot, 1-2 commits since.
 drift_far          = "#a88954"  # Drift dot, 3+ commits since.
 drift_text         = "#55595e"
 drift_far_text     = "#8a7847"
-scope_on_bg        = "#1e2225"
+scope_on_bg        = "#1e2225"  # The scope toggle's selected segment
 scope_on_border    = "#2a2f34"
 scope_on_fg        = "#a8acaf"
 scope_off_fg       = "#55595e"
@@ -274,7 +269,7 @@ scope_hover_bg     = "#1d1f22"
 repo_label         = "#878c91"
 group_label        = "#94989e"
 row_title          = "#a8acaf"  # A run row's title when the row is not the open one.
-transcript_prompt  = "#84a3c0"
+transcript_prompt  = "#84a3c0"  # The transcript body's four line tones
 transcript_body    = "#92969b"
 transcript_detail  = "#606469"
 transcript_lead    = "#b2b6bb"
@@ -348,7 +343,7 @@ error_underline           = "#bd685f"  # 2px dotted
 hover_underline           = "#6683a3"  # 1px solid
 diagnostic_row_bg         = "#1a1618"
 diagnostic_inline_message = "#a6736d"
-diagnostic_card_message   = "#bd827c"
+diagnostic_card_message   = "#bd827c"  # The Diagnostic state's card message headline.
 
 # The File view's structural chrome (GitHub issue #31's "editor chrome" checklist item) -
 # selection, the current-line highlight, the caret, and a handful of tokens for editor features
@@ -418,12 +413,12 @@ process_exited = "#d3b26c"  # The process exited label, once the child is gone.
 "ansi.14"      = "#29b8db"
 "ansi.15"      = "#ffffff"
 
-# Exact colours for Surface C's real Completions popup item rows - read directly from
-# design_handoff_jerry_ade/revision/Jerry.dc.html's own completions/KBG/KFG data (the sel ? ...
+# Exact colours for Surface C's real Completions popup item rows - each its own token rather
+# than a reuse of a nearby-but-not-identical existing one (e.g.
 [completions_popup]
-item_selected_bg   = "#283847"
-item_selected_fg   = "#c3c7ca"
-item_fg            = "#a0a5aa"
+item_selected_bg   = "#283847"  # A selected completion row's background.
+item_selected_fg   = "#c3c7ca"  # A selected completion row's label colour.
+item_fg            = "#a0a5aa"  # An unselected completion row's label colour
 "kind_function.fg" = "#84a3c0"
 "kind_function.bg" = "#283847"
 "kind_variable.fg" = "#b49555"
@@ -443,7 +438,7 @@ green_bg        = "#294839"
 green_bg_hover  = "#315543"
 green_fg        = "#8fbba2"
 green_keycap    = "#395e4a"
-green_keycap_fg = "#7eac93"
+green_keycap_fg = "#7eac93"  # The keycap glyph colour inside a green primary button
 blue_bg         = "#283847"
 blue_bg_hover   = "#304356"
 blue_fg         = "#95b0c9"
@@ -462,35 +457,29 @@ knob_on        = "#afc9ba"
 knob_off       = "#606469"
 checkbox_hover = "#416b51"
 
-# Settings-surface-only colours read directly from Jerry.dc.html's inline literals for the
-# settingsOpen block - real values present in the mockup but missing from tokens.rs's
-# transcription (predates the Settings section).
+# Settings-surface-only colours: the ones that have no equivalent in another module.
 [settings]
-nav_row_hover           = "#191a1c"
-subtitle                = "#696e73"
-card_row_sep            = "#202326"
+nav_row_hover           = "#191a1c"  # A nav row's hover background
+subtitle                = "#696e73"  # The content column's page-subtitle text
+card_row_sep            = "#202326"  # A card row's own bottom separator
 agent_ready             = "#5c9d77"  # A binary-found status dot on the Agents page.
 agent_not_found         = "#b96057"  # A binary-not-found status dot on the Agents page
 worktree_prunable_dot   = "#3b3f44"  # The Worktrees page's "merged and prunable" row dot
 card_selected_bg        = "#191c1f"
 card_unselected_bg      = "#16181a"
-theme_card_hover_border = "#373c41"
-snippet_section         = "#a684b9"
+theme_card_hover_border = "#373c41"  # A Theme card's hover border.
+snippet_section         = "#a684b9"  # The config snippet block's section-header line colour.
 
-# Palette-only (⌘P) colours read directly from Jerry.dc.html's inline literals for the
-# paletteOpen block - real values missing from tokens.rs's transcription (predates the palette
-# section).
+# Palette-only (⌘P) colours: the ones that have no equivalent in another module.
 [palette]
-prefix            = "#5a6f86"
-group_header      = "#53575b"
-row_hover         = "#1b1e20"
-label_selected    = "#c3c7ca"
-"command_chip.fg" = "#7586b0"
-"command_chip.bg" = "#1f252e"
+prefix            = "#5a6f86"  # The input row's scope-prefix glyph.
+group_header      = "#53575b"  # A result group's uppercase header label
+row_hover         = "#1b1e20"  # An unselected result row's hover background
+label_selected    = "#c3c7ca"  # The selected/first row's label colour
+"command_chip.fg" = "#7586b0"  # A command result's kind chip (fg, bg)
+"command_chip.bg" = "#1f252e"  # A command result's kind chip (fg, bg)
 
-# The git graph tab (design handoff design_handoff_jerry_ade/revision 2/CHANGELOG.md, 2026-07-31
-# entry, "git graph (issue #1)") - real hex values transcribed directly from that entry's
-# §2/§3, not paraphrased.
+# The git graph tab (GitHub issue #1).
 [graph]
 tab_chip_bg                = "#29212c"  # The tab chip's own background (§1: "#2a2030 bg").
 tab_chip_fg                = "#ab80a1"  # The tab chip's fork-glyph colour (§1: "#c98fbf fork glyph").
@@ -582,8 +571,7 @@ local_border = "#232528"  # Defaults to border::DIVIDER's own value.
 "unknown.fg" = "#606469"
 "unknown.bg" = "#232629"
 
-# The status bar's three type tiers (design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md
-# §3).
+# The status bar's three type tiers - see docs/design/layout.md.
 [status_bar]
 primary       = "#94989e"  # Tier 1
 secondary     = "#6f7479"  # Tier 2

--- a/assets/themes/paper.toml
+++ b/assets/themes/paper.toml
@@ -75,13 +75,13 @@ button_disabled        = "#d7dbdf"
 keycap                 = "#ccd2d7"
 keycap_hint            = "#d2d7db"  # The hint-size keycap's own border
 selected_edge          = "#90a9bf"  # 2px left edge on a selected row
-diagnostic_card        = "#e6cbcd"
+diagnostic_card        = "#e6cbcd"  # The Diagnostic popover's own border.
 diagnostic_card_footer = "#dfd5d7"  # The Diagnostic popover's own footer band's top border
 
 # The Files tree's own structural marks (GitHub issue #18 §3).
 [tree]
 indent_guide        = "#d3d8dc"
-indent_guide_active = "#90a9bf"  # The guide for a level in the selected file's ancestor chain
+indent_guide_active = "#90a9bf"
 
 # The overlay scrollbar (GitHub issue #30).
 [scrollbar]
@@ -165,11 +165,10 @@ status_deleted  = "#ab7270"  # D
 tree_added      = "#598669"  # "A" mark
 tree_modified   = "#907843"  # "M" mark
 
-# Tokens used only by the Revision R12 rail rewrite (design_handoff_jerry_ade/revision 3/
-# REVISION-2026-07-31.md §2) that have no exact match elsewhere in this module - every other
-# colour that section calls for (the branch/note/model/activity greys, the amber flag, the
-# spine/selection edges) already has one, reused directly at the call site rather than
-# duplicated here under a second name.
+# Tokens the rail needs that have no exact match elsewhere in this module - every other colour
+# it calls for (the branch/note/model/activity greys, the amber flag, the spine/selection edges)
+# already has one, reused directly at the call site rather than duplicated here under a second
+# name.
 [rail]
 repo_header_name   = "#666b70"  # Repo group header's uppercase name.
 worktree_active_bg = "#dfe3e7"
@@ -189,9 +188,8 @@ repo_fail_count    = "#a66663"  # The repo header's red urgency **count**
 "local.fg"  = "#586f99"  # Steel blue - qwen-local.
 "local.bg"  = "#c7d3ec"  # Steel blue - qwen-local.
 
-# The Changes panel - four stacked, collapsible sections in one scroller
-# (design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md §1), plus the file row's own
-# seen/unseen and discard states (STAGE-A-CHANGELOG.md §4i).
+# The Changes panel - four stacked, collapsible sections in one scroller, plus the file row's
+# own seen/unseen and discard states.
 [changes]
 edge_uncommitted      = "#90a9bf"  # UNCOMMITTED's 2px left edge - what is dirty in the checkout.
 edge_neutral          = "#d3d8dc"  # COMMITS' 2px left edge.
@@ -217,8 +215,7 @@ discard_fg            = "#975351"  # The armed Discard? pill's label.
 hover_action_hover_bg = "#ced5dc"
 discard_hover_bg      = "#f1d3d5"  # The discard button's hover fill
 
-# Per-provider rate-limit budget - the meter on an agent tab and in the budget popover
-# (design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md §2).
+# Per-provider rate-limit budget - the meter on an agent tab and in the budget popover.
 [budget]
 ok       = "#366948"  # Above 40% remaining.
 warn     = "#846127"  # 15-40% remaining.
@@ -226,8 +223,8 @@ critical = "#a66663"  # Below 15% remaining.
 track    = "#d3d8dc"  # The unfilled remainder of the meter
 stale    = "#8c9197"
 
-# Diff-line review notes (GitHub issue #288, STAGE-A-CHANGELOG.md §1's two §6.2 rows and the
-# audit's top-5 #2) - the notes bar above the hunks and the card pinned beneath a line.
+# Diff-line review notes (GitHub issue #288) - the notes bar above the hunks and the card pinned
+# beneath a line.
 [notes]
 edge             = "#4678a3"
 card_bg          = "#e0e6eb"  # The pinned card's fill.
@@ -249,9 +246,7 @@ send_hover_bg    = "#c4d4e1"  # Its hover fill.
 send_fg          = "#355269"  # Its label.
 send_cap_fg      = "#4b6c87"  # Its ⌘⏎ keycaps' glyphs.
 
-# Agent history - the sidebar's run list and the run-transcript tab (GitHub issue #227,
-# design_handoff_jerry_ade/revision 5/REVISION-2026-08-13.md §4/§5, transcribed from that
-# revision's own tables and from revision 5/tokens.rs's history module).
+# Agent history - the sidebar's run list and the run-transcript tab (GitHub issue #227).
 [history]
 out_done_fg        = "#366948"  # done - its last turn ended cleanly and Jerry watched it end.
 out_done_bg        = "#d0e0d6"
@@ -266,7 +261,7 @@ drift_near         = "#3b5e7a"  # Drift dot, 1-2 commits since.
 drift_far          = "#846127"  # Drift dot, 3+ commits since.
 drift_text         = "#979da2"
 drift_far_text     = "#907843"
-scope_on_bg        = "#d7dde1"
+scope_on_bg        = "#d7dde1"  # The scope toggle's selected segment
 scope_on_border    = "#c6cdd4"
 scope_on_fg        = "#4c5053"
 scope_off_fg       = "#979da2"
@@ -274,7 +269,7 @@ scope_hover_bg     = "#dbe0e3"
 repo_label         = "#666b70"
 group_label        = "#5b6065"
 row_title          = "#4c5053"  # A run row's title when the row is not the open one.
-transcript_prompt  = "#3b5e7a"
+transcript_prompt  = "#3b5e7a"  # The transcript body's four line tones
 transcript_body    = "#5e6267"
 transcript_detail  = "#8c9197"
 transcript_lead    = "#43474b"
@@ -348,7 +343,7 @@ error_underline           = "#a84e4c"  # 2px dotted
 hover_underline           = "#4b6c8d"  # 1px solid
 diagnostic_row_bg         = "#ede7ea"
 diagnostic_inline_message = "#915b59"
-diagnostic_card_message   = "#8c504f"
+diagnostic_card_message   = "#8c504f"  # The Diagnostic state's card message headline.
 
 # The File view's structural chrome (GitHub issue #31's "editor chrome" checklist item) -
 # selection, the current-line highlight, the caret, and a handful of tokens for editor features
@@ -418,12 +413,12 @@ process_exited = "#5c4000"  # The process exited label, once the child is gone.
 "ansi.14"      = "#0598bc"
 "ansi.15"      = "#a5a5a5"
 
-# Exact colours for Surface C's real Completions popup item rows - read directly from
-# design_handoff_jerry_ade/revision/Jerry.dc.html's own completions/KBG/KFG data (the sel ? ...
+# Exact colours for Surface C's real Completions popup item rows - each its own token rather
+# than a reuse of a nearby-but-not-identical existing one (e.g.
 [completions_popup]
-item_selected_bg   = "#afc6d9"
-item_selected_fg   = "#373a3d"
-item_fg            = "#51565a"
+item_selected_bg   = "#afc6d9"  # A selected completion row's background.
+item_selected_fg   = "#373a3d"  # A selected completion row's label colour.
+item_fg            = "#51565a"  # An unselected completion row's label colour
 "kind_function.fg" = "#3b5e7a"
 "kind_function.bg" = "#afc6d9"
 "kind_variable.fg" = "#7b5702"
@@ -443,7 +438,7 @@ green_bg        = "#9dc1ab"
 green_bg_hover  = "#8cb59b"
 green_fg        = "#2c573c"
 green_keycap    = "#83ac90"
-green_keycap_fg = "#38644a"
+green_keycap_fg = "#38644a"  # The keycap glyph colour inside a green primary button
 blue_bg         = "#afc6d9"
 blue_bg_hover   = "#9ebad0"
 blue_fg         = "#355269"
@@ -462,35 +457,29 @@ knob_on        = "#2c4435"
 knob_off       = "#8c9197"
 checkbox_hover = "#75a181"
 
-# Settings-surface-only colours read directly from Jerry.dc.html's inline literals for the
-# settingsOpen block - real values present in the mockup but missing from tokens.rs's
-# transcription (predates the Settings section).
+# Settings-surface-only colours: the ones that have no equivalent in another module.
 [settings]
-nav_row_hover           = "#e3e6e8"
-subtitle                = "#82888d"
-card_row_sep            = "#d7dbdf"
+nav_row_hover           = "#e3e6e8"  # A nav row's hover background
+subtitle                = "#82888d"  # The content column's page-subtitle text
+card_row_sep            = "#d7dbdf"  # A card row's own bottom separator
 agent_ready             = "#377a4e"  # A binary-found status dot on the Agents page.
 agent_not_found         = "#b65553"  # A binary-not-found status dot on the Agents page
 worktree_prunable_dot   = "#b3b9be"  # The Worktrees page's "merged and prunable" row dot
 card_selected_bg        = "#dfe5e9"
 card_unselected_bg      = "#e6eaed"
-theme_card_hover_border = "#b6bdc4"
-snippet_section         = "#74548c"
+theme_card_hover_border = "#b6bdc4"  # A Theme card's hover border.
+snippet_section         = "#74548c"  # The config snippet block's section-header line colour.
 
-# Palette-only (⌘P) colours read directly from Jerry.dc.html's inline literals for the
-# paletteOpen block - real values missing from tokens.rs's transcription (predates the palette
-# section).
+# Palette-only (⌘P) colours: the ones that have no equivalent in another module.
 [palette]
-prefix            = "#708ba3"
-group_header      = "#9a9fa4"
-row_hover         = "#dee2e5"
-label_selected    = "#373a3d"
-"command_chip.fg" = "#586f99"
-"command_chip.bg" = "#d0d9e7"
+prefix            = "#708ba3"  # The input row's scope-prefix glyph.
+group_header      = "#9a9fa4"  # A result group's uppercase header label
+row_hover         = "#dee2e5"  # An unselected result row's hover background
+label_selected    = "#373a3d"  # The selected/first row's label colour
+"command_chip.fg" = "#586f99"  # A command result's kind chip (fg, bg)
+"command_chip.bg" = "#d0d9e7"  # A command result's kind chip (fg, bg)
 
-# The git graph tab (design handoff design_handoff_jerry_ade/revision 2/CHANGELOG.md, 2026-07-31
-# entry, "git graph (issue #1)") - real hex values transcribed directly from that entry's
-# §2/§3, not paraphrased.
+# The git graph tab (GitHub issue #1).
 [graph]
 tab_chip_bg                = "#ded4e5"  # The tab chip's own background (§1: "#2a2030 bg").
 tab_chip_fg                = "#80577b"  # The tab chip's fork-glyph colour (§1: "#c98fbf fork glyph").
@@ -582,8 +571,7 @@ local_border = "#d3d8dc"  # Defaults to border::DIVIDER's own value.
 "unknown.fg" = "#8c9197"
 "unknown.bg" = "#d2d7db"
 
-# The status bar's three type tiers (design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md
-# §3).
+# The status bar's three type tiers - see docs/design/layout.md.
 [status_bar]
 primary       = "#5b6065"  # Tier 1
 secondary     = "#7c8287"  # Tier 2

--- a/assets/themes/slate.toml
+++ b/assets/themes/slate.toml
@@ -75,13 +75,13 @@ button_disabled        = "#1b1e22"
 keycap                 = "#202429"
 keycap_hint            = "#1e2125"  # The hint-size keycap's own border
 selected_edge          = "#2d435b"  # 2px left edge on a selected row
-diagnostic_card        = "#321c1c"
+diagnostic_card        = "#321c1c"  # The Diagnostic popover's own border.
 diagnostic_card_footer = "#251d1e"  # The Diagnostic popover's own footer band's top border
 
 # The Files tree's own structural marks (GitHub issue #18 §3).
 [tree]
 indent_guide        = "#1d2024"
-indent_guide_active = "#2d435b"  # The guide for a level in the selected file's ancestor chain
+indent_guide_active = "#2d435b"
 
 # The overlay scrollbar (GitHub issue #30).
 [scrollbar]
@@ -165,11 +165,10 @@ status_deleted  = "#854840"  # D
 tree_added      = "#347155"  # "A" mark
 tree_modified   = "#746019"  # "M" mark
 
-# Tokens used only by the Revision R12 rail rewrite (design_handoff_jerry_ade/revision 3/
-# REVISION-2026-07-31.md §2) that have no exact match elsewhere in this module - every other
-# colour that section calls for (the branch/note/model/activity greys, the amber flag, the
-# spine/selection edges) already has one, reused directly at the call site rather than
-# duplicated here under a second name.
+# Tokens the rail needs that have no exact match elsewhere in this module - every other colour
+# it calls for (the branch/note/model/activity greys, the amber flag, the spine/selection edges)
+# already has one, reused directly at the call site rather than duplicated here under a second
+# name.
 [rail]
 repo_header_name   = "#6b7177"  # Repo group header's uppercase name.
 worktree_active_bg = "#161a1d"
@@ -189,9 +188,8 @@ repo_fail_count    = "#934c43"  # The repo header's red urgency **count**
 "local.fg"  = "#596a9f"  # Steel blue - qwen-local.
 "local.bg"  = "#1b2238"  # Steel blue - qwen-local.
 
-# The Changes panel - four stacked, collapsible sections in one scroller
-# (design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md §1), plus the file row's own
-# seen/unseen and discard states (STAGE-A-CHANGELOG.md §4i).
+# The Changes panel - four stacked, collapsible sections in one scroller, plus the file row's
+# own seen/unseen and discard states.
 [changes]
 edge_uncommitted      = "#2d435b"  # UNCOMMITTED's 2px left edge - what is dirty in the checkout.
 edge_neutral          = "#1d2024"  # COMMITS' 2px left edge.
@@ -217,8 +215,7 @@ discard_fg            = "#a6574c"  # The armed Discard? pill's label.
 hover_action_hover_bg = "#1e2229"
 discard_hover_bg      = "#2e1616"  # The discard button's hover fill
 
-# Per-provider rate-limit budget - the meter on an agent tab and in the budget popover
-# (design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md §2).
+# Per-provider rate-limit budget - the meter on an agent tab and in the budget popover.
 [budget]
 ok       = "#468e6b"  # Above 40% remaining.
 warn     = "#8f6c1d"  # 15-40% remaining.
@@ -226,8 +223,8 @@ critical = "#934c43"  # Below 15% remaining.
 track    = "#1d2024"  # The unfilled remainder of the meter
 stale    = "#4d5258"
 
-# Diff-line review notes (GitHub issue #288, STAGE-A-CHANGELOG.md §1's two §6.2 rows and the
-# audit's top-5 #2) - the notes bar above the hunks and the card pinned beneath a line.
+# Diff-line review notes (GitHub issue #288) - the notes bar above the hunks and the card pinned
+# beneath a line.
 [notes]
 edge             = "#396ba2"
 card_bg          = "#14181d"  # The pinned card's fill.
@@ -249,9 +246,7 @@ send_hover_bg    = "#192532"  # Its hover fill.
 send_fg          = "#6e8dae"  # Its label.
 send_cap_fg      = "#557699"  # Its ⌘⏎ keycaps' glyphs.
 
-# Agent history - the sidebar's run list and the run-transcript tab (GitHub issue #227,
-# design_handoff_jerry_ade/revision 5/REVISION-2026-08-13.md §4/§5, transcribed from that
-# revision's own tables and from revision 5/tokens.rs's history module).
+# Agent history - the sidebar's run list and the run-transcript tab (GitHub issue #227).
 [history]
 out_done_fg        = "#468e6b"  # done - its last turn ended cleanly and Jerry watched it end.
 out_done_bg        = "#12221b"
@@ -266,7 +261,7 @@ drift_near         = "#5e83a9"  # Drift dot, 1-2 commits since.
 drift_far          = "#8f6c1d"  # Drift dot, 3+ commits since.
 drift_text         = "#45494f"
 drift_far_text     = "#746019"
-scope_on_bg        = "#1a1e22"
+scope_on_bg        = "#1a1e22"  # The scope toggle's selected segment
 scope_on_border    = "#22282f"
 scope_on_fg        = "#85898e"
 scope_off_fg       = "#45494f"
@@ -274,7 +269,7 @@ scope_hover_bg     = "#181c1f"
 repo_label         = "#6b7177"
 group_label        = "#757a81"
 row_title          = "#85898e"  # A run row's title when the row is not the open one.
-transcript_prompt  = "#5e83a9"
+transcript_prompt  = "#5e83a9"  # The transcript body's four line tones
 transcript_body    = "#74787f"
 transcript_detail  = "#4d5258"
 transcript_lead    = "#8d9197"
@@ -348,7 +343,7 @@ error_underline           = "#ca5d4f"  # 2px dotted
 hover_underline           = "#5f81ab"  # 1px solid
 diagnostic_row_bg         = "#191415"
 diagnostic_inline_message = "#ae6e64"
-diagnostic_card_message   = "#b36b61"
+diagnostic_card_message   = "#b36b61"  # The Diagnostic state's card message headline.
 
 # The File view's structural chrome (GitHub issue #31's "editor chrome" checklist item) -
 # selection, the current-line highlight, the caret, and a handful of tokens for editor features
@@ -418,12 +413,12 @@ process_exited = "#b28c23"  # The process exited label, once the child is gone.
 "ansi.14"      = "#29b8db"
 "ansi.15"      = "#ffffff"
 
-# Exact colours for Surface C's real Completions popup item rows - read directly from
-# design_handoff_jerry_ade/revision/Jerry.dc.html's own completions/KBG/KFG data (the sel ? ...
+# Exact colours for Surface C's real Completions popup item rows - each its own token rather
+# than a reuse of a nearby-but-not-identical existing one (e.g.
 [completions_popup]
-item_selected_bg   = "#1c2f42"
-item_selected_fg   = "#9a9ea3"
-item_fg            = "#7f848b"
+item_selected_bg   = "#1c2f42"  # A selected completion row's background.
+item_selected_fg   = "#9a9ea3"  # A selected completion row's label colour.
+item_fg            = "#7f848b"  # An unselected completion row's label colour
 "kind_function.fg" = "#5e83a9"
 "kind_function.bg" = "#1c2f42"
 "kind_variable.fg" = "#99760b"
@@ -443,7 +438,7 @@ green_bg        = "#123f2e"
 green_bg_hover  = "#134a35"
 green_fg        = "#609b7d"
 green_keycap    = "#1b5139"
-green_keycap_fg = "#518f72"
+green_keycap_fg = "#518f72"  # The keycap glyph colour inside a green primary button
 blue_bg         = "#1c2f42"
 blue_bg_hover   = "#203850"
 blue_fg         = "#6e8dae"
@@ -462,35 +457,29 @@ knob_on        = "#82a392"
 knob_off       = "#4d5258"
 checkbox_hover = "#1e5b3e"
 
-# Settings-surface-only colours read directly from Jerry.dc.html's inline literals for the
-# settingsOpen block - real values present in the mockup but missing from tokens.rs's
-# transcription (predates the Settings section).
+# Settings-surface-only colours: the ones that have no equivalent in another module.
 [settings]
-nav_row_hover           = "#16181a"
-subtitle                = "#545a60"
-card_row_sep            = "#1b1e22"
+nav_row_hover           = "#16181a"  # A nav row's hover background
+subtitle                = "#545a60"  # The content column's page-subtitle text
+card_row_sep            = "#1b1e22"  # A card row's own bottom separator
 agent_ready             = "#208559"  # A binary-found status dot on the Agents page.
 agent_not_found         = "#aa3b2d"  # A binary-not-found status dot on the Agents page
 worktree_prunable_dot   = "#30353b"  # The Worktrees page's "merged and prunable" row dot
 card_selected_bg        = "#15191d"
 card_unselected_bg      = "#131619"
-theme_card_hover_border = "#2d3239"
-snippet_section         = "#9061a2"
+theme_card_hover_border = "#2d3239"  # A Theme card's hover border.
+snippet_section         = "#9061a2"  # The config snippet block's section-header line colour.
 
-# Palette-only (⌘P) colours read directly from Jerry.dc.html's inline literals for the
-# paletteOpen block - real values missing from tokens.rs's transcription (predates the palette
-# section).
+# Palette-only (⌘P) colours: the ones that have no equivalent in another module.
 [palette]
-prefix            = "#425b78"
-group_header      = "#43474d"
-row_hover         = "#171a1d"
-label_selected    = "#9a9ea3"
-"command_chip.fg" = "#596a9f"
-"command_chip.bg" = "#1a1f2c"
+prefix            = "#425b78"  # The input row's scope-prefix glyph.
+group_header      = "#43474d"  # A result group's uppercase header label
+row_hover         = "#171a1d"  # An unselected result row's hover background
+label_selected    = "#9a9ea3"  # The selected/first row's label colour
+"command_chip.fg" = "#596a9f"  # A command result's kind chip (fg, bg)
+"command_chip.bg" = "#1a1f2c"  # A command result's kind chip (fg, bg)
 
-# The git graph tab (design handoff design_handoff_jerry_ade/revision 2/CHANGELOG.md, 2026-07-31
-# entry, "git graph (issue #1)") - real hex values transcribed directly from that entry's
-# §2/§3, not paraphrased.
+# The git graph tab (GitHub issue #1).
 [graph]
 tab_chip_bg                = "#251b29"  # The tab chip's own background (§1: "#2a2030 bg").
 tab_chip_fg                = "#955f86"  # The tab chip's fork-glyph colour (§1: "#c98fbf fork glyph").
@@ -582,8 +571,7 @@ local_border = "#1d2024"  # Defaults to border::DIVIDER's own value.
 "unknown.fg" = "#4d5258"
 "unknown.bg" = "#1e2125"
 
-# The status bar's three type tiers (design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md
-# §3).
+# The status bar's three type tiers - see docs/design/layout.md.
 [status_bar]
 primary       = "#757a81"  # Tier 1
 secondary     = "#595e65"  # Tier 2

--- a/crates/app/src/budget/mod.rs
+++ b/crates/app/src/budget/mod.rs
@@ -1,7 +1,5 @@
 //! Per-provider rate-limit budget: the agent pane's `claude 5h ▓░░░░░░ 19% 7d ▓▓▓▓░░░ 60%`
-//! readout and the popover behind it (GitHub issue #294,
-//! `design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md` §2,
-//! `STAGE-A-CHANGELOG.md` §4c/§4t/§4u′).
+//! readout and the popover behind it (GitHub issue #294).
 //!
 //! Split the way every feature folder in this crate is split - pure, GPUI-window-free logic
 //! apart from the `gpui::Div`-building code that draws it:
@@ -28,10 +26,9 @@
 //!
 //! # Two bars, not one - decided by what the payloads actually contain
 //!
-//! The design bundle disagreed with itself here (`REVISION-2026-08-14.md` §2 describes one meter
-//! "filled to the tighter of the two windows"; `Jerry.dc.html` and §4u′ draw one bar per window),
-//! and issue #294's Phase 0 spike resolved it against the real data rather than by picking a
-//! document. **Both** supported providers expose two genuinely independent windows with their
+//! The design disagreed with itself here - one meter "filled to the tighter of the two windows"
+//! in one place, one bar per window in another - and issue #294's Phase 0 spike resolved it
+//! against the real data rather than by picking a document. **Both** supported providers expose two genuinely independent windows with their
 //! own utilisation *and their own reset instant*: Claude's `five_hour`/`seven_day`, Codex's
 //! `primary_window`/`secondary_window`. They do not move together - a session window refills in
 //! hours, a week does not - so a single bar filled to the tighter one answers the reader's only

--- a/crates/app/src/budget/render.rs
+++ b/crates/app/src/budget/render.rs
@@ -16,10 +16,10 @@ use crate::status_bar::render::StatusTier;
 use crate::status_bar::resources;
 use crate::work_surface::agents::ProcessKind;
 
-/// §4c: "Click opens a popover (292 wide, above the bar)".
+/// The design: "Click opens a popover (292 wide, above the bar)".
 const POPOVER_WIDTH: f32 = 292.0;
 
-/// The pane strip's meter: `Jerry.dc.html`'s own `30x3` track, one per window.
+/// The pane strip's meter: a 30x3 track, one per window.
 const METER_WIDTH: f32 = 30.0;
 const METER_HEIGHT: f32 = 3.0;
 
@@ -310,12 +310,12 @@ impl AdeApp {
 
     /// `RATE LIMITS` and the `Refresh` control.
     ///
-    /// **`Refresh` sits in the header, not next to `Updated N ago` in the foot.** §4c's prose runs
-    /// the two together in one sentence ("`Updated 3m ago` and a `Refresh` that sets `Updated just
-    /// now`"), but `Jerry.dc.html` - the newest state of the bundle, and the build §4u′ describes -
+    /// **`Refresh` sits in the header, not next to `Updated N ago` in the foot.** The design's
+    /// prose runs the two together in one sentence ("`Updated 3m ago` and a `Refresh` that sets
+    /// `Updated just now`"), but its own markup - the newer of the two -
     /// puts `Refresh` at the head opposite the title and leaves the foot to `Updated N ago` and the
     /// `counts spend, not headroom` footnote. That is also the better reading of the same sentence:
-    /// it fixes what `Refresh` *does* to the foot line, not where it is drawn. The mock wins on
+    /// it fixes what `Refresh` *does* to the foot line, not where it is drawn. The markup wins on
     /// placement; the prose's actual claim - that the foot line is derived from a real read - is
     /// what [`Self::render_budget_popover_footer`] implements.
     fn render_budget_popover_header(&self, cx: &mut Context<Self>) -> impl IntoElement {

--- a/crates/app/src/budget/state.rs
+++ b/crates/app/src/budget/state.rs
@@ -138,8 +138,7 @@ impl Provider {
     /// Every provider, in the order `Other providers` lists them.
     pub const ALL: [Provider; 2] = [Provider::Claude, Provider::Codex];
 
-    /// The lowercase name the pane strip prints (`Jerry.dc.html`'s `paneBudgetName` is
-    /// `budgetDefs[].id`, lowercase).
+    /// The lowercase name the pane strip prints.
     pub fn id(self) -> &'static str {
         match self {
             Provider::Claude => "claude",

--- a/crates/app/src/code_surface/code_view.rs
+++ b/crates/app/src/code_surface/code_view.rs
@@ -1,5 +1,5 @@
-//! Pure logic for Surface C's File view (`design_handoff_jerry_ade/README.md`'s "File view"
-//! subsection): reads a file off disk, detects its line-ending style, picks a language label
+//! Pure logic for Surface C's File view (`docs/design/work-surface.md`): reads a file off disk,
+//! detects its line-ending style, picks a language label
 //! from its extension, and - for a real subset of extensions - produces syntax-colored spans by
 //! parsing with `tree-sitter` and walking the resulting AST. Deliberately `gpui`-window-free
 //! (only [`gpui::Rgba`] is used, for plain colour data), mirroring this crate's split between
@@ -27,8 +27,8 @@
 //! recursive AST walk matching node kinds against per-language node-kind tables maintained here -
 //! see [`HIGHLIGHT_NAMES`] and [`HIGHLIGHT_KINDS`] for how the standard capture vocabulary those
 //! real query files emit (`keyword`, `function.method`, `constant.builtin`, `punctuation.bracket`,
-//! ...) is folded down into the six buckets `design_handoff_jerry_ade/README.md`'s File view
-//! colour table actually defines, and [`highlight_query_for`] for the one genuinely surprising
+//! ...) is folded down into the six buckets the File view's designed colour table
+//! actually defines, and [`highlight_query_for`] for the one genuinely surprising
 //! part (TypeScript's own query file is a supplement, not a whole query).
 //!
 //! Adding a further grammar is now a [`Grammar`] variant plus a thin wrapper - no node-kind table.
@@ -111,8 +111,7 @@ use wt_core::diff::{DiffFile, DiffLineKind};
 /// consistent rather than picking a second, arbitrary number.
 pub const MAX_FILE_BYTES: usize = 2 * 1024 * 1024;
 
-/// Which of Surface C's two views is showing - `design_handoff_jerry_ade/README.md`'s
-/// `code_view` state field (`Diff | File`).
+/// Which of Surface C's two views is showing (`Diff | File`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CodeView {
     #[default]
@@ -210,8 +209,8 @@ pub fn highlighter_for_extension(
 }
 
 /// A syntax span's classification - GitHub issue #31's extended scope-coverage checklist (22 real
-/// `tree-sitter-highlight` buckets, up from the original six-bucket
-/// `design_handoff_jerry_ade/README.md` File view table), plus the [`Text`](HighlightKind::Text)
+/// `tree-sitter-highlight` buckets, up from the File view's original six-bucket designed
+/// table), plus the [`Text`](HighlightKind::Text)
 /// fallback every byte a query doesn't classify at all still receives. See [`HIGHLIGHT_NAMES`] for
 /// the real, verified capture names each variant is reached through, and
 /// `theme::syntax`'s own module docs for the palette design (which variants are real,
@@ -2981,8 +2980,8 @@ pub fn cache_is_fresh(
     cached.path == path && cached.mtime == mtime && cached.len == len
 }
 
-/// The File view breadcrumb's path segments (`design_handoff_jerry_ade/README.md`: "`src ›
-/// db › query_builder.rs`") - every `Normal` path component of `path`, in order. Root/prefix/
+/// The File view breadcrumb's path segments (`src › db › query_builder.rs`) - every `Normal`
+/// path component of `path`, in order. Root/prefix/
 /// `.`/`..` components are skipped.
 pub fn breadcrumb_segments(path: &Path) -> Vec<String> {
     path.components()
@@ -2993,8 +2992,8 @@ pub fn breadcrumb_segments(path: &Path) -> Vec<String> {
         .collect()
 }
 
-/// The File view's 3px git-gutter marker set (`design_handoff_jerry_ade/README.md`: "a 3px git
-/// gutter (`#2c6244` for agent-touched lines, transparent otherwise)") - the new-file line
+/// The File view's 3px git-gutter marker set - tinted for agent-touched lines, transparent
+/// otherwise - the new-file line
 /// numbers (1-indexed) a hunk actually *added*, derived from `file`'s hunks via
 /// `crate::sidebar::changes::parse_hunk_new_range`. Context lines advance the new-file line counter
 /// without being marked; removed lines don't exist in the new file, so they never advance it.

--- a/crates/app/src/code_surface/diff_view.rs
+++ b/crates/app/src/code_surface/diff_view.rs
@@ -872,16 +872,16 @@ fn render_diff_gutter_number(number: Option<usize>) -> impl IntoElement {
 /// `you`.
 ///
 /// `filter` dims every line whose author is somebody *else* to
-/// `crate::provenance::render::FILTER_DIM_OPACITY` (the mock's 0.32). A line with no author is
-/// deliberately **not** dimmed - `Jerry.dc.html`'s own `muted = attr && who && who !== attr` - so
-/// filtering by one author never hides the context its work sits in.
+/// `crate::provenance::render::FILTER_DIM_OPACITY`. A line with no author is
+/// deliberately **not** dimmed - a line only mutes when it has an author and that author is not
+/// the filtered one - so filtering by one author never hides the context its work sits in.
 ///
 /// ## The note channel (GitHub issue #288)
 ///
 /// A **third** left-edge channel, and by the same discipline: *is there a note on this line* is
-/// its own fact, so it gets its own column rather than sharing one. `Jerry.dc.html` draws it as a
+/// its own fact, so it gets its own column rather than sharing one. The design draws it as a
 /// 14px centred glyph immediately after the gutters - `●` where a note is pinned. `○` is the note
-/// **cursor**: the line `C` would toggle a note on, which in the mock is the "a note exists here
+/// **cursor**: the line `C` would toggle a note on, which in the design is the "a note exists here
 /// but is hidden" state and here is "this is the line you are on". A line with neither draws
 /// nothing at all, following the author bar's own rule that the honest rendering of no answer is
 /// an empty column.
@@ -1062,8 +1062,8 @@ pub(in crate::code_surface) fn render_diff_line(
         })
 }
 
-/// `Jerry.dc.html`'s own 14px note column: `●` for a pinned note, `○` for the note cursor, and
-/// genuinely nothing for a line that is neither.
+/// The 14px note column: `●` for a pinned note, `○` for the note cursor, and genuinely nothing
+/// for a line that is neither.
 fn render_note_column(note: Option<NoteMark>, is_note_cursor: bool) -> impl IntoElement {
     let (glyph, color) = match (note, is_note_cursor) {
         (Some(_), _) => ("\u{25cf}", theme::notes::DOT),

--- a/crates/app/src/code_surface/editing.rs
+++ b/crates/app/src/code_surface/editing.rs
@@ -1839,7 +1839,7 @@ pub(in crate::code_surface) fn render_editable_file_view_line(
             // Multi-cursor (Revision R13, issue #28): every *secondary* real cursor's own
             // selection fill/caret bar on this row, painted with the exact same real tokens as
             // the primary's own above - `theme.rs` has no separate "secondary cursor" color, and
-            // inventing one with no `design_handoff_jerry_ade` spec to back it would be an
+            // inventing one with no design spec to back it would be an
             // unjustified guess (`CONTRIBUTING.md`'s own "exact values" discipline) - so a real
             // multi-cursor agent simply shows several real, identically-styled carets/
             // selections rather than a fabricated visual distinction between them. Empty in
@@ -5106,9 +5106,9 @@ mod editing_tests {
         );
     }
 
-    /// Real, live-reproduced coverage for `design_handoff_jerry_ade/revision 3/
-    /// REVISION-2026-07-31.md` §1 ("the open file tabs, the active tab ... the commit composer"
-    /// is worktree-scoped) and the coordinator's own explicit call-out: a user with an unsaved
+    /// Real, live-reproduced coverage for the design's rule that "the open file tabs, the active
+    /// tab ... the commit composer" are worktree-scoped, and the coordinator's own explicit
+    /// call-out: a user with an unsaved
     /// edit open who switches worktrees must never lose it - real data loss, no confirm dialog,
     /// nothing, was the bug. Drives two *real* worktrees (temp directories) that both have a file
     /// at the identical relative path `sample.txt`, edits both with different, real unsaved

--- a/crates/app/src/code_surface/file_view.rs
+++ b/crates/app/src/code_surface/file_view.rs
@@ -1103,9 +1103,8 @@ mod editor_scrollbar_mark_tests {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(in crate::code_surface) struct Crumb {
     pub text: String,
-    /// `true` for exactly one crumb: the file's own name. The design (`design_handoff_jerry_ade/
-    /// revision/Jerry.dc.html`, the File view breadcrumb band) renders that one at `#a9b0b7` and
-    /// every other crumb - ancestor directories *and* enclosing symbols alike - at `#5e646a`.
+    /// `true` for exactly one crumb: the file's own name. The breadcrumb band renders that one
+    /// brighter than every other crumb - ancestor directories *and* enclosing symbols alike.
     pub active: bool,
 }
 
@@ -1143,9 +1142,8 @@ pub(in crate::code_surface) fn breadcrumb_crumbs(
     crumbs
 }
 
-/// The File view's breadcrumb (`design_handoff_jerry_ade/README.md`: "Breadcrumb 26 (`src › db ›
-/// query_builder.rs › impl QueryBuilder › build`, 10.5px mono, separators `#3d4248`, active crumb
-/// `#a9b0b7`) with error/warning counts right").
+/// The File view's breadcrumb - `src › db › query_builder.rs › impl QueryBuilder › build`, with
+/// error/warning counts right-aligned.
 ///
 /// `symbol_path` is the live enclosing-symbol chain at the caret and `diagnostic_counts` the real
 /// `(errors, warnings)` pair from this same frame's `LspFileStatus::Analyzed` - `None` whenever
@@ -1289,8 +1287,7 @@ mod db {
                 "impl QueryBuilder",
                 "build",
             ],
-            "design_handoff_jerry_ade/README.md's own breadcrumb example, minus the mockup's \
-             elided `mod db`"
+            "the design's own breadcrumb example, minus its elided `mod db`"
         );
     }
 

--- a/crates/app/src/code_surface/lsp_ui.rs
+++ b/crates/app/src/code_surface/lsp_ui.rs
@@ -536,13 +536,11 @@ impl AdeApp {
 /// their own popovers (see either constant's own docs): it gives the real "is there room below
 /// the offending row" measurement a concrete number to compare real available space against, and
 /// stops a genuinely enormous multi-paragraph `rustc` message from painting past the window.
-/// Not from the design mockup, whose own diagnostic card (`design_handoff_jerry_ade/revision 3/
-/// Jerry.dc.html`) is exactly as tall as its two real lines of text - just a practical ceiling
-/// comfortably above a real message plus note plus footer.
+/// Not a designed value - the designed diagnostic card is exactly as tall as its two real lines
+/// of text. Just a practical ceiling comfortably above a real message plus note plus footer.
 const DIAGNOSTIC_CARD_MAX_HEIGHT: gpui::Pixels = px(190.0);
 
-/// 470px - the design mockup's own diagnostic card width (`design_handoff_jerry_ade/revision 3/
-/// Jerry.dc.html`: `width:470px` on the card itself).
+/// 470px - the designed diagnostic card width.
 const DIAGNOSTIC_CARD_WIDTH: gpui::Pixels = px(470.0);
 
 /// How long the Diagnostic card's `copy` button reads `copied` after a real click before flipping
@@ -562,8 +560,8 @@ impl AdeApp {
     /// the File view's own flex column, listing *every* diagnostic anywhere in the open file. Both
     /// halves of that were wrong. Being an ordinary flex child (never `.absolute()`), it took real,
     /// permanent vertical space away from the code view - the design's `lsp_popup` state model
-    /// (`design_handoff_jerry_ade/revision 3/README.md`) describes an anchored popup, not a docked
-    /// panel. And the design's own Diagnostic state is one card for one offending span ("a card
+    /// describes an anchored popup, not a docked panel. And the design's own Diagnostic state is
+    /// one card for one offending span ("a card
     /// below: message, note, `rust-analyzer · E0277`"), not a whole-file dump.
     ///
     /// It now paints exactly the way [`Self::render_hover_card`] and
@@ -806,17 +804,14 @@ impl CardAnchor {
 /// exactly the reason [`render_hover_card_content`] is split out of [`AdeApp::render_hover_card`]:
 /// the positioning math needs `&self` and this doesn't.
 ///
-/// Follows the design mockup's own Diagnostic card structure (`design_handoff_jerry_ade/revision
-/// 3/Jerry.dc.html`): a severity dot, the message's own first line, the rest of the message as a
-/// dimmer note, and a `source · code` footer. The mockup's `quick fix: wrap in Column::from ⌘.`
-/// chip is deliberately **not** drawn - this app has no `textDocument/codeAction` support at all,
-/// so a chip there would be a button bound to nothing.
+/// Follows the designed Diagnostic card structure: a severity dot, the message's own first line,
+/// the rest of the message as a dimmer note, and a `source · code` footer. The design's
+/// `quick fix: wrap in Column::from ⌘.` chip is deliberately **not** drawn - this app has no
+/// `textDocument/codeAction` support at all, so a chip there would be a button bound to nothing.
 ///
-/// Chrome follows the mockup's own diagnostic card exactly, not [`AdeApp::render_hover_card`]'s
-/// neutral popover chrome: `theme::syntax::DIAGNOSTIC_ROW_BG` (`#191416`) for the background and
-/// `theme::border::DIAGNOSTIC_CARD` (`#3a2224`) for the border, both read directly off
-/// `design_handoff_jerry_ade/revision 3/Jerry.dc.html`'s card (`background:#191416;border:1px
-/// solid #3a2224`) - the red tint is how this card reads as *ambient/alarming* at a glance,
+/// Chrome follows that card exactly, not [`AdeApp::render_hover_card`]'s neutral popover chrome:
+/// `theme::syntax::DIAGNOSTIC_ROW_BG` for the background and `theme::border::DIAGNOSTIC_CARD` for
+/// the border - the red tint is how this card reads as *ambient/alarming* at a glance,
 /// distinct from Hover/Completions' neutral `theme::surface::POPOVER`/`theme::border::POPOVER`.
 /// `theme::radius::CARD_SM` and no shadow still match every other popover (the design's own
 /// "Design tokens" section: "**one** [shadow] in the whole product - the completion popup").
@@ -1071,17 +1066,14 @@ pub(in crate::code_surface) fn diagnostic_card_message_color(
 /// [`AdeApp::render_hover_card`]'s own real "is there room below the hovered row" measurement
 /// (mirroring [`AdeApp::render_completions_popover`]'s identical `POPOVER_MAX_HEIGHT` judgment -
 /// see that constant's own docs) has a concrete number to compare real available space against,
-/// and so a real, unusually long doc string can't paint past the window. Not derived from the
-/// design mockup (`design_handoff_jerry_ade/revision/Jerry.dc.html`'s own hover card has no
-/// fixed height - it's exactly as tall as its own real content), just a practical, generous
-/// ceiling comfortably above what a real signature + doc + footer normally needs.
+/// and so a real, unusually long doc string can't paint past the window. Not a designed value -
+/// the designed hover card has no fixed height, being exactly as tall as its own content. Just a
+/// practical, generous ceiling comfortably above what a real signature + doc + footer needs.
 const HOVER_CARD_MAX_HEIGHT: gpui::Pixels = px(220.0);
-/// 430px - the design mockup's own real hover card width
-/// (`design_handoff_jerry_ade/revision 3/Jerry.dc.html`: `width:430px` on the card).
+/// 430px - the designed hover card width.
 const HOVER_CARD_MAX_WIDTH: gpui::Pixels = px(430.0);
-/// 10px - the header/body/footer bands' own real shared horizontal padding
-/// (`Jerry.dc.html`: `padding:7px 10px 6px`/`padding:7px 10px`/`padding:6px 10px` - all three
-/// bands agree on `10px` left/right). Named so [`render_hover_signature`]'s own real max-width
+/// 10px - the header/body/footer bands' own real shared horizontal padding: all three bands
+/// agree on `10px` left/right. Named so [`render_hover_signature`]'s own real max-width
 /// (card width minus both sides' padding) can be computed from the same real numbers the bands
 /// themselves paint with, rather than a second, independently-guessed constant that could drift.
 const HOVER_CARD_HORIZONTAL_PADDING: gpui::Pixels = px(10.0);
@@ -1410,9 +1402,8 @@ impl AdeApp {
 }
 
 /// The Hover popover's own signature line, syntax-highlighted like real code rather than painted
-/// as flat text (`design_handoff_jerry_ade/revision 3/Jerry.dc.html`'s own hover card shows `pub
-/// trait Into<T>: Sized` with real per-token colors - keyword purple, type gold - not one flat
-/// heading color).
+/// as flat text - the design shows a signature with real per-token colours, keyword purple and
+/// type gold, not one flat heading colour.
 ///
 /// Runs `signature` through [`code_view::highlight_block`] as a standalone fragment, the exact
 /// same "highlight a fragment on its own, not as part of a real open file" recipe the Diff and
@@ -1894,8 +1885,7 @@ pub(in crate::code_surface) fn diagnostic_inline_message_color(
     }
 }
 
-/// The File view row's real, dim end-of-line diagnostic message (`design_handoff_jerry_ade/
-/// revision 3/README.md`'s Diagnostic state: "dim inline message at end of line") - shared by both
+/// The File view row's real, dim end-of-line diagnostic message - shared by both
 /// row renderers, the read-only [`crate::code_surface::file_view::render_file_view_line`] and the
 /// live-buffer `crate::code_surface::editing::render_editable_file_view_line`, so the two can't
 /// drift apart on this.

--- a/crates/app/src/code_surface/render.rs
+++ b/crates/app/src/code_surface/render.rs
@@ -57,7 +57,7 @@ impl AdeApp {
         // badge", and this toolbar is one of them. Unlike the Changes rows, it keeps the slot the
         // word pill had - after the name rather than ahead of the directory - because a single
         // header line has no column of siblings to align with, which is exactly what the fixed
-        // column exists for. That is `Jerry.dc.html`'s own diff toolbar order too.
+        // column exists for. That is the designed diff toolbar order too.
         let letter = diff_file.map(|file| changes::status_letter(file.status));
         let stats = diff_file.map(changes::diff_file_stats);
         let rename_label = diff_file.and_then(changes::rename_label);
@@ -136,8 +136,8 @@ impl AdeApp {
                         .child(label),
                 )
             })
-            // GitHub issue #287 / `STAGE-A-CHANGELOG.md` §4b: the one dismissible `<agent> only ✕`
-            // indicator, in `Jerry.dc.html`'s own slot - after the diffstat, before the toolbar's
+            // GitHub issue #287: the one dismissible `<agent> only ✕`
+            // indicator, in the design's own slot - after the diffstat, before the toolbar's
             // spacer - and present *only* while a filter is really in force, so a filtered diff
             // can never read as the whole diff and an unfiltered one carries no dead control.
             .children(self.render_author_filter_indicator(cx))

--- a/crates/app/src/code_surface/symbols.rs
+++ b/crates/app/src/code_surface/symbols.rs
@@ -1,6 +1,6 @@
 //! The File view breadcrumb's **symbol path** - the real chain of enclosing declarations around
-//! wherever the caret currently sits (`design_handoff_jerry_ade/README.md`: "Breadcrumb 26
-//! (`src › db › query_builder.rs › impl QueryBuilder › build`, ...)").
+//! wherever the caret currently sits - the breadcrumb's
+//! `src › db › query_builder.rs › impl QueryBuilder › build`.
 //!
 //! GitHub issue #178: the breadcrumb band used to render only `code_view::breadcrumb_segments`'
 //! path components, which the Surface C toolbar directly above it already shows - a literal

--- a/crates/app/src/code_surface/tabs.rs
+++ b/crates/app/src/code_surface/tabs.rs
@@ -1982,9 +1982,8 @@ mod multi_file_tab_tests {
         );
     }
 
-    /// Real, live-reproduced coverage for `design_handoff_jerry_ade/revision 3/
-    /// REVISION-2026-07-31.md` §3 ("Switching worktrees swaps the whole strip. Each worktree
-    /// remembers its own ... open files") - the real bug this revision fixes: `AdeApp::
+    /// Real, live-reproduced coverage for the design's rule that "switching worktrees swaps the
+    /// whole strip. Each worktree remembers its own ... open files" - the real bug it fixes: `AdeApp::
     /// select_worktree` used to clear `open_files` unconditionally on every switch, so a
     /// worktree's tabs were lost the moment you navigated away. Drives two *real* worktrees
     /// (temp directories, real `AdeApp::select_worktree` switches, real `open_file_view` calls),

--- a/crates/app/src/code_surface/zoom.rs
+++ b/crates/app/src/code_surface/zoom.rs
@@ -300,7 +300,7 @@ mod code_zoom_tests {
             app.read_with(cx, |app, _| app.settings.appearance.editor_zoom_percent),
             AdeApp::ZOOM_DEFAULT_PERCENT,
             "resetting zoom - the toolbar value's own click affordance - must land exactly on \
-             100%, matching design_handoff_jerry_ade/revision/CHANGELOG.md's change 6"
+             100%"
         );
     }
 

--- a/crates/app/src/graph_view/mod.rs
+++ b/crates/app/src/graph_view/mod.rs
@@ -1,5 +1,4 @@
-//! The git graph tab (GitHub issue #1, phase (a) - design handoff
-//! `design_handoff_jerry_ade/revision 2/CHANGELOG.md`, 2026-07-31 entry).
+//! The git graph tab (GitHub issue #1, phase (a)). See `docs/design/work-surface.md`.
 //!
 //! Split the way every feature folder in this crate is split - see `crate::sidebar`'s own docs
 //! for the convention this mirrors:
@@ -55,7 +54,7 @@
 //! Agent-to-commit correlation (which agent
 //! authored a commit) is a
 //! separate, later feature too; a first draft carried an always-empty per-commit agent column
-//! for it, but `design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §6.2 removed that
+//! for it, but the design removed that
 //! column outright rather than leave it honestly empty - a commit belongs to a worktree, which
 //! can hold several agents, so pinning one agent's live status to a past commit was imprecise on
 //! its own terms, independent of whether the phase (a) data existed to fill it in. The row list

--- a/crates/app/src/graph_view/rebase_render.rs
+++ b/crates/app/src/graph_view/rebase_render.rs
@@ -58,7 +58,7 @@ impl gpui::Render for DraggedRebaseRow {
 /// exactly like every other keycap in the app. Each spec is the real, registered keystroke of the
 /// matching action in `crate::default_key_bindings` - `"P"`/`"S"`/`"D"` are shown uppercase (a
 /// keycap is a key, not a character) while the binding itself is the unmodified letter, the same
-/// way `Jerry.dc.html`'s own reference footer prints them.
+/// way the designed reference footer prints them.
 const REBASE_FOOTER_HINTS: [(&str, &str); 5] = [
     ("alt+\u{2191}\u{2193}", "reorder"),
     ("P", "pick"),

--- a/crates/app/src/graph_view/render.rs
+++ b/crates/app/src/graph_view/render.rs
@@ -2156,8 +2156,8 @@ impl AdeApp {
                     .text_color(theme::text::BODY)
                     .child(row.commit.subject.clone()),
             )
-            // The working-tree row's own union figure (GitHub issue #287) - `Jerry.dc.html`'s
-            // `Git graph` state carries `13 files · +319 −145` in this slot, between the subject
+            // The working-tree row's own union figure (GitHub issue #287) - the design carries
+            // `13 files · +319 −145` in this slot, between the subject
             // and the author column. Read straight off the uncommitted change set, so it is the
             // same number the Uncommitted section's header states rather than a second count of
             // the same working tree. A commit row has no note: what a commit changed is its own
@@ -3244,10 +3244,9 @@ fn render_graph_footer_action_button(
 /// One "Files changed" row - the change-row visual's spirit (git's own status letter + path),
 /// simplified since a historical commit has no review checkbox or per-file stat counts to show.
 ///
-/// The commit file list is the third of the three places `STAGE-A-CHANGELOG.md` §4j names as
-/// having carried the old word badge, and like the Uncommitted rows it is a *list*, so the letter
-/// sits in its fixed column ahead of the directory and every filename below it starts on the same
-/// x - `Jerry.dc.html`'s own `gFiles` rows, in that order.
+/// The commit file list is the third of the three places that carried the old word badge, and
+/// like the Uncommitted rows it is a *list*, so the letter sits in its fixed column ahead of the
+/// directory and every filename below it starts on the same x.
 fn render_graph_file_row(file: wt_core::graph::CommitFileChange) -> impl IntoElement {
     let (dir, name) = changes::split_dir_name(&file.path);
     let letter = changes::status_letter(file.status);

--- a/crates/app/src/graph_view/state.rs
+++ b/crates/app/src/graph_view/state.rs
@@ -142,8 +142,8 @@ pub(crate) struct GraphBranchMergeFacts {
 
 /// Whether the branch menu's "Merge into current branch…" row is live, and if not, the real
 /// reason - rendered *on the row itself*, dimmed and un-clickable, never a silent no-op (GitHub
-/// issue #241; `design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md` §1 rule 3: "disabled
-/// while anything is uncommitted, with the reason on the button itself").
+/// issue #241). The design's rule: "disabled while anything is uncommitted, with the reason on
+/// the button itself".
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum GraphBranchMergeGate {
     /// Every precondition holds. `current_branch` is the branch the merge would land in - the
@@ -180,9 +180,8 @@ impl GraphBranchMergeGate {
 /// The one place the graph decides whether "Merge into current branch…" may run (GitHub issue
 /// #241).
 ///
-/// The two *content* preconditions and their exact wording come straight from the design's own
-/// `mergeReady`/`mergeWhy` (`design_handoff_jerry_ade/revision 5/Jerry.dc.html`):
-/// `!uncommitted.length && !liveAgents.length`, reported as `N files still uncommitted` /
+/// The two *content* preconditions and their exact wording come straight from the design: no
+/// uncommitted files and no live agents, reported as `N files still uncommitted` /
 /// `N agents still working`. The structural ones ahead of them are this app's own: they describe
 /// states in which `wt_core::merge::attempt_merge_into_current` could not do anything meaningful
 /// at all, and each mirrors a real `wt_core::Error` variant that function would otherwise return

--- a/crates/app/src/hooks/event.rs
+++ b/crates/app/src/hooks/event.rs
@@ -73,8 +73,8 @@ pub const QUESTION_MAX_CHARS: usize = 200;
 /// Longest [`HookReport::prompt`] Jerry will keep - GitHub issue #227's run title.
 ///
 /// Narrower than [`QUESTION_MAX_CHARS`] and wider than [`ACTIVITY_MAX_CHARS`], because this is a
-/// *title*: `design_handoff_jerry_ade/revision 5/REVISION-2026-08-13.md` §3's history row shows it
-/// on one truncated line ("Reproduce the refresh race in a test"), and the transcript tab header
+/// *title*: a history row shows it on one truncated line ("Reproduce the refresh race in a
+/// test"), and the transcript tab header
 /// shows the same string. A user's first message can be a page long; the first sentence of it is
 /// what names the run.
 pub const PROMPT_MAX_CHARS: usize = 120;

--- a/crates/app/src/icons.rs
+++ b/crates/app/src/icons.rs
@@ -1,6 +1,6 @@
 //! The app's shipped icon set: real [Phosphor Icons](https://phosphoricons.com) SVGs (MIT),
 //! vendored under `assets/icons/`, plus the one render helper every consuming surface draws them
-//! through (GitHub issue #282, `design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md` §8).
+//! through (GitHub issue #282, `docs/design/decisions.md` §8).
 //!
 //! ## Why an asset, not another hand-drawn shape
 //!
@@ -229,10 +229,9 @@ impl Icon {
 }
 
 /// A named optical box: the one square every icon in a given row is drawn inside. Each variant is
-/// a real measurement off the reviewed mock (`design_handoff_jerry_ade/revision 5/Jerry.dc.html`),
-/// not a round number picked here - the surfaces these serve are being rebuilt against that file.
+/// a real designed measurement, not a round number picked here.
 ///
-/// Phosphor's canvas is square, so a box named here is square too. Where the mock's hand-drawn
+/// Phosphor's canvas is square, so a box named here is square too. Where the design's hand-drawn
 /// stand-in was slightly non-square (the segmented tabs' stated 11x10), the square box is the
 /// larger dimension, which is also what the mock's own markup really occupies - see
 /// [`IconSize::PanelTab`].
@@ -244,17 +243,17 @@ pub enum IconSize {
     /// magnifier 8x8, diff 7x7 - so three icons on one row had three weights". The mock's own
     /// shapes actually span y 3.5-14.5, i.e. 11x11; 11 is the box both readings agree on.
     PanelTab,
-    /// 13px - a row of the app's shared menu (`crate::menu`). `Jerry.dc.html`'s own context-menu
-    /// row draws its leading glyph in a `width:13px;height:13px` box.
+    /// 13px - a row of the app's shared menu (`crate::menu`), whose leading glyph sits in a
+    /// 13x13 box.
     MenuRow,
-    /// 14px - the work-surface tab strip's per-tab chip (`Jerry.dc.html`:
-    /// `width:14px;height:14px`), shared by every tab kind on that strip, terminal included.
+    /// 14px - the work-surface tab strip's per-tab chip, shared by every tab kind on that strip,
+    /// terminal included.
     TabChip,
-    /// 15px - the sidebar strip's buttons (`Jerry.dc.html`: each strip glyph sits in a
-    /// `position:relative;width:15px;height:15px` wrapper inside a 38px-wide cell).
+    /// 15px - the sidebar strip's buttons: each strip glyph sits in a 15x15 wrapper inside a
+    /// 38px-wide cell.
     Strip,
     /// 12px - the icon buttons: the search panel's count row (replace / filter) and the rail
-    /// footer's prune button. `Jerry.dc.html`'s `width:17px;height:17px` on these controls is the
+    /// footer's prune button. The designed 17px on these controls is the
     /// **hit box** (`theme::band::ICON_BUTTON_HIT`), not the glyph's own optical size - a
     /// distinction this size got wrong the first time round (GitHub issue filed 2026-08-16,
     /// screenshot-reported: "icons in buttons are too big"). The hand-drawn stand-ins actually
@@ -477,7 +476,7 @@ mod tests {
     ];
 
     #[test]
-    fn every_mapped_slot_from_the_design_handoff_has_its_phosphor_glyph() {
+    fn every_mapped_icon_slot_has_its_phosphor_glyph() {
         assert_eq!(
             MAPPING.len(),
             Icon::ALL.len(),
@@ -633,7 +632,7 @@ mod tests {
         assert_eq!(IconSize::PanelTab.box_size(), px(11.0));
         assert_eq!(IconSize::TabChip.box_size(), px(14.0));
         assert_eq!(IconSize::Strip.box_size(), px(15.0));
-        // 12, not 17 - `Jerry.dc.html`'s 17px on these controls is the surrounding hit box
+        // 12, not 17 - the designed 17px on these controls is the surrounding hit box
         // (`theme::band::ICON_BUTTON_HIT`); the funnel/trash hand-drawn glyphs inside it only
         // really occupy up to 11x7 and 9x12 respectively. See `IconSize::Control`'s doc comment.
         assert_eq!(IconSize::Control.box_size(), px(12.0));

--- a/crates/app/src/keymap.rs
+++ b/crates/app/src/keymap.rs
@@ -98,9 +98,8 @@ fn detected_platform_is_macos() -> bool {
     std::env::consts::OS == "macos"
 }
 
-/// The two-column glyph table `design_handoff_jerry_ade/README.md`'s "Keyboard affordances"
-/// section describes: `mod alt ctrl shift enter esc tab bksp` on macOS vs. Windows/Linux.
-/// Transcribed from `Jerry.dc.html`'s own `KEYMAPS` fixture.
+/// The two-column glyph table (`docs/design/vocabulary.md`): `mod alt ctrl shift enter esc tab
+/// bksp` on macOS vs. Windows/Linux.
 struct KeymapTable {
     modifier: &'static str,
     alt: &'static str,
@@ -136,8 +135,7 @@ const WINDOWS_LINUX_TABLE: KeymapTable = KeymapTable {
 
 /// Resolves one spec token (`"mod"`, `"shift"`, ...) to its platform glyph, or returns the
 /// token unchanged if it isn't one of the eight recognized modifier/key names - a bare letter
-/// (`"N"`, `"K"`) or a decorative placeholder (`"1…8"`) passes straight through unresolved,
-/// matching `Jerry.dc.html`'s own `combo(spec)`.
+/// (`"N"`, `"K"`) or a decorative placeholder (`"1…8"`) passes straight through unresolved.
 pub fn resolve_token(token: &str, macos: bool) -> String {
     let table = if macos {
         &MACOS_TABLE

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -354,10 +354,9 @@ pub fn default_key_bindings() -> Vec<gpui::KeyBinding> {
             root::ToggleChangeSeen,
             Some("diff && !file-editor && !text-input"),
         ),
-        // `design_handoff_jerry_ade/revision 5/Jerry.dc.html`'s own `changesHints` (line 4548):
-        // `[['space', 'stage'], ['V', 'mark seen'], ['⌥click', 'filter by author']]` - three
-        // keycap hints on the Changes panel's footer, of which `space stage` was the one with no
-        // binding behind it at all. `STAGE-A-CHANGELOG.md` §2's ride-along I10 lists the same
+        // The Changes panel's footer carries three keycap hints - `space stage`, `V mark seen`,
+        // `⌥click filter by author` - of which `space stage` was the one with no
+        // binding behind it at all. An audit item lists the same
         // strip.
         //
         // Scoped exactly like `v` above and `]` above that, and its subject is the same one

--- a/crates/app/src/lsp/completion.rs
+++ b/crates/app/src/lsp/completion.rs
@@ -405,9 +405,8 @@ fn kind_has_no_one_word_type(kind: Option<lsp_types::CompletionItemKind>) -> boo
     )
 }
 
-/// The Completions detail pane's own real signature line (its top band, syntax-highlighted in
-/// mono - `design_handoff_jerry_ade/revision 3/Jerry.dc.html`'s `fn push_str(&mut self, string:
-/// &str)` example) - the same [`CompletionDetail::signature`] [`completion_item_display`] reads
+/// The Completions detail pane's own real signature line - its top band, syntax-highlighted in
+/// mono - the same [`CompletionDetail::signature`] [`completion_item_display`] reads
 /// (see [`split_completion_detail`]'s own docs for why `label_details.detail` is deliberately not
 /// consulted here), falling back to the bare `label` for an item with no real
 /// detail at all (a bare `label`/`kind`-only item that hasn't been resolved yet, or a server that
@@ -476,10 +475,9 @@ fn strip_leading_kind_parenthetical(detail: &str) -> &str {
     }
 }
 
-/// A completion item's real doc prose, for the detail pane's own body text
-/// (`design_handoff_jerry_ade/revision 3/README.md`: "Right 300: signature in mono, doc in 11px
-/// Plex Sans #7d848b, module path footer" - the Completions popup's own doc/module-path pane,
-/// mirroring `crate::lsp::hover::HoverRenderModel::doc` exactly). `None` for an item with no real
+/// A completion item's real doc prose, for the detail pane's own body text - the Completions
+/// popup's own doc/module-path pane, mirroring `crate::lsp::hover::HoverRenderModel::doc`
+/// exactly. `None` for an item with no real
 /// documentation - an honest "nothing to show", never a fabricated empty string.
 ///
 /// Reuses [`crate::lsp::hover::degrade_markdown_to_plain_text`] for a genuinely `Markdown`-kinded
@@ -571,9 +569,8 @@ pub fn completion_row_hint(item: &lsp_types::CompletionItem) -> Option<String> {
     completion_import_source(item).or_else(|| split_completion_detail(item).signature)
 }
 
-/// The Completions popup's real kind-badge category (design:
-/// `design_handoff_jerry_ade/revision/Jerry.dc.html`'s own `f`/`v`/`t` kind badges, lines
-/// ~1792-1793 and ~467-473) - a coarse grouping of the much finer-grained real
+/// The Completions popup's real kind-badge category - the design's own `f`/`v`/`t` badges, a
+/// coarse grouping of the much finer-grained real
 /// `lsp_types::CompletionItemKind` a server actually reports, kept here (not in
 /// `crate::lsp::completion_popup`) so the mapping is testable without a live `gpui` window, matching
 /// this module's own gpui-free convention (see this module's own top docs).

--- a/crates/app/src/lsp/completion_popup.rs
+++ b/crates/app/src/lsp/completion_popup.rs
@@ -37,10 +37,9 @@
 //! An audit for that issue flagged this popover's `theme::surface::POPOVER` background,
 //! `theme::radius::CARD_SM` (5px) corner radius, and `theme::shadow::POPOVER` shadow as
 //! inconsistent with the `theme::surface::PALETTE`/`theme::radius::CARD`/`theme::shadow::MENU`
-//! recipe every dropdown/context-menu in the app now shares. They're not drift: each value is
-//! pinned to `design_handoff_jerry_ade/Jerry.dc.html`'s own completions-popup markup (line ~406 -
-//! `border-radius:5px;background:#181c20;box-shadow:0 8px 20px rgba(0,0,0,.5)`), which specifies
-//! a genuinely different recipe from the app-level menus for this specific surface. Left
+//! recipe every dropdown/context-menu in the app now shares. They're not drift: the design
+//! specifies a genuinely different recipe from the app-level menus for this specific surface, and
+//! this is it. Left
 //! unchanged, along with `crate::code_surface::lsp_ui`'s hover card, which intentionally matches
 //! it (same `theme::surface::POPOVER`/`theme::border::POPOVER` pair, plus every plain tooltip via
 //! `crate::root::widgets::TextTooltip`) - all three are the "info popover" family, not the "menu"
@@ -117,22 +116,18 @@ impl CompletionsStatus {
     }
 }
 
-/// 290px - the design mockup's own real completions-list column width
-/// (`design_handoff_jerry_ade/revision 3/Jerry.dc.html`: `width:290px` on the list column), plus
-/// its own `1px` right divider. Design-review follow-up: this used to be the popup's *entire*
+/// 290px - the designed completions-list column width, plus its own `1px` right divider. Design-review follow-up: this used to be the popup's *entire*
 /// width, with the detail pane below left out of scope entirely (see [`DETAIL_WIDTH`]'s own docs
 /// for why that was a real, addressable gap rather than a permanent one).
 const LIST_WIDTH: gpui::Pixels = gpui::px(290.0);
-/// 300px - the design mockup's own real signature/doc/module-path detail pane width
-/// (`Jerry.dc.html`: `width:300px` on the right column), shown alongside [`LIST_WIDTH`] only
-/// while [`CompletionsStatus::Ready`] has a real selected item to describe - `Loading`/`Failed`
-/// show the list column alone, since neither has anything real for a detail pane to describe.
-/// `README.md`'s own summary confirms this is core to "the differentiator" three-popup language
-/// server UI ("Right 300: signature in mono, doc in 11px Plex Sans #7d848b, module path
-/// footer"), not optional polish - this was a real, previously undocumented-to-the-user scope
-/// cut, not a deliberate permanent simplification.
+/// 300px - the designed signature/doc/module-path detail pane width, shown alongside
+/// [`LIST_WIDTH`] only while [`CompletionsStatus::Ready`] has a real selected item to describe -
+/// `Loading`/`Failed` show the list column alone, since neither has anything real for a detail
+/// pane to describe. The detail pane is core to the three-popup language-server UI
+/// (`docs/design/work-surface.md`), not optional polish - leaving it out was a real scope cut,
+/// not a deliberate permanent simplification.
 const DETAIL_WIDTH: gpui::Pixels = gpui::px(300.0);
-/// The design mockup's own real completion-item row height (`Jerry.dc.html`: `height:22px`).
+/// The designed completion-item row height.
 /// `uniform_list`'s one real requirement is that every row is exactly this tall - see
 /// [`AdeApp::render_completions_popover`]'s own docs.
 const POPOVER_ROW_HEIGHT: gpui::Pixels = gpui::px(22.0);
@@ -142,9 +137,9 @@ const POPOVER_ROW_HEIGHT: gpui::Pixels = gpui::px(22.0);
 /// judgment every other real editor makes here - `vendor/zed/crates/editor`'s own completions
 /// menu defaults to 12 lines too (`max_height_in_lines`), as does VS Code's.
 const MAX_VISIBLE_COMPLETION_ROWS: usize = 12;
-/// The popover's own real `py(3.0)` top/bottom padding, as a single vertical total - the design
-/// mockup's own completions-list column padding is `3px 0` (`Jerry.dc.html`: `padding:3px 0` on
-/// the `290px` list column), so the popup is exactly this much taller than its list.
+/// The popover's own real `py(3.0)` top/bottom padding, as a single vertical total - the
+/// designed completions-list column padding is `3px 0`, so the popup is exactly this much taller
+/// than its list.
 const POPOVER_VERTICAL_PADDING: gpui::Pixels = gpui::px(6.0);
 /// The popover's own real `border_1()`, top plus bottom. GPUI lays out border-box, so this counts
 /// toward the popup's painted height and therefore toward its own `max_h` - leaving it out of
@@ -680,10 +675,9 @@ impl AdeApp {
             .w(LIST_WIDTH)
             .flex()
             .flex_col()
-            // `py(3.0)`, not `py(4.0)`: the design mockup's own completions-list column padding
-            // is `3px 0` (`Jerry.dc.html`: `padding:3px 0` on the `290px` list column) - see
-            // `POPOVER_VERTICAL_PADDING`'s own docs, which restate the same `3px 0` as one
-            // vertical total.
+            // `py(3.0)`, not `py(4.0)`: the designed completions-list column padding is `3px 0`
+            // - see `POPOVER_VERTICAL_PADDING`'s own docs, which restate it as one vertical
+            // total.
             .py(gpui::px(3.0));
 
         // The selected item, if any - drives the detail pane below. Read once, outside the
@@ -715,9 +709,8 @@ impl AdeApp {
                 selected_item = visible
                     .get(*selected)
                     .and_then(|index| self.described_completion_item(items, *index));
-                // `border-right:1px solid #23282c` in the mockup, on the list column's own right
-                // edge (`Jerry.dc.html`: `width:290px;border-right:1px solid #23282c`) - only
-                // while there's a real detail pane beside it to divide from.
+                // The seam lives on the list column's own right edge - only while there's a real
+                // detail pane beside it to divide from.
                 if selected_item.is_some() {
                     list_column = list_column.border_r_1().border_color(theme::border::CARD);
                 }
@@ -888,18 +881,16 @@ impl AdeApp {
             .bg(theme::surface::POPOVER)
             .border_1()
             .border_color(theme::border::POPOVER)
-            // `CARD_SM` (`5px`), not `CARD` (`6px`) - the design mockup's own completions popup
-            // border-radius is `5px` (`Jerry.dc.html`: `border-radius:5px` on the popup itself),
+            // `CARD_SM` (`5px`), not `CARD` (`6px`) - the designed completions popup radius,
             // matching `crate::code_surface::lsp_ui::AdeApp::render_hover_card`'s own popover,
             // which already used the correct radius here.
             .rounded(theme::radius::CARD_SM)
             .shadow(vec![BoxShadow::new(
                 shadow_x,
                 shadow_y,
-                // `0.50`, not `0.55` - the design mockup's own completions popup shadow is
-                // `rgba(0,0,0,.5)` (`Jerry.dc.html`: `box-shadow:0 8px 20px rgba(0,0,0,.5)`),
-                // matching `theme::shadow::POPOVER`'s own doc comment, which already recorded
-                // the correct `0.50` even though this call site had drifted from it.
+                // `0.50`, not `0.55` - the designed completions popup shadow, matching
+                // `theme::shadow::POPOVER`'s own doc comment, which already recorded the correct
+                // `0.50` even though this call site had drifted from it.
                 gpui::black().opacity(0.50),
             )
             .blur_radius(shadow_blur)])
@@ -912,10 +903,9 @@ impl AdeApp {
             .occlude()
             .child(list_column);
 
-        // The detail pane - `border-right` lives on the list column's own right edge in the
-        // mockup (`Jerry.dc.html`: `border-right:1px solid #23282c` on the 290px list), so it's
-        // applied to `list_column` above only when there's a real detail pane beside it to
-        // divide from; a lone list column (Loading/Failed) has no seam to draw.
+        // The detail pane - the seam lives on the list column's own right edge, so it's applied
+        // to `list_column` above only when there's a real detail pane beside it to divide from;
+        // a lone list column (Loading/Failed) has no seam to draw.
         if let Some(item) = selected_item {
             popover = popover.child(self.render_completion_detail_pane(item, extension, cx));
         }
@@ -951,8 +941,7 @@ fn render_completion_row(
         .flex_none()
         .w_full()
         .h(POPOVER_ROW_HEIGHT)
-        // `px(8.0)`, not `px(10.0)` - the design mockup's own completion-item row padding is
-        // `0 8px` (`Jerry.dc.html`: `padding:0 8px` on each `.completions` row).
+        // `px(8.0)`, not `px(10.0)` - the designed completion-item row padding is `0 8px`.
         .px(gpui::px(8.0))
         .flex()
         .items_center()
@@ -1030,8 +1019,7 @@ fn render_completion_row(
 }
 
 /// A real completion item's kind badge - a 13x13 box with a one-letter glyph, colored per
-/// [`completion_view::CompletionKindBadge`] - matches the design mockup's own kind-badge markup
-/// exactly (`Jerry.dc.html`: `width:13px;height:13px;border-radius:2px` with `font:500 8px`).
+/// [`completion_view::CompletionKindBadge`] - the designed 13x13 kind badge exactly.
 fn render_completion_kind_badge(kind: completion_view::CompletionKindBadge) -> gpui::AnyElement {
     let (fg, bg) = match kind {
         completion_view::CompletionKindBadge::Function => theme::completions_popup::KIND_FUNCTION,
@@ -1056,8 +1044,7 @@ fn render_completion_kind_badge(kind: completion_view::CompletionKindBadge) -> g
 }
 
 impl AdeApp {
-    /// The Completions popup's own detail pane - the design mockup's real, 300px right column
-    /// (`design_handoff_jerry_ade/revision 3/Jerry.dc.html`: `width:300px;padding:8px 10px`),
+    /// The Completions popup's own detail pane - the designed 300px right column,
     /// describing whichever item is currently selected: a syntax-highlighted signature line, doc
     /// prose, and a module-path footer - mirroring `crate::code_surface::lsp_ui`'s Hover card
     /// exactly (same three-piece shape, same reasoning for showing it), just for the selected
@@ -1645,10 +1632,8 @@ mod completions_scroll_tests {
 }
 
 /// Regression coverage for the design-review follow-up: the Completions popup used to be a
-/// list-only single column - `design_handoff_jerry_ade/revision 3/Jerry.dc.html`'s own mockup
-/// (and `README.md`'s "Right 300: signature in mono, doc in 11px Plex Sans #7d848b, module path
-/// footer") describes a real two-column popup with a detail pane and a footer hint row, neither
-/// of which existed before this fix. These tests prove the real painted layout, not just that
+/// list-only single column, where the design describes a real two-column popup with a detail
+/// pane and a footer hint row, neither of which existed before this fix. These tests prove the real painted layout, not just that
 /// the new code compiles and runs.
 #[cfg(test)]
 mod completion_detail_pane_tests {

--- a/crates/app/src/lsp/diagnostics.rs
+++ b/crates/app/src/lsp/diagnostics.rs
@@ -1,11 +1,11 @@
-//! Pure logic for Surface C's File view *Diagnostic* state (`design_handoff_jerry_ade/
-//! README.md`'s "Language server UI" subsection): turns a `Vec<lsp_types::Diagnostic>` (as
+//! Pure logic for Surface C's File view *Diagnostic* state (`docs/design/work-surface.md`'s
+//! language-server UI): turns a `Vec<lsp_types::Diagnostic>` (as
 //! published by `rust-analyzer` via `lsp_core::LspClient::diagnostics_for`) into per-line,
 //! byte-range-addressed data `crate::root`'s renderer draws a dotted underline/row tint/inline
 //! message/card from. Deliberately `gpui`-window-free, mirroring `crate::code_surface::code_view`'s split
 //! between pure logic and `crate::root`'s `Div` construction.
 //!
-//! Completions and Hover (`design_handoff_jerry_ade/README.md`'s `lsp_popup` state) are out of
+//! Completions and Hover - the other two `lsp_popup` states - are out of
 //! scope here - `lsp_core::LspClient`'s generic `request`/`notify` methods are equally usable
 //! for those later; only this module's mapping logic is diagnostics-specific.
 

--- a/crates/app/src/lsp/hover.rs
+++ b/crates/app/src/lsp/hover.rs
@@ -1,5 +1,5 @@
-//! Pure logic for Surface C's File view *Hover* state (`design_handoff_jerry_ade/README.md`'s
-//! "Language server UI" subsection) - turns an `lsp_types::Hover` response (returned by
+//! Pure logic for Surface C's File view *Hover* state (`docs/design/work-surface.md`'s
+//! language-server UI) - turns an `lsp_types::Hover` response (returned by
 //! `rust-analyzer` via `lsp_core::LspClient::request`, see `crate::root::AdeApp::request_hover`)
 //! into a render model `crate::root` draws a signature/doc/module-path card from, plus the
 //! position-encoding helper the hover trigger needs to build that request. Deliberately
@@ -8,7 +8,7 @@
 //!
 //! ## Completions are out of scope
 //!
-//! `design_handoff_jerry_ade/README.md`'s `lsp_popup` state also covers `Completions`, not built
+//! The `lsp_popup` state also covers `Completions`, not built
 //! here. The design's Completions popup assumes an editable caret mid-edit (`⏎ accept` inserts
 //! the selected candidate) - `crate::code_surface::code_view`'s File view is read-only, with no caret and no
 //! text insertion, so a Completions popup would show real candidates with no way to accept one:
@@ -110,7 +110,7 @@ pub fn position_for_line_byte_offset(
 /// this module's top-level docs for how [`build_hover_render_model`] derives these three fields.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HoverRenderModel {
-    /// The crate/module path prefix (`design_handoff_jerry_ade/README.md`: "`core::convert`"),
+    /// The crate/module path prefix (e.g. `core::convert`),
     /// when the hovered symbol is path-qualified and rust-analyzer's response included one -
     /// `None` for a local/parameter/literal/anything else with no module path.
     pub module_path: Option<String>,
@@ -591,9 +591,8 @@ pub fn build_hover_render_model(hover: &lsp_types::Hover) -> Option<HoverRenderM
 /// Picks the first usable `(Uri, Range)` out of an `lsp_types::GotoDefinitionResponse`, an
 /// untagged three-way union per the LSP spec (a single `Location`, a `Vec<Location>`, or a
 /// `Vec<LocationLink>`) - `lsp_core::client`'s end-to-end definition test observes rust-analyzer
-/// replying with the `Array` shape for a call-site query. Only the *first* location is used:
-/// `design_handoff_jerry_ade/README.md`'s `F12 definition` footer navigates to one place, not a
-/// disambiguation list. `Range` (not just a line number) is returned so the caller can navigate
+/// replying with the `Array` shape for a call-site query. Only the *first* location is used: the
+/// hover card's `F12 definition` footer navigates to one place, not a disambiguation list. `Range` (not just a line number) is returned so the caller can navigate
 /// without a second lookup, even though `crate::root::AdeApp::trigger_goto_definition` only uses
 /// `range.start.line`.
 pub fn first_definition_location(

--- a/crates/app/src/menu/mod.rs
+++ b/crates/app/src/menu/mod.rs
@@ -1,8 +1,8 @@
 //! The app's one shared menu (GitHub issue #290): the popover every "list of actions" surface
 //! draws, and the pure model behind it.
 //!
-//! `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4t states the reason for the
-//! folder existing at all, verbatim: "Two requests, one build: right-click actions on rail rows,
+//! The design states the reason for the folder existing at all, verbatim: "Two requests, one
+//! build: right-click actions on rail rows,
 //! and History moved into an overflow. Both are 'a list of actions', so they are **one menu
 //! component** - 206 wide, 24px rows, keycaps right-aligned, destructive rows in `#c4726d` on a
 //! `#2a1719` hover - rather than two idioms that drift."

--- a/crates/app/src/menu/model.rs
+++ b/crates/app/src/menu/model.rs
@@ -7,9 +7,8 @@
 //! tree's own `crate::sidebar::context_menu`, which is where all of this was written first; this
 //! module is that model with its file-tree specifics (a `ContextTarget`, a fixed `MenuAction`
 //! enum) lifted out into the generic [`MenuEntry<A>`], so the file tree, the rail's row menus and
-//! the sidebar strip's `⋯` overflow are one component rather than three that drift
-//! (`design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4t: "Both are 'a list of
-//! actions', so they are **one menu component**").
+//! the sidebar strip's `⋯` overflow are one component rather than three that drift - "Both are
+//! 'a list of actions', so they are **one menu component**".
 //!
 //! `A` is the caller's own action payload - `crate::sidebar::context_menu::MenuAction` for the
 //! tree, `crate::rail::menu::RailMenuAction` for the rail. Everything the popover *draws* (label,
@@ -160,7 +159,7 @@ pub const MENU_EDGE_MARGIN: f32 = 4.0;
 pub const MENU_BORDER: f32 = 2.0;
 
 /// The gap the `⋯` overflow menu leaves between the button it hangs off and its own top edge, in
-/// px (`Jerry.dc.html`'s own `br.bottom + 4`).
+/// px.
 pub const MENU_ANCHOR_GAP: f32 = 4.0;
 
 /// The popover's real painted height for exactly the `rows` it is about to paint - action rows

--- a/crates/app/src/palette/render.rs
+++ b/crates/app/src/palette/render.rs
@@ -794,10 +794,8 @@ impl AdeApp {
             )
     }
 
-    /// A 1.5×16 bar at the palette input's real insertion point - matching `Jerry.dc.html`'s own
-    /// `paletteEmpty`/`paletteTyped` fixture (`design_handoff_jerry_ade/revision/Jerry.dc.html`),
-    /// which renders the identical two-position caret rather than a fixed one, so this isn't a
-    /// new invention. `margin_right`/`margin_left` place it on whichever side of the text it sits
+    /// A 1.5×16 bar at the palette input's real insertion point - the design renders the
+    /// identical two-position caret rather than a fixed one, so this isn't a new invention. `margin_right`/`margin_left` place it on whichever side of the text it sits
     /// on: before the placeholder (empty query) or after the real typed text (non-empty).
     /// The palette's input row: scope-prefix glyph, typed query (or its placeholder), a caret at
     /// the real insertion point, and the clickable segmented scope control.
@@ -805,8 +803,7 @@ impl AdeApp {
     /// The caret used to be a fixed bar rendered unconditionally *after* the text/placeholder,
     /// which read as a UI artefact rather than a real insertion-point indicator (the design
     /// audit's own wording). It now sits before the placeholder while the query is empty, and
-    /// immediately after the real typed text once something has been entered - matching
-    /// `Jerry.dc.html`'s own two-position fixture.
+    /// immediately after the real typed text once something has been entered.
     ///
     /// In a drill-down step the placeholder states the question being asked and the segmented
     /// scope control is dropped: scopes filter the root list's three candidate kinds, and a step
@@ -842,8 +839,7 @@ impl AdeApp {
             )
             // GitHub issue #336: through the one helper that owns this structure, like every
             // other simple input in the app. The palette keeps its own caret *metrics* (16px
-            // tall, 3px before the placeholder, 2px after the typed text -
-            // `Jerry.dc.html`'s own `paletteEmpty`/`paletteTyped` fixture) through
+            // tall, 3px before the placeholder, 2px after the typed text) through
             // `SimpleInputCaret`, which is exactly why that type exists. What it gains is a caret
             // that follows `TextField::caret` instead of sitting at the end of the query
             // regardless, a real selection highlight, and real click/drag/double-click selection.

--- a/crates/app/src/palette/state.rs
+++ b/crates/app/src/palette/state.rs
@@ -622,7 +622,7 @@ pub fn build_language_server_groups(
 ///
 /// **`Agents` and `Terminals` are two groups, not one** (GitHub issue #381). Both are open panes
 /// and both are worth switching to by name, but a plain `ProcessKind::Shell` is not an agent -
-/// `Jerry.dc.html` has never counted the terminal among a worktree's `agents`, and filing a shell
+/// the design has never counted a terminal among a worktree's agents, and filing a shell
 /// under a heading that reads `Agents` told the user the opposite of what the rest of the app
 /// (the rail, which gives a shell no agent row at all; the pane chrome, which draws a shell a
 /// different bottom bar) tells them. Splitting rather than filtering is deliberate: the palette

--- a/crates/app/src/provenance/change_set.rs
+++ b/crates/app/src/provenance/change_set.rs
@@ -10,7 +10,7 @@
 //! > it be staged twice, and suppress the `⚠` shared-file ring entirely, because nothing then has
 //! > two authors.
 //! >
-//! > — `design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md` §1
+//! > — the design's own rule for a shared worktree
 //!
 //! [`ChangeSet`] enforces that structurally rather than by convention: it is built through a map
 //! keyed by path, so a second row for one path is not a thing that can be constructed. A diff
@@ -373,9 +373,8 @@ mod tests {
     use crate::provenance::store::ProvenanceStore;
     use crate::sidebar::changes::diff_file_stats;
 
-    /// The base content of the mock's shared file, as committed - the `Review · uncommitted`
-    /// fixture from `design_handoff_jerry_ade/revision 5/Jerry.dc.html` (`changeSets.s3` →
-    /// `src/api/users.rs`), reduced to the lines its hunks actually show.
+    /// The base content of the design's shared file, as committed - its `Review · uncommitted`
+    /// example (`src/api/users.rs`), reduced to the lines its hunks actually show.
     const USERS_RS_BASE: &str = "\
 impl UserApi {
     pub async fn list(&self, page: Page) -> Result<Vec<User>> {
@@ -700,8 +699,8 @@ impl UserApi {
             "and the human's own hand edit flipped that line back to `you` (Orca's second rule)"
         );
 
-        // Context lines are nobody's. `Jerry.dc.html` gives its unchanged rows no author at all,
-        // and painting one would tint a line this diff does not change.
+        // Context lines are nobody's. The design gives its unchanged rows no author at all, and
+        // painting one would tint a line this diff does not change.
         for (hunk, hunk_authors) in file.hunks.iter().zip(&authors) {
             for (line, author) in hunk.lines.iter().zip(hunk_authors) {
                 if line.kind == DiffLineKind::Context {

--- a/crates/app/src/provenance/mod.rs
+++ b/crates/app/src/provenance/mod.rs
@@ -16,8 +16,8 @@
 //! record of that at all, because both agents write through the same working tree as the same OS
 //! user.
 //!
-//! The competitive audit (`design_handoff_jerry_ade/revision 5/AUDIT-2026-08-13-competitive-v2.md`
-//! §3.1) found the closest shipped mechanism to be binary - AI or human - and concluded that
+//! A competitive audit found the closest shipped mechanism to be binary - AI or human - and
+//! concluded that
 //! "per-agent attribution inside a shared worktree is genuinely unclaimed… the one thing Jerry's
 //! architecture is uniquely positioned to do". This folder is that mechanism.
 //!

--- a/crates/app/src/provenance/render.rs
+++ b/crates/app/src/provenance/render.rs
@@ -68,8 +68,7 @@ use crate::work_surface;
 use crate::work_surface::agents::ProcessKind;
 
 /// How far a line that is **not** the filtered author's is dimmed while a per-author filter is
-/// active - `Jerry.dc.html`'s own `opacity: .32`, quoted as an acceptance criterion by GitHub
-/// issue #287 ("other authors' lines dim (the mock uses 0.32 opacity)").
+/// active - the designed 0.32 opacity, an acceptance criterion of GitHub issue #287.
 ///
 /// Dimmed, never hidden: the lines around a filtered author's work are what make it legible as a
 /// change, and removing them would turn a filter into a different, much less honest diff.
@@ -136,8 +135,8 @@ fn agent_tint_of(key: &AgentKey) -> Option<(Rgba, Rgba)> {
 /// The colour of `author`'s gutter bar, or `None` for a line that carries no bar at all.
 ///
 /// `you` deliberately does **not** take [`AuthorStyle::fg`] here: the chip's glyph has to read
-/// against its own fill, while the bar is a 2px stripe against the diff's background, and
-/// `Jerry.dc.html` gives the two different values (`#8b9197` and `#4e545a`). An agent's bar and
+/// against its own fill, while the bar is a 2px stripe against the diff's background, and the
+/// design gives the two different values. An agent's bar and
 /// chip glyph are one value, because its own tint already is.
 pub fn author_gutter_color(author: &Author) -> Option<Rgba> {
     match author {
@@ -150,8 +149,7 @@ pub fn author_gutter_color(author: &Author) -> Option<Rgba> {
 /// The sentence a gutter bar's, or a chip's, tooltip states - `None` for an author that is not
 /// drawn at all, which therefore has no tooltip either.
 ///
-/// `STAGE-A-CHANGELOG.md` §1 gives `you`'s wording outright; an agent's is its own name, which is
-/// what `Jerry.dc.html`'s `attrOf` puts in the same slot.
+/// `you`'s wording is the design's own; an agent's is simply its own name.
 pub fn author_tooltip(author: &Author) -> Option<String> {
     match author {
         Author::You => Some("you \u{2014} hand edit".to_string()),
@@ -161,7 +159,8 @@ pub fn author_tooltip(author: &Author) -> Option<String> {
 
 /// Whether one diff line is dimmed to [`FILTER_DIM_OPACITY`] by an active per-author filter.
 ///
-/// `Jerry.dc.html`'s own predicate, kept exactly: `muted = attr && who && who !== attr`. Three
+/// The designed predicate, kept exactly: a line is muted when a filter is active, the line has
+/// an author, and that author is not the filtered one. Three
 /// things follow from it, and all three are load-bearing rather than incidental:
 ///
 /// - **No filter, nothing dims.** A diff at rest is one flat, honest surface.
@@ -186,7 +185,7 @@ pub fn line_is_dimmed(author: Option<&Author>, filter: Option<&Author>) -> bool 
 pub const SHARED_RING_TOOLTIP: &str =
     "Two agents edited this file \u{2014} click to filter the diff by author";
 
-/// The filter indicator's tooltip, verbatim from `Jerry.dc.html`'s own `title=`.
+/// The filter indicator's tooltip, verbatim from the design.
 pub const FILTER_INDICATOR_TOOLTIP: &str =
     "Showing one author's lines \u{2014} click to show every author";
 
@@ -489,7 +488,7 @@ impl AdeApp {
         let author = self.active_author_filter()?;
         let style = author_style(author)?;
         let dot = author_gutter_color(author)?;
-        // `your lines only` rather than `you only` - `Jerry.dc.html`'s own `attrFilterLabel`.
+        // `your lines only` rather than `you only` - the design's own wording.
         let label = match author {
             Author::You => "your lines".to_string(),
             _ => style.label.clone(),
@@ -681,7 +680,8 @@ mod tests {
         );
     }
 
-    /// `Jerry.dc.html`'s `muted = attr && who && who !== attr`, all four arms.
+    /// The mute predicate - filter active, line authored, author not the filtered one - all four
+    /// arms.
     #[test]
     fn a_filter_dims_other_authors_lines_and_nothing_else() {
         let claude = agent(AgentKind::Claude);
@@ -746,11 +746,12 @@ mod tests {
     }
 }
 
-/// The mock's shared-file sad path, rendered for real (GitHub issue #287's acceptance criteria).
+/// The design's shared-file sad path, rendered for real (GitHub issue #287's acceptance
+/// criteria).
 ///
-/// > `Jerry.dc.html`'s `Review · uncommitted` state, `src/api/users.rs`: the row shows the `⚠`
-/// > ring and **three author chips** […]; the open diff shows **three distinct gutter tints, one
-/// > of which is the neutral hand-edit tint**.
+/// > A file two agents both edited shows the `⚠` ring and **three author chips** on its row;
+/// > the open diff shows **three distinct gutter tints, one of which is the neutral hand-edit
+/// > tint**.
 ///
 /// Everything below is built from real parts: a real git repo, real agent sessions in it, real
 /// provenance recorded through the store's own `PreToolUse`/write/`PostToolUse` sequence, and a

--- a/crates/app/src/rail/menu.rs
+++ b/crates/app/src/rail/menu.rs
@@ -2,8 +2,7 @@
 //! and the `⋯` overflow each offer, and what running one of those rows means.
 //!
 //! GPUI-free, like every other `state`-shaped module in this folder - the row sets are exactly
-//! what `design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md` §4 lists, so they are worth
-//! asserting directly, without a window. [`crate::rail::menu_render`] is the `impl AdeApp` half:
+//! what the design lists, so they are worth asserting directly, without a window. [`crate::rail::menu_render`] is the `impl AdeApp` half:
 //! opening these menus off a real right-click, and running the actions below.
 //!
 //! Every row is drawn by the app's one shared menu ([`crate::menu`]) - this module only decides
@@ -209,9 +208,9 @@ pub fn agent_menu_groups(running: bool) -> Vec<Vec<MenuEntry<RailMenuAction>>> {
 ///
 /// It does, as of GitHub issue #227: [`crate::rail::strip::SidebarView::History`] is a real
 /// sidebar view - the repo → worktree → run index, with its own scope toggle and its own
-/// run-transcript centre tab - reached through this overflow rather than through a cell, per
-/// `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4t ("a permanent cell in a 5-cell
-/// strip is a claim that you switch to it constantly. If you don't, it belongs in the overflow").
+/// run-transcript centre tab - reached through this overflow rather than through a cell: "a
+/// permanent cell in a 5-cell strip is a claim that you switch to it constantly. If you don't, it
+/// belongs in the overflow".
 ///
 /// Kept as a named constant rather than collapsed into an ungated row: the row that reads it, the
 /// reason it would show while disabled, and this fact are one thing, and §7 rule 1 ("Ship the

--- a/crates/app/src/rail/menu_render.rs
+++ b/crates/app/src/rail/menu_render.rs
@@ -385,8 +385,8 @@ impl AdeApp {
     /// stop-gap rail header it was parked in and into the sidebar strip that was always its home,
     /// where it goes through `crate::rail::strip_render::strip_cell` like every other child - so
     /// it carries the column rule, the 38px width and the glyph-only hover the rest of the strip
-    /// does. `Jerry.dc.html` gives it a `border-left` (rather than the view cells' `border-right`)
-    /// because it sits on the far side of the strip's flex spacer.
+    /// does. It carries a `border-left` rather than the view cells' `border-right`, because it
+    /// sits on the far side of the strip's flex spacer.
     ///
     /// None of the menu machinery below changed in that move, exactly as this comment promised it
     /// would not: a `gpui::canvas` still captures the button's real window-space rect (the same

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -37,10 +37,8 @@ fn agent_state_word(status: Status) -> &'static str {
 /// How many agents in this window are waiting on a human - the Worktrees cell's state marker
 /// (GitHub issue #291).
 ///
-/// `REVISION-2026-08-13.md` §1 names the unit outright ("worktrees shows agents needing a human")
-/// and `Jerry.dc.html` computes exactly it:
-/// `sessions.filter(s => s.status === 'ask' || s.status === 'fail').length`. Those are this app's
-/// [`Status::Ask`] and [`Status::Fail`].
+/// The unit is *agents needing a human* - this app's [`Status::Ask`] and [`Status::Fail`], and
+/// nothing else.
 ///
 /// A filter over [`rail::urgency_counts`]' one real pass, not a second classification - the same
 /// relationship `crate::title_bar::render::title_bar_agent_state_chips` already has to it, so the
@@ -74,7 +72,7 @@ fn agent_trailing_text(agent: &AgentRow) -> String {
     }
 }
 
-/// An agent row's title colour (`STAGE-A-CHANGELOG.md` §4n, `Jerry.dc.html`'s own `titleFg`).
+/// An agent row's title colour.
 ///
 /// Three states, in order: the globally active agent is [`theme::text::SELECTED`]; an
 /// [`Status::Idle`] one drops to [`theme::text::DIMMER`] (it is paused, and the rail's job is
@@ -98,10 +96,9 @@ fn agent_title_color(status: Status, is_selected: bool) -> theme::ColorToken {
 
 /// A worktree row's 2px left edge: **selection or nothing**.
 ///
-/// `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4m is the whole of this function,
-/// and the three parameters are its history. The rail used to paint each worktree row with its
-/// most urgent agent's status colour, with dedicated greys for the bare and prunable cases. All
-/// three are deleted:
+/// The three parameters are this function's history. The rail used to paint each worktree row
+/// with its most urgent agent's status colour, with dedicated greys for the bare and prunable
+/// cases. All three are deleted:
 ///
 /// 1. **A worktree has no status. Its agents do.** Colouring the worktree row states an agent's
 ///    condition on the wrong object.
@@ -129,9 +126,8 @@ fn worktree_row_edge(
     is_selected.then_some(theme::border::SELECTED_EDGE)
 }
 
-/// Which of the repo header's **two** urgency counts a dot+count pair is
-/// (`design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md` §4: "`● 2` amber... needs input
-/// and `● 1` red... failed").
+/// Which of the repo header's **two** urgency counts a dot+count pair is - amber for needs
+/// input, red for failed. See `docs/design/rail.md`.
 ///
 /// An enum rather than two near-identical render functions, so the pair really is one control
 /// drawn twice - the thing that goes wrong otherwise is §4l's own defect, two copies of a row
@@ -796,10 +792,9 @@ impl AdeApp {
         self._prune_task = Some(task);
     }
 
-    /// The whole left column (`design_handoff_jerry_ade/README.md`'s Zone 1): the sidebar strip,
-    /// the filter row, the real scrollable body of whichever view the strip has selected, and the
-    /// footer - see the README's "Rail chrome" section for the exact band heights this composes
-    /// (`theme::band::{CHROME_HEADER,FILTER_ROW,SURFACE_FOOTER}`).
+    /// The whole left column (`docs/design/rail.md`): the sidebar strip, the filter row, the
+    /// real scrollable body of whichever view the strip has selected, and the footer - composed
+    /// out of `theme::band::{CHROME_HEADER,FILTER_ROW,SURFACE_FOOTER}`.
     ///
     /// GitHub issue #291 turned this from "the rail" into "the sidebar, which is showing the
     /// rail": `crate::rail::strip_render::AdeApp::render_sidebar_strip` replaced the plain rail
@@ -932,11 +927,10 @@ impl AdeApp {
     /// Filter row 30: `/` plus the real typed query, or the placeholder text when empty -
     /// see [`Self::handle_filter_key_down`] for the (deliberately minimal) text input.
     ///
-    /// Its placeholder follows the strip's selected view (GitHub issue #291) -
-    /// `design_handoff_jerry_ade/revision 5/REVISION-2026-08-13.md` §1: "**Filter row** stays, and
-    /// its placeholder follows the view: `filter worktrees and agents` / `filter runs` / `filter
-    /// problems`." The query itself is one field across both views, and both really honour it, so
-    /// the placeholder never promises a filter that does nothing (§7 rule 1).
+    /// Its placeholder follows the strip's selected view (GitHub issue #291): `filter worktrees
+    /// and agents` / `filter runs` / `filter problems`. The query itself is one field across both
+    /// views, and both really honour it, so the placeholder never promises a filter that does
+    /// nothing.
     pub(in crate::rail) fn render_rail_filter_row(
         &self,
         view: rail_strip::SidebarView,
@@ -961,7 +955,6 @@ impl AdeApp {
             .flex_none()
             .items_center()
             .gap(px(6.0))
-            // `Jerry.dc.html:109` - `padding:0 12px`, not 10px.
             .px(px(12.0))
             .h(theme::band::FILTER_ROW)
             .border_b_1()
@@ -1019,10 +1012,9 @@ impl AdeApp {
     /// read - [`rail::RepoGroup::waiting_count`]) is always this repo's real, complete worktree
     /// list; only `rows` (what actually renders/expands below the header) is narrowed by
     /// [`Self::filter_query`] - fixing the bug where typing into the filter box moved both
-    /// numbers, not just which rows were visible (`design_handoff_jerry_ade/revision 3/
-    /// REVISION-2026-07-31.md` §2.0: "a repo you have scrolled past still reports that
-    /// something in it wants a human" - typing into the filter box is the same promise, just
-    /// scrolled-past-in-time rather than in-space).
+    /// numbers, not just which rows were visible. A repo you have scrolled past still reports
+    /// that something in it wants a human; typing into the filter box is the same promise, just
+    /// scrolled-past-in-time rather than in-space.
     ///
     /// Every repo in [`Self::repos`] gets its own real `all_rows`/`rows` here, not just
     /// [`Self::focused_repo`] - the focused repo's come from [`Self::build_worktree_rows`] (which
@@ -1094,10 +1086,9 @@ impl AdeApp {
         rail::group_worktrees_by_repo(repo_inputs)
     }
 
-    /// The rail's one real structure (`design_handoff_jerry_ade/revision 3/
-    /// REVISION-2026-07-31.md` §2.1: "Two levels, always: **repo group → worktree → agents**.
-    /// There is **no rail mode toggle**"). See [`Self::build_repo_groups`] for how the groups
-    /// themselves are built.
+    /// The rail's one real structure: two levels, always - **repo group → worktree → agents**,
+    /// with no rail mode toggle (`docs/design/decisions.md` §7). See [`Self::build_repo_groups`]
+    /// for how the groups themselves are built.
     ///
     /// Takes the groups rather than rebuilding them (GitHub issue #291): the sidebar strip above
     /// this list gates itself on the same data, and one pass is what guarantees the switcher and
@@ -1630,8 +1621,7 @@ impl AdeApp {
         // The slot itself is always emitted, even for a childless worktree - it stays empty
         // (no glyph, no tooltip, no hover, no click) rather than disappearing, so every row's
         // branch label lands at the same x offset regardless of whether that row has anything to
-        // expand (design_handoff_jerry_ade revision 5's own `w.caret` binding does the same: the
-        // glyph is emptied to "" but its fixed-width wrapper div never leaves the layout).
+        // expand - the glyph is emptied but its fixed-width wrapper never leaves the layout.
         let caret = {
             let worktree_path = row.path.clone();
             div()
@@ -1654,10 +1644,9 @@ impl AdeApp {
                         // no colour of its own - the glyph inherits this wrapper's, which is the
                         // element the hover is armed on.
                         .hover(|el| el.text_color(theme::text::STRONG))
-                        // §4's "tooltips on every icon-only control". The wording is
-                        // `Jerry.dc.html`'s own, which states the thing the glyph cannot: this
-                        // control toggles the group *without* selecting the worktree, which is
-                        // what the `stop_propagation` below actually does.
+                        // Tooltips on every icon-only control. The wording states the thing the
+                        // glyph cannot: this control toggles the group *without* selecting the
+                        // worktree, which is what the `stop_propagation` below actually does.
                         .tooltip(text_tooltip("Collapse or expand without selecting"))
                         // `STAGE-A-CHANGELOG.md` §4o/§4p: this used to be its own hand-drawn
                         // glyph, which is exactly the drift §4p closed - "every disclosure caret
@@ -1843,9 +1832,8 @@ impl AdeApp {
             header.into_any_element()
         };
 
-        // No question-preview card renders here, deliberately. `design_handoff_jerry_ade/revision
-        // 3/REVISION-2026-07-31.md` §2.3, verbatim: "**No question preview.** The amber ask box is
-        // gone from the rail; the question belongs in the agent pane where it can be answered."
+        // No question-preview card renders here, deliberately: the question belongs in the agent
+        // pane where it can be answered, not in a rail row that cannot answer it.
         // This is a design-driven removal of a card that really did ship (GitHub issue #268),
         // confirmed as deliberate on 2026-08-14, not a regression: an amber box quoting a question
         // in a surface with no way to answer it costs the rail's densest column two lines per
@@ -1944,16 +1932,15 @@ impl AdeApp {
             // after it), carrying the 1px `#1e2225` connector line, then the agent's own content
             // box - never padding *on* that content box, which would draw its border-left (the
             // status edge) flush with the worktree row's own left edge instead of indented under
-            // it. `Jerry.dc.html`'s own agent row is exactly this shape (an outer
-            // `padding-left:13px` flex wrapper holding the connector `div`, then the content
-            // `div` with its own `border-left`) - GPUI's border draws at a box's outer edge same
+            // it. The designed agent row is exactly this shape - an outer `padding-left:13px`
+            // flex wrapper holding the connector, then the content box with its own
+            // `border-left`. GPUI's border draws at a box's outer edge same
             // as CSS, so folding padding-left and border-left onto one div here reproduced the
             // bug the opposite way.
             .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
                 this.select_agent(id, window, cx);
             }))
-            // The agent row's context menu (GitHub issue #290). It sits on this outer wrapper -
-            // the same element `Jerry.dc.html` hangs its own `onContextMenu="{{ a.ctx }}"` on -
+            // The agent row's context menu (GitHub issue #290). It sits on this outer wrapper,
             // so the whole row, indent and connector included, is a right-click target rather
             // than just the content box. `stop_propagation` keeps the event from also reaching an
             // ancestor's handler and replacing this menu with a worktree one - the same guard the
@@ -1981,13 +1968,12 @@ impl AdeApp {
                     .flex_col()
                     .pl(px(7.0))
                     .pr(px(10.0))
-                    // §4n's tighter agent block: `5 10 6 7` -> `4 10 5 7`.
+                    // The tighter agent block: `5 10 6 7` -> `4 10 5 7`.
                     .pt(px(4.0))
                     .pb(px(5.0))
                     .gap(px(2.0))
-                    // `Jerry.dc.html`'s own agent row: `border-left:2px solid {{ a.edge }}`, with
-                    // `edge: live ? st.color : 'transparent'` - a *fixed* 2px slot painted only
-                    // for the focused agent. Two things were wrong with the width/colour pair
+                    // The designed agent row carries a *fixed* 2px edge slot, painted only for
+                    // the focused agent. Two things were wrong with the width/colour pair
                     // this replaces (`2px status` selected, `1px #1e2225` otherwise), both of
                     // them created by moving the indent onto the wrapper above: the 1px fallback
                     // is the *same* `#1e2225` as the connector `div` immediately to its left, so
@@ -2080,10 +2066,10 @@ impl AdeApp {
 
     /// A worktree row's `\u{21ba} N earlier runs` line (GitHub issue #227).
     ///
-    /// `design_handoff_jerry_ade/revision 5/REVISION-2026-08-13.md` §6, in full: "A 19-high
-    /// `\u{21ba} 2 earlier runs` line under a worktree row, switching the sidebar to History for
-    /// that worktree. **Only on worktrees with no live agent** - a first pass put it under every
-    /// worktree: eight identical rows, no information, and it pushed the rail past its height."
+    /// A 19-high `\u{21ba} N earlier runs` line under a worktree row, switching the sidebar to
+    /// History for that worktree. **Only on worktrees with no live agent** - a first pass put it
+    /// under every worktree: eight identical rows, no information, and it pushed the rail past
+    /// its height.
     ///
     /// This **replaced** the inline `HISTORY` section that used to render here - a small label
     /// plus one two-line row per past run, each with its own `Resume`/`Reopen` button - which is
@@ -2545,10 +2531,9 @@ mod prune_regression_tests {
     }
 }
 
-/// Real, `Context<AdeApp>`-driven coverage for Revision R12's rail rewrite: the repo-group →
-/// worktree-row → agent-row structure (`design_handoff_jerry_ade/revision 3/
-/// REVISION-2026-07-31.md` §2), the per-worktree collapse memory, and the agent row's "select
-/// the worktree and raise this agent's tab" click behaviour.
+/// Real, `Context<AdeApp>`-driven coverage for the rail's structure: the repo-group →
+/// worktree-row → agent-row nesting, the per-worktree collapse memory, and the agent row's
+/// "select the worktree and raise this agent's tab" click behaviour.
 #[cfg(test)]
 mod rail_row_tests {
     use super::*;
@@ -2963,9 +2948,8 @@ mod rail_row_tests {
     }
 
     /// The real bug the coordinator's audit found: typing into the rail's filter box must
-    /// change only which rows a repo group *renders*, never the header's `N wt` count
-    /// (`design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §2.1) - that number must
-    /// keep reporting the repo's real, complete worktree list, exactly like `RepoGroup::
+    /// change only which rows a repo group *renders*, never the header's `N wt` count - that
+    /// number must keep reporting the repo's real, complete worktree list, exactly like `RepoGroup::
     /// waiting_count` (proven independently, against hand-built rows, by `crate::rail::state`'s
     /// own `repo_group_header_counts_read_the_real_worktree_list_not_the_displayed_rows`) does.
     /// This test drives the same guarantee through the real, live `AdeApp`: two real worktrees,
@@ -4667,9 +4651,9 @@ mod agent_chip_icon_pack_tests {
     }
 }
 
-/// Revision 6's status rename (`design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4g,
-/// GitHub issue #280): [`Status::Review`] renders as `Finished`/`finished`, and the old
-/// `Review ready` wording must never come back to any rendered surface.
+/// The status rename (GitHub issue #280, `docs/design/decisions.md` §10): [`Status::Review`]
+/// renders as `Finished`/`finished`, and the old `Review ready` wording must never come back to
+/// any rendered surface.
 ///
 /// Pure, GPUI-window-free coverage over the real production functions every status-derived
 /// string in the window comes out of - the same "collect every rendered string, then assert one
@@ -4785,10 +4769,8 @@ mod status_wording_tests {
     }
 }
 
-/// Revision 6's rail corrections (GitHub issue #289, `design_handoff_jerry_ade/revision 5/
-/// REVISION-2026-08-14.md` §4 and `STAGE-A-CHANGELOG.md` §4k-§4s), in their pure, window-free
-/// half: the two colour decisions that were structurally wrong before, and the deletion of the
-/// rail's ask card.
+/// The rail's corrections (GitHub issue #289), in their pure, window-free half: the two colour
+/// decisions that were structurally wrong before, and the deletion of the rail's ask card.
 #[cfg(test)]
 mod rail_correction_tests {
     use super::*;
@@ -5053,10 +5035,9 @@ mod rail_rev6_render_tests {
         );
     }
 
-    /// `Jerry.dc.html`'s own agent row indents under its worktree by a real 13px, holding the 1px
-    /// `#1e2225` connector the design's own §4n text calls out ("the connector... was already
-    /// there and does its job once the groups are separated") - so the agent's own status edge
-    /// sits *inset* under the worktree row, not flush with its left edge. A real, measured
+    /// An agent row indents under its worktree by a real 13px, holding the 1px connector that
+    /// separates the groups - so the agent's own status edge sits *inset* under the worktree row,
+    /// not flush with its left edge. A real, measured
     /// regression: an earlier cut folded the 13px indent and the status-edge border onto the same
     /// element, which (GPUI draws a border at a box's own outer edge, same as CSS) put the edge
     /// at the worktree row's own x, not indented under it - the hierarchy the row is supposed to

--- a/crates/app/src/rail/repo.rs
+++ b/crates/app/src/rail/repo.rs
@@ -1,6 +1,5 @@
 //! A **repo**: one git repository the user has added to Jerry - the top level of the rail's
-//! two-level grouping, `design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §2.0 ("What
-//! a repo is here, and why the rail groups by one"). A real checkout on disk (`~/code/
+//! two-level grouping (`docs/design/rail.md`). A real checkout on disk (`~/code/
 //! jerry-core`); every worktree belongs to exactly one repo and carries it (`repo:` on the
 //! worktree record, a later phase's concern - see [`Repo::worktrees`]'s own docs for why that
 //! field can't just be derived by walking up a worktree's path).
@@ -55,9 +54,9 @@ pub struct Repo {
     /// [`display_name`]), persisted alongside the path so a repo whose directory has since been
     /// renamed or gone missing still has something honest to call itself.
     pub name: String,
-    /// Every worktree belonging to this repo, main checkout included (`design_handoff_jerry_ade/
-    /// revision 3/REVISION-2026-07-31.md` §2.0: "The repo's main checkout is itself a worktree
-    /// row in its group"). Populated by a real `wt_core::list_worktrees_porcelain` fetch for
+    /// Every worktree belonging to this repo, main checkout included - the repo's main checkout
+    /// is itself a worktree row in its group. Populated by a real
+    /// `wt_core::list_worktrees_porcelain` fetch for
     /// *every* repo, not just the focused one - `crate::root::AdeApp::load_repo_worktrees`
     /// (a one-shot fetch, run once per newly [`crate::root::AdeApp::add_repo`]-ed repo and once
     /// per repo restored from `repos.toml` at startup) and `crate::root::AdeApp::

--- a/crates/app/src/rail/state.rs
+++ b/crates/app/src/rail/state.rs
@@ -1,5 +1,5 @@
-//! The agent rail's data model: pure, GPUI-free types and functions for grouping and
-//! filtering (`design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md`'s Zone 1). No `gpui`
+//! The agent rail's data model: pure, GPUI-free types and functions for grouping and filtering
+//! (`docs/design/rail.md`). No `gpui`
 //! dependency, so this logic is unit-testable without a real window, terminal, or git state.
 //! `crate::root` gathers the real signals (`TerminalPane`, `wt_core::list_worktrees`,
 //! `wt_core::diff::diff_against_base`) into the plain types this module operates on, and renders
@@ -38,9 +38,8 @@ pub struct AgentRow {
     /// The process exit code, only for [`Status::Fail`]/[`Status::Review`]/exited-`Idle`
     /// rows. `None` while still running or never started.
     pub exit_code: Option<u32>,
-    /// The agent row's "what it is doing" trailing text for a [`Status::Run`] row -
-    /// `design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §2.3: "the live tool call -
-    /// `writing auth.rs`, `editing reports.rs`, `bench 3 of 5`, `148 of 312`".
+    /// The agent row's "what it is doing" trailing text for a [`Status::Run`] row - the live
+    /// tool call: `writing auth.rs`, `editing reports.rs`, `bench 3 of 5`, `148 of 312`.
     ///
     /// A sibling field here rather than a payload on [`Status::Run`] itself (status-conditional,
     /// but a row-level fact rather than part of the status enum) - keeping [`Status`] itself a plain
@@ -145,8 +144,8 @@ pub fn sum_diff_stat(diff: &WorktreeDiff) -> (usize, usize) {
     (add, del)
 }
 
-/// Real per-status counts across every agent row, in [`Status::ORDER`] - the status bar's
-/// five urgency-counter squares (`design_handoff_jerry_ade/revision/CHANGELOG.md`'s change 7).
+/// Real per-status counts across every agent row, in [`Status::ORDER`] - the five
+/// urgency-counter squares.
 /// Unlike [`group_worktrees_by_repo`], a status with zero matching rows still gets a real `0`
 /// entry rather than being omitted, since the status bar always shows all five squares. Built
 /// from the
@@ -315,8 +314,8 @@ impl WorktreeRow {
     }
 
     /// This row's rank for sorting *inside* a repo group (and, via [`RepoGroup::rank`], the
-    /// groups themselves) - `design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §2.1's
-    /// full seven-step order: `input → failed → review → running → idle → bare → prunable`.
+    /// groups themselves) - the full seven-step order:
+    /// `input → failed → review → running → idle → bare → prunable`.
     /// Lower sorts first (more urgent).
     ///
     /// The first five steps are exactly [`Status::urgency_rank`] (§2.3's own agent state words -
@@ -457,9 +456,8 @@ pub struct RepoWorktrees {
     pub repo_id: RepoId,
     pub repo_name: String,
     /// This repo's real, complete worktree list - unaffected by the rail's filter box. The
-    /// source of the group header's `N wt` and `N worktrees waiting` counts
-    /// (`design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §2.0: "a repo you have
-    /// scrolled past still reports that something in it wants a human" - a header that shrank
+    /// source of the group header's `N wt` and `N worktrees waiting` counts: a repo you have
+    /// scrolled past still reports that something in it wants a human, and a header that shrank
     /// or grew as the *filter box* was typed into would break that same promise for the repo
     /// you're currently looking at). See [`Self::rows`] for the separate, filtered list.
     pub all_rows: Vec<WorktreeRow>,
@@ -483,9 +481,8 @@ pub struct RepoWorktrees {
     pub rows_loaded: bool,
 }
 
-/// One repo group in the rail - `design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md`
-/// §2.0-2.1: the rail's only grouping axis, always present (even for a single repo), with its
-/// own worktree rows ranked most-urgent-first inside it.
+/// One repo group in the rail - the rail's only grouping axis, always present (even for a single
+/// repo), with its own worktree rows ranked most-urgent-first inside it.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RepoGroup {
     pub repo_id: RepoId,
@@ -508,10 +505,9 @@ impl RepoGroup {
     /// The group header's **red** urgency count: worktrees in this repo holding at least one
     /// failed agent, hidden at zero.
     ///
-    /// Revision 6 (`design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md` §4,
-    /// `STAGE-A-CHANGELOG.md` §4q) split the header's single amber `N worktrees waiting` into two
-    /// counts, because merging them "said 'three worktrees want you' when one of the three had
-    /// actually died, and amber is the wrong colour for that". §7 rule 4, verbatim: **"Two states
+    /// The header's single amber `N worktrees waiting` was split into two counts, because merging
+    /// them "said 'three worktrees want you' when one of the three had actually died, and amber is
+    /// the wrong colour for that". The general rule, verbatim: **"Two states
     /// distinguished anywhere in the app are never summed anywhere in it."** The title bar has
     /// always shown `ask`/`fail`/`running` apart; the rail header now does too.
     ///
@@ -760,8 +756,8 @@ pub fn flatten_rail_list_items(
 /// twice is two specifications of one thing, and the reader cannot tell which is real").
 ///
 /// Both the noun and the verb agree through [`crate::root::plural`] rather than a hand-written
-/// ternary (§7 rule 9) - `Jerry.dc.html`'s own `askTip` conjugates `needs`/`need` too, and a
-/// tooltip reading "1 worktrees here need input" would be exactly the defect that rule exists for.
+/// ternary - a tooltip reading "1 worktrees here need input" is exactly the defect that helper
+/// exists for.
 /// Hiding at zero is the *caller's* decision (a content choice, made at the render site by not
 /// drawing the pair at all), so this function is total and always returns a real sentence.
 pub fn needs_input_tooltip(count: usize) -> String {
@@ -794,9 +790,8 @@ pub fn failed_tooltip(count: usize) -> String {
 /// theirs into `diff::STAT_ADD`/`diff::STAT_DEL`. Same number, read the same way, styled two
 /// different ways depending on which panel it was in.
 ///
-/// The deletion half is `Option` rather than a `−0`: `Jerry.dc.html`'s own `wtStats` returns
-/// `del: d ? '−' + d : ''`, so a pure-addition diff shows one part, not a second one that says
-/// nothing. Both zero is `None` outright - the row's prose fallback (`checkout · clean`, `merged ·
+/// The deletion half is `Option` rather than a `−0`, so a pure-addition diff shows one part, not
+/// a second one that says nothing. Both zero is `None` outright - the row's prose fallback (`checkout · clean`, `merged ·
 /// prunable`), which stays neutral, is what occupies that slot instead.
 pub fn diff_stat_parts(add: usize, del: usize) -> Option<(String, Option<String>)> {
     if add == 0 && del == 0 {

--- a/crates/app/src/rail/status.rs
+++ b/crates/app/src/rail/status.rs
@@ -1,5 +1,5 @@
-//! Agent-status derivation - the "who needs me" mechanism `design_handoff_jerry_ade/README.md`
-//! calls the whole point of the agent rail.
+//! Agent-status derivation - the "who needs me" mechanism that is the whole point of the agent
+//! rail (`docs/design/rail.md`).
 //!
 //! GPUI-free and pty/process-free: takes small, already-read signals ([`ProcessSignal`], a
 //! [`TerminalSignal`], a `has_reviewable_diff` bool, a
@@ -135,8 +135,8 @@ pub const RUN_RECENT_OUTPUT_WINDOW: Duration = Duration::from_secs(2);
 /// [`RUN_RECENT_OUTPUT_WINDOW`].
 pub const AGENT_ASK_IDLE_THRESHOLD: Duration = Duration::from_secs(15);
 
-/// The status vocabulary from `design_handoff_jerry_ade/README.md`'s "Status vocabulary" table,
-/// backed one-to-one by `crate::theme::status::*`.
+/// The app's whole status vocabulary (`docs/design/vocabulary.md`), backed one-to-one by
+/// `crate::theme::status::*`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Status {
     /// Needs input.
@@ -153,11 +153,9 @@ pub enum Status {
 }
 
 impl Status {
-    /// Rank used to sort the "by urgency" group order from
-    /// `design_handoff_jerry_ade/README.md`: `Needs input → Failed → Finished → Running →
-    /// Idle`. Lower sorts first. (The README spells that third group `Review ready`; revision 6
-    /// renamed the rendered word to `Finished` - see [`Self::label`] - without touching the
-    /// order itself.)
+    /// Rank used to sort by urgency: `Needs input → Failed → Finished → Running → Idle`. Lower
+    /// sorts first. (The third was originally worded `Review ready`; only the rendered word
+    /// changed - see [`Self::label`] - never the order.)
     pub fn urgency_rank(self) -> u8 {
         match self {
             Status::Ask => 0,
@@ -168,11 +166,10 @@ impl Status {
         }
     }
 
-    /// The label text from the README's status table, with revision 6's one rename applied:
-    /// [`Status::Review`] renders as `Finished`, never `Review ready`
-    /// (`design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4g, GitHub issue #280). The
+    /// The rendered label for each status, with one rename applied: [`Status::Review`] renders as
+    /// `Finished`, never `Review ready` (GitHub issue #280, `docs/design/decisions.md` §10). The
     /// old label "states a judgement the agent cannot make", collides with the user's own review
-    /// progress, and contradicts the file's own vocabulary; `Finished` states the fact, and the
+    /// progress, and contradicts the app's own vocabulary; `Finished` states the fact, and the
     /// file count rendered beside it (see `crate::rail::render`'s `agent_trailing_text`) carries
     /// what there is to look at. The *variant* deliberately keeps its `Review` name - the enum is
     /// an internal identifier, this is only about the rendered string.
@@ -197,8 +194,7 @@ impl Status {
         }
     }
 
-    /// The status pill's background colour (`design_handoff_jerry_ade/README.md`'s "Agent
-    /// context bar" spec) - `crate::theme::status::*_BG`, one per [`Status`].
+    /// The status pill's background colour - `crate::theme::status::*_BG`, one per [`Status`].
     pub fn pill_bg(self) -> gpui::Rgba {
         match self {
             Status::Ask => crate::theme::status::ASK_BG.into(),

--- a/crates/app/src/rail/strip.rs
+++ b/crates/app/src/rail/strip.rs
@@ -9,9 +9,9 @@
 //!
 //! ## What the strip is
 //!
-//! `design_handoff_jerry_ade/revision 5/REVISION-2026-08-13.md` §1 introduced it - "The left panel
-//! was hard-wired to one thing. It is now a switchable surface with a **horizontal icon strip
-//! along the top** - Cursor's arrangement, not VS Code's vertical activity bar. A vertical bar
+//! The left panel was once hard-wired to one thing. It is now a switchable surface with a
+//! **horizontal icon strip along the top** - Cursor's arrangement, not VS Code's vertical
+//! activity bar. A vertical bar
 //! costs 44px of permanent width on a window whose whole job is fitting three panels side by
 //! side" - and `STAGE-A-CHANGELOG.md` §4v is its final form, which this module implements.
 //!
@@ -83,10 +83,9 @@ impl SidebarView {
         }
     }
 
-    /// The view's hint - the second half of its tooltip, quoted from `Jerry.dc.html`'s own
-    /// `sideViews` table. §1 explains why every cell needs one: "With labels gone, [the] glyphs
-    /// are the only affordance identifying the views, so the hint has to live somewhere
-    /// reachable."
+    /// The view's hint - the second half of its tooltip. Every cell needs one: with labels gone,
+    /// the glyphs are the only affordance identifying the views, so the hint has to live
+    /// somewhere reachable.
     pub const fn hint(self) -> &'static str {
         match self {
             SidebarView::Worktrees => "repo \u{b7} worktree \u{b7} agent",
@@ -112,11 +111,10 @@ impl SidebarView {
         }
     }
 
-    /// The cell's `title="<view> — <hint>"` tooltip (§1), with the marker's real count appended in
-    /// parentheses when there is one - `Jerry.dc.html`'s own
-    /// `v.label + ' — ' + v.hint + (badge ? ' (' + badge + ')' : '')`.
+    /// The cell's `"<view> — <hint>"` tooltip, with the marker's real count appended in
+    /// parentheses when there is one.
     ///
-    /// The count living *here* rather than on the cell is §4v's own correction: "The 9px pill
+    /// The count living *here* rather than on the cell is a design correction: "The 9px pill
     /// printing a count at 7px sat on top of the glyph and was a second vocabulary for state in a
     /// strip built to match the tabs - which already mark state with a **5px square dot**. That is
     /// what the cells use now, in the badge's colour, with the count moved to the tooltip."
@@ -206,8 +204,7 @@ impl StripCell {
     }
 
     /// The colour this cell's glyph rests at: [`theme::text::SELECTED`] for the view you are in,
-    /// [`theme::text::FAINTER`] for one you are not (`Jerry.dc.html`'s own
-    /// `fg: on ? '#dde2e7' : '#5e646a'`).
+    /// [`theme::text::FAINTER`] for one you are not.
     pub const fn glyph_color(self) -> theme::ColorToken {
         if self.selected {
             theme::text::SELECTED
@@ -249,7 +246,7 @@ pub struct Problem {
 }
 
 impl Problem {
-    /// `line:column`, the way `Jerry.dc.html`'s own `p.line` prints it (`212:17`).
+    /// `line:column`, the way every compiler prints one (`212:17`).
     pub fn position(&self) -> String {
         format!("{}:{}", self.line, self.column)
     }
@@ -330,8 +327,8 @@ impl ProblemTally {
 
     /// The marker for this tally, or `None` when the worktree is clean.
     ///
-    /// Red once anything is a real error, amber otherwise - `Jerry.dc.html`'s own
-    /// `probTally.err ? '#e0625c' : '#e2a336'`. A worktree with only warnings is genuinely not in
+    /// Red once anything is a real error, amber otherwise. A worktree with only warnings is
+    /// genuinely not in
     /// the same state as one that does not compile, and the strip is the only place that says so
     /// before you open the view.
     pub fn marker(self) -> Option<StripMarker> {
@@ -405,10 +402,9 @@ pub fn problems_filtered_away_note(hidden: usize) -> String {
 /// cannot survive the gate because they are built here, below it, rather than beside a `when(..)`
 /// in the renderer that someone could later write for one and not the other.
 ///
-/// `agents_needing_you` is the real count of agents waiting on a human. §1 names the unit
-/// outright - "worktrees shows agents needing a human" - and `Jerry.dc.html` computes exactly
-/// that (`sessions.filter(s => s.status === 'ask' || s.status === 'fail').length`), which is why
-/// this is an agent count and not the worktree count §4v's one-line hue table reads as. It comes
+/// `agents_needing_you` is the real count of agents waiting on a human - the design names the
+/// unit outright, "worktrees shows agents needing a human", which is why this is an agent count
+/// and not a worktree count. It comes
 /// from the same `crate::rail::state::urgency_counts` pass over the same [`crate::rail::state::
 /// AgentRow`]s the title bar's own dots read, so the two can never report different numbers for
 /// the same window. `problems` is the real tally for the selected worktree.
@@ -548,8 +544,8 @@ mod tests {
         );
     }
 
-    /// §2's row spec prints `line:column`, 1-based - the shape `Jerry.dc.html`'s own `212:17`
-    /// takes, and the shape the click's own target line is derived from.
+    /// A row prints `line:column`, 1-based - the shape every compiler prints, and the shape the
+    /// click's own target line is derived from.
     #[test]
     fn a_rows_position_reads_the_way_every_compiler_prints_one() {
         let row = problem(Severity::Error, "src/db/mod.rs", 118, "no method", "rustc");
@@ -727,7 +723,7 @@ mod tests {
         assert!(cells.iter().all(|cell| cell.marker.is_none()));
     }
 
-    /// `Jerry.dc.html`'s `probTally.err ? '#e0625c' : '#e2a336'`, and the Worktrees cell's single
+    /// The Problems cell's red-once-there-is-an-error rule and the Worktrees cell's single
     /// amber - read through the real tokens, so a theme rename can't quietly decouple them.
     #[test]
     fn the_marker_hues_are_the_apps_own_status_hues() {

--- a/crates/app/src/rail/strip_render.rs
+++ b/crates/app/src/rail/strip_render.rs
@@ -7,9 +7,9 @@
 //!
 //! ## The strip speaks the tab language
 //!
-//! `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4v, verbatim, on what the cells
-//! are: "**38px full-height cells, no radius, no gap**, selected = a filled slab that cuts the
-//! column rule to join the panel below, inactive = transparent over a recessed strip." Then, on
+//! What the cells are, verbatim from the design: "**38px full-height cells, no radius, no gap**,
+//! selected = a filled slab that cuts the column rule to join the panel below, inactive =
+//! transparent over a recessed strip." Then, on
 //! the divisions: "each cell carries `border-right: 1px #1c2023` - the same rule the tabs use
 //! between them ... Segments divided by vertical rules is most of what makes a tab strip legible;
 //! the first cut had the slab and the cut-out but no divisions, so it read as icons on a dark
@@ -45,10 +45,10 @@
 //! [`crate::rail::strip`], which can assert them without a window.
 //!
 //! **What the design does not ask for here, and this therefore does not do**: grouping rows by
-//! file, and an `all`/`this worktree` scope toggle. `Jerry.dc.html`'s `probRows` is a flat list,
-//! and §6's scope toggle belongs to *Agent history* ("**Agent history** is repo → worktree → run,
+//! file, and an `all`/`this worktree` scope toggle. Problems is a flat list, and the scope toggle
+//! belongs to *Agent history* ("**Agent history** is repo → worktree → run,
 //! matching the rail, with an `all` / `this worktree` scope toggle") - Problems is specified the
-//! other way in the same revision, as following the selected worktree and only that. A scope
+//! other way, as following the selected worktree and only that. A scope
 //! toggle here would contradict §2's own reason for keying the store at all.
 
 use super::*;
@@ -474,9 +474,9 @@ impl AdeApp {
     }
 
     /// One Problems row: a 5px severity square, the message, and the file/position/source line
-    /// under it - `Jerry.dc.html`'s own `probRows` markup - and the click that opens it.
+    /// under it - and the click that opens it.
     ///
-    /// **The click** is `REVISION-2026-08-13.md` §2's own half of the row spec ("severity square,
+    /// **The click** is the design's own half of the row spec ("severity square,
     /// message, file, line, source; opens the file at the line on click"). It goes through
     /// [`Self::open_file_at_line`], the same one move go-to-definition and a terminal `path:line`
     /// link already make - so a Problems row lands the caret on the diagnostic's line through the
@@ -569,12 +569,12 @@ impl AdeApp {
             )
     }
 
-    /// The row's `file` cell: the directory prefix dimmed, the file name at the mock's own
-    /// `#7d848b` ([`theme::text::DIMMER`]).
+    /// The row's `file` cell: the directory prefix dimmed, the file name at
+    /// [`theme::text::DIMMER`].
     ///
-    /// `Jerry.dc.html` prints the **bare file name** here (`p.file.split('/').pop()`), and this
+    /// The design prints the **bare file name** here, and this
     /// deliberately keeps the directory in front of it. The reason is the one thing #292 adds that
-    /// the mock's rows do not have: these rows *open a file*. Four `mod.rs` rows that all read
+    /// the designed rows do not have: these rows *open a file*. Four `mod.rs` rows that all read
     /// `mod.rs` give no way to tell which file a click is about to open - and the design already
     /// has a shape for exactly this tension, in the Search view one section over, whose rows carry
     /// `dir` and `file` as two spans at two weights rather than dropping either. This is that
@@ -662,9 +662,9 @@ pub(in crate::rail) fn strip_cell(
 /// why the already-lit selected cell keeps its own [`theme::text::SELECTED`] rather than taking
 /// [`theme::text::GLYPH_HOVER`]: at `#dde2e7` over `#c8ced4` that assignment would make hovering
 /// the *active* view visibly dim it, re-creating in one direction the exact "hover out-reads
-/// selected" collision the section moved hover off background to fix. (`Jerry.dc.html` applies its
-/// one `style-hover` to every cell from a shared template, so its selected cell really does dim;
-/// the stated rule is the one followed here.)
+/// selected" collision the design moved hover off background to fix. (The design applies its one
+/// hover style to every cell from a shared template, so its selected cell really does dim; the
+/// stated rule is the one followed here.)
 fn strip_glyph_hover(selected: bool) -> theme::ColorToken {
     if selected {
         theme::text::SELECTED
@@ -673,9 +673,8 @@ fn strip_glyph_hover(selected: bool) -> theme::ColorToken {
     }
 }
 
-/// A cell's state marker: the tabs' own 5px square dot, in the marker's hue, at `Jerry.dc.html`'s
-/// own `right:7 top:8` (§4v: "Badges moved to `right:5 top:6` - on a square cell, corner-anchored
-/// badges read as clipped", and the final markup settled one step further in again).
+/// A cell's state marker: the tabs' own 5px square dot, in the marker's hue, inset from the
+/// cell's corner - on a square cell, corner-anchored badges read as clipped.
 ///
 /// [`theme::radius::MARK_SM`] rather than [`theme::radius::MARK`] because that 1px is what makes a
 /// 5px square read as a square: this app already uses a real circle for "an agent's status", and
@@ -1442,7 +1441,7 @@ mod problems_view_tests {
 
     /// §2's header "names every severity the list is showing", over a real three-severity list -
     /// and the strip's marker over the same one pass. The marker is red because there is a real
-    /// error in it (`Jerry.dc.html`'s `probTally.err ? '#e0625c' : '#e2a336'`).
+    /// error in it, and the marker is red once anything is.
     #[gpui::test]
     fn the_header_and_the_marker_are_tallied_over_the_real_published_list(cx: &mut TestAppContext) {
         let repo = init_repo();

--- a/crates/app/src/review_notes/flow.rs
+++ b/crates/app/src/review_notes/flow.rs
@@ -231,7 +231,7 @@ impl AdeApp {
     /// Clicking a diff line: pin a note beneath it, or - if the click landed on the line whose
     /// note is already open for typing - close that note again.
     ///
-    /// `STAGE-A-CHANGELOG.md` §1 says the gesture *toggles*, and `Jerry.dc.html` implements that
+    /// The design says the gesture *toggles*, and implements that
     /// against a fixed set of pre-authored notes, where "toggle" can only mean show/hide. Here the
     /// note does not exist until you make one, so toggling has to mean create/remove - with one
     /// deliberate asymmetry: a card you have **written into** is never destroyed by a click. It

--- a/crates/app/src/review_notes/mod.rs
+++ b/crates/app/src/review_notes/mod.rs
@@ -2,9 +2,7 @@
 //! one prompt, delivered to a **named** agent's pty, and **kept pinned** afterwards so the
 //! revision can be checked against them.
 //!
-//! Spec of record: `design_handoff_jerry_ade/revision 5/AUDIT-2026-08-13-competitive-v2.md`
-//! §6 top-5 #2, `STAGE-A-CHANGELOG.md` §1 (the two `§6.2` rows) and §3's verification list, and
-//! `Jerry.dc.html`'s `Review · uncommitted` state for the markup.
+//! See `docs/design/work-surface.md` for where this sits in the centre surface.
 //!
 //! ## The three rules, and where each one lives
 //!
@@ -48,8 +46,8 @@ use std::path::{Path, PathBuf};
 
 /// Which line of a diff a note is pinned beneath.
 ///
-/// **Not a row index.** `Jerry.dc.html`'s own `noteDefs` key notes by their position in the
-/// rendered line array, which is fine for a mock whose diff never changes and fatal here: this
+/// **Not a row index.** The design keys notes by their position in the rendered line array,
+/// which is fine for a mockup whose diff never changes and fatal here: this
 /// app re-reads the working tree constantly, and a row index would silently re-anchor every note
 /// on a file the moment a hunk above it grew by a line. The issue's requirement is that notes are
 /// *"keyed per worktree + path + line"*, and the only stable meaning of "line" in a unified diff
@@ -128,7 +126,7 @@ pub enum NoteMark {
 }
 
 impl NoteMark {
-    /// The card's own word, verbatim from `Jerry.dc.html`'s `noteMark`.
+    /// The card's own word, verbatim design copy.
     pub fn label(self) -> &'static str {
         match self {
             NoteMark::Draft => "draft",

--- a/crates/app/src/review_notes/render.rs
+++ b/crates/app/src/review_notes/render.rs
@@ -1,8 +1,7 @@
 //! The two surfaces GitHub issue #288 adds: the **notes bar** above the hunks, and the **card**
 //! pinned beneath a line.
 //!
-//! Both are transcribed from `Jerry.dc.html`'s `Review · uncommitted` state - the bar is the
-//! `hasNotes` block, the card is the `l.isNote` branch of the diff row loop. Every colour is a
+//! Both come from the design's `Review · uncommitted` state. Every colour is a
 //! [`crate::theme::notes`] token, and every string that is design copy is quoted in the doc
 //! comment beside it.
 
@@ -38,9 +37,9 @@ fn note_draft_handle() -> TextFieldHandle {
         })
 }
 
-/// The bar's fixed second line, **verbatim** from `Jerry.dc.html` and from `STAGE-A-CHANGELOG.md`
-/// §1's own row for this feature: *"A notes bar above the hunks: count, the line `one prompt,
-/// line-anchored · pinned after the revision`, and `Send notes to <agent>` with `⌘⏎` keycaps"*.
+/// The bar's fixed second line, **verbatim** design copy: *"A notes bar above the hunks: count,
+/// the line `one prompt, line-anchored · pinned after the revision`, and `Send notes to <agent>`
+/// with `⌘⏎` keycaps"*.
 pub const NOTES_BAR_META: &str = "one prompt, line-anchored \u{b7} pinned after the revision";
 
 /// The send button's tooltip, verbatim from the mock's own `title=` attribute.
@@ -67,10 +66,9 @@ pub const SEND_NOTES_SPEC: &str = "mod+enter";
 
 /// What an empty card says while it is waiting to be written into.
 ///
-/// **A derivation, not a transcription.** `Jerry.dc.html`'s cards are all pre-authored demo data,
-/// so the mock has no empty state for one at all - in it, "toggle a note" can only ever mean
-/// show/hide something that already exists. A real reviewer starts from nothing, and a blank card
-/// with no prompt would read as a rendering fault.
+/// **A derivation, not a transcription.** The design has no empty state for a card at all - in
+/// it, "toggle a note" can only ever mean show/hide something that already exists. A real reviewer
+/// starts from nothing, and a blank card with no prompt would read as a rendering fault.
 const NOTE_PLACEHOLDER: &str = "what should change on this line?";
 
 /// The notes bar's own count sentence, and the design copy it is checked against.
@@ -411,9 +409,9 @@ impl AdeApp {
 
     /// One pinned note, as a row of the diff's own `uniform_list`.
     ///
-    /// ## The one place this is not the mock
+    /// ## The one place this is not the design
     ///
-    /// `Jerry.dc.html` draws the card as a free-height block whose text wraps. It cannot be one
+    /// The design draws the card as a free-height block whose text wraps. It cannot be one
     /// here: since GitHub issue #224 the diff is a `gpui::uniform_list`, which measures item 0 and
     /// lays **every** slot out at exactly that height (`rems(1.6)`, a diff line's own line
     /// height). A taller card would be silently clipped, and a list that measured itself from a
@@ -596,8 +594,7 @@ impl AdeApp {
             //
             // `w_full` is a percentage against the definite width `uniform_list` really hands
             // each item, so the card is the pane's width less the insets below, whatever it says.
-            // `Jerry.dc.html`'s own card is a block in normal flow with `margin:3px 14px 5px
-            // 74px`, i.e. exactly this: full width, inset.
+            // The designed card is a block in normal flow, inset on all four sides - exactly this.
             .w_full()
             // The mock's own inset: the card starts where the code text does, not at the gutter,
             // so it visibly belongs to the line above it.

--- a/crates/app/src/root/layout.rs
+++ b/crates/app/src/root/layout.rs
@@ -1,6 +1,6 @@
-//! Pure width-clamping logic for Zone 1/Zone 3's drag-to-resize splitters
-//! (`design_handoff_jerry_ade/README.md`'s Layout table: rail "276 (range 240–340)", files/
-//! changes panel "320 (260 in empty states)").
+//! Pure width-clamping logic for Zone 1/Zone 3's drag-to-resize splitters - the rail is 276 wide
+//! over a 240-340 range, the files/changes panel 320 (260 in empty states). See
+//! `docs/design/layout.md`.
 //!
 //! Deliberately `gpui`-free (plain `f32`s, not `gpui::Pixels`) so the clamp math is directly
 //! unit-testable without a window, mirroring `crate::work_surface::state`/`crate::rail::status`'s own

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -395,8 +395,7 @@ pub struct AdeApp {
     /// module docs). Zero-to-many: the app's *current* single-repo-per-window behaviour is just
     /// the common case of this list holding exactly one entry, not a separate code path - see
     /// [`Self::add_repo`]. Order is insertion order and carries no meaning of its own (a later
-    /// rail-rendering phase orders *groups* by urgency, not by this `Vec`'s order -
-    /// `design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §2.0).
+    /// rail-rendering phase orders *groups* by urgency, not by this `Vec`'s order).
     pub(crate) repos: Vec<Repo>,
     /// Which of [`Self::repos`] is "the" repo for every currently-single-repo-scoped piece of
     /// state this app still has (the file tree, the diff, a fresh agent's cwd, `worktrees`
@@ -738,8 +737,7 @@ pub struct AdeApp {
     /// `crate::rail::strip::SidebarView`.
     ///
     /// The window's first rail-level view state: before the strip, the left column was hard-wired
-    /// to one thing (`design_handoff_jerry_ade/revision 5/REVISION-2026-08-13.md` §1: "The left
-    /// panel was hard-wired to one thing. It is now a switchable surface"). Deliberately **not**
+    /// to one thing rather than a switchable surface. Deliberately **not**
     /// persisted: it is a per-window navigation position like the right panel's own
     /// [`Self::right_sidebar_view`], not a preference, and a window restored onto Problems for a
     /// checkout whose diagnostics have not been recomputed yet would open on an empty panel with
@@ -949,9 +947,9 @@ pub struct AdeApp {
     /// like every other popover here does.
     pub(crate) commit_composer_bounds: gpui::Bounds<Pixels>,
     /// Ordered list of currently-open file tabs, rendered after every agent's own tab by
-    /// `Self::render_tab_strip` - **per worktree**, keyed by [`Self::file_tree_root`]
-    /// (`design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §3: "Switching worktrees
-    /// swaps the whole strip. Each worktree remembers its own ... open files"). No duplicates
+    /// `Self::render_tab_strip` - **per worktree**, keyed by [`Self::file_tree_root`]:
+    /// switching worktrees swaps the whole strip, and each worktree remembers its own open
+    /// files. No duplicates
     /// within one worktree's list: opening an already-open file just activates its existing entry
     /// (`Self::push_open_file`). Removed only on explicit tab close (`Self::close_file_tab`) -
     /// **not** on a worktree switch: these are worktree-*relative* paths, which is exactly why a
@@ -1096,7 +1094,7 @@ pub struct AdeApp {
     /// [`Self::graph_focus`] for the identical role on the graph tab.
     pub(crate) review_focus: OverlayFocus,
     /// Which runs the sidebar's History view is showing - `all` or `this worktree`
-    /// (`design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md` §6, GitHub issue #227).
+    /// (GitHub issue #227).
     ///
     /// Deliberately not persisted, for exactly [`Self::sidebar_view`]'s own reason: it is a
     /// per-window navigation position, not a preference.
@@ -1308,8 +1306,7 @@ pub struct AdeApp {
     /// Real, live per-tab text-editing state for the File view (Revision R8.5a) - keyed by
     /// **both** the owning worktree ([`Self::file_tree_root`] at the time the buffer was created)
     /// and the worktree-relative path, exactly like [`Self::open_files_by_worktree`]'s own outer
-    /// key, so an unsaved edit survives a worktree switch away and back
-    /// (`design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §1/§3) and two worktrees that
+    /// key, so an unsaved edit survives a worktree switch away and back, and two worktrees that
     /// happen to share a relative path can never merge or overwrite each other's in-memory
     /// content. Created lazily the first time a file is opened in File view (see
     /// [`crate::code_surface::file_view::AdeApp::render_file_view`]), seeded from the exact same
@@ -1505,9 +1502,8 @@ pub struct AdeApp {
     /// (GitHub issue #17 - see [`text_history::TextField`]); unlike the palette's, this widget
     /// lives for the whole agent, so its history does too.
     pub(crate) filter_query: text_history::TextField,
-    /// Explicit per-worktree expand/collapse overrides for the rail's worktree rows
-    /// (`design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §2.2: "caret state is
-    /// remembered per worktree"), keyed by worktree path. Absence means "use the default" -
+    /// Explicit per-worktree expand/collapse overrides for the rail's worktree rows - caret state
+    /// is remembered per worktree - keyed by worktree path. Absence means "use the default" -
     /// [`crate::rail::render::AdeApp::worktree_is_expanded`] is the one place that default is
     /// decided (collapsed for a worktree whose most urgent agent is idle, expanded otherwise) -
     /// so a worktree the user has never touched the caret on tracks that live default rather
@@ -3401,9 +3397,9 @@ impl Render for AdeApp {
                 |el| el.on_action(cx.listener(Self::handle_discard_worktree_menu_command)),
             )
             .child(self.render_title_bar(cx))
-            // The Settings surface (`design_handoff_jerry_ade/README.md`: "a separate surface,
-            // not a modal: it replaces the three zones while the title bar and status bar
-            // stay") swaps out only this one child - the title bar above and the status bar
+            // The Settings surface is a separate surface, not a modal: it replaces the three
+            // zones while the title bar and status bar stay. It
+            // swaps out only this one child - the title bar above and the status bar
             // below are unconditional siblings, rendered every frame regardless of
             // `settings_open`.
             .child(if self.settings_open {

--- a/crates/app/src/root/plural.rs
+++ b/crates/app/src/root/plural.rs
@@ -4,8 +4,7 @@
 //!
 //! > **Every count goes through the pluralisation helper; never inline a ternary.**
 //!
-//! (Revision 6, `design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md` §7 rule 9,
-//! restating §6 and `REVISION-2026-08-13.md` §8a.)
+//! (A design rule, restated across three revisions before this module existed.)
 //!
 //! Before this module existed, every counter in the app conjugated itself: a dozen copies of
 //! `if count == 1 { "" } else { "s" }`, plus a second, worse population of labels that simply

--- a/crates/app/src/root/scrollbar.rs
+++ b/crates/app/src/root/scrollbar.rs
@@ -107,10 +107,9 @@ use crate::root::scrollbar_geometry as geometry;
 /// The scrollbar's own thickness (track + thumb width/height) - the hit target as well as the
 /// visual width.
 ///
-/// This used to be a local `8.0` chosen to match this UI's compact chrome, because the mockup had
-/// no scrollbar spec at all. Rev 6 supplies one (`design_handoff_jerry_ade/revision 5/
-/// STAGE-A-CHANGELOG.md` §4p, whose own note is that "for the Rust build this is a spec, not
-/// CSS"), so the number now tracks [`theme::scrollbar::WIDTH`] along with the rest of §4p's table:
+/// This used to be a local `8.0` chosen to match this UI's compact chrome, because there was no
+/// scrollbar spec at all. There is one now, so the number tracks [`theme::scrollbar::WIDTH`]
+/// along with the rest of that spec's table:
 /// [`theme::scrollbar::THUMB_RADIUS`], [`theme::scrollbar::THUMB_INSET`], and a *transparent*
 /// track. The thumb is inset on each side, so what is actually painted is `10 - 2*2 = 6px` wide,
 /// visually slimmer than the old flush 8px bar, on a larger hit target.

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -1983,8 +1983,8 @@ impl AdeApp {
         cx.notify();
     }
 
-    /// The current worktree's open file tabs (`design_handoff_jerry_ade/revision 3/
-    /// REVISION-2026-07-31.md` §3) - an empty slice for a worktree that has never opened one,
+    /// The current worktree's open file tabs - an empty slice for a worktree that has never
+    /// opened one,
     /// never a panic or a fabricated default. See [`Self::open_files_by_worktree`]'s own docs for
     /// why this is keyed by [`Self::file_tree_root`] rather than a flat, unscoped `Vec`.
     pub(crate) fn open_files(&self) -> &[PathBuf] {
@@ -2190,8 +2190,8 @@ impl AdeApp {
 ///
 /// **Deliberately does *not* touch `open_files`/`edit_buffers` anymore.** Both moved to real,
 /// per-worktree-keyed storage (`AdeApp::open_files_by_worktree`, keyed by
-/// [`AdeApp::file_tree_root`]; `AdeApp::edit_buffers`, keyed by `(file_tree_root, path)`) -
-/// `design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §1/§3's explicit requirement that
+/// [`AdeApp::file_tree_root`]; `AdeApp::edit_buffers`, keyed by `(file_tree_root, path)`) - the
+/// design's explicit requirement that
 /// each worktree remembers its own open files, and that an unsaved edit must survive fluidly
 /// hopping between worktrees rather than being silently discarded. Clearing them here used to be
 /// how this function kept one worktree's tabs/buffers from leaking into another's; now that both

--- a/crates/app/src/root/widgets.rs
+++ b/crates/app/src/root/widgets.rs
@@ -189,9 +189,8 @@ pub(crate) fn render_sidebar_message(text: String, color: gpui::Rgba) -> gpui::A
         .into_any_element()
 }
 
-/// Git's own status letter for one file - `A`/`M`/`D` - in the fixed 9px, centred column
-/// `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4j specifies, with the tooltip
-/// that spells it out.
+/// Git's own status letter for one file - `A`/`M`/`D` - in the fixed 9px, centred column the
+/// design specifies, with the tooltip that spells it out.
 ///
 /// One function for all four sites that show it (the Uncommitted rows, the diff toolbar above a
 /// file, the commit file list, and the review file list) rather than four hand-written spans, for
@@ -1110,8 +1109,8 @@ pub(crate) fn text_editing_modifiers(
 /// One [`SimpleInput`]'s caret metrics.
 ///
 /// Exists because the command palette's caret is genuinely a different control from every other
-/// field's: `design_handoff_jerry_ade/revision/Jerry.dc.html`'s own `paletteEmpty`/`paletteTyped`
-/// fixture draws it 16px tall with a 3px gap before the placeholder and a 2px gap after the typed
+/// field's: the design draws it 16px tall with a 3px gap before the placeholder and a 2px gap
+/// after the typed
 /// text, while every other input in the app is the plain flush 14px bar this type defaults to. The
 /// alternative to modelling that here was leaving the palette hand-assembling its own row
 /// forever, which is exactly how it ended up the one field whose caret ignored
@@ -1274,8 +1273,7 @@ impl AdeApp {
 /// The fill behind a centered modal panel - the New file prompt
 /// (`crate::root::new_file::AdeApp::render_new_file_prompt`).
 ///
-/// Derived from `theme::surface::SCRIM`, the design handoff's own scrim colour
-/// (`design_handoff_jerry_ade/revision/README.md`: "Scrim rgba(6,7,8,.62)"), rather than a raw
+/// Derived from `theme::surface::SCRIM`, the designed scrim colour, rather than a raw
 /// `gpui::black()` literal - a literal colour rather than a token, which is exactly what this
 /// app's theming discipline exists to keep out. The alpha stays at 0.35: a small centered dialog
 /// does not dim as hard as the palette, which replaces the entire workspace and uses the

--- a/crates/app/src/run_history/mod.rs
+++ b/crates/app/src/run_history/mod.rs
@@ -1,9 +1,7 @@
 //! Agent history: the sidebar's repo → worktree → run index, and the run-transcript centre tab
 //! (GitHub issue #227). Everything about one feature, in one folder.
 //!
-//! Design sources, read directly rather than paraphrased:
-//! `design_handoff_jerry_ade/revision 5/REVISION-2026-08-13.md` (the whole document) as amended by
-//! `REVISION-2026-08-14.md` §4/§6/§7, and `Jerry.dc.html`'s own `Run · transcript` state.
+//! See `docs/design/work-surface.md` and `docs/design/sidebar.md`.
 //!
 //! ## The one sentence the whole feature hangs off
 //!

--- a/crates/app/src/run_history/model.rs
+++ b/crates/app/src/run_history/model.rs
@@ -95,7 +95,7 @@ impl Outcome {
         }
     }
 
-    /// How the synthesised closing line opens, per outcome - `Jerry.dc.html`'s own four strings.
+    /// How the synthesised closing line opens, per outcome - the design's own four strings.
     pub const fn closing_lead(self) -> &'static str {
         match self {
             Outcome::Done => "Finished.",
@@ -167,10 +167,9 @@ pub fn drift_sentence(commits: usize) -> String {
     )
 }
 
-/// Which runs the History view is showing - `REVISION-2026-08-14.md` §6's `all` / `this worktree`
-/// toggle.
+/// Which runs the History view is showing - the `all` / `this worktree` toggle.
 ///
-/// `All` is the default, matching `Jerry.dc.html`'s own `hScope` default, and it is the one that
+/// `All` is the design's own default, and it is the one that
 /// makes this surface worth visiting: the rail already tells you about the worktree you are in.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum HistoryScope {
@@ -493,9 +492,9 @@ pub fn earlier_runs_label(count: usize) -> String {
 /// `crate::hooks::flow::AdeApp::resume_past_agent` would honestly refuse it anyway.
 ///
 /// `collapsed` names the worktrees whose group the user has explicitly folded. A group not in it
-/// opens if it is the active worktree, or if the scope is already narrowed to one worktree -
-/// `Jerry.dc.html`'s own default, and the reason `REVISION-2026-08-14.md` §6 says the active
-/// worktree "opens by default" rather than "is the only one open".
+/// opens if it is the active worktree, or if the scope is already narrowed to one worktree - the
+/// design's own default, and the reason it says the active worktree "opens by default" rather
+/// than "is the only one open".
 pub fn build_run_tree(
     runs: &[PastAgent],
     worktrees: &[HistoryWorktree],

--- a/crates/app/src/run_history/render.rs
+++ b/crates/app/src/run_history/render.rs
@@ -1,9 +1,9 @@
 //! The real sidebar History body (GitHub issue #227): the scope toggle, the count line, the
 //! repo → worktree → run tree, and the click that opens a run's transcript.
 //!
-//! `design_handoff_jerry_ade/revision 5/REVISION-2026-08-13.md` §3 is the whole brief for this
-//! file, in one sentence: History "is a **list you pick from**, like a file tree - not a
-//! document. Centre tabs hold things you read or work in; the sidebar holds things you navigate."
+//! The whole brief for this file is one design sentence: History "is a **list you pick from**,
+//! like a file tree - not a document. Centre tabs hold things you read or work in; the sidebar
+//! holds things you navigate."
 //! So nothing here renders a transcript; a row's only job is to open one
 //! ([`crate::run_history::tab`]).
 //!

--- a/crates/app/src/run_history/tab.rs
+++ b/crates/app/src/run_history/tab.rs
@@ -1,9 +1,8 @@
 //! The real run-transcript centre tab (GitHub issue #227): its strip entry, its header, its
 //! dimmed body, and its footer's `Resume here` / `Start a new agent from this`.
 //!
-//! `design_handoff_jerry_ade/revision 5/REVISION-2026-08-13.md` §3-§4 is this file's brief. Two
-//! of its sentences are load-bearing enough to repeat here, because breaking either one is what
-//! the design caught *itself* doing:
+//! Two of the design's own sentences are load-bearing enough to repeat here, because breaking
+//! either one is what it caught *itself* doing:
 //!
 //! 1. **Keyed by run id, never the live agent's buffer.** "Borrowing the live buffer produces a
 //!    pane whose header and body describe two different runs, whose diffstats contradict each

--- a/crates/app/src/run_history/transcript_store.rs
+++ b/crates/app/src/run_history/transcript_store.rs
@@ -1,7 +1,7 @@
 //! Real, on-disk transcripts for finished runs, **keyed by run id** (GitHub issue #227).
 //!
-//! `design_handoff_jerry_ade/revision 5/REVISION-2026-08-13.md` §3: "Archived runs carry their own
-//! transcript, keyed by run id (`runOutputs`), never the live agent's buffer." This module is that
+//! The design's rule: "Archived runs carry their own transcript, keyed by run id, never the live
+//! agent's buffer." This module is that
 //! key-value store, and the key is the same [`crate::review::state::baseline_key`] every other
 //! per-run persisted thing in this app is filed under, so a transcript can never end up attached
 //! to a different run than the record beside it.

--- a/crates/app/src/search/engine.rs
+++ b/crates/app/src/search/engine.rs
@@ -669,16 +669,16 @@ pub fn replace_across(
 }
 
 /// How many characters of context sit before the hit on a match row before the prefix elides from
-/// the left. `Jerry.dc.html`'s own `trimPre`: `s.length > 16 ? '…' + s.slice(-15)`.
+/// the left.
 pub const ELIDE_PREFIX_MAX: usize = 16;
 
-/// The same for the tail. `Jerry.dc.html`'s own `trimPost`: `s.length > 26 ? s.slice(0, 25) + '…'`.
+/// The same for the tail.
 pub const ELIDE_SUFFIX_MAX: usize = 26;
 
 /// Splits `line` around `range` into the three spans a match row draws, with the design's own
 /// left-elision applied.
 ///
-/// `Jerry.dc.html` states the rule and the reason verbatim: "The row is ~40 characters at 10px
+/// The design states the rule and the reason verbatim: "The row is ~40 characters at 10px
 /// mono. A long prefix pushes the match clean out of the box, which defeats the point of showing
 /// the line at all - so the prefix elides from the LEFT and the hit stays at a fixed early column,
 /// the way VS Code does it. The tail may overflow; the tail is only context."
@@ -1103,9 +1103,8 @@ mod perf_tests {
 /// for the walk, the reads or the writes, because the walk's own rules (`.git`, symlinks, binary
 /// files, the size cap) are exactly the part an in-memory fixture cannot exercise.
 ///
-/// The corpus mirrors `Jerry.dc.html`'s own fixture (`refresh_token` across `src/auth/`,
-/// `tests/` and `migrations/`) so the shapes asserted here are the shapes the panel was designed
-/// against.
+/// The corpus mirrors the design's own example (`refresh_token` across `src/auth/`, `tests/` and
+/// `migrations/`) so the shapes asserted here are the shapes the panel was designed against.
 #[cfg(test)]
 mod worktree_tests {
     use super::*;

--- a/crates/app/src/search/glob.rs
+++ b/crates/app/src/search/glob.rs
@@ -1,7 +1,6 @@
-//! The pure glob matcher behind the search panel's `include` / `exclude` path filters
-//! (`design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md` §5: "a funnel for path filters",
-//! and STAGE-A-CHANGELOG.md §4v's "Include/exclude globs behind `⋯` - `src/**, tests/**` /
-//! `target/**, *.lock`").
+//! The pure glob matcher behind the search panel's `include` / `exclude` path filters - the
+//! design's "funnel for path filters", with include/exclude globs behind it (`src/**, tests/**`
+//! / `target/**, *.lock`).
 //!
 //! ## Why hand-rolled rather than `globset`
 //!

--- a/crates/app/src/search/mod.rs
+++ b/crates/app/src/search/mod.rs
@@ -1,8 +1,8 @@
 //! The right panel's **Search** tab: everything about one feature, in one folder.
 //!
-//! `design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md` §5 ("Search is a real panel") and
-//! `STAGE-A-CHANGELOG.md` §4u/§4v/§4w re-scoped search from a flat list of filenames into the
-//! middle tab of `Files · Search · Changes`, with the verdict this whole folder exists to satisfy:
+//! Search was re-scoped from a flat list of filenames into a real panel - the
+//! middle tab of `Files · Search · Changes` - with the verdict this whole folder exists to
+//! satisfy:
 //! **"a search result that only names a file is an index, not a result. Show the line."**
 //!
 //! Split the way every feature folder in this crate is split - pure, GPUI-free logic separate from

--- a/crates/app/src/search/render.rs
+++ b/crates/app/src/search/render.rs
@@ -1,7 +1,7 @@
 //! The real GPUI Search panel - the middle tab of `Files · Search · Changes`, as `impl AdeApp`
 //! methods.
 //!
-//! Built from top to bottom exactly as `Jerry.dc.html`'s own `showFind` block is:
+//! Built from top to bottom exactly as the design's own search panel is:
 //!
 //! - the **query row** (30 high): leading `⌕`, the real query input, then the `Aa` / `ab` / `.*`
 //!   modifier buttons,
@@ -1376,9 +1376,8 @@ mod panel_tests {
     use gpui::TestAppContext;
     use tempfile::TempDir;
 
-    /// A real worktree on disk with `refresh_token` across four files - the same corpus
-    /// `Jerry.dc.html`'s own search fixture uses, so what these tests see is what the design was
-    /// drawn against.
+    /// A real worktree on disk with `refresh_token` across four files - the same corpus the
+    /// design's own search example uses, so what these tests see is what it was drawn against.
     fn fixture_repo() -> TempDir {
         let repo = TempDir::new().expect("tempdir");
         let write = |relative: &str, content: &str| {
@@ -1431,7 +1430,7 @@ mod panel_tests {
     /// `⇄`/funnel toggle buttons kept their real 17px hit box, but the SVG glyph inside each one
     /// was wrongly stretched to fill that whole box instead of painting at
     /// `icons::IconSize::Control`'s real 12px optical box (`icons.rs`'s doc comment has the
-    /// bounding-box measurements off `Jerry.dc.html` this 12 comes from).
+    /// bounding-box measurements this 12 comes from).
     #[gpui::test]
     fn the_count_row_toggle_icons_paint_smaller_than_their_hit_box(cx: &mut TestAppContext) {
         let repo = fixture_repo();

--- a/crates/app/src/settings/render.rs
+++ b/crates/app/src/settings/render.rs
@@ -64,8 +64,8 @@ impl AdeApp {
         }
     }
 
-    /// The Settings surface's own key handler - just `Esc`-to-close
-    /// (`design_handoff_jerry_ade/README.md`: "esc ... returns to the workspace"). Nav is
+    /// The Settings surface's own key handler - just `Esc`-to-close, returning to the
+    /// workspace. Nav is
     /// click-only, so unlike [`Self::handle_palette_key_down`] this needs no arrow-key/tab
     /// handling.
     pub(in crate::settings) fn handle_settings_key_down(
@@ -164,8 +164,7 @@ impl AdeApp {
         self._lsp_rows_task = Some(task);
     }
 
-    /// The Settings surface (`design_handoff_jerry_ade/README.md`'s "Settings" section): a
-    /// 212px nav plus a content column. `track_focus`/`on_key_down` here are what make `Esc`
+    /// The Settings surface (`docs/design/settings.md`): a 212px nav plus a content column. `track_focus`/`on_key_down` here are what make `Esc`
     /// actually reach [`Self::handle_settings_key_down`] - the same pattern `Self::render_palette`
     /// uses for its own panel (`vendor/zed/crates/gpui/src/elements/div.rs`'s `Div::track_focus`/
     /// `Interactivity::on_key_down`).
@@ -181,9 +180,9 @@ impl AdeApp {
             .child(self.render_settings_content(cx))
     }
 
-    /// The 212px nav column - `design_handoff_jerry_ade/revision/README.md`: "Nav 212 wide ...
-    /// Groups (Workspace, Interface, Editor, Other) with the same 9.5px uppercase header as the
-    /// rail." All eleven pages are clickable navigation (`crate::settings::state::nav_groups`); seven
+    /// The 212px nav column: four groups - Workspace, Interface, Editor, Other - under the same
+    /// uppercase header the rail uses.
+    /// All eleven pages are clickable navigation (`crate::settings::state::nav_groups`); seven
     /// render real content past this point - see `crate::settings::state`'s module docs.
     pub(in crate::settings) fn render_settings_nav(
         &self,
@@ -286,8 +285,7 @@ impl AdeApp {
                             .text_size(px(10.0))
                             .text_color(theme::text::HINT)
                             // Real crate name/version (`env!` reads this crate's own
-                            // `Cargo.toml` at compile time), not Jerry.dc.html's fabricated
-                            // "jerry 0.4.2".
+                            // `Cargo.toml` at compile time), never a hardcoded one.
                             .child(format!(
                                 "{} {} \u{b7} settings.toml",
                                 env!("CARGO_PKG_NAME"),
@@ -325,9 +323,8 @@ impl AdeApp {
             let badge = match page {
                 SettingsPage::Agents => Some(agent_count.to_string()),
                 SettingsPage::Worktrees => Some(worktree_count.to_string()),
-                // Live counts, not Jerry.dc.html's fabricated sample badges (Keybindings' mockup
-                // `48` doesn't match this app's real, smaller count - see
-                // `crate::settings::state::keybinding_rows`'s own docs).
+                // Live counts, never a fixed sample number - see
+                // `crate::settings::state::keybinding_rows`'s own docs.
                 // Built-in + real, disk-loaded custom themes (GitHub issue #5) - one combined
                 // count, matching `Self::render_settings_theme_page`'s own combined card list.
                 SettingsPage::Theme => {
@@ -408,10 +405,8 @@ impl AdeApp {
     }
 
     /// The content column: header block (title + subtitle) plus whichever page's real (or
-    /// honestly placeholder) body - `design_handoff_jerry_ade/revision/README.md`'s "Content
-    /// column" section. Header and scrollable body are both capped at
-    /// `theme::zone::SETTINGS_CONTENT_MAX_WIDTH` (700px), left-aligned inside the 26px padding -
-    /// matching `Jerry.dc.html`'s own `max-width:700px` wrapper.
+    /// honestly placeholder) body. Header and scrollable body are both capped at
+    /// `theme::zone::SETTINGS_CONTENT_MAX_WIDTH` (700px), left-aligned inside the 26px padding.
     pub(in crate::settings) fn render_settings_content(
         &mut self,
         cx: &mut Context<Self>,
@@ -518,9 +513,9 @@ impl AdeApp {
             )
     }
 
-    /// *Agents › Installed* - `design_handoff_jerry_ade/README.md`: "bordered card ... of four
-    /// rows ... agent badge ... name ... binary path ... model ... a `default` pill ... green
-    /// dot + 'ready' ... Edit." This app drops the `model`/`default`/`Edit` pieces (see
+    /// *Agents › Installed* - the designed card: agent badge, name, binary path, model, a
+    /// `default` pill, a green dot and `ready`, then `Edit`. This app drops the
+    /// `model`/`default`/`Edit` pieces (see
     /// `crate::settings::state`'s module docs for why) and shows [`settings::AGENT_KINDS`]'s two real
     /// rows instead of the mockup's four fabricated ones, each with a live PATH-derived status.
     pub(in crate::settings) fn render_settings_agents_page(
@@ -647,8 +642,8 @@ impl AdeApp {
             )
     }
 
-    /// The Installed card's footer - `design_handoff_jerry_ade/README.md`: "Card footer ...
-    /// '+ Add an agent — any binary that speaks a resumable agent on stdin'." Rendered dimmed
+    /// The Installed card's footer - `+ Add an agent — any binary that speaks a resumable agent
+    /// on stdin`, which is the product position stated in the design. Rendered dimmed
     /// and inert (no `on_click`) - `crate::work_surface::agents::AgentKind` is a fixed Rust enum,
     /// so there is no runtime "register a new agent binary" flow to wire this to yet.
     pub(in crate::settings) fn render_settings_agents_footer(&self) -> impl IntoElement {
@@ -683,9 +678,9 @@ impl AdeApp {
             )
     }
 
-    /// *Worktrees › Disk* - `design_handoff_jerry_ade/README.md`: "same card shape: status dot
-    /// ... worktree path ... branch ... size ... a right-aligned Open ... or Prune ...
-    /// action. Footer totals ... and a Prune 1 merged action." Every row and total here reads
+    /// *Worktrees › Disk* - the same card shape as Agents: status dot, worktree path, branch,
+    /// size, and a right-aligned `Open` or `Prune`, over a footer of totals and a prune action.
+    /// Every row and total here reads
     /// existing state (`Self::worktrees`, `Self::worktree_notes`, `Self::worktree_disk_usage`/
     /// `Self::disk_usage`), and Prune - both the row action and the footer action - dispatches
     /// through the same `Self::request_prune`/`Self::execute_prune` two-click-confirmation path
@@ -947,8 +942,8 @@ impl AdeApp {
     /// detection - Revision R6's job, per the doc comment this replaced) - the same chip the
     /// status bar and terminal footer render, not a fourth copy.
     ///
-    /// `Restore agents on launch` and `Confirm before discarding a worktree` - two more rows
-    /// `Jerry.dc.html`'s own `settingsRows.general` fixture shows - stay left out for the same
+    /// `Restore agents on launch` and `Confirm before discarding a worktree` - two more rows the
+    /// design's General page shows - stay left out for the same
     /// reason as the Agents/Worktrees toggle sections (see `crate::settings::state`'s module docs):
     /// agent-restore-on-launch and a discard-confirmation flow are app behaviour this build
     /// doesn't have, not settings plumbing around behaviour that already exists.
@@ -3068,8 +3063,8 @@ impl AdeApp {
 
     /// *Language servers* - PATH-detection rows, following the same pattern as
     /// [`Self::render_settings_agents_page`] (`crate::settings::state::detect_lsp_rows`, cached in
-    /// [`Self::lsp_rows`]). `format on save`/`inlay hints`/`diagnostics in the rail` toggles from
-    /// `Jerry.dc.html`'s own `settingsRows.lsp` fixture are left out for the same reason as the
+    /// [`Self::lsp_rows`]). The designed `format on save`/`inlay hints`/`diagnostics in the rail`
+    /// toggles are left out for the same reason as the
     /// Agents/Worktrees toggle sections (see `crate::settings::state`'s module docs). No config
     /// banner/snippet either: these rows are live-detected `$PATH` state, not `settings.toml`
     /// keys.
@@ -5319,8 +5314,8 @@ mod export_theme_name_tests {
     }
 }
 
-/// A nav-only Settings page's placeholder body - `Jerry.dc.html`'s own `setStub` copy, "not
-/// designed in this mockup". Used for every page [`SettingsPage::is_implemented`] reports
+/// A nav-only Settings page's placeholder body, saying so out loud rather than faking content.
+/// Used for every page [`SettingsPage::is_implemented`] reports
 /// `false` for - see `crate::settings::state`'s module docs for why.
 pub(in crate::settings) fn render_settings_placeholder_page() -> impl IntoElement {
     div()

--- a/crates/app/src/settings/state.rs
+++ b/crates/app/src/settings/state.rs
@@ -1,5 +1,5 @@
-//! Pure data model for the Settings surface (`design_handoff_jerry_ade/revision/README.md`'s
-//! "Settings" section). Maps already-real app state (agent binaries on `$PATH`, the worktree
+//! Pure data model for the Settings surface (`docs/design/settings.md`). Maps already-real app
+//! state (agent binaries on `$PATH`, the worktree
 //! list, the registered global keybindings) to what a settings row should show, with no `gpui`
 //! dependency so it's directly unit-testable; `crate::root` turns the result into `gpui::Div`
 //! trees. Config-file-backed values live in `crate::settings::store` instead - this module is
@@ -9,8 +9,8 @@
 //!
 //! General, Agents, Worktrees, Appearance, Themes, Keybindings, Editor, Language servers, and
 //! Notifications render real, live-derived content (see [`SettingsPage::is_implemented`]).
-//! Integrations and About are honest nav-only placeholders - `Jerry.dc.html`'s own `setStub`
-//! copy, "not designed in this mockup". Editor is a partial exception, not a full one: its one
+//! Integrations and About are honest nav-only placeholders that say so out loud rather than
+//! faking content. Editor is a partial exception, not a full one: its one
 //! real row is the minimap (`crate::code_surface::minimap`, GitHub issue #30's
 //! `editor.minimap.enabled`) - indentation/soft-wrap/whitespace-display still have no real
 //! backing anywhere in this codebase, so those stay left off the page entirely rather than
@@ -22,7 +22,7 @@
 //!
 //! ## Why the Agents/Worktrees "Behaviour"/"Policy" toggle sections are left out
 //!
-//! `Jerry.dc.html`'s `settingsRows.agents`/`settingsRows.worktrees` fixtures show toggles like
+//! The design's Agents and Worktrees pages show toggles like
 //! "Plan before editing" or a "Worktree root" path field, but nothing in this app persists a
 //! value per agent or per worktree (even `crate::settings::store::Settings` is a flat, global
 //! struct with nowhere to hang a per-agent bool). Rendering them anyway would be a control bound
@@ -34,8 +34,7 @@ use std::path::PathBuf;
 use crate::rail::state::WorktreeNote;
 use crate::work_surface::agents::AgentKind;
 
-/// Every page `Jerry.dc.html`'s `settingsNavDefs` fixture lists, in the order the design's four
-/// nav groups present them (see [`nav_groups`]).
+/// Every Settings page, in the order the four nav groups present them (see [`nav_groups`]).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SettingsPage {
     General,
@@ -117,11 +116,10 @@ impl SettingsPage {
         )
     }
 
-    /// The content column's one-line rationale under the page title
-    /// (`design_handoff_jerry_ade/revision/README.md`'s "Content column" section) - app-authored
-    /// text, not copy from the mockup (`Jerry.dc.html` has no per-page subtitle fixture). Every
-    /// nav-only page shares the same placeholder text; the placeholder page *body* is separately
-    /// the mockup's verbatim `setStub` copy - see `crate::settings::render::render_settings_placeholder_page`.
+    /// The content column's one-line rationale under the page title - app-authored text, the
+    /// design carrying no per-page subtitle. Every nav-only page shares the same placeholder
+    /// text; the placeholder page *body* is separate - see
+    /// `crate::settings::render::render_settings_placeholder_page`.
     pub fn subtitle(self) -> &'static str {
         match self {
             SettingsPage::General => {
@@ -163,7 +161,7 @@ pub struct NavGroup {
     pub pages: Vec<SettingsPage>,
 }
 
-/// The fixed nav structure - `Jerry.dc.html`'s own `settingsNavDefs` grouping and order,
+/// The fixed nav structure - the design's own grouping and order,
 /// unchanged. Every page is clickable navigation even though not every page renders real
 /// content past that point (see [`SettingsPage::is_implemented`]).
 pub fn nav_groups() -> Vec<NavGroup> {
@@ -224,8 +222,8 @@ impl AgentRow {
         self.resolved_path.is_some()
     }
 
-    /// The status label next to the row's status dot ("green dot + 'ready'" per
-    /// `design_handoff_jerry_ade/revision/README.md`), or the honest opposite when not found.
+    /// The status label next to the row's status dot - a green dot and `ready`, or the honest
+    /// opposite when not found.
     pub fn status_label(&self) -> &'static str {
         if self.is_ready() {
             "ready"
@@ -287,9 +285,8 @@ pub fn worktree_dot_status(is_main: bool, note: &WorktreeNote) -> WorktreeDotSta
     }
 }
 
-/// A worktree row's right-aligned action - `design_handoff_jerry_ade/README.md`'s "a
-/// right-aligned Open ... or Prune ... action" (the main checkout's row has no action at all;
-/// every other row is `Open` or `Prune`, never both).
+/// A worktree row's right-aligned action - `Open` or `Prune`, never both. The main checkout's
+/// row has no action at all.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WorktreeRowAction {
     /// The main checkout - `git worktree remove` refuses it outright, and there's nowhere else
@@ -382,10 +379,10 @@ pub struct LspLanguage {
     /// file-tree row for that language would show.
     pub ext: &'static str,
     pub binary: &'static str,
-    /// Generic descriptive copy, not a live count - `Jerry.dc.html`'s own `lspDefs` notes mix
-    /// this with fabricated live data ("1,284 crates indexed") this app has no per-language
-    /// agent summary to back (`crate::lsp::client`'s server clients are keyed by worktree, not
-    /// surfaced here). Every note here is deliberately the descriptive kind only.
+    /// Generic descriptive copy, not a live count. The design mixes this slot with live figures
+    /// ("1,284 crates indexed") this app has no per-language agent summary to back
+    /// (`crate::lsp::client`'s server clients are keyed by worktree, not surfaced here), so every
+    /// note here is deliberately the descriptive kind only.
     pub note: &'static str,
     /// This server's real official install/docs page - see
     /// `crate::language::SettingsLspRow::install_url`'s own docs for how each was verified.
@@ -447,8 +444,8 @@ impl LspRow {
         self.resolved_path.is_some()
     }
 
-    /// `Jerry.dc.html`'s own word for the not-found state - `"not installed"`, distinct from the
-    /// Agents page's `"not found"`; each page keeps its own mockup's wording.
+    /// This page's own word for the not-found state - `"not installed"`, distinct from the
+    /// Agents page's `"not found"`; each page keeps its own designed wording.
     pub fn status_label(&self) -> &'static str {
         if self.is_ready() {
             "ready"
@@ -2120,8 +2117,8 @@ mod tests {
         // *global* and so is not counted here - the right panel's Search tab has no editor to be
         // scoped to, and a real Cmd/Ctrl-modified keystroke never reaches a focused pty anyway.
         // The Changes-footer prose fix added 1 more: `space` -> `ToggleChangeStaged`, alongside
-        // `v` and `]` - `Jerry.dc.html`'s `changesHints` advertises `space stage` in that footer
-        // and nothing was bound to it. All three of those now also carry `&& !text-input`, since
+        // `v` and `]` - the Changes footer advertises `space stage` and nothing was bound to it.
+        // All three of those now also carry `&& !text-input`, since
         // issue #288's pinned note card is a real text input *inside* the `"diff"` node that
         // `"file-editor"` does not cover.
         // GitHub issue #336 added 4 more scoped bindings: `TextCopy`/`TextCut`/`TextPaste`/

--- a/crates/app/src/settings/store.rs
+++ b/crates/app/src/settings/store.rs
@@ -884,9 +884,9 @@ impl Settings {
 }
 
 /// Which settings page a [`snippet_lines`]/[`config_keys_line`] call is for - only the four
-/// pages `crate::settings::render` shows a config banner/snippet block on. Every other page
-/// `Jerry.dc.html`'s own `cfgKeys` fixture lists isn't backed by a [`Settings`] field, so a
-/// banner for it would describe a file section that doesn't exist.
+/// pages `crate::settings::render` shows a config banner/snippet block on. Every other designed
+/// page isn't backed by a [`Settings`] field, so a banner for it would describe a file section
+/// that doesn't exist.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConfigPage {
     General,
@@ -896,9 +896,9 @@ pub enum ConfigPage {
     Notifications,
 }
 
-/// The config banner's dot-joined key list for `page` - rewritten from `Jerry.dc.html`'s own
-/// `cfgKeys` fixture to list only the [`Settings`] field paths this app actually persists (that
-/// fixture also names settings this app doesn't implement, e.g. `window.restore_sessions`).
+/// The config banner's dot-joined key list for `page` - narrowed from the design's own list to
+/// only the [`Settings`] field paths this app actually persists (the design also names settings
+/// this app doesn't implement, e.g. `window.restore_sessions`).
 pub fn config_keys_line(page: ConfigPage) -> &'static str {
     match page {
         ConfigPage::General => "window.controls \u{b7} terminal.shell",

--- a/crates/app/src/settings/theme_file_format.rs
+++ b/crates/app/src/settings/theme_file_format.rs
@@ -134,10 +134,10 @@ const MAX_KEY_NOTE: usize = 60;
 /// Turns a token's own doc into a note worth putting next to a value in a theme file, or `None`.
 ///
 /// A doc comment is written for someone editing `crate::theme`, not for someone editing a theme,
-/// so some of them are whole paragraphs of design history and cite things (`Jerry.dc.html`, issue
-/// numbers, other tokens) a theme author has no use for. This keeps the short, genuinely
-/// descriptive ones - which is most of the palette, since the tokens ported from the design
-/// handoff carry real one-line labels like `window body` - and drops the rest rather than
+/// so some of them are whole paragraphs of design rationale and cite things (issue numbers,
+/// other tokens, `docs/design/`) a theme author has no use for. This keeps the short, genuinely
+/// descriptive ones - which is most of the palette, most tokens carrying a real one-line label
+/// like `window body` - and drops the rest rather than
 /// wrapping an essay into the file. No note is better than a wall of text.
 fn key_note_from(doc: &str) -> Option<String> {
     let sentence = first_sentence(doc);

--- a/crates/app/src/settings/widgets.rs
+++ b/crates/app/src/settings/widgets.rs
@@ -1,10 +1,10 @@
 //! Two render helpers shared by every settings page backed by `crate::settings::store::Settings`
 //! (General, Appearance & scaling, Themes - see `crate::settings::store::ConfigPage`'s own docs
-//! for why only those three), plus the `toggle`/`stepper`/`choice` row-control widgets
-//! `design_handoff_jerry_ade/revision/README.md`'s "Settings rows" section defines.
+//! for why only those three), plus the `toggle`/`stepper`/`choice` row-control widgets the design
+//! defines (`docs/design/settings.md`).
 //! `crate::settings::render` is the only caller; this module exists separately so the
-//! visual "control shape" stays independent of any one page's field-mutation logic. (That
-//! section also defines a `path` control shape - `value` + `Change…` - but no page wires a
+//! visual "control shape" stays independent of any one page's field-mutation logic. (The design
+//! also defines a `path` control shape - `value` + `Change…` - but no page wires a
 //! click handler to a `Change…` action, so it isn't built here.)
 //!
 //! Every row-control text size in this module routes through `Self::ui_text_size`
@@ -138,7 +138,7 @@ impl AdeApp {
         self.spawn_open_command(program, args, url.to_string(), cx);
     }
 
-    /// The config banner (`design_handoff_jerry_ade/revision/CHANGELOG.md`'s change 3): a
+    /// The config banner: a
     /// bordered strip directly under a real page's header showing the real settings file path,
     /// that page's real key list (`crate::settings::store::config_keys_line`), the real
     /// `TOML | JSON` segment, and an `Open file` button. Only ever called for the three pages
@@ -330,9 +330,9 @@ impl AdeApp {
             )
     }
 
-    /// One real settings row shell - `design_handoff_jerry_ade/revision/README.md`'s "Settings
-    /// rows" spec: "11px vertical padding, bottom border, label + hint on the left, control
-    /// right." `control` is whichever of [`Self::render_toggle_control`]/
+    /// One real settings row shell - 11px vertical padding, bottom border, label plus hint on
+    /// the left, control right.
+    /// `control` is whichever of [`Self::render_toggle_control`]/
     /// [`Self::render_stepper_control`]/[`Self::render_choice_control`] the caller built.
     pub(in crate::settings) fn render_settings_row(
         &self,
@@ -375,8 +375,8 @@ impl AdeApp {
             .child(control)
     }
 
-    /// The real 26×15 toggle control (`design_handoff_jerry_ade/revision/README.md`'s "Settings
-    /// rows" spec) - `id` must be unique per row (used as the GPUI element id). Always
+    /// The real 26×15 toggle control - `id` must be unique per row (used as the GPUI element
+    /// id). Always
     /// interactive - see [`Self::render_toggle_control_gated`] for the variant a parent
     /// switch/setting can disable.
     pub(in crate::settings) fn render_toggle_control(
@@ -443,8 +443,8 @@ impl AdeApp {
             })
     }
 
-    /// The real `− value +` stepper control (`design_handoff_jerry_ade/revision/README.md`'s
-    /// "Settings rows" spec) - `value` is already-formatted display text (e.g. `"13 px"`).
+    /// The real `− value +` stepper control - `value` is already-formatted display text (e.g.
+    /// `"13 px"`).
     pub(in crate::settings) fn render_stepper_control(
         &self,
         id_prefix: &'static str,

--- a/crates/app/src/sidebar/changes.rs
+++ b/crates/app/src/sidebar/changes.rs
@@ -1,4 +1,4 @@
-//! Pure logic for Zone 3's "Changes" list (`design_handoff_jerry_ade/README.md`'s Zone 3 spec)
+//! Pure logic for Zone 3's "Changes" list (`docs/design/sidebar.md`)
 //! and the fold-marker treatment used when rendering a file's hunks.
 //!
 //! Deliberately GPUI-window-free, mirroring `crate::work_surface::state`/`crate::rail::status`'s split: only
@@ -34,10 +34,9 @@ pub fn diff_file_stats(file: &DiffFile) -> (u32, u32) {
     (add, del)
 }
 
-/// Git's own status letter for one file row - `A`, `M` or `D`
-/// (`design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4j).
+/// Git's own status letter for one file row - `A`, `M` or `D`.
 ///
-/// **Total, not optional**, and that is the whole point of §4j: the `new`/`del` word pills this
+/// **Total, not optional**, and that is the whole point: the `new`/`del` word pills this
 /// replaced marked only the exceptions, so a *modified* file - the common case - got no mark at
 /// all and "the row could not answer 'what happened to this file', which is the first thing a
 /// reviewer asks". Every row gets a letter, in a fixed column, so every filename also starts on
@@ -223,8 +222,7 @@ impl StagedProgress {
     }
 }
 
-/// Splits a diff file path into the Changes row / diff toolbar's `dir` and `name` fields
-/// (`design_handoff_jerry_ade/README.md`: "`dir` 10.5px mono ... `name` 11.5px/450 mono").
+/// Splits a diff file path into the Changes row / diff toolbar's `dir` and `name` fields.
 /// `wt_core::diff` paths are repo-relative (stripped of the `a/`/`b/` prefixes `git diff`
 /// prints - see that module's `parse_diff_git_header`), so a root-level file's `dir` is empty,
 /// not `.`.

--- a/crates/app/src/sidebar/context_menu.rs
+++ b/crates/app/src/sidebar/context_menu.rs
@@ -10,8 +10,8 @@
 //! Everything *generic* about a menu - what a row is, how groups become separated rows, the
 //! popover's painted height, and the edge-aware geometry that keeps it on screen - moved to
 //! [`crate::menu::model`] when GitHub issue #290 promoted this component into the app's one
-//! shared menu (`design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4t: "Both are 'a list
-//! of actions', so they are **one menu component** ... rather than two idioms that drift"). The
+//! shared menu - "Both are 'a list of actions', so they are **one menu component** ... rather
+//! than two idioms that drift". The
 //! file tree draws through that shared popover now; what stays here is only what is genuinely the
 //! file tree's own: its targets, its actions, and its row sets.
 

--- a/crates/app/src/sidebar/file_tree.rs
+++ b/crates/app/src/sidebar/file_tree.rs
@@ -278,9 +278,9 @@ fn visit(dir: &Path, depth: usize, walk: &mut Walk) -> io::Result<()> {
     Ok(())
 }
 
-/// A file tree row's real 13×13 language chip - `design_handoff_jerry_ade/README.md`'s Zone 3
-/// table (`.rs`→`rs`, `.toml`→`to`, `.md`→`md`, `.sql`→`sq`, matching `theme::lang::*` from
-/// Phase A's `theme.rs`), plus a neutral fallback (`theme::lang::UNKNOWN`) for any other
+/// A file tree row's real 13×13 language chip (`.rs`→`rs`, `.toml`→`to`, `.md`→`md`,
+/// `.sql`→`sq`, matching `theme::lang::*`), plus a neutral fallback (`theme::lang::UNKNOWN`) for
+/// any other
 /// extension so every file row still gets *some* chip rather than one silently missing.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct LangChip {
@@ -340,7 +340,7 @@ pub fn directory_paths(entries: &[FileTreeEntry]) -> HashSet<PathBuf> {
 /// A row's left padding before any indentation (`crate::sidebar::render`'s `pl(px(8.0) + indent)`).
 pub const ROW_LEFT_PAD: f32 = 8.0;
 
-/// Horizontal indent per nesting level, per `design_handoff_jerry_ade/README.md`'s Zone 3 spec.
+/// Horizontal indent per nesting level.
 pub const INDENT_STEP: f32 = 13.0;
 
 /// Where level `level`'s vertical indent guide sits, in pixels from the row's left edge.

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -804,8 +804,8 @@ impl AdeApp {
             .collect()
     }
 
-    /// The file tree - `design_handoff_jerry_ade/README.md`'s Zone 3 "Files (tree)" spec:
-    /// rect-composed folder/language-chip icons (see [`render_folder_icon`]/
+    /// The file tree (`docs/design/sidebar.md`): rect-composed folder/language-chip icons (see
+    /// [`render_folder_icon`]/
     /// [`render_lang_chip`], never emoji or an SVG pipeline), collapse/expand (see
     /// [`Self::toggle_dir_expanded`]/`crate::sidebar::file_tree::visible_entries`).
     ///
@@ -1673,19 +1673,16 @@ impl AdeApp {
         row.into_any_element()
     }
 
-    /// Zone 3's header band (36 high): the real `Files · Search · Changes` segmented control
-    /// (`design_handoff_jerry_ade/README.md`: "Header 36: segmented `Files | Changes`
-    /// (Files is first and default...)", with GitHub issue #162 adding Search in the middle) plus
+    /// Zone 3's header band (36 high): the real `Files · Search · Changes` segmented control -
+    /// Files first and default, with GitHub issue #162 having added Search in the middle - plus
     /// the real `+n`/`−n` totals across the currently loaded diff, summed from the same real
     /// per-file stats (`crate::sidebar::changes::diff_file_stats`) the Changes rows themselves
     /// show.
     ///
-    /// The three segments are **icons**, not text - `STAGE-A-CHANGELOG.md` §4w: "`Files` /
-    /// `Search` / `Changes` were the only text tabs left in a window whose left strip is already
-    /// iconographic. Now three 26x19 buttons in the same segmented shell, selected state
-    /// unchanged, each with a tooltip carrying the old label plus its old hint." The tooltip
-    /// strings below are `Jerry.dc.html`'s own `title` attributes on those three buttons,
-    /// transcribed rather than paraphrased.
+    /// The three segments are **icons**, not text: `Files` / `Search` / `Changes` were the only
+    /// text tabs left in a window whose left strip is already iconographic. Three 26x19 buttons
+    /// in the same segmented shell, selected state unchanged, each with a tooltip carrying the
+    /// old label plus its old hint.
     pub(in crate::sidebar) fn render_right_sidebar_toggle(
         &self,
         cx: &mut Context<Self>,
@@ -1751,10 +1748,9 @@ impl AdeApp {
             // `crate::root::scrollbar::CONTENT_CLEARANCE`'s own docs for the value.
             .pr(px(scrollbar::CONTENT_CLEARANCE))
             // The third of the window's three column headers, so the rule it draws is the same
-            // one the sidebar strip and the centre tab strip draw - GitHub issue #291 /
-            // `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4v: "all three borders
-            // are `#191c1f` ... [otherwise it] would have read as one rule changing shade
-            // mid-span". This was `theme::border::INNER` (`#1c2023`), a third shade on the same y.
+            // one the sidebar strip and the centre tab strip draw (GitHub issue #291). All three
+            // share one colour; otherwise it reads as one rule changing shade mid-span. This was
+            // `theme::border::INNER` (`#1c2023`), a third shade on the same y.
             .border_b_1()
             .border_color(theme::border::RAIL_INNER)
             .child(toggle)
@@ -1860,8 +1856,7 @@ impl AdeApp {
     }
 
     /// Zone 3's whole real body: the `Files | Changes` header, then either the scrollable file
-    /// tree, or the Changes list's own header/scrollable-rows/footer trio -
-    /// `design_handoff_jerry_ade/README.md`'s Changes spec ("Header 7/12 ... Footer 29"). Both
+    /// tree, or the Changes list's own header/scrollable-rows/footer trio. Both
     /// list arms wrap their list in a plain `flex_1().min_h_0()` column, so a long list scrolls
     /// under its own pinned header/footer instead of pushing them off-screen.
     ///
@@ -1914,10 +1909,10 @@ impl AdeApp {
             // GitHub issue #285: four collapsible sections, with the commit composer pinned
             // **above** them rather than at the panel's foot. The composer is a git control and
             // the sections are what it acts on, so it reads first; that ordering is
-            // `REVISION-2026-08-14.md` §1's own sketch. Of the four, only Runs is pinned to the
-            // panel's own *bottom*, in its own capped well below the other three's shared
-            // scroller (`Self::render_changes_runs_section`) - `Jerry.dc.html` line 1433's own
-            // separate `max-height:170px` wrapper, not a fourth entry in the shared one.
+            // the design's own ordering. Of the four, only Runs is pinned to the panel's own
+            // *bottom*, in its own capped well below the other three's shared scroller
+            // (`Self::render_changes_runs_section`) - a separate, capped wrapper, not a fourth
+            // entry in the shared one.
             RightSidebarView::Changes => container
                 .child(self.render_commit_composer(cx))
                 .children(self.render_changes_row_error(cx))
@@ -2167,10 +2162,9 @@ impl AdeApp {
                 // one - the exact defect §4e removed them from the agent header for.
                 //
                 // No per-file rows, though issue #285's own checklist says "diffstat, file list
-                // and commit context" - a deliberate deviation from that restated checklist back
-                // toward `Jerry.dc.html` itself: line 1422's `baseRows` is a synthetic one-entry
-                // array (`wtBaseDefs`'s `files` is a plain count, never an array of files), so a
-                // committed file was never meant to be its own row here. Requested directly:
+                // and commit context" - a deliberate deviation from that restated checklist: the
+                // design carries a plain file *count* here, never an array of files, so a
+                // committed file was never meant to be its own row. Requested directly:
                 // "commited files should not appear on the changes tab under against master."
                 let base = self.changes_base_branch().map(str::to_string);
                 if let Some(base) = base {
@@ -2246,9 +2240,8 @@ impl AdeApp {
     /// The Changes panel's main scroller: **three** of its four sections' worth of rows
     /// (Uncommitted, Commits, Against main) in a single `gpui::list`, with the same shared overlay
     /// scrollbar every other scrollable region in this app draws (`crate::root::scrollbar`). Runs
-    /// is deliberately excluded - it renders in its own pinned-bottom well,
-    /// [`Self::render_changes_runs_section`], matching `Jerry.dc.html` line 1433's own separate
-    /// `max-height:170px;overflow-y:auto` wrapper rather than sharing this scroller.
+    /// is deliberately excluded - it renders in its own pinned-bottom, capped well,
+    /// [`Self::render_changes_runs_section`], rather than sharing this scroller.
     ///
     /// `gpui::list`, not the `uniform_list` this panel used to use, for one structural reason: even
     /// with Runs split out, these three sections still put a 24px header and a 27px file row in the
@@ -2316,8 +2309,7 @@ impl AdeApp {
     }
 
     /// The Runs section, pinned to the Changes panel's own bottom in its own capped,
-    /// independently-scrolled well - `Jerry.dc.html` line 1433's `flex:none;max-height:170px;
-    /// overflow-y:auto` wrapper, which sits *outside* the shared scroller the other three
+    /// independently-scrolled well, which sits *outside* the shared scroller the other three
     /// sections share rather than as a fourth entry inside it (the user: "run row should be
     /// pinned to the bottom and not to the top look at the design").
     ///
@@ -2539,10 +2531,8 @@ impl AdeApp {
     /// Clicking focuses that agent's tab - a real, existing action
     /// ([`Self::activate_agent_tab`]), not a new surface.
     ///
-    /// No row tooltip, though `Jerry.dc.html`'s own markup carries one (`title="{{ r.tip }}"`,
-    /// stating the live/frozen consequence `STAGE-A-CHANGELOG.md` §4l moved off the row's visible
-    /// text) - a deliberate, requested deviation from both the mock and that citation, not an
-    /// oversight.
+    /// No row tooltip, though the design carries one stating the live/frozen consequence that
+    /// was moved off the row's visible text - a deliberate, requested deviation, not an oversight.
     fn render_run_row(&self, run: &sections::RunRow, cx: &mut Context<Self>) -> impl IntoElement {
         let agent_id = run.agent_id;
         let selector = format!("changes-run-{}", run.agent_id);
@@ -3390,8 +3380,8 @@ impl AdeApp {
         self.open_uncommitted_change().is_some()
     }
 
-    /// `space`'s action handler ([`crate::root::ToggleChangeStaged`]) - the binding behind
-    /// `Jerry.dc.html`'s `changesHints` first hint, `space stage` (line 4548).
+    /// `space`'s action handler ([`crate::root::ToggleChangeStaged`]) - the binding behind the
+    /// Changes footer's first hint, `space stage`.
     ///
     /// Its subject is [`Self::open_change`], exactly like [`Self::handle_toggle_change_seen_action`]
     /// beside it, and for the same reason: that path is *both* the file whose diff is on screen
@@ -4194,11 +4184,9 @@ impl AdeApp {
     }
 }
 
-/// The Changes list's footer 29 - **three keycap hints and no prose at all**, exactly as
-/// `design_handoff_jerry_ade/revision 5/Jerry.dc.html` line 4548 declares it:
-/// `changesHints: this.mkHints([['space', 'stage'], ['V', 'mark seen'], ['⌥click', 'filter by
-/// author']])`, rendered through the same `diffHints` hint-row template (line 842) that is purely a
-/// loop over keycap+label pairs. `STAGE-A-CHANGELOG.md` §2's ride-along I10 lists the same strip.
+/// The Changes list's footer 29 - **three keycap hints and no prose at all**: `space stage`,
+/// `V mark seen`, `⌥click filter by author`, rendered through the same hint-row template the diff
+/// footer uses, which is purely a loop over keycap+label pairs.
 ///
 /// This band used to open with the sentence `click a file to open its diff in the centre` as a
 /// shrinkable lead-in. That string comes from `README.md`'s Changes section - a *superseded*
@@ -4314,11 +4302,8 @@ pub(in crate::sidebar) const CHANGES_SEEN_SPEC: &str = "v";
 /// the cursor. (The Changes view's *no-diff* arm still has no footer; that arm renders a single
 /// message rather than a list, so there is nothing for a footer to sit under.)
 ///
-/// The shape is the hint strip the design handoff already specifies for
-/// exactly this job - `design_handoff_jerry_ade/revision/Jerry.dc.html`'s own `diffHints` strip:
-/// `height:28px ... padding:0 12px;background:#111316;border-top:1px solid #1c2023`, hints at
-/// `gap:11`, each hint `gap:5`, hint-size keycaps, label `400 10px 'IBM Plex Sans'` in `#4a5057`.
-/// Which is this app's
+/// The shape is the hint strip the design already specifies for exactly this job - a 28-high
+/// band with hint-size keycaps and their labels. Which is this app's
 /// `theme::band::SURFACE_FOOTER`/`surface::FOOTER`/`border::INNER`/`text::PATH` and the
 /// `KeycapSize::Hint` keycap it already had.
 ///
@@ -4441,11 +4426,10 @@ pub(in crate::sidebar) fn render_tree_caret(
 /// entirely from `div()`s (never an emoji glyph, which is what caused the "tofu box" bug:
 /// no matching glyph installed on the reporting machine).
 ///
-/// The two rects are *not* styled identically (verified against `design_handoff_jerry_ade/
-/// Jerry.dc.html`'s `n.folderBd`/`n.folderBg`): the body alternates between a filled `bg`
+/// The two rects are *not* styled identically: the body alternates between a filled `bg`
 /// (open) and transparent (collapsed), both with a `border` - but the tab is always
 /// solid-filled with the `border` colour and has no separate border of its own. An earlier
-/// version gave the tab the same hollow-when-collapsed treatment as the body; the mockup's
+/// version gave the tab the same hollow-when-collapsed treatment as the body; the design's
 /// collapsed-folder tab is solid, not outlined.
 pub(in crate::sidebar) fn render_folder_icon(open: bool) -> impl IntoElement {
     let (fill, border): (gpui::Rgba, gpui::Rgba) = if open {
@@ -4546,8 +4530,7 @@ pub(in crate::sidebar) fn render_moved_tag() -> impl IntoElement {
         .child("moved")
 }
 
-/// The Changes row's real five-segment 3×8 stat bar (`design_handoff_jerry_ade/README.md`:
-/// "a five-segment 3×8 stat bar (`#4e8c68` / `#a35f5b` / `#22262a`)"), per
+/// The Changes row's real five-segment 3×8 stat bar, per
 /// `crate::sidebar::changes::stat_bar_segments`'s real, unit-tested proportional allocation.
 pub(in crate::sidebar) fn render_stat_bar(segments: [changes::StatSegment; 5]) -> impl IntoElement {
     div()
@@ -8125,9 +8108,9 @@ mod changes_sections_tests {
         // section is read-only.
         //
         // And, separately: no row per committed file either, reported directly ("commited files
-        // should not appear on the changes tab under against master") and confirmed against
-        // `Jerry.dc.html` line 1422's own `baseRows` - a synthetic one-entry array, never a
-        // per-file loop. Against main's only real body row is its context card.
+        // should not appear on the changes tab under against master") and confirmed against the
+        // design, which carries a plain count here rather than a per-file loop. Against main's
+        // only real body row is its context card.
         let repo = four_scope_repo();
         let (app, cx) = open_changes_view(cx, &repo);
         open_every_section(&app, cx);
@@ -8989,7 +8972,7 @@ mod change_row_tests {
         );
     }
 
-    /// The same honesty half for `Jerry.dc.html`'s *first* `changesHints` entry, `space stage`.
+    /// The same honesty half for the Changes footer's *first* hint, `space stage`.
     #[gpui::test]
     fn the_footer_shows_the_space_keycap_only_while_the_binding_is_live(cx: &mut TestAppContext) {
         let repo = mixed_status_repo();
@@ -9013,9 +8996,9 @@ mod change_row_tests {
     }
 
     /// The live bug this fixes: the footer used to open with the sentence `click a file to open
-    /// its diff in the centre` - `README.md`'s wording for the *superseded* pre-`#285` panel -
-    /// ahead of the keycaps, so a user saw truncated prose where `Jerry.dc.html` line 4548's
-    /// `changesHints` specifies three chips and nothing else.
+    /// its diff in the centre` - the wording for the *superseded* pre-`#285` panel - ahead of the
+    /// keycaps, so a user saw truncated prose where the design specifies three chips and nothing
+    /// else.
     ///
     /// Asserted geometrically rather than by hunting for a string, because that is what actually
     /// pins the design: the mock's strip is `padding:0 12px` with the hints as its first child, so
@@ -9088,7 +9071,7 @@ mod change_row_tests {
             app.read_with(cx, |app, _| app
                 .staged_files
                 .contains(&PathBuf::from("modified.txt"))),
-            "a real `space` keystroke stages the open row - `Jerry.dc.html`'s `space stage`"
+            "a real `space` keystroke stages the open row - the footer's `space stage` hint"
         );
         assert!(
             cx.debug_bounds("stage-checkbox-modified.txt").is_some(),
@@ -9198,7 +9181,7 @@ mod change_row_tests {
         let modifiers = keystroke.modifiers();
         assert!(
             !modifiers.control && !modifiers.alt && !modifiers.platform && !modifiers.shift,
-            "a bare `space`, exactly as `Jerry.dc.html`'s `changesHints` prints it"
+            "a bare `space`, exactly as the Changes footer prints it"
         );
         let predicate = |binding: &gpui::KeyBinding| {
             binding

--- a/crates/app/src/sidebar/sections.rs
+++ b/crates/app/src/sidebar/sections.rs
@@ -1,8 +1,8 @@
 //! Pure logic for the Changes panel's four stacked sections (GitHub issue #285).
 //!
-//! `design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md` §1: the right panel's single flat
-//! change list becomes **four collapsible sections in one scroller**, each with its own count and
-//! diffstat, the commit box pinned above them.
+//! The right panel's single flat change list became **four collapsible sections in one
+//! scroller**, each with its own count and diffstat, the commit box pinned above them. See
+//! `docs/design/sidebar.md`.
 //!
 //! > Sections, not a segmented picker: triage needs to see that there are uncommitted changes
 //! > *and* three commits *and* a run waiting, without operating a control.
@@ -99,9 +99,8 @@ pub enum ChangesSection {
 }
 
 impl ChangesSection {
-    /// Top to bottom, exactly as `Jerry.dc.html` both paints them (`onSecUnc` at line 1314,
-    /// `onSecCommits` at 1370, `onSecBase` at 1390, `onSecRuns` last at 1434) and says so in its own
-    /// comment: "Four stacked sections, in this order: Uncommitted, Commits, Against main, Runs.
+    /// Top to bottom, exactly as the design paints them and states in as many words:
+    /// "Four stacked sections, in this order: Uncommitted, Commits, Against main, Runs.
     /// The first three are one ladder of git state, narrowing to widening. Runs is not on that
     /// ladder — it indexes the same changes by author — so it sits after it rather than inside it,
     /// which also keeps Uncommitted's top edge fixed however many agents have run."
@@ -438,8 +437,8 @@ pub enum SectionRow {
     Commit(wt_core::diff::BranchCommit),
     /// The Against-main section's *only* body row (besides its own notes): what would land, and
     /// how far ahead or behind the branch is. Unlike the other three sections, Against main never
-    /// lists a row per file - `Jerry.dc.html` line 1422's own `baseRows` is a synthetic one-entry
-    /// array (`wtBaseDefs`'s `files` is a plain count, never an array of files), and the panel's
+    /// lists a row per file - the design carries a plain file *count* here, never an array of
+    /// files, and the panel's
     /// own header count reads that count directly (`Self::changes_section_rows`), not the number
     /// of rows this section renders - a deliberate exception to `SectionHeader::count`'s usual
     /// "derived from the body" rule, and a deliberate removal of this section's earlier per-file
@@ -473,7 +472,7 @@ impl SectionRow {
     /// Which of the four sections this row belongs to - what
     /// `Self::render_changes_sections`/`Self::render_changes_runs_section` (in `sidebar::render`)
     /// split the flattened `changes_section_rows` list on to give Runs its own pinned-bottom
-    /// scroller (`Jerry.dc.html` line 1433) instead of sharing the other three's.
+    /// scroller instead of sharing the other three's.
     pub fn section(&self) -> ChangesSection {
         match self {
             SectionRow::Header(header) => header.section,
@@ -729,10 +728,10 @@ mod tests {
 
     #[test]
     fn the_order_matches_the_mock_not_the_issue_sketch() {
-        // `Jerry.dc.html` paints `onSecUnc`, `onSecCommits`, `onSecBase`, then `onSecRuns` last,
-        // and says so in its own comment - "Runs is not on [the git-state] ladder ... so it sits
+        // The design paints Uncommitted, Commits, Against main, then Runs last, and says so in
+        // as many words - "Runs is not on [the git-state] ladder ... so it sits
         // after it rather than inside it, which also keeps Uncommitted's top edge fixed however
-        // many agents have run." `REVISION-2026-08-14.md` §1's sketch lists Runs first; the mock
+        // many agents have run." An earlier sketch listed Runs first; the design
         // wins the disagreement.
         assert_eq!(
             ChangesSection::ORDER,

--- a/crates/app/src/status_bar/process_stats/mod.rs
+++ b/crates/app/src/status_bar/process_stats/mod.rs
@@ -172,9 +172,8 @@ pub trait ProcessSampler {
 ///
 /// This is only ever a *denominator*: the Resources popover's `MEMORY` meter fills to the agents'
 /// real summed resident bytes over this total. `None` therefore means "draw the value, draw no
-/// fill" - never a fallback constant, since a real numerator over a guessed total is precisely the
-/// fabricated fraction `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4d calls the
-/// defect this panel would otherwise ship with.
+/// fill" - never a fallback constant, since a real numerator over a guessed total is precisely
+/// the fabricated fraction this panel would otherwise ship with.
 pub fn system_memory_bytes() -> Option<u64> {
     backend::system_memory_bytes()
 }

--- a/crates/app/src/status_bar/render.rs
+++ b/crates/app/src/status_bar/render.rs
@@ -26,11 +26,9 @@ pub(crate) fn available_cores() -> usize {
     })
 }
 
-/// The three type tiers rev 6 rebuilt the bar around
-/// (`design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md` §3, and
-/// `STAGE-A-CHANGELOG.md` §4c's diagnosis: "the cause was not density - it was that after the
-/// cut, **all thirteen-then-five readouts sat at 10px in `#4a5057`**, one flat tone on `#101214`.
-/// No hierarchy means the eye has to read all of it to find any of it").
+/// The three type tiers the bar was rebuilt around. The diagnosis: "the cause was not density -
+/// it was that after the cut, **all thirteen-then-five readouts sat at 10px in `#4a5057`**, one
+/// flat tone on `#101214`. No hierarchy means the eye has to read all of it to find any of it".
 ///
 /// A named enum rather than three ad-hoc `.text_color(...)`/`.text_size(...)` pairs at each call
 /// site: the whole defect was that every readout independently picked the same tone, so the fix
@@ -111,10 +109,10 @@ fn running_agents_label(count: usize) -> String {
 ///
 /// ## What this bar carries, and what it deliberately no longer does
 ///
-/// `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4b counted the old bar's thirteen
-/// readouts and found eight of them lifted from VS Code's status bar: "VS Code's footer answers
-/// 'what am I typing into'; Jerry's job is watching agents. Wrong app's chrome." Deleted with
-/// this rebuild, code paths and all (§7 rule 5: "Replacing a control means deleting its old keys
+/// An audit counted the old bar's thirteen readouts and found eight of them lifted from VS
+/// Code's status bar: "VS Code's footer answers 'what am I typing into'; Jerry's job is watching
+/// agents. Wrong app's chrome." Deleted with
+/// this rebuild, code paths and all ("Replacing a control means deleting its old keys
 /// in the same edit"): `ln N`, the indent width, the line ending, the encoding, the editor-zoom
 /// readout, the UI-scale readout, `N servers · M errors`, the five urgency-counter dots, and the
 /// `N wt · Y GB` cluster.

--- a/crates/app/src/status_bar/resources.rs
+++ b/crates/app/src/status_bar/resources.rs
@@ -1,9 +1,8 @@
 //! The Resources popover's data model: the `repo → worktree → agent` cost tree behind the status
-//! bar's `41% cpu · 3.4 GB` readout (GitHub issue #293,
-//! `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4d).
+//! bar's `41% cpu · 3.4 GB` readout (GitHub issue #293).
 //!
 //! Pure and GPUI-free, like `crate::rail::state` - the whole point of this module is that the one
-//! sentence §4d insists on ("**everything derives from `resDefs`, so the bar readout is the sum of
+//! sentence the design insists on ("**everything derives from one source, so the bar readout is the sum of
 //! the tree** - a hardcoded total that drifts from its own breakdown is the defect this panel
 //! would otherwise ship with") is a property that can be tested directly, without a window.
 //!

--- a/crates/app/src/terminal/pane.rs
+++ b/crates/app/src/terminal/pane.rs
@@ -262,8 +262,8 @@ fn eof_poll_decision(
     }
 }
 
-/// The terminal body's default/fallback font size and line height -
-/// `design_handoff_jerry_ade/README.md`'s Surface A/B body spec, "lines at 12px/19 mono". Set
+/// The terminal body's default/fallback font size and line height - the designed 12px/19 mono.
+/// Set
 /// explicitly (`.text_size()`/`.line_height()`) on the pane root by [`TerminalPane`]'s
 /// `Render` impl, not per-row - rows inherit both from the root. Explicit rather than the
 /// GPUI-default `.text_xs()` (no `.line_height()`, so GPUI's own default `phi()` - the golden

--- a/crates/app/src/theme.rs
+++ b/crates/app/src/theme.rs
@@ -1,5 +1,5 @@
-//! Jerry's design tokens, ported from `design_handoff_jerry_ade/tokens.rs` (colour/size
-//! constants transcribed from the reviewed mockup `Jerry.dc.html`).
+//! Jerry's design tokens: every colour and dimension the UI paints, defined once here. What
+//! each group is *for*, and the rules that constrain it, is `docs/design/`.
 //!
 //! ## Runtime-swappable colour tokens ([`ColorToken`])
 //!
@@ -878,13 +878,10 @@ pub mod surface {
     pub const RAIL: ColorToken = token("surface.rail", 0x101113); // left rail + right panel
     /// The sidebar strip's own recessed band (GitHub issue #291) - the 36px view switcher above
     /// the rail. Deliberately **darker than [`RAIL`]**, and that is the whole reason it is its own
-    /// token rather than a reuse of [`WINDOW`] or [`PTY`]:
-    /// `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4v, verbatim - "a tab only
-    /// reads as connected if the strip behind it is **darker than the panel**, and here strip and
-    /// rail were both `#101113`, so the slab floated. Strip is now `#0c0e10`; the selected cell is
-    /// `#101113`, exactly the rail's own background". `Jerry.dc.html`'s own final markup then
-    /// settled one step lower again (`background:#0a0b0d`, matching §4v's closing verification
-    /// line "selected `rgb(16,17,19)` over strip `rgb(10,11,13)`"), which is the value here.
+    /// token rather than a reuse of [`WINDOW`] or [`PTY`]: a tab only reads as connected if the
+    /// strip behind it is **darker than the panel**. A strip sharing the rail's own background
+    /// makes the selected cell float instead of sitting in the strip, so this is two steps below
+    /// [`RAIL`], which the selected cell itself uses.
     ///
     /// A theme that lifted this to or above [`RAIL`] would not merely recolour the strip - it
     /// would destroy the selected cell's "cut the column rule and join the panel below" reading,
@@ -906,20 +903,18 @@ pub mod surface {
     pub const SEGMENT_TRACK: ColorToken = token("surface.segment_track", 0x171a1d);
     pub const SEGMENT_ACTIVE: ColorToken = token("surface.segment_active", 0x242a2f);
     pub const KEYCAP: ColorToken = token("surface.keycap", 0x181c1f);
-    /// The hint-size keycap's own background - distinct from [`KEYCAP`]'s standard-size
-    /// `#181c1f` (`Jerry.dc.html`: `background:#15181a;border:1px solid #23272b`).
+    /// The hint-size keycap's own background - distinct from [`KEYCAP`]'s standard-size value.
     pub const KEYCAP_HINT: ColorToken = token("surface.keycap_hint", 0x15181a);
     pub const CHIP_NEUTRAL: ColorToken = token("surface.chip_neutral", 0x23272b);
     pub const CURRENT_LINE: ColorToken = token("surface.current_line", 0x181c20);
     /// The Changes panel's Runs section - pinned to the panel's own bottom in its own capped,
     /// independently-scrolled well, distinct from the lighter [`HEADER`] the other three sections'
-    /// shared scroller sits on (`Jerry.dc.html` line 1433: `background:#0f1113`).
+    /// shared scroller sits on.
     pub const RUNS_WELL: ColorToken = token("surface.runs_well", 0x0f1113);
-    /// The Windows/Linux title bar's close caption button's hover fill. The design handoff
-    /// (`Jerry.dc.html`: `style-hover="background:#8c3a38"`, unchanged through revision 3) spec'd
-    /// a muted maroon; Colin asked for this to be the real Windows Fluent Design close-hover red
+    /// The Windows/Linux title bar's close caption button's hover fill. The original design
+    /// spec'd a muted maroon; Colin asked for the real Windows Fluent Design close-hover red
     /// (`#E81123`, the same color Windows 10/11's own native title bar uses) instead - a
-    /// deliberate override of the handoff, not a stale-spec bug.
+    /// deliberate override, not a stale-spec bug.
     pub const TITLE_BAR_CLOSE_HOVER: ColorToken = token("surface.title_bar_close_hover", 0xe81123);
     /// GitHub issue #129: the shared row-hover fill for every dropdown/context-menu in the app
     /// (`+` menu, title bar menu, tree context menu, git graph's push/row menus) - distinct from
@@ -932,10 +927,8 @@ pub mod surface {
     /// mouse-hover styled at all - a real, mockup-verified design difference, not drift; see
     /// `crate::lsp::completion_popup`'s own module docs).
     pub const MENU_ROW_HOVER: ColorToken = token("surface.menu_row_hover", 0x1d2226);
-    /// The same row hover, for a **destructive** menu row (GitHub issue #290).
-    /// `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4t specifies the shared menu's
-    /// rows as "destructive rows in `#c4726d` on a `#2a1719` hover" - so the destructive tint is
-    /// carried on the hover fill too, not on the resting label alone. Without it, `Delete` and
+    /// The same row hover, for a **destructive** menu row (GitHub issue #290). The destructive
+    /// tint is carried on the hover fill too, not on the resting label alone. Without it, `Delete` and
     /// `Copy Path` are visually identical the moment the pointer is on either of them, which is
     /// exactly when the click is about to happen.
     ///
@@ -947,9 +940,8 @@ pub mod surface {
     /// A file tab's close-affordance hover fill - one hex step off [`CHIP_NEUTRAL`]
     /// (`#23272b`), kept as its own token.
     pub const TAB_CLOSE_HOVER: ColorToken = token("surface.tab_close_hover", 0x23282c);
-    /// The Hover/Diagnostic popover footer's own band background
-    /// (`design_handoff_jerry_ade/revision 3/Jerry.dc.html`: `background:#141719` on both cards'
-    /// `source · code`/`F12 definition` footer rows) - one hex step darker than [`CARD_SUNK`]
+    /// The Hover/Diagnostic popover footer's own band background, shared by both cards'
+    /// `source · code`/`F12 definition` footer rows - one hex step darker than [`CARD_SUNK`]
     /// (`#131619`, used for every *other* card footer in the app), not a duplicate of it: the
     /// mockup genuinely uses two adjacent-but-different footer tones, and this app's own contrast
     /// tests already pin `CARD_SUNK`'s exact value elsewhere, so reusing it here would have
@@ -1012,8 +1004,7 @@ pub mod border {
     /// The hint-size keycap's own border - see [`super::surface::KEYCAP_HINT`].
     pub const KEYCAP_HINT: ColorToken = token("border.keycap_hint", 0x23272b);
     pub const SELECTED_EDGE: ColorToken = token("border.selected_edge", 0x3f5b74); // 2px left edge on a selected row
-    /// The Diagnostic popover's own border (`design_handoff_jerry_ade/revision 3/Jerry.dc.html`:
-    /// `border:1px solid #3a2224` on the diagnostic card). Paired with
+    /// The Diagnostic popover's own border. Paired with
     /// [`super::syntax::DIAGNOSTIC_ROW_BG`] for that card's background - together they give the
     /// Diagnostic popover the design's own red-tinted chrome, distinct from the Hover/Completions
     /// popovers' neutral [`POPOVER`] - see `crate::code_surface::lsp_ui::render_diagnostic_card_content`.
@@ -1118,9 +1109,8 @@ pub mod text {
     /// The colour a hovered glyph lifts to in a surface whose *background* already encodes
     /// selection - today the sidebar strip's cells (GitHub issue #291).
     ///
-    /// `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4v derives it from a real
-    /// defect and states the rule verbatim: **"two states must not compete on one property. If
-    /// background says 'selected', hover says it somewhere else."** Making the selected cell match
+    /// The rule this exists for: **two states must not compete on one property. If background
+    /// says 'selected', hover says it somewhere else.** Making the selected cell match
     /// the rail (which the cut-out requires) dropped selected to luminance 16.9 while a background
     /// hover sat at 25.4, so hovering an *inactive* view out-read the active one. "Hover moved off
     /// background entirely: the cell sets `color`, every glyph part draws with `currentColor`, and
@@ -1203,23 +1193,19 @@ pub mod status {
     ];
 }
 
-/// Tokens used only by the Revision R12 rail rewrite (`design_handoff_jerry_ade/revision 3/
-/// REVISION-2026-07-31.md` §2) that have no exact match elsewhere in this module - every other
-/// colour that section calls for (the branch/note/model/activity greys, the amber flag, the
-/// spine/selection edges) already has one, reused directly at the call site rather than
-/// duplicated here under a second name.
+/// Tokens the rail needs that have no exact match elsewhere in this module - every other colour
+/// it calls for (the branch/note/model/activity greys, the amber flag, the spine/selection edges)
+/// already has one, reused directly at the call site rather than duplicated here under a second
+/// name. See `docs/design/rail.md`.
 pub mod rail {
     use super::{token, ColorToken};
 
     /// Repo group header's uppercase name.
     ///
-    /// Revision 6 (`design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4s) retargeted this
-    /// from the rail-only `#787f86` to the app-wide section-label value: "It was `#787f86` at
-    /// `.08em` while every other section label in the app - `Runs`, `Uncommitted`, `Commits`,
-    /// `Resources`, `Rate limits` - was already `#9aa1a8` at `.09em`. It now uses that token."
-    /// `Jerry.dc.html`'s rail band and all four Changes-panel section labels really do paint the
-    /// same `#9aa1a8`, which is why [`super::changes::SECTION_LABEL`] carries the identical value:
-    /// a repo band is a section header, not a rail-specific ornament.
+    /// The app-wide section-label value, not a rail-only one: `Runs`, `Uncommitted`, `Commits`,
+    /// `Resources` and `Rate limits` all paint this same grey, which is why
+    /// [`super::changes::SECTION_LABEL`] carries the identical value. A repo band is a section
+    /// header, not a rail-specific ornament.
     ///
     /// Kept under its own `rail.` key rather than folded into one shared constant because the key
     /// is a *themable* name a user's `.toml` may already set - renaming it would silently drop
@@ -1234,8 +1220,7 @@ pub mod rail {
     /// (`STAGE-A-CHANGELOG.md` §4n: agent title `450 11.5px/16px` `#c2c7cc` -> `450 11px/15px`
     /// **`#a3a9b0`**). Deliberately dimmer than [`super::text::STRONG`] (`#c2c7cc`), which the
     /// branch above it uses: "Fix hierarchy by shrinking the child, never by growing the parent."
-    /// A `crate::rail::Status::Idle` agent drops further still, to [`super::text::DIMMER`]
-    /// (`#7d848b`), exactly as `Jerry.dc.html`'s own `titleFg` does.
+    /// A `crate::rail::Status::Idle` agent drops further still, to [`super::text::DIMMER`].
     pub const AGENT_TITLE: ColorToken = token("rail.agent_title", 0xa3a9b0);
     /// The repo header's amber urgency **count** - the number beside the [`super::status::ASK`]
     /// dot (`REVISION-2026-08-14.md` §4: "`● 2` amber (`#e2a336` dot, `#c99b4e` text, needs
@@ -1691,8 +1676,7 @@ pub mod syntax {
     /// The Diagnostic state's dim, end-of-line inline message text (`README.md`: `#6b4a48`).
     pub const DIAGNOSTIC_INLINE_MESSAGE: ColorToken =
         token("syntax.diagnostic_inline_message", 0xb6706b);
-    /// The Diagnostic state's card message text (`design_handoff_jerry_ade/revision 3/
-    /// Jerry.dc.html`'s diagnostic card headline: `color:#e3908b`). Same hex as
+    /// The Diagnostic state's card message headline. Same hex as
     /// [`super::button::DANGER_FG_HOVER`], kept as its own token - unrelated elements that
     /// happen to share a designed red. Was previously `0xf07f77` - a real, uncaught typo against
     /// this same doc comment's own cited value, fixed as part of GitHub issue #186's design
@@ -1894,13 +1878,12 @@ pub mod term {
     pub const MENU_SEL_FG: ColorToken = token("term.menu_sel_fg", 0xe0b263);
     pub const MENU_SEL_BG: ColorToken = token("term.menu_sel_bg", 0x1f1a10);
     pub const CURSOR: ColorToken = token("term.cursor", 0x5a9ad4);
-    /// A clickable path/`path:line` link inside terminal output (`Jerry.dc.html`:
-    /// `color:#7fb4e3;border-bottom:1px dotted #3d6a91`).
+    /// A clickable path/`path:line` link inside terminal output, under a dotted
+    /// [`LINK_UNDERLINE`] rule.
     pub const LINK: ColorToken = token("term.link", 0x7fb4e3);
     pub const LINK_UNDERLINE: ColorToken = token("term.link_underline", 0x3d6a91);
-    /// The link's hover state (`Jerry.dc.html`: `style-hover="color:#a5cdf0;border-bottom:1px
-    /// solid #78a8d0"`). Same value as [`super::button::BLUE_FG`], kept as its own token for a
-    /// distinct element.
+    /// The link's hover state, which also swaps the dotted underline for a solid one. Same value
+    /// as [`super::button::BLUE_FG`], kept as its own token for a distinct element.
     pub const LINK_HOVER: ColorToken = token("term.link_hover", 0xa5cdf0);
     pub const LINK_UNDERLINE_HOVER: ColorToken = token("term.link_underline_hover", 0x78a8d0);
 
@@ -2085,8 +2068,7 @@ pub mod terminal {
 pub mod env {
     use super::{token, ColorToken};
 
-    /// Defaults to [`super::term::PROMPT`]'s own value (`Jerry.dc.html`'s `footRemoteFg` for
-    /// `plat === 'windows'`), independently themeable from it.
+    /// Defaults to [`super::term::PROMPT`]'s own value, independently themeable from it.
     pub const WSL_FG: ColorToken = token("env.wsl_fg", 0x8fbde6);
     pub const WSL_BG: ColorToken = token("env.wsl_bg", 0x16222c);
     pub const WSL_BORDER: ColorToken = token("env.wsl_border", 0x24384a);
@@ -2113,8 +2095,7 @@ pub mod env {
 ///
 /// # The reserved-hue allocation rule
 ///
-/// Quoted verbatim from the rev-6 design bundle, `design_handoff_jerry_ade/revision 5/
-/// STAGE-A-CHANGELOG.md` §4a ("Colour allocation rule", added after review):
+/// See `docs/design/decisions.md` §9 for how this rule came about:
 ///
 /// > **Five hue families are structural and reserved. Agent identity is allocated only outside
 /// > them.**
@@ -2227,8 +2208,6 @@ pub mod lang {
     ); // "to"
     pub const MD: (ColorToken, ColorToken) =
         (token("lang.md.fg", 0x7f9ad4), token("lang.md.bg", 0x1d2532)); // "md"
-                                                                        // Verified directly against `design_handoff_jerry_ade/revision/tokens.rs:149-160`'s real
-                                                                        // hex values, not paraphrased.
     pub const SQL: (ColorToken, ColorToken) = (
         token("lang.sql.fg", 0x6ab97f),
         token("lang.sql.bg", 0x1b2a20),
@@ -2321,9 +2300,8 @@ pub mod button {
     pub const GREEN_BG_HOVER: ColorToken = token("button.green_bg_hover", 0x2c6045);
     pub const GREEN_FG: ColorToken = token("button.green_fg", 0x9fdcb6);
     pub const GREEN_KEYCAP: ColorToken = token("button.green_keycap", 0x376b4d);
-    /// The keycap glyph colour inside a green primary button (`README.md`/`Jerry.dc.html`:
-    /// `#8ac9a4`) - not in `tokens.rs`'s `button` module (only [`GREEN_KEYCAP`], the border, is
-    /// transcribed there), added here directly.
+    /// The keycap glyph colour inside a green primary button - the fill to [`GREEN_KEYCAP`]'s
+    /// border.
     pub const GREEN_KEYCAP_FG: ColorToken = token("button.green_keycap_fg", 0x8ac9a4);
     // The equivalent blue keycap glyph colour (`#8fbde6`) needs no separate constant here -
     // it's the exact same value already ported as `term::PROMPT`.
@@ -2410,9 +2388,9 @@ pub mod toggle {
 /// the same grey.
 ///
 /// [`TREE_MODIFIED`] is **not** this `M` and is deliberately left alone: the Files tree paints
-/// its own change marks amber (`#a3873f`) in `Jerry.dc.html`'s own tree rows, where the mark is
-/// the only thing saying a file is dirty at all and genuinely is the exception. On a Changes row
-/// every line is a change, which is exactly why §4j's `M` recedes.
+/// its own change marks amber, where the mark is the only thing saying a file is dirty at all
+/// and genuinely is the exception. On a Changes row every line is a change, which is exactly why
+/// this `M` recedes.
 pub mod tag {
     use super::{token, ColorToken};
 
@@ -2438,10 +2416,8 @@ pub mod tag {
     ];
 }
 
-/// Exact colours for Surface C's real Completions popup item rows - read directly from
-/// `design_handoff_jerry_ade/revision/Jerry.dc.html`'s own `completions`/`KBG`/`KFG` data (the
-/// `sel ? ... : ...` ternaries around line 2289, and the `KBG`/`KFG` maps around line 1792) - not
-/// reused from any nearby-but-not-identical existing token (e.g. [`super::text::SELECTED`]
+/// Exact colours for Surface C's real Completions popup item rows - each its own token rather
+/// than a reuse of a nearby-but-not-identical existing one (e.g. [`super::text::SELECTED`]
 /// (`#dde2e7`) is a real, different colour from this module's own [`ITEM_SELECTED_FG`]
 /// (`#e3e8ed`), and [`super::surface::CURRENT_LINE`] (`#181c20`) - the File view's current-line
 /// tint - is the exact same hex as [`super::surface::POPOVER`] itself, which is why reusing it as
@@ -2449,28 +2425,27 @@ pub mod tag {
 pub mod completions_popup {
     use super::{token, ColorToken};
 
-    /// A selected completion row's real background (`Jerry.dc.html`: `c.sel ? '#243c50' : ...`).
+    /// A selected completion row's background.
     pub const ITEM_SELECTED_BG: ColorToken = token("completions_popup.item_selected_bg", 0x243c50);
-    /// A selected completion row's real label colour (`Jerry.dc.html`: `c.sel ? '#e3e8ed' : ...`).
+    /// A selected completion row's label colour.
     pub const ITEM_SELECTED_FG: ColorToken = token("completions_popup.item_selected_fg", 0xe3e8ed);
-    /// An unselected completion row's real label colour (`Jerry.dc.html`: `... : '#b8bfc6'`) -
-    /// the exact same hex as [`super::text::BODY`], carried here as its own token.
+    /// An unselected completion row's label colour - the exact same hex as
+    /// [`super::text::BODY`], carried here as its own token.
     pub const ITEM_FG: ColorToken = token("completions_popup.item_fg", 0xb8bfc6);
 
-    /// `(fg, bg)` for a `function`/`method`/`constructor`-shaped completion item's kind badge
-    /// (`Jerry.dc.html`'s `KFG.f`/`KBG.f`).
+    /// `(fg, bg)` for a `function`/`method`/`constructor`-shaped completion item's kind badge.
     pub const KIND_FUNCTION: (ColorToken, ColorToken) = (
         token("completions_popup.kind_function.fg", 0x8fbde6),
         token("completions_popup.kind_function.bg", 0x243c50),
     );
     /// `(fg, bg)` for a `variable`/`field`/`property`/`constant`-shaped completion item's kind
-    /// badge (`Jerry.dc.html`'s `KFG.v`/`KBG.v`).
+    /// badge.
     pub const KIND_VARIABLE: (ColorToken, ColorToken) = (
         token("completions_popup.kind_variable.fg", 0xd8a94a),
         token("completions_popup.kind_variable.bg", 0x33280f),
     );
     /// `(fg, bg)` for a `class`/`struct`/`interface`/`enum`/`type`-shaped completion item's kind
-    /// badge (`Jerry.dc.html`'s `KFG.t`/`KBG.t`).
+    /// badge.
     pub const KIND_TYPE: (ColorToken, ColorToken) = (
         token("completions_popup.kind_type.fg", 0xc294e0),
         token("completions_popup.kind_type.bg", 0x33203e),
@@ -2492,21 +2467,18 @@ pub mod completions_popup {
     ];
 }
 
-/// Settings-surface-only colours read directly from `Jerry.dc.html`'s inline literals for the
-/// `settingsOpen` block - real values present in the mockup but missing from `tokens.rs`'s
-/// transcription (predates the Settings section). Every other Settings colour reuses an
-/// existing token from another module - see `crate::root`'s Settings render methods.
+/// Settings-surface-only colours: the ones that have no equivalent in another module. Every
+/// other Settings colour reuses an existing token - see `crate::root`'s Settings render methods.
 pub mod settings {
     use super::{token, ColorToken};
 
-    /// A nav row's hover background (`Jerry.dc.html`: `style-hover="background:#17191b"`) -
-    /// distinct from [`super::surface::ROW_HOVER`] (`#15181b`).
+    /// A nav row's hover background - distinct from [`super::surface::ROW_HOVER`] (`#15181b`).
     pub const NAV_ROW_HOVER: ColorToken = token("settings.nav_row_hover", 0x17191b);
-    /// The content column's page-subtitle text (`Jerry.dc.html`: `color:#767d84`) - close to
-    /// but distinct from [`super::text::DIM`] (`#8b9197`).
+    /// The content column's page-subtitle text - close to but distinct from
+    /// [`super::text::DIM`] (`#8b9197`).
     pub const SUBTITLE: ColorToken = token("settings.subtitle", 0x767d84);
-    /// A card row's own bottom separator (`Jerry.dc.html`: `border-bottom:1px solid #1f2327`) -
-    /// distinct from [`super::border::CARD_FIELD`] (`#22272b`).
+    /// A card row's own bottom separator - distinct from [`super::border::CARD_FIELD`]
+    /// (`#22272b`).
     pub const CARD_ROW_SEP: ColorToken = token("settings.card_row_sep", 0x1f2327);
     /// A binary-found status dot on the Agents page. Same hex as [`super::status::REVIEW`],
     /// kept as its own token: the agent `Status` palette is reserved for agent urgency
@@ -2523,11 +2495,10 @@ pub mod settings {
     /// [`CARD_UNSELECTED_BG`] for the unselected counterpart.
     pub const CARD_SELECTED_BG: ColorToken = token("settings.card_selected_bg", 0x161b1f);
     pub const CARD_UNSELECTED_BG: ColorToken = token("settings.card_unselected_bg", 0x131619);
-    /// A Theme card's hover border (`Jerry.dc.html`: `style-hover="border-color:#3a4148"`).
+    /// A Theme card's hover border.
     pub const THEME_CARD_HOVER_BORDER: ColorToken =
         token("settings.theme_card_hover_border", 0x3a4148);
-    /// The config snippet block's section-header line colour (`Jerry.dc.html`'s `CSFG.s`:
-    /// `#c294e0`).
+    /// The config snippet block's section-header line colour.
     pub const SNIPPET_SECTION: ColorToken = token("settings.snippet_section", 0xc294e0);
 
     /// Every real [`ColorToken`] this module declares, paired with its own Rust `const` name -
@@ -2549,10 +2520,8 @@ pub mod settings {
 
 /// The overlay scrollbar (GitHub issue #30).
 ///
-/// Rev 5 of the mockup had no scrollbar spec at all - every scrollable region there relied on raw
-/// browser/OS scrolling - so these values used to be a judgment-call derivation from neighbouring
-/// neutral tokens. **Rev 6 supersedes that with a real spec**, `design_handoff_jerry_ade/
-/// revision 5/STAGE-A-CHANGELOG.md` §4p, whose own note is explicit that it governs this build:
+/// These values used to be a judgment-call derivation from neighbouring neutral tokens, there
+/// being no scrollbar spec at all. The real spec that superseded that:
 ///
 /// > | Part | Value |
 /// > |---|---|
@@ -2598,8 +2567,7 @@ pub mod scrollbar {
     pub const TOKENS: &[(&str, ColorToken)] = &[("THUMB", THUMB), ("THUMB_HOVER", THUMB_HOVER)];
 }
 
-/// Per-provider rate-limit budget - the meter on an agent tab and in the budget popover
-/// (`design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md` §2).
+/// Per-provider rate-limit budget - the meter on an agent tab and in the budget popover.
 ///
 /// Rev 6 moved budget from a single global footer readout to **one meter per agent**, because a
 /// budget is per-provider and a provider belongs to an agent. There is then **one bar per window**
@@ -2656,9 +2624,8 @@ pub mod budget {
     ];
 }
 
-/// The Changes panel - four stacked, collapsible sections in one scroller
-/// (`design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md` §1), plus the file row's own
-/// seen/unseen and discard states (`STAGE-A-CHANGELOG.md` §4i).
+/// The Changes panel - four stacked, collapsible sections in one scroller, plus the file row's
+/// own seen/unseen and discard states. See `docs/design/sidebar.md`.
 ///
 /// # The four sections and their left edges
 ///
@@ -2713,12 +2680,9 @@ pub mod changes {
 
     /// Section header label - 9.5px/600 uppercase, `.09em` tracking.
     ///
-    /// `#9aa1a8`, not §1's transcribed `#787f86`: `STAGE-A-CHANGELOG.md` §4s is the later word on
-    /// the same value ("every other section label in the app - `Runs`, `Uncommitted`, `Commits`,
-    /// `Resources`, `Rate limits` - was already `#9aa1a8` at `.09em`") and `Jerry.dc.html` - which
-    /// outranks both prose files - really does paint all four of these labels `#9aa1a8`. Same
-    /// value, same citation, as [`super::rail::REPO_HEADER_NAME`]: a repo band and a Changes
-    /// section are the same kind of header.
+    /// Every section label in the app paints this same grey - `Runs`, `Uncommitted`, `Commits`,
+    /// `Resources`, `Rate limits`. Same value as [`super::rail::REPO_HEADER_NAME`]: a repo band
+    /// and a Changes section are the same kind of header.
     pub const SECTION_LABEL: ColorToken = token("changes.section_label", 0x9aa1a8);
     /// Section header count - 9.5px mono, immediately after the label.
     pub const SECTION_COUNT: ColorToken = token("changes.section_count", 0x4a5057);
@@ -2785,13 +2749,11 @@ pub mod changes {
     /// border weight, on two unrelated elements.
     pub const SHARED_RING: ColorToken = token("changes.shared_ring", 0x8a6420);
 
-    /// The `you` gutter bar in the diff view - Orca's second rule, kept: *"your own hand edit
-    /// flips that line back to you"* (`REVISION-2026-08-14.md` §1), and `you` is deliberately
-    /// **not** an agent, so it is deliberately not an agent tint either.
+    /// The `you` gutter bar in the diff view - *your own hand edit flips that line back to you*,
+    /// and `you` is deliberately **not** an agent, so it is deliberately not an agent tint either.
     ///
-    /// `#4e545a`, `Jerry.dc.html`'s own `attrOf('you').bg` - a neutral, outside
-    /// [`super::agent`]'s whole pool by construction, so a hand edit can never be mistaken for
-    /// whichever agent happens to hold the nearest hue.
+    /// A neutral, outside [`super::agent`]'s whole pool by construction, so a hand edit can never
+    /// be mistaken for whichever agent happens to hold the nearest hue.
     pub const HAND_EDIT_GUTTER: ColorToken = token("changes.hand_edit_gutter", 0x4e545a);
     /// The `you` author chip's glyph, the neutral counterpart to an agent chip's own tint.
     pub const HAND_EDIT_CHIP_FG: ColorToken = token("changes.hand_edit_chip_fg", 0x8b9197);
@@ -2848,8 +2810,7 @@ pub mod changes {
     ];
 }
 
-/// The status bar's three type tiers
-/// (`design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md` §3).
+/// The status bar's three type tiers - see `docs/design/layout.md`.
 ///
 /// > Three tiers instead of one flat 10px smear - the problem was never density, it was that five
 /// > readouts at `#4a5057` all read at once, so you had to read all of it to find any of it.
@@ -2874,10 +2835,9 @@ pub mod status_bar {
     /// Tier 1 - the readouts you are meant to find first (`main ↑2 ↓0`, `4 agents running`).
     pub const PRIMARY: ColorToken = token("status_bar.primary", 0xa9b0b7);
     /// Tier 2 - the supporting half of a split readout, dimmer than [`PRIMARY`] but still meant
-    /// to be read (`design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4c's `#7d848b`
-    /// "secondary" row: provider names in the bar once GitHub issue #294 lands, and today the
+    /// to be read: provider names in the bar once GitHub issue #294 lands, and today the
     /// Resources popover's own memory column, which is that same "detail you read only if the
-    /// count surprised you" tone).
+    /// count surprised you" tone.
     pub const SECONDARY: ColorToken = token("status_bar.secondary", 0x7d848b);
     /// Tier 3 - resource readouts, present but never competing (`41% cpu · 3.4 GB`).
     pub const RECESSIVE: ColorToken = token("status_bar.recessive", 0x4a5057);
@@ -2918,10 +2878,10 @@ pub mod status_bar {
     ];
 }
 
-/// Diff-line review notes (GitHub issue #288, `STAGE-A-CHANGELOG.md` §1's two `§6.2` rows and
-/// the audit's top-5 #2) - the notes bar above the hunks and the card pinned beneath a line.
+/// Diff-line review notes (GitHub issue #288) - the notes bar above the hunks and the card
+/// pinned beneath a line.
 ///
-/// Every value here is transcribed directly from `Jerry.dc.html`'s own inline styles for that
+/// Every value here is its own token rather than a reuse of a neighbouring one, for that
 /// surface (the `hasNotes` bar and the `l.isNote` branch of the diff row loop), not derived.
 ///
 /// The one colour worth naming twice is [`EDGE`]: `#5a9ad4` is this palette's *selection* blue -
@@ -3006,9 +2966,8 @@ pub mod notes {
     ];
 }
 
-/// Agent history - the sidebar's run list and the run-transcript tab (GitHub issue #227,
-/// `design_handoff_jerry_ade/revision 5/REVISION-2026-08-13.md` §4/§5, transcribed from that
-/// revision's own tables and from `revision 5/tokens.rs`'s `history` module).
+/// Agent history - the sidebar's run list and the run-transcript tab (GitHub issue #227). See
+/// `docs/design/work-surface.md` and `docs/design/sidebar.md`.
 ///
 /// # Two independent axes
 ///
@@ -3078,10 +3037,9 @@ pub mod history {
     /// The drift label in the far band only (§4: "`N commits since` in `#a3873f`").
     pub const DRIFT_FAR_TEXT: ColorToken = token("history.drift_far_text", 0xa3873f);
 
-    /// The scope toggle's selected segment (`REVISION-2026-08-14.md` §6's `all` / `this worktree`
-    /// pair) - `Jerry.dc.html`'s own `hScopes` fill and border. Its own keys rather than
-    /// [`surface::SEGMENT_ACTIVE`]'s, because the mock draws this control as a *bordered* pill
-    /// inside a 27px band rather than as the settings screen's tracked segmented control.
+    /// The scope toggle's selected segment - the `all` / `this worktree` pair. Its own keys
+    /// rather than [`surface::SEGMENT_ACTIVE`]'s, because this control is a *bordered* pill
+    /// inside a 27px band rather than the settings screen's tracked segmented control.
     pub const SCOPE_ON_BG: ColorToken = token("history.scope_on_bg", 0x1d2226);
     pub const SCOPE_ON_BORDER: ColorToken = token("history.scope_on_border", 0x2a3138);
     pub const SCOPE_ON_FG: ColorToken = token("history.scope_on_fg", 0xc2c7cc);
@@ -3097,10 +3055,9 @@ pub mod history {
     /// A run row's title when the row is not the open one.
     pub const ROW_TITLE: ColorToken = token("history.row_title", 0xc2c7cc);
 
-    /// The transcript body's four line tones, transcribed from `Jerry.dc.html`'s own `LFG` map
-    /// (`p` / `c` / `d` / `w`) - the leading `❯ claude --resume …` command line, ordinary body
-    /// text, the indented `⎿ …` detail lines, and the `● …` lead line that opens and closes a
-    /// synthesised transcript.
+    /// The transcript body's four line tones - the leading `❯ claude --resume …` command line,
+    /// ordinary body text, the indented `⎿ …` detail lines, and the `● …` lead line that opens
+    /// and closes a synthesised transcript.
     ///
     /// A **captured** transcript is plain text with no styling of its own (the terminal grid's
     /// colours are not stored - see `crate::run_history::transcript_store`), so every one of its
@@ -3209,12 +3166,9 @@ pub mod search {
     ];
 }
 
-/// The git graph tab (design handoff `design_handoff_jerry_ade/revision 2/CHANGELOG.md`,
-/// 2026-07-31 entry, "git graph (issue #1)") - real hex values transcribed directly from that
-/// entry's §2/§3, not paraphrased. The column header band and the removal of the per-commit
-/// session column (`HEADER`/`HEADER_BG`/`HEADER_LABEL_FG` below) are `revision 3/
-/// REVISION-2026-07-31.md` §6.1/§6.2 instead - that revision supersedes the revision-2 entry
-/// for those two points only, everything else here is still the revision-2 values.
+/// The git graph tab (GitHub issue #1). The column header band and the removal of the per-commit
+/// session column (`HEADER`/`HEADER_BG`/`HEADER_LABEL_FG` below) came later and supersede the
+/// graph's first spec on those two points only; everything else here is that first spec's values.
 pub mod graph {
     use super::{px, token, ColorToken, Pixels};
 
@@ -3565,10 +3519,9 @@ pub mod band {
     /// title bar and must line up pixel-perfect, so they read off one constant instead of three
     /// values that could drift independently.
     ///
-    /// `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4v is the reason this is one
-    /// constant and not three, and it is worth reading before changing it - the design really did
-    /// raise one of the three to 38 and produced "a visible staircase at every column boundary".
-    /// Its rule, verbatim: **"column headers that share a y are one rule, not three. Changing any
+    /// This is one constant and not three because raising one of the three to 38 once produced
+    /// "a visible staircase at every column boundary".
+    /// The rule, verbatim: **"column headers that share a y are one rule, not three. Changing any
     /// of their heights changes a line that spans the whole window - check the other two in the
     /// same edit."** The same section also fixes the *colour* of that rule at
     /// [`super::border::RAIL_INNER`] for all three, "which once the rules lined up would have read
@@ -3581,14 +3534,12 @@ pub mod band {
     pub const PTY_HEADER: Pixels = px(27.0);
     /// The **shell** pane's info footer band (`pid` · grid dimensions · environment chip ·
     /// right-aligned static copy) - the alternative to [`SURFACE_FOOTER`] (the **agent** pane's
-    /// readout strip: GitHub issue #295 / `STAGE-A-CHANGELOG.md` §4t), never stacked with it. A
-    /// pane gets exactly one bottom bar, chosen by `ProcessKind`, matching `Jerry.dc.html`'s
-    /// mutually exclusive `isTerminal` / `isChat` branches.
+    /// readout strip: GitHub issue #295), never stacked with it. A pane gets exactly one bottom
+    /// bar, chosen by `ProcessKind`.
     pub const PTY_INFO_FOOTER: Pixels = px(26.0);
     pub const BREADCRUMB: Pixels = px(26.0);
-    /// 26 -> 28 (`CHANGELOG.md`'s change 7: "Height 26 -> 28"), then 28 -> 30 for rev 6's
-    /// three-tier rebuild (`design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4c:
-    /// "bar 28 -> 30 high, group gap 9 -> 14").
+    /// Raised twice, 26 -> 28 -> 30, the second time for the three-tier rebuild that also took
+    /// the group gap from 9 to 14 (GitHub issue #293).
     pub const STATUS_BAR: Pixels = px(30.0);
     pub const PALETTE_INPUT: Pixels = px(44.0);
     pub const PALETTE_ROW: Pixels = px(30.0);
@@ -3610,10 +3561,10 @@ pub mod band {
     /// The tab strip's `+` menu popover's row height.
     pub const PLUS_MENU_ROW: Pixels = px(29.0);
 
-    // The right panel's Search tab (GitHub issue #162). Every value below is a real measurement
-    // off `Jerry.dc.html`'s own `showFind` block, not a round number picked here. The query row
-    // itself is [`FILTER_ROW`] (30), shared with the rail's own filter - they are the same object
-    // in two places and must not drift.
+    // The right panel's Search tab (GitHub issue #162). Every value below is a real designed
+    // measurement, not a round number picked here. The query row itself is [`FILTER_ROW`] (30),
+    // shared with the rail's own filter - they are the same object in two places and must not
+    // drift.
     /// The `⇄` replace row, revealed under the query row.
     pub const SEARCH_REPLACE_ROW: Pixels = px(28.0);
     /// One of the two `include`/`exclude` glob rows, revealed under those.
@@ -3649,9 +3600,8 @@ pub mod zone {
     pub const COMPOSER_WIDTH: Pixels = px(560.0);
     /// The tab strip's `+` menu popover's width.
     pub const PLUS_MENU_WIDTH: Pixels = px(326.0);
-    /// One sidebar-strip cell's width (GitHub issue #291). `STAGE-A-CHANGELOG.md` §4v: the strip's
-    /// cells "are now the same object" as the centre tabs - "**38px full-height cells, no radius,
-    /// no gap**" - which `Jerry.dc.html`'s own markup renders as `width:38px` inside a
+    /// One sidebar-strip cell's width (GitHub issue #291). The strip's cells are the same object
+    /// as the centre tabs - **full-height cells, no radius, no gap** - inside a
     /// [`super::band::CHROME_HEADER`]-high band. Every cell in the strip is exactly this wide,
     /// view cells and the `+`/`⋯` alike, which is what makes the dividing rules read as a tab
     /// strip's segments rather than as icons on a dark band.
@@ -3716,27 +3666,25 @@ pub mod font {
     pub const MONO: &str = "IBM Plex Mono";
 }
 
-/// Palette-only (⌘P) colours read directly from `Jerry.dc.html`'s inline literals for the
-/// `paletteOpen` block - real values missing from `tokens.rs`'s transcription (predates the
-/// palette section).
+/// Palette-only (⌘P) colours: the ones that have no equivalent in another module. See
+/// `docs/design/command-palette.md`.
 pub mod palette {
     use super::{token, ColorToken};
 
-    /// The input row's scope-prefix glyph (`Jerry.dc.html`: `color:#5f7f9e`).
+    /// The input row's scope-prefix glyph.
     pub const PREFIX: ColorToken = token("palette.prefix", 0x5f7f9e);
-    /// A result group's uppercase header label (`Jerry.dc.html`: `color:#5b6167`) - close to
-    /// but distinct from [`super::text::FAINT`] (`#6b7178`).
+    /// A result group's uppercase header label - close to but distinct from
+    /// [`super::text::FAINT`] (`#6b7178`).
     pub const GROUP_HEADER: ColorToken = token("palette.group_header", 0x5b6167);
-    /// An unselected result row's hover background (`Jerry.dc.html`: `style-hover`:
-    /// `background:#191d20`) - distinct from [`super::surface::ROW_HOVER`] (`#15181b`, which
+    /// An unselected result row's hover background - distinct from
+    /// [`super::surface::ROW_HOVER`] (`#15181b`, which
     /// happens to equal the palette panel's own background, [`super::surface::PALETTE`]).
     pub const ROW_HOVER: ColorToken = token("palette.row_hover", 0x191d20);
-    /// The selected/first row's label colour (`Jerry.dc.html`: `fg: first ? '#e3e8ed' :
-    /// '#c2c7cc'`) - one hex step brighter than [`super::text::SELECTED`] (`#dde2e7`).
+    /// The selected/first row's label colour - one hex step brighter than
+    /// [`super::text::SELECTED`] (`#dde2e7`).
     pub const LABEL_SELECTED: ColorToken = token("palette.label_selected", 0xe3e8ed);
-    /// A command result's kind chip `(fg, bg)` (`Jerry.dc.html`: `background:#1d2532` /
-    /// `color:#7f9ad4`) - the same hex pair as [`super::lang::MD`], kept as its own token since
-    /// a command chip and a Markdown-file chip are unrelated concepts.
+    /// A command result's kind chip `(fg, bg)` - the same hex pair as [`super::lang::MD`], kept
+    /// as its own token since a command chip and a Markdown-file chip are unrelated concepts.
     pub const COMMAND_CHIP: (ColorToken, ColorToken) = (
         token("palette.command_chip.fg", 0x7f9ad4),
         token("palette.command_chip.bg", 0x1d2532),
@@ -3755,11 +3703,10 @@ pub mod palette {
     ];
 }
 
-/// Revision R8's new `lang` chip tokens (item 6) - verified against the exact hex values in
-/// `design_handoff_jerry_ade/revision/tokens.rs:149-160`, independently reconstructed from the
-/// raw `u32` here rather than reusing [`hex`] (the same function under test), so a transcription
-/// error in [`lang::TS`]/[`lang::VUE`]/[`lang::PY`]/[`lang::GO`] would actually be caught rather
-/// than tautologically confirmed.
+/// The four later `lang` chip tokens, checked against their designed hex values - reconstructed
+/// independently from the raw `u32` here rather than by reusing [`hex`] (the same function under
+/// test), so a transcription error in [`lang::TS`]/[`lang::VUE`]/[`lang::PY`]/[`lang::GO`] would
+/// actually be caught rather than tautologically confirmed.
 #[cfg(test)]
 mod lang_token_tests {
     use super::{lang, Rgba};
@@ -4033,9 +3980,8 @@ mod token_registry_tests {
     }
 }
 
-/// Enforces the reserved-hue allocation rule from `design_handoff_jerry_ade/revision 5/
-/// STAGE-A-CHANGELOG.md` §4a - quoted in full in [`agent`]'s own docs, which is the rule these
-/// tests exist to make unbreakable.
+/// Enforces the reserved-hue allocation rule quoted in full in [`agent`]'s own docs, which is
+/// the rule these tests exist to make unbreakable.
 ///
 /// # Why this is a test and not a review note
 ///
@@ -4840,9 +4786,9 @@ mod syntax_contrast_tests {
 
     /// The sidebar strip's one structural invariant, in every bundled theme (GitHub issue #291).
     ///
-    /// `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4v: "a tab only reads as
-    /// connected if the strip behind it is **darker than the panel**, and here strip and rail were
-    /// both `#101113`, so the slab floated." The selected cell fills with [`surface::RAIL`] and
+    /// A tab only reads as connected if the strip behind it is **darker than the panel**: with
+    /// strip and rail on one colour the slab floats. The selected cell fills with
+    /// [`surface::RAIL`] and
     /// paints its own rule in the same colour, so a theme that let [`surface::SIDEBAR_STRIP`]
     /// collapse onto `RAIL` would take the strip's entire selection idiom with it - a failure no
     /// contrast floor catches, because both colours would still be perfectly legible.

--- a/crates/app/src/title_bar/render.rs
+++ b/crates/app/src/title_bar/render.rs
@@ -411,11 +411,8 @@ fn title_bar_agent_state_chips(rows: &[AgentRow]) -> Vec<(Status, usize, String)
         .collect()
 }
 
-/// Title-bar text for one agent-status chip
-/// (`design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §4: "Title bar |
-/// `2 agents need input · 1 agent failed · 4 agents running` | agent-level, one chip per
-/// non-empty state", confirmed verbatim by
-/// `design_handoff_jerry_ade/revision 3/CHANGELOG.md`'s own "Counts" section). `None` for a
+/// Title-bar text for one agent-status chip - `2 agents need input · 1 agent failed · 4 agents
+/// running`, agent-level, one chip per non-empty state. `None` for a
 /// zero count - hidden entirely, never an empty chip - and for [`Status::Review`]/
 /// [`Status::Idle`]: the design's own title-bar example names exactly three states
 /// (`Status::Ask`/`Status::Fail`/`Status::Run`), and finished/idle counts already have a
@@ -447,10 +444,9 @@ fn title_bar_agent_state_chip_text(status: Status, count: usize) -> Option<Strin
     }
 }
 
-/// One title-bar agent-state chip, rebuilt for rev 6 as a **compact dot + count**
-/// (`design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4b's table: "agent status counts |
-/// title-bar text badges · footer dot cluster | **title bar, compact dots**, words in the
-/// tooltip").
+/// One title-bar agent-state chip, rebuilt as a **compact dot + count** with the words moved into
+/// the tooltip - this is also where the status bar's own footer dot cluster went
+/// (`docs/design/decisions.md` §11).
 ///
 /// The sentence is not deleted, it *moves*: `sentence` - still
 /// [`title_bar_agent_state_chip_text`]'s fully conjugated `"2 agents need input"` - becomes this
@@ -870,8 +866,7 @@ mod agent_state_chip_text_tests {
             title_bar_agent_state_chip_text(Status::Run, 1).as_deref(),
             Some("1 agent running")
         );
-        // `design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §4's own literal
-        // example text - "4 agents running" - reproduced verbatim.
+        // The design's own literal example text - "4 agents running" - reproduced verbatim.
         assert_eq!(
             title_bar_agent_state_chip_text(Status::Run, 4).as_deref(),
             Some("4 agents running")

--- a/crates/app/src/work_surface/agents.rs
+++ b/crates/app/src/work_surface/agents.rs
@@ -182,9 +182,8 @@ pub struct Agent {
     /// label/title; `TerminalPane` doesn't expose its own `cwd` back out.
     pub cwd: PathBuf,
     pub pane: Entity<TerminalPane>,
-    /// When this agent was spawned - the rail agent row's real elapsed-time trailing text
-    /// (`design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §2.3: "elapsed 9.5px mono
-    /// right"). Set once, here, and never mutated afterwards - this app has no
+    /// When this agent was spawned - the rail agent row's real elapsed-time trailing text.
+    /// Set once, here, and never mutated afterwards - this app has no
     /// pause/resume-with-a-fresh-clock concept (see `crate::work_surface::state::pty_state_label`'s
     /// docs), so "elapsed" is simply wall-clock time since this real process was spawned.
     pub spawned_at: Instant,

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -897,10 +897,9 @@ impl AdeApp {
     ///
     /// Same order as the strip, just with the shells dropped, so `secondary-2` still means "the
     /// second agent you can see, reading left to right" - it simply stops counting the terminal
-    /// sitting between them. GitHub issue #381: `Jerry.dc.html` has never treated a terminal as
-    /// an agent (`isAgent = t => activeWt.agents.indexOf(t) >= 0`, with `'terminal'` a separate
-    /// tab id its `isFileTab` test excludes by name), and the design's own keybinding table calls
-    /// this `Jump to session by position`. Counting shells made the keycap row advertise more
+    /// sitting between them. GitHub issue #381: the design has never treated a terminal as an
+    /// agent - a shell is its own kind of tab throughout - and its keybinding table calls this
+    /// `Jump to session by position`. Counting shells made the keycap row advertise more
     /// positions than there were agents and pushed every real agent off its own number.
     ///
     /// A shell is not made unreachable by this: it still has a real tab to click, and - since
@@ -1006,8 +1005,8 @@ impl AdeApp {
     /// staying clipped to the space actually available.
     ///
     /// The `+` button rides inside the same scrollable region, immediately after the last tab
-    /// (exactly where `Jerry.dc.html`'s own tab row puts it: `sc-for tabs`, then the `+` cell,
-    /// then a `flex:1` filler, then the trailing hint cluster), so reaching it when tabs overflow
+    /// (exactly where the designed tab row puts it: the tabs, then the `+` cell, then a growing
+    /// filler, then the trailing hint cluster), so reaching it when tabs overflow
     /// is the same one scroll gesture that reaches the last tab - not a second, independently
     /// reachable control pinned somewhere else.
     ///
@@ -1026,8 +1025,8 @@ impl AdeApp {
     /// PR #403 (GitHub issue #402) tried to fix that same report by making the scroller
     /// `.flex_initial()` and moving the `+` button out behind a new growing pusher, which pinned
     /// the `+` to the far right of the strip. That mis-read a plain tab row (a `+` immediately
-    /// after the last tab, bare strip after it - what `Jerry.dc.html` itself draws, and what
-    /// every other tabbed editor draws) as a layout bug, and left the actual 12px spacer
+    /// after the last tab, bare strip after it - what the design draws, and what every other
+    /// tabbed editor draws) as a layout bug, and left the actual 12px spacer
     /// untouched. The product owner's verdict on the result was immediate: "you fixed the plus
     /// button on the right, why? And the padding is still here." Both halves of that change are
     /// reverted here.
@@ -1036,7 +1035,7 @@ impl AdeApp {
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
         // No `border_b` here, deliberately: the *children* own this column's bottom edge. GitHub
-        // issue #291 / `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4v, verbatim -
+        // issue #291 - the defect this fixes was that
         // "the centre column drew its bottom edge **twice** - once on the tab-strip container and
         // once on every tab - so under an inactive tab the rule was 1.6px of two shades stacked,
         // and the active tab's cut-out (its `border-bottom` set to its own background, so it joins
@@ -2046,8 +2045,7 @@ impl AdeApp {
     /// agent surface.
     ///
     /// **Not rendered over a `Shell` tab in a worktree that does have agents** - see
-    /// [`Self::render_center_pane`]'s `show_context_bar`, which reproduces `Jerry.dc.html`'s
-    /// `showAgentBar: noAgents || activeWt.agents.indexOf(tab) >= 0` and the mock's own reason:
+    /// [`Self::render_center_pane`]'s `show_context_bar`, and the design's own reason:
     /// "The whole row is agent identity, so it belongs to agent panes only… in a terminal pane
     /// there is no agent to describe. Kept when the worktree has no agents at all, since it holds
     /// that empty state's CTA."
@@ -2218,10 +2216,9 @@ impl AdeApp {
     /// [`Self::render_plus_menu`]'s "Open file…" row sets).
     ///
     /// An agent pane's pid rides **this header**, and a shell's rides its info footer - which is
-    /// exactly where `Jerry.dc.html` puts each. The mock's two pane branches are mutually
-    /// exclusive (`isChat: isAgent(tab)` vs `isTerminal: tab === 'terminal'`) and only the
-    /// `isTerminal` one has a `pid`/`termSize` bottom bar; the `isChat` header reads
-    /// `{{ focus.cli }} · pid {{ focus.pid }} … {{ focus.ptyHint }}`. See
+    /// exactly where the design puts each. Its two pane branches are mutually exclusive, and only
+    /// the shell one has a pid/grid-size bottom bar; the agent header carries the invocation, the
+    /// pid and the pty hint instead. See
     /// [`Self::render_pty_info_footer`] and [`Self::render_pty_footer`] for the bottom half of
     /// that same split.
     ///
@@ -2326,10 +2323,9 @@ impl AdeApp {
     /// docs), and a hint about file:line references.
     ///
     /// [`ProcessKind::Shell`] only, and mutually exclusive with [`Self::render_pty_footer`] - a
-    /// pane gets one bottom bar, never both. `Jerry.dc.html`'s two pane branches are `sc-if`
-    /// siblings on mutually exclusive conditions (`isTerminal: tab === 'terminal'` vs
-    /// `isChat: isAgent(tab)`), and only the `isTerminal` one carries this bar:
-    /// `pid {{ focus.pid }} │ {{ termSize }} │ [{{ footRemote }}] … file:line references open in
+    /// pane gets one bottom bar, never both. The design's two pane branches are mutually
+    /// exclusive, and only the shell one carries this bar:
+    /// `pid … │ grid size │ [environment chip] … file:line references open in
     /// a tab`. Its `isChat` sibling's only bottom bar is the `hasBar` readout strip. Issue #20
     /// named this bar "the **terminal** footer" too ("2. Terminal: move Clear into the footer"),
     /// and §4b gates the environment chip "in both the window bar and **the terminal footer**".
@@ -2419,11 +2415,11 @@ impl AdeApp {
     /// `STAGE-A-CHANGELOG.md` §4t).
     ///
     /// [`ProcessKind::Agent`] only, and mutually exclusive with
-    /// [`Self::render_pty_info_footer`] - a pane gets one bottom bar, never both. §4t's "the bar
-    /// now renders **whenever there is an agent**" is a statement about *status*, not about pane
-    /// kind: it means the strip no longer waits for a status that offers a button. A `Shell` tab
-    /// is not "an agent" in that sentence's sense - `Jerry.dc.html` gates the whole strip on
-    /// `isChat: isAgent(tab)`, and §4u′ says so from the other direction when it accepts that the
+    /// [`Self::render_pty_info_footer`] - a pane gets one bottom bar, never both. "The bar now
+    /// renders whenever there is an agent" is a statement about *status*, not about pane kind: it
+    /// means the strip no longer waits for a status that offers a button. A `Shell` tab is not
+    /// "an agent" in that sentence's sense - the design gates the whole strip on the pane being
+    /// an agent pane, and says so from the other direction when it accepts that the
     /// budget popover is "reachable only from an agent pane. **On a terminal tab**, the graph or
     /// Settings there is no way to open it… those surfaces have no agent spending anything."
     /// Reading it as "whenever there is a pane" is what stacked this strip under the terminal's
@@ -2768,11 +2764,10 @@ impl AdeApp {
                                 .overflow_hidden()
                                 .child(agent.pane.clone().into_any_element()),
                         )
-                        // One bottom bar per pane, picked by pane kind - never both stacked.
-                        // `Jerry.dc.html`'s two pane branches are mutually exclusive `sc-if`
-                        // siblings: `isTerminal` gets `pid │ 148×38 │ [wsl] … file:line
-                        // references open in a tab`, `isChat` gets the `hasBar` readout strip
-                        // (actions · cost · budget) and puts its pid in the header instead.
+                        // One bottom bar per pane, picked by pane kind - never both stacked. A
+                        // shell gets `pid │ 148×38 │ [wsl] … file:line references open in a tab`;
+                        // an agent gets the readout strip (actions · cost · budget) and puts its
+                        // pid in the header instead.
                         // Rendering both under every pane is the duplication reported live
                         // against the shipped build - see the two methods' own docs.
                         .child(match agent.kind {
@@ -5741,8 +5736,7 @@ mod select_agent_cross_repo_tests {
 }
 
 /// GitHub issue #295: the agent pane's context bar is identity-only, and its bottom strip is a
-/// readout rather than an action bar (`design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md`
-/// §4e/§4r/§4t).
+/// readout rather than an action bar (`docs/design/decisions.md` §12).
 ///
 /// These drive the real painted surface - real spawned child processes, real
 /// `VisualTestContext::debug_bounds` measurements of what actually reached the screen, and real
@@ -5960,10 +5954,9 @@ mod agent_pane_readout_tests {
     /// "the footer of the terminals and agents… right now both are displayed at the same time in
     /// both terminal and agents but should not".
     ///
-    /// `Jerry.dc.html`'s two pane branches are mutually exclusive `sc-if` siblings
-    /// (`isTerminal: tab === 'terminal'` and `isChat: isAgent(tab)`). The `isTerminal` one is the
-    /// only one with a `pid │ {{ termSize }} │ [{{ footRemote }}] … file:line references open in
-    /// a tab` bar; the `isChat` one's only bottom bar is the `hasBar` readout strip. So a `Shell`
+    /// The design's two pane branches are mutually exclusive. The shell one is the only one with
+    /// a `pid │ grid size │ [environment chip] … file:line references open in a tab` bar; the
+    /// agent one's only bottom bar is the readout strip. So a `Shell`
     /// tab paints the info footer and **not** the readout strip.
     #[gpui::test]
     fn a_shell_tab_paints_the_info_footer_and_not_the_agent_readout_strip(cx: &mut TestAppContext) {
@@ -6610,8 +6603,8 @@ mod tab_strip_trailing_margin_tests {
     ///
     /// The real, measured cause: `#tab-strip` ended in a bare `w(px(12))` bordered spacer left
     /// behind by PR #398 (GitHub issue #397) when it deleted the trailing agent-jump keycap
-    /// cluster's *content* but kept its padding. `Jerry.dc.html`'s own tab row has no such thing:
-    /// the 12px there is that cluster's own `padding:0 12px`, and padding with no content in it
+    /// cluster's *content* but kept its padding. The designed tab row has no such thing:
+    /// the 12px there is that cluster's own padding, and padding with no content in it
     /// is not breathing room, it is 12px of dead chrome. With the scroller sitting behind it, the
     /// tabs it clips stopped 12px short of the pane's real right edge instead of running flush
     /// into it - which is exactly the margin both screenshots show, and exactly what survived
@@ -6688,8 +6681,8 @@ mod tab_strip_trailing_margin_tests {
     ///
     /// PR #403 moved the `+` out of the scroller and put a growing `#tab-strip-pusher` in front of
     /// it, which pinned it to the far right of the strip whether the tabs filled it or not. That
-    /// is not what `Jerry.dc.html` draws - its tab row is `sc-for tabs`, then the `+` cell, then a
-    /// `flex:1` filler - nor what any other tabbed editor draws, and it was rejected on sight by
+    /// is not what the design draws - its tab row is the tabs, then the `+` cell, then a growing
+    /// filler - nor what any other tabbed editor draws, and it was rejected on sight by
     /// the product owner. The `+` belongs immediately after the last tab; the bare strip after it
     /// is the design, not a gap in need of filling.
     #[gpui::test]

--- a/crates/app/src/work_surface/state.rs
+++ b/crates/app/src/work_surface/state.rs
@@ -38,9 +38,8 @@ pub enum TabRef {
     Review(AgentId),
     /// The run-transcript tab (GitHub issue #227), showing one finished run's own recording.
     ///
-    /// Carries no payload, like `Graph` and unlike `Review`: `design_handoff_jerry_ade/revision
-    /// 5/REVISION-2026-08-13.md` §3 is "**one run tab per worktree**; opening another replaces
-    /// it", and this order is already per worktree
+    /// Carries no payload, like `Graph` and unlike `Review`: there is **one run tab per
+    /// worktree** and opening another replaces it, and this order is already per worktree
     /// (`crate::root::AdeApp::tab_order`), so within one strip there is never a second one to
     /// tell this apart from. Which run it shows lives in
     /// `crate::root::AdeApp::run_tab_by_worktree` - keeping it out of the identity is what makes
@@ -239,11 +238,11 @@ pub const TRANSPARENT: Rgba = Rgba {
 /// colour, so the same agent is the same colour on its rail badge, its CLI tab chip, its Changes
 /// panel run rows and the conflict side headers.
 ///
-/// Every tint returned here comes from [`theme::agent`]'s pool, which rev 6 reallocated to satisfy
-/// the reserved-hue rule in `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4a: agent
+/// Every tint returned here comes from [`theme::agent`]'s pool, reallocated to satisfy the
+/// reserved-hue rule (`docs/design/decisions.md` §9): agent
 /// identity is allocated only *outside* the five structural hue families (amber, violet, green,
 /// red, blue). Claude is copper and Codex is teal; both used to sit inside a reserved family
-/// (amber and green respectively), which is exactly what §4a fixed. See [`theme::agent`]'s own
+/// (amber and green respectively), which is exactly what that rule fixed. See [`theme::agent`]'s own
 /// docs for the full rule and table, and `theme::agent_tint_allocation_tests` for the test that
 /// keeps it true - **map a new agent to a pool tint here rather than inventing a colour**, or that
 /// test will fail.
@@ -349,10 +348,9 @@ pub struct TabColors {
 
 /// An inactive tab's `underline` is the **window's column rule**, not a tab-level decoration -
 /// which is why it is [`theme::border::RAIL_INNER`] and not [`theme::border::ZONE`]. GitHub issue
-/// #291 / `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4v: once the three column
-/// headers line up, "**All three column headers are now 36** ... and all three borders are
-/// `#191c1f` - the centre strip had been `#1e2225`, which once the rules lined up would have read
-/// as one rule changing shade mid-span."
+/// #291: once the three column headers line up, all three of their bottom rules must be one
+/// colour - the centre strip had been a shade lighter, which once the rules lined up read as one
+/// rule changing shade mid-span.
 ///
 /// The active tab keeps painting its own background there instead - "so it joins the pane below" -
 /// which is the cut-out `crate::rail::strip_render`'s selected cell copies for the left column.
@@ -417,9 +415,8 @@ pub fn live_tab_label(title: Option<&str>, program: &str) -> String {
     }
 }
 
-/// The `+` menu's "New agent" row secondary text (`design_handoff_jerry_ade/revision 3/
-/// REVISION-2026-07-31.md` §3: "*New agent* (`runs in <branch>`)") - the real, currently selected
-/// worktree's branch substituted in, never a hardcoded model/kind name (that was the pre-fix
+/// The `+` menu's "New agent" row secondary text - `runs in <branch>`, with the real, currently
+/// selected worktree's branch substituted in, never a hardcoded model/kind name (that was the pre-fix
 /// bug: the row showed `agent.kind.label()`, e.g. `"Claude"`, which is not what this spec item
 /// asks for at all). Falls back to `(detached)` for a worktree with no recorded branch, mirroring
 /// `crate::work_surface::render::AdeApp::render_agent_context_bar`'s own branch fallback so the
@@ -654,7 +651,7 @@ mod tests {
         assert!(
             same(active.bg, active.underline),
             "an active tab's underline must match its own background - that's how it visually \
-             merges into the surface below it, per design_handoff_jerry_ade/README.md"
+             merges into the surface below it"
         );
     }
 

--- a/crates/lsp-core/src/lib.rs
+++ b/crates/lsp-core/src/lib.rs
@@ -1,6 +1,6 @@
 //! `lsp-core`: a Language Server Protocol client, built to spawn and drive `rust-analyzer` for
-//! Surface C's File view (`design_handoff_jerry_ade/README.md`'s "Language server UI"
-//! subsection, *Diagnostic* state - see `crate::diagnostics_view` in the `app` crate for how a
+//! Surface C's File view (`docs/design/work-surface.md`'s language-server UI,
+//! *Diagnostic* state - see `crate::diagnostics_view` in the `app` crate for how a
 //! `PublishDiagnosticsParams` becomes rendered UI).
 //!
 //! ## Scope decision: this crate, not a module of `app`

--- a/crates/wt-core/src/diff.rs
+++ b/crates/wt-core/src/diff.rs
@@ -319,9 +319,9 @@ pub fn diff_against_base(worktree_path: &Path) -> Result<DiffBase, Error> {
 ///
 /// Deliberately a *different question* from [`diff_against_base`], not a filtered view of it.
 /// `diff_against_base` compares against the merge-base with the default branch, so its file list
-/// mixes work that is already committed on this branch with work that is not
-/// (`design_handoff_jerry_ade/revision 5/REVISION-2026-08-14.md` §1's *Against main* scope: "what
-/// would land"). This compares against `HEAD`, so a file whose only difference from `main` is
+/// mixes work that is already committed on this branch with work that is not - the
+/// *Against main* scope, "what would land". This compares against `HEAD`, so a file whose only
+/// difference from `main` is
 /// already inside a commit on this branch does not appear here at all. The two agree only on a
 /// branch with no commits of its own.
 ///
@@ -635,9 +635,8 @@ fn sum_numstat(text: &str) -> (u32, u32) {
 
 /// Merge-state of a worktree's `HEAD` against the repository's detected default base branch
 /// (see the module docs' "What 'base' means" section for the detection order) - powers the
-/// session rail's "by project" worktree rows
-/// (`design_handoff_jerry_ade/README.md`: a worktree whose branch is fully merged into the
-/// default branch, with no running session, is offered as `merged HH:MM · prunable`).
+/// rail's worktree rows: a worktree whose branch is fully merged into the default branch, with
+/// no running agent, is offered as `merged HH:MM · prunable`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WorktreeMergeStatus {
     /// The short name of the detected default branch this was checked against.

--- a/crates/wt-core/src/graph.rs
+++ b/crates/wt-core/src/graph.rs
@@ -1,5 +1,4 @@
-//! Read-only commit-graph data for the git graph tab (design handoff
-//! `design_handoff_jerry_ade/revision 2/CHANGELOG.md`, 2026-07-31 entry, "git graph (issue #1)").
+//! Read-only commit-graph data for the git graph tab (GitHub issue #1).
 //!
 //! This module builds the data a graph *view* renders: a topologically-walked list of commits,
 //! each assigned to a lane so merges and branch points can be drawn as a real lane diagram, plus
@@ -327,11 +326,10 @@ pub fn build_graph(
     // `HEAD`'s own commit really is the first row - see the module docs on why this is skipped
     // (not faked) for scopes where a newer commit on another branch legitimately sorts first.
     //
-    // Named `Working tree`, not `Uncommitted changes`, since rev 6 (audit item I5, applied in
-    // `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md`'s §3.2.5 row). The panel already
+    // Named `Working tree`, not `Uncommitted changes`. The panel already
     // has a section called `Uncommitted`; this row is the working tree *as a point on the graph*,
     // one step past `HEAD`, and naming it after the other surface's section made two different
-    // things share a word. `Jerry.dc.html`'s own `Git graph` state reads `Working tree`.
+    // things share a word. The design's own graph reads `Working tree`.
     if let Some(first) = rows.first() {
         if Some(&first.commit.id) == head_id.map(|id| id.to_string()).as_ref()
             && is_dirty(repo_path).unwrap_or(false)

--- a/crates/wt-core/src/run_drift.rs
+++ b/crates/wt-core/src/run_drift.rs
@@ -1,7 +1,7 @@
 //! How far a worktree's branch has moved on since a moment in time - the real git side of
 //! GitHub issue #227's **drift** axis.
 //!
-//! `design_handoff_jerry_ade/revision 5/REVISION-2026-08-13.md` §4 defines drift as a count of
+//! The design defines drift as a count of
 //! "commits since" a finished agent run ended, banded into `at the tip` / `1-2 commits since` /
 //! `3+ commits since`. The band and its wording are the app's (`app::run_history::model`); the
 //! *number* is this module, and it is a real `git log` traversal in the run's own checkout, never

--- a/crates/wt-core/src/stage.rs
+++ b/crates/wt-core/src/stage.rs
@@ -1,6 +1,6 @@
-//! Real git-index staging primitives for the Changes panel's staging checkbox
-//! (`design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §5: "The checkbox **is**
-//! staging"). Before this module existed, `app::sidebar::render::AdeApp::toggle_staged` only
+//! Real git-index staging primitives for the Changes panel's staging checkbox - the design's
+//! rule is that "the checkbox **is** staging".
+//! Before this module existed, `app::sidebar::render::AdeApp::toggle_staged` only
 //! flipped an in-memory `HashSet<PathBuf>` - real git never saw anything until the commit
 //! composer's own `git add` ran at commit time (`crate::undo::commit_paths`). That contradicted
 //! the design's explicit framing: checking the box is supposed to be real, immediate staging,
@@ -48,8 +48,8 @@ pub fn unstage_path(worktree_path: &Path, path: &Path) -> Result<(), Error> {
     check_success(&args, &output)
 }
 
-/// Real, immediate **discard** of one path's uncommitted changes - the second click of
-/// `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4i's two-step `Discard?` confirm
+/// Real, immediate **discard** of one path's uncommitted changes - the second click of the
+/// two-step `Discard?` confirm
 /// (GitHub issue #286). Puts `path` back exactly as `HEAD` has it, in both the index and the
 /// working tree, or removes it outright if `HEAD` never had it.
 ///


### PR DESCRIPTION
Part 2 of 3 for #414. Stacked on #418 — **base is `docs/414-design-write`, not `master`**, so review the diff against that branch. Merge after #418.

## What

Removes all 364 `design_handoff_jerry_ade`/`Jerry.dc.html` citations from `crates/` (81 files), plus `Cargo.toml` and `assets/icons/README.md`. Lowers the `design_handoff_citations` ratchet from 364 to **0**.

Four rules, applied per site rather than mechanically:

| Citation carries | Action |
|---|---|
| A rule or a measured value | Keep the sentence, drop the path |
| A durable design rule | Point at `docs/design/<file>.md` instead |
| Pure archaeology — revision IDs, "verified against the mockup", the mockup's own fixture/variable names | Delete |
| A "not the mockup's fake data" disclaimer | Rephrase positively |

Concretely, the third rule is most of the volume. `(Jerry.dc.html: style-hover="background:#17191b")` next to a `token(...)` call that already contains that hex is provenance, not information. The first rule is the one worth reading the diff for — e.g. `theme::surface::SIDEBAR_STRIP` keeps *"a tab only reads as connected if the strip behind it is darker than the panel"* and loses the section number, the two intermediate hex values and the revision history around it.

Two structural notes:

- **`assets/themes/*.toml` are generated, not hand-written.** They embed `theme.rs`'s module docs verbatim, so they were regenerated through their own real path (`JERRY_REGENERATE_THEMES=1 cargo test -p app --lib builtin_themes`), not edited. Their own round-trip test confirms it.
- **`docs/design/` deliberately isn't cited everywhere a path was removed.** Most sites carried a *value*, and the new docs don't hold values — a pointer there would be a dead end. The pointers land only where a module genuinely maps to a page (`rail::state` → `rail.md`, `settings::state` → `settings.md`, `icons` → `decisions.md` §8, …).

## Why

Roughly a third of the 364 citations pointed at directories that were **never committed** — `revision 2/`, `revision 3/`, `revision 5/`, `STAGE-A-CHANGELOG.md`, `REVISION-2026-08-13.md`, `AUDIT-2026-08-13-competitive-v2.md`. An outside contributor reading `theme.rs` or `rail/render.rs` hit an unresolvable path roughly every other screen.

They are also the single largest class of comment-rule violation in the codebase: `CLAUDE.md` excludes design history, revision IDs and issue archaeology from source comments precisely because that material goes stale in place, which is exactly what happened.

## Testing

- [x] `/check` (conventions + fmt + clippy `-D warnings`) passes locally
- [x] `.claude/hooks/check-conventions.sh` passes at the new baseline (`handoff citations: 0/0`)
- [x] **Behaviour is unchanged**, verified mechanically rather than asserted:

  ```sh
  git diff -- crates/ | grep '^[-+]' | grep -v '^[-+][-+]' \
    | grep -vE '^[-+][[:space:]]*(///|//!|//)'
  ```

  Output is five test assertion messages and the one test rename (`every_mapped_slot_from_the_design_handoff_has_its_phosphor_glyph` → `every_mapped_icon_slot_has_its_phosphor_glyph`). Nothing else.
- [x] `cargo test -p wt-core` — 302 passed
- [x] `cargo test -p app --lib` on the pure modules touched heaviest: `theme::` (142), `icons::` (19), `rail::state` (43), `rail::status` (25), `sidebar::sections` (16), `sidebar::changes` (41), `palette::state` (27), `provenance::change_set` (9), `run_history::model` (27) — all pass
- [x] `cargo test -p app --lib builtin_themes` — 9 passed, confirming the regenerated theme files match their generator
- [x] `rail::strip` (5), `search::` (1) and `settings::state` (1) each have failures — **pre-existing**, reproduced identically on the parent branch before this diff, consistent with #348
- [ ] `verify` capture — n/a, comments only
- [ ] New behaviour test — n/a, no behaviour change

## Architecture notes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)