### PR TITLE
test(code_surface): tier, purge and unbreak Surface C's test suite

### DIFF
--- a/crates/app/src/code_surface/code_view.rs
+++ b/crates/app/src/code_surface/code_view.rs
@@ -3076,21 +3076,21 @@ mod tests {
     }
 
     #[test]
-    fn detects_lf_from_real_bytes() {
-        assert_eq!(detect_line_ending(b"fn main() {\n}\n"), LineEnding::Lf);
-    }
-
-    #[test]
-    fn detects_crlf_from_real_bytes() {
-        assert_eq!(
-            detect_line_ending(b"fn main() {\r\n}\r\n"),
-            LineEnding::Crlf
-        );
-    }
-
-    #[test]
-    fn a_file_with_no_newline_at_all_defaults_to_lf() {
-        assert_eq!(detect_line_ending(b"no newline here"), LineEnding::Lf);
+    fn detect_line_ending_reads_the_real_bytes_and_defaults_to_lf() {
+        let cases: &[(&[u8], LineEnding)] = &[
+            (b"fn main() {\n}\n", LineEnding::Lf),
+            (b"fn main() {\r\n}\r\n", LineEnding::Crlf),
+            // Nothing to read: a file with no newline at all is LF, not "unknown".
+            (b"no newline here", LineEnding::Lf),
+        ];
+        for (bytes, expected) in cases {
+            assert_eq!(
+                detect_line_ending(bytes),
+                *expected,
+                "{:?}",
+                String::from_utf8_lossy(bytes)
+            );
+        }
     }
 
     fn plain_line(text: &str) -> RenderedLine {
@@ -3100,116 +3100,69 @@ mod tests {
         }
     }
 
+    /// Every shape `detect_indent_width` has to get right, in one table. The two "one-off" rows
+    /// are the audit's own reproductions: a C-style block-comment header's single leading space
+    /// and a hanging-indent continuation line must each lose to the file's real, repeated indent
+    /// unit rather than being picked just for appearing first.
     #[test]
-    fn detect_indent_width_finds_the_first_real_space_indented_line() {
-        let lines: Vec<RenderedLine> = ["fn main() {", "    let x = 1;", "}"]
-            .iter()
-            .map(|text| plain_line(text))
-            .collect();
-        assert_eq!(detect_indent_width(&lines), Some(4));
-    }
-
-    #[test]
-    fn detect_indent_width_skips_tab_indented_lines() {
-        let lines: Vec<RenderedLine> = ["fn main() {", "\tlet x = 1;", "  let y = 2;"]
-            .iter()
-            .map(|text| plain_line(text))
-            .collect();
-        assert_eq!(
-            detect_indent_width(&lines),
-            Some(2),
-            "a tab-indented line has no single \"N spaces\" answer - keep scanning for a real \
-             space-indented one"
-        );
-    }
-
-    #[test]
-    fn detect_indent_width_skips_whitespace_only_lines() {
-        let lines: Vec<RenderedLine> = ["fn main() {", "    ", "      let x = 1;"]
-            .iter()
-            .map(|text| plain_line(text))
-            .collect();
-        assert_eq!(
-            detect_indent_width(&lines),
-            Some(6),
-            "a blank/whitespace-only line says nothing about the real indent unit"
-        );
-    }
-
-    #[test]
-    fn detect_indent_width_with_no_indentation_anywhere_is_none() {
-        let lines: Vec<RenderedLine> = ["fn main() {", "}"]
-            .iter()
-            .map(|text| plain_line(text))
-            .collect();
-        assert_eq!(detect_indent_width(&lines), None);
-    }
-
-    #[test]
-    fn detect_indent_width_on_an_empty_file_is_none() {
-        assert_eq!(detect_indent_width(&[]), None);
-    }
-
-    /// The audit's exact reproduction: a C-style block-comment header's single leading space
-    /// must not be naively picked as "the" indent width just for appearing before the file's
-    /// real, repeated 4-space body indent.
-    #[test]
-    fn detect_indent_width_is_not_fooled_by_a_single_block_comment_header_line() {
-        let lines: Vec<RenderedLine> = [
-            "/**",
-            " * Copyright 2024 Example Corp.",
-            " */",
-            "fn main() {",
-            "    let x = 1;",
-            "    let y = 2;",
-            "    let z = 3;",
-            "}",
-        ]
-        .iter()
-        .map(|text| plain_line(text))
-        .collect();
-        assert_eq!(
-            detect_indent_width(&lines),
-            Some(4),
-            "the real, repeated 4-space body indent should win over a one-off single leading \
-             space from a C-style block comment header"
-        );
-    }
-
-    /// The audit's other exact reproduction: a one-off hanging-indent continuation line must not
-    /// out-vote the file's real, repeated indent unit.
-    #[test]
-    fn detect_indent_width_is_not_fooled_by_a_single_hanging_indent_continuation_line() {
-        let lines: Vec<RenderedLine> = [
-            "let long_name =",
-            "  some_call(a, b);",
-            "fn main() {",
-            "    let x = 1;",
-            "    let y = 2;",
-            "}",
-        ]
-        .iter()
-        .map(|text| plain_line(text))
-        .collect();
-        assert_eq!(
-            detect_indent_width(&lines),
-            Some(4),
-            "a one-off 2-space hanging-indent continuation line must not out-vote the file's \
-             real, repeated 4-space indent"
-        );
-    }
-
-    #[test]
-    fn detect_indent_width_breaks_a_tie_toward_the_smaller_width() {
-        let lines: Vec<RenderedLine> = ["  two spaces", "    four spaces"]
-            .iter()
-            .map(|text| plain_line(text))
-            .collect();
-        assert_eq!(
-            detect_indent_width(&lines),
-            Some(2),
-            "an exact tie in occurrence count should prefer the smaller, more conventional width"
-        );
+    fn detect_indent_width_picks_the_files_real_repeated_indent_unit() {
+        let cases: &[(&str, &[&str], Option<usize>)] = &[
+            (
+                "plain space indent",
+                &["fn main() {", "    let x = 1;", "}"],
+                Some(4),
+            ),
+            // A tab-indented line has no single "N spaces" answer - keep scanning.
+            (
+                "tab lines skipped",
+                &["fn main() {", "\tlet x = 1;", "  let y = 2;"],
+                Some(2),
+            ),
+            // A blank/whitespace-only line says nothing about the real indent unit.
+            (
+                "blank lines skipped",
+                &["fn main() {", "    ", "      let x = 1;"],
+                Some(6),
+            ),
+            ("no indentation at all", &["fn main() {", "}"], None),
+            ("empty file", &[], None),
+            (
+                "block comment header",
+                &[
+                    "/**",
+                    " * Copyright 2024 Example Corp.",
+                    " */",
+                    "fn main() {",
+                    "    let x = 1;",
+                    "    let y = 2;",
+                    "    let z = 3;",
+                    "}",
+                ],
+                Some(4),
+            ),
+            (
+                "hanging indent continuation",
+                &[
+                    "let long_name =",
+                    "  some_call(a, b);",
+                    "fn main() {",
+                    "    let x = 1;",
+                    "    let y = 2;",
+                    "}",
+                ],
+                Some(4),
+            ),
+            // An exact tie in occurrence count prefers the smaller, more conventional width.
+            (
+                "tie breaks smaller",
+                &["  two spaces", "    four spaces"],
+                Some(2),
+            ),
+        ];
+        for (label, texts, expected) in cases {
+            let lines: Vec<RenderedLine> = texts.iter().map(|text| plain_line(text)).collect();
+            assert_eq!(detect_indent_width(&lines), *expected, "{label}");
+        }
     }
 
     #[test]
@@ -3259,183 +3212,428 @@ mod tests {
     const SAMPLE_RUST: &str =
         "/// Adds one.\nfn add(left: i32) -> i32 {\n    let name = \"x\";\n    left + 1\n}\n";
 
-    #[test]
-    fn fn_keyword_is_classified_as_keyword() {
-        let spans = highlight_rust(SAMPLE_RUST);
-        let span = find_span(&spans, SAMPLE_RUST, "fn").expect("fn span");
-        assert_eq!(span.kind, HighlightKind::Keyword);
-    }
-
-    #[test]
-    fn a_string_literal_is_classified_as_string() {
-        let spans = highlight_rust(SAMPLE_RUST);
-        let span = find_span(&spans, SAMPLE_RUST, "\"x\"").expect("string literal span");
-        assert_eq!(span.kind, HighlightKind::String);
-    }
-
-    #[test]
-    fn a_function_name_is_classified_as_function() {
-        let spans = highlight_rust(SAMPLE_RUST);
-        let span = find_span(&spans, SAMPLE_RUST, "add").expect("function name span");
-        assert_eq!(span.kind, HighlightKind::FunctionDefinition);
-    }
-
-    #[test]
-    fn a_primitive_type_identifier_is_classified_as_type_builtin() {
-        let spans = highlight_rust(SAMPLE_RUST);
-        // "i32" appears twice (parameter type, return type); just confirm at least one
-        // occurrence was classified as TypeBuiltin - `i32` is a real `(primitive_type)` node in
-        // `tree-sitter-rust`'s own grammar, captured `@type.builtin`, not the plain `@type` a
-        // user-defined type name would get.
-        let type_spans: Vec<_> = spans
-            .iter()
-            .filter(|span| SAMPLE_RUST[span.start..span.end] == *"i32")
-            .collect();
-        assert!(!type_spans.is_empty());
-        assert!(type_spans
-            .iter()
-            .all(|span| span.kind == HighlightKind::TypeBuiltin));
-    }
-
-    #[test]
-    fn a_doc_comment_is_classified_as_comment_doc() {
-        let spans = highlight_rust(SAMPLE_RUST);
-        // The `line_comment` node's byte range includes its trailing newline; it's treated as
-        // one span rather than recursed into, since its children are just lexical pieces, not
-        // separately-colourable syntax. `///` is a real `(doc_comment)` child node, captured
-        // `@comment.documentation` - its own dedicated bucket since GitHub issue #31, not the
-        // plain `Comment` an ordinary `//` line gets.
-        let span = find_span(&spans, SAMPLE_RUST, "/// Adds one.\n").expect("doc comment span");
-        assert_eq!(span.kind, HighlightKind::CommentDoc);
-    }
-
-    #[test]
-    fn self_is_classified_as_variable_builtin_not_keyword() {
-        let source = "impl Foo {\n    fn bar(&self) -> i32 {\n        self.value\n    }\n}\n";
-        let spans = highlight_rust(source);
-        let span = find_span(&spans, source, "self").expect("self span");
-        assert_eq!(span.kind, HighlightKind::VariableBuiltin);
-    }
-
-    #[test]
-    fn highlighting_invalid_rust_still_returns_a_real_non_empty_span_list() {
-        // Tree-sitter produces a best-effort tree for malformed input rather than failing
-        // outright - confirm this doesn't panic and still classifies the keyword token present.
-        let spans = highlight_rust("fn (((( broken");
-        assert!(spans.iter().any(|span| span.kind == HighlightKind::Keyword));
-    }
-
     // Real TypeScript highlighting coverage - mirrors `highlight_rust`'s own test shape above.
     // Before this fix, none of `highlight_typescript`'s real, common-case behavior had any test
     // coverage at all.
 
     const SAMPLE_TYPESCRIPT: &str = "/** Adds one. */\nfunction add(left: number): number {\n    const name = \"x\";\n    return left + 1;\n}\n";
 
+    /// One row per real token this module's docs claim a bucket for, across every grammar - the
+    /// table form of what used to be one `#[test]` per row.
+    ///
+    /// Each row asks exactly what the renderer asks: which [`HighlightKind`] covers this token's
+    /// first byte ([`kind_at`]). Behaviour that is *not* a single token -> single bucket lookup
+    /// (definition vs. call site, casing sweeps, injected fences, bracket rings) keeps its own
+    /// test below; this table is only for the flat ones.
     #[test]
-    fn typescript_function_keyword_is_classified_as_keyword() {
-        let spans = highlight_typescript(SAMPLE_TYPESCRIPT, false);
-        let span = find_span(&spans, SAMPLE_TYPESCRIPT, "function").expect("function span");
-        assert_eq!(span.kind, HighlightKind::Keyword);
+    fn every_documented_token_lands_in_its_documented_bucket() {
+        let cases: &[(
+            &str,
+            crate::language::HighlighterFn,
+            &str,
+            &str,
+            HighlightKind,
+        )] = &[
+            (
+                "rust",
+                highlight_rust,
+                SAMPLE_RUST,
+                "fn",
+                HighlightKind::Keyword,
+            ),
+            (
+                "rust",
+                highlight_rust,
+                SAMPLE_RUST,
+                "add",
+                HighlightKind::FunctionDefinition,
+            ),
+            (
+                "rust",
+                highlight_rust,
+                SAMPLE_RUST,
+                "\"x\"",
+                HighlightKind::String,
+            ),
+            (
+                "rust",
+                highlight_rust,
+                SAMPLE_RUST,
+                "i32",
+                HighlightKind::TypeBuiltin,
+            ),
+            (
+                "rust",
+                highlight_rust,
+                SAMPLE_RUST,
+                "/// Adds one.",
+                HighlightKind::CommentDoc,
+            ),
+            (
+                "ts",
+                highlight_ts,
+                SAMPLE_TYPESCRIPT,
+                "function",
+                HighlightKind::Keyword,
+            ),
+            (
+                "ts",
+                highlight_ts,
+                SAMPLE_TYPESCRIPT,
+                "add",
+                HighlightKind::FunctionDefinition,
+            ),
+            (
+                "ts",
+                highlight_ts,
+                SAMPLE_TYPESCRIPT,
+                "\"x\"",
+                HighlightKind::String,
+            ),
+            (
+                "ts",
+                highlight_ts,
+                SAMPLE_TYPESCRIPT,
+                "number",
+                HighlightKind::TypeBuiltin,
+            ),
+            (
+                "ts",
+                highlight_ts,
+                SAMPLE_TYPESCRIPT,
+                "/** Adds one. */",
+                HighlightKind::Comment,
+            ),
+            // `(regex) @string.special`, its own bucket since GitHub issue #183 - it used to
+            // fall through to the plain `"string"` entry and read as an ordinary string.
+            (
+                "ts",
+                highlight_ts,
+                "const pattern = /^[a-z]+$/;\n",
+                "^[a-z]+$",
+                HighlightKind::StringSpecial,
+            ),
+            // The three `name`-field collisions that all used to come out `Function`: a
+            // `const` binding, an `interface` member, and a class method (which really is one).
+            (
+                "ts",
+                highlight_ts,
+                "const s: string = \"hi\";\n",
+                "s: string",
+                HighlightKind::Variable,
+            ),
+            (
+                "ts",
+                highlight_ts,
+                "interface Point { x: number }\n",
+                "x: number",
+                HighlightKind::Property,
+            ),
+            (
+                "ts",
+                highlight_ts,
+                "class Point {\n    length() {\n        return 0;\n    }\n}\n",
+                "length",
+                HighlightKind::FunctionDefinition,
+            ),
+            // A TSX tag name is the same collision once more, and gets its own `Tag` bucket.
+            (
+                "tsx",
+                highlight_tsx,
+                "const el = <div />;\n",
+                "div",
+                HighlightKind::Tag,
+            ),
+            (
+                "python",
+                highlight_python,
+                SAMPLE_PYTHON,
+                "def",
+                HighlightKind::Keyword,
+            ),
+            (
+                "python",
+                highlight_python,
+                SAMPLE_PYTHON,
+                "add",
+                HighlightKind::FunctionDefinition,
+            ),
+            (
+                "python",
+                highlight_python,
+                SAMPLE_PYTHON,
+                "\"x\"",
+                HighlightKind::String,
+            ),
+            (
+                "python",
+                highlight_python,
+                SAMPLE_PYTHON,
+                "int",
+                HighlightKind::Type,
+            ),
+            (
+                "python",
+                highlight_python,
+                "# a real comment\nx = 1\n",
+                "# a real comment",
+                HighlightKind::Comment,
+            ),
+            // A method name and a class name are two different `name` fields of two different
+            // node kinds, told apart inside one real parse.
+            (
+                "python",
+                highlight_python,
+                "class Foo:\n    def bar(self):\n        pass\n",
+                "bar",
+                HighlightKind::FunctionDefinition,
+            ),
+            (
+                "toml",
+                highlight_toml,
+                SAMPLE_TOML,
+                "name",
+                HighlightKind::Property,
+            ),
+            (
+                "toml",
+                highlight_toml,
+                SAMPLE_TOML,
+                "\"jerry\"",
+                HighlightKind::String,
+            ),
+            (
+                "toml",
+                highlight_toml,
+                SAMPLE_TOML,
+                "true",
+                HighlightKind::ConstantBuiltin,
+            ),
+            (
+                "toml",
+                highlight_toml,
+                SAMPLE_TOML,
+                "1979-05-27",
+                HighlightKind::StringSpecial,
+            ),
+            (
+                "go",
+                highlight_go,
+                SAMPLE_GO,
+                "func",
+                HighlightKind::Keyword,
+            ),
+            (
+                "go",
+                highlight_go,
+                SAMPLE_GO,
+                "add",
+                HighlightKind::FunctionDefinition,
+            ),
+            (
+                "go",
+                highlight_go,
+                SAMPLE_GO,
+                "len(",
+                HighlightKind::FunctionBuiltin,
+            ),
+            // A JSON key must win the more specific `string.special.key` registration over the
+            // plain `string` one; a JSON *value* must not.
+            (
+                "json",
+                highlight_json,
+                SAMPLE_JSON,
+                "\"name\"",
+                HighlightKind::Property,
+            ),
+            (
+                "json",
+                highlight_json,
+                SAMPLE_JSON,
+                "\"jerry\"",
+                HighlightKind::String,
+            ),
+            (
+                "json",
+                highlight_json,
+                SAMPLE_JSON,
+                "3",
+                HighlightKind::Number,
+            ),
+            (
+                "yaml",
+                highlight_yaml,
+                SAMPLE_YAML,
+                "count",
+                HighlightKind::Property,
+            ),
+            (
+                "yaml",
+                highlight_yaml,
+                SAMPLE_YAML,
+                "true",
+                HighlightKind::ConstantBuiltin,
+            ),
+            // `(anchor_name) @label` is the YAML half of the cross-language `"label"`
+            // registration; the C `goto` target below is its other half.
+            (
+                "yaml",
+                highlight_yaml,
+                SAMPLE_YAML,
+                "base\n",
+                HighlightKind::Label,
+            ),
+            (
+                "yaml",
+                highlight_yaml,
+                SAMPLE_YAML,
+                "&base",
+                HighlightKind::PunctuationSpecial,
+            ),
+            (
+                "yaml",
+                highlight_yaml,
+                SAMPLE_YAML,
+                "*base",
+                HighlightKind::PunctuationSpecial,
+            ),
+            ("c", highlight_c, SAMPLE_C, "return", HighlightKind::Keyword),
+            (
+                "c",
+                highlight_c,
+                SAMPLE_C,
+                "add",
+                HighlightKind::FunctionDefinition,
+            ),
+            ("c", highlight_c, SAMPLE_C, "done:", HighlightKind::Label),
+            (
+                "c",
+                highlight_c,
+                SAMPLE_C,
+                ";",
+                HighlightKind::PunctuationDelimiter,
+            ),
+            (
+                "markdown",
+                highlight_markdown,
+                SAMPLE_MARKDOWN,
+                "Title",
+                HighlightKind::Heading,
+            ),
+            (
+                "markdown",
+                highlight_markdown,
+                SAMPLE_MARKDOWN,
+                "bold",
+                HighlightKind::Strong,
+            ),
+            (
+                "markdown",
+                highlight_markdown,
+                SAMPLE_MARKDOWN,
+                "italic",
+                HighlightKind::Emphasis,
+            ),
+            (
+                "markdown",
+                highlight_markdown,
+                SAMPLE_MARKDOWN,
+                "inline code",
+                HighlightKind::String,
+            ),
+            (
+                "markdown",
+                highlight_markdown,
+                SAMPLE_MARKDOWN,
+                "https://example.com",
+                HighlightKind::Link,
+            ),
+            (
+                "markdown",
+                highlight_markdown,
+                SAMPLE_MARKDOWN,
+                "link",
+                HighlightKind::Link,
+            ),
+            // `string.special` must not match JSON's more specific `string.special.key`: the
+            // recognized-name rule needs every dot-part of the name present in the capture.
+            (
+                "css",
+                highlight_css,
+                SAMPLE_CSS,
+                "ff0000",
+                HighlightKind::StringSpecial,
+            ),
+        ];
+        for (label, highlighter, source, token, expected) in cases {
+            assert_eq!(
+                kind_at(&highlighter(source), source, token),
+                *expected,
+                "{label}: {token:?}"
+            );
+        }
     }
 
+    /// Tree-sitter produces a best-effort tree for malformed input rather than failing outright:
+    /// every grammar must still classify the keyword it *can* see, and none may panic.
     #[test]
-    fn typescript_string_literal_is_classified_as_string() {
-        let spans = highlight_typescript(SAMPLE_TYPESCRIPT, false);
-        let span = find_span(&spans, SAMPLE_TYPESCRIPT, "\"x\"").expect("string literal span");
-        assert_eq!(span.kind, HighlightKind::String);
+    fn highlighting_invalid_input_still_returns_a_real_non_empty_span_list() {
+        let cases: &[(&str, crate::language::HighlighterFn, &str)] = &[
+            ("rust", highlight_rust, "fn (((( broken"),
+            ("typescript", highlight_ts, "function (((( broken"),
+            ("python", highlight_python, "def (((( broken"),
+        ];
+        for (label, highlighter, source) in cases {
+            let spans = highlighter(source);
+            assert!(
+                spans.iter().any(|span| span.kind == HighlightKind::Keyword),
+                "{label}: malformed input must still classify its real leading keyword"
+            );
+        }
     }
 
-    /// `(regex) @string.special` - its own dedicated bucket since GitHub issue #183 (previously
-    /// fell through to the plain `"string"` entry, reading a regex literal as an ordinary
-    /// string).
-    #[test]
-    fn typescript_regex_literal_is_classified_as_string_special() {
-        let source = "const pattern = /^[a-z]+$/;\n";
-        let spans = highlight_typescript(source, false);
-        assert_eq!(
-            kind_at(&spans, source, "^[a-z]+$"),
-            HighlightKind::StringSpecial
-        );
-    }
+    // GitHub issue #200's own doc-tag coverage. `every_documented_token_lands_in_its_documented_
+    // bucket`'s TypeScript doc-comment row above deliberately calls `highlight_ts` directly - the
+    // raw grammar layer, bypassing `HighlightOptions::apply` entirely (same reason
+    // `colorize_bracket_pairs`'s own tests do this) - so it stays correct unchanged:
+    // `split_doc_comment_tags` only ever runs inside `apply()`, which every real, live rendering
+    // path (`load_file_with_options`, `highlight_block`) goes through but that pinned raw-grammar
+    // row doesn't.
 
+    /// Each shape `doc_tag_ranges` has to tell apart, in one table.
+    ///
+    /// The unclosed-inline row is the interesting one: `{@link` with no closing `}` never
+    /// matches the inline shape, but still degrades to the plain block-tag rule for the `@link`
+    /// word itself rather than emitting nothing for an honest, if malformed, doc comment.
     #[test]
-    fn typescript_function_declaration_name_is_classified_as_function() {
-        let spans = highlight_typescript(SAMPLE_TYPESCRIPT, false);
-        let span = find_span(&spans, SAMPLE_TYPESCRIPT, "add").expect("function name span");
-        assert_eq!(span.kind, HighlightKind::FunctionDefinition);
-    }
-
-    #[test]
-    fn typescript_predefined_type_is_classified_as_type_builtin() {
-        let spans = highlight_typescript(SAMPLE_TYPESCRIPT, false);
-        // `number` is a real `(predefined_type)` node, captured `@type.builtin`.
-        let type_spans: Vec<_> = spans
-            .iter()
-            .filter(|span| SAMPLE_TYPESCRIPT[span.start..span.end] == *"number")
-            .collect();
-        assert!(!type_spans.is_empty());
-        assert!(type_spans
-            .iter()
-            .all(|span| span.kind == HighlightKind::TypeBuiltin));
-    }
-
-    #[test]
-    fn typescript_doc_comment_is_classified_as_comment() {
-        let spans = highlight_typescript(SAMPLE_TYPESCRIPT, false);
-        let span =
-            find_span(&spans, SAMPLE_TYPESCRIPT, "/** Adds one. */").expect("doc comment span");
-        assert_eq!(span.kind, HighlightKind::Comment);
-    }
-
-    // GitHub issue #200's own doc-tag coverage. `typescript_doc_comment_is_classified_as_comment`
-    // just above deliberately calls `highlight_typescript` directly - the raw grammar layer,
-    // bypassing `HighlightOptions::apply` entirely (same reason `colorize_bracket_pairs`'s own
-    // tests do this) - so it stays correct unchanged: `split_doc_comment_tags` only ever runs
-    // inside `apply()`, which every real, live rendering path (`load_file_with_options`,
-    // `highlight_block`) goes through but this one pinned raw-grammar test doesn't.
-
-    #[test]
-    fn doc_tag_ranges_finds_a_real_block_tag_preceded_by_whitespace() {
-        let text = "Adds one.\n@param left the number to add to\n@returns the sum";
-        let ranges: Vec<&str> = doc_tag_ranges(text)
-            .into_iter()
-            .map(|range| &text[range])
-            .collect();
-        assert_eq!(ranges, vec!["@param", "@returns"]);
-    }
-
-    #[test]
-    fn doc_tag_ranges_never_matches_an_email_style_at_sign() {
-        let text = "Contact foo@example.com for details.";
-        assert!(
-            doc_tag_ranges(text).is_empty(),
-            "an `@` directly preceded by an identifier byte (the `o` in `foo`) is not a real \
-             doc tag - got: {:?}",
-            doc_tag_ranges(text)
-        );
-    }
-
-    #[test]
-    fn doc_tag_ranges_finds_a_real_inline_link_tag_brace_to_brace() {
-        let text = "See {@link Foo#bar} for more.";
-        let ranges: Vec<&str> = doc_tag_ranges(text)
-            .into_iter()
-            .map(|range| &text[range])
-            .collect();
-        assert_eq!(ranges, vec!["{@link Foo#bar}"]);
-    }
-
-    /// An unclosed `{@link` never matches the *inline*-tag shape (no real `}` to close it), but
-    /// still degrades gracefully to the plain block-tag rule for the `@link` word itself, rather
-    /// than emitting nothing at all for an honest, if malformed, doc comment.
-    #[test]
-    fn doc_tag_ranges_falls_back_to_a_bare_block_tag_for_an_unclosed_inline_tag() {
-        let text = "See {@link Foo#bar for more.";
-        let ranges: Vec<&str> = doc_tag_ranges(text)
-            .into_iter()
-            .map(|range| &text[range])
-            .collect();
-        assert_eq!(ranges, vec!["@link"]);
+    fn doc_tag_ranges_recognizes_every_real_tag_shape_and_nothing_else() {
+        let cases: &[(&str, &str, &[&str])] = &[
+            (
+                "block tags",
+                "Adds one.\n@param left the number to add to\n@returns the sum",
+                &["@param", "@returns"],
+            ),
+            // An `@` directly preceded by an identifier byte (the `o` in `foo`) is an email
+            // address, not a tag.
+            ("email address", "Contact foo@example.com for details.", &[]),
+            (
+                "inline link tag",
+                "See {@link Foo#bar} for more.",
+                &["{@link Foo#bar}"],
+            ),
+            (
+                "unclosed inline tag",
+                "See {@link Foo#bar for more.",
+                &["@link"],
+            ),
+        ];
+        for (label, text, expected) in cases {
+            let ranges: Vec<&str> = doc_tag_ranges(text)
+                .into_iter()
+                .map(|range| &text[range])
+                .collect();
+            assert_eq!(ranges, *expected, "{label}");
+        }
     }
 
     /// The real, full pipeline (`HighlightOptions::default().highlight(..)`, the same call
@@ -3502,228 +3700,12 @@ mod tests {
         );
     }
 
-    /// The real, live-verified regression this fix addresses: a `variable_declarator`'s own
-    /// `name` field collides with `function_declaration`'s `name` field in
-    /// `tree-sitter-typescript`'s real grammar, and the old, parent-kind-unaware matching
-    /// misclassified every `const`/`let`/`var` binding's name as a Function. `s` here must be
-    /// classified `Variable` (a use/declaration of a variable, not a function) - previously
-    /// asserted as plain `Text`, back when `"variable"` wasn't yet a registered highlight name at
-    /// all (GitHub issue #31 registered it); `theme::syntax::VARIABLE` is still a real, direct
-    /// alias of `theme::syntax::TEXT` (see that module's docs), so this is a classification-only
-    /// change with no visual difference.
-    #[test]
-    fn typescript_const_variable_name_is_not_misclassified_as_a_function() {
-        // The audit's exact reproduction. `find_span`'s plain substring search would otherwise
-        // match the embedded "s" inside "const" itself, so the real declared variable's own byte
-        // offset (right after "const ") is computed explicitly instead.
-        let source = "const s: string = \"hi\";\n";
-        let variable_start = source.find("const ").expect("const") + "const ".len();
-        let spans = highlight_typescript(source, false);
-        let kind = spans
-            .iter()
-            .find(|span| span.start <= variable_start && variable_start < span.end)
-            .map_or(HighlightKind::Text, |span| span.kind);
-        assert_eq!(
-            kind,
-            HighlightKind::Variable,
-            "a const/let/var binding's own name must never be classified as a function"
-        );
-    }
-
-    /// The same real collision, for an `interface` member name (`property_signature`'s `name`
-    /// field) - must not be classified as a function either. Classified `Property` (a real,
-    /// registered bucket since GitHub issue #31 - `tree-sitter-javascript`'s own
-    /// `(property_identifier) @property` rule is unconditional), not plain `Text` as before that
-    /// scope existed.
-    #[test]
-    fn typescript_interface_member_name_is_not_misclassified_as_a_function() {
-        let source = "interface Point { x: number }\n";
-        let spans = highlight_typescript(source, false);
-        assert_eq!(
-            kind_at(&spans, source, "x: number"),
-            HighlightKind::Property
-        );
-    }
-
-    /// The same real collision, for a class method's own name (`method_definition`'s `name`
-    /// field, a `property_identifier`) - this one, unlike the two above, genuinely *should* be
-    /// classified as a function.
-    #[test]
-    fn typescript_class_method_name_is_classified_as_a_function_method() {
-        let source = "class Point {\n    length() {\n        return 0;\n    }\n}\n";
-        let spans = highlight_typescript(source, false);
-        let span = find_span(&spans, source, "length").expect("method name span");
-        // `(method_definition name: (property_identifier) @function.method)` - its own
-        // dedicated bucket since GitHub issue #31 (previously folded into plain `Function`).
-        assert_eq!(span.kind, HighlightKind::FunctionDefinition);
-    }
-
-    /// The same real collision, for a real function call's callee (`call_expression`'s
-    /// `function` field) - genuinely a function, and must stay classified as one.
-    #[test]
-    fn typescript_call_expression_callee_is_classified_as_a_function() {
-        let source = "function top() {}\ntop();\n";
-        let spans = highlight_typescript(source, false);
-        let function_spans: Vec<_> = spans
-            .iter()
-            .filter(|span| source[span.start..span.end] == *"top")
-            .collect();
-        assert_eq!(function_spans.len(), 2, "the declaration and the call site");
-        assert_eq!(
-            function_spans[0].kind,
-            HighlightKind::FunctionDefinition,
-            "the `function top()` declaration is a real definition site"
-        );
-        assert_eq!(
-            function_spans[1].kind,
-            HighlightKind::Function,
-            "the `top()` call site stays a plain function - this split is the whole point of \
-             JAVASCRIPT_DEFINITION_SUPPLEMENT"
-        );
-    }
-
-    /// A real TSX tag name (`jsx_self_closing_element`'s own `name` field) is the same real
-    /// collision one more time - must not render as a Function either. Classified `Tag` (its own
-    /// real, dedicated bucket since GitHub issue #31 - previously folded into `Type`; see
-    /// `theme::syntax::TAG`'s own docs for why the two still render identically).
-    #[test]
-    fn tsx_tag_name_is_not_misclassified_as_a_function() {
-        let source = "const el = <div />;\n";
-        let spans = highlight_typescript(source, true);
-        let span = find_span(&spans, source, "div").expect("tag name span");
-        assert_ne!(span.kind, HighlightKind::Function);
-        assert_eq!(span.kind, HighlightKind::Tag);
-    }
-
-    #[test]
-    fn highlighting_invalid_typescript_still_returns_a_real_non_empty_span_list() {
-        let spans = highlight_typescript("function (((( broken", false);
-        assert!(spans.iter().any(|span| span.kind == HighlightKind::Keyword));
-    }
-
     // Real Python highlighting coverage - mirrors `highlight_rust`'s own test shape above.
     // Before this fix, none of `highlight_python`'s real, common-case behavior had any test
     // coverage at all.
 
     const SAMPLE_PYTHON: &str =
         "def add(left: int) -> int:\n    name = \"x\"\n    return left + 1\n";
-
-    #[test]
-    fn python_def_keyword_is_classified_as_keyword() {
-        let spans = highlight_python(SAMPLE_PYTHON);
-        let span = find_span(&spans, SAMPLE_PYTHON, "def").expect("def span");
-        assert_eq!(span.kind, HighlightKind::Keyword);
-    }
-
-    #[test]
-    fn python_string_literal_is_classified_as_string() {
-        let spans = highlight_python(SAMPLE_PYTHON);
-        let span = find_span(&spans, SAMPLE_PYTHON, "\"x\"").expect("string literal span");
-        assert_eq!(span.kind, HighlightKind::String);
-    }
-
-    #[test]
-    fn python_function_definition_name_is_classified_as_function() {
-        let spans = highlight_python(SAMPLE_PYTHON);
-        let span = find_span(&spans, SAMPLE_PYTHON, "add").expect("function name span");
-        assert_eq!(span.kind, HighlightKind::FunctionDefinition);
-    }
-
-    #[test]
-    fn python_type_annotation_is_classified_as_type() {
-        let spans = highlight_python(SAMPLE_PYTHON);
-        let type_spans: Vec<_> = spans
-            .iter()
-            .filter(|span| SAMPLE_PYTHON[span.start..span.end] == *"int")
-            .collect();
-        assert!(!type_spans.is_empty());
-        assert!(type_spans
-            .iter()
-            .all(|span| span.kind == HighlightKind::Type));
-    }
-
-    #[test]
-    fn python_comment_is_classified_as_comment() {
-        let source = "# a real comment\nx = 1\n";
-        let spans = highlight_python(source);
-        let span = find_span(&spans, source, "# a real comment").expect("comment span");
-        assert_eq!(span.kind, HighlightKind::Comment);
-    }
-
-    /// Matches Rust's own `self_is_classified_as_variable_builtin_not_keyword` test - a
-    /// deliberate, documented choice that Python's `self` gets the same `VariableBuiltin`
-    /// treatment Rust's does. Rust gets it from its grammar's own `(self) @variable.builtin` rule;
-    /// Python's grammar has no rule for `self` at all, so it comes from
-    /// [`PYTHON_HIGHLIGHTS_SUPPLEMENT`]'s second rule - see there.
-    #[test]
-    fn python_self_is_classified_as_variable_builtin_not_a_plain_identifier() {
-        let source = "class Foo:\n    def bar(self):\n        return self.value\n";
-        let spans = highlight_python(source);
-        let self_spans: Vec<_> = spans
-            .iter()
-            .filter(|span| source[span.start..span.end] == *"self")
-            .collect();
-        assert!(!self_spans.is_empty());
-        assert!(self_spans
-            .iter()
-            .all(|span| span.kind == HighlightKind::VariableBuiltin));
-    }
-
-    /// The real, live-verified regression this fix addresses: `class_definition`'s own `name`
-    /// field is a plain `identifier` in `tree-sitter-python`'s real grammar (unlike Rust/
-    /// TypeScript, where it's a distinct `type_identifier` node), and the old, parent-kind-
-    /// unaware matching misclassified every class name as a Function instead of a Type.
-    #[test]
-    fn python_class_name_is_classified_as_type_not_function() {
-        let source = "class Foo:\n    pass\n";
-        let spans = highlight_python(source);
-        let span = find_span(&spans, source, "Foo").expect("class name span");
-        assert_eq!(
-            span.kind,
-            HighlightKind::Type,
-            "a class's own declared name should be a Type, not a Function"
-        );
-    }
-
-    /// The same fixture's `def`, to prove the two real, colliding `"name"`-field cases (function
-    /// vs. class) are correctly told apart within one real, combined parse - not just correct in
-    /// isolation.
-    #[test]
-    fn python_method_name_inside_a_class_is_still_classified_as_function() {
-        let source = "class Foo:\n    def bar(self):\n        pass\n";
-        let spans = highlight_python(source);
-        let span = find_span(&spans, source, "bar").expect("method name span");
-        assert_eq!(span.kind, HighlightKind::FunctionDefinition);
-    }
-
-    /// The real call-expression collision one more time, for Python's own `call` node kind
-    /// (distinct from Rust/TypeScript's `call_expression`).
-    #[test]
-    fn python_call_callee_is_classified_as_a_function() {
-        let source = "def top():\n    pass\n\ntop()\n";
-        let spans = highlight_python(source);
-        let function_spans: Vec<_> = spans
-            .iter()
-            .filter(|span| source[span.start..span.end] == *"top")
-            .collect();
-        assert_eq!(function_spans.len(), 2, "the definition and the call site");
-        assert_eq!(
-            function_spans[0].kind,
-            HighlightKind::FunctionDefinition,
-            "the `def top()` name is a real definition site"
-        );
-        assert_eq!(
-            function_spans[1].kind,
-            HighlightKind::Function,
-            "the `top()` call site stays a plain function"
-        );
-    }
-
-    #[test]
-    fn highlighting_invalid_python_still_returns_a_real_non_empty_span_list() {
-        let spans = highlight_python("def (((( broken");
-        assert!(spans.iter().any(|span| span.kind == HighlightKind::Keyword));
-    }
 
     // ---------------------------------------------------------------------------------------
     // `tree-sitter-highlight` migration coverage.
@@ -4307,182 +4289,15 @@ mod tests {
 
     const SAMPLE_TOML: &str = "name = \"jerry\"\ncount = 3\nenabled = true\nbuilt = 1979-05-27\n";
 
-    #[test]
-    fn toml_key_is_classified_as_property() {
-        let spans = highlight_toml(SAMPLE_TOML);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_TOML, "name"),
-            HighlightKind::Property
-        );
-    }
-
-    #[test]
-    fn toml_string_value_is_classified_as_string() {
-        let spans = highlight_toml(SAMPLE_TOML);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_TOML, "\"jerry\""),
-            HighlightKind::String
-        );
-    }
-
-    #[test]
-    fn toml_boolean_is_classified_as_constant_builtin() {
-        let spans = highlight_toml(SAMPLE_TOML);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_TOML, "true"),
-            HighlightKind::ConstantBuiltin
-        );
-    }
-
-    /// `(local_date) @string.special` - its own dedicated bucket since GitHub issue #183
-    /// (previously fell through to the plain `"string"` entry).
-    #[test]
-    fn toml_date_literal_is_classified_as_string_special() {
-        let spans = highlight_toml(SAMPLE_TOML);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_TOML, "1979-05-27"),
-            HighlightKind::StringSpecial
-        );
-    }
-
     const SAMPLE_GO: &str =
         "package main\n\nfunc add(x int) int {\n\treturn len(fmt.Sprint(x))\n}\n";
 
