### PR TITLE
chore(app): repair, tier and purge the settings/theme/lsp/search suite (#425)

### DIFF
--- a/assets/themes/ember.toml
+++ b/assets/themes/ember.toml
@@ -81,7 +81,7 @@ diagnostic_card_footer = "#251d22"  # The Diagnostic popover's own footer band's
 # The Files tree's own structural marks (GitHub issue #18 §3).
 [tree]
 indent_guide        = "#1c2124"
-indent_guide_active = "#224959"  # The guide for a level in the selected file's ancestor chain
+indent_guide_active = "#224959"
 
 # The overlay scrollbar (GitHub issue #30).
 [scrollbar]

--- a/assets/themes/jerry-dim.toml
+++ b/assets/themes/jerry-dim.toml
@@ -81,7 +81,7 @@ diagnostic_card_footer = "#312829"  # The Diagnostic popover's own footer band's
 # The Files tree's own structural marks (GitHub issue #18 §3).
 [tree]
 indent_guide        = "#292c30"
-indent_guide_active = "#435971"  # The guide for a level in the selected file's ancestor chain
+indent_guide_active = "#435971"
 
 # The overlay scrollbar (GitHub issue #30).
 [scrollbar]

--- a/assets/themes/moss.toml
+++ b/assets/themes/moss.toml
@@ -81,7 +81,7 @@ diagnostic_card_footer = "#292224"  # The Diagnostic popover's own footer band's
 # The Files tree's own structural marks (GitHub issue #18 §3).
 [tree]
 indent_guide        = "#232528"
-indent_guide_active = "#3f5264"  # The guide for a level in the selected file's ancestor chain
+indent_guide_active = "#3f5264"
 
 # The overlay scrollbar (GitHub issue #30).
 [scrollbar]

--- a/assets/themes/paper.toml
+++ b/assets/themes/paper.toml
@@ -81,7 +81,7 @@ diagnostic_card_footer = "#dfd5d7"  # The Diagnostic popover's own footer band's
 # The Files tree's own structural marks (GitHub issue #18 §3).
 [tree]
 indent_guide        = "#d3d8dc"
-indent_guide_active = "#90a9bf"  # The guide for a level in the selected file's ancestor chain
+indent_guide_active = "#90a9bf"
 
 # The overlay scrollbar (GitHub issue #30).
 [scrollbar]

--- a/assets/themes/slate.toml
+++ b/assets/themes/slate.toml
@@ -81,7 +81,7 @@ diagnostic_card_footer = "#251d1e"  # The Diagnostic popover's own footer band's
 # The Files tree's own structural marks (GitHub issue #18 §3).
 [tree]
 indent_guide        = "#1d2024"
-indent_guide_active = "#2d435b"  # The guide for a level in the selected file's ancestor chain
+indent_guide_active = "#2d435b"
 
 # The overlay scrollbar (GitHub issue #30).
 [scrollbar]

--- a/crates/app/src/lsp/client.rs
+++ b/crates/app/src/lsp/client.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::lsp::completion_popup::{CompletionsEntry, CompletionsStatus};
 #[cfg(test)]
-use crate::root::focus::palette_focus_tests;
+use crate::test_support::open_test_app;
 
 /// [`AdeApp::lsp_clients`]' real key: a repository root paired with the real server binary
 /// running for it - see that field's own docs for why a bare `PathBuf` was widened to this
@@ -2488,12 +2488,12 @@ mod lsp_client_eviction_tests {
     fn switching_between_several_worktrees_never_lets_lsp_clients_grow_past_one(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let worktree_a = tempfile::tempdir().expect("tempdir a");
-        let worktree_b = tempfile::tempdir().expect("tempdir b");
-        let worktree_c = tempfile::tempdir().expect("tempdir c");
+        let repo = crate::lsp::fixtures::temp_repo();
+        let worktree_a = crate::lsp::fixtures::temp_repo();
+        let worktree_b = crate::lsp::fixtures::temp_repo();
+        let worktree_c = crate::lsp::fixtures::temp_repo();
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![
@@ -2566,11 +2566,11 @@ mod lsp_client_eviction_tests {
     fn a_worktree_switch_evicts_every_language_client_for_the_old_root_not_just_one(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let worktree_old = tempfile::tempdir().expect("tempdir old");
-        let worktree_new = tempfile::tempdir().expect("tempdir new");
+        let repo = crate::lsp::fixtures::temp_repo();
+        let worktree_old = crate::lsp::fixtures::temp_repo();
+        let worktree_new = crate::lsp::fixtures::temp_repo();
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![
@@ -2865,15 +2865,12 @@ process.stdin.on('data', (d) => {
                 serde_json::json!({ "uri": target, "message": message }),
             )
             .expect("the fake server should accept a real notification");
-        let deadline = Instant::now() + Duration::from_secs(10);
         let target = uri(target);
-        while !client.has_diagnostics_result_uri(&target) {
-            assert!(
-                Instant::now() < deadline,
-                "the real publishDiagnostics push never landed in the client's own sink"
-            );
-            std::thread::sleep(Duration::from_millis(10));
-        }
+        assert!(
+            test_support::wait_until(Duration::from_secs(10), || client
+                .has_diagnostics_result_uri(&target)),
+            "the real publishDiagnostics push never landed in the client's own sink"
+        );
     }
 
     /// Same real push as [`publish_and_wait`], at an explicit `character..character_end` UTF-16
@@ -2899,15 +2896,12 @@ process.stdin.on('data', (d) => {
                 }),
             )
             .expect("the fake server should accept a real notification");
-        let deadline = Instant::now() + Duration::from_secs(10);
         let target = uri(target);
-        while !client.has_diagnostics_result_uri(&target) {
-            assert!(
-                Instant::now() < deadline,
-                "the real publishDiagnostics push never landed in the client's own sink"
-            );
-            std::thread::sleep(Duration::from_millis(10));
-        }
+        assert!(
+            test_support::wait_until(Duration::from_secs(10), || client
+                .has_diagnostics_result_uri(&target)),
+            "the real publishDiagnostics push never landed in the client's own sink"
+        );
     }
 
     /// Same real push as [`publish_and_wait`], at a real `line` and a real `severity`, naming a
@@ -2938,15 +2932,12 @@ process.stdin.on('data', (d) => {
                 }),
             )
             .expect("the fake server should accept a real notification");
-        let deadline = Instant::now() + Duration::from_secs(10);
         let target = uri(target);
-        while !client.has_diagnostics_result_uri(&target) {
-            assert!(
-                Instant::now() < deadline,
-                "the real publishDiagnostics push never landed in the client's own sink"
-            );
-            std::thread::sleep(Duration::from_millis(10));
-        }
+        assert!(
+            test_support::wait_until(Duration::from_secs(10), || client
+                .has_diagnostics_result_uri(&target)),
+            "the real publishDiagnostics push never landed in the client's own sink"
+        );
     }
 
     /// Same real push as [`publish_and_wait`], but carrying the `source` and `code` fields a real
@@ -2972,33 +2963,28 @@ process.stdin.on('data', (d) => {
                 }),
             )
             .expect("the fake server should accept a real notification");
-        let deadline = Instant::now() + Duration::from_secs(10);
         let target = uri(target);
-        while !client.has_diagnostics_result_uri(&target) {
-            assert!(
-                Instant::now() < deadline,
-                "the real publishDiagnostics push never landed in the client's own sink"
-            );
-            std::thread::sleep(Duration::from_millis(10));
-        }
+        assert!(
+            test_support::wait_until(Duration::from_secs(10), || client
+                .has_diagnostics_result_uri(&target)),
+            "the real publishDiagnostics push never landed in the client's own sink"
+        );
     }
 
     fn wait_for_relay_observation(client: &lsp_core::LspClient) -> String {
         let observed = uri("file:///relay-observed");
-        let deadline = Instant::now() + Duration::from_secs(30);
-        loop {
-            if let Some(diagnostics) = client.diagnostics_for_uri(&observed) {
-                if let Some(first) = diagnostics.first() {
-                    return first.message.clone();
-                }
-            }
-            assert!(
-                Instant::now() < deadline,
-                "the primary never observed any relay response at all - a hanging primary is \
-                 exactly the failure this path must never produce"
-            );
-            std::thread::sleep(Duration::from_millis(20));
-        }
+        let mut message = None;
+        assert!(
+            test_support::wait_until(Duration::from_secs(30), || {
+                message = client
+                    .diagnostics_for_uri(&observed)
+                    .and_then(|diagnostics| diagnostics.first().map(|first| first.message.clone()));
+                message.is_some()
+            }),
+            "the primary never observed any relay response at all - a hanging primary is \
+             exactly the failure this path must never produce"
+        );
+        message.expect("the wait above only returns true once a real message landed")
     }
 
     #[test]
@@ -3089,7 +3075,7 @@ process.stdin.on('data', (d) => {
     /// errors. Also pins the `None`-vs-`Some(vec![])` distinction across the merge.
     #[test]
     fn a_two_server_connection_merges_both_halves_real_diagnostics() {
-        let root = tempfile::tempdir().expect("tempdir");
+        let root = crate::lsp::fixtures::temp_repo();
         let primary = spawn_fake_server(root.path(), "primary", "normal");
         let companion = spawn_fake_server(root.path(), "companion", "normal");
         let target = "file:///merged.vue";
@@ -3135,7 +3121,7 @@ process.stdin.on('data', (d) => {
     /// including passing `None` through as `None`.
     #[test]
     fn a_single_server_connection_passes_diagnostics_straight_through() {
-        let root = tempfile::tempdir().expect("tempdir");
+        let root = crate::lsp::fixtures::temp_repo();
         let client = spawn_fake_server(root.path(), "solo", "normal");
         let connection = LspConnection::Single(client.clone());
         let target = "file:///solo.rs";
@@ -3153,7 +3139,7 @@ process.stdin.on('data', (d) => {
     /// for a hybrid-mode primary, not a failure), so the companion's real answer is what surfaces.
     #[test]
     fn hover_falls_back_to_the_companion_when_the_primary_has_nothing() {
-        let root = tempfile::tempdir().expect("tempdir");
+        let root = crate::lsp::fixtures::temp_repo();
         let primary = spawn_fake_server(root.path(), "primary", "normal");
         let companion = spawn_fake_server(root.path(), "companion", "hover");
         let params = lsp_core::lsp_types::HoverParams {
@@ -3233,7 +3219,7 @@ process.stdin.on('data', (d) => {
     /// such an identifier did nothing at all: the facade hardcoded its fallback to hover only.
     #[test]
     fn goto_definition_falls_back_to_the_companion_on_an_empty_array_answer() {
-        let root = tempfile::tempdir().expect("tempdir");
+        let root = crate::lsp::fixtures::temp_repo();
         let primary = spawn_fake_server(root.path(), "primary", "normal");
 
         let single = LspConnection::Single(primary.clone());
@@ -3281,7 +3267,7 @@ process.stdin.on('data', (d) => {
     /// `.vue` script block were always empty with no fallback ever attempted.
     #[test]
     fn completion_falls_back_to_the_companion_on_an_empty_completion_list() {
-        let root = tempfile::tempdir().expect("tempdir");
+        let root = crate::lsp::fixtures::temp_repo();
         let primary = spawn_fake_server(root.path(), "primary", "normal");
 
         let single = LspConnection::Single(primary.clone());
@@ -3343,15 +3329,14 @@ process.stdin.on('data', (d) => {
     fn a_debounced_re_sync_never_drops_an_already_ready_popup_back_to_loading(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let root = repo.path().to_path_buf();
         std::fs::create_dir_all(root.join("src")).expect("mkdir src");
         let absolute = root.join("src").join("main.rs");
         std::fs::write(&absolute, "fn a() {\n    x\n}\n").expect("write main.rs");
         let relative = PathBuf::from("src/main.rs");
 
-        let (app, cx): (Entity<AdeApp>, &mut VisualTestContext) =
-            palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx): (Entity<AdeApp>, &mut VisualTestContext) = open_test_app(cx, root.clone());
         let server = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
         app.update_in(cx, |app, window, cx| {
             app.lsp_clients.insert(
@@ -3366,19 +3351,14 @@ process.stdin.on('data', (d) => {
         // lsp_uri_cache` has a real entry for this path - populated by `Self::dispatch_did_open`'s
         // own background task, which `Self::render_center_pane` is what actually drives here
         // (mirroring `wait_for_real_diagnostics`'s own reasoning).
-        let uri_cache_deadline = std::time::Instant::now() + Duration::from_secs(10);
-        loop {
-            app.update(cx, |app, cx| app.render_center_pane(cx));
-            cx.run_until_parked();
-            if app.read_with(cx, |app, _| app.lsp_uri_cache.contains_key(&absolute)) {
-                break;
-            }
-            assert!(
-                std::time::Instant::now() < uri_cache_deadline,
-                "the fake client's uri never reached AdeApp::lsp_uri_cache"
-            );
-            std::thread::sleep(Duration::from_millis(20));
-        }
+        assert!(
+            crate::lsp::fixtures::wait_until_parked(cx, Duration::from_secs(10), |cx| {
+                app.update(cx, |app, cx| app.render_center_pane(cx));
+                cx.run_until_parked();
+                app.read_with(cx, |app, _| app.lsp_uri_cache.contains_key(&absolute))
+            }),
+            "the fake client's uri never reached AdeApp::lsp_uri_cache"
+        );
 
         // A pre-existing `Ready` popup for this exact path, seeded directly - standing in for
         // whatever real server response is already showing by the time a later keystroke's
@@ -3432,15 +3412,14 @@ process.stdin.on('data', (d) => {
     /// does: the decision under test is synchronous, before any request is ever dispatched.
     #[gpui::test]
     fn accepting_a_completion_does_not_immediately_reopen_the_popup(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let root = repo.path().to_path_buf();
         std::fs::create_dir_all(root.join("src")).expect("mkdir src");
         let absolute = root.join("src").join("main.rs");
         std::fs::write(&absolute, "fn a() {\n    \n}\n").expect("write main.rs");
         let relative = PathBuf::from("src/main.rs");
 
-        let (app, cx): (Entity<AdeApp>, &mut VisualTestContext) =
-            palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx): (Entity<AdeApp>, &mut VisualTestContext) = open_test_app(cx, root.clone());
         let server = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
         app.update_in(cx, |app, window, cx| {
             app.lsp_clients.insert(
@@ -3531,14 +3510,13 @@ process.stdin.on('data', (d) => {
     fn selecting_a_completion_item_resolves_its_real_detail_and_documentation(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let root = repo.path().to_path_buf();
         let absolute = root.join("main.rs");
         std::fs::write(&absolute, "fn a() {}\n").expect("write main.rs");
         let relative = PathBuf::from("main.rs");
 
-        let (app, cx): (Entity<AdeApp>, &mut VisualTestContext) =
-            palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx): (Entity<AdeApp>, &mut VisualTestContext) = open_test_app(cx, root.clone());
         let server = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
         app.update_in(cx, |app, window, cx| {
             app.lsp_clients.insert(
@@ -3616,14 +3594,13 @@ process.stdin.on('data', (d) => {
     fn a_real_resolved_detail_replaces_a_placeholder_the_server_sent_inline(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let root = repo.path().to_path_buf();
         let absolute = root.join("main.rs");
         std::fs::write(&absolute, "fn a() {}\n").expect("write main.rs");
         let relative = PathBuf::from("main.rs");
 
-        let (app, cx): (Entity<AdeApp>, &mut VisualTestContext) =
-            palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx): (Entity<AdeApp>, &mut VisualTestContext) = open_test_app(cx, root.clone());
         let server = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
         app.update_in(cx, |app, window, cx| {
             app.lsp_clients.insert(
@@ -3696,14 +3673,13 @@ process.stdin.on('data', (d) => {
     fn an_item_whose_resolve_was_cancelled_by_moving_on_is_resolved_again_on_return(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let root = repo.path().to_path_buf();
         let absolute = root.join("main.rs");
         std::fs::write(&absolute, "fn a() {}\n").expect("write main.rs");
         let relative = PathBuf::from("main.rs");
 
-        let (app, cx): (Entity<AdeApp>, &mut VisualTestContext) =
-            palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx): (Entity<AdeApp>, &mut VisualTestContext) = open_test_app(cx, root.clone());
         let server = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
         app.update_in(cx, |app, window, cx| {
             app.lsp_clients.insert(
@@ -3785,14 +3761,13 @@ process.stdin.on('data', (d) => {
     /// must not fire a second, redundant request for the same thing.
     #[gpui::test]
     fn an_item_with_a_resolve_already_in_flight_is_not_asked_twice(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let root = repo.path().to_path_buf();
         let absolute = root.join("main.rs");
         std::fs::write(&absolute, "fn a() {}\n").expect("write main.rs");
         let relative = PathBuf::from("main.rs");
 
-        let (app, cx): (Entity<AdeApp>, &mut VisualTestContext) =
-            palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx): (Entity<AdeApp>, &mut VisualTestContext) = open_test_app(cx, root.clone());
         let server = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
         app.update_in(cx, |app, window, cx| {
             app.lsp_clients.insert(
@@ -3868,14 +3843,13 @@ process.stdin.on('data', (d) => {
     /// request should never leave in the first place).
     #[gpui::test]
     fn a_server_without_resolve_support_is_never_asked_to_resolve(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let root = repo.path().to_path_buf();
         let absolute = root.join("main.vue");
         std::fs::write(&absolute, "<template></template>\n").expect("write main.vue");
         let relative = PathBuf::from("main.vue");
 
-        let (app, cx): (Entity<AdeApp>, &mut VisualTestContext) =
-            palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx): (Entity<AdeApp>, &mut VisualTestContext) = open_test_app(cx, root.clone());
         // `vue-language-server` is the fake client key `crate::language::lsp_binary_for_extension`
         // resolves for `.vue` - reused here purely to get a `Ready` client under the right key,
         // not because this test cares about the real Vue companion mechanism at all.
@@ -3924,7 +3898,7 @@ process.stdin.on('data', (d) => {
     /// bound is the actual proof, not the returned value.
     #[test]
     fn a_request_outside_the_fallback_list_never_consults_the_companion() {
-        let root = tempfile::tempdir().expect("tempdir");
+        let root = crate::lsp::fixtures::temp_repo();
         let spec = vue_companion_spec();
         assert!(
             !spec.fallback_methods.contains(&"textDocument/references"),
@@ -4033,7 +4007,7 @@ process.stdin.on('data', (d) => {
     /// plausible-looking "everything's fine" status.
     #[test]
     fn a_dead_companion_flips_liveness_and_is_named_in_the_real_status() {
-        let root = tempfile::tempdir().expect("tempdir");
+        let root = crate::lsp::fixtures::temp_repo();
         let primary = spawn_fake_server(root.path(), "vue-language-server", "normal");
         let companion =
             spawn_fake_server(root.path(), "typescript-language-server (vue)", "normal");
@@ -4050,15 +4024,12 @@ process.stdin.on('data', (d) => {
             .notify_raw("test/die", serde_json::Value::Null)
             .expect("the fake server should accept the notification that kills it");
 
-        let deadline = Instant::now() + Duration::from_secs(10);
-        while connection.is_connection_alive() {
-            assert!(
-                Instant::now() < deadline,
-                "a WithCompanion connection must stop reporting itself alive once either half's \
-                 real process dies"
-            );
-            std::thread::sleep(Duration::from_millis(20));
-        }
+        assert!(
+            test_support::wait_until(Duration::from_secs(10), || !connection
+                .is_connection_alive()),
+            "a WithCompanion connection must stop reporting itself alive once either half's \
+             real process dies"
+        );
         let reason = connection
             .liveness_failure_reason()
             .expect("a dead half must produce a real reason");
@@ -4085,7 +4056,7 @@ process.stdin.on('data', (d) => {
     /// The same honesty rule in the other direction: a dead primary names the primary.
     #[test]
     fn a_dead_primary_is_named_rather_than_blamed_on_the_companion() {
-        let root = tempfile::tempdir().expect("tempdir");
+        let root = crate::lsp::fixtures::temp_repo();
         let primary = spawn_fake_server(root.path(), "vue-language-server", "normal");
         let connection = LspConnection::WithCompanion {
             primary: primary.clone(),
@@ -4095,28 +4066,26 @@ process.stdin.on('data', (d) => {
         primary
             .notify_raw("test/die", serde_json::Value::Null)
             .expect("notification accepted");
-        let deadline = Instant::now() + Duration::from_secs(10);
-        loop {
-            if let Some(reason) = connection.liveness_failure_reason() {
-                assert!(
-                    reason.contains("vue-language-server"),
-                    "the message must name the real primary, got: {reason}"
-                );
-                break;
-            }
-            assert!(
-                Instant::now() < deadline,
-                "the dead primary was never noticed"
-            );
-            std::thread::sleep(Duration::from_millis(20));
-        }
+        let mut reason = None;
+        assert!(
+            test_support::wait_until(Duration::from_secs(10), || {
+                reason = connection.liveness_failure_reason();
+                reason.is_some()
+            }),
+            "the dead primary was never noticed"
+        );
+        let reason = reason.expect("the wait above only returns true once a reason landed");
+        assert!(
+            reason.contains("vue-language-server"),
+            "the message must name the real primary, got: {reason}"
+        );
     }
 
     /// A companion that failed its own spawn must be surfaced honestly rather than silently
     /// leaving the user with half the analysis and a confident-looking status.
     #[test]
     fn a_companion_that_failed_to_spawn_is_surfaced_in_the_real_file_status() {
-        let root = tempfile::tempdir().expect("tempdir");
+        let root = crate::lsp::fixtures::temp_repo();
         let primary = spawn_fake_server(root.path(), "vue-language-server", "normal");
         let connection = LspConnection::Single(primary.clone());
         let status = lsp_file_status(
@@ -4137,7 +4106,7 @@ process.stdin.on('data', (d) => {
     /// alone is genuinely working in the meantime.
     #[test]
     fn a_still_spawning_companion_leaves_the_primarys_own_status_intact() {
-        let root = tempfile::tempdir().expect("tempdir");
+        let root = crate::lsp::fixtures::temp_repo();
         let primary = spawn_fake_server(root.path(), "vue-language-server", "normal");
         let connection = LspConnection::Single(primary.clone());
         let status = lsp_file_status(
@@ -4155,14 +4124,10 @@ process.stdin.on('data', (d) => {
 
     /// Waits for a genuinely spawned server's real process death to be observed by its client.
     fn wait_until_dead(client: &lsp_core::LspClient) {
-        let deadline = Instant::now() + Duration::from_secs(10);
-        while client.is_connection_alive() {
-            assert!(
-                Instant::now() < deadline,
-                "the real process death should have been observed within 10s"
-            );
-            std::thread::sleep(Duration::from_millis(20));
-        }
+        assert!(
+            test_support::wait_until(Duration::from_secs(10), || !client.is_connection_alive()),
+            "the real process death should have been observed within 10s"
+        );
     }
 
     /// The real bug: nothing in this crate ever checked `is_connection_alive` on a *cadence*. It
@@ -4177,8 +4142,8 @@ process.stdin.on('data', (d) => {
     /// flip.
     #[gpui::test]
     fn a_dead_ready_client_is_reaped_into_a_real_named_failed_state(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::lsp::fixtures::temp_repo();
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         let client = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
         let key: LspClientKey = (repo.path().to_path_buf(), "rust-analyzer");
 
@@ -4245,9 +4210,9 @@ process.stdin.on('data', (d) => {
     fn restarting_clears_the_dead_client_and_all_of_its_document_bookkeeping(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let root = repo.path().to_path_buf();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx) = open_test_app(cx, root.clone());
         let opened = root.join("src").join("main.rs");
         let relative = PathBuf::from("src/main.rs");
 
@@ -4322,14 +4287,14 @@ process.stdin.on('data', (d) => {
     async fn a_restart_drops_the_in_flight_tasks_that_would_repopulate_cleared_bookkeeping(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let root = repo.path().to_path_buf();
         std::fs::create_dir_all(root.join("src")).expect("mkdir src");
         let absolute = root.join("src").join("main.rs");
         std::fs::write(&absolute, "fn main() {}\n").expect("write main.rs");
         let relative = PathBuf::from("src/main.rs");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx) = open_test_app(cx, root.clone());
         let server = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
         app.update_in(cx, |app, window, cx| {
             app.lsp_clients.insert(
@@ -4383,9 +4348,9 @@ process.stdin.on('data', (d) => {
     /// the real [`AdeApp::execute_palette_command`], not by asserting the enum variant exists.
     #[gpui::test]
     fn the_restart_palette_command_runs_the_real_restart(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let root = repo.path().to_path_buf();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx) = open_test_app(cx, root.clone());
 
         app.update(cx, |app, _cx| {
             app.lsp_clients.insert(
@@ -4430,9 +4395,9 @@ process.stdin.on('data', (d) => {
     /// `lsp_diagnostics_wiring_tests`.
     #[gpui::test]
     async fn a_restart_frees_the_key_so_a_fresh_spawn_is_really_attempted(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let root = repo.path().to_path_buf();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx) = open_test_app(cx, root.clone());
         let key: LspClientKey = (root.clone(), "rust-analyzer");
 
         let first = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
@@ -4506,7 +4471,7 @@ process.stdin.on('data', (d) => {
     async fn restarting_one_server_leaves_every_other_live_client_untouched(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let root = repo.path().to_path_buf();
         std::fs::create_dir_all(root.join("src")).expect("mkdir src");
         let rust_absolute = root.join("src").join("main.rs");
@@ -4516,7 +4481,7 @@ process.stdin.on('data', (d) => {
         let rust_relative = PathBuf::from("src/main.rs");
         let ts_relative = PathBuf::from("src/app.ts");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx) = open_test_app(cx, root.clone());
         let rust_server = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
         let ts_server = spawn_fake_server(repo.path(), "typescript-language-server", "normal");
         app.update_in(cx, |app, window, cx| {
@@ -4629,7 +4594,7 @@ process.stdin.on('data', (d) => {
     async fn restarting_every_server_still_forgets_the_whole_roots_conversation(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let root = repo.path().to_path_buf();
         std::fs::create_dir_all(root.join("src")).expect("mkdir src");
         let rust_absolute = root.join("src").join("main.rs");
@@ -4639,7 +4604,7 @@ process.stdin.on('data', (d) => {
         let rust_relative = PathBuf::from("src/main.rs");
         let ts_relative = PathBuf::from("src/app.ts");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx) = open_test_app(cx, root.clone());
         let rust_server = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
         let ts_server = spawn_fake_server(repo.path(), "typescript-language-server", "normal");
         app.update_in(cx, |app, window, cx| {
@@ -4702,14 +4667,13 @@ process.stdin.on('data', (d) => {
     /// companion must forget the `.vue` bookkeeping (the companion really was sent that file) and
     /// must not take the primary's own client down with it.
     #[gpui::test]
-    // Real vue-language-server spawn, not installed in CI - GitHub issue #348.
-    #[ignore]
+    #[ignore = "external: vue-language-server; see docs/testing.md"]
     fn restarting_a_companion_forgets_its_own_documents_without_touching_its_primary(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let root = repo.path().to_path_buf();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx) = open_test_app(cx, root.clone());
         let spec = vue_companion_spec();
         let vue_absolute = root.join("src").join("App.vue");
         let vue_relative = PathBuf::from("src/App.vue");
@@ -4775,9 +4739,9 @@ process.stdin.on('data', (d) => {
     /// the restart itself skips those keys, so offering one would be a row that does nothing.
     #[gpui::test]
     fn the_restartable_server_list_is_the_real_live_client_map(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let root = repo.path().to_path_buf();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx) = open_test_app(cx, root.clone());
         let ready = spawn_fake_server(repo.path(), "rust-analyzer", "normal");
 
         app.update(cx, |app, _cx| {
@@ -4831,8 +4795,8 @@ process.stdin.on('data', (d) => {
     fn a_real_relay_round_trip_delivers_the_companions_body_in_the_real_wire_shape(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::lsp::fixtures::temp_repo();
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         let spec = vue_companion_spec();
         let primary = spawn_fake_server(repo.path(), "vue-language-server", "normal");
         let companion = spawn_fake_server(repo.path(), spec.client_key, "normal");
@@ -4875,8 +4839,8 @@ process.stdin.on('data', (d) => {
     fn a_companion_that_never_answers_still_gets_a_real_null_response_back_to_the_primary(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::lsp::fixtures::temp_repo();
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         let spec = vue_companion_spec();
         let primary = spawn_fake_server(repo.path(), "vue-language-server", "normal");
         let companion = spawn_fake_server(repo.path(), spec.client_key, "silent");
@@ -4922,8 +4886,8 @@ process.stdin.on('data', (d) => {
     fn a_relay_arriving_before_the_companion_is_ready_still_answers_the_primary(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::lsp::fixtures::temp_repo();
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         let spec = vue_companion_spec();
         let primary = spawn_fake_server(repo.path(), "vue-language-server", "normal");
 
@@ -4961,7 +4925,7 @@ process.stdin.on('data', (d) => {
     /// itself in both directions, against real handshakes rather than a version assumption.
     #[test]
     fn only_a_companion_that_really_advertises_pull_support_becomes_a_pull_target() {
-        let root = tempfile::tempdir().expect("tempdir");
+        let root = crate::lsp::fixtures::temp_repo();
         let primary = spawn_fake_server(root.path(), "primary", "pull");
 
         assert!(
@@ -5006,8 +4970,8 @@ process.stdin.on('data', (d) => {
     fn a_relay_with_a_real_id_but_a_malformed_command_still_answers_the_primary(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::lsp::fixtures::temp_repo();
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         let spec = vue_companion_spec();
         let primary = spawn_fake_server(repo.path(), "vue-language-server", "normal");
         let companion = spawn_fake_server(repo.path(), spec.client_key, "normal");
@@ -5041,78 +5005,19 @@ process.stdin.on('data', (d) => {
             "the real id must come back with an honest null body rather than nothing at all"
         );
     }
-
-    /// Item 5 of the issue's scope: the facade must add no meaningful overhead to the already-
-    /// working single-server path. Measures a real, non-network method (the server's own
-    /// advertised `textDocumentSync` capability, read under a `Mutex`) called directly on the raw
-    /// client vs. through `LspConnection::Single`'s delegating method.
-    ///
-    /// No hard threshold is asserted on the *ratio* - timing in a sandbox under real parallel
-    /// process load is genuinely noisy, and a flaky performance gate is worse than none. What is
-    /// asserted is a deliberately generous, real bound - 1000ns - not "zero"/"unmeasurable": on a
-    /// loaded CI runner the delta is real wall-clock time and can land anywhere under that
-    /// ceiling, not nanoseconds as the ceiling's own headroom might suggest. Kept in the normal,
-    /// non-`#[ignore]` suite on purpose, matching this project's own established convention for
-    /// its other timing-sensitive tests (see `lsp_diagnostics_wiring_tests`'s module docs) - this
-    /// project has no separate slow/perf-test lane. The measured numbers are printed so a
-    /// regression is visible in the log even when the assertion passes.
-    #[test]
-    fn single_delegation_stays_under_a_generous_1000ns_ceiling() {
-        let root = tempfile::tempdir().expect("tempdir");
-        let client = spawn_fake_server(root.path(), "bench", "normal");
-        let connection = LspConnection::Single(client.clone());
-        const ITERATIONS: u32 = 200_000;
-
-        // A real warm-up pass, so neither measurement pays first-touch costs the other doesn't.
-        for _ in 0..1_000 {
-            std::hint::black_box(client.supports_document_sync());
-            std::hint::black_box(connection.supports_document_sync());
-        }
-
-        let started = Instant::now();
-        for _ in 0..ITERATIONS {
-            std::hint::black_box(client.supports_document_sync());
-        }
-        let direct = started.elapsed();
-
-        let started = Instant::now();
-        for _ in 0..ITERATIONS {
-            std::hint::black_box(connection.supports_document_sync());
-        }
-        let through_facade = started.elapsed();
-
-        let direct_ns = direct.as_nanos() as f64 / f64::from(ITERATIONS);
-        let facade_ns = through_facade.as_nanos() as f64 / f64::from(ITERATIONS);
-        println!(
-            "supports_document_sync: direct {direct_ns:.1}ns/call, via LspConnection::Single \
-             {facade_ns:.1}ns/call, delta {:.1}ns",
-            facade_ns - direct_ns
-        );
-        assert!(
-            facade_ns - direct_ns < 1_000.0,
-            "the facade's enum match + delegate should stay well under this generous 1000ns \
-             ceiling; a real microsecond-or-more of added cost per call would mean it isn't the \
-             cheap branch it claims to be (direct {direct_ns:.1}ns, facade {facade_ns:.1}ns)"
-        );
-    }
 }
 
-/// Slow, end-to-end coverage proving the real async path from a real `rust-analyzer`
-/// `publishDiagnostics` response through to [`AdeApp::render_file_view`]'s rendered output,
-/// through this crate's own real code path (`AdeApp::open_file_view` -> `ensure_lsp_client` ->
-/// `dispatch_did_open` -> `render_file_view`) rather than by calling `lsp_core` directly and
-/// bypassing `AdeApp`.
+/// End-to-end coverage of the real async path from a real language server's own
+/// `publishDiagnostics` through to [`AdeApp::render_file_view`]'s rendered output, driven through
+/// this crate's real code path (`AdeApp::open_file_view` -> `ensure_lsp_client` ->
+/// `dispatch_did_open` -> `render_file_view`) rather than by calling `lsp_core` directly.
 ///
-/// This genuinely spawns a real `rust-analyzer` against a tiny, dependency-free scratch cargo
-/// project (kept dependency-free so `cargo metadata`/rust-analyzer's own workspace discovery
-/// never needs network access) with a genuine `let x: i32 = "not a number";` type mismatch, and
-/// polls real wall-clock time (up to 480s - see this module's own real-deadline constants for
-/// the exact per-test budgets, widened past `lsp_core::client`'s own e2e test's 180s baseline;
-/// see the docs on the deadlines themselves for why) for the diagnostic to actually arrive - no
-/// sleep stands in for that wait, and nothing is fabricated if the wait times out (the assertion
-/// just fails). This is a genuinely slow test (real process spawn plus real sysroot indexing)
-/// kept in the normal, non-`#[ignore]` suite on purpose - this project has no separate "slow
-/// test" lane.
+/// Every test here that spawns a real server is `external` tier (`docs/testing.md`): it needs a
+/// binary this repo does not vendor, and it polls real wall-clock time for minutes while that
+/// server indexes a sysroot. The one exception is
+/// [`Self::a_transient_pull_failure_is_retried_not_treated_as_a_permanent_stall`], which drives
+/// the same wiring from [`super::lsp_connection_facade_tests::spawn_fake_server`]'s deterministic
+/// stand-in instead and so stays on the PR gate.
 #[cfg(test)]
 mod lsp_diagnostics_wiring_tests {
     use super::*;
@@ -5152,8 +5057,8 @@ mod lsp_diagnostics_wiring_tests {
     /// Same minimal, dependency-free scratch cargo project shape as
     /// `lsp_core::client::tests::write_scratch_project` - kept as its own small copy here
     /// rather than exporting that one across the crate boundary.
-    fn write_scratch_project(main_rs: &str) -> tempfile::TempDir {
-        let dir = tempfile::TempDir::new().expect("tempdir");
+    fn write_scratch_project(main_rs: &str) -> crate::lsp::fixtures::TempRepo {
+        let dir = crate::lsp::fixtures::temp_repo();
         std::fs::write(
             dir.path().join("Cargo.toml"),
             "[package]\nname = \"app_lsp_wiring_fixture\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
@@ -5167,32 +5072,23 @@ mod lsp_diagnostics_wiring_tests {
     /// Repeatedly re-renders the centre pane and drains the deterministic test executor until
     /// `AdeApp::file_view_diagnostics` holds at least one diagnostic, or `deadline` passes. The
     /// real `publishDiagnostics` notification arrives on `lsp_core`'s own raw OS reader thread,
-    /// outside GPUI's scheduler entirely, so this must genuinely keep re-checking over real
-    /// time, like `lsp_core::client`'s own `wait_for_update` polling loop one layer down.
+    /// outside GPUI's scheduler entirely, so this must genuinely keep re-checking over real time.
     fn wait_for_real_diagnostics(
         app: &Entity<AdeApp>,
         cx: &mut VisualTestContext,
-        deadline: Instant,
+        deadline: Duration,
     ) {
-        loop {
-            app.update(cx, |app, cx| {
-                app.render_center_pane(cx);
-            });
-            cx.run_until_parked();
-
-            let has_diagnostics = app.read_with(cx, |app, _| !app.file_view_diagnostics.is_empty());
-            if has_diagnostics {
-                return;
-            }
-            assert!(
-                Instant::now() < deadline,
-                "no real diagnostic reached AdeApp::file_view_diagnostics within the caller's \
-                 real deadline (this helper is shared by callers with different real timeouts - \
-                 480s for rust-analyzer, 240s for typescript-language-server/pyright - so the \
-                 message deliberately doesn't hardcode either one)"
-            );
-            std::thread::sleep(Duration::from_millis(200));
-        }
+        assert!(
+            crate::lsp::fixtures::wait_until_parked(cx, deadline, |cx| {
+                app.update(cx, |app, cx| {
+                    app.render_center_pane(cx);
+                });
+                cx.run_until_parked();
+                app.read_with(cx, |app, _| !app.file_view_diagnostics.is_empty())
+            }),
+            "no real diagnostic reached AdeApp::file_view_diagnostics within the caller's own \
+             deadline"
+        );
     }
 
     /// The end-to-end proof this fix exists to deliver: a real `rust-analyzer`, spawned via this
@@ -5201,6 +5097,7 @@ mod lsp_diagnostics_wiring_tests {
     /// - ends up in `AdeApp::file_view_diagnostics`, which is exactly what
     /// `AdeApp::render_file_view`'s row builder reads to draw the underline/card.
     #[gpui::test]
+    #[ignore = "external: rust-analyzer; see docs/testing.md"]
     fn a_real_diagnostic_reaches_file_view_diagnostics_through_the_real_app_code_path(
         cx: &mut TestAppContext,
     ) {
@@ -5210,7 +5107,7 @@ mod lsp_diagnostics_wiring_tests {
         );
         let main_rs = project.path().join("src").join("main.rs");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, project.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, project.path().to_path_buf());
 
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(main_rs.clone(), window, cx);
@@ -5220,8 +5117,7 @@ mod lsp_diagnostics_wiring_tests {
         // must happen before `ensure_lsp_client` ever gets a chance to run.
         cx.run_until_parked();
 
-        let deadline = Instant::now() + Duration::from_secs(480);
-        wait_for_real_diagnostics(&app, cx, deadline);
+        wait_for_real_diagnostics(&app, cx, Duration::from_secs(480));
 
         app.read_with(cx, |app, _| {
             let all_diagnostics: Vec<&diagnostics_view::LineDiagnostic> =
@@ -5308,13 +5204,12 @@ mod lsp_diagnostics_wiring_tests {
     /// path the Rust test above exercises, but for a real `.ts` file, proving the extension-based
     /// dispatch that replaced the old boolean gate genuinely reaches a non-Rust language too.
     #[gpui::test]
-    // Real typescript-language-server spawn, not installed in CI - GitHub issue #348.
-    #[ignore]
+    #[ignore = "external: typescript-language-server; see docs/testing.md"]
     fn a_real_typescript_diagnostic_reaches_file_view_diagnostics_through_the_real_app_code_path(
         cx: &mut TestAppContext,
     ) {
         let _serialize = serialize_real_lsp_subprocess_test();
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::lsp::fixtures::temp_repo();
         std::fs::write(
             dir.path().join("tsconfig.json"),
             "{\"compilerOptions\": {\"strict\": true, \"target\": \"ES2020\"}}\n",
@@ -5342,15 +5237,14 @@ mod lsp_diagnostics_wiring_tests {
             .expect("npm should be on PATH in this sandbox (real, live network install)");
         assert!(status.success(), "npm install typescript@5 failed");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, dir.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, dir.path().to_path_buf());
 
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(main_ts.clone(), window, cx);
         });
         cx.run_until_parked();
 
-        let deadline = Instant::now() + Duration::from_secs(240);
-        wait_for_real_diagnostics(&app, cx, deadline);
+        wait_for_real_diagnostics(&app, cx, Duration::from_secs(240));
 
         app.read_with(cx, |app, _| {
             let all_diagnostics: Vec<&diagnostics_view::LineDiagnostic> =
@@ -5389,21 +5283,20 @@ mod lsp_diagnostics_wiring_tests {
     fn wait_until(
         app: &Entity<AdeApp>,
         cx: &mut VisualTestContext,
-        deadline: Instant,
+        deadline: Duration,
         message: &str,
         predicate: impl Fn(&AdeApp) -> bool,
     ) {
-        loop {
-            app.update(cx, |app, cx| {
-                app.render_center_pane(cx);
-            });
-            cx.run_until_parked();
-            if app.read_with(cx, |app, _| predicate(app)) {
-                return;
-            }
-            assert!(Instant::now() < deadline, "{message}");
-            std::thread::sleep(Duration::from_millis(200));
-        }
+        assert!(
+            crate::lsp::fixtures::wait_until_parked(cx, deadline, |cx| {
+                app.update(cx, |app, cx| {
+                    app.render_center_pane(cx);
+                });
+                cx.run_until_parked();
+                app.read_with(cx, |app, _| predicate(app))
+            }),
+            "{message}"
+        );
     }
 
     /// Drives a real edit through the exact same code path a real keystroke does
@@ -5436,6 +5329,7 @@ mod lsp_diagnostics_wiring_tests {
     /// identifier reaches a real `textDocument/completion` response, and accepting it splices the
     /// real chosen item's text into the real buffer via `EditBuffer::replace_range`.
     #[gpui::test]
+    #[ignore = "external: rust-analyzer; see docs/testing.md"]
     fn rust_analyzer_tracks_a_real_live_unsaved_edit_for_both_diagnostics_and_completions(
         cx: &mut TestAppContext,
     ) {
@@ -5444,14 +5338,14 @@ mod lsp_diagnostics_wiring_tests {
             "fn main() {\n    let x: i32 = 1;\n    println!(\"{}\", x);\n}\n",
         );
         let main_rs = project.path().join("src").join("main.rs");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, project.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, project.path().to_path_buf());
 
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(main_rs.clone(), window, cx);
         });
         cx.run_until_parked();
 
-        let indexed_deadline = Instant::now() + Duration::from_secs(480);
+        let indexed_deadline = Duration::from_secs(480);
         wait_until(
             &app,
             cx,
@@ -5482,29 +5376,10 @@ mod lsp_diagnostics_wiring_tests {
             );
         });
 
-        // Widened twice from a real, observed 180s-deadline failure under genuine full-suite
-        // parallel load (`cargo test -p app --lib` with its default, num-cpus-wide test-
-        // threads): the whole suite repeatedly ran 3-5x its normal wall-clock length (up to
-        // ~330s vs. the usual ~70-100s) on this same sandbox, and this real rust-analyzer -
-        // already `Ready` and only asked to recompute diagnostics for a two-line edit, not
-        // re-index from scratch - still hadn't published the new diagnostic even at 300s on a
-        // later, still-more-contended run (this module's own `REAL_LSP_SUBPROCESS_TEST_LOCK`
-        // and the `None`-is-retried fix in `AdeApp::schedule_lsp_sync`'s own retry loop both
-        // already close the *other* real bugs this same investigation found - this deadline
-        // widening is a distinct, additional real-headroom fix, not a substitute for either).
-        // The wait itself already polls correctly (real `std::thread::sleep` between checks,
-        // bounded by a real deadline, not a fixed tick count - see `wait_until`'s own docs); the
-        // deadline itself was just too tight for how slow a real subprocess can genuinely get
-        // when dozens of sibling tests' own real subprocesses (other `rust-analyzer`/`pyright`/
-        // `typescript-language-server`/pty sessions, and - on this particular shared sandbox -
-        // other agents' own concurrent full test-suite runs) are contending for the same CPU
-        // cores. 480s keeps real headroom for that without losing the "assertion still fails if
-        // diagnostics genuinely never arrive" property that makes this a real regression gate,
-        // not a rubber stamp - and rust-analyzer gets the widest budget of the three real
-        // servers this module covers because it is, empirically, the one that has actually
-        // needed it (typescript-language-server/pyright's own 240s deadlines have not been
-        // observed failing across dozens of full-suite reproduction runs).
-        let diagnostic_deadline = Instant::now() + Duration::from_secs(480);
+        // Real rust-analyzer, recomputing after an edit under whatever load the machine is
+        // already under - the widest budget of the three servers this module covers, empirically
+        // the one that has needed it.
+        let diagnostic_deadline = Duration::from_secs(480);
         wait_until(
             &app,
             cx,
@@ -5556,7 +5431,7 @@ mod lsp_diagnostics_wiring_tests {
             "\nfn call() {\n    prin",
         );
 
-        let completion_deadline = Instant::now() + Duration::from_secs(60);
+        let completion_deadline = Duration::from_secs(60);
         wait_until(
             &app,
             cx,
@@ -5628,13 +5503,13 @@ mod lsp_diagnostics_wiring_tests {
     fn a_transient_pull_failure_is_retried_not_treated_as_a_permanent_stall(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let root = repo.path().to_path_buf();
         std::fs::create_dir_all(root.join("src")).expect("mkdir src");
         let absolute = root.join("src").join("main.rs");
         std::fs::write(&absolute, "fn main() {}\n").expect("write main.rs");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx) = open_test_app(cx, root.clone());
         let server = super::lsp_connection_facade_tests::spawn_fake_server(
             repo.path(),
             "rust-analyzer",
@@ -5682,27 +5557,19 @@ mod lsp_diagnostics_wiring_tests {
         // uses `type_text`'s own advance for the sync debounce - `run_until_parked()` alone does
         // not carry the virtual clock forward on its own, so without this the retry's own timer
         // would never fire and this loop would hang until the real deadline below.
-        let deadline = Instant::now() + Duration::from_secs(10);
-        let mut retried_past_the_first_failure = false;
-        while Instant::now() < deadline {
-            cx.background_executor
-                .advance_clock(PULL_DIAGNOSTICS_EMPTY_RETRY_DELAY);
-            cx.run_until_parked();
-            if server
-                .diagnostics_for_uri(&file_uri)
-                .is_some_and(|diagnostics| {
-                    diagnostics
-                        .iter()
-                        .any(|d| d.message == "real diagnostic from a retried pull")
-                })
-            {
-                retried_past_the_first_failure = true;
-                break;
-            }
-            std::thread::sleep(Duration::from_millis(20));
-        }
         assert!(
-            retried_past_the_first_failure,
+            crate::lsp::fixtures::wait_until_parked(cx, Duration::from_secs(10), |cx| {
+                cx.background_executor
+                    .advance_clock(PULL_DIAGNOSTICS_EMPTY_RETRY_DELAY);
+                cx.run_until_parked();
+                server
+                    .diagnostics_for_uri(&file_uri)
+                    .is_some_and(|diagnostics| {
+                        diagnostics
+                            .iter()
+                            .any(|d| d.message == "real diagnostic from a retried pull")
+                    })
+            }),
             "the retry loop must survive the fake server's first, deliberately-erroring pull \
              attempt and pick up the real, non-empty result its second attempt answers with - a \
              pre-fix build stops retrying after that first error and never reaches it"
@@ -5713,13 +5580,12 @@ mod lsp_diagnostics_wiring_tests {
     /// - see `crate::language`'s own docs on why `npm install typescript@5` is a genuine, real
     /// project-local requirement in this sandbox, not conservative caution.
     #[gpui::test]
-    // Real typescript-language-server spawn, not installed in CI - GitHub issue #348.
-    #[ignore]
+    #[ignore = "external: typescript-language-server, npm; see docs/testing.md"]
     fn typescript_language_server_tracks_a_real_live_unsaved_edit_for_both_diagnostics_and_completions(
         cx: &mut TestAppContext,
     ) {
         let _serialize = serialize_real_lsp_subprocess_test();
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::lsp::fixtures::temp_repo();
         std::fs::write(
             dir.path().join("tsconfig.json"),
             "{\"compilerOptions\": {\"strict\": true, \"target\": \"ES2020\"}}\n",
@@ -5741,13 +5607,13 @@ mod lsp_diagnostics_wiring_tests {
             .expect("npm should be on PATH in this sandbox (real, live network install)");
         assert!(status.success(), "npm install typescript@5 failed");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, dir.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, dir.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(main_ts.clone(), window, cx);
         });
         cx.run_until_parked();
 
-        let indexed_deadline = Instant::now() + Duration::from_secs(240);
+        let indexed_deadline = Duration::from_secs(240);
         wait_until(
             &app,
             cx,
@@ -5772,7 +5638,7 @@ mod lsp_diagnostics_wiring_tests {
                 .is_dirty());
         });
 
-        let diagnostic_deadline = Instant::now() + Duration::from_secs(240);
+        let diagnostic_deadline = Duration::from_secs(240);
         wait_until(
             &app,
             cx,
@@ -5796,7 +5662,7 @@ mod lsp_diagnostics_wiring_tests {
         });
         type_text(&app, cx, completion_trigger_offset, "\nconsol");
 
-        let completion_deadline = Instant::now() + Duration::from_secs(60);
+        let completion_deadline = Duration::from_secs(60);
         wait_until(
             &app,
             cx,
@@ -5838,24 +5704,23 @@ mod lsp_diagnostics_wiring_tests {
 
     /// The same real, live proof as the two tests above, for `pyright-langserver`.
     #[gpui::test]
-    // Real pyright-langserver spawn, not installed in CI - GitHub issue #348.
-    #[ignore]
+    #[ignore = "external: pyright-langserver; see docs/testing.md"]
     fn pyright_tracks_a_real_live_unsaved_edit_for_both_diagnostics_and_completions(
         cx: &mut TestAppContext,
     ) {
         let _serialize = serialize_real_lsp_subprocess_test();
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::lsp::fixtures::temp_repo();
         let main_py = dir.path().join("main.py");
         let baseline = "ok: int = 1\nprint(ok)\n";
         std::fs::write(&main_py, baseline).expect("write main.py");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, dir.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, dir.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(main_py.clone(), window, cx);
         });
         cx.run_until_parked();
 
-        let indexed_deadline = Instant::now() + Duration::from_secs(240);
+        let indexed_deadline = Duration::from_secs(240);
         wait_until(
             &app,
             cx,
@@ -5875,7 +5740,7 @@ mod lsp_diagnostics_wiring_tests {
                 .is_dirty());
         });
 
-        let diagnostic_deadline = Instant::now() + Duration::from_secs(240);
+        let diagnostic_deadline = Duration::from_secs(240);
         wait_until(
             &app,
             cx,
@@ -5902,7 +5767,7 @@ mod lsp_diagnostics_wiring_tests {
         });
         type_text(&app, cx, completion_trigger_offset, "\npri");
 
-        let completion_deadline = Instant::now() + Duration::from_secs(60);
+        let completion_deadline = Duration::from_secs(60);
         wait_until(
             &app,
             cx,

--- a/crates/app/src/lsp/completion.rs
+++ b/crates/app/src/lsp/completion.rs
@@ -1043,216 +1043,181 @@ mod tests {
         chars.iter().map(|c| c.to_string()).collect()
     }
 
+    /// Every real shape of "the user typed something" the popup can be asked to open on: an
+    /// identifier byte invokes an ordinary completion, an advertised character opens a real
+    /// trigger-character one, and anything else opens nothing at all.
     #[test]
-    fn an_identifier_continuation_character_triggers_an_invoked_completion() {
-        let context = completion_trigger(Some('x'), &triggers(&["."])).expect("should trigger");
-        assert_eq!(
-            context.trigger_kind,
-            lsp_types::CompletionTriggerKind::INVOKED
-        );
-        assert_eq!(context.trigger_character, None);
+    fn every_typed_character_opens_exactly_the_completion_it_should() {
+        use lsp_types::CompletionTriggerKind as Kind;
+        let advertised = triggers(&[".", "::"]);
+        for (typed, advertised, expected) in [
+            (
+                Some('x'),
+                advertised.as_slice(),
+                Some((Kind::INVOKED, None)),
+            ),
+            (Some('9'), &[][..], Some((Kind::INVOKED, None))),
+            (Some('_'), &[][..], Some((Kind::INVOKED, None))),
+            (
+                Some('.'),
+                advertised.as_slice(),
+                Some((Kind::TRIGGER_CHARACTER, Some("."))),
+            ),
+            (Some(' '), advertised.as_slice(), None),
+            (Some(';'), advertised.as_slice(), None),
+            (Some(')'), &[][..], None),
+            // The very start of the buffer - no character behind the caret at all.
+            (None, advertised.as_slice(), None),
+        ] {
+            let context = completion_trigger(typed, advertised);
+            match expected {
+                None => assert_eq!(context, None, "{typed:?} must not open a completion"),
+                Some((kind, character)) => {
+                    let context =
+                        context.unwrap_or_else(|| panic!("{typed:?} must open a completion"));
+                    assert_eq!(context.trigger_kind, kind, "for {typed:?}");
+                    assert_eq!(
+                        context.trigger_character.as_deref(),
+                        character,
+                        "for {typed:?}"
+                    );
+                }
+            }
+        }
     }
 
-    #[test]
-    fn a_digit_or_underscore_also_triggers_an_invoked_completion() {
-        assert!(completion_trigger(Some('9'), &[]).is_some());
-        assert!(completion_trigger(Some('_'), &[]).is_some());
+    fn range(start_character: u32, end_character: u32) -> lsp_types::Range {
+        lsp_types::Range {
+            start: lsp_types::Position {
+                line: 0,
+                character: start_character,
+            },
+            end: lsp_types::Position {
+                line: 0,
+                character: end_character,
+            },
+        }
     }
 
+    /// The three real shapes a server can answer an edit in. The `InsertAndReplace` row is the
+    /// load-bearing one: taking the wider `replace` half would swallow text past the caret that
+    /// the user never asked to lose.
     #[test]
-    fn a_server_advertised_trigger_character_triggers_a_real_trigger_character_completion() {
-        let context = completion_trigger(Some('.'), &triggers(&[".", "::"])).expect("trigger");
-        assert_eq!(
-            context.trigger_kind,
-            lsp_types::CompletionTriggerKind::TRIGGER_CHARACTER
-        );
-        assert_eq!(context.trigger_character.as_deref(), Some("."));
-    }
-
-    #[test]
-    fn whitespace_and_punctuation_do_not_trigger_when_not_a_real_advertised_trigger_character() {
-        assert_eq!(completion_trigger(Some(' '), &triggers(&["."])), None);
-        assert_eq!(completion_trigger(Some(';'), &triggers(&["."])), None);
-        assert_eq!(completion_trigger(Some(')'), &[]), None);
-    }
-
-    #[test]
-    fn the_start_of_the_buffer_never_triggers() {
-        assert_eq!(completion_trigger(None, &triggers(&["."])), None);
-    }
-
-    #[test]
-    fn completion_text_edit_prefers_a_real_plain_edit() {
-        let item = lsp_types::CompletionItem {
-            label: "println!".to_string(),
-            text_edit: Some(lsp_types::CompletionTextEdit::Edit(lsp_types::TextEdit {
-                range: lsp_types::Range {
-                    start: lsp_types::Position {
-                        line: 0,
-                        character: 0,
-                    },
-                    end: lsp_types::Position {
-                        line: 0,
-                        character: 3,
-                    },
-                },
-                new_text: "println!".to_string(),
-            })),
-            ..Default::default()
-        };
-        let (range, text) = completion_text_edit(&item).expect("a real edit");
-        assert_eq!(range.start.character, 0);
-        assert_eq!(range.end.character, 3);
-        assert_eq!(text, "println!");
-    }
-
-    #[test]
-    fn completion_text_edit_reads_the_insert_half_of_a_real_insert_and_replace_edit() {
-        let item = lsp_types::CompletionItem {
-            label: "println!".to_string(),
-            text_edit: Some(lsp_types::CompletionTextEdit::InsertAndReplace(
-                lsp_types::InsertReplaceEdit {
+    fn completion_text_edit_reads_the_insert_half_of_every_real_edit_shape() {
+        for (name, text_edit, expected) in [
+            (
+                "a plain edit",
+                Some(lsp_types::CompletionTextEdit::Edit(lsp_types::TextEdit {
+                    range: range(0, 3),
                     new_text: "println!".to_string(),
-                    insert: lsp_types::Range {
-                        start: lsp_types::Position {
-                            line: 0,
-                            character: 0,
-                        },
-                        end: lsp_types::Position {
-                            line: 0,
-                            character: 3,
-                        },
+                })),
+                Some((0, 3)),
+            ),
+            (
+                "an insert-and-replace edit",
+                Some(lsp_types::CompletionTextEdit::InsertAndReplace(
+                    lsp_types::InsertReplaceEdit {
+                        new_text: "println!".to_string(),
+                        insert: range(0, 3),
+                        replace: range(0, 10),
                     },
-                    replace: lsp_types::Range {
-                        start: lsp_types::Position {
-                            line: 0,
-                            character: 0,
-                        },
-                        end: lsp_types::Position {
-                            line: 0,
-                            character: 10,
-                        },
-                    },
-                },
-            )),
-            ..Default::default()
-        };
-        let (range, _) = completion_text_edit(&item).expect("a real edit");
-        assert_eq!(
-            range.end.character, 3,
-            "the insert half (3), not the wider replace half (10), must be used"
-        );
+                )),
+                Some((0, 3)),
+            ),
+            ("no edit at all", None, None),
+        ] {
+            let item = lsp_types::CompletionItem {
+                label: "println!".to_string(),
+                text_edit,
+                ..Default::default()
+            };
+            match expected {
+                None => assert_eq!(completion_text_edit(&item), None, "{name}"),
+                Some((start, end)) => {
+                    let (edit_range, text) =
+                        completion_text_edit(&item).unwrap_or_else(|| panic!("{name}"));
+                    assert_eq!(edit_range.start.character, start, "{name}");
+                    assert_eq!(edit_range.end.character, end, "{name}");
+                    assert_eq!(text, "println!", "{name}");
+                }
+            }
+        }
     }
 
     #[test]
-    fn completion_text_edit_is_none_without_a_real_text_edit() {
-        let item = lsp_types::CompletionItem {
-            label: "foo".to_string(),
-            ..Default::default()
-        };
-        assert_eq!(completion_text_edit(&item), None);
-    }
-
-    #[test]
-    fn completion_plain_insert_text_prefers_a_real_insert_text_over_the_label() {
-        let item = lsp_types::CompletionItem {
-            label: "foo (function)".to_string(),
-            insert_text: Some("foo".to_string()),
-            ..Default::default()
-        };
-        assert_eq!(completion_plain_insert_text(&item), "foo");
-    }
-
-    #[test]
-    fn completion_plain_insert_text_falls_back_to_the_real_label_when_insert_text_is_absent() {
-        let item = lsp_types::CompletionItem {
-            label: "foo".to_string(),
-            insert_text: None,
-            ..Default::default()
-        };
-        assert_eq!(completion_plain_insert_text(&item), "foo");
+    fn completion_plain_insert_text_prefers_insert_text_and_falls_back_to_the_label() {
+        for (insert_text, expected) in [(Some("foo".to_string()), "foo"), (None, "foo (function)")]
+        {
+            let item = lsp_types::CompletionItem {
+                label: "foo (function)".to_string(),
+                insert_text: insert_text.clone(),
+                ..Default::default()
+            };
+            assert_eq!(completion_plain_insert_text(&item), expected);
+        }
     }
 
     #[test]
     fn identifier_prefix_start_walks_back_to_the_real_start_of_the_typed_word() {
-        assert_eq!(identifier_prefix_start("let x = pri", 11), 8);
-        assert_eq!(identifier_prefix_start("    foo_bar2", 12), 4);
+        for (line, cursor, expected) in [
+            ("let x = pri", 11, 8),
+            ("    foo_bar2", 12, 4),
+            // Stops at a real non-identifier byte rather than running through it.
+            ("foo.bar", 7, 4),
+            ("a.b", 3, 2),
+            // No prefix at all: the cursor is its own start.
+            ("foo.", 4, 4),
+            ("", 0, 0),
+        ] {
+            assert_eq!(
+                identifier_prefix_start(line, cursor),
+                expected,
+                "{line:?} at {cursor}"
+            );
+        }
     }
 
+    /// Every kind the popup gives a badge to, and the letter each badge paints - the glyphs the
+    /// design mockups specify. A kind with no badge slot, and an item with no kind at all, both
+    /// have to come back bare rather than pick an arbitrary bucket.
     #[test]
-    fn identifier_prefix_start_stops_at_a_real_non_identifier_byte() {
-        assert_eq!(identifier_prefix_start("foo.bar", 7), 4);
-        assert_eq!(identifier_prefix_start("a.b", 3), 2);
-    }
+    fn every_completion_kind_lands_in_its_documented_badge_bucket() {
+        use lsp_types::CompletionItemKind as ItemKind;
+        for (kind, expected) in [
+            (
+                Some(ItemKind::FUNCTION),
+                Some(CompletionKindBadge::Function),
+            ),
+            (Some(ItemKind::METHOD), Some(CompletionKindBadge::Function)),
+            (
+                Some(ItemKind::CONSTRUCTOR),
+                Some(CompletionKindBadge::Function),
+            ),
+            (
+                Some(ItemKind::VARIABLE),
+                Some(CompletionKindBadge::Variable),
+            ),
+            (Some(ItemKind::FIELD), Some(CompletionKindBadge::Variable)),
+            (
+                Some(ItemKind::CONSTANT),
+                Some(CompletionKindBadge::Variable),
+            ),
+            (Some(ItemKind::STRUCT), Some(CompletionKindBadge::Type)),
+            (Some(ItemKind::CLASS), Some(CompletionKindBadge::Type)),
+            (Some(ItemKind::ENUM), Some(CompletionKindBadge::Type)),
+            (Some(ItemKind::KEYWORD), None),
+            (None, None),
+        ] {
+            assert_eq!(completion_kind_badge(kind), expected, "for {kind:?}");
+        }
 
-    #[test]
-    fn identifier_prefix_start_is_the_cursor_itself_with_no_real_prefix() {
-        assert_eq!(identifier_prefix_start("foo.", 4), 4);
-        assert_eq!(identifier_prefix_start("", 0), 0);
-    }
-
-    #[test]
-    fn completion_kind_badge_groups_function_like_kinds() {
-        assert_eq!(
-            completion_kind_badge(Some(lsp_types::CompletionItemKind::FUNCTION)),
-            Some(CompletionKindBadge::Function)
-        );
-        assert_eq!(
-            completion_kind_badge(Some(lsp_types::CompletionItemKind::METHOD)),
-            Some(CompletionKindBadge::Function)
-        );
-        assert_eq!(
-            completion_kind_badge(Some(lsp_types::CompletionItemKind::CONSTRUCTOR)),
-            Some(CompletionKindBadge::Function)
-        );
-    }
-
-    #[test]
-    fn completion_kind_badge_groups_variable_like_kinds() {
-        assert_eq!(
-            completion_kind_badge(Some(lsp_types::CompletionItemKind::VARIABLE)),
-            Some(CompletionKindBadge::Variable)
-        );
-        assert_eq!(
-            completion_kind_badge(Some(lsp_types::CompletionItemKind::FIELD)),
-            Some(CompletionKindBadge::Variable)
-        );
-        assert_eq!(
-            completion_kind_badge(Some(lsp_types::CompletionItemKind::CONSTANT)),
-            Some(CompletionKindBadge::Variable)
-        );
-    }
-
-    #[test]
-    fn completion_kind_badge_groups_type_like_kinds() {
-        assert_eq!(
-            completion_kind_badge(Some(lsp_types::CompletionItemKind::STRUCT)),
-            Some(CompletionKindBadge::Type)
-        );
-        assert_eq!(
-            completion_kind_badge(Some(lsp_types::CompletionItemKind::CLASS)),
-            Some(CompletionKindBadge::Type)
-        );
-        assert_eq!(
-            completion_kind_badge(Some(lsp_types::CompletionItemKind::ENUM)),
-            Some(CompletionKindBadge::Type)
-        );
-    }
-
-    #[test]
-    fn completion_kind_badge_is_none_for_a_kind_with_no_real_badge_slot_or_no_kind_at_all() {
-        assert_eq!(
-            completion_kind_badge(Some(lsp_types::CompletionItemKind::KEYWORD)),
-            None
-        );
-        assert_eq!(completion_kind_badge(None), None);
-    }
-
-    #[test]
-    fn completion_kind_badge_letters_match_the_design_mockups_own_glyphs() {
-        assert_eq!(CompletionKindBadge::Function.letter(), "f");
-        assert_eq!(CompletionKindBadge::Variable.letter(), "v");
-        assert_eq!(CompletionKindBadge::Type.letter(), "t");
+        for (badge, letter) in [
+            (CompletionKindBadge::Function, "f"),
+            (CompletionKindBadge::Variable, "v"),
+            (CompletionKindBadge::Type, "t"),
+        ] {
+            assert_eq!(badge.letter(), letter, "for {badge:?}");
+        }
     }
 
     fn item(label: &str) -> lsp_types::CompletionItem {
@@ -1353,24 +1318,23 @@ mod tests {
         assert_eq!(rank_completion_items(&items, "new"), vec![0, 1]);
     }
 
+    /// The spec's own "when falsy the label is used" fallback - and falsy has to cover an empty
+    /// string, not just a missing field, or a server that sends `""` filters everything out.
     #[test]
-    fn completion_filter_text_prefers_a_real_server_supplied_filter_text() {
-        let mut with_filter = item("new(…)");
-        with_filter.filter_text = Some("new".to_string());
-        assert_eq!(completion_filter_text(&with_filter), "new");
-    }
-
-    #[test]
-    fn completion_filter_text_falls_back_to_the_label_when_absent_or_empty() {
-        assert_eq!(completion_filter_text(&item("version")), "version");
-        let mut blank = item("version");
-        blank.filter_text = Some(String::new());
-        assert_eq!(
-            completion_filter_text(&blank),
-            "version",
-            "the spec's own \"when falsy the label is used\" fallback must cover an empty string, \
-             not just a missing field"
-        );
+    fn completion_filter_text_prefers_the_servers_own_and_falls_back_to_the_label() {
+        for (filter_text, label, expected) in [
+            (Some("new"), "new(…)", "new"),
+            (None, "version", "version"),
+            (Some(""), "version", "version"),
+        ] {
+            let mut candidate = item(label);
+            candidate.filter_text = filter_text.map(str::to_string);
+            assert_eq!(
+                completion_filter_text(&candidate),
+                expected,
+                "for {label:?}"
+            );
+        }
     }
 
     #[test]
@@ -1467,35 +1431,15 @@ mod tests {
         assert_eq!(completion_match("ab", "abc"), None);
     }
 
+    /// The row's right-hand hint and the detail pane's signature line, over every real shape a
+    /// server sends. The `label_details` rows are the regression: `rust-analyzer`'s own
+    /// `label_details.detail` for a trait-provided method (`.into()`, `.try_into()`, …) is a
+    /// trait-source annotation (`"(as Into)"`), not a type - preferring it over the legacy
+    /// `detail` field broke the hint for some of the most common completions there are, so both
+    /// functions must ignore `label_details` entirely.
     #[test]
-    fn completion_item_display_trims_and_drops_a_real_blank_detail() {
-        let item = lsp_types::CompletionItem {
-            label: "foo".to_string(),
-            detail: Some("  fn() -> i32  ".to_string()),
-            ..Default::default()
-        };
-        let (label, detail) = completion_item_display(&item);
-        assert_eq!(label, "foo");
-        assert_eq!(detail.as_deref(), Some("fn() -> i32"));
-
-        let no_detail_item = lsp_types::CompletionItem {
-            label: "bar".to_string(),
-            detail: Some("   ".to_string()),
-            ..Default::default()
-        };
-        assert_eq!(completion_item_display(&no_detail_item).1, None);
-    }
-
-    /// The real, live-reported bug: `rust-analyzer`'s own real `label_details.detail` for a
-    /// trait-provided method (`.into()`, `.try_into()`, ...) is a short trait-source annotation
-    /// (`"(as Into)"`), not a type at all - a real, live dump proved preferring it over the
-    /// legacy `detail` field (which *is* the real, clean signature for these same items) broke
-    /// the row hint for some of the most common completions there are. Both
-    /// `completion_item_display` and `completion_signature_text` must ignore `label_details`
-    /// entirely and read the legacy field.
-    #[test]
-    fn completion_item_display_ignores_a_real_rust_analyzer_trait_source_label_details_detail() {
-        let item = lsp_types::CompletionItem {
+    fn the_row_hint_and_signature_line_read_the_legacy_detail_and_never_label_details() {
+        let trait_provided = lsp_types::CompletionItem {
             label: "into".to_string(),
             detail: Some("fn(self) -> T".to_string()),
             label_details: Some(lsp_types::CompletionItemLabelDetails {
@@ -1504,26 +1448,7 @@ mod tests {
             }),
             ..Default::default()
         };
-        assert_eq!(
-            completion_item_display(&item).1.as_deref(),
-            Some("fn(self) -> T"),
-            "the row's own right-side hint must read the real legacy detail string, never the \
-             trait-source annotation rust-analyzer puts in label_details.detail"
-        );
-    }
-
-    #[test]
-    fn completion_item_display_falls_back_to_the_bare_label_with_no_real_detail_at_all() {
-        let item = lsp_types::CompletionItem {
-            label: "push_str".to_string(),
-            ..Default::default()
-        };
-        assert_eq!(completion_item_display(&item).1, None);
-    }
-
-    #[test]
-    fn completion_signature_text_ignores_label_details_and_cleans_the_legacy_detail() {
-        let item = lsp_types::CompletionItem {
+        let typescript_method = lsp_types::CompletionItem {
             label: "pushStr".to_string(),
             detail: Some("(method) QueryBuilder.pushStr(s: string): void".to_string()),
             label_details: Some(lsp_types::CompletionItemLabelDetails {
@@ -1532,36 +1457,61 @@ mod tests {
             }),
             ..Default::default()
         };
-        assert_eq!(
-            completion_signature_text(&item),
-            "pushStr(s: string): void",
-            "the pane's own signature line must clean the real legacy detail string, never read \
-             label_details at all"
-        );
-    }
-
-    #[test]
-    fn completion_signature_text_falls_back_to_the_legacy_detail_string() {
-        let item = lsp_types::CompletionItem {
+        let padded = lsp_types::CompletionItem {
+            label: "foo".to_string(),
+            detail: Some("  fn() -> i32  ".to_string()),
+            ..Default::default()
+        };
+        let blank = lsp_types::CompletionItem {
+            label: "bar".to_string(),
+            detail: Some("   ".to_string()),
+            ..Default::default()
+        };
+        let bare = lsp_types::CompletionItem {
+            label: "push_str".to_string(),
+            ..Default::default()
+        };
+        let rust_signature = lsp_types::CompletionItem {
             label: "push_str".to_string(),
             detail: Some("fn push_str(&mut self, string: &str)".to_string()),
             ..Default::default()
         };
-        assert_eq!(
-            completion_signature_text(&item),
-            "fn push_str(&mut self, string: &str)",
-            "rust-analyzer's own convention - a real, complete, standalone signature string \
-             with no kind/qualifier prefix to clean - must pass through unchanged"
-        );
-    }
 
-    #[test]
-    fn completion_signature_text_falls_back_to_the_bare_label_with_nothing_else_real() {
-        let item = lsp_types::CompletionItem {
-            label: "push_str".to_string(),
-            ..Default::default()
-        };
-        assert_eq!(completion_signature_text(&item), "push_str");
+        for (name, candidate, hint, signature) in [
+            (
+                "a padded detail",
+                &padded,
+                Some("fn() -> i32"),
+                "fn() -> i32",
+            ),
+            ("a blank detail", &blank, None, "bar"),
+            ("no detail at all", &bare, None, "push_str"),
+            (
+                "a trait-provided method",
+                &trait_provided,
+                Some("fn(self) -> T"),
+                "fn(self) -> T",
+            ),
+            (
+                "a TypeScript method",
+                &typescript_method,
+                Some("pushStr(s: string): void"),
+                "pushStr(s: string): void",
+            ),
+            (
+                "a standalone rust-analyzer signature",
+                &rust_signature,
+                Some("fn push_str(&mut self, string: &str)"),
+                "fn push_str(&mut self, string: &str)",
+            ),
+        ] {
+            assert_eq!(
+                completion_item_display(candidate).1.as_deref(),
+                hint,
+                "{name}"
+            );
+            assert_eq!(completion_signature_text(candidate), signature, "{name}");
+        }
     }
 
     /// The real, live-reported bug ("the shown things are still modules instead of real types"),
@@ -2363,160 +2313,116 @@ mod tests {
 
     /// Real, live-observed shapes from both servers this app supports - a real dump against a
     /// genuinely spawned rust-analyzer/typescript-language-server, not synthetic guesses (see
-    /// `clean_completion_detail`'s own docs).
+    /// `clean_completion_detail`'s own docs). The three "untouched" rows are the false-positive
+    /// guards: a genuine parenthesized parameter list or tuple type at the start of `detail` is
+    /// distinguished from a kind descriptor by the `:`/`,` inside its parens, and a label
+    /// reappearing deep in a return type is not a `Qualifier.` prefix.
     #[test]
-    fn clean_completion_detail_strips_a_real_typescript_method_kind_and_qualifier_prefix() {
-        assert_eq!(
-            clean_completion_detail("(method) QueryBuilder.pushStr(s: string): void", "pushStr"),
-            "pushStr(s: string): void"
-        );
+    fn clean_completion_detail_strips_only_a_real_kind_or_qualifier_prefix() {
+        for (detail, label, expected) in [
+            (
+                "(method) QueryBuilder.pushStr(s: string): void",
+                "pushStr",
+                "pushStr(s: string): void",
+            ),
+            ("(property) Foo.bar: string", "bar", "bar: string"),
+            ("fn(&mut self, &str)", "push_str", "fn(&mut self, &str)"),
+            ("fn(self) -> T", "into", "fn(self) -> T"),
+            ("(x: number) => void", "onClick", "(x: number) => void"),
+            ("(number, string)", "pair", "(number, string)"),
+            ("fn() -> Option<Table>", "Table", "fn() -> Option<Table>"),
+        ] {
+            assert_eq!(
+                clean_completion_detail(detail, label),
+                expected,
+                "for {detail:?}"
+            );
+        }
+    }
+
+    /// Every real shape a server can answer `documentation` in. Markdown is degraded to plain
+    /// text; plain text passes through untouched; nothing real means nothing shown.
+    #[test]
+    fn completion_documentation_text_reads_every_real_documentation_shape() {
+        for (name, documentation, expected) in [
+            (
+                "a plain string",
+                Some(lsp_types::Documentation::String(
+                    "Appends a given string slice.".to_string(),
+                )),
+                Some("Appends a given string slice."),
+            ),
+            (
+                "markdown markup",
+                Some(lsp_types::Documentation::MarkupContent(
+                    lsp_types::MarkupContent {
+                        kind: lsp_types::MarkupKind::Markdown,
+                        value: "Appends a **given** string slice.".to_string(),
+                    },
+                )),
+                Some("Appends a given string slice."),
+            ),
+            (
+                "plain-text markup",
+                Some(lsp_types::Documentation::MarkupContent(
+                    lsp_types::MarkupContent {
+                        kind: lsp_types::MarkupKind::PlainText,
+                        value: "`not markdown` stays as-is".to_string(),
+                    },
+                )),
+                Some("`not markdown` stays as-is"),
+            ),
+            ("nothing at all", None, None),
+            (
+                "a blank string",
+                Some(lsp_types::Documentation::String("   ".to_string())),
+                None,
+            ),
+        ] {
+            let candidate = lsp_types::CompletionItem {
+                label: "push_str".to_string(),
+                documentation,
+                ..Default::default()
+            };
+            assert_eq!(
+                completion_documentation_text(&candidate).as_deref(),
+                expected,
+                "{name}"
+            );
+        }
     }
 
     #[test]
-    fn clean_completion_detail_strips_a_real_typescript_property_kind_and_qualifier_prefix() {
-        assert_eq!(
-            clean_completion_detail("(property) Foo.bar: string", "bar"),
-            "bar: string"
-        );
-    }
-
-    #[test]
-    fn clean_completion_detail_leaves_a_real_rust_analyzer_signature_untouched() {
-        assert_eq!(
-            clean_completion_detail("fn(&mut self, &str)", "push_str"),
-            "fn(&mut self, &str)"
-        );
-        assert_eq!(
-            clean_completion_detail("fn(self) -> T", "into"),
-            "fn(self) -> T"
-        );
-    }
-
-    /// The real guard against a false-positive strip: a genuine parenthesized parameter list or
-    /// tuple type at the very start of `detail` must never be mistaken for a kind descriptor -
-    /// distinguished by the real presence of `:`/`,` inside the parens, which no real TypeScript
-    /// kind descriptor (`method`, `property`, `local var`, ...) ever contains.
-    #[test]
-    fn clean_completion_detail_never_strips_a_real_parenthesized_type() {
-        assert_eq!(
-            clean_completion_detail("(x: number) => void", "onClick"),
-            "(x: number) => void"
-        );
-        assert_eq!(
-            clean_completion_detail("(number, string)", "pair"),
-            "(number, string)"
-        );
-    }
-
-    #[test]
-    fn clean_completion_detail_only_strips_a_real_bare_dotted_qualifier() {
-        // The label reappearing deep inside a return type, with no real `Qualifier.` immediately
-        // before it, must not be mistaken for one.
-        assert_eq!(
-            clean_completion_detail("fn() -> Option<Table>", "Table"),
-            "fn() -> Option<Table>"
-        );
-    }
-
-    #[test]
-    fn completion_documentation_text_reads_a_real_plain_string_shape() {
-        let item = lsp_types::CompletionItem {
-            label: "push_str".to_string(),
-            documentation: Some(lsp_types::Documentation::String(
-                "Appends a given string slice.".to_string(),
-            )),
-            ..Default::default()
-        };
-        assert_eq!(
-            completion_documentation_text(&item).as_deref(),
-            Some("Appends a given string slice.")
-        );
-    }
-
-    #[test]
-    fn completion_documentation_text_degrades_a_real_markdown_markup_content() {
-        let item = lsp_types::CompletionItem {
-            label: "push_str".to_string(),
-            documentation: Some(lsp_types::Documentation::MarkupContent(
-                lsp_types::MarkupContent {
-                    kind: lsp_types::MarkupKind::Markdown,
-                    value: "Appends a **given** string slice.".to_string(),
-                },
-            )),
-            ..Default::default()
-        };
-        assert_eq!(
-            completion_documentation_text(&item).as_deref(),
-            Some("Appends a given string slice.")
-        );
-    }
-
-    #[test]
-    fn completion_documentation_text_passes_a_real_plain_text_markup_content_through_unmodified() {
-        let item = lsp_types::CompletionItem {
-            label: "push_str".to_string(),
-            documentation: Some(lsp_types::Documentation::MarkupContent(
-                lsp_types::MarkupContent {
-                    kind: lsp_types::MarkupKind::PlainText,
-                    value: "`not markdown` stays as-is".to_string(),
-                },
-            )),
-            ..Default::default()
-        };
-        assert_eq!(
-            completion_documentation_text(&item).as_deref(),
-            Some("`not markdown` stays as-is")
-        );
-    }
-
-    #[test]
-    fn completion_documentation_text_is_none_for_a_real_absent_or_blank_documentation() {
-        let no_doc = lsp_types::CompletionItem {
-            label: "foo".to_string(),
-            ..Default::default()
-        };
-        assert_eq!(completion_documentation_text(&no_doc), None);
-
-        let blank_doc = lsp_types::CompletionItem {
-            label: "foo".to_string(),
-            documentation: Some(lsp_types::Documentation::String("   ".to_string())),
-            ..Default::default()
-        };
-        assert_eq!(completion_documentation_text(&blank_doc), None);
-    }
-
-    #[test]
-    fn completion_module_path_reads_a_real_label_details_description() {
-        let item = lsp_types::CompletionItem {
-            label: "push_str".to_string(),
-            label_details: Some(lsp_types::CompletionItemLabelDetails {
-                detail: Some("(&mut self, &str)".to_string()),
-                description: Some("alloc::string::String".to_string()),
-            }),
-            ..Default::default()
-        };
-        assert_eq!(
-            completion_module_path(&item).as_deref(),
-            Some("alloc::string::String")
-        );
-    }
-
-    #[test]
-    fn completion_module_path_is_none_without_real_label_details_or_a_real_description() {
-        let no_label_details = lsp_types::CompletionItem {
-            label: "foo".to_string(),
-            ..Default::default()
-        };
-        assert_eq!(completion_module_path(&no_label_details), None);
-
-        let no_description = lsp_types::CompletionItem {
-            label: "foo".to_string(),
-            label_details: Some(lsp_types::CompletionItemLabelDetails {
-                detail: Some("()".to_string()),
-                description: None,
-            }),
-            ..Default::default()
-        };
-        assert_eq!(completion_module_path(&no_description), None);
+    fn completion_module_path_reads_only_a_real_label_details_description() {
+        for (name, label_details, expected) in [
+            (
+                "a real description",
+                Some(lsp_types::CompletionItemLabelDetails {
+                    detail: Some("(&mut self, &str)".to_string()),
+                    description: Some("alloc::string::String".to_string()),
+                }),
+                Some("alloc::string::String"),
+            ),
+            ("no label details at all", None, None),
+            (
+                "label details with no description",
+                Some(lsp_types::CompletionItemLabelDetails {
+                    detail: Some("()".to_string()),
+                    description: None,
+                }),
+                None,
+            ),
+        ] {
+            let candidate = lsp_types::CompletionItem {
+                label: "push_str".to_string(),
+                label_details,
+                ..Default::default()
+            };
+            assert_eq!(
+                completion_module_path(&candidate).as_deref(),
+                expected,
+                "{name}"
+            );
+        }
     }
 }

--- a/crates/app/src/lsp/completion_popup.rs
+++ b/crates/app/src/lsp/completion_popup.rs
@@ -1314,8 +1314,8 @@ fn resolve_completion_edit(
 #[cfg(test)]
 mod completions_scroll_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
     use crate::root::scrollbar::ScrollableHandle;
+    use crate::test_support::open_test_app;
     use gpui::{Entity, TestAppContext, VisualTestContext};
 
     /// Comfortably more than both the old 12-item render cap and the
@@ -1348,13 +1348,13 @@ mod completions_scroll_tests {
     ) -> (
         Entity<AdeApp>,
         &mut VisualTestContext,
-        tempfile::TempDir,
+        crate::lsp::fixtures::TempRepo,
         PathBuf,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let file = repo.path().join("sample.rs");
         std::fs::write(&file, "fn main() {}\n").expect("write sample.rs");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file, window, cx);
         });
@@ -1653,17 +1653,17 @@ mod completions_scroll_tests {
 #[cfg(test)]
 mod completion_detail_pane_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
+    use crate::test_support::open_test_app;
     use gpui::TestAppContext;
 
     fn seed_ready_popup(
         cx: &mut TestAppContext,
         items: Vec<lsp_core::lsp_types::CompletionItem>,
     ) -> (gpui::Entity<AdeApp>, &mut gpui::VisualTestContext, PathBuf) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let file = repo.path().join("sample.rs");
         std::fs::write(&file, "fn main() {}\n").expect("write sample.rs");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file, window, cx);
         });
@@ -1815,11 +1815,11 @@ mod completion_detail_pane_tests {
     fn a_short_lists_flipped_above_position_is_close_to_the_caret_not_the_worst_case_height(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let file = repo.path().join("sample.rs");
         let lines: Vec<String> = (0..30).map(|i| format!("fn f{i}() {{}}")).collect();
         std::fs::write(&file, lines.join("\n") + "\n").expect("write sample.rs");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file, window, cx);
         });
@@ -1954,10 +1954,10 @@ mod completion_detail_pane_tests {
     fn accepting_a_real_auto_import_writes_its_import_line_and_keeps_the_caret(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let file = repo.path().join("main.ts");
         std::fs::write(&file, "const a = 1;\n\nconst other = app\n").expect("write main.ts");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file, window, cx);
         });
@@ -2032,10 +2032,10 @@ mod completion_detail_pane_tests {
     /// diagnostic at all) and still cannot be bundled.
     #[gpui::test]
     fn the_auto_import_setting_off_inserts_the_name_without_the_import(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let file = repo.path().join("main.ts");
         std::fs::write(&file, "const a = 1;\n\nconst other = app\n").expect("write main.ts");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file, window, cx);
         });
@@ -2447,10 +2447,10 @@ mod completion_detail_pane_tests {
     fn a_loading_popup_paints_only_the_list_column_with_no_detail_pane_or_footer_hints(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::lsp::fixtures::temp_repo();
         let file = repo.path().join("sample.rs");
         std::fs::write(&file, "fn main() {}\n").expect("write sample.rs");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file, window, cx);
         });

--- a/crates/app/src/lsp/diagnostics.rs
+++ b/crates/app/src/lsp/diagnostics.rs
@@ -368,25 +368,20 @@ mod tests {
         );
     }
 
+    /// UTF-16 is what the protocol counts in and UTF-8 is what the buffer stores, so a
+    /// multi-byte character is the whole point: in `"café x"` the `'x'` is UTF-16 unit 5 but
+    /// byte 6. Anything past the line end clamps rather than panicking.
     #[test]
-    fn utf16_offset_to_byte_offset_is_identity_for_pure_ascii() {
-        assert_eq!(utf16_offset_to_byte_offset("let x = 1;", 4), 4);
-    }
-
-    #[test]
-    fn utf16_offset_to_byte_offset_accounts_for_a_real_multi_byte_char() {
-        // "café x" - 'é' is 2 UTF-8 bytes but only 1 UTF-16 code unit, so the real byte offset
-        // of the 'x' that follows it must be 6 (c=1,a=1,f=1,é=2 bytes,space=1 => byte 6), even
-        // though its UTF-16 offset is only 5 (c=1,a=1,f=1,é=1 unit,space=1 => unit 5).
-        let text = "caf\u{e9} x"; // '\u{e9}' is 'é'
-        let x_byte_offset = text.find('x').expect("'x' present");
-        assert_eq!(x_byte_offset, 6);
-        assert_eq!(utf16_offset_to_byte_offset(text, 5), x_byte_offset);
-    }
-
-    #[test]
-    fn utf16_offset_to_byte_offset_clamps_past_the_real_line_end() {
-        assert_eq!(utf16_offset_to_byte_offset("abc", 999), 3);
+    fn utf16_offset_to_byte_offset_converts_and_clamps() {
+        for (line, utf16_offset, expected) in
+            [("let x = 1;", 4, 4), ("caf\u{e9} x", 5, 6), ("abc", 999, 3)]
+        {
+            assert_eq!(
+                utf16_offset_to_byte_offset(line, utf16_offset),
+                expected,
+                "{line:?} at UTF-16 offset {utf16_offset}"
+            );
+        }
     }
 
     #[test]
@@ -458,38 +453,39 @@ mod tests {
         assert_eq!(Severity::from_lsp(None), Severity::Error);
     }
 
+    /// The worst severity in a line's list, and the ranking behind "worst" - never "whichever
+    /// the `Vec` happens to hold first", which is what a header count would silently get wrong.
     #[test]
-    fn worst_severity_is_none_for_an_empty_slice() {
+    fn worst_severity_ranks_by_severity_not_by_vec_order() {
+        fn at(severity: Severity) -> LineDiagnostic {
+            let mut diagnostic = line_diag(0..1);
+            diagnostic.severity = severity;
+            diagnostic
+        }
         assert_eq!(Severity::worst(&[]), None);
-    }
-
-    #[test]
-    fn worst_severity_picks_error_over_hint_regardless_of_vec_order() {
-        let mut a = line_diag(0..1);
-        a.severity = Severity::Hint;
-        let mut b = line_diag(0..1);
-        b.severity = Severity::Error;
-        // Error listed second, on purpose - the real ordering, not "first in the Vec", must win.
-        assert_eq!(
-            Severity::worst(&[a.clone(), b.clone()]),
-            Some(Severity::Error)
-        );
-        // Same pair, reversed order - the answer must not depend on Vec order either way.
-        assert_eq!(Severity::worst(&[b, a]), Some(Severity::Error));
-    }
-
-    #[test]
-    fn worst_severity_ranks_warning_above_information_and_hint() {
-        let mut hint = line_diag(0..1);
-        hint.severity = Severity::Hint;
-        let mut info = line_diag(0..1);
-        info.severity = Severity::Information;
-        let mut warning = line_diag(0..1);
-        warning.severity = Severity::Warning;
-        assert_eq!(
-            Severity::worst(&[hint, info, warning]),
-            Some(Severity::Warning)
-        );
+        for (name, diagnostics, expected) in [
+            (
+                "error listed last",
+                vec![at(Severity::Hint), at(Severity::Error)],
+                Severity::Error,
+            ),
+            (
+                "error listed first",
+                vec![at(Severity::Error), at(Severity::Hint)],
+                Severity::Error,
+            ),
+            (
+                "warning outranks information and hint",
+                vec![
+                    at(Severity::Hint),
+                    at(Severity::Information),
+                    at(Severity::Warning),
+                ],
+                Severity::Warning,
+            ),
+        ] {
+            assert_eq!(Severity::worst(&diagnostics), Some(expected), "{name}");
+        }
     }
 
     #[test]

--- a/crates/app/src/lsp/fixtures.rs
+++ b/crates/app/src/lsp/fixtures.rs
@@ -1,0 +1,50 @@
+//! Test-only fixtures shared by this folder's own test modules.
+//!
+//! Owns exactly one thing: handing a test a worktree root the app will agree with. Anything
+//! git-, wait- or process-shaped belongs in `crates/test-support`, and anything that opens a
+//! window in `crate::test_support`.
+
+use gpui::VisualTestContext;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+/// A real temporary directory whose [`Self::path`] is the root to hand
+/// [`crate::test_support::open_test_app`].
+///
+/// The path is canonicalized because `AdeApp` canonicalizes the repo root it is given
+/// ([`crate::rail::repo::canonical_repo_path`]) and then keys `lsp_clients` by an exact
+/// `(PathBuf, &str)` pair and `edit_buffers`/`open_files` by `path.strip_prefix(file_tree_root)`.
+/// On macOS `std::env::temp_dir()` is itself behind a symlink (`/var` -> `/private/var`), so a
+/// fixture that builds paths from `tempfile::TempDir::path()` verbatim produces keys that never
+/// match the ones the app resolved.
+pub(in crate::lsp) struct TempRepo {
+    /// Held for its `Drop`; the directory is removed when this value is.
+    _dir: tempfile::TempDir,
+    root: PathBuf,
+}
+
+impl TempRepo {
+    pub(in crate::lsp) fn path(&self) -> &Path {
+        &self.root
+    }
+}
+
+pub(in crate::lsp) fn temp_repo() -> TempRepo {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path().canonicalize().expect("canonicalize tempdir");
+    TempRepo { _dir: dir, root }
+}
+
+/// `test_support::wait_until`'s GPUI-driven sibling, for the state that only advances after a
+/// real render plus a `run_until_parked` between polls — a real server's `publishDiagnostics`
+/// arrives on `lsp_core`'s own OS reader thread, outside GPUI's scheduler entirely.
+///
+/// The shared helper cannot serve these callers: its condition closure takes no arguments, and
+/// theirs needs the `VisualTestContext` this hands back each time.
+pub(in crate::lsp) fn wait_until_parked(
+    cx: &mut VisualTestContext,
+    deadline: Duration,
+    mut attempt: impl FnMut(&mut VisualTestContext) -> bool,
+) -> bool {
+    test_support::wait_until(deadline, || attempt(cx))
+}

--- a/crates/app/src/lsp/hover.rs
+++ b/crates/app/src/lsp/hover.rs
@@ -715,25 +715,20 @@ mod tests {
         assert_eq!(sections.description, None);
     }
 
+    /// UTF-16 is what the protocol counts in and UTF-8 is what the buffer stores, so a
+    /// multi-byte character is the whole point: in `"café x"` the `'x'` is byte 6 but UTF-16 unit
+    /// 5. Anything past the line end clamps rather than panicking.
     #[test]
-    fn byte_offset_to_utf16_offset_is_identity_for_pure_ascii() {
-        assert_eq!(byte_offset_to_utf16_offset("let x = 1;", 4), 4);
-    }
-
-    #[test]
-    fn byte_offset_to_utf16_offset_accounts_for_a_real_multi_byte_char() {
-        // "café x" - 'é' is 2 UTF-8 bytes but only 1 UTF-16 code unit, so the real UTF-16 offset
-        // of the 'x' that follows it must be 5 (c=1,a=1,f=1,é=1 unit,space=1 => unit 5), even
-        // though its real byte offset is 6.
-        let text = "caf\u{e9} x";
-        let x_byte_offset = text.find('x').expect("'x' present");
-        assert_eq!(x_byte_offset, 6);
-        assert_eq!(byte_offset_to_utf16_offset(text, x_byte_offset), 5);
-    }
-
-    #[test]
-    fn byte_offset_to_utf16_offset_clamps_past_the_real_line_end() {
-        assert_eq!(byte_offset_to_utf16_offset("abc", 999), 3);
+    fn byte_offset_to_utf16_offset_converts_and_clamps() {
+        for (line, byte_offset, expected) in
+            [("let x = 1;", 4, 4), ("caf\u{e9} x", 6, 5), ("abc", 999, 3)]
+        {
+            assert_eq!(
+                byte_offset_to_utf16_offset(line, byte_offset),
+                expected,
+                "{line:?} at byte {byte_offset}"
+            );
+        }
     }
 
     #[test]
@@ -857,16 +852,6 @@ mod tests {
             vec!["const name = formatName(\"Ada\", \"Lovelace\");\nconsole.log(name);".to_string()],
             "a real fenced @example body must survive as real, multi-line example code"
         );
-    }
-
-    #[test]
-    fn degrade_markdown_to_plain_text_strips_a_real_fenced_code_block_and_starts_a_new_paragraph() {
-        let plain = degrade_markdown_to_plain_text(REAL_TYPESCRIPT_MARKDOWN_HOVER);
-        assert_eq!(
-            plain,
-            "\nfunction addOne(x: number): number\n\nAdds one to the given number."
-        );
-        assert!(!plain.contains('`'), "no backtick should survive degrading");
     }
 
     #[test]
@@ -1085,33 +1070,11 @@ mod tests {
         }
     }
 
+    /// Every real shape a server can answer go-to-definition in. The `Link` row is the one that
+    /// matters most: it must read the target's own *selection* range (the name span), not the
+    /// whole target range, which can start well before the item at its doc comment.
     #[test]
-    fn first_definition_location_reads_a_real_scalar_response() {
-        let response = lsp_types::GotoDefinitionResponse::Scalar(location("file:///a.rs", 4));
-        let (uri, range) = first_definition_location(&response).expect("a real location");
-        assert_eq!(uri.as_str(), "file:///a.rs");
-        assert_eq!(range.start.line, 4);
-    }
-
-    #[test]
-    fn first_definition_location_reads_the_real_first_array_entry() {
-        let response = lsp_types::GotoDefinitionResponse::Array(vec![
-            location("file:///first.rs", 1),
-            location("file:///second.rs", 2),
-        ]);
-        let (uri, range) = first_definition_location(&response).expect("a real location");
-        assert_eq!(uri.as_str(), "file:///first.rs");
-        assert_eq!(range.start.line, 1);
-    }
-
-    #[test]
-    fn first_definition_location_is_none_for_a_real_empty_array() {
-        let response = lsp_types::GotoDefinitionResponse::Array(vec![]);
-        assert_eq!(first_definition_location(&response), None);
-    }
-
-    #[test]
-    fn first_definition_location_reads_a_real_link_response_using_target_selection_range() {
+    fn first_definition_location_reads_the_first_target_of_every_real_response_shape() {
         let link = lsp_types::LocationLink {
             origin_selection_range: None,
             target_uri: "file:///target.rs".parse().expect("real test URI"),
@@ -1136,12 +1099,40 @@ mod tests {
                 },
             },
         };
-        let response = lsp_types::GotoDefinitionResponse::Link(vec![link]);
-        let (uri, range) = first_definition_location(&response).expect("a real location");
-        assert_eq!(uri.as_str(), "file:///target.rs");
-        // The real *selection* range (the target's own name span), not the whole real target
-        // range (which could start well before the item, e.g. at its own doc comment).
-        assert_eq!(range.start.line, 2);
-        assert_eq!(range.start.character, 3);
+        for (name, response, expected) in [
+            (
+                "a scalar location",
+                lsp_types::GotoDefinitionResponse::Scalar(location("file:///a.rs", 4)),
+                Some(("file:///a.rs", 4)),
+            ),
+            (
+                "an array - the first entry wins",
+                lsp_types::GotoDefinitionResponse::Array(vec![
+                    location("file:///first.rs", 1),
+                    location("file:///second.rs", 2),
+                ]),
+                Some(("file:///first.rs", 1)),
+            ),
+            (
+                "an empty array",
+                lsp_types::GotoDefinitionResponse::Array(vec![]),
+                None,
+            ),
+            (
+                "a link, read through its selection range",
+                lsp_types::GotoDefinitionResponse::Link(vec![link]),
+                Some(("file:///target.rs", 2)),
+            ),
+        ] {
+            match expected {
+                None => assert_eq!(first_definition_location(&response), None, "{name}"),
+                Some((expected_uri, expected_line)) => {
+                    let (uri, range) =
+                        first_definition_location(&response).unwrap_or_else(|| panic!("{name}"));
+                    assert_eq!(uri.as_str(), expected_uri, "{name}");
+                    assert_eq!(range.start.line, expected_line, "{name}");
+                }
+            }
+        }
     }
 }

--- a/crates/app/src/lsp/mod.rs
+++ b/crates/app/src/lsp/mod.rs
@@ -31,3 +31,5 @@ pub mod hover;
 
 pub(crate) mod client;
 pub(crate) mod completion_popup;
+#[cfg(test)]
+pub(crate) mod fixtures;

--- a/crates/app/src/search/engine.rs
+++ b/crates/app/src/search/engine.rs
@@ -1542,16 +1542,7 @@ mod worktree_tests {
 #[cfg(test)]
 mod layered_exclude_tests {
     use super::*;
-    use std::process::Command;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let status = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .status()
-            .expect("git runs");
-        assert!(status.success(), "git {args:?} failed");
-    }
+    use test_support::{git, seed_empty_repo_at};
 
     /// A real git worktree with:
     /// - `target/`, a real `.gitignore`d build directory sized enough that including it would
@@ -1565,9 +1556,7 @@ mod layered_exclude_tests {
     fn fixture() -> tempfile::TempDir {
         let dir = tempfile::tempdir().expect("a temp worktree");
         let root = dir.path();
-        git(root, &["init", "-q"]);
-        git(root, &["config", "user.email", "t@example.com"]);
-        git(root, &["config", "user.name", "Test"]);
+        seed_empty_repo_at(root);
 
         let write = |relative: &str, content: &str| {
             let path = root.join(relative);
@@ -1708,9 +1697,7 @@ mod layered_exclude_tests {
     fn an_ungitignored_build_directory_is_excluded_in_both_toggle_states() {
         let dir = tempfile::tempdir().expect("a temp worktree");
         let root = dir.path();
-        git(root, &["init", "-q"]);
-        git(root, &["config", "user.email", "t@example.com"]);
-        git(root, &["config", "user.name", "Test"]);
+        seed_empty_repo_at(root);
         let write = |relative: &str, content: &str| {
             let path = root.join(relative);
             fs::create_dir_all(path.parent().expect("a parent")).expect("mkdir");

--- a/crates/app/src/search/fixtures.rs
+++ b/crates/app/src/search/fixtures.rs
@@ -1,0 +1,34 @@
+//! Test-only fixtures shared by this folder's own test modules.
+//!
+//! Owns exactly one thing: handing a test a worktree root the app will agree with. Anything
+//! git-, wait- or process-shaped belongs in `crates/test-support`, and anything that opens a
+//! window in `crate::test_support`.
+
+use std::path::{Path, PathBuf};
+
+/// A real temporary directory whose [`Self::path`] is the root to hand
+/// [`crate::test_support::open_test_app`].
+///
+/// The path is canonicalized because `AdeApp` canonicalizes the repo root it is given
+/// ([`crate::rail::repo::canonical_repo_path`]) and then keys `open_files`/`edit_buffers` by
+/// `path.strip_prefix(file_tree_root)`. On macOS `std::env::temp_dir()` is itself behind a
+/// symlink (`/var` -> `/private/var`), so a fixture that builds paths from
+/// `tempfile::TempDir::path()` verbatim produces keys that never match the ones the app resolved
+/// — which is exactly how a replace-all could once overwrite a file the editor still held dirty.
+pub(in crate::search) struct TempRepo {
+    /// Held for its `Drop`; the directory is removed when this value is.
+    _dir: tempfile::TempDir,
+    root: PathBuf,
+}
+
+impl TempRepo {
+    pub(in crate::search) fn path(&self) -> &Path {
+        &self.root
+    }
+}
+
+pub(in crate::search) fn temp_repo() -> TempRepo {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path().canonicalize().expect("canonicalize tempdir");
+    TempRepo { _dir: dir, root }
+}

--- a/crates/app/src/search/mod.rs
+++ b/crates/app/src/search/mod.rs
@@ -30,4 +30,6 @@ pub mod glob;
 pub mod in_file;
 pub mod state;
 
+#[cfg(test)]
+pub(crate) mod fixtures;
 pub(crate) mod render;

--- a/crates/app/src/search/render.rs
+++ b/crates/app/src/search/render.rs
@@ -1371,16 +1371,15 @@ mod tests {
 #[cfg(test)]
 mod panel_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
     use crate::search::state::SearchField;
+    use crate::test_support::open_test_app;
     use gpui::TestAppContext;
-    use tempfile::TempDir;
 
     /// A real worktree on disk with `refresh_token` across four files - the same corpus
     /// `Jerry.dc.html`'s own search fixture uses, so what these tests see is what the design was
     /// drawn against.
-    fn fixture_repo() -> TempDir {
-        let repo = TempDir::new().expect("tempdir");
+    fn fixture_repo() -> crate::search::fixtures::TempRepo {
+        let repo = crate::search::fixtures::temp_repo();
         let write = |relative: &str, content: &str| {
             let path = repo.path().join(relative);
             std::fs::create_dir_all(path.parent().expect("a parent")).expect("mkdir");
@@ -1402,9 +1401,9 @@ mod panel_tests {
 
     fn open_search<'a>(
         cx: &'a mut TestAppContext,
-        repo: &TempDir,
+        repo: &crate::search::fixtures::TempRepo,
     ) -> (gpui::Entity<AdeApp>, &'a mut gpui::VisualTestContext) {
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| app.open_search_panel(window, cx));
         cx.run_until_parked();
         (app, cx)
@@ -1479,7 +1478,7 @@ mod panel_tests {
     #[gpui::test]
     fn mod_shift_f_opens_the_panel_with_the_query_focused(cx: &mut TestAppContext) {
         let repo = fixture_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.dispatch_action(SearchInWorktree);
         cx.run_until_parked();
 
@@ -1784,7 +1783,7 @@ mod panel_tests {
     /// clamping to a valid one.
     #[gpui::test]
     fn clicking_a_match_row_opens_the_file_on_exactly_the_line_it_reports(cx: &mut TestAppContext) {
-        let repo = TempDir::new().expect("tempdir");
+        let repo = crate::search::fixtures::temp_repo();
         let mut content = String::new();
         for line in 1..=41 {
             content.push_str(&format!("// padding line {line}\n"));
@@ -2026,9 +2025,8 @@ mod panel_tests {
 #[cfg(test)]
 mod search_virtualization_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
+    use crate::test_support::open_test_app;
     use gpui::TestAppContext;
-    use tempfile::TempDir;
 
     /// Deliberately more match rows than any plausible test viewport can show at
     /// `theme::band::SEARCH_MATCH_ROW` each - a single file with `ROW_COUNT` distinct one-per-line
@@ -2036,8 +2034,8 @@ mod search_virtualization_tests {
     /// shape the live report itself described.
     const ROW_COUNT: usize = 300;
 
-    fn fixture_repo() -> TempDir {
-        let repo = TempDir::new().expect("tempdir");
+    fn fixture_repo() -> crate::search::fixtures::TempRepo {
+        let repo = crate::search::fixtures::temp_repo();
         let mut content = String::new();
         for i in 0..ROW_COUNT {
             content.push_str(&format!("let needle_{i} = needle;\n"));
@@ -2048,9 +2046,9 @@ mod search_virtualization_tests {
 
     fn open_search<'a>(
         cx: &'a mut TestAppContext,
-        repo: &TempDir,
+        repo: &crate::search::fixtures::TempRepo,
     ) -> (gpui::Entity<AdeApp>, &'a mut gpui::VisualTestContext) {
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| app.open_search_panel(window, cx));
         cx.run_until_parked();
         (app, cx)
@@ -2571,9 +2569,8 @@ impl AdeApp {
 #[cfg(test)]
 mod find_bar_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
+    use crate::test_support::open_test_app;
     use gpui::TestAppContext;
-    use tempfile::TempDir;
 
     const SAMPLE: &str = "let refresh_token = issue();\n\
                           if refresh_token.expired() { drop(refresh_token); }\n\
@@ -2582,11 +2579,15 @@ mod find_bar_tests {
 
     fn repo_with_open_file(
         cx: &mut TestAppContext,
-    ) -> (TempDir, gpui::Entity<AdeApp>, &mut gpui::VisualTestContext) {
-        let repo = TempDir::new().expect("tempdir");
+    ) -> (
+        crate::search::fixtures::TempRepo,
+        gpui::Entity<AdeApp>,
+        &mut gpui::VisualTestContext,
+    ) {
+        let repo = crate::search::fixtures::temp_repo();
         let file = repo.path().join("session.rs");
         std::fs::write(&file, SAMPLE).expect("write");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file.clone(), window, cx);
         });

--- a/crates/app/src/settings/custom_theme.rs
+++ b/crates/app/src/settings/custom_theme.rs
@@ -1110,30 +1110,41 @@ keyword = "#ff79c6"
         assert_eq!(theme.base, None);
     }
 
+    /// Every real way a theme file can be wrong, and the exact error each one has to produce -
+    /// a typo'd key must be named, not silently ignored, or a user edits a file and sees nothing
+    /// change with no explanation.
     #[test]
-    fn an_unknown_key_is_a_real_rejection_not_a_silently_ignored_typo() {
-        let err =
-            parse_theme_file_str("name = \"T\"\n\n[syntax]\nkeywrod = \"#ff79c6\"\n").unwrap_err();
-        assert_eq!(
-            err,
-            ThemeFileError::UnknownKey("syntax.keywrod".to_string())
-        );
-    }
+    fn every_real_malformed_theme_file_is_rejected_with_an_error_naming_what_is_wrong() {
+        for (name, text, expected) in [
+            (
+                "a typo'd key",
+                "name = \"T\"\n\n[syntax]\nkeywrod = \"#ff79c6\"\n",
+                ThemeFileError::UnknownKey("syntax.keywrod".to_string()),
+            ),
+            (
+                "a typo'd table",
+                "name = \"T\"\n\n[surfaces]\nwindow = \"#0c0d10\"\n",
+                ThemeFileError::UnknownKey("surfaces.window".to_string()),
+            ),
+            (
+                "a top-level key outside any table",
+                "name = \"T\"\nwindow = \"#0c0d10\"\n",
+                ThemeFileError::UnknownTable("window".to_string()),
+            ),
+            (
+                "a blank name",
+                "name = \"   \"\n",
+                ThemeFileError::EmptyName,
+            ),
+            (
+                "a name a built-in theme already has",
+                "name = \"Jerry Dark\"\n",
+                ThemeFileError::NameCollidesWithBuiltin("Jerry Dark".to_string()),
+            ),
+        ] {
+            assert_eq!(parse_theme_file_str(text).unwrap_err(), expected, "{name}");
+        }
 
-    #[test]
-    fn an_unknown_table_is_a_real_rejection() {
-        let err =
-            parse_theme_file_str("name = \"T\"\n\n[surfaces]\nwindow = \"#0c0d10\"\n").unwrap_err();
-        assert_eq!(
-            err,
-            ThemeFileError::UnknownKey("surfaces.window".to_string())
-        );
-        let err = parse_theme_file_str("name = \"T\"\nwindow = \"#0c0d10\"\n").unwrap_err();
-        assert_eq!(err, ThemeFileError::UnknownTable("window".to_string()));
-    }
-
-    #[test]
-    fn every_real_invalid_colour_shape_is_rejected_with_the_offending_key_named() {
         for bad in ["0c0d10", "#0c0", "#gggggg", "#0c0d1012", "not-a-color", ""] {
             let err =
                 parse_theme_file_str(&format!("name = \"T\"\n\n[surface]\nwindow = \"{bad}\"\n"))
@@ -1143,9 +1154,27 @@ keyword = "#ff79c6"
                 ThemeFileError::InvalidColor {
                     key: "surface.window".to_string(),
                     value: bad.to_string(),
-                }
+                },
+                "colour {bad:?}"
             );
         }
+
+        for text in [
+            "name = \"T\"\npreview = [\"#010203\"]\n",
+            "name = \"T\"\npreview = \"#010203\"\n",
+            "name = \"T\"\npreview = [\"nope\", \"#040506\", \"#070809\", \"#0a0b0c\", \"#0d0e0f\"]\n",
+        ] {
+            let err = parse_theme_file_str(text).unwrap_err();
+            assert!(
+                matches!(err, ThemeFileError::InvalidPreview(_)),
+                "expected an InvalidPreview error for {text:?}, got {err:?}"
+            );
+        }
+
+        assert!(matches!(
+            parse_theme_file_str("this is not valid toml {{{").unwrap_err(),
+            ThemeFileError::Parse(_)
+        ));
     }
 
     #[test]
@@ -1156,27 +1185,6 @@ keyword = "#ff79c6"
         .expect("pair and array keys are real");
         assert_eq!(theme.overrides["agent.sonnet.fg"], rgba(0xff0000));
         assert_eq!(theme.overrides["graph.lanes.0"], rgba(0x00ff00));
-    }
-
-    #[test]
-    fn an_empty_name_is_a_real_rejection_not_a_silent_fallback() {
-        let err = parse_theme_file_str("name = \"   \"\n").unwrap_err();
-        assert_eq!(err, ThemeFileError::EmptyName);
-    }
-
-    #[test]
-    fn a_name_colliding_with_a_builtin_theme_is_rejected() {
-        let err = parse_theme_file_str("name = \"Jerry Dark\"\n").unwrap_err();
-        assert_eq!(
-            err,
-            ThemeFileError::NameCollidesWithBuiltin("Jerry Dark".to_string())
-        );
-    }
-
-    #[test]
-    fn parse_theme_file_str_rejects_garbage_toml_with_a_real_parse_error() {
-        let err = parse_theme_file_str("this is not valid toml {{{").unwrap_err();
-        assert!(matches!(err, ThemeFileError::Parse(_)));
     }
 
     /// A real round trip through this module's own writer and reader - the property
@@ -1259,36 +1267,20 @@ keyword = "#ff79c6"
         );
     }
 
-    #[test]
-    fn a_malformed_preview_is_a_real_rejection() {
-        for (text, _) in [
-            ("name = \"T\"\npreview = [\"#010203\"]\n", ()),
-            ("name = \"T\"\npreview = \"#010203\"\n", ()),
-            (
-                "name = \"T\"\npreview = [\"nope\", \"#040506\", \"#070809\", \"#0a0b0c\", \"#0d0e0f\"]\n",
-                (),
-            ),
-        ] {
-            let err = parse_theme_file_str(text).unwrap_err();
-            assert!(
-                matches!(err, ThemeFileError::InvalidPreview(_)),
-                "expected an InvalidPreview error for {text:?}, got {err:?}"
-            );
-        }
-    }
-
     // ---- readability ------------------------------------------------------------------------
 
     /// A palette whose body text is literally the same colour as the surface behind it is the real
     /// unreadable case this check exists for.
+    /// Text the same colour as the surface behind it is the extreme, and a few hex digits off is
+    /// the near-miss a hand-author could easily mistake for "different enough" - both are
+    /// unreadable and both must be rejected.
     #[test]
-    fn text_the_same_colour_as_its_background_is_rejected() {
-        let mut palette = theme::Palette::new();
-        palette.insert("surface.window", rgba(0x0c0d10));
-        palette.insert("text.body", rgba(0x0c0d10));
-        let err = check_palette_readability(&palette).unwrap_err();
+    fn text_that_does_not_clear_the_contrast_floor_against_its_background_is_rejected() {
+        let mut identical = theme::Palette::new();
+        identical.insert("surface.window", rgba(0x0c0d10));
+        identical.insert("text.body", rgba(0x0c0d10));
         assert_eq!(
-            err,
+            check_palette_readability(&identical).unwrap_err(),
             ThemeFileError::LowContrast {
                 what: "body text",
                 foreground: "text.body",
@@ -1297,21 +1289,16 @@ keyword = "#ff79c6"
                 floor_per_hundred: MIN_CONTRAST_PER_HUNDRED,
             }
         );
-    }
 
-    /// A real near-miss, not just the identical-colour extreme: a hand-author could easily mistake
-    /// this for "different enough", but it is still unreadable.
-    #[test]
-    fn text_a_few_hex_digits_off_from_its_background_is_still_rejected() {
-        let mut palette = theme::Palette::new();
-        palette.insert("surface.window", rgba(0x0c0d10));
-        palette.insert("text.body", rgba(0x11131a));
+        let mut near_miss = theme::Palette::new();
+        near_miss.insert("surface.window", rgba(0x0c0d10));
+        near_miss.insert("text.body", rgba(0x11131a));
         assert!(
             matches!(
-                check_palette_readability(&palette),
+                check_palette_readability(&near_miss),
                 Err(ThemeFileError::LowContrast { .. })
             ),
-            "expected a LowContrast rejection"
+            "a near-miss is still unreadable"
         );
     }
 
@@ -1354,24 +1341,11 @@ keyword = "#ff79c6"
         assert!(check_palette_readability(&theme::Palette::new()).is_ok());
     }
 
-    #[test]
-    fn every_built_in_theme_is_really_readable_once_compiled() {
-        for def in THEME_DEFS.iter() {
-            let palette = compile_palette_by_name(def.name, &[])
-                .expect("a bundled theme must compile")
-                .unwrap_or_default();
-            assert!(
-                check_palette_readability(&palette).is_ok(),
-                "{} is not readable: {:?}",
-                def.name,
-                check_palette_readability(&palette)
-            );
-        }
-    }
-
     /// Pins the real measured headroom every bundled theme has over the floor - so a future edit
     /// that quietly weakened the floor, or a palette change that quietly ate the margin, shows up
-    /// as a real test failure rather than passing on a technicality.
+    /// as a real test failure rather than passing on a technicality. Strictly stronger than
+    /// `check_palette_readability`'s own 1.6:1 validity floor, over the same pairs, so it stands
+    /// in for a plain "is it readable at all" check too.
     #[test]
     fn every_built_in_theme_clears_the_floor_with_real_headroom() {
         for def in THEME_DEFS.iter() {
@@ -1503,23 +1477,20 @@ keyword = "#ff79c6"
         assert_eq!(palette["surface.window"], rgba(0x333333));
     }
 
+    /// A cycle in the `base` chain must come back as a real reported error naming the loop, not
+    /// a hang - including the one-theme case, where a theme names itself.
     #[test]
     fn a_base_cycle_is_a_real_reported_error_not_a_hang() {
         let a = theme_named("A", Some("B"), &[]);
         let b = theme_named("B", Some("A"), &[]);
-        let err = compile_palette(&a, &[&a, &b]).unwrap_err();
         assert_eq!(
-            err,
+            compile_palette(&a, &[&a, &b]).unwrap_err(),
             ThemeFileError::BaseCycle(vec!["A".to_string(), "B".to_string(), "A".to_string()])
         );
-    }
 
-    #[test]
-    fn a_theme_naming_itself_as_its_own_base_is_a_real_reported_cycle() {
         let self_based = theme_named("Loop", Some("Loop"), &[]);
-        let err = compile_palette(&self_based, &[&self_based]).unwrap_err();
         assert_eq!(
-            err,
+            compile_palette(&self_based, &[&self_based]).unwrap_err(),
             ThemeFileError::BaseCycle(vec!["Loop".to_string(), "Loop".to_string()])
         );
     }
@@ -2042,19 +2013,19 @@ keyword = "#ff79c6"
 
     #[test]
     fn custom_themes_dir_for_is_a_real_sibling_of_the_given_settings_path() {
-        let settings_path = Path::new("/home/user/.config/jerry/settings.toml");
-        assert_eq!(
-            custom_themes_dir_for(settings_path),
-            Path::new("/home/user/.config/jerry/themes")
-        );
-    }
-
-    #[test]
-    fn custom_themes_dir_for_falls_back_to_a_bare_name_for_a_settings_path_with_no_parent() {
-        assert_eq!(
-            custom_themes_dir_for(Path::new("settings.toml")),
-            Path::new("themes")
-        );
+        for (settings_path, expected) in [
+            (
+                "/home/user/.config/jerry/settings.toml",
+                "/home/user/.config/jerry/themes",
+            ),
+            // No parent at all - a bare name rather than an empty path.
+            ("settings.toml", "themes"),
+        ] {
+            assert_eq!(
+                custom_themes_dir_for(Path::new(settings_path)),
+                Path::new(expected)
+            );
+        }
     }
 
     /// Proves the built-in files really do go through the *same* parse/validate core a

--- a/crates/app/src/settings/render.rs
+++ b/crates/app/src/settings/render.rs
@@ -5339,7 +5339,7 @@ pub(in crate::settings) fn render_settings_placeholder_page() -> impl IntoElemen
 #[cfg(test)]
 mod settings_keymap_filter_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
+    use crate::test_support::open_test_app;
     use gpui::TestAppContext;
 
     #[gpui::test]
@@ -5347,7 +5347,7 @@ mod settings_keymap_filter_tests {
         cx: &mut TestAppContext,
     ) {
         let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         cx.dispatch_action(ToggleSettings);
         app.update_in(cx, |app, window, cx| {
@@ -5402,7 +5402,7 @@ mod settings_keymap_filter_tests {
 #[cfg(test)]
 mod search_exclude_settings_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
+    use crate::test_support::open_test_app;
     use gpui::TestAppContext;
 
     fn open_test_app_with_real_settings_path(
@@ -5431,7 +5431,7 @@ mod search_exclude_settings_tests {
     #[gpui::test]
     fn typing_a_pattern_and_pressing_enter_adds_it_and_clears_the_field(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         cx.dispatch_action(ToggleSettings);
         app.update_in(cx, |app, window, cx| {
@@ -5481,7 +5481,7 @@ mod search_exclude_settings_tests {
     #[gpui::test]
     fn enter_on_a_blank_or_duplicate_pattern_is_a_silent_no_op(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         cx.dispatch_action(ToggleSettings);
         app.update_in(cx, |app, window, cx| {
@@ -5588,7 +5588,7 @@ mod search_exclude_settings_tests {
 #[cfg(test)]
 mod terminal_font_size_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
+    use crate::test_support::open_test_app;
     use gpui::TestAppContext;
 
     #[gpui::test]
@@ -5596,7 +5596,7 @@ mod terminal_font_size_tests {
         cx: &mut TestAppContext,
     ) {
         let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let pane = app
@@ -5654,7 +5654,7 @@ mod terminal_font_size_tests {
         cx: &mut TestAppContext,
     ) {
         let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         // A second real agent, spawned at whatever the default font size already was.
@@ -5693,7 +5693,7 @@ mod terminal_font_size_tests {
 #[cfg(test)]
 mod settings_lsp_install_action_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
+    use crate::test_support::open_test_app;
     use gpui::TestAppContext;
 
     fn synthetic_row(binary: &'static str, ready: bool) -> settings::LspRow {
@@ -5710,7 +5710,7 @@ mod settings_lsp_install_action_tests {
     #[gpui::test]
     fn install_action_renders_only_for_a_genuinely_not_installed_row(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         cx.dispatch_action(ToggleSettings);
         app.update_in(cx, |app, window, cx| {
@@ -5748,8 +5748,8 @@ mod settings_lsp_install_action_tests {
 mod shell_setting_tests {
     use super::*;
     use crate::rail::status::Status;
-    use crate::root::focus::palette_focus_tests;
     use crate::terminal::pane::TerminalSpec;
+    use crate::test_support::open_test_app;
     use gpui::TestAppContext;
 
     /// Same shape as the sibling test modules' own helper (`keybinding_rebind_tests`,
@@ -5822,7 +5822,7 @@ mod shell_setting_tests {
     #[gpui::test]
     fn an_unconfigured_shell_still_spawns_the_real_os_default(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let expected = PathBuf::from(TerminalSpec::default_shell_program_display())
@@ -6382,14 +6382,14 @@ mod shell_suggestion_dropdown_tests {
 /// actually persisted and applied" discipline.
 #[cfg(test)]
 mod caret_settings_tests {
-    use crate::root::focus::palette_focus_tests;
     use crate::settings::store::CaretStyle;
+    use crate::test_support::open_test_app;
     use gpui::TestAppContext;
 
     #[gpui::test]
     fn set_caret_style_changes_the_real_persisted_setting(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         assert_eq!(
             app.read_with(cx, |app, _| app.settings.appearance.caret_style),
@@ -6425,7 +6425,7 @@ mod caret_settings_tests {
         cx: &mut TestAppContext,
     ) {
         let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         assert!(
             app.read_with(cx, |app, _| app.settings.appearance.caret_blink),
@@ -6472,7 +6472,7 @@ mod indent_guide_settings_tests {
     /// own `open_app_with_state_dir` (that one isn't `pub(crate)`, so this is a small, deliberate
     /// duplicate rather than a cross-module dependency on a test-only helper), which is what gives
     /// this test a real `settings.toml` to persist to and reload from, unlike
-    /// `crate::root::focus::palette_focus_tests::open_test_app`'s deliberately unpersisted `None`.
+    /// `crate::test_support::open_test_app`'s deliberately unpersisted `None`.
     ///
     /// Loads real settings from `settings_path` first (via `Settings::load_or_init_at`, the same
     /// real load `crate::root::mod`'s own startup path uses) rather than always constructing with
@@ -6552,7 +6552,7 @@ mod indent_guide_settings_tests {
 /// own measured-bounds technique rather than only reading the render code.
 #[cfg(test)]
 mod settings_keymap_filter_caret_tests {
-    use crate::root::focus::palette_focus_tests;
+    use crate::test_support::open_test_app;
     use gpui::TestAppContext;
     use std::time::Duration;
 
@@ -6561,7 +6561,7 @@ mod settings_keymap_filter_caret_tests {
         cx: &mut TestAppContext,
     ) {
         let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         app.update_in(cx, |app, window, cx| {
             app.open_settings(window, cx);
@@ -6631,7 +6631,7 @@ mod settings_keymap_filter_caret_tests {
         cx: &mut TestAppContext,
     ) {
         let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_settings(window, cx);
             app.settings_page = crate::settings::SettingsPage::General;
@@ -6689,7 +6689,7 @@ mod settings_keymap_filter_caret_tests {
         cx: &mut TestAppContext,
     ) {
         let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         // `on_focus`/`on_blur` (`AdeApp::wire_caret_blink`'s own mechanism) only fire while GPUI
         // considers the window itself "active" - a real, freshly opened test window starts out
         // not active at all.
@@ -6731,7 +6731,7 @@ mod settings_keymap_filter_caret_tests {
 mod keybinding_rebind_tests {
     use super::*;
     use crate::keymap_overrides::BindingIdentity;
-    use crate::root::focus::palette_focus_tests;
+    use crate::test_support::open_test_app;
     use gpui::TestAppContext;
 
     fn open_test_app_with_real_settings_path(
@@ -6889,7 +6889,7 @@ mod keybinding_rebind_tests {
         let repo = tempfile::tempdir().expect("tempdir");
         let file_path = repo.path().join("main.rs");
         std::fs::write(&file_path, "fn main() {}\n").expect("write main.rs");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         app.update_in(cx, |app, window, cx| {
             app.open_file_view(file_path, window, cx);
         });
@@ -6952,7 +6952,7 @@ mod keybinding_rebind_tests {
 #[cfg(test)]
 mod theme_swap_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
+    use crate::test_support::open_test_app;
     use gpui::TestAppContext;
 
     /// `crate::theme::CURRENT_THEME` is real, thread-local, mutable state - reset it after this
@@ -6974,7 +6974,7 @@ mod theme_swap_tests {
     ) {
         let _guard = ResetThemeIndexOnDrop;
         let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         assert!(
             theme::current_theme_palette().is_none(),
@@ -7023,7 +7023,7 @@ mod theme_swap_tests {
     fn follow_system_selects_paper_on_light_and_jerry_dark_on_dark(cx: &mut TestAppContext) {
         let _guard = ResetThemeIndexOnDrop;
         let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, cx| {
             app.apply_follow_system_appearance(gpui::WindowAppearance::Light, cx);
@@ -7060,7 +7060,7 @@ mod theme_swap_tests {
     ) {
         let _guard = ResetThemeIndexOnDrop;
         let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, cx| {
             app.set_theme_name("Slate".to_string(), cx);
@@ -7103,7 +7103,7 @@ mod theme_swap_tests {
     ) {
         let _guard = ResetThemeIndexOnDrop;
         let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         assert!(!app.read_with(cx, |app, _| app.settings.theme.follow_system));
 
         let appearance_before = app.read_with(cx, |_, cx| cx.window_appearance());

--- a/crates/app/src/settings/state.rs
+++ b/crates/app/src/settings/state.rs
@@ -529,6 +529,9 @@ pub struct KeybindingRow {
 pub(crate) fn action_label(action: &dyn gpui::Action) -> Option<&'static str> {
     match action.name() {
         "app::NewAgent" => Some("New agent"),
+        // macOS-only (`cmd-q`, registered in `crate::default_key_bindings`), and the same wording
+        // the application menu's own row uses (`title_bar::menu_model::MenuCommand::Quit`).
+        "app::Quit" => Some("Quit Jerry"),
         "app::TogglePalette" => Some("Command palette"),
         "app::ToggleSettings" => Some("Open settings"),
         "app::GotoDefinition" => Some("Go to definition"),
@@ -1372,65 +1375,6 @@ mod tests {
     }
 
     #[test]
-    fn nav_groups_match_the_documented_2026_07_29_regroup() {
-        let groups = nav_groups();
-        let labels: Vec<&str> = groups.iter().map(|g| g.label).collect();
-        assert_eq!(labels, vec!["Workspace", "Interface", "Editor", "Other"]);
-        assert_eq!(
-            groups[0].pages,
-            vec![
-                SettingsPage::General,
-                SettingsPage::Agents,
-                SettingsPage::Worktrees
-            ]
-        );
-        assert_eq!(
-            groups[1].pages,
-            vec![
-                SettingsPage::Appearance,
-                SettingsPage::Theme,
-                SettingsPage::Keymap
-            ]
-        );
-        assert_eq!(
-            groups[2].pages,
-            vec![SettingsPage::Editor, SettingsPage::LanguageServers]
-        );
-        assert_eq!(
-            groups[3].pages,
-            vec![
-                SettingsPage::Notifications,
-                SettingsPage::Integrations,
-                SettingsPage::About
-            ]
-        );
-    }
-
-    #[test]
-    fn exactly_the_nine_documented_pages_are_implemented() {
-        for page in SettingsPage::ALL {
-            let expected = matches!(
-                page,
-                SettingsPage::General
-                    | SettingsPage::Agents
-                    | SettingsPage::Worktrees
-                    | SettingsPage::Appearance
-                    | SettingsPage::Theme
-                    | SettingsPage::Keymap
-                    | SettingsPage::Editor
-                    | SettingsPage::LanguageServers
-                    | SettingsPage::Notifications
-            );
-            assert_eq!(
-                page.is_implemented(),
-                expected,
-                "{:?} implemented-ness should match the design's documented scope",
-                page.label()
-            );
-        }
-    }
-
-    #[test]
     fn nav_only_pages_share_the_same_honest_placeholder_subtitle() {
         // `About`, not `Notifications`: GitHub issue #226 made Notifications a real, implemented
         // page, so it no longer shows the shared nav-only placeholder text - `About` is still
@@ -1464,47 +1408,38 @@ mod tests {
         assert_eq!(ids.len(), original_len, "duplicate SettingsPage::id()");
     }
 
+    /// One row per `AGENT_KINDS` entry, each carrying its own real resolved path and status -
+    /// the mixed case is the one that matters, since an all-or-nothing bug passes both extremes.
     #[test]
-    fn detect_agent_rows_reports_ready_for_a_resolver_that_finds_the_binary() {
-        let rows = detect_agent_rows(|name| Some(PathBuf::from(format!("/usr/bin/{name}"))));
-        assert_eq!(rows.len(), 2, "one row per AGENT_KINDS entry");
-        assert!(rows.iter().all(|row| row.is_ready()));
-        assert!(rows.iter().all(|row| row.status_label() == "ready"));
-        let claude = rows
+    fn detect_agent_rows_reports_each_binarys_own_real_status() {
+        let all_found = detect_agent_rows(|name| Some(PathBuf::from(format!("/usr/bin/{name}"))));
+        assert_eq!(all_found.len(), 2, "one row per AGENT_KINDS entry");
+        assert!(all_found.iter().all(|row| row.is_ready()));
+        assert!(all_found.iter().all(|row| row.status_label() == "ready"));
+        let claude = all_found
             .iter()
             .find(|row| row.kind == AgentKind::Claude)
             .expect("a Claude row should exist");
         assert_eq!(claude.binary_name, "claude");
         assert_eq!(claude.resolved_path, Some(PathBuf::from("/usr/bin/claude")));
-    }
 
-    #[test]
-    fn detect_agent_rows_reports_not_found_for_a_resolver_that_finds_nothing() {
-        let rows = detect_agent_rows(|_name| None);
-        assert!(rows.iter().all(|row| !row.is_ready()));
-        assert!(rows.iter().all(|row| row.status_label() == "not found"));
-    }
+        let none_found = detect_agent_rows(|_name| None);
+        assert!(none_found.iter().all(|row| !row.is_ready()));
+        assert!(none_found
+            .iter()
+            .all(|row| row.status_label() == "not found"));
 
-    #[test]
-    fn detect_agent_rows_can_report_mixed_real_and_not_found_status() {
-        // Proves the two rows' statuses are independent, not all-or-nothing.
-        let rows = detect_agent_rows(|name| {
-            if name == "claude" {
-                Some(PathBuf::from("/usr/bin/claude"))
-            } else {
-                None
-            }
-        });
-        let claude = rows
-            .iter()
-            .find(|row| row.kind == AgentKind::Claude)
-            .expect("claude row");
-        let codex = rows
-            .iter()
-            .find(|row| row.kind == AgentKind::Codex)
-            .expect("codex row");
-        assert!(claude.is_ready());
-        assert!(!codex.is_ready());
+        let mixed =
+            detect_agent_rows(|name| (name == "claude").then(|| PathBuf::from("/usr/bin/claude")));
+        let ready = |kind| {
+            mixed
+                .iter()
+                .find(|row| row.kind == kind)
+                .expect("a row per kind")
+                .is_ready()
+        };
+        assert!(ready(AgentKind::Claude));
+        assert!(!ready(AgentKind::Codex));
     }
 
     fn note(clean: Option<bool>, merged: bool, is_locked: bool) -> WorktreeNote {
@@ -1520,87 +1455,86 @@ mod tests {
         }
     }
 
+    /// The dot a worktree row paints, over every real note shape. `Prunable` outranks plain
+    /// `Clean`, a main checkout is always `Main` however dirty it is, and a *locked* merged-clean
+    /// worktree is deliberately not prunable - the same rule `WorktreeNote::is_prunable` states,
+    /// which this is a thin reduction of rather than a second implementation.
     #[test]
-    fn worktree_dot_status_main_checkout_is_always_main_regardless_of_note() {
-        let dirty_main = note(Some(false), false, false);
-        assert_eq!(
-            worktree_dot_status(true, &dirty_main),
-            WorktreeDotStatus::Main
-        );
-    }
-
-    #[test]
-    fn worktree_dot_status_prunable_takes_priority_over_plain_clean() {
-        let merged_clean = note(Some(true), true, false);
-        assert_eq!(
-            worktree_dot_status(false, &merged_clean),
-            WorktreeDotStatus::Prunable
-        );
-    }
-
-    #[test]
-    fn worktree_dot_status_dirty_and_clean_and_unknown() {
-        assert_eq!(
-            worktree_dot_status(false, &note(Some(false), false, false)),
-            WorktreeDotStatus::Dirty
-        );
-        assert_eq!(
-            worktree_dot_status(false, &note(Some(true), false, false)),
-            WorktreeDotStatus::Clean
-        );
+    fn worktree_dot_status_reduces_every_real_note_to_its_own_dot() {
         let unknown = WorktreeNote {
             is_main: false,
             clean: None,
             merge: None,
             is_locked: false,
         };
-        assert_eq!(
-            worktree_dot_status(false, &unknown),
-            WorktreeDotStatus::Unknown
-        );
+        for (name, is_main, note, expected) in [
+            (
+                "a dirty main checkout",
+                true,
+                note(Some(false), false, false),
+                WorktreeDotStatus::Main,
+            ),
+            (
+                "merged and clean",
+                false,
+                note(Some(true), true, false),
+                WorktreeDotStatus::Prunable,
+            ),
+            (
+                "dirty",
+                false,
+                note(Some(false), false, false),
+                WorktreeDotStatus::Dirty,
+            ),
+            (
+                "clean but unmerged",
+                false,
+                note(Some(true), false, false),
+                WorktreeDotStatus::Clean,
+            ),
+            ("no note at all", false, unknown, WorktreeDotStatus::Unknown),
+            (
+                "locked, merged and clean",
+                false,
+                note(Some(true), true, true),
+                WorktreeDotStatus::Clean,
+            ),
+        ] {
+            assert_eq!(worktree_dot_status(is_main, &note), expected, "{name}");
+        }
     }
 
     #[test]
-    fn worktree_dot_status_locked_merged_clean_is_not_prunable_matching_worktree_note() {
-        // Mirrors `crate::rail::state`'s own locked-worktree test - this function is a thin reduction
-        // of `WorktreeNote::is_prunable`, not a second implementation of the same rule.
-        let locked = note(Some(true), true, true);
-        assert_eq!(
-            worktree_dot_status(false, &locked),
-            WorktreeDotStatus::Clean
-        );
-    }
-
-    #[test]
-    fn worktree_row_action_main_checkout_has_no_action() {
+    fn worktree_row_action_offers_prune_only_where_pruning_is_real() {
         let main_note = WorktreeNote {
             is_main: true,
             clean: Some(true),
             merge: None,
             is_locked: false,
         };
-        assert_eq!(
-            worktree_row_action(true, &main_note),
-            WorktreeRowAction::None
-        );
-    }
-
-    #[test]
-    fn worktree_row_action_prunable_gets_prune_others_get_open() {
-        let prunable = note(Some(true), true, false);
-        assert_eq!(
-            worktree_row_action(false, &prunable),
-            WorktreeRowAction::Prune
-        );
-
-        let unmerged = note(Some(true), false, false);
-        assert_eq!(
-            worktree_row_action(false, &unmerged),
-            WorktreeRowAction::Open
-        );
-
-        let dirty = note(Some(false), false, false);
-        assert_eq!(worktree_row_action(false, &dirty), WorktreeRowAction::Open);
+        for (name, is_main, note, expected) in [
+            ("a main checkout", true, main_note, WorktreeRowAction::None),
+            (
+                "merged and clean",
+                false,
+                note(Some(true), true, false),
+                WorktreeRowAction::Prune,
+            ),
+            (
+                "clean but unmerged",
+                false,
+                note(Some(true), false, false),
+                WorktreeRowAction::Open,
+            ),
+            (
+                "dirty",
+                false,
+                note(Some(false), false, false),
+                WorktreeRowAction::Open,
+            ),
+        ] {
+            assert_eq!(worktree_row_action(is_main, &note), expected, "{name}");
+        }
     }
 
     #[test]
@@ -1772,19 +1706,33 @@ mod tests {
             .all(|language| language.binary == "synthetic-binary"));
     }
 
+    /// One row per registered language, each carrying its own real status - the mixed case is
+    /// the one that matters, since an all-or-nothing bug passes both extremes.
     #[test]
-    fn detect_lsp_rows_reports_ready_for_a_resolver_that_finds_every_binary() {
-        let rows = detect_lsp_rows(|name| Some(PathBuf::from(format!("/usr/bin/{name}"))));
-        assert_eq!(rows.len(), lsp_languages().len());
-        assert!(rows.iter().all(|row| row.is_ready()));
-        assert!(rows.iter().all(|row| row.status_label() == "ready"));
-    }
+    fn detect_lsp_rows_reports_each_binarys_own_real_status() {
+        let all_found = detect_lsp_rows(|name| Some(PathBuf::from(format!("/usr/bin/{name}"))));
+        assert_eq!(all_found.len(), lsp_languages().len());
+        assert!(all_found.iter().all(|row| row.is_ready()));
+        assert!(all_found.iter().all(|row| row.status_label() == "ready"));
 
-    #[test]
-    fn detect_lsp_rows_reports_not_installed_for_a_resolver_that_finds_nothing() {
-        let rows = detect_lsp_rows(|_| None);
-        assert!(rows.iter().all(|row| !row.is_ready()));
-        assert!(rows.iter().all(|row| row.status_label() == "not installed"));
+        let none_found = detect_lsp_rows(|_| None);
+        assert!(none_found.iter().all(|row| !row.is_ready()));
+        assert!(none_found
+            .iter()
+            .all(|row| row.status_label() == "not installed"));
+
+        let mixed = detect_lsp_rows(|name| {
+            (name == "rust-analyzer").then(|| PathBuf::from("/usr/bin/rust-analyzer"))
+        });
+        let ready = |language| {
+            mixed
+                .iter()
+                .find(|row| row.language == language)
+                .unwrap_or_else(|| panic!("a {language} row should exist"))
+                .is_ready()
+        };
+        assert!(ready("Rust"));
+        assert!(!ready("Go"));
     }
 
     /// Proves [`detect_lsp_rows`] carries the real install URL straight through from
@@ -1808,27 +1756,6 @@ mod tests {
             rust.install_url,
             "https://rust-analyzer.github.io/book/rust_analyzer_binary.html"
         );
-    }
-
-    #[test]
-    fn detect_lsp_rows_can_report_mixed_real_and_not_installed_status() {
-        let rows = detect_lsp_rows(|name| {
-            if name == "rust-analyzer" {
-                Some(PathBuf::from("/usr/bin/rust-analyzer"))
-            } else {
-                None
-            }
-        });
-        let rust = rows
-            .iter()
-            .find(|row| row.language == "Rust")
-            .expect("a Rust row should exist");
-        let go = rows
-            .iter()
-            .find(|row| row.language == "Go")
-            .expect("a Go row should exist");
-        assert!(rust.is_ready());
-        assert!(!go.is_ready());
     }
 
     #[test]
@@ -1877,301 +1804,44 @@ mod tests {
         }
     }
 
+    /// The keystroke-swallowing bug class this page's rows exist to make visible: a binding that
+    /// claims a plain letter or a bare `Ctrl+C` *globally* eats that keystroke out of a focused
+    /// terminal or text field. Each command below is registered with a real context predicate for
+    /// that reason, so each must report as scoped rather than global.
     #[test]
-    fn keybinding_rows_are_derived_in_real_registration_order() {
-        let bindings = crate::default_key_bindings();
-        let rows = keybinding_rows(&bindings, &[]);
-        let commands: Vec<&str> = rows.iter().map(|row| row.command).collect();
-        assert_eq!(
-            commands,
-            vec![
-                "New agent",
-                "Command palette",
-                "Open settings",
-                "Text: undo",
-                "Text: redo",
-                "Text: redo",
-                "Text: copy selection",
-                "Text: cut selection",
-                "Text: paste",
-                "Text: select all",
-                "Go to definition",
-                "New terminal",
-                "New agent pane",
-                "Open git graph",
-                "Search in this worktree",
-                "Find in this file",
-                "Next changed file",
-                "Mark file seen / unseen",
-                "Stage / unstage file",
-                "Jump to agent 1",
-                "Jump to agent 2",
-                "Jump to agent 3",
-                "Jump to agent 4",
-                "Jump to agent 5",
-                "Jump to agent 6",
-                "Jump to agent 7",
-                "Jump to agent 8",
-                "Editor: delete backward",
-                "Editor: delete forward",
-                "Editor: insert newline",
-                "Editor: move left",
-                "Editor: move right",
-                "Editor: move up",
-                "Editor: move down",
-                "Editor: extend selection left",
-                "Editor: extend selection right",
-                "Editor: extend selection up",
-                "Editor: extend selection down",
-                // GitHub issue #27's "Ctrl+Shift+arrows (word-wise)".
-                "Editor: move left one word",
-                "Editor: move right one word",
-                "Editor: extend selection left one word",
-                "Editor: extend selection right one word",
-                "Editor: go to line start",
-                "Editor: go to line end",
-                "Editor: select all",
-                "Editor: copy",
-                "Editor: cut",
-                "Editor: paste",
-                "Editor: save file",
-                "Editor: save file (overwrite external change)",
-                // Multi-cursor (Revision R13, issue #28): Ctrl+D/Ctrl+Shift+L/Ctrl+K Ctrl+D.
-                "Editor: select next occurrence",
-                "Editor: select all occurrences",
-                "Editor: skip occurrence",
-                // GitHub issue #26's real Tab/Shift+Tab indentation, scoped
-                // `"file-editor && !completions"` - see `crate::default_key_bindings`'s own docs
-                // for why `Tab` no longer falls through to plain-text insertion here.
-                "Editor: indent",
-                "Editor: dedent",
-                // `Escape` here is `EditorCollapseCursors`, not a separate `EditorEscape` - it
-                // composes GitHub issue #28's own multi-cursor collapse with issue #26's
-                // accessibility focus-out hatch, since only one binding can genuinely own the
-                // File view's plain `Escape` at equal context depth (see `crate::code_surface::
-                // editing::AdeApp::handle_editor_collapse_cursors_action`'s own docs).
-                "Editor: collapse cursors",
-                "Completions: select previous",
-                "Completions: select next",
-                "Completions: accept selected",
-                "Completions: accept selected",
-                "Completions: dismiss",
-                // GitHub issue #26's manual completion trigger/refresh, scoped plain
-                // `"file-editor"` (fires whether the popup is open or closed).
-                "Completions: trigger",
-                // Revision R8.5c's `"merge-editor"`-scoped bindings for Surface D's merge
-                // hand-edit whole-file editor - the same real `Editor*` action *types*/labels as
-                // the `"file-editor"` set above (reused, not duplicated - see
-                // `crate::code_surface::editing::AdeApp::active_edit_target`'s own docs), minus
-                // `EditorSaveAnyway` (deliberately never bound here - there is no
-                // external-change-conflict concept for a merge hand-edit buffer) and minus every
-                // `Completions*` binding (no completions popup is ever wired up for this
-                // surface).
-                "Editor: delete backward",
-                "Editor: delete forward",
-                "Editor: insert newline",
-                "Editor: move left",
-                "Editor: move right",
-                "Editor: move up",
-                "Editor: move down",
-                "Editor: extend selection left",
-                "Editor: extend selection right",
-                "Editor: extend selection up",
-                "Editor: extend selection down",
-                "Editor: move left one word",
-                "Editor: move right one word",
-                "Editor: extend selection left one word",
-                "Editor: extend selection right one word",
-                "Editor: go to line start",
-                "Editor: go to line end",
-                "Editor: select all",
-                "Editor: copy",
-                "Editor: cut",
-                "Editor: paste",
-                "Editor: save file",
-                // The same GitHub issue #26 indent/dedent/escape bindings, mirrored here for the
-                // merge hand-edit target - scoped plain `"merge-editor"` (no completions popup
-                // exists for this surface, so there's no `!completions` narrowing to mirror).
-                "Editor: indent",
-                "Editor: dedent",
-                "Editor: move focus out",
-                // GitHub issue #19's file-tree bindings, each scoped to
-                // `"file-tree && !tree-editing"` - see `crate::default_key_bindings`' own docs
-                // and `crate::sidebar::tree_ops`' module docs for why both halves of that
-                // predicate are load-bearing.
-                "Files tree: rename",
-                "Files tree: copy",
-                "Files tree: cut",
-                "Files tree: paste",
-                // GitHub issue #105's `Delete` (runs immediately, no confirmation) and its own
-                // real undo/redo, `Ctrl+Z`/`Ctrl+Shift+Z` - distinct actions from `TextUndo`/
-                // `TextRedo`, scoped the same `"file-tree && !tree-editing"` as every binding
-                // above.
-                "Files tree: delete",
-                "Files tree: undo",
-                "Files tree: redo",
-                // GitHub issue #26's `Ctrl+W` - closes the focused tab, scoped `Some("!terminal")`.
-                "Close focused tab",
-                // GitHub issue #20's terminal footer `clear`, scoped `Some("terminal")`.
-                "Terminal: clear",
-                // GitHub issue #158's terminal copy/paste, both scoped `Some("terminal")`.
-                "Terminal: copy selection",
-                "Terminal: paste",
-                // GitHub issue #304's interactive-rebase plan verbs, scoped
-                // `Some("rebase-plan && !text-input")` (and plain `Some("rebase-plan")` for the
-                // last) - the real bindings behind design spec §1.4's footer keycap hints.
-                "Rebase plan: move row up",
-                "Rebase plan: move row down",
-                "Rebase plan: pick",
-                "Rebase plan: squash",
-                "Rebase plan: drop",
-                "Rebase plan: start rebase",
-                "Diff: send review notes to the agent",
-                "Diff: note on this line",
-            ]
-        );
-    }
-
-    #[test]
-    fn keybinding_rows_report_the_real_global_context_for_every_default_binding() {
-        // Regression coverage for the bug this replaced: a hand-copied list once labeled
-        // `Go to definition` `context: "editor"` even though it's actually registered global.
-        //
-        // Revision R8.5a added a second real scoped context (`"file-editor"`, the real File
-        // view text-editing actions) alongside the pre-existing `"diff"` one (`]` ->
-        // `NextChangedFile`) - both are deliberately non-global for the same real reason
-        // (swallowing ordinary keystrokes in a focused terminal agent), so the scoped count
-        // grew from 1 to 1 + 19 real `Editor*` bindings (a fix round added `EditorSaveAnyway`,
-        // the real escape hatch for a permanently-stuck `AdeApp::file_external_conflict`). A
-        // later fix round changed `]`'s own registered predicate from `Some("diff")` to
-        // `Some("diff && !file-editor")` (a real, live-reproduced bug: since `"file-editor"` is
-        // *added onto* the same node's context rather than replacing `"diff"`, the bare
-        // `"diff"` predicate kept matching - and kept swallowing a literal `]` keystroke - even
-        // while a file was actively being edited) - `KeybindingRow::context` only ever reports
-        // the coarse `"global"`/`"scoped"` distinction (see its own docs), so that predicate
-        // change doesn't move this test's own counts, but `]` is still exactly as "scoped" as
-        // before. Revision R8.5b added 5 more real scoped bindings for the Completions popup
-        // (`CompletionsUp`/`CompletionsDown`/`CompletionsDismiss`, plus `CompletionsAccept`
-        // bound twice - `tab` and `enter`), each `Some("file-editor && completions")`.
-        // Revision R8.5c added 18 more real scoped bindings for Surface D's merge hand-edit
-        // whole-file editor, each `Some("merge-editor")` - the same 18 `Editor*` actions as the
-        // `"file-editor"` set minus `EditorSaveAnyway` (see
-        // `keybinding_rows_are_derived_in_real_registration_order`'s own updated expectations
-        // for exactly which).
-        // GitHub issue #17 added 3 more real scoped bindings, `TextUndo` (`secondary-z`) and
-        // `TextRedo` (bound twice - `secondary-shift-z` and `ctrl-y`), each `Some("text-input")`:
-        // `secondary-z` resolves to plain `Ctrl+Z` on Linux/Windows, which a focused terminal
-        // needs unclaimed to send the real `SIGTSTP` suspend control byte
-        // (`crate::terminal::pane::keystroke_to_bytes`) - see `crate::default_key_bindings`'s own
-        // docs for the full reasoning.
-        // GitHub issue #27 added 8 more real scoped bindings: `EditorWordLeft`/`EditorWordRight`/
-        // `EditorSelectWordLeft`/`EditorSelectWordRight`, each bound once under `"file-editor"`
-        // and once under `"merge-editor"` - the same word-wise-caret-navigation set both real
-        // editors share, matching every other `Editor*` action's own dual registration.
-        // Revision R13 (issue #28) added 4 more real scoped bindings, all File-view-only
-        // (`crate::merge::editing`'s `"merge-editor"` context deliberately does not get these):
-        // `EditorSelectNextOccurrence` (`Ctrl+D`), `EditorSelectAllOccurrences` (`Ctrl+Shift+L`),
-        // `EditorSkipOccurrence` (`Ctrl+K Ctrl+D`, all three `Some("file-editor")`), and
-        // `EditorCollapseCursors` (`Esc`, `Some("file-editor && !completions")` - narrowed rather
-        // than the other three's bare `"file-editor"` because GitHub issue #26 also wants the
-        // File view's plain `Escape` for its own accessibility focus-out hatch, and only one
-        // binding can genuinely own a keystroke at equal context depth; see `crate::
-        // code_surface::editing::AdeApp::handle_editor_collapse_cursors_action`'s own docs for how
-        // it composes both real behaviors from this one binding rather than a separate
-        // `EditorEscape` shadowing or being shadowed by it).
-        // GitHub issue #26 added 7 more real scoped bindings on top of that (not counting
-        // `EditorCollapseCursors` above, which is issue #28's own action): `EditorIndent`/
-        // `EditorDedent` under `"file-editor && !completions"` (2), the same two again plus
-        // `EditorEscape` under plain `"merge-editor"` (3, `EditorEscape` here since
-        // `"merge-editor"` never gets multi-cursor actions and so never faces the same collision
-        // `EditorCollapseCursors` resolves in the File view), `CompletionsInvoke` under plain
-        // `"file-editor"` (1), and `CloseFocusedTab` under `Some("!terminal")` (1, the same real
-        // terminal-control-byte conflict class `"ctrl-shift-t"` above already established).
-        // GitHub issue #105 added 3 more real scoped bindings: `FileTreeDelete` (`Delete`, runs
-        // immediately - no confirmation step, so no different scoping from Copy/Cut/Paste/Rename
-        // above it) and its own `FileTreeUndo`/`FileTreeRedo` (`Ctrl+Z`/`Ctrl+Shift+Z`) - distinct
-        // actions from `TextUndo`/`TextRedo`, all three `Some("file-tree && !tree-editing")`.
-        // GitHub issue #20 added 1 more real scoped binding: `TerminalClear`
-        // (`cmd-k`/`ctrl-shift-l`), `Some("terminal")`.
-        // GitHub issue #155 removed 1: `FileTreeContextMenu` (`Shift+F10`) - right-click plus
-        // each row's own already-bound shortcut covers the same ground, so a second
-        // keyboard-only path to the menu had no real justification of its own.
-        // GitHub issue #158 added 2 more real scoped bindings: `TerminalCopy`/`TerminalPaste`
-        // (`cmd-c`/`cmd-v` on macOS, `ctrl-shift-c`/`ctrl-shift-v` elsewhere), both
-        // `Some("terminal")` - see `crate::default_key_bindings`'s own entry for why the shifted
-        // variants, and why leaving them unbound was the bug.
-        // GitHub issue #286 added 1 more real scoped binding: `v` -> `ToggleChangeSeen`, under
-        // the same `Some("diff && !file-editor")` predicate `]` carries and for the same reason -
-        // a plain letter must never be claimed over a focused terminal, and the seen-state it
-        // toggles belongs to the file whose diff is open.
-        // GitHub issue #304 added 6 more real scoped bindings: the interactive-rebase plan's own
-        // `RebaseReorderUp`/`RebaseReorderDown`/`RebasePickRow`/`RebaseSquashRow`/`RebaseDropRow`
-        // under `Some("rebase-plan && !text-input")` (5 - see `crate::default_key_bindings` for
-        // why the negated conjunct is load-bearing over a surface that contains a real text
-        // field) and `RebaseStart` under plain `Some("rebase-plan")` (1).
-        // GitHub issue #288 added 2 more real scoped bindings, on the diff's own review-notes
-        // surface: `SendReviewNotes` (`mod+enter`) under plain `Some("diff-view")` - the notes
-        // bar draws it as keycaps, and having just typed a note is the likeliest moment to send
-        // the batch - and `ToggleLineNote` (`c`) under `Some("diff-view && !text-input")`, the
-        // same negated conjunct and the same reason as the rebase plan's plain letters above:
-        // the pinned note card is a real text field inside that very container.
-        // GitHub issue #162 added 1 more scoped binding: `mod+F` -> `FindInFile` under
-        // `Some("file-editor")`. Its sibling `mod+shift+F` -> `SearchInWorktree` is deliberately
-        // *global* and so is not counted here - the right panel's Search tab has no editor to be
-        // scoped to, and a real Cmd/Ctrl-modified keystroke never reaches a focused pty anyway.
-        // The Changes-footer prose fix added 1 more: `space` -> `ToggleChangeStaged`, alongside
-        // `v` and `]` - `Jerry.dc.html`'s `changesHints` advertises `space stage` in that footer
-        // and nothing was bound to it. All three of those now also carry `&& !text-input`, since
-        // issue #288's pinned note card is a real text input *inside* the `"diff"` node that
-        // `"file-editor"` does not cover.
-        // GitHub issue #336 added 4 more scoped bindings: `TextCopy`/`TextCut`/`TextPaste`/
-        // `TextSelectAll` (`mod+C`/`mod+X`/`mod+V`/`mod+A`) under
-        // `Some("text-input && !file-editor && !merge-editor")` - the same `"text-input"` tag
-        // `TextUndo`/`TextRedo` above carry, with the two editor surfaces excluded because their
-        // own `Editor*` actions already own those exact keystrokes there at the same predicate
-        // depth (see `crate::default_key_bindings`' own entry).
-        let bindings = crate::default_key_bindings();
-        let rows = keybinding_rows(&bindings, &[]);
-        assert!(!rows.is_empty());
-        let scoped: Vec<&KeybindingRow> =
-            rows.iter().filter(|row| row.context != "global").collect();
-        assert_eq!(
-            scoped.len(),
-            90,
-            "expected `] -> NextChangedFile` (1) plus every real Editor* binding (19) plus \
-             every real Completions* binding (5) plus every real merge-editor binding (18) plus \
-             TextUndo/TextRedo (3, GitHub issue #17) plus every real \
-             file-tree binding (7, GitHub issues #19 and #105, less 1 for issue #155's removed \
-             FileTreeContextMenu) plus every real word-wise Editor* \
-             binding (8, GitHub issue #27) plus every real multi-cursor Editor* binding (4, \
-             GitHub issue #28) plus every real GitHub issue #26 binding (7, not counting \
-             EditorCollapseCursors above, which is issue #28's own action) plus TerminalClear \
-             (1, GitHub issue #20) plus TerminalCopy/TerminalPaste (2, GitHub issue #158) plus \
-             every real interactive-rebase plan binding (6, GitHub issue #304) plus every \
-             real review-note binding (2, GitHub issue #288) plus `space -> \
-             ToggleChangeStaged` (1, the Changes footer's own `space stage` hint) plus \
-             `mod+F -> FindInFile` (1, GitHub issue #162's in-file find) plus \
-             TextCopy/TextCut/TextPaste/TextSelectAll (4, GitHub issue #336) to be scoped, \
-             not global"
-        );
+    fn every_binding_registered_behind_a_context_is_reported_as_scoped_not_global() {
+        let rows = keymap_page_rows();
+        let scoped: Vec<&str> = rows
+            .iter()
+            .filter(|row| row.context != "global")
+            .map(|row| row.command)
+            .collect();
         assert!(
-            scoped
-                .iter()
-                .filter(|row| row.command.starts_with("Files tree: "))
-                .count()
-                == 7,
-            "every file-tree binding must be reported as scoped - a globally-bound Ctrl+C would \
-             be exactly the keystroke-swallowing bug class this list's own docs catalogue"
+            !scoped.is_empty(),
+            "premise: some bindings really are scoped"
         );
-        assert!(
-            scoped.iter().any(|row| row.command == "Next changed file"),
-            "the diff-scoped (now diff && !file-editor) ] binding must still be reported as \
-             scoped"
-        );
-        assert!(
-            scoped.iter().any(|row| row.command == "Editor: save file"),
-            "a real file-editor-scoped binding must be reported as scoped too"
-        );
+        for command in [
+            "Files tree: rename",
+            "Files tree: copy",
+            "Files tree: cut",
+            "Files tree: paste",
+            "Files tree: delete",
+            "Next changed file",
+            "Mark file seen / unseen",
+            "Stage / unstage file",
+            "Editor: save file",
+            "Completions: accept selected",
+            "Terminal: clear",
+            "Terminal: copy selection",
+            "Rebase plan: pick",
+            "Diff: note on this line",
+        ] {
+            assert!(
+                scoped.contains(&command),
+                "{command:?} must be reported as scoped - a global binding for it would swallow \
+                 that keystroke out of a focused terminal or text field"
+            );
+        }
     }
 
     #[test]

--- a/crates/app/src/settings/store.rs
+++ b/crates/app/src/settings/store.rs
@@ -1446,6 +1446,10 @@ mod tests {
         );
     }
 
+    /// Save then load has to be the identity on every field a user can change - a field that
+    /// silently reverts to its default on the next launch is not a real setting. Asserted as a
+    /// whole-value equality rather than field by field, so a newly added field is covered here
+    /// the moment it is mutated below.
     #[test]
     fn a_settings_value_round_trips_through_real_toml_save_and_load() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -1455,6 +1459,10 @@ mod tests {
         settings.window.controls = WindowControlsStyle::MacosStyle;
         settings.appearance.interface_scale_percent = 125;
         settings.appearance.editor_font_size = 15.5;
+        assert!(
+            settings.appearance.show_indent_guides,
+            "premise: the real default is guides on, so `false` below is a real change"
+        );
         settings.appearance.show_indent_guides = false;
         settings.theme.name = "Slate".to_string();
         settings.theme.high_contrast_diff = true;
@@ -1465,34 +1473,6 @@ mod tests {
         assert_eq!(settings, loaded);
     }
 
-    /// GitHub issue #122's `show_indent_guides` toggle, round-tripped through real TOML
-    /// save/load exactly like [`a_settings_value_round_trips_through_real_toml_save_and_load`]
-    /// above covers several other `AppearanceSettings` fields - a dedicated test so a future
-    /// change to that shared fixture can't silently stop covering this one field.
-    #[test]
-    fn show_indent_guides_round_trips_through_real_toml_save_and_load() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("settings.toml");
-
-        assert!(
-            Settings::default().appearance.show_indent_guides,
-            "sanity check: the real default is guides on"
-        );
-
-        let mut settings = Settings::default();
-        settings.appearance.show_indent_guides = false;
-        settings.save_at(&path).expect("save should succeed");
-        let loaded = Settings::load_or_init_at(&path);
-
-        assert_eq!(settings, loaded);
-        assert!(!loaded.appearance.show_indent_guides);
-    }
-
-    /// GitHub issue #168's `bracket_pair_colorization` toggle, round-tripped through real TOML
-    /// save/load - same dedicated-test discipline as [`show_indent_guides_round_trips_through_real_toml_save_and_load`]
-    /// above, and additionally pinning that a file written *before* this key existed still loads
-    /// with the feature on. That backward-compatibility case is the one that matters here: this
-    /// shipped enabled, so a missing key has to mean "on", never "off".
     #[test]
     fn bracket_pair_colorization_round_trips_and_defaults_on_for_an_older_file() {
         let dir = tempfile::tempdir().expect("tempdir");

--- a/crates/app/src/settings/widgets.rs
+++ b/crates/app/src/settings/widgets.rs
@@ -693,84 +693,42 @@ impl ChoiceOption {
 #[cfg(test)]
 mod open_command_tests {
     use super::open_command_for;
-    use std::ffi::OsString;
+    use std::ffi::{OsStr, OsString};
     use std::path::Path;
 
     fn os_strings(values: &[&str]) -> Vec<OsString> {
         values.iter().map(OsString::from).collect()
     }
 
+    /// Every platform's real command, for both target shapes this is genuinely reused for: a
+    /// local settings path, and the Language servers page's `https://` install URL
+    /// (`AdeApp::open_install_url`). An unrecognized OS falls back to `xdg-open` rather than
+    /// failing.
+    ///
+    /// Windows' empty-string argument is load-bearing, not incidental - see
+    /// [`open_command_for`]'s own docs: without it, `start` treats the target itself as its
+    /// window-title argument.
     #[test]
-    fn macos_uses_the_real_open_command() {
-        let (program, args) =
-            open_command_for("macos", Path::new("/home/x/settings.toml").as_os_str());
-        assert_eq!(program, "open");
-        assert_eq!(args, os_strings(&["/home/x/settings.toml"]));
-    }
-
-    #[test]
-    fn windows_uses_cmd_start_with_a_required_empty_title_argument() {
-        let (program, args) = open_command_for(
-            "windows",
+    fn every_platform_opens_every_real_target_with_its_own_command() {
+        const URL: &str = "https://rust-analyzer.github.io/book/rust_analyzer_binary.html";
+        for target in [
+            Path::new("/home/x/settings.toml").as_os_str(),
             Path::new(r"C:\Users\x\settings.toml").as_os_str(),
-        );
-        assert_eq!(program, "cmd");
-        // The empty string is load-bearing, not incidental - see `open_command_for`'s docs:
-        // without it, `start` would treat the path itself as its window-title argument.
-        assert_eq!(
-            args,
-            os_strings(&["/c", "start", "", r"C:\Users\x\settings.toml"])
-        );
-    }
-
-    #[test]
-    fn linux_uses_the_real_xdg_open_command() {
-        let (program, args) =
-            open_command_for("linux", Path::new("/home/x/settings.toml").as_os_str());
-        assert_eq!(program, "xdg-open");
-        assert_eq!(args, os_strings(&["/home/x/settings.toml"]));
-    }
-
-    #[test]
-    fn an_unrecognized_target_os_falls_back_to_xdg_open() {
-        let (program, _) = open_command_for("freebsd", Path::new("/x").as_os_str());
-        assert_eq!(program, "xdg-open");
-    }
-
-    /// [`open_command_for`] is genuinely reused for a URL target too (the Language servers
-    /// page's `Install` action, `AdeApp::open_install_url`), not just a local file path - proves
-    /// the same three real per-platform commands work unchanged for an `https://` target on
-    /// every platform R11 already verified, matching this test module's own established
-    /// pattern.
-    #[test]
-    fn every_platform_command_works_unchanged_for_a_real_url_target() {
-        let url =
-            std::ffi::OsStr::new("https://rust-analyzer.github.io/book/rust_analyzer_binary.html");
-
-        let (program, args) = open_command_for("macos", url);
-        assert_eq!(program, "open");
-        assert_eq!(
-            args,
-            os_strings(&["https://rust-analyzer.github.io/book/rust_analyzer_binary.html"])
-        );
-
-        let (program, args) = open_command_for("windows", url);
-        assert_eq!(program, "cmd");
-        assert_eq!(
-            args,
-            os_strings(&[
-                "/c",
-                "start",
-                "",
-                "https://rust-analyzer.github.io/book/rust_analyzer_binary.html"
-            ])
-        );
-
-        let (program, args) = open_command_for("linux", url);
-        assert_eq!(program, "xdg-open");
-        assert_eq!(
-            args,
-            os_strings(&["https://rust-analyzer.github.io/book/rust_analyzer_binary.html"])
-        );
+            OsStr::new(URL),
+        ] {
+            let raw = target.to_string_lossy().into_owned();
+            for (os, program, args) in [
+                ("macos", "open", os_strings(&[&raw])),
+                ("windows", "cmd", os_strings(&["/c", "start", "", &raw])),
+                ("linux", "xdg-open", os_strings(&[&raw])),
+                ("freebsd", "xdg-open", os_strings(&[&raw])),
+            ] {
+                assert_eq!(
+                    open_command_for(os, target),
+                    (program, args),
+                    "{os} / {raw}"
+                );
+            }
+        }
     }
 }

--- a/crates/app/src/theme.rs
+++ b/crates/app/src/theme.rs
@@ -3794,36 +3794,21 @@ mod lang_token_tests {
         same(a.0.resolve(), b.0.resolve()) && same(a.1.resolve(), b.1.resolve())
     }
 
+    /// The four language chips design spec D pins by hex. The rest of the chips are checked only
+    /// for distinctness, below - the spec names these four.
     #[test]
-    fn ts_matches_the_real_spec_d_hex_pair() {
-        assert!(same_pair(
-            lang::TS,
-            (rgba_from_u32(0x6b9bd1), rgba_from_u32(0x1b2838))
-        ));
-    }
-
-    #[test]
-    fn vue_matches_the_real_spec_d_hex_pair() {
-        assert!(same_pair(
-            lang::VUE,
-            (rgba_from_u32(0x5cb87f), rgba_from_u32(0x16261e))
-        ));
-    }
-
-    #[test]
-    fn py_matches_the_real_spec_d_hex_pair() {
-        assert!(same_pair(
-            lang::PY,
-            (rgba_from_u32(0xc9b04a), rgba_from_u32(0x2a2612))
-        ));
-    }
-
-    #[test]
-    fn go_matches_the_real_spec_d_hex_pair() {
-        assert!(same_pair(
-            lang::GO,
-            (rgba_from_u32(0x5fa8c4), rgba_from_u32(0x152730))
-        ));
+    fn every_spec_pinned_lang_chip_still_carries_its_spec_hex_pair() {
+        for (name, chip, foreground, background) in [
+            ("ts", lang::TS, 0x6b9bd1, 0x1b2838),
+            ("vue", lang::VUE, 0x5cb87f, 0x16261e),
+            ("py", lang::PY, 0xc9b04a, 0x2a2612),
+            ("go", lang::GO, 0x5fa8c4, 0x152730),
+        ] {
+            assert!(
+                same_pair(chip, (rgba_from_u32(foreground), rgba_from_u32(background))),
+                "{name}'s chip no longer matches its spec hex pair"
+            );
+        }
     }
 
     #[test]
@@ -3864,29 +3849,13 @@ mod ui_scale_tests {
     use super::ui_scale::scaled_px;
 
     #[test]
-    fn one_hundred_percent_is_a_real_no_op() {
-        assert_eq!(scaled_px(12.0, 100), px(12.0));
-    }
-
-    #[test]
-    fn scales_up_and_down_proportionally() {
-        // `125`/`50` (not e.g. `90`) so the expected value is exactly representable in `f32`
-        // and this stays an exact-equality check rather than needing an epsilon comparison.
-        assert_eq!(scaled_px(12.0, 125), px(15.0));
-        assert_eq!(scaled_px(12.0, 50), px(6.0));
+    fn ui_scale_scales_proportionally_and_leaves_one_hundred_percent_alone() {
+        for (percent, expected) in [(100, 12.0), (150, 18.0), (50, 6.0)] {
+            assert_eq!(scaled_px(12.0, percent), px(expected), "at {percent}%");
+        }
     }
 }
 
-/// Real, source-parsing coverage that [`TOKEN_GROUPS`] is honestly *total* - the property every
-/// other piece of this rewrite depends on. The registry is what theme-file key validation
-/// (`crate::settings::custom_theme`), the built-in theme generator
-/// (`crate::settings::builtin_themes`) and the "generate from colour" action all walk, so a token
-/// that exists in this file but not in the registry would be a colour no theme could ever change
-/// *and* one no generated file would ever mention - silently, with nothing else failing.
-///
-/// Reflection can't see `const` declarations, so these tests read this module's own real source
-/// (`include_str!("theme.rs")` - the literal file being compiled, not a copy) and compare what it
-/// declares against what the registry lists.
 #[cfg(test)]
 mod token_registry_tests {
     use super::*;
@@ -4821,23 +4790,6 @@ mod syntax_contrast_tests {
             .collect()
     }
 
-    #[test]
-    fn every_syntax_token_clears_a_real_contrast_floor_in_jerry_dark_and_paper() {
-        const MIN_RATIO: f32 = 2.5;
-        for name in ["Jerry Dark", "Paper"] {
-            let _guard = with_bundled_theme(name);
-            let background = surface::CENTER.resolve();
-            for (key, token) in syntax_tokens() {
-                let ratio = contrast_ratio(token.resolve(), background);
-                assert!(
-                    ratio >= MIN_RATIO,
-                    "{key} only reaches {ratio:.2}:1 against surface::CENTER in {name} - below \
-                     the real {MIN_RATIO}:1 floor"
-                );
-            }
-        }
-    }
-
     /// The sidebar strip's one structural invariant, in every bundled theme (GitHub issue #291).
     ///
     /// `design_handoff_jerry_ade/revision 5/STAGE-A-CHANGELOG.md` §4v: "a tab only reads as
@@ -4882,18 +4834,27 @@ mod syntax_contrast_tests {
         }
     }
 
+    /// Two floors, because `Jerry Dark` and `Paper` are the two palettes actually authored - the
+    /// other four are mechanical `derive_shift` transforms and are held to a looser bound so a
+    /// derivation artifact does not read as a palette defect.
     #[test]
-    fn every_syntax_token_clears_a_looser_floor_across_every_bundled_theme() {
+    fn every_syntax_token_clears_its_themes_own_contrast_floor() {
+        const MIN_RATIO_AUTHORED: f32 = 2.5;
         const MIN_RATIO: f32 = 1.5;
         for def in crate::settings::state::THEME_DEFS.iter() {
             let _guard = with_bundled_theme(def.name);
+            let min_ratio = if matches!(def.name, "Jerry Dark" | "Paper") {
+                MIN_RATIO_AUTHORED
+            } else {
+                MIN_RATIO
+            };
             let background = surface::CENTER.resolve();
             for (key, token) in syntax_tokens() {
                 let ratio = contrast_ratio(token.resolve(), background);
                 assert!(
-                    ratio >= MIN_RATIO,
+                    ratio >= min_ratio,
                     "{key} only reaches {ratio:.2}:1 against surface::CENTER in {} - below the \
-                     real {MIN_RATIO}:1 floor",
+                     real {min_ratio}:1 floor",
                     def.name
                 );
             }
@@ -4974,42 +4935,15 @@ mod syntax_bracket_ring_tests {
     }
 
     /// The whole point of the feature: two nesting levels a reader is comparing must not look
-    /// alike. Cyclically adjacent (depth `n` against `n + 1`) is the pair that matters most, since
-    /// those two nest directly inside one another.
-    #[test]
-    fn cyclically_adjacent_ring_colours_stay_far_apart_in_every_bundled_theme() {
-        // Lower again than the ring this replaced, and for the same *kind* of reason it was
-        // lowered once before: ΔE is bought with chroma, and the redesign's ring is deliberately
-        // held below the palette's accents in chroma (that is the spec - a bracket must never
-        // shout louder than a string). Six hues at one lightness and one low chroma have a
-        // mathematical ceiling on how far apart they can be, and 18 is set from what a reader
-        // needs - ~8x the ~2.3 just-noticeable difference - not from what an optimiser can reach.
-        // Real measured worst case across every bundled theme: 20.7.
-        const MIN_DELTA_E: f32 = 18.0;
-        for def in crate::settings::state::THEME_DEFS.iter() {
-            let _guard = with_bundled_theme(def.name);
-            let ring = ring_tokens();
-            for index in 0..ring.len() {
-                let (name_a, token_a) = ring[index];
-                let (name_b, token_b) = ring[(index + 1) % ring.len()];
-                let distance = delta_e(token_a.resolve(), token_b.resolve());
-                assert!(
-                    distance >= MIN_DELTA_E,
-                    "{name_a} and {name_b} are adjacent depths but only ΔE {distance:.1} apart in \
-                     {} - a reader could not tell one nesting level from the next",
-                    def.name
-                );
-            }
-        }
-    }
-
-    /// Non-adjacent depths matter too, just less: six levels of nesting has to stay legible, not
-    /// merely three.
+    /// alike. Every pair, not only the cyclically adjacent ones - six levels of nesting has to
+    /// stay legible, not merely three.
     #[test]
     fn no_two_ring_colours_collide_in_any_bundled_theme() {
-        // With six hues evenly spaced at one lightness and one chroma, the nearest pair *is* an
-        // adjacent pair, so this floor is the same one - see above for why it is what it is. Real
-        // measured worst case: 20.7.
+        // ΔE is bought with chroma, and this ring is deliberately held below the palette's accents
+        // in chroma (a bracket must never shout louder than a string). Six hues at one lightness
+        // and one low chroma have a mathematical ceiling on how far apart they can be, so 18 is
+        // set from what a reader needs - ~8x the ~2.3 just-noticeable difference - not from what
+        // an optimiser can reach. Real measured worst case across every bundled theme: 20.7.
         const MIN_DELTA_E: f32 = 18.0;
         for def in crate::settings::state::THEME_DEFS.iter() {
             let _guard = with_bundled_theme(def.name);
@@ -5027,11 +4961,14 @@ mod syntax_bracket_ring_tests {
         }
     }
 
-    /// No ring colour may be confusable with a semantic accent - the spec's own words. This is a
-    /// new check, and it exists because of a real defect in the ring this replaced: its
-    /// `BRACKET_1` sat at OKLCH hue 23 against `ERROR_UNDERLINE`'s 25, two degrees apart, so a
-    /// matched depth-0 bracket wore essentially the error colour. Every ΔE check of the day passed,
-    /// because they only ever compared ring colours to *plain text* and to each other.
+    /// No ring colour may be confusable with a semantic accent - the spec's own words. It exists
+    /// because of a real defect in the ring this replaced: its `BRACKET_1` sat at OKLCH hue 23
+    /// against `ERROR_UNDERLINE`'s 25, two degrees apart, so a matched depth-0 bracket wore
+    /// essentially the error colour. Every ΔE check of the day passed, because they only ever
+    /// compared ring colours to *plain text* and to each other.
+    ///
+    /// Two floors, because Jerry Dark is where these colours are actually authored and the other
+    /// themes are mechanical `derive_shift` transforms of it: 18 there, 12 everywhere.
     #[test]
     fn no_ring_colour_is_confusable_with_a_syntax_accent() {
         // This floor was **raised** from 8.0 when the ring moved off the accent lightness band
@@ -5060,13 +4997,23 @@ mod syntax_bracket_ring_tests {
             ("VARIABLE", syntax::VARIABLE),
             ("ERROR_UNDERLINE", syntax::ERROR_UNDERLINE),
         ];
+        /// Measured worst case in Jerry Dark itself is 20.8, against 11.3 for the ring this
+        /// replaced - a palette that grew from eight semantic hue families to ten ended up with a
+        /// *more* clearly separated ring, which is the whole argument for spending lightness
+        /// rather than hue on it.
+        const MIN_DELTA_E_AUTHORED: f32 = 18.0;
         for def in crate::settings::state::THEME_DEFS.iter() {
             let _guard = with_bundled_theme(def.name);
+            let floor = if def.name == "Jerry Dark" {
+                MIN_DELTA_E_AUTHORED
+            } else {
+                MIN_DELTA_E
+            };
             for (ring_name, ring_token) in ring_tokens() {
                 for (accent_name, accent_token) in accents {
                     let distance = delta_e(ring_token.resolve(), accent_token.resolve());
                     assert!(
-                        distance >= MIN_DELTA_E,
+                        distance >= floor,
                         "{ring_name} is only ΔE {distance:.1} from {accent_name} in {} - a \
                          coloured bracket must never impersonate a semantic token",
                         def.name
@@ -5076,52 +5023,31 @@ mod syntax_bracket_ring_tests {
         }
     }
 
-    /// The other thing an uncoloured bracket can be. Since the redesign,
-    /// `syntax::PUNCTUATION_BRACKET` is no longer plain text but its own dimmer tone, so a ring
-    /// colour has to stay clear of *both* - this covers the half
-    /// `every_ring_colour_is_perceptibly_different_from_plain_text` does not.
+    /// A *matched* bracket reading like an *unmatched* one would erase the whole
+    /// matched/unmatched distinction this feature's honest-degradation design rests on. Since the
+    /// redesign there are two tones to stay clear of, not one: plain text, and
+    /// `syntax::PUNCTUATION_BRACKET`'s own dimmer unmatched tone.
     #[test]
-    fn every_ring_colour_stays_clear_of_the_de_emphasized_bracket_tone() {
+    fn every_ring_colour_stays_clear_of_both_tones_it_must_not_be_mistaken_for() {
+        // Real measured worst case: 16.7, in Jerry Dark. If this fires after a change to the
+        // defaults, the generated theme files probably need regenerating (see
+        // `crate::settings::builtin_themes`).
         const MIN_DELTA_E: f32 = 14.0;
         for def in crate::settings::state::THEME_DEFS.iter() {
             let _guard = with_bundled_theme(def.name);
-            let unmatched = syntax::PUNCTUATION_BRACKET.resolve();
-            for (name, token) in ring_tokens() {
-                let distance = delta_e(token.resolve(), unmatched);
-                assert!(
-                    distance >= MIN_DELTA_E,
-                    "{name} is only ΔE {distance:.1} from the unmatched-bracket tone in {} - the \
-                     matched/unmatched distinction would be invisible",
-                    def.name
-                );
-            }
-        }
-    }
-
-    /// A *matched* bracket reading identically to an *unmatched* one would erase the whole
-    /// matched/unmatched distinction this feature's honest-degradation design rests on - and
-    /// `syntax::PUNCTUATION_BRACKET` is exactly `syntax::TEXT` by deliberate design, so this one
-    /// check covers both.
-    #[test]
-    fn every_ring_colour_is_perceptibly_different_from_plain_text() {
-        // Real measured worst case: 16.7, in Jerry Dark. Note this check got *harder* in the
-        // redesign, not easier: `syntax::PUNCTUATION_BRACKET` is no longer plain text but a
-        // genuinely dimmer tone, so a ring colour now has to stay clear of two different things.
-        // `every_ring_colour_stays_clear_of_the_de_emphasized_bracket_tone` covers the other one.
-        const MIN_DELTA_E: f32 = 14.0;
-        for def in crate::settings::state::THEME_DEFS.iter() {
-            let _guard = with_bundled_theme(def.name);
-            let text = syntax::TEXT.resolve();
-            for (name, token) in ring_tokens() {
-                let distance = delta_e(token.resolve(), text);
-                assert!(
-                    distance >= MIN_DELTA_E,
-                    "{name} is only ΔE {distance:.1} from plain text in {} - a matched bracket \
-                     would be indistinguishable from an unmatched one. If this fired after a \
-                     change to the defaults, the five generated theme files probably need \
-                     regenerating (see crate::settings::builtin_themes).",
-                    def.name
-                );
+            for (reference_name, reference) in [
+                ("the unmatched-bracket tone", syntax::PUNCTUATION_BRACKET),
+                ("plain text", syntax::TEXT),
+            ] {
+                for (name, token) in ring_tokens() {
+                    let distance = delta_e(token.resolve(), reference.resolve());
+                    assert!(
+                        distance >= MIN_DELTA_E,
+                        "{name} is only ΔE {distance:.1} from {reference_name} in {} - a matched \
+                         bracket would be indistinguishable from an unmatched one",
+                        def.name
+                    );
+                }
             }
         }
     }
@@ -5234,42 +5160,6 @@ mod syntax_bracket_ring_tests {
                  far enough out of register to read as a foreign accent",
                 def.name
             );
-        }
-    }
-
-    /// A ring colour sits between two semantic hues and must never be mistakable for either.
-    ///
-    /// The strict, Jerry-Dark-only counterpart to
-    /// `no_ring_colour_is_confusable_with_a_syntax_accent`. Its floor was raised from 11 to 18 when
-    /// the ring moved onto the punctuation lightness band: measured worst case here is now ΔE 20.8,
-    /// against 11.3 for the ring this replaced. A palette that grew from eight semantic hue
-    /// families to ten therefore ended up with a *more* clearly separated bracket ring, not a less
-    /// one - which is the whole argument for spending lightness rather than hue on it.
-    #[test]
-    fn no_ring_colour_impersonates_the_semantic_token_it_borrows_its_hue_from() {
-        const MIN_DELTA_E: f32 = 18.0;
-        let semantic: [(&str, ColorToken); 10] = [
-            ("KEYWORD", syntax::KEYWORD),
-            ("FUNCTION", syntax::FUNCTION),
-            ("FUNCTION_DEFINITION", syntax::FUNCTION_DEFINITION),
-            ("TYPE", syntax::TYPE),
-            ("CONSTANT", syntax::CONSTANT),
-            ("STRING", syntax::STRING),
-            ("VARIABLE", syntax::VARIABLE),
-            ("VARIABLE_PARAMETER", syntax::VARIABLE_PARAMETER),
-            ("PROPERTY", syntax::PROPERTY),
-            ("ATTRIBUTE", syntax::ATTRIBUTE),
-        ];
-        let _guard = with_bundled_theme("Jerry Dark");
-        for (ring_name, ring_token) in ring_tokens() {
-            for (semantic_name, semantic_token) in semantic {
-                let distance = delta_e(ring_token.resolve(), semantic_token.resolve());
-                assert!(
-                    distance >= MIN_DELTA_E,
-                    "{ring_name} is only ΔE {distance:.1} from {semantic_name} - a coloured \
-                     bracket would read as that token rather than as structure"
-                );
-            }
         }
     }
 


### PR DESCRIPTION
Part of #425 (epic #427). Slice **D6 — settings / theme / lsp / search**.

## What

**Every test in this slice passes now.** The baseline had 38 failures nobody owned.

```
before: Summary [ 16.342s] 633 tests run: 595 passed, 38 failed, 2370 skipped
after:  Summary [ 13.963s] 559 tests run: 559 passed, 2372 skipped
```

Test count: **633 → 559 runnable, −74 (−11.7%)**; +4 → 6 `external`-tier tests that
never run on the gate (637 → 565 counting those). Wall clock 16.3s → 14.0s.

### Two real product fixes fell out of the failing tests

**1. `app::Quit` had no Keybindings-page label.** `cmd-q` is a real registered global
binding on macOS (`crate::default_key_bindings`), but `settings::state::action_label`
had no arm for it, so the Keybindings settings page silently omitted the row.
`every_registered_global_keybinding_has_a_real_keybindings_page_label` — a drift guard
that exists precisely for this — was failing with `missing: ["app::Quit"]`. The test was
right; the product was wrong. Added `"app::Quit" => Some("Quit Jerry")`, matching the
wording the macOS application menu's own row already uses.

**2. The five generated theme files were stale against their own generator.**
`settings::builtin_themes::tests::every_checked_in_builtin_theme_file_matches_the_generator`
was failing on `assets/themes/jerry-dim.toml`. Cause: GitHub issue #406 rewrote
`theme::tree::INDENT_GUIDE_ACTIVE`'s doc comment (the guide no longer paints), so the
generator stopped emitting an inline comment for that key while the checked-in files kept
the old one. Regenerated all five via the module's own
`JERRY_REGENERATE_THEMES=1` utility — the whole delta is that one dropped trailing comment
per file, and `every_builtin_theme_resolves_exactly_what_the_generator_produces` already
proved no colour moved.

> This is the one place I touched a file outside `crates/app/src/{settings,lsp,search}/`
> and `theme.rs`. `assets/themes/*.toml` is the artefact `settings/builtin_themes.rs`
> generates and the failing test is in this slice, so regenerating it here is the fix;
> leaving it would have meant leaving a failing test failing.

### The other 35 failures were the documented macOS canonicalization bug

Exactly the cause the wave-2 briefing warned about. Fixtures handed `AdeApp` a bare
`tempfile::TempDir::path()` while building their expected paths from that *same*
uncanonicalized root; `AdeApp` canonicalizes (`rail::repo::canonical_repo_path`) and then
keys `lsp_clients` by exact `(PathBuf, &str)` and `edit_buffers`/`open_files` by
`strip_prefix(file_tree_root)`, so on macOS (`/var -> /private/var`) nothing ever matched.

Fixed with a canonicalized-root `TempRepo`, following `code_surface::fixtures::temp_repo`'s
established pattern — one per folder (`lsp/fixtures.rs`, `search/fixtures.rs`) rather than
editing a file shared with the other parallel slices. **Follow-up worth doing:** these are
now three near-identical copies (code_surface, lsp, search); they belong in
`crate::test_support` once the wave lands and the collision risk is gone.

The `search::render` failure was the same bug with real teeth: a replace-all wrote over a
file the editor still held with unsaved edits, because the "is this file dirty?" lookup
missed on the uncanonicalized key. The guard itself was fine; the fixture could never
reach it.

## Testing

- [x] `/check` — conventions + fmt + clippy `-D warnings` all pass:
  ```
  check-conventions: OK (glob imports: 303/303, render adapter calls: 202/221)
  cargo fmt --all -- --check   → clean
  cargo clippy --workspace --all-targets -- -D warnings → Finished, no warnings
  ```
- [x] `cargo nextest run -p app --lib -E 'test(/^(settings|lsp|search|theme)::/)'` — 559/559 pass
- [x] No leaked children after a run (`pgrep -fl 'node -e'` → empty)
- [ ] `verify` capture — not attached: this touches `settings/render.rs` and `theme.rs` but
      only inside `#[cfg(test)]` blocks plus one `action_label` match arm. No painted pixel
      changes except the five regenerated theme files, whose colour values are byte-identical
      (only a trailing comment moved).

## What I did with each pre-existing failure

| Failure(s) | Count | Disposition |
|---|---|---|
| `lsp::client::lsp_connection_facade_tests::*` (12) | 12 | **Fixed** — canonicalized fixture root |
| `lsp::completion_popup::{completion_detail_pane,completions_scroll}_tests::*` | 18 | **Fixed** — same |
| `search::render::panel_tests::a_file_open_in_the_editor_with_unsaved_edits_is_refused_and_named` | 1 | **Fixed** — same |
| `lsp::client::lsp_diagnostics_wiring_tests::a_transient_pull_failure_is_retried_not_treated_as_a_permanent_stall` | 1 | **Fixed** — same (was 11.3s, now 0.5s) |
| `lsp::client::lsp_diagnostics_wiring_tests::rust_analyzer_tracks_a_real_live_unsaved_edit_…` | 1 | **Re-tiered `external`** — spawns a real `rust-analyzer`; timed out at nextest's 120s kill |
| `settings::state::tests::every_registered_global_keybinding_has_a_real_keybindings_page_label` | 1 | **Fixed the product** — see above |
| `settings::builtin_themes::tests::every_checked_in_builtin_theme_file_matches_the_generator` | 1 | **Regenerated the assets** — see above |
| | **38** | 0 left failing, 0 left unmentioned |

## `#348` caveats removed

All four bare `#[ignore]`s with prose about CI became proper `external`-tier markers naming
the binary, and two more real-language-server tests that were **never** ignored (and so were
running a 480s wall-clock poll on the PR gate) joined them:

| Test | Was | Now |
|---|---|---|
| `restarting_a_companion_forgets_its_own_documents_without_touching_its_primary` | `// Real vue-language-server spawn, not installed in CI - GitHub issue #348.` + bare `#[ignore]` | `#[ignore = "external: vue-language-server; see docs/testing.md"]` |
| `a_real_typescript_diagnostic_reaches_file_view_diagnostics_through_the_real_app_code_path` | same shape, `#348` | `#[ignore = "external: typescript-language-server; see docs/testing.md"]` |
| `typescript_language_server_tracks_a_real_live_unsaved_edit_…` | same shape, `#348` | `#[ignore = "external: typescript-language-server, npm; see docs/testing.md"]` |
| `pyright_tracks_a_real_live_unsaved_edit_…` | same shape, `#348` | `#[ignore = "external: pyright-langserver; see docs/testing.md"]` |
| `a_real_diagnostic_reaches_file_view_diagnostics_through_the_real_app_code_path` | **not ignored** — real `rust-analyzer`, 480s deadline | `#[ignore = "external: rust-analyzer; see docs/testing.md"]` |
| `rust_analyzer_tracks_a_real_live_unsaved_edit_…` | **not ignored** — real `rust-analyzer`, TIMEOUT | `#[ignore = "external: rust-analyzer; see docs/testing.md"]` |

Two module docs claiming these were "kept in the normal, non-`#[ignore]` suite on purpose"
were rewritten to say what is actually true. No `#348` reference remains anywhere in this slice.

**Tiering judgement I made, flagged for review:** `lsp_connection_facade_tests`'s
`spawn_fake_server` runs a fixture LSP server under `node`. I kept those ~40 tests at `ui`
rather than `external`. `docs/testing.md`'s tier table enumerates external as *"real
`rust-analyzer` / `typescript-language-server` / `pyright` / `gopls`"* and bars `ui` from
*"external language servers"* — a `node -e` fixture is neither. Moving them to `external`
would take the whole LSP-lifecycle surface off the gate for a binary that is already an
implicit dev dependency. Happy to flip it if you read the policy the other way.

## Deletions, with the criterion for each

Criteria are `docs/testing.md`'s five. 74 net removals.

### Criterion 1 — sweep redundancy (N tests differing only by an input value → one table-driven test)

**`lsp/completion.rs` (75 → 48)**

| Collapsed | → | Into |
|---|---|---|
| `an_identifier_continuation_character_triggers…`, `a_digit_or_underscore_also_triggers…`, `a_server_advertised_trigger_character…`, `whitespace_and_punctuation_do_not_trigger…`, `the_start_of_the_buffer_never_triggers` (5) | 1 | `every_typed_character_opens_exactly_the_completion_it_should` |
| `completion_text_edit_prefers_a_real_plain_edit`, `…reads_the_insert_half_of_a_real_insert_and_replace_edit`, `…is_none_without_a_real_text_edit` (3) | 1 | `completion_text_edit_reads_the_insert_half_of_every_real_edit_shape` |
| `completion_plain_insert_text_prefers…`, `…falls_back_to_the_real_label…` (2) | 1 | `completion_plain_insert_text_prefers_insert_text_and_falls_back_to_the_label` |
| `identifier_prefix_start_walks_back…`, `…stops_at_a_real_non_identifier_byte`, `…is_the_cursor_itself_with_no_real_prefix` (3) | 1 | `identifier_prefix_start_walks_back_to_the_real_start_of_the_typed_word` |
| `completion_kind_badge_groups_{function,variable,type}_like_kinds`, `…is_none_for_a_kind_with_no_real_badge_slot…`, `…letters_match_the_design_mockups_own_glyphs` (5) | 1 | `every_completion_kind_lands_in_its_documented_badge_bucket` |
| `completion_filter_text_prefers…`, `…falls_back_to_the_label_when_absent_or_empty` (2) | 1 | `completion_filter_text_prefers_the_servers_own_and_falls_back_to_the_label` |
| `clean_completion_detail_*` (5) | 1 | `clean_completion_detail_strips_only_a_real_kind_or_qualifier_prefix` |
| `completion_documentation_text_*` (4) | 1 | `completion_documentation_text_reads_every_real_documentation_shape` |
| `completion_module_path_*` (2) | 1 | `completion_module_path_reads_only_a_real_label_details_description` |
| `completion_item_display_*` (3) + `completion_signature_text_*` (3) | 1 | `the_row_hint_and_signature_line_read_the_legacy_detail_and_never_label_details` — the same six inputs asserted against both functions, so the two named regressions survive as rows |

**`lsp/hover.rs` (35 → 29)**

| Collapsed | → | Into |
|---|---|---|
| `byte_offset_to_utf16_offset_{is_identity_for_pure_ascii,accounts_for_a_real_multi_byte_char,clamps_past_the_real_line_end}` (3) | 1 | `byte_offset_to_utf16_offset_converts_and_clamps` |
| `first_definition_location_{reads_a_real_scalar_response,reads_the_real_first_array_entry,is_none_for_a_real_empty_array,reads_a_real_link_response…}` (4) | 1 | `first_definition_location_reads_the_first_target_of_every_real_response_shape` |

**`lsp/diagnostics.rs` (21 → 17)**

| Collapsed | → | Into |
|---|---|---|
| `utf16_offset_to_byte_offset_*` (3) | 1 | `utf16_offset_to_byte_offset_converts_and_clamps` |
| `worst_severity_{is_none_for_an_empty_slice,picks_error_over_hint…,ranks_warning_above_information_and_hint}` (3) | 1 | `worst_severity_ranks_by_severity_not_by_vec_order` |

**`settings/widgets.rs` (5 → 1)**

`macos_uses_the_real_open_command`, `windows_uses_cmd_start_with_a_required_empty_title_argument`,
`linux_uses_the_real_xdg_open_command`, `an_unrecognized_target_os_falls_back_to_xdg_open`,
`every_platform_command_works_unchanged_for_a_real_url_target` → one
`every_platform_opens_every_real_target_with_its_own_command` over the 4 × 3 grid. Strictly
*more* coverage than the five it replaces (the URL case previously only ran on three of the
four OS strings).

**`settings/custom_theme.rs` (59 → 49)**

| Collapsed | → | Into |
|---|---|---|
| `an_unknown_key_is_a_real_rejection…`, `an_unknown_table_is_a_real_rejection`, `an_empty_name_is_a_real_rejection…`, `a_name_colliding_with_a_builtin_theme_is_rejected`, `parse_theme_file_str_rejects_garbage_toml…`, `every_real_invalid_colour_shape_is_rejected…`, `a_malformed_preview_is_a_real_rejection` (7) | 1 | `every_real_malformed_theme_file_is_rejected_with_an_error_naming_what_is_wrong` — every `ThemeFileError` variant still asserted, as a row |
| `text_the_same_colour_as_its_background_is_rejected` + `text_a_few_hex_digits_off…_is_still_rejected` (2) | 1 | `text_that_does_not_clear_the_contrast_floor_against_its_background_is_rejected` |
| `a_base_cycle_is_a_real_reported_error_not_a_hang` + `a_theme_naming_itself_as_its_own_base_is_a_real_reported_cycle` (2) | 1 | `a_base_cycle_is_a_real_reported_error_not_a_hang` |
| `custom_themes_dir_for_is_a_real_sibling…` + `…falls_back_to_a_bare_name…` (2) | 1 | `custom_themes_dir_for_is_a_real_sibling_of_the_given_settings_path` |

**`settings/state.rs` (47 → 36)**

| Collapsed | → | Into |
|---|---|---|
| `detect_agent_rows_{reports_ready…,reports_not_found…,can_report_mixed…}` (3) | 1 | `detect_agent_rows_reports_each_binarys_own_real_status` |
| `detect_lsp_rows_{reports_ready…,reports_not_installed…,can_report_mixed…}` (3) | 1 | `detect_lsp_rows_reports_each_binarys_own_real_status` (install-URL test kept separate — different claim) |
| `worktree_dot_status_*` (4) | 1 | `worktree_dot_status_reduces_every_real_note_to_its_own_dot` |
| `worktree_row_action_{main_checkout_has_no_action,prunable_gets_prune_others_get_open}` (2) | 1 | `worktree_row_action_offers_prune_only_where_pruning_is_real` |

**`theme.rs` (58 → 50)**

| Collapsed | → | Into |
|---|---|---|
| `{ts,vue,py,go}_matches_the_real_spec_d_hex_pair` (4) | 1 | `every_spec_pinned_lang_chip_still_carries_its_spec_hex_pair` |
| `one_hundred_percent_is_a_real_no_op` + `scales_up_and_down_proportionally` (2) | 1 | `ui_scale_scales_proportionally_and_leaves_one_hundred_percent_alone` |
| `cyclically_adjacent_ring_colours_stay_far_apart…` (deleted) | — | strictly subsumed by `no_two_ring_colours_collide_in_any_bundled_theme` — same `MIN_DELTA_E = 18.0`, and the surviving test's own comment already said *"the nearest pair **is** an adjacent pair"* |
| `every_ring_colour_stays_clear_of_the_de_emphasized_bracket_tone` + `every_ring_colour_is_perceptibly_different_from_plain_text` (2) | 1 | `every_ring_colour_stays_clear_of_both_tones_it_must_not_be_mistaken_for` — same floor, two reference colours |
| `no_ring_colour_impersonates_the_semantic_token_it_borrows_its_hue_from` (2 with its sibling) | 1 | folded into `no_ring_colour_is_confusable_with_a_syntax_accent` as a per-theme floor (18 for authored Jerry Dark, 12 elsewhere) — both thresholds still enforced |
| `every_syntax_token_clears_a_real_contrast_floor_in_jerry_dark_and_paper` + `…clears_a_looser_floor_across_every_bundled_theme` (2) | 1 | `every_syntax_token_clears_its_themes_own_contrast_floor` — same per-theme-floor shape |

**`settings/store.rs` (39 → 38)**

`show_indent_guides_round_trips_through_real_toml_save_and_load` folded into
`a_settings_value_round_trips_through_real_toml_save_and_load`. Its own doc comment already
admitted it duplicated that test's fixture; the mutation and the default-is-on premise check
moved across, so nothing is lost.

### Criterion 2 — implementation mirroring (the assertion recomputes what the code does)

**`settings/state.rs`**

- `keybinding_rows_are_derived_in_real_registration_order` — a **145-entry literal transcript**
  of `default_key_bindings()`'s own order run through `action_label`, plus ~40 lines of
  per-issue archaeology inside the array. It recomputed the function under test and would
  have had to become platform-conditional the moment `app::Quit` got its label.
  `every_registered_global_keybinding_has_a_real_keybindings_page_label` (every binding
  resolves) and `every_keybinding_row_is_genuinely_distinguishable_from_every_other` (no two
  rows a user can't tell apart) keep the properties that matter.
- `keybinding_rows_report_the_real_global_context_for_every_default_binding` — `scoped.len() == 90`,
  a magic number maintained by hand alongside ~80 lines of "issue #N added 3 more" changelog
  comments (which `CLAUDE.md`'s comment rule forbids outright). **Rewritten, not deleted**, as
  `every_binding_registered_behind_a_context_is_reported_as_scoped_not_global`: a named list of
  the commands whose global registration would swallow a keystroke out of a focused terminal.
  That is the real user-visible property; the count never was.
- `nav_groups_match_the_documented_2026_07_29_regroup` — re-lists `nav_groups()`'s own literal.
  `all_eleven_pages_are_covered_by_the_four_nav_groups_exactly_once` keeps the real invariant
  (no page orphaned, none duplicated).
- `exactly_the_nine_documented_pages_are_implemented` — restates `SettingsPage::is_implemented`'s
  own match arms. `nav_only_pages_share_the_same_honest_placeholder_subtitle` keeps the
  user-visible consequence.

### Criterion 3 — vacuous

**`lsp/client.rs`** — `single_delegation_stays_under_a_generous_1000ns_ceiling`. A 200,000-iteration
wall-clock microbenchmark asserting that an enum match + delegate costs under **1µs** per call.
`docs/testing.md` bars a `unit` test from asserting on wall-clock, and this bound is loose enough
that it would pass with the delegation removed entirely. Its own doc comment said it was "kept in
the normal suite on purpose… this project has no separate slow/perf-test lane" — the policy now
has one and this isn't it.

### Criterion 5 — duplicate coverage across layers

**`lsp/hover.rs`** — `degrade_markdown_to_plain_text_strips_a_real_fenced_code_block_and_starts_a_new_paragraph`.
Same `REAL_TYPESCRIPT_MARKDOWN_HOVER` fixture as
`a_real_markdown_typescript_hover_still_splits_into_a_readable_signature_and_doc`, which drives
it through `build_hover_render_model` and asserts both halves of the split *and* that no backtick
survives. Kept the one that states the user-visible outcome.

**`settings/custom_theme.rs`** — `every_built_in_theme_is_really_readable_once_compiled`
(`check_palette_readability(&palette).is_ok()`, a 1.6:1 validity floor). Strictly weaker than
`every_built_in_theme_clears_the_floor_with_real_headroom`, which runs the same
`READABILITY_PAIRS` over the same themes at WCAG's 4.5:1. Noted that in the survivor's doc.

## Other procedure steps

**Step 3 — `thread::sleep`.** All **13** sites in the slice are gone; `grep -c 'thread::sleep'`
over `settings/`, `lsp/`, `search/`, `theme.rs` is now **0**. Eight became
`test_support::wait_until`; four needed a render + `run_until_parked` *between* polls, which the
shared helper's zero-argument closure can't express, so `lsp/fixtures.rs` grows a
`wait_until_parked(cx, deadline, attempt)` — the same shape and the same reasoning as
`code_surface::fixtures`' own copy, and it delegates to `test_support::wait_until` underneath
rather than sleeping itself.

**Step 4 — route setup through `crates/test-support`.** `search/engine.rs`'s local
`fn git(dir, args)` deleted; its two `git init` + `git config user.email/user.name` fixtures now
call `test_support::{git, seed_empty_repo_at}`. That was the slice's only duplicate `fn git`.

**Step 5 — `ChildGuard`.** Not needed, and I want to be explicit rather than silently skip a box:
the slice's only real subprocess spawns are `spawn_fake_server`'s `node` children, and
`lsp_core::LspClient` already `SIGKILL`s its whole process tree in `Drop`
(`crates/lsp-core/src/client.rs:1295`). Verified empirically — `pgrep -fl 'node -e'` is empty
after a full slice run. The `npm install` calls in the now-`external` tests use
`Command::status()`, which reaps.

**Migrated off the `palette_focus_tests` re-export.** All 72 `palette_focus_tests::open_test_app`
call sites in this slice now use `crate::test_support::open_test_app` directly. Zero
`palette_focus_tests` references remain in `settings/`, `lsp/` or `search/`.

## `test-support` helpers I needed and could not have

None — `wait_until` and `seed_empty_repo_at` covered everything. `crates/test-support/src/**` is
untouched.

## Architecture notes

Two new `#[cfg(test)]` modules, `crates/app/src/lsp/fixtures.rs` and
`crates/app/src/search/fixtures.rs`, mirroring `code_surface/fixtures.rs`. Test-only, no
production surface, no crate-boundary change. As noted above, the three copies should become one
in `crate::test_support` once the parallel wave has landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
