### PR TITLE
chore: adopt cargo-nextest as the workspace test runner

### DIFF
--- a/.claude/commands/setup.md
+++ b/.claude/commands/setup.md
@@ -15,6 +15,14 @@ rustc --version   # should report 1.95.0, matching rust-toolchain.toml
 If it doesn't match, `rustup` picks up `rust-toolchain.toml` automatically on the next `cargo`
 invocation in this directory — nothing to install by hand unless `rustup` itself is missing.
 
+Tests run under `cargo-nextest`, which this repo configures in `.config/nextest.toml` (per-test
+process isolation and a two-minute per-test timeout). Unlike rtk below, it is not optional — check
+for it and install it if absent:
+
+```sh
+cargo nextest --version || cargo install cargo-nextest --locked
+```
+
 ## 2. System dependencies
 
 Detect the platform and check accordingly; don't run installer commands for a platform other than

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,23 @@
+# Test-runner policy for `cargo nextest run`. Each test gets its own process, so a hung or
+# resource-leaking test can be killed on its own instead of squatting a shared runner thread.
+
+[profile.default]
+# One broken module must not hide the state of the rest of the suite.
+fail-fast = false
+
+# Reported slow at 30s, killed after 4 periods (2 minutes). `cargo test` has no equivalent, which
+# is why a single blocking test can currently keep a run alive indefinitely.
+slow-timeout = { period = "30s", terminate-after = 4 }
+
+# Flakes get fixed, not retried into a green run.
+retries = 0
+
+# TODO(#424): once the `external` test tier exists, add a `[[profile.default.overrides]]` giving it
+# a longer slow-timeout — a real language-server handshake legitimately takes seconds.
+
+[profile.ci]
+# Failures are repeated at the end of the log, where the Actions summary is readable.
+failure-output = "immediate-final"
+
+[profile.ci.junit]
+path = "junit.xml"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,12 @@ it that way as more people touch it.
 — see the [README](README.md#gpui-version-pin) for the pinned revision. Cargo fetches them
 automatically; no manual checkout is needed.
 
+Tests run under [`cargo-nextest`](https://nexte.st), not `cargo test` — install it once:
+
+```sh
+cargo install cargo-nextest --locked
+```
+
 Coding standards (what "no fake functionality" means, the exact hard rules on `unwrap`/`unsafe`/
 paths/git argv, comment style, GPUI patterns) live in [`CLAUDE.md`](CLAUDE.md) — read that, not this
 file, for how the code itself should look. This file covers the human contribution process around
@@ -25,9 +31,17 @@ cargo fmt --all -- --check
 ```
 
 Run them together as `/check` if you're working through Claude Code. None are optional or "mostly
-passing." `cargo test --workspace` is intentionally not part of this list right now — see
-[issue #348](https://github.com/ColinEspinas/jerry/issues/348); run tests relevant to what you're
-touching manually instead.
+passing." The test suite is intentionally not part of this list right now — see
+[issue #348](https://github.com/ColinEspinas/jerry/issues/348); run the tests relevant to what
+you're touching manually instead, scoped to a crate:
+
+```sh
+cargo nextest run -p wt-core
+```
+
+`.config/nextest.toml` gives every test its own process and kills one that is still running after
+two minutes, so a hung test fails that test instead of the whole run. `cargo test` has no
+equivalent and will sit there indefinitely — prefer `cargo nextest run`.
 
 See [`docs/development-workflow.md`](docs/development-workflow.md) for how a change actually moves
 from a GitHub issue to a merged PR in this repo, including which Claude Code skill covers which

--- a/README.md
+++ b/README.md
@@ -112,11 +112,19 @@ cargo fmt --all -- --check
 must all pass — see [`CLAUDE.md`](CLAUDE.md) for the full standards, [`CONTRIBUTING.md`](CONTRIBUTING.md)
 for the process, and [`docs/development-workflow.md`](docs/development-workflow.md) for how a
 change moves from issue to merged PR. `.github/workflows/ci.yml` runs the same checks on every
-push. `cargo test --workspace` is not currently part of this gate — see
-[issue #348](https://github.com/ColinEspinas/jerry/issues/348). If you're using
-[Claude Code](https://claude.com/claude-code), this repo's `.claude/` directory (skills, agents,
-commands) is set up already — install [rtk](https://github.com/rtk-ai/rtk) and run `/setup` to
-cut token usage on command output; optional, not a build dependency.
+push. The test suite is not currently part of this gate — see
+[issue #348](https://github.com/ColinEspinas/jerry/issues/348) — but tests run under
+[`cargo-nextest`](https://nexte.st) rather than `cargo test`, for the per-test process isolation
+and timeout configured in `.config/nextest.toml`:
+
+```sh
+cargo install cargo-nextest --locked
+cargo nextest run -p wt-core
+```
+
+If you're using [Claude Code](https://claude.com/claude-code), this repo's `.claude/` directory
+(skills, agents, commands) is set up already — install [rtk](https://github.com/rtk-ai/rtk) and run
+`/setup` to cut token usage on command output; optional, not a build dependency.
 
 ## License
 


### PR DESCRIPTION
Closes #423

## What

Adds `.config/nextest.toml` and makes `cargo nextest run` the documented way to run this
workspace's tests. Every test now runs in its own process, is reported slow at 30s, and is **killed
at 2 minutes**. `cargo test` has no equivalent — a blocking test squats a worker thread and the run
never ends, which is the symptom that makes the suite unusable today.

- `[profile.default]`: `fail-fast = false`, `slow-timeout = { period = "30s", terminate-after = 4 }`,
  `retries = 0`.
- `[profile.ci]`: inherits the above, adds `failure-output = "immediate-final"` and JUnit output.
- The `external`-tier `slow-timeout` override is a `TODO` referencing #424 — that tier does not
  exist yet.
- Install line (`cargo install cargo-nextest --locked`) added to `CONTRIBUTING.md`, `README.md`, and
  `.claude/commands/setup.md`.

No change to the pre-commit gate or `/check`; the suite is not green yet (that's #426).

## Why

See #423. `cargo test -p app --lib -- --test-threads=4` was observed running for 22 minutes with
509 leaked child processes and no way to stop any individual test.

## Testing

- [x] `/check` (conventions + fmt + clippy `-D warnings`) passes locally
- [ ] `verify` capture attached — n/a, no UI surface
- [x] New/changed behavior confirmed by real runs, pasted below

### 1. The three core crates run and report

```
$ cargo nextest run -p wt-core -p pty-core -p lsp-core
    Starting 369 tests across 3 binaries
        FAIL [   0.033s] ( 13/369) lsp-core client::tests::drop_without_shutdown_does_not_leave_an_orphaned_process
        FAIL [   0.024s] ( 18/369) lsp-core client::tests::spawn_performs_a_real_handshake_and_shutdown_leaves_no_orphan
        FAIL [   0.220s] ( 26/369) lsp-core proc::tests::collect_descendant_pids_finds_a_real_child_process
        FAIL [   0.221s] ( 27/369) lsp-core proc::tests::terminate_tree_kills_a_real_process_and_its_real_child
        FAIL [   0.019s] ( 44/369) pty-core tests::drop_kills_child_and_it_does_not_become_an_orphan
        FAIL [   0.024s] ( 45/369) pty-core tests::drop_terminates_entire_process_tree_including_escaped_grandchild
        FAIL [   1.009s] ( 72/369) pty-core tests::long_output_arrives_complete_and_in_order_across_chunk_boundaries
        SLOW [> 30.000s] (───────) lsp-core client::tests::a_real_but_frozen_server_fails_the_write_within_the_budget_instead_of_hanging_forever
        SLOW [> 30.000s] (───────) lsp-core client::tests::a_writer_queued_behind_one_that_gives_up_is_refused_rather_than_corrupting_the_stream
     Summary [  30.045s] 369 tests run: 362 passed (2 slow), 7 failed, 0 skipped
```

wt-core 302/302 pass, pty-core 13/16, lsp-core 47/51. The 7 failures are the macOS process-tree
kill bug tracked in #422, not this change. Confirmed for pty-core: `cargo test -p pty-core --lib`
fails the same 3 tests (`13 passed; 3 failed`).

### 2. A hung test is killed at the configured `terminate-after`

Temporarily added to `wt-core`, run against the committed config (2 minutes, not shortened), then
removed — it is not in this diff:

```rust
#[test]
fn temporary_hang_demo_delete_before_commit() {
    std::thread::sleep(std::time::Duration::from_secs(600));
}
```

```
$ cargo nextest run -p wt-core -E 'test(temporary_hang_demo)'
    Starting 1 test across 1 binary (302 tests skipped)
        SLOW [> 30.000s] (───) wt-core run_drift::tests::temporary_hang_demo_delete_before_commit
        SLOW [> 60.000s] (───) wt-core run_drift::tests::temporary_hang_demo_delete_before_commit
        SLOW [> 90.000s] (───) wt-core run_drift::tests::temporary_hang_demo_delete_before_commit
 TERMINATING [>120.000s] (───) wt-core run_drift::tests::temporary_hang_demo_delete_before_commit
     TIMEOUT [ 120.008s] (1/1) wt-core run_drift::tests::temporary_hang_demo_delete_before_commit
  stdout ───

    running 1 test
    test run_drift::tests::temporary_hang_demo_delete_before_commit has been running for over 60 seconds

    (test timed out)

────────────
     Summary [ 120.013s] 1 test run: 0 passed, 1 timed out, 302 skipped
error: test run failed
```

A 600-second sleep died at 120.008s. Under `cargo test` the same test runs to completion (or
forever, if it never returns).

### 3. Process-per-test overhead on the `app` binary — measured

The `app` test binary is **167,333,096 bytes (159.6 MB)** and holds **3,134 tests** (`--lib`);
`wt-core`/`pty-core`/`lsp-core` add 369, so 3,503 in the workspace. Machine: macOS 26.5.2, Apple
Silicon, 12 cores.

**(a) Same 123 real tests, one process vs one process per test.** `text_history::*` + `theme::*`,
both pure-logic modules; identical test set both ways, single-threaded both ways, min of 3 batches:

```
123 tests selected
one process, all 123 tests :      6.5 ms
one process per test (123 execs):    776.9 ms
added by re-exec                    :    770.4 ms
per test                           :     6.26 ms
```

**(b) Marginal cost of the binary's size.** Sequential execs selecting zero tests, so this is
exec + dyld + libtest init only; min of 3 batches of 100:

```
baseline /usr/bin/true: 0.161s / 100 execs = 1.61 ms per exec
wt-core exec, 0 tests: 0.266s / 100 execs = 2.66 ms per exec     (13.6 MB binary)
app exec, 0 tests: 0.679s / 100 execs = 6.79 ms per exec         (159.6 MB binary)
app exec, 1 trivial test: 0.642s / 100 execs = 6.42 ms per exec
```

So ~1.6 ms is process spawn itself, ~1.1 ms is a small test binary, and the 160 MB image adds
**~3.8 ms** on top of that. macOS maps the image lazily, so 160 MB does not cost anything like
160 MB of I/O per exec.

Caveat, stated because it moved the number by 2x: the **first** batch measured against a
freshly-linked binary gave 13.16 ms/exec for `app` and 6.21 ms for `wt-core`. Warm (steady state,
which is what a real run sees after the first few tests) it settles at the numbers above. The warm
numbers are the ones that describe a real suite run; the cold ones are reported here so the 2x
spread isn't hidden.

**What this costs the whole suite:**

| | serialised | wall clock at 12-way |
|---|---|---|
| `app --lib`, 3,134 tests × 6.4 ms | ~20.1 s | **~1.7 s** |
| core crates, 369 tests × 2.7 ms | ~1.0 s | ~0.1 s |

Cross-check against a real end-to-end nextest run of the 123-test subset: `Summary [0.246s] 123
tests run: 123 passed`.

**Verdict: the overhead does not dominate.** ~1.7 s of added wall clock against an `app` suite that
currently does not terminate at all. For reference, `cargo nextest run -p wt-core` (302 tests, real
`git` subprocesses) takes 9.9 s vs 8.7 s for `cargo test -p wt-core --lib` — and that gap is mostly
scheduling noise on a CPU-saturated run, not exec cost.

This does mean the 160 MB binary is not the reason to purge tests. If #425 wants a smaller suite,
the argument has to be about what the tests do (spawning real processes), not about re-exec cost.

## Architecture notes

None — no crate boundary or Command/Query change.