-    #[test]
-    fn go_func_keyword_is_classified_as_keyword() {
-        let spans = highlight_go(SAMPLE_GO);
-        assert_eq!(kind_at(&spans, SAMPLE_GO, "func"), HighlightKind::Keyword);
-    }
-
-    #[test]
-    fn go_function_definition_name_is_classified_as_function() {
-        let spans = highlight_go(SAMPLE_GO);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_GO, "add"),
-            HighlightKind::FunctionDefinition
-        );
-    }
-
-    /// `@function.builtin` (`len`) - its own dedicated bucket since GitHub issue #183 (previously
-    /// fell through to the plain `"function"` entry's subset match, same as a call to `add`).
-    #[test]
-    fn go_builtin_function_call_is_classified_as_function_builtin() {
-        let spans = highlight_go(SAMPLE_GO);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_GO, "len("),
-            HighlightKind::FunctionBuiltin
-        );
-    }
-
     const SAMPLE_JSON: &str = "{\n  \"name\": \"jerry\",\n  \"count\": 3\n}\n";
-
-    #[test]
-    fn json_object_key_is_classified_as_property_not_string() {
-        let spans = highlight_json(SAMPLE_JSON);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_JSON, "\"name\""),
-            HighlightKind::Property,
-            "a real JSON key must win the more-specific string.special.key registration over \
-             the plain string entry"
-        );
-    }
-
-    #[test]
-    fn json_string_value_is_classified_as_string_not_property() {
-        let spans = highlight_json(SAMPLE_JSON);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_JSON, "\"jerry\""),
-            HighlightKind::String
-        );
-    }
-
-    #[test]
-    fn json_number_value_is_classified_as_number() {
-        let spans = highlight_json(SAMPLE_JSON);
-        assert_eq!(kind_at(&spans, SAMPLE_JSON, "3"), HighlightKind::Number);
-    }
 
     const SAMPLE_YAML: &str = "anchor: &base\n  enabled: true\nalias: *base\ncount: 3\n";
 
