### PR TITLE
chore(ci): restore the test suite to CI and the local pre-commit gate (#426)

### DIFF
--- a/.claude/commands/check.md
+++ b/.claude/commands/check.md
@@ -1,5 +1,5 @@
 ---
-description: Run the full pre-commit gate (conventions, fmt, clippy) - the same thing CI runs
+description: Run the full pre-commit gate (conventions, fmt, clippy, tests) - the same thing CI runs
 model: haiku
 ---
 
@@ -10,14 +10,18 @@ rather than continuing past it:
 .claude/hooks/check-conventions.sh
 cargo fmt --all -- --check
 cargo clippy --workspace --all-targets -- -D warnings
+cargo nextest run --workspace
 ```
 
 If a step fails, show the actual failing output (not a summary) and stop — don't run later steps
 against code that hasn't passed the earlier ones. If everything passes, say so in one line; this
 command doesn't need a report beyond pass/fail plus whatever failed.
 
-**`cargo test --workspace` is deliberately not part of this gate right now** — see
-[GitHub issue #348](https://github.com/ColinEspinas/jerry/issues/348), which tracks getting the
-suite back into CI and this gate once resolved. If your change needs test coverage verified, run
-the relevant scoped tests yourself (e.g. `cargo test -p wt-core`, or `cargo test -p app --lib
-<module>::`) — don't treat a clean `/check` as proof the full suite passes.
+The test step covers the `unit` and `ui` tiers, which is what CI's `Linux (test)` job runs. The
+`external` tier is `#[ignore]`d and skipped — it needs real language servers and runs only in the
+nightly `External` job (see [`docs/testing.md`](../../docs/testing.md)). If you changed something
+that tier covers, run it yourself with `cargo nextest run --workspace --profile external
+--run-ignored all` and the servers installed.
+
+If `cargo nextest` isn't installed, run `/setup` — don't fall back to `cargo test`, which has no
+per-test timeout and will simply hang on a blocked test instead of naming it.

--- a/.claude/conventions-baseline.json
+++ b/.claude/conventions-baseline.json
@@ -1,5 +1,5 @@
 {
   "_comment": "Ratchet baseline for .claude/hooks/check-conventions.sh - these numbers may only go down, never up. Recount with the exact commands in that script's comments after fixing a batch of violations, and lower the number in the same commit.",
   "glob_imports_app_src": 301,
-  "render_adapter_calls": 221
+  "render_adapter_calls": 201
 }

--- a/.claude/conventions-baseline.json
+++ b/.claude/conventions-baseline.json
@@ -1,5 +1,5 @@
 {
   "_comment": "Ratchet baseline for .claude/hooks/check-conventions.sh - these numbers may only go down, never up. Recount with the exact commands in that script's comments after fixing a batch of violations, and lower the number in the same commit.",
-  "glob_imports_app_src": 301,
-  "render_adapter_calls": 201
+  "glob_imports_app_src": 300,
+  "render_adapter_calls": 196
 }

--- a/.claude/hooks/pre-commit-check.sh
+++ b/.claude/hooks/pre-commit-check.sh
@@ -1,14 +1,17 @@
 #!/usr/bin/env bash
 # PreToolUse:Bash hook. Runs CLAUDE.md's pre-commit gate - the structural ratchet
-# (check-conventions.sh), fmt --check, and clippy -D warnings - before a `git commit` command
-# executes, so a lint-failing or convention-regressing change never lands in history.
-# `cargo test --workspace` is intentionally not part of this gate (or `/check`'s) right now -
-# GitHub issue #348 tracks why and getting it back. Run tests relevant to your change manually.
+# (check-conventions.sh), fmt --check, clippy -D warnings, and the `unit`/`ui` test tiers - before
+# a `git commit` command executes, so a lint-failing, convention-regressing or test-breaking
+# change never lands in history.
+#
+# Tests run through `cargo nextest`, not `cargo test`: per-test processes plus
+# `.config/nextest.toml`'s `slow-timeout` mean one hung test is a named failure rather than a hook
+# that never returns. The `external` tier is `#[ignore]`d and skipped by default (docs/testing.md).
 #
 # Exit code contract, matching Claude Code's PreToolUse protocol: this hook must NEVER hard-fail
 # in a way that blocks work for a reason unrelated to the gate itself. Missing `jq`, missing
-# `cargo`, or a command that isn't a git commit all exit 0 (allow, unmodified) rather than error.
-# Only a genuine fmt/clippy failure produces a deny decision.
+# `cargo`, missing `cargo-nextest`, or a command that isn't a git commit all exit 0 (allow,
+# unmodified) rather than error. Only a genuine fmt/clippy/test failure produces a deny decision.
 
 set -u
 
@@ -36,10 +39,17 @@ fi
 if [ -z "$FAIL" ] && command -v cargo &>/dev/null; then
   cargo clippy --workspace --all-targets -- -D warnings >/tmp/jerry-precommit-clippy.log 2>&1 || FAIL="clippy"
 fi
+# `cargo-nextest` is a separate binary, not part of a rustup toolchain: a contributor who hasn't
+# run `/setup` yet skips this step rather than being blocked by it, per this file's exit contract.
+if [ -z "$FAIL" ] && command -v cargo-nextest &>/dev/null; then
+  cargo nextest run --workspace >/tmp/jerry-precommit-nextest.log 2>&1 || FAIL="nextest"
+fi
 
 if [ -n "$FAIL" ]; then
   if [ "$FAIL" = "conventions" ]; then
     REASON="the convention ratchet failed - see /tmp/jerry-precommit-conventions.log."
+  elif [ "$FAIL" = "nextest" ]; then
+    REASON="cargo nextest run --workspace failed - see /tmp/jerry-precommit-nextest.log. Run /check before committing."
   else
     REASON="cargo $FAIL failed - see /tmp/jerry-precommit-$FAIL.log. Run /check before committing."
   fi

--- a/.claude/hooks/pre-commit-check.sh
+++ b/.claude/hooks/pre-commit-check.sh
@@ -41,8 +41,15 @@ if [ -z "$FAIL" ] && command -v cargo &>/dev/null; then
 fi
 # `cargo-nextest` is a separate binary, not part of a rustup toolchain: a contributor who hasn't
 # run `/setup` yet skips this step rather than being blocked by it, per this file's exit contract.
-if [ -z "$FAIL" ] && command -v cargo-nextest &>/dev/null; then
-  cargo nextest run --workspace >/tmp/jerry-precommit-nextest.log 2>&1 || FAIL="nextest"
+# The skip is announced, not silent - a gate that quietly drops its only behavioural check reads as
+# a passing gate.
+if [ -z "$FAIL" ] && command -v cargo &>/dev/null; then
+  if command -v cargo-nextest &>/dev/null; then
+    cargo nextest run --workspace >/tmp/jerry-precommit-nextest.log 2>&1 || FAIL="nextest"
+  else
+    echo "pre-commit-check: cargo-nextest missing - tests NOT run for this commit." >&2
+    echo "  cargo install cargo-nextest --locked   (or run /setup)" >&2
+  fi
 fi
 
 if [ -n "$FAIL" ]; then

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -10,12 +10,12 @@ changed and why from the diff alone.
 
 ## Steps
 
-1. **Run the gate.** `/check` (conventions + fmt + clippy `-D warnings`). Don't proceed past a
-   failure — a PR opened against a red gate just moves the failure to someone else's screen.
-   `cargo test --workspace` isn't part of this gate right now
-   ([issue #348](https://github.com/ColinEspinas/jerry/issues/348)) — run whatever tests are
-   relevant to the change manually (e.g. `cargo test -p wt-core`, or a scoped `cargo test -p app
-   --lib <module>::`) and note the result in the PR's Testing section instead of leaving it blank.
+1. **Run the gate.** `/check` (conventions + fmt + clippy `-D warnings` + `cargo nextest run
+   --workspace`). Don't proceed past a failure — a PR opened against a red gate just moves the
+   failure to someone else's screen. That covers the `unit` and `ui` tiers; if the change touches
+   the `external` tier (real language servers, `docs/testing.md`), run that yourself with
+   `cargo nextest run --workspace --profile external --run-ignored all` and note the result in the
+   PR's Testing section instead of leaving it blank.
 
 2. **Decide if this is UI-visible.** `git diff --name-only` against the target branch — did it
    touch a `render.rs`, `theme.rs`, or anything else that changes what the app looks like? If so,

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -12,12 +12,28 @@ slow-timeout = { period = "30s", terminate-after = 4 }
 # Flakes get fixed, not retried into a green run.
 retries = 0
 
-# TODO(#424): once the `external` test tier exists, add a `[[profile.default.overrides]]` giving it
-# a longer slow-timeout — a real language-server handshake legitimately takes seconds.
-
 [profile.ci]
 # Failures are repeated at the end of the log, where the Actions summary is readable.
 failure-output = "immediate-final"
 
 [profile.ci.junit]
 path = "junit.xml"
+
+# The `external` tier (docs/testing.md): real `rust-analyzer` / `typescript-language-server` /
+# `vue-language-server` / `pyright-langserver` processes. A real handshake plus a first index pass
+# legitimately takes seconds, so 30s/2min is too tight to distinguish "slow server" from "hung
+# test" here.
+#
+# This is a profile rather than the `[[profile.default.overrides]]` with a filterset that this
+# file's own TODO(#424) asked for, because that filterset cannot be written:
+# nextest's filterset language has no ignore-status predicate (verified against cargo-nextest
+# 0.9.143 - `ignored()` is a parse error, and `default()` refers to the profile's `default-filter`,
+# not to `#[ignore]`). The alternative, enumerating the tier's test names in a `test(/.../)`
+# filterset, would rot silently the moment a tier member is added or renamed. Selecting the tier by
+# the profile the tier's own CI job runs under is the version of this that cannot drift.
+#
+# Inherits `ci`, so the nightly external job gets the same immediate-final output and JUnit report
+# as the PR gate.
+[profile.external]
+inherits = "ci"
+slow-timeout = { period = "120s", terminate-after = 3 }

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,10 +14,12 @@
 
 ## Testing
 
-- [ ] `/check` (conventions + fmt + clippy `-D warnings`) passes locally
+- [ ] `/check` (conventions + fmt + clippy `-D warnings` + `cargo nextest run --workspace`) passes
+      locally
 - [ ] `verify` capture attached below, if this touches `render.rs`/`theme.rs`/layout
-- [ ] New/changed behavior has a real test, run manually and confirmed passing (`cargo test
-      --workspace` isn't part of the gate right now - issue #348)
+- [ ] New/changed behavior has a real test, in the right tier (docs/testing.md)
+- [ ] If this touches the `external` tier, it was run with the servers installed:
+      `cargo nextest run --workspace --profile external --run-ignored all`
 
 <!-- Note anything that couldn't be run and why ("not run: needs a live rust-analyzer") rather
      than silently leaving a box unchecked. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,15 @@ name: CI
 on:
   push:
   pull_request:
+  # Both exist for the `external` job below, which is gated to these two events and never runs on
+  # a PR. Everything else in this workflow runs on them too, which is deliberate: a nightly rebuild
+  # is the cheapest signal there is that a toolchain or transitive-dependency update broke the
+  # build without anyone pushing.
+  workflow_dispatch:
+  schedule:
+    # 04:00 UTC - outside working hours in every timezone this project is worked in, so a nightly
+    # run never competes with a PR for runner capacity.
+    - cron: "0 4 * * *"
 
 env:
   CARGO_TERM_COLOR: always
@@ -17,14 +26,9 @@ env:
   JERRY_DISABLE_PROVIDER_POLL: "1"
 
 jobs:
-  # Build + the workspace's own [workspace.lints]-backed clippy check + fmt on Linux.
-  # Deliberately NOT running `cargo test --workspace` here: a real run (PR #347) showed most
-  # of the GPUI-window-touching suite failing/timing out in a non-interactive environment -
-  # far broader than the one confirmed-flaky test (#320) or the missing-language-server gap
-  # (#348). Restoring the test step needs that investigated first, not a blind re-enable -
-  # see #348, which now tracks both. The `git config --global` step below stays: it's the
-  # real fix for a `wt-core` test's own submodule-commit failure ("Author identity unknown"
-  # on a fresh runner with no global git identity), independent of whether tests run in CI.
+  # Build + the workspace's own [workspace.lints]-backed clippy check + fmt on Linux. The test run
+  # is the separate `linux-test` job below, so a clippy failure and a test failure are two distinct
+  # red checks rather than one, and neither has to wait on the other's slowest step.
   linux:
     name: Linux (build, clippy, fmt)
     runs-on: ubuntu-latest
@@ -106,11 +110,93 @@ jobs:
       - name: cargo clippy --workspace --all-targets -- -D warnings
         run: cargo clippy --workspace --all-targets -- -D warnings
 
-  # Build-only signal on macOS and Windows, as two separate jobs (not a matrix) so all
-  # three platforms read as peers in the Actions UI, rather than Linux standing alone
-  # against one oddly-combined "the other two" job. Not every contributor can build and
-  # run the full test suite on both of these platforms locally, so these two jobs are the
-  # real verification that the workspace compiles there at all.
+  # The PR gate's test run: the `unit` and `ui` tiers of docs/testing.md, which is exactly what
+  # `cargo nextest run` executes by default - the `external` tier is `#[ignore]`d, and nextest
+  # skips ignored tests unless asked for them (`--run-ignored`, which only the `external` job
+  # below passes).
+  #
+  # `nextest`, not `cargo test`, because the reason the suite could not be in CI at all was that
+  # one test blocking on a language server that never answers froze the whole run with no way to
+  # attribute it (issue #348 observed 2,808 of ~2,900 tests logged, then 13+ minutes of nothing).
+  # nextest runs each test in its own process and enforces `.config/nextest.toml`'s
+  # `slow-timeout`, so that failure mode is now a named, killed test instead of a dead run.
+  linux-test:
+    name: Linux (test)
+    runs-on: ubuntu-latest
+    # A hard ceiling well above the ~10-minute target in issue #426, so a pathological hang still
+    # surfaces as a failed job rather than burning the six-hour default.
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      # The same list, for the same reasons, as the `linux` job above - see that job's own comment
+      # for why each package is on it and why several of upstream Zed's are not. Compiling the
+      # test binaries needs everything compiling the app needs.
+      - name: Install Linux system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            clang \
+            cmake \
+            pkg-config \
+            libfontconfig-dev \
+            libvulkan1 \
+            mesa-vulkan-drivers \
+            libwayland-dev \
+            libxkbcommon-dev \
+            libxkbcommon-x11-dev \
+            libx11-xcb-dev \
+            libasound2-dev
+
+      - name: Install Rust 1.95.0
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.95.0"
+
+      # Pinned to the version this change was actually written and validated against, per this
+      # project's "same version we verified against, not latest" convention (see
+      # `crates/app/Cargo.toml`'s `tree-sitter`/`alacritty_terminal` comments).
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest@0.9.143
+
+      - name: Cache cargo/target
+        uses: Swatinem/rust-cache@v2
+
+      # A fresh runner has no global git identity, unlike every developer machine. `wt-core`'s
+      # `discard_worktree_refuses_when_stash_push_captures_nothing_and_an_unrelated_stash_already_exists`
+      # runs `git commit` inside a real submodule checkout, and `git submodule update --init`
+      # creates an independent git directory that does not inherit the parent fixture's *local*
+      # identity - so that commit fails with a real "Author identity unknown" (observed, not
+      # hypothetical: commit ac8e6cd). This is the fix.
+      - name: Configure git identity
+        run: |
+          git config --global user.email "ci@example.invalid"
+          git config --global user.name "CI"
+
+      - name: cargo nextest run --workspace --profile ci
+        run: cargo nextest run --workspace --profile ci
+
+  # Build + the full `unit`/`ui` suite on macOS and Windows, as two separate jobs (not a
+  # matrix) so all three platforms read as peers in the Actions UI, rather than Linux
+  # standing alone against one oddly-combined "the other two" job. Not every contributor
+  # can build and run the suite on both of these platforms locally, so these two jobs are
+  # the only verification that the workspace works there at all.
+  #
+  # These ran a single narrow filter (`cargo test -p app --lib status_bar::process_stats`)
+  # until issue #426; the widening is the point of that issue, and it is expected to find
+  # things. The bug that dominated this epic was a macOS-specific path canonicalization
+  # difference (`/var` is a symlink to `/private/var`, so a `PathBuf` comparison that holds
+  # on Linux does not hold there), and it went unseen precisely because no macOS runner ever
+  # executed the tests that would have caught it. Windows has its own untested path-equality
+  # traps - drive-letter case, UNC and `\\?\` prefixes - and no one has ever run this suite
+  # there. A first red run on either platform is this change working, not this change
+  # failing.
   #
   # `crates/app/Cargo.toml` has real per-target `[target.'cfg(target_os =
   # "...")'.dependencies]` sections for `gpui_platform` (Revision R11, extended in R12):
@@ -123,8 +209,9 @@ jobs:
   # needs no `--features` flag on either platform: per-target dependency/feature
   # selection is Cargo's job, resolved automatically from the actual build target.
   macos:
-    name: macOS (build + sampling tests)
+    name: macOS (build + test)
     runs-on: macos-latest
+    timeout-minutes: 45
     # A real, platform-specific build-script requirement found by reading
     # `vendor/zed/crates/gpui_macos/build.rs` directly (not assumed): it unconditionally
     # shells out to `xcrun -sdk macosx metal` to compile real Metal shaders - this needs
@@ -142,35 +229,40 @@ jobs:
         with:
           toolchain: "1.95.0"
 
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest@0.9.143
+
       - name: Cache cargo/target
         uses: Swatinem/rust-cache@v2
+
+      # Same reason as the Linux test job's identical step: `wt-core`'s submodule-commit test
+      # needs a global git identity a fresh runner does not have.
+      - name: Configure git identity
+        run: |
+          git config --global user.email "ci@example.invalid"
+          git config --global user.name "CI"
 
       - name: cargo build --workspace
         run: cargo build --workspace
 
-      # GitHub issue #283: the macOS per-process CPU/memory sampling backend
-      # (`crate::status_bar::process_stats::macos`) is real `proc_pid_rusage` FFI that nobody
-      # working on this repo can run locally - this project's dev environment is Linux/WSL2-only
-      # (see this file's own comments above). `cargo build` above does not help: it does not
-      # compile `#[cfg(test)]` modules at all, so without this step not one line of that
-      # backend's tests would ever execute on any macOS machine.
-      #
-      # This is deliberately a *narrow* filter, not the fuller `cargo test` this job's own
-      # comments explain is out of scope: `status_bar::process_stats` needs no language servers,
-      # no git fixtures and no filesystem watchers, so it is free of every environment gap that
-      # keeps the rest of the suite off these runners.
-      #
-      # It earns its keep concretely. `ri_user_time`/`ri_system_time` are mach *timebase* units,
-      # not nanoseconds, and reading them as nanoseconds under-reports CPU by ~41.7x on Apple
-      # Silicon while being exactly right on Intel - a defect this backend genuinely shipped with
-      # for one commit. `macos-latest` is Apple Silicon, and that backend's busy-child test
-      # asserts a real lower bound against wall-clock time, so this step is what would catch it.
-      - name: cargo test (per-process sampling backend)
-        run: cargo test -p app --lib status_bar::process_stats
+      # This job is what makes GitHub issue #283's macOS per-process CPU/memory sampling backend
+      # (`crate::status_bar::process_stats::macos`, real `proc_pid_rusage` FFI) actually get
+      # executed: `cargo build` above does not compile `#[cfg(test)]` modules at all, so without a
+      # test step not one line of that backend's tests would ever run on any macOS machine. It
+      # earns its keep concretely - `ri_user_time`/`ri_system_time` are mach *timebase* units, not
+      # nanoseconds, and reading them as nanoseconds under-reports CPU by ~41.7x on Apple Silicon
+      # while being exactly right on Intel, a defect this backend genuinely shipped with for one
+      # commit. `macos-latest` is Apple Silicon, and that backend's busy-child test asserts a real
+      # lower bound against wall-clock time.
+      - name: cargo nextest run --workspace --profile ci
+        run: cargo nextest run --workspace --profile ci
 
   windows:
-    name: Windows (build + sampling tests)
+    name: Windows (build + test)
     runs-on: windows-latest
+    timeout-minutes: 45
     # A real, platform-specific build-script quirk found by reading
     # `vendor/zed/crates/gpui_windows/build.rs` directly (not assumed): its
     # `fxc.exe`-based HLSL shader compilation is gated behind
@@ -190,17 +282,132 @@ jobs:
         with:
           toolchain: "1.95.0"
 
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest@0.9.143
+
       - name: Cache cargo/target
         uses: Swatinem/rust-cache@v2
+
+      # Same reason as the Linux test job's identical step: `wt-core`'s submodule-commit test
+      # needs a global git identity a fresh runner does not have.
+      - name: Configure git identity
+        run: |
+          git config --global user.email "ci@example.invalid"
+          git config --global user.name "CI"
 
       - name: cargo build --workspace
         run: cargo build --workspace
 
-      # GitHub issue #283, the Windows twin of the macOS job's step above - same reasoning,
-      # same narrow filter. `crate::status_bar::process_stats::windows` is real `GetProcessTimes`
-      # + PSAPI FFI written on a Linux machine and cross-compile-checked only; `cargo build`
-      # above does not compile `#[cfg(test)]` modules, so this step is the one thing that ever
-      # executes it on a real Windows machine. Without it, the backend's own "CI covers this"
-      # claim would be empty.
-      - name: cargo test (per-process sampling backend)
-        run: cargo test -p app --lib status_bar::process_stats
+      # The Windows twin of the macOS job's test step - same reasoning. GitHub issue #283's
+      # `crate::status_bar::process_stats::windows` is real `GetProcessTimes` + PSAPI FFI written
+      # on a Linux machine and cross-compile-checked only; `cargo build` above does not compile
+      # `#[cfg(test)]` modules, so this step is the one thing that ever executes it on a real
+      # Windows machine. Without it, the backend's own "CI covers this" claim would be empty.
+      - name: cargo nextest run --workspace --profile ci
+        run: cargo nextest run --workspace --profile ci
+
+  # The `external` tier (docs/testing.md): tests that spawn a real language server. Never on a PR,
+  # by the `if` below - these need binaries the repo does not vendor and a live npm registry, so
+  # they are slow, network-dependent and outside anything a contributor's PR controls. Nightly and
+  # on demand only.
+  #
+  # `--run-ignored all` runs the whole suite *including* the ignored tier, rather than
+  # `ignored-only`: an `external` test that passes while its `unit`/`ui` neighbours have regressed
+  # is not a useful signal, and the extra cost is one already-cached build away.
+  external:
+    name: External (real language servers)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      # Same list, same reasons, as the `linux` job above.
+      - name: Install Linux system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            clang \
+            cmake \
+            pkg-config \
+            libfontconfig-dev \
+            libvulkan1 \
+            mesa-vulkan-drivers \
+            libwayland-dev \
+            libxkbcommon-dev \
+            libxkbcommon-x11-dev \
+            libx11-xcb-dev \
+            libasound2-dev
+
+      # `rust-analyzer` is a real rustup component, not a separate download, so requesting it here
+      # pins it to the same 1.95.0 toolchain the rest of the workflow uses - the strongest pin
+      # available for it, and free. Verified: `rustup component list` reports
+      # `rust-analyzer-<host>` and installing it puts a `rust-analyzer` proxy on PATH.
+      - name: Install Rust 1.95.0
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.95.0"
+          components: rust-analyzer
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest@0.9.143
+
+      # Version pinning, per this project's "same version we verified against, not latest"
+      # convention (`crates/app/Cargo.toml`'s `tree-sitter`/`alacritty_terminal` comments):
+      #
+      # - `@vue/language-server@3.3.8` is a real, established pin. `crate::language`'s own module
+      #   docs record the live investigation done against exactly that version, and issue #348
+      #   re-confirmed the Vue test passes against it (2.15s).
+      #
+      # - `typescript-language-server` and `pyright` are deliberately NOT pinned, and this is a
+      #   known gap rather than an oversight. `git blame` on all four of their tests
+      #   (`crates/app/src/lsp/client.rs`, commits b0c08523 / e75f9dd3 / 06b06dac / 1aa4cd54)
+      #   names no version in any commit message or nearby comment, and nothing else in the repo
+      #   records one. Issue #348 established the negative half only: `typescript-language-server`
+      #   5.3.0 ("latest" at the time) fails those tests fast. Guessing a pin from that is worse
+      #   than leaving it unpinned - a wrong pin looks authoritative and hides the drift.
+      #   TODO(#426): the "Resolved server versions" step below prints what npm actually resolved
+      #   on each nightly run. Bisect from a run where these tests pass, then pin here.
+      #
+      # `gopls` is deliberately absent: `crate::language`'s registry gives Go `lsp: None` and
+      # `gopls` is PATH-detection-only on the Settings page, so no test in this workspace ever
+      # spawns it. Installing it would be cargo-culting issue #348's list.
+      - name: Install language servers
+        run: |
+          npm install -g \
+            "@vue/language-server@3.3.8" \
+            typescript-language-server \
+            pyright
+
+      # The evidence-gathering half of the unpinned-version TODO above: every nightly run records
+      # exactly which versions it tested against, so pinning later is a lookup, not a re-guess.
+      # `|| true` because this step exists to record information, not to gate: `npm ls` exits
+      # non-zero on any pre-existing peer-dependency complaint in the runner image's own global
+      # tree, which has nothing to do with whether the servers installed.
+      - name: Resolved server versions
+        run: |
+          npm ls -g --depth=0 || true
+          rust-analyzer --version
+
+      - name: Cache cargo/target
+        uses: Swatinem/rust-cache@v2
+
+      # Same reason as the Linux test job's identical step: `wt-core`'s submodule-commit test
+      # needs a global git identity a fresh runner does not have.
+      - name: Configure git identity
+        run: |
+          git config --global user.email "ci@example.invalid"
+          git config --global user.name "CI"
+
+      # `--profile external` inherits `ci` and raises `slow-timeout` - see `.config/nextest.toml`
+      # for why the tier gets its own profile rather than a filterset override.
+      - name: cargo nextest run --workspace --profile external --run-ignored all
+        run: cargo nextest run --workspace --profile external --run-ignored all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,32 @@
 name: CI
 
 on:
+  # Scoped to the default branch on purpose. An unscoped `push:` alongside `pull_request:` fires
+  # two complete, identical runs of this workflow for every push to a PR branch - verified on
+  # GitHub issue #426's own branch, where runs 31974623400 (push) and 31974624833 (pull_request)
+  # are the same commit. At GitHub's billing multipliers (Linux 1x, Windows 2x, macOS 10x) one run
+  # of this workflow is roughly 200 billed minutes, so the duplicate bought no extra signal at
+  # about 200 minutes a push. PR branches are covered by `pull_request` alone.
   push:
+    branches: [master]
   pull_request:
-  # Both exist for the `external` job below, which is gated to these two events and never runs on
-  # a PR. Everything else in this workflow runs on them too, which is deliberate: a nightly rebuild
-  # is the cheapest signal there is that a toolchain or transitive-dependency update broke the
-  # build without anyone pushing.
+  # The `external` job below is gated to these two events specifically, and never runs on `push`
+  # or `pull_request`. Everything else in this workflow runs on them too, which is deliberate: a
+  # nightly rebuild is the cheapest signal there is that a toolchain or transitive-dependency
+  # update broke the build without anyone pushing.
   workflow_dispatch:
   schedule:
     # 04:00 UTC - outside working hours in every timezone this project is worked in, so a nightly
     # run never competes with a PR for runner capacity.
     - cron: "0 4 * * *"
+
+# A new push supersedes the run still in flight for the same branch or PR instead of racing it to
+# completion on paid runners. `github.event_name` is part of the key as well as the ref, so that a
+# push to the default branch cannot cancel a `schedule` run that shares that ref - the nightly is
+# the only execution the `external` tier ever gets.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -180,21 +195,21 @@ jobs:
       - name: cargo nextest run --workspace --profile ci
         run: cargo nextest run --workspace --profile ci
 
-  # Build + the full `unit`/`ui` suite on macOS and Windows, as two separate jobs (not a
-  # matrix) so all three platforms read as peers in the Actions UI, rather than Linux
-  # standing alone against one oddly-combined "the other two" job. Not every contributor
-  # can build and run the suite on both of these platforms locally, so these two jobs are
-  # the only verification that the workspace works there at all.
+  # macOS and Windows are two separate jobs (not a matrix) so all three platforms read as
+  # peers in the Actions UI, rather than Linux standing alone against one oddly-combined
+  # "the other two" job. Not every contributor can build and run the suite on either of
+  # these platforms locally, so these two jobs are the only verification that the workspace
+  # works there at all.
   #
-  # These ran a single narrow filter (`cargo test -p app --lib status_bar::process_stats`)
-  # until issue #426; the widening is the point of that issue, and it is expected to find
-  # things. The bug that dominated this epic was a macOS-specific path canonicalization
-  # difference (`/var` is a symlink to `/private/var`, so a `PathBuf` comparison that holds
-  # on Linux does not hold there), and it went unseen precisely because no macOS runner ever
-  # executed the tests that would have caught it. Windows has its own untested path-equality
-  # traps - drive-letter case, UNC and `\\?\` prefixes - and no one has ever run this suite
-  # there. A first red run on either platform is this change working, not this change
-  # failing.
+  # They are deliberately *not* symmetric in what they test. macOS runs the full `unit`/`ui`
+  # suite; Windows runs the narrow `status_bar::process_stats` filter it ran before issue
+  # #426. See the Windows job's own comment for why - that asymmetry is a recorded decision,
+  # not an oversight.
+  #
+  # macOS earned the full suite immediately: the bug that dominated this epic was a
+  # macOS-specific path canonicalization difference (`/var` is a symlink to `/private/var`,
+  # so a `PathBuf` comparison that holds on Linux does not hold there), and it went unseen
+  # precisely because no macOS runner ever executed the tests that would have caught it.
   #
   # `crates/app/Cargo.toml` has real per-target `[target.'cfg(target_os =
   # "...")'.dependencies]` sections for `gpui_platform` (Revision R11, extended in R12):
@@ -257,8 +272,20 @@ jobs:
       - name: cargo nextest run --workspace --profile ci
         run: cargo nextest run --workspace --profile ci
 
+  # DELIBERATELY NARROW - do not widen this to `--workspace` without reading issue #440 first.
+  #
+  # Issue #426 widened this job to the full suite for exactly one run, and that run is the whole
+  # argument: 3073 tests, 134 failed and 26 timed out, in 1407 seconds. Those failures are real
+  # and they are a large investigation of their own - paths formatted into strings, forward
+  # slashes baked into expected values, and 26 timeouts whose mechanism nobody has diagnosed yet.
+  # Issue #440 tracks that work. It was split out of epic #427 rather than done here because
+  # chasing it would hold a finished epic behind an unbounded piece of work.
+  #
+  # So Windows test coverage is deferred, not forgotten, and this job is back to the
+  # `status_bar::process_stats` filter it ran before #426. The full suite does not pass on
+  # Windows yet; re-widening it before #440 is done just turns this check permanently red.
   windows:
-    name: Windows (build + test)
+    name: Windows (build + sampling tests)
     runs-on: windows-latest
     timeout-minutes: 45
     # A real, platform-specific build-script quirk found by reading
@@ -280,31 +307,20 @@ jobs:
         with:
           toolchain: "1.95.0"
 
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-nextest@0.9.143
-
       - name: Cache cargo/target
         uses: Swatinem/rust-cache@v2
-
-      # Same reason as the Linux test job's identical step: `wt-core`'s submodule-commit test
-      # needs a global git identity a fresh runner does not have.
-      - name: Configure git identity
-        run: |
-          git config --global user.email "ci@example.invalid"
-          git config --global user.name "CI"
 
       - name: cargo build --workspace
         run: cargo build --workspace
 
-      # The Windows twin of the macOS job's test step - same reasoning. GitHub issue #283's
-      # `crate::status_bar::process_stats::windows` is real `GetProcessTimes` + PSAPI FFI written
-      # on a Linux machine and cross-compile-checked only; `cargo build` above does not compile
-      # `#[cfg(test)]` modules, so this step is the one thing that ever executes it on a real
-      # Windows machine. Without it, the backend's own "CI covers this" claim would be empty.
-      - name: cargo nextest run --workspace --profile ci
-        run: cargo nextest run --workspace --profile ci
+      # GitHub issue #283, the Windows twin of the macOS job's step above - same reasoning,
+      # same narrow filter. `crate::status_bar::process_stats::windows` is real `GetProcessTimes`
+      # + PSAPI FFI written on a Linux machine and cross-compile-checked only; `cargo build`
+      # above does not compile `#[cfg(test)]` modules, so this step is the one thing that ever
+      # executes it on a real Windows machine. Without it, the backend's own "CI covers this"
+      # claim would be empty.
+      - name: cargo test (per-process sampling backend)
+        run: cargo test -p app --lib status_bar::process_stats
 
   # The `external` tier (docs/testing.md): tests that spawn a real language server. Never on a PR,
   # by the `if` below - these need binaries the repo does not vendor and a live npm registry, so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,13 @@ on:
   # Scoped to the default branch on purpose. An unscoped `push:` alongside `pull_request:` fires
   # two complete, identical runs of this workflow for every push to a PR branch - verified on
   # GitHub issue #426's own branch, where runs 31974623400 (push) and 31974624833 (pull_request)
-  # are the same commit. At GitHub's billing multipliers (Linux 1x, Windows 2x, macOS 10x) one run
-  # of this workflow is roughly 200 billed minutes, so the duplicate bought no extra signal at
-  # about 200 minutes a push. PR branches are covered by `pull_request` alone.
+  # are the same commit. PR branches are covered by `pull_request` alone.
+  #
+  # This is not about money: the repository is public, so GitHub-hosted standard runners are free
+  # and the usual Linux/Windows/macOS billing multipliers do not apply to it at all. It is about
+  # the two things that are genuinely scarce here - concurrent runner slots, where the macOS
+  # allowance is much smaller than the overall one, and the 10 GB per-repository Actions cache the
+  # duplicate run was evicting entries from.
   push:
     branches: [master]
   pull_request:
@@ -21,9 +25,9 @@ on:
     - cron: "0 4 * * *"
 
 # A new push supersedes the run still in flight for the same branch or PR instead of racing it to
-# completion on paid runners. `github.event_name` is part of the key as well as the ref, so that a
-# push to the default branch cannot cancel a `schedule` run that shares that ref - the nightly is
-# the only execution the `external` tier ever gets.
+# completion and holding runner slots nothing is waiting on. `github.event_name` is part of the key
+# as well as the ref, so that a push to the default branch cannot cancel a `schedule` run that
+# shares that ref - the nightly is the only execution the `external` tier ever gets.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
@@ -41,12 +45,65 @@ env:
   JERRY_DISABLE_PROVIDER_POLL: "1"
 
 jobs:
-  # Build + the workspace's own [workspace.lints]-backed clippy check + fmt on Linux. The test run
-  # is the separate `linux-test` job below, so a clippy failure and a test failure are two distinct
-  # red checks rather than one, and neither has to wait on the other's slowest step.
-  linux:
-    name: Linux (build, clippy, fmt)
+  # The platform-independent half of the gate, and the only job that is not tied to an OS.
+  # `cargo fmt`, the convention ratchet and the version check all read source text: their answer
+  # cannot differ between Linux, macOS and Windows, so running them three times would burn three
+  # runners to produce the same result. They run once, here, on the cheapest one.
+  #
+  # Deliberately compile-free - no system packages, no cargo cache, no `cargo build`. None of these
+  # three steps needs a compiled workspace, which is what makes this the fast "you got something
+  # obviously wrong" signal that lands in about a minute while the platform jobs are still linking.
+  #
+  # clippy is NOT here, and that is the one real asymmetry in this file: it is a *compiled* lint, so
+  # it only ever sees the `#[cfg(target_os = ...)]` code of the platform it runs on. Running it once
+  # on Linux would leave `status_bar::process_stats::{macos,windows}` - 14 `unsafe` FFI sites, the
+  # code this project's own standards are strictest about - linted by nobody. So each platform job
+  # below runs clippy over its own target instead.
+  lint:
+    name: Lint (fmt, conventions)
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Install Rust 1.95.0
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.95.0"
+          components: rustfmt
+
+      # Deterministic ratchet, not a cargo lint: fails if the count of `use super::*` globs or
+      # of adapter calls in render.rs files rose vs .claude/conventions-baseline.json. See that
+      # script's own comments and docs/architecture/decisions.md (§3).
+      - name: Convention ratchet
+        run: .claude/hooks/check-conventions.sh
+
+      # Catches a crate manifest that regresses to a hardcoded version (issue #317).
+      - name: Crate version inheritance
+        run: .claude/hooks/check-release-version.sh
+
+      - name: cargo fmt --all -- --check
+        run: cargo fmt --all -- --check
+
+  # The three platform jobs below are deliberately the same shape: build, clippy, test. Whatever
+  # differs between them is a property of the platform, never of this file's own taste - the only
+  # intentional difference is Windows' test scope, which has its own comment.
+  #
+  # The test step is the `unit` and `ui` tiers of docs/testing.md, which is exactly what
+  # `cargo nextest run` executes by default - the `external` tier is `#[ignore]`d, and nextest skips
+  # ignored tests unless asked for them (`--run-ignored`, which only the `external` job passes).
+  #
+  # `nextest`, not `cargo test`: each test runs in its own process under `.config/nextest.toml`'s
+  # `slow-timeout`, so a test that blocks forever is a named, killed failure rather than a run that
+  # never ends.
+  linux:
+    name: Linux (build, clippy, test)
+    runs-on: ubuntu-latest
+    # A hard ceiling well above the ~10-minute target in issue #426, so a pathological hang still
+    # surfaces as a failed job rather than burning the six-hour default.
+    timeout-minutes: 45
     # System libraries GPUI's Linux backend (both the `wayland` and `x11`
     # gpui_platform features are compiled in, Revision R12 - see that file's own
     # Cargo.toml comment, and `crate::gpui_linux`'s real `guess_compositor()`-based
@@ -101,74 +158,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.95.0"
-          components: rustfmt, clippy
-
-      - name: Cache cargo/target
-        uses: Swatinem/rust-cache@v2
-
-      - name: cargo build --workspace
-        run: cargo build --workspace
-
-      # Deterministic ratchet, not a cargo lint: fails if the count of `use super::*` globs or
-      # of adapter calls in render.rs files rose vs .claude/conventions-baseline.json. See that
-      # script's own comments and docs/architecture/decisions.md (§3).
-      - name: Convention ratchet
-        run: .claude/hooks/check-conventions.sh
-
-      # Catches a crate manifest that regresses to a hardcoded version (issue #317).
-      - name: Crate version inheritance
-        run: .claude/hooks/check-release-version.sh
-
-      - name: cargo fmt --all -- --check
-        run: cargo fmt --all -- --check
-
-      - name: cargo clippy --workspace --all-targets -- -D warnings
-        run: cargo clippy --workspace --all-targets -- -D warnings
-
-  # The PR gate's test run: the `unit` and `ui` tiers of docs/testing.md, which is exactly what
-  # `cargo nextest run` executes by default - the `external` tier is `#[ignore]`d, and nextest
-  # skips ignored tests unless asked for them (`--run-ignored`, which only the `external` job
-  # below passes).
-  #
-  # `nextest`, not `cargo test`: each test runs in its own process under `.config/nextest.toml`'s
-  # `slow-timeout`, so a test that blocks forever is a named, killed failure rather than a run
-  # that never ends.
-  linux-test:
-    name: Linux (test)
-    runs-on: ubuntu-latest
-    # A hard ceiling well above the ~10-minute target in issue #426, so a pathological hang still
-    # surfaces as a failed job rather than burning the six-hour default.
-    timeout-minutes: 45
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 1
-
-      # The same list, for the same reasons, as the `linux` job above - see that job's own comment
-      # for why each package is on it and why several of upstream Zed's are not. Compiling the
-      # test binaries needs everything compiling the app needs.
-      - name: Install Linux system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            build-essential \
-            clang \
-            cmake \
-            pkg-config \
-            libfontconfig-dev \
-            libvulkan1 \
-            mesa-vulkan-drivers \
-            libwayland-dev \
-            libxkbcommon-dev \
-            libxkbcommon-x11-dev \
-            libx11-xcb-dev \
-            libasound2-dev
-
-      - name: Install Rust 1.95.0
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: "1.95.0"
+          components: clippy
 
       # Pinned to the version this change was actually written and validated against, per this
       # project's "same version we verified against, not latest" convention (see
@@ -178,8 +168,15 @@ jobs:
         with:
           tool: cargo-nextest@0.9.143
 
+      # `save-if` keeps the restore on every run but writes the cache only from the default branch.
+      # A repository gets 10 GB of Actions cache in total and GitHub evicts the least recently used
+      # entry once that fills; four jobs each saving a multi-gigabyte Rust target dir on every PR
+      # push churns that budget hard enough to evict the very entries the next run wants. Writing
+      # from master alone keeps one warm, stable entry per job instead.
       - name: Cache cargo/target
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
 
       # A fresh runner has no global git identity, unlike every developer machine. `wt-core`'s
       # `discard_worktree_refuses_when_stash_push_captures_nothing_and_an_unrelated_stash_already_exists`
@@ -192,19 +189,24 @@ jobs:
           git config --global user.email "ci@example.invalid"
           git config --global user.name "CI"
 
+      - name: cargo build --workspace
+        run: cargo build --workspace
+
+      - name: cargo clippy --workspace --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
       - name: cargo nextest run --workspace --profile ci
         run: cargo nextest run --workspace --profile ci
 
-  # macOS and Windows are two separate jobs (not a matrix) so all three platforms read as
-  # peers in the Actions UI, rather than Linux standing alone against one oddly-combined
-  # "the other two" job. Not every contributor can build and run the suite on either of
+  # macOS and Windows are separate jobs rather than a matrix so all three platforms read as
+  # peers in the Actions UI. Not every contributor can build and run the suite on either of
   # these platforms locally, so these two jobs are the only verification that the workspace
   # works there at all.
   #
-  # They are deliberately *not* symmetric in what they test. macOS runs the full `unit`/`ui`
-  # suite; Windows runs the narrow `status_bar::process_stats` filter it ran before issue
-  # #426. See the Windows job's own comment for why - that asymmetry is a recorded decision,
-  # not an oversight.
+  # Same shape as the Linux job above - build, clippy, test - with one deliberate difference:
+  # Windows runs the narrow `status_bar::process_stats` filter it ran before issue #426 rather
+  # than the full suite. See the Windows job's own comment; that asymmetry is a recorded
+  # decision, not an oversight.
   #
   # macOS earned the full suite immediately: the bug that dominated this epic was a
   # macOS-specific path canonicalization difference (`/var` is a symlink to `/private/var`,
@@ -222,7 +224,7 @@ jobs:
   # needs no `--features` flag on either platform: per-target dependency/feature
   # selection is Cargo's job, resolved automatically from the actual build target.
   macos:
-    name: macOS (build + test)
+    name: macOS (build, clippy, test)
     runs-on: macos-latest
     timeout-minutes: 45
     # A real, platform-specific build-script requirement found by reading
@@ -241,16 +243,21 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.95.0"
+          components: clippy
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest@0.9.143
 
+      # Same `save-if` reasoning as the Linux job - see that job's own comment on the 10 GB
+      # per-repository Actions cache budget.
       - name: Cache cargo/target
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
 
-      # Same reason as the Linux test job's identical step: `wt-core`'s submodule-commit test
+      # Same reason as the Linux job's identical step: `wt-core`'s submodule-commit test
       # needs a global git identity a fresh runner does not have.
       - name: Configure git identity
         run: |
@@ -259,6 +266,13 @@ jobs:
 
       - name: cargo build --workspace
         run: cargo build --workspace
+
+      # clippy runs per platform, not once on Linux, because it only ever lints the
+      # `#[cfg(target_os = ...)]` code of the target it runs against. This step is the only thing
+      # that lints `crate::status_bar::process_stats::macos` at all - 7 `unsafe` `proc_pid_rusage`
+      # FFI sites that a Linux-only clippy pass cannot even parse into its analysis.
+      - name: cargo clippy --workspace --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
       # This job is what makes GitHub issue #283's macOS per-process CPU/memory sampling backend
       # (`crate::status_bar::process_stats::macos`, real `proc_pid_rusage` FFI) actually get
@@ -285,7 +299,7 @@ jobs:
   # `status_bar::process_stats` filter it ran before #426. The full suite does not pass on
   # Windows yet; re-widening it before #440 is done just turns this check permanently red.
   windows:
-    name: Windows (build + sampling tests)
+    name: Windows (build, clippy, sampling tests)
     runs-on: windows-latest
     timeout-minutes: 45
     # A real, platform-specific build-script quirk found by reading
@@ -306,12 +320,26 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.95.0"
+          components: clippy
 
+      # Same `save-if` reasoning as the Linux job - see that job's own comment on the 10 GB
+      # per-repository Actions cache budget.
       - name: Cache cargo/target
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: cargo build --workspace
         run: cargo build --workspace
+
+      # The Windows twin of the macOS job's clippy step, and the only thing that lints
+      # `crate::status_bar::process_stats::windows` - 7 `unsafe` `GetProcessTimes`/PSAPI FFI sites
+      # written on a Linux machine and, until this step, never seen by clippy on any target where
+      # they actually compile. Note this lints the whole workspace for the Windows target even
+      # though the test step below is narrow: linting is cheap and has none of the 3073-test
+      # problems issue #440 tracks.
+      - name: cargo clippy --workspace --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
       # GitHub issue #283, the Windows twin of the macOS job's step above - same reasoning,
       # same narrow filter. `crate::status_bar::process_stats::windows` is real `GetProcessTimes`
@@ -402,10 +430,13 @@ jobs:
           npm ls -g --depth=0 || true
           rust-analyzer --version
 
+      # No `save-if` here, unlike the three platform jobs: this job only ever runs from
+      # `workflow_dispatch` or the nightly `schedule`, never on a PR, so it is not a source of
+      # cache churn and its own entry is worth keeping warm between nightlies.
       - name: Cache cargo/target
         uses: Swatinem/rust-cache@v2
 
-      # Same reason as the Linux test job's identical step: `wt-core`'s submodule-commit test
+      # Same reason as the Linux job's identical step: `wt-core`'s submodule-commit test
       # needs a global git identity a fresh runner does not have.
       - name: Configure git identity
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,11 +115,9 @@ jobs:
   # skips ignored tests unless asked for them (`--run-ignored`, which only the `external` job
   # below passes).
   #
-  # `nextest`, not `cargo test`, because the reason the suite could not be in CI at all was that
-  # one test blocking on a language server that never answers froze the whole run with no way to
-  # attribute it (issue #348 observed 2,808 of ~2,900 tests logged, then 13+ minutes of nothing).
-  # nextest runs each test in its own process and enforces `.config/nextest.toml`'s
-  # `slow-timeout`, so that failure mode is now a named, killed test instead of a dead run.
+  # `nextest`, not `cargo test`: each test runs in its own process under `.config/nextest.toml`'s
+  # `slow-timeout`, so a test that blocks forever is a named, killed failure rather than a run
+  # that never ends.
   linux-test:
     name: Linux (test)
     runs-on: ubuntu-latest
@@ -360,26 +358,17 @@ jobs:
         with:
           tool: cargo-nextest@0.9.143
 
-      # Version pinning, per this project's "same version we verified against, not latest"
-      # convention (`crates/app/Cargo.toml`'s `tree-sitter`/`alacritty_terminal` comments):
+      # Pinned to the version verified against, not latest, per `crates/app/Cargo.toml`'s
+      # `tree-sitter`/`alacritty_terminal` convention. `@vue/language-server@3.3.8` is the version
+      # `crate::language`'s module docs were written against.
       #
-      # - `@vue/language-server@3.3.8` is a real, established pin. `crate::language`'s own module
-      #   docs record the live investigation done against exactly that version, and issue #348
-      #   re-confirmed the Vue test passes against it (2.15s).
+      # `typescript-language-server` and `pyright` are deliberately unpinned: no version is
+      # recorded anywhere in the repo for the tests that use them, and a guessed pin looks
+      # authoritative while hiding drift. TODO(#426): the "Resolved server versions" step prints
+      # what npm resolved on each nightly run - bisect from a passing run, then pin.
       #
-      # - `typescript-language-server` and `pyright` are deliberately NOT pinned, and this is a
-      #   known gap rather than an oversight. `git blame` on all four of their tests
-      #   (`crates/app/src/lsp/client.rs`, commits b0c08523 / e75f9dd3 / 06b06dac / 1aa4cd54)
-      #   names no version in any commit message or nearby comment, and nothing else in the repo
-      #   records one. Issue #348 established the negative half only: `typescript-language-server`
-      #   5.3.0 ("latest" at the time) fails those tests fast. Guessing a pin from that is worse
-      #   than leaving it unpinned - a wrong pin looks authoritative and hides the drift.
-      #   TODO(#426): the "Resolved server versions" step below prints what npm actually resolved
-      #   on each nightly run. Bisect from a run where these tests pass, then pin here.
-      #
-      # `gopls` is deliberately absent: `crate::language`'s registry gives Go `lsp: None` and
-      # `gopls` is PATH-detection-only on the Settings page, so no test in this workspace ever
-      # spawns it. Installing it would be cargo-culting issue #348's list.
+      # `gopls` is absent because no test spawns it: `crate::language` gives Go `lsp: None`, and
+      # the Settings page only detects it on PATH.
       - name: Install language servers
         run: |
           npm install -g \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,19 +16,18 @@ the product description; this file only covers how to build it.
 cargo build --workspace
 cargo clippy --workspace --all-targets -- -D warnings
 cargo fmt --all -- --check
+cargo nextest run --workspace
 ```
 
-All three together are the pre-commit gate — run them as `/check` before considering anything
-done. `.claude/hooks/pre-commit-check.sh` runs the same three automatically before any
+All four together are the pre-commit gate — run them as `/check` before considering anything
+done. `.claude/hooks/pre-commit-check.sh` runs the same four automatically before any
 `git commit`, as a safety net. None are optional; a PR that needs `#[allow(...)]` to silence a
 lint either fixes the underlying issue or justifies the allow with a one-line comment.
 
-**`cargo test --workspace` is deliberately not part of this gate right now.** A real run
-surfaced most of the GPUI-window-touching suite failing/timing out outside an interactive
-session — investigated in [GitHub issue #348](https://github.com/ColinEspinas/jerry/issues/348),
-which also tracks getting it back into CI and this gate once resolved. Run tests relevant to what
-you're touching manually in the meantime (e.g. `cargo test -p wt-core`, or a scoped
-`cargo test -p app --lib <module>::`), and don't treat a clean `/check` as proof the suite passes.
+The test step covers the `unit` and `ui` tiers; the `external` tier is `#[ignore]`d and runs only
+in CI's nightly job (see "Testing" below). `cargo nextest`, not `cargo test`: `.config/nextest.toml`
+gives each test its own process and a real timeout, so a hung test fails that test instead of
+sitting on the whole run forever.
 
 Run the app with `cargo run --release -p app [repo-path]`. Use `--release` unless you're actively
 recompiling every few seconds: a debug-profile GPUI build is commonly 5–20× slower for the per-frame

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,20 +28,24 @@ Every change must pass, locally, before you open a PR — the same checks CI run
 cargo build --workspace
 cargo clippy --workspace --all-targets -- -D warnings
 cargo fmt --all -- --check
+cargo nextest run --workspace
 ```
 
 Run them together as `/check` if you're working through Claude Code. None are optional or "mostly
-passing." The test suite is intentionally not part of this list right now — see
-[issue #348](https://github.com/ColinEspinas/jerry/issues/348); run the tests relevant to what
-you're touching manually instead, scoped to a crate:
+passing."
+
+`.config/nextest.toml` gives every test its own process and kills one that is still running after
+two minutes, so a hung test fails that test instead of the whole run. `cargo test` has no
+equivalent and will sit there indefinitely — prefer `cargo nextest run`. While iterating, scope it
+to what you're touching:
 
 ```sh
 cargo nextest run -p wt-core
 ```
 
-`.config/nextest.toml` gives every test its own process and kills one that is still running after
-two minutes, so a hung test fails that test instead of the whole run. `cargo test` has no
-equivalent and will sit there indefinitely — prefer `cargo nextest run`.
+That covers the `unit` and `ui` tiers. The `external` tier — tests that spawn a real language
+server — is `#[ignore]`d, never part of the PR gate, and runs in its own nightly CI job. See
+[`docs/testing.md`](docs/testing.md).
 
 See [`docs/development-workflow.md`](docs/development-workflow.md) for how a change actually moves
 from a GitHub issue to a merged PR in this repo, including which Claude Code skill covers which

--- a/README.md
+++ b/README.md
@@ -107,15 +107,14 @@ deliberately, not casually.
 ```sh
 cargo clippy --workspace --all-targets -- -D warnings
 cargo fmt --all -- --check
+cargo nextest run --workspace
 ```
 
 must all pass — see [`CLAUDE.md`](CLAUDE.md) for the full standards, [`CONTRIBUTING.md`](CONTRIBUTING.md)
 for the process, and [`docs/development-workflow.md`](docs/development-workflow.md) for how a
 change moves from issue to merged PR. `.github/workflows/ci.yml` runs the same checks on every
-push. The test suite is not currently part of this gate — see
-[issue #348](https://github.com/ColinEspinas/jerry/issues/348) — but tests run under
-[`cargo-nextest`](https://nexte.st) rather than `cargo test`, for the per-test process isolation
-and timeout configured in `.config/nextest.toml`:
+push, on Linux, macOS and Windows. Tests run under [`cargo-nextest`](https://nexte.st) rather than
+`cargo test`, for the per-test process isolation and timeout configured in `.config/nextest.toml`:
 
 ```sh
 cargo install cargo-nextest --locked

--- a/README.md
+++ b/README.md
@@ -112,8 +112,9 @@ cargo nextest run --workspace
 
 must all pass — see [`CLAUDE.md`](CLAUDE.md) for the full standards, [`CONTRIBUTING.md`](CONTRIBUTING.md)
 for the process, and [`docs/development-workflow.md`](docs/development-workflow.md) for how a
-change moves from issue to merged PR. `.github/workflows/ci.yml` runs the same checks on every
-push, on Linux, macOS and Windows. Tests run under [`cargo-nextest`](https://nexte.st) rather than
+change moves from issue to merged PR. `.github/workflows/ci.yml` runs the same checks on Linux and
+macOS; Windows builds and runs only its platform-specific sampling tests, because the full suite
+does not pass there yet (issue #440). Tests run under [`cargo-nextest`](https://nexte.st) rather than
 `cargo test`, for the per-test process isolation and timeout configured in `.config/nextest.toml`:
 
 ```sh

--- a/crates/app/src/code_surface/file_view.rs
+++ b/crates/app/src/code_surface/file_view.rs
@@ -1861,6 +1861,10 @@ mod lsp_failed_status_chip_tests {
 
     const CHIP_SELECTOR: &str = "file-view-lsp-status";
 
+    // The assertion below is that the click's own `ensure_lsp_client` reached `Spawning`/`Ready`,
+    // which only happens when a real `rust-analyzer` is on PATH; without one the restart lands
+    // straight back in `Failed` and the test fails. That is the `external` tier by definition.
+    #[ignore = "external: rust-analyzer; see docs/testing.md"]
     #[gpui::test]
     async fn clicking_the_failed_status_chip_really_restarts_the_language_servers(
         cx: &mut TestAppContext,

--- a/crates/app/src/graph_view/render.rs
+++ b/crates/app/src/graph_view/render.rs
@@ -8039,6 +8039,25 @@ mod graph_virtualization_tests {
             app.open_git_graph(window, cx);
         });
         cx.run_until_parked();
+        // The walk behind this is real `gix`/`git` I/O against a real fixture - the one step in
+        // this helper that can fail for a reason the test itself does not control. Every caller
+        // then opens with `debug_bounds("graph-row-0")`, which answers `None` for a failed walk
+        // and a broken renderer alike, so a walk failure used to surface as "the first commit row
+        // must really paint" and blame the wrong thing entirely. Naming the real load state here
+        // is what makes that distinguishable on a CI runner nobody can attach a debugger to.
+        app.read_with(cx, |app, _| match &app.graph_state.load {
+            GraphLoadState::Loaded(graph) => assert!(
+                !graph.rows.is_empty(),
+                "the graph walk succeeded but produced no rows for this fixture"
+            ),
+            GraphLoadState::Error(err) => panic!("the real graph walk failed: {err}"),
+            GraphLoadState::Loading => {
+                panic!("the graph walk was still in flight after run_until_parked")
+            }
+            GraphLoadState::NotLoaded => {
+                panic!("opening the graph tab never started a walk at all")
+            }
+        });
         (app, cx)
     }
 

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -3382,6 +3382,10 @@ mod repo_checkout_tests {
     /// promise: repo A's own tab strip (`crate::work_surface::render::AdeApp::
     /// combined_tab_order`) must *not* show repo B's agent while B isn't the active worktree -
     /// cross-repo visibility lives in the rail alone, never a new tab-strip affordance.
+    // Asserts the folded-in row carries `Status::Run`, which requires the spawned `claude` CLI to
+    // still be a live process. On a machine without that binary the PTY child exits immediately
+    // and the status is `Fail`, so this needs the real agent CLI - the `external` tier.
+    #[ignore = "external: claude; see docs/testing.md"]
     #[gpui::test]
     fn build_repo_groups_folds_a_non_focused_repos_real_agent_into_its_own_row(
         cx: &mut TestAppContext,

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -4671,6 +4671,10 @@ mod repo_list_tests {
     /// killed" guarantee the `open_repo_in_current_window` mirror test proves via the identical
     /// technique (asserting against the live agent list and each one's own `TerminalPane::
     /// is_running`).
+    // Asserts `TerminalPane::is_running` on a spawned `claude` CLI, so it needs that binary to
+    // exist: without it the PTY child exits at once and the persistence being proven here cannot
+    // be observed at all. The `external` tier.
+    #[ignore = "external: claude; see docs/testing.md"]
     #[gpui::test]
     fn checkout_repo_from_rail_leaves_the_previous_repos_agents_running(cx: &mut TestAppContext) {
         let repo_a = crate::test_support::temp_root();

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -7975,6 +7975,10 @@ mod changes_sections_tests {
         );
     }
 
+    // Asserts both run rows report `live` and read `running`, which requires the spawned `claude`
+    // CLI to be a real live process - without that binary the child exits immediately and the row
+    // honestly reports an ended run. The `external` tier.
+    #[ignore = "external: claude; see docs/testing.md"]
     #[gpui::test]
     fn a_live_runs_row_states_that_it_is_running_and_switching_focus_changes_no_count(
         cx: &mut TestAppContext,

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -5391,6 +5391,9 @@ mod agent_pane_readout_tests {
     /// at a time: the pane only notices an exit on a simulated-clock poll tick, while the child
     /// itself only exits in real time. `test_support::wait_until` is the workspace's one
     /// sanctioned wall-clock wait (`docs/testing.md`).
+    ///
+    /// `#[cfg(unix)]` to match its only caller, which spawns a real `/bin/false`.
+    #[cfg(unix)]
     fn wait_for_exit(app: &gpui::Entity<AdeApp>, cx: &mut gpui::VisualTestContext, id: AgentId) {
         let exited = test_support::wait_until(std::time::Duration::from_secs(30), || {
             app.update(cx, |_app, cx| cx.notify());

--- a/crates/lsp-core/src/client.rs
+++ b/crates/lsp-core/src/client.rs
@@ -1747,6 +1747,9 @@ fn run_stderr_drain_loop(stderr: std::process::ChildStderr, server: &'static str
 mod tests {
     use super::*;
     use std::time::Instant;
+    // Only `IncomingHarness` uses this, and it is `#[cfg(unix)]` - the import has to carry the
+    // same gate or it is an unused import on Windows.
+    #[cfg(unix)]
     use test_support::ChildGuard;
 
     /// GitHub issue #46's own real, remaining Windows gotcha - `canonicalize`'s own docs. Not a

--- a/crates/pty-core/src/lib.rs
+++ b/crates/pty-core/src/lib.rs
@@ -1196,6 +1196,12 @@ mod pty_session_tests {
     /// failure. Generous: it has to survive a full-suite run where other tests' own child
     /// processes are competing for the same cores. `test_support::wait_until` returns as soon as
     /// the condition holds, so an idle machine pays none of it.
+    ///
+    /// `#[cfg(unix)]` because every one of its use sites is: the process-tree teardown and
+    /// SIGSTOP/SIGCONT state assertions this bounds have no Windows twin (see this module's own
+    /// header). Without the gate it is dead code on Windows - which nothing caught until clippy
+    /// started running on that target.
+    #[cfg(unix)]
     const TEARDOWN_DEADLINE: Duration = Duration::from_secs(5);
 
     /// Reads from `session.output()` until `needle` appears in the accumulated (lossy

--- a/crates/test-support/src/repo.rs
+++ b/crates/test-support/src/repo.rs
@@ -33,6 +33,14 @@ pub fn seed_empty_repo_at(dir: &Path) {
     // checkout and put `\r` into content, diff-hunk and blame assertions the fixture wrote with
     // `\n`. Pinned here so a fixture behaves identically on all three platforms (#440, finding 2).
     git(dir, &["config", "core.autocrlf", "false"]);
+    // Every `git commit` runs an auto-gc check, which can fork a real background repack. A fixture
+    // that seeds hundreds of commits and then hands the repository straight to `gix` can have its
+    // objects moved from loose to packed *while* that walk is opening them - which surfaces as a
+    // genuinely intermittent `An object with id <sha> could not be found`, observed twice on the
+    // Linux runner in `crate::graph_view::render::graph_virtualization_tests`. Fixtures are
+    // short-lived and thrown away, so they gain nothing from packing in the first place.
+    git(dir, &["config", "gc.auto", "0"]);
+    git(dir, &["config", "maintenance.auto", "false"]);
 }
 
 /// A git repository on branch `main` with one commit (`file.txt`) and a clean working tree.
@@ -82,6 +90,10 @@ pub fn seed_commits(dir: &Path, count: usize) {
 pub fn seed_bare_remote() -> TempDir {
     let dir = TempDir::new().expect("tempdir");
     git(dir.path(), &["init", "--bare", "-b", "main"]);
+    // Same reason as `seed_empty_repo_at`'s pair: a receiving repository runs its own auto-gc
+    // after a push, and a fixture never benefits from being packed.
+    git(dir.path(), &["config", "gc.auto", "0"]);
+    git(dir.path(), &["config", "maintenance.auto", "false"]);
     dir
 }
 
@@ -167,6 +179,23 @@ mod repo_seed_tests {
         seed_commits(dir.path(), 7);
 
         assert_eq!(commit_count(dir.path()), 7);
+    }
+
+    /// A seeded repository must never run a background repack. A fixture that seeds hundreds of
+    /// commits and hands the result straight to `gix` otherwise races git's auto-gc, which moves
+    /// objects from loose to packed mid-walk and produces an intermittent
+    /// `An object with id <sha> could not be found` - twice observed on the Linux runner. Pinned
+    /// as a real assertion because a silent config line is exactly the kind of thing a later
+    /// change drops without noticing.
+    #[test]
+    fn a_seeded_repo_never_runs_a_background_gc() {
+        let repo = seed_repo();
+
+        assert_eq!(git_output(repo.path(), &["config", "gc.auto"]), "0");
+        assert_eq!(
+            git_output(repo.path(), &["config", "maintenance.auto"]),
+            "false"
+        );
     }
 
     #[test]

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -48,10 +48,10 @@ process that applies them.
    against `design_handoff_jerry_ade/revision/` or the issue's acceptance criteria. The only way
    UI-visible work gets checked against something real instead of "looks right."
 
-7. **Finish — `ship`.** Runs `/check` (the gate: conventions, fmt, clippy — not tests right now,
-   see [issue #348](https://github.com/ColinEspinas/jerry/issues/348)), commits, pushes, and
-   opens the PR from `.github/pull_request_template.md` with a real summary — not a generic one.
-   Works standalone for anything that didn't start from a scoped issue, too.
+7. **Finish — `ship`.** Runs `/check` (the gate: conventions, fmt, clippy, and the `unit`/`ui`
+   test tiers), commits, pushes, and opens the PR from `.github/pull_request_template.md` with a
+   real summary — not a generic one. Works standalone for anything that didn't start from a scoped
+   issue, too.
 
 8. **Get reviewed — `review`.** Checks a diff or PR against `CLAUDE.md`'s standards and posts real
    findings with `gh pr review`, not a line-by-line narration.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -138,11 +138,38 @@ a signal the subject already emits: perturbing nothing beats polling coarsely.
 
 ## Running tests
 
-`cargo test --workspace` is deliberately **not** part of the pre-commit gate — see `CLAUDE.md` and
-[GitHub issue #348](https://github.com/ColinEspinas/jerry/issues/348). Run what you touched:
+`cargo nextest run --workspace` is part of the pre-commit gate (`CLAUDE.md`, `/check`) and runs on
+every PR in CI, on Linux, macOS and Windows. It covers the `unit` and `ui` tiers: the `external`
+tier is `#[ignore]`d, and nextest skips ignored tests unless asked for them.
+
+While iterating, scope it to what you touched:
 
 ```sh
 cargo nextest run -p wt-core
 cargo nextest run -p test-support
 cargo nextest run -p app --lib -E 'test(/my_concern_tests/)'
 ```
+
+### The `external` tier
+
+Never on a PR. It runs in `ci.yml`'s `External (real language servers)` job, on a nightly schedule
+and on `workflow_dispatch`. To run it locally you need the servers on `PATH` and a live npm
+registry (one fixture does its own `npm install typescript@5`):
+
+```sh
+rustup component add rust-analyzer
+npm install -g "@vue/language-server@3.3.8" typescript-language-server pyright
+cargo nextest run --workspace --profile external --run-ignored all
+```
+
+`--profile external` inherits the `ci` profile and raises `slow-timeout` to 120s — a real
+handshake plus a first index pass legitimately takes seconds, which the default 30s/2min budget
+cannot tell apart from a hang.
+
+Only `@vue/language-server` is pinned, to the version `crate::language`'s own module docs were
+written against. `typescript-language-server` and `pyright` are knowingly unpinned: no commit
+message or comment in this repo records the version their tests were written against, and the only
+established fact is negative — `typescript-language-server@5.3.0` fails them. The nightly job
+prints `npm ls -g --depth=0` so a pin can eventually be derived from a run that actually passes,
+rather than guessed. `gopls` is not installed: `crate::language` gives Go `lsp: None`, so nothing
+in this workspace ever spawns it.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -139,8 +139,14 @@ a signal the subject already emits: perturbing nothing beats polling coarsely.
 ## Running tests
 
 `cargo nextest run --workspace` is part of the pre-commit gate (`CLAUDE.md`, `/check`) and runs on
-every PR in CI, on Linux, macOS and Windows. It covers the `unit` and `ui` tiers: the `external`
-tier is `#[ignore]`d, and nextest skips ignored tests unless asked for them.
+every PR in CI, on Linux and macOS. It covers the `unit` and `ui` tiers: the `external` tier is
+`#[ignore]`d, and nextest skips ignored tests unless asked for them.
+
+**Windows is not a test platform yet.** Its CI job builds the workspace and runs only
+`status_bar::process_stats`, the FFI backend that exists nowhere else. The full suite does not pass
+there — a single trial run scored 134 failures and 26 timeouts, mostly paths formatted into strings
+and forward slashes baked into expected values — and GitHub issue #440 tracks fixing it. Until then
+nothing asks a contributor to run the suite on Windows, and a Windows result is not a gate.
 
 While iterating, scope it to what you touched:
 


### PR DESCRIPTION
## Summary

Closes #426 — the last piece of epic #427. Puts the test suite back where it belongs: on every PR
in CI (Linux and macOS), in the local pre-commit gate, and gives the `external` tier its own
nightly job. Windows builds and runs its platform-specific sampling tests only — see "Wave 3"
below for why that is deliberate. Then deletes every "tests are deliberately not part of the gate — see #348"
caveat in the repo.

**Status: wave 3 applied — see the section at the bottom, which supersedes parts of what
follows.** The original body is kept intact below for review history; where it conflicts with
"Wave 3", wave 3 is current. The suite is green locally and the first real CI run has happened,
so the "nothing has ever run" caveats below are no longer true.

## Why

The suite left CI in #348 because one test blocking on a language server that never answers froze
the whole run with no way to attribute it (2,808 of ~2,900 tests logged, then 13+ minutes of
nothing). Every part of that has since been fixed by this epic: nextest gives per-test processes
and a real timeout, and `docs/testing.md`'s three tiers say which tests may spawn a real server at
all. Nothing is left justifying the caveats.

## What changed

### `.github/workflows/ci.yml`

- **New `Linux (test)` job** — `cargo nextest run --workspace --profile ci`, the `unit` + `ui`
  tiers (`external` is `#[ignore]`d and skipped by default). Same system-dependency install as the
  existing Linux job.
- **Restored the `git config --global` identity step.** The comment in `ci.yml` claimed this step
  existed; it did not — it was deleted along with the test step in d30e7de. It is the real fix for
  `wt-core`'s
  `discard_worktree_refuses_when_stash_push_captures_nothing_and_an_unrelated_stash_already_exists`
  failing with "Author identity unknown" on a fresh runner (`git submodule update --init` creates
  an independent git dir that does not inherit the fixture's *local* identity). It is now on all
  three test jobs, not just Linux.
- **New `External (real language servers)` job** — `workflow_dispatch` + a nightly `schedule`
  only, never on a PR, enforced by an explicit `if:` on the job. Installs the servers, then
  `--profile external --run-ignored all`.
- **macOS widened** from `cargo test -p app --lib status_bar::process_stats` to the full
  `cargo nextest run --workspace --profile ci`. (Windows was widened too, then reverted in wave 3 —
  see below.)
- `cargo-nextest` is installed via `taiki-e/install-action@v2`, pinned to `0.9.143` — the version
  this change was written and validated against, per the project's "same version we verified
  against, not latest" convention.

### Language-server version pinning

This was the real open work #426 left. What I could establish, and what I could not:

| Server | Pin | Evidence |
|---|---|---|
| `rust-analyzer` | toolchain `1.95.0` | It is a **rustup component**, not a separate download. `components: rust-analyzer` on `dtolnay/rust-toolchain` pins it to the same toolchain as everything else — the strongest pin available, and free. Verified: `rustup component list` reports `rust-analyzer-<host>`, and installing it puts a `rust-analyzer` proxy on `PATH`. |
| `@vue/language-server` | **`3.3.8`** | `crate::language`'s module docs record the whole live investigation against exactly that version, and #348 re-confirmed the Vue test passes against it (2.15s). |
| `typescript-language-server` | **unpinned, knowingly** | `git blame` on all three of its tests leads to b0c08523 / e75f9dd3 / 06b06dac / 1aa4cd54; **not one names a version**, in the commit message or in a nearby comment, and nothing else in the repo records one. The only established fact is negative: #348 found `5.3.0` ("latest") fails them. |
| `pyright` | **unpinned, knowingly** | Same test, same blame (b0c08523), same result: no version recorded anywhere. #348 saw "latest" fail with the same shape. |
| `gopls` | **not installed** | Not a gap — a correction. `crate::language`'s registry gives Go `lsp: None` and `gopls` is PATH-detection-only on the Settings page ("a real detectable binary this app deliberately never spawns a client for"). **No test in this workspace spawns it.** #426 inherited it from #348's list; installing it would be cargo-culting. |

Rather than guess a pin — a wrong pin looks authoritative and hides the drift — the external job
has a `Resolved server versions` step that prints `npm ls -g --depth=0` and `rust-analyzer
--version` on every nightly run. That turns the nightly into the mechanism that *produces* the
evidence for a real pin, instead of a place a guess would quietly rot. `TODO(#426)` marks it.

### `.config/nextest.toml` — the TODO(#424) the tier issue left

Resolved as a `[profile.external]` (`inherits = "ci"`, `slow-timeout` 120s) rather than the
`[[profile.default.overrides]]` + filterset the TODO imagined, **because that filterset cannot be
written**: nextest's filterset language has no ignore-status predicate. Verified empirically
against cargo-nextest 0.9.143 — `ignored()` is a parse error, and `default()` refers to the
profile's `default-filter`, not to `#[ignore]`. The alternative, enumerating the tier's test names
in a `test(/.../)` filterset, would rot silently the first time a tier member is added or renamed.
Selecting the tier by the profile its own CI job runs under is the version of this that cannot
drift. The reasoning is in the file, not just here.

### The local gate

`cargo nextest run --workspace` joins conventions + fmt + clippy in
`.claude/hooks/pre-commit-check.sh` and `.claude/commands/check.md`. The hook's exit contract is
preserved: a missing `cargo-nextest` skips the step (exit 0, allow) rather than blocking a
contributor who has not run `/setup` — only a genuine test failure denies.

### Every #348 caveat removed

Re-derived with a fresh `grep -rn "348" .` rather than trusting #426's list, which is stale (it
names `.claude/skills/setup/SKILL.md`, which does not exist — the setup entry point is
`.claude/commands/setup.md` — and predates `docs/testing.md`, which carries its own #348
paragraph). `Cargo.lock` and `design_handoff_jerry_ade/*.html` match incidentally.

Removed: `CLAUDE.md`, `CONTRIBUTING.md`, `README.md`, `docs/development-workflow.md`,
`docs/testing.md`, `.github/pull_request_template.md`, `.claude/skills/ship/SKILL.md`,
`.claude/hooks/pre-commit-check.sh`, `.claude/commands/check.md`, `.github/workflows/ci.yml`'s
job comment.

Four `#348` references remain **on purpose**, and none is a caveat — they are the citation for a
factual claim whose only record is that issue: the observed hang that justifies nextest over
`cargo test`, and the "5.3.0 fails" finding that is the entire reason the two npm servers are
unpinned. Deleting them to satisfy a grep would destroy the evidence the next person needs. Flagging
this explicitly since #426's "Done when" asks for a clean grep — say the word and I will inline the
facts and drop the numbers.

## Testing

- [x] `.claude/hooks/check-conventions.sh` — OK (globs 301/301, render adapter calls 201/201 after
      the ratchet commit; see the caveat about `CLAUDE_PROJECT_DIR` below)
- [x] `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings` — no
      Rust changed in this PR
- [x] `actionlint` on `.github/workflows/ci.yml` — exit 0, clean (includes its shellcheck pass over
      every `run:` block)
- [x] YAML parsed and every job/step/`if:`/trigger asserted structurally
- [x] `.config/nextest.toml` — `[profile.external]` proven to parse, inherit `[profile.ci.junit]`
      (a real `junit.xml` is written to `target/nextest/external/`), and work in this workspace via
      `cargo nextest run -p test-support --profile external --run-ignored all`
- [x] `cargo nextest run -p wt-core -p test-support -p pty-core -p lsp-core --profile ci` — **392
      passed, 0 failed**
- [x] `.claude/hooks/pre-commit-check.sh` — `bash -n` clean; non-`git commit` input still exits 0
- [x] `cargo nextest run --workspace --profile ci` — ran to completion on macOS:
      **3,341 tests in 167s (2m47s); 3,216 passed, 125 failed, 9 skipped.** Red, as expected — the
      125 are the D5/D6/D7 slices still in flight, not this PR (which changes no Rust). Two things
      this run does establish:
      - **The runtime target is realistic.** 2m47s locally, against a ~10-minute CI budget.
      - **The `external` tier is genuinely skipped by default** — 9 skipped, 0 attempted spawns, no
        hang. That is the exact failure mode #348 was about, and it is gone.

### One real find already, from running on macOS

`app keymap::tests::resolve_keystroke_renders_the_secondary_modifier_as_the_cross_platform_mod_glyph`
fails at `crates/app/src/keymap.rs:328` with `left: ["⌃", "N"]` / `right: ["⌘", "N"]` — the
secondary-modifier glyph resolves to Control where the test expects Command, **on a real macOS
machine**. This is precisely the class of bug the narrow `status_bar::process_stats` filter could
never have caught, found the first time the suite was pointed at a Mac. It is in `crates/app` and so
outside this PR's boundary; flagging it for whoever owns that slice rather than fixing it here.

### What can only be verified once the suite is green

Stated plainly rather than claimed:

- **That the jobs pass.** Every job's *syntax and structure* is verified; none of them has run.
- **macOS and Windows.** Nobody has ever run this suite on Windows, and macOS has only ever run one
  narrow module filter. The bug that dominated this epic was macOS-specific path canonicalization
  (`/var` → `/private/var`); Windows has its own untested path-equality traps (drive-letter case,
  UNC, `\\?\`). **Expect the first real run to find things — that is this change working, not this
  change failing.**
- **The ~10-minute Linux target.** Unmeasurable until it runs on a real runner.
- **The external job end to end.** It needs a live npm registry and real server processes.
- **Whether the two unpinned servers pass at all.** That is exactly what the nightly is for.

## The ratchet (separate commit, 731e33c)

`render_adapter_calls` lowered 221 → 201, the real count on this branch. The epic's purge slices
already removed those 20 and lowered `glob_imports_app_src` in the same pass, but left this number
where it was — and a ratchet sitting 20 above the truth silently permits 20 new violations, which
is the one thing it exists to prevent. Kept as its own commit because this file is a conflict
magnet while D5/D6/D7 land in parallel; drop or redo it on rebase without touching the rest.

**A real trap found while doing it, worth knowing about:** `check-conventions.sh` starts with
`cd "${CLAUDE_PROJECT_DIR:-.}"`. Run from a worktree while `CLAUDE_PROJECT_DIR` still points at the
main checkout, it silently measures **the wrong tree** and reports a confident, wrong pass. It told
me `201/221` and then `222/222` for the same command in the same directory, because it was reading
`~/Documents/Dev/jerry` (on `master`, 304/222) both times, not this branch. Verified the real
numbers by running the greps directly here (301 globs, 201 adapter calls) and re-running the script
with `CLAUDE_PROJECT_DIR` pointed at the worktree: `OK (glob imports: 301/301, render adapter
calls: 201/201)`. Anyone rebasing this file should do the same, or they will confirm a number that
was never measured.

## Notes for the reviewer

- **The gate blocked its own commit**, exactly as designed: the extended
  `.claude/hooks/pre-commit-check.sh` denied `git commit` because the suite is red from the
  in-flight slices. Both commits were made through a one-time, explicitly authorized bypass of that
  hook, with the gate itself left exactly as written. Recording it here rather than quietly routing
  around it.
- The purge is still in flight, so `crates/` is untouched by this PR by design — including
  `crates/app/src/lsp/client.rs`'s four remaining bare `#[ignore]`s (D6's slice). Their `#348`
  comments and missing reason strings are that PR's job, not this one's.
- Observed while running the core crates: `lsp-core`'s
  `a_real_but_frozen_server_fails_the_write_within_the_budget_instead_of_hanging_forever` and
  `a_writer_queued_behind_one_that_gives_up_is_refused_rather_than_corrupting_the_stream` each take
  **30.045s** and trip nextest's SLOW threshold. They pass, and the duration is the budget they are
  asserting — but they are `unit`-tier tests 3,000× over that tier's 10 ms budget, and together
  they are a minute of every CI run. Worth a look as a follow-up; deliberately not touched here.


---

# Wave 3 — the first real CI run, and what it found

The first run of the jobs above is what this section is about. It supersedes the "what can only be
verified once the suite is green" caveats: the suite has now run.

## The four failures, and why they are one defect

Linux reported 4 failures out of 3128; macOS 4 out of 3125. They are the same four, and all four
are an `external`-tier test wearing a `ui`-tier marker — the exact case `docs/testing.md`'s tier
table exists to separate.

| Test | Needs | Now |
|---|---|---|
| `code_surface::file_view::lsp_failed_status_chip_tests::clicking_the_failed_status_chip_really_restarts_the_language_servers` | a real `rust-analyzer` | `#[ignore = "external: rust-analyzer; …"]` |
| `rail::render::repo_checkout_tests::build_repo_groups_folds_a_non_focused_repos_real_agent_into_its_own_row` | the `claude` CLI | `#[ignore = "external: claude; …"]` |
| `root::repo_list_tests::checkout_repo_from_rail_leaves_the_previous_repos_agents_running` | the `claude` CLI | `#[ignore = "external: claude; …"]` |
| `sidebar::render::changes_sections_tests::a_live_runs_row_states_that_it_is_running_and_switching_focus_changes_no_count` | the `claude` CLI | `#[ignore = "external: claude; …"]` |

The reason strings name the specific binary rather than a generic "external": an agent CLI is not
a language server, and a future reader installing the wrong one learns nothing.

**Read rather than assumed.** `ProcessKind::claude()` resolves through `AgentKind::binary_name()`
to the literal `claude` on `$PATH`, with no fallback, and all three of those tests then assert the
process is genuinely alive (`Status::Run`, `TerminalPane::is_running`, `row.live`). The CI log is
explicit about the consequence: `assertion left == right failed … left: Fail, right: Run`. The PTY
child exec'd a binary that does not exist on a runner and exited immediately. The LSP one is the
same shape one layer over: it asserts the click's own `ensure_lsp_client` reached
`Spawning`/`Ready`, which cannot happen without `rust-analyzer` installed.

These pass on the maintainer's laptop only because that laptop has both binaries — verified, the
real `claude` there is `~/.superconductor/bin/claude`. "Passes where the binary happens to exist,
fails on a clean runner" is the definition of the `external` tier.

## The fifth test: no defect, and no change

`graph_view::render::graph_virtualization_tests::loading_more_commits_keeps_the_selected_row_on_the_same_commit`
was reported as a fifth, Linux-only failure. **It is not a failure.** The Linux job log records:

```
PASS [   6.852s] ( 811/3128) app graph_view::render::graph_virtualization_tests::loading_more_commits_keeps_the_selected_row_on_the_same_commit
…
Summary [ 426.154s] 3128 tests run: 3124 passed, 4 failed, 30 skipped
```

Four failures, and this is not one of them. The 6.9s is its duration, not a timeout — nextest's
slow threshold is 30s. That time is real fixture cost (`seed_commits` writing 520 real git commits
through the `git` CLI), not a timing assumption, so there is no `run_until_parked`/`wait_until` fix
to make and nothing to re-tier. Deliberately left alone.

## Closing the class, not the four instances

Eleven other tests spawn a real agent CLI and none of them failed, which is the interesting case:
a grep cannot tell a test that *needs* the binary from one that merely *calls* the API.

So this was verified by experiment rather than by reading. The entire workspace was run with
`claude`, `codex`, `rust-analyzer`, `typescript-language-server`, `pyright` and
`vue-language-server` all removed from `PATH` (a shim `PATH` keeping `cargo`/`rustc`/`node`, since
the CI runner does have `node` — several `ui` tests legitimately drive a `node`-based *fake* LSP
server, which is not an external server and correctly stays in the gate):

```
Summary [ 113.861s] 3121 tests run: 3121 passed, 34 skipped
```

Zero failures with every external binary absent. The eleven remaining agent-spawning tests assert
on tab-strip and rail *structure*, not on process liveness, so they behave identically either way —
hermetic, and they stay in the gate. The class is closed with evidence, not with a blanket re-tier
that would have cost eleven green tests for nothing.

## Windows: back to its narrow scope (issue #440)

The one full-suite Windows run scored **134 failures and 26 timeouts across 3073 tests, in 1407
seconds**. That is a real investigation — paths formatted into strings, forward slashes baked into
expected values, and 26 timeouts whose mechanism nobody has diagnosed — and it is #440's work, split
out of #427 rather than allowed to hold a finished epic behind unbounded work.

So the Windows job is reverted to exactly what it ran before this PR: `cargo build --workspace`
plus `cargo test -p app --lib status_bar::process_stats`, the `GetProcessTimes`/PSAPI FFI backend
that is covered nowhere else. The job carries a `DELIBERATELY NARROW — do not widen this without
reading issue #440 first` comment stating *why*, so the next reader does not take it for an
oversight. `docs/testing.md` and `README.md` no longer claim the suite runs on Windows; testing.md
now says plainly that Windows is not a test platform yet and that a Windows result is not a gate.

Windows coverage is deferred, not forgotten.

## Duplicate runs: about 200 billed minutes back per push

The workflow triggered on bare `push:` **and** `pull_request:`, so every push to a PR branch fired
two complete, identical runs. Verified on this branch — runs `31974623400` (push) and
`31974624833` (pull_request) are the same commit, and there were three such pairs. At GitHub's
billing multipliers (Linux 1×, Windows 2×, macOS 10×) one run of this workflow is roughly 200
billed minutes, so the duplicate cost about that much per push for no added signal.

- `push:` is now scoped to `branches: [master]`. PR branches run once, via `pull_request`.
  `workflow_dispatch` and `schedule` are untouched — the `external` job depends on them.
- A `concurrency:` group with `cancel-in-progress: true` now supersedes a run still in flight
  instead of racing it.
- The comment above the triggers claimed both events existed for the `external` job. That was not
  accurate — `external` is gated on `workflow_dispatch` and `schedule` — and it is corrected rather
  than preserved.

**One deliberate refinement over the literal ask:** the concurrency key includes `github.event_name`
alongside workflow and ref. Without it, a push to `master` and the nightly `schedule` run share a
ref and would cancel each other — and the nightly is the only execution the `external` tier ever
gets. Flagging it explicitly since it is a small deviation.

**Verified on the very first push:** commit `bb3396c` produced exactly one run, where every
preceding commit on this branch produced a push/pull_request pair.

## macOS cost — noted, not acted on

macOS is the most expensive job here at 10× billing, and its scope is deliberately unchanged (it is
the platform this epic's real product bug lived on). Two cheap, scope-preserving ideas, raised here
rather than done:

1. **The `cargo build --workspace` step is likely redundant with the test step.**
   `cargo nextest run --workspace` compiles the same dependency graph plus the test harnesses, into
   the same target dir. Dropping the explicit build would not reduce what is *tested*, only what is
   compiled twice — but it would stop catching a break in a non-test target, so it wants measuring
   before anyone does it.
2. **`Swatinem/rust-cache` currently saves the cache on every run.** Adding
   `save-if: ${{ github.ref == 'refs/heads/master' }}` would keep the restore on PR runs while
   skipping the compress-and-upload step, which is pure overhead on a 10×-billed runner.

## Verification

- [x] `CLAUDE_PROJECT_DIR=$PWD .claude/hooks/check-conventions.sh` — `OK (glob imports: 300/300,
      render adapter calls: 196/196)`
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo nextest run --workspace` — **3121 passed, 34 skipped, 0 failed.** Was 3125 passed / 30
      skipped; exactly the four re-tiered tests moved, and nothing else changed.
- [x] The same run with every external binary stripped from `PATH` — **3121 passed, 34 skipped, 0
      failed** (see "Closing the class").
