### PR TITLE
fix(pty-core): walk the process tree with libproc on macOS, not /proc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4776,6 +4776,7 @@ name = "lsp-core"
 version = "0.1.1"
 dependencies = [
  "dunce",
+ "libc",
  "log",
  "lsp-types",
  "nix",
@@ -6148,6 +6149,7 @@ version = "0.1.1"
 dependencies = [
  "anyhow",
  "filedescriptor",
+ "libc",
  "nix",
  "portable-pty",
  "tempfile",

--- a/crates/lsp-core/Cargo.toml
+++ b/crates/lsp-core/Cargo.toml
@@ -57,14 +57,21 @@ pty-core = { path = "../pty-core" }
 # fn canonicalize(path) { fs::canonicalize(path) }`), so this is zero behavioral change there.
 dunce = "1.0.5"
 
-# Process-tree kill (SIGTERM-then-SIGKILL, plus a `/proc` descendant sweep so a `cargo
-# check`/`rustc` child rust-analyzer spawned while indexing doesn't survive as an orphan) -
-# unix-only, mirroring `pty-core`'s own kill implementation (see `src/client.rs`'s module
-# docs for the differences: SIGTERM instead of SIGHUP, no process-group/`setsid` handling
-# since rust-analyzer is spawned as a plain `std::process::Command` child, not a pty session
-# leader). Pinned to the exact version `pty-core/Cargo.toml` already pins.
+# Process-tree kill (SIGTERM-then-SIGKILL, plus a descendant sweep so a `cargo check`/`rustc`
+# child rust-analyzer spawned while indexing doesn't survive as an orphan, and `kill(pid, 0)`
+# as the liveness check the grace loop polls) - unix-only, mirroring `pty-core`'s own kill
+# implementation (see `src/client.rs`'s module docs for the differences: SIGTERM instead of
+# SIGHUP, no process-group/`setsid` handling since rust-analyzer is spawned as a plain
+# `std::process::Command` child, not a pty session leader). Pinned to the exact version
+# `pty-core/Cargo.toml` already pins.
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.28", default-features = false, features = ["fs", "poll", "signal"] }
+
+# macOS only, and for the exact same reason as `pty-core/Cargo.toml`'s own entry: `/proc` does
+# not exist there, so `crate::proc::child_pids_of`'s descendant walk goes through `libproc`'s
+# `proc_listchildpids` instead. Already resolved in this workspace's lock file.
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = "0.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/lsp-core/src/proc.rs
+++ b/crates/lsp-core/src/proc.rs
@@ -1,4 +1,4 @@
-//! `/proc`-based process-tree discovery and signaling, mirroring `pty-core`'s own kill
+//! Process-tree discovery and signaling, mirroring `pty-core`'s own kill
 //! implementation (`crates/pty-core/src/lib.rs`'s `child_pids_of`/`collect_descendant_pids`/
 //! `terminate_process_tree`), though not a literal shared dependency: pty-core doesn't expose
 //! those as `pub`, and pty-core's child is a pty session/process-group leader signaled via
@@ -11,10 +11,12 @@
 //!
 //! ## Platform scope: unix only, same as `pty-core`
 //!
-//! Every function in this module is `#[cfg(unix)]`: `/proc` itself, and the `nix` signal calls
-//! (`kill`/`SIGTERM`/`SIGKILL`) they're built on, are unix-specific - `nix` itself is only a
-//! dependency at all `[target.'cfg(unix)'.dependencies]` in `Cargo.toml`. On Windows there is no
-//! `/proc` descendant walk and no signal-based kill; the real equivalent this crate's two
+//! Every function in this module is `#[cfg(unix)]`: the `nix` signal calls
+//! (`kill`/`SIGTERM`/`SIGKILL`) they're built on are unix-specific - `nix` itself is only a
+//! dependency at all `[target.'cfg(unix)'.dependencies]` in `Cargo.toml`. The descendant walk
+//! itself is per-OS within unix, exactly as `pty-core`'s is: `/proc/<pid>/task/<pid>/children`
+//! on Linux, `libproc`'s `proc_listchildpids` on macOS. On Windows there is no
+//! descendant walk and no signal-based kill; the real equivalent this crate's two
 //! callers (`LspClient::shutdown`/`Drop` in `client.rs`) use instead on that platform is a
 //! direct `std::process::Child::kill()` on the already-held child handle (`TerminateProcess`
 //! under the hood) - narrower than the unix path (it reaches only the direct `rust-analyzer`
@@ -31,18 +33,19 @@
 //! loudly instead of silently picking up logic that was never reasoned about for it.
 
 use std::collections::HashSet;
+#[cfg(all(unix, not(target_os = "macos")))]
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
-/// Depth cap for the `/proc` descendant-tree walk - purely defensive against a pathological
+/// Depth cap for the descendant-tree walk - purely defensive against a pathological
 /// process tree; rust-analyzer's own real child processes are nowhere near this deep.
 const TREE_WALK_MAX_DEPTH: usize = 8;
 
 /// Reads the current direct children of `pid` from Linux's `/proc/<pid>/task/<pid>/children`.
 /// Best-effort: returns an empty list if the file can't be read (process already gone,
-/// non-Linux unix, permissions, ...) rather than erroring - used only for teardown cleanup,
-/// where "found nothing else to clean up" is an acceptable fallback.
-#[cfg(unix)]
+/// a unix without procfs, permissions, ...) rather than erroring - used only for teardown
+/// cleanup, where "found nothing else to clean up" is an acceptable fallback.
+#[cfg(all(unix, not(target_os = "macos")))]
 fn child_pids_of(pid: u32) -> Vec<u32> {
     let path = PathBuf::from(format!("/proc/{pid}/task/{pid}/children"));
     std::fs::read_to_string(&path)
@@ -55,9 +58,57 @@ fn child_pids_of(pid: u32) -> Vec<u32> {
         .unwrap_or_default()
 }
 
-/// Breadth-first, depth-capped walk of `root_pid`'s descendant tree via `/proc`. Must be called
-/// *before* signaling anything - reading it after a process starts dying races against the
-/// kernel reparenting its children out from under `children` (the same real ordering
+/// Reads the current direct children of `pid` from macOS's `libproc`, which has no `/proc` for
+/// the branch above to read. Best-effort in exactly the same way: an empty list, never an
+/// error, when the process is already gone or cannot be queried.
+///
+/// `proc_listchildpids` returns the number of pids it wrote and truncates *silently* when the
+/// buffer is too small - it reports the capacity it filled with no error of any kind - so a
+/// completely full buffer is retried at double the capacity rather than trusted to be complete.
+#[cfg(target_os = "macos")]
+#[allow(unsafe_code)]
+fn child_pids_of(pid: u32) -> Vec<u32> {
+    // A parent with more direct children than this is pathological, not a real rust-analyzer
+    // process tree; the doubling below stops here rather than growing without bound.
+    const MAX_CAPACITY: usize = 4096;
+
+    let Ok(ppid) = libc::pid_t::try_from(pid) else {
+        return Vec::new();
+    };
+
+    let mut capacity = 64usize;
+    loop {
+        let mut buffer: Vec<libc::pid_t> = vec![0; capacity];
+        let buffer_bytes = capacity * std::mem::size_of::<libc::pid_t>();
+
+        // SAFETY: `proc_listchildpids` writes at most `buffersize` bytes through the buffer
+        // pointer, which addresses a live, uniquely borrowed `Vec` allocation of exactly
+        // `buffer_bytes` bytes for the whole call and is not retained by the callee. The cast
+        // is the one Apple's own header requires - the parameter is a bare `void *`. It reports
+        // how many pids it wrote, or 0 on failure, and never a negative count.
+        let written = unsafe {
+            libc::proc_listchildpids(
+                ppid,
+                buffer.as_mut_ptr().cast::<libc::c_void>(),
+                buffer_bytes as libc::c_int,
+            )
+        };
+
+        let written = usize::try_from(written).unwrap_or(0).min(capacity);
+        if written < capacity || capacity == MAX_CAPACITY {
+            buffer.truncate(written);
+            return buffer
+                .into_iter()
+                .filter_map(|child| u32::try_from(child).ok())
+                .collect();
+        }
+        capacity = (capacity * 2).min(MAX_CAPACITY);
+    }
+}
+
+/// Breadth-first, depth-capped walk of `root_pid`'s descendant tree via [`child_pids_of`]. Must
+/// be called *before* signaling anything - reading it after a process starts dying races against
+/// the kernel reparenting its children out from under it (the same real ordering
 /// requirement `pty-core::collect_descendant_pids`'s own docs describe).
 #[cfg(unix)]
 pub fn collect_descendant_pids(root_pid: u32) -> Vec<u32> {
@@ -84,10 +135,21 @@ pub fn collect_descendant_pids(root_pid: u32) -> Vec<u32> {
     discovered
 }
 
-/// Real, direct `/proc/<pid>` existence check - not a cached or assumed answer.
+/// Real, direct existence check via the portable POSIX `kill(pid, 0)` probe - not a cached or
+/// assumed answer, and not procfs, so it answers the same on every unix.
+///
+/// `EPERM` counts as "exists": the kernel only reports it for a process that is genuinely there
+/// but not signalable by this user, and treating that as gone would make [`terminate_tree`]'s
+/// grace loop declare victory over something still running.
 #[cfg(unix)]
 pub fn pid_exists(pid: u32) -> bool {
-    PathBuf::from(format!("/proc/{pid}")).exists()
+    let Ok(raw) = i32::try_from(pid) else {
+        return false;
+    };
+    match nix::sys::signal::kill(nix::unistd::Pid::from_raw(raw), None) {
+        Ok(()) => true,
+        Err(errno) => errno == nix::errno::Errno::EPERM,
+    }
 }
 
 /// Sends `signal` to a real, single pid via `nix::sys::signal::kill`. Errors (e.g. `ESRCH`
@@ -131,8 +193,8 @@ pub fn terminate_tree(root_pid: u32, grace: Duration) {
 }
 
 // Every function above is `#[cfg(unix)]` (see this module's own doc comment on why), and
-// both tests below exercise them directly (`collect_descendant_pids`, `signal_pid`,
-// `terminate_tree`, `pid_exists`) - there is no non-unix variant of either test to keep
+// the tests below exercise them directly (`collect_descendant_pids`, `signal_pid`,
+// `terminate_tree`, `pid_exists`) - there is no non-unix variant of any of them to keep
 // around, unlike `pty-core`'s own test module (which mixes unix-only and cross-platform
 // tests, and so gates individual test functions instead).
 #[cfg(all(test, unix))]
@@ -140,25 +202,54 @@ mod tests {
     use super::*;
     use std::process::{Command, Stdio};
 
+    /// The two answers [`pid_exists`] has to get right for [`terminate_tree`]'s grace loop to
+    /// mean anything: a process that is genuinely running, and one that has already been
+    /// reaped.
     #[test]
-    fn collect_descendant_pids_finds_a_real_child_process() {
-        let mut child = Command::new("sh")
-            .arg("-c")
-            .arg("sleep 30")
+    fn pid_exists_separates_a_live_process_from_a_reaped_one() {
+        assert!(
+            pid_exists(std::process::id()),
+            "this very test process is unambiguously alive"
+        );
+
+        let mut child = Command::new("true")
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()
-            .expect("spawning `sh -c 'sleep 30'` should succeed");
+            .expect("spawning `true` should succeed");
+        let pid = child.id();
+        child.wait().expect("reaping `true` should succeed");
+
+        assert!(
+            !pid_exists(pid),
+            "pid {pid} was reaped, so it should read as gone rather than alive"
+        );
+    }
+
+    /// `sleep 30 & wait`, not a bare `sleep 30`: macOS's `/bin/sh` `exec`s a lone final command
+    /// in place rather than forking for it, so `sh -c 'sleep 30'` leaves a process *named*
+    /// `sleep` at the shell's own pid and no child at all for this walk to find. Backgrounding
+    /// forces a real fork on every shell - the same form the sibling test below already uses.
+    #[test]
+    fn collect_descendant_pids_finds_a_real_child_process() {
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg("sleep 30 & wait")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawning `sh -c 'sleep 30 & wait'` should succeed");
         let sh_pid = child.id();
 
-        // Give the shell a moment to actually exec `sleep` as its own child.
+        // Give the shell a moment to actually fork `sleep` as its own child.
         std::thread::sleep(Duration::from_millis(200));
 
         let descendants = collect_descendant_pids(sh_pid);
         assert!(
             !descendants.is_empty(),
-            "expected `sh -c 'sleep 30'` to have spawned a real, discoverable `sleep` child"
+            "expected `sh -c 'sleep 30 & wait'` to have spawned a real, discoverable `sleep` child"
         );
 
         let _ = child.kill();

--- a/crates/pty-core/Cargo.toml
+++ b/crates/pty-core/Cargo.toml
@@ -20,12 +20,22 @@ anyhow = { workspace = true }
 # crate-level "Platform scope" docs for why non-unix has no self-pipe/poll shutdown signal.
 filedescriptor = "0.8"
 
-# Process-group signals and the `/proc` descendant walk are unix-only; see the crate-level
-# doc comment in src/lib.rs for why non-unix instead calls `portable_pty::Child::kill()`
-# directly. Already a transitive dep of `portable-pty` 0.9.0 on unix (pinned here to the
-# exact version already resolved in Cargo.lock, so this adds no new version surface).
+# Process-group signals, the `kill(pid, 0)` liveness check and the descendant walk are
+# unix-only; see the crate-level doc comment in src/lib.rs for why non-unix instead calls
+# `portable_pty::Child::kill()` directly. Already a transitive dep of `portable-pty` 0.9.0 on
+# unix (pinned here to the exact version already resolved in Cargo.lock, so this adds no new
+# version surface).
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.28", default-features = false, features = ["signal"] }
+
+# macOS only: there is no `/proc` there, so `child_pids_of`'s descendant walk goes through
+# `libproc`'s `proc_listchildpids` (declared in `<libproc.h>`, implemented in libSystem, which
+# every macOS binary already links) instead. Raw `libc` rather than the `libproc` crate for the
+# reasons `crates/app/src/status_bar/process_stats/macos.rs` already sets out: `libc` declares
+# the call with the exact signature used, and it is already resolved in this workspace's lock
+# file, so this adds no new build surface.
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = "0.2"
 
 [dev-dependencies]
 # Test-only: `resolve_on_path_skips_a_same_named_directory` needs a real, isolated temporary

--- a/crates/pty-core/src/lib.rs
+++ b/crates/pty-core/src/lib.rs
@@ -18,9 +18,11 @@
 //! ## Platform scope: full on unix, narrower (but real) on Windows
 //!
 //! The reader-thread shutdown signaling (a self-pipe polled alongside the pty fd) and the
-//! process-tree kill (process-group signals plus a `/proc` descendant walk) are `#[cfg(unix)]`.
-//! `child_pids_of`/`pid_exists` read Linux's `/proc` specifically; on a non-Linux unix (e.g.
-//! macOS) they already degrade gracefully to "found nothing" (see their own docs), so
+//! process-tree kill (process-group signals plus a descendant walk) are `#[cfg(unix)]`.
+//! `pid_exists` is the portable POSIX `kill(pid, 0)` probe, so it answers the same on every
+//! unix. `child_pids_of` is per-OS: Linux reads `/proc/<pid>/task/<pid>/children`, macOS calls
+//! `libproc`'s `proc_listchildpids` (there is no `/proc` there). Any other unix has neither and
+//! degrades gracefully to "found nothing" (see that function's own docs), so
 //! `terminate_process_tree` still sends real signals to the child's process group there, just
 //! without the escaped-grandchild walk.
 //!
@@ -121,11 +123,11 @@
 //! shell). That's not sufficient alone: a descendant that calls `setsid()` itself (e.g.
 //! `setsid sleep 100 &`, or any daemonizing tool) detaches into its own session and process
 //! group, unreachable via the parent's pgid. To handle that, [`kill`](PtySession::kill) /
-//! [`shutdown`](PtySession::shutdown) / `Drop` all first walk `/proc/<pid>/task/<pid>/children`
-//! (Linux procfs; breadth-first, depth-capped) to snapshot the *entire* descendant set
-//! **before** sending any signal - reading it after the fact races against the kernel
-//! reparenting a dying process's children out from under that file - then signal both the
-//! process group and every discovered descendant individually. See
+//! [`shutdown`](PtySession::shutdown) / `Drop` all first walk the descendant tree
+//! (breadth-first, depth-capped, through the per-OS `child_pids_of` above) to snapshot the
+//! *entire* descendant set **before** sending any signal - reading it after the fact races
+//! against the kernel reparenting a dying process's children out from under it - then signal
+//! both the process group and every discovered descendant individually. See
 //! `drop_terminates_entire_process_tree_including_escaped_grandchild` in the test module for
 //! the regression case this fixes.
 //!
@@ -1035,9 +1037,9 @@ impl Drop for PtySession {
 
 /// Reads the current direct children of `pid` from Linux's `/proc/<pid>/task/<pid>/children`.
 /// Best-effort: returns an empty list if the file can't be read (process already gone,
-/// non-Linux unix, permissions, etc.) rather than erroring - this is used for cleanup,
+/// a unix without procfs, permissions, etc.) rather than erroring - this is used for cleanup,
 /// where "found nothing to additionally clean up" is an acceptable fallback.
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "macos")))]
 fn child_pids_of(pid: u32) -> Vec<u32> {
     let path = PathBuf::from(format!("/proc/{pid}/task/{pid}/children"));
     std::fs::read_to_string(&path)
@@ -1050,9 +1052,57 @@ fn child_pids_of(pid: u32) -> Vec<u32> {
         .unwrap_or_default()
 }
 
-/// Breadth-first, depth-capped walk of `root_pid`'s descendant tree via `/proc`. Must be
-/// called *before* signaling anything: reading it after a process starts dying races
-/// against the kernel reparenting its children out from under `children`.
+/// Reads the current direct children of `pid` from macOS's `libproc`, which has no `/proc` for
+/// the branch above to read. Best-effort in exactly the same way: an empty list, never an
+/// error, when the process is already gone or cannot be queried.
+///
+/// `proc_listchildpids` returns the number of pids it wrote and truncates *silently* when the
+/// buffer is too small - it reports the capacity it filled with no error of any kind - so a
+/// completely full buffer is retried at double the capacity rather than trusted to be complete.
+#[cfg(target_os = "macos")]
+#[allow(unsafe_code)]
+fn child_pids_of(pid: u32) -> Vec<u32> {
+    // A parent with more direct children than this is pathological, not a real agent process
+    // tree; the doubling below stops here rather than growing without bound.
+    const MAX_CAPACITY: usize = 4096;
+
+    let Ok(ppid) = libc::pid_t::try_from(pid) else {
+        return Vec::new();
+    };
+
+    let mut capacity = 64usize;
+    loop {
+        let mut buffer: Vec<libc::pid_t> = vec![0; capacity];
+        let buffer_bytes = capacity * std::mem::size_of::<libc::pid_t>();
+
+        // SAFETY: `proc_listchildpids` writes at most `buffersize` bytes through the buffer
+        // pointer, which addresses a live, uniquely borrowed `Vec` allocation of exactly
+        // `buffer_bytes` bytes for the whole call and is not retained by the callee. The cast
+        // is the one Apple's own header requires - the parameter is a bare `void *`. It reports
+        // how many pids it wrote, or 0 on failure, and never a negative count.
+        let written = unsafe {
+            libc::proc_listchildpids(
+                ppid,
+                buffer.as_mut_ptr().cast::<libc::c_void>(),
+                buffer_bytes as libc::c_int,
+            )
+        };
+
+        let written = usize::try_from(written).unwrap_or(0).min(capacity);
+        if written < capacity || capacity == MAX_CAPACITY {
+            buffer.truncate(written);
+            return buffer
+                .into_iter()
+                .filter_map(|child| u32::try_from(child).ok())
+                .collect();
+        }
+        capacity = (capacity * 2).min(MAX_CAPACITY);
+    }
+}
+
+/// Breadth-first, depth-capped walk of `root_pid`'s descendant tree via [`child_pids_of`]. Must
+/// be called *before* signaling anything: reading it after a process starts dying races
+/// against the kernel reparenting its children out from under it.
 #[cfg(unix)]
 fn collect_descendant_pids(root_pid: u32) -> Vec<u32> {
     let mut discovered = Vec::new();
@@ -1078,9 +1128,21 @@ fn collect_descendant_pids(root_pid: u32) -> Vec<u32> {
     discovered
 }
 
+/// Whether `pid` is still a live (or zombie-but-unreaped) process, via the portable POSIX
+/// `kill(pid, 0)` existence probe - no procfs, so this answers the same on every unix.
+///
+/// `EPERM` counts as "exists": the kernel only reports it for a process that is genuinely
+/// there but not signalable by this user, and treating that as gone would make
+/// [`terminate_process_tree`]'s grace loop declare victory over something still running.
 #[cfg(unix)]
 fn pid_exists(pid: u32) -> bool {
-    PathBuf::from(format!("/proc/{pid}")).exists()
+    let Ok(raw) = i32::try_from(pid) else {
+        return false;
+    };
+    match nix::sys::signal::kill(nix::unistd::Pid::from_raw(raw), None) {
+        Ok(()) => true,
+        Err(errno) => errno == nix::errno::Errno::EPERM,
+    }
 }
 
 /// Terminates `root_pid`'s process group *and* any descendants that escaped it (e.g. via
@@ -1222,7 +1284,12 @@ mod tests {
     /// structure changing, not a live hazard being probed.
     ///
     /// `seq` writes into a pty, so the line discipline turns each `\n` into `\r\n`; the
-    /// comparison below normalizes that rather than pretending it doesn't happen.
+    /// comparison below normalizes that rather than pretending it doesn't happen. It drops
+    /// every `\r` rather than only collapsing `\r\n`, because macOS's line discipline re-emits
+    /// the `\r` when its output queue fills mid-expansion and yields `\r\r\n` - observed on a
+    /// real Mac roughly once per 4096-byte queue boundary under exactly the backpressure this
+    /// test creates, with no byte lost, reordered or duplicated. `seq`'s own payload is digits
+    /// only, so dropping carriage returns costs the assertions below nothing.
     #[test]
     fn long_output_arrives_complete_and_in_order_across_chunk_boundaries() {
         const LINES: usize = 200_000;
@@ -1255,7 +1322,7 @@ mod tests {
         }
 
         let text = String::from_utf8(collected).expect("`seq` output is plain ASCII");
-        let normalized = text.replace("\r\n", "\n");
+        let normalized = text.replace('\r', "");
         let lines: Vec<&str> = normalized.trim_end_matches('\n').split('\n').collect();
 
         assert_eq!(
@@ -1275,6 +1342,35 @@ mod tests {
                  truncated or duplicated somewhere around a chunk boundary",
             );
         }
+    }
+
+    /// The two answers [`pid_exists`] has to get right for every teardown assertion below to
+    /// mean anything: a process that is genuinely running, and one that has already been
+    /// reaped.
+    ///
+    /// unix-only: uses `pid_exists` directly, which is a `#[cfg(unix)]` helper function (see
+    /// the crate-level "Platform scope" docs).
+    #[cfg(unix)]
+    #[test]
+    fn pid_exists_separates_a_live_process_from_a_reaped_one() {
+        assert!(
+            pid_exists(std::process::id()),
+            "this very test process is unambiguously alive"
+        );
+
+        let mut child = std::process::Command::new("true")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawning `true` should succeed");
+        let pid = child.id();
+        child.wait().expect("reaping `true` should succeed");
+
+        assert!(
+            !pid_exists(pid),
+            "pid {pid} was reaped, so it should read as gone rather than alive"
+        );
     }
 
     // unix-only: uses pid_exists/is_executable directly, which are #[cfg(unix)]
@@ -1312,15 +1408,20 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn drop_terminates_entire_process_tree_including_escaped_grandchild() {
-        // Regression test for a process that escapes the child's process group by
-        // calling `setsid()` itself (e.g. a daemonizing subprocess): `killpg` on the
-        // direct child's pgid alone cannot reach it. The shell reports the detached
-        // grandchild's pid back to us over the pty so we don't have to race /proc to
-        // discover it ourselves.
+        // Regression test for a process that escapes the child's process group (e.g. a
+        // daemonizing subprocess): `killpg` on the direct child's pgid alone cannot reach it,
+        // so only the descendant walk can. The shell reports the detached grandchild's pid
+        // back over the pty so we don't have to race the walk to discover it ourselves.
+        //
+        // `set -m` rather than a `setsid` prefix: turning on job control makes the shell put
+        // each background job in its own process group, which is precisely what defeats
+        // `killpg`, and unlike `setsid(1)` it is a shell builtin that exists everywhere -
+        // macOS ships no `setsid` binary at all, so that spelling silently degraded this into
+        // a test whose "grandchild" was a `command not found` zombie.
         let session = spawn(
             SpawnOptions::new("sh")
                 .arg("-c")
-                .arg("setsid sleep 100 & echo GRANDCHILD:$!; exec sleep 300"),
+                .arg("set -m; sleep 100 & echo GRANDCHILD:$!; exec sleep 300"),
         )
         .expect("spawning the shell pipeline should succeed");
 
@@ -1340,6 +1441,14 @@ mod tests {
         assert!(
             pid_exists(grandchild_pid),
             "detached grandchild {grandchild_pid} should be alive before drop"
+        );
+        // `pid_exists` alone would also be satisfied by an unreaped zombie, which is what this
+        // test degraded into on macOS before; the walk only lists a pid the kernel still
+        // reports as a child, and it is the mechanism actually under test here.
+        assert!(
+            collect_descendant_pids(direct_pid).contains(&grandchild_pid),
+            "the descendant walk should discover the detached grandchild {grandchild_pid} \
+             under direct child {direct_pid} - without it, `Drop` has no way to reach it"
         );
 
         drop(session);


### PR DESCRIPTION
Closes #422

## What

`child_pids_of` read Linux's `/proc/<pid>/task/<pid>/children` on every unix. macOS has no
`/proc`, so on macOS the descendant walk always returned nothing, the tree kill degraded to
`killpg` on the direct child's process group alone, and anything that had escaped that group
survived.

- **macOS gets a real `child_pids_of`**, built on libproc's `proc_listchildpids` — the one
  `unsafe` FFI site in each crate, each with its own `#[allow(unsafe_code)]` and `SAFETY`
  comment, following `crates/app/src/status_bar/process_stats/macos.rs`.
- **The Linux `/proc` body is byte-for-byte unchanged**, only re-gated to
  `cfg(all(unix, not(target_os = "macos")))`. Any other unix keeps degrading to "found nothing",
  exactly as before.
- **`pid_exists` moves off `/proc/<pid>` to the portable POSIX `kill(pid, 0)` probe** — no FFI,
  no new dependency (`nix` was already there), same answer on every unix. `EPERM` counts as
  "exists", since it means the process is genuinely there but not signalable by this user.
- `collect_descendant_pids` / `terminate_process_tree` and the depth cap are untouched — they
  only consume `child_pids_of`.
- Windows is out of scope, per the issue.

Both crates' module docs previously *documented* the macOS gap as accepted; those paragraphs are
rewritten, since they are now wrong.

### Three tests that were not asserting what they claimed

Reviewer attention here — these are behavioral changes to tests, not just the fix:

1. `drop_terminates_entire_process_tree_including_escaped_grandchild` built its escaped
   grandchild with a `setsid` prefix. **macOS ships no `setsid` binary at all**
   (`/bin/sh: setsid: command not found`), so the pid it reported was a dead child that
   `kill(pid, 0)` sees as an unreaped zombie. The test therefore passed on macOS without ever
   exercising a process-group escape — and flaked whenever the shell reaped the zombie first.
   It now uses `set -m`, a POSIX shell builtin present everywhere, which puts each background
   job in its own process group — precisely what defeats `killpg`. Verified with `ps`:

   ```
   $ /bin/sh -c 'set -m; sleep 5 & echo PID:$!; sleep 1; ps -o pid,ppid,pgid,comm -p $!; ps -o pid,pgid,comm -p $$'
   PID:26354
     PID  PPID  PGID COMM
   26354 26352 26354 sleep      <- own pgid, ppid is the shell
   self pgid:
     PID  PGID COMM
   26352 26350 /bin/sh          <- shell's pgid is different
   ```

   It also now asserts the walk really discovers that pid, which `pid_exists` alone (satisfied
   by a zombie) did not.

2. `collect_descendant_pids_finds_a_real_child_process` spawned `sh -c 'sleep 30'`. macOS's
   `/bin/sh` **execs a lone final command in place** rather than forking, so there was no child
   process to discover at all:

   ```
   $ /bin/sh -c 'sleep 20' & sleep 1; ps -o pid,ppid,comm -p $!; pgrep -P $!
     PID  PPID COMM
   72220 72216 sleep       <- the "shell" pid IS sleep
   (no children; pgrep exit 1)
   ```

   Now `sh -c 'sleep 30 & wait'`, the form its own sibling test already used.

3. `long_output_arrives_complete_and_in_order_across_chunk_boundaries` normalized only `\r\n`.
   Under the backpressure this test deliberately creates, macOS's line discipline re-emits the
   `\r` when its output queue fills mid-expansion and writes `\r\r\n`. Dumped the raw bytes over
   10 runs to be sure this was not a real stream defect — it is purely an inserted `\r`, with no
   byte lost, reordered or duplicated, landing at ~4096-byte queue boundaries:

   ```
   attempt 0: anomaly at 4640: "48\r\n949\r\n950\r\r\n951\r\n952\r"
   attempt 1: anomaly at 61945: "10435\r\n10436\r\r\n10437\r\n10"
   attempt 1: anomaly at 66041: "11020\r\n11021\r\r\n11022\r\n11"   <- 66041 - 61945 = 4096
   attempt 6: anomaly at 430937: "63148\r\n63149\r\r\n63150\r\n63"
   attempt 6: anomaly at 435033: "63733\r\n63734\r\r\n63735\r\n63"  <- 435033 - 430937 = 4096
   ```

   `seq`'s payload is digits only, so the test now drops carriage returns outright. Its line
   count and per-line ordering assertions are unchanged and still catch any real loss.

## Testing

- [x] `/check` (conventions + fmt + clippy `-D warnings`) passes locally

```
$ cargo fmt --all -- --check && echo "FMT OK"
FMT OK
$ .claude/hooks/check-conventions.sh
check-conventions: OK (glob imports: 304/304, render adapter calls: 222/222)
$ cargo clippy --workspace --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 41.73s
```

- [ ] `verify` capture — n/a, no `render.rs`/`theme.rs`/layout change
- [x] New/changed behavior has a real test, run manually and confirmed passing

All runs below are on this real macOS host (Darwin 25.5, Apple Silicon). `cargo test --workspace`
is not part of the gate (#348), and was not run.

### `cargo nextest run -p pty-core` — before

```
Summary [   1.863s] 16 tests run: 14 passed, 2 failed, 0 skipped
   FAIL [   0.023s] ( 5/16) pty-core tests::drop_kills_child_and_it_does_not_become_an_orphan
   FAIL [   0.077s] (15/16) pty-core tests::drop_terminates_entire_process_tree_including_escaped_grandchild

thread '...drop_kills_child_and_it_does_not_become_an_orphan' panicked at crates/pty-core/src/lib.rs:1292:9:
child pid 47632 should be alive immediately after spawn
```

### `cargo nextest run -p pty-core` — after

```
Summary [   1.865s] 17 tests run: 17 passed, 0 skipped
```

17, not 16: this PR adds `pid_exists_separates_a_live_process_from_a_reaped_one`. Run 10x
back-to-back, 10/10 green, zero surviving `sleep` processes afterwards.

### `cargo nextest run -p lsp-core` — before

```
Summary [  30.043s] 51 tests run: 47 passed, 4 failed, 0 skipped
   FAIL [   0.031s] (15/51) lsp-core client::tests::drop_without_shutdown_does_not_leave_an_orphaned_process
   FAIL [   0.028s] (18/51) lsp-core client::tests::spawn_performs_a_real_handshake_and_shutdown_leaves_no_orphan
   FAIL [   0.215s] (26/51) lsp-core proc::tests::collect_descendant_pids_finds_a_real_child_process
   FAIL [   0.218s] (39/51) lsp-core proc::tests::terminate_tree_kills_a_real_process_and_its_real_child
```

The issue reports 14 failures here; 10 of those were environmental on my host —
`rust-analyzer` was not installed, so the rustup shim exited immediately and every test needing a
live server failed with `ConnectionClosed`. The four above are the real `/proc` failures, and are
what this PR is measured against.

### `cargo nextest run -p lsp-core` — after

```
Summary [  30.037s] 52 tests run: 52 passed, 0 skipped
```

52, not 51: this PR adds `pid_exists_separates_a_live_process_from_a_reaped_one` here too.

### The tests have teeth

To confirm none of the above passes for free, `child_pids_of`'s macOS branch was temporarily
stubbed to `return Vec::new()` (i.e. the old behavior) and both suites re-run:

```
Summary [  30.064s] 69 tests run: 66 passed, 3 failed, 0 skipped
   FAIL (26/69) lsp-core proc::tests::collect_descendant_pids_finds_a_real_child_process
   FAIL (28/69) lsp-core proc::tests::terminate_tree_kills_a_real_process_and_its_real_child
   FAIL (45/69) pty-core tests::drop_terminates_entire_process_tree_including_escaped_grandchild
```

Exactly the three tree-walk tests fail, and only those. The stub was reverted.

### Product-level check

The issue's third "done when" bullet asks for a check in the running app. **The GUI check was not
performed** — I could not drive Jerry's window interactively. What was run instead is the same
scenario one layer down, through the exact `PtySession` drop path `app`'s terminal pane uses: a
real interactive `/bin/zsh` in a real pty, `sleep 30422 &` typed in as input, then the session
dropped (what closing a pane does). Throwaway harness, not committed:

```
### BASE (current master behavior) ###
BEFORE pane close, pgrep -f 'sleep 30422' -> "67262"
AFTER  pane close, pgrep -f 'sleep 30422' -> "67262"
background job survived the pane close: 67262
test result: FAILED. 0 passed; 1 failed

### WITH THIS PR ###
BEFORE pane close, pgrep -f 'sleep 30422' -> "67657"
AFTER  pane close, pgrep -f 'sleep 30422' -> ""
test result: ok. 1 passed; 0 failed
```

That is the reported product bug, reproduced and fixed. A human should still do the real
click-through before this is called closed.

### Not verified here

Everything above ran on macOS only. The Linux `/proc` path is unchanged so it cannot have
regressed, but the two test-shape changes (`set -m`, `sleep 30 & wait`) do run on Linux and were
not executed there — CI's ubuntu job is the first real check of those. Both are strictly weaker
demands on the shell than what they replace, so the expected failure mode is a less strict test,
not a broken one.

## Architecture notes

No crate-boundary or Command/Query change. `pty-core` and `lsp-core` each gain a
`[target.'cfg(target_os = "macos")'.dependencies] libc` entry; `libc` was already resolved in
`Cargo.lock` (it is an existing unix dependency of `app`), so this adds no new build surface.
Raw `libc` over the `libproc` crate for the reasons
`crates/app/src/status_bar/process_stats/macos.rs` already documents. The `proc_listchildpids`
signature was verified against the fetched source at
`~/.cargo/registry/src/index.crates.io-*/libc-0.2.189/src/unix/bsd/apple/mod.rs:4991`, and its
runtime contract (returns a pid *count*, not a byte count; truncates silently on a short buffer,
which is why the implementation retries at double capacity) was measured with a standalone C
probe on this host rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
