### PR TITLE
feat(test-support): shared gpui-free fixtures and a written testing policy

### DIFF
--- a/.claude/conventions-baseline.json
+++ b/.claude/conventions-baseline.json
@@ -1,5 +1,5 @@
 {
   "_comment": "Ratchet baseline for .claude/hooks/check-conventions.sh - these numbers may only go down, never up. Recount with the exact commands in that script's comments after fixing a batch of violations, and lower the number in the same commit.",
   "glob_imports_app_src": 304,
-  "render_adapter_calls": 222
+  "render_adapter_calls": 221
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,10 +125,13 @@ what this rule would have flagged.
 
 ## Testing
 
-`#[gpui::test]` + `TestAppContext`/`VisualTestContext` for anything touching a `Render`/`Entity` —
-not a snapshot of stdout, which doesn't cover a retained-mode GPU UI. Name test modules by concern
-(`mod change_row_selection_tests`, not `mod tests`) — the existing 175-name convention is good,
-keep it. Fixtures live under a sibling `testdata/` directory, not inlined as string literals.
+Every test is one of three tiers: `unit` (plain `#[test]`, pure logic or a tempdir, < 10 ms), `ui`
+(`#[gpui::test]` + `TestAppContext`/`VisualTestContext` for anything touching a `Render`/`Entity`,
+< 2 s), or `external` (`#[ignore = "external: <binary>; …"]`, a real language server or agent
+process, its own CI job and never the PR gate). Shared fixtures — argv-only `git`, seeded
+repositories, `wait_until`, `ChildGuard` — come from `crates/test-support`, which stays `gpui`-free;
+GPUI ones from `crates/app/src/test_support.rs`. What deserves a test, what gets deleted and why,
+and the no-`thread::sleep` rule: [`docs/testing.md`](docs/testing.md).
 
 ## Workflow
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,7 @@ dependencies = [
  "sha2",
  "streaming-iterator",
  "tempfile",
+ "test-support",
  "toml 0.8.23",
  "tree-sitter",
  "tree-sitter-c",
@@ -7929,6 +7930,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-support"
+version = "0.1.1"
+dependencies = [
+ "tempfile",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9890,6 +9898,7 @@ dependencies = [
  "gix",
  "sha2",
  "tempfile",
+ "test-support",
  "thiserror 1.0.69",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ members = [
     "crates/pty-core",
     "crates/lsp-core",
     "crates/app",
+    # Dev-dependency only, and deliberately gpui-free so the core crates can use it too
+    # (docs/architecture/decisions.md §1, docs/testing.md).
+    "crates/test-support",
 ]
 
 [workspace.package]

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -379,6 +379,9 @@ windows-sys = { version = "0.61.2", features = [
 
 [dev-dependencies]
 tempfile = "3"
+# Shared, gpui-free fixtures (real seeded repositories, argv-only `git`, bounded waits,
+# `ChildGuard`) - see `docs/testing.md`.
+test-support = { path = "../test-support" }
 # `test-support` unlocks GPUI's real interactive test harness (`#[gpui::test]`,
 # `TestAppContext`/`VisualTestContext` - a real window, real focus tracking, real action
 # dispatch/keystroke simulation, not a mock). Kept as a permanent dependency, not a temporary

--- a/crates/app/src/graph_view/render.rs
+++ b/crates/app/src/graph_view/render.rs
@@ -4316,40 +4316,9 @@ fn lane_for_ref(row: &GraphRow, _chip: &wt_core::graph::RefChip) -> usize {
 #[cfg(test)]
 mod graph_row_menu_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
+    use crate::test_support::open_test_app;
     use gpui::{Bounds, Entity, Pixels, Point, Size, TestAppContext};
-
-    fn git(dir: &std::path::Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    /// Three real commits, clean working tree at the end - `build_graph` yields exactly three
-    /// real commit rows (indices 0..=2, newest first), with no "Working tree" row to
-    /// throw off the indices these tests target.
-    fn seed_three_commits(dir: &std::path::Path) {
-        git(dir, &["init", "-b", "main"]);
-        git(dir, &["config", "user.email", "test@example.com"]);
-        git(dir, &["config", "user.name", "Test User"]);
-        std::fs::write(dir.join("a.txt"), "1\n").expect("write a.txt");
-        git(dir, &["add", "."]);
-        git(dir, &["commit", "-m", "first"]);
-        std::fs::write(dir.join("a.txt"), "2\n").expect("write a.txt");
-        git(dir, &["commit", "-am", "second"]);
-        std::fs::write(dir.join("a.txt"), "3\n").expect("write a.txt");
-        git(dir, &["commit", "-am", "third"]);
-    }
+    use test_support::seed_three_commits;
 
     fn open_seeded_graph(
         cx: &mut TestAppContext,
@@ -4360,7 +4329,7 @@ mod graph_row_menu_tests {
     ) {
         let repo = tempfile::tempdir().expect("tempdir");
         seed_three_commits(repo.path());
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_git_graph(window, cx);
         });
@@ -4707,7 +4676,7 @@ mod graph_row_menu_tests {
     fn the_dots_button_anchors_off_its_own_real_captured_bounds(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
         seed_three_commits(repo.path());
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let scrolled_bounds = Bounds {
@@ -4864,7 +4833,7 @@ mod graph_row_menu_tests {
     ) {
         let repo = tempfile::tempdir().expect("tempdir");
         seed_three_commits(repo.path());
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         app.update_in(cx, |app, window, cx| {

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -55,6 +55,11 @@ pub mod sidebar;
 pub mod sound;
 pub mod status_bar;
 pub mod terminal;
+// The GPUI half of this workspace's shared fixtures; the gpui-free half is `crates/test-support`
+// (see that crate's docs and `docs/testing.md`). `cfg(test)`, so none of it is compiled into the
+// shipped binary.
+#[cfg(test)]
+pub(crate) mod test_support;
 pub mod text_history;
 pub mod theme;
 // `pub(crate)`, unlike every other feature folder above: this one exposes no public item at

--- a/crates/app/src/root/focus.rs
+++ b/crates/app/src/root/focus.rs
@@ -238,28 +238,12 @@ impl AdeApp {
 #[cfg(test)]
 pub(crate) mod palette_focus_tests {
     use super::*;
-    use gpui::{Entity, TestAppContext};
+    use gpui::TestAppContext;
 
-    /// Opens an `AdeApp` in a test GPUI window against a throwaway temp directory (not a real
-    /// git repo, so `worktrees`/`diff_state` end up empty/errored - irrelevant to what these
-    /// tests check). `pub(crate)` since `settings_focus_tests` and others reuse this
-    /// same setup. Uses `AdeApp::new_with_settings` (in-memory `Settings::default()`, `None`
-    /// path), not `AdeApp::new`, so tests never read or write a real `settings.toml`.
-    pub(crate) fn open_test_app(
-        cx: &mut TestAppContext,
-        repo_path: PathBuf,
-    ) -> (Entity<AdeApp>, &mut gpui::VisualTestContext) {
-        cx.add_window_view(|window, cx| {
-            AdeApp::new_with_settings(
-                Some(repo_path),
-                true,
-                settings_store::Settings::default(),
-                None,
-                window,
-                cx,
-            )
-        })
-    }
+    /// The window fixture now lives in [`crate::test_support`]; re-exported here so the call
+    /// sites that still say `palette_focus_tests::open_test_app` keep resolving while they are
+    /// migrated (GitHub issue #425).
+    pub(crate) use crate::test_support::open_test_app;
 
     /// Without a focus restore in `close_palette`, `Window::focus` stayed on the untracked
     /// `palette_focus_handle` and every action dispatch after that - including the next ⌘P -

--- a/crates/app/src/sidebar/file_tree_watch.rs
+++ b/crates/app/src/sidebar/file_tree_watch.rs
@@ -87,68 +87,32 @@ pub fn spawn_file_tree_watcher(
 mod tests {
     use super::*;
     use std::fs;
-    use std::process::Command;
     use std::sync::atomic::AtomicBool;
     use std::sync::Arc;
-    use std::time::{Duration, Instant};
+    use std::time::Duration;
     use tempfile::TempDir;
+    use test_support::{git, seed_repo, stays_false, wait_until};
 
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}",
-            args,
-            dir
-        );
-    }
-
-    /// A real git repository - see [`spawn_file_tree_watcher`]'s own docs on why its
-    /// `wt_core::git_common_dir` gate means every one of this module's tests needs a real repo,
-    /// not just a plain temp directory.
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        fs::write(dir.path().join("base.txt"), "base\n").expect("write");
-        git(dir.path(), &["add", "base.txt"]);
-        git(dir.path(), &["commit", "-m", "initial"]);
-        dir
-    }
-
-    /// Real-time bounded wait for the watcher's async, OS-thread-delivered callback to fire - see
-    /// `crate::rail::worktree_watch::tests::wait_until_dirty`'s identical own docs for why this
-    /// can't be a simulated/deterministic clock.
+    /// The watcher's callback is delivered by an OS thread, not by a GPUI executor, so there is
+    /// no deterministic clock to park - a real-time bounded wait is the only option.
     fn wait_until_dirty(dirty: &DirtyFlag) -> bool {
-        let deadline = Instant::now() + Duration::from_secs(3);
-        while Instant::now() < deadline {
-            if dirty.swap(false, Ordering::SeqCst) {
-                return true;
-            }
-            std::thread::sleep(Duration::from_millis(10));
-        }
-        false
+        wait_until(Duration::from_secs(3), || {
+            dirty.swap(false, Ordering::SeqCst)
+        })
     }
 
-    /// The inverse of [`wait_until_dirty`]: asserts the flag stays clear for a real, bounded
-    /// window - used to prove `.git/` churn is genuinely filtered out, not just "usually" missed
-    /// by a race.
+    /// The inverse of [`wait_until_dirty`]: proves `.git/` churn is genuinely filtered out
+    /// rather than just slow to arrive.
     fn assert_stays_clean(dirty: &DirtyFlag) {
-        std::thread::sleep(Duration::from_millis(500));
         assert!(
-            !dirty.load(Ordering::SeqCst),
+            stays_false(Duration::from_millis(500), || dirty.load(Ordering::SeqCst)),
             "a change confined to .git/ must never mark the file tree dirty"
         );
     }
 
     #[test]
     fn a_real_new_file_is_noticed() {
-        let dir = init_repo();
+        let dir = seed_repo();
         let dirty: DirtyFlag = Arc::new(AtomicBool::new(false));
         let _watcher =
             spawn_file_tree_watcher(dir.path(), dirty.clone()).expect("spawn_file_tree_watcher");
@@ -163,7 +127,7 @@ mod tests {
 
     #[test]
     fn a_real_file_edit_in_a_nested_directory_is_noticed() {
-        let dir = init_repo();
+        let dir = seed_repo();
         fs::create_dir_all(dir.path().join("src/nested")).expect("mkdir");
         let file = dir.path().join("src/nested/a.rs");
         fs::write(&file, "fn main() {}").expect("write");
@@ -182,7 +146,7 @@ mod tests {
 
     #[test]
     fn a_real_deletion_is_noticed() {
-        let dir = init_repo();
+        let dir = seed_repo();
         let file = dir.path().join("gone.txt");
         fs::write(&file, "content").expect("write");
 
@@ -200,7 +164,7 @@ mod tests {
 
     #[test]
     fn a_change_confined_to_dot_git_is_filtered_out() {
-        let dir = init_repo();
+        let dir = seed_repo();
 
         let dirty: DirtyFlag = Arc::new(AtomicBool::new(false));
         let _watcher =
@@ -217,7 +181,7 @@ mod tests {
 
     #[test]
     fn a_real_change_alongside_dot_git_churn_is_still_noticed() {
-        let dir = init_repo();
+        let dir = seed_repo();
 
         let dirty: DirtyFlag = Arc::new(AtomicBool::new(false));
         let _watcher =
@@ -234,7 +198,7 @@ mod tests {
 
     #[test]
     fn a_missing_directory_yields_no_watcher_rather_than_panicking() {
-        let dir = init_repo();
+        let dir = seed_repo();
         let missing = dir.path().join("does-not-exist");
         let dirty: DirtyFlag = Arc::new(AtomicBool::new(false));
         assert!(spawn_file_tree_watcher(&missing, dirty).is_none());

--- a/crates/app/src/test_support.rs
+++ b/crates/app/src/test_support.rs
@@ -1,0 +1,73 @@
+//! GPUI-flavoured test fixtures: opening a real `AdeApp` in a test window.
+//!
+//! Deliberately *not* part of `crates/test-support`, which the gpui-free core crates
+//! dev-depend on (`docs/architecture/decisions.md` §1) — a Cargo feature would not be enough,
+//! since workspace feature unification would pull `gpui` into their dev graph anyway. Repo,
+//! git and wait fixtures with no GPUI in them belong there, not here.
+
+use crate::root::AdeApp;
+use crate::settings::store as settings_store;
+use gpui::{Entity, TestAppContext, VisualTestContext};
+use std::path::PathBuf;
+
+/// Opens an `AdeApp` in a test GPUI window against `repo_path`.
+///
+/// Uses `AdeApp::new_with_settings` with an in-memory `Settings::default()` and no settings
+/// path, so a test never reads or writes the developer's real `settings.toml`.
+pub(crate) fn open_test_app(
+    cx: &mut TestAppContext,
+    repo_path: PathBuf,
+) -> (Entity<AdeApp>, &mut VisualTestContext) {
+    open_test_app_with_settings(cx, repo_path, settings_store::Settings::default(), None)
+}
+
+/// [`open_test_app`] with an explicit settings value and, optionally, a real on-disk settings
+/// path — for the tests that assert on what actually gets persisted.
+pub(crate) fn open_test_app_with_settings(
+    cx: &mut TestAppContext,
+    repo_path: PathBuf,
+    settings: settings_store::Settings,
+    settings_path: Option<PathBuf>,
+) -> (Entity<AdeApp>, &mut VisualTestContext) {
+    cx.add_window_view(|window, cx| {
+        AdeApp::new_with_settings(Some(repo_path), true, settings, settings_path, window, cx)
+    })
+}
+
+#[cfg(test)]
+mod test_window_fixture_tests {
+    use crate::rail::repo::canonical_repo_path;
+    use crate::settings::store::Settings;
+    use crate::test_support::{open_test_app, open_test_app_with_settings};
+    use gpui::TestAppContext;
+
+    #[gpui::test]
+    fn open_test_app_focuses_the_repository_it_is_given(cx: &mut TestAppContext) {
+        let repo = test_support::seed_repo();
+
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.focused_repo_path()),
+            canonical_repo_path(repo.path()),
+            "the fixture must open on the caller's repository, not one remembered on disk"
+        );
+    }
+
+    #[gpui::test]
+    fn open_test_app_with_settings_carries_the_settings_it_is_given(cx: &mut TestAppContext) {
+        let repo = test_support::seed_repo();
+        let mut settings = Settings::default();
+        settings.appearance.editor_font_size = 21.0;
+
+        let (app, cx) = open_test_app_with_settings(cx, repo.path().to_path_buf(), settings, None);
+        cx.run_until_parked();
+
+        assert_eq!(
+            app.read_with(cx, |app, _| app.settings.appearance.editor_font_size),
+            21.0,
+            "a test that passes settings in must see them, or it is asserting on defaults"
+        );
+    }
+}

--- a/crates/test-support/Cargo.toml
+++ b/crates/test-support/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "test-support"
+version = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
+license = { workspace = true }
+description = "Shared, gpui-free test fixtures for this workspace: real git repositories, bounded waits, process teardown"
+
+[lints]
+workspace = true
+
+[dependencies]
+# The one dependency this crate is allowed: `seed_repo`/`seed_bare_remote` hand back a live
+# temp directory, so `TempDir` is part of the public signature rather than an implementation
+# detail. Same major version every consuming crate already dev-depends on.
+tempfile = "3"

--- a/crates/test-support/src/child.rs
+++ b/crates/test-support/src/child.rs
@@ -1,0 +1,154 @@
+//! RAII teardown for a test that spawns a real process.
+//!
+//! A test that returns early — or fails an assertion, which unwinds — must not leave its child
+//! behind: leaked children are what make a full-suite run peg a machine (`docs/testing.md`'s
+//! hard rules).
+
+use std::io;
+use std::ops::{Deref, DerefMut};
+use std::process::{Child, Command, ExitStatus};
+
+/// A [`Child`] that is killed and reaped when it goes out of scope, however the test exits.
+///
+/// Derefs to the wrapped [`Child`], so `guard.stdin`, `guard.id()` and `guard.try_wait()` work
+/// unchanged.
+pub struct ChildGuard {
+    // `Option` only so `into_inner` can hand the child back without `Drop` also killing it.
+    child: Option<Child>,
+}
+
+impl ChildGuard {
+    /// Takes ownership of an already-spawned child.
+    pub fn new(child: Child) -> Self {
+        Self { child: Some(child) }
+    }
+
+    /// Spawns `command` and guards the result.
+    pub fn spawn(command: &mut Command) -> io::Result<Self> {
+        command.spawn().map(Self::new)
+    }
+
+    /// Whether the process is still running, without blocking on it.
+    pub fn is_running(&mut self) -> bool {
+        matches!(self.child_mut().try_wait(), Ok(None))
+    }
+
+    /// Kills the process now and waits for it, rather than at end of scope. `Ok(None)` means it
+    /// had already exited.
+    pub fn kill_and_wait(&mut self) -> io::Result<Option<ExitStatus>> {
+        let child = self.child_mut();
+        if let Ok(Some(_)) = child.try_wait() {
+            return Ok(None);
+        }
+        child.kill()?;
+        child.wait().map(Some)
+    }
+
+    /// Gives up the guard's ownership — the caller becomes responsible for teardown.
+    pub fn into_inner(mut self) -> Child {
+        self.child.take().expect("child guard already consumed")
+    }
+
+    fn child_mut(&mut self) -> &mut Child {
+        self.child.as_mut().expect("child guard already consumed")
+    }
+}
+
+impl Deref for ChildGuard {
+    type Target = Child;
+
+    fn deref(&self) -> &Child {
+        self.child.as_ref().expect("child guard already consumed")
+    }
+}
+
+impl DerefMut for ChildGuard {
+    fn deref_mut(&mut self) -> &mut Child {
+        self.child.as_mut().expect("child guard already consumed")
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        if let Some(child) = self.child.as_mut() {
+            // Both results are deliberately discarded: an already-exited child reports "no such
+            // process" here, and panicking inside `Drop` during an assertion failure's unwind
+            // would replace the real failure message with an abort.
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+#[cfg(test)]
+mod child_teardown_tests {
+    use crate::ChildGuard;
+    use std::process::{Command, Stdio};
+
+    /// A process that genuinely blocks until it is killed, using a binary every machine running
+    /// this suite already needs: `git hash-object --stdin` reads until EOF, which never comes
+    /// while the test holds the write end of the pipe.
+    fn blocked_child() -> ChildGuard {
+        let mut command = Command::new("git");
+        command
+            .args(["hash-object", "--stdin"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        ChildGuard::spawn(&mut command).expect("spawn git hash-object")
+    }
+
+    #[test]
+    fn kill_and_wait_stops_a_running_process() {
+        let mut guard = blocked_child();
+        assert!(
+            guard.is_running(),
+            "the fixture child must start out blocked"
+        );
+
+        let status = guard.kill_and_wait().expect("kill_and_wait");
+
+        assert!(
+            status.is_some(),
+            "a running child must report the status it was killed with"
+        );
+        assert!(
+            !guard.is_running(),
+            "after kill_and_wait the process must really be gone, not merely signalled"
+        );
+    }
+
+    #[test]
+    fn kill_and_wait_is_a_no_op_for_a_child_that_already_exited() {
+        let mut guard =
+            ChildGuard::spawn(Command::new("git").arg("--version").stdout(Stdio::null()))
+                .expect("spawn git --version");
+        guard.wait().expect("wait for git --version");
+
+        assert!(
+            guard.kill_and_wait().expect("kill_and_wait").is_none(),
+            "an already-exited child is not an error to tear down"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dropping_the_guard_kills_the_process() {
+        let pid = {
+            let guard = blocked_child();
+            guard.id().to_string()
+        };
+
+        let alive = Command::new("kill")
+            .args(["-0", &pid])
+            .stderr(Stdio::null())
+            .status()
+            .expect("spawn kill -0")
+            .success();
+        assert!(
+            !alive,
+            "the guard drops at the end of its scope, so pid {pid} must be killed and reaped by \
+             the time the test reaches this line"
+        );
+    }
+}

--- a/crates/test-support/src/git.rs
+++ b/crates/test-support/src/git.rs
@@ -1,0 +1,182 @@
+//! Real `git` CLI invocation for tests.
+//!
+//! Every entry point takes an argument vector, never an interpolated shell string, so a fixture
+//! path containing a space or a quote behaves the same as any other (CLAUDE.md's git rule).
+//! This module owns running git and writing files; deciding *what* a fixture repository
+//! contains belongs to [`crate::repo`].
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+/// Runs `git` in `dir` and panics with both output streams if it fails.
+pub fn git(dir: &Path, args: &[&str]) {
+    assert_success(dir, args, git_try(dir, args));
+}
+
+/// Runs `git` in `dir` with extra environment variables (`GIT_AUTHOR_DATE`, `GIT_EDITOR`, …).
+pub fn git_with_env(dir: &Path, args: &[&str], env: &[(&str, &str)]) {
+    let mut command = Command::new("git");
+    command.current_dir(dir).args(args);
+    for (key, value) in env {
+        command.env(key, value);
+    }
+    let output = command.output().expect("failed to spawn git");
+    assert_success(dir, args, output);
+}
+
+/// The trimmed stdout of a successful `git` invocation.
+pub fn git_output(dir: &Path, args: &[&str]) -> String {
+    let output = git_try(dir, args);
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    assert_success(dir, args, output);
+    stdout
+}
+
+/// Runs `git` without asserting anything — for the tests whose subject *is* a failing git
+/// command (a conflicted merge, a rejected push).
+pub fn git_try(dir: &Path, args: &[&str]) -> Output {
+    // `.output()`, not `.status()`: `status()` inherits stdout/stderr, so seeding a repository
+    // dumps git's per-file chatter into the test runner's output.
+    Command::new("git")
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .expect("failed to spawn git")
+}
+
+/// Writes `contents` to `dir`-relative `relative_path`, creating parent directories.
+pub fn write_file(dir: &Path, relative_path: impl AsRef<Path>, contents: &str) {
+    let path = dir.join(relative_path);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("create parent directories");
+    }
+    std::fs::write(&path, contents).expect("write fixture file");
+}
+
+/// Writes a file and commits it — the two-step every fixture repeats.
+pub fn commit(dir: &Path, relative_path: impl AsRef<Path>, contents: &str, message: &str) {
+    let relative_path = relative_path.as_ref();
+    write_file(dir, relative_path, contents);
+    git(dir, &["add", path_arg(relative_path)]);
+    git(dir, &["commit", "-m", message]);
+}
+
+/// Like [`commit`], but with an explicit author/committer timestamp instead of "whenever this
+/// line happened to run" — what a test asserting on commit order or on rendered dates needs.
+pub fn commit_at(
+    dir: &Path,
+    relative_path: impl AsRef<Path>,
+    contents: &str,
+    message: &str,
+    unix_seconds: i64,
+) {
+    let relative_path = relative_path.as_ref();
+    write_file(dir, relative_path, contents);
+    git(dir, &["add", path_arg(relative_path)]);
+    let date = format!("{unix_seconds} +0000");
+    git_with_env(
+        dir,
+        &["commit", "-m", message],
+        &[("GIT_AUTHOR_DATE", &date), ("GIT_COMMITTER_DATE", &date)],
+    );
+}
+
+fn path_arg(path: &Path) -> &str {
+    path.to_str().expect("fixture paths are UTF-8")
+}
+
+fn assert_success(dir: &Path, args: &[&str], output: Output) {
+    assert!(
+        output.status.success(),
+        "git {args:?} failed in {dir:?}:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[cfg(test)]
+mod git_invocation_tests {
+    use crate::{commit, commit_at, git, git_output, git_try, seed_empty_repo, seed_repo};
+
+    #[test]
+    fn git_output_returns_trimmed_stdout() {
+        let repo = seed_repo();
+
+        let branch = git_output(repo.path(), &["rev-parse", "--abbrev-ref", "HEAD"]);
+
+        assert_eq!(
+            branch, "main",
+            "git_output must hand back stdout with the trailing newline stripped"
+        );
+    }
+
+    #[test]
+    fn git_try_reports_a_failure_instead_of_panicking() {
+        let repo = seed_repo();
+
+        let output = git_try(repo.path(), &["rev-parse", "definitely-not-a-ref"]);
+
+        assert!(
+            !output.status.success(),
+            "git_try is the escape hatch for tests whose subject is a failing git command, so \
+             it must report the failure rather than abort the test"
+        );
+    }
+
+    #[test]
+    fn a_path_containing_a_space_survives_the_argument_vector() {
+        let repo = seed_empty_repo();
+
+        commit(repo.path(), "a file.txt", "x\n", "spaces");
+
+        let tracked = git_output(repo.path(), &["ls-files"]);
+        assert_eq!(
+            tracked, "a file.txt",
+            "argv, not an interpolated shell string: the space must never split the argument"
+        );
+    }
+
+    #[test]
+    fn commit_creates_missing_parent_directories() {
+        let repo = seed_empty_repo();
+
+        commit(
+            repo.path(),
+            "src/nested/deep.rs",
+            "fn main() {}\n",
+            "nested",
+        );
+
+        assert!(
+            repo.path().join("src/nested/deep.rs").is_file(),
+            "a fixture naming a nested path must not have to mkdir it first"
+        );
+    }
+
+    #[test]
+    fn commit_at_uses_the_timestamp_it_was_given() {
+        let repo = seed_empty_repo();
+
+        commit_at(repo.path(), "a.txt", "1\n", "dated", 1_700_000_000);
+
+        assert_eq!(
+            git_output(repo.path(), &["log", "-1", "--format=%at"]),
+            "1700000000",
+            "an explicitly dated commit is what lets a test assert on ordering deterministically"
+        );
+    }
+
+    #[test]
+    fn git_runs_in_the_directory_it_is_given_not_the_process_cwd() {
+        let outer = seed_repo();
+        let inner = seed_empty_repo();
+
+        git(inner.path(), &["checkout", "-b", "side"]);
+
+        assert_eq!(
+            git_output(outer.path(), &["rev-parse", "--abbrev-ref", "HEAD"]),
+            "main",
+            "each call is scoped to its own `dir`, so parallel fixtures never collide"
+        );
+    }
+}

--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -1,0 +1,31 @@
+//! Shared test fixtures for this workspace: real git repositories, bounded waits, and RAII
+//! teardown for spawned processes.
+//!
+//! Every crate here may dev-depend on this one, so it stays free of `gpui`
+//! (`docs/architecture/decisions.md` §1) — including behind a Cargo feature, since workspace
+//! feature unification would leak `gpui` back into the core crates' dev graph. GPUI-flavoured
+//! helpers live in `crates/app/src/test_support.rs` instead.
+//!
+//! The policy these fixtures serve — the three tiers, what deserves a test, and what gets
+//! deleted — is [`docs/testing.md`](../../../docs/testing.md).
+
+// Every function here runs inside a consumer's `#[cfg(test)]` code, where a broken fixture must
+// abort the test with a diagnostic rather than propagate a `Result` nobody can act on.
+#![allow(clippy::expect_used)]
+
+mod child;
+mod git;
+mod repo;
+mod wait;
+
+pub use child::ChildGuard;
+pub use git::{commit, commit_at, git, git_output, git_try, git_with_env, write_file};
+pub use repo::{
+    add_worktree, seed_bare_remote, seed_commits, seed_empty_repo, seed_empty_repo_at, seed_repo,
+    seed_repo_at, seed_three_commits,
+};
+pub use wait::{stays_false, wait_until};
+
+/// Re-exported so a consumer can name the type [`seed_repo`] returns without repeating the
+/// `tempfile` dependency in its own manifest.
+pub use tempfile::TempDir;

--- a/crates/test-support/src/repo.rs
+++ b/crates/test-support/src/repo.rs
@@ -1,0 +1,208 @@
+//! Fixture repositories: what a seeded repo *contains*, built out of [`crate::git`].
+//!
+//! Each `seed_*` function has an `_at` sibling that takes an existing directory, for the tests
+//! that need the repository somewhere specific (a worktree, a nested path) rather than in a
+//! throwaway temp directory.
+
+use crate::git::{commit, git};
+use std::path::Path;
+use tempfile::TempDir;
+
+/// The identity every fixture commit carries. A repository with no `user.email`/`user.name`
+/// cannot commit at all, and inheriting the developer's own identity would make fixtures differ
+/// between machines.
+const AUTHOR_EMAIL: &str = "test@example.com";
+const AUTHOR_NAME: &str = "Test User";
+
+/// A git repository on branch `main` with a configured identity and **no commits**.
+pub fn seed_empty_repo() -> TempDir {
+    let dir = TempDir::new().expect("tempdir");
+    seed_empty_repo_at(dir.path());
+    dir
+}
+
+/// [`seed_empty_repo`] into an existing directory.
+pub fn seed_empty_repo_at(dir: &Path) {
+    git(dir, &["init", "-b", "main"]);
+    git(dir, &["config", "user.email", AUTHOR_EMAIL]);
+    git(dir, &["config", "user.name", AUTHOR_NAME]);
+    // A machine with commit signing configured globally would otherwise block every fixture
+    // commit on a passphrase prompt that never arrives in a test runner.
+    git(dir, &["config", "commit.gpgsign", "false"]);
+}
+
+/// A git repository on branch `main` with one commit (`file.txt`) and a clean working tree.
+pub fn seed_repo() -> TempDir {
+    let dir = TempDir::new().expect("tempdir");
+    seed_repo_at(dir.path());
+    dir
+}
+
+/// [`seed_repo`] into an existing directory.
+pub fn seed_repo_at(dir: &Path) {
+    seed_empty_repo_at(dir);
+    commit(dir, "file.txt", "hello\n", "initial commit");
+}
+
+/// Three commits (`first`, `second`, `third`) each rewriting `a.txt`, clean working tree at the
+/// end — so a graph built from this has exactly three rows (newest first) and no "Working tree"
+/// row shifting the indices a test names by literal position.
+///
+/// Not `seed_commits(dir, 3)`: these three carry real content changes, which is what a test
+/// asserting on a diff, a blame or a commit message needs.
+pub fn seed_three_commits(dir: &Path) {
+    seed_empty_repo_at(dir);
+    commit(dir, "a.txt", "1\n", "first");
+    commit(dir, "a.txt", "2\n", "second");
+    commit(dir, "a.txt", "3\n", "third");
+}
+
+/// `count` commits, clean working tree at the end. The first touches `a.txt`; the rest are
+/// `--allow-empty`, which keeps a large seed cheap — an empty commit is as real a graph row as
+/// any other. Use [`seed_three_commits`] when the *content* of each commit matters.
+pub fn seed_commits(dir: &Path, count: usize) {
+    seed_empty_repo_at(dir);
+    if count == 0 {
+        return;
+    }
+    commit(dir, "a.txt", "1\n", "first");
+    for index in 1..count {
+        git(
+            dir,
+            &["commit", "--allow-empty", "-m", &format!("commit {index}")],
+        );
+    }
+}
+
+/// A bare repository on branch `main` — the push/fetch target for remote-facing tests.
+pub fn seed_bare_remote() -> TempDir {
+    let dir = TempDir::new().expect("tempdir");
+    git(dir.path(), &["init", "--bare", "-b", "main"]);
+    dir
+}
+
+/// Adds a real worktree for a new `branch` at `worktree_path`, which must not exist yet.
+pub fn add_worktree(repo_path: &Path, branch: &str, worktree_path: &Path) {
+    let path = worktree_path
+        .to_str()
+        .expect("fixture worktree paths are UTF-8");
+    git(repo_path, &["worktree", "add", "-b", branch, path]);
+}
+
+#[cfg(test)]
+mod repo_seed_tests {
+    use crate::{
+        add_worktree, git_output, seed_bare_remote, seed_commits, seed_empty_repo, seed_repo,
+        seed_repo_at, seed_three_commits,
+    };
+    use tempfile::TempDir;
+
+    fn commit_count(dir: &std::path::Path) -> usize {
+        git_output(dir, &["rev-list", "--count", "HEAD"])
+            .parse()
+            .expect("rev-list --count is a number")
+    }
+
+    #[test]
+    fn seed_repo_leaves_one_commit_and_a_clean_tree() {
+        let repo = seed_repo();
+
+        assert_eq!(commit_count(repo.path()), 1);
+        assert_eq!(
+            git_output(repo.path(), &["status", "--porcelain"]),
+            "",
+            "a fixture that starts dirty makes every downstream status assertion ambiguous"
+        );
+    }
+
+    #[test]
+    fn seed_empty_repo_has_a_branch_but_no_commits() {
+        let repo = seed_empty_repo();
+
+        // `symbolic-ref`, not `rev-parse --abbrev-ref`: the latter needs HEAD to resolve to a
+        // commit, which is exactly what this fixture does not have.
+        assert_eq!(
+            git_output(repo.path(), &["symbolic-ref", "--short", "HEAD"]),
+            "main",
+            "the unborn branch must still be `main`, not the machine's init.defaultBranch"
+        );
+        assert!(
+            git_output(repo.path(), &["rev-list", "--all"]).is_empty(),
+            "seed_empty_repo is the fixture for code paths that must cope with no commits"
+        );
+    }
+
+    #[test]
+    fn seed_three_commits_leaves_three_commits_and_a_clean_tree() {
+        let dir = TempDir::new().expect("tempdir");
+
+        seed_three_commits(dir.path());
+
+        assert_eq!(commit_count(dir.path()), 3);
+        assert_eq!(
+            git_output(dir.path(), &["log", "--format=%s"]),
+            "third\nsecond\nfirst",
+            "the three messages are part of the fixture's contract - tests assert on them"
+        );
+        assert_eq!(
+            git_output(dir.path(), &["show", "HEAD:a.txt"]),
+            "3",
+            "each of the three commits must carry a real content change, not be empty"
+        );
+        assert_eq!(
+            git_output(dir.path(), &["status", "--porcelain"]),
+            "",
+            "graph tests index rows by position, which a stray working-tree row would shift"
+        );
+    }
+
+    #[test]
+    fn seed_commits_makes_exactly_the_number_asked_for() {
+        let dir = TempDir::new().expect("tempdir");
+
+        seed_commits(dir.path(), 7);
+
+        assert_eq!(commit_count(dir.path()), 7);
+    }
+
+    #[test]
+    fn seed_repo_at_works_inside_an_existing_directory() {
+        let parent = TempDir::new().expect("tempdir");
+        let nested = parent.path().join("nested/repo");
+        std::fs::create_dir_all(&nested).expect("mkdir");
+
+        seed_repo_at(&nested);
+
+        assert_eq!(commit_count(&nested), 1);
+    }
+
+    #[test]
+    fn seed_bare_remote_is_really_bare() {
+        let remote = seed_bare_remote();
+
+        assert_eq!(
+            git_output(remote.path(), &["rev-parse", "--is-bare-repository"]),
+            "true",
+            "a non-bare push target rejects pushes to its checked-out branch"
+        );
+    }
+
+    #[test]
+    fn add_worktree_creates_a_real_second_working_copy() {
+        let repo = seed_repo();
+        let container = TempDir::new().expect("tempdir");
+        let worktree = container.path().join("feature");
+
+        add_worktree(repo.path(), "feature", &worktree);
+
+        assert!(
+            worktree.join("file.txt").is_file(),
+            "the added worktree must be a real checkout, not just a registered path"
+        );
+        assert_eq!(
+            git_output(&worktree, &["rev-parse", "--abbrev-ref", "HEAD"]),
+            "feature",
+            "the worktree must be on the branch it was created for"
+        );
+    }
+}

--- a/crates/test-support/src/wait.rs
+++ b/crates/test-support/src/wait.rs
@@ -1,0 +1,118 @@
+//! Bounded waits for conditions only a real OS thread can satisfy — a file watcher's callback,
+//! a spawned process reaching a state.
+//!
+//! This module is the *only* sanctioned wall-clock wait in the workspace (`docs/testing.md`).
+//! Anything a GPUI executor drives waits with `cx.run_until_parked()` instead, and nothing waits
+//! with a bare `thread::sleep`: a fixed sleep is simultaneously too short on a loaded machine
+//! and pure dead time on an idle one.
+
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// How often `condition` is re-checked. Short enough that a satisfied condition is noticed
+/// almost immediately, long enough not to spin a core while waiting.
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+/// Polls `condition` until it returns `true` or `deadline` elapses; the return value says which,
+/// so the caller supplies the assertion message.
+///
+/// ```no_run
+/// # use std::time::Duration;
+/// # let watcher_fired = || true;
+/// assert!(
+///     test_support::wait_until(Duration::from_secs(3), watcher_fired),
+///     "the watcher must observe a real file write within the tier's budget"
+/// );
+/// ```
+pub fn wait_until(deadline: Duration, mut condition: impl FnMut() -> bool) -> bool {
+    let expiry = Instant::now() + deadline;
+    loop {
+        if condition() {
+            return true;
+        }
+        let remaining = expiry.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return false;
+        }
+        thread::sleep(POLL_INTERVAL.min(remaining));
+    }
+}
+
+/// The inverse of [`wait_until`]: `true` if `condition` stayed false for the whole `window`.
+///
+/// For proving something is genuinely filtered out rather than merely slow to arrive — the case
+/// that would otherwise be written as a bare `thread::sleep` followed by one assertion.
+pub fn stays_false(window: Duration, condition: impl FnMut() -> bool) -> bool {
+    !wait_until(window, condition)
+}
+
+#[cfg(test)]
+mod bounded_wait_tests {
+    use crate::{stays_false, wait_until};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn wait_until_returns_as_soon_as_the_condition_holds() {
+        let polls = AtomicUsize::new(0);
+        let started = Instant::now();
+
+        let satisfied = wait_until(Duration::from_secs(30), || {
+            polls.fetch_add(1, Ordering::SeqCst) >= 2
+        });
+
+        assert!(
+            satisfied,
+            "the condition became true well inside the deadline"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "a satisfied wait must return immediately, not sit out its deadline - it took {:?}",
+            started.elapsed()
+        );
+    }
+
+    #[test]
+    fn wait_until_gives_up_after_the_deadline() {
+        let started = Instant::now();
+
+        let satisfied = wait_until(Duration::from_millis(50), || false);
+
+        assert!(
+            !satisfied,
+            "a condition that never holds must report failure"
+        );
+        assert!(
+            started.elapsed() >= Duration::from_millis(50),
+            "the full deadline must really be waited out before giving up"
+        );
+    }
+
+    #[test]
+    fn wait_until_checks_the_condition_before_sleeping() {
+        let started = Instant::now();
+
+        assert!(wait_until(Duration::from_secs(30), || true));
+        assert!(
+            started.elapsed() < Duration::from_millis(10),
+            "an already-satisfied condition must cost no wall-clock time at all"
+        );
+    }
+
+    #[test]
+    fn stays_false_reports_a_condition_that_never_fires() {
+        assert!(stays_false(Duration::from_millis(30), || false));
+    }
+
+    #[test]
+    fn stays_false_reports_a_condition_that_does_fire() {
+        let polls = AtomicUsize::new(0);
+
+        assert!(
+            !stays_false(Duration::from_secs(30), || polls
+                .fetch_add(1, Ordering::SeqCst)
+                >= 1),
+            "a condition that becomes true inside the window must fail the quiet-period check"
+        );
+    }
+}

--- a/crates/wt-core/Cargo.toml
+++ b/crates/wt-core/Cargo.toml
@@ -21,3 +21,8 @@ tempfile = "3"
 # outright. Already present in this workspace's lockfile via other dependencies, so this adds no
 # new crate to the build graph.
 sha2 = "0.10"
+
+[dev-dependencies]
+# Shared fixtures (real seeded repositories, argv-only `git`) - see `docs/testing.md`. Usable
+# here precisely because it carries no `gpui` (docs/architecture/decisions.md §1).
+test-support = { path = "../test-support" }

--- a/crates/wt-core/src/stage.rs
+++ b/crates/wt-core/src/stage.rs
@@ -227,49 +227,12 @@ fn path_from_bytes(bytes: &[u8]) -> PathBuf {
 mod tests {
     use super::*;
     use std::fs;
-    use std::process::Command;
     use tempfile::TempDir;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn git_output(dir: &Path, args: &[&str]) -> String {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(output.status.success(), "git {args:?} failed in {dir:?}");
-        String::from_utf8_lossy(&output.stdout).trim().to_string()
-    }
-
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        fs::write(dir.path().join("file.txt"), "hello\n").expect("write file");
-        git(dir.path(), &["add", "file.txt"]);
-        git(dir.path(), &["commit", "-m", "initial commit"]);
-        dir
-    }
+    use test_support::{git, git_output, seed_repo};
 
     #[test]
     fn stage_path_really_adds_a_modified_file_to_the_real_index() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "changed\n").expect("modify");
 
         stage_path(repo.path(), Path::new("file.txt")).expect("stage_path");
@@ -283,7 +246,7 @@ mod tests {
 
     #[test]
     fn stage_path_really_adds_a_new_untracked_file() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("new.txt"), "new\n").expect("write new file");
 
         stage_path(repo.path(), Path::new("new.txt")).expect("stage_path");
@@ -297,7 +260,7 @@ mod tests {
 
     #[test]
     fn unstage_path_really_removes_a_path_from_the_real_index_without_touching_the_working_tree() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "changed\n").expect("modify");
         git(repo.path(), &["add", "file.txt"]);
         let staged_before = git_output(repo.path(), &["status", "--porcelain", "file.txt"]);
@@ -323,7 +286,7 @@ mod tests {
 
     #[test]
     fn unstage_path_is_a_harmless_no_op_when_already_unstaged() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "changed\n").expect("modify");
 
         unstage_path(repo.path(), Path::new("file.txt")).expect("unstage_path on a clean index");
@@ -334,7 +297,7 @@ mod tests {
 
     #[test]
     fn staged_paths_reflects_the_real_git_index_including_files_staged_by_something_else() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "changed\n").expect("modify");
         fs::write(repo.path().join("also.txt"), "also\n").expect("write");
         // Staged directly via a real `git add`, standing in for something other than
@@ -354,13 +317,13 @@ mod tests {
 
     #[test]
     fn staged_paths_is_empty_on_a_clean_index() {
-        let repo = init_repo();
+        let repo = seed_repo();
         assert!(staged_paths(repo.path()).expect("staged_paths").is_empty());
     }
 
     #[test]
     fn staged_paths_never_includes_an_unstaged_modification() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "changed but not staged\n").expect("modify");
 
         let staged = staged_paths(repo.path()).expect("staged_paths");
@@ -375,7 +338,7 @@ mod tests {
     /// GitHub issue #220 is about. `committed.txt` is genuinely part of a commit and clean on
     /// disk; the caller then dirties whatever else it wants to contrast against it.
     fn repo_with_a_committed_clean_file() -> TempDir {
-        let dir = init_repo();
+        let dir = seed_repo();
         git(dir.path(), &["checkout", "-b", "feature"]);
         fs::write(dir.path().join("committed.txt"), "committed\n").expect("write");
         git(dir.path(), &["add", "committed.txt"]);
@@ -417,7 +380,7 @@ mod tests {
 
     #[test]
     fn dirty_paths_includes_a_staged_file() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "changed\n").expect("modify");
         git(repo.path(), &["add", "file.txt"]);
 
@@ -432,7 +395,7 @@ mod tests {
 
     #[test]
     fn dirty_paths_includes_an_unstaged_file() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "changed\n").expect("modify");
 
         assert!(
@@ -445,7 +408,7 @@ mod tests {
 
     #[test]
     fn dirty_paths_includes_an_untracked_file() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("brand-new.txt"), "new\n").expect("write");
 
         assert!(
@@ -459,7 +422,7 @@ mod tests {
 
     #[test]
     fn dirty_paths_includes_a_deleted_tracked_file() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::remove_file(repo.path().join("file.txt")).expect("remove");
 
         assert!(
@@ -472,7 +435,7 @@ mod tests {
 
     #[test]
     fn dirty_paths_includes_both_halves_of_a_live_rename() {
-        let repo = init_repo();
+        let repo = seed_repo();
         git(repo.path(), &["mv", "file.txt", "renamed.txt"]);
 
         let dirty = dirty_paths(repo.path()).expect("dirty_paths");
@@ -493,7 +456,7 @@ mod tests {
 
     #[test]
     fn dirty_paths_reports_a_nested_path_relative_to_the_worktree_root() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::create_dir_all(repo.path().join("src/db")).expect("mkdir");
         fs::write(repo.path().join("src/db/query.rs"), "fn q() {}\n").expect("write");
 
@@ -511,7 +474,7 @@ mod tests {
     /// non-`-z` porcelain output (`"my file.txt"`, with real quotes). `-z` emits it raw.
     #[test]
     fn dirty_paths_handles_a_path_with_a_space_without_quoting_it() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("my file.txt"), "spaces\n").expect("write");
 
         assert!(
@@ -548,7 +511,7 @@ mod tests {
 
     #[test]
     fn stage_then_unstage_round_trips_back_to_a_clean_staged_set() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "changed\n").expect("modify");
 
         stage_path(repo.path(), Path::new("file.txt")).expect("stage_path");
@@ -563,7 +526,7 @@ mod tests {
 
     #[test]
     fn discard_path_really_restores_a_modified_file_from_head() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "the agent wrote this\n").expect("modify");
 
         discard_path(repo.path(), Path::new("file.txt")).expect("discard_path");
@@ -585,7 +548,7 @@ mod tests {
     /// -- <path>` is what really discards both halves.
     #[test]
     fn discard_path_also_drops_a_change_that_was_already_staged() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "the agent wrote this\n").expect("modify");
         git(repo.path(), &["add", "file.txt"]);
         assert_eq!(
@@ -607,7 +570,7 @@ mod tests {
 
     #[test]
     fn discard_path_restores_a_file_the_agent_deleted() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::remove_file(repo.path().join("file.txt")).expect("delete");
 
         discard_path(repo.path(), Path::new("file.txt")).expect("discard_path");
@@ -621,7 +584,7 @@ mod tests {
 
     #[test]
     fn discard_path_removes_an_untracked_file_outright() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("new.txt"), "brand new\n").expect("write");
 
         discard_path(repo.path(), Path::new("new.txt")).expect("discard_path");
@@ -638,7 +601,7 @@ mod tests {
     /// branch, and both halves have to really happen.
     #[test]
     fn discard_path_removes_a_staged_addition_from_both_the_index_and_the_disk() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("new.txt"), "brand new\n").expect("write");
         git(repo.path(), &["add", "new.txt"]);
         assert_eq!(
@@ -657,7 +620,7 @@ mod tests {
 
     #[test]
     fn discarding_one_path_leaves_every_other_dirty_path_alone() {
-        let repo = init_repo();
+        let repo = seed_repo();
         fs::write(repo.path().join("file.txt"), "edited\n").expect("modify");
         fs::write(repo.path().join("other.txt"), "also new\n").expect("write");
 

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -136,3 +136,28 @@ running log, explicitly not a substitute for `git log`.
 `README.md`'s `## Status` states current status directly rather than deferring to `ASSESSMENT.md`.
 Design decisions worth recording going forward get a new numbered entry above, not an appended
 paragraph in a long-running file.
+
+## 5. `crates/test-support` is a real crate, not a feature-gated one
+
+**Status:** Accepted.
+
+**Context:** Test setup had no shared home, so it was copy-pasted instead: `fn git(dir, args)`
+appeared ~30 times across `wt-core` and `app`, alongside 1,223 separate tempdir setups and 303
+wall-clock waits. The obvious single crate to fix that has a trap in it — `crates/app`'s fixtures
+need `gpui` (a test window, `VisualTestContext`), and `wt-core`/`pty-core`/`lsp-core` must be able
+to dev-depend on the same crate without acquiring `gpui` (§1).
+
+A Cargo feature (`test-support = { features = ["gpui"] }` for `app` only) looks like it solves
+this and does not: features unify across a workspace build, so one crate enabling `gpui` enables it
+for every other crate resolving the same dependency. The core crates' dev graph would silently
+regain `gpui` — exactly the outcome §1 exists to prevent, and one no `Cargo.toml` review would
+catch.
+
+**Decision:** Two homes, split by dependency rather than by feature. `crates/test-support` is
+`gpui`-free and depends only on `tempfile`; anything needing `gpui` lives in
+`crates/app/src/test_support.rs`, inside the one crate already allowed to have it.
+
+**Consequences:** `cargo tree -e normal,dev,build -i gpui` reaching only `crates/app` is a
+checkable invariant, not a convention. A helper that "just needs a `TestAppContext`" is not added
+to `crates/test-support` under any flag — it goes in `crates/app` or it is restructured to take
+plain data. The policy those fixtures serve is [`docs/testing.md`](../testing.md).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,138 @@
+# Testing policy
+
+What deserves a test in Jerry, what it may cost, and what gets deleted. `CLAUDE.md`'s "Testing"
+section states the rule in two sentences and points here for the detail.
+
+This exists because the suite grew to 3,564 tests and 109,987 lines inside `#[cfg(test)]` blocks —
+**45.3% of the workspace's 242,846 lines** — with `fn git(dir, args)` copy-pasted ~30 times and
+1,223 separate tempdir setups. Nothing in the repo said what a test was *for*, so nothing said when
+not to write one.
+
+## The three tiers
+
+Every test belongs to exactly one tier, and the tier decides what it may do and what it may cost.
+
+| Tier | Marker | May do | Must not | Budget |
+|---|---|---|---|---|
+| `unit` | plain `#[test]` | pure logic, tempdir filesystem | spawn a process, open a gpui window, sleep, assert on wall-clock | < 10 ms |
+| `ui` | `#[gpui::test]` + `TestAppContext` / `VisualTestContext` | real git fixtures, real key/action dispatch | external language servers, real agent processes, sleep | < 2 s |
+| `external` | `#[ignore = "external: <binary>; see docs/testing.md"]` | real `rust-analyzer` / `typescript-language-server` / `pyright` / `gopls`, real OS process-tree semantics | — | dedicated CI job only |
+
+Tiers 1 and 2 are the PR gate. Tier 3 never is.
+
+Today that is 2,186 plain `#[test]` and 1,006 `#[gpui::test]` in `crates/app` alone — the split
+already roughly exists, it has just never been named or enforced.
+
+A `unit` test that shells out to `git` against a tempdir repository is still a `unit` test: the
+budget is what separates the tiers in practice, and a seeded fixture repo costs a few hundred
+milliseconds of `git` at most. What pushes a test into `ui` is needing a window; what pushes it
+into `external` is needing a binary the repo does not vendor or a real agent process.
+
+## What deserves a test
+
+- One test per behaviour a **user** could notice — not one per branch of the implementation.
+- One regression test per fixed bug, named after the symptom.
+- Pure derivations (colours, geometry, formatting) get **one table-driven invariant test**, not one
+  test per input.
+- Explicitly not worth a test: a constant equalling its own literal; a field round-tripping through
+  its own getter; "a render function returned some element"; exhaustively enumerating a sweep the
+  code itself already iterates over.
+
+## Deletion criteria
+
+The five reasons a test gets removed. A removal cites exactly one of them, by number, in the PR
+body:
+
+1. **Sweep redundancy** — N tests differing only by an input value. Collapse to one table-driven test.
+2. **Implementation mirroring** — the assertion recomputes what the code under test does.
+3. **Vacuous** — would still pass with the feature removed, or only asserts on test-local data.
+4. **Pixel over-specification** — asserts an exact `Pixels` literal with no invariant behind it.
+   Keep `all_three_elbow_pieces_paint_their_horizontal_stroke_on_the_very_same_pixel_row`;
+   drop the "...equals 12.5px" siblings.
+5. **Duplicate coverage across layers** — the same behaviour asserted in both a `unit` and a `ui`
+   test. Keep the cheaper one, unless the wiring itself is what is at risk.
+
+## Hard rules
+
+- **No `thread::sleep` in test code.** Use `cx.run_until_parked()` or
+  `test_support::wait_until(deadline, cond)`. There are **303** existing wall-clock waits, including
+  a `from_secs(9)` and ten `from_millis(500)`; they are the purge issue's problem, but the rule
+  starts here.
+- Any test that spawns a process owns its teardown, via an RAII guard from `test-support`.
+- Any test that opens a file watcher shuts it down. A leaked watcher thread fails the tier's budget.
+- Every `#[ignore]` carries a reason string naming exactly what is missing.
+- Existing conventions that stay, unchanged: fixtures live under a sibling `testdata/` directory,
+  never inlined as string literals; test modules are named by concern
+  (`mod change_row_selection_tests`, not `mod tests`).
+
+## `crates/test-support`
+
+The shared fixtures, dev-dependency only. It is **`gpui`-free** so `wt-core`, `pty-core` and
+`lsp-core` can dev-depend on it without violating
+[`decisions.md` §1](architecture/decisions.md) — including behind a Cargo feature, which would not
+help: workspace feature unification would pull `gpui` into their dev graph anyway. GPUI-flavoured
+helpers live in `crates/app/src/test_support.rs` instead.
+
+Add it with `test-support = { path = "../test-support" }` under `[dev-dependencies]`, then
+`use test_support::{git, seed_repo};`.
+
+### Running git
+
+| Helper | Does |
+|---|---|
+| `git(dir, &["commit", "-m", "x"])` | runs git, panics with both streams on failure |
+| `git_output(dir, args) -> String` | trimmed stdout of a successful invocation |
+| `git_try(dir, args) -> Output` | runs git without asserting — for tests whose subject *is* a failure |
+| `git_with_env(dir, args, &[("GIT_AUTHOR_DATE", …)])` | as `git`, with extra environment variables |
+| `write_file(dir, "src/a.rs", "…")` | writes a `dir`-relative file, creating parent directories |
+| `commit(dir, "a.txt", "1\n", "message")` | write + `add` + `commit` |
+| `commit_at(dir, "a.txt", "1\n", "message", 1_700_000_000)` | as `commit`, with an explicit author/committer timestamp |
+
+Argv, never an interpolated shell string — the same rule production code follows (`CLAUDE.md`).
+
+### Seeding repositories
+
+| Helper | Yields |
+|---|---|
+| `seed_repo() -> TempDir` | branch `main`, one commit (`file.txt`), clean tree |
+| `seed_repo_at(dir)` | the same, into an existing directory |
+| `seed_empty_repo() -> TempDir` / `seed_empty_repo_at(dir)` | branch `main`, identity configured, **no** commits |
+| `seed_three_commits(dir)` | `first`/`second`/`third`, each rewriting `a.txt`, clean tree |
+| `seed_commits(dir, count)` | `count` commits, cheap (`--allow-empty` after the first) |
+| `seed_bare_remote() -> TempDir` | a bare repo on `main`, as a push/fetch target |
+| `add_worktree(repo, "feature", &path)` | a real second working copy on a new branch |
+
+Every seeded repo configures `user.email`, `user.name` and `commit.gpgsign=false`, so a fixture
+behaves the same on a machine with commit signing configured globally.
+
+### Waiting and teardown
+
+| Helper | Does |
+|---|---|
+| `wait_until(deadline: Duration, cond) -> bool` | polls until `cond` holds or the deadline passes; the caller writes the assertion message |
+| `stays_false(window: Duration, cond) -> bool` | the inverse — proves something stays quiet for a bounded window |
+| `ChildGuard` | kill-on-drop wrapper for a spawned `Child`; derefs to `Child`, plus `spawn`, `is_running`, `kill_and_wait`, `into_inner` |
+
+`wait_until` is the *only* sanctioned wall-clock wait in the workspace. Anything a GPUI executor
+drives waits with `cx.run_until_parked()` instead.
+
+### GPUI fixtures (`crates/app/src/test_support.rs`)
+
+- `open_test_app(cx, repo_path) -> (Entity<AdeApp>, &mut VisualTestContext)` — a real test window
+  with in-memory settings, so a test never reads or writes the developer's `settings.toml`.
+- `open_test_app_with_settings(cx, repo_path, settings, settings_path)` — for tests that assert on
+  what gets persisted.
+
+`crate::root::focus::palette_focus_tests::open_test_app` is a re-export of the first, kept so the
+~500 call sites that still name it keep resolving while they are migrated (GitHub issue #425).
+
+## Running tests
+
+`cargo test --workspace` is deliberately **not** part of the pre-commit gate — see `CLAUDE.md` and
+[GitHub issue #348](https://github.com/ColinEspinas/jerry/issues/348). Run what you touched:
+
+```sh
+cargo nextest run -p wt-core
+cargo nextest run -p test-support
+cargo nextest run -p app --lib -E 'test(/my_concern_tests/)'
+```


### PR DESCRIPTION
Closes #424

## What

Two things that did not exist before: a written testing policy, and the shared fixtures it assumes.

**`docs/testing.md`** — the three tiers (`unit` / `ui` / `external`) with what each may do and what
it may cost, what deserves a test at all, the five deletion criteria the purge (#425) cites by
number per removal, and the hard rules (no `thread::sleep`, spawned processes own their teardown,
every `#[ignore]` names what is missing). `CLAUDE.md`'s four-line Testing section is rewritten to
the tier summary plus a pointer — the policy is not duplicated in both places.

**`crates/test-support`** — dev-dependency-only crate, `tempfile` its single dependency:

| Area | Helpers |
|---|---|
| git (argv only) | `git(dir, &[..])`, `git_output`, `git_try`, `git_with_env`, `write_file`, `commit`, `commit_at` |
| fixtures | `seed_repo` / `seed_repo_at`, `seed_empty_repo` / `seed_empty_repo_at`, `seed_three_commits`, `seed_commits`, `seed_bare_remote`, `add_worktree` |
| waiting | `wait_until(deadline, cond) -> bool`, `stays_false(window, cond) -> bool` |
| processes | `ChildGuard` (kill-on-drop, derefs to `Child`, plus `spawn`/`is_running`/`kill_and_wait`/`into_inner`) |

The GPUI window fixture moves to `crates/app/src/test_support.rs`
(`open_test_app`, `open_test_app_with_settings`) rather than sitting behind a Cargo feature —
see the Architecture notes below. `palette_focus_tests::open_test_app` becomes a re-export of it,
so the ~500 call sites still naming it keep resolving until #425 migrates them.

Three call sites are migrated as proof the crate works — not as the migration, which is #425's job:

- `crates/wt-core/src/stage.rs` — dropped its local `git`, `git_output`, `init_repo`.
- `crates/app/src/sidebar/file_tree_watch.rs` — dropped its local `git`/`init_repo` and **both** of
  its wall-clock sleeps (`wait_until_dirty` and `assert_stays_clean` now go through
  `wait_until`/`stays_false`).
- `crates/app/src/graph_view/render.rs` (`graph_row_menu_tests`) — dropped its local `git` and the
  `seed_three_commits` the shared fixture is modelled on, byte-for-byte in behaviour (`first`/
  `second`/`third`, each rewriting `a.txt`, clean tree).

Net: 174 lines deleted from existing test modules, 21 tests added covering the fixtures themselves.

## Why

`fn git(dir, args)` was copy-pasted ~30 times, with 1,223 separate tempdir setups and 303 wall-clock
waits, because nothing in the repo said where shared setup should live or what a test was for. Seven
agents are about to route ~109,000 lines of test setup through this crate; a helper missing here
becomes a serialized one-file PR that stalls a batch.

## Testing

- [x] `/check` (conventions + fmt + clippy `-D warnings`) passes locally
- [ ] `verify` capture — not applicable, no rendered output changes
- [x] New/changed behavior has a real test, run manually and confirmed passing

```
$ .claude/hooks/check-conventions.sh
check-conventions: OK (glob imports: 304/304, render adapter calls: 221/221)

$ cargo fmt --all -- --check
(no output)

$ cargo clippy --workspace --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 8.13s
```

`render_adapter_calls` is ratcheted 222 → 221 in the same commit: migrating `graph_row_menu_tests`
removed one `std::process::Command::new` from a `render.rs`.

The new crate, in full:

```
$ cargo nextest run -p test-support
     Summary [   0.437s] 21 tests run: 21 passed, 0 skipped
```

`wt-core`, in full, after the `stage.rs` migration:

```
$ cargo nextest run --no-fail-fast -p wt-core
     Summary [   8.413s] 302 tests run: 302 passed, 0 skipped
```

The migrated `app` modules (scoped, per CLAUDE.md — the full `app` suite is issue #348):

```
$ cargo nextest run --no-fail-fast -p app --lib \
    -E 'test(/file_tree_watch/) or test(/graph_row_menu_tests/) or test(/test_window_fixture_tests/)'
     Summary [   4.263s] 29 tests run: 27 passed, 2 failed, 3113 skipped
        FAIL app sidebar::file_tree_watch::tests::a_change_confined_to_dot_git_is_filtered_out
        FAIL app root::state::file_tree_watch_integration_tests::selecting_a_different_worktree_re_arms_the_watcher_on_the_new_root
```

**Both failures are pre-existing on this branch's base**, verified by stashing this change and
re-running the same two tests — the second one (`/var` vs `/private/var` canonicalization on macOS)
touches no file this PR modifies:

```
$ git stash && cargo nextest run -p app --lib -E 'test(/a_change_confined_to_dot_git/)'
        FAIL [   0.620s] (1/1) app sidebar::file_tree_watch::tests::a_change_confined_to_dot_git_is_filtered_out
$ git stash && cargo nextest run -p app --lib -E 'test(/selecting_a_different_worktree_re_arms/)'
        FAIL [   0.878s] (1/1) app root::state::file_tree_watch_integration_tests::selecting_a_different_worktree_re_arms_the_watcher_on_the_new_root
```

## Architecture notes

New crate boundary, recorded as `docs/architecture/decisions.md` §5. The load-bearing part is that
the GPUI helpers are **not** a Cargo feature of `test-support`: workspace feature unification would
enable that feature for every crate resolving the same dependency, putting `gpui` back into the core
crates' dev graph — precisely what §1 exists to prevent, and invisible to a `Cargo.toml` review.
Two homes, split by dependency instead.

The invariant is checkable, not just asserted:

```
$ cargo tree -e normal,dev,build -i gpui --workspace
gpui v0.2.2 (https://github.com/zed-industries/zed?rev=7b030b50...)
[build-dependencies]
└── gpui_macos v0.1.0 (...)
    └── gpui_platform v0.1.0 (...)
        └── app v0.1.1 (crates/app)

gpui v0.2.2 (https://github.com/zed-industries/zed?rev=7b030b50...)
├── app v0.1.1 (crates/app)
├── gpui_macos v0.1.0 (...) (*)
└── gpui_platform v0.1.0 (...) (*)
[dev-dependencies]
└── app v0.1.1 (crates/app)
```

`crates/app` is the only crate that reaches `gpui` by any edge kind. Per-crate counts of `gpui`
lines in each full (normal + dev + build) tree:

```
wt-core: 0    pty-core: 0    lsp-core: 0    test-support: 0
```

```
$ cargo tree -p test-support -e normal,dev,build
test-support v0.1.1 (crates/test-support)
└── tempfile v3.27.0
```