-    #[test]
-    fn yaml_key_is_classified_as_property() {
-        let spans = highlight_yaml(SAMPLE_YAML);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_YAML, "count"),
-            HighlightKind::Property
-        );
-    }
-
-    #[test]
-    fn yaml_boolean_is_classified_as_constant_builtin() {
-        let spans = highlight_yaml(SAMPLE_YAML);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_YAML, "true"),
-            HighlightKind::ConstantBuiltin
-        );
-    }
-
-    /// `(anchor_name) @label` - the cross-language `"label"` registration's YAML half, its own
-    /// dedicated bucket since GitHub issue #183 (its C half is a goto target - see
-    /// `c_goto_label_is_classified_as_label` below; previously both fell through to
-    /// `Variable`).
-    #[test]
-    fn yaml_anchor_name_is_classified_as_label() {
-        let spans = highlight_yaml(SAMPLE_YAML);
-        assert_eq!(kind_at(&spans, SAMPLE_YAML, "base\n"), HighlightKind::Label);
-    }
-
-    /// `"&"/"*" @punctuation.special` - its own dedicated bucket since GitHub issue #183
-    /// (previously fell through to `Operator`).
-    #[test]
-    fn yaml_anchor_and_alias_sigils_are_classified_as_punctuation_special() {
-        let spans = highlight_yaml(SAMPLE_YAML);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_YAML, "&base"),
-            HighlightKind::PunctuationSpecial
-        );
-        assert_eq!(
-            kind_at(&spans, SAMPLE_YAML, "*base"),
-            HighlightKind::PunctuationSpecial
-        );
-    }
-
     const SAMPLE_C: &str =
         "int add(int x) {\n  int total = 0;\n  goto done;\n done:\n  return total;\n}\n";
-
-    #[test]
-    fn c_keyword_is_classified_as_keyword() {
-        let spans = highlight_c(SAMPLE_C);
-        assert_eq!(kind_at(&spans, SAMPLE_C, "return"), HighlightKind::Keyword);
-    }
-
-    #[test]
-    fn c_function_definition_name_is_classified_as_function() {
-        let spans = highlight_c(SAMPLE_C);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_C, "add"),
-            HighlightKind::FunctionDefinition
-        );
-    }
-
-    /// `(statement_identifier) @label` - the `"label"` registration's C half (a goto target, not
-    /// a lifetime - see [`HighlightKind::Label`]'s own docs on the cross-language unification).
-    #[test]
-    fn c_goto_label_is_classified_as_label() {
-        let spans = highlight_c(SAMPLE_C);
-        assert_eq!(kind_at(&spans, SAMPLE_C, "done:"), HighlightKind::Label);
-    }
-
-    /// `";" @delimiter` - the new, plain `"delimiter"` registration, distinct from the
-    /// already-registered `"punctuation.delimiter"`.
-    #[test]
-    fn c_semicolon_is_classified_as_punctuation_delimiter() {
-        let spans = highlight_c(SAMPLE_C);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_C, ";"),
-            HighlightKind::PunctuationDelimiter
-        );
-    }
 
     const SAMPLE_MARKDOWN: &str = "# Title\n\nSome **bold** and *italic* text with `inline code` and a [link](https://example.com).\n\n```rust\nfn main() {}\n```\n";
 
@@ -4498,57 +4313,6 @@ mod tests {
             spans.iter().any(|span| span.kind != HighlightKind::Text),
             "a real markdown document must produce at least one non-Text span - if this fails, \
              the inline grammar injection isn't firing at all"
-        );
-    }
-
-    #[test]
-    fn markdown_heading_text_is_classified_as_heading() {
-        let spans = highlight_markdown(SAMPLE_MARKDOWN);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_MARKDOWN, "Title"),
-            HighlightKind::Heading
-        );
-    }
-
-    #[test]
-    fn markdown_bold_text_is_classified_as_strong() {
-        let spans = highlight_markdown(SAMPLE_MARKDOWN);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_MARKDOWN, "bold"),
-            HighlightKind::Strong
-        );
-    }
-
-    #[test]
-    fn markdown_italic_text_is_classified_as_emphasis() {
-        let spans = highlight_markdown(SAMPLE_MARKDOWN);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_MARKDOWN, "italic"),
-            HighlightKind::Emphasis
-        );
-    }
-
-    #[test]
-    fn markdown_inline_code_is_classified_as_literal_string() {
-        let spans = highlight_markdown(SAMPLE_MARKDOWN);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_MARKDOWN, "inline code"),
-            HighlightKind::String
-        );
-    }
-
-    #[test]
-    fn markdown_link_destination_and_label_are_classified_as_link() {
-        let spans = highlight_markdown(SAMPLE_MARKDOWN);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_MARKDOWN, "https://example.com"),
-            HighlightKind::Link,
-            "the link destination"
-        );
-        assert_eq!(
-            kind_at(&spans, SAMPLE_MARKDOWN, "link"),
-            HighlightKind::Link,
-            "the link's own visible label text"
         );
     }
 
@@ -4693,72 +4457,36 @@ mod tests {
         );
     }
 
-    /// `(color_value) @string.special` gets its own real bucket since GitHub issue #183
-    /// (previously fell through to the plain `"string"` entry), and must **not** resolve through
-    /// the more specific `"string.special.key"` one that JSON registers: the recognized-name rule
-    /// requires every one of a recognized name's own dot-parts to be present in the capture, and
-    /// `key` is not present in `string.special`.
-    #[test]
-    fn css_color_literal_is_a_string_special_not_a_json_style_key() {
-        let spans = highlight_css(SAMPLE_CSS);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_CSS, "ff0000"),
-            HighlightKind::StringSpecial
-        );
-    }
-
     const SAMPLE_MARKDOWN_FENCES: &str = "# Fences\n\n```html\n<div class=\"card\">hi</div>\n```\n\n```css\n.card { color: red; }\n```\n\n```rust\nfn main() {}\n```\n\n```zig\nconst x = 1;\n```\n\n```\nplain fence\n```\n";
 
-    /// GitHub issue #154's own headline ask - "including in the markdown files". A ` ```html `
-    /// fence's *content* really is reparsed by `tree-sitter-html`: `div` comes out
-    /// [`Tag`](HighlightKind::Tag), which no markdown query has any rule capable of producing.
+    /// GitHub issue #154's own headline ask - "including in the markdown files". A tagged
+    /// fence's *content* really is reparsed by that tag's own grammar, and each of these buckets
+    /// is one no markdown query has any rule capable of producing.
+    ///
+    /// Three languages in one table because that is the point: the same injection query resolves
+    /// all of them, with no per-language code anywhere in [`MARKDOWN_INJECTION_QUERY`] or
+    /// [`Grammar::for_injection_name`]. The ` ```rust ` rows also cover the fence's very first
+    /// token, which is exactly the one a parent highlight left open over the injected range
+    /// would silently steal.
     #[test]
-    fn a_markdown_html_fence_really_highlights_its_content_as_html() {
+    fn a_tagged_markdown_fence_really_highlights_its_content_with_that_languages_grammar() {
         let spans = highlight_markdown(SAMPLE_MARKDOWN_FENCES);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_MARKDOWN_FENCES, "div class"),
-            HighlightKind::Tag
-        );
-        assert_eq!(
-            kind_at(&spans, SAMPLE_MARKDOWN_FENCES, "class="),
-            HighlightKind::Attribute
-        );
-        assert_eq!(
-            kind_at(&spans, SAMPLE_MARKDOWN_FENCES, "card\">"),
-            HighlightKind::String
-        );
-    }
-
-    #[test]
-    fn a_markdown_css_fence_really_highlights_its_content_as_css() {
-        let spans = highlight_markdown(SAMPLE_MARKDOWN_FENCES);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_MARKDOWN_FENCES, "card { "),
-            HighlightKind::Property,
-            "the class selector inside the ```css fence"
-        );
-        assert_eq!(
-            kind_at(&spans, SAMPLE_MARKDOWN_FENCES, "color: red"),
-            HighlightKind::Property
-        );
-    }
-
-    /// The proof that this is a real, general mechanism rather than an html/css special case: the
-    /// exact same injection query resolves ` ```rust ` too, with no Rust-specific code anywhere in
-    /// [`MARKDOWN_INJECTION_QUERY`] or [`Grammar::for_injection_name`].
-    #[test]
-    fn a_markdown_rust_fence_really_highlights_its_content_as_rust() {
-        let spans = highlight_markdown(SAMPLE_MARKDOWN_FENCES);
-        assert_eq!(
-            kind_at(&spans, SAMPLE_MARKDOWN_FENCES, "fn main"),
-            HighlightKind::Keyword,
-            "the `fn` keyword - the first token of the fence's content, which is exactly the one \
-             a parent highlight left open over the injected range would silently steal"
-        );
-        assert_eq!(
-            kind_at(&spans, SAMPLE_MARKDOWN_FENCES, "main()"),
-            HighlightKind::FunctionDefinition
-        );
+        let cases: &[(&str, &str, HighlightKind)] = &[
+            ("html tag name", "div class", HighlightKind::Tag),
+            ("html attribute", "class=", HighlightKind::Attribute),
+            ("html attribute value", "card\">", HighlightKind::String),
+            ("css class selector", "card { ", HighlightKind::Property),
+            ("css declaration", "color: red", HighlightKind::Property),
+            ("rust keyword", "fn main", HighlightKind::Keyword),
+            ("rust fn name", "main()", HighlightKind::FunctionDefinition),
+        ];
+        for (label, token, expected) in cases {
+            assert_eq!(
+                kind_at(&spans, SAMPLE_MARKDOWN_FENCES, token),
+                *expected,
+                "{label}"
+            );
+        }
     }
 
     /// The honest fallback, both halves of it: a fence tagged with a language this app has no

--- a/crates/app/src/code_surface/diff_view.rs
+++ b/crates/app/src/code_surface/diff_view.rs
@@ -3,12 +3,14 @@
 
 use super::zoom::zoom_scoped;
 use super::*;
-use crate::review_notes::{NoteAnchor, NoteMark};
 #[cfg(test)]
-use crate::root::focus::palette_focus_tests;
+use crate::code_surface::fixtures::temp_repo;
+use crate::review_notes::{NoteAnchor, NoteMark};
 use crate::root::plural;
 use crate::root::scrollbar;
 use crate::root::widgets::render_sidebar_message;
+#[cfg(test)]
+use crate::test_support::open_test_app;
 use std::rc::Rc;
 
 /// Every row of the Diff view's virtualized list, in the flat order it scrolls in - built once
