### PR TITLE
test(terminal): tier and purge the terminal + pty suite, and stop it leaking children

### DIFF
--- a/.claude/conventions-baseline.json
+++ b/.claude/conventions-baseline.json
@@ -1,5 +1,5 @@
 {
   "_comment": "Ratchet baseline for .claude/hooks/check-conventions.sh - these numbers may only go down, never up. Recount with the exact commands in that script's comments after fixing a batch of violations, and lower the number in the same commit.",
-  "glob_imports_app_src": 304,
+  "glob_imports_app_src": 303,
   "render_adapter_calls": 221
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6154,6 +6154,7 @@ dependencies = [
  "nix",
  "portable-pty",
  "tempfile",
+ "test-support",
  "thiserror 1.0.69",
 ]
 

--- a/crates/app/src/terminal/grid.rs
+++ b/crates/app/src/terminal/grid.rs
@@ -1010,7 +1010,7 @@ impl TerminalGrid {
 }
 
 #[cfg(test)]
-mod tests {
+mod grid_emulation_tests {
     use super::*;
 
     fn row_text(row: &[GridCell]) -> String {
@@ -1164,15 +1164,6 @@ mod tests {
         assert!(row_text(&rows[0]).starts_with("SECOND"));
     }
 
-    #[test]
-    fn sgr_red_foreground_resolves_to_the_named_palette_color() {
-        let mut grid = TerminalGrid::new(2, 10);
-        grid.append_bytes(b"\x1b[31mR\x1b[0m");
-        let rows = grid.visible_rows(&TerminalPalette::default());
-        assert_eq!(rows[0][0].c, 'R');
-        assert_eq!(rows[0][0].fg, TerminalPalette::default().ansi[1]);
-    }
-
     /// GitHub issue #208's pure half. Two renders of the *same* grid state under two different
     /// palettes must produce two different sets of colours - which is only true because every
     /// resolution path (unstyled default fg/bg, a named ANSI colour, and `Color::Indexed(0..=15)`)
@@ -1257,30 +1248,20 @@ mod tests {
         assert!(rows[0][0].bold);
     }
 
+    /// A resize has to change what the emulator reports *and* what it hands the renderer - a
+    /// `dimensions()` that moved without the painted rows following it would silently paint the
+    /// old geometry.
     #[test]
-    fn resize_changes_the_visible_row_and_column_count() {
+    fn a_resize_changes_both_the_reported_dimensions_and_the_visible_rows() {
         let mut grid = TerminalGrid::new(5, 20);
+        assert_eq!(grid.dimensions(), (20, 5));
+
         grid.resize(10, 40);
+
+        assert_eq!(grid.dimensions(), (40, 10));
         let rows = grid.visible_rows(&TerminalPalette::default());
         assert_eq!(rows.len(), 10);
         assert_eq!(rows[0].len(), 40);
-    }
-
-    #[test]
-    fn clear_screen_erases_previously_written_text() {
-        let mut grid = TerminalGrid::new(5, 20);
-        grid.append_bytes(b"hello");
-        grid.append_bytes(b"\x1b[2J\x1b[1;1H");
-        let rows = grid.visible_rows(&TerminalPalette::default());
-        assert_eq!(row_text(&rows[0]).trim(), "");
-    }
-
-    #[test]
-    fn dimensions_reports_the_real_current_cols_and_rows() {
-        let mut grid = TerminalGrid::new(5, 20);
-        assert_eq!(grid.dimensions(), (20, 5));
-        grid.resize(10, 40);
-        assert_eq!(grid.dimensions(), (40, 10));
     }
 
     #[test]
@@ -1305,14 +1286,6 @@ mod tests {
         // not wherever the cursor happened to be before.
         grid.append_bytes(b"X");
         assert_eq!(grid.visible_rows(&TerminalPalette::default())[0][0].c, 'X');
-    }
-
-    #[test]
-    fn mark_ended_sets_the_flag() {
-        let mut grid = TerminalGrid::new(2, 10);
-        assert!(!grid.ended);
-        grid.mark_ended();
-        assert!(grid.ended);
     }
 
     /// Pushes `count` numbered lines (`"line 0\r\n"`, `"line 1\r\n"`, ...) through a real grid -
@@ -1805,67 +1778,54 @@ mod wide_char_tests {
         row.iter().map(|cell| cell.width).collect()
     }
 
-    /// The core fact this issue rests on, straight out of real parsed UTF-8: a CJK ideograph
-    /// occupies its own cell plus a following spacer cell, and both are now labelled as such.
-    #[test]
-    fn a_cjk_character_is_a_wide_cell_followed_by_a_spacer_cell() {
-        let mut grid = TerminalGrid::new(2, 10);
-        grid.append_bytes("你好X".as_bytes());
-        let rows = grid.visible_rows(&TerminalPalette::default());
-
-        assert_eq!(rows[0][0].c, '你');
-        assert_eq!(rows[0][2].c, '好');
-        assert_eq!(rows[0][4].c, 'X');
-        assert_eq!(
-            widths(&rows[0][..5]),
-            vec![
-                CellWidth::Wide,
-                CellWidth::Spacer,
-                CellWidth::Wide,
-                CellWidth::Spacer,
-                CellWidth::Narrow,
-            ],
-        );
-    }
-
-    /// The spacer's own `c` is a literal space `alacritty_terminal` wrote there
+    /// The core fact this issue rests on, straight out of real parsed UTF-8: what counts as a
+    /// double-width character and what does not. CJK ideographs and emoji occupy their own cell
+    /// plus a following spacer; `é` is multi-*byte* but single-*width*, and conflating the two
+    /// would push every accented Latin character a column to the right.
+    ///
+    /// The spacer's own `c` is checked here too: it is a literal space `alacritty_terminal` wrote
     /// (`term/mod.rs:1127-1129`), not a copy of the character or a NUL - which is precisely why
     /// painting it used to insert a stray blank column after every wide glyph. Pinned so a future
     /// dependency bump that changed it can't silently invalidate the renderer's assumption.
     #[test]
-    fn the_spacer_cell_really_holds_a_plain_space_of_its_own() {
-        let mut grid = TerminalGrid::new(2, 10);
-        grid.append_bytes("好".as_bytes());
-        let rows = grid.visible_rows(&TerminalPalette::default());
-        assert_eq!(rows[0][1].c, ' ');
-        assert_eq!(rows[0][1].width, CellWidth::Spacer);
-    }
+    fn real_utf8_is_labelled_wide_or_narrow_by_its_real_column_width() {
+        let wide = || vec![CellWidth::Wide, CellWidth::Spacer];
+        for (text, chars, expected) in [
+            (
+                "你好X",
+                vec!['你', '好', 'X'],
+                [wide(), wide(), vec![CellWidth::Narrow]].concat(),
+            ),
+            // `🎉` (U+1F389) is a real 4-byte sequence `unicode-width` reports as two columns.
+            (
+                "🎉ok",
+                vec!['🎉', 'o', 'k'],
+                [wide(), vec![CellWidth::Narrow; 2]].concat(),
+            ),
+            ("éa", vec!['é', 'a'], vec![CellWidth::Narrow; 2]),
+        ] {
+            let mut grid = TerminalGrid::new(2, 10);
+            grid.append_bytes(text.as_bytes());
+            let rows = grid.visible_rows(&TerminalPalette::default());
 
-    /// Emoji, not just CJK - the other half of what issue #211 asks for. `🎉` (U+1F389) is a real
-    /// 4-byte UTF-8 sequence and `unicode-width` reports it as two columns.
-    #[test]
-    fn an_emoji_is_a_wide_cell_too() {
-        let mut grid = TerminalGrid::new(2, 10);
-        grid.append_bytes("🎉ok".as_bytes());
-        let rows = grid.visible_rows(&TerminalPalette::default());
-
-        assert_eq!(rows[0][0].c, '🎉');
-        assert_eq!(rows[0][0].width, CellWidth::Wide);
-        assert_eq!(rows[0][1].width, CellWidth::Spacer);
-        assert_eq!(rows[0][2].c, 'o');
-        assert_eq!(rows[0][2].width, CellWidth::Narrow);
-    }
-
-    /// A multi-byte UTF-8 character that is *not* double-width (`é`, two bytes, one column) must
-    /// stay [`CellWidth::Narrow`] - "multi-byte" and "double-width" are different properties, and
-    /// conflating them would push every accented Latin character a column to the right.
-    #[test]
-    fn a_multi_byte_but_single_width_character_stays_narrow() {
-        let mut grid = TerminalGrid::new(2, 10);
-        grid.append_bytes("éa".as_bytes());
-        let rows = grid.visible_rows(&TerminalPalette::default());
-        assert_eq!(rows[0][0].c, 'é');
-        assert_eq!(widths(&rows[0][..2]), vec![CellWidth::Narrow; 2]);
+            assert_eq!(
+                widths(&rows[0][..expected.len()]),
+                expected,
+                "cell widths for {text:?}"
+            );
+            let painted: Vec<char> = rows[0][..expected.len()]
+                .iter()
+                .zip(&expected)
+                .filter(|(_, width)| **width != CellWidth::Spacer)
+                .map(|(cell, _)| cell.c)
+                .collect();
+            assert_eq!(painted, chars, "characters for {text:?}");
+            for (cell, width) in rows[0].iter().zip(&expected) {
+                if *width == CellWidth::Spacer {
+                    assert_eq!(cell.c, ' ', "a spacer cell holds a plain space of its own");
+                }
+            }
+        }
     }
 
     /// The end-of-row case: a wide character that doesn't fit in the last column wraps, and
@@ -1961,8 +1921,10 @@ mod selection_tests {
         }
     }
 
+    /// Every way a gesture can end up selecting nothing worth copying - none of which may
+    /// overwrite the clipboard with an empty string or a stray character.
     #[test]
-    fn nothing_is_selected_until_a_selection_is_actually_dragged() {
+    fn nothing_worth_copying_is_never_reported_as_a_selection() {
         let mut grid = TerminalGrid::new(5, 20);
         grid.append_bytes(b"hello world");
         assert_eq!(grid.selected_text(), None, "no selection has been anchored");
@@ -1975,6 +1937,15 @@ mod selection_tests {
             None,
             "an anchored-but-never-dragged selection must not put a stray character on the \
              clipboard"
+        );
+
+        // A real drag, but across rows that have nothing on them at all.
+        grid.start_selection(left(2, 0));
+        grid.update_selection(right(2, 15));
+        assert_eq!(
+            grid.selected_text(),
+            None,
+            "an all-blank span must not overwrite the clipboard with an empty string"
         );
     }
 
@@ -2050,18 +2021,6 @@ mod selection_tests {
         assert_eq!(grid.selected_text(), None);
     }
 
-    #[test]
-    fn a_drag_across_blank_screen_selects_nothing_worth_copying() {
-        let mut grid = TerminalGrid::new(5, 20);
-        grid.start_selection(left(2, 0));
-        grid.update_selection(right(2, 15));
-        assert_eq!(
-            grid.selected_text(),
-            None,
-            "an all-blank span must not overwrite the clipboard with an empty string"
-        );
-    }
-
     /// The selection has to be *visible*, not just readable - a `GridCell` that never carried
     /// the flag would leave the renderer with nothing to paint, so a user dragging across the
     /// terminal would see no feedback at all.
@@ -2069,6 +2028,14 @@ mod selection_tests {
     fn selected_cells_are_flagged_for_the_renderer() {
         let mut grid = TerminalGrid::new(5, 20);
         grid.append_bytes(b"hello world");
+        assert!(
+            grid.visible_rows(&TerminalPalette::default())
+                .iter()
+                .flatten()
+                .all(|cell| !cell.selected),
+            "sanity check: with no selection anchored, no cell carries the flag"
+        );
+
         grid.start_selection(left(0, 6));
         grid.update_selection(right(0, 10));
 
@@ -2083,14 +2050,6 @@ mod selection_tests {
             rows[1].iter().all(|cell| !cell.selected),
             "a single-row selection must not flag cells on any other row"
         );
-    }
-
-    #[test]
-    fn no_selection_means_no_cell_is_flagged() {
-        let mut grid = TerminalGrid::new(5, 20);
-        grid.append_bytes(b"hello world");
-        let rows = grid.visible_rows(&TerminalPalette::default());
-        assert!(rows.iter().flatten().all(|cell| !cell.selected));
     }
 
     /// A wide character's *trailing spacer* column is genuinely part of the selection as far as

--- a/crates/app/src/terminal/links.rs
+++ b/crates/app/src/terminal/links.rs
@@ -172,39 +172,54 @@ pub fn resolve(cwd: &Path, path: &str) -> PathBuf {
 }
 
 #[cfg(test)]
-mod tests {
+mod link_detection_tests {
     use super::*;
 
+    /// Every real shape of file reference this app is expected to turn into a clickable link,
+    /// against the one thing that matters about each: which path, which line, which column.
+    /// A backtrace frame (`at src/main.rs:142:9`) needs no special-casing - it is structurally
+    /// just another `path:line:col` occurrence, which is why it sits in the same table.
     #[test]
-    fn detects_a_real_cargo_style_path_line_col_reference() {
-        let matches = find_links("src/main.rs:42:10");
-        assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].path, "src/main.rs");
-        assert_eq!(matches[0].line, Some(42));
-        assert_eq!(matches[0].column, Some(10));
-        assert_eq!(matches[0].start, 0);
-        assert_eq!(matches[0].end, "src/main.rs:42:10".chars().count());
-    }
-
-    #[test]
-    fn detects_a_real_cargo_diagnostic_arrow_line_with_a_leading_prefix() {
-        let text = "  --> src/lib.rs:12:5";
-        let matches = find_links(text);
-        assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].path, "src/lib.rs");
-        assert_eq!(matches[0].line, Some(12));
-        assert_eq!(matches[0].column, Some(5));
-        // The link must start exactly where the real path begins, not at the arrow.
-        assert_eq!(matches[0].start, text.find("src/lib.rs").unwrap());
-    }
-
-    #[test]
-    fn a_line_number_with_no_column_is_a_real_partial_match_not_a_whole_line_style() {
-        let matches = find_links("thread panicked at tests/upload.rs:88");
-        assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].path, "tests/upload.rs");
-        assert_eq!(matches[0].line, Some(88));
-        assert_eq!(matches[0].column, None);
+    fn every_real_shape_of_file_reference_resolves_to_its_own_path_line_and_column() {
+        for (text, path, line, column) in [
+            ("src/main.rs:42:10", "src/main.rs", Some(42), Some(10)),
+            ("  --> src/lib.rs:12:5", "src/lib.rs", Some(12), Some(5)),
+            (
+                "   3: my_crate::do_thing\n             at src/main.rs:142:9",
+                "src/main.rs",
+                Some(142),
+                Some(9),
+            ),
+            (
+                "thread panicked at tests/upload.rs:88",
+                "tests/upload.rs",
+                Some(88),
+                None,
+            ),
+            (" M Cargo.toml", "Cargo.toml", None, None),
+            (
+                " A src/db/query_builder.rs",
+                "src/db/query_builder.rs",
+                None,
+                None,
+            ),
+            // `:0` is a real, if unusual, shape terminal output can contain, and must never flow
+            // through as a real one-based line target.
+            ("foo.rs:0", "foo.rs", None, None),
+        ] {
+            let matches = find_links(text);
+            assert_eq!(matches.len(), 1, "expected exactly one link in {text:?}");
+            assert_eq!(matches[0].path, path, "path in {text:?}");
+            assert_eq!(matches[0].line, line, "line in {text:?}");
+            assert_eq!(matches[0].column, column, "column in {text:?}");
+            // The link starts where the real path begins, not at whatever prefix precedes it.
+            let start_char = text.char_indices().nth(matches[0].start).map(|(i, _)| i);
+            assert_eq!(
+                start_char,
+                text.find(path),
+                "the link span must begin at the path itself in {text:?}"
+            );
+        }
     }
 
     /// `  ↳ tests/upload.rs:88:` must link only the path portion, not the whole line - and the
@@ -226,40 +241,6 @@ mod tests {
     }
 
     #[test]
-    fn a_bare_repo_root_filename_with_a_known_extension_is_a_real_link() {
-        let matches = find_links(" M Cargo.toml");
-        assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].path, "Cargo.toml");
-        assert_eq!(matches[0].line, None);
-    }
-
-    #[test]
-    fn a_multi_segment_path_with_no_line_number_is_still_a_real_link() {
-        let matches = find_links(" A src/db/query_builder.rs");
-        assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].path, "src/db/query_builder.rs");
-        assert_eq!(matches[0].line, None);
-    }
-
-    #[test]
-    fn ordinary_prose_with_dots_but_no_real_extension_is_never_linked() {
-        for line in [
-            "e.g. this failed",
-            "see v0.14.0 for details",
-            "p = 0.00 < 0.05",
-            "left: 5242880",
-            "scan/baseline           time:   [41.203 ms 41.878 ms 42.611 ms]",
-            "Compiling jerry-db v0.14.0 (~/.jerry/wt/index-scan)",
-        ] {
-            assert!(
-                find_links(line).is_empty(),
-                "expected no link in {line:?}, got {:?}",
-                find_links(line)
-            );
-        }
-    }
-
-    #[test]
     fn multiple_links_on_one_line_are_all_detected_left_to_right() {
         let matches = find_links("see src/a.rs:1 and src/b.rs:2 both");
         assert_eq!(matches.len(), 2);
@@ -270,78 +251,20 @@ mod tests {
         assert!(matches[0].end <= matches[1].start);
     }
 
-    /// A real backtrace frame (`at src/main.rs:142:9`) is structurally just another
-    /// `path:line:col` occurrence - covered with no special-casing.
-    #[test]
-    fn a_real_backtrace_frame_is_detected_like_any_other_path_line_col_reference() {
-        let matches = find_links("   3: my_crate::do_thing\n             at src/main.rs:142:9");
-        assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].path, "src/main.rs");
-        assert_eq!(matches[0].line, Some(142));
-        assert_eq!(matches[0].column, Some(9));
-    }
-
-    #[test]
-    fn resolve_joins_a_relative_path_onto_the_given_cwd() {
-        let cwd = Path::new("/home/colin/wt/feature");
-        assert_eq!(
-            resolve(cwd, "src/main.rs"),
-            PathBuf::from("/home/colin/wt/feature/src/main.rs")
-        );
-    }
-
-    /// See [`resolve`]'s own "Deliberate" doc section: an absolute path resolves to itself even
-    /// when it names something outside `cwd` - this function is not the gate against a bogus
-    /// link opening a tab (`open_terminal_link`'s `path.is_file()` check is).
-    #[test]
-    fn resolve_leaves_an_absolute_path_untouched() {
-        let cwd = Path::new("/home/colin/wt/feature");
-        assert_eq!(resolve(cwd, "/etc/hosts"), PathBuf::from("/etc/hosts"));
-    }
-
-    /// A real repro: `no such file or directory: ../../../etc/shadow.conf` in terminal output
-    /// must resolve to a path with no literal `..` left in it, and per [`resolve`]'s documented
-    /// choice, is allowed to land outside `cwd` rather than being rejected.
-    #[test]
-    fn resolve_normalizes_dot_dot_segments_and_deliberately_allows_escaping_cwd() {
-        let cwd = Path::new("/home/colin/wt/feature");
-        assert_eq!(
-            resolve(cwd, "../../../etc/shadow.conf"),
-            PathBuf::from("/home/etc/shadow.conf"),
-            "`..` segments must be collapsed into a real path with no literal `..` left in it"
-        );
-    }
-
-    #[test]
-    fn resolve_normalizes_a_dot_dot_that_would_otherwise_go_above_the_root() {
-        let cwd = Path::new("/home");
-        assert_eq!(
-            resolve(cwd, "../../../etc/passwd"),
-            PathBuf::from("/etc/passwd"),
-            "a `..` with nowhere left to pop (already at the real filesystem root) must be \
-             dropped, not underflow into something nonsensical"
-        );
-    }
-
-    /// A real cargo help-text line containing a bare `https://` URL, mod-clicked, used to
-    /// resolve to a nonexistent absolute path (`/doc.rust-lang.org/...`) because the old
-    /// regex's leading `/?` alternation latched onto the second slash of `://`. A URL must
-    /// never be detected as a link at all.
-    #[test]
-    fn a_url_in_real_cargo_output_is_never_detected_as_a_link() {
-        let text = "see https://doc.rust-lang.org/cargo/reference/manifest.html for more";
-        assert!(
-            find_links(text).is_empty(),
-            "expected no link in {text:?}, got {:?}",
-            find_links(text)
-        );
-    }
-
-    /// Further real false positives found by probing the production regex against realistic
-    /// terminal output.
+    /// The false positives found by probing the production regex against realistic terminal
+    /// output. A URL is the sharpest of them: mod-clicking one used to resolve to a nonexistent
+    /// absolute path (`/doc.rust-lang.org/...`), because the old regex's leading `/?`
+    /// alternation latched onto the second slash of `://`.
     #[test]
     fn realistic_non_path_output_never_produces_a_false_link() {
         for line in [
+            "e.g. this failed",
+            "see v0.14.0 for details",
+            "p = 0.00 < 0.05",
+            "left: 5242880",
+            "scan/baseline           time:   [41.203 ms 41.878 ms 42.611 ms]",
+            "Compiling jerry-db v0.14.0 (~/.jerry/wt/index-scan)",
+            "see https://doc.rust-lang.org/cargo/reference/manifest.html for more",
             // An SSH-style git remote: before the fix, this matched a fake `github.c` (`"c"`
             // is a known bare extension) *and* a fake `foo/bar.git`.
             "$ git clone git@github.com:foo/bar.git",
@@ -349,8 +272,7 @@ mod tests {
             // *any* extension, so `12.5/100.0` looked exactly like `path/file.ext`.
             "12.5/100.0 MB downloaded",
             "the answer is 42/7.0 approx",
-            // A URL whose host:port looks path-shaped once the scheme/host prefix is ignored -
-            // covered by the same URL rejection as the `doc.rust-lang.org` case above.
+            // A URL whose host:port looks path-shaped once the scheme/host prefix is ignored.
             "curl http://127.0.0.1:8080/api/v1/health.json",
         ] {
             assert!(
@@ -361,16 +283,32 @@ mod tests {
         }
     }
 
-    /// `foo.rs:0` is a real, if unusual, shape terminal output could contain - `0` must never
-    /// flow through as a real line number.
+    /// See [`resolve`]'s own "Deliberate" doc section: an absolute path resolves to itself, and
+    /// a relative one is allowed to land outside `cwd` rather than being rejected - this
+    /// function is not the gate against a bogus link opening a tab (`open_terminal_link`'s
+    /// `path.is_file()` check is). What it does guarantee is that no literal `..` survives, and
+    /// that a `..` with nowhere left to pop is dropped rather than underflowing.
     #[test]
-    fn a_captured_line_number_of_zero_is_treated_as_no_line() {
-        let matches = find_links("foo.rs:0");
-        assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].path, "foo.rs");
-        assert_eq!(
-            matches[0].line, None,
-            "a captured `:0` must never pass through as a real one-based line target"
-        );
+    fn resolve_produces_a_real_absolute_path_with_no_dot_dot_left_in_it() {
+        for (cwd, path, expected) in [
+            (
+                "/home/colin/wt/feature",
+                "src/main.rs",
+                "/home/colin/wt/feature/src/main.rs",
+            ),
+            ("/home/colin/wt/feature", "/etc/hosts", "/etc/hosts"),
+            (
+                "/home/colin/wt/feature",
+                "../../../etc/shadow.conf",
+                "/home/etc/shadow.conf",
+            ),
+            ("/home", "../../../etc/passwd", "/etc/passwd"),
+        ] {
+            assert_eq!(
+                resolve(Path::new(cwd), path),
+                PathBuf::from(expected),
+                "resolving {path:?} against {cwd:?}"
+            );
+        }
     }
 }

--- a/crates/app/src/terminal/osc.rs
+++ b/crates/app/src/terminal/osc.rs
@@ -212,7 +212,7 @@ impl OscWatcher {
 }
 
 #[cfg(test)]
-mod tests {
+mod osc_signal_tests {
     use super::*;
 
     fn watch(bytes: &[u8]) -> OscWatcher {
@@ -221,77 +221,80 @@ mod tests {
         watcher
     }
 
+    /// Every real spelling of "the agent wants the human", and the near-misses that share its
+    /// prefix. OSC can be terminated by BEL *or* by ST (`ESC \`) - real senders use both - and
+    /// OSC 777 carries non-notification sub-commands only one of which is an attention request.
     #[test]
-    fn a_bare_osc_9_notification_pings_for_attention_once() {
-        let mut watcher = watch(b"\x1b]9;Claude needs your permission\x07");
-        assert!(watcher.take_attention_ping());
-        assert!(
-            !watcher.take_attention_ping(),
-            "the ping is a point-in-time event and must not re-fire on a second read"
-        );
+    fn only_a_real_attention_request_pings_and_it_pings_exactly_once() {
+        for (bytes, expected) in [
+            (b"\x1b]9;Claude needs your permission\x07".as_slice(), true),
+            (b"\x1b]9;done\x1b\\".as_slice(), true),
+            (
+                b"\x1b]777;notify;Gemini;waiting on you\x07".as_slice(),
+                true,
+            ),
+            (b"\x1b]777;precmd;0\x07".as_slice(), false),
+            (b"\x1b]9\x07".as_slice(), false),
+            (b"\x1b]9;4;1;42\x07".as_slice(), false),
+        ] {
+            let mut watcher = watch(bytes);
+            assert_eq!(
+                watcher.take_attention_ping(),
+                expected,
+                "{bytes:?} must {}ping for attention",
+                if expected { "" } else { "not " }
+            );
+            assert!(
+                !watcher.take_attention_ping(),
+                "the ping is a point-in-time event and must not re-fire on a second read"
+            );
+        }
     }
 
+    /// The OSC 9;4 progress vocabulary, whole: each documented state, the percentage rules, and
+    /// the reports that define no progress at all.
     #[test]
-    fn an_st_terminated_osc_9_also_pings() {
-        // OSC can be terminated by BEL *or* by ST (`ESC \`); real senders use both.
-        let mut watcher = watch(b"\x1b]9;done\x1b\\");
-        assert!(watcher.take_attention_ping());
-    }
-
-    #[test]
-    fn osc_777_notify_pings_but_other_777_subcommands_do_not() {
-        let mut watcher = watch(b"\x1b]777;notify;Gemini;waiting on you\x07");
-        assert!(watcher.take_attention_ping());
-
-        let mut watcher = watch(b"\x1b]777;precmd;0\x07");
-        assert!(
-            !watcher.take_attention_ping(),
-            "OSC 777 has non-notification sub-commands; only `notify` is an attention request"
-        );
-    }
-
-    #[test]
-    fn osc_9_4_is_progress_not_a_notification() {
-        let mut watcher = watch(b"\x1b]9;4;1;42\x07");
-        assert_eq!(
-            watcher.progress(),
+    fn every_progress_report_parses_to_its_documented_meaning() {
+        let normal = |percent| {
             Some(Progress {
                 state: ProgressState::Normal,
-                percent: Some(42)
+                percent,
             })
-        );
-        assert!(
-            !watcher.take_attention_ping(),
-            "a progress report is not a request for the human's attention"
-        );
-    }
-
-    #[test]
-    fn every_progress_state_parses_to_its_documented_meaning() {
-        assert_eq!(watch(b"\x1b]9;4;0;0\x07").progress(), None);
-        assert_eq!(
-            watch(b"\x1b]9;4;2;80\x07").progress(),
-            Some(Progress {
-                state: ProgressState::Error,
-                percent: Some(80)
-            })
-        );
-        assert_eq!(
-            watch(b"\x1b]9;4;3;0\x07").progress(),
-            Some(Progress {
-                state: ProgressState::Indeterminate,
-                percent: None
-            }),
-            "indeterminate defines no percentage - reporting the sender's filler 0 as \"0% done\" \
-             would be inventing a fact"
-        );
-        assert_eq!(
-            watch(b"\x1b]9;4;4;33\x07").progress(),
-            Some(Progress {
-                state: ProgressState::Paused,
-                percent: Some(33)
-            })
-        );
+        };
+        for (bytes, expected) in [
+            (b"\x1b]9;4;1;42\x07".as_slice(), normal(Some(42))),
+            // Clamped, and an unparseable percentage is absent rather than zero.
+            (b"\x1b]9;4;1;999\x07".as_slice(), normal(Some(100))),
+            (b"\x1b]9;4;1;abc\x07".as_slice(), normal(None)),
+            (
+                b"\x1b]9;4;2;80\x07".as_slice(),
+                Some(Progress {
+                    state: ProgressState::Error,
+                    percent: Some(80),
+                }),
+            ),
+            // Indeterminate defines no percentage - reporting the sender's filler 0 as "0% done"
+            // would be inventing a fact.
+            (
+                b"\x1b]9;4;3;0\x07".as_slice(),
+                Some(Progress {
+                    state: ProgressState::Indeterminate,
+                    percent: None,
+                }),
+            ),
+            (
+                b"\x1b]9;4;4;33\x07".as_slice(),
+                Some(Progress {
+                    state: ProgressState::Paused,
+                    percent: Some(33),
+                }),
+            ),
+            (b"\x1b]9;4;0;0\x07".as_slice(), None),
+            (b"\x1b]9;4;7;50\x07".as_slice(), None),
+            (b"\x1b]9;4\x07".as_slice(), None),
+        ] {
+            assert_eq!(watch(bytes).progress(), expected, "parsing {bytes:?}");
+        }
     }
 
     #[test]
@@ -302,40 +305,17 @@ mod tests {
         assert!(!ProgressState::Paused.is_active());
     }
 
+    /// Progress is live state, not an append-only log: a later report replaces an earlier one,
+    /// and a clear report really clears it.
     #[test]
-    fn a_clear_report_clears_an_earlier_progress() {
-        let mut watcher = OscWatcher::default();
-        watcher.feed(b"\x1b]9;4;1;50\x07");
-        assert!(watcher.progress().is_some());
-        watcher.feed(b"\x1b]9;4;0\x07");
-        assert_eq!(watcher.progress(), None);
-    }
-
-    #[test]
-    fn a_later_progress_report_supersedes_an_earlier_one() {
+    fn a_later_progress_report_supersedes_an_earlier_one_and_a_clear_wipes_it() {
         let mut watcher = OscWatcher::default();
         watcher.feed(b"\x1b]9;4;1;10\x07");
         watcher.feed(b"\x1b]9;4;1;90\x07");
         assert_eq!(watcher.progress().and_then(|p| p.percent), Some(90));
-    }
 
-    #[test]
-    fn a_percentage_above_100_is_clamped_and_a_junk_one_is_dropped() {
-        assert_eq!(
-            watch(b"\x1b]9;4;1;999\x07").progress().unwrap().percent,
-            Some(100)
-        );
-        assert_eq!(
-            watch(b"\x1b]9;4;1;abc\x07").progress().unwrap().percent,
-            None,
-            "an unparseable percentage is absent, not zero"
-        );
-    }
-
-    #[test]
-    fn an_out_of_range_progress_state_is_ignored_entirely() {
-        assert_eq!(watch(b"\x1b]9;4;7;50\x07").progress(), None);
-        assert_eq!(watch(b"\x1b]9;4\x07").progress(), None);
+        watcher.feed(b"\x1b]9;4;0\x07");
+        assert_eq!(watcher.progress(), None);
     }
 
     #[test]
@@ -363,11 +343,5 @@ mod tests {
             watcher.feed(chunk);
         }
         assert_eq!(watcher.progress().and_then(|p| p.percent), Some(77));
-    }
-
-    #[test]
-    fn a_bare_osc_9_with_no_message_is_not_a_notification() {
-        let mut watcher = watch(b"\x1b]9\x07");
-        assert!(!watcher.take_attention_ping());
     }
 }

--- a/crates/app/src/terminal/pane.rs
+++ b/crates/app/src/terminal/pane.rs
@@ -464,19 +464,29 @@ fn configured_shell_program(configured: Option<&str>) -> Option<PathBuf> {
 mod shell_program_tests {
     use super::*;
 
+    /// Both platform variants' own decisions, side by side. The Windows row is GitHub issue
+    /// #50's actual regression: the fallback must be a real Windows path (`cmd.exe`), never the
+    /// Unix `/bin/bash` this crate used to fall back to unconditionally - `$SHELL` is a Unix-only
+    /// convention Windows never sets, so every Windows session with no override was trying to
+    /// launch a Unix path that does not exist there at all.
     #[test]
-    fn a_real_env_value_is_used_verbatim() {
+    fn an_env_value_is_used_verbatim_and_an_absent_one_falls_back_per_platform() {
         assert_eq!(
             shell_program_from_env(Some(std::ffi::OsString::from("/usr/bin/zsh")), "/bin/bash"),
             PathBuf::from("/usr/bin/zsh")
         );
-    }
-
-    #[test]
-    fn an_absent_env_value_falls_back() {
         assert_eq!(
             shell_program_from_env(None, "/bin/bash"),
             PathBuf::from("/bin/bash")
+        );
+
+        let windows_fallback = shell_program_from_env(None, "cmd.exe");
+        assert_eq!(windows_fallback, PathBuf::from("cmd.exe"));
+        assert_ne!(
+            windows_fallback,
+            PathBuf::from("/bin/bash"),
+            "the Windows default shell must never be the Unix path - that real path does not \
+             exist on Windows, which is the whole bug GitHub issue #50 reports"
         );
     }
 
@@ -513,24 +523,28 @@ mod shell_program_tests {
         );
     }
 
-    /// The zero-config path this setting must never disturb: no override (or a blank one, which
-    /// the settings field can genuinely produce) spawns *exactly* what this app spawned before
-    /// the setting existed.
+    /// The zero-config path this setting must never disturb: no override - or one the settings
+    /// field can genuinely produce that carries no real program name - spawns *exactly* what this
+    /// app spawned before the setting existed. Trimming happens at the edge, so `" fish "` (a
+    /// real, plausible copy-paste) spawns `fish` rather than a name with spaces in it that no
+    /// `PATH` entry could ever match.
     #[test]
-    fn no_configured_shell_is_byte_for_byte_the_previous_os_default() {
+    fn a_configured_shell_is_trimmed_and_a_nameless_one_falls_back_to_the_os_default() {
         let cwd = std::env::temp_dir();
         let os_default = TerminalSpec::default_shell_program();
 
-        assert_eq!(TerminalSpec::shell(cwd.clone(), None).program, os_default);
+        for configured in [None, Some(""), Some("   ")] {
+            assert_eq!(
+                TerminalSpec::shell(cwd.clone(), configured).program,
+                os_default,
+                "{configured:?} names no real program, so it means 'use the system default'"
+            );
+            assert_eq!(configured_shell_program(configured), None);
+        }
+
         assert_eq!(
-            TerminalSpec::shell(cwd.clone(), Some("")).program,
-            os_default,
-            "an empty setting means 'use the system default', not a program with no name"
-        );
-        assert_eq!(
-            TerminalSpec::shell(cwd, Some("   ")).program,
-            os_default,
-            "a whitespace-only setting must fall back too, never spawn a program named ' '"
+            configured_shell_program(Some("  zsh  ")),
+            Some(PathBuf::from("zsh"))
         );
     }
 
@@ -567,30 +581,6 @@ mod shell_program_tests {
             ),
             Ok(_) => panic!("a shell that doesn't exist must not spawn"),
         }
-    }
-
-    /// Trimming happens at the edge, so `" fish "` (a real, plausible copy-paste) spawns `fish`
-    /// rather than a name with spaces in it that no `PATH` entry could ever match.
-    #[test]
-    fn a_configured_shell_is_trimmed_before_it_becomes_a_program() {
-        assert_eq!(
-            configured_shell_program(Some("  zsh  ")),
-            Some(PathBuf::from("zsh"))
-        );
-        assert_eq!(configured_shell_program(None), None);
-        assert_eq!(configured_shell_program(Some(" ")), None);
-    }
-
-    #[test]
-    fn the_windows_fallback_is_a_real_windows_path_not_the_unix_one() {
-        let windows_fallback = shell_program_from_env(None, "cmd.exe");
-        assert_eq!(windows_fallback, PathBuf::from("cmd.exe"));
-        assert_ne!(
-            windows_fallback,
-            PathBuf::from("/bin/bash"),
-            "the Windows default shell must never be the Unix path - that real path does not \
-             exist on Windows, which is the whole bug this issue reports"
-        );
     }
 }
 
@@ -2933,8 +2923,124 @@ impl Render for TerminalPane {
     }
 }
 
+/// Shared fixtures for the test modules below that drive a **real** child process on a **real**
+/// pty. Everything here exists because those two clocks are genuinely different: the poll loop's
+/// ticks are driven by GPUI's simulated executor clock, while the pty reader is an ordinary OS
+/// thread that only makes progress in real wall-clock time. A loop that advanced only the virtual
+/// clock would race ahead of the reader; a fixed `thread::sleep` would be simultaneously too
+/// short under load and dead time when idle. `test_support::wait_until`/`stays_false` are the
+/// workspace's one sanctioned wall-clock wait (`docs/testing.md`), so both clocks advance
+/// together, one poll at a time.
+#[cfg(test)]
+mod pty_pane_fixtures {
+    use super::{TerminalPane, TerminalSpec, POLL_INTERVAL, ROW_FONT_SIZE_PX};
+    use gpui::{AppContext, Entity, TestAppContext};
+    use std::time::Duration;
+
+    /// How long a real pty round trip is given before a test calls it a failure. Generous: it has
+    /// to survive a full-suite run where dozens of other tests' own child processes are competing
+    /// for the same cores.
+    pub(super) const PTY_ROUND_TRIP: Duration = Duration::from_secs(30);
+
+    /// A pane backed by a real child process, spawned and settled.
+    pub(super) fn spawn_pane(
+        cx: &mut TestAppContext,
+        program: &str,
+        args: &[&str],
+    ) -> Entity<TerminalPane> {
+        let pane = cx.new(|cx| {
+            TerminalPane::new(
+                TerminalSpec::command(
+                    program,
+                    args.iter().map(|arg| arg.to_string()).collect(),
+                    std::env::temp_dir(),
+                ),
+                ROW_FONT_SIZE_PX,
+                cx,
+            )
+        });
+        cx.run_until_parked();
+        pane
+    }
+
+    /// Drives real poll ticks until `done` holds, or until [`PTY_ROUND_TRIP`] elapses.
+    pub(super) fn pump_until(
+        cx: &mut TestAppContext,
+        mut done: impl FnMut(&mut TestAppContext) -> bool,
+    ) -> bool {
+        cx.run_until_parked();
+        test_support::wait_until(PTY_ROUND_TRIP, || {
+            cx.background_executor.advance_clock(POLL_INTERVAL);
+            cx.run_until_parked();
+            done(cx)
+        })
+    }
+
+    /// The inverse: drives real poll ticks for `window` and reports whether `unwanted` stayed
+    /// false throughout - for proving something genuinely never reaches the child, rather than
+    /// merely being slow to arrive.
+    pub(super) fn stays_absent(
+        cx: &mut TestAppContext,
+        window: Duration,
+        mut unwanted: impl FnMut(&mut TestAppContext) -> bool,
+    ) -> bool {
+        cx.run_until_parked();
+        test_support::stays_false(window, || {
+            cx.background_executor.advance_clock(POLL_INTERVAL);
+            cx.run_until_parked();
+            unwanted(cx)
+        })
+    }
+
+    /// Drops `pane` and makes GPUI actually release it, killing its real child process tree.
+    ///
+    /// **Every test in this file that spawns a real pty must end with this.** GPUI releases an
+    /// entity whose last handle was dropped during `flush_effects`, which only runs inside an app
+    /// update - letting the `Entity` fall out of scope at the end of a test body does not trigger
+    /// one, and `run_until_parked` does not either. Until it happens the pane's `PtySession` is
+    /// still alive, so `PtySession::drop`'s process-tree teardown has not run and the child (and
+    /// anything it spawned) keeps running for the rest of the test *binary's* life.
+    ///
+    /// That is not a theoretical hazard: sampled every 100ms during a single-process
+    /// `cargo test -p app --lib terminal::` run before this existed, this module alone held **29
+    /// live children at once**. GitHub issue #427 counted 509 across all of `crates/app`. It does
+    /// not show up in a before/after `ps` diff, because the moment the test binary exits, the pty
+    /// master fd closes and the kernel SIGHUPs each pty's foreground process group - so the
+    /// evidence is only visible while the run is in flight.
+    ///
+    /// `pane_teardown_tests` pins the underlying property this relies on.
+    pub(super) fn release(cx: &mut TestAppContext, pane: Entity<TerminalPane>) {
+        drop(pane);
+        // A pane built with `add_window_view` is the window's *root view*, so the window holds a
+        // strong handle of its own and dropping the test's is not enough. Closing the test's
+        // windows here rather than asking each caller to is deliberate: `release` is the last
+        // statement of a test either way, and a helper that silently worked for `cx.new` panes
+        // and silently did nothing for windowed ones is exactly the kind of half-teardown this
+        // whole fixture exists to stop.
+        for window in cx.windows() {
+            let _ = window.update(cx, |_, window, _| window.remove_window());
+        }
+        cx.update(|_cx| {});
+        cx.run_until_parked();
+    }
+
+    /// Whether any visible grid row contains `needle`.
+    pub(super) fn grid_shows(
+        cx: &mut TestAppContext,
+        pane: &Entity<TerminalPane>,
+        needle: &str,
+    ) -> bool {
+        pane.read_with(cx, |pane, _| {
+            pane.visible_text_lines()
+                .iter()
+                .any(|line| line.contains(needle))
+        })
+    }
+}
+
 #[cfg(test)]
 mod cadence_tests {
+    use super::pty_pane_fixtures::{grid_shows, pump_until, release, spawn_pane};
     use super::*;
     use gpui::TestAppContext;
 
@@ -2946,21 +3052,17 @@ mod cadence_tests {
     /// on 8ms ticks forever, and the "nothing may drain in less than one background interval"
     /// window asserted here would see the Ctrl-L echo arrive early.
     ///
-    /// Deterministic despite the real pty: the *arrival* of the echo into pty-core's channel
-    /// takes real wall time (covered by a real sleep, generously sized), but the *drain* only
-    /// happens on poll ticks, and those are driven purely by the test executor's fake clock.
+    /// Deterministic despite the real pty, and without a fixed sleep: the *arrival* of the echo
+    /// into pty-core's channel takes real wall time, but the *drain* only ever happens on a poll
+    /// tick, and those are driven purely by the test executor's simulated clock. So the property
+    /// is stated in virtual time - "no drain may happen before one full background interval of
+    /// simulated time has passed" - and real time is only ever allowed to pass through
+    /// `test_support::wait_until`'s own bounded poll.
     #[gpui::test]
     fn a_background_pane_drains_on_the_background_interval_read_fresh_each_tick(
         cx: &mut TestAppContext,
     ) {
-        let pane = cx.new(|cx| {
-            TerminalPane::new(
-                TerminalSpec::command("cat", Vec::new(), std::env::temp_dir()),
-                ROW_FONT_SIZE_PX,
-                cx,
-            )
-        });
-        cx.run_until_parked();
+        let pane = spawn_pane(cx, "cat", &[]);
 
         // Fire the loop's first (foreground-armed) tick, demote the pane, then fire one more
         // tick so the demotion is picked up and a BACKGROUND_POLL_INTERVAL sleep is armed.
@@ -2970,65 +3072,42 @@ mod cadence_tests {
         cx.background_executor.advance_clock(POLL_INTERVAL);
         cx.run_until_parked();
 
-        // Ctrl-L; the pty's ECHOCTL echo ("^L", see
-        // `clear_with_a_live_session_sends_a_real_ctrl_l_the_pty_echoes_back`) lands in the
-        // output channel within real milliseconds - sleep long enough that it is certainly
-        // sitting there before any virtual time passes.
+        // Ctrl-L; the pty's ECHOCTL echo is "^L" (see
+        // `clear_with_a_live_session_sends_a_real_ctrl_l_the_pty_echoes_back`).
         pane.update(cx, |pane, cx| pane.clear(cx));
-        std::thread::sleep(Duration::from_millis(400));
 
-        // Three foreground-sized steps: 24ms of virtual time, less than one 33ms background
-        // tick - a correctly-backgrounded pane must not have drained the echo yet.
-        for _ in 0..3 {
-            cx.background_executor.advance_clock(POLL_INTERVAL);
-            cx.run_until_parked();
-        }
-        let lines = pane.read_with(cx, |pane, _| pane.visible_text_lines());
+        // Advance one *foreground*-sized step at a time, counting how much simulated time it
+        // took for the echo to appear. A loop that hoisted `is_foreground` out and kept the
+        // spawn-time `true` would drain it on the very next 8ms tick; one that re-reads the flag
+        // cannot drain before its 33ms background timer next fires, whenever the echo arrives.
+        let mut virtual_elapsed = Duration::ZERO;
         assert!(
-            !lines.iter().any(|line| line.contains("^L")),
-            "a background pane drained pty output in under one BACKGROUND_POLL_INTERVAL - \
-             the poll loop is not reading the live foreground flag each tick"
-        );
-
-        // Past the background interval the echo must drain normally (bounded tick loop, as in
-        // the ctrl-l test above, since exactly which tick isn't under test).
-        let mut saw_caret_l = false;
-        for _ in 0..50 {
-            cx.background_executor
-                .advance_clock(BACKGROUND_POLL_INTERVAL);
-            cx.run_until_parked();
-            let lines = pane.read_with(cx, |pane, _| pane.visible_text_lines());
-            if lines.iter().any(|line| line.contains("^L")) {
-                saw_caret_l = true;
-                break;
-            }
-        }
-        assert!(
-            saw_caret_l,
+            test_support::wait_until(super::pty_pane_fixtures::PTY_ROUND_TRIP, || {
+                cx.background_executor.advance_clock(POLL_INTERVAL);
+                cx.run_until_parked();
+                virtual_elapsed += POLL_INTERVAL;
+                grid_shows(cx, &pane, "^L")
+            }),
             "the background cadence must still drain output - coarser, not never"
         );
+        assert!(
+            virtual_elapsed >= BACKGROUND_POLL_INTERVAL,
+            "a background pane drained pty output after only {virtual_elapsed:?} of simulated \
+             time, less than one BACKGROUND_POLL_INTERVAL ({BACKGROUND_POLL_INTERVAL:?}) - the \
+             poll loop is not reading the live foreground flag each tick"
+        );
 
-        // And a promoted pane resumes draining (which tick is again not under test - only
-        // that promotion doesn't strand it).
+        // And a promoted pane resumes draining (which tick is not under test here - only that
+        // promotion doesn't strand it).
         pane.update(cx, |pane, cx| {
             pane.set_foreground(true);
             pane.clear(cx); // wipes the grid, sends a fresh Ctrl-L
         });
-        std::thread::sleep(Duration::from_millis(400));
-        let mut saw_caret_l_again = false;
-        for _ in 0..50 {
-            cx.background_executor.advance_clock(POLL_INTERVAL);
-            cx.run_until_parked();
-            let lines = pane.read_with(cx, |pane, _| pane.visible_text_lines());
-            if lines.iter().any(|line| line.contains("^L")) {
-                saw_caret_l_again = true;
-                break;
-            }
-        }
         assert!(
-            saw_caret_l_again,
+            pump_until(cx, |cx| grid_shows(cx, &pane, "^L")),
             "a pane promoted back to foreground must keep draining output"
         );
+        release(cx, pane);
     }
 
     #[test]
@@ -3082,38 +3161,10 @@ mod resize_tests {
     }
 
     #[test]
-    fn size_to_grid_derives_columns_and_rows_from_the_given_size_not_a_fixed_constant() {
-        // A plausible centre-pane content width once Phase A's shell chrome (rail + panel +
-        // borders) is subtracted from a 1440px window - roughly 820px, not the full 1440.
-        let (rows, cols) = size_to_grid(size(px(820.0), px(800.0)), test_cell_size());
-        assert_eq!(cols, (820.0 / APPROX_CELL_WIDTH_PX) as u16);
-        assert_eq!(rows, (800.0 / ROW_LINE_HEIGHT_PX) as u16);
-    }
-
-    #[test]
     fn size_to_grid_enforces_a_minimum_row_and_column_count() {
         let (rows, cols) = size_to_grid(size(px(10.0), px(10.0)), test_cell_size());
         assert_eq!(cols, 20);
         assert_eq!(rows, 10);
-    }
-
-    #[test]
-    fn size_to_grid_from_a_real_pane_width_is_plausible_not_the_full_window_derived_count() {
-        // Regression guard for the Phase-A bug: deriving columns from the whole 1440px window
-        // (ignoring shell chrome either side) computed ~205 columns; the real centre-pane
-        // width is ~820-840px, ~118-120 columns. Both are "correct" `size_to_grid` outputs for
-        // their inputs - the bug was `maybe_resize_pty` feeding it the wrong one. Pins the two
-        // magnitudes apart so a regression back to `window.viewport_size()` gets caught here.
-        let (_rows, whole_window_cols) =
-            size_to_grid(size(px(1440.0), px(928.0)), test_cell_size());
-        let (_rows, real_pane_cols) = size_to_grid(size(px(828.0), px(800.0)), test_cell_size());
-        assert!(
-            whole_window_cols > real_pane_cols * 3 / 2,
-            "expected the whole-window column count ({whole_window_cols}) to be \
-             substantially larger than the real-pane-width column count ({real_pane_cols}) \
-             - if they're close, something about the approximation changed"
-        );
-        assert!(real_pane_cols < 130, "got {real_pane_cols}");
     }
 
     #[test]
@@ -3129,31 +3180,6 @@ mod resize_tests {
             big_cells,
             (small_cells.0 / 2, small_cells.1 / 2),
             "doubling the cell size must exactly halve both dimensions"
-        );
-    }
-
-    #[test]
-    fn size_to_grid_documents_the_real_before_after_column_count_at_a_typical_pane_width() {
-        // At a plausible centre-pane width (828px) and typical panel height (~800px): how many
-        // rows the old guessed cell size (7.0 x 16.0) computed versus the line-height-corrected
-        // one (7.0 x 19.0). Isolates the height half of the Phase-C bug - the width half is
-        // that `cell_size`'s width now comes from a real font-metrics measurement instead of a
-        // guess, which this pure function can't itself demonstrate.
-        let old_guess = size(px(APPROX_CELL_WIDTH_PX), px(16.0));
-        let new_real = size(px(APPROX_CELL_WIDTH_PX), px(ROW_LINE_HEIGHT_PX));
-        let pane = size(px(828.0), px(800.0));
-
-        let (old_rows, _) = size_to_grid(pane, old_guess);
-        let (new_rows, _) = size_to_grid(pane, new_real);
-
-        // The old, too-short line-height guess asked for more rows than the pane could
-        // actually show without clipping (`800.0 / 16.0 = 50` vs. `800.0 / 19.0 = 42`) - a
-        // ~19% over-request, not a rounding artifact.
-        assert_eq!(old_rows, 50);
-        assert_eq!(new_rows, 42);
-        assert!(
-            old_rows > new_rows,
-            "the old guess must over-request rows relative to the real, corrected line height"
         );
     }
 
@@ -3295,66 +3321,6 @@ mod eof_poll_tests {
             None => panic!("expected the tick cap to force a resolution"),
         }
     }
-
-    /// Empirical proof (no GPUI needed) that the race `eof_poll_decision` exists to handle is
-    /// genuine: a child that closes its own pty-attached stdio before actually exiting causes
-    /// the output channel to disconnect while the process is still alive - a single
-    /// non-blocking `try_wait` at that moment legitimately observes nothing, and only a later
-    /// retry observes the real exit status.
-    #[test]
-    fn real_process_closing_pty_fds_before_exiting_is_not_yet_reaped_at_eof() {
-        let mut session = pty_core::spawn(
-            pty_core::SpawnOptions::new("sh")
-                .arg("-c")
-                .arg("exec 0<&- 1>&- 2>&-; sleep 1; exit 7"),
-        )
-        .expect("spawning the shell should succeed");
-
-        // Drain until the output channel disconnects - exactly the `TryRecvError::
-        // Disconnected` signal `TerminalPane`'s poll loop reacts to.
-        let deadline = Instant::now() + Duration::from_secs(5);
-        loop {
-            let remaining = deadline.saturating_duration_since(Instant::now());
-            if remaining.is_zero() {
-                panic!("timed out waiting for the pty output channel to disconnect (EOF)");
-            }
-            if session.output().recv_timeout(remaining).is_err() {
-                break; // disconnected
-            }
-        }
-
-        // At the moment of EOF the process has not exited yet (it's mid-`sleep 1`) - a
-        // single `try_wait` here legitimately observes nothing. If this assertion itself
-        // fails, the test's timing assumption is wrong, not the fix under test.
-        let immediately_after_eof = session
-            .try_wait()
-            .expect("try_wait should not error for a live child");
-        assert!(
-            immediately_after_eof.is_none(),
-            "expected the process to still be alive (sleeping) right after its pty fds \
-             closed - a single try_wait must not yet observe an exit"
-        );
-
-        // The bounded retry loop `eof_poll_decision` drives in real usage: keep checking
-        // until the real exit status becomes observable.
-        let mut observed = None;
-        let poll_deadline = Instant::now() + Duration::from_secs(5);
-        while Instant::now() < poll_deadline {
-            if let Some(status) = session
-                .try_wait()
-                .expect("try_wait should not error while polling")
-            {
-                observed = Some(status);
-                break;
-            }
-            std::thread::sleep(Duration::from_millis(20));
-        }
-
-        let status =
-            observed.expect("the process should eventually be reaped with a real exit status");
-        assert!(!status.success());
-        assert_eq!(status.exit_code(), 7);
-    }
 }
 
 #[cfg(test)]
@@ -3389,119 +3355,86 @@ mod keystroke_tests {
         );
     }
 
+    /// Direct proof of the control-byte mapping itself, independent of whether GPUI's own
+    /// dispatch ever lets these keystrokes reach this pane's `on_key_down` to be mapped. For
+    /// both of them it no longer does in practice - `secondary-p` is `TogglePalette`'s unscoped
+    /// global binding, and `secondary-z` is scoped away from terminals by
+    /// `TextUndo`/`TextRedo`'s `Some("text-input")` - which is exactly why the pure mapping is
+    /// pinned here: `crate::root::focus::tab_strip_keybinding_tests` and
+    /// `crate::root::focus::text_undo_scoping_tests` prove the app-level dispatch's half; this
+    /// proves what reaches the pty for whatever context still gets here.
     #[test]
-    fn an_unmodified_letter_is_still_forwarded_normally() {
-        let ks = keystroke("n", Modifiers::default());
-        assert_eq!(keystroke_to_bytes(&ks), Some(b"n".to_vec()));
-    }
-
-    /// Direct proof of the control-byte mapping alone: this mapping sends the standard readline
-    /// "previous history" control byte (`0x10`) a focused terminal needs to receive, independent
-    /// of whether GPUI's own dispatch ever actually lets a Ctrl+P keystroke reach this pane's
-    /// `on_key_down` to be mapped. It no longer does in practice: `secondary-p` is now
-    /// `TogglePalette`'s own real, unscoped global keybinding (see
-    /// `crate::default_key_bindings`'s docs for the accepted tradeoff), so GPUI's action dispatch
-    /// intercepts a focused terminal's Ctrl+P before this mapping is ever consulted. Mirrors
-    /// `crate::root::focus::tab_strip_keybinding_tests::
-    /// ctrl_p_opens_the_palette_even_while_a_terminal_is_focused`: that test proves the app-level
-    /// dispatch *does* now intercept it; this one just pins that the pure byte-mapping function
-    /// itself is unchanged, for whatever unmodified-by-a-global-binding context still reaches it.
-    #[test]
-    fn ctrl_p_maps_to_the_real_readline_previous_history_control_byte() {
-        let modifiers = Modifiers {
+    fn a_ctrl_letter_maps_to_its_real_control_byte_and_a_plain_letter_to_itself() {
+        let control = Modifiers {
             control: true,
             ..Default::default()
         };
-        let ks = keystroke("p", modifiers);
+        // The standard readline "previous history" byte, and the SIGTSTP terminal-suspend byte -
+        // the two essentially every interactive program relies on.
         assert_eq!(
-            keystroke_to_bytes(&ks),
-            Some(vec![0x10]),
-            "Ctrl+P must map to the real Ctrl+<letter> control code (0x10), the standard \
-             readline 'previous history' byte every real shell relies on"
+            keystroke_to_bytes(&keystroke("p", control)),
+            Some(vec![0x10])
         );
-    }
-
-    /// Direct proof of the control-byte mapping `TextUndo`/`TextRedo`'s `Some("text-input")`
-    /// scoping depends on: no terminal surface ever carries `"text-input"`, specifically because
-    /// `secondary-z` resolves to plain `Ctrl+Z` on Linux/Windows, and this mapping sends the real
-    /// `SIGTSTP` terminal-suspend control byte (`0x1a`) a focused interactive program relies on.
-    /// Mirrors `ctrl_p_maps_to_the_real_readline_previous_history_control_byte` and
-    /// `crate::root::focus::text_undo_scoping_tests`'s own
-    /// `secondary_z_with_a_terminal_focused_does_not_reach_text_undo`: that test proves the
-    /// scoped dispatch doesn't intercept it; this one proves what reaches the pty once it
-    /// doesn't.
-    #[test]
-    fn ctrl_z_maps_to_the_real_sigtstp_control_byte() {
-        let modifiers = Modifiers {
-            control: true,
-            ..Default::default()
-        };
-        let ks = keystroke("z", modifiers);
         assert_eq!(
-            keystroke_to_bytes(&ks),
-            Some(vec![0x1a]),
-            "Ctrl+Z must map to the real Ctrl+<letter> control code (0x1a), the SIGTSTP \
-             terminal-suspend byte essentially every interactive program relies on"
+            keystroke_to_bytes(&keystroke("z", control)),
+            Some(vec![0x1a])
+        );
+        assert_eq!(
+            keystroke_to_bytes(&keystroke("n", Modifiers::default())),
+            Some(b"n".to_vec()),
+            "an unmodified letter is still forwarded as itself"
         );
     }
 
     /// Regression test for GitHub issue #236: Shift+Tab silently sent the exact same byte as
     /// plain Tab, so any CLI relying on the standard back-tab sequence to detect Shift+Tab
     /// (readline-based tools, Claude Code's own mode-cycling shortcut) never saw it and did
-    /// nothing. Pinning both mappings side by side in one test is the point - it's not enough
-    /// for Shift+Tab to produce *something*, it must produce something a real terminal would
-    /// never also produce for plain Tab.
-    #[test]
-    fn shift_tab_sends_the_real_back_tab_sequence_distinct_from_plain_tab() {
-        let plain = keystroke("tab", Modifiers::default());
-        assert_eq!(
-            keystroke_to_bytes(&plain),
-            Some(b"\t".to_vec()),
-            "plain Tab must still send the ordinary tab byte"
-        );
-
-        let shifted = keystroke(
-            "tab",
-            Modifiers {
-                shift: true,
-                ..Default::default()
-            },
-        );
-        assert_eq!(
-            keystroke_to_bytes(&shifted),
-            Some(b"\x1b[Z".to_vec()),
-            "Shift+Tab must send the standard CSI back-tab sequence (\\x1b[Z), not the plain \
-             tab byte - this is what readline-based tools and Claude Code's own CLI listen for \
-             to cycle their mode in the opposite direction"
-        );
-
-        assert_ne!(
-            keystroke_to_bytes(&plain),
-            keystroke_to_bytes(&shifted),
-            "Tab and Shift+Tab must be distinguishable on the wire"
-        );
-    }
-
-    /// Ctrl+Shift+Tab is deliberately left alone by the back-tab fix above: it still falls
-    /// through to the plain `"tab"` match arm and sends `\t`, exactly as it did before GitHub
-    /// issue #236 was fixed. This pins that the fix's `!modifiers.control` guard actually does
-    /// what its comment says, rather than back-tab semantics silently spreading to a modifier
+    /// nothing. Pinning the mappings side by side is the point - it's not enough for Shift+Tab
+    /// to produce *something*, it must produce something a real terminal would never also
+    /// produce for plain Tab. Ctrl+Shift+Tab is deliberately left alone by that fix (its
+    /// `!modifiers.control` guard), so back-tab semantics cannot spread to a modifier
     /// combination nobody asked for.
     #[test]
-    fn ctrl_shift_tab_is_unaffected_by_the_back_tab_fix() {
-        let ks = keystroke(
-            "tab",
-            Modifiers {
-                shift: true,
-                control: true,
-                ..Default::default()
-            },
-        );
-        assert_eq!(
-            keystroke_to_bytes(&ks),
-            Some(b"\t".to_vec()),
-            "Ctrl+Shift+Tab must keep sending the plain tab byte, unchanged by the Shift+Tab \
-             back-tab fix"
+    fn shift_tab_sends_the_real_back_tab_sequence_distinct_from_every_other_tab() {
+        let shift = Modifiers {
+            shift: true,
+            ..Default::default()
+        };
+        let ctrl_shift = Modifiers {
+            shift: true,
+            control: true,
+            ..Default::default()
+        };
+
+        for (modifiers, expected, why) in [
+            (
+                Modifiers::default(),
+                b"\t".as_slice(),
+                "plain Tab must still send the ordinary tab byte",
+            ),
+            (
+                shift,
+                b"\x1b[Z".as_slice(),
+                "Shift+Tab must send the standard CSI back-tab sequence, which is what \
+                 readline-based tools and Claude Code's own CLI listen for",
+            ),
+            (
+                ctrl_shift,
+                b"\t".as_slice(),
+                "Ctrl+Shift+Tab must keep sending the plain tab byte, unchanged by the fix",
+            ),
+        ] {
+            assert_eq!(
+                keystroke_to_bytes(&keystroke("tab", modifiers)),
+                Some(expected.to_vec()),
+                "{why}"
+            );
+        }
+
+        assert_ne!(
+            keystroke_to_bytes(&keystroke("tab", Modifiers::default())),
+            keystroke_to_bytes(&keystroke("tab", shift)),
+            "Tab and Shift+Tab must be distinguishable on the wire"
         );
     }
 }
@@ -3520,166 +3453,194 @@ mod link_segment_tests {
         }
     }
 
-    #[test]
-    fn a_row_with_no_links_is_a_single_plain_segment() {
-        let segments = split_segments(10, &[]);
-        assert_eq!(segments, vec![RowSegment::Plain { start: 0, end: 10 }]);
-    }
-
     /// The CHANGELOG's contract: "a line is authored as `[prefix, colour, link, suffix]` - the
-    /// link is a span inside the line, not a whole-line style". A link in the middle of an
-    /// otherwise plain row must split it into a plain prefix, the link, and a plain suffix -
-    /// never a whole-row link, and never dropping the surrounding plain text.
+    /// link is a span inside the line, not a whole-line style". Every position a link can take
+    /// on a row, and what each one must leave around it: never a whole-row link, never a dropped
+    /// plain run, and never an empty segment where the link happens to touch an edge.
     #[test]
-    fn a_link_in_the_middle_splits_into_prefix_link_suffix_not_a_whole_line_style() {
-        // `"  \u{21b3} tests/upload.rs:88:"` - the link spans chars 4..19 (`tests/upload.rs:88`).
-        let links = [link(4, 19, "tests/upload.rs")];
-        let segments = split_segments(20, &links);
-        assert_eq!(
-            segments,
-            vec![
-                RowSegment::Plain { start: 0, end: 4 },
-                RowSegment::Link {
-                    start: 4,
-                    end: 19,
-                    link: links[0].clone(),
-                },
-                RowSegment::Plain { start: 19, end: 20 },
-            ]
-        );
+    fn a_link_is_a_span_inside_the_row_wherever_on_it_the_link_falls() {
+        let plain = |start, end| RowSegment::Plain { start, end };
+        let linked = |start, end, path: &str| RowSegment::Link {
+            start,
+            end,
+            link: link(start, end, path),
+        };
+
+        for (what, row_len, links, expected) in [
+            ("no links at all", 10, vec![], vec![plain(0, 10)]),
+            (
+                // `"  \u{21b3} tests/upload.rs:88:"` - the link spans chars 4..19.
+                "in the middle",
+                20,
+                vec![link(4, 19, "tests/upload.rs")],
+                vec![plain(0, 4), linked(4, 19, "tests/upload.rs"), plain(19, 20)],
+            ),
+            (
+                "at the very start",
+                8,
+                vec![link(0, 5, "a.txt")],
+                vec![linked(0, 5, "a.txt"), plain(5, 8)],
+            ),
+            (
+                "at the very end",
+                8,
+                vec![link(3, 8, "a.txt")],
+                vec![plain(0, 3), linked(3, 8, "a.txt")],
+            ),
+            (
+                "covering the whole row",
+                10,
+                vec![link(0, 10, "src/main.rs")],
+                vec![linked(0, 10, "src/main.rs")],
+            ),
+            (
+                "two links with plain text between them",
+                14,
+                vec![link(2, 5, "a.rs"), link(9, 12, "b.rs")],
+                vec![
+                    plain(0, 2),
+                    linked(2, 5, "a.rs"),
+                    plain(5, 9),
+                    linked(9, 12, "b.rs"),
+                    plain(12, 14),
+                ],
+            ),
+        ] {
+            assert_eq!(split_segments(row_len, &links), expected, "a link {what}");
+        }
+    }
+}
+
+/// The property every other test in this file depends on without saying so: a `TerminalPane`
+/// that goes out of scope takes its whole real process tree with it.
+///
+/// This is what makes the terminal suite leak-free. GitHub issue #427 measured 509 child
+/// processes surviving a single app test run; PR #432 fixed the macOS half of the teardown
+/// (`pty_core`'s descendant walk read `/proc`, which does not exist there), and `pty_core`'s own
+/// `drop_terminates_entire_process_tree_including_escaped_grandchild` pins that at the crate
+/// level. What was never pinned is the layer the leak was actually reported at: that a *pane* (a
+/// GPUI entity, released by the app rather than by an explicit `drop` a test author has to
+/// remember) really does reach that teardown. If it stopped doing so, every real-pty test in this
+/// file would start leaking again and nothing would fail.
+///
+/// unix-only, like `pty-core`'s own teardown suite: it needs real process-group and
+/// escaped-descendant semantics.
+#[cfg(all(test, unix))]
+mod pane_teardown_tests {
+    use super::pty_pane_fixtures::{spawn_pane, PTY_ROUND_TRIP};
+    use gpui::TestAppContext;
+    use std::process::{Command, Stdio};
+    use test_support::ChildGuard;
+
+    /// Whether `pid` names a live process, asked of the OS itself via `kill -0` rather than
+    /// through `pty_core`'s own (private) `pid_exists` - so what is checked here is independent
+    /// of the code under test.
+    fn pid_is_alive(pid: &str) -> bool {
+        let mut command = Command::new("kill");
+        command
+            .args(["-0", pid])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let mut probe = ChildGuard::spawn(&mut command).expect("spawn kill -0");
+        probe
+            .wait()
+            .expect("kill -0 should always terminate")
+            .success()
     }
 
-    #[test]
-    fn a_link_at_the_very_start_has_no_leading_plain_segment() {
-        let links = [link(0, 5, "a.txt")];
-        let segments = split_segments(8, &links);
-        assert_eq!(
-            segments,
-            vec![
-                RowSegment::Link {
-                    start: 0,
-                    end: 5,
-                    link: links[0].clone(),
-                },
-                RowSegment::Plain { start: 5, end: 8 },
-            ]
+    #[gpui::test]
+    fn dropping_a_pane_takes_its_whole_real_process_tree_with_it(cx: &mut TestAppContext) {
+        // `set -m` turns on job control, which puts the background job in its own process group -
+        // precisely what defeats a `killpg` on the direct child alone, so only a real descendant
+        // walk can reach it. The shell reports the escaped grandchild's pid back over the pty so
+        // this test does not have to race that walk to discover it.
+        let pane = spawn_pane(
+            cx,
+            "sh",
+            &[
+                "-c",
+                "set -m; sleep 100 & echo ADE-GRANDCHILD:$!; exec sleep 300",
+            ],
         );
-    }
 
-    #[test]
-    fn a_link_at_the_very_end_has_no_trailing_plain_segment() {
-        let links = [link(3, 8, "a.txt")];
-        let segments = split_segments(8, &links);
-        assert_eq!(
-            segments,
-            vec![
-                RowSegment::Plain { start: 0, end: 3 },
-                RowSegment::Link {
-                    start: 3,
-                    end: 8,
-                    link: links[0].clone(),
-                },
-            ]
+        let mut reported = None;
+        assert!(
+            super::pty_pane_fixtures::pump_until(cx, |cx| {
+                reported = pane.read_with(cx, |pane, _| {
+                    pane.visible_text_lines().iter().find_map(|line| {
+                        line.split_once("ADE-GRANDCHILD:")
+                            .map(|(_, pid)| pid.trim().to_string())
+                    })
+                });
+                reported.is_some()
+            }),
+            "the shell must report its detached grandchild's pid over the real pty"
         );
-    }
+        let grandchild = reported.expect("pump_until only returns true once this is Some");
+        let direct = pane
+            .read_with(cx, |pane, _| {
+                pane.session.as_ref().and_then(|s| s.process_id())
+            })
+            .expect("a live pane has a real child pid")
+            .to_string();
 
-    #[test]
-    fn multiple_links_each_get_their_own_span_with_plain_text_between_them() {
-        let links = [link(2, 5, "a.rs"), link(9, 12, "b.rs")];
-        let segments = split_segments(14, &links);
-        assert_eq!(
-            segments,
-            vec![
-                RowSegment::Plain { start: 0, end: 2 },
-                RowSegment::Link {
-                    start: 2,
-                    end: 5,
-                    link: links[0].clone(),
-                },
-                RowSegment::Plain { start: 5, end: 9 },
-                RowSegment::Link {
-                    start: 9,
-                    end: 12,
-                    link: links[1].clone(),
-                },
-                RowSegment::Plain { start: 12, end: 14 },
-            ]
+        assert!(
+            pid_is_alive(&direct),
+            "sanity check: the direct child is up"
         );
-    }
+        assert!(
+            pid_is_alive(&grandchild),
+            "sanity check: the escaped grandchild is up"
+        );
 
-    #[test]
-    fn a_link_covering_the_whole_row_is_a_single_link_segment() {
-        let links = [link(0, 10, "src/main.rs")];
-        let segments = split_segments(10, &links);
-        assert_eq!(
-            segments,
-            vec![RowSegment::Link {
-                start: 0,
-                end: 10,
-                link: links[0].clone(),
-            }]
-        );
+        drop(pane);
+        // `cx.update` and not just `run_until_parked`, and this is the whole point of the
+        // fixture below: GPUI releases an entity whose last handle was dropped during
+        // `flush_effects`, which only runs inside an app update. `run_until_parked` alone does
+        // not trigger one, so `TerminalPane` - and with it `PtySession`, and with it the child
+        // process tree - is *not* dropped by `drop(pane)` on its own. That is exactly how a test
+        // suite ends up with hundreds of live children at once (GitHub issue #427 measured 509),
+        // and why `release_panes` exists.
+        cx.update(|_cx| {});
+        cx.run_until_parked();
+
+        for (pid, what) in [
+            (&direct, "direct child"),
+            (&grandchild, "escaped grandchild"),
+        ] {
+            assert!(
+                test_support::wait_until(PTY_ROUND_TRIP, || !pid_is_alive(pid)),
+                "the {what} ({pid}) was still alive after its TerminalPane was dropped - every \
+                 real-pty test in this file leaks a process if this stops holding"
+            );
+        }
     }
 }
 
 #[cfg(test)]
 mod clear_pty_signal_tests {
-    use super::*;
+    use super::pty_pane_fixtures::{grid_shows, pump_until, release, spawn_pane};
     use gpui::TestAppContext;
 
-    /// End-to-end proof that `clear()` signals the child process: a [`TerminalPane`] backed by
-    /// a real `cat` child on a real pty, [`TerminalPane::clear`] called, and what this test
-    /// observes is the pty's own cooked-mode line-discipline echo - not a direct assertion
-    /// that `write_input` was called, but its round-tripped effect landing back in the grid.
-    /// With `ECHOCTL` (the standard-on-Linux termios default), the raw `0x0c` byte `clear()`
-    /// writes is echoed back as the two printable characters `^L`.
+    /// End-to-end proof that `clear()` signals the child process: a [`super::TerminalPane`]
+    /// backed by a real `cat` child on a real pty, [`super::TerminalPane::clear`] called, and
+    /// what this test observes is the pty's own cooked-mode line-discipline echo - not a direct
+    /// assertion that `write_input` was called, but its round-tripped effect landing back in the
+    /// grid. With `ECHOCTL` (the standard termios default), the raw `0x0c` byte `clear()` writes
+    /// is echoed back as the two printable characters `^L`.
     #[gpui::test]
     fn clear_with_a_live_session_sends_a_real_ctrl_l_the_pty_echoes_back(cx: &mut TestAppContext) {
-        let pane = cx.new(|cx| {
-            TerminalPane::new(
-                TerminalSpec::command("cat", Vec::new(), std::env::temp_dir()),
-                ROW_FONT_SIZE_PX,
-                cx,
-            )
-        });
-        cx.run_until_parked();
+        let pane = spawn_pane(cx, "cat", &[]);
 
         pane.update(cx, |pane, cx| pane.clear(cx));
 
-        // The real pty reader thread and the real `cat` child it feeds run entirely outside
-        // GPUI's deterministic scheduler, so `advance_clock` alone (a purely *simulated* clock)
-        // grants them zero actual wall-clock scheduling time. Standalone, with an otherwise idle
-        // CPU, the real echo lands within real microseconds and a loop that only ever advances
-        // the virtual clock never notices it's racing ahead of real time - but under real
-        // full-suite parallel load (dozens of other tests' own real subprocesses contending for
-        // the same cores) the OS can genuinely take real milliseconds to schedule this thread,
-        // and a loop with no real-time floor at all can burn through every check before that
-        // happens. A real `std::thread::sleep` between checks (bounded by a real deadline, not a
-        // fixed tick count) gives it a genuine chance, mirroring this same file's own
-        // `a_background_pane_drains_on_the_background_interval_read_fresh_each_tick`'s upfront
-        // `std::thread::sleep(Duration::from_millis(400))` for the identical Ctrl-L/ECHOCTL
-        // round trip.
-        let mut saw_caret_l = false;
-        let deadline = std::time::Instant::now() + Duration::from_secs(45);
-        loop {
-            cx.background_executor.advance_clock(POLL_INTERVAL);
-            cx.run_until_parked();
-            let lines = pane.read_with(cx, |pane, _| pane.visible_text_lines());
-            if lines.iter().any(|line| line.contains("^L")) {
-                saw_caret_l = true;
-                break;
-            }
-            if std::time::Instant::now() >= deadline {
-                break;
-            }
-            std::thread::sleep(Duration::from_millis(5));
-        }
         assert!(
-            saw_caret_l,
+            pump_until(cx, |cx| grid_shows(cx, &pane, "^L")),
             "expected the real pty's own echo of the Ctrl-L byte clear() sends to eventually \
              appear in the grid - this is what actually proves the byte reached the pty, not \
              just that write_input() was called"
         );
+        release(cx, pane);
     }
 }
 
@@ -3689,6 +3650,7 @@ mod clear_pty_signal_tests {
 /// escape bytes are produced by a real `printf`, exactly as a real agent CLI produces them.
 #[cfg(test)]
 mod terminal_signal_tests {
+    use super::pty_pane_fixtures::{pump_until, release, spawn_pane};
     use super::*;
     use crate::rail::title_signal::{classify_title, TitleSignal};
     use crate::terminal::osc::{Progress, ProgressState};
@@ -3697,40 +3659,18 @@ mod terminal_signal_tests {
     /// Spawns a real `sh` that writes `script`'s escape sequences and then blocks, so the
     /// process is still alive (and the pane still `is_running`) while the assertions run - the
     /// same real-pty pattern this module's other tests use, and `sh` rather than bare `printf`
-    /// so the sequences and the sleep are one child process.
+    /// so the sequences and the wait are one child process.
     fn pane_emitting(cx: &mut TestAppContext, script: &str) -> gpui::Entity<TerminalPane> {
-        cx.new(|cx| {
-            TerminalPane::new(
-                TerminalSpec::command(
-                    "sh",
-                    vec!["-c".to_string(), format!("{script}; sleep 60")],
-                    std::env::temp_dir(),
-                ),
-                ROW_FONT_SIZE_PX,
-                cx,
-            )
-        })
+        spawn_pane(cx, "sh", &["-c", &format!("{script}; sleep 60")])
     }
 
-    /// Drives the pane's real poll loop until `done` reports true, or gives up. The pty write
-    /// itself takes real wall time (a real process, real fd) while the *drain* only happens on
-    /// poll ticks, which the test executor's clock drives - hence both a real sleep and the
-    /// virtual-clock loop, matching `cadence_tests`' own approach.
+    /// Drives the pane's real poll loop until `done` reports true, or gives up.
     fn poll_until(
         cx: &mut TestAppContext,
         pane: &gpui::Entity<TerminalPane>,
         done: impl Fn(&TerminalPane) -> bool,
     ) -> bool {
-        cx.run_until_parked();
-        for _ in 0..60 {
-            std::thread::sleep(Duration::from_millis(50));
-            cx.background_executor.advance_clock(POLL_INTERVAL);
-            cx.run_until_parked();
-            if pane.read_with(cx, |pane, _| done(pane)) {
-                return true;
-            }
-        }
-        false
+        pump_until(cx, |cx| pane.read_with(cx, |pane, _| done(pane)))
     }
 
     #[gpui::test]
@@ -3753,8 +3693,7 @@ mod terminal_signal_tests {
             "a real agent CLI's real working title must classify as Busy end to end"
         );
 
-        pane.update(cx, |pane, cx| pane.shutdown(cx));
-        cx.run_until_parked();
+        release(cx, pane);
     }
 
     #[gpui::test]
@@ -3778,8 +3717,7 @@ mod terminal_signal_tests {
             "the pane's ping must survive being read"
         );
 
-        pane.update(cx, |pane, cx| pane.shutdown(cx));
-        cx.run_until_parked();
+        release(cx, pane);
     }
 
     #[gpui::test]
@@ -3790,8 +3728,7 @@ mod terminal_signal_tests {
             "a real OSC 777 notify off a real pty never reached the pane"
         );
 
-        pane.update(cx, |pane, cx| pane.shutdown(cx));
-        cx.run_until_parked();
+        release(cx, pane);
     }
 
     #[gpui::test]
@@ -3813,22 +3750,14 @@ mod terminal_signal_tests {
             "a progress report is not a notification - OSC 9;4 must not ping for attention"
         );
 
-        pane.update(cx, |pane, cx| pane.shutdown(cx));
-        cx.run_until_parked();
+        release(cx, pane);
     }
 
     #[gpui::test]
     fn a_pty_process_that_says_nothing_reports_no_signal_at_all(cx: &mut TestAppContext) {
         // The honest default, and the one every non-agent process hits: a `cat` sitting on a
         // real pty has no title, no ping and no progress - not an invented one.
-        let pane = cx.new(|cx| {
-            TerminalPane::new(
-                TerminalSpec::command("cat", Vec::new(), std::env::temp_dir()),
-                ROW_FONT_SIZE_PX,
-                cx,
-            )
-        });
-        cx.run_until_parked();
+        let pane = spawn_pane(cx, "cat", &[]);
         for _ in 0..5 {
             cx.background_executor.advance_clock(POLL_INTERVAL);
             cx.run_until_parked();
@@ -3839,8 +3768,7 @@ mod terminal_signal_tests {
             assert_eq!(pane.progress(), None);
         });
 
-        pane.update(cx, |pane, cx| pane.shutdown(cx));
-        cx.run_until_parked();
+        release(cx, pane);
     }
 }
 
@@ -3864,77 +3792,63 @@ mod cell_position_tests {
         )
     }
 
+    /// Where a pixel lands, and what happens at each of the four edges. The `side` matters as
+    /// much as the column: it is what decides whether the cell under the pointer is included in
+    /// the selection at all (`Selection::to_range`'s `range_simple` drops a cell the selection
+    /// ends left of), so the half-cell boundary is real behaviour, not a detail - and clamping a
+    /// past-the-right-edge drag to the *left* of the last column would silently drop that column
+    /// from the selection.
     #[test]
-    fn the_top_left_pixel_is_row_zero_column_zero() {
-        assert_eq!(
-            at(0.0, 0.0),
-            CellPosition {
-                row: 0,
-                column: 0,
-                side: CellSide::Left
-            }
-        );
-    }
+    fn a_pixel_resolves_to_the_cell_containing_it_and_clamps_at_every_edge() {
+        for (x, y, row, column, side, what) in [
+            (0.0, 0.0, 0, 0, CellSide::Left, "the top-left pixel"),
+            // x = 34px -> column 3 (30..40), 0.4 of the way in; y = 55px -> row 2 (40..60).
+            (34.0, 55.0, 2, 3, CellSide::Left, "a cell's own left half"),
+            (
+                34.9,
+                0.0,
+                0,
+                3,
+                CellSide::Left,
+                "just short of the midpoint",
+            ),
+            (35.0, 0.0, 0, 3, CellSide::Right, "exactly the midpoint"),
+            (39.9, 0.0, 0, 3, CellSide::Right, "the far end of the cell"),
+            (
+                10_000.0,
+                0.0,
+                0,
+                79,
+                CellSide::Right,
+                "a drag past the right edge",
+            ),
+            (
+                0.0,
+                10_000.0,
+                23,
+                0,
+                CellSide::Left,
+                "a drag past the bottom",
+            ),
+        ] {
+            assert_eq!(
+                at(x, y),
+                CellPosition { row, column, side },
+                "{what} at ({x}, {y})"
+            );
+        }
 
-    #[test]
-    fn a_position_resolves_to_the_cell_containing_it() {
-        // x = 34px -> column 3 (30..40), 0.4 of the way in -> left half.
-        // y = 55px -> row 2 (40..60).
-        assert_eq!(
-            at(34.0, 55.0),
-            CellPosition {
-                row: 2,
-                column: 3,
-                side: CellSide::Left
-            }
-        );
-    }
-
-    /// The side is what decides whether the cell under the pointer is included in the selection
-    /// at all (`Selection::to_range`'s `range_simple` drops a cell the selection ends left of),
-    /// so the half-cell boundary is real behavior, not a detail.
-    #[test]
-    fn the_right_half_of_a_cell_reports_the_right_side() {
-        assert_eq!(at(35.0, 0.0).side, CellSide::Right);
-        assert_eq!(at(39.9, 0.0).side, CellSide::Right);
-        assert_eq!(at(34.9, 0.0).side, CellSide::Left);
-        assert_eq!(
-            at(35.0, 0.0).column,
-            3,
-            "the column is unchanged by the side"
-        );
-    }
-
-    #[test]
-    fn a_drag_past_the_right_edge_clamps_to_the_last_column_inclusively() {
-        let position = at(10_000.0, 0.0);
-        assert_eq!(position.column, 79);
-        assert_eq!(
-            position.side,
-            CellSide::Right,
-            "clamping to the *left* of the last column would silently drop that column from \
-             the selection"
-        );
-    }
-
-    #[test]
-    fn a_drag_past_the_bottom_clamps_to_the_last_row() {
-        assert_eq!(at(0.0, 10_000.0).row, 23);
-    }
-
-    /// Dragging back above/left of the grid origin (a real gesture - the pointer leaves the
-    /// pane) must clamp to the first cell rather than underflow into a huge `usize`.
-    #[test]
-    fn a_position_above_and_left_of_the_origin_clamps_to_the_first_cell() {
-        let position = cell_position_in_grid(
+        // Dragging back above/left of the grid origin - a real gesture, the pointer leaves the
+        // pane - must clamp to the first cell rather than underflow into a huge `usize`.
+        let outside = cell_position_in_grid(
             point(px(0.0), px(0.0)),
             point(px(100.0), px(200.0)),
             size(px(10.0), px(20.0)),
             24,
             80,
         );
-        assert_eq!(position.row, 0);
-        assert_eq!(position.column, 0);
+        assert_eq!(outside.row, 0);
+        assert_eq!(outside.column, 0);
     }
 
     /// A failed font measurement can only produce a zero cell size; dividing by it would make
@@ -3995,23 +3909,17 @@ mod paste_payload_tests {
 /// clipboard write, and a real clipboard read produces real bytes on a real pty.
 #[cfg(test)]
 mod clipboard_tests {
+    use super::pty_pane_fixtures::{grid_shows, pump_until, release, spawn_pane};
     use super::*;
     use gpui::TestAppContext;
 
     fn new_pane(cx: &mut TestAppContext, program: &str) -> gpui::Entity<TerminalPane> {
-        cx.new(|cx| {
-            TerminalPane::new(
-                TerminalSpec::command(program, Vec::new(), std::env::temp_dir()),
-                ROW_FONT_SIZE_PX,
-                cx,
-            )
-        })
+        spawn_pane(cx, program, &[])
     }
 
     #[gpui::test]
     fn copying_a_real_selection_writes_it_to_the_real_system_clipboard(cx: &mut TestAppContext) {
         let pane = new_pane(cx, "cat");
-        cx.run_until_parked();
 
         cx.update(|cx| cx.write_to_clipboard(gpui::ClipboardItem::new_string("before".into())));
 
@@ -4036,6 +3944,7 @@ mod clipboard_tests {
         );
         let text = cx.update(|cx| cx.read_from_clipboard().and_then(|item| item.text()));
         assert_eq!(text.as_deref(), Some("world"));
+        release(cx, pane);
     }
 
     /// Copy with nothing selected must leave the clipboard alone. Overwriting it with `""` (the
@@ -4044,7 +3953,6 @@ mod clipboard_tests {
     #[gpui::test]
     fn copying_with_no_selection_leaves_the_clipboard_untouched(cx: &mut TestAppContext) {
         let pane = new_pane(cx, "cat");
-        cx.run_until_parked();
 
         cx.update(|cx| cx.write_to_clipboard(gpui::ClipboardItem::new_string("keep me".into())));
 
@@ -4056,6 +3964,7 @@ mod clipboard_tests {
         assert!(!copied);
         let text = cx.update(|cx| cx.read_from_clipboard().and_then(|item| item.text()));
         assert_eq!(text.as_deref(), Some("keep me"));
+        release(cx, pane);
     }
 
     /// End-to-end proof that paste reaches the *child process*, observed the same way
@@ -4066,7 +3975,6 @@ mod clipboard_tests {
     #[gpui::test]
     fn pasting_writes_the_real_clipboard_text_to_the_real_pty(cx: &mut TestAppContext) {
         let pane = new_pane(cx, "cat");
-        cx.run_until_parked();
 
         cx.update(|cx| {
             cx.write_to_clipboard(gpui::ClipboardItem::new_string("ade-pasted-text".into()))
@@ -4074,30 +3982,21 @@ mod clipboard_tests {
         let pasted = pane.update(cx, |pane, cx| pane.paste_from_clipboard(cx));
         assert!(pasted, "a live session must accept a real paste");
 
-        let mut saw_pasted_text = false;
-        for _ in 0..50 {
-            cx.background_executor.advance_clock(POLL_INTERVAL);
-            cx.run_until_parked();
-            let lines = pane.read_with(cx, |pane, _| pane.visible_text_lines());
-            if lines.iter().any(|line| line.contains("ade-pasted-text")) {
-                saw_pasted_text = true;
-                break;
-            }
-        }
         assert!(
-            saw_pasted_text,
+            pump_until(cx, |cx| grid_shows(cx, &pane, "ade-pasted-text")),
             "expected the real pty's own echo of the pasted bytes to appear in the grid"
         );
+        release(cx, pane);
     }
 
     #[gpui::test]
     fn pasting_an_empty_clipboard_writes_nothing(cx: &mut TestAppContext) {
         let pane = new_pane(cx, "cat");
-        cx.run_until_parked();
 
         cx.update(|cx| cx.write_to_clipboard(gpui::ClipboardItem::new_string(String::new())));
         let pasted = pane.update(cx, |pane, cx| pane.paste_from_clipboard(cx));
         assert!(!pasted);
+        release(cx, pane);
     }
 }
 
@@ -4111,45 +4010,9 @@ mod clipboard_tests {
 /// fires.
 #[cfg(test)]
 mod send_prompt_tests {
+    use super::pty_pane_fixtures::{grid_shows, pump_until, release, spawn_pane, stays_absent};
     use super::*;
     use gpui::TestAppContext;
-
-    /// A real child on a real pty. `program`/`args` are spawned as-is.
-    fn new_pane(
-        cx: &mut TestAppContext,
-        program: &str,
-        args: Vec<String>,
-    ) -> gpui::Entity<TerminalPane> {
-        cx.new(|cx| {
-            TerminalPane::new(
-                TerminalSpec::command(program, args, std::env::temp_dir()),
-                ROW_FONT_SIZE_PX,
-                cx,
-            )
-        })
-    }
-
-    /// Pumps the real poll loop until `ready`, or gives up after a real wall-clock deadline.
-    /// Mixes virtual-clock advance with a real `sleep`, exactly as
-    /// `crate::work_surface::render`'s own `wait_for_real_pty_output` does and for the same
-    /// reason: the pty reader is a real OS thread, so a virtual-clock-only loop races it.
-    fn pump_until(
-        cx: &mut TestAppContext,
-        mut ready: impl FnMut(&mut TestAppContext) -> bool,
-    ) -> bool {
-        let deadline = std::time::Instant::now() + Duration::from_secs(20);
-        loop {
-            cx.background_executor.advance_clock(POLL_INTERVAL);
-            cx.run_until_parked();
-            if ready(cx) {
-                return true;
-            }
-            if std::time::Instant::now() >= deadline {
-                return false;
-            }
-            std::thread::sleep(Duration::from_millis(5));
-        }
-    }
 
     /// The real thing: a child that turns bracketed paste on (exactly as an agent's full-screen
     /// TUI does) receives a real multi-line batch, in one write, and echoes it back.
@@ -4160,12 +4023,7 @@ mod send_prompt_tests {
         // `printf` sets `DECSET 2004` on its own output, which is how the grid - and therefore
         // `bracketed_paste_enabled` - learns about it. Nothing here is simulated: the mode really
         // arrives over the pty from a real child, then `cat` echoes whatever is written back.
-        let pane = new_pane(
-            cx,
-            "sh",
-            vec!["-c".to_string(), "printf '\\033[?2004h'; cat".to_string()],
-        );
-        cx.run_until_parked();
+        let pane = spawn_pane(cx, "sh", &["-c", "printf '\\033[?2004h'; cat"]);
         assert!(
             pump_until(cx, |cx| pane
                 .read_with(cx, |pane, _| pane.bracketed_paste_enabled())),
@@ -4185,17 +4043,12 @@ mod send_prompt_tests {
         );
 
         assert!(
-            pump_until(cx, |cx| {
-                pane.read_with(cx, |pane, _| {
-                    pane.visible_text_lines()
-                        .iter()
-                        .any(|line| line.contains("ade-note-tenant-id"))
-                })
-            }),
+            pump_until(cx, |cx| grid_shows(cx, &pane, "ade-note-tenant-id")),
             "the real pty's own echo of the batched prompt must appear in the grid - this is \
              round-tripped evidence the note text genuinely left the app, not an assertion that \
              `write_input` was called"
         );
+        release(cx, pane);
     }
 
     /// The refusal. Without bracketed paste, `paste_payload` turns every `\n` into the Enter
@@ -4206,8 +4059,7 @@ mod send_prompt_tests {
     fn a_multi_line_batch_is_refused_when_the_child_has_bracketed_paste_off(
         cx: &mut TestAppContext,
     ) {
-        let pane = new_pane(cx, "cat", Vec::new());
-        cx.run_until_parked();
+        let pane = spawn_pane(cx, "cat", &[]);
         assert!(
             !pane.read_with(cx, |pane, _| pane.bracketed_paste_enabled()),
             "precondition: a plain `cat` never turns bracketed paste on"
@@ -4221,26 +4073,21 @@ mod send_prompt_tests {
             "a payload that could split must be refused, not sent"
         );
 
-        // Pumped for real, so "nothing arrived" is a measured fact rather than an assumption
-        // about timing.
-        for _ in 0..40 {
-            cx.background_executor.advance_clock(POLL_INTERVAL);
-            cx.run_until_parked();
-            std::thread::sleep(Duration::from_millis(2));
-        }
-        pane.read_with(cx, |pane, _| {
-            assert!(
-                !pane
-                    .visible_text_lines()
-                    .iter()
-                    .any(|line| line.contains("ade-refused")),
-                "not one byte of a refused batch may reach the child"
-            );
-            assert!(
-                pane.spawn_error.is_some(),
-                "and the refusal must be said out loud on the pane, not swallowed"
-            );
-        });
+        // Pumped for real over a bounded quiet window, so "nothing arrived" is a measured fact
+        // rather than an assumption about timing.
+        assert!(
+            stays_absent(cx, Duration::from_millis(200), |cx| grid_shows(
+                cx,
+                &pane,
+                "ade-refused"
+            )),
+            "not one byte of a refused batch may reach the child"
+        );
+        assert!(
+            pane.read_with(cx, |pane, _| pane.spawn_error.is_some()),
+            "and the refusal must be said out loud on the pane, not swallowed"
+        );
+        release(cx, pane);
     }
 
     /// The other half of the same rule: the single-line delivery form
@@ -4250,30 +4097,24 @@ mod send_prompt_tests {
     fn the_single_line_form_is_delivered_to_a_child_with_bracketed_paste_off(
         cx: &mut TestAppContext,
     ) {
-        let pane = new_pane(cx, "cat", Vec::new());
-        cx.run_until_parked();
+        let pane = spawn_pane(cx, "cat", &[]);
 
         let sent = pane.update(cx, |pane, cx| {
             pane.send_prompt("line 5: ade-flat-one \u{b7} line 9: ade-flat-two", cx)
         });
         assert!(sent);
         assert!(
-            pump_until(cx, |cx| {
-                pane.read_with(cx, |pane, _| {
-                    pane.visible_text_lines()
-                        .iter()
-                        .any(|line| line.contains("ade-flat-two"))
-                })
-            }),
+            pump_until(cx, |cx| grid_shows(cx, &pane, "ade-flat-two")),
             "the flat form must really reach the child"
         );
+        release(cx, pane);
     }
 
     #[gpui::test]
     fn an_empty_prompt_writes_nothing(cx: &mut TestAppContext) {
-        let pane = new_pane(cx, "cat", Vec::new());
-        cx.run_until_parked();
+        let pane = spawn_pane(cx, "cat", &[]);
         assert!(!pane.update(cx, |pane, cx| pane.send_prompt("", cx)));
+        release(cx, pane);
     }
 }
 
@@ -4286,6 +4127,7 @@ mod send_prompt_tests {
 /// can't be moved out from under the test by a prompt arriving mid-run.
 #[cfg(test)]
 mod mouse_selection_tests {
+    use super::pty_pane_fixtures::release;
     use super::*;
     use gpui::{point, Entity, Modifiers, MouseButton, TestAppContext, VisualTestContext};
 
@@ -4377,6 +4219,7 @@ mod mouse_selection_tests {
             Some("world"),
             "a real left-drag across the grid must produce a real alacritty_terminal selection"
         );
+        release(cx, pane);
     }
 
     /// A plain click is how a user dismisses a selection, and it must not leave a one-character
@@ -4403,6 +4246,7 @@ mod mouse_selection_tests {
             pane.read_with(cx, |pane, _| pane.selected_text_for_test()),
             None
         );
+        release(cx, pane);
     }
 
     /// Moving the mouse over the terminal with no button held must never start or extend a
@@ -4427,34 +4271,7 @@ mod mouse_selection_tests {
             pane.read_with(cx, |pane, _| pane.selected_text_for_test()),
             None
         );
-    }
-
-    /// A drag repaints the cells it covers - the flag has to survive all the way into what
-    /// `render_row` consumes, or the user gets no visual feedback at all while dragging.
-    #[gpui::test]
-    fn a_drag_marks_the_covered_cells_selected_for_the_renderer(cx: &mut TestAppContext) {
-        let (pane, cx, bounds, cell_size) = painted_pane(cx);
-
-        let start = point(
-            bounds.origin.x + px(PANE_PADDING_PX) + cell_size.width * 0.1,
-            cell_centre(bounds, cell_size, 0, 0).y,
-        );
-        let end = point(
-            bounds.origin.x + px(PANE_PADDING_PX) + cell_size.width * 4.9,
-            cell_centre(bounds, cell_size, 0, 4).y,
-        );
-        cx.simulate_mouse_down(start, MouseButton::Left, Modifiers::none());
-        cx.simulate_mouse_move(end, MouseButton::Left, Modifiers::none());
-        cx.run_until_parked();
-
-        let flagged = pane.read_with(cx, |pane, _| {
-            pane.grid.visible_rows(&TerminalPalette::default())[0]
-                .iter()
-                .filter(|cell| cell.selected)
-                .map(|cell| cell.c)
-                .collect::<String>()
-        });
-        assert_eq!(flagged, "hello");
+        release(cx, pane);
     }
 
     /// GitHub issue #211's mouse-math half, end to end through real GPUI event dispatch at real
@@ -4493,33 +4310,7 @@ mod mouse_selection_tests {
                 .as_deref(),
             Some("world")
         );
-    }
-
-    /// Dragging over the wide characters themselves - including across the second (spacer) column
-    /// of the last one - must copy them once each, with no emulator-written padding spaces.
-    #[gpui::test]
-    fn a_drag_over_cjk_characters_copies_them_once_each(cx: &mut TestAppContext) {
-        let (pane, cx, bounds, cell_size) = painted_pane_showing(cx, "你好world".as_bytes());
-
-        let start = point(
-            bounds.origin.x + px(PANE_PADDING_PX) + cell_size.width * 0.1,
-            cell_centre(bounds, cell_size, 0, 0).y,
-        );
-        let end = point(
-            bounds.origin.x + px(PANE_PADDING_PX) + cell_size.width * 3.9,
-            cell_centre(bounds, cell_size, 0, 3).y,
-        );
-
-        cx.simulate_mouse_down(start, MouseButton::Left, Modifiers::none());
-        cx.simulate_mouse_move(end, MouseButton::Left, Modifiers::none());
-        cx.simulate_mouse_up(end, MouseButton::Left, Modifiers::none());
-        cx.run_until_parked();
-
-        assert_eq!(
-            pane.read_with(cx, |pane, _| pane.selected_text_for_test())
-                .as_deref(),
-            Some("你好")
-        );
+        release(cx, pane);
     }
 }
 
@@ -4543,6 +4334,7 @@ mod mouse_selection_tests {
 /// here; pasting CJK works today, typing it through an IME does not.
 #[cfg(test)]
 mod utf8_input_tests {
+    use super::pty_pane_fixtures::release;
     use super::*;
     use gpui::{Modifiers, TestAppContext};
 
@@ -4657,6 +4449,7 @@ mod utf8_input_tests {
                 CellWidth::Spacer,
             ]
         );
+        release(cx, pane);
     }
 }
 
@@ -4671,6 +4464,7 @@ mod utf8_input_tests {
 /// elements - not a re-derivation of the layout a second way.
 #[cfg(test)]
 mod wide_char_render_tests {
+    use super::pty_pane_fixtures::release;
     use super::*;
 
     /// Row 0 of a real grid after parsing `bytes`.
@@ -4720,11 +4514,13 @@ mod wide_char_render_tests {
         );
     }
 
-    /// Every wide character is its own two-column run - never merged with the next one, so a glyph
-    /// whose real advance overshoots two cells can't accumulate that overshoot across a run.
-    /// Narrow text still merges into as few runs as possible.
+    /// Every wide character is its own two-column run - never merged with the next one (so a
+    /// glyph whose real advance overshoots two cells can't accumulate that overshoot across a
+    /// run) and never merged into the narrow text around it, whatever their colours, since the
+    /// merged span would be sized for the wrong number of columns. Narrow text still merges into
+    /// as few runs as possible.
     #[test]
-    fn each_wide_character_is_its_own_two_column_run() {
+    fn each_wide_character_is_its_own_two_column_run_never_merged_with_its_neighbours() {
         let runs = row_runs(&row_zero("你好world", 20));
 
         assert_eq!(runs[0].text, "你");
@@ -4740,6 +4536,18 @@ mod wide_char_render_tests {
             runs[2].text.chars().count(),
             "a narrow run covers exactly one column per character"
         );
+
+        // A wide character with narrow text on *both* sides of it - the case a merge would be
+        // most tempted by.
+        let surrounded = row_runs(&row_zero("a好b", 20));
+        let shapes: Vec<(&str, usize)> = surrounded
+            .iter()
+            .map(|run| (run.text.trim_end(), run.columns))
+            .collect();
+        assert_eq!(shapes[0], ("a", 1));
+        assert_eq!(shapes[1], ("好", 2));
+        // The trailing run is `b` plus the row's blank remainder.
+        assert_eq!(&shapes[2].0[..1], "b");
     }
 
     /// The pixel width a wide run is pinned to, and the fact a narrow one is left unpinned (it can
@@ -4749,21 +4557,6 @@ mod wide_char_render_tests {
         let runs = row_runs(&row_zero("你好world", 20));
         assert_eq!(wide_run_width(&runs[0], px(8.0)), Some(px(16.0)));
         assert_eq!(wide_run_width(&runs[2], px(8.0)), None);
-    }
-
-    /// A narrow run and a wide run can never be merged, whatever their colours - the merged span
-    /// would be sized for the wrong number of columns.
-    #[test]
-    fn a_wide_run_never_merges_into_the_narrow_text_around_it() {
-        let runs = row_runs(&row_zero("a好b", 20));
-        let shapes: Vec<(&str, usize)> = runs
-            .iter()
-            .map(|run| (run.text.trim_end(), run.columns))
-            .collect();
-        assert_eq!(shapes[0], ("a", 1));
-        assert_eq!(shapes[1], ("好", 2));
-        // The trailing run is `b` plus the row's blank remainder.
-        assert_eq!(&shapes[2].0[..1], "b");
     }
 
     /// Link detection has to see the row's real text, not the emulator's padding. With the spacer
@@ -4789,20 +4582,27 @@ mod wide_char_render_tests {
 
         let link_text: String = linked.iter().map(|run| run.text.as_str()).collect();
         assert_eq!(link_text, "/tmp/日本/main.rs:12");
-    }
 
-    /// A link sitting *after* a wide character still gets its own span, and the plain text around
-    /// it is preserved - i.e. `split_segments`'s char offsets and the painted cells stayed in
-    /// lockstep once the spacers were dropped.
-    #[test]
-    fn a_link_after_a_wide_character_still_lands_on_the_right_characters() {
-        let runs = row_runs(&row_zero("好 src/main.rs done", 40));
-        let linked: Vec<&RowRun> = runs.iter().filter(|run| run.link.is_some()).collect();
-        let link_text: String = linked.iter().map(|run| run.text.as_str()).collect();
-        assert_eq!(link_text, "src/main.rs");
-
-        let painted: String = runs.iter().map(|run| run.text.as_str()).collect();
-        assert_eq!(painted.trim_end(), "好 src/main.rs done");
+        // And a link sitting *after* a wide character still gets its own span with the plain
+        // text around it preserved - i.e. `split_segments`'s char offsets and the painted cells
+        // stayed in lockstep once the spacers were dropped.
+        let after = row_runs(&row_zero("好 src/main.rs done", 40));
+        let after_linked: Vec<&RowRun> = after.iter().filter(|run| run.link.is_some()).collect();
+        assert_eq!(
+            after_linked
+                .iter()
+                .map(|run| run.text.as_str())
+                .collect::<String>(),
+            "src/main.rs"
+        );
+        assert_eq!(
+            after
+                .iter()
+                .map(|run| run.text.as_str())
+                .collect::<String>()
+                .trim_end(),
+            "好 src/main.rs done"
+        );
     }
 
     /// Selection is still carried per wide character - a run that lost the flag halfway would
@@ -4860,6 +4660,7 @@ mod wide_char_render_tests {
             pane.read_with(cx, |pane, _| pane.visible_text_lines())[0],
             "完了 🎉"
         );
+        release(cx, pane);
     }
 }
 
@@ -4875,6 +4676,7 @@ mod wide_char_render_tests {
 /// re-derived a second way.
 #[cfg(test)]
 mod terminal_theme_tests {
+    use super::pty_pane_fixtures::release;
     use super::*;
     use gpui::{Entity, TestAppContext, VisualTestContext};
     use std::rc::Rc;
@@ -4996,38 +4798,7 @@ mod terminal_theme_tests {
             light.foreground,
             light.background
         );
-    }
-
-    /// Two visually distinct *dark* themes must differ too - a guard against a fix that only
-    /// happened to work because one bundled theme inverts lightness.
-    #[gpui::test]
-    fn two_different_dark_themes_paint_two_different_terminals(cx: &mut TestAppContext) {
-        let (pane, cx) = painted_pane(cx, b"hello world");
-
-        let ember = {
-            let _theme = with_bundled_theme("Ember");
-            pane.update(cx, |_pane, cx| cx.notify());
-            cx.run_until_parked();
-            pane.read_with(cx, |pane, _| pane.last_painted_palette_for_test())
-                .expect("painted")
-        };
-        let moss = {
-            let _theme = with_bundled_theme("Moss");
-            pane.update(cx, |_pane, cx| cx.notify());
-            cx.run_until_parked();
-            pane.read_with(cx, |pane, _| pane.last_painted_palette_for_test())
-                .expect("painted")
-        };
-
-        assert_eq!(
-            ember.background,
-            bundled_rgb("Ember", "terminal.background")
-        );
-        assert_eq!(moss.background, bundled_rgb("Moss", "terminal.background"));
-        assert_ne!(
-            ember, moss,
-            "two bundled dark themes must not paint the terminal identically"
-        );
+        release(cx, pane);
     }
 
     /// A colour the *running program* asked for by name (`SGR 32`, "green") has to come out of the
@@ -5055,21 +4826,7 @@ mod terminal_theme_tests {
             light_green, dark_green,
             "Paper ships the light ANSI palette, so its green is genuinely a different colour"
         );
-    }
-
-    /// Unstyled text - the overwhelming majority of what a terminal paints - must take the theme's
-    /// foreground, and an unstyled cell's background must be the theme's terminal background.
-    #[gpui::test]
-    fn unstyled_output_takes_the_themes_own_foreground_and_background(cx: &mut TestAppContext) {
-        let (pane, cx) = painted_pane(cx, b"plain");
-        let _theme = with_bundled_theme("Slate");
-        pane.update(cx, |_pane, cx| cx.notify());
-        cx.run_until_parked();
-
-        let cell = pane.read_with(cx, |pane, _| pane.painted_rows_for_test()[0][0]);
-        assert_eq!(cell.c, 'p');
-        assert_eq!(cell.fg, bundled_rgb("Slate", "terminal.foreground"));
-        assert_eq!(cell.bg, bundled_rgb("Slate", "terminal.background"));
+        release(cx, pane);
     }
 }
 
@@ -5080,6 +4837,7 @@ mod terminal_theme_tests {
 /// loop while scrolled back neither moving the viewport nor going unnoticed.
 #[cfg(test)]
 mod scrollback_pane_tests {
+    use super::pty_pane_fixtures::release;
     use super::*;
     use gpui::{Modifiers, TestAppContext};
 
@@ -5139,34 +4897,56 @@ mod scrollback_pane_tests {
         });
     }
 
-    /// Pumps real poll ticks until `predicate` sees the pty round-trip land, or until a generous
-    /// cap is reached, then returns the joined visible text.
+    /// Pumps real poll ticks until `predicate` sees the pty round-trip land, or until
+    /// `pty_pane_fixtures`' own cap is reached, then returns the joined visible text.
     ///
     /// Every test in this module that observes forwarded bytes does it by letting a real child
     /// process echo them back, which is a real kernel pty round-trip: the write has to reach the
     /// child, the child has to be scheduled, and its reply has to come back through the poll
-    /// loop. A fixed tick count is therefore a wall-clock assumption, and this workspace has a
-    /// documented history of exactly that going flaky under heavy concurrent test load. Waiting
-    /// on the *condition* instead - with a cap so a genuine regression still fails, and fails
-    /// fast - removes the assumption without weakening a single assertion: every caller still
-    /// asserts the exact byte counts afterwards.
+    /// loop. Waiting on the *condition* - with a cap so a genuine regression still fails, and
+    /// fails fast - weakens no assertion: every caller still asserts the exact byte counts
+    /// afterwards.
     fn drain_until(
         pane: &gpui::Entity<TerminalPane>,
         cx: &mut gpui::VisualTestContext,
         predicate: impl Fn(&str) -> bool,
     ) -> String {
-        let mut joined = String::new();
-        for _ in 0..400 {
+        let joined = |cx: &mut gpui::VisualTestContext| {
+            pane.read_with(cx, |pane, _| pane.visible_text_lines())
+                .join("")
+        };
+        test_support::wait_until(super::pty_pane_fixtures::PTY_ROUND_TRIP, || {
             cx.background_executor.advance_clock(POLL_INTERVAL);
             cx.run_until_parked();
-            joined = pane
-                .read_with(cx, |pane, _| pane.visible_text_lines())
-                .join("");
-            if predicate(&joined) {
-                break;
-            }
-        }
-        joined
+            predicate(&joined(cx))
+        });
+        joined(cx)
+    }
+
+    /// A pane on a real `cat -v` child: it visualizes control bytes (`ESC` -> the literal two
+    /// characters `^[`) as ordinary printable text, so bytes this pane forwards to the child show
+    /// up in this same pane's own grid as literal text instead of being reinterpreted as escape
+    /// sequences by this same grid's own VT parser - the one way to observe the *exact* bytes a
+    /// real child process received without a second, hand-rolled test-only pty seam.
+    fn alt_screen_pane(
+        cx: &mut TestAppContext,
+    ) -> (gpui::Entity<TerminalPane>, &mut gpui::VisualTestContext) {
+        let (pane, cx) = cx.add_window_view(|_window, cx| {
+            TerminalPane::new(
+                TerminalSpec::command("cat", vec!["-v".to_string()], std::env::temp_dir()),
+                ROW_FONT_SIZE_PX,
+                cx,
+            )
+        });
+        cx.run_until_parked();
+        pane.update(cx, |pane, cx| {
+            pane.inject_bytes_for_test(b"\x1b[?1049h", cx); // enter the alt screen
+        });
+        assert!(
+            pane.read_with(cx, |pane, _| pane.grid.alt_scroll_forwarding_active()),
+            "sanity check: the grid must report the alt screen as active"
+        );
+        (pane, cx)
     }
 
     #[gpui::test]
@@ -5193,6 +4973,7 @@ mod scrollback_pane_tests {
             0,
             "PageDown by the same one page must land exactly back at live"
         );
+        release(cx, pane);
     }
 
     /// Real proof PageUp/PageDown are claimed *before* `keystroke_to_bytes`/`PtySession::
@@ -5232,6 +5013,7 @@ mod scrollback_pane_tests {
             "no new content may appear after PageUp with no further input - a real echoed PageUp \
              byte sequence would show up here"
         );
+        release(cx, pane);
     }
 
     #[gpui::test]
@@ -5258,6 +5040,7 @@ mod scrollback_pane_tests {
             !pane.read_with(cx, |pane, _| pane.grid.is_scrolled_back()),
             "a real keystroke reaching the pty must jump the view back to live"
         );
+        release(cx, pane);
     }
 
     fn wheel_event(delta: gpui::ScrollDelta) -> ScrollWheelEvent {
@@ -5293,6 +5076,7 @@ mod scrollback_pane_tests {
             );
         });
         assert_eq!(pane.read_with(cx, |pane, _| pane.grid.scroll_offset()), 0);
+        release(cx, pane);
     }
 
     /// GitHub issues #362/#368: a mouse-wheel scroll reaching a pane whose child has the alt
@@ -5304,150 +5088,69 @@ mod scrollback_pane_tests {
     /// Page keys, not the arrow keys issue #362 originally shipped: see
     /// [`TerminalPane::forward_scroll_as_page_keys`]'s own docs for the live evidence (Claude
     /// Code's CLI printing "Scroll wheel is sending arrow keys · use PgUp/PgDn to scroll" at a
-    /// real user). This asserts the *absence* of arrow bytes as hard as it asserts the presence
-    /// of page bytes - sending both would leave the regression half-alive.
+    /// real user). Every case asserts the *absence* of arrow bytes as hard as it asserts the
+    /// presence of page bytes - sending both would leave the regression half-alive.
     ///
-    /// `cat -v`, not plain `cat`: it visualizes control bytes (`ESC` -> the literal two
-    /// characters `^[`) as ordinary printable text, so the forwarded `\x1b[5~` bytes show up in
-    /// this pane's own grid as the literal string `^[[5~` instead of being reinterpreted as a
-    /// real escape sequence by this same grid's own VT parser - the one way to observe the
-    /// *exact* bytes a real child process received without a second, hand-rolled test-only pty
-    /// seam.
+    /// The magnitudes matter as much as the direction: a scroll under one notch still forwards
+    /// exactly one press (not zero), and a fast flick of several notches forwards proportionally
+    /// more (not one per *line*, which would fling a full-screen program three screenfuls away on
+    /// a single detent) - so the [`WHEEL_LINES_PER_NOTCH`] division can never quietly become a
+    /// constant `1`.
     #[gpui::test]
-    fn alt_screen_scroll_forwards_page_keys_to_the_real_pty(cx: &mut TestAppContext) {
-        let (pane, cx) = cx.add_window_view(|_window, cx| {
-            TerminalPane::new(
-                TerminalSpec::command("cat", vec!["-v".to_string()], std::env::temp_dir()),
-                ROW_FONT_SIZE_PX,
-                cx,
-            )
-        });
-        cx.run_until_parked();
+    fn an_alt_screen_scroll_forwards_page_keys_proportionally_and_never_arrow_keys(
+        cx: &mut TestAppContext,
+    ) {
+        for (lines, page_ups, page_downs, what) in [
+            (2.0, 1, 0, "a two-line upward scroll, under one notch"),
+            (
+                -3.0,
+                0,
+                1,
+                "a three-line downward scroll, exactly one notch",
+            ),
+            (3.0 * WHEEL_LINES_PER_NOTCH, 3, 0, "a three-notch flick"),
+        ] {
+            let (pane, cx) = alt_screen_pane(cx);
 
-        pane.update(cx, |pane, cx| {
-            pane.inject_bytes_for_test(b"\x1b[?1049h", cx); // enter the alt screen
-        });
-        assert!(
-            pane.read_with(cx, |pane, _| pane.grid.alt_scroll_forwarding_active()),
-            "sanity check: the grid must report the alt screen as active before scrolling"
-        );
+            pane.update_in(cx, |pane, window, cx| {
+                pane.handle_scroll_wheel(
+                    &wheel_event(gpui::ScrollDelta::Lines(gpui::point(0.0, lines))),
+                    window,
+                    cx,
+                );
+            });
 
-        pane.update_in(cx, |pane, window, cx| {
-            pane.handle_scroll_wheel(
-                &wheel_event(gpui::ScrollDelta::Lines(gpui::point(0.0, 2.0))),
-                window,
-                cx,
+            let joined = drain_until(&pane, cx, |text| {
+                text.matches("^[[5~").count() >= page_ups
+                    && text.matches("^[[6~").count() >= page_downs
+            });
+
+            assert_eq!(
+                pane.read_with(cx, |pane, _| pane.grid.scroll_offset()),
+                0,
+                "the alt screen has no scrollback of its own - scroll_display must never have \
+                 moved for {what}"
             );
-        });
-
-        // Real `cat -v` printing back exactly what it received on stdin - pump the poll loop
-        // until it lands.
-        let joined = drain_until(&pane, cx, |text| text.contains("^[[5~"));
-
-        assert_eq!(
-            pane.read_with(cx, |pane, _| pane.grid.scroll_offset()),
-            0,
-            "the alt screen has no scrollback of its own - scroll_display must never have moved"
-        );
-        assert_eq!(
-            joined.matches("^[[5~").count(),
-            1,
-            "a two-line upward scroll is under one wheel notch, so it must forward exactly one \
-             real PageUp byte sequence, visualized by `cat -v` as the literal text `^[[5~`: \
-             {joined:?}"
-        );
-        assert_eq!(
-            joined.matches("^[[6~").count(),
-            0,
-            "an upward scroll must never also send a PageDown byte sequence: {joined:?}"
-        );
-        assert_eq!(
-            joined.matches("^[[A").count() + joined.matches("^[[B").count(),
-            0,
-            "GitHub issue #368: no arrow-key bytes may reach the child any more - forwarding \
-             those is what made Claude Code's CLI tell the user to press PgUp/PgDn instead: \
-             {joined:?}"
-        );
-    }
-
-    /// The mirror of the test above: downward scroll on the alt screen must forward PageDown
-    /// bytes, not PageUp.
-    #[gpui::test]
-    fn alt_screen_scroll_down_forwards_page_down_keys(cx: &mut TestAppContext) {
-        let (pane, cx) = cx.add_window_view(|_window, cx| {
-            TerminalPane::new(
-                TerminalSpec::command("cat", vec!["-v".to_string()], std::env::temp_dir()),
-                ROW_FONT_SIZE_PX,
-                cx,
-            )
-        });
-        cx.run_until_parked();
-
-        pane.update(cx, |pane, cx| {
-            pane.inject_bytes_for_test(b"\x1b[?1049h", cx); // enter the alt screen
-        });
-
-        pane.update_in(cx, |pane, window, cx| {
-            pane.handle_scroll_wheel(
-                &wheel_event(gpui::ScrollDelta::Lines(gpui::point(0.0, -3.0))),
-                window,
-                cx,
+            assert_eq!(
+                joined.matches("^[[5~").count(),
+                page_ups,
+                "{what} must forward exactly {page_ups} real PageUp sequence(s), visualized by \
+                 `cat -v` as the literal text `^[[5~`: {joined:?}"
             );
-        });
-
-        let joined = drain_until(&pane, cx, |text| text.contains("^[[6~"));
-        assert_eq!(
-            joined.matches("^[[6~").count(),
-            1,
-            "a three-line downward scroll is exactly one wheel notch \
-             ([`WHEEL_LINES_PER_NOTCH`]), so it must forward exactly one real PageDown byte \
-             sequence - not one per line, which would fling a full-screen program three \
-             screenfuls away on a single detent: {joined:?}"
-        );
-        assert_eq!(joined.matches("^[[5~").count(), 0);
-        assert_eq!(
-            joined.matches("^[[A").count() + joined.matches("^[[B").count(),
-            0
-        );
-    }
-
-    /// GitHub issue #368: a *fast flick* still scales - several notches' worth of accumulated
-    /// delta forwards proportionally more page presses, rather than being flattened to one.
-    /// Pinned alongside the single-notch cases above so the [`WHEEL_LINES_PER_NOTCH`] division
-    /// can never quietly become a constant `1`.
-    #[gpui::test]
-    fn a_fast_alt_screen_flick_forwards_proportionally_more_page_keys(cx: &mut TestAppContext) {
-        let (pane, cx) = cx.add_window_view(|_window, cx| {
-            TerminalPane::new(
-                TerminalSpec::command("cat", vec!["-v".to_string()], std::env::temp_dir()),
-                ROW_FONT_SIZE_PX,
-                cx,
-            )
-        });
-        cx.run_until_parked();
-
-        pane.update(cx, |pane, cx| {
-            pane.inject_bytes_for_test(b"\x1b[?1049h", cx); // enter the alt screen
-        });
-
-        // Three notches' worth of upward delta in one event.
-        pane.update_in(cx, |pane, window, cx| {
-            pane.handle_scroll_wheel(
-                &wheel_event(gpui::ScrollDelta::Lines(gpui::point(
-                    0.0,
-                    3.0 * WHEEL_LINES_PER_NOTCH,
-                ))),
-                window,
-                cx,
+            assert_eq!(
+                joined.matches("^[[6~").count(),
+                page_downs,
+                "{what} must forward exactly {page_downs} real PageDown sequence(s): {joined:?}"
             );
-        });
-
-        let joined = drain_until(&pane, cx, |text| text.matches("^[[5~").count() >= 3);
-        assert_eq!(
-            joined.matches("^[[5~").count(),
-            3,
-            "three notches of upward delta must forward three real PageUp presses: {joined:?}"
-        );
+            assert_eq!(
+                joined.matches("^[[A").count() + joined.matches("^[[B").count(),
+                0,
+                "GitHub issue #368: no arrow-key bytes may reach the child any more - forwarding \
+                 those is what made Claude Code's CLI tell the user to press PgUp/PgDn instead: \
+                 {joined:?}"
+            );
+            release(cx, pane);
+        }
     }
 
     /// GitHub issue #368: a **real** PageUp keystroke must reach the child process while a
@@ -5461,22 +5164,7 @@ mod scrollback_pane_tests {
     /// `cat -v` again visualizes the exact bytes that really crossed the pty.
     #[gpui::test]
     fn a_real_page_key_reaches_a_full_screen_program(cx: &mut TestAppContext) {
-        let (pane, cx) = cx.add_window_view(|_window, cx| {
-            TerminalPane::new(
-                TerminalSpec::command("cat", vec!["-v".to_string()], std::env::temp_dir()),
-                ROW_FONT_SIZE_PX,
-                cx,
-            )
-        });
-        cx.run_until_parked();
-
-        pane.update(cx, |pane, cx| {
-            pane.inject_bytes_for_test(b"\x1b[?1049h", cx); // enter the alt screen
-        });
-        assert!(
-            pane.read_with(cx, |pane, _| pane.grid.alt_screen_active()),
-            "sanity check: the alt screen must really be active"
-        );
+        let (pane, cx) = alt_screen_pane(cx);
 
         pane.update_in(cx, |pane, window, cx| {
             pane.handle_key_down(&key_event(nav_key("pageup")), window, cx);
@@ -5496,6 +5184,7 @@ mod scrollback_pane_tests {
             1,
             "a real PageDown press must cross the pty as the standard `ESC [ 6 ~`: {joined:?}"
         );
+        release(cx, pane);
     }
 
     /// GitHub issue #362: once a full-screen program exits the alt screen, a mouse-wheel scroll
@@ -5531,6 +5220,7 @@ mod scrollback_pane_tests {
             "back on the normal screen, a scroll must move real scroll_display exactly as \
              before this issue - not still be forwarded to the child as key presses"
         );
+        release(cx, pane);
     }
 
     /// **GitHub issue #368, the live report: a genuinely fresh, empty Shell pane could still be
@@ -5625,6 +5315,7 @@ mod scrollback_pane_tests {
             "real overflow must still create real scrollback"
         );
         assert!(cx.debug_bounds("terminal-scrollbar").is_some());
+        release(cx, pane);
     }
 
     /// GitHub issue #368: the discard `maybe_resize_pty` performs on settling has to wait for
@@ -5675,48 +5366,11 @@ mod scrollback_pane_tests {
             "once the resize really reached the live pty, the pane is settled and the one-time \
              discard has run"
         );
+        release(cx, pane);
     }
 
-    /// GitHub issue #362: a freshly-opened pane whose child prints only a handful of lines -
-    /// genuinely fewer than the real viewport height - must never show the scrollbar affordance.
-    /// `crate::root::scrollbar::render_vertical_scrollbar` already returns `None` whenever
-    /// `TerminalScrollHandle::max_scroll_offset` is at or below zero (see that function's own
-    /// docs), so this is really a test that a fresh pane's real `scroll_history_len` starts and
-    /// stays `0` for genuinely non-overflowing content - the scrollbar's own gate does the rest.
-    #[gpui::test]
-    fn a_fresh_pane_with_little_content_shows_no_scrollbar(cx: &mut TestAppContext) {
-        let (pane, cx) = new_pane(cx);
-        pane.update(cx, |pane, cx| {
-            pane.inject_bytes_for_test(b"$ echo hello\r\nhello\r\n$ ", cx);
-        });
-        cx.run_until_parked();
-
-        assert_eq!(
-            pane.read_with(cx, |pane, _| pane.grid.scroll_history_len()),
-            0,
-            "a handful of lines, well under the real viewport height, must never manufacture \
-             scrollback"
-        );
-        assert!(
-            cx.debug_bounds("terminal-scrollbar").is_none(),
-            "the scrollbar must not be painted when there is nothing to scroll to"
-        );
-
-        // Genuine overflow - more lines than the real viewport holds - must still show it.
-        let rows = pane.read_with(cx, |pane, _| pane.grid_dimensions().1 as usize);
-        push_numbered_lines(&pane, cx, rows * 3);
-
-        assert!(
-            pane.read_with(cx, |pane, _| pane.grid.scroll_history_len()) > 0,
-            "sanity check: this really did overflow"
-        );
-        assert!(
-            cx.debug_bounds("terminal-scrollbar").is_some(),
-            "genuine overflow must still show the scrollbar - this fix must not suppress it"
-        );
-    }
-
-    /// The precise mechanism behind the test above (GitHub issue #362): `TerminalPane::new`
+    /// The precise mechanism behind the placeholder-spawn race (GitHub issue #362):
+    /// `TerminalPane::new`
     /// spawns the child (and sizes `TerminalGrid`) at the `TERMINAL_ROWS`/`TERMINAL_COLS`
     /// placeholder before this pane has ever measured its own real content-box size. If the
     /// child prints more than the eventual *real* (smaller) viewport will hold - but still less
@@ -5842,6 +5496,7 @@ mod scrollback_pane_tests {
              via the ordinary shrink path - this fix must not have latched some permanent \
              discard-on-every-resize behavior"
         );
+        release(cx, pane);
     }
 
     /// Trackpad pixel deltas rarely divide evenly by the row height - two individually-sub-line
@@ -5888,6 +5543,7 @@ mod scrollback_pane_tests {
             "two 2/3-row deltas together exceed one full row and must produce a real one-line \
              scroll, not be dropped individually"
         );
+        release(cx, pane);
     }
 
     /// The real integration proof for GitHub issue #331's "stay put" requirement, at the pane
@@ -5988,6 +5644,7 @@ mod scrollback_pane_tests {
         cx.run_until_parked();
         assert!(!pane.read_with(cx, |pane, _| pane.grid.is_scrolled_back()));
         assert!(!pane.read_with(cx, |pane, _| pane.new_output_while_scrolled));
+        release(cx, pane);
     }
 
     /// The scrollbar's own `ScrollableHandle` adapter (GitHub issue #331): synced from real grid

--- a/crates/pty-core/Cargo.toml
+++ b/crates/pty-core/Cargo.toml
@@ -42,3 +42,8 @@ libc = "0.2"
 # directory to prepend to `$PATH` (see that test's docs). Matches the exact version
 # `crates/app/Cargo.toml`/`crates/wt-core/Cargo.toml` already pin.
 tempfile = "3"
+# The workspace's shared fixtures: `wait_until` (the one sanctioned wall-clock wait, replacing
+# this crate's hand-rolled poll loops) and `ChildGuard` (kill-on-drop teardown for a test that
+# spawns a real process outside a `PtySession`). Deliberately `gpui`-free, so depending on it
+# here cannot violate `docs/architecture/decisions.md` §1.
+test-support = { path = "../test-support" }

--- a/crates/pty-core/src/lib.rs
+++ b/crates/pty-core/src/lib.rs
@@ -1187,10 +1187,16 @@ fn terminate_process_tree(root_pid: u32, grace: Duration) {
 }
 
 #[cfg(test)]
-mod tests {
+mod pty_session_tests {
     use super::*;
     use std::sync::mpsc::RecvTimeoutError;
     use std::time::{Duration, Instant};
+
+    /// How long a real child process is given to reach a state before a test calls it a
+    /// failure. Generous: it has to survive a full-suite run where other tests' own child
+    /// processes are competing for the same cores. `test_support::wait_until` returns as soon as
+    /// the condition holds, so an idle machine pays none of it.
+    const TEARDOWN_DEADLINE: Duration = Duration::from_secs(5);
 
     /// Reads from `session.output()` until `needle` appears in the accumulated (lossy
     /// UTF-8) output or `timeout` elapses, returning whatever was collected either way.
@@ -1311,8 +1317,10 @@ mod tests {
                 Ok(chunk) => {
                     collected.extend_from_slice(&chunk);
                     received += 1;
-                    // See the doc comment: this pause is what makes the channel actually fill
-                    // and the reader thread actually block, which is the path under test.
+                    // Not a wait, so `docs/testing.md`'s no-sleep rule does not reach it:
+                    // this is the test's *stimulus*. Stalling the consumer is the only way to
+                    // make the bounded channel actually fill and the reader thread actually
+                    // block in `send`, which is the path under test.
                     if received.is_multiple_of(OUTPUT_CHANNEL_CAPACITY) {
                         std::thread::sleep(Duration::from_millis(5));
                     }
@@ -1358,12 +1366,16 @@ mod tests {
             "this very test process is unambiguously alive"
         );
 
-        let mut child = std::process::Command::new("true")
+        // `ChildGuard` even though this child is expected to exit on its own and is reaped
+        // explicitly below: if the assertion above ever fails, the unwind must still not leave a
+        // process behind (`docs/testing.md`'s teardown rule).
+        let mut command = std::process::Command::new("true");
+        command
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .spawn()
-            .expect("spawning `true` should succeed");
+            .stderr(std::process::Stdio::null());
+        let mut child =
+            test_support::ChildGuard::spawn(&mut command).expect("spawning `true` should succeed");
         let pid = child.id();
         child.wait().expect("reaping `true` should succeed");
 
@@ -1392,15 +1404,11 @@ mod tests {
 
         drop(session);
 
-        let deadline = Instant::now() + Duration::from_secs(5);
-        while pid_exists(pid) {
-            assert!(
-                Instant::now() < deadline,
-                "child pid {pid} was still alive {:?} after PtySession was dropped - orphaned process",
-                deadline.elapsed()
-            );
-            std::thread::sleep(Duration::from_millis(20));
-        }
+        assert!(
+            test_support::wait_until(TEARDOWN_DEADLINE, || !pid_exists(pid)),
+            "child pid {pid} was still alive {TEARDOWN_DEADLINE:?} after PtySession was dropped \
+             - orphaned process"
+        );
     }
 
     // unix-only: uses pid_exists/is_executable directly, which are #[cfg(unix)]
@@ -1453,15 +1461,12 @@ mod tests {
 
         drop(session);
 
-        let deadline = Instant::now() + Duration::from_secs(5);
-        while pid_exists(direct_pid) || pid_exists(grandchild_pid) {
-            assert!(
-                Instant::now() < deadline,
-                "direct child ({direct_pid}) or its escaped grandchild ({grandchild_pid}) was \
-                 still alive after PtySession was dropped - orphaned process"
-            );
-            std::thread::sleep(Duration::from_millis(20));
-        }
+        assert!(
+            test_support::wait_until(TEARDOWN_DEADLINE, || !pid_exists(direct_pid)
+                && !pid_exists(grandchild_pid)),
+            "direct child ({direct_pid}) or its escaped grandchild ({grandchild_pid}) was still \
+             alive {TEARDOWN_DEADLINE:?} after PtySession was dropped - orphaned process"
+        );
     }
 
     // unix-only: uses pid_exists/is_executable directly, which are #[cfg(unix)]
@@ -1507,46 +1512,34 @@ mod tests {
             .process_id()
             .expect("a spawned unix child should report a pid");
 
+        let steady = |pid| {
+            let state = proc_state(pid);
+            state.starts_with('S') || state.starts_with('R')
+        };
+
         // Give the kernel a moment to settle the freshly spawned process into a steady
         // running/sleeping state before asserting anything about it.
-        let deadline = Instant::now() + Duration::from_secs(5);
-        while !proc_state(pid).starts_with('S') && !proc_state(pid).starts_with('R') {
-            assert!(
-                Instant::now() < deadline,
-                "process never reached a steady state"
-            );
-            std::thread::sleep(Duration::from_millis(20));
-        }
+        assert!(
+            test_support::wait_until(TEARDOWN_DEADLINE, || steady(pid)),
+            "process {pid} never reached a steady state - last observed state: {:?}",
+            proc_state(pid)
+        );
 
         session.pause().expect("pause should succeed");
-        let deadline = Instant::now() + Duration::from_secs(5);
-        loop {
-            let state = proc_state(pid);
-            if state.starts_with('T') {
-                break;
-            }
-            assert!(
-                Instant::now() < deadline,
-                "process {pid} never reached the real kernel-reported stopped state \
-                 (State: T) after pause() - last observed state: {state:?}"
-            );
-            std::thread::sleep(Duration::from_millis(20));
-        }
+        assert!(
+            test_support::wait_until(TEARDOWN_DEADLINE, || proc_state(pid).starts_with('T')),
+            "process {pid} never reached the real kernel-reported stopped state (State: T) after \
+             pause() - last observed state: {:?}",
+            proc_state(pid)
+        );
 
         session.resume().expect("resume should succeed");
-        let deadline = Instant::now() + Duration::from_secs(5);
-        loop {
-            let state = proc_state(pid);
-            if state.starts_with('S') || state.starts_with('R') {
-                break;
-            }
-            assert!(
-                Instant::now() < deadline,
-                "process {pid} never left the real kernel-reported stopped state after \
-                 resume() - last observed state: {state:?}"
-            );
-            std::thread::sleep(Duration::from_millis(20));
-        }
+        assert!(
+            test_support::wait_until(TEARDOWN_DEADLINE, || steady(pid)),
+            "process {pid} never left the real kernel-reported stopped state after resume() - \
+             last observed state: {:?}",
+            proc_state(pid)
+        );
     }
 
     /// GitHub issue #242 phase B fix: an earlier version of `pause`/`resume` sent a plain
@@ -1570,18 +1563,11 @@ mod tests {
         }
 
         fn wait_for_state(pid: u32, prefix: char, what: &str) {
-            let deadline = Instant::now() + Duration::from_secs(5);
-            loop {
-                let state = proc_state(pid);
-                if state.starts_with(prefix) {
-                    return;
-                }
-                assert!(
-                    Instant::now() < deadline,
-                    "process {pid} never reached {what} - last observed state: {state:?}"
-                );
-                std::thread::sleep(Duration::from_millis(20));
-            }
+            assert!(
+                test_support::wait_until(TEARDOWN_DEADLINE, || proc_state(pid).starts_with(prefix)),
+                "process {pid} never reached {what} - last observed state: {:?}",
+                proc_state(pid)
+            );
         }
 
         let session = spawn(
@@ -1623,15 +1609,13 @@ mod tests {
     #[test]
     fn pause_and_resume_are_a_harmless_no_op_once_the_child_has_already_exited() {
         let mut session = spawn(SpawnOptions::new("true")).expect("spawning `true`");
-        let deadline = Instant::now() + Duration::from_secs(5);
-        while session
-            .try_wait()
-            .expect("try_wait should not error")
-            .is_none()
-        {
-            assert!(Instant::now() < deadline, "`true` never exited");
-            std::thread::sleep(Duration::from_millis(20));
-        }
+        assert!(
+            test_support::wait_until(TEARDOWN_DEADLINE, || session
+                .try_wait()
+                .expect("try_wait should not error")
+                .is_some()),
+            "`true` never exited"
+        );
         session
             .pause()
             .expect("pause on an already-exited child must be a harmless no-op");
@@ -1696,15 +1680,17 @@ mod tests {
         // thread blocks in `send` once the channel fills, which backpressures its
         // `read`, which fills the kernel pty buffer, which blocks `yes`'s `write` - so
         // growth should stay small and bounded.
-        std::thread::sleep(Duration::from_millis(500));
-        let rss_after = read_self_rss_kb();
-
-        let growth_kb = rss_after.saturating_sub(rss_before);
+        //
+        // `stays_false` rather than a bare sleep-then-measure: it holds the same 500ms window
+        // open while asserting the bound *continuously*, so a transient spike is caught too.
         assert!(
-            growth_kb < 20_000,
-            "RSS grew by {growth_kb} kB while an undrained `yes` pipe ran for 500ms - \
-             the output channel does not appear to be backpressuring (expected growth \
-             bounded by the channel capacity, well under 20MB)"
+            test_support::stays_false(Duration::from_millis(500), || {
+                read_self_rss_kb().saturating_sub(rss_before) >= 20_000
+            }),
+            "RSS grew by {} kB while an undrained `yes` pipe ran for 500ms - the output channel \
+             does not appear to be backpressuring (expected growth bounded by the channel \
+             capacity, well under 20MB)",
+            read_self_rss_kb().saturating_sub(rss_before)
         );
     }
 


### PR DESCRIPTION
Part of #425 (epic #427) — slice **D4: `crates/app/src/terminal/` + `crates/pty-core`**.

## What

**The headline is teardown, not the purge.** `crates/app`'s terminal tests were holding real child
processes alive for the whole of a test run, and this PR stops it.

GPUI releases an entity whose last handle was dropped during `flush_effects`, which only runs
inside an app update. `cx.run_until_parked()` does not trigger one, and neither does letting an
`Entity<TerminalPane>` fall out of scope at the end of a test body. So `PtySession::drop` — and
with it #432's process-tree teardown — **never ran**, and each test's child (plus anything it
spawned) survived until the test *binary* exited.

This never showed up in a before/after `ps` diff, which is why it was easy to miss: the moment the
test binary exits, the pty master fd closes and the kernel SIGHUPs each pty's foreground process
group, so every stray dies at once. The damage is entirely *mid-run*, which is where #427's 509
came from. Sampling every 20ms while the run is in flight:

```
########## BASELINE (74dcb7c), cargo test -p app --lib terminal:: -- --test-threads=8 ##########
test result: FAILED. 183 passed; 1 failed; 0 ignored; 0 measured; 2958 filtered out; finished in 1.04s

===== LIVE TEST-SPAWNED CHILDREN, SAMPLED EVERY 20ms DURING THE RUN =====
samples taken  : 52
PEAK concurrent: 29
worst sample:
40481 40338 cat
40485 40338 cat
40486 40338 cat
40487 40338 cat
40532 40338 cat
40488 40338 cat
40537 40338 cat
40490 40338 cat
40492 40338 cat
40542 40338 <defunct>
40543 40338 <defunct>
40544 40338 <defunct>
40546 40338 <defunct>
40554 40338 <defunct>
40557 40338 <defunct>
40501 40338 cat -v
40503 40338 cat
40508 40338 cat -v
40509 40338 cat
40511 40338 cat -v
40513 40338 cat -v
40514 40338 cat
40516 40338 cat
40472 40338 sh -c exec 0<&- 1>&- 2>&-; sleep 1; exit 7
40521 40338 cat
40523 40338 cat
40525 40338 cat
40526 40338 cat
40528 40338 cat
```

```
########## AFTER, identical command and sampler ##########
test result: ok. 129 passed; 0 failed; 0 ignored; 0 measured; 2958 filtered out; finished in 0.49s

===== LIVE TEST-SPAWNED CHILDREN, SAMPLED EVERY 20ms DURING THE RUN =====
samples taken  : 25
PEAK concurrent: 5
worst sample:
39196 39182 cat
39300 39182 cat
39301 39182 cat
39302 39182 cat
39299 39182 cat
```

**29 → 5**, and the remaining 5 are not leaks: that is at most one live child per libtest thread
(`--test-threads=8`) genuinely mid-test. Every one of them is a child of the same test binary and
is reaped before the next test starts.

A counted process has to satisfy both halves — its own command is one of the programs these tests
spawn (`cat`, `cat -v`, `sh -c …`, `sleep N`, `printf …`, `<defunct>`) **and** its parent is a
`target/debug/deps/` test binary — so no system process can be miscounted. The sampler is in the
session scratchpad, not the repo.

What actually fixes it:

- **`pty_pane_fixtures::release(cx, pane)`** is now the mandatory last statement of all 35
  real-pty tests in `pane.rs`. It drops the pane, closes the test's windows (a pane built with
  `add_window_view` is the window's *root view*, so the window holds a strong handle of its own —
  dropping only the test's handle is a silent no-op for those), then forces the flush.
- **`pane_teardown_tests::dropping_a_pane_takes_its_whole_real_process_tree_with_it`** pins the
  property at the layer the leak was actually reported at. `pty-core`'s own
  `drop_terminates_entire_process_tree_including_escaped_grandchild` only covers the crate level;
  nothing asserted that a *pane* reaches that teardown. It uses the same `set -m` escaped-grandchild
  shell, reads the grandchild's pid back over the real pty, and probes liveness with `kill -0`
  through `test_support::ChildGuard` — deliberately not through `pty_core`'s own `pid_exists`, so
  the check is independent of the code under test. **This test is what found the bug**: it failed
  for 30s against the baseline before `release` existed.

### Counts and wall-clock

| | before | after | |
|---|---|---|---|
| `app` `terminal::` tests | 184 (1 failing) | **129** | **−29.9 %** |
| `app` `terminal::` nextest run | 1.165 s | **0.503 s** | −57 % |
| `pty-core` tests | 17 | 17 | unchanged |
| `pty-core` nextest run | 1.764 s | 1.861 s | unchanged |
| peak concurrent leaked children | 29 | **5** | |
| `thread::sleep` in this slice's test code | 19 | **0** | |

```
     Summary [   0.503s] 129 tests run: 129 passed, 2958 skipped
     Summary [   1.861s] 17 tests run: 17 passed, 0 skipped
```

`crates/test-support` is untouched, as required.

## Every deletion, with its criterion

Criteria are `docs/testing.md`'s five. 55 tests removed; nothing lost its last coverage.

**Criterion 1 — sweep redundancy (N tests differing only by an input value) — 44 removed**

| Module | Collapsed | Into |
|---|---|---|
| `links.rs` | 7 positive-detection tests (`cargo` arrow line, backtrace frame, bare filename, multi-segment path, `:line` with no col, `:0`) | `every_real_shape_of_file_reference_resolves_to_its_own_path_line_and_column` |
| `links.rs` | 3 false-positive tests (prose, URL, realistic non-path output) | `realistic_non_path_output_never_produces_a_false_link` |
| `links.rs` | 4 `resolve` tests | `resolve_produces_a_real_absolute_path_with_no_dot_dot_left_in_it` |
| `osc.rs` | 4 attention-ping tests (OSC 9 BEL / OSC 9 ST / OSC 777 notify / 777 precmd) | `only_a_real_attention_request_pings_and_it_pings_exactly_once` |
| `osc.rs` | 4 progress-parsing tests (states, clamping, out-of-range, 9;4-is-not-a-ping) | `every_progress_report_parses_to_its_documented_meaning` |
| `osc.rs` | 2 progress-supersede/clear tests | `a_later_progress_report_supersedes_an_earlier_one_and_a_clear_wipes_it` |
| `grid.rs` | 4 wide-char width tests (CJK / emoji / `é` / spacer char) | `real_utf8_is_labelled_wide_or_narrow_by_its_real_column_width` |
| `grid.rs` | `dimensions_reports_the_real_current_cols_and_rows` + `resize_changes_the_visible_row_and_column_count` | `a_resize_changes_both_the_reported_dimensions_and_the_visible_rows` |
| `grid.rs` | `a_drag_across_blank_screen_selects_nothing_worth_copying` | `nothing_worth_copying_is_never_reported_as_a_selection` |
| `pane.rs` | 6 `split_segments` position tests (none/middle/start/end/whole-row/multiple) | `a_link_is_a_span_inside_the_row_wherever_on_it_the_link_falls` |
| `pane.rs` | 7 `cell_position_in_grid` tests (top-left, containing cell, side, both clamps, origin, degenerate) | `a_pixel_resolves_to_the_cell_containing_it_and_clamps_at_every_edge` + the degenerate-cell-size guard |
| `pane.rs` | `ctrl_p_maps_…` + `ctrl_z_maps_…` + `an_unmodified_letter_is_still_forwarded_normally` | `a_ctrl_letter_maps_to_its_real_control_byte_and_a_plain_letter_to_itself` |
| `pane.rs` | `shift_tab_sends_…` + `ctrl_shift_tab_is_unaffected_…` | `shift_tab_sends_the_real_back_tab_sequence_distinct_from_every_other_tab` |
| `pane.rs` | 3 alt-screen wheel-forwarding tests (up / down / fast flick) — each spawned its own real `cat -v` pty | `an_alt_screen_scroll_forwards_page_keys_proportionally_and_never_arrow_keys` |
| `pane.rs` | `an_absent_env_value_falls_back` + `the_windows_fallback_is_a_real_windows_path_not_the_unix_one` + `a_real_env_value_is_used_verbatim` | `an_env_value_is_used_verbatim_and_an_absent_one_falls_back_per_platform` |
| `pane.rs` | `a_configured_shell_is_trimmed_before_it_becomes_a_program` | `a_configured_shell_is_trimmed_and_a_nameless_one_falls_back_to_the_os_default` |
| `pane.rs` | `two_different_dark_themes_paint_two_different_terminals` (Ember/Moss vs. the headline test's default/Paper — same assertion, different bundled themes) | `switching_to_the_light_theme_really_repaints_the_terminal_light` |
| `pane.rs` | `a_wide_run_never_merges_into_the_narrow_text_around_it` | `each_wide_character_is_its_own_two_column_run_never_merged_with_its_neighbours` |
| `pane.rs` | `a_link_after_a_wide_character_still_lands_on_the_right_characters` | `a_link_containing_wide_characters_is_still_detected_as_one_link` |

**Criterion 2 — implementation mirroring (the assertion recomputes what the code does) — 2 removed**

- `pane.rs` `size_to_grid_derives_columns_and_rows_from_the_given_size_not_a_fixed_constant` —
  asserted `cols == (820.0 / APPROX_CELL_WIDTH_PX) as u16`, i.e. `size_to_grid`'s own body.
- `pane.rs` `size_to_grid_from_a_real_pane_width_is_plausible_not_the_full_window_derived_count` —
  "a wider input yields more columns", which is the division restated. The regression it named
  (`maybe_resize_pty` feeding the window size instead of the pane size) is not observable from
  `size_to_grid` at all, and is covered by `padding_box_measurement_over_requests_columns_and_rows_relative_to_the_real_content_box`.

**Criterion 3 — vacuous (would still pass with the feature removed) — 3 removed**

- `grid.rs` `mark_ended_sets_the_flag` — a field round-tripping through its own setter;
  `docs/testing.md` names this exact shape as not worth a test.
- `pane.rs` `size_to_grid_documents_the_real_before_after_column_count_at_a_typical_pane_width` —
  asserts `50` and `42` rows for a *hypothetical old* cell size (`7.0 × 16.0`) that no longer
  exists anywhere in the code. Purely test-local data. (Also criterion 4.)
- `pane.rs` `eof_poll_tests::real_process_closing_pty_fds_before_exiting_is_not_yet_reaped_at_eof`
  — see below.

**Criterion 5 — duplicate coverage across layers (keep the cheaper one) — 6 removed**

- `grid.rs` `sgr_red_foreground_resolves_to_the_named_palette_color` — `every_themeable_colour_comes_from_the_supplied_palette_not_a_hardcoded_one` asserts SGR 31 against the same palette entry.
- `grid.rs` `clear_screen_erases_previously_written_text` — `TerminalGrid::clear` *is*
  `append_bytes(b"\x1b[3J\x1b[2J\x1b[H")`, so `clear_erases_visible_text_and_homes_the_cursor` drives
  the identical bytes and asserts strictly more.
- `grid.rs` `no_selection_means_no_cell_is_flagged` — folded into
  `selected_cells_are_flagged_for_the_renderer` as its precondition, so the assertion survives at
  no extra test cost.
- `pane.rs` `mouse_selection_tests::a_drag_marks_the_covered_cells_selected_for_the_renderer` —
  the flag is `grid.rs`'s `selected_cells_are_flagged_for_the_renderer`; the GPUI wiring is
  `a_real_mouse_drag_selects_the_text_it_dragged_over`.
- `pane.rs` `mouse_selection_tests::a_drag_over_cjk_characters_copies_them_once_each` — same
  behaviour as `grid.rs`'s `selecting_a_wide_character_copies_it_once_not_once_plus_its_spacer`;
  the pixel-math-over-wide-characters wiring is
  `a_drag_after_two_cjk_characters_still_hits_the_columns_it_looks_like_it_hits`.
- `pane.rs` `terminal_theme_tests::unstyled_output_takes_the_themes_own_foreground_and_background`
  — the resolution is `grid.rs`'s `every_themeable_colour_comes_from_the_supplied_palette_not_a_hardcoded_one`; that a *painted* cell follows the live theme is `a_named_ansi_colour_is_painted_from_the_themes_own_palette`.
- `pane.rs` `scrollback_pane_tests::a_fresh_pane_with_little_content_shows_no_scrollbar` —
  `a_fresh_pane_never_becomes_scrollable_as_its_layout_settles` asserts the same
  scrollbar-absent-then-present pair across five real window geometries instead of one.

## The pre-existing failure in this slice

`terminal::pane::eof_poll_tests::real_process_closing_pty_fds_before_exiting_is_not_yet_reaped_at_eof`
(deterministic, 5/5). **Deleted, criterion 3.**

It never calls `eof_poll_decision` — it asserts a property of the operating system, and that
property is false on macOS. A pty master does not report EOF when the child closes its stdio; it
reports EOF when the *controlling-terminal session leader* exits, so the "channel disconnected but
the process is still alive" window the test asserts cannot exist. Measured directly with a
throwaway probe against `pty_core::spawn` before deleting:

```
A close-then-sleep5 ("exec 0<&- 1>&- 2>&-; sleep 5; exit 7")
  → EOF at 5.015673417s, try_wait = Ok(Some(ExitStatus { code: 7, signal: None }))
B setsid-grandchild-holds ("set -m; (sleep 5) & exec 0<&- 1>&- 2>&-; wait; exit 7")
  → EOF at 5.02223425s,  try_wait = Ok(Some(ExitStatus { code: 7, signal: None }))
```

EOF arrives at the moment the shell exits, not when it closes its fds, and the child is already
reaped by then — so the single `try_wait` the test requires to return `None` always returns
`Some`. The test's own comment anticipated this: *"If this assertion itself fails, the test's
timing assumption is wrong, not the fix under test."* It was.

`eof_poll_decision`'s full contract stays covered by its three sibling unit tests
(`resolves_immediately_when_try_wait_already_has_a_status`,
`keeps_waiting_while_try_wait_has_no_answer_and_the_tick_cap_is_not_reached`,
`gives_up_at_the_tick_cap_with_a_synthetic_failed_status_not_silence`), which are deterministic and
spawn nothing.

## `thread::sleep` → `wait_until` / `stays_false` (19 → 0)

Four near-identical hand-rolled real-pty pump loops (`clear_pty_signal_tests`' inline 45s loop,
`terminal_signal_tests::poll_until`, `send_prompt_tests::pump_until`,
`scrollback_pane_tests::drain_until`) are now one `pty_pane_fixtures` module built on
`test_support::wait_until`/`stays_false`, which advance the simulated GPUI clock and real
wall-clock together, one poll at a time.

The interesting one is `cadence_tests::a_background_pane_drains_on_the_background_interval_read_fresh_each_tick`,
which had two `thread::sleep(400ms)` calls. Its property is now stated in *simulated* time —
"no drain may happen before one full `BACKGROUND_POLL_INTERVAL` of simulated time has passed" —
so real time only ever passes through `wait_until`'s bounded poll. It still kills the mutant it
exists to catch (hoisting `is_foreground` out of the poll loop), verified by making the demotion a
no-op:

```
thread '…::a_background_pane_drains_on_the_background_interval_read_fresh_each_tick' panicked at
crates/app/src/terminal/pane.rs:3071:9:
a background pane drained pty output after only 16ms of simulated time, less than one
BACKGROUND_POLL_INTERVAL (33ms) - the poll loop is not reading the live foreground flag each tick
```

It also got 4.5× faster: 0.840 s → 0.188 s.

In `pty-core`, seven hand-rolled `while … { sleep(20ms) }` loops became `wait_until` against a
shared `TEARDOWN_DEADLINE`, and `output_channel_backpressures_instead_of_growing_unboundedly`'s
`sleep(500ms)` became `stays_false`, which holds the same window open while asserting the RSS
bound *continuously* rather than only at the end.

**One `thread::sleep` deliberately remains**, at `pty-core/src/lib.rs:1325`, and it is not a wait —
it is the test's *stimulus*. Stalling the consumer is the only way to make the bounded channel
actually fill and the reader thread actually block in `send`, which is the path
`long_output_arrives_complete_and_in_order_across_chunk_boundaries` exists to exercise. The comment
now says so explicitly. (`lib.rs:1176` is production code, not test code.)

## Other procedure steps

- **Tiering**: nothing in this slice needs a binary the repo does not vendor. `cat`, `sh`, `sleep`,
  `printf`, `seq`, `true`, `yes` are all POSIX and already required by `pty-core`'s existing suite,
  so no test moved to `external`. The `#[cfg(target_os = "linux")]` and `#[cfg(unix)]` gates that
  were already there are unchanged.
- **`crates/test-support` routing**: `pty-core` gains it as a dev-dependency for `wait_until` and
  `ChildGuard`. There is no local `fn git`/`seed_*`/tempdir duplication in this slice to remove —
  it is the one slice with no git fixtures at all.
- **`ChildGuard`**: added to `pty-core`'s `pid_exists_separates_a_live_process_from_a_reaped_one`
  (the one real process this slice spawns outside a `PtySession`) and used by the new
  `pane_teardown_tests` liveness probe. Every other real process here is owned by a `PtySession`,
  whose `Drop` is the RAII guard — which is exactly why making that `Drop` actually run was the
  work.
- **Conventions**: `mod tests` renamed by concern in the three files that still had it
  (`grid::grid_emulation_tests`, `links::link_detection_tests`, `osc::osc_signal_tests`,
  `pty_core::pty_session_tests`). One `use super::*` glob removed, so
  `.claude/conventions-baseline.json`'s ratchet goes **304 → 303**.

## Why

#425 step 5, and the part of #427 that actually costs developers something. #432 made process-tree
kill work on macOS; it could not make a test that never reaches the kill clean up.

## Testing

- [x] `/check` (conventions + fmt + clippy `-D warnings`) passes locally

```
$ cargo clippy --workspace --all-targets -- -D warnings   # exit 0
$ cargo fmt --all -- --check                              # exit 0
$ .claude/hooks/check-conventions.sh
check-conventions: OK (glob imports: 303/303, render adapter calls: 221/221)
```

- [ ] `verify` capture — not applicable, no UI-visible change (test code and one dev-dependency).
- [x] New/changed behaviour has a real test, run manually and confirmed passing.

```
$ cargo nextest run -p app --lib -E 'test(/^terminal::/)'
     Summary [   0.503s] 129 tests run: 129 passed, 2958 skipped

$ cargo nextest run -p pty-core
     Summary [   1.861s] 17 tests run: 17 passed, 0 skipped
```

Not run, stated rather than left unchecked: the three `#[cfg(target_os = "linux")]` bodies in
`pty-core` (`pause_really_stops_the_process_and_resume_really_restarts_it`,
`pause_and_resume_really_reach_an_escaped_grandchild_process_too`, and
`output_channel_backpressures_instead_of_growing_unboundedly`) had their poll loops swapped for
`wait_until`/`stays_false` but **could not be compiled locally** — only `aarch64-apple-darwin` is
installed, so `cargo check --target x86_64-unknown-linux-gnu` is not available here. The edits are
mechanical (same condition, same 5 s deadline) but they rely on CI's Linux job.

`cargo test --workspace` is not part of the gate (#348); nothing outside
`crates/app/src/terminal/` and `crates/pty-core/` was touched, plus the ratchet baseline.

## Architecture notes

`crates/pty-core` gains `test-support` as a **dev**-dependency only. `test-support` is deliberately
`gpui`-free (`docs/testing.md`), so this cannot pull `gpui` into a core crate's graph and does not
touch `docs/architecture/decisions.md` §1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