@@ -1121,22 +1123,7 @@ pub(in crate::code_surface) struct DiffLineChrome<'a> {
 mod diff_render_tests {
     use super::*;
     use gpui::TestAppContext;
-
-    fn git(dir: &std::path::Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
+    use test_support::git;
 
     /// Renders a real diff of a real `.rs` file (one line changed - a real, git-produced
     /// context/removed/added hunk) and checks real things about the result: every row really
@@ -1145,10 +1132,8 @@ mod diff_render_tests {
     /// keyword and the changed integer literal - not flat, uncoloured text.
     #[gpui::test]
     fn opening_a_real_diff_renders_real_syntax_highlighted_rows(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
+        let repo = temp_repo();
+        test_support::seed_empty_repo_at(repo.path());
         std::fs::write(
             repo.path().join("sample.rs"),
             "fn add(x: i32) -> i32 {\n    x + 1\n}\n",
@@ -1163,7 +1148,7 @@ mod diff_render_tests {
         )
         .expect("rewrite sample.rs");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         app.update_in(cx, |app, window, cx| {
@@ -1224,10 +1209,8 @@ mod diff_render_tests {
     fn repeated_refreshes_of_the_same_open_diff_reuse_the_cached_highlighting(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
+        let repo = temp_repo();
+        test_support::seed_empty_repo_at(repo.path());
         std::fs::write(
             repo.path().join("sample.rs"),
             "fn add() -> i32 {\n    1\n}\n",
@@ -1242,7 +1225,7 @@ mod diff_render_tests {
         )
         .expect("rewrite sample.rs");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         app.update_in(cx, |app, window, cx| {
             app.open_change_diff(PathBuf::from("sample.rs"), window, cx);
@@ -1282,10 +1265,8 @@ mod diff_render_tests {
     fn switching_the_open_diff_to_a_different_file_recomputes_the_highlight_cache(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
+        let repo = temp_repo();
+        test_support::seed_empty_repo_at(repo.path());
         std::fs::write(repo.path().join("a.rs"), "fn a() -> i32 {\n    1\n}\n")
             .expect("write a.rs");
         std::fs::write(repo.path().join("b.py"), "def b():\n    return 1\n").expect("write b.py");
@@ -1296,7 +1277,7 @@ mod diff_render_tests {
             .expect("rewrite a.rs");
         std::fs::write(repo.path().join("b.py"), "def b():\n    return 2\n").expect("rewrite b.py");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         app.update_in(cx, |app, window, cx| {
             app.open_change_diff(PathBuf::from("a.rs"), window, cx);
@@ -1356,10 +1337,8 @@ mod diff_render_tests {
     fn a_diff_past_the_rendered_line_cap_still_highlights_every_line_it_actually_renders(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
+        let repo = temp_repo();
+        test_support::seed_empty_repo_at(repo.path());
         std::fs::write(repo.path().join("big.rs"), "fn noop() {}\n").expect("write big.rs");
         git(repo.path(), &["add", "."]);
         git(repo.path(), &["commit", "-m", "initial"]);
@@ -1371,7 +1350,7 @@ mod diff_render_tests {
         }
         std::fs::write(repo.path().join("big.rs"), &content).expect("rewrite big.rs");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         app.update_in(cx, |app, window, cx| {
             app.open_change_diff(PathBuf::from("big.rs"), window, cx);
@@ -1814,27 +1793,7 @@ mod diff_row_plan_tests {
 mod diff_virtualization_tests {
     use super::*;
     use gpui::{Entity, TestAppContext};
-
-    fn git(dir: &std::path::Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn init_repo(dir: &std::path::Path) {
-        git(dir, &["init", "-b", "main"]);
-        git(dir, &["config", "user.email", "test@example.com"]);
-        git(dir, &["config", "user.name", "Test User"]);
-    }
+    use test_support::git;
 
     /// A real repository whose working tree differs from its committed base by `added` brand-new
     /// lines in one file - a single real git hunk, `added` lines long.
@@ -1844,7 +1803,7 @@ mod diff_virtualization_tests {
     /// `rems(1.6)` row height (about 21px at the default editor font size) only on the order of
     /// 50 rows can be on screen at once - far fewer than either number.
     fn seed_big_diff(dir: &std::path::Path, added: usize) {
-        init_repo(dir);
+        test_support::seed_empty_repo_at(dir);
         std::fs::write(dir.join("big.rs"), "fn noop() {}\n").expect("write big.rs");
         git(dir, &["add", "."]);
         git(dir, &["commit", "-m", "initial"]);
@@ -1860,7 +1819,7 @@ mod diff_virtualization_tests {
     /// of a 60-line file - two real git hunks with a real unchanged span between them, which is
     /// what makes `changes::fold_gap_between` produce a genuine `⋯ N unchanged lines` row.
     fn seed_two_hunk_diff(dir: &std::path::Path) {
-        init_repo(dir);
+        test_support::seed_empty_repo_at(dir);
         let original: String = (1..=60).map(|n| format!("fn f{n}() {{ {n} }}\n")).collect();
         std::fs::write(dir.join("two.rs"), &original).expect("write two.rs");
         git(dir, &["add", "."]);
@@ -1883,7 +1842,7 @@ mod diff_virtualization_tests {
         repo: &std::path::Path,
         path: &str,
     ) -> (Entity<AdeApp>, &'a mut gpui::VisualTestContext) {
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.to_path_buf());
         cx.run_until_parked();
         let path = PathBuf::from(path);
         app.update_in(cx, |app, window, cx| {
@@ -1907,7 +1866,7 @@ mod diff_virtualization_tests {
 
     #[gpui::test]
     fn a_diff_line_far_below_the_viewport_is_never_painted(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         seed_big_diff(repo.path(), 350);
         let (_app, cx) = open_diff_on(cx, repo.path(), "big.rs");
 
@@ -1933,7 +1892,7 @@ mod diff_virtualization_tests {
     fn scrolling_the_virtualized_diff_materializes_a_row_that_was_not_painted(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         seed_big_diff(repo.path(), 350);
         let (_app, cx) = open_diff_on(cx, repo.path(), "big.rs");
 
@@ -1968,7 +1927,7 @@ mod diff_virtualization_tests {
     /// warning.
     #[gpui::test]
     fn hunk_headers_and_fold_markers_paint_at_the_shared_row_height(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         seed_two_hunk_diff(repo.path());
         let (app, cx) = open_diff_on(cx, repo.path(), "two.rs");
 
@@ -2037,7 +1996,7 @@ mod diff_virtualization_tests {
     fn the_truncation_notice_is_the_last_item_of_the_list_at_the_shared_row_height(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         seed_big_diff(repo.path(), 350);
         let (_app, cx) = open_diff_on(cx, repo.path(), "big.rs");
 
@@ -2078,7 +2037,7 @@ mod diff_virtualization_tests {
     /// must still get none, so this can't pass by drawing a scrollbar unconditionally.
     #[gpui::test]
     fn the_overlay_scrollbar_still_tracks_the_virtualized_list(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         seed_big_diff(repo.path(), 350);
         let (app, cx) = open_diff_on(cx, repo.path(), "big.rs");
         // The scrollbar is built from the geometry the *previous* frame's layout wrote onto the
@@ -2094,8 +2053,8 @@ mod diff_virtualization_tests {
         );
 
         // A diff that genuinely fits must still get no scrollbar at all.
-        let small = tempfile::tempdir().expect("tempdir");
-        init_repo(small.path());
+        let small = temp_repo();
+        test_support::seed_empty_repo_at(small.path());
         std::fs::write(small.path().join("small.rs"), "fn a() -> i32 {\n    1\n}\n")
             .expect("write small.rs");
         git(small.path(), &["add", "."]);
@@ -2133,7 +2092,7 @@ mod diff_virtualization_tests {
     fn every_virtualized_row_resolves_its_own_line_through_the_identity_guard(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         seed_two_hunk_diff(repo.path());
         let (app, cx) = open_diff_on(cx, repo.path(), "two.rs");
 

--- a/crates/app/src/code_surface/edit_buffer.rs
+++ b/crates/app/src/code_surface/edit_buffer.rs
@@ -3006,23 +3006,18 @@ impl QueryBuilder {
         assert_eq!(buf.content, "    a;\n    \nb;\n\n");
     }
 
+    /// The three positions worth pinning: an empty buffer's only offset, the very last byte, and
+    /// a line boundary (which resolves to the *start of the next* line, not the end of the
+    /// previous one).
     #[test]
-    fn line_col_for_offset_at_the_very_start_of_an_empty_file_is_zero_zero() {
-        let buf = buffer("");
-        assert_eq!(buf.line_col_for_offset(0), (0, 0));
-    }
+    fn line_col_for_offset_resolves_the_documented_edge_positions() {
+        assert_eq!(buffer("").line_col_for_offset(0), (0, 0));
 
-    #[test]
-    fn line_col_for_offset_at_the_very_end_of_the_file() {
-        let buf = buffer("abc\ndef");
-        assert_eq!(buf.line_col_for_offset(7), (1, 3));
-    }
-
-    #[test]
-    fn line_col_for_offset_exactly_on_a_line_boundary_is_the_start_of_the_next_line() {
         let buf = buffer("abc\ndef");
         // Byte 4 is 'd', the first byte of line 1.
-        assert_eq!(buf.line_col_for_offset(4), (1, 0));
+        for (offset, expected) in [(4usize, (1usize, 0usize)), (7, (1, 3))] {
+            assert_eq!(buf.line_col_for_offset(offset), expected, "offset {offset}");
+        }
     }
 
     #[test]

--- a/crates/app/src/code_surface/editing.rs
+++ b/crates/app/src/code_surface/editing.rs
@@ -55,6 +55,8 @@ use crate::code_surface::blame;
 use crate::code_surface::blame_view::render_inline_blame_span;
 use crate::code_surface::code_view;
 use crate::code_surface::edit_buffer::EditBuffer;
+#[cfg(test)]
+use crate::code_surface::fixtures::temp_repo;
 use crate::code_surface::indent;
 use crate::code_surface::lsp_ui::{
     diagnostic_row_bg, diagnostic_underline_color, render_inline_diagnostic_message,
@@ -71,6 +73,8 @@ use crate::root::{
     EditorSkipOccurrence, EditorUp, EditorWordLeft, EditorWordRight, TextRedo, TextUndo,
 };
 use crate::settings::store as settings_store;
+#[cfg(test)]
+use crate::test_support::open_test_app;
 use crate::theme;
 
 /// How long after the last keystroke [`AdeApp::schedule_rehighlight`] waits before running a real
@@ -2532,7 +2536,6 @@ mod caret_paint_quad_tests {
 mod editing_tests {
     use super::*;
     use crate::code_surface::{DiffBase, DiffLoadState};
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
 
     fn write_file(repo: &std::path::Path, name: &str, content: &str) -> PathBuf {
@@ -2583,9 +2586,9 @@ mod editing_tests {
     fn typing_changes_real_content_and_updates_syntax_highlighting_after_the_debounce(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.rs", "foo(x: i32) {}\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         let relative = PathBuf::from("sample.rs");
 
@@ -2690,9 +2693,9 @@ mod editing_tests {
     /// driven through the real, bound `EditorRight` keystroke, not a direct method call.
     #[gpui::test]
     fn arrow_keys_move_the_real_caret_and_cross_a_real_line_boundary(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "ab\ncd\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.txt");
@@ -2733,9 +2736,9 @@ mod editing_tests {
     /// `EditorSelectRight` keystroke.
     #[gpui::test]
     fn shift_arrow_extends_a_real_selection_through_the_real_key_bindings(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "hello\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.txt");
@@ -2760,9 +2763,9 @@ mod editing_tests {
     fn ctrl_shift_arrow_extends_a_real_selection_word_wise_through_the_real_key_bindings(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "hello world\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.txt");
@@ -2810,9 +2813,9 @@ mod editing_tests {
     fn double_click_selects_the_real_word_and_triple_click_selects_the_real_line(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "hello world\nsecond line\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         let relative = PathBuf::from("sample.txt");
 
@@ -2869,9 +2872,9 @@ mod editing_tests {
     /// functionality" rule targets).
     #[gpui::test]
     fn an_indented_lines_indent_guide_paints_when_the_setting_is_on(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.rs", "fn main() {\n    let x = 1;\n}\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         assert!(
             app.read_with(cx, |app, _| app.settings.appearance.show_indent_guides),
             "sanity check: the real default is guides on"
@@ -2890,9 +2893,9 @@ mod editing_tests {
     /// setting *could* gate it.
     #[gpui::test]
     fn no_indent_guide_paints_when_the_setting_is_off(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.rs", "fn main() {\n    let x = 1;\n}\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, _cx| {
             app.settings.appearance.show_indent_guides = false;
         });
@@ -2921,10 +2924,10 @@ mod editing_tests {
     fn selection_survives_a_row_scrolling_out_of_the_virtualized_range_and_back(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let many_lines: String = (0..500).map(|n| format!("line {n}\n")).collect();
         let file_path = write_file(repo.path(), "sample.txt", &many_lines);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         let relative = PathBuf::from("sample.txt");
 
@@ -3000,9 +3003,9 @@ mod editing_tests {
     fn ctrl_d_through_real_key_bindings_adds_a_cursor_and_typing_fans_out_to_both(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "value + value\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.txt");
@@ -3048,9 +3051,9 @@ mod editing_tests {
     /// `EditorSelectAllOccurrences` keystroke selects every real occurrence at once.
     #[gpui::test]
     fn ctrl_shift_l_through_real_key_bindings_selects_every_occurrence(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "value + value + value\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.txt");
@@ -3078,9 +3081,9 @@ mod editing_tests {
     fn ctrl_k_ctrl_d_through_real_key_bindings_skips_without_adding_a_cursor(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "value + value\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.txt");
@@ -3105,9 +3108,9 @@ mod editing_tests {
     /// `EditorCollapseCursors` keystroke collapses back to a single cursor.
     #[gpui::test]
     fn escape_through_real_key_bindings_collapses_multi_cursor_state(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "value + value\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.txt");
@@ -3143,9 +3146,9 @@ mod editing_tests {
     fn backspace_and_delete_remove_real_text_through_the_real_key_bindings(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "abc\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.txt");
@@ -3180,9 +3183,9 @@ mod editing_tests {
     /// the real dirty flag - driven through the real, bound `EditorSave` keystroke.
     #[gpui::test]
     fn editor_save_writes_real_content_to_disk_and_clears_the_dirty_flag(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "hello\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.txt");
@@ -3222,9 +3225,9 @@ mod editing_tests {
     fn external_change_while_dirty_is_detected_and_blocks_save_without_overwriting_either_version(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "original\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         let relative = PathBuf::from("sample.txt");
 
@@ -3236,7 +3239,11 @@ mod editing_tests {
         // A real external change, bypassing this app entirely.
         std::fs::write(&file_path, "changed on disk, a completely different size\n")
             .expect("external rewrite");
-        std::thread::sleep(crate::root::FILE_FRESHNESS_CHECK_INTERVAL + Duration::from_millis(50));
+        // Force the throttled freshness check to run now, instead of waiting out its real
+        // wall-clock interval.
+        app.update(cx, |app, _| {
+            app.file_view_last_freshness_check = None;
+        });
 
         app.update(cx, |app, cx| {
             app.render_center_pane(cx);
@@ -3274,9 +3281,9 @@ mod editing_tests {
     fn a_save_with_no_external_interference_is_not_falsely_flagged_as_a_conflict(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "hello\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         let relative = PathBuf::from("sample.txt");
 
@@ -3296,22 +3303,6 @@ mod editing_tests {
         assert_eq!(on_disk, "well hello\n");
     }
 
-    /// `.output()`, not `.status()` - see `crate::sidebar::render::virtualization_tests::git`'s
-    /// own comment for why (a 40-line "create mode 100644" dump would otherwise land in every
-    /// test run's output here too).
-    fn git(dir: &std::path::Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .args(args)
-            .current_dir(dir)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {args:?} failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
     /// GitHub issue #89 ("Changes not showing in editor and file tree"): saving a file never
     /// called `AdeApp::load_diff`, so `AdeApp::diff_state` - the one thing both the file tree's
     /// "M"/"A" marks (`crate::sidebar::render::tree_change_marks`) and the Changes/diff view
@@ -3325,17 +3316,15 @@ mod editing_tests {
     /// reloaded `diff_state` reports the file as changed without any other trigger in between.
     #[gpui::test]
     fn saving_a_file_immediately_refreshes_diff_state_for_issue_89(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
+        let repo = temp_repo();
+        test_support::seed_empty_repo_at(repo.path());
         let file_path = write_file(repo.path(), "sample.txt", "one\ntwo\nthree\n");
-        git(repo.path(), &["add", "."]);
-        git(repo.path(), &["commit", "-m", "initial"]);
-        git(repo.path(), &["checkout", "-b", "feature"]);
+        test_support::git(repo.path(), &["add", "."]);
+        test_support::git(repo.path(), &["commit", "-m", "initial"]);
+        test_support::git(repo.path(), &["checkout", "-b", "feature"]);
         let relative = PathBuf::from("sample.txt");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let changed_before_edit = app.read_with(cx, |app, _| match &app.diff_state {
@@ -3392,9 +3381,9 @@ mod editing_tests {
     fn the_conflict_flag_does_not_self_clear_once_file_view_cache_catches_up_while_still_dirty(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "original\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         let relative = PathBuf::from("sample.txt");
 
@@ -3403,7 +3392,11 @@ mod editing_tests {
         });
 
         std::fs::write(&file_path, "changed on disk\n").expect("external rewrite");
-        std::thread::sleep(crate::root::FILE_FRESHNESS_CHECK_INTERVAL + Duration::from_millis(50));
+        // Force the throttled freshness check to run now, instead of waiting out its real
+        // wall-clock interval.
+        app.update(cx, |app, _| {
+            app.file_view_last_freshness_check = None;
+        });
 
         // First real freshness check: detects the conflict, and dispatches (then resolves) a
         // real background reload that catches `file_view_cache` up to the new disk content.
@@ -3419,7 +3412,11 @@ mod editing_tests {
         // A second full throttle interval, with the buffer still dirty and disk still not
         // matching the buffer's own load-time snapshot - `file_view_cache` is now fresh (it
         // caught up above), but the real conflict has not actually been resolved.
-        std::thread::sleep(crate::root::FILE_FRESHNESS_CHECK_INTERVAL + Duration::from_millis(50));
+        // Force the throttled freshness check to run now, instead of waiting out its real
+        // wall-clock interval.
+        app.update(cx, |app, _| {
+            app.file_view_last_freshness_check = None;
+        });
         app.update(cx, |app, cx| {
             app.render_center_pane(cx);
         });
@@ -3443,9 +3440,9 @@ mod editing_tests {
     fn replace_and_mark_text_in_range_records_a_real_composition_and_unmark_clears_it(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "ab\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         let relative = PathBuf::from("sample.txt");
 
@@ -3488,33 +3485,15 @@ mod editing_tests {
     /// actions to the `"file-editor"` key context rather than binding them globally.
     #[gpui::test]
     fn editor_actions_are_a_safe_no_op_while_the_diff_view_is_active(cx: &mut TestAppContext) {
-        fn git(dir: &std::path::Path, args: &[&str]) {
-            let output = std::process::Command::new("git")
-                .current_dir(dir)
-                .args(args)
-                .output()
-                .expect("failed to spawn git");
-            assert!(
-                output.status.success(),
-                "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-                args,
-                dir,
-                String::from_utf8_lossy(&output.stdout),
-                String::from_utf8_lossy(&output.stderr)
-            );
-        }
-
-        let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
+        let repo = temp_repo();
+        test_support::seed_empty_repo_at(repo.path());
         write_file(repo.path(), "sample.rs", "fn add() -> i32 {\n    1\n}\n");
-        git(repo.path(), &["add", "."]);
-        git(repo.path(), &["commit", "-m", "initial"]);
-        git(repo.path(), &["checkout", "-b", "feature"]);
+        test_support::git(repo.path(), &["add", "."]);
+        test_support::git(repo.path(), &["commit", "-m", "initial"]);
+        test_support::git(repo.path(), &["checkout", "-b", "feature"]);
         write_file(repo.path(), "sample.rs", "fn add() -> i32 {\n    2\n}\n");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         app.update_in(cx, |app, window, cx| {
             app.open_change_diff(PathBuf::from("sample.rs"), window, cx);
@@ -3571,13 +3550,13 @@ mod editing_tests {
     fn clicking_a_real_editable_row_places_the_real_cursor_without_panicking(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(
             repo.path(),
             "sample.txt",
             "a short line\nworld, a longer real line of text\n",
         );
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         let relative = PathBuf::from("sample.txt");
 
@@ -3637,13 +3616,13 @@ mod editing_tests {
     fn clicking_past_the_end_of_a_short_line_places_the_cursor_at_the_end_of_that_line(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(
             repo.path(),
             "sample.txt",
             "a short line\nworld, a longer real line of text that runs on for a while\n",
         );
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         let relative = PathBuf::from("sample.txt");
 
@@ -3687,9 +3666,9 @@ mod editing_tests {
     /// anywhere but the very first pixel column to hit-test against.
     #[gpui::test]
     fn clicking_on_a_real_blank_line_places_the_cursor_there(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "first\n\nthird\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         let relative = PathBuf::from("sample.txt");
 
@@ -3727,9 +3706,9 @@ mod editing_tests {
     fn clicking_below_the_last_line_places_the_cursor_at_the_end_of_the_buffer(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "one\ntwo\nthree");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         let relative = PathBuf::from("sample.txt");
 
@@ -3777,12 +3756,12 @@ mod editing_tests {
     /// truncated file.
     #[gpui::test]
     fn a_file_with_invalid_utf8_bytes_does_not_get_a_real_edit_buffer(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("binary.txt");
         // A lone UTF-8 continuation byte (0x80) is never valid on its own - real, genuinely
         // invalid UTF-8, not a contrived edge case.
         std::fs::write(&file_path, [b'h', b'i', 0x80, b'\n']).expect("write invalid-utf8 file");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         let relative = PathBuf::from("binary.txt");
 
@@ -3809,9 +3788,9 @@ mod editing_tests {
     /// the real, explicit, opt-in escape hatch this fixes it with.
     #[gpui::test]
     fn editor_save_anyway_resolves_a_real_permanently_stuck_conflict(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "original\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.txt");
@@ -3821,7 +3800,11 @@ mod editing_tests {
         });
 
         std::fs::write(&file_path, "changed on disk\n").expect("external rewrite");
-        std::thread::sleep(crate::root::FILE_FRESHNESS_CHECK_INTERVAL + Duration::from_millis(50));
+        // Force the throttled freshness check to run now, instead of waiting out its real
+        // wall-clock interval.
+        app.update(cx, |app, _| {
+            app.file_view_last_freshness_check = None;
+        });
         app.update(cx, |app, cx| {
             app.render_center_pane(cx);
         });
@@ -3896,9 +3879,9 @@ mod editing_tests {
     /// write and bump the file's real mtime for no reason.
     #[gpui::test]
     fn force_save_active_file_is_a_real_no_op_on_an_already_clean_buffer(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "hello\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         let relative = PathBuf::from("sample.txt");
 
@@ -3938,9 +3921,9 @@ mod editing_tests {
     fn a_pending_save_whose_buffer_vanished_before_the_writer_loop_checked_it_does_not_leak_file_save_running(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "hello\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         let relative = PathBuf::from("sample.txt");
 
@@ -4006,9 +3989,9 @@ mod editing_tests {
     fn real_cjk_ime_composition_with_a_non_default_caret_does_not_corrupt_the_selection_or_panic_on_the_next_keystroke(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "prefix ok\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         let relative = PathBuf::from("sample.txt");
 
@@ -4072,9 +4055,9 @@ mod editing_tests {
     fn a_literal_right_bracket_keystroke_reaches_the_real_edit_buffer_while_the_file_view_is_editing(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.rs", "abc\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.rs");
@@ -4115,9 +4098,9 @@ mod editing_tests {
     fn completions_keybindings_are_correctly_scoped_in_both_the_open_and_closed_state(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.rs", "ab\ncd\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.rs");
@@ -4335,9 +4318,9 @@ mod editing_tests {
     /// round trips is precisely what the issue asks for.
     #[gpui::test]
     fn typing_past_the_trigger_point_narrows_the_real_completions_list(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.rs", "let x = \n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.rs");
@@ -4400,9 +4383,9 @@ mod editing_tests {
     /// so this isn't passing by simply matching everything.
     #[gpui::test]
     fn a_real_non_contiguous_typed_prefix_still_matches_the_right_item(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.rs", "let x = \n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.rs");
@@ -4434,9 +4417,9 @@ mod editing_tests {
     fn keyboard_selection_stays_aligned_with_the_filtered_completions_view(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.rs", "let x = \n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.rs");
@@ -4493,85 +4476,23 @@ mod editing_tests {
         );
     }
 
-    /// GitHub issue #121, test (a): pressing a real `Enter` keystroke after an indented line
-    /// carries that exact same real leading whitespace over to the new line, through the real,
-    /// bound `EditorEnter` keystroke (not a direct handler call) - matching this file's own
-    /// established "simulate the real keystroke" precedent for `Enter` regression coverage (see
-    /// `completions_keybindings_are_correctly_scoped_in_both_the_open_and_closed_state` just
-    /// above).
-    #[gpui::test]
-    fn enter_carries_the_real_leading_whitespace_of_the_previous_line_over(
-        cx: &mut TestAppContext,
-    ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let file_path = write_file(repo.path(), "sample.rs", "fn main() {\n    let x = 1;\n}\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        open_file_for_editing(&app, cx, file_path.clone());
-        bind_real_keys(cx);
-        let relative = PathBuf::from("sample.rs");
-
-        app.update(cx, |app, cx| {
-            // Right after the `;`, before that line's own trailing newline.
-            app.edit_buffer_mut(&relative)
-                .unwrap()
-                .move_to("fn main() {\n    let x = 1;".len());
-            cx.notify();
-        });
-
-        cx.simulate_keystrokes("enter");
-
-        assert_eq!(
-            app.read_with(cx, |app, _| app
-                .edit_buffer(&relative)
-                .unwrap()
-                .content
-                .clone()),
-            "fn main() {\n    let x = 1;\n    \n}\n",
-            "the new line must start with the exact same real 4-space indentation the line \
-             above it had, read from the real buffer content"
-        );
-    }
-
-    /// GitHub issue #121, test (b): pressing `Enter` on a real column-0 line (no leading
-    /// whitespace at all) inserts a bare newline - no whitespace fabricated out of nowhere.
-    #[gpui::test]
-    fn enter_adds_no_whitespace_after_a_column_zero_line(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let file_path = write_file(repo.path(), "sample.rs", "foo();\nbar();\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        open_file_for_editing(&app, cx, file_path.clone());
-        bind_real_keys(cx);
-        let relative = PathBuf::from("sample.rs");
-
-        app.update(cx, |app, cx| {
-            app.edit_buffer_mut(&relative).unwrap().move_to(6); // end of "foo();"
-            cx.notify();
-        });
-
-        cx.simulate_keystrokes("enter");
-
-        assert_eq!(
-            app.read_with(cx, |app, _| app
-                .edit_buffer(&relative)
-                .unwrap()
-                .content
-                .clone()),
-            "foo();\n\nbar();\n",
-            "a column-0 line must not gain any real indentation it never had"
-        );
-    }
-
     /// GitHub issue #121, test (c) - stretch goal: `Enter` right after a real opening bracket
     /// adds one more real indent unit on top of the carried-over whitespace, using the exact same
     /// real indent-unit resolution (tabs/spaces/width) `Self::handle_editor_indent_action`'s own
     /// `Tab` uses - proven here by checking the inserted whitespace is real 4 literal spaces (the
     /// default `EditorSettings::tab_width`/`insert_spaces`, not a hardcoded `"    "` this test
     /// would pass even if the production code had a different, wrong hardcoded width).
+    ///
+    /// This is the *only* `Enter` test at this layer, deliberately: the individual auto-indent
+    /// rules (carry-over, column zero, Python's `:` header) are covered directly against
+    /// `EditBuffer::insert_newline_with_auto_indent`, and what a keystroke test adds over those
+    /// is the wiring - the bound `EditorEnter` reaching the handler with the real, settings-
+    /// derived indent unit, which the `tab_width = 2` half below is what actually proves.
     #[gpui::test]
     fn enter_adds_one_extra_real_indent_level_after_an_opening_bracket(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.rs", "fn main() {\n}\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.rs");
@@ -4615,40 +4536,6 @@ mod editing_tests {
         );
     }
 
-    /// GitHub issue #121, PR #136 review (Colin Espinas: "Missing indent when no opening
-    /// character is there like when we use ':' in python"): a real Python file's block header
-    /// ending in `:` (no opening bracket at all) must still get one extra real indent level,
-    /// the same way an opening bracket already does for every language.
-    #[gpui::test]
-    fn enter_adds_one_extra_real_indent_level_after_a_python_colon_header(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let file_path = write_file(repo.path(), "sample.py", "if True:\n    pass\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        open_file_for_editing(&app, cx, file_path.clone());
-        bind_real_keys(cx);
-        let relative = PathBuf::from("sample.py");
-
-        app.update(cx, |app, cx| {
-            app.edit_buffer_mut(&relative)
-                .unwrap()
-                .move_to("if True:".len());
-            cx.notify();
-        });
-
-        cx.simulate_keystrokes("enter");
-
-        assert_eq!(
-            app.read_with(cx, |app, _| app
-                .edit_buffer(&relative)
-                .unwrap()
-                .content
-                .clone()),
-            "if True:\n    \n    pass\n",
-            "a Python block header ending in ':' must add one real indent unit, exactly like \
-             an opening bracket does"
-        );
-    }
-
     /// Revision R8.5b audit finding 1's direct regression test: the sixth instance of this
     /// project's recurring "a keystroke gets swallowed" bug class. Before this fix, `Self::
     /// completions_open_for_active_path` returned `true` for *any* real [`CompletionsEntry`],
@@ -4664,9 +4551,9 @@ mod editing_tests {
     fn enter_and_down_are_not_swallowed_while_completions_are_merely_loading_or_failed(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.rs", "ab\ncd\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.rs");
@@ -4789,9 +4676,9 @@ mod editing_tests {
     fn a_real_typing_burst_undoes_and_redoes_as_one_step_through_the_real_key_bindings(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "ab\ncd\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.txt");
@@ -4840,9 +4727,9 @@ mod editing_tests {
     fn a_real_space_typed_into_the_file_view_is_text_not_the_stage_binding(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "ab\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.txt");
@@ -4864,9 +4751,9 @@ mod editing_tests {
     /// explicitly, and it is a literal `Ctrl` on every OS (see `crate::default_key_bindings`).
     #[gpui::test]
     fn ctrl_y_really_redoes_in_the_code_editor(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "ab\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.txt");
@@ -4883,9 +4770,9 @@ mod editing_tests {
     /// undo.
     #[gpui::test]
     fn secondary_z_in_the_code_editor_reaches_text_undo(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "ab\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.txt");
@@ -4913,9 +4800,9 @@ mod editing_tests {
     fn secondary_z_still_reaches_text_undo_while_the_completions_popup_is_open(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.rs", "ab\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.rs");
@@ -4958,10 +4845,10 @@ mod editing_tests {
     /// real tab-activation path rather than by poking `edit_buffers` directly.
     #[gpui::test]
     fn a_files_undo_history_survives_switching_to_another_tab_and_back(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let first = write_file(repo.path(), "first.txt", "one\n");
         let second = write_file(repo.path(), "second.txt", "two\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, first.clone());
         bind_real_keys(cx);
         let first_relative = PathBuf::from("first.txt");
@@ -5002,9 +4889,9 @@ mod editing_tests {
     /// real undo step with the pre-reload history still behind it.
     #[gpui::test]
     fn an_external_rewrite_of_a_clean_buffer_reloads_as_one_undoable_step(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "original\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.txt");
@@ -5023,8 +4910,9 @@ mod editing_tests {
             "sanity check: the buffer must really be clean before the external rewrite"
         );
 
-        // A real external writer rewrites the file, with a genuinely newer mtime.
-        std::thread::sleep(std::time::Duration::from_millis(20));
+        // A real external writer rewrites the file. No wait for a newer mtime is needed:
+        // `code_view::cache_is_fresh` compares length as well, and this content is a different
+        // length from what the buffer was loaded with.
         std::fs::write(&file_path, "rewritten by an agent\n").expect("external rewrite");
         // Force the throttled freshness check to run, then let the load it dispatches resolve.
         app.update(cx, |app, _| {
@@ -5066,9 +4954,9 @@ mod editing_tests {
     fn an_external_rewrite_of_a_dirty_buffer_leaves_the_buffer_and_its_history_untouched(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.txt", "original\n");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("sample.txt");
@@ -5076,7 +4964,8 @@ mod editing_tests {
         cx.simulate_input("MINE");
         assert!(app.read_with(cx, |app, _| app.edit_buffer(&relative).unwrap().is_dirty()));
 
-        std::thread::sleep(std::time::Duration::from_millis(20));
+        // A different length from the loaded content, so the freshness check below sees the
+        // rewrite without this test having to wait for a coarser mtime to tick over.
         std::fs::write(&file_path, "theirs\n").expect("external rewrite");
         app.update(cx, |app, _| {
             app.file_view_last_freshness_check = None;
@@ -5120,15 +5009,15 @@ mod editing_tests {
     fn switching_worktrees_and_back_preserves_unsaved_edits_without_cross_worktree_collision(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = tempfile::tempdir().expect("tempdir a");
-        let repo_b = tempfile::tempdir().expect("tempdir b");
+        let repo_a = temp_repo();
+        let repo_b = temp_repo();
         // Deliberately the *same* relative path in both worktrees - the real collision risk this
         // test exists to rule out.
         let file_a = write_file(repo_a.path(), "sample.txt", "worktree a original\n");
         let file_b = write_file(repo_b.path(), "sample.txt", "worktree b original\n");
         let relative = PathBuf::from("sample.txt");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo_a.path().to_path_buf());
         app.update(cx, |app, _cx| {
             app.worktrees = vec![
                 crate::rail::worktrees::WorktreeItem {
@@ -5244,13 +5133,13 @@ mod editing_tests {
     fn toggling_bracket_pair_colorization_re_highlights_an_already_open_buffer(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(
             repo.path(),
             "sample.rs",
             "fn main() { let v = vec![(1, 2)]; }\n",
         );
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
 
         let relative = PathBuf::from("sample.rs");
@@ -5333,14 +5222,14 @@ let last = 5;
     fn open_foldable_file(
         cx: &mut TestAppContext,
     ) -> (Entity<AdeApp>, &mut gpui::VisualTestContext, PathBuf) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let repo_path = repo.path().to_path_buf();
         // The tempdir must outlive the test body; every other test in this module keeps it in a
         // local, but these need the app *and* the context back, so it is leaked deliberately -
         // the process exits at the end of the test binary anyway.
         std::mem::forget(repo);
         let file_path = write_file(&repo_path, "sample.rs", FOLDABLE_SOURCE);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_path);
+        let (app, cx) = open_test_app(cx, repo_path);
         open_file_for_editing(&app, cx, file_path.clone());
         (app, cx, file_path)
     }
@@ -5631,10 +5520,10 @@ let last = 5;
     /// file opened in between is entirely unaffected.
     #[gpui::test]
     fn fold_state_is_per_file(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let folded_file = write_file(repo.path(), "sample.rs", FOLDABLE_SOURCE);
         let other_file = write_file(repo.path(), "other.rs", FOLDABLE_SOURCE);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         open_file_for_editing(&app, cx, folded_file.clone());
         click_fold_chevron(cx, 1);
@@ -5677,9 +5566,9 @@ let last = 5;
     /// silently do nothing at all.
     #[gpui::test]
     fn clicking_below_a_folded_files_content_still_reveals_the_caret_row(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.rs", LAST_LINE_FOLD_SOURCE);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
 
         click_fold_chevron(cx, 2);
@@ -5728,9 +5617,9 @@ let last = 5;
     /// expand it back into view.
     #[gpui::test]
     fn a_real_external_rewrite_clears_stale_fold_state_for_that_file(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_file(repo.path(), "sample.rs", FOLDABLE_SOURCE);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
 
         click_fold_chevron(cx, 1);
@@ -5755,9 +5644,11 @@ let last = 5;
             "fn alpha() {\n    let a = 1;\n    let b = 2;\n    let c = 3;\n}\n",
         )
         .expect("rewrite sample.rs");
-        std::thread::sleep(
-            crate::root::FILE_FRESHNESS_CHECK_INTERVAL + std::time::Duration::from_millis(50),
-        );
+        // Force the throttled freshness check to run now, instead of waiting out its real
+        // wall-clock interval.
+        app.update(cx, |app, _| {
+            app.file_view_last_freshness_check = None;
+        });
         app.update(cx, |app, cx| {
             app.render_center_pane(cx);
         });
@@ -5823,7 +5714,6 @@ let last = 5;
 #[cfg(test)]
 mod caret_alignment_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
 
     /// A deliberately dense single line: `tree-sitter` splits it into dozens of real runs
@@ -5840,12 +5730,13 @@ mod caret_alignment_tests {
         Entity<AdeApp>,
         &mut gpui::VisualTestContext,
         PathBuf,
-        tempfile::TempDir,
+        crate::code_surface::fixtures::TempRepo,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let file_path = repo.path().join("dense.rs");
+        let repo = temp_repo();
+        let root = repo.path().canonicalize().expect("canonical tempdir");
+        let file_path = root.join("dense.rs");
         std::fs::write(&file_path, format!("fn main() {{\n{DENSE_LINE}\n}}\n")).expect("write");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, root.clone());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path, window, cx);
         });
@@ -5936,13 +5827,13 @@ mod caret_alignment_tests {
     fn painted_code_text_matches_the_caret_shaping_for_real_multi_byte_text(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         // 2-byte Latin-1 accents, 3-byte CJK and a 4-byte emoji, all inside real Rust string
         // literals so `tree-sitter` still splits the line into several runs around them.
         let line = "    let s = \"café\" ; let t = \"日本語\" ; let u = \"🙂\" ;";
         let file_path = repo.path().join("unicode.rs");
         std::fs::write(&file_path, format!("fn main() {{\n{line}\n}}\n")).expect("write");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path, window, cx);
         });

--- a/crates/app/src/code_surface/file_view.rs
+++ b/crates/app/src/code_surface/file_view.rs
@@ -7,12 +7,14 @@ use super::lsp_ui::{
 };
 use super::zoom::zoom_scoped;
 use super::*;
-use crate::lsp::client::{lsp_file_status, LspFileStatus};
 #[cfg(test)]
-use crate::root::focus::palette_focus_tests;
+use crate::code_surface::fixtures::temp_repo;
+use crate::lsp::client::{lsp_file_status, LspFileStatus};
 use crate::root::plural;
 use crate::root::scrollbar;
 use crate::root::widgets::render_sidebar_message;
+#[cfg(test)]
+use crate::test_support::open_test_app;
 use std::collections::HashSet;
 
 impl AdeApp {
@@ -1863,13 +1865,13 @@ mod lsp_failed_status_chip_tests {
     async fn clicking_the_failed_status_chip_really_restarts_the_language_servers(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let root = repo.path().to_path_buf();
         std::fs::create_dir_all(root.join("src")).expect("mkdir src");
         let main_rs = root.join("src").join("main.rs");
         std::fs::write(&main_rs, "fn main() {}\n").expect("write main.rs");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx) = open_test_app(cx, root.clone());
         let key = (root.clone(), "rust-analyzer");
         app.update_in(cx, |app, window, cx| {
             // A real, already-recorded failure - exactly the state `reap_dead_lsp_clients` puts a

--- a/crates/app/src/code_surface/fixtures.rs
+++ b/crates/app/src/code_surface/fixtures.rs
@@ -1,0 +1,63 @@
+//! Test-only fixtures shared by this folder's own test modules.
+//!
+//! Owns exactly one thing: handing a test a repository root the app will agree with. Anything
+//! git-, wait- or process-shaped belongs in `crates/test-support` instead, and anything that
+//! opens a window in `crate::test_support`.
+
+use gpui::VisualTestContext;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+/// A real temporary directory whose [`Self::path`] is the root to hand
+/// [`crate::test_support::open_test_app`].
+///
+/// The path is canonicalized because `AdeApp` canonicalizes the repo root it is given
+/// ([`crate::rail::repo::canonical_repo_path`]) and then keys `edit_buffers`/`open_files` by
+/// `path.strip_prefix(file_tree_root)`. On macOS `std::env::temp_dir()` is itself behind a
+/// symlink (`/var` -> `/private/var`), so a fixture that builds file paths from
+/// `tempfile::TempDir::path()` verbatim produces paths that cannot be stripped against the root
+/// the app resolved, and every worktree-relative lookup in the test then silently misses.
+pub(in crate::code_surface) struct TempRepo {
+    /// Held for its `Drop`; the directory is removed when this value is.
+    _dir: tempfile::TempDir,
+    root: PathBuf,
+}
+
+impl TempRepo {
+    pub(in crate::code_surface) fn path(&self) -> &Path {
+        &self.root
+    }
+
+    /// Writes `contents` to a `self`-relative `name`, creating parent directories, and returns
+    /// the absolute path.
+    pub(in crate::code_surface) fn write(&self, name: &str, contents: &str) -> PathBuf {
+        let path = self.root.join(name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create parent directories");
+        }
+        std::fs::write(&path, contents).expect("write fixture file");
+        path
+    }
+}
+
+pub(in crate::code_surface) fn temp_repo() -> TempRepo {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path().canonicalize().expect("canonicalize tempdir");
+    TempRepo { _dir: dir, root }
+}
+
+/// `test_support::wait_until`'s GPUI-driven sibling, for the `external`-tier tests that poll a
+/// real language server: re-runs `attempt` until it reports `true` or `deadline` elapses, and
+/// reports which - so the caller writes its own assertion message, exactly as the shared helper
+/// does.
+///
+/// The shared helper cannot serve these callers: its condition closure takes no arguments, and
+/// the state they poll only advances after a real render plus a `run_until_parked` that has to
+/// happen *between* polls, on the `VisualTestContext` this hands back each time.
+pub(in crate::code_surface) fn wait_until_parked(
+    cx: &mut VisualTestContext,
+    deadline: Duration,
+    mut attempt: impl FnMut(&mut VisualTestContext) -> bool,
+) -> bool {
+    test_support::wait_until(deadline, || attempt(cx))
+}

--- a/crates/app/src/code_surface/lsp_ui.rs
+++ b/crates/app/src/code_surface/lsp_ui.rs
@@ -7,11 +7,13 @@ use super::*;
 // `AdeApp::lsp_connection_for_path`'s facade instead of raw client states (see
 // `crate::lsp::client::LspConnection`), so a non-test import here would be genuinely unused.
 #[cfg(test)]
-use crate::lsp::client::LspClientState;
+use crate::code_surface::fixtures::{temp_repo, wait_until_parked};
 #[cfg(test)]
-use crate::root::focus::palette_focus_tests;
+use crate::lsp::client::LspClientState;
 use crate::root::scrollbar;
 use crate::root::widgets::render_keycap;
+#[cfg(test)]
+use crate::test_support::open_test_app;
 use std::time::Duration;
 
 /// How long the pointer has to rest on one real token before a real `textDocument/hover` request
@@ -2004,15 +2006,13 @@ mod lsp_hover_wiring_tests {
     use gpui::{Entity, TestAppContext, VisualTestContext};
     use std::time::{Duration, Instant};
 
-    fn write_scratch_project(main_rs: &str) -> tempfile::TempDir {
-        let dir = tempfile::TempDir::new().expect("tempdir");
-        std::fs::write(
-            dir.path().join("Cargo.toml"),
+    fn write_scratch_project(main_rs: &str) -> crate::code_surface::fixtures::TempRepo {
+        let dir = temp_repo();
+        dir.write(
+            "Cargo.toml",
             "[package]\nname = \"app_hover_wiring_fixture\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
-        )
-        .expect("write Cargo.toml");
-        std::fs::create_dir(dir.path().join("src")).expect("mkdir src");
-        std::fs::write(dir.path().join("src").join("main.rs"), main_rs).expect("write main.rs");
+        );
+        dir.write("src/main.rs", main_rs);
         dir
     }
 
@@ -2037,24 +2037,22 @@ mod lsp_hover_wiring_tests {
                     cx,
                 );
             });
-            loop {
+            // Each attempt waits for its *own* round trip to settle before the retry below
+            // sends another one, so a slow server is waited on rather than flooded.
+            let settled = wait_until_parked(cx, ONE_REQUEST_WINDOW, |cx| {
                 cx.run_until_parked();
-                let settled = app.read_with(cx, |app, _| {
+                app.read_with(cx, |app, _| {
                     matches!(
                         app.hover.as_ref().map(|entry| &entry.status),
                         Some(HoverStatus::Ready(_)) | Some(HoverStatus::Failed(_))
                     )
-                });
-                if settled {
-                    break;
-                }
-                assert!(
-                    Instant::now() < deadline,
-                    "AdeApp::hover never left its real Loading state within the real deadline"
-                );
-                std::thread::sleep(Duration::from_millis(200));
-            }
-            let resolved = app.update(cx, |app, _| match &app.hover {
+                })
+            });
+            assert!(
+                settled || Instant::now() < deadline,
+                "AdeApp::hover never left its real Loading state within the real deadline"
+            );
+            let resolved = app.read_with(cx, |app, _| match &app.hover {
                 Some(HoverEntry {
                     status: HoverStatus::Ready(Some(model)),
                     ..
@@ -2070,9 +2068,42 @@ mod lsp_hover_wiring_tests {
                  call site within the real deadline - rust-analyzer kept answering with real \
                  \"nothing here\"/errors past its own indexing window"
             );
-            std::thread::sleep(Duration::from_millis(300));
         }
     }
+
+    /// How long one real request is given to settle before the enclosing retry loop sends
+    /// another. Its own bound, separate from the whole test's `deadline`.
+    const ONE_REQUEST_WINDOW: Duration = Duration::from_secs(5);
+
+    /// Drives real renders until `key`'s language server reports `Ready`, or the tier's real
+    /// deadline passes. Re-rendering (not just waiting) is load-bearing: `render_file_view` is
+    /// what spawns the client and, once it is Ready, what dispatches `didOpen` - and there is no
+    /// window compositor driving repaints in a headless test.
+    fn wait_for_ready_client(
+        app: &Entity<AdeApp>,
+        cx: &mut VisualTestContext,
+        root: &Path,
+        key: &str,
+    ) {
+        let ready = wait_until_parked(cx, CLIENT_HANDSHAKE_WINDOW, |cx| {
+            app.update(cx, |app, cx| {
+                app.render_center_pane(cx);
+            });
+            cx.run_until_parked();
+            app.read_with(cx, |app, _| {
+                matches!(
+                    app.lsp_clients.get(&(root.to_path_buf(), key)),
+                    Some(LspClientState::Ready(_))
+                )
+            })
+        });
+        assert!(
+            ready,
+            "the real {key} client never became Ready within {CLIENT_HANDSHAKE_WINDOW:?}"
+        );
+    }
+
+    const CLIENT_HANDSHAKE_WINDOW: Duration = Duration::from_secs(120);
 
     /// Click position for `"    let result = add_one(41);"` (line index 8, 0-based), reused from
     /// `lsp_core::client::tests::rust_analyzer_returns_a_real_hover_for_a_documented_function`'s
@@ -2095,11 +2126,12 @@ mod lsp_hover_wiring_tests {
     /// `render_file_view`'s `ensure_lsp_client` path) resolves to a `HoverRenderModel` whose
     /// signature and doc text match the fixture's documented function.
     #[gpui::test]
+    #[ignore = "external: rust-analyzer; see docs/testing.md"]
     fn a_real_click_resolves_to_a_real_hover_render_model(cx: &mut TestAppContext) {
         let project = write_scratch_project(FIXTURE_SOURCE);
         let main_rs = project.path().join("src").join("main.rs");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, project.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, project.path().to_path_buf());
 
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(main_rs.clone(), window, cx);
@@ -2115,28 +2147,7 @@ mod lsp_hover_wiring_tests {
         // Keeps re-rendering (the trigger for `dispatch_did_open` once the client is Ready)
         // while waiting for the handshake - a single "wait, then render once" could leave
         // `didOpen` never sent for a client that only just became Ready.
-        let client_deadline = Instant::now() + Duration::from_secs(120);
-        loop {
-            app.update(cx, |app, cx| {
-                app.render_center_pane(cx);
-            });
-            cx.run_until_parked();
-            let ready = app.read_with(cx, |app, _| {
-                matches!(
-                    app.lsp_clients
-                        .get(&(project.path().to_path_buf(), "rust-analyzer")),
-                    Some(LspClientState::Ready(_))
-                )
-            });
-            if ready {
-                break;
-            }
-            assert!(
-                Instant::now() < client_deadline,
-                "the real rust-analyzer client never became Ready within 120s"
-            );
-            std::thread::sleep(Duration::from_millis(200));
-        }
+        wait_for_ready_client(&app, cx, project.path(), "rust-analyzer");
 
         let deadline = Instant::now() + Duration::from_secs(120);
         let model = request_hover_until_resolved(&app, cx, main_rs.clone(), deadline);
@@ -2182,8 +2193,8 @@ mod lsp_hover_wiring_tests {
     /// directly instead.
     #[gpui::test]
     fn f12_action_reaches_the_real_handler_on_a_fresh_window(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = temp_repo();
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         assert_eq!(
             app.read_with(cx, |app, _| app.hover.clone()),
@@ -2204,11 +2215,12 @@ mod lsp_hover_wiring_tests {
     /// the call site the request was sent from. Calls `trigger_goto_definition` directly rather
     /// than `cx.dispatch_action(GotoDefinition)` - see this module's docs above.
     #[gpui::test]
+    #[ignore = "external: rust-analyzer; see docs/testing.md"]
     fn f12_action_navigates_to_the_real_definition_line(cx: &mut TestAppContext) {
         let project = write_scratch_project(FIXTURE_SOURCE);
         let main_rs = project.path().join("src").join("main.rs");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, project.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, project.path().to_path_buf());
 
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(main_rs.clone(), window, cx);
@@ -2217,28 +2229,7 @@ mod lsp_hover_wiring_tests {
 
         // See the hover test above's identical loop for why re-rendering, not just waiting,
         // matters.
-        let client_deadline = Instant::now() + Duration::from_secs(120);
-        loop {
-            app.update(cx, |app, cx| {
-                app.render_center_pane(cx);
-            });
-            cx.run_until_parked();
-            let ready = app.read_with(cx, |app, _| {
-                matches!(
-                    app.lsp_clients
-                        .get(&(project.path().to_path_buf(), "rust-analyzer")),
-                    Some(LspClientState::Ready(_))
-                )
-            });
-            if ready {
-                break;
-            }
-            assert!(
-                Instant::now() < client_deadline,
-                "the real rust-analyzer client never became Ready within 120s"
-            );
-            std::thread::sleep(Duration::from_millis(200));
-        }
+        wait_for_ready_client(&app, cx, project.path(), "rust-analyzer");
 
         // `trigger_goto_definition` reads `hover`'s path/position regardless of whether the
         // hover content itself has resolved - a `Loading` entry already carries a valid request
@@ -2254,35 +2245,31 @@ mod lsp_hover_wiring_tests {
         });
         cx.run_until_parked();
 
-        // Retried on a timer rather than called once: a `textDocument/definition` response can
-        // honestly be empty while rust-analyzer is still mid-index, and a real user would just
-        // press F12 again.
-        let definition_deadline = Instant::now() + Duration::from_secs(120);
-        loop {
+        // Retried rather than called once: a `textDocument/definition` response can honestly be
+        // empty while rust-analyzer is still mid-index, and a real user would just press F12
+        // again. The request itself runs on a background OS thread, so each attempt polls (which
+        // re-drains the executor between tries) rather than reading once.
+        let navigated = wait_until_parked(cx, DEFINITION_WINDOW, |cx| {
             app.update(cx, |app, cx| {
                 app.trigger_goto_definition(cx);
             });
-            cx.run_until_parked();
-            // The definition request runs on a background OS thread; GPUI's deterministic test
-            // executor's `run_until_parked` only drains its own scheduled queue, which is empty
-            // again the instant that background call is dispatched, so a wall-clock sleep is
-            // needed before a second `run_until_parked` can observe the completion callback.
-            std::thread::sleep(Duration::from_millis(300));
-            cx.run_until_parked();
-            // `fn add_one` is on line 4 (1-based), different from `CALL_SITE_LINE` (9), proving
-            // this is real navigation, not a no-op that left the cursor where it was.
-            let navigated = app.read_with(cx, |app, _| app.code_cursor == Some(4));
-            if navigated {
-                break;
-            }
-            assert!(
-                Instant::now() < definition_deadline,
-                "trigger_goto_definition never navigated AdeApp::code_cursor to the real \
-                 definition line within 120s - last observed code_cursor: {:?}",
-                app.read_with(cx, |app, _| app.code_cursor)
-            );
-        }
+            wait_until_parked(cx, ONE_REQUEST_WINDOW, |cx| {
+                cx.run_until_parked();
+                // `fn add_one` is on line 4 (1-based), different from `CALL_SITE_LINE` (9),
+                // proving this is real navigation, not a no-op that left the cursor where it was.
+                app.read_with(cx, |app, _| app.code_cursor == Some(4))
+            })
+        });
+        assert!(
+            navigated,
+            "trigger_goto_definition never navigated AdeApp::code_cursor to the real definition \
+             line within {DEFINITION_WINDOW:?} - last observed code_cursor: {:?}",
+            app.read_with(cx, |app, _| app.code_cursor)
+        );
     }
+
+    /// How long the whole retry sequence for one real `textDocument/definition` answer is given.
+    const DEFINITION_WINDOW: Duration = Duration::from_secs(120);
 
     /// Real, end-to-end coverage for the Ctrl/Cmd+click go-to-definition affordance: a real
     /// simulated mouse click, with a real secondary modifier held, on the real painted call-site
@@ -2290,38 +2277,18 @@ mod lsp_hover_wiring_tests {
     /// `trigger_goto_definition` the way [`f12_action_navigates_to_the_real_definition_line`]
     /// tests the mechanism itself. This is what actually proves the click *routes* there.
     #[gpui::test]
+    #[ignore = "external: rust-analyzer; see docs/testing.md"]
     fn ctrl_click_on_a_real_token_navigates_to_its_real_definition(cx: &mut TestAppContext) {
         let project = write_scratch_project(FIXTURE_SOURCE);
         let main_rs = project.path().join("src").join("main.rs");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, project.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, project.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(main_rs.clone(), window, cx);
         });
         cx.run_until_parked();
 
-        let client_deadline = Instant::now() + Duration::from_secs(120);
-        loop {
-            app.update(cx, |app, cx| {
-                app.render_center_pane(cx);
-            });
-            cx.run_until_parked();
-            let ready = app.read_with(cx, |app, _| {
-                matches!(
-                    app.lsp_clients
-                        .get(&(project.path().to_path_buf(), "rust-analyzer")),
-                    Some(LspClientState::Ready(_))
-                )
-            });
-            if ready {
-                break;
-            }
-            assert!(
-                Instant::now() < client_deadline,
-                "the real rust-analyzer client never became Ready within 120s"
-            );
-            std::thread::sleep(Duration::from_millis(200));
-        }
+        wait_for_ready_client(&app, cx, project.path(), "rust-analyzer");
 
         let (row_bounds, shaped) = app
             .read_with(cx, |app, _| {
@@ -2332,38 +2299,31 @@ mod lsp_hover_wiring_tests {
             row_bounds.left() + shaped.x_for_index(CALL_SITE_BYTE_RANGE.start + 1),
             row_bounds.center().y,
         );
-        // `Modifiers::secondary()` reads `control` on every platform this test actually runs on
-        // (non-macOS - see that method's own docs) - a real, held Ctrl, not a stand-in for it.
-        let ctrl_click = gpui::Modifiers {
-            control: true,
-            ..Default::default()
-        };
+        // The real modifier the production click handler checks for (`Modifiers::secondary()`),
+        // which is Cmd on macOS and Ctrl elsewhere - held for real, not stood in for.
+        let ctrl_click = gpui::Modifiers::secondary_key();
 
         // Retried the same real way `f12_action_navigates_to_the_real_definition_line` retries
         // its own equivalent request: a real `textDocument/definition` response can honestly come
         // back empty while rust-analyzer is still mid-index, and a real user would just click
         // again. Re-clicking (not just re-waiting) is load-bearing here - a single stale response
         // means nothing will ever change without a fresh request.
-        let definition_deadline = Instant::now() + Duration::from_secs(120);
-        loop {
+        let navigated = wait_until_parked(cx, DEFINITION_WINDOW, |cx| {
             cx.simulate_click(click_point, ctrl_click);
-            cx.run_until_parked();
-            std::thread::sleep(Duration::from_millis(300));
-            cx.run_until_parked();
-            // `fn add_one` is on line 4 (1-based), different from `CALL_SITE_LINE` (9) - real
-            // navigation, not the click's own plain caret placement being mistaken for it.
-            let navigated = app.read_with(cx, |app, _| app.code_cursor == Some(4));
-            if navigated {
-                break;
-            }
-            assert!(
-                Instant::now() < definition_deadline,
-                "a real Ctrl+click on the real call-site token never navigated \
-                 AdeApp::code_cursor to the real definition line within 120s - last observed \
-                 code_cursor: {:?}",
-                app.read_with(cx, |app, _| app.code_cursor)
-            );
-        }
+            wait_until_parked(cx, ONE_REQUEST_WINDOW, |cx| {
+                cx.run_until_parked();
+                // `fn add_one` is on line 4 (1-based), different from `CALL_SITE_LINE` (9) - real
+                // navigation, not the click's own plain caret placement being mistaken for it.
+                app.read_with(cx, |app, _| app.code_cursor == Some(4))
+            })
+        });
+        assert!(
+            navigated,
+            "a real Ctrl+click on the real call-site token never navigated AdeApp::code_cursor \
+             to the real definition line within {DEFINITION_WINDOW:?} - last observed \
+             code_cursor: {:?}",
+            app.read_with(cx, |app, _| app.code_cursor)
+        );
     }
 
     /// A plain click still just places the caret and dismisses `Self::hover` - it must *not*
@@ -2372,10 +2332,10 @@ mod lsp_hover_wiring_tests {
     /// `Self::hover`'s own state alone.
     #[gpui::test]
     fn a_plain_click_with_no_modifier_does_not_trigger_navigation(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, "fn one() {}\nfn two() {}\n").expect("write sample.rs");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
         });
@@ -2484,10 +2444,10 @@ mod hover_popover_position_tests {
     /// message.
     #[gpui::test]
     fn a_genuinely_empty_hover_result_paints_no_popup_at_all(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, "fn main() {}\n").expect("write sample.rs");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
         });
@@ -2563,10 +2523,10 @@ mod hover_popover_position_tests {
     fn a_real_long_signature_wraps_inside_the_card_instead_of_being_clipped(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, "fn main() {}\n").expect("write sample.rs");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
         });
@@ -2645,13 +2605,13 @@ mod hover_popover_position_tests {
     fn a_card_with_no_room_below_sits_against_its_row_not_a_card_height_above_it(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.txt");
         // Long enough that its later rows are genuinely near the bottom of the painted body -
         // the only way to make a card flip for real rather than by faking bounds.
         let source: String = (1..=200).map(|index| format!("line {index}\n")).collect();
         std::fs::write(&file_path, &source).expect("write sample.txt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
         });
@@ -2712,10 +2672,10 @@ mod hover_popover_position_tests {
     /// (the pre-fix bug) would paint at the same spot regardless of which line was hovered.
     #[gpui::test]
     fn the_real_painted_hover_card_moves_with_the_real_hovered_row(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.txt");
         std::fs::write(&file_path, "one\ntwo\nthree\nfour\nfive\n").expect("write sample.txt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
         });
@@ -2782,10 +2742,10 @@ mod hover_popover_position_tests {
     fn the_real_painted_hover_card_moves_horizontally_with_the_real_hovered_column(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.txt");
         std::fs::write(&file_path, "aaaa bbbb cccc dddd\n").expect("write sample.txt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
         });
@@ -2871,8 +2831,9 @@ mod hover_popover_position_tests {
 ///
 /// Nothing here is stubbed: two real Node processes, a real `npm install typescript` for the real
 /// `--tsdk` this app resolves on its own, and real assertions on the actual diagnostic text and
-/// hover markdown the real servers produce. It is genuinely slow for that reason, and kept in the
-/// normal (non-`#[ignore]`) suite on purpose - this project has no separate slow-test lane.
+/// hover markdown the real servers produce. That makes it `external` tier (`docs/testing.md`):
+/// it needs binaries this repo does not vendor and live network access, so it runs in the
+/// dedicated external job, never in the PR gate.
 ///
 /// The fixture carries **two** deliberately different real errors, because in Vue's hybrid mode
 /// each server answers a genuinely different class of question (see `crate::language`'s own docs):
@@ -2930,16 +2891,15 @@ mod vue_two_server_wiring_tests {
     /// `node_modules/typescript/lib/typescript.js` specifically, and refuses to spawn without it).
     /// A stubbed stand-in would be worse than useless here - the real `vue-language-server` really
     /// does load this file, and a fake one would produce a different, equally fake failure.
-    fn write_scratch_vue_project() -> tempfile::TempDir {
-        let dir = tempfile::TempDir::new().expect("tempdir");
-        std::fs::write(
-            dir.path().join("tsconfig.json"),
+    fn write_scratch_vue_project() -> crate::code_surface::fixtures::TempRepo {
+        let dir = temp_repo();
+        dir.write(
+            "tsconfig.json",
             "{\"compilerOptions\": {\"strict\": true, \"target\": \"ES2020\", \
              \"module\": \"ESNext\", \"moduleResolution\": \"Bundler\", \"jsx\": \"preserve\"}, \
              \"include\": [\"**/*.ts\", \"**/*.vue\"]}\n",
-        )
-        .expect("write tsconfig.json");
-        std::fs::write(dir.path().join("App.vue"), FIXTURE_VUE).expect("write App.vue");
+        );
+        dir.write("App.vue", FIXTURE_VUE);
         let status = std::process::Command::new("npm")
             .args([
                 "install",
@@ -2969,26 +2929,23 @@ mod vue_two_server_wiring_tests {
     /// on GPUI's deterministic test executor only ticks when the clock is actually advanced - and
     /// the real `vue-language-server` will not produce a single diagnostic until its relayed
     /// `tsserver/request` has been answered.
-    fn wait_until(
+    fn wait_for(
         app: &Entity<AdeApp>,
         cx: &mut VisualTestContext,
-        deadline: Instant,
+        deadline: Duration,
         message: &str,
         predicate: impl Fn(&AdeApp) -> bool,
     ) {
-        loop {
+        let held = wait_until_parked(cx, deadline, |cx| {
             app.update(cx, |app, cx| {
                 app.render_center_pane(cx);
             });
             cx.background_executor
                 .advance_clock(LSP_DIAGNOSTICS_POLL_INTERVAL + Duration::from_millis(10));
             cx.run_until_parked();
-            if app.read_with(cx, |app, _| predicate(app)) {
-                return;
-            }
-            assert!(Instant::now() < deadline, "{message}");
-            std::thread::sleep(Duration::from_millis(200));
-        }
+            app.read_with(cx, |app, _| predicate(app))
+        });
+        assert!(held, "{message}");
     }
 
     fn diagnostic_messages(app: &AdeApp) -> Vec<String> {
@@ -3000,8 +2957,7 @@ mod vue_two_server_wiring_tests {
     }
 
     #[gpui::test]
-    // Real typescript-language-server + vue-language-server spawn, not installed in CI - GitHub issue #348.
-    #[ignore]
+    #[ignore = "external: vue-language-server, typescript-language-server, npm; see docs/testing.md"]
     fn a_real_vue_file_gets_real_diagnostics_from_both_servers_and_a_real_hover(
         cx: &mut TestAppContext,
     ) {
@@ -3012,7 +2968,7 @@ mod vue_two_server_wiring_tests {
         let _ = env_logger::builder().parse_default_env().try_init();
         let project = write_scratch_vue_project();
         let app_vue = project.path().join("App.vue");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, project.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, project.path().to_path_buf());
 
         let opened_at = Instant::now();
         app.update_in(cx, |app, window, cx| {
@@ -3025,10 +2981,10 @@ mod vue_two_server_wiring_tests {
         let companion_key = language::companion_for_extension(Some("vue"))
             .expect("vue has a real companion")
             .client_key;
-        wait_until(
+        wait_for(
             &app,
             cx,
-            Instant::now() + Duration::from_secs(180),
+            Duration::from_secs(180),
             "the real vue-language-server and its real typescript-language-server companion were \
              never both Ready - check that both are installed and that @vue/typescript-plugin \
              resolved",
@@ -3047,10 +3003,10 @@ mod vue_two_server_wiring_tests {
 
         // The companion's own contribution: a real TypeScript semantic error for `.vue` content,
         // which only exists because the real `@vue/typescript-plugin` is genuinely loaded.
-        wait_until(
+        wait_for(
             &app,
             cx,
-            Instant::now() + Duration::from_secs(180),
+            Duration::from_secs(180),
             "no real TypeScript diagnostic for the genuine `.vue` script type error ever reached \
              file_view_diagnostics",
             |app| {
@@ -3063,10 +3019,10 @@ mod vue_two_server_wiring_tests {
 
         // The primary's own contribution: a real Vue template compile error, which the companion
         // does not and cannot report.
-        wait_until(
+        wait_for(
             &app,
             cx,
-            Instant::now() + Duration::from_secs(120),
+            Duration::from_secs(120),
             "no real Vue template diagnostic ever reached file_view_diagnostics - without it, \
              only one of the two real servers is genuinely contributing",
             |app| {
@@ -3105,9 +3061,11 @@ mod vue_two_server_wiring_tests {
         // A real hover, through the facade's real companion fallback: the primary answers `null`
         // for every position in a `.vue` file (real, expected hybrid-mode behavior), so a
         // non-`None` result here can only have come from the companion via `LspConnection`.
-        let hover_deadline = Instant::now() + Duration::from_secs(120);
         let hover_started = Instant::now();
-        let model = loop {
+        let mut resolved = None;
+        // Each attempt waits out its own real round trip before the next one is sent, so a
+        // still-indexing server is waited on rather than flooded with fresh requests.
+        let answered = wait_until_parked(cx, Duration::from_secs(120), |cx| {
             app.update(cx, |app, cx| {
                 app.hover = None;
                 app.request_hover(
@@ -3118,41 +3076,31 @@ mod vue_two_server_wiring_tests {
                     cx,
                 );
             });
-            loop {
+            wait_until_parked(cx, Duration::from_secs(5), |cx| {
                 cx.run_until_parked();
-                let settled = app.read_with(cx, |app, _| {
+                app.read_with(cx, |app, _| {
                     matches!(
                         app.hover.as_ref().map(|entry| &entry.status),
                         Some(HoverStatus::Ready(_)) | Some(HoverStatus::Failed(_))
                     )
-                });
-                if settled {
-                    break;
-                }
-                assert!(
-                    Instant::now() < hover_deadline,
-                    "AdeApp::hover never left its real Loading state within the real deadline"
-                );
-                std::thread::sleep(Duration::from_millis(200));
-            }
-            let resolved = app.update(cx, |app, _| match &app.hover {
+                })
+            });
+            resolved = app.read_with(cx, |app, _| match &app.hover {
                 Some(HoverEntry {
                     status: HoverStatus::Ready(Some(model)),
                     ..
                 }) => Some(model.clone()),
                 _ => None,
             });
-            if let Some(model) = resolved {
-                break model;
-            }
-            assert!(
-                Instant::now() < hover_deadline,
-                "no real, non-empty hover ever came back for the genuine `bad` identifier in the \
-                 real .vue script block - the companion fallback in LspConnection::request is \
-                 what has to supply it, since the primary genuinely answers null there"
-            );
-            std::thread::sleep(Duration::from_millis(300));
-        };
+            resolved.is_some()
+        });
+        assert!(
+            answered,
+            "no real, non-empty hover ever came back for the genuine `bad` identifier in the \
+             real .vue script block - the companion fallback in LspConnection::request is \
+             what has to supply it, since the primary genuinely answers null there"
+        );
+        let model = resolved.expect("the wait above only succeeds with a real resolved hover");
         println!(
             "vue e2e: real hover resolved in {:?}: {model:?}",
             hover_started.elapsed()
@@ -3177,7 +3125,7 @@ mod vue_two_server_wiring_tests {
         let uri = lsp_core::LspClient::uri_for_path(&app_vue).expect("a real file:// uri");
 
         let definition = retry_until_some(
-            Instant::now() + Duration::from_secs(120),
+            Duration::from_secs(120),
             "no real go-to-definition ever came back for `shape` in the real .vue script block - \
              the real vue-language-server answers an empty array there, so only the companion \
              fallback in LspConnection::request can supply one",
@@ -3213,7 +3161,7 @@ mod vue_two_server_wiring_tests {
         println!("vue e2e: real go-to-definition answer: {definition:?}");
 
         let completions = retry_until_some(
-            Instant::now() + Duration::from_secs(120),
+            Duration::from_secs(120),
             "no real completions ever came back after `shape.` in the real .vue script block - \
              the real vue-language-server answers an empty items list there",
             || {
@@ -3253,14 +3201,18 @@ mod vue_two_server_wiring_tests {
     /// Calls `attempt` until it returns a real `Some` or `deadline` passes. Both real servers are
     /// still settling for a while after the first diagnostic lands, so a single shot would be a
     /// race; nothing is fabricated on timeout, the assertion just fails.
-    fn retry_until_some<T>(deadline: Instant, message: &str, attempt: impl Fn() -> Option<T>) -> T {
-        loop {
-            if let Some(value) = attempt() {
-                return value;
-            }
-            assert!(Instant::now() < deadline, "{message}");
-            std::thread::sleep(Duration::from_millis(300));
-        }
+    fn retry_until_some<T>(
+        deadline: Duration,
+        message: &str,
+        attempt: impl Fn() -> Option<T>,
+    ) -> T {
+        let mut resolved = None;
+        let answered = test_support::wait_until(deadline, || {
+            resolved = attempt();
+            resolved.is_some()
+        });
+        assert!(answered, "{message}");
+        resolved.expect("the wait above only succeeds with a real answer")
     }
 }
 
@@ -3285,15 +3237,15 @@ mod hover_pointer_tests {
         name: &str,
         source: &str,
     ) -> (
-        tempfile::TempDir,
+        crate::code_surface::fixtures::TempRepo,
         PathBuf,
         Entity<AdeApp>,
         &'a mut VisualTestContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join(name);
         std::fs::write(&file_path, source).expect("write fixture");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
         });
@@ -3579,11 +3531,11 @@ mod hover_pointer_tests {
     /// first real paint) quietly reintroduces the same bug through a different door.
     #[gpui::test]
     fn the_full_real_pipeline_also_survives_hovering_a_covered_token(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, "fn alpha() {}\nfn beta() {}\n").expect("write sample.rs");
         let client = spawn_fake_server(repo.path(), "rust-analyzer", "hover");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, _cx| {
             app.lsp_clients.insert(
                 (repo.path().to_path_buf(), "rust-analyzer"),
@@ -3748,13 +3700,13 @@ mod diagnostic_popover_tests {
     /// `flex_none` child of the File view's flex column, it genuinely shortened the code list.
     #[gpui::test]
     fn the_real_diagnostic_card_floats_over_the_code_without_reflowing_it(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, SOURCE).expect("write sample.rs");
         // A real, minimal LSP server installed *before* the first render, so `ensure_lsp_client`
         // finds a Ready entry for this key and never spawns a real rust-analyzer for the fixture.
         let client = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, _cx| {
             app.lsp_clients.insert(
                 (repo.path().to_path_buf(), "rust-analyzer"),
@@ -3839,11 +3791,11 @@ mod diagnostic_popover_tests {
     fn the_real_diagnostic_card_is_anchored_under_the_offending_span_not_the_row_edge(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, SOURCE).expect("write sample.rs");
         let client = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, _cx| {
             app.lsp_clients.insert(
                 (repo.path().to_path_buf(), "rust-analyzer"),
@@ -3893,11 +3845,11 @@ mod diagnostic_popover_tests {
     fn the_real_card_shows_the_caret_line_only_and_yields_to_the_other_lsp_popups(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, SOURCE).expect("write sample.rs");
         let client = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, _cx| {
             app.lsp_clients.insert(
                 (repo.path().to_path_buf(), "rust-analyzer"),
@@ -3980,11 +3932,11 @@ mod diagnostic_popover_tests {
     /// happened to be underneath.
     #[gpui::test]
     fn moving_the_real_pointer_onto_the_diagnostic_card_does_not_hide_it(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, SOURCE).expect("write sample.rs");
         let client = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, _cx| {
             app.lsp_clients.insert(
                 (repo.path().to_path_buf(), "rust-analyzer"),
@@ -4048,11 +4000,11 @@ mod diagnostic_popover_tests {
     fn hovering_directly_over_the_diagnostic_span_shows_the_diagnostic_not_an_empty_hover(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, SOURCE).expect("write sample.rs");
         let client = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, _cx| {
             app.lsp_clients.insert(
                 (repo.path().to_path_buf(), "rust-analyzer"),
@@ -4114,11 +4066,11 @@ mod diagnostic_popover_tests {
     fn hovering_directly_over_the_diagnostic_span_shows_the_diagnostic_over_real_hover_content_too(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, SOURCE).expect("write sample.rs");
         let client = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, _cx| {
             app.lsp_clients.insert(
                 (repo.path().to_path_buf(), "rust-analyzer"),
@@ -4176,11 +4128,11 @@ mod diagnostic_popover_tests {
     fn hovering_a_diagnostic_span_shows_the_card_even_while_the_caret_is_elsewhere(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, SOURCE).expect("write sample.rs");
         let client = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, _cx| {
             app.lsp_clients.insert(
                 (repo.path().to_path_buf(), "rust-analyzer"),
@@ -4237,15 +4189,15 @@ mod diagnostic_popover_tests {
     ) -> (
         Entity<AdeApp>,
         &'a mut VisualTestContext,
-        tempfile::TempDir,
+        crate::code_surface::fixtures::TempRepo,
         std::sync::Arc<lsp_core::LspClient>,
         String,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, SOURCE).expect("write sample.rs");
         let client = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, _cx| {
             app.lsp_clients.insert(
                 (repo.path().to_path_buf(), "rust-analyzer"),
@@ -4500,11 +4452,11 @@ mod inline_diagnostic_message_tests {
     fn a_real_long_inline_message_truncates_instead_of_overlapping_the_real_code_text(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, "fn alpha() {}\nfn beta() {}\n").expect("write sample.rs");
         let client = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, _cx| {
             app.lsp_clients.insert(
                 (repo.path().to_path_buf(), "rust-analyzer"),
@@ -4770,10 +4722,10 @@ mod hover_card_footer_layout_tests {
     fn the_module_path_and_definition_chip_sit_at_opposite_ends_of_the_real_footer(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, "fn add_one(x: i32) -> i32 { x + 1 }\n").expect("write");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
         });
@@ -4836,10 +4788,10 @@ mod hover_card_footer_layout_tests {
     fn clicking_through_the_hover_card_never_also_reaches_the_file_view_row_behind_it(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, "fn line_one() {}\nfn line_two() {}\n").expect("write");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
         });
@@ -4894,12 +4846,12 @@ mod hover_card_footer_layout_tests {
     ) -> (
         gpui::Entity<AdeApp>,
         &'a mut gpui::VisualTestContext,
-        tempfile::TempDir,
+        crate::code_surface::fixtures::TempRepo,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, "fn add_one(x: i32) -> i32 { x + 1 }\n").expect("write");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
         });
@@ -4980,10 +4932,10 @@ mod hover_card_footer_layout_tests {
     /// `render_doc_prose` run - not just as part of the ordinary flat doc-paragraph text.
     #[gpui::test]
     fn a_real_jsdoc_tag_in_the_hover_doc_body_paints_its_own_tag_run(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, "fn add_one(x: i32) -> i32 { x + 1 }\n").expect("write");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
         });
@@ -5029,10 +4981,10 @@ mod hover_card_footer_layout_tests {
     fn real_jsdoc_block_tags_in_the_hover_doc_body_paint_their_own_structured_sections(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, "fn add_one(x: i32) -> i32 { x + 1 }\n").expect("write");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
         });
@@ -5084,10 +5036,10 @@ mod hover_card_footer_layout_tests {
     fn a_tall_signature_keeps_the_footer_pinned_and_shows_a_real_scrollbar(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, "fn add_one(x: i32) -> i32 { x + 1 }\n").expect("write");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
         });
@@ -5159,10 +5111,10 @@ mod hover_card_footer_layout_tests {
     /// unadorned as it always was.
     #[gpui::test]
     fn a_short_signature_paints_no_scrollbar(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, "fn add_one(x: i32) -> i32 { x + 1 }\n").expect("write");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
         });

--- a/crates/app/src/code_surface/mod.rs
+++ b/crates/app/src/code_surface/mod.rs
@@ -78,6 +78,8 @@ pub(crate) mod blame_view;
 pub(crate) mod diff_view;
 pub(crate) mod editing;
 pub(crate) mod file_view;
+#[cfg(test)]
+pub(crate) mod fixtures;
 pub(crate) mod lsp_ui;
 pub(crate) mod markdown_preview;
 pub(crate) mod minimap;

--- a/crates/app/src/code_surface/render.rs
+++ b/crates/app/src/code_surface/render.rs
@@ -4,9 +4,11 @@
 
 use super::*;
 #[cfg(test)]
-use crate::root::focus::palette_focus_tests;
+use crate::code_surface::fixtures::temp_repo;
 use crate::root::widgets::render_status_letter;
 use crate::settings::widgets::ChoiceOption;
+#[cfg(test)]
+use crate::test_support::open_test_app;
 
 impl AdeApp {
     /// A themed explanatory message for every [`DiffLoadState`] that isn't a loaded diff, as its
@@ -438,37 +440,19 @@ mod choice_control_dispatch_tests {
     use super::*;
     use gpui::TestAppContext;
 
-    fn git_repo(dir: &std::path::Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
     #[gpui::test]
     fn clicking_a_segment_by_structural_position_selects_the_matching_real_value(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        git_repo(repo.path(), &["init", "-b", "main"]);
-        git_repo(repo.path(), &["config", "user.email", "test@example.com"]);
-        git_repo(repo.path(), &["config", "user.name", "Test User"]);
+        let repo = temp_repo();
+        test_support::seed_empty_repo_at(repo.path());
         std::fs::write(repo.path().join("a.txt"), "1\n").expect("write a.txt");
-        git_repo(repo.path(), &["add", "."]);
-        git_repo(repo.path(), &["commit", "-m", "initial"]);
-        git_repo(repo.path(), &["checkout", "-b", "feature"]);
+        test_support::git(repo.path(), &["add", "."]);
+        test_support::git(repo.path(), &["commit", "-m", "initial"]);
+        test_support::git(repo.path(), &["checkout", "-b", "feature"]);
         std::fs::write(repo.path().join("a.txt"), "1\nchanged\n").expect("rewrite a.txt");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         app.update_in(cx, |app, window, cx| {
@@ -520,10 +504,10 @@ mod markdown_preview_toggle_tests {
 
     #[gpui::test]
     fn the_toggle_only_appears_for_a_real_md_file(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         std::fs::write(repo.path().join("readme.md"), "# hi\n").expect("write readme.md");
         std::fs::write(repo.path().join("main.rs"), "fn main() {}\n").expect("write main.rs");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         app.update_in(cx, |app, window, cx| {
@@ -547,14 +531,14 @@ mod markdown_preview_toggle_tests {
 
     #[gpui::test]
     fn clicking_preview_renders_the_real_parsed_document_with_no_panic(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         std::fs::write(
             repo.path().join("readme.md"),
             "# Title\n\nSome **bold** text, a [link](https://example.com), and:\n\n- one\n- two\n\n\
              ```rust\nfn main() {}\n```\n\n| a | b |\n|---|---|\n| 1 | 2 |\n",
         )
         .expect("write readme.md");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         app.update_in(cx, |app, window, cx| {
@@ -601,10 +585,10 @@ mod markdown_preview_toggle_tests {
     /// like `code_view` already resets.
     #[gpui::test]
     fn opening_a_different_markdown_file_resets_the_toggle_back_to_source(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         std::fs::write(repo.path().join("a.md"), "# a\n").expect("write a.md");
         std::fs::write(repo.path().join("b.md"), "# b\n").expect("write b.md");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         app.update_in(cx, |app, window, cx| {
@@ -640,11 +624,11 @@ mod markdown_preview_toggle_tests {
     ) -> (
         gpui::Entity<AdeApp>,
         &'a mut gpui::VisualTestContext,
-        tempfile::TempDir,
+        crate::code_surface::fixtures::TempRepo,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         std::fs::write(repo.path().join("readme.md"), contents).expect("write readme.md");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(repo.path().join("readme.md"), window, cx);

--- a/crates/app/src/code_surface/tabs.rs
+++ b/crates/app/src/code_surface/tabs.rs
@@ -5,7 +5,9 @@
 
 use super::*;
 #[cfg(test)]
-use crate::root::focus::palette_focus_tests;
+use crate::code_surface::fixtures::temp_repo;
+#[cfg(test)]
+use crate::test_support::open_test_app;
 
 impl AdeApp {
     /// Loads (or reloads) the diff of `root` against its detected base branch. Runs on
@@ -992,7 +994,7 @@ mod code_view_cache_tests {
     /// `.rs` fixture. (It was `root/code_surface.rs` before that file was split into this folder.)
     #[gpui::test]
     fn opening_a_large_real_file_does_not_block_render_on_the_full_parse(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("large.rs");
         let source =
             std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/src/lsp/client.rs"))
@@ -1004,7 +1006,7 @@ mod code_view_cache_tests {
         code_view::load_file(&file_path).expect("load_file baseline");
         let baseline_duration = baseline_start.elapsed();
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
         });
@@ -1050,7 +1052,7 @@ mod code_view_cache_tests {
     /// `load_file` call would allocate a new `Vec`.
     #[gpui::test]
     fn repeated_renders_of_the_same_open_file_reuse_the_cached_parse(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(
             &file_path,
@@ -1058,7 +1060,7 @@ mod code_view_cache_tests {
         )
         .expect("write sample.rs");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
@@ -1106,16 +1108,16 @@ mod code_view_cache_tests {
     }
 
     /// A content change (different mtime/len) must invalidate the cache - confirms this isn't a
-    /// cache that never refreshes. Sleeps past [`FILE_FRESHNESS_CHECK_INTERVAL`] first, since the
+    /// cache that never refreshes. Clears the throttle rather than waiting it out, since the
     /// throttle window itself is covered separately by
     /// `renders_within_the_throttle_window_do_not_pick_up_a_fresh_on_disk_change` below.
     #[gpui::test]
     fn a_real_on_disk_change_to_the_open_file_invalidates_the_cache(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, "fn add() -> i32 {\n    1\n}\n").expect("write sample.rs");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
         });
@@ -1141,8 +1143,11 @@ mod code_view_cache_tests {
         )
         .expect("rewrite sample.rs");
 
-        // Past the throttle window, so the next freshness check isn't skipped.
-        std::thread::sleep(FILE_FRESHNESS_CHECK_INTERVAL + std::time::Duration::from_millis(50));
+        // Clear the throttle so the next freshness check runs, rather than waiting out its
+        // real wall-clock interval.
+        app.update(cx, |app, _| {
+            app.file_view_last_freshness_check = None;
+        });
 
         app.update(cx, |app, cx| {
             app.render_center_pane(cx);
@@ -1167,17 +1172,17 @@ mod code_view_cache_tests {
     }
 
     /// Proves [`AdeApp::file_view_last_freshness_check`]'s throttling: a change made within
-    /// [`FILE_FRESHNESS_CHECK_INTERVAL`] of the last check isn't picked up yet, but the same
-    /// change is picked up once the window passes.
+    /// `FILE_FRESHNESS_CHECK_INTERVAL` of the last check isn't picked up yet, but the same
+    /// change is picked up once that record is cleared.
     #[gpui::test]
     fn renders_within_the_throttle_window_do_not_pick_up_a_fresh_on_disk_change(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = repo.path().join("sample.rs");
         std::fs::write(&file_path, "fn add() -> i32 {\n    1\n}\n").expect("write sample.rs");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path.clone(), window, cx);
         });
@@ -1227,8 +1232,10 @@ mod code_view_cache_tests {
             "no reload should have been dispatched while the freshness check was throttled"
         );
 
-        // Past the throttle window - the change is now observed.
-        std::thread::sleep(FILE_FRESHNESS_CHECK_INTERVAL + std::time::Duration::from_millis(50));
+        // Clear the throttle - the change is now observed.
+        app.update(cx, |app, _| {
+            app.file_view_last_freshness_check = None;
+        });
         app.update(cx, |app, cx| {
             app.render_center_pane(cx);
         });
@@ -1264,13 +1271,13 @@ mod cross_file_navigation_tests {
     fn navigating_to_an_uncached_file_then_opening_a_different_file_first_does_not_leak_the_cursor(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_b = repo.path().join("b.txt");
         let file_c = repo.path().join("c.txt");
         std::fs::write(&file_b, "one\ntwo\nthree\nfour\nfive\n").expect("write b.txt");
         std::fs::write(&file_c, "hello\nworld\n").expect("write c.txt");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         // Landing on B's line 5 - B isn't cached yet, so this sets `pending_cursor_line` rather
         // than `code_cursor` directly.
@@ -1336,12 +1343,12 @@ mod unreadable_file_tests {
     fn an_unreadable_file_settles_into_a_stable_error_state_without_respawning(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         // A deterministic, cross-platform read failure: no such path exists, so `load_file`'s
         // `fs::metadata`/`fs::read` fail every time, with no platform-specific setup needed.
         let missing_path = repo.path().join("does-not-exist.rs");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(missing_path.clone(), window, cx);
@@ -1431,7 +1438,7 @@ mod reopened_file_caret_tests {
     /// lie about where the next keystroke will land, in the one widget that exists to say so.
     #[gpui::test]
     fn reopening_a_file_reports_its_restored_caret_line_not_line_one(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let target = repo.path().join("many.txt");
         // Long enough that the caret's row genuinely cannot be on screen at scroll offset 0 -
         // otherwise "the view scrolled to the caret" and "the view never moved" look identical.
@@ -1440,8 +1447,7 @@ mod reopened_file_caret_tests {
         let other = repo.path().join("other.txt");
         std::fs::write(&other, "x\n").expect("write");
 
-        let (app, cx) =
-            crate::root::focus::palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_and_settle(&app, cx, target.clone());
         let relative = PathBuf::from("many.txt");
 
@@ -1532,12 +1538,11 @@ mod reopened_file_caret_tests {
     /// buffer's caret" would break if the buffer were ever seeded at a non-zero offset.
     #[gpui::test]
     fn a_first_open_is_caret_at_line_one(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let target = repo.path().join("fresh.txt");
         std::fs::write(&target, "a\nb\nc\n").expect("write");
 
-        let (app, cx) =
-            crate::root::focus::palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         open_and_settle(&app, cx, target);
 
         app.read_with(cx, |app, _| {
@@ -1581,9 +1586,9 @@ mod multi_file_tab_tests {
     /// real no-duplicate rule.
     #[gpui::test]
     fn opening_the_same_file_twice_does_not_duplicate_its_tab(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let ((a, _b, _c), (a_rel, _, _)) = write_three_files(repo.path());
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(a.clone(), window, cx);
@@ -1611,9 +1616,9 @@ mod multi_file_tab_tests {
     /// active agent" order.
     #[gpui::test]
     fn closing_the_active_tab_activates_the_tab_that_was_to_its_right(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let ((a, b, c), (a_rel, b_rel, c_rel)) = write_three_files(repo.path());
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         for path in [a, b, c] {
             app.update_in(cx, |app, window, cx| {
@@ -1673,9 +1678,9 @@ mod multi_file_tab_tests {
     /// other real half of [`AdeApp::close_file_tab`]'s contract.
     #[gpui::test]
     fn closing_a_non_active_tab_does_not_change_what_is_active(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let ((a, b, _c), (a_rel, b_rel, _)) = write_three_files(repo.path());
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(a, window, cx);
@@ -1711,9 +1716,9 @@ mod multi_file_tab_tests {
     /// browser tab doesn't close it.
     #[gpui::test]
     fn selecting_a_agent_deactivates_the_open_file_tab_without_closing_it(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let ((a, _b, _c), (a_rel, _, _)) = write_three_files(repo.path());
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         let agent_id = app.read_with(cx, |app, _| {
             app.agents
@@ -1759,37 +1764,19 @@ mod multi_file_tab_tests {
     fn next_changed_file_advances_through_every_changed_file_and_wraps_around(
         cx: &mut TestAppContext,
     ) {
-        fn git(dir: &std::path::Path, args: &[&str]) {
-            let output = std::process::Command::new("git")
-                .current_dir(dir)
-                .args(args)
-                .output()
-                .expect("failed to spawn git");
-            assert!(
-                output.status.success(),
-                "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-                args,
-                dir,
-                String::from_utf8_lossy(&output.stdout),
-                String::from_utf8_lossy(&output.stderr)
-            );
-        }
-
-        let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
+        let repo = temp_repo();
+        test_support::seed_empty_repo_at(repo.path());
         std::fs::write(repo.path().join("a.txt"), "1\n").expect("write a.txt");
         std::fs::write(repo.path().join("b.txt"), "1\n").expect("write b.txt");
         std::fs::write(repo.path().join("c.txt"), "1\n").expect("write c.txt");
-        git(repo.path(), &["add", "."]);
-        git(repo.path(), &["commit", "-m", "initial"]);
-        git(repo.path(), &["checkout", "-b", "feature"]);
+        test_support::git(repo.path(), &["add", "."]);
+        test_support::git(repo.path(), &["commit", "-m", "initial"]);
+        test_support::git(repo.path(), &["checkout", "-b", "feature"]);
         std::fs::write(repo.path().join("a.txt"), "1\nchanged\n").expect("rewrite a.txt");
         std::fs::write(repo.path().join("b.txt"), "1\nchanged\n").expect("rewrite b.txt");
         std::fs::write(repo.path().join("c.txt"), "1\nchanged\n").expect("rewrite c.txt");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let order: Vec<PathBuf> = app.read_with(cx, |app, _| {
@@ -1843,22 +1830,6 @@ mod multi_file_tab_tests {
         );
     }
 
-    fn git_repo(dir: &std::path::Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
     /// Regression test for "switching tabs shows the wrong Diff/File view": `code_view` is a
     /// single global field, not per-tab, so switching from a tab left in `File` view to a
     /// different tab with a diff used to incorrectly stay in `File` view instead of forcing
@@ -1867,19 +1838,17 @@ mod multi_file_tab_tests {
     fn switching_to_a_tab_with_a_real_diff_shows_the_diff_not_the_last_view_mode(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        git_repo(repo.path(), &["init", "-b", "main"]);
-        git_repo(repo.path(), &["config", "user.email", "test@example.com"]);
-        git_repo(repo.path(), &["config", "user.name", "Test User"]);
+        let repo = temp_repo();
+        test_support::seed_empty_repo_at(repo.path());
         std::fs::write(repo.path().join("changed.txt"), "1\n").expect("write changed.txt");
         std::fs::write(repo.path().join("plain.txt"), "plain\n").expect("write plain.txt");
-        git_repo(repo.path(), &["add", "."]);
-        git_repo(repo.path(), &["commit", "-m", "initial"]);
-        git_repo(repo.path(), &["checkout", "-b", "feature"]);
+        test_support::git(repo.path(), &["add", "."]);
+        test_support::git(repo.path(), &["commit", "-m", "initial"]);
+        test_support::git(repo.path(), &["checkout", "-b", "feature"]);
         std::fs::write(repo.path().join("changed.txt"), "1\nchanged\n")
             .expect("rewrite changed.txt");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let changed_rel = PathBuf::from("changed.txt");
@@ -1929,17 +1898,15 @@ mod multi_file_tab_tests {
     /// `open_change`, so re-clicking such a tab did nothing.
     #[gpui::test]
     fn reactivating_a_tab_whose_diff_disappeared_shows_real_content_again(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        git_repo(repo.path(), &["init", "-b", "main"]);
-        git_repo(repo.path(), &["config", "user.email", "test@example.com"]);
-        git_repo(repo.path(), &["config", "user.name", "Test User"]);
+        let repo = temp_repo();
+        test_support::seed_empty_repo_at(repo.path());
         std::fs::write(repo.path().join("a.txt"), "1\n").expect("write a.txt");
-        git_repo(repo.path(), &["add", "."]);
-        git_repo(repo.path(), &["commit", "-m", "initial"]);
-        git_repo(repo.path(), &["checkout", "-b", "feature"]);
+        test_support::git(repo.path(), &["add", "."]);
+        test_support::git(repo.path(), &["commit", "-m", "initial"]);
+        test_support::git(repo.path(), &["checkout", "-b", "feature"]);
         std::fs::write(repo.path().join("a.txt"), "1\nchanged\n").expect("rewrite a.txt");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let rel = PathBuf::from("a.txt");
@@ -1994,14 +1961,14 @@ mod multi_file_tab_tests {
     fn switching_worktrees_and_back_preserves_each_worktree_s_open_file_tabs(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = tempfile::tempdir().expect("tempdir a");
-        let repo_b = tempfile::tempdir().expect("tempdir b");
+        let repo_a = temp_repo();
+        let repo_b = temp_repo();
         let ((a1, a2, _), (a1_rel, a2_rel, _)) = write_three_files(repo_a.path());
         let b1 = repo_b.path().join("notes.txt");
         std::fs::write(&b1, "notes\n").expect("write notes.txt");
         let b1_rel = PathBuf::from("notes.txt");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo_a.path().to_path_buf());
         app.update(cx, |app, _cx| {
             app.worktrees = vec![
                 crate::rail::worktrees::WorktreeItem {
@@ -2143,9 +2110,9 @@ mod stale_completions_popup_tests {
     fn switching_tabs_away_and_back_does_not_resurrect_a_stale_completions_popup(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let ((a, b), (a_rel, b_rel)) = write_two_files(repo.path());
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         for path in [a, b] {
             app.update_in(cx, |app, window, cx| {
@@ -2199,9 +2166,9 @@ mod stale_completions_popup_tests {
     fn closing_a_tab_with_an_open_popup_never_lets_it_resurface_for_another_file(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let ((a, b), (a_rel, _b_rel)) = write_two_files(repo.path());
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         for path in [a.clone(), b] {
             app.update_in(cx, |app, window, cx| {
@@ -2313,11 +2280,11 @@ mod terminal_link_click_tests {
 
     #[gpui::test]
     fn mod_click_on_a_detected_link_opens_the_real_file_tab(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         std::fs::create_dir_all(repo.path().join("src")).expect("mkdir src");
         std::fs::write(repo.path().join("src/main.rs"), "fn main() {}\n").expect("write");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         let (bounds, cell_size) = inject_link_row_and_measure(&app, cx);
 
         cx.simulate_click(
@@ -2346,11 +2313,11 @@ mod terminal_link_click_tests {
     /// an ordinary click inside the terminal is never silently hijacked into a file navigation.
     #[gpui::test]
     fn a_bare_click_on_a_detected_link_does_not_open_anything(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         std::fs::create_dir_all(repo.path().join("src")).expect("mkdir src");
         std::fs::write(repo.path().join("src/main.rs"), "fn main() {}\n").expect("write");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         let (bounds, cell_size) = inject_link_row_and_measure(&app, cx);
 
         cx.simulate_click(link_click_position(bounds, cell_size), Modifiers::none());
@@ -2376,11 +2343,11 @@ mod terminal_link_click_tests {
     /// same modifiers for both) to hold the modifier only at mouse-down.
     #[gpui::test]
     fn mod_held_only_during_mouse_down_still_opens_the_real_file_tab(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         std::fs::create_dir_all(repo.path().join("src")).expect("mkdir src");
         std::fs::write(repo.path().join("src/main.rs"), "fn main() {}\n").expect("write");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         let (bounds, cell_size) = inject_link_row_and_measure(&app, cx);
         let position = link_click_position(bounds, cell_size);
 
@@ -2404,10 +2371,10 @@ mod terminal_link_click_tests {
     /// refuse it, not open a permanent junk tab.
     #[gpui::test]
     fn mod_click_on_a_link_to_a_nonexistent_path_does_not_open_a_tab(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         // Deliberately never created: `src/` itself doesn't exist in this repo at all.
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         let (bounds, cell_size) = inject_link_row_and_measure(&app, cx);
 
         cx.simulate_click(

--- a/crates/app/src/code_surface/zoom.rs
+++ b/crates/app/src/code_surface/zoom.rs
@@ -3,8 +3,10 @@
 
 use super::*;
 #[cfg(test)]
-use crate::root::focus::palette_focus_tests;
+use crate::code_surface::fixtures::temp_repo;
 use crate::root::rem_scope::WithRemSize;
+#[cfg(test)]
+use crate::test_support::open_test_app;
 
 impl AdeApp {
     /// Editor-zoom range (70-200%, in steps of 10) and default (100%) - re-exported from
@@ -240,9 +242,9 @@ mod code_zoom_tests {
     fn zoom_in_and_out_clamp_at_the_documented_boundaries_through_the_real_app(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_single_file(repo.path());
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path, window, cx);
         });
@@ -278,9 +280,9 @@ mod code_zoom_tests {
 
     #[gpui::test]
     fn resetting_zoom_returns_to_100_percent(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let file_path = write_single_file(repo.path());
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path, window, cx);
         });
@@ -311,12 +313,12 @@ mod code_zoom_tests {
     /// unconditionally rather than only when the toggle happened to be off.
     #[gpui::test]
     fn zoom_applies_globally_to_every_open_file_not_just_the_active_one(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let a = repo.path().join("a.rs");
         let b = repo.path().join("b.rs");
         std::fs::write(&a, "fn a() {}\n").expect("write a.rs");
         std::fs::write(&b, "fn b() {}\n").expect("write b.rs");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(a.clone(), window, cx);
@@ -352,9 +354,9 @@ mod code_zoom_tests {
     /// already does.
     #[gpui::test]
     fn zoom_survives_a_worktree_switch(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let worktree_b = tempfile::tempdir().expect("tempdir b");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = temp_repo();
+        let worktree_b = temp_repo();
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         // A plain, directly-seeded `worktrees` list (mirroring
         // `lsp_client_eviction_tests::switching_between_several_worktrees_never_lets_lsp_clients_
@@ -417,10 +419,10 @@ mod code_zoom_tests {
     /// tab to 100%, since the zoom used to be remembered *per path*, not globally).
     #[gpui::test]
     fn closing_and_reopening_a_tab_keeps_the_same_global_zoom(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         let a = repo.path().join("a.rs");
         std::fs::write(&a, "fn a() {}\n").expect("write a.rs");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(a.clone(), window, cx);
@@ -472,11 +474,11 @@ mod code_zoom_tests {
     /// than its allocated slot, overlapping the row below).
     #[gpui::test]
     fn zoom_scales_text_but_not_the_gutter_width(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = temp_repo();
         // 1200 lines - enough to reach a 4-digit line number (1000), which the second half
         // needs; line 1 (used by the first half) exists regardless of file size.
         let file_path = write_many_line_file(repo.path(), 1200);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path, window, cx);
         });


### PR DESCRIPTION
<!-- Refs #425 (sub-PR D2), epic #427. Not `Closes` — this is one slice of seven. -->

## What

Surface C's test suite, tiered and purged against `docs/testing.md` — and, unexpectedly, unbroken.

**The headline is not the purge.** Measured on `74dcb7c`, `code_surface` had **70 failing tests and
3 timeouts**, not the 3 timeouts the sub-issue budgeted for. All 70 shared one root cause, and it
is a test-fixture bug, not a product bug:

- `AdeApp::new_with_settings` canonicalizes the repo root it is given (`rail::repo::canonical_repo_path`).
- `spawn_file_load` keys `edit_buffers`/`open_files` by `path.strip_prefix(self.file_tree_root)`.
- On macOS `std::env::temp_dir()` sits behind a `/var -> /private/var` symlink, and every fixture in
  this folder handed `AdeApp` a bare `tempfile::TempDir::path()` while building file paths from the
  *same* uncanonicalized root.

So the strip failed, the buffer got keyed by its absolute path, and every
`app.edit_buffer(&PathBuf::from("sample.txt"))` in the module returned `None`. New
`code_surface::fixtures::temp_repo()` hands out a canonicalized root; 69 of the 70 failures and 2 of
the 3 timeouts were that one bug.

### The three pre-existing timeouts

Each burned the full 120s nextest kill on every run — 6 minutes of wall clock per suite run.

| Test | What I did |
|---|---|
| `lsp_hover_wiring_tests::a_real_click_resolves_to_a_real_hover_render_model` | **Re-tiered `external`** (`#[ignore = "external: rust-analyzer; see docs/testing.md"]`). It spawns a real rust-analyzer through `ensure_lsp_client`; that is the `external` tier by definition. Once the fixture bug was fixed it does pass here in 14s — but it needs a binary this repo does not vendor, so it belongs in the dedicated job, not the gate. |
| `lsp_hover_wiring_tests::f12_action_navigates_to_the_real_definition_line` | **Re-tiered `external`**, same reason, same rust-analyzer spawn. |
| `lsp_hover_wiring_tests::ctrl_click_on_a_real_token_navigates_to_its_real_definition` | **Re-tiered `external` and fixed.** This one could *never* have passed on macOS: it held a literal `gpui::Modifiers { control: true, .. }` with a comment claiming "reads `control` on every platform this test actually runs on (non-macOS)", while the production click handler checks `Modifiers::secondary()` — which is **Cmd** on macOS. The retry loop therefore spun until the timeout, forever. It now holds `gpui::Modifiers::secondary_key()`, the real platform-correct modifier, and passes. |

All four `external` tests in this module (the three above plus the Vue two-server one) were run
explicitly with `--run-ignored` and pass — real output below.

### Everything else

- **`#348` caveat comments gone.** `lsp_ui.rs`'s bare `#[ignore]` + "not installed in CI - GitHub
  issue #348" is now `#[ignore = "external: vue-language-server, typescript-language-server, npm;
  see docs/testing.md"]`, and the "kept in the normal (non-`#[ignore]`) suite on purpose — this
  project has no separate slow-test lane" paragraph is replaced with the tier it actually belongs to.
- **Zero `thread::sleep`** left in `code_surface/` (20 sites). The gate-tier ones are replaced with
  the deterministic `app.file_view_last_freshness_check = None` this file *already* used elsewhere
  to clear the same throttle; the `external`-tier LSP poll loops go through a new
  `fixtures::wait_until_parked`, a thin wrapper over `test_support::wait_until` that hands the
  closure the `VisualTestContext` so it can `run_until_parked` between polls.
- **Zero local `fn git`** (4 copies across `diff_view.rs`, `editing.rs`, `render.rs`, `tabs.rs`) —
  all now `test_support::git`, and every hand-rolled `init -b main` + `config user.email/user.name`
  sequence (7 of them) is `test_support::seed_empty_repo_at`.
- **All 123 `palette_focus_tests::open_test_app` call sites** in this folder migrated to
  `crate::test_support::open_test_app`.
- No `ChildGuard` was applicable: nothing in this folder owns a raw `Child`. The LSP processes are
  owned by `AdeApp`'s own client, and `write_scratch_vue_project`'s `npm` call is a blocking
  `.status()`.

## Why

`code_surface` is the largest test surface in the app (~19,000 test lines). Two thirds of a full
`-p app --lib` run's wall clock was this module's three timeouts, and 70 of its tests had been
failing on every macOS developer's machine without anyone owning them.

## Numbers

| | Before (`74dcb7c`) | After |
|---|---|---|
| Tests declared | 622 | 552 |
| Tests run | 621 | 548 |
| Passed | 548 | **548** |
| Failed | **70** | **0** |
| Timed out | **3** | **0** |
| `external` (ignored) | 1 | 4 |
| `cargo nextest` wall clock | **133.843s** | **14.058s** |

**−70 tests (11.3%)**, all passing, **9.5× faster**. Below the epic's 40–50% target, and
deliberately so: I deleted only what one of the five criteria actually justifies. The remaining
tests in this folder are overwhelmingly one-behaviour-each (undo/redo semantics, multi-cursor, IME
composition, fold state, hover/diagnostic popover placement) rather than input sweeps, and I did not
delete real coverage to hit a number.

### Deletions, with criteria

74 tests removed, 4 table-driven replacements added.

| # | Criterion | Removed | Replaced by |
|---|---|---|---|
| 1 | **1 — sweep redundancy** | 34 single-token classification tests in `code_view.rs` (`fn_keyword_is_classified_as_keyword`, `typescript_string_literal_…`, `toml_date_literal_…`, `yaml_anchor_name_…`, `c_semicolon_…`, `markdown_bold_text_…`, `css_color_literal_…`, and the rest across all 11 grammars) — each was one `highlight_X(source)` + one `kind_at` assertion, differing only by which token and bucket | `every_documented_token_lands_in_its_documented_bucket` — 44 rows, same assertions, same helper |
| 2 | **1 — sweep redundancy** | 7 definition/call-site tests (`a_function_name_is_classified_as_function`, `typescript_function_declaration_name_…`, `typescript_call_expression_callee_…`, `python_function_definition_name_…`, `python_call_callee_…`, `go_function_definition_name_…`, `c_function_definition_name_…`) | already covered by the existing 5-language table `a_definition_site_and_a_call_site_are_really_different_buckets_in_every_language`; the definition-site half also became rows in the new table |
| 3 | **1 — sweep redundancy** | 3 `highlighting_invalid_{rust,typescript,python}_still_returns_a_real_non_empty_span_list` | `highlighting_invalid_input_still_returns_a_real_non_empty_span_list`, a 3-row table |
| 4 | **1 — sweep redundancy** | `self_is_classified_as_variable_builtin_not_keyword`, `python_self_is_classified_as_variable_builtin_not_a_plain_identifier` | already covered by `self_and_this_share_the_variable_builtin_bucket_across_languages` |
| 5 | **1 — sweep redundancy** | `python_class_name_is_classified_as_type_not_function` | already covered by `python_class_names_are_classified_as_types_whatever_their_casing` (which pins all four casings) |
| 6 | **1 — sweep redundancy** | 6 more `code_view.rs` one-assertion classification tests (`a_primitive_type_identifier_…`, `typescript_predefined_type_…`, `python_type_annotation_…`, `typescript_const_variable_name_…`, `typescript_interface_member_name_…`, `typescript_class_method_name_…`, `tsx_tag_name_…`, `python_method_name_inside_a_class_…`) | rows in the new table |
| 7 | **1 — sweep redundancy** | 3 `detect_line_ending` tests (LF / CRLF / no-newline) | `detect_line_ending_reads_the_real_bytes_and_defaults_to_lf` |
| 8 | **1 — sweep redundancy** | 8 `detect_indent_width_*` tests | `detect_indent_width_picks_the_files_real_repeated_indent_unit`, 8 rows, each keeping its own `why` as a row comment |
| 9 | **1 — sweep redundancy** | 4 `doc_tag_ranges_*` tests | `doc_tag_ranges_recognizes_every_real_tag_shape_and_nothing_else` |
| 10 | **1 — sweep redundancy** | 3 `a_markdown_{html,css,rust}_fence_really_highlights_its_content_as_*` | `a_tagged_markdown_fence_really_highlights_its_content_with_that_languages_grammar`, 7 rows |
| 11 | **1 — sweep redundancy** | 3 `edit_buffer.rs` `line_col_for_offset_*` tests (empty file / end of file / line boundary — same function, different offsets) | `line_col_for_offset_resolves_the_documented_edge_positions` |
| 12 | **5 — duplicate coverage across layers** | 3 `editing.rs` `#[gpui::test]`s: `enter_carries_the_real_leading_whitespace_of_the_previous_line_over`, `enter_adds_no_whitespace_after_a_column_zero_line`, `enter_adds_one_extra_real_indent_level_after_a_python_colon_header` | each rule is already asserted directly against `EditBuffer::insert_newline_with_auto_indent` in `edit_buffer.rs`. The *wiring* (bound `EditorEnter` → handler → real settings-derived indent unit) is what a keystroke test adds, and `enter_adds_one_extra_real_indent_level_after_an_opening_bracket` keeps it — including its `tab_width = 2` half, which is the only thing that actually proves the settings path |

Nothing was deleted that was the last coverage of a user-visible behaviour. The classification
collapses keep every (token → bucket) pair as a table row; the criterion-5 deletions keep the
identical assertion one layer down.

I deliberately did **not** delete `real_typescript_source_gets_real_depth_varying_bracket_colours` /
`real_python_source_…` (superficially a 3-way sweep with the Rust one): each carries a real-grammar
premise the others do not (a TS type-argument `<` really being captured as `punctuation.bracket`; a
Python `#` comment's paren), and the cheaper pure-layer tests assert the invariant, not the grammar.
Same call for `editing.rs`'s four `clicking_*` tests — three different regressions with three
different symptoms, not one behaviour with three inputs.

## Testing

- [x] `/check` (conventions + fmt + clippy `-D warnings`) passes locally
- [ ] `verify` capture — n/a, no rendering behaviour changed (all edits are inside `#[cfg(test)]`
      plus one new test-only module)
- [x] New/changed behaviour has a real test, run manually and confirmed passing

### Gate

```
FMT OK
    Checking app v0.1.1 (/…/crates/app)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 9.08s
check-conventions: OK (glob imports: 304/304, render adapter calls: 220/221)
```

The `render.rs` adapter-call count dropped 221 → 220 (its local `fn git_repo` is gone). I left
`.claude/conventions-baseline.json` alone rather than racing the six sibling PRs for it — worth
ratcheting to 220 once the wave lands.

### Before — `cargo nextest run -p app --lib -E 'test(/^code_surface::/)'` at `74dcb7c`

```
     TIMEOUT [ 120.011s] (619/621) app code_surface::lsp_ui::lsp_hover_wiring_tests::a_real_click_resolves_to_a_real_hover_render_model
     TIMEOUT [ 120.014s] (620/621) app code_surface::lsp_ui::lsp_hover_wiring_tests::ctrl_click_on_a_real_token_navigates_to_its_real_definition
     TIMEOUT [ 120.015s] (621/621) app code_surface::lsp_ui::lsp_hover_wiring_tests::f12_action_navigates_to_the_real_definition_line
     Summary [ 133.843s] 621 tests run: 548 passed, 70 failed, 3 timed out, 2521 skipped
```

A representative failure — the whole 70 look like this:

```
    thread 'code_surface::editing::caret_alignment_tests::an_end_of_line_caret_lands_on_the_end_of_the_real_painted_text'
      panicked at crates/app/src/code_surface/editing.rs:6016:18:
    real edit buffer
```

### After — same command, this branch

```
     Summary [  14.058s] 548 tests run: 548 passed, 2524 skipped
cargo nextest run -p app --lib -E 'test(/^code_surface::/)'  73.95s user 15.17s system 578% cpu 15.413 total
```

### The `external` tier, run explicitly

```
$ cargo nextest run -p app --lib -E 'test(/^code_surface::/)' --run-ignored ignored-only
        PASS [   1.160s] (1/4) app code_surface::lsp_ui::lsp_hover_wiring_tests::a_real_click_resolves_to_a_real_hover_render_model
        PASS [   2.275s] (2/4) app code_surface::lsp_ui::vue_two_server_wiring_tests::a_real_vue_file_gets_real_diagnostics_from_both_servers_and_a_real_hover
        PASS [   5.674s] (3/4) app code_surface::lsp_ui::lsp_hover_wiring_tests::f12_action_navigates_to_the_real_definition_line
        PASS [   5.707s] (4/4) app code_surface::lsp_ui::lsp_hover_wiring_tests::ctrl_click_on_a_real_token_navigates_to_its_real_definition
     Summary [   5.709s] 4 tests run: 4 passed, 3068 skipped
```

The Vue one is genuinely doing the work it claims — its own `println!`s, uncaptured:

```
vue e2e: real merged diagnostics after 820.984417ms: ["'picked' is declared but its value is never read.", "Type 'string' is not assignable to type 'number'.", "Element is missing end tag.", "Invalid end tag."]
vue e2e: real hover resolved in 28.68775ms: HoverRenderModel { module_path: None, signature: "const bad: number", doc: None }
vue e2e: real completion labels after `shape.`: ["alpha", "beta"]
```

(These ran on a machine that happens to have `rust-analyzer`, `vue-language-server`,
`typescript-language-server` and `npm` installed. That is exactly why they are `external` and not
in the gate.)

## Architecture notes

One new test-only module, `crates/app/src/code_surface/fixtures.rs` (`#[cfg(test)]`), scoped
`pub(in crate::code_surface)`. It owns two things:

- `TempRepo` / `temp_repo()` — a `tempfile::TempDir` whose `path()` is canonicalized, so a fixture
  and `AdeApp` agree on the repo root. It keeps a `.path()` accessor precisely so the ~150 existing
  `repo.path()` call sites needed no change.
- `wait_until_parked(cx, deadline, attempt)` — a three-line wrapper over `test_support::wait_until`
  whose closure receives the `VisualTestContext`.

Both deliberately live here rather than in `crates/test-support` (which is `gpui`-free and
off-limits inside a module PR) or `crates/app/src/test_support.rs` (shared by all seven parallel
slices). **If the orchestrator wants either promoted, `wait_until_parked` is the one worth having
workspace-wide** — every `external`-tier GPUI test that polls a real process needs it, and
`test_support::wait_until`'s no-argument closure cannot express it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
