### PR TITLE
test(app-shell): unbreak, tier and purge the rail / work_surface / root / title_bar suite (#425)

### DIFF
--- a/crates/app/src/rail/menu_render.rs
+++ b/crates/app/src/rail/menu_render.rs
@@ -449,53 +449,15 @@ impl AdeApp {
 #[cfg(test)]
 mod rail_menu_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
     use std::fs;
     use std::path::Path;
-    use std::process::Command;
-    use tempfile::TempDir;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        fs::write(dir.path().join("base.txt"), "base\n").expect("write");
-        git(dir.path(), &["add", "base.txt"]);
-        git(dir.path(), &["commit", "-m", "initial"]);
-        dir
-    }
 
     fn add_worktree(repo_path: &Path, branch: &str, name: &str) -> PathBuf {
-        let container = TempDir::new().expect("tempdir");
+        let container = crate::test_support::temp_root();
         let path = container.path().join(name);
         drop(container);
-        git(
-            repo_path,
-            &[
-                "worktree",
-                "add",
-                "-b",
-                branch,
-                path.to_str().expect("utf8 path"),
-            ],
-        );
+        test_support::add_worktree(repo_path, branch, &path);
         path
     }
 
@@ -629,9 +591,9 @@ mod rail_menu_tests {
     fn right_clicking_a_worktree_row_paints_the_row_set_the_revision_lists(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let feature = add_worktree(repo.path(), "feature", "feature");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         // A real agent session in the main worktree, so the Archive row has a real count to
         // report (a plain shell gets no rail row, and so is not something this row promises).
@@ -677,9 +639,9 @@ mod rail_menu_tests {
     /// was opened on - including one that was not the selected worktree when the menu opened.
     #[gpui::test]
     fn new_agent_here_really_spawns_an_agent_into_that_worktree(cx: &mut TestAppContext) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let feature = add_worktree(repo.path(), "feature", "feature");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         app.read_with(cx, |app, _| {
             assert_eq!(
@@ -715,8 +677,8 @@ mod rail_menu_tests {
     fn right_clicking_an_agent_row_paints_open_one_pause_or_resume_and_one_archive_run(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let agent_id = spawn_agent(&app, cx);
@@ -752,7 +714,7 @@ mod rail_menu_tests {
     /// an effect rather than the test passing on a scroller that never scrolled.
     #[gpui::test]
     fn scrolling_the_rail_does_not_move_or_clip_an_open_menu(cx: &mut TestAppContext) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         for index in 0..8 {
             add_worktree(
                 repo.path(),
@@ -760,7 +722,7 @@ mod rail_menu_tests {
                 &format!("wt{index}"),
             );
         }
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         // Small enough that nine worktree rows genuinely overflow the rail's own viewport -
         // without a list that really scrolls, this test would pass against a menu nailed to a
@@ -826,8 +788,8 @@ mod rail_menu_tests {
     fn the_overflow_button_opens_history_and_settings_under_its_own_right_edge(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let button = cx
@@ -868,8 +830,8 @@ mod rail_menu_tests {
     /// it: Settings opens the real Settings surface, and the menu closes behind it.
     #[gpui::test]
     fn picking_settings_from_the_overflow_really_opens_settings(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let button = cx.debug_bounds("rail-overflow").expect("button");
@@ -896,8 +858,8 @@ mod rail_menu_tests {
     fn archive_run_ends_the_run_and_leaves_the_worktree_and_its_files_alone(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         let written = repo.path().join("agent-wrote-this.txt");
         fs::write(&written, "work\n").expect("write");
@@ -924,9 +886,9 @@ mod rail_menu_tests {
     fn remove_worktree_takes_two_clicks_and_then_really_removes_the_checkout(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let feature = add_worktree(repo.path(), "feature", "feature");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         right_click_worktree_row(&app, cx, &feature);
@@ -965,9 +927,9 @@ mod rail_menu_tests {
     /// never be one click away from deleting a checkout.
     #[gpui::test]
     fn dismissing_the_menu_disarms_a_half_confirmed_removal(cx: &mut TestAppContext) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let feature = add_worktree(repo.path(), "feature", "feature");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         right_click_worktree_row(&app, cx, &feature);
@@ -1003,8 +965,8 @@ mod rail_menu_tests {
     /// picking one of the two destinations its ellipsis promises.
     #[gpui::test]
     fn open_in_opens_its_second_level_in_the_same_menu(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         right_click_worktree_row(&app, cx, repo.path());
@@ -1028,8 +990,8 @@ mod rail_menu_tests {
     /// rail's bottom", asserted against the popover's *painted* bounds rather than its arithmetic.
     #[gpui::test]
     fn a_menu_opened_at_the_windows_foot_flips_above_the_pointer(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let viewport = cx.update(|window, _cx| window.bounds().size);

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -2361,18 +2361,15 @@ mod agent_trailing_text_count_tests {
         }
     }
 
+    /// The row's trailing text conjugates with its own count - and no count at all is an empty
+    /// string, not `"0 files"`: the absence of a measurement and a measured zero are different
+    /// facts, and only the latter is a conjugation case.
     #[test]
-    fn review_file_count_conjugates_at_zero_one_and_two() {
+    fn the_review_file_count_conjugates_and_an_unmeasured_row_says_nothing() {
         assert_eq!(agent_trailing_text(&review_row(Some(0))), "0 files");
         assert_eq!(agent_trailing_text(&review_row(Some(1))), "1 file");
         assert_eq!(agent_trailing_text(&review_row(Some(2))), "2 files");
         assert_eq!(agent_trailing_text(&review_row(Some(12))), "12 files");
-    }
-
-    /// No count at all is still an empty string, not `"0 files"` - the absence of a measurement
-    /// and a measured zero are different facts, and only the latter is a conjugation case.
-    #[test]
-    fn an_unmeasured_review_row_has_no_trailing_text() {
         assert_eq!(agent_trailing_text(&review_row(None)), "");
     }
 }
@@ -3176,16 +3173,10 @@ mod rail_row_tests {
              {:?}",
             spec.args
         );
-    }
 
-    /// A stale/unknown key (the record was pruned, or never existed) must be a genuine no-op -
-    /// nothing is spawned, and nothing else about the app's state changes.
-    #[gpui::test]
-    fn resume_past_agent_is_a_no_op_for_an_unknown_key(cx: &mut TestAppContext) {
-        let repo = crate::test_support::temp_root();
-        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
+        // A stale/unknown key (the record was pruned, or never existed) is a genuine no-op -
+        // nothing is spawned, and nothing else about the app's state changes.
         let count_before = app.read_with(cx, |app, _| app.agents.iter().count());
-
         let resumed = app.update_in(cx, |app, window, cx| {
             app.resume_past_agent("no-such-key", window, cx)
         });
@@ -5690,8 +5681,11 @@ mod rail_filter_selection_tests {
         );
     }
 
+    /// Any edit made while a selection is live replaces that whole range rather than acting at
+    /// the caret: a paste substitutes its clipboard content for it, and one Backspace empties it
+    /// rather than removing a single character from its end.
     #[gpui::test]
-    fn paste_over_a_selection_replaces_it(cx: &mut TestAppContext) {
+    fn an_edit_over_a_live_selection_replaces_the_whole_range(cx: &mut TestAppContext) {
         let repo = crate::test_support::temp_root();
         let (app, cx) = open_filter_with(cx, repo.path(), "origin/main");
         cx.update(|_window, cx| {
@@ -5708,12 +5702,7 @@ mod rail_filter_selection_tests {
             "upstream/main",
             "a paste with a live selection replaces that whole range"
         );
-    }
 
-    #[gpui::test]
-    fn backspace_over_a_selection_deletes_the_whole_range(cx: &mut TestAppContext) {
-        let repo = crate::test_support::temp_root();
-        let (app, cx) = open_filter_with(cx, repo.path(), "origin/main");
         cx.simulate_keystrokes(&secondary("a"));
         cx.simulate_keystrokes("backspace");
         cx.run_until_parked();

--- a/crates/app/src/rail/render.rs
+++ b/crates/app/src/rail/render.rs
@@ -2380,57 +2380,17 @@ mod agent_trailing_text_count_tests {
 #[cfg(test)]
 mod prune_regression_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
-    use std::fs;
     use std::path::Path;
-    use std::process::Command;
-    use tempfile::TempDir;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        fs::write(dir.path().join("base.txt"), "base\n").expect("write");
-        git(dir.path(), &["add", "base.txt"]);
-        git(dir.path(), &["commit", "-m", "initial"]);
-        dir
-    }
 
     /// Same linked-worktree idiom `merge::flow`'s test module uses. Created with no new
     /// commits, so its branch tip trivially equals `main`'s - a genuinely-merged, clean
     /// worktree without needing a second real merge to produce one.
     fn add_worktree(repo_path: &Path, branch: &str, name: &str) -> PathBuf {
-        let container = TempDir::new().expect("tempdir");
+        let container = crate::test_support::temp_root();
         let path = container.path().join(name);
         drop(container);
-        git(
-            repo_path,
-            &[
-                "worktree",
-                "add",
-                "-b",
-                branch,
-                path.to_str().expect("utf8 path"),
-            ],
-        );
+        test_support::add_worktree(repo_path, branch, &path);
         path
     }
 
@@ -2478,10 +2438,10 @@ mod prune_regression_tests {
     fn a_second_confirm_while_first_batch_is_in_flight_does_not_prune_a_worktree_seeded_after_it(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let first = add_worktree(repo.path(), "first-feature", "first-feature-wt");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, _cx| {
             seed_one_prunable_worktree(app, first.clone(), "first-feature");
         });
@@ -2554,7 +2514,6 @@ mod rail_row_tests {
     use super::*;
     use crate::hooks::store::LiveRun;
     use crate::rail::worktrees::WorktreeItem;
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
 
     fn worktree_item(path: PathBuf, label: &str) -> WorktreeItem {
@@ -2592,10 +2551,10 @@ mod rail_row_tests {
     /// the exemption itself.
     #[gpui::test]
     fn worktree_is_expanded_defaults_to_the_real_idle_rooted_rule(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt = tempfile::tempdir().expect("tempdir wt");
-        let other_wt = tempfile::tempdir().expect("tempdir other wt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt = crate::test_support::temp_root();
+        let other_wt = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![
@@ -2666,8 +2625,8 @@ mod rail_row_tests {
     /// the rail and the tab strip are allowed to disagree about that on purpose.
     #[gpui::test]
     fn a_worktree_with_only_a_shell_open_produces_no_agent_row(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, _cx| {
             app.worktrees = vec![worktree_item(repo.path().to_path_buf(), "repo")];
         });
@@ -2737,9 +2696,9 @@ mod rail_row_tests {
     /// the plain idle default.
     #[gpui::test]
     fn the_selected_worktree_never_idle_collapses_by_default(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt = tempfile::tempdir().expect("tempdir wt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![worktree_item(wt.path().to_path_buf(), "wt")];
@@ -2797,9 +2756,9 @@ mod rail_row_tests {
     /// a real per-worktree memory, not a write-only flag.
     #[gpui::test]
     fn toggle_worktree_collapsed_flips_and_remembers_the_override(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt = tempfile::tempdir().expect("tempdir wt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![worktree_item(wt.path().to_path_buf(), "wt")];
@@ -2857,10 +2816,10 @@ mod rail_row_tests {
     /// exact agent the active tab - not just one half of the pair.
     #[gpui::test]
     fn selecting_an_agent_selects_its_worktree_and_raises_its_tab(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt_a = tempfile::tempdir().expect("tempdir a");
-        let wt_b = tempfile::tempdir().expect("tempdir b");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt_a = crate::test_support::temp_root();
+        let wt_b = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![
@@ -2923,10 +2882,10 @@ mod rail_row_tests {
     fn render_rail_list_does_not_panic_across_bare_and_multi_agent_worktrees(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let bare_wt = tempfile::tempdir().expect("tempdir bare");
-        let busy_wt = tempfile::tempdir().expect("tempdir busy");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let bare_wt = crate::test_support::temp_root();
+        let busy_wt = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![
@@ -2974,10 +2933,10 @@ mod rail_row_tests {
     fn build_repo_groups_header_wt_count_is_unaffected_by_the_filter_query(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt_alpha = tempfile::tempdir().expect("tempdir alpha");
-        let wt_beta = tempfile::tempdir().expect("tempdir beta");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt_alpha = crate::test_support::temp_root();
+        let wt_beta = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![
@@ -3030,9 +2989,9 @@ mod rail_row_tests {
     ) {
         use crate::work_surface::agents::AgentKind;
 
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt = tempfile::tempdir().expect("tempdir wt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![worktree_item(wt.path().to_path_buf(), "wt")];
@@ -3119,9 +3078,9 @@ mod rail_row_tests {
     ) {
         use crate::work_surface::agents::AgentKind;
 
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt = tempfile::tempdir().expect("tempdir wt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, _cx| {
             app.worktrees = vec![worktree_item(wt.path().to_path_buf(), "wt")];
         });
@@ -3180,9 +3139,9 @@ mod rail_row_tests {
     ) {
         use crate::work_surface::agents::AgentKind;
 
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt = tempfile::tempdir().expect("tempdir wt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, _cx| {
             app.worktrees = vec![worktree_item(wt.path().to_path_buf(), "wt")];
         });
@@ -3223,8 +3182,8 @@ mod rail_row_tests {
     /// nothing is spawned, and nothing else about the app's state changes.
     #[gpui::test]
     fn resume_past_agent_is_a_no_op_for_an_unknown_key(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         let count_before = app.read_with(cx, |app, _| app.agents.iter().count());
 
         let resumed = app.update_in(cx, |app, window, cx| {
@@ -3250,44 +3209,14 @@ mod rail_row_tests {
 /// (`crate::root::AdeApp::select_worktree_by_path`'s cross-repo fallback).
 #[cfg(test)]
 mod repo_checkout_tests {
-    use crate::root::focus::palette_focus_tests;
     use crate::work_surface::agents::ProcessKind;
     use crate::work_surface::state::TabRef;
     use gpui::TestAppContext;
     use std::path::Path;
-    use std::process::Command;
-    use tempfile::TempDir;
 
     /// A minimal, real `git init`-ed repo - mirrors `crate::root::state::
     /// load_worktrees_integration_tests`'s identical own helper, duplicated locally per this
     /// crate's own established per-test-module convention rather than shared.
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(dir.path().join("base.txt"), "base\n").expect("write");
-        git(dir.path(), &["add", "base.txt"]);
-        git(dir.path(), &["commit", "-m", "initial"]);
-        dir
-    }
-
     /// The repo header is **not a click target** - per explicit user direction, after two
     /// subtler header-click behaviors were both rejected in review (auto-selecting the repo's
     /// main worktree; then a "pure navigation" focus switch that still re-rooted the sidebar):
@@ -3302,11 +3231,11 @@ mod repo_checkout_tests {
     /// `on_click`, not merely that it does something subtler than before.
     #[gpui::test]
     fn clicking_a_non_focused_repos_header_does_nothing_at_all(cx: &mut TestAppContext) {
-        let repo_a = tempfile::tempdir().expect("tempdir a");
-        let repo_b = tempfile::tempdir().expect("tempdir b");
+        let repo_a = crate::test_support::temp_root();
+        let repo_b = crate::test_support::temp_root();
         std::fs::write(repo_b.path().join("b.txt"), "b\n").expect("write");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
 
         let repo_b_id = app.update(cx, |app, cx| app.add_repo(repo_b.path().to_path_buf(), cx));
@@ -3388,10 +3317,10 @@ mod repo_checkout_tests {
     fn build_repo_groups_marks_a_non_focused_repos_data_as_loaded_once_its_real_fetch_resolves(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = tempfile::tempdir().expect("tempdir a");
-        let repo_b = init_repo();
+        let repo_a = crate::test_support::temp_root();
+        let repo_b = crate::test_support::temp_repo();
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
 
         let repo_a_id = app.read_with(cx, |app, _| {
@@ -3466,10 +3395,10 @@ mod repo_checkout_tests {
     fn build_repo_groups_folds_a_non_focused_repos_real_agent_into_its_own_row(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = tempfile::tempdir().expect("tempdir a");
-        let repo_b = init_repo();
+        let repo_a = crate::test_support::temp_root();
+        let repo_b = crate::test_support::temp_repo();
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
 
         // Focus repo B long enough to spawn a real Claude agent into it, mirroring how a user
@@ -3556,8 +3485,8 @@ mod repo_checkout_tests {
     /// (`crate::root::mod`) uses for the real switch case.
     #[gpui::test]
     fn clicking_the_already_focused_repos_header_does_not_reset_it(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let repo_id = app.read_with(cx, |app, _| {
@@ -3589,19 +3518,10 @@ mod repo_checkout_tests {
     /// Same linked-worktree idiom the sibling test modules use: created with no new commits of its
     /// own, which is all these tests need from it (a second, real, selectable worktree row).
     fn add_worktree(repo_path: &Path, branch: &str, name: &str) -> std::path::PathBuf {
-        let container = TempDir::new().expect("tempdir");
+        let container = crate::test_support::temp_root();
         let path = container.path().join(name);
         drop(container);
-        git(
-            repo_path,
-            &[
-                "worktree",
-                "add",
-                "-b",
-                branch,
-                path.to_str().expect("utf8 path"),
-            ],
-        );
+        test_support::add_worktree(repo_path, branch, &path);
         path
     }
 
@@ -3618,11 +3538,11 @@ mod repo_checkout_tests {
     fn clicking_a_non_focused_repos_worktree_row_switches_repo_and_selects_it(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = init_repo();
-        let repo_b = init_repo();
+        let repo_a = crate::test_support::temp_repo();
+        let repo_b = crate::test_support::temp_repo();
         let repo_b_feature = add_worktree(repo_b.path(), "feature", "b-feature");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
 
         app.update(cx, |app, cx| {
@@ -3707,14 +3627,14 @@ mod repo_checkout_tests {
     fn a_cross_repo_worktree_selection_survives_the_repos_own_background_fetch(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = init_repo();
-        let repo_b = init_repo();
+        let repo_a = crate::test_support::temp_repo();
+        let repo_b = crate::test_support::temp_repo();
         // Two linked worktrees, so the target is not at index 0 and a stale index would be
         // visible as a wrong selection rather than accidentally landing on the right row.
         let _first = add_worktree(repo_b.path(), "first", "b-first");
         let target = add_worktree(repo_b.path(), "second", "b-second");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
         app.update(cx, |app, cx| {
             app.add_repo(repo_b.path().to_path_buf(), cx);
@@ -3762,10 +3682,10 @@ mod repo_checkout_tests {
     /// `git worktree remove`) must still do nothing - never a repo switch to something arbitrary.
     #[gpui::test]
     fn selecting_a_worktree_path_no_repo_knows_about_still_does_nothing(cx: &mut TestAppContext) {
-        let repo_a = init_repo();
-        let repo_b = init_repo();
+        let repo_a = crate::test_support::temp_repo();
+        let repo_b = crate::test_support::temp_repo();
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
         app.update(cx, |app, cx| {
             app.add_repo(repo_b.path().to_path_buf(), cx);
@@ -3813,8 +3733,8 @@ mod repo_checkout_tests {
     fn an_agent_spawned_in_a_repo_opened_through_a_symlink_still_appears_in_the_rail(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
-        let link_holder = TempDir::new().expect("tempdir");
+        let repo = crate::test_support::temp_repo();
+        let link_holder = crate::test_support::temp_root();
         let link = link_holder.path().join("repo-link");
         std::os::unix::fs::symlink(repo.path(), &link).expect("symlink");
         assert_ne!(
@@ -3823,7 +3743,7 @@ mod repo_checkout_tests {
             "sanity check: the symlink really is a different path from the real repo"
         );
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, link.clone());
+        let (app, cx) = crate::test_support::open_test_app(cx, link.clone());
         cx.run_until_parked();
 
         // The real spawn chokepoint every "New agent" entry point funnels through.
@@ -3872,13 +3792,13 @@ mod repo_checkout_tests {
     #[cfg(unix)]
     #[gpui::test]
     fn opening_a_symlinked_folder_stores_the_resolved_repo_path(cx: &mut TestAppContext) {
-        let repo_a = init_repo();
-        let repo_b = init_repo();
-        let link_holder = TempDir::new().expect("tempdir");
+        let repo_a = crate::test_support::temp_repo();
+        let repo_b = crate::test_support::temp_repo();
+        let link_holder = crate::test_support::temp_root();
         let link = link_holder.path().join("repo-b-link");
         std::os::unix::fs::symlink(repo_b.path(), &link).expect("symlink");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
 
         app.update_in(cx, |app, window, cx| {
@@ -3930,56 +3850,17 @@ mod repo_checkout_tests {
 /// centre pane each independently believed.
 #[cfg(test)]
 mod worktree_tab_attribution_tests {
-    use crate::root::focus::palette_focus_tests;
     use crate::work_surface::state::TabRef;
     use gpui::TestAppContext;
     use std::path::{Path, PathBuf};
-    use std::process::Command;
-    use tempfile::TempDir;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
 
     /// A real repository with a real commit - `wt_core::list_worktrees_porcelain` reports nothing
     /// at all for a bare `tempfile::tempdir()`, so these tests need a genuine main worktree row.
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(dir.path().join("base.txt"), "base\n").expect("write");
-        git(dir.path(), &["add", "base.txt"]);
-        git(dir.path(), &["commit", "-m", "initial"]);
-        dir
-    }
-
     fn add_worktree(repo_path: &Path, branch: &str, name: &str) -> PathBuf {
-        let container = TempDir::new().expect("tempdir");
+        let container = crate::test_support::temp_root();
         let path = container.path().join(name);
         drop(container);
-        git(
-            repo_path,
-            &[
-                "worktree",
-                "add",
-                "-b",
-                branch,
-                path.to_str().expect("utf8 path"),
-            ],
-        );
+        test_support::add_worktree(repo_path, branch, &path);
         path
     }
 
@@ -4014,8 +3895,8 @@ mod worktree_tab_attribution_tests {
     /// selected, and the startup shell genuinely lives in it.
     #[gpui::test]
     fn a_fresh_launch_genuinely_selects_the_repos_own_main_worktree(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         app.read_with(cx, |app, _| {
@@ -4062,9 +3943,9 @@ mod worktree_tab_attribution_tests {
     fn the_startup_terminal_is_a_real_worktrees_tab_and_survives_switching_away_and_back(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let feature = add_worktree(repo.path(), "feature", "feature");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let startup_agent = app.read_with(cx, |app, _| {
@@ -4142,9 +4023,9 @@ mod worktree_tab_attribution_tests {
     fn launching_against_a_subdirectory_still_attributes_its_shell_to_a_real_worktree(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         std::fs::create_dir_all(repo.path().join("crates")).expect("mkdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().join("crates"));
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().join("crates"));
         cx.run_until_parked();
 
         let startup_agent = app.read_with(cx, |app, _| {
@@ -4191,9 +4072,9 @@ mod worktree_tab_attribution_tests {
     /// worktree, not silently redirect to the repo's main one.
     #[gpui::test]
     fn launching_inside_a_linked_worktree_selects_that_worktree_not_main(cx: &mut TestAppContext) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let feature = add_worktree(repo.path(), "feature", "feature");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, feature.clone());
+        let (app, cx) = crate::test_support::open_test_app(cx, feature.clone());
         cx.run_until_parked();
 
         app.read_with(cx, |app, _| {
@@ -4218,9 +4099,9 @@ mod worktree_tab_attribution_tests {
     fn opening_a_folder_lands_on_a_real_worktree_and_spawns_its_shell_there(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = init_repo();
-        let repo_b = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let repo_a = crate::test_support::temp_repo();
+        let repo_b = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
 
         app.update_in(cx, |app, window, cx| {
@@ -4268,11 +4149,11 @@ mod worktree_tab_attribution_tests {
     fn a_worktree_click_racing_the_open_fetch_still_gets_its_guaranteed_shell(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = init_repo();
-        let repo_b = init_repo();
+        let repo_a = crate::test_support::temp_repo();
+        let repo_b = crate::test_support::temp_repo();
         let feature = add_worktree(repo_b.path(), "feature", "feature");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
         // Repo B is already a known repo with a real, already-fetched worktree list - which is
         // what makes the racing click below able to resolve a row at all.
@@ -4326,9 +4207,9 @@ mod worktree_tab_attribution_tests {
     /// merely looking plausible.
     #[gpui::test]
     fn nothing_selected_means_nothing_shown_anywhere(cx: &mut TestAppContext) {
-        let repo_a = init_repo();
-        let repo_b = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let repo_a = crate::test_support::temp_repo();
+        let repo_b = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
 
         // Repo B enters through the real "Open Folder…" gesture, so it genuinely has a live shell
@@ -4408,7 +4289,6 @@ mod worktree_tab_attribution_tests {
 /// measured-bounds technique rather than only reading the render code.
 #[cfg(test)]
 mod rail_filter_caret_tests {
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
     use std::time::Duration;
 
@@ -4416,8 +4296,8 @@ mod rail_filter_caret_tests {
     fn caret_sits_before_the_placeholder_when_empty_and_after_the_text_once_typed(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update_in(cx, |app, window, cx| {
             window.focus(&app.filter_focus_handle, cx);
@@ -4481,8 +4361,8 @@ mod rail_filter_caret_tests {
     /// into it and then typing, never focus with no further interaction.
     #[gpui::test]
     fn focusing_the_rail_filter_starts_the_real_shared_blink_loop(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         // `on_focus`/`on_blur` (`AdeApp::wire_caret_blink`'s own mechanism) only fire while GPUI
         // considers the window itself "active" - a real, freshly opened test window starts out
         // not active at all.
@@ -4519,7 +4399,6 @@ mod rail_filter_caret_tests {
 #[cfg(test)]
 mod agent_chip_icon_pack_tests {
     use crate::rail::worktrees::WorktreeItem;
-    use crate::root::focus::palette_focus_tests;
     use crate::work_surface::agents::ProcessKind;
     use gpui::{px, TestAppContext};
 
@@ -4553,14 +4432,14 @@ mod agent_chip_icon_pack_tests {
     fn open_with_a_running_agent(
         cx: &mut TestAppContext,
     ) -> (
-        tempfile::TempDir,
-        tempfile::TempDir,
+        crate::test_support::TempRoot,
+        crate::test_support::TempRoot,
         gpui::Entity<crate::root::AdeApp>,
         &mut gpui::VisualTestContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt = tempfile::tempdir().expect("tempdir wt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![worktree_item(wt.path().to_path_buf(), "wt")];
@@ -4599,7 +4478,7 @@ mod agent_chip_icon_pack_tests {
     fn the_rail_agent_row_switches_to_a_real_pack_icon_once_one_is_configured(
         cx: &mut TestAppContext,
     ) {
-        let pack_dir = tempfile::tempdir().expect("tempdir");
+        let pack_dir = crate::test_support::temp_root();
         // The seeded agent is a real `AgentKind::Claude` (`work_surface::agent_icon_name`'s own
         // mapping), so `claude.svg` is the real file this specific row's chip looks for.
         std::fs::write(pack_dir.path().join("claude.svg"), "<svg></svg>").expect("write");
@@ -4640,7 +4519,7 @@ mod agent_chip_icon_pack_tests {
     /// that the pack icon cannot regress back into the invisible-alpha-mask failure mode.
     #[gpui::test]
     fn the_pack_icon_element_is_a_real_image_not_a_colour_dependent_svg(cx: &mut TestAppContext) {
-        let pack_dir = tempfile::tempdir().expect("tempdir");
+        let pack_dir = crate::test_support::temp_root();
         std::fs::write(pack_dir.path().join("claude.svg"), "<svg></svg>").expect("write");
 
         let (_repo, _wt, app, cx) = open_with_a_running_agent(cx);
@@ -4900,7 +4779,6 @@ mod rail_correction_tests {
 mod rail_rev6_render_tests {
     use super::*;
     use crate::rail::worktrees::WorktreeItem;
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
 
     fn worktree_item(path: PathBuf, label: &str) -> WorktreeItem {
@@ -4941,14 +4819,14 @@ mod rail_rev6_render_tests {
     fn open_with_a_failed_agent(
         cx: &mut TestAppContext,
     ) -> (
-        tempfile::TempDir,
-        tempfile::TempDir,
+        crate::test_support::TempRoot,
+        crate::test_support::TempRoot,
         gpui::Entity<crate::root::AdeApp>,
         &mut gpui::VisualTestContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt = tempfile::tempdir().expect("tempdir wt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![worktree_item(wt.path().to_path_buf(), "wt")];
@@ -5010,8 +4888,8 @@ mod rail_rev6_render_tests {
     /// exercise.
     #[gpui::test]
     fn each_urgency_pair_is_an_element_only_when_its_own_count_is_nonzero(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, _cx| {
             let repo_id = app.repos[0].id;
             for kind in [UrgencyCount::NeedsInput, UrgencyCount::Failed] {
@@ -5162,8 +5040,8 @@ mod rail_rev6_render_tests {
     /// old path to go in the same edit.
     #[gpui::test]
     fn the_prune_control_is_a_bin_icon_in_a_seventeen_pixel_box(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (_app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (_app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let button = cx
@@ -5215,10 +5093,10 @@ mod rail_rev6_render_tests {
     fn the_repo_header_sits_closer_to_its_rows_than_the_rows_sit_to_each_other(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let alpha = tempfile::tempdir().expect("tempdir alpha");
-        let beta = tempfile::tempdir().expect("tempdir beta");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let alpha = crate::test_support::temp_root();
+        let beta = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, cx| {
             app.worktrees = vec![
                 worktree_item(alpha.path().to_path_buf(), "alpha"),
@@ -5297,10 +5175,8 @@ mod rail_rev6_render_tests {
 mod rail_virtualization_tests {
     use super::*;
     use crate::rail::worktrees::WorktreeItem;
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
     use std::path::Path;
-    use tempfile::TempDir;
 
     /// Deliberately more rows than any plausible test viewport can show at 27px each, mirroring
     /// `crate::sidebar::render::virtualization_tests`' own 300-file tree fixture - "dozens to
@@ -5332,12 +5208,15 @@ mod rail_virtualization_tests {
     /// directly" - both paths converge on the exact same `WorktreeItem`/`WorktreeRow`/`RepoGroup`
     /// types this file's own `rail_row_tests`/`prune_regression_tests` already seed the same way
     /// for their own synthetic fixtures. Returns every seeded path in seed order; the caller owns
-    /// `keepalive` so the real `TempDir`s (and the directories they hold open) outlive the test.
-    fn seed_many_worktrees(app: &mut AdeApp, keepalive: &mut Vec<TempDir>) -> Vec<PathBuf> {
+    /// `keepalive` so the real temporary directories outlive the test.
+    fn seed_many_worktrees(
+        app: &mut AdeApp,
+        keepalive: &mut Vec<crate::test_support::TempRoot>,
+    ) -> Vec<PathBuf> {
         let mut paths = Vec::with_capacity(ROW_COUNT);
         let mut items = Vec::with_capacity(ROW_COUNT);
         for index in 0..ROW_COUNT {
-            let dir = TempDir::new().expect("tempdir");
+            let dir = crate::test_support::temp_root();
             let path = dir.path().to_path_buf();
             keepalive.push(dir);
             items.push(worktree_item(path.clone(), &format!("wt-{index:03}")));
@@ -5372,8 +5251,8 @@ mod rail_virtualization_tests {
     /// draw`" - before *that* surface's equivalent fix.
     #[gpui::test]
     fn a_worktree_row_far_below_the_viewport_is_never_painted(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         let mut keepalive = Vec::new();
         let paths = app.update(cx, |app, _cx| seed_many_worktrees(app, &mut keepalive));
         app.update(cx, |_app, cx| cx.notify());
@@ -5407,8 +5286,8 @@ mod rail_virtualization_tests {
     fn scrolling_the_virtualized_rail_materializes_a_row_that_was_not_painted(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         let mut keepalive = Vec::new();
         let paths = app.update(cx, |app, _cx| seed_many_worktrees(app, &mut keepalive));
         app.update(cx, |_app, cx| cx.notify());
@@ -5481,8 +5360,8 @@ mod rail_virtualization_tests {
     fn hovering_a_visible_row_does_not_materialize_a_row_far_below_the_viewport(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         let mut keepalive = Vec::new();
         let paths = app.update(cx, |app, _cx| seed_many_worktrees(app, &mut keepalive));
         app.update(cx, |_app, cx| cx.notify());
@@ -5532,7 +5411,6 @@ mod rail_virtualization_tests {
 #[cfg(test)]
 mod rail_filter_selection_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
 
     fn secondary(key: &str) -> String {
@@ -5550,7 +5428,7 @@ mod rail_filter_selection_tests {
         repo: &std::path::Path,
         text: &str,
     ) -> (gpui::Entity<AdeApp>, &'a mut gpui::VisualTestContext) {
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.to_path_buf());
         cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
         app.update_in(cx, |app, window, cx| {
             window.focus(&app.filter_focus_handle, cx);
@@ -5608,7 +5486,7 @@ mod rail_filter_selection_tests {
     fn shift_arrow_extends_a_real_selection_and_a_plain_arrow_collapses_it(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_filter_with(cx, repo.path(), "origin");
 
         cx.simulate_keystrokes("home shift-right shift-right shift-right");
@@ -5632,7 +5510,7 @@ mod rail_filter_selection_tests {
 
     #[gpui::test]
     fn a_real_click_places_the_caret_and_a_drag_selects_the_range_between(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_filter_with(cx, repo.path(), "origin/main");
 
         // A click at the field's own text origin: byte 0, whatever the glyph metrics are.
@@ -5680,7 +5558,7 @@ mod rail_filter_selection_tests {
 
     #[gpui::test]
     fn a_real_double_click_selects_the_word_under_the_pointer(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_filter_with(cx, repo.path(), "origin/main");
         // Over the `a` of `main`, so the pointer is genuinely inside the second word.
         let inside_second_word = point_inside_glyph(&app, cx, 8);
@@ -5702,7 +5580,7 @@ mod rail_filter_selection_tests {
 
     #[gpui::test]
     fn a_shift_click_extends_from_the_existing_anchor(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_filter_with(cx, repo.path(), "origin/main");
         let left_edge = point_at_offset(&app, cx, 0);
         cx.simulate_mouse_down(
@@ -5734,7 +5612,7 @@ mod rail_filter_selection_tests {
 
     #[gpui::test]
     fn select_all_then_copy_puts_the_real_text_on_the_real_clipboard(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_filter_with(cx, repo.path(), "origin/main");
         // Seeded with something else first, so a green result cannot come from a clipboard that
         // simply already said the right thing.
@@ -5765,7 +5643,7 @@ mod rail_filter_selection_tests {
 
     #[gpui::test]
     fn cut_removes_the_selection_and_paste_puts_it_back_somewhere_else(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_filter_with(cx, repo.path(), "origin/main");
 
         cx.simulate_keystrokes("home shift-right shift-right shift-right");
@@ -5814,7 +5692,7 @@ mod rail_filter_selection_tests {
 
     #[gpui::test]
     fn paste_over_a_selection_replaces_it(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_filter_with(cx, repo.path(), "origin/main");
         cx.update(|_window, cx| {
             cx.write_to_clipboard(gpui::ClipboardItem::new_string("upstream".into()))
@@ -5834,7 +5712,7 @@ mod rail_filter_selection_tests {
 
     #[gpui::test]
     fn backspace_over_a_selection_deletes_the_whole_range(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_filter_with(cx, repo.path(), "origin/main");
         cx.simulate_keystrokes(&secondary("a"));
         cx.simulate_keystrokes("backspace");
@@ -5854,7 +5732,7 @@ mod rail_filter_selection_tests {
     /// overlay never painted, this entry does not exist at all and there is no quad either.
     #[gpui::test]
     fn the_selection_is_really_measured_from_the_row_that_painted_it(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_filter_with(cx, repo.path(), "origin/main");
         cx.simulate_keystrokes(&secondary("a"));
         cx.run_until_parked();

--- a/crates/app/src/rail/repo.rs
+++ b/crates/app/src/rail/repo.rs
@@ -437,14 +437,14 @@ mod tests {
 
     #[test]
     fn a_missing_file_loads_as_empty_state_rather_than_failing() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         let state = RepoState::load_at(&dir.path().join("does-not-exist.toml"));
         assert_eq!(state, RepoState::default());
     }
 
     #[test]
     fn a_corrupted_file_loads_as_empty_state_rather_than_failing() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         let path = dir.path().join("repos.toml");
         std::fs::write(&path, "this is not valid toml {{{").expect("write");
         assert_eq!(RepoState::load_at(&path), RepoState::default());
@@ -455,7 +455,7 @@ mod tests {
     /// selection (unknown repo, never selected in, since deleted).
     #[test]
     fn a_remembered_worktree_is_returned_only_while_it_still_exists() {
-        let worktree = tempfile::tempdir().expect("tempdir");
+        let worktree = crate::test_support::temp_root();
         let mut state = RepoState::default();
         state.repos.insert(
             "/repo/a".to_string(),
@@ -490,7 +490,7 @@ mod tests {
 
     #[test]
     fn saving_and_loading_round_trips_a_real_file() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         let path = dir.path().join("repos.toml");
         let mut state = RepoState::default();
         state.repos.insert(
@@ -515,7 +515,7 @@ mod tests {
 
     #[test]
     fn saving_leaves_no_temp_file_behind() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         let path = dir.path().join("nested").join("repos.toml");
         let mut state = RepoState::default();
         state.repos.insert(
@@ -545,7 +545,7 @@ mod tests {
     /// a second `jerry` instance saving its own repo must not erase the first's.
     #[test]
     fn saving_merges_with_another_instances_repo_instead_of_erasing_it() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         let path = dir.path().join("repos.toml");
 
         let mut instance_a = RepoState::default();
@@ -586,7 +586,7 @@ mod tests {
     /// disk.
     #[test]
     fn a_merged_save_really_deletes_an_owned_repos_entry() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         let path = dir.path().join("repos.toml");
         let owned: std::collections::BTreeSet<String> =
             ["/repo/a".to_string()].into_iter().collect();
@@ -632,7 +632,7 @@ mod tests {
 
     #[test]
     fn last_focused_existing_path_is_none_when_the_remembered_directory_no_longer_exists() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         let gone = dir.path().join("deleted-repo");
         std::fs::create_dir(&gone).expect("mkdir");
         let key = gone.to_str().expect("utf8 path").to_string();
@@ -663,7 +663,7 @@ mod tests {
     /// check that must reject this, not merely "something is there".
     #[test]
     fn last_focused_existing_path_is_none_when_the_remembered_path_was_replaced_by_a_file() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         let replaced = dir.path().join("was-a-repo");
         std::fs::create_dir(&replaced).expect("mkdir");
         let key = replaced.to_str().expect("utf8 path").to_string();
@@ -698,7 +698,7 @@ mod tests {
 
     #[test]
     fn last_focused_existing_path_resolves_a_real_known_and_still_existing_repo() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         let key = dir.path().to_str().expect("utf8 path").to_string();
 
         let mut state = RepoState::default();
@@ -721,7 +721,7 @@ mod tests {
     /// real mechanism GitHub issue #90's "remembers the last-opened folder" needs.
     #[test]
     fn save_merged_at_persists_last_focused() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         let path = dir.path().join("repos.toml");
         let owned: std::collections::BTreeSet<String> =
             ["/repo/a".to_string()].into_iter().collect();
@@ -746,7 +746,7 @@ mod tests {
     /// separate `save_merged_at` calls simulating two real `AdeApp::focus_repo` calls.
     #[test]
     fn save_merged_at_overwrites_a_previous_last_focused_with_a_newer_one() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         let path = dir.path().join("repos.toml");
         let owned: std::collections::BTreeSet<String> =
             ["/repo/a".to_string(), "/repo/b".to_string()]

--- a/crates/app/src/rail/repo.rs
+++ b/crates/app/src/rail/repo.rs
@@ -422,29 +422,30 @@ mod tests {
         );
     }
 
+    /// A repo's display name is its path's own basename, falling back to the whole path when
+    /// there is no basename to take - and a freshly constructed repo starts with nothing loaded,
+    /// so nothing renders a worktree list it has not actually fetched yet.
     #[test]
-    fn repo_new_derives_a_display_name_from_the_path_basename() {
+    fn repo_new_names_itself_from_its_path_and_starts_with_nothing_loaded() {
         let repo = Repo::new(RepoId(0), PathBuf::from("/home/user/code/jerry-core"));
         assert_eq!(repo.name, "jerry-core");
         assert!(repo.worktrees.is_empty());
+        assert!(!repo.worktrees_loaded);
+
+        assert_eq!(Repo::new(RepoId(0), PathBuf::from("/")).name, "/");
     }
 
+    /// Neither a file that is not there nor one that is not valid TOML may fail the load - a
+    /// hand-edited or half-written `repos.toml` degrades to the empty state, never an error the
+    /// caller has to handle at startup.
     #[test]
-    fn repo_new_falls_back_to_the_whole_path_when_there_is_no_basename() {
-        let repo = Repo::new(RepoId(0), PathBuf::from("/"));
-        assert_eq!(repo.name, "/");
-    }
-
-    #[test]
-    fn a_missing_file_loads_as_empty_state_rather_than_failing() {
+    fn a_missing_or_corrupted_file_loads_as_empty_state_rather_than_failing() {
         let dir = crate::test_support::temp_root();
-        let state = RepoState::load_at(&dir.path().join("does-not-exist.toml"));
-        assert_eq!(state, RepoState::default());
-    }
+        assert_eq!(
+            RepoState::load_at(&dir.path().join("does-not-exist.toml")),
+            RepoState::default()
+        );
 
-    #[test]
-    fn a_corrupted_file_loads_as_empty_state_rather_than_failing() {
-        let dir = crate::test_support::temp_root();
         let path = dir.path().join("repos.toml");
         std::fs::write(&path, "this is not valid toml {{{").expect("write");
         assert_eq!(RepoState::load_at(&path), RepoState::default());
@@ -611,83 +612,61 @@ mod tests {
         );
     }
 
-    /// GitHub issue #90's own real "still valid" check - the four cases
-    /// [`RepoState::last_focused_existing_path`]'s own docs enumerate.
+    /// GitHub issue #90's own real "still valid" check - every case
+    /// [`RepoState::last_focused_existing_path`]'s own docs enumerate. The last is the one an
+    /// independent audit found missing: the remembered path still `exists()` (so a plain
+    /// `exists()` check would wrongly accept it) but the directory has been replaced by a plain
+    /// file, which only `is_dir()` rejects.
     #[test]
-    fn last_focused_existing_path_is_none_when_nothing_was_ever_remembered() {
-        let state = RepoState::default();
-        assert_eq!(state.last_focused_existing_path(), None);
-    }
+    fn last_focused_existing_path_resolves_only_a_known_repo_that_is_still_a_real_directory() {
+        assert_eq!(RepoState::default().last_focused_existing_path(), None);
 
-    #[test]
-    fn last_focused_existing_path_is_none_when_the_key_is_not_a_known_repo() {
-        // `last_focused` names a key that was never actually added to `repos` (e.g. a hand-
-        // edited file, or a repo since removed) - must not resolve to a path anyway.
-        let state = RepoState {
+        // `last_focused` naming a key that was never added to `repos` (a hand-edited file, or a
+        // repo since removed) must not resolve to a path anyway.
+        let unknown = RepoState {
             last_focused: Some("/repo/never-added".to_string()),
             ..RepoState::default()
         };
-        assert_eq!(state.last_focused_existing_path(), None);
-    }
+        assert_eq!(unknown.last_focused_existing_path(), None);
 
-    #[test]
-    fn last_focused_existing_path_is_none_when_the_remembered_directory_no_longer_exists() {
         let dir = crate::test_support::temp_root();
+        let remembered = |path: &std::path::Path| {
+            let key = path.to_str().expect("utf8 path").to_string();
+            let mut state = RepoState::default();
+            state.repos.insert(
+                key.clone(),
+                RepoRecord {
+                    name: "repo".to_string(),
+                    selected_worktree: None,
+                },
+            );
+            state.last_focused = Some(key);
+            state
+        };
+
+        let live = dir.path().join("live-repo");
+        std::fs::create_dir(&live).expect("mkdir");
+        assert_eq!(
+            remembered(&live).last_focused_existing_path(),
+            Some(live.clone())
+        );
+
         let gone = dir.path().join("deleted-repo");
         std::fs::create_dir(&gone).expect("mkdir");
-        let key = gone.to_str().expect("utf8 path").to_string();
-
-        let mut state = RepoState::default();
-        state.repos.insert(
-            key.clone(),
-            RepoRecord {
-                name: "deleted-repo".to_string(),
-                selected_worktree: None,
-            },
-        );
-        state.last_focused = Some(key);
-        // The directory is removed *after* being recorded - simulating a repo that was open,
-        // remembered, and has since been deleted or moved.
+        let state = remembered(&gone);
         std::fs::remove_dir(&gone).expect("rmdir");
-
         assert_eq!(
             state.last_focused_existing_path(),
             None,
             "a deleted/moved remembered folder must fall back to empty, not a broken path"
         );
-    }
 
-    /// The other real "no longer a usable repo" case an independent audit found this method
-    /// missing: the remembered path still `exists()` (so a plain `exists()` check would wrongly
-    /// accept it), but a real directory was replaced by a plain file - `is_dir()` is the real
-    /// check that must reject this, not merely "something is there".
-    #[test]
-    fn last_focused_existing_path_is_none_when_the_remembered_path_was_replaced_by_a_file() {
-        let dir = crate::test_support::temp_root();
         let replaced = dir.path().join("was-a-repo");
         std::fs::create_dir(&replaced).expect("mkdir");
-        let key = replaced.to_str().expect("utf8 path").to_string();
-
-        let mut state = RepoState::default();
-        state.repos.insert(
-            key.clone(),
-            RepoRecord {
-                name: "was-a-repo".to_string(),
-                selected_worktree: None,
-            },
-        );
-        state.last_focused = Some(key);
-
-        // The directory is removed and replaced with a plain file of the same name - the path
-        // still `exists()`, but is no longer a real, usable repo checkout.
+        let state = remembered(&replaced);
         std::fs::remove_dir(&replaced).expect("rmdir");
         std::fs::write(&replaced, "not a repo").expect("write");
-        assert!(replaced.exists(), "sanity check: the path still exists");
-        assert!(
-            !replaced.is_dir(),
-            "sanity check: it is a file now, not a directory"
-        );
-
+        assert!(replaced.exists() && !replaced.is_dir());
         assert_eq!(
             state.last_focused_existing_path(),
             None,
@@ -696,56 +675,12 @@ mod tests {
         );
     }
 
-    #[test]
-    fn last_focused_existing_path_resolves_a_real_known_and_still_existing_repo() {
-        let dir = crate::test_support::temp_root();
-        let key = dir.path().to_str().expect("utf8 path").to_string();
-
-        let mut state = RepoState::default();
-        state.repos.insert(
-            key.clone(),
-            RepoRecord {
-                name: "repo".to_string(),
-                selected_worktree: None,
-            },
-        );
-        state.last_focused = Some(key);
-
-        assert_eq!(
-            state.last_focused_existing_path(),
-            Some(dir.path().to_path_buf())
-        );
-    }
-
     /// [`RepoState::save_merged_at`] must persist `last_focused` too, not just `repos` - the
-    /// real mechanism GitHub issue #90's "remembers the last-opened folder" needs.
+    /// real mechanism GitHub issue #90's "remembers the last-opened folder" needs - and it is a
+    /// single global value, so a later save with a genuine new focus overwrites whatever the
+    /// previous save left, across two separate calls simulating two real `AdeApp::focus_repo`s.
     #[test]
-    fn save_merged_at_persists_last_focused() {
-        let dir = crate::test_support::temp_root();
-        let path = dir.path().join("repos.toml");
-        let owned: std::collections::BTreeSet<String> =
-            ["/repo/a".to_string()].into_iter().collect();
-
-        let mut state = RepoState::default();
-        state.repos.insert(
-            "/repo/a".to_string(),
-            RepoRecord {
-                name: "a".to_string(),
-                selected_worktree: None,
-            },
-        );
-        state.last_focused = Some("/repo/a".to_string());
-        state.save_merged_at(&path, &owned).expect("save");
-
-        let reloaded = RepoState::load_at(&path);
-        assert_eq!(reloaded.last_focused, Some("/repo/a".to_string()));
-    }
-
-    /// `last_focused` is a real, single global value - a later save from the same instance with
-    /// a genuine new focus must overwrite whatever the previous save left, even across two
-    /// separate `save_merged_at` calls simulating two real `AdeApp::focus_repo` calls.
-    #[test]
-    fn save_merged_at_overwrites_a_previous_last_focused_with_a_newer_one() {
+    fn save_merged_at_persists_last_focused_and_a_later_save_overwrites_it() {
         let dir = crate::test_support::temp_root();
         let path = dir.path().join("repos.toml");
         let owned: std::collections::BTreeSet<String> =
@@ -754,20 +689,16 @@ mod tests {
                 .collect();
 
         let mut state = RepoState::default();
-        state.repos.insert(
-            "/repo/a".to_string(),
-            RepoRecord {
-                name: "a".to_string(),
-                selected_worktree: None,
-            },
-        );
-        state.repos.insert(
-            "/repo/b".to_string(),
-            RepoRecord {
-                name: "b".to_string(),
-                selected_worktree: None,
-            },
-        );
+        for name in ["a", "b"] {
+            state.repos.insert(
+                format!("/repo/{name}"),
+                RepoRecord {
+                    name: name.to_string(),
+                    selected_worktree: None,
+                },
+            );
+        }
+
         state.last_focused = Some("/repo/a".to_string());
         state.save_merged_at(&path, &owned).expect("save a focused");
         assert_eq!(
@@ -784,55 +715,32 @@ mod tests {
         );
     }
 
-    #[test]
-    fn repo_new_starts_with_worktrees_unloaded() {
-        let repo = Repo::new(RepoId(0), PathBuf::from("/home/user/code/jerry-core"));
-        assert!(!repo.worktrees_loaded);
-    }
-
     /// The concurrency cap's real shape: ten due repos with a cap of four must split into
     /// `[4, 4, 2]`, never a single batch of ten (which would let all ten real `git worktree list`
     /// subprocesses fire at once) and never one repo per batch either (which would serialize the
-    /// whole sweep needlessly).
+    /// whole sweep needlessly). A cap of zero is a defensive floor rather than a real call site -
+    /// every real caller passes a positive constant - and must neither panic (`[T]::chunks`
+    /// itself panics on a zero chunk size) nor silently drop every id.
     #[test]
-    fn batch_repos_for_refresh_splits_into_capped_chunks() {
-        let ids: Vec<RepoId> = (0..10).map(RepoId).collect();
-        let batches = batch_repos_for_refresh(&ids, 4);
-        assert_eq!(
-            batches.iter().map(Vec::len).collect::<Vec<_>>(),
-            vec![4, 4, 2],
-            "ten ids with a cap of four must split 4/4/2, bounding every single batch's real \
-             concurrent subprocess count to the cap"
-        );
-        // Order is preserved and nothing is dropped or duplicated - every id from the input
-        // appears exactly once, in its original relative order.
-        let flattened: Vec<RepoId> = batches.into_iter().flatten().collect();
-        assert_eq!(flattened, ids);
-    }
-
-    #[test]
-    fn batch_repos_for_refresh_fewer_ids_than_the_cap_is_a_single_batch() {
-        let ids: Vec<RepoId> = (0..3).map(RepoId).collect();
-        let batches = batch_repos_for_refresh(&ids, 4);
-        assert_eq!(batches.len(), 1);
-        assert_eq!(batches[0].len(), 3);
-    }
-
-    #[test]
-    fn batch_repos_for_refresh_of_no_ids_is_no_batches() {
-        assert!(batch_repos_for_refresh(&[], 4).is_empty());
-    }
-
-    /// A defensive floor, not a real call site (every real caller uses a real positive constant):
-    /// `concurrency == 0` must not panic (`[T]::chunks` itself panics on a zero chunk size) or
-    /// silently drop every id - it degrades to one id per batch instead.
-    #[test]
-    fn batch_repos_for_refresh_treats_a_zero_concurrency_as_one() {
-        let ids: Vec<RepoId> = (0..3).map(RepoId).collect();
-        let batches = batch_repos_for_refresh(&ids, 0);
-        assert_eq!(
-            batches.iter().map(Vec::len).collect::<Vec<_>>(),
-            vec![1, 1, 1]
-        );
+    fn batch_repos_for_refresh_caps_every_batch_and_never_loses_an_id() {
+        for (count, concurrency, expected) in [
+            (10, 4, vec![4, 4, 2]),
+            (3, 4, vec![3]),
+            (0, 4, vec![]),
+            (3, 0, vec![1, 1, 1]),
+        ] {
+            let ids: Vec<RepoId> = (0..count).map(RepoId).collect();
+            let batches = batch_repos_for_refresh(&ids, concurrency);
+            assert_eq!(
+                batches.iter().map(Vec::len).collect::<Vec<_>>(),
+                expected,
+                "{count} ids at a concurrency of {concurrency}"
+            );
+            let flattened: Vec<RepoId> = batches.into_iter().flatten().collect();
+            assert_eq!(
+                flattened, ids,
+                "every id must appear exactly once, in its original relative order"
+            );
+        }
     }
 }

--- a/crates/app/src/rail/state.rs
+++ b/crates/app/src/rail/state.rs
@@ -1165,6 +1165,8 @@ mod tests {
         assert!(!running_row.matches_filter("writing auth.rs"));
     }
 
+    /// Unlike `group_by_urgency`, every status must appear in the tally even when its count is
+    /// zero - including the all-zero case, which must still be five rows rather than none.
     #[test]
     fn urgency_counts_covers_every_status_in_order_including_zero_counts() {
         let rows = vec![
@@ -1180,16 +1182,12 @@ mod tests {
                 (Status::Review, 1),
                 (Status::Run, 0),
                 (Status::Idle, 0),
-            ],
-            "unlike group_by_urgency, every status must appear even when its count is zero"
+            ]
         );
-    }
 
-    #[test]
-    fn urgency_counts_with_no_agents_is_all_zero_not_omitted() {
-        let counts = urgency_counts(&[]);
-        assert_eq!(counts.len(), 5);
-        assert!(counts.iter().all(|(_, count)| *count == 0));
+        let empty = urgency_counts(&[]);
+        assert_eq!(empty.len(), 5);
+        assert!(empty.iter().all(|(_, count)| *count == 0));
     }
 
     #[test]
@@ -1220,121 +1218,62 @@ mod tests {
         assert_eq!(filter_agents(&rows, "").len(), 2);
     }
 
-    #[test]
-    fn worktree_note_main_checkout_is_never_prunable_even_if_merged() {
-        let note = WorktreeNote {
-            is_main: true,
-            clean: Some(true),
-            merge: Some(WorktreeMergeStatus {
+    fn note(
+        is_main: bool,
+        clean: Option<bool>,
+        merged: Option<bool>,
+        is_locked: bool,
+    ) -> WorktreeNote {
+        WorktreeNote {
+            is_main,
+            clean,
+            merge: merged.map(|merged| WorktreeMergeStatus {
                 base_branch: "main".to_string(),
-                merged: true,
-                head_committer_unix_seconds: Some(0),
+                merged,
+                // 11:04 UTC == 11 * 3600 + 4 * 60 seconds into the day.
+                head_committer_unix_seconds: Some(if merged { 11 * 3600 + 4 * 60 } else { 0 }),
             }),
-            is_locked: false,
-        };
-        assert!(!note.is_prunable());
-        assert_eq!(note.label(), "checkout · clean");
+            is_locked,
+        }
     }
 
+    /// Every real combination of the four inputs a worktree note is built from, and the two
+    /// answers it owes for each: what the row says, and whether the worktree may be offered for
+    /// pruning at all. Only one combination is prunable - a linked worktree that is merged,
+    /// clean and unlocked. A dirty one would be refused by `wt_core::remove_worktree` anyway; a
+    /// locked one must never be offered regardless of merge state, though the merged fact still
+    /// shows; and the main checkout is never prunable however merged and clean it is.
     #[test]
-    fn worktree_note_dirty_main_checkout_label() {
-        let note = WorktreeNote {
-            is_main: true,
-            clean: Some(false),
-            merge: None,
-            is_locked: false,
-        };
-        assert_eq!(note.label(), "checkout · dirty");
-    }
-
-    #[test]
-    fn worktree_note_merged_and_clean_linked_worktree_is_prunable() {
-        // 11:04 UTC == 11 * 3600 + 4 * 60 seconds into the day.
-        let seconds_since_midnight = 11 * 3600 + 4 * 60;
-        let note = WorktreeNote {
-            is_main: false,
-            clean: Some(true),
-            merge: Some(WorktreeMergeStatus {
-                base_branch: "main".to_string(),
-                merged: true,
-                head_committer_unix_seconds: Some(seconds_since_midnight),
-            }),
-            is_locked: false,
-        };
-        assert!(note.is_prunable());
-        assert_eq!(note.label(), "merged 11:04 · prunable");
-    }
-
-    #[test]
-    fn worktree_note_merged_but_dirty_linked_worktree_is_not_prunable() {
-        let note = WorktreeNote {
-            is_main: false,
-            clean: Some(false),
-            merge: Some(WorktreeMergeStatus {
-                base_branch: "main".to_string(),
-                merged: true,
-                head_committer_unix_seconds: Some(0),
-            }),
-            is_locked: false,
-        };
-        assert!(
-            !note.is_prunable(),
-            "a dirty worktree must never be offered as prunable, even if its branch is merged \
-             - wt_core::remove_worktree would refuse it anyway"
-        );
-        assert_eq!(note.label(), "dirty");
-    }
-
-    #[test]
-    fn worktree_note_unmerged_linked_worktree_is_not_prunable() {
-        let note = WorktreeNote {
-            is_main: false,
-            clean: Some(true),
-            merge: Some(WorktreeMergeStatus {
-                base_branch: "main".to_string(),
-                merged: false,
-                head_committer_unix_seconds: Some(0),
-            }),
-            is_locked: false,
-        };
-        assert!(!note.is_prunable());
-        assert_eq!(note.label(), "clean");
-    }
-
-    #[test]
-    fn worktree_note_with_no_detectable_base_is_never_prunable() {
-        let note = WorktreeNote {
-            is_main: false,
-            clean: Some(true),
-            merge: None,
-            is_locked: false,
-        };
-        assert!(!note.is_prunable());
-    }
-
-    #[test]
-    fn worktree_note_locked_merged_clean_worktree_is_never_prunable_but_label_says_locked() {
-        // A locked worktree can be genuinely merged and clean - lock state is independent of
-        // merge/dirty state.
-        let note = WorktreeNote {
-            is_main: false,
-            clean: Some(true),
-            merge: Some(WorktreeMergeStatus {
-                base_branch: "main".to_string(),
-                merged: true,
-                head_committer_unix_seconds: Some(0),
-            }),
-            is_locked: true,
-        };
-        assert!(
-            !note.is_prunable(),
-            "a locked worktree must never be offered as prunable regardless of merge/clean state"
-        );
-        assert_eq!(
-            note.label(),
-            "merged 00:00 · locked",
-            "the merged fact should still be visible, just not offered as prunable"
-        );
+    fn only_a_merged_clean_unlocked_linked_worktree_is_prunable() {
+        let cases: &[(WorktreeNote, bool, &str)] = &[
+            (
+                note(true, Some(true), Some(true), false),
+                false,
+                "checkout \u{b7} clean",
+            ),
+            (
+                note(true, Some(false), None, false),
+                false,
+                "checkout \u{b7} dirty",
+            ),
+            (
+                note(false, Some(true), Some(true), false),
+                true,
+                "merged 11:04 \u{b7} prunable",
+            ),
+            (note(false, Some(false), Some(true), false), false, "dirty"),
+            (note(false, Some(true), Some(false), false), false, "clean"),
+            (note(false, Some(true), None, false), false, "clean"),
+            (
+                note(false, Some(true), Some(true), true),
+                false,
+                "merged 11:04 \u{b7} locked",
+            ),
+        ];
+        for (note, prunable, label) in cases {
+            assert_eq!(note.is_prunable(), *prunable, "{note:?}");
+            assert_eq!(note.label(), *label, "{note:?}");
+        }
     }
 
     fn worktree_entry(path: &str, note: WorktreeNote) -> WorktreeEntry {
@@ -1918,16 +1857,74 @@ mod tests {
     }
 
     /// §4q's "each with its own tooltip", conjugated in both the noun and the verb (§7 rule 9).
+    /// Every count-bearing label the rail renders agrees with its own number in both noun and
+    /// verb, at zero, one and two - and none of them dodges into the parenthesised `(s)` escape
+    /// hatch. The conjugation helper itself is pinned by `crate::root::plural`'s own tests; what
+    /// this pins is that each of these call sites really goes through it.
     #[test]
-    fn the_two_urgency_tooltips_agree_with_their_own_counts_in_noun_and_verb() {
+    fn every_count_bearing_rail_label_conjugates_rather_than_dodging() {
         assert_eq!(needs_input_tooltip(1), "1 worktree here needs input");
         assert_eq!(needs_input_tooltip(2), "2 worktrees here need input");
         assert_eq!(failed_tooltip(1), "1 worktree here has a failed agent");
         assert_eq!(failed_tooltip(3), "3 worktrees here have failed agents");
+
+        assert_eq!(prune_armed_tooltip(1), "Click again to remove 1 worktree");
+        assert_eq!(prune_armed_tooltip(2), "Click again to remove 2 worktrees");
+
+        assert_eq!(worktree_disk_label(0, "0 B"), "0 worktrees \u{b7} 0 B");
+        assert_eq!(worktree_disk_label(1, "4.2 GB"), "1 worktree \u{b7} 4.2 GB");
+        assert_eq!(
+            worktree_disk_label(2, "4.2 GB"),
+            "2 worktrees \u{b7} 4.2 GB"
+        );
+
+        for (n, confirm, pruning, pruned) in [
+            (0, "0 worktrees", "0 worktrees", "0 worktrees"),
+            (1, "1 worktree", "1 worktree", "1 worktree"),
+            (2, "2 worktrees", "2 worktrees", "2 worktrees"),
+        ] {
+            assert_eq!(
+                prune_confirm_label(n),
+                format!("click prune again to remove {confirm}")
+            );
+            assert_eq!(pruning_label(n), format!("pruning {pruning}\u{2026}"));
+            assert_eq!(pruned_label(n), format!("pruned {pruned}"));
+        }
+
+        for n in 0..4 {
+            for label in [prune_confirm_label(n), pruning_label(n), pruned_label(n)] {
+                assert!(
+                    !label.contains("(s)"),
+                    "prune label must conjugate, not dodge: {label}"
+                );
+            }
+        }
     }
 
-    /// §4o: the rail's diffstat is returned as its two coloured parts, never as one pre-joined
-    /// string - and a diff with no deletions renders one part, not a `\u{2212}0` that says nothing.
+    /// The prune tooltip's own sentence *shapes*, which are more than conjugation: an unmeasured
+    /// candidate drops the whole size clause rather than reporting a size that leaves it out, a
+    /// truncated scan keeps `disk_usage_label`'s `+` suffix so the number stays a floor rather
+    /// than a claim, and zero candidates changes the sentence rather than reading `0 prunable`.
+    #[test]
+    fn the_prune_tooltip_states_the_count_and_only_a_measured_size() {
+        assert_eq!(
+            prune_tooltip(1, Some((214 * 1024 * 1024, false))),
+            "Prune merged worktrees \u{2014} 1 prunable, frees 214.0 MB"
+        );
+        assert_eq!(
+            prune_tooltip(3, Some((2 * 1024 * 1024 * 1024, true))),
+            "Prune merged worktrees \u{2014} 3 prunable, frees 2.0 GB+"
+        );
+        assert_eq!(
+            prune_tooltip(1, None),
+            "Prune merged worktrees \u{2014} 1 prunable"
+        );
+        assert_eq!(
+            prune_tooltip(0, Some((0, false))),
+            "Prune merged worktrees \u{2014} nothing prunable"
+        );
+    }
+
     #[test]
     fn diff_stat_parts_splits_the_rail_diffstat_and_drops_an_empty_deletion() {
         assert_eq!(
@@ -1952,88 +1949,6 @@ mod tests {
 
     /// §4's prune tooltip: "Prune merged worktrees \u{2014} 1 prunable, frees 214 MB" - the words
     /// the icon itself cannot carry, including the size only when it is really known.
-    #[test]
-    fn the_prune_tooltip_states_the_count_and_only_a_measured_size() {
-        assert_eq!(
-            prune_tooltip(1, Some((214 * 1024 * 1024, false))),
-            "Prune merged worktrees \u{2014} 1 prunable, frees 214.0 MB"
-        );
-        assert_eq!(
-            prune_tooltip(3, Some((2 * 1024 * 1024 * 1024, true))),
-            "Prune merged worktrees \u{2014} 3 prunable, frees 2.0 GB+",
-            "a truncated scan keeps the `+` suffix `disk_usage_label` already uses - the number \
-             is a floor, and the tooltip must not round it into a claim"
-        );
-        assert_eq!(
-            prune_tooltip(1, None),
-            "Prune merged worktrees \u{2014} 1 prunable",
-            "an unmeasured candidate drops the whole clause rather than reporting a size that \
-             leaves it out"
-        );
-        assert_eq!(
-            prune_tooltip(0, Some((0, false))),
-            "Prune merged worktrees \u{2014} nothing prunable",
-            "zero candidates changes the sentence's shape rather than reading `0 prunable`"
-        );
-    }
-
-    /// The armed half of the two-click prune, kept from the text button it replaced.
-    #[test]
-    fn the_armed_prune_tooltip_conjugates_its_own_count() {
-        assert_eq!(prune_armed_tooltip(1), "Click again to remove 1 worktree");
-        assert_eq!(prune_armed_tooltip(2), "Click again to remove 2 worktrees");
-    }
-
-    /// The rail footer and Settings → Disk share this one line, and it used to read
-    /// `"1 worktrees · 4.2 GB"` in both places for a fresh single-checkout repo.
-    #[test]
-    fn worktree_disk_label_conjugates_at_zero_one_and_two() {
-        assert_eq!(worktree_disk_label(0, "0 B"), "0 worktrees \u{b7} 0 B");
-        assert_eq!(worktree_disk_label(1, "4.2 GB"), "1 worktree \u{b7} 4.2 GB");
-        assert_eq!(
-            worktree_disk_label(2, "4.2 GB"),
-            "2 worktrees \u{b7} 4.2 GB"
-        );
-    }
-
-    #[test]
-    fn prune_labels_conjugate_at_zero_one_and_two() {
-        assert_eq!(
-            prune_confirm_label(0),
-            "click prune again to remove 0 worktrees"
-        );
-        assert_eq!(
-            prune_confirm_label(1),
-            "click prune again to remove 1 worktree"
-        );
-        assert_eq!(
-            prune_confirm_label(2),
-            "click prune again to remove 2 worktrees"
-        );
-
-        assert_eq!(pruning_label(0), "pruning 0 worktrees\u{2026}");
-        assert_eq!(pruning_label(1), "pruning 1 worktree\u{2026}");
-        assert_eq!(pruning_label(2), "pruning 2 worktrees\u{2026}");
-
-        assert_eq!(pruned_label(0), "pruned 0 worktrees");
-        assert_eq!(pruned_label(1), "pruned 1 worktree");
-        assert_eq!(pruned_label(2), "pruned 2 worktrees");
-    }
-
-    /// None of the prune/disk labels may fall back to the `worktree(s)` escape hatch these
-    /// three replaced - that spelling dodges the conjugation instead of doing it.
-    #[test]
-    fn no_prune_label_uses_the_parenthesised_plural_escape_hatch() {
-        for n in 0..4 {
-            for label in [prune_confirm_label(n), pruning_label(n), pruned_label(n)] {
-                assert!(
-                    !label.contains("(s)"),
-                    "prune label must conjugate, not dodge: {label}"
-                );
-            }
-        }
-    }
-
     #[test]
     fn format_elapsed_picks_the_largest_whole_unit() {
         assert_eq!(format_elapsed(Duration::from_secs(0)), "0s");
@@ -2081,26 +1996,6 @@ mod tests {
             "matches only the agent-less row, via its real path - the label alone never \
              contains a directory component like this"
         );
-    }
-
-    #[test]
-    fn is_prunable_helper_looks_up_by_path() {
-        let mut notes = HashMap::new();
-        notes.insert(
-            PathBuf::from("/repo-wt/merged"),
-            WorktreeNote {
-                is_main: false,
-                clean: Some(true),
-                merge: Some(WorktreeMergeStatus {
-                    base_branch: "main".to_string(),
-                    merged: true,
-                    head_committer_unix_seconds: Some(0),
-                }),
-                is_locked: false,
-            },
-        );
-        assert!(is_prunable(&notes, Path::new("/repo-wt/merged")));
-        assert!(!is_prunable(&notes, Path::new("/repo-wt/unknown")));
     }
 
     #[test]
@@ -2329,24 +2224,21 @@ mod tests {
         assert_eq!(merged_ahead_behind.behind, 0);
     }
 
+    /// A real directory tree's sizes are summed recursively; a path that isn't there at all is
+    /// zero rather than an error the caller has to handle.
     #[test]
-    fn disk_usage_bytes_sums_real_file_sizes_recursively() {
+    fn disk_usage_bytes_sums_a_real_tree_and_reports_zero_for_a_missing_one() {
         let dir = crate::test_support::temp_root();
         std::fs::write(dir.path().join("a.txt"), vec![b'x'; 100]).expect("write");
         let sub = dir.path().join("sub");
         std::fs::create_dir(&sub).expect("mkdir");
         std::fs::write(sub.join("b.txt"), vec![b'y'; 250]).expect("write");
 
-        let (total, truncated) = disk_usage_bytes(dir.path());
-        assert_eq!(total, 350);
-        assert!(!truncated);
-    }
-
-    #[test]
-    fn disk_usage_bytes_on_a_nonexistent_path_is_zero_not_an_error() {
-        let (total, truncated) = disk_usage_bytes(Path::new("/definitely/not/a/real/path/xyz"));
-        assert_eq!(total, 0);
-        assert!(!truncated);
+        assert_eq!(disk_usage_bytes(dir.path()), (350, false));
+        assert_eq!(
+            disk_usage_bytes(Path::new("/definitely/not/a/real/path/xyz")),
+            (0, false)
+        );
     }
 
     #[test]

--- a/crates/app/src/rail/state.rs
+++ b/crates/app/src/rail/state.rs
@@ -2217,46 +2217,19 @@ mod tests {
         assert_eq!(sum_diff_stat(&diff), (2, 1));
     }
 
-    fn git(dir: &Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn init_repo() -> tempfile::TempDir {
-        let dir = tempfile::TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(dir.path().join("file.txt"), "hello\n").expect("write file");
-        git(dir.path(), &["add", "file.txt"]);
-        git(dir.path(), &["commit", "-m", "initial commit"]);
-        dir
-    }
-
     /// End-to-end, against a real tempdir git repo: [`compute_status_snapshot`] reports a
     /// prunable, clean, merged worktree correctly, and a dirty one as not prunable, in one
     /// snapshot covering both the diff side and the worktree-note side.
     #[test]
     fn compute_status_snapshot_reports_real_diff_and_merge_state() {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
 
         // A linked worktree with an uncommitted change - should show up in `diffs` with a
         // real added-line count, and not be considered clean.
-        let dirty_wt_dir = tempfile::TempDir::new().expect("tempdir");
+        let dirty_wt_dir = crate::test_support::temp_root();
         let dirty_wt_path = dirty_wt_dir.path().join("dirty-wt");
         drop(dirty_wt_dir);
-        git(
+        test_support::git(
             repo.path(),
             &[
                 "worktree",
@@ -2270,10 +2243,10 @@ mod tests {
 
         // A linked worktree that's clean and fully merged (no unique commits) - a real prune
         // candidate.
-        let merged_wt_dir = tempfile::TempDir::new().expect("tempdir");
+        let merged_wt_dir = crate::test_support::temp_root();
         let merged_wt_path = merged_wt_dir.path().join("merged-wt");
         drop(merged_wt_dir);
-        git(
+        test_support::git(
             repo.path(),
             &[
                 "worktree",
@@ -2358,7 +2331,7 @@ mod tests {
 
     #[test]
     fn disk_usage_bytes_sums_real_file_sizes_recursively() {
-        let dir = tempfile::TempDir::new().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         std::fs::write(dir.path().join("a.txt"), vec![b'x'; 100]).expect("write");
         let sub = dir.path().join("sub");
         std::fs::create_dir(&sub).expect("mkdir");

--- a/crates/app/src/rail/status.rs
+++ b/crates/app/src/rail/status.rs
@@ -432,81 +432,155 @@ mod tests {
         }
     }
 
+    /// The exact facts first: an exit code and a missing process both settle the answer outright,
+    /// and only a real *agent session*'s clean exit can mean "review ready" - a plain shell
+    /// closing next to an unrelated worktree diff is a terminal that closed, not finished
+    /// reviewable work (see `ProcessKind::is_agent_session`'s docs).
     #[test]
-    fn no_process_is_idle_regardless_of_kind_or_diff() {
-        assert_eq!(
-            derive_status(ProcessKind::Shell, ProcessSignal::NoProcess, quiet(), true),
-            Status::Idle
-        );
-        assert_eq!(
-            derive_status(
+    fn an_exit_or_a_missing_process_settles_the_status_outright() {
+        let cases: &[(ProcessKind, ProcessSignal, bool, Status, &str)] = &[
+            (
+                ProcessKind::Shell,
+                ProcessSignal::NoProcess,
+                true,
+                Status::Idle,
+                "a process that never started is idle whatever the diff says",
+            ),
+            (
                 ProcessKind::claude(),
                 ProcessSignal::NoProcess,
-                quiet(),
-                true
+                true,
+                Status::Idle,
+                "and that holds for an agent too",
             ),
-            Status::Idle
-        );
+            (
+                ProcessKind::Shell,
+                ProcessSignal::Exited { success: false },
+                true,
+                Status::Fail,
+                "a non-zero exit is a failure whatever the diff says",
+            ),
+            (
+                ProcessKind::claude(),
+                ProcessSignal::Exited { success: false },
+                false,
+                Status::Fail,
+                "for an agent as much as a shell",
+            ),
+            (
+                ProcessKind::claude(),
+                ProcessSignal::Exited { success: true },
+                true,
+                Status::Review,
+                "an agent session's clean exit with real changes is review-ready",
+            ),
+            (
+                ProcessKind::claude(),
+                ProcessSignal::Exited { success: true },
+                false,
+                Status::Idle,
+                "with nothing to review it is idle, not an empty review row",
+            ),
+            (
+                ProcessKind::Shell,
+                ProcessSignal::Exited { success: true },
+                true,
+                Status::Idle,
+                "a shell isn't an agent session - its exit can't be \"review ready\"",
+            ),
+        ];
+        for (kind, signal, has_diff, expected, why) in cases {
+            assert_eq!(
+                derive_status(*kind, *signal, quiet(), *has_diff),
+                *expected,
+                "{why}"
+            );
+        }
     }
 
+    /// The quiescence ladder, with no other signal in play: recent output is `Run` for every
+    /// kind; past the recent window a shell is `Idle` (it is sitting at its prompt, not asking
+    /// anything) while an agent is still `Run` - the whole reason the second, longer threshold
+    /// exists is that normal tool-call latency must not flicker to "needs input" - and only past
+    /// that agent threshold does an agent reach `Ask`.
     #[test]
-    fn running_within_the_recent_window_is_run_for_every_kind() {
-        let signal = ProcessSignal::Running {
-            idle: Duration::from_millis(500),
-        };
-        assert_eq!(
-            derive_status(ProcessKind::Shell, signal, quiet(), false),
-            Status::Run
-        );
-        assert_eq!(
-            derive_status(ProcessKind::claude(), signal, quiet(), false),
-            Status::Run
-        );
-        assert_eq!(
-            derive_status(ProcessKind::codex(), signal, quiet(), false),
-            Status::Run
-        );
+    fn quiescence_alone_walks_the_two_thresholds_per_process_kind() {
+        let recent = Duration::from_millis(500);
+        let between = RUN_RECENT_OUTPUT_WINDOW + Duration::from_secs(1);
+        let long = AGENT_ASK_IDLE_THRESHOLD + Duration::from_secs(1);
+        let cases: &[(ProcessKind, Duration, Status, &str)] = &[
+            (
+                ProcessKind::Shell,
+                recent,
+                Status::Run,
+                "a shell just wrote something",
+            ),
+            (
+                ProcessKind::claude(),
+                recent,
+                Status::Run,
+                "and so did claude",
+            ),
+            (
+                ProcessKind::codex(),
+                recent,
+                Status::Run,
+                "and so did codex",
+            ),
+            (
+                ProcessKind::Shell,
+                between,
+                Status::Idle,
+                "a shell at its prompt is idle, not \"needs input\" - it isn't asking anything",
+            ),
+            (
+                ProcessKind::claude(),
+                between,
+                Status::Run,
+                "an agent between the two thresholds is still working",
+            ),
+            (ProcessKind::codex(), between, Status::Run, "codex likewise"),
+            (
+                ProcessKind::claude(),
+                long,
+                Status::Ask,
+                "past its own threshold a silent agent is asking",
+            ),
+            (ProcessKind::codex(), long, Status::Ask, "codex likewise"),
+        ];
+        for (kind, idle, expected, why) in cases {
+            assert_eq!(
+                derive_status(
+                    *kind,
+                    ProcessSignal::Running { idle: *idle },
+                    quiet(),
+                    false
+                ),
+                *expected,
+                "{why}"
+            );
+        }
     }
 
+    /// The real false-positive class the terminal signal exists to fix (GitHub issue #239), one
+    /// observed live: Claude Code kept its `\u{25d0}`/`\u{25d1}` spinner animating through a
+    /// 9-second run of `sleep 3` tool calls that wrote nothing at all. Purely by idle time that
+    /// agent is "needs input"; by its own title it is plainly still working. An advancing
+    /// progress report says the same thing - but a stalled or paused one is exactly when the
+    /// human may be wanted, so it buys no indefinite reprieve.
     #[test]
-    fn a_quiet_shell_past_the_recent_window_is_idle_not_ask() {
-        let signal = ProcessSignal::Running {
-            idle: RUN_RECENT_OUTPUT_WINDOW + Duration::from_secs(1),
-        };
-        assert_eq!(
-            derive_status(ProcessKind::Shell, signal, quiet(), false),
-            Status::Idle,
-            "a shell sitting at its prompt is idle, not \"needs input\" - it isn't asking anything"
-        );
-    }
-
-    #[test]
-    fn an_agent_paused_between_the_two_thresholds_is_still_run() {
-        // Past the "recent" window but not yet past the longer agent-specific ask threshold:
-        // this is the whole reason the second threshold exists (see the module docs) - normal
-        // tool-call/thinking latency must not flicker to "needs input".
-        let signal = ProcessSignal::Running {
-            idle: RUN_RECENT_OUTPUT_WINDOW + Duration::from_secs(1),
-        };
-        assert_eq!(
-            derive_status(ProcessKind::claude(), signal, quiet(), false),
-            Status::Run
-        );
-        assert_eq!(
-            derive_status(ProcessKind::codex(), signal, quiet(), false),
-            Status::Run
-        );
-    }
-
-    #[test]
-    fn a_busy_title_keeps_a_long_quiet_agent_on_run_instead_of_ask() {
-        // The real false-positive class this signal exists to fix (GitHub issue #239), and one
-        // observed live: Claude Code kept its `\u{25d0}`/`\u{25d1}` spinner animating through a
-        // 9-second run of `sleep 3` tool calls that wrote nothing at all to the terminal. Purely
-        // by idle time that agent is "needs input"; by its own title it is plainly still working.
+    fn a_live_work_signal_holds_a_long_quiet_agent_on_run_but_a_stalled_one_does_not() {
         let long_quiet = ProcessSignal::Running {
             idle: AGENT_ASK_IDLE_THRESHOLD * 20,
         };
+        let progress = |state| TerminalSignal {
+            progress: Some(Progress {
+                state,
+                percent: Some(40),
+            }),
+            ..TerminalSignal::default()
+        };
+
         assert_eq!(
             derive_status(ProcessKind::claude(), long_quiet, quiet(), false),
             Status::Ask,
@@ -522,50 +596,28 @@ mod tests {
             Status::Run,
             "an agent whose own title says it is working must not be reported as needing input"
         );
-    }
-
-    #[test]
-    fn an_active_progress_report_also_keeps_a_long_quiet_agent_on_run() {
-        let long_quiet = ProcessSignal::Running {
-            idle: AGENT_ASK_IDLE_THRESHOLD * 20,
-        };
         for state in [ProgressState::Normal, ProgressState::Indeterminate] {
-            let terminal = TerminalSignal {
-                progress: Some(Progress {
-                    state,
-                    percent: Some(40),
-                }),
-                ..TerminalSignal::default()
-            };
             assert_eq!(
-                derive_status(ProcessKind::claude(), long_quiet, terminal, false),
+                derive_status(ProcessKind::claude(), long_quiet, progress(state), false),
                 Status::Run,
                 "{state:?} is work actually advancing"
             );
         }
-        // A stalled or paused report is exactly when the human may be wanted, so it must not buy
-        // the process an indefinite "still running" - the idle clock takes over again.
         for state in [ProgressState::Error, ProgressState::Paused] {
-            let terminal = TerminalSignal {
-                progress: Some(Progress {
-                    state,
-                    percent: Some(40),
-                }),
-                ..TerminalSignal::default()
-            };
             assert_eq!(
-                derive_status(ProcessKind::claude(), long_quiet, terminal, false),
+                derive_status(ProcessKind::claude(), long_quiet, progress(state), false),
                 Status::Ask,
                 "{state:?} must not be able to claim the agent is still working"
             );
         }
     }
 
+    /// The threshold exists only because Jerry used to have no better signal. When the agent says
+    /// outright that it is blocked on the human - a `NeedsAttention` title, an unanswered OSC 9
+    /// notification, or both alongside a still-spinning busy glyph - waiting the timer out is
+    /// pure added latency, so attention outranks everything short of an exact fact.
     #[test]
-    fn a_needs_attention_title_reaches_ask_long_before_the_idle_threshold() {
-        // The 15s threshold exists only because Jerry used to have no better signal. When the
-        // agent says outright that it's blocked on the human, waiting the timer out is pure
-        // added latency.
+    fn a_real_attention_claim_reaches_ask_immediately_and_outranks_a_busy_one() {
         let barely_quiet = ProcessSignal::Running {
             idle: Duration::from_millis(100),
         };
@@ -583,41 +635,34 @@ mod tests {
             ),
             Status::Ask
         );
-    }
-
-    #[test]
-    fn an_unanswered_osc_notification_reaches_ask_long_before_the_idle_threshold() {
-        let barely_quiet = ProcessSignal::Running {
-            idle: Duration::from_millis(100),
-        };
-        let terminal = TerminalSignal {
-            attention_pinged: true,
-            ..TerminalSignal::default()
-        };
         assert_eq!(
-            derive_status(ProcessKind::claude(), barely_quiet, terminal, false),
+            derive_status(
+                ProcessKind::claude(),
+                barely_quiet,
+                TerminalSignal {
+                    attention_pinged: true,
+                    ..TerminalSignal::default()
+                },
+                false
+            ),
             Status::Ask
         );
-    }
-
-    #[test]
-    fn attention_outranks_busy_when_an_agent_claims_both() {
-        // An agent that is both spinning a busy glyph and has an unanswered notification out is
-        // one that needs the human now and happens to still be rendering - see the module docs.
-        let terminal = TerminalSignal {
-            title: Some(TitleSignal::Busy),
-            attention_pinged: true,
-            progress: Some(Progress {
-                state: ProgressState::Normal,
-                percent: Some(10),
-            }),
-        };
-        let signal = ProcessSignal::Running {
-            idle: Duration::from_millis(100),
-        };
         assert_eq!(
-            derive_status(ProcessKind::claude(), signal, terminal, false),
-            Status::Ask
+            derive_status(
+                ProcessKind::claude(),
+                barely_quiet,
+                TerminalSignal {
+                    title: Some(TitleSignal::Busy),
+                    attention_pinged: true,
+                    progress: Some(Progress {
+                        state: ProgressState::Normal,
+                        percent: Some(10),
+                    }),
+                },
+                false
+            ),
+            Status::Ask,
+            "an agent that is both spinning and has an unanswered ping out needs the human now"
         );
     }
 
@@ -640,13 +685,16 @@ mod tests {
         }
     }
 
+    /// Neither side channel may move a shell row. A shell prompt, a `vim` session, or a stray
+    /// `printf '\e]0;...\a'` in someone's `.bashrc` can put any glyph or word in a shell's title,
+    /// and none of that makes a shell an agent session that can need input. The hook half is
+    /// deliberately defensive: hooks are only ever installed for `AgentKind::Claude` spawns, so a
+    /// shell should structurally never carry one - but "structurally impossible" is exactly the
+    /// kind of claim that quietly stops being true, and a shell driven to `Ask`/`Review`/`Fail`
+    /// by an inbox entry would be a real bug.
     #[test]
-    fn a_shell_never_reaches_ask_no_matter_how_agent_like_its_title_looks() {
-        // A shell prompt, a `vim` session, or a stray `printf '\e]0;...\a'` in someone's
-        // `.bashrc` can put any glyph or word in a shell's title. None of that makes a shell an
-        // agent session that can need input - see the module docs. This also covers the reverse
-        // direction: a busy-looking title must not hold a shell on `Run` either.
-        let every_signal = [
+    fn neither_a_terminal_signal_nor_a_hook_fact_can_move_a_shell_row() {
+        let every_terminal_signal = [
             titled(TitleSignal::NeedsAttention),
             titled(TitleSignal::Busy),
             titled(TitleSignal::Idle),
@@ -664,38 +712,54 @@ mod tests {
                 }),
             },
         ];
-        for terminal in every_signal {
-            assert_eq!(
-                derive_status(
-                    ProcessKind::Shell,
-                    ProcessSignal::Running {
-                        idle: AGENT_ASK_IDLE_THRESHOLD * 2
-                    },
-                    terminal,
-                    false
-                ),
-                Status::Idle,
-                "a quiet shell stays Idle regardless of {terminal:?}"
-            );
-            assert_eq!(
-                derive_status(
-                    ProcessKind::Shell,
-                    ProcessSignal::Running {
-                        idle: Duration::from_millis(100)
-                    },
-                    terminal,
-                    false
-                ),
-                Status::Run,
-                "a freshly-active shell stays Run regardless of {terminal:?}"
-            );
+        for terminal in every_terminal_signal {
+            for (idle, expected) in [
+                (AGENT_ASK_IDLE_THRESHOLD * 2, Status::Idle),
+                (Duration::from_millis(100), Status::Run),
+            ] {
+                assert_eq!(
+                    derive_status(
+                        ProcessKind::Shell,
+                        ProcessSignal::Running { idle },
+                        terminal,
+                        false
+                    ),
+                    expected,
+                    "a shell at idle={idle:?} must stay {expected:?} regardless of {terminal:?}"
+                );
+            }
+        }
+
+        for fact in [
+            HookFact::Working,
+            HookFact::NeedsInput,
+            HookFact::TurnEnded,
+            HookFact::TurnFailed,
+        ] {
+            for (idle, expected) in [
+                (AGENT_ASK_IDLE_THRESHOLD * 2, Status::Idle),
+                (Duration::from_millis(50), Status::Run),
+            ] {
+                assert_eq!(
+                    super::derive_status(
+                        ProcessKind::Shell,
+                        ProcessSignal::Running { idle },
+                        quiet(),
+                        hooked(fact),
+                        true
+                    ),
+                    expected,
+                    "a shell at idle={idle:?} must stay {expected:?} regardless of a {fact:?} hook"
+                );
+            }
         }
     }
 
+    /// An exit is an exact fact: neither a stale title glyph from just before the process died
+    /// nor a `Working` hook from the same moment may argue with it, or resurrect a process that
+    /// was never started.
     #[test]
-    fn a_terminal_signal_never_overrides_an_exit_or_a_missing_process() {
-        // An exit is an exact fact - a stale title glyph from just before the process died must
-        // not be able to argue with it.
+    fn no_side_channel_overrides_an_exit_or_a_missing_process() {
         let shouting = TerminalSignal {
             title: Some(TitleSignal::Busy),
             attention_pinged: true,
@@ -704,91 +768,63 @@ mod tests {
                 percent: Some(50),
             }),
         };
-        assert_eq!(
-            derive_status(
-                ProcessKind::claude(),
+        for (signal, has_diff, expected) in [
+            (
                 ProcessSignal::Exited { success: false },
-                shouting,
-                false
+                false,
+                Status::Fail,
             ),
-            Status::Fail
-        );
+            (
+                ProcessSignal::Exited { success: true },
+                true,
+                Status::Review,
+            ),
+            (ProcessSignal::NoProcess, true, Status::Idle),
+        ] {
+            assert_eq!(
+                derive_status(ProcessKind::claude(), signal, shouting, has_diff),
+                expected
+            );
+        }
+
+        for fact in [
+            HookFact::Working,
+            HookFact::NeedsInput,
+            HookFact::TurnEnded,
+            HookFact::TurnFailed,
+        ] {
+            assert_eq!(
+                super::derive_status(
+                    ProcessKind::claude(),
+                    ProcessSignal::Exited { success: false },
+                    quiet(),
+                    hooked(fact),
+                    false
+                ),
+                Status::Fail,
+                "{fact:?} must not argue with a non-zero exit"
+            );
+            assert_eq!(
+                super::derive_status(
+                    ProcessKind::claude(),
+                    ProcessSignal::NoProcess,
+                    quiet(),
+                    hooked(fact),
+                    true
+                ),
+                Status::Idle,
+                "{fact:?} must not invent a process that was never started"
+            );
+        }
         assert_eq!(
-            derive_status(
+            super::derive_status(
                 ProcessKind::claude(),
                 ProcessSignal::Exited { success: true },
-                shouting,
+                quiet(),
+                hooked(HookFact::Working),
                 true
             ),
             Status::Review
-        );
-        assert_eq!(
-            derive_status(
-                ProcessKind::claude(),
-                ProcessSignal::NoProcess,
-                shouting,
-                true
-            ),
-            Status::Idle
-        );
-    }
-
-    #[test]
-    fn an_agent_quiet_past_the_ask_threshold_is_ask() {
-        let signal = ProcessSignal::Running {
-            idle: AGENT_ASK_IDLE_THRESHOLD + Duration::from_secs(1),
-        };
-        assert_eq!(
-            derive_status(ProcessKind::claude(), signal, quiet(), false),
-            Status::Ask
-        );
-        assert_eq!(
-            derive_status(ProcessKind::codex(), signal, quiet(), false),
-            Status::Ask
-        );
-    }
-
-    #[test]
-    fn nonzero_exit_is_fail_regardless_of_diff() {
-        let signal = ProcessSignal::Exited { success: false };
-        assert_eq!(
-            derive_status(ProcessKind::Shell, signal, quiet(), true),
-            Status::Fail
-        );
-        assert_eq!(
-            derive_status(ProcessKind::claude(), signal, quiet(), false),
-            Status::Fail
-        );
-    }
-
-    #[test]
-    fn zero_exit_with_a_real_diff_is_review() {
-        let signal = ProcessSignal::Exited { success: true };
-        assert_eq!(
-            derive_status(ProcessKind::claude(), signal, quiet(), true),
-            Status::Review
-        );
-    }
-
-    #[test]
-    fn a_shell_zero_exit_with_a_real_diff_is_idle_not_review() {
-        // A plain shell exiting next to an unrelated worktree diff isn't a session that
-        // finished reviewable work - it's a terminal that closed. Only a real agent session's
-        // clean exit means "review ready" (see `ProcessKind::is_agent_session`'s docs).
-        let signal = ProcessSignal::Exited { success: true };
-        assert_eq!(
-            derive_status(ProcessKind::Shell, signal, quiet(), true),
-            Status::Idle,
-            "a shell isn't an agent session - its exit can't be \"review ready\""
-        );
-    }
-
-    #[test]
-    fn zero_exit_with_no_diff_is_idle_not_review() {
-        let signal = ProcessSignal::Exited { success: true };
-        assert_eq!(
-            derive_status(ProcessKind::claude(), signal, quiet(), false),
-            Status::Idle
         );
     }
 
@@ -960,93 +996,6 @@ mod tests {
             ),
             Status::Run
         );
-    }
-
-    #[test]
-    fn a_hook_fact_never_overrides_an_exit_or_a_missing_process() {
-        // An exit is an exact fact. A `Working` hook from just before the process died must not
-        // resurrect it - the same rule `TerminalSignal` already obeys.
-        for fact in [
-            HookFact::Working,
-            HookFact::NeedsInput,
-            HookFact::TurnEnded,
-            HookFact::TurnFailed,
-        ] {
-            assert_eq!(
-                super::derive_status(
-                    ProcessKind::claude(),
-                    ProcessSignal::Exited { success: false },
-                    quiet(),
-                    hooked(fact),
-                    false
-                ),
-                Status::Fail,
-                "{fact:?} must not argue with a non-zero exit"
-            );
-            assert_eq!(
-                super::derive_status(
-                    ProcessKind::claude(),
-                    ProcessSignal::NoProcess,
-                    quiet(),
-                    hooked(fact),
-                    true
-                ),
-                Status::Idle,
-                "{fact:?} must not invent a process that was never started"
-            );
-        }
-        assert_eq!(
-            super::derive_status(
-                ProcessKind::claude(),
-                ProcessSignal::Exited { success: true },
-                quiet(),
-                hooked(HookFact::Working),
-                true
-            ),
-            Status::Review
-        );
-    }
-
-    #[test]
-    fn a_hook_fact_can_never_change_a_shell_row() {
-        // Defensive, and deliberately so. Hooks are only ever installed for `AgentKind::Claude`
-        // spawns, so a shell should structurally never carry one - but "structurally impossible"
-        // is exactly the kind of claim that quietly stops being true, and a shell that could be
-        // driven to `Ask`/`Review`/`Fail` by an inbox entry would be a real bug. This pins the
-        // gate rather than trusting the surrounding architecture to keep holding.
-        for fact in [
-            HookFact::Working,
-            HookFact::NeedsInput,
-            HookFact::TurnEnded,
-            HookFact::TurnFailed,
-        ] {
-            assert_eq!(
-                super::derive_status(
-                    ProcessKind::Shell,
-                    ProcessSignal::Running {
-                        idle: AGENT_ASK_IDLE_THRESHOLD * 2
-                    },
-                    quiet(),
-                    hooked(fact),
-                    true
-                ),
-                Status::Idle,
-                "a quiet shell stays Idle regardless of a {fact:?} hook"
-            );
-            assert_eq!(
-                super::derive_status(
-                    ProcessKind::Shell,
-                    ProcessSignal::Running {
-                        idle: Duration::from_millis(50)
-                    },
-                    quiet(),
-                    hooked(fact),
-                    true
-                ),
-                Status::Run,
-                "a freshly-active shell stays Run regardless of a {fact:?} hook"
-            );
-        }
     }
 
     #[test]

--- a/crates/app/src/rail/strip_render.rs
+++ b/crates/app/src/rail/strip_render.rs
@@ -731,38 +731,7 @@ fn severity_color(severity: diagnostics_view::Severity) -> theme::ColorToken {
 #[cfg(test)]
 mod sidebar_strip_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
-    use std::fs;
-    use std::path::Path;
-    use std::process::Command;
-    use tempfile::TempDir;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        fs::write(dir.path().join("base.txt"), "base\n").expect("write");
-        git(dir.path(), &["add", "base.txt"]);
-        git(dir.path(), &["commit", "-m", "initial"]);
-        dir
-    }
 
     /// The four bounds every geometry assertion below reads: the two view cells, the `+` and the
     /// `⋯`, in the order the strip paints them.
@@ -800,8 +769,8 @@ mod sidebar_strip_tests {
     /// as a row of separated buttons.
     #[gpui::test]
     fn every_strip_cell_is_a_full_height_38px_slab_with_no_gap(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (_app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (_app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let band = cx
@@ -862,8 +831,8 @@ mod sidebar_strip_tests {
     /// height but drew three different border colours, and the centre one drew its edge twice.
     #[gpui::test]
     fn all_three_column_headers_end_on_one_line(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (_app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (_app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let rail = cx
@@ -901,8 +870,8 @@ mod sidebar_strip_tests {
     /// re-introduced `border_b` on it fails here rather than shipping as a doubled line.
     #[gpui::test]
     fn the_centre_columns_bottom_edge_is_carried_all_the_way_across(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (_app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (_app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let centre = cx.debug_bounds("tab-strip").expect("the tab strip");
@@ -936,8 +905,8 @@ mod sidebar_strip_tests {
     /// painted positions, so a cell with no handler fails here.
     #[gpui::test]
     fn clicking_a_cell_really_switches_the_panel_under_it(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         assert!(
@@ -982,8 +951,8 @@ mod sidebar_strip_tests {
     /// [`IconSize::Strip`] square - measured on the frame, not asserted against the enum.
     #[gpui::test]
     fn both_view_glyphs_are_phosphor_assets_in_one_shared_optical_box(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (_app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (_app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let box_size = f32::from(IconSize::Strip.box_size());
@@ -1022,8 +991,8 @@ mod sidebar_strip_tests {
     /// way to assert it.
     #[gpui::test]
     fn a_window_with_nothing_waiting_paints_no_state_marker(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         assert!(
@@ -1055,8 +1024,8 @@ mod sidebar_strip_tests {
     /// worth doing on an empty day.
     #[gpui::test]
     fn an_empty_day_drops_the_view_cells_and_keeps_the_trailing_pair(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         assert!(
             cx.debug_bounds("sidebar-strip-worktrees").is_some(),
@@ -1099,8 +1068,8 @@ mod sidebar_strip_tests {
     /// result over data that was never there.
     #[gpui::test]
     fn the_filter_rows_placeholder_follows_the_selected_view(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         assert!(
@@ -1136,8 +1105,8 @@ mod sidebar_strip_tests {
     /// into a 38px cell, so this proves the real spawn still happens from a real click on it.
     #[gpui::test]
     fn the_plus_cell_still_spawns_a_real_agent(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let before = app.read_with(cx, |app, _| app.agents.iter().count());
@@ -1170,41 +1139,14 @@ mod problems_view_tests {
         publish_full_and_wait, spawn_fake_server,
     };
     use crate::rail::worktrees::WorktreeItem;
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
     use std::path::Path;
-    use std::process::Command;
     use std::sync::Arc;
-    use tempfile::TempDir;
 
     /// LSP severity numbers, as a real server sends them.
     const ERROR: u8 = 1;
     const WARNING: u8 = 2;
     const HINT: u8 = 4;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {args:?} failed in {dir:?}: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(dir.path().join("base.txt"), "base\n").expect("write");
-        git(dir.path(), &["add", "base.txt"]);
-        git(dir.path(), &["commit", "-m", "initial"]);
-        dir
-    }
 
     /// Writes a real file under `root` and hands back its absolute path and its `file://` uri -
     /// the two things a real publish and a real click each need.
@@ -1264,15 +1206,15 @@ mod problems_view_tests {
     fn a_diagnostic_from_another_checkout_never_renders_under_the_active_one(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
-        let other = TempDir::new().expect("tempdir");
+        let repo = crate::test_support::temp_repo();
+        let other = crate::test_support::temp_root();
         let here = repo.path().to_path_buf();
         let there = other.path().to_path_buf();
 
         let (_, here_uri) = real_file(&here, "src/here.rs", "fn here() {}\n");
         let (_, there_uri) = real_file(&there, "src/there.rs", "fn there() {}\n");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, here.clone());
+        let (app, cx) = crate::test_support::open_test_app(cx, here.clone());
         cx.run_until_parked();
 
         let here_server = spawn_fake_server(&here, "rust-analyzer", "normal");
@@ -1368,12 +1310,12 @@ mod problems_view_tests {
     fn a_row_for_a_never_opened_file_really_opens_it_at_the_diagnostics_line(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let root = repo.path().to_path_buf();
         let (buried, buried_uri) =
             real_file(&root, "src/db/orm/select.rs", &"// filler\n".repeat(60));
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx) = crate::test_support::open_test_app(cx, root.clone());
         cx.run_until_parked();
 
         let server = spawn_fake_server(&root, "rust-analyzer", "normal");
@@ -1445,13 +1387,13 @@ mod problems_view_tests {
     /// error in it (`Jerry.dc.html`'s `probTally.err ? '#e0625c' : '#e2a336'`).
     #[gpui::test]
     fn the_header_and_the_marker_are_tallied_over_the_real_published_list(cx: &mut TestAppContext) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let root = repo.path().to_path_buf();
         let (_, broken) = real_file(&root, "src/db/orm/select.rs", "fn a() {}\n");
         let (_, noisy) = real_file(&root, "src/db/query_builder.rs", "fn b() {}\n");
         let (_, chatty) = real_file(&root, "src/api/orders.rs", "fn c() {}\n");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx) = crate::test_support::open_test_app(cx, root.clone());
         cx.run_until_parked();
 
         let server = spawn_fake_server(&root, "rust-analyzer", "normal");
@@ -1543,8 +1485,8 @@ mod problems_view_tests {
     fn a_diagnostic_about_a_file_outside_the_checkout_is_the_only_one_dropped(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
-        let registry = TempDir::new().expect("tempdir");
+        let repo = crate::test_support::temp_repo();
+        let registry = crate::test_support::temp_root();
         let root = repo.path().to_path_buf();
         let (_, dependency) = real_file(
             registry.path(),
@@ -1556,7 +1498,7 @@ mod problems_view_tests {
         // landed): the dependency row must be the only one dropped, not everything.
         let (_, mine) = real_file(&root, "src/lib.rs", "pub fn mine() {}\n");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx) = crate::test_support::open_test_app(cx, root.clone());
         cx.run_until_parked();
 
         let server = spawn_fake_server(&root, "rust-analyzer", "normal");
@@ -1606,11 +1548,11 @@ mod problems_view_tests {
     /// row whose click could only ever open nothing must not be counted either.
     #[gpui::test]
     fn a_row_for_a_deleted_file_disappears_from_the_list_and_the_tally(cx: &mut TestAppContext) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let root = repo.path().to_path_buf();
         let (doomed, doomed_uri) = real_file(&root, "src/scratch.rs", "fn tmp() {}\n");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx) = crate::test_support::open_test_app(cx, root.clone());
         cx.run_until_parked();
 
         let server = spawn_fake_server(&root, "rust-analyzer", "normal");
@@ -1659,11 +1601,11 @@ mod problems_view_tests {
     fn restarting_the_language_server_empties_the_list_rather_than_stranding_it(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let root = repo.path().to_path_buf();
         let (_, uri) = real_file(&root, "src/main.rs", "fn main() {}\n");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, root.clone());
+        let (app, cx) = crate::test_support::open_test_app(cx, root.clone());
         cx.run_until_parked();
 
         let server = spawn_fake_server(&root, "rust-analyzer", "normal");

--- a/crates/app/src/rail/title_signal.rs
+++ b/crates/app/src/rail/title_signal.rs
@@ -164,25 +164,17 @@ fn has_word(haystack: &str, word: &str) -> bool {
 mod tests {
     use super::*;
 
+    /// The real captures this module was written against, byte for byte: Gemini CLI's idle title
+    /// (OSC 0 payload, trailing padding included) and Claude Code 2.1.228's whole session
+    /// transcript - at rest, a spinner alternating across a 9-second stretch of silent `sleep 3`
+    /// tool calls, then back to rest. Nothing here is invented; see the module docs.
     #[test]
-    fn the_exact_gemini_idle_title_captured_from_a_real_session_reads_as_idle() {
-        // Byte-for-byte what Gemini CLI wrote to a real pty on this machine (OSC 0 payload,
-        // trailing padding included) - see the module docs.
-        assert_eq!(
-            classify_title(
-                "\u{25c7}  Ready (scratchpad)                                                    "
-            ),
-            TitleSignal::Idle
-        );
-    }
-
-    #[test]
-    fn the_real_claude_code_session_transcript_classifies_end_to_end() {
-        // The exact titles Claude Code 2.1.228 wrote to a real pty, in order, over one session:
-        // at rest, then a spinner alternating across a 9-second stretch of silent `sleep 3` tool
-        // calls, then back to rest. Nothing here is invented - see the module docs for the
-        // capture. This is the whole signal, pinned as one sequence.
+    fn the_real_captured_session_titles_classify_end_to_end() {
         let transcript = [
+            (
+                "\u{25c7}  Ready (scratchpad)                                                    ",
+                TitleSignal::Idle,
+            ),
             ("\u{2733} Claude Code", TitleSignal::Idle),
             ("\u{25d0} Claude Code", TitleSignal::Busy),
             (
@@ -203,80 +195,81 @@ mod tests {
         }
     }
 
+    /// Every glyph family this module knows, and the rule that a glyph outranks contradicting
+    /// prose - the glyph is the deliberate signal, the prose is incidental. `\u{25d0}`/`\u{25d1}`
+    /// and the Braille frames were observed live; the rest of each contiguous set is included
+    /// because it must not read as anything else (see the constants' own docs).
     #[test]
-    fn every_frame_of_claude_codes_half_circle_spinner_reads_as_busy() {
-        // `\u{25d0}`/`\u{25d1}` were observed live; the other two are the rest of the same
-        // contiguous set (see the constants' docs) and must not read as anything else.
-        for frame in ['\u{25d0}', '\u{25d1}', '\u{25d2}', '\u{25d3}'] {
-            assert_eq!(
-                classify_title(&format!("{frame} doing something")),
-                TitleSignal::Busy,
-                "{frame:?}"
-            );
+    fn a_status_glyph_decides_the_signal_whatever_the_prose_says() {
+        let cases: &[(&str, TitleSignal)] = &[
+            ("\u{25d0} doing something", TitleSignal::Busy),
+            ("\u{25d1} doing something", TitleSignal::Busy),
+            ("\u{25d2} doing something", TitleSignal::Busy),
+            ("\u{25d3} doing something", TitleSignal::Busy),
+            ("\u{2726} Working (jerry)", TitleSignal::Busy),
+            ("\u{23f2} (jerry)", TitleSignal::Busy),
+            ("\u{25c7} Ready", TitleSignal::Idle),
+            (
+                "\u{270b} Waiting for permission",
+                TitleSignal::NeedsAttention,
+            ),
+            ("\u{280b} some-cli", TitleSignal::Busy),
+            ("\u{2819} some-cli", TitleSignal::Busy),
+            ("\u{2839} some-cli", TitleSignal::Busy),
+            ("\u{2807} some-cli", TitleSignal::Busy),
+            ("\u{2800} some-cli", TitleSignal::Busy),
+            ("\u{28ff} some-cli", TitleSignal::Busy),
+            ("\u{2726} almost done", TitleSignal::Busy),
+            ("\u{270b} working on it", TitleSignal::NeedsAttention),
+        ];
+        for (title, expected) in cases {
+            assert_eq!(classify_title(title), *expected, "{title:?}");
         }
     }
 
+    /// Keywords match case-insensitively, and only on whole words - including at either end of
+    /// the title, which the boundary check has to treat as a boundary rather than a missing
+    /// character, and after an earlier non-matching occurrence, which `has_word`'s scan-onward
+    /// loop has to get past ("already ready").
     #[test]
-    fn geminis_documented_glyph_set_maps_to_its_four_states() {
-        assert_eq!(
-            classify_title("\u{2726} Working (jerry)"),
-            TitleSignal::Busy
-        );
-        assert_eq!(classify_title("\u{23f2} (jerry)"), TitleSignal::Busy);
-        assert_eq!(classify_title("\u{25c7} Ready"), TitleSignal::Idle);
-        assert_eq!(
-            classify_title("\u{270b} Waiting for permission"),
-            TitleSignal::NeedsAttention
-        );
-    }
-
-    #[test]
-    fn a_braille_spinner_frame_anywhere_means_busy() {
-        for frame in [
-            '\u{280b}', '\u{2819}', '\u{2839}', '\u{2807}', '\u{2800}', '\u{28ff}',
-        ] {
-            assert_eq!(
-                classify_title(&format!("{frame} some-cli")),
-                TitleSignal::Busy,
-                "{frame:?} is a Braille spinner frame"
-            );
+    fn a_keyword_matches_case_insensitively_on_whole_words_anywhere_in_the_title() {
+        let cases: &[(&str, TitleSignal)] = &[
+            ("agent: thinking", TitleSignal::Busy),
+            ("[Ready]", TitleSignal::Idle),
+            ("build done.", TitleSignal::Idle),
+            ("waiting for approval", TitleSignal::NeedsAttention),
+            ("WORKING", TitleSignal::Busy),
+            ("Idle", TitleSignal::Idle),
+            ("PERMISSION needed", TitleSignal::NeedsAttention),
+            ("ready", TitleSignal::Idle),
+            ("ready to go", TitleSignal::Idle),
+            ("all ready", TitleSignal::Idle),
+            ("already ready", TitleSignal::Idle),
+            ("\u{2026}\u{2026}ready\u{2026}\u{2026}", TitleSignal::Idle),
+        ];
+        for (title, expected) in cases {
+            assert_eq!(classify_title(title), *expected, "{title:?}");
         }
     }
 
+    /// The false-positive class the word-boundary guard exists for: terminal titles are mostly
+    /// paths, and plenty of ordinary ones embed these letters. An ordinary shell title - and a
+    /// multibyte one, whose bytes `has_word`'s offset arithmetic must never split - claims
+    /// nothing at all.
     #[test]
-    fn a_glyph_beats_a_contradicting_keyword() {
-        assert_eq!(
-            classify_title("\u{2726} almost done"),
-            TitleSignal::Busy,
-            "the glyph is the deliberate signal; the prose is incidental"
-        );
-        assert_eq!(
-            classify_title("\u{270b} working on it"),
-            TitleSignal::NeedsAttention
-        );
-    }
-
-    #[test]
-    fn keywords_match_only_on_whole_words() {
-        assert_eq!(classify_title("agent: thinking"), TitleSignal::Busy);
-        assert_eq!(classify_title("[Ready]"), TitleSignal::Idle);
-        assert_eq!(classify_title("build done."), TitleSignal::Idle);
-        assert_eq!(
-            classify_title("waiting for approval"),
-            TitleSignal::NeedsAttention
-        );
-    }
-
-    #[test]
-    fn a_path_that_merely_contains_a_keyword_as_a_substring_does_not_match() {
-        // The exact false-positive class the word-boundary guard exists for: terminal titles
-        // are mostly paths, and plenty of ordinary ones embed these letters.
+    fn an_ordinary_title_claims_no_status_even_when_it_embeds_the_letters() {
         for title in [
             "~/src/already/main.rs",
             "vim ~/notes/readyish.md",
             "npm run networking-tests",
             "~/code/rethinking/mod.rs",
             "~/work/idleness.txt",
+            "colin@jerry: ~/spike/ade",
+            "bash",
+            "",
+            "make -j8",
+            "\u{2713} tests passed",
+            "日本語のタイトル",
         ] {
             assert_eq!(
                 classify_title(title),
@@ -284,52 +277,5 @@ mod tests {
                 "{title:?} must not be read as a status claim"
             );
         }
-    }
-
-    #[test]
-    fn an_ordinary_shell_title_is_unknown() {
-        for title in [
-            "colin@jerry: ~/spike/ade",
-            "bash",
-            "",
-            "make -j8",
-            "\u{2713} tests passed",
-        ] {
-            assert_eq!(classify_title(title), TitleSignal::Unknown, "{title:?}");
-        }
-    }
-
-    #[test]
-    fn classification_is_case_insensitive_for_keywords() {
-        assert_eq!(classify_title("WORKING"), TitleSignal::Busy);
-        assert_eq!(classify_title("Idle"), TitleSignal::Idle);
-        assert_eq!(
-            classify_title("PERMISSION needed"),
-            TitleSignal::NeedsAttention
-        );
-    }
-
-    #[test]
-    fn a_word_at_either_end_of_the_title_still_matches() {
-        // The boundary check has to treat "start of string" and "end of string" as boundaries,
-        // not as missing characters that fail the test.
-        assert_eq!(classify_title("ready"), TitleSignal::Idle);
-        assert_eq!(classify_title("ready to go"), TitleSignal::Idle);
-        assert_eq!(classify_title("all ready"), TitleSignal::Idle);
-    }
-
-    #[test]
-    fn a_real_word_after_a_non_matching_occurrence_is_still_found() {
-        // Exercises `has_word`'s scan-onward loop: the first "ready" is inside "already" and
-        // must be rejected without ending the search.
-        assert_eq!(classify_title("already ready"), TitleSignal::Idle);
-    }
-
-    #[test]
-    fn multibyte_titles_do_not_panic_and_classify_by_their_glyph() {
-        // `has_word`'s byte-offset arithmetic must never split a UTF-8 character.
-        assert_eq!(classify_title("日本語のタイトル"), TitleSignal::Unknown);
-        assert_eq!(classify_title("\u{25c7} 準備完了"), TitleSignal::Idle);
-        assert_eq!(classify_title("……ready……"), TitleSignal::Idle);
     }
 }

--- a/crates/app/src/rail/worktree_watch.rs
+++ b/crates/app/src/rail/worktree_watch.rs
@@ -92,22 +92,18 @@ pub fn spawn_worktree_watcher(repo_path: &Path, dirty: DirtyFlag) -> Option<Reco
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::{Duration, Instant};
+    use std::time::Duration;
 
     /// Real-time bounded wait for the watcher's async, OS-thread-delivered callback to fire -
     /// there is no deterministic/simulated clock to advance here (unlike `gpui`'s test
-    /// executor), since `notify`'s events come from the real kernel on a real background
-    /// thread. A generous 3s ceiling, polled every 10ms; real inotify delivery is normally
-    /// sub-millisecond, so this only ever times out on a genuine failure to detect the change.
+    /// executor), since `notify`'s events come from the real kernel on a real background thread.
+    /// `test_support::wait_until` is the workspace's one sanctioned wall-clock wait
+    /// (`docs/testing.md`); real inotify delivery is normally sub-millisecond, so the generous
+    /// ceiling only ever elapses on a genuine failure to detect the change.
     fn wait_until_dirty(dirty: &DirtyFlag) -> bool {
-        let deadline = Instant::now() + Duration::from_secs(3);
-        while Instant::now() < deadline {
-            if dirty.swap(false, Ordering::SeqCst) {
-                return true;
-            }
-            std::thread::sleep(Duration::from_millis(10));
-        }
-        false
+        test_support::wait_until(Duration::from_secs(3), || {
+            dirty.swap(false, Ordering::SeqCst)
+        })
     }
 
     #[test]

--- a/crates/app/src/rail/worktree_watch.rs
+++ b/crates/app/src/rail/worktree_watch.rs
@@ -92,37 +92,7 @@ pub fn spawn_worktree_watcher(repo_path: &Path, dirty: DirtyFlag) -> Option<Reco
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
-    use std::process::Command;
     use std::time::{Duration, Instant};
-    use tempfile::TempDir;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        fs::write(dir.path().join("base.txt"), "base\n").expect("write");
-        git(dir.path(), &["add", "base.txt"]);
-        git(dir.path(), &["commit", "-m", "initial"]);
-        dir
-    }
 
     /// Real-time bounded wait for the watcher's async, OS-thread-delivered callback to fire -
     /// there is no deterministic/simulated clock to advance here (unlike `gpui`'s test
@@ -142,15 +112,15 @@ mod tests {
 
     #[test]
     fn a_real_worktree_add_is_noticed() {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let dirty: DirtyFlag = Arc::new(AtomicBool::new(false));
         let _watcher =
             spawn_worktree_watcher(repo.path(), dirty.clone()).expect("spawn_worktree_watcher");
 
-        let container = TempDir::new().expect("tempdir");
+        let container = crate::test_support::temp_root();
         let linked_path = container.path().join("added-wt");
         drop(container);
-        git(
+        test_support::git(
             repo.path(),
             &[
                 "worktree",
@@ -169,11 +139,11 @@ mod tests {
 
     #[test]
     fn a_real_worktree_remove_is_noticed() {
-        let repo = init_repo();
-        let container = TempDir::new().expect("tempdir");
+        let repo = crate::test_support::temp_repo();
+        let container = crate::test_support::temp_root();
         let linked_path = container.path().join("removed-wt");
         drop(container);
-        git(
+        test_support::git(
             repo.path(),
             &[
                 "worktree",
@@ -188,7 +158,7 @@ mod tests {
         let _watcher =
             spawn_worktree_watcher(repo.path(), dirty.clone()).expect("spawn_worktree_watcher");
 
-        git(
+        test_support::git(
             repo.path(),
             &[
                 "worktree",
@@ -205,11 +175,11 @@ mod tests {
 
     #[test]
     fn a_real_worktree_lock_is_noticed() {
-        let repo = init_repo();
-        let container = TempDir::new().expect("tempdir");
+        let repo = crate::test_support::temp_repo();
+        let container = crate::test_support::temp_root();
         let linked_path = container.path().join("locked-wt");
         drop(container);
-        git(
+        test_support::git(
             repo.path(),
             &[
                 "worktree",
@@ -224,7 +194,7 @@ mod tests {
         let _watcher =
             spawn_worktree_watcher(repo.path(), dirty.clone()).expect("spawn_worktree_watcher");
 
-        git(
+        test_support::git(
             repo.path(),
             &[
                 "worktree",
@@ -246,14 +216,14 @@ mod tests {
     /// lives one level up from `worktrees/`.
     #[test]
     fn a_branch_switch_in_the_main_worktree_is_noticed() {
-        let repo = init_repo();
-        git(repo.path(), &["branch", "other"]);
+        let repo = crate::test_support::temp_repo();
+        test_support::git(repo.path(), &["branch", "other"]);
 
         let dirty: DirtyFlag = Arc::new(AtomicBool::new(false));
         let _watcher =
             spawn_worktree_watcher(repo.path(), dirty.clone()).expect("spawn_worktree_watcher");
 
-        git(repo.path(), &["checkout", "other"]);
+        test_support::git(repo.path(), &["checkout", "other"]);
 
         assert!(
             wait_until_dirty(&dirty),
@@ -265,11 +235,11 @@ mod tests {
     /// alone, since that worktree's real `HEAD` lives under there.
     #[test]
     fn a_branch_switch_in_a_linked_worktree_is_noticed() {
-        let repo = init_repo();
-        let container = TempDir::new().expect("tempdir");
+        let repo = crate::test_support::temp_repo();
+        let container = crate::test_support::temp_root();
         let linked_path = container.path().join("switch-wt");
         drop(container);
-        git(
+        test_support::git(
             repo.path(),
             &[
                 "worktree",
@@ -279,13 +249,13 @@ mod tests {
                 linked_path.to_str().expect("utf8 path"),
             ],
         );
-        git(&linked_path, &["branch", "switch-target"]);
+        test_support::git(&linked_path, &["branch", "switch-target"]);
 
         let dirty: DirtyFlag = Arc::new(AtomicBool::new(false));
         let _watcher =
             spawn_worktree_watcher(repo.path(), dirty.clone()).expect("spawn_worktree_watcher");
 
-        git(&linked_path, &["checkout", "switch-target"]);
+        test_support::git(&linked_path, &["checkout", "switch-target"]);
 
         assert!(
             wait_until_dirty(&dirty),
@@ -295,7 +265,7 @@ mod tests {
 
     #[test]
     fn a_non_repository_yields_no_watcher_rather_than_panicking() {
-        let dir = TempDir::new().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         let dirty: DirtyFlag = Arc::new(AtomicBool::new(false));
         assert!(spawn_worktree_watcher(dir.path(), dirty).is_none());
     }
@@ -307,7 +277,7 @@ mod tests {
     /// that fallback, not silently missed until the next poll.
     #[test]
     fn the_very_first_worktree_add_in_a_repo_is_still_noticed_via_the_fallback_watch() {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         assert!(
             !repo.path().join(".git").join("worktrees").exists(),
             "precondition: this repo has never had a linked worktree"
@@ -322,10 +292,10 @@ mod tests {
         );
         let _watcher = watcher;
 
-        let container = TempDir::new().expect("tempdir");
+        let container = crate::test_support::temp_root();
         let linked_path = container.path().join("first-ever-wt");
         drop(container);
-        git(
+        test_support::git(
             repo.path(),
             &[
                 "worktree",

--- a/crates/app/src/rail/worktrees.rs
+++ b/crates/app/src/rail/worktrees.rs
@@ -230,105 +230,82 @@ mod tests {
         }
     }
 
+    /// A row's label, in the three-way order the function itself resolves it: the branch name
+    /// when there is one, else the short sha of the commit it is detached at, else the directory
+    /// name (an unborn worktree with no commit at all).
     #[test]
-    fn labels_use_branch_name_when_available() {
-        let items = build_worktree_items(vec![status("/repo", Some("main"), true)]);
-        assert_eq!(items.len(), 1);
-        assert_eq!(items[0].label, "main");
-        assert_eq!(items[0].path, PathBuf::from("/repo"));
-        assert!(items[0].is_main);
-        assert!(items[0].error.is_none());
-    }
+    fn a_label_is_the_branch_then_the_short_sha_then_the_directory_name() {
+        let on_branch = build_worktree_items(vec![status("/repo", Some("main"), true)]);
+        assert_eq!(on_branch[0].label, "main");
+        assert_eq!(on_branch[0].path, PathBuf::from("/repo"));
+        assert!(on_branch[0].is_main);
 
-    #[test]
-    fn detached_head_labels_with_the_short_sha_not_the_directory_name() {
-        let items = build_worktree_items(vec![status("/repos/feature-x", None, false)]);
-        assert_eq!(items[0].label, "deadbee");
-        assert_eq!(items[0].short_sha.as_deref(), Some("deadbee"));
-        assert_eq!(items[0].branch, None);
-        assert!(items[0].is_detached);
-        assert!(!items[0].is_main);
-    }
+        let detached = build_worktree_items(vec![status("/repos/feature-x", None, false)]);
+        assert_eq!(detached[0].label, "deadbee");
+        assert_eq!(detached[0].short_sha.as_deref(), Some("deadbee"));
+        assert_eq!(detached[0].branch, None);
+        assert!(detached[0].is_detached && !detached[0].is_main);
 
-    #[test]
-    fn falls_back_to_directory_name_when_there_is_no_commit_at_all() {
         let mut unborn = status("/repos/fresh", None, false);
         unborn.head_commit = None;
-        let items = build_worktree_items(vec![unborn]);
-        assert_eq!(items[0].label, "fresh");
-        assert_eq!(items[0].short_sha, None);
+        let unborn = build_worktree_items(vec![unborn]);
+        assert_eq!(unborn[0].label, "fresh");
+        assert_eq!(unborn[0].short_sha, None);
     }
 
+    /// The lock and bare flags git reports carry through to the row unchanged, and an empty
+    /// listing maps to no rows rather than a synthesised one.
     #[test]
-    fn empty_list_maps_to_empty_items() {
-        assert_eq!(build_worktree_items(Vec::new()), Vec::new());
-    }
-
-    #[test]
-    fn locked_state_and_reason_are_preserved() {
+    fn lock_and_bare_state_carry_through_and_an_empty_listing_makes_no_rows() {
         let mut locked = status("/repo-wt/locked", Some("locked-branch"), false);
         locked.is_locked = true;
         locked.lock_reason = Some("external disk".to_string());
-        let items = build_worktree_items(vec![locked]);
-        assert!(items[0].is_locked);
-        assert_eq!(items[0].lock_reason.as_deref(), Some("external disk"));
-    }
+        let locked = build_worktree_items(vec![locked]);
+        assert!(locked[0].is_locked);
+        assert_eq!(locked[0].lock_reason.as_deref(), Some("external disk"));
 
-    #[test]
-    fn unlocked_state_is_preserved() {
-        let items = build_worktree_items(vec![status("/repo-wt/unlocked", Some("x"), false)]);
-        assert!(!items[0].is_locked);
-        assert_eq!(items[0].lock_reason, None);
-    }
-
-    #[test]
-    fn bare_entry_is_flagged_bare_and_never_main() {
         let mut bare = status("/bare-repo", None, false);
         bare.is_bare = true;
         bare.head_commit = None;
         bare.is_detached = false;
-        let items = build_worktree_items(vec![bare]);
-        assert!(items[0].is_bare);
-        assert!(!items[0].is_main);
+        let bare = build_worktree_items(vec![bare]);
+        assert!(bare[0].is_bare && !bare[0].is_main);
+
+        assert_eq!(build_worktree_items(Vec::new()), Vec::new());
     }
 
-    /// The central "don't silently list a broken worktree as healthy" guarantee (issue #12):
-    /// a prunable entry must be both flagged via `is_broken`/`broken_reason` *and* rejected by
-    /// the plain `error.is_none()` gate every existing selection/agent-spawn/diff call site
-    /// already uses, with no changes needed at those call sites.
+    /// The central "don't silently list a broken worktree as healthy" guarantee (issue #12): a
+    /// prunable entry must be both flagged via `is_broken`/`broken_reason` *and* rejected by the
+    /// plain `error.is_none()` gate every existing selection/agent-spawn/diff call site already
+    /// uses, with no changes needed at those call sites - reason or no reason - while a healthy
+    /// entry stays usable.
     #[test]
-    fn a_prunable_entry_is_marked_broken_and_unusable() {
+    fn a_prunable_entry_is_marked_broken_and_unusable_with_or_without_a_reason() {
         let mut gone = status("/repo-wt/gone", Some("gone-branch"), false);
         gone.is_prunable = true;
         gone.prunable_reason = Some("gitdir file points to non-existent location".to_string());
-        let items = build_worktree_items(vec![gone]);
-        assert!(items[0].is_broken);
+        let gone = build_worktree_items(vec![gone]);
+        assert!(gone[0].is_broken);
         assert_eq!(
-            items[0].broken_reason.as_deref(),
+            gone[0].broken_reason.as_deref(),
             Some("gitdir file points to non-existent location")
         );
         assert!(
-            items[0].error.is_some(),
+            gone[0].error.is_some(),
             "a broken worktree must also fail the existing error.is_none() usability gate"
         );
-    }
 
-    #[test]
-    fn a_prunable_entry_with_no_reason_still_reports_a_real_error() {
-        let mut gone = status("/repo-wt/gone-no-reason", Some("gone"), false);
-        gone.is_prunable = true;
-        let items = build_worktree_items(vec![gone]);
-        assert!(items[0].is_broken);
-        assert_eq!(items[0].broken_reason, None);
-        assert!(items[0].error.is_some());
-    }
+        let mut unexplained = status("/repo-wt/gone-no-reason", Some("gone"), false);
+        unexplained.is_prunable = true;
+        let unexplained = build_worktree_items(vec![unexplained]);
+        assert!(unexplained[0].is_broken);
+        assert_eq!(unexplained[0].broken_reason, None);
+        assert!(unexplained[0].error.is_some());
 
-    #[test]
-    fn a_healthy_entry_is_not_broken() {
-        let items = build_worktree_items(vec![status("/repo", Some("main"), true)]);
-        assert!(!items[0].is_broken);
-        assert_eq!(items[0].broken_reason, None);
-        assert!(items[0].error.is_none());
+        let healthy = build_worktree_items(vec![status("/repo", Some("main"), true)]);
+        assert!(!healthy[0].is_broken);
+        assert_eq!(healthy[0].broken_reason, None);
+        assert!(healthy[0].error.is_none());
     }
 
     // --- `recover_selection` ------------------------------------------------------------
@@ -350,34 +327,33 @@ mod tests {
         }
     }
 
+    /// Nothing to recover: no prior selection at all, or one that is still there and usable.
     #[test]
-    fn no_prior_selection_needs_no_recovery() {
-        let new_items = vec![item("/repo", true, None)];
-        assert_eq!(
-            recover_selection(None, &new_items),
-            SelectionRecovery::NoPriorSelection
-        );
-    }
-
-    #[test]
-    fn a_selection_that_is_still_present_is_unchanged() {
-        let previous = item("/repo-wt/feature", false, None);
+    fn a_still_usable_or_absent_selection_needs_no_recovery() {
         let new_items = vec![
             item("/repo", true, None),
             item("/repo-wt/feature", false, None),
         ];
+        assert_eq!(
+            recover_selection(None, &new_items),
+            SelectionRecovery::NoPriorSelection
+        );
+
+        let previous = item("/repo-wt/feature", false, None);
         assert_eq!(
             recover_selection(Some(&previous), &new_items),
             SelectionRecovery::Unchanged(1)
         );
     }
 
+    /// A selection that vanished - or that is still listed but has since gone broken - falls back
+    /// to the main worktree with a real notice naming what was lost, and reports `None` honestly
+    /// when there is no usable main to fall back to either.
     #[test]
-    fn a_vanished_selection_falls_back_to_main_with_a_notice() {
+    fn a_vanished_or_broken_selection_falls_back_to_a_usable_main_or_to_nothing() {
         let previous = item("/repo-wt/feature", false, None);
-        let new_items = vec![item("/repo", true, None)];
-        let recovery = recover_selection(Some(&previous), &new_items);
-        match recovery {
+
+        match recover_selection(Some(&previous), &[item("/repo", true, None)]) {
             SelectionRecovery::FellBackToMain { new_index, notice } => {
                 assert_eq!(new_index, Some(0));
                 assert!(notice.contains("/repo-wt/feature"));
@@ -385,32 +361,21 @@ mod tests {
             }
             other => panic!("expected FellBackToMain, got {other:?}"),
         }
-    }
 
-    #[test]
-    fn a_selection_that_became_broken_also_falls_back_to_main() {
-        let previous = item("/repo-wt/feature", false, None);
-        let new_items = vec![
+        let now_broken = vec![
             item("/repo", true, None),
             item("/repo-wt/feature", false, Some("worktree is prunable")),
         ];
-        let recovery = recover_selection(Some(&previous), &new_items);
         assert!(matches!(
-            recovery,
+            recover_selection(Some(&previous), &now_broken),
             SelectionRecovery::FellBackToMain {
                 new_index: Some(0),
                 ..
             }
         ));
-    }
 
-    #[test]
-    fn falling_back_with_no_usable_main_at_all_reports_none() {
-        let previous = item("/repo-wt/feature", false, None);
-        let new_items: Vec<WorktreeItem> = Vec::new();
-        let recovery = recover_selection(Some(&previous), &new_items);
         assert!(matches!(
-            recovery,
+            recover_selection(Some(&previous), &[]),
             SelectionRecovery::FellBackToMain {
                 new_index: None,
                 ..
@@ -420,82 +385,61 @@ mod tests {
 
     // --- `selection_for_opened_repo` -----------------------------------------------------
 
-    /// The overwhelmingly common `jerry .` case: the opened path *is* the main worktree, so
-    /// both of this function's rules agree and it lands on the one obvious row.
+    /// The three real launch shapes: `jerry .` at the repo root (both of this function's rules
+    /// agree on the one obvious row), `jerry ~/repo-wt/feature` directly inside a linked worktree
+    /// (which must win over main, never be silently redirected), and the live-reproduced
+    /// subdirectory launch `jerry ./crates`. Before that last rule existed,
+    /// `AdeApp::current_worktree_path` fell back to the bare subdirectory path and the startup
+    /// shell it spawned there belonged to no rail row at all - a real, live tab that no worktree
+    /// claimed, permanently unreachable the moment any worktree row was clicked.
     #[test]
-    fn opening_a_repo_root_selects_its_own_main_worktree() {
+    fn an_opened_path_selects_its_own_worktree_or_the_main_one_it_sits_under() {
         let items = vec![
             item("/repo", true, None),
             item("/repo-wt/feature", false, None),
         ];
-        assert_eq!(
-            selection_for_opened_repo(Path::new("/repo"), &items),
-            Some(0)
-        );
+        for (opened, expected, why) in [
+            ("/repo", Some(0), "the repo root is its own main worktree"),
+            (
+                "/repo-wt/feature",
+                Some(1),
+                "the worktree the user actually pointed at must win over the main worktree",
+            ),
+            (
+                "/repo/crates",
+                Some(0),
+                "a subdirectory is not a worktree, so this must land on the real main worktree",
+            ),
+        ] {
+            assert_eq!(
+                selection_for_opened_repo(Path::new(opened), &items),
+                expected,
+                "{why}"
+            );
+        }
     }
 
-    /// `jerry ~/repo-wt/feature` - launching directly inside a linked worktree must land on
-    /// *that* worktree, never silently redirect to main.
+    /// A row that isn't usable is never selected, however exactly the opened path matches it -
+    /// selecting one would hand every downstream consumer a path that isn't on disk. With no
+    /// usable row left at all, "nothing" is the honest answer rather than an index that doesn't
+    /// resolve.
     #[test]
-    fn opening_a_linked_worktree_directly_selects_that_worktree_not_main() {
-        let items = vec![
-            item("/repo", true, None),
-            item("/repo-wt/feature", false, None),
-        ];
-        assert_eq!(
-            selection_for_opened_repo(Path::new("/repo-wt/feature"), &items),
-            Some(1),
-            "the worktree the user actually pointed at must win over the main worktree"
-        );
-    }
-
-    /// The real, live-reproduced subdirectory launch (`jerry ./crates`): the opened path is a
-    /// genuine directory but not any worktree, so nothing can match it exactly. Before this
-    /// rule existed, `AdeApp::current_worktree_path` fell back to that bare subdirectory path, and
-    /// the startup shell it spawned there belonged to no rail row at all - a real, live tab
-    /// that no worktree claimed, and which became permanently unreachable the moment any
-    /// worktree row was clicked.
-    #[test]
-    fn opening_a_subdirectory_of_a_repo_falls_back_to_the_main_worktree() {
-        let items = vec![
-            item("/repo", true, None),
-            item("/repo-wt/feature", false, None),
-        ];
-        assert_eq!(
-            selection_for_opened_repo(Path::new("/repo/crates"), &items),
-            Some(0),
-            "a subdirectory is not a worktree, so this must land on the real main worktree \
-             rather than on the subdirectory itself"
-        );
-    }
-
-    /// A repo with genuinely nothing usable to select is a real, honest state - reported as
-    /// such rather than papered over with an index that doesn't resolve to a usable row.
-    #[test]
-    fn opening_a_repo_with_no_usable_worktree_at_all_selects_nothing() {
-        assert_eq!(selection_for_opened_repo(Path::new("/repo"), &[]), None);
-    }
-
-    /// An exact path match that is nonetheless *broken* must not be selected - it would hand
-    /// every downstream consumer a path that isn't on disk. Falls through to main instead.
-    #[test]
-    fn a_broken_exact_match_is_skipped_in_favour_of_a_usable_main() {
-        let items = vec![
+    fn an_unusable_row_is_never_selected_even_on_an_exact_path_match() {
+        let broken_match = vec![
             item("/repo", true, None),
             item("/repo-wt/gone", false, Some("worktree is prunable")),
         ];
         assert_eq!(
-            selection_for_opened_repo(Path::new("/repo-wt/gone"), &items),
+            selection_for_opened_repo(Path::new("/repo-wt/gone"), &broken_match),
             Some(0),
             "a prunable exact match is not usable, so this must fall back to main"
         );
-    }
 
-    /// And a broken *main* is skipped too, leaving the honest "nothing usable" answer rather
-    /// than an index pointing at an unusable row.
-    #[test]
-    fn a_broken_main_worktree_is_not_selected_either() {
-        let items = vec![item("/repo", true, Some("worktree is prunable"))];
-        assert_eq!(selection_for_opened_repo(Path::new("/repo"), &items), None);
+        let broken_main = vec![item("/repo", true, Some("worktree is prunable"))];
+        assert_eq!(
+            selection_for_opened_repo(Path::new("/repo"), &broken_main),
+            None
+        );
+        assert_eq!(selection_for_opened_repo(Path::new("/repo"), &[]), None);
     }
 }

--- a/crates/app/src/root/caret_blink.rs
+++ b/crates/app/src/root/caret_blink.rs
@@ -193,7 +193,6 @@ impl AdeApp {
 #[cfg(test)]
 mod caret_blink_focus_order_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
     use gpui::{Entity, TestAppContext, VisualTestContext};
 
     /// A real repo directory with a real file in it, opened in a real File view, so
@@ -202,11 +201,15 @@ mod caret_blink_focus_order_tests {
     /// `track_focus`'d (`crate::code_surface::render`).
     fn open_app_with_a_focusable_editor(
         cx: &mut TestAppContext,
-    ) -> (Entity<AdeApp>, &mut VisualTestContext, tempfile::TempDir) {
-        let repo = tempfile::tempdir().expect("tempdir");
+    ) -> (
+        Entity<AdeApp>,
+        &mut VisualTestContext,
+        crate::test_support::TempRoot,
+    ) {
+        let repo = crate::test_support::temp_root();
         let file_path = repo.path().join("notes.txt");
         std::fs::write(&file_path, "hello\n").expect("write notes.txt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         // `on_focus`/`on_blur` only fire while GPUI considers the window itself active - a
         // freshly opened test window starts out inactive, so this is a real precondition, not
         // scaffolding (the same note every other caret-blink test in this codebase carries).

--- a/crates/app/src/root/focus.rs
+++ b/crates/app/src/root/focus.rs
@@ -251,7 +251,7 @@ pub(crate) mod palette_focus_tests {
     /// click first.
     #[gpui::test]
     fn toggle_palette_reopens_after_being_closed(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         cx.dispatch_action(TogglePalette);
@@ -279,7 +279,7 @@ pub(crate) mod palette_focus_tests {
     /// initial agent's pane focus up front, the very first ⌘P would silently do nothing.
     #[gpui::test]
     fn toggle_palette_works_on_a_fresh_window_with_nothing_clicked_yet(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         cx.dispatch_action(TogglePalette);
@@ -296,7 +296,7 @@ pub(crate) mod palette_focus_tests {
     /// [`OverlayFocus`]'s `opened_agent` field).
     #[gpui::test]
     fn toggle_palette_still_works_after_a_palette_spawned_new_shell(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         let initial_agent_id = app.read_with(cx, |app, _| app.agents.active_id());
@@ -332,7 +332,7 @@ pub(crate) mod palette_focus_tests {
     /// mid-query, it's an ordinary character appended to the query like any other.
     #[gpui::test]
     fn scope_prefix_only_fires_on_an_empty_query(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         cx.dispatch_action(TogglePalette);
@@ -375,7 +375,7 @@ pub(crate) mod palette_focus_tests {
     fn secondary_keystroke_opens_the_palette_through_the_real_key_bindings(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
 
@@ -417,8 +417,8 @@ mod tab_strip_keybinding_tests {
     /// sense over.
     #[gpui::test]
     fn opening_the_palette_closes_an_already_open_plus_menu(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, cx| {
             app.plus_menu_open = true;
@@ -435,8 +435,8 @@ mod tab_strip_keybinding_tests {
 
     #[gpui::test]
     fn opening_settings_closes_an_already_open_plus_menu(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, cx| {
             app.plus_menu_open = true;
@@ -458,8 +458,8 @@ mod tab_strip_keybinding_tests {
     fn ctrl_shift_t_spawns_a_real_shell_agent_through_the_real_key_bindings(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
 
         let agents_before = app.read_with(cx, |app, _| app.agents.iter().count());
@@ -490,8 +490,8 @@ mod tab_strip_keybinding_tests {
     fn secondary_shift_n_spawns_a_real_agent_through_the_real_key_bindings(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
 
         let agents_before = app.read_with(cx, |app, _| app.agents.iter().count());
@@ -527,8 +527,8 @@ mod tab_strip_keybinding_tests {
     /// in practice) pty-forwarding half of `Ctrl+P`.
     #[gpui::test]
     fn ctrl_p_opens_the_palette_even_while_a_terminal_is_focused(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
 
         // Explicitly focus the initial shell agent - the real, concrete "a terminal pane
@@ -575,9 +575,9 @@ mod tab_strip_keybinding_tests {
     /// unconditionally, silently killing every bound shortcut until the next click.
     #[gpui::test]
     fn ctrl_p_still_works_after_ctrl_shift_t_with_a_file_tab_active(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         std::fs::write(repo.path().join("a.txt"), "hello\n").expect("write a.txt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
 
         app.update_in(cx, |app, window, cx| {
@@ -612,8 +612,8 @@ mod tab_strip_keybinding_tests {
     /// next click.
     #[gpui::test]
     fn ctrl_p_still_works_after_closing_the_active_agent_tab(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
 
         let first_id = app.read_with(cx, |app, _| {
@@ -658,8 +658,8 @@ mod tab_strip_keybinding_tests {
     /// rail (`AdeApp::archive_agent`, which delegates to `Self::close_agent`).
     #[gpui::test]
     fn ctrl_p_still_works_after_archiving_the_active_agent(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
 
         let first_id = app.read_with(cx, |app, _| {
@@ -700,22 +700,6 @@ mod tab_strip_keybinding_tests {
         );
     }
 
-    fn git(dir: &std::path::Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
     #[gpui::test]
     fn bracket_advances_to_the_next_changed_file_through_the_real_key_bindings(
         cx: &mut TestAppContext,
@@ -724,19 +708,19 @@ mod tab_strip_keybinding_tests {
         // bare `]` would swallow a literal `]` typed into any focused terminal instead of
         // forwarding it to the pty. This opens a file first (`AdeApp::open_change_diff`) to
         // establish "diff"-context focus before simulating the keystroke.
-        let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
+        let repo = crate::test_support::temp_root();
+        test_support::git(repo.path(), &["init", "-b", "main"]);
+        test_support::git(repo.path(), &["config", "user.email", "test@example.com"]);
+        test_support::git(repo.path(), &["config", "user.name", "Test User"]);
         std::fs::write(repo.path().join("a.txt"), "1\n").expect("write a.txt");
         std::fs::write(repo.path().join("b.txt"), "1\n").expect("write b.txt");
-        git(repo.path(), &["add", "."]);
-        git(repo.path(), &["commit", "-m", "initial"]);
-        git(repo.path(), &["checkout", "-b", "feature"]);
+        test_support::git(repo.path(), &["add", "."]);
+        test_support::git(repo.path(), &["commit", "-m", "initial"]);
+        test_support::git(repo.path(), &["checkout", "-b", "feature"]);
         std::fs::write(repo.path().join("a.txt"), "1\nchanged\n").expect("rewrite a.txt");
         std::fs::write(repo.path().join("b.txt"), "1\nchanged\n").expect("rewrite b.txt");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         bind_real_keys(cx);
 
@@ -776,17 +760,17 @@ mod tab_strip_keybinding_tests {
     /// before and after `]` for an uninteresting reason instead of proving the scoping works.
     #[gpui::test]
     fn bracket_does_not_fire_globally_while_a_terminal_is_focused(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
+        let repo = crate::test_support::temp_root();
+        test_support::git(repo.path(), &["init", "-b", "main"]);
+        test_support::git(repo.path(), &["config", "user.email", "test@example.com"]);
+        test_support::git(repo.path(), &["config", "user.name", "Test User"]);
         std::fs::write(repo.path().join("a.txt"), "1\n").expect("write a.txt");
-        git(repo.path(), &["add", "."]);
-        git(repo.path(), &["commit", "-m", "initial"]);
-        git(repo.path(), &["checkout", "-b", "feature"]);
+        test_support::git(repo.path(), &["add", "."]);
+        test_support::git(repo.path(), &["commit", "-m", "initial"]);
+        test_support::git(repo.path(), &["checkout", "-b", "feature"]);
         std::fs::write(repo.path().join("a.txt"), "1\nchanged\n").expect("rewrite a.txt");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         bind_real_keys(cx);
 
@@ -827,8 +811,8 @@ mod tab_strip_keybinding_tests {
     fn secondary_3_jumps_to_the_third_real_agent_through_the_real_key_bindings(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
 
         // Tab 1 is `open_test_app`'s own startup shell. Four more, then retagged so the strip
@@ -898,8 +882,8 @@ mod tab_strip_keybinding_tests {
     /// case is covered by the keystroke test above.
     #[gpui::test]
     fn jump_to_agent_at_activates_the_right_agent_by_position(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         let mut ids = vec![app.read_with(cx, |app, _| {
             app.agents.active_id().expect("the initial shell agent")
@@ -968,8 +952,8 @@ mod settings_focus_tests {
     fn toggle_settings_action_opens_then_real_escape_closes_it_and_focus_stays_live(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         cx.dispatch_action(ToggleSettings);
         assert!(
@@ -999,8 +983,8 @@ mod settings_focus_tests {
     /// here for Settings.
     #[gpui::test]
     fn toggle_settings_works_on_a_fresh_window_with_nothing_clicked_yet(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         cx.dispatch_action(ToggleSettings);
 
@@ -1020,8 +1004,8 @@ mod settings_focus_tests {
     fn secondary_comma_keystroke_opens_settings_through_the_real_key_bindings(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
 
         let secondary_comma = if cfg!(target_os = "macos") {
@@ -1046,8 +1030,8 @@ mod settings_focus_tests {
     /// ([`AdeApp::render_workspace_body`]) without touching `AdeApp::agents` itself.
     #[gpui::test]
     fn closing_settings_leaves_open_agent_tabs_intact(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         let agents_before = app.read_with(cx, |app, _| app.agents.iter().count());
         let active_before = app.read_with(cx, |app, _| app.agents.active_id());
@@ -1079,8 +1063,8 @@ mod settings_focus_tests {
     /// not reset settings_page" contract.
     #[gpui::test]
     fn settings_page_selection_persists_across_a_close_and_reopen(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         cx.dispatch_action(ToggleSettings);
         app.update_in(cx, |app, window, cx| {
@@ -1108,8 +1092,8 @@ mod settings_focus_tests {
     /// palette handle - covers `AdeApp::close_palette`'s Settings-aware branch.
     #[gpui::test]
     fn open_settings_palette_command_leaves_real_focus_on_settings(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         cx.dispatch_action(TogglePalette);
         app.update_in(cx, |app, window, cx| {
@@ -1146,8 +1130,8 @@ mod settings_focus_tests {
     fn opening_settings_populates_real_agent_rows_from_a_background_path_search(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         assert!(
             app.read_with(cx, |app, _| app.agent_rows.is_empty()),
@@ -1179,8 +1163,8 @@ mod settings_focus_tests {
     fn opening_settings_populates_real_lsp_rows_from_a_background_path_search(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         assert!(app.read_with(cx, |app, _| app.lsp_rows.is_empty()));
 
@@ -1197,8 +1181,8 @@ mod settings_focus_tests {
 
     #[gpui::test]
     fn settings_opens_to_general_by_default_on_a_fresh_window(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         cx.dispatch_action(ToggleSettings);
 
@@ -1214,8 +1198,8 @@ mod settings_focus_tests {
     /// `select_settings_page` performs.
     #[gpui::test]
     fn every_settings_page_renders_without_panicking(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         cx.dispatch_action(ToggleSettings);
         cx.run_until_parked();
@@ -1243,8 +1227,8 @@ mod settings_focus_tests {
     fn window_controls_style_change_updates_the_real_persisted_settings_field(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         assert_eq!(
             app.read_with(cx, |app, _| app.window_controls_style()),
@@ -1280,10 +1264,10 @@ mod code_focus_tests {
     fn open_test_app_with_a_plain_text_file(
         cx: &mut TestAppContext,
     ) -> (Entity<AdeApp>, &mut gpui::VisualTestContext, PathBuf) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let file_path = repo.path().join("notes.txt");
         std::fs::write(&file_path, "hello\n").expect("write notes.txt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         (app, cx, file_path)
     }
 
@@ -1430,10 +1414,10 @@ mod text_undo_scoping_tests {
     /// covers the other half of.
     #[gpui::test]
     fn secondary_z_with_a_terminal_focused_does_not_reach_text_undo(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let file_path = repo.path().join("notes.txt");
         std::fs::write(&file_path, "hello\n").expect("write notes.txt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("notes.txt");
@@ -1484,10 +1468,10 @@ mod text_undo_scoping_tests {
     fn secondary_z_with_the_palette_open_undoes_the_query_not_the_file_editor_behind_it(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let file_path = repo.path().join("notes.txt");
         std::fs::write(&file_path, "hello\n").expect("write notes.txt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         open_file_for_editing(&app, cx, file_path.clone());
         bind_real_keys(cx);
         let relative = PathBuf::from("notes.txt");
@@ -1537,8 +1521,8 @@ mod text_undo_scoping_tests {
     /// be reachable, or Ctrl+Z would resurrect a query the user already dismissed.
     #[gpui::test]
     fn reopening_the_palette_starts_a_genuinely_fresh_history(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
 
         app.update_in(cx, |app, window, cx| app.open_palette(window, cx));
@@ -1561,8 +1545,8 @@ mod text_undo_scoping_tests {
     /// `"text-input"` - only the filter row itself is tagged.
     #[gpui::test]
     fn secondary_z_in_the_settings_keybindings_filter_undoes_the_filter(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
 
         app.update_in(cx, |app, window, cx| {
@@ -1604,8 +1588,8 @@ mod text_undo_scoping_tests {
     fn secondary_z_in_the_rail_filter_undoes_it_including_a_real_escape_clear(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
 
         app.update_in(cx, |app, window, cx| {
@@ -1645,8 +1629,8 @@ mod text_undo_scoping_tests {
     fn secondary_z_in_the_new_file_prompt_undoes_the_name_and_a_fresh_prompt_has_no_history(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         bind_real_keys(cx);
 
         app.update_in(cx, |app, window, cx| {
@@ -1712,11 +1696,10 @@ mod palette_result_focus_tests {
     use crate::palette::state as palette;
     use gpui::{Entity, TestAppContext};
     use std::fs;
-    use tempfile::TempDir;
 
     /// `src/main.rs` (the file every test opens) plus a sibling, so the palette's own filtering
     /// has something to actually discriminate between.
-    fn seed(repo: &TempDir) {
+    fn seed(repo: &crate::test_support::TempRoot) {
         fs::create_dir_all(repo.path().join("src")).expect("mkdir");
         fs::write(repo.path().join("src/main.rs"), "fn main() {}\n").expect("write");
         fs::write(repo.path().join("src/other.rs"), "pub fn o() {}\n").expect("write");
@@ -1724,10 +1707,14 @@ mod palette_result_focus_tests {
 
     fn open_seeded(
         cx: &mut TestAppContext,
-    ) -> (TempDir, Entity<AdeApp>, &mut gpui::VisualTestContext) {
-        let repo = TempDir::new().expect("tempdir");
+    ) -> (
+        crate::test_support::TempRoot,
+        Entity<AdeApp>,
+        &mut gpui::VisualTestContext,
+    ) {
+        let repo = crate::test_support::temp_root();
         seed(&repo);
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
         cx.run_until_parked();
         (repo, app, cx)
@@ -2172,8 +2159,8 @@ mod palette_result_focus_tests {
     /// itself expects and excludes.
     #[gpui::test]
     fn every_palette_command_is_findable_by_its_own_label(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         for command in palette::PaletteCommand::ALL {
             if matches!(
@@ -2255,13 +2242,13 @@ mod tabless_window_keybinding_tests {
     ) -> (
         Entity<AdeApp>,
         &mut gpui::VisualTestContext,
-        tempfile::TempDir,
+        crate::test_support::TempRoot,
         PathBuf,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let file_path = repo.path().join("a.txt");
         std::fs::write(&file_path, "hello\n").expect("write a.txt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         (app, cx, repo, file_path)
     }

--- a/crates/app/src/root/focus.rs
+++ b/crates/app/src/root/focus.rs
@@ -275,20 +275,39 @@ pub(crate) mod palette_focus_tests {
         );
     }
 
-    /// A fresh window starts with `Window::focus == None` - without `AdeApp::new` giving the
-    /// initial agent's pane focus up front, the very first ⌘P would silently do nothing.
+    /// Scope-prefix coverage requested alongside the focus fix: `>`/`@` should only switch the
+    /// palette's scope when typed as the very first character of an empty query - typed
+    /// mid-query, it's an ordinary character appended to the query like any other.
     #[gpui::test]
-    fn toggle_palette_works_on_a_fresh_window_with_nothing_clicked_yet(cx: &mut TestAppContext) {
+    fn scope_prefix_only_fires_on_an_empty_query(cx: &mut TestAppContext) {
         let repo = crate::test_support::temp_root();
         let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         cx.dispatch_action(TogglePalette);
+        cx.simulate_input(">");
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.palette_scope, palette::PaletteScope::Commands);
+            assert_eq!(app.palette_query.as_str(), "");
+        });
 
-        assert!(
-            app.read_with(cx, |app, _| app.palette_open),
-            "secondary-p on a completely fresh window (nothing clicked yet) should still open the \
-             palette"
-        );
+        // Back to a fresh, empty-query palette state before the mid-query case.
+        cx.dispatch_action(TogglePalette);
+        cx.dispatch_action(TogglePalette);
+        app.read_with(cx, |app, _| {
+            assert_eq!(app.palette_scope, palette::PaletteScope::All);
+            assert_eq!(app.palette_query.as_str(), "");
+        });
+
+        cx.simulate_input("x");
+        cx.simulate_input(">");
+        app.read_with(cx, |app, _| {
+            assert_eq!(
+                app.palette_scope,
+                palette::PaletteScope::All,
+                "a `>` typed mid-query (query is non-empty) must not switch scope"
+            );
+            assert_eq!(app.palette_query.as_str(), "x>");
+        });
     }
 
     /// Spawning an agent from the palette swaps the active agent; verifies `close_palette`
@@ -325,41 +344,6 @@ pub(crate) mod palette_focus_tests {
              center pane now renders a different agent's terminal pane than the one focus \
              was captured from, so close_palette must not restore that now-stale handle"
         );
-    }
-
-    /// Scope-prefix coverage requested alongside the focus fix: `>`/`@` should only switch the
-    /// palette's scope when typed as the very first character of an empty query - typed
-    /// mid-query, it's an ordinary character appended to the query like any other.
-    #[gpui::test]
-    fn scope_prefix_only_fires_on_an_empty_query(cx: &mut TestAppContext) {
-        let repo = crate::test_support::temp_root();
-        let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
-
-        cx.dispatch_action(TogglePalette);
-        cx.simulate_input(">");
-        app.read_with(cx, |app, _| {
-            assert_eq!(app.palette_scope, palette::PaletteScope::Commands);
-            assert_eq!(app.palette_query.as_str(), "");
-        });
-
-        // Back to a fresh, empty-query palette state before the mid-query case.
-        cx.dispatch_action(TogglePalette);
-        cx.dispatch_action(TogglePalette);
-        app.read_with(cx, |app, _| {
-            assert_eq!(app.palette_scope, palette::PaletteScope::All);
-            assert_eq!(app.palette_query.as_str(), "");
-        });
-
-        cx.simulate_input("x");
-        cx.simulate_input(">");
-        app.read_with(cx, |app, _| {
-            assert_eq!(
-                app.palette_scope,
-                palette::PaletteScope::All,
-                "a `>` typed mid-query (query is non-empty) must not switch scope"
-            );
-            assert_eq!(app.palette_query.as_str(), "x>");
-        });
     }
 
     /// Unlike every other test in this module, which dispatches `TogglePalette` directly, this
@@ -412,29 +396,11 @@ mod tab_strip_keybinding_tests {
     }
 
     /// The `+` menu popover is rendered as an unconditional sibling of both the palette and
-    /// Settings (`AdeApp::plus_menu_open`'s own docs) - opening either while it happened to
-    /// still be open must close it, or it would paint on top of a surface it no longer makes
-    /// sense over.
+    /// Settings (`AdeApp::plus_menu_open`'s own docs) - opening either while it happened to still
+    /// be open must close it, or it would paint on top of a surface it no longer makes sense
+    /// over.
     #[gpui::test]
-    fn opening_the_palette_closes_an_already_open_plus_menu(cx: &mut TestAppContext) {
-        let repo = crate::test_support::temp_root();
-        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
-
-        app.update(cx, |app, cx| {
-            app.plus_menu_open = true;
-            cx.notify();
-        });
-        cx.dispatch_action(TogglePalette);
-
-        assert!(app.read_with(cx, |app, _| app.palette_open));
-        assert!(
-            !app.read_with(cx, |app, _| app.plus_menu_open),
-            "opening the palette should have closed the still-open plus menu"
-        );
-    }
-
-    #[gpui::test]
-    fn opening_settings_closes_an_already_open_plus_menu(cx: &mut TestAppContext) {
+    fn opening_the_palette_or_settings_closes_an_already_open_plus_menu(cx: &mut TestAppContext) {
         let repo = crate::test_support::temp_root();
         let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
@@ -443,11 +409,21 @@ mod tab_strip_keybinding_tests {
             cx.notify();
         });
         cx.dispatch_action(ToggleSettings);
-
         assert!(app.read_with(cx, |app, _| app.settings_open));
         assert!(
             !app.read_with(cx, |app, _| app.plus_menu_open),
             "opening Settings should have closed the still-open plus menu"
+        );
+
+        app.update(cx, |app, cx| {
+            app.plus_menu_open = true;
+            cx.notify();
+        });
+        cx.dispatch_action(TogglePalette);
+        assert!(app.read_with(cx, |app, _| app.palette_open));
+        assert!(
+            !app.read_with(cx, |app, _| app.plus_menu_open),
+            "and opening the palette should have closed it too"
         );
     }
 
@@ -978,22 +954,6 @@ mod settings_focus_tests {
         );
     }
 
-    /// `secondary-,` works from a fresh window with nothing clicked yet - same case as
-    /// `palette_focus_tests::toggle_palette_works_on_a_fresh_window_with_nothing_clicked_yet`,
-    /// here for Settings.
-    #[gpui::test]
-    fn toggle_settings_works_on_a_fresh_window_with_nothing_clicked_yet(cx: &mut TestAppContext) {
-        let repo = crate::test_support::temp_root();
-        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
-
-        cx.dispatch_action(ToggleSettings);
-
-        assert!(
-            app.read_with(cx, |app, _| app.settings_open),
-            "secondary-, on a completely fresh window (nothing clicked yet) should still open Settings"
-        );
-    }
-
     /// With the old `"cmd-,"` binding, `Ctrl+,` was never recognized as matching any
     /// `KeyBinding` (`"cmd"`/`"super"`/`"win"` only ever mean the platform modifier, never Ctrl,
     /// on Linux - `vendor/zed/crates/gpui/src/platform/keystroke.rs`), so the keystroke fell
@@ -1067,6 +1027,11 @@ mod settings_focus_tests {
         let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         cx.dispatch_action(ToggleSettings);
+        assert_eq!(
+            app.read_with(cx, |app, _| app.settings_page),
+            SettingsPage::General,
+            "a fresh window opens Settings on General"
+        );
         app.update_in(cx, |app, window, cx| {
             app.select_settings_page(SettingsPage::Worktrees, window, cx);
         });
@@ -1123,21 +1088,25 @@ mod settings_focus_tests {
         );
     }
 
-    /// Opening Settings must populate [`AdeApp::agent_rows`] from the background `$PATH` search
-    /// (see [`AdeApp::load_agent_rows`]) rather than leave it empty. `run_until_parked` drives
-    /// the spawned task to completion; without it this would race the still-in-flight search.
+    /// Opening Settings must populate both background-`$PATH`-searched row lists
+    /// ([`AdeApp::agent_rows`] for the Agents page, [`AdeApp::lsp_rows`] for Language servers -
+    /// see [`AdeApp::load_agent_rows`]) rather than leave them empty, and must not run either
+    /// search before it is opened. `run_until_parked` drives the spawned tasks to completion;
+    /// without it this would race the still-in-flight searches.
     #[gpui::test]
-    fn opening_settings_populates_real_agent_rows_from_a_background_path_search(
+    fn opening_settings_populates_both_row_lists_from_a_background_path_search(
         cx: &mut TestAppContext,
     ) {
         let repo = crate::test_support::temp_root();
         let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
-        assert!(
-            app.read_with(cx, |app, _| app.agent_rows.is_empty()),
-            "agent_rows should still be empty before Settings has ever been opened - nothing \
-             should eagerly run a $PATH search that's only ever shown on the Agents page"
-        );
+        app.read_with(cx, |app, _| {
+            assert!(
+                app.agent_rows.is_empty() && app.lsp_rows.is_empty(),
+                "neither list may be populated before Settings has ever been opened - nothing \
+                 should eagerly run a $PATH search that's only ever shown on those pages"
+            );
+        });
 
         cx.dispatch_action(ToggleSettings);
         cx.run_until_parked();
@@ -1156,40 +1125,13 @@ mod settings_focus_tests {
                 "{kind:?} should have a real row after a real $PATH search"
             );
         }
-    }
 
-    /// Mirrors the Agents-page test above, for [`AdeApp::lsp_rows`] (the Language servers page).
-    #[gpui::test]
-    fn opening_settings_populates_real_lsp_rows_from_a_background_path_search(
-        cx: &mut TestAppContext,
-    ) {
-        let repo = crate::test_support::temp_root();
-        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
-
-        assert!(app.read_with(cx, |app, _| app.lsp_rows.is_empty()));
-
-        cx.dispatch_action(ToggleSettings);
-        cx.run_until_parked();
-
-        let rows = app.read_with(cx, |app, _| app.lsp_rows.clone());
+        let lsp_rows = app.read_with(cx, |app, _| app.lsp_rows.clone());
         let languages = settings::lsp_languages();
-        assert_eq!(rows.len(), languages.len());
+        assert_eq!(lsp_rows.len(), languages.len());
         for def in languages {
-            assert!(rows.iter().any(|row| row.language == def.language));
+            assert!(lsp_rows.iter().any(|row| row.language == def.language));
         }
-    }
-
-    #[gpui::test]
-    fn settings_opens_to_general_by_default_on_a_fresh_window(cx: &mut TestAppContext) {
-        let repo = crate::test_support::temp_root();
-        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
-
-        cx.dispatch_action(ToggleSettings);
-
-        assert_eq!(
-            app.read_with(cx, |app, _| app.settings_page),
-            SettingsPage::General
-        );
     }
 
     /// Every page in `SettingsPage::ALL` must render without panicking. Running the test
@@ -1271,8 +1213,18 @@ mod code_focus_tests {
         (app, cx, file_path)
     }
 
+    /// Every window-level action must still reach its real handler once a plain `.txt` File
+    /// view is mounted. Without [`AdeApp::code_focus_handle`] tracking real focus there, these
+    /// dispatches silently fall back to the window's internal dispatch root (GPUI's own
+    /// `Window::focus_node_id_in_rendered_frame` falls back to `dispatch_tree.root_node_id()`
+    /// whenever the focused `FocusId` isn't found in the last rendered frame) instead of
+    /// reaching the handler at all.
+    ///
+    /// `GotoDefinition` is included even though a `.txt` file has no hover entry for it to act
+    /// on: `handle_goto_definition_action`'s early return with `hover == None` is harmless, and
+    /// what is under test is that dispatch reached the handler, not what it did once there.
     #[gpui::test]
-    fn toggle_settings_action_reaches_the_real_handler_with_a_file_view_open(
+    fn every_window_action_still_reaches_its_handler_with_a_file_view_open(
         cx: &mut TestAppContext,
     ) {
         let (app, cx, file_path) = open_test_app_with_a_plain_text_file(cx);
@@ -1287,53 +1239,14 @@ mod code_focus_tests {
         );
 
         cx.dispatch_action(ToggleSettings);
-        assert!(
-            app.read_with(cx, |app, _| app.settings_open),
-            "secondary-, must still reach handle_toggle_settings_action once a plain .txt File view is \
-             mounted - without AdeApp::code_focus_handle tracking real focus there, this dispatch \
-             would silently fall back to the window's internal dispatch root (GPUI's own \
-             `Window::focus_node_id_in_rendered_frame` falls back to `dispatch_tree.root_node_id\
-             ()` whenever the focused FocusId isn't found in the last rendered frame) instead of \
-             reaching this handler"
-        );
-    }
-
-    #[gpui::test]
-    fn toggle_palette_action_reaches_the_real_handler_with_a_file_view_open(
-        cx: &mut TestAppContext,
-    ) {
-        let (app, cx, file_path) = open_test_app_with_a_plain_text_file(cx);
-
-        app.update_in(cx, |app, window, cx| {
-            app.open_file_view(file_path.clone(), window, cx);
-        });
-        cx.run_until_parked();
+        assert!(app.read_with(cx, |app, _| app.settings_open));
 
         cx.dispatch_action(TogglePalette);
-        assert!(
-            app.read_with(cx, |app, _| app.palette_open),
-            "secondary-p must still reach handle_toggle_palette_action once a File view is mounted, \
-             for exactly the same real reason secondary-, must"
-        );
-    }
-
-    #[gpui::test]
-    fn goto_definition_action_reaches_the_real_handler_with_a_file_view_open(
-        cx: &mut TestAppContext,
-    ) {
-        let (app, cx, file_path) = open_test_app_with_a_plain_text_file(cx);
-
-        app.update_in(cx, |app, window, cx| {
-            app.open_file_view(file_path.clone(), window, cx);
-        });
-        cx.run_until_parked();
+        assert!(app.read_with(cx, |app, _| app.palette_open));
 
         assert_eq!(app.read_with(cx, |app, _| app.hover.clone()), None);
         cx.dispatch_action(GotoDefinition);
         cx.run_until_parked();
-        // `handle_goto_definition_action` only has a harmless early return with `hover == None`
-        // (a .txt file has no hover entry) - what's under test is that dispatch reached the
-        // handler at all with a File view open, not what it did once there.
         assert_eq!(app.read_with(cx, |app, _| app.hover.clone()), None);
     }
 

--- a/crates/app/src/root/layout.rs
+++ b/crates/app/src/root/layout.rs
@@ -53,43 +53,64 @@ pub fn panel_width_for_cursor(body_right: f32, cursor_x: f32) -> f32 {
 mod tests {
     use super::*;
 
+    /// The rail's width is how far right of the body's *own* left edge the cursor is, clamped to
+    /// its documented range. The body deliberately does not start at window x=0 in the middle
+    /// case, so a dropped `body_left` term cannot pass.
     #[test]
-    fn rail_width_is_the_cursors_distance_from_the_bodys_left_edge() {
-        assert_eq!(rail_width_for_cursor(0.0, 300.0), 300.0);
+    fn rail_width_measures_from_the_bodys_left_edge_and_clamps_to_its_range() {
+        for (body_left, cursor_x, expected, why) in [
+            (
+                0.0,
+                300.0,
+                300.0,
+                "the plain distance from the body's left edge",
+            ),
+            (
+                50.0,
+                350.0,
+                300.0,
+                "measured from the body, not the window origin",
+            ),
+            (
+                0.0,
+                10_000.0,
+                RAIL_MAX,
+                "never wider than its documented maximum",
+            ),
+            (
+                0.0,
+                -10_000.0,
+                RAIL_MIN,
+                "never narrower than its documented minimum",
+            ),
+        ] {
+            assert_eq!(
+                rail_width_for_cursor(body_left, cursor_x),
+                expected,
+                "{why}"
+            );
+        }
     }
 
+    /// The panel's handle sits on its *left* edge and the panel is flush against the body's right
+    /// edge, so it grows as the cursor moves left - the mirror image of the rail's measurement,
+    /// clamped to its own documented range.
     #[test]
-    fn rail_never_exceeds_its_documented_maximum() {
-        assert_eq!(rail_width_for_cursor(0.0, 10_000.0), RAIL_MAX);
-    }
-
-    #[test]
-    fn rail_never_drops_below_its_documented_minimum() {
-        assert_eq!(rail_width_for_cursor(0.0, -10_000.0), RAIL_MIN);
-    }
-
-    #[test]
-    fn rail_width_still_measures_from_a_body_thats_not_flush_with_the_window_origin() {
-        // The body (the div `rail_width_for_cursor` is really measuring against) doesn't
-        // itself start at window x=0 - confirm the offset is subtracted, not assumed away.
-        assert_eq!(rail_width_for_cursor(50.0, 350.0), 300.0);
-    }
-
-    #[test]
-    fn panel_width_is_the_cursors_distance_from_the_bodys_right_edge() {
-        // The panel's handle sits on its *left* edge, and the panel itself is flush against
-        // the body's right edge, so the panel grows as the cursor moves left (away from that
-        // right edge) - the mirror image of the rail's left-edge measurement.
-        assert_eq!(panel_width_for_cursor(1200.0, 900.0), 300.0);
-    }
-
-    #[test]
-    fn panel_never_exceeds_its_maximum() {
-        assert_eq!(panel_width_for_cursor(1200.0, -10_000.0), PANEL_MAX);
-    }
-
-    #[test]
-    fn panel_never_drops_below_its_documented_floor() {
-        assert_eq!(panel_width_for_cursor(1200.0, 10_000.0), PANEL_MIN);
+    fn panel_width_measures_back_from_the_bodys_right_edge_and_clamps_to_its_range() {
+        for (cursor_x, expected, why) in [
+            (
+                900.0,
+                300.0,
+                "the plain distance back from the body's right edge",
+            ),
+            (-10_000.0, PANEL_MAX, "never wider than its maximum"),
+            (
+                10_000.0,
+                PANEL_MIN,
+                "never narrower than its documented floor",
+            ),
+        ] {
+            assert_eq!(panel_width_for_cursor(1200.0, cursor_x), expected, "{why}");
+        }
     }
 }

--- a/crates/app/src/root/menu_commands.rs
+++ b/crates/app/src/root/menu_commands.rs
@@ -456,14 +456,14 @@ impl AdeApp {
 #[cfg(test)]
 mod menu_command_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests::open_test_app;
+    use crate::test_support::open_test_app;
     use gpui::TestAppContext;
 
     /// `menu_command_enabled(Save)` must track real edit-buffer state: `false` with nothing
     /// open, `true` once a real file is loaded into the File view.
     #[gpui::test]
     fn menu_command_enabled_save_tracks_the_real_active_edit_buffer(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let file_path = repo.path().join("notes.txt");
         std::fs::write(&file_path, "hello\n").expect("write notes.txt");
         let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
@@ -488,7 +488,7 @@ mod menu_command_tests {
     /// in a genuinely empty window.
     #[gpui::test]
     fn menu_command_enabled_zoom_requires_a_real_code_surface(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         assert!(
@@ -504,7 +504,7 @@ mod menu_command_tests {
     /// initial shell agent, so "no active agent" has to be reached by really archiving it).
     #[gpui::test]
     fn menu_command_enabled_archive_agent_tracks_the_real_active_agent(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
@@ -539,7 +539,7 @@ mod menu_command_tests {
     /// will dispatch through - not just a direct method call.
     #[gpui::test]
     fn dispatching_zoom_in_action_reaches_the_real_zoom_in_handler(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let file_path = repo.path().join("notes.rs");
         std::fs::write(&file_path, "fn main() {}\n").expect("write notes.rs");
         let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
@@ -568,7 +568,7 @@ mod menu_command_tests {
     /// separate `disabled:` bookkeeping.
     #[gpui::test]
     fn zoom_in_action_is_unavailable_with_no_code_surface_showing(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
         let _ = app;
 

--- a/crates/app/src/root/menus.rs
+++ b/crates/app/src/root/menus.rs
@@ -221,7 +221,7 @@ impl AdeApp {
 #[cfg(test)]
 mod menu_surface_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests::open_test_app;
+    use crate::test_support::open_test_app;
     use gpui::TestAppContext;
 
     /// Opens every one of them at once by writing their real state fields directly - the state
@@ -263,7 +263,7 @@ mod menu_surface_tests {
 
     #[gpui::test]
     fn closing_all_menu_surfaces_really_closes_every_one_of_them(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, cx| {
@@ -298,7 +298,7 @@ mod menu_surface_tests {
     /// level of the shared primitive: whichever surface is being opened is the only survivor.
     #[gpui::test]
     fn opening_any_one_surface_closes_all_the_others(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         for keep in MenuSurface::ALL {
@@ -334,7 +334,7 @@ mod menu_surface_tests {
     /// calls the close path directly.
     #[gpui::test]
     fn the_window_losing_focus_really_closes_every_open_menu(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let (app, cx) = open_test_app(cx, repo.path().to_path_buf());
 
         // `deactivate_window` is a no-op unless this window really is the platform's active one,

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -1,80 +1,15 @@
-//! The top-level three-pane window: a left worktree sidebar, a tabbed center pane of
-//! terminal agents, and a right file tree, composed as GPUI entities.
+//! The top-level three-pane window: a left worktree rail, a tabbed centre pane of terminal
+//! agents, and a right file tree, composed as GPUI entities.
 //!
-//! ## What lives here, and what doesn't
+//! Owns [`AdeApp`] itself - the one state struct every subsystem reads and mutates - its
+//! construction ([`state`]), the crate's GPUI actions, the `Render` impl that composes the
+//! zones, and the genuinely cross-zone mechanics: focus and overlay discipline ([`focus`]),
+//! pane resizing ([`resize`], [`layout`]), the scoped rem-size override ([`rem_scope`]), the
+//! shared widgets ([`widgets`]), pluralisation ([`plural`]), the background-task slot type
+//! ([`task_pool`]) and the "New file" prompt ([`new_file`]).
 //!
-//! This module is the *app shell*, not a grab-bag of rendering code. It owns [`AdeApp`]
-//! itself (the one state struct every subsystem reads and mutates) and its construction
-//! ([`state`]), the crate's GPUI actions, the `Render` impl that composes the zones, and
-//! the genuinely cross-zone mechanics: focus/overlay discipline ([`focus`], [`OverlayFocus`]), pane resizing
-//! ([`resize`] plus its pure width-clamp half, [`layout`]), the scoped rem-size override
-//! Surface C's zoom paints through ([`rem_scope`]), the shared keycap/chip/message widgets
-//! ([`widgets`]), the app-wide pluralisation helper every counter in the window conjugates
-//! through ([`plural`] - see its module docs for the rule, which is binding on new code), the
-//! background-task slot type ([`task_pool`]), and the "New file" prompt
-//! ([`new_file`]), which is an overlay reachable from two different zones and so belongs to
-//! neither.
-//!
-//! Everything *about one subsystem* lives in that subsystem's own folder instead - both its
-//! pure, window-free logic and the `impl AdeApp` blocks that draw it: `crate::rail`,
-//! `crate::work_surface`, `crate::sidebar`, `crate::code_surface`, `crate::merge`,
-//! `crate::palette`, `crate::settings`, `crate::status_bar`, `crate::title_bar`,
-//! `crate::terminal`, `crate::lsp`, `crate::worktree_history`. So "everything about
-//! feature X" is one directory, not two unrelated ones.
-//!
-//! ## Offloading `wt-core`'s blocking calls
-//!
-//! `wt_core::list_worktrees` performs blocking I/O (`gix` object-database reads, and
-//! sometimes spawning `git`). It's never called directly from `render` or an event handler;
-//! [`AdeApp::load_worktrees`] hands it to `cx.background_executor().spawn(..)` and only
-//! touches `self` again inside a `this.update(cx, ..)` callback once the background task
-//! resolves. `crate::sidebar::file_tree::build_file_tree`'s `std::fs::read_dir` walk follows the same
-//! pattern.
-//!
-//! ## One rail row per worktree; agents are tabs scoped to it
-//!
-//! [`crate::work_surface::agents::Agents`] holds any number of independent, simultaneously-running
-//! terminal agents (a plain shell, or an agent CLI), each pinned to the worktree it was
-//! started in. The agent rail shows exactly one row per worktree
-//! (`crate::rail::state::WorktreeRow`, aggregating every agent open in it), and the centre pane's tab
-//! strip (`AdeApp::render_tab_strip`) only ever shows the *currently selected* worktree's own
-//! agents - never a flat, unscoped list of every agent across every worktree.
-//!
-//! Selecting a worktree in the sidebar still never spawns or kills anything - but, unlike
-//! before this revision, it *does* change which agent is "active"
-//! (`crate::work_surface::agents::Agents::activate_for_worktree`, called from [`AdeApp::select_worktree`]):
-//! the active agent must always belong to the selected worktree, or the centre pane would show
-//! one worktree's terminal while the rail highlights another. [`AdeApp::selected`] itself still
-//! drives the file tree, and which worktree `current_worktree_path` resolves to for the *next* "New
-//! terminal"/"New agent pane" click - that part is unchanged. Spawning an agent is still always
-//! its own explicit action, never an implicit side effect of browsing.
-//!
-//! ### A tab always belongs to a real, selected worktree - never to a repo
-//!
-//! The invariant that ties all of the above together, and the one a family of reported bugs all
-//! turned out to be violations of:
-//!
-//! > **A tab is never shown, never spawnable, and never implicitly attributed to anything except a
-//! > real, currently-selected worktree. There is no such thing as "a repo's own tab".**
-//!
-//! [`AdeApp::current_worktree_path`] is the single chokepoint that enforces it, and it returns
-//! `Option<PathBuf>` precisely so that "nothing is selected" is a state the app can *say* rather
-//! than paper over. It used to fall back to [`AdeApp::focused_repo_path`] whenever
-//! [`AdeApp::selected`] was `None`, which quietly made a repo root behave like a worktree it is
-//! not - see that method's own docs for the three live-reproduced failures that produced
-//! (a real tab no rail row claimed and that a single click orphaned forever; the rail, tab strip,
-//! and centre pane disagreeing three ways; and the reported "I select a worktree and the startup
-//! terminal is lost").
-//!
-//! The other half is that the `None` state is kept genuinely rare rather than merely handled: the
-//! two real "open a repo" gestures - a CLI launch ([`AdeApp::new_with_settings`]) and "Open
-//! Folder…" ([`AdeApp::open_repo_in_current_window`]) - both funnel through
-//! [`AdeApp::load_worktrees_for_opened_repo`], which resolves the repo's real worktree list,
-//! genuinely selects the right worktree of it
-//! ([`crate::rail::worktrees::selection_for_opened_repo`]), and only then spawns that window's
-//! guaranteed initial shell, into that concretely-selected worktree. So a focused repo at rest
-//! always has a real worktree selected; `None` is confined to the brief in-flight window before
-//! that first fetch lands, and to genuine error states.
+//! Everything *about one subsystem* lives in that subsystem's own folder instead, pure logic
+//! and `impl AdeApp` blocks alike - so "everything about feature X" is one directory, not two.
 
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -2966,59 +2901,21 @@ impl AdeApp {
         }
     }
 
-    /// GitHub issue #90's "Open Folder…" (`crate::title_bar::menu`'s File-menu row) and the
-    /// empty-state view's own "Open Folder" button (`Self::render_empty_state`) both funnel
-    /// through here: `path` becomes a real, focused repo in the *current* window, and every
-    /// single-repo-scoped piece of state this app still has is reset/reloaded against it via
-    /// [`Self::reset_repo_scoped_state`] (the exact same reset [`Self::select_worktree`] applies
-    /// on every worktree switch, extracted so this real "switch to an entirely different repo"
-    /// gesture can share it rather than reimplementing a partial copy) - unlike plain
-    /// [`Self::add_repo`] + [`Self::focus_repo`] alone, which (per their own docs) don't reload
-    /// anything, since until now the only place that combination ran was startup, where the
-    /// caller went on to do the reload itself right afterwards ([`Self::new_with_settings`]).
+    /// Makes `path` a real, focused repo in the *current* window: the File menu's "Open Folder…"
+    /// row and the empty state's own button both funnel through here.
     ///
-    /// An independent audit of this method's first version found (and this now fixes) two real
-    /// gaps beyond the incomplete state reset above:
-    /// - it never (re)started [`Self::start_worktree_watch`]/[`Self::start_status_polling`] - a
-    ///   window that starts empty and only later opens a folder never got rail status polling at
-    ///   all, and a window switching from repo A to repo B kept its watcher bound to A's path.
-    ///   Both are safe to call unconditionally here: assigning a fresh `Task`/watcher to their own
-    ///   field drops (and so cancels) whatever was previously running there, so this can never
-    ///   leave two loops running at once.
-    /// - a genuinely empty window's Settings/palette overlay may have captured
-    ///   [`Self::empty_state_focus_handle`] as its own "return focus to" target
-    ///   ([`OverlayFocus::capture`]) - once a real repo is focused, [`Self::render_empty_state`]
-    ///   stops being part of the rendered tree at all, so restoring focus to it later would
-    ///   silently dangle every global keybinding. [`OverlayFocus::forget_target`] is this
-    ///   project's own established fix for exactly this class of bug (see its own docs).
+    /// Every single-repo-scoped piece of state is reset against it via
+    /// [`Self::reset_repo_scoped_state`], the worktree watcher and status polling are rebound to
+    /// it (both are safe to call unconditionally - assigning a fresh `Task`/watcher to its own
+    /// field cancels whatever was running there), and a Settings/palette overlay still holding
+    /// [`Self::empty_state_focus_handle`] as its return target forgets it, since
+    /// [`Self::render_empty_state`] leaves the rendered tree the moment a repo is focused.
     ///
-    /// ## Cross-repo agent persistence
-    ///
-    /// Every agent open before this call, in *every* repo, stays exactly as it was: a real PTY
-    /// process left running in the background, never paused and never closed just because
-    /// `path` is about to become the focused repo instead. This used to shut down every other
-    /// repo's agents right here (the same real teardown [`Self::close_agent`] always uses) on the
-    /// reasoning that nothing yet let a user reach them again - the tab strip
-    /// ([`crate::work_surface::render::AdeApp::combined_tab_order`]) is still genuinely scoped to
-    /// the *active worktree* (`Agents::iter_for_cwd`), so a repo other than `path` shows none of
-    /// its own tabs the moment focus moves away. That reasoning no longer holds: the rail's own
-    /// per-repo groups ([`crate::rail::render::AdeApp::build_repo_groups`]) now fold every repo's
-    /// real open agents into their own rows regardless of focus, with genuinely live status, so a
-    /// background repo's agent is still fully reachable - just through the rail instead of the
-    /// tab strip - and closing it out from under the user the instant they looked away would be a
-    /// real, silent kill of work they never asked to stop. Switching back to that repo later
-    /// (another call here, or [`Self::checkout_repo_from_rail`]) finds the exact same
-    /// [`AgentId`]s mid-work, never a fresh respawn.
-    ///
-    /// Idempotent against a repo already known to this window (re-opening an already-added repo
-    /// just re-focuses and reloads it, rather than duplicating anything) - the same
-    /// [`Self::add_repo`] guarantee this builds on. A repo with no agent open yet in its own root
-    /// (a genuinely new repo, or one whose root worktree was closed by hand) gets one spawned
-    /// here, the same "a fresh window starts with one shell in the repo root" default
-    /// [`Self::new_with_settings`] gives a CLI-launched repo - a repo revisited after being
-    /// unfocused keeps whatever real agent(s) it already had running, per the cross-repo
-    /// persistence above, so this never spawns a redundant second shell into a worktree that
-    /// already has one.
+    /// Agents open in *other* repos stay running: the rail's per-repo groups fold every repo's
+    /// agents into their own rows regardless of focus, so a background repo's agent is still
+    /// reachable, and switching back finds the same [`AgentId`]s mid-work rather than a respawn.
+    /// Idempotent for an already-known repo, and a repo that already has an agent in its own root
+    /// gets no redundant second shell.
     pub(crate) fn open_repo_in_current_window(
         &mut self,
         path: PathBuf,
@@ -3057,45 +2954,17 @@ impl AdeApp {
         self.start_status_polling(cx);
     }
 
-    /// The rail's real repo-switch engine - the rail-native sibling of
-    /// [`Self::open_repo_in_current_window`]. It began as GitHub issue #113's "click a repo
-    /// header in the rail and it checks out", but the repo header is deliberately **not
-    /// clickable at all anymore** (explicit user direction, after two subtler header-click
-    /// behaviors were both rejected in review - see
-    /// [`crate::rail::render::AdeApp::render_repo_group`]'s own docs: in the rail, only worktree
-    /// rows and agent rows are click targets). So today this has exactly one real caller:
-    /// [`Self::select_worktree_by_path`]'s cross-repo fallback, reached by clicking a worktree
-    /// row under a non-focused repo's group.
+    /// The rail's repo-switch engine, reached from [`Self::select_worktree_by_path`]'s cross-repo
+    /// fallback when a worktree row under a non-focused repo's group is clicked. (The repo header
+    /// itself is inert - in the rail, only worktree rows and agent rows are click targets.)
     ///
-    /// Shares `open_repo_in_current_window`'s real repo-switch reload
-    /// (`Self::reset_repo_scoped_state`, `Self::start_worktree_watch`/`Self::start_status_polling`,
-    /// forgetting a dangling [`Self::empty_state_focus_handle`] overlay target, and real
-    /// cross-repo agent persistence - see that method's own "Cross-repo agent persistence" docs,
-    /// which apply here unchanged) but deliberately does **not** call [`Self::add_repo`] or spawn
-    /// an initial shell: `id` must already be a known [`Self::repos`] entry (every row the rail
-    /// renders came from there), and unlike "Open Folder…" - which always guarantees *some* real
-    /// terminal is running so a freshly opened folder is never inert - this focuses the repo
-    /// with nothing selected and nothing spawned, leaving the follow-up worktree selection to
-    /// its caller.
+    /// Shares [`Self::open_repo_in_current_window`]'s repo-switch reload and its cross-repo agent
+    /// persistence, but never calls [`Self::add_repo`] and never spawns a shell: `id` must
+    /// already be a known [`Self::repos`] entry, and the repo comes up focused with nothing
+    /// selected and nothing reactivated, leaving the follow-up worktree selection to its caller.
     ///
-    /// A no-op if `id` isn't (or is no longer) a known repo - the same defensive guard
-    /// [`Self::focus_repo`] already has, reused here rather than duplicated - or if `id` is
-    /// already [`Self::focused_repo`] (a repeat call for the repo already showing must not
-    /// reset any of its live state).
-    ///
-    /// Unlike [`Self::open_repo_in_current_window`], this never spawns a fallback shell: a repo
-    /// that `id` has never had a real agent open in comes up genuinely empty, a real "focused,
-    /// nothing open yet" state - the user opens something next via the tab strip's own `+` (the
-    /// rail repo header's own `+` is inert until a real "add worktree" design lands - see
-    /// [`crate::rail::render::AdeApp::render_repo_group_new_button`]). A repo `id` has visited
-    /// *before*, though, may already have real agents left running from that earlier visit (see
-    /// [`Self::open_repo_in_current_window`]'s cross-repo persistence docs) - none of them are
-    /// closed or respawned here, and none are *reactivated* either: `Agents::clear_active` below
-    /// leaves the centre pane showing nothing until a worktree row is genuinely selected (see
-    /// the inline comment below and `Agents::clear_active`'s own docs for why clearing, not
-    /// skipping, is the correct half-measure-free behavior). There is no cross-restart
-    /// persistence of *which tabs were open* for a repo yet - a real, disclosed gap, not a
-    /// silently stubbed one.
+    /// A no-op for an unknown `id`, or for one already in [`Self::focused_repo`] - a repeat call
+    /// for the repo already showing must not reset any of its live state.
     pub(crate) fn checkout_repo_from_rail(
         &mut self,
         id: RepoId,

--- a/crates/app/src/root/mod.rs
+++ b/crates/app/src/root/mod.rs
@@ -3919,8 +3919,8 @@ mod settings_persist_tests {
     fn a_later_edit_queued_while_an_earlier_one_is_delayed_is_never_overwritten_by_it(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
 
         let (app, cx) = open_test_app_with_real_settings_path(
@@ -3990,8 +3990,8 @@ mod settings_persist_tests {
     fn a_burst_of_edits_with_decreasing_delays_converges_on_the_final_value(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
 
         let (app, cx) = open_test_app_with_real_settings_path(
@@ -4060,17 +4060,6 @@ mod repo_list_tests {
     /// in this module use) has no worktrees `wt_core::list_worktrees_porcelain` can report at
     /// all, which is fine for tests about agent persistence but not for one that needs a real
     /// main-worktree row to select.
-    fn init_repo() -> tempfile::TempDir {
-        let dir = tempfile::tempdir().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(dir.path().join("README.md"), "hello\n").expect("write");
-        git(dir.path(), &["add", "README.md"]);
-        git(dir.path(), &["commit", "-m", "initial"]);
-        dir
-    }
-
     fn open_test_app_with_real_settings_path(
         cx: &mut TestAppContext,
         repo_path: PathBuf,
@@ -4093,8 +4082,8 @@ mod repo_list_tests {
     /// keep working exactly as before" is this test.
     #[gpui::test]
     fn a_fresh_window_starts_with_exactly_one_focused_repo(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.read_with(cx, |app, _| {
             assert_eq!(app.repos.len(), 1);
@@ -4106,9 +4095,9 @@ mod repo_list_tests {
 
     #[gpui::test]
     fn add_repo_appends_a_new_entry_without_changing_focus(cx: &mut TestAppContext) {
-        let repo_a = tempfile::tempdir().expect("tempdir");
-        let repo_b = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let repo_a = crate::test_support::temp_root();
+        let repo_b = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         let focused_before = app.read_with(cx, |app, _| app.focused_repo_path());
 
         app.update(cx, |app, cx| {
@@ -4130,8 +4119,8 @@ mod repo_list_tests {
     /// `~/.config/jerry`) must not produce a second rail group for the same repo.
     #[gpui::test]
     fn add_repo_is_idempotent_for_the_same_path(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         let (first_id, second_id) = app.update(cx, |app, cx| {
             let first = app.repos[0].id;
@@ -4154,9 +4143,9 @@ mod repo_list_tests {
 
     #[gpui::test]
     fn focus_repo_moves_focus_to_a_known_repo(cx: &mut TestAppContext) {
-        let repo_a = tempfile::tempdir().expect("tempdir");
-        let repo_b = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let repo_a = crate::test_support::temp_root();
+        let repo_b = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
 
         let repo_b_id = app.update(cx, |app, cx| app.add_repo(repo_b.path().to_path_buf(), cx));
         app.update(cx, |app, cx| app.focus_repo(repo_b_id, cx));
@@ -4171,8 +4160,8 @@ mod repo_list_tests {
     /// path.
     #[gpui::test]
     fn focus_repo_with_an_unknown_id_is_a_no_op(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         let focused_before = app.read_with(cx, |app, _| app.focused_repo_path());
 
         app.update(cx, |app, cx| app.focus_repo(RepoId(u64::MAX), cx));
@@ -4187,9 +4176,9 @@ mod repo_list_tests {
     /// repos are currently added should survive an app restart".
     #[gpui::test]
     fn adding_a_repo_persists_to_a_real_repos_toml(cx: &mut TestAppContext) {
-        let repo_a = tempfile::tempdir().expect("tempdir");
-        let repo_b = tempfile::tempdir().expect("tempdir");
-        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let repo_a = crate::test_support::temp_root();
+        let repo_b = crate::test_support::temp_root();
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
 
         let (app, cx) = open_test_app_with_real_settings_path(
@@ -4225,9 +4214,9 @@ mod repo_list_tests {
     fn opening_against_one_repo_does_not_erase_another_instances_already_persisted_repo(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = tempfile::tempdir().expect("tempdir");
-        let repo_b = tempfile::tempdir().expect("tempdir");
-        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let repo_a = crate::test_support::temp_root();
+        let repo_b = crate::test_support::temp_root();
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
 
         // Simulate a second `jerry` instance that already added `repo_b` and saved it.
@@ -4272,7 +4261,7 @@ mod repo_list_tests {
     /// (`Self::new_with_settings`'s own docs) ran at all.
     #[gpui::test]
     fn no_cli_arg_and_nothing_persisted_is_a_genuinely_empty_window(cx: &mut TestAppContext) {
-        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
 
         let (app, _cx) = cx.add_window_view(|window, cx| {
@@ -4307,8 +4296,8 @@ mod repo_list_tests {
     fn a_fresh_launch_with_no_cli_arg_reopens_the_remembered_last_focused_repo(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
 
         // "Launch 1": a real CLI-argument launch against `repo`, which focuses (and so persists)
@@ -4356,9 +4345,9 @@ mod repo_list_tests {
     fn a_remembered_repo_that_no_longer_exists_falls_back_to_a_genuinely_empty_window(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let repo_path = repo.path().to_path_buf();
-        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
 
         let (_first, cx) =
@@ -4401,8 +4390,8 @@ mod repo_list_tests {
     fn use_remembered_repo_false_stays_empty_even_with_a_real_remembered_repo(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
 
         let (_first, cx) = open_test_app_with_real_settings_path(
@@ -4442,9 +4431,9 @@ mod repo_list_tests {
     fn open_repo_in_current_window_focuses_and_reloads_a_real_repo_from_empty(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         std::fs::write(repo.path().join("a.txt"), "hello\n").expect("write");
-        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
 
         let (app, cx) = cx.add_window_view(|window, cx| {
@@ -4490,11 +4479,11 @@ mod repo_list_tests {
     fn open_repo_in_current_window_clears_stale_ui_state_from_the_previous_repo(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = tempfile::tempdir().expect("tempdir");
-        let repo_b = tempfile::tempdir().expect("tempdir");
+        let repo_a = crate::test_support::temp_root();
+        let repo_b = crate::test_support::temp_root();
         std::fs::write(repo_b.path().join("y.txt"), "b\n").expect("write");
 
-        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
 
         // Arm several pieces of real per-repo UI state against repo A - the same kinds of state
@@ -4540,23 +4529,23 @@ mod repo_list_tests {
     fn switching_away_from_a_zero_linked_worktree_repo_and_back_keeps_its_worktree_row(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = tempfile::tempdir().expect("tempdir");
-        git(repo_a.path(), &["init", "-b", "main"]);
-        git(repo_a.path(), &["config", "user.email", "test@example.com"]);
-        git(repo_a.path(), &["config", "user.name", "Test User"]);
+        let repo_a = crate::test_support::temp_root();
+        test_support::git(repo_a.path(), &["init", "-b", "main"]);
+        test_support::git(repo_a.path(), &["config", "user.email", "test@example.com"]);
+        test_support::git(repo_a.path(), &["config", "user.name", "Test User"]);
         std::fs::write(repo_a.path().join("a.txt"), "hello\n").expect("write");
-        git(repo_a.path(), &["add", "a.txt"]);
-        git(repo_a.path(), &["commit", "-m", "init"]);
+        test_support::git(repo_a.path(), &["add", "a.txt"]);
+        test_support::git(repo_a.path(), &["commit", "-m", "init"]);
 
-        let repo_b = tempfile::tempdir().expect("tempdir");
-        git(repo_b.path(), &["init", "-b", "main"]);
-        git(repo_b.path(), &["config", "user.email", "test@example.com"]);
-        git(repo_b.path(), &["config", "user.name", "Test User"]);
+        let repo_b = crate::test_support::temp_root();
+        test_support::git(repo_b.path(), &["init", "-b", "main"]);
+        test_support::git(repo_b.path(), &["config", "user.email", "test@example.com"]);
+        test_support::git(repo_b.path(), &["config", "user.name", "Test User"]);
         std::fs::write(repo_b.path().join("b.txt"), "hello\n").expect("write");
-        git(repo_b.path(), &["add", "b.txt"]);
-        git(repo_b.path(), &["commit", "-m", "init"]);
+        test_support::git(repo_b.path(), &["add", "b.txt"]);
+        test_support::git(repo_b.path(), &["commit", "-m", "init"]);
 
-        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
 
         app.read_with(cx, |app, _| {
@@ -4606,22 +4595,6 @@ mod repo_list_tests {
         });
     }
 
-    fn git(dir: &std::path::Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
     /// Critical fix (independent audit): the original `open_repo_in_current_window` never
     /// (re)started the real status-polling loop or the worktree filesystem watcher - a window
     /// that starts empty and only later opens a folder never got either at all. `repo` is a real
@@ -4634,9 +4607,9 @@ mod repo_list_tests {
     fn open_repo_in_current_window_starts_status_polling_and_worktree_watch(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
+        test_support::git(repo.path(), &["init", "-b", "main"]);
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
 
         let (app, cx) = cx.add_window_view(|window, cx| {
@@ -4696,11 +4669,11 @@ mod repo_list_tests {
     fn open_repo_in_current_window_rebinds_the_worktree_watcher_to_the_new_repo(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = tempfile::tempdir().expect("tempdir");
-        git(repo_a.path(), &["init", "-b", "main"]);
-        let repo_b = tempfile::tempdir().expect("tempdir");
+        let repo_a = crate::test_support::temp_root();
+        test_support::git(repo_a.path(), &["init", "-b", "main"]);
+        let repo_b = crate::test_support::temp_root();
 
-        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
         app.read_with(cx, |app, _| {
             assert!(
@@ -4736,10 +4709,10 @@ mod repo_list_tests {
     fn open_repo_in_current_window_leaves_the_previous_repos_agents_running(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = tempfile::tempdir().expect("tempdir");
-        let repo_b = tempfile::tempdir().expect("tempdir");
+        let repo_a = crate::test_support::temp_root();
+        let repo_b = crate::test_support::temp_root();
 
-        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
         let repo_a_agent_id = app.read_with(cx, |app, _| {
             assert_eq!(
@@ -4831,10 +4804,10 @@ mod repo_list_tests {
     /// is_running`).
     #[gpui::test]
     fn checkout_repo_from_rail_leaves_the_previous_repos_agents_running(cx: &mut TestAppContext) {
-        let repo_a = tempfile::tempdir().expect("tempdir");
-        let repo_b = tempfile::tempdir().expect("tempdir");
+        let repo_a = crate::test_support::temp_root();
+        let repo_b = crate::test_support::temp_root();
 
-        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
 
         let claude_agent_id = app.update_in(cx, |app, window, cx| {
@@ -4922,10 +4895,10 @@ mod repo_list_tests {
     fn checking_out_a_repo_from_the_rail_clears_the_centre_pane_instead_of_reactivating(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = tempfile::tempdir().expect("tempdir");
-        let repo_b = tempfile::tempdir().expect("tempdir");
+        let repo_a = crate::test_support::temp_root();
+        let repo_b = crate::test_support::temp_root();
 
-        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
 
         let repo_b_id = app.update(cx, |app, cx| app.add_repo(repo_b.path().to_path_buf(), cx));
@@ -5030,10 +5003,10 @@ mod repo_list_tests {
     fn checking_out_a_repo_from_the_rail_never_selects_a_worktree_on_its_own(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = init_repo();
-        let repo_b = init_repo();
+        let repo_a = crate::test_support::temp_repo();
+        let repo_b = crate::test_support::temp_repo();
 
-        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
 
         let repo_b_id = app.update(cx, |app, cx| app.add_repo(repo_b.path().to_path_buf(), cx));
@@ -5077,10 +5050,10 @@ mod repo_list_tests {
     fn checking_out_a_repo_from_the_rail_never_shows_the_previous_repos_worktrees_even_briefly(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = init_repo();
-        let repo_b = init_repo();
+        let repo_a = crate::test_support::temp_repo();
+        let repo_b = crate::test_support::temp_repo();
 
-        let (app, cx) = focus::palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
 
         let repo_b_id = app.update(cx, |app, cx| app.add_repo(repo_b.path().to_path_buf(), cx));
@@ -5117,8 +5090,8 @@ mod repo_list_tests {
     fn open_repo_in_current_window_forgets_a_dangling_empty_state_focus_target(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
 
         let (app, cx) = cx.add_window_view(|window, cx| {
@@ -5166,8 +5139,8 @@ mod repo_list_tests {
     /// this proves both real entry points genuinely spawn nothing.
     #[gpui::test]
     fn new_agent_and_new_agent_pane_are_no_ops_with_no_focused_repo(cx: &mut TestAppContext) {
-        let other_repo = tempfile::tempdir().expect("tempdir");
-        let settings_dir = tempfile::tempdir().expect("tempdir");
+        let other_repo = crate::test_support::temp_root();
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
 
         // A real *other* repo is known to this process (persisted from a previous focus) - the

--- a/crates/app/src/root/new_file.rs
+++ b/crates/app/src/root/new_file.rs
@@ -464,7 +464,6 @@ impl AdeApp {
 
 #[cfg(test)]
 mod tests {
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
     use std::time::Instant;
 
@@ -477,9 +476,9 @@ mod tests {
     fn cancelling_new_file_while_a_file_tab_is_open_does_not_leave_focus_dangling(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         std::fs::write(repo.path().join("a.txt"), "hello\n").expect("write a.txt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
 
         app.update_in(cx, |app, window, cx| {
@@ -513,8 +512,8 @@ mod tests {
     fn cancelling_new_file_with_no_file_tab_and_no_active_agent_does_not_leave_focus_dangling(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
 
         let initial_id = app.read_with(cx, |app, _| {
@@ -555,8 +554,8 @@ mod tests {
     fn creating_a_new_file_writes_a_real_empty_file_with_no_false_conflict(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update_in(cx, |app, window, cx| {
             app.start_new_file(repo.path().to_path_buf(), window, cx);
@@ -601,9 +600,9 @@ mod tests {
 
     #[gpui::test]
     fn creating_a_file_that_already_exists_is_refused_with_a_real_error(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         std::fs::write(repo.path().join("existing.txt"), "already here").expect("seed file");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update_in(cx, |app, window, cx| {
             app.start_new_file(repo.path().to_path_buf(), window, cx);
@@ -635,8 +634,8 @@ mod tests {
 
     #[gpui::test]
     fn escape_cancels_the_new_file_prompt_without_touching_disk(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update_in(cx, |app, window, cx| {
             app.start_new_file(repo.path().to_path_buf(), window, cx);
@@ -664,15 +663,14 @@ mod tests {
 /// measured-bounds technique.
 #[cfg(test)]
 mod new_file_caret_tests {
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
 
     #[gpui::test]
     fn caret_sits_before_the_placeholder_when_empty_and_after_the_text_once_typed(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update_in(cx, |app, window, cx| {
             app.start_new_file(repo.path().to_path_buf(), window, cx);
@@ -744,8 +742,8 @@ mod new_file_caret_tests {
     /// unique to the real subscription this fix adds.
     #[gpui::test]
     fn blurring_the_new_file_prompt_stops_the_real_shared_blink_loop(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         // `on_focus`/`on_blur` listeners (`AdeApp::wire_caret_blink`'s own mechanism) only
         // fire while GPUI considers the window itself "active" - a real, freshly opened test
         // window starts out not active at all, so this is a real, necessary precondition, not

--- a/crates/app/src/root/scrollbar_geometry.rs
+++ b/crates/app/src/root/scrollbar_geometry.rs
@@ -78,106 +78,112 @@ pub fn offset_for_pointer(viewport: f32, max_offset: f32, track_start: f32, poin
 mod tests {
     use super::*;
 
+    /// The proportional relationship, its floor, and its cap, in one table: the thumb is the
+    /// visible fraction of the whole document, never shorter than [`MIN_THUMB_LENGTH`], and never
+    /// longer than the viewport it lives in.
     #[test]
-    fn thumb_fills_the_track_when_content_fits_without_scrolling() {
-        assert_eq!(thumb_length(400.0, 0.0), 400.0);
+    fn thumb_length_is_the_visible_fraction_floored_and_capped() {
+        for (viewport, max_offset, expected, why) in [
+            (
+                400.0,
+                0.0,
+                400.0,
+                "content that fits without scrolling fills the track",
+            ),
+            (
+                400.0,
+                1200.0,
+                100.0,
+                "400 visible of 1600 total is a quarter of the track",
+            ),
+            (
+                400.0,
+                100_000.0,
+                MIN_THUMB_LENGTH,
+                "an enormous document would compute a sub-pixel thumb without the floor",
+            ),
+            (
+                10.0,
+                5.0,
+                10.0,
+                "and the floor never pushes past the viewport itself",
+            ),
+        ] {
+            assert_eq!(thumb_length(viewport, max_offset), expected, "{why}");
+        }
     }
 
+    /// The thumb travels the whole track and stops at both ends - including for a stale or
+    /// overshot `scrolled` value (e.g. a frame where the content just shrank), the same real bug
+    /// class `list_example.rs`'s own `bug_detected` assertion exists to catch.
     #[test]
-    fn thumb_shrinks_proportionally_to_how_much_of_the_document_is_visible() {
-        // Viewport 400, document 1600 total (400 visible + 1200 more to scroll) -> the visible
-        // fraction is 1/4, so the thumb should be 1/4 of the 400px track (100px) - well above the
-        // floor, so the floor doesn't mask the proportional math here.
-        assert_eq!(thumb_length(400.0, 1200.0), 100.0);
+    fn thumb_position_spans_the_track_and_clamps_at_both_ends() {
+        let (viewport, max_offset) = (400.0, 1200.0);
+        let track = viewport - thumb_length(viewport, max_offset);
+
+        for (scrolled, expected, why) in [
+            (0.0, 0.0, "unscrolled sits at the track top"),
+            (max_offset, track, "fully scrolled sits at the track bottom"),
+            (
+                -50.0,
+                0.0,
+                "a negative offset must not send the thumb off-track",
+            ),
+            (5_000.0, track, "and neither must an overshot one"),
+        ] {
+            assert_eq!(
+                thumb_position(viewport, max_offset, scrolled),
+                expected,
+                "{why}"
+            );
+        }
+        assert_eq!(
+            thumb_position(400.0, 0.0, 0.0),
+            0.0,
+            "an unscrollable region has no meaningful thumb position"
+        );
     }
 
+    /// A click centers the thumb under the pointer and clamps to the track's own ends - measured
+    /// from a `track_start` that is deliberately not the window origin, so a dropped
+    /// `track_start` term cannot pass.
     #[test]
-    fn thumb_never_shrinks_below_the_documented_floor() {
-        // An enormous document (100,000px more to scroll) against a 400px viewport would compute
-        // a sub-pixel raw thumb length without the floor.
-        assert_eq!(thumb_length(400.0, 100_000.0), MIN_THUMB_LENGTH);
-    }
-
-    #[test]
-    fn thumb_never_exceeds_the_viewport_even_for_a_viewport_smaller_than_the_floor() {
-        assert_eq!(thumb_length(10.0, 5.0), 10.0);
-    }
-
-    #[test]
-    fn thumb_sits_at_the_track_top_when_unscrolled() {
-        assert_eq!(thumb_position(400.0, 1200.0, 0.0), 0.0);
-    }
-
-    #[test]
-    fn thumb_sits_at_the_track_bottom_when_scrolled_to_the_end() {
-        let viewport = 400.0;
-        let max_offset = 1200.0;
+    fn a_click_centers_the_thumb_under_the_pointer_and_clamps_to_the_track() {
+        let (viewport, max_offset, track_start) = (400.0, 1200.0, 50.0);
         let thumb = thumb_length(viewport, max_offset);
-        let expected_track = viewport - thumb;
+
+        for (pointer, expected, why) in [
+            (
+                track_start + thumb / 2.0,
+                0.0,
+                "the very top of the track jumps to the start",
+            ),
+            (
+                track_start + viewport - thumb / 2.0,
+                max_offset,
+                "the very bottom jumps to the end",
+            ),
+            (
+                -1_000.0,
+                0.0,
+                "a pointer above the track clamps rather than undershooting",
+            ),
+            (
+                10_000.0,
+                max_offset,
+                "and one below it clamps rather than overshooting",
+            ),
+        ] {
+            assert_eq!(
+                offset_for_pointer(viewport, max_offset, track_start, pointer),
+                expected,
+                "{why}"
+            );
+        }
         assert_eq!(
-            thumb_position(viewport, max_offset, max_offset),
-            expected_track
+            offset_for_pointer(400.0, 0.0, 0.0, 200.0),
+            0.0,
+            "an unscrollable region always jumps to zero"
         );
-    }
-
-    #[test]
-    fn thumb_position_is_never_negative_or_past_the_track_even_for_out_of_range_input() {
-        // A stale/overshot `scrolled` value (e.g. a frame where content just shrank) must not
-        // send the thumb off-track - the same real bug class `list_example.rs`'s own
-        // `bug_detected` assertion exists to catch, guarded against here instead by clamping.
-        assert_eq!(thumb_position(400.0, 1200.0, -50.0), 0.0);
-        let viewport = 400.0;
-        let max_offset = 1200.0;
-        let thumb = thumb_length(viewport, max_offset);
-        assert_eq!(
-            thumb_position(viewport, max_offset, 5_000.0),
-            viewport - thumb
-        );
-    }
-
-    #[test]
-    fn an_unscrollable_region_has_no_meaningful_thumb_position() {
-        assert_eq!(thumb_position(400.0, 0.0, 0.0), 0.0);
-    }
-
-    #[test]
-    fn clicking_the_very_top_of_the_track_jumps_to_the_start() {
-        let viewport = 400.0;
-        let max_offset = 1200.0;
-        let thumb = thumb_length(viewport, max_offset);
-        // Pointer at exactly `track_start + thumb/2` centers the thumb there, i.e. offset 0.
-        assert_eq!(
-            offset_for_pointer(viewport, max_offset, 0.0, thumb / 2.0),
-            0.0
-        );
-    }
-
-    #[test]
-    fn clicking_the_very_bottom_of_the_track_jumps_to_the_end() {
-        let viewport = 400.0;
-        let max_offset = 1200.0;
-        let thumb = thumb_length(viewport, max_offset);
-        let track_start = 50.0; // a viewport that doesn't start at window y=0
-        let pointer_at_bottom = track_start + viewport - thumb / 2.0;
-        assert_eq!(
-            offset_for_pointer(viewport, max_offset, track_start, pointer_at_bottom),
-            max_offset
-        );
-    }
-
-    #[test]
-    fn clicking_above_or_below_the_track_clamps_rather_than_over_or_under_shooting() {
-        let viewport = 400.0;
-        let max_offset = 1200.0;
-        assert_eq!(offset_for_pointer(viewport, max_offset, 0.0, -1_000.0), 0.0);
-        assert_eq!(
-            offset_for_pointer(viewport, max_offset, 0.0, 10_000.0),
-            max_offset
-        );
-    }
-
-    #[test]
-    fn an_unscrollable_region_always_jumps_to_zero() {
-        assert_eq!(offset_for_pointer(400.0, 0.0, 0.0, 200.0), 0.0);
     }
 }

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -2396,61 +2396,22 @@ mod tests {
 #[cfg(test)]
 mod load_worktrees_integration_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
     use std::fs;
     use std::path::Path;
-    use std::process::Command;
-    use tempfile::TempDir;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        fs::write(dir.path().join("base.txt"), "base\n").expect("write");
-        git(dir.path(), &["add", "base.txt"]);
-        git(dir.path(), &["commit", "-m", "initial"]);
-        dir
-    }
 
     fn add_worktree(repo_path: &Path, branch: &str, name: &str) -> PathBuf {
-        let container = TempDir::new().expect("tempdir");
+        let container = crate::test_support::temp_root();
         let path = container.path().join(name);
         drop(container);
-        git(
-            repo_path,
-            &[
-                "worktree",
-                "add",
-                "-b",
-                branch,
-                path.to_str().expect("utf8 path"),
-            ],
-        );
+        test_support::add_worktree(repo_path, branch, &path);
         path
     }
 
     #[gpui::test]
     fn a_real_worktree_add_appears_after_a_refresh(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         assert_eq!(
             app.read_with(cx, |app, _| app.worktrees.len()),
@@ -2475,9 +2436,9 @@ mod load_worktrees_integration_tests {
 
     #[gpui::test]
     fn a_real_worktree_remove_disappears_after_a_refresh(cx: &mut TestAppContext) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let feature = add_worktree(repo.path(), "feature", "removed-wt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         assert_eq!(app.read_with(cx, |app, _| app.worktrees.len()), 2);
 
@@ -2497,12 +2458,12 @@ mod load_worktrees_integration_tests {
 
     #[gpui::test]
     fn a_real_lock_with_reason_is_reflected_after_a_refresh(cx: &mut TestAppContext) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let feature = add_worktree(repo.path(), "feature", "locked-wt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
-        git(
+        test_support::git(
             repo.path(),
             &[
                 "worktree",
@@ -2533,9 +2494,9 @@ mod load_worktrees_integration_tests {
     fn a_manually_deleted_worktree_directory_is_marked_broken_after_a_refresh(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let feature = add_worktree(repo.path(), "feature", "gone-wt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         fs::remove_dir_all(&feature).expect("manually delete the worktree directory");
@@ -2559,9 +2520,9 @@ mod load_worktrees_integration_tests {
     fn selection_survives_a_refresh_when_the_selected_worktree_is_still_present(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let feature = add_worktree(repo.path(), "feature", "stays-wt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let feature_index = app
@@ -2607,9 +2568,9 @@ mod load_worktrees_integration_tests {
     fn selecting_a_worktree_then_really_removing_it_falls_back_to_main_with_a_notice(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let feature = add_worktree(repo.path(), "feature", "vanishes-wt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let feature_index = app
@@ -2676,44 +2637,14 @@ mod load_worktrees_integration_tests {
 #[cfg(test)]
 mod multi_repo_worktree_loading_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
     use std::path::Path;
-    use std::process::Command;
-    use tempfile::TempDir;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}:\nstdout: {}\nstderr: {}",
-            args,
-            dir,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(dir.path().join("base.txt"), "base\n").expect("write");
-        git(dir.path(), &["add", "base.txt"]);
-        git(dir.path(), &["commit", "-m", "initial"]);
-        dir
-    }
 
     fn add_worktree(repo_path: &Path, branch: &str, name: &str) {
-        let container = TempDir::new().expect("tempdir");
+        let container = crate::test_support::temp_root();
         let path = container.path().join(name);
         drop(container);
-        git(
+        test_support::git(
             repo_path,
             &[
                 "worktree",
@@ -2730,9 +2661,9 @@ mod multi_repo_worktree_loading_tests {
     /// the currently focused repo A's.
     #[gpui::test]
     fn a_non_focused_repos_worktrees_load_in_the_background(cx: &mut TestAppContext) {
-        let repo_a = init_repo();
-        let repo_b = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let repo_a = crate::test_support::temp_repo();
+        let repo_b = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
 
         let repo_b_id = app.update(cx, |app, cx| app.add_repo(repo_b.path().to_path_buf(), cx));
@@ -2793,12 +2724,12 @@ mod multi_repo_worktree_loading_tests {
     /// gives the focused repo's own `AdeApp::worktrees_error` case on a real fetch failure.
     #[gpui::test]
     fn a_repo_whose_path_disappears_before_its_first_load_does_not_panic(cx: &mut TestAppContext) {
-        let repo_a = init_repo();
-        let doomed = TempDir::new().expect("tempdir");
+        let repo_a = crate::test_support::temp_repo();
+        let doomed = crate::test_support::temp_root();
         let doomed_path = doomed.path().to_path_buf();
-        git(&doomed_path, &["init", "-b", "main"]);
+        test_support::git(&doomed_path, &["init", "-b", "main"]);
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
 
         let doomed_id = app.update(cx, |app, cx| app.add_repo(doomed_path.clone(), cx));
@@ -2834,9 +2765,9 @@ mod multi_repo_worktree_loading_tests {
     fn a_non_focused_repos_worktrees_are_not_refetched_before_the_poll_interval_elapses(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = init_repo();
-        let repo_b = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let repo_a = crate::test_support::temp_repo();
+        let repo_b = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
 
         let repo_b_id = app.update(cx, |app, cx| app.add_repo(repo_b.path().to_path_buf(), cx));
@@ -2908,11 +2839,13 @@ mod multi_repo_worktree_loading_tests {
     fn the_periodic_sweep_refreshes_every_repo_even_with_more_than_the_concurrency_cap(
         cx: &mut TestAppContext,
     ) {
-        let repo_focused = init_repo();
+        let repo_focused = crate::test_support::temp_repo();
         let extra_count = REPO_WORKTREES_FETCH_CONCURRENCY * 2 + 1;
-        let extra_repos: Vec<TempDir> = (0..extra_count).map(|_| init_repo()).collect();
+        let extra_repos: Vec<crate::test_support::TempRoot> = (0..extra_count)
+            .map(|_| crate::test_support::temp_repo())
+            .collect();
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_focused.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_focused.path().to_path_buf());
         cx.run_until_parked();
 
         let extra_ids: Vec<RepoId> = extra_repos
@@ -2974,35 +2907,7 @@ mod file_tree_watch_integration_tests {
     use crate::root::AdeApp;
     use crate::settings::store as settings_store;
     use gpui::TestAppContext;
-    use std::fs;
-    use std::path::{Path, PathBuf};
-    use std::process::Command;
-    use tempfile::TempDir;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed in {:?}",
-            args,
-            dir
-        );
-    }
-
-    fn init_repo() -> TempDir {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        fs::write(dir.path().join("base.txt"), "base\n").expect("write");
-        git(dir.path(), &["add", "base.txt"]);
-        git(dir.path(), &["commit", "-m", "initial"]);
-        dir
-    }
+    use std::path::PathBuf;
 
     /// `Self::start_file_tree_watch` only ever arms a real watcher for a real, `Some` settings
     /// path (see that method's own docs on why) - `root::focus::palette_focus_tests::
@@ -3012,7 +2917,7 @@ mod file_tree_watch_integration_tests {
         cx: &mut TestAppContext,
         repo_path: PathBuf,
     ) -> (gpui::Entity<AdeApp>, &mut gpui::VisualTestContext) {
-        let config_dir = tempfile::tempdir().expect("tempdir");
+        let config_dir = crate::test_support::temp_root();
         let settings_path = config_dir.path().join("settings.toml");
         // Leaked deliberately: `config_dir` must outlive the returned `AdeApp`, and this helper
         // has no later point to drop it at - the OS reclaims it at process exit either way, the
@@ -3032,7 +2937,7 @@ mod file_tree_watch_integration_tests {
 
     #[gpui::test]
     fn opening_the_app_arms_a_real_file_tree_watcher(cx: &mut TestAppContext) {
-        let repo = init_repo();
+        let repo = crate::test_support::temp_repo();
         let (app, cx) = open_test_app_with_real_settings_path(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
@@ -3044,11 +2949,11 @@ mod file_tree_watch_integration_tests {
 
     #[gpui::test]
     fn selecting_a_different_worktree_re_arms_the_watcher_on_the_new_root(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let container = TempDir::new().expect("tempdir");
+        let repo = crate::test_support::temp_repo();
+        let container = crate::test_support::temp_root();
         let linked_path = container.path().join("added-wt");
         drop(container);
-        git(
+        test_support::git(
             repo.path(),
             &[
                 "worktree",

--- a/crates/app/src/root/state.rs
+++ b/crates/app/src/root/state.rs
@@ -2217,89 +2217,43 @@ pub(super) fn reset_per_worktree_ui_state(
 mod tests {
     use super::*;
 
+    /// Every piece of per-worktree UI state this function owns is cleared in one call - staged
+    /// files, the open change, expanded directories, and both halves of the tree selection - and
+    /// calling it against already-empty state is a real no-op rather than a panic.
     #[test]
-    fn reset_per_worktree_ui_state_clears_staged_files_and_open_change() {
-        let mut staged_files = HashSet::new();
-        staged_files.insert(PathBuf::from("src/main.rs"));
-        staged_files.insert(PathBuf::from("Cargo.toml"));
+    fn reset_per_worktree_ui_state_clears_every_field_it_owns() {
+        let mut staged_files: HashSet<PathBuf> = ["src/main.rs", "Cargo.toml"]
+            .into_iter()
+            .map(PathBuf::from)
+            .collect();
         let mut open_change = Some(PathBuf::from("src/main.rs"));
-        let mut expanded_dirs = HashSet::new();
-        let mut selected_tree_path = None;
-        let mut additional_tree_selection = HashSet::new();
-
-        reset_per_worktree_ui_state(
-            &mut staged_files,
-            &mut open_change,
-            &mut expanded_dirs,
-            &mut selected_tree_path,
-            &mut additional_tree_selection,
-        );
-
-        assert!(staged_files.is_empty());
-        assert_eq!(open_change, None);
-    }
-
-    #[test]
-    fn reset_per_worktree_ui_state_is_a_no_op_when_already_empty() {
-        let mut staged_files = HashSet::new();
-        let mut open_change = None;
-        let mut expanded_dirs = HashSet::new();
-        let mut selected_tree_path = None;
-        let mut additional_tree_selection = HashSet::new();
-
-        reset_per_worktree_ui_state(
-            &mut staged_files,
-            &mut open_change,
-            &mut expanded_dirs,
-            &mut selected_tree_path,
-            &mut additional_tree_selection,
-        );
-
-        assert!(staged_files.is_empty());
-        assert_eq!(open_change, None);
-        assert!(expanded_dirs.is_empty());
-    }
-
-    #[test]
-    fn reset_per_worktree_ui_state_clears_expanded_dirs_too() {
-        let mut staged_files = HashSet::new();
-        let mut open_change = None;
-        let mut expanded_dirs = HashSet::new();
-        let mut selected_tree_path = None;
-        let mut additional_tree_selection = HashSet::new();
-        expanded_dirs.insert(PathBuf::from("/repo/worktree-a/src"));
-        expanded_dirs.insert(PathBuf::from("/repo/worktree-a/tests"));
-
-        reset_per_worktree_ui_state(
-            &mut staged_files,
-            &mut open_change,
-            &mut expanded_dirs,
-            &mut selected_tree_path,
-            &mut additional_tree_selection,
-        );
-
-        assert!(expanded_dirs.is_empty());
-    }
-
-    #[test]
-    fn reset_per_worktree_ui_state_clears_selected_tree_path() {
-        let mut staged_files = HashSet::new();
-        let mut open_change = None;
-        let mut expanded_dirs = HashSet::new();
+        let mut expanded_dirs: HashSet<PathBuf> =
+            ["/repo/worktree-a/src", "/repo/worktree-a/tests"]
+                .into_iter()
+                .map(PathBuf::from)
+                .collect();
         let mut selected_tree_path = Some(PathBuf::from("/repo/worktree-a/src/main.rs"));
-        let mut additional_tree_selection = HashSet::new();
-        additional_tree_selection.insert(PathBuf::from("/repo/worktree-a/src/lib.rs"));
+        let mut additional_tree_selection: HashSet<PathBuf> =
+            [PathBuf::from("/repo/worktree-a/src/lib.rs")]
+                .into_iter()
+                .collect();
 
-        reset_per_worktree_ui_state(
-            &mut staged_files,
-            &mut open_change,
-            &mut expanded_dirs,
-            &mut selected_tree_path,
-            &mut additional_tree_selection,
-        );
+        // Twice: once against real state, once against the empty state it leaves behind.
+        for _ in 0..2 {
+            reset_per_worktree_ui_state(
+                &mut staged_files,
+                &mut open_change,
+                &mut expanded_dirs,
+                &mut selected_tree_path,
+                &mut additional_tree_selection,
+            );
 
-        assert_eq!(selected_tree_path, None);
-        assert!(additional_tree_selection.is_empty());
+            assert!(staged_files.is_empty());
+            assert_eq!(open_change, None);
+            assert!(expanded_dirs.is_empty());
+            assert_eq!(selected_tree_path, None);
+            assert!(additional_tree_selection.is_empty());
+        }
     }
 
     /// [`AdeApp::open_files`]/[`AdeApp::open_files_mut`] resolve through

--- a/crates/app/src/test_support.rs
+++ b/crates/app/src/test_support.rs
@@ -8,7 +8,59 @@
 use crate::root::AdeApp;
 use crate::settings::store as settings_store;
 use gpui::{Entity, TestAppContext, VisualTestContext};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+/// A temporary directory whose [`Self::path`] is already the root `AdeApp` will resolve it to.
+///
+/// `AdeApp` canonicalizes every repo root it is handed ([`crate::rail::repo::canonical_repo_path`])
+/// and then keys repos, worktrees, agents and open files by exact-path equality or `strip_prefix`
+/// against it. On macOS `std::env::temp_dir()` is behind a `/var` -> `/private/var` symlink, so a
+/// fixture that hands the app a bare `tempfile::TempDir::path()` and then builds its expected
+/// values from that same uncanonicalized path compares two different strings for the same
+/// directory, and every worktree-scoped lookup in the test silently misses.
+pub(crate) struct TempRoot {
+    /// Held for its `Drop`; the directory is removed when this value is.
+    _dir: tempfile::TempDir,
+    root: PathBuf,
+}
+
+impl TempRoot {
+    pub(crate) fn path(&self) -> &Path {
+        &self.root
+    }
+
+    pub(crate) fn to_path_buf(&self) -> PathBuf {
+        self.root.clone()
+    }
+
+    /// Writes `contents` to a `self`-relative `name`, creating parent directories, and returns the
+    /// absolute path.
+    pub(crate) fn write(&self, name: &str, contents: &str) -> PathBuf {
+        let path = self.root.join(name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create parent directories");
+        }
+        std::fs::write(&path, contents).expect("write fixture file");
+        path
+    }
+}
+
+/// An empty [`TempRoot`] — for the tests whose subject is a directory, not a repository.
+pub(crate) fn temp_root() -> TempRoot {
+    let dir = tempfile::tempdir().expect("tempdir");
+    canonicalized(dir)
+}
+
+/// A [`TempRoot`] holding `test_support::seed_repo`'s repository: branch `main`, one commit
+/// (`file.txt`), clean tree.
+pub(crate) fn temp_repo() -> TempRoot {
+    canonicalized(test_support::seed_repo())
+}
+
+fn canonicalized(dir: tempfile::TempDir) -> TempRoot {
+    let root = dir.path().canonicalize().expect("canonicalize tempdir");
+    TempRoot { _dir: dir, root }
+}
 
 /// Opens an `AdeApp` in a test GPUI window against `repo_path`.
 ///

--- a/crates/app/src/title_bar/menu.rs
+++ b/crates/app/src/title_bar/menu.rs
@@ -523,28 +523,27 @@ mod title_menu_tests {
         )
     }
 
-    /// Clicking the real "File" label - a genuine painted div with its own `on_click`, hit-test
-    /// via a real simulated click at its own captured bounds - opens the real File dropdown, not
+    /// Clicking each real label - a genuine painted div with its own `on_click`, hit-tested via a
+    /// real simulated click at its own captured bounds - opens that label's own dropdown, not
     /// just a state flip.
     #[gpui::test]
-    fn clicking_the_file_label_opens_the_real_file_menu(cx: &mut TestAppContext) {
+    fn clicking_each_title_label_opens_its_own_real_menu(cx: &mut TestAppContext) {
         let (app, cx) = open_windows_variant(cx);
-        let bounds = app.read_with(cx, |app, _| {
-            app.title_menu_button_bounds[TitleMenu::File.index()]
-        });
-        assert_ne!(
-            bounds,
-            gpui::Bounds::default(),
-            "the File label should have really painted by now"
-        );
 
-        cx.simulate_click(center_of(bounds), gpui::Modifiers::none());
-        cx.run_until_parked();
+        for menu in TitleMenu::ALL {
+            let bounds = app.read_with(cx, |app, _| app.title_menu_button_bounds[menu.index()]);
+            assert_ne!(
+                bounds,
+                gpui::Bounds::default(),
+                "the {} label should have really painted by now",
+                menu.label()
+            );
 
-        assert_eq!(
-            app.read_with(cx, |app, _| app.title_menu_open),
-            Some(TitleMenu::File)
-        );
+            cx.simulate_click(center_of(bounds), gpui::Modifiers::none());
+            cx.run_until_parked();
+
+            assert_eq!(app.read_with(cx, |app, _| app.title_menu_open), Some(menu));
+        }
     }
 
     /// The File menu's first row ("Open File…") really opens the command palette scoped to
@@ -676,22 +675,6 @@ mod title_menu_tests {
         });
     }
 
-    #[gpui::test]
-    fn clicking_the_edit_label_opens_the_real_edit_menu(cx: &mut TestAppContext) {
-        let (app, cx) = open_windows_variant(cx);
-        let bounds = app.read_with(cx, |app, _| {
-            app.title_menu_button_bounds[TitleMenu::Edit.index()]
-        });
-
-        cx.simulate_click(center_of(bounds), gpui::Modifiers::none());
-        cx.run_until_parked();
-
-        assert_eq!(
-            app.read_with(cx, |app, _| app.title_menu_open),
-            Some(TitleMenu::Edit)
-        );
-    }
-
     /// The Edit menu's *first* row is now real **text** undo (GitHub issue #17), and it is a real
     /// affordance in both directions: inert with nothing to undo (no `on_click` attached at all,
     /// per `render_dropdown_menu_row`'s own enabled/disabled contract), and genuinely undoing the
@@ -767,22 +750,6 @@ mod title_menu_tests {
         assert_eq!(app.read_with(cx, |app, _| app.title_menu_open), None);
     }
 
-    #[gpui::test]
-    fn clicking_the_view_label_opens_the_real_view_menu(cx: &mut TestAppContext) {
-        let (app, cx) = open_windows_variant(cx);
-        let bounds = app.read_with(cx, |app, _| {
-            app.title_menu_button_bounds[TitleMenu::View.index()]
-        });
-
-        cx.simulate_click(center_of(bounds), gpui::Modifiers::none());
-        cx.run_until_parked();
-
-        assert_eq!(
-            app.read_with(cx, |app, _| app.title_menu_open),
-            Some(TitleMenu::View)
-        );
-    }
-
     /// The View menu's first row ("Command Palette") really opens the real palette (default
     /// scope, unlike the File menu's files-scoped row).
     #[gpui::test]
@@ -804,22 +771,6 @@ mod title_menu_tests {
             assert!(app.palette_open);
             assert_eq!(app.title_menu_open, None);
         });
-    }
-
-    #[gpui::test]
-    fn clicking_the_agent_label_opens_the_real_agent_menu(cx: &mut TestAppContext) {
-        let (app, cx) = open_windows_variant(cx);
-        let bounds = app.read_with(cx, |app, _| {
-            app.title_menu_button_bounds[TitleMenu::Agent.index()]
-        });
-
-        cx.simulate_click(center_of(bounds), gpui::Modifiers::none());
-        cx.run_until_parked();
-
-        assert_eq!(
-            app.read_with(cx, |app, _| app.title_menu_open),
-            Some(TitleMenu::Agent)
-        );
     }
 
     /// The Agent menu's first row ("New Terminal") really spawns a new real agent tab (the
@@ -849,22 +800,6 @@ mod title_menu_tests {
             );
             assert_eq!(app.title_menu_open, None);
         });
-    }
-
-    #[gpui::test]
-    fn clicking_the_help_label_opens_the_real_help_menu(cx: &mut TestAppContext) {
-        let (app, cx) = open_windows_variant(cx);
-        let bounds = app.read_with(cx, |app, _| {
-            app.title_menu_button_bounds[TitleMenu::Help.index()]
-        });
-
-        cx.simulate_click(center_of(bounds), gpui::Modifiers::none());
-        cx.run_until_parked();
-
-        assert_eq!(
-            app.read_with(cx, |app, _| app.title_menu_open),
-            Some(TitleMenu::Help)
-        );
     }
 
     /// The Help menu's real "About" row (the third row, after a divider - so this test drives it

--- a/crates/app/src/title_bar/menu.rs
+++ b/crates/app/src/title_bar/menu.rs
@@ -6,8 +6,6 @@
 //! versus "what can I actually do from it".
 
 use super::*;
-#[cfg(test)]
-use crate::root::focus::palette_focus_tests;
 use crate::root::widgets::{menu_popover_chrome, render_menu_group_divider};
 use crate::title_bar::menu_model::{MenuCommand, MenuRow};
 use crate::work_surface::render::render_dropdown_menu_row;
@@ -476,8 +474,8 @@ mod title_menu_tests {
     fn open_windows_variant(
         cx: &mut TestAppContext,
     ) -> (Entity<AdeApp>, &mut gpui::VisualTestContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, cx| {
             app.set_window_controls_style(WindowControlsStyle::WindowsLinuxStyle, cx);
         });
@@ -590,9 +588,9 @@ mod title_menu_tests {
     fn file_menu_open_folder_row_focuses_a_real_chosen_folder_in_this_window(
         cx: &mut TestAppContext,
     ) {
-        let original_repo = tempfile::tempdir().expect("tempdir");
-        let chosen_repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, original_repo.path().to_path_buf());
+        let original_repo = crate::test_support::temp_root();
+        let chosen_repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, original_repo.path().to_path_buf());
         app.update(cx, |app, cx| {
             app.set_window_controls_style(WindowControlsStyle::WindowsLinuxStyle, cx);
         });
@@ -704,10 +702,10 @@ mod title_menu_tests {
     /// `mod+z` does inside a text widget.
     #[gpui::test]
     fn edit_menu_text_undo_row_is_inert_until_there_is_real_text_to_undo(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let file_path = repo.path().join("notes.txt");
         std::fs::write(&file_path, "hello\n").expect("write notes.txt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, cx| {
             app.set_window_controls_style(WindowControlsStyle::WindowsLinuxStyle, cx);
         });
@@ -965,105 +963,6 @@ mod title_menu_tests {
         );
     }
 
-    /// The Agent menu's "Discard worktree" row's real two-step confirm - mirrors the agent
-    /// footer's own identical two-click button
-    /// (`crate::work_surface::render::AdeApp::render_footer_action_button`), reusing the
-    /// exact same real [`AdeApp::request_discard_worktree`]/[`AdeApp::discard_confirm_armed`]
-    /// this test drives through the menu row instead of the footer button. Needs a real,
-    /// non-main worktree (`crate::worktree_history::flow::AdeApp::request_discard_worktree`
-    /// unconditionally refuses on the main worktree), so this sets one up the same way
-    /// `crate::worktree_history::flow::worktree_history_regression_tests::add_worktree` does.
-    #[gpui::test]
-    fn agent_menu_discard_row_arms_then_executes_a_real_discard(cx: &mut TestAppContext) {
-        use std::process::Command;
-
-        fn git(dir: &std::path::Path, args: &[&str]) {
-            let output = Command::new("git")
-                .current_dir(dir)
-                .args(args)
-                .output()
-                .expect("failed to spawn git");
-            assert!(output.status.success(), "git {args:?} failed in {dir:?}");
-        }
-
-        let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(repo.path().join("base.txt"), "base\n").expect("write");
-        git(repo.path(), &["add", "base.txt"]);
-        git(repo.path(), &["commit", "-m", "initial"]);
-
-        let worktree_container = tempfile::tempdir().expect("tempdir");
-        let worktree_path = worktree_container.path().join("feature-wt");
-        drop(worktree_container);
-        git(
-            repo.path(),
-            &[
-                "worktree",
-                "add",
-                "-b",
-                "feature",
-                worktree_path.to_str().expect("utf8 path"),
-            ],
-        );
-        std::fs::write(worktree_path.join("dirty.txt"), "uncommitted\n").expect("write");
-
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        app.update(cx, |app, cx| {
-            app.set_window_controls_style(WindowControlsStyle::WindowsLinuxStyle, cx);
-        });
-        let id = app.update_in(cx, |app, window, cx| {
-            app.agents.spawn(
-                ProcessKind::Shell,
-                worktree_path.clone(),
-                app.settings.appearance.terminal_font_size,
-                app.settings.terminal.shell_override(),
-                None,
-                window,
-                cx,
-            )
-        });
-        app.update_in(cx, |app, window, cx| {
-            app.select_agent(id, window, cx);
-        });
-        cx.run_until_parked();
-
-        // Agent>Discard worktree is the last row - two dividers and three earlier rows above
-        // it, so this drives the real handler directly (`request_discard_worktree`) rather than
-        // computing that row's exact pixel offset. What's under real test here is the *result*
-        // of two real calls through the exact same real method the row's `on_click` calls - the
-        // arm-then-close-or-not menu logic itself is covered separately below.
-        app.update_in(cx, |app, window, cx| {
-            app.request_discard_worktree(id, window, cx);
-        });
-        cx.run_until_parked();
-        assert_eq!(
-            app.read_with(cx, |app, _| app.discard_confirm_armed),
-            Some(id),
-            "the first click should only arm confirmation, matching the footer's own two-click \
-             discipline"
-        );
-        assert!(
-            worktree_path.exists(),
-            "an armed-but-not-yet-confirmed discard must not have touched the real worktree"
-        );
-
-        app.update_in(cx, |app, window, cx| {
-            app.request_discard_worktree(id, window, cx);
-        });
-        cx.run_until_parked();
-
-        assert!(
-            !worktree_path.exists(),
-            "the second, confirming click should have run the real discard, actually removing \
-             the worktree directory"
-        );
-        app.read_with(cx, |app, _| {
-            assert_eq!(app.discard_confirm_armed, None);
-        });
-    }
-
     /// The title menu's own click-handling for the Discard row (not just
     /// `request_discard_worktree` itself, already covered above): the first, arming click must
     /// leave the menu open so the row's label can really swap to "confirm discard?" for a second
@@ -1077,41 +976,14 @@ mod title_menu_tests {
     fn agent_menu_discard_row_stays_open_while_armed_and_closes_once_confirmed(
         cx: &mut TestAppContext,
     ) {
-        use std::process::Command;
-
-        fn git(dir: &std::path::Path, args: &[&str]) {
-            let output = Command::new("git")
-                .current_dir(dir)
-                .args(args)
-                .output()
-                .expect("failed to spawn git");
-            assert!(output.status.success(), "git {args:?} failed in {dir:?}");
-        }
-
-        let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(repo.path().join("base.txt"), "base\n").expect("write");
-        git(repo.path(), &["add", "base.txt"]);
-        git(repo.path(), &["commit", "-m", "initial"]);
-
-        let worktree_container = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_repo();
+        let worktree_container = crate::test_support::temp_root();
         let worktree_path = worktree_container.path().join("feature-wt");
         drop(worktree_container);
-        git(
-            repo.path(),
-            &[
-                "worktree",
-                "add",
-                "-b",
-                "feature",
-                worktree_path.to_str().expect("utf8 path"),
-            ],
-        );
-        std::fs::write(worktree_path.join("dirty.txt"), "uncommitted\n").expect("write");
+        test_support::add_worktree(repo.path(), "feature", &worktree_path);
+        test_support::write_file(&worktree_path, "dirty.txt", "uncommitted\n");
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, cx| {
             app.set_window_controls_style(WindowControlsStyle::WindowsLinuxStyle, cx);
         });
@@ -1139,9 +1011,7 @@ mod title_menu_tests {
         // The Discard row is the 8th real row (index 7, 0-based) in the Agent menu: New
         // Terminal, New Agent Pane, [divider], Next Agent, Previous Agent, [divider], Review
         // Agent, Archive Agent, Keep All Changes, Discard Worktree - seven real rows and two
-        // dividers sit above it (see `MenuCommand::rows`'s own row order). `Review Agent` joined
-        // that third group with GitHub issue #295, which deleted the agent pane footer's own
-        // `Review` door along with the rest of the finished-agent action bar.
+        // dividers sit above it (see `MenuCommand::rows`'s own row order).
         let bounds = app.read_with(cx, |app, _| {
             app.title_menu_button_bounds[TitleMenu::Agent.index()]
         });
@@ -1208,9 +1078,9 @@ mod title_menu_tests {
     /// resolves through whichever worktree is genuinely current.
     #[gpui::test]
     fn select_relative_agent_cycles_through_real_agents_and_wraps_around(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let other_wt = tempfile::tempdir().expect("tempdir b");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let other_wt = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![
@@ -1383,8 +1253,8 @@ mod title_menu_tests {
     /// them back on the terminal they were trying to leave.
     #[gpui::test]
     fn next_agent_skips_shells_and_enters_the_cycle_from_one(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         for _ in 0..2 {

--- a/crates/app/src/title_bar/render.rs
+++ b/crates/app/src/title_bar/render.rs
@@ -793,8 +793,12 @@ mod agent_state_chip_text_tests {
         }
     }
 
+    /// The formatter's silence rules: a zero count never renders a chip for any status, and
+    /// `Review`/`Idle` never render one at all however non-zero they are. The design's own
+    /// title-bar example names exactly three states (§4) - finished and idle counts already have
+    /// a real home in the rail's agent rows and the status bar's five-way dot row.
     #[test]
-    fn a_zero_count_is_hidden_for_every_status() {
+    fn chip_text_is_silent_for_a_zero_count_and_for_review_or_idle() {
         for status in Status::ORDER {
             assert_eq!(
                 title_bar_agent_state_chip_text(status, 0),
@@ -802,15 +806,30 @@ mod agent_state_chip_text_tests {
                 "a zero count must never render a chip, for {status:?}"
             );
         }
-    }
-
-    #[test]
-    fn review_and_idle_never_get_a_title_bar_chip_even_with_a_real_nonzero_count() {
-        // The design's own title-bar example names exactly three states (§4) - finished and
-        // idle counts already have a real home in the rail's own agent rows and the status
-        // bar's five-way dot row, so they must stay silent here even when genuinely non-zero.
         assert_eq!(title_bar_agent_state_chip_text(Status::Review, 3), None);
         assert_eq!(title_bar_agent_state_chip_text(Status::Idle, 5), None);
+    }
+
+    /// Each shown state's own wording, conjugated against its own count. `Run`'s two-and
+    /// four-agent forms are `design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §4's
+    /// literal example text, reproduced verbatim.
+    #[test]
+    fn each_shown_state_conjugates_its_own_noun_and_verb() {
+        let cases: &[(Status, usize, &str)] = &[
+            (Status::Ask, 1, "1 agent needs input"),
+            (Status::Ask, 2, "2 agents need input"),
+            (Status::Ask, 7, "7 agents need input"),
+            (Status::Fail, 1, "1 agent failed"),
+            (Status::Fail, 2, "2 agents failed"),
+            (Status::Run, 1, "1 agent running"),
+            (Status::Run, 4, "4 agents running"),
+        ];
+        for (status, count, expected) in cases {
+            assert_eq!(
+                title_bar_agent_state_chip_text(*status, *count).as_deref(),
+                Some(*expected)
+            );
+        }
     }
 
     /// The title bar's half of revision 6's `Review ready` → `Finished` rename (GitHub issue
@@ -832,48 +851,6 @@ mod agent_state_chip_text_tests {
                 );
             }
         }
-    }
-
-    #[test]
-    fn ask_conjugates_its_verb_at_exactly_one_vs_two_or_more() {
-        assert_eq!(
-            title_bar_agent_state_chip_text(Status::Ask, 1).as_deref(),
-            Some("1 agent needs input")
-        );
-        assert_eq!(
-            title_bar_agent_state_chip_text(Status::Ask, 2).as_deref(),
-            Some("2 agents need input")
-        );
-        assert_eq!(
-            title_bar_agent_state_chip_text(Status::Ask, 7).as_deref(),
-            Some("7 agents need input")
-        );
-    }
-
-    #[test]
-    fn fail_pluralizes_the_noun_only_the_verb_does_not_conjugate() {
-        assert_eq!(
-            title_bar_agent_state_chip_text(Status::Fail, 1).as_deref(),
-            Some("1 agent failed")
-        );
-        assert_eq!(
-            title_bar_agent_state_chip_text(Status::Fail, 2).as_deref(),
-            Some("2 agents failed")
-        );
-    }
-
-    #[test]
-    fn run_matches_the_design_doc_s_own_worked_example_exactly() {
-        assert_eq!(
-            title_bar_agent_state_chip_text(Status::Run, 1).as_deref(),
-            Some("1 agent running")
-        );
-        // `design_handoff_jerry_ade/revision 3/REVISION-2026-07-31.md` §4's own literal
-        // example text - "4 agents running" - reproduced verbatim.
-        assert_eq!(
-            title_bar_agent_state_chip_text(Status::Run, 4).as_deref(),
-            Some("4 agents running")
-        );
     }
 
     /// Rev 6 §7 rule 4, quoted verbatim: "Two states distinguished anywhere in the app are never
@@ -903,6 +880,18 @@ mod agent_state_chip_text_tests {
                  that summed two states would report more"
             );
         }
+        // The degenerate case the same bug would show up in first: one agent can only ever be
+        // in one state, so it can only ever produce one chip.
+        for status in [Status::Ask, Status::Fail, Status::Run] {
+            let single = title_bar_agent_state_chips(&[row(1, status)]);
+            assert_eq!(
+                single.len(),
+                1,
+                "one agent in {status:?} must produce exactly one chip"
+            );
+            assert_eq!(single[0].1, 1);
+        }
+
         let charged: usize = chips.iter().map(|(_, count, _)| count).sum();
         let chip_eligible = rows
             .iter()
@@ -915,22 +904,6 @@ mod agent_state_chip_text_tests {
              across {} chips for {chip_eligible} eligible agents",
             chips.len()
         );
-    }
-
-    /// A single agent can only ever be in one state, so exactly one chip can ever exist for a
-    /// one-agent window - the degenerate case of the rule above, and the one a "count it in both"
-    /// bug would show up in first.
-    #[test]
-    fn one_agent_produces_exactly_one_chip_whatever_its_state() {
-        for status in [Status::Ask, Status::Fail, Status::Run] {
-            let chips = title_bar_agent_state_chips(&[row(1, status)]);
-            assert_eq!(
-                chips.len(),
-                1,
-                "one agent in {status:?} must produce exactly one chip"
-            );
-            assert_eq!(chips[0].1, 1);
-        }
     }
 
     /// §4b's compaction: the chip shows a bare count, and the fully conjugated sentence is what
@@ -957,11 +930,6 @@ mod agent_state_chip_text_tests {
     }
 
     #[test]
-    fn zero_agents_anywhere_produces_an_entirely_empty_chip_list() {
-        assert_eq!(title_bar_agent_state_chips(&[]), Vec::new());
-    }
-
-    #[test]
     fn only_non_empty_states_produce_a_chip_and_review_idle_are_excluded() {
         let rows = vec![
             row(1, Status::Ask),
@@ -973,6 +941,11 @@ mod agent_state_chip_text_tests {
             vec![(Status::Ask, 1, "1 agent needs input".to_string())],
             "only the one non-empty Ask/Fail/Run state should produce a chip - Review and Idle \
              must stay silent even though they are the majority of the rows"
+        );
+        assert_eq!(
+            title_bar_agent_state_chips(&[]),
+            Vec::new(),
+            "and with no agents anywhere the list is entirely empty"
         );
     }
 
@@ -1223,22 +1196,19 @@ mod agent_state_chip_live_tests {
         // "^L" - so what's checked here is the actual thing this test cares about,
         // `idle_duration` itself, not a literal byte sequence that this particular shell state
         // was never going to produce.
-        let refresh_deadline = std::time::Instant::now() + std::time::Duration::from_secs(45);
-        let mut first_agent_refreshed = false;
-        loop {
-            cx.background_executor
-                .advance_clock(std::time::Duration::from_millis(8));
-            cx.run_until_parked();
-            let idle = first_pane.read_with(cx, |pane, _| pane.idle_duration());
-            if idle.is_some_and(|idle| idle < std::time::Duration::from_secs(1)) {
-                first_agent_refreshed = true;
-                break;
-            }
-            if std::time::Instant::now() >= refresh_deadline {
-                break;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(5));
-        }
+        // Both clocks advance together, one poll at a time: the pane only notices new output on
+        // a simulated-clock poll tick, while the real pty reader is an ordinary OS thread that
+        // only makes progress in real time. `test_support::wait_until` is the workspace's one
+        // sanctioned wall-clock wait (`docs/testing.md`).
+        let first_agent_refreshed =
+            test_support::wait_until(std::time::Duration::from_secs(30), || {
+                cx.background_executor
+                    .advance_clock(std::time::Duration::from_millis(8));
+                cx.run_until_parked();
+                first_pane
+                    .read_with(cx, |pane, _| pane.idle_duration())
+                    .is_some_and(|idle| idle < std::time::Duration::from_secs(1))
+            });
         assert!(
             first_agent_refreshed,
             "expected the first agent's real pty activity to refresh after this real Ctrl-L \

--- a/crates/app/src/title_bar/render.rs
+++ b/crates/app/src/title_bar/render.rs
@@ -4,8 +4,6 @@
 //! [`super::menu`].
 
 use super::*;
-#[cfg(test)]
-use crate::root::focus::palette_focus_tests;
 use crate::root::plural;
 
 /// Half-diagonal of an 11×1px rect rotated ±45° about its own center - `5.5 * cos(45°)`. Used to
@@ -630,8 +628,8 @@ mod caption_button_tests {
     /// calls the real `Window::remove_window` and closes the real window - not a mock.
     #[gpui::test]
     fn clicking_the_close_caption_button_closes_the_real_window(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         // Pin the Windows/Linux caption-button variant regardless of the real host OS this test
         // happens to run on, so the test is deterministic everywhere.
@@ -673,8 +671,8 @@ mod caption_button_tests {
     fn a_single_click_on_empty_title_bar_space_never_reaches_the_maximize_call(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         let _ = app;
 
@@ -721,8 +719,8 @@ mod macos_dot_cluster_tests {
     /// regression by failing its second assertion.
     #[gpui::test]
     fn clicking_the_macos_maximize_dot_toggles_fullscreen_both_ways(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         // Pin the macOS dot-cluster variant regardless of the real host OS this test happens to
         // run on, so the test is deterministic everywhere (the same reasoning
@@ -1040,7 +1038,6 @@ mod agent_state_chip_text_tests {
 #[cfg(test)]
 mod agent_state_chip_live_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
 
     fn worktree_item(path: PathBuf, label: &str) -> WorktreeItem {
@@ -1078,8 +1075,8 @@ mod agent_state_chip_live_tests {
     /// real spawned process, only the bookkeeping `kind` the rail/chip logic reads.
     #[gpui::test]
     fn closing_the_only_real_agent_makes_the_chip_row_disappear(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let startup_agent_id = app
@@ -1139,9 +1136,9 @@ mod agent_state_chip_live_tests {
     fn a_second_real_spawned_agent_flips_the_live_chip_from_singular_to_plural(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt_b = tempfile::tempdir().expect("tempdir wt-b");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt_b = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         let startup_agent_id = app

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -3248,7 +3248,6 @@ pub(in crate::work_surface) fn render_status_pill(status: Status) -> impl IntoEl
 mod tab_scoping_tests {
     use super::*;
     use crate::rail::worktrees::WorktreeItem;
-    use crate::root::focus::palette_focus_tests;
     use gpui::{Focusable, TestAppContext};
 
     fn worktree_item(path: PathBuf, label: &str) -> WorktreeItem {
@@ -3278,9 +3277,9 @@ mod tab_scoping_tests {
     /// spawned into the same worktree must both show up as that worktree's tabs.
     #[gpui::test]
     fn multiple_agents_in_one_worktree_all_show_as_tabs_under_it(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt_a = tempfile::tempdir().expect("tempdir a");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt_a = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![worktree_item(wt_a.path().to_path_buf(), "wt-a")];
@@ -3328,10 +3327,10 @@ mod tab_scoping_tests {
     /// hook_injection_for` would hand a real spawn.
     #[gpui::test]
     fn spawn_resume_prepends_resume_ahead_of_the_real_hook_injection(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
-        let hook_temp = tempfile::tempdir().expect("hook temp dir");
+        let hook_temp = crate::test_support::temp_root();
         let runtime = crate::hooks::HookRuntime::start(hook_temp.path())
             .expect("the hook runtime must start in a test sandbox");
         let injection = runtime.injection();
@@ -3389,9 +3388,9 @@ mod tab_scoping_tests {
     fn ctrl_p_still_works_after_switching_to_a_worktree_with_no_open_agent(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt_empty = tempfile::tempdir().expect("tempdir empty");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt_empty = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
 
         app.update(cx, |app, _cx| {
@@ -3427,10 +3426,10 @@ mod tab_scoping_tests {
     /// showing/pointing at the previously selected worktree's agent.
     #[gpui::test]
     fn switching_worktree_selection_shows_that_worktrees_own_tabs(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt_a = tempfile::tempdir().expect("tempdir a");
-        let wt_b = tempfile::tempdir().expect("tempdir b");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt_a = crate::test_support::temp_root();
+        let wt_b = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             seed_two_worktrees(app, wt_a.path().to_path_buf(), wt_b.path().to_path_buf());
@@ -3493,9 +3492,9 @@ mod tab_scoping_tests {
     fn closing_the_active_tab_falls_back_to_a_sibling_in_the_same_worktree(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt_a = tempfile::tempdir().expect("tempdir a");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt_a = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         app.update(cx, |app, _cx| {
             app.worktrees = vec![worktree_item(wt_a.path().to_path_buf(), "wt-a")];
         });
@@ -3556,10 +3555,10 @@ mod tab_scoping_tests {
     fn closing_the_last_tab_in_a_worktree_never_falls_back_to_a_different_worktrees_agent(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt_a = tempfile::tempdir().expect("tempdir a");
-        let wt_b = tempfile::tempdir().expect("tempdir b");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt_a = crate::test_support::temp_root();
+        let wt_b = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.update(|_window, cx| cx.bind_keys(crate::default_key_bindings()));
         app.update(cx, |app, _cx| {
             seed_two_worktrees(app, wt_a.path().to_path_buf(), wt_b.path().to_path_buf());
@@ -3622,8 +3621,8 @@ mod tab_scoping_tests {
     /// `Agents`' own raw creation order - see that method's own docs on why).
     #[gpui::test]
     fn drag_reordering_two_agent_tabs_changes_their_order(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         let (initial_id, id2, id3) = app.update_in(cx, |app, window, cx| {
             let initial_id = app.agents.active_id().expect("initial shell agent");
@@ -3679,8 +3678,8 @@ mod tab_scoping_tests {
     /// itself must all be real no-ops.
     #[gpui::test]
     fn drag_reorder_is_a_no_op_for_an_unknown_or_identical_id(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         let initial_id = app.read_with(cx, |app, _| {
             app.agents.active_id().expect("initial shell agent")
         });
@@ -3726,9 +3725,9 @@ mod tab_scoping_tests {
     /// the very pane the user is watching.
     #[gpui::test]
     fn only_the_active_agents_pane_polls_at_the_foreground_cadence(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt_empty = tempfile::tempdir().expect("tempdir empty");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt_empty = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         let foreground_ids =
             |app: &gpui::Entity<AdeApp>, cx: &mut TestAppContext| -> Vec<AgentId> {
@@ -3797,25 +3796,24 @@ mod tab_scoping_tests {
         );
     }
 
-    /// The real cross-kind capability GitHub issue #16 exists to unlock: a file tab dragged so it
-    /// lands between two agent tabs must actually interleave them in the combined tab order,
-    /// not just reorder within its own kind - the exact case the old, kind-locked
-    /// `DraggedAgentTab`/`DraggedFileTab` types could never produce (GPUI's `on_drop::<T>`
-    /// dispatches purely on the dragged value's concrete type, so a `DraggedFileTab` could never
-    /// be dropped onto an agent tab's `on_drop::<DraggedAgentTab>` handler or vice versa).
+    /// The real cross-kind capability GitHub issue #16 (file tabs) and #93 (the graph tab) exist
+    /// to unlock: a non-agent tab dragged so it lands between two agent tabs must actually
+    /// interleave them in the combined tab order, not just reorder within its own kind - the
+    /// exact case the old, kind-locked `DraggedAgentTab`/`DraggedFileTab` types could never
+    /// produce (GPUI's `on_drop::<T>` dispatches purely on the dragged value's concrete type).
+    /// Both non-agent kinds are dragged here, because `Self::reorder_tab` is kind-agnostic and
+    /// what is at risk is that each tab kind's own renderer really routes into it.
     ///
-    /// The second tab spawned here is a real `Claude` agent, not a second `Shell` - Revision
-    /// R12 §3's bare-worktree suppression (`Self::current_worktree_is_bare`) treats "every open
-    /// agent is a `Shell`" as bare and hides file tabs from `Self::combined_tab_order` entirely
-    /// (`a_bare_worktrees_tab_strip_shows_only_its_shell_tab_and_preserves_file_tab_state`
-    /// covers that directly), which would make this drag-interleaving assertion moot for reasons
-    /// that have nothing to do with what this test actually exercises.
+    /// The second agent spawned here is a real `Claude`, not a second `Shell` - a worktree whose
+    /// every agent is a `Shell` reads as bare (`Self::current_worktree_is_bare`), a state whose
+    /// own effect on the strip is covered by `a_bare_worktrees_tab_strip_still_shows_every_open_file_tab`.
     #[gpui::test]
-    fn dragging_a_file_tab_between_two_agent_tabs_interleaves_them(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let file_path = repo.path().join("a.txt");
-        std::fs::write(&file_path, "hello\n").expect("write a.txt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+    fn dragging_a_file_or_graph_tab_between_two_agent_tabs_interleaves_them(
+        cx: &mut TestAppContext,
+    ) {
+        let repo = crate::test_support::temp_root();
+        let file_path = repo.write("a.txt", "hello\n");
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         let (initial_id, second_id) = app.update_in(cx, |app, window, cx| {
             let initial_id = app.agents.active_id().expect("initial shell agent");
@@ -3829,82 +3827,31 @@ mod tab_scoping_tests {
                 cx,
             );
             app.open_file_view(file_path.clone(), window, cx);
-            (initial_id, second_id)
-        });
-
-        let before = app.read_with(cx, |app, _| app.combined_tab_order());
-        assert_eq!(
-            before,
-            vec![
-                work_surface::TabRef::Agent(initial_id),
-                work_surface::TabRef::Agent(second_id),
-                work_surface::TabRef::File(PathBuf::from("a.txt")),
-            ],
-            "with no drag yet, agents come first (creation order), then files - the old \
-             two-block layout"
-        );
-
-        // The real cross-kind drop: drag the file tab so it lands between the two agent tabs.
-        app.update(cx, |app, cx| {
-            app.reorder_tab(
-                work_surface::TabRef::File(PathBuf::from("a.txt")),
-                work_surface::TabRef::Agent(second_id),
-                false,
-                cx,
-            );
-        });
-
-        let after = app.read_with(cx, |app, _| app.combined_tab_order());
-        assert_eq!(
-            after,
-            vec![
-                work_surface::TabRef::Agent(initial_id),
-                work_surface::TabRef::File(PathBuf::from("a.txt")),
-                work_surface::TabRef::Agent(second_id),
-            ],
-            "the file tab must now sit between the two agent tabs - the real cross-group \
-             interleaving this revision exists to unlock"
-        );
-    }
-
-    /// GitHub issue #93: the git graph tab must be a full, kind-agnostic member of the same
-    /// drag-to-reorder system as agent/file tabs, not a fixed trailing entry - dragging it so it
-    /// lands between two agent tabs must actually interleave it into `Self::combined_tab_order`,
-    /// mirroring `dragging_a_file_tab_between_two_agent_tabs_interleaves_them`'s own file-tab
-    /// case exactly.
-    #[gpui::test]
-    fn dragging_the_graph_tab_between_two_agent_tabs_interleaves_it(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-
-        let (initial_id, second_id) = app.update_in(cx, |app, window, cx| {
-            let initial_id = app.agents.active_id().expect("initial shell agent");
-            let second_id = app.agents.spawn(
-                ProcessKind::claude(),
-                repo.path().to_path_buf(),
-                12.0,
-                None,
-                None,
-                window,
-                cx,
-            );
             app.open_git_graph(window, cx);
             (initial_id, second_id)
         });
 
-        let before = app.read_with(cx, |app, _| app.combined_tab_order());
+        let file_ref = work_surface::TabRef::File(PathBuf::from("a.txt"));
         assert_eq!(
-            before,
+            app.read_with(cx, |app, _| app.combined_tab_order()),
             vec![
                 work_surface::TabRef::Agent(initial_id),
                 work_surface::TabRef::Agent(second_id),
+                file_ref.clone(),
                 work_surface::TabRef::Graph,
             ],
-            "with no drag yet, agents come first (creation order), then the freshly opened \
-             graph tab"
+            "with no drag yet, agents come first (creation order), then the non-agent tabs - the \
+             old two-block layout"
         );
 
+        // The real cross-kind drops: each non-agent tab lands between the two agent tabs.
         app.update(cx, |app, cx| {
+            app.reorder_tab(
+                file_ref.clone(),
+                work_surface::TabRef::Agent(second_id),
+                false,
+                cx,
+            );
             app.reorder_tab(
                 work_surface::TabRef::Graph,
                 work_surface::TabRef::Agent(second_id),
@@ -3913,62 +3860,16 @@ mod tab_scoping_tests {
             );
         });
 
-        let after = app.read_with(cx, |app, _| app.combined_tab_order());
         assert_eq!(
-            after,
+            app.read_with(cx, |app, _| app.combined_tab_order()),
             vec![
                 work_surface::TabRef::Agent(initial_id),
+                file_ref,
                 work_surface::TabRef::Graph,
                 work_surface::TabRef::Agent(second_id),
             ],
-            "the graph tab must now sit between the two agent tabs, the same real \
-             cross-kind interleaving file/agent tabs already get"
-        );
-    }
-
-    /// `Self::start_dragging_tab`/`Self::drop_dragged_tab` must treat `TabRef::Graph` exactly
-    /// like any other tab kind - recording it while dragged, then clearing that record once
-    /// dropped - mirroring `start_dragging_tab_records_exactly_the_tab_that_started_the_drag`'s
-    /// own agent-tab case.
-    #[gpui::test]
-    fn dragging_the_graph_tab_dims_its_own_slot_then_clears_on_drop(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-
-        let initial_id = app.update_in(cx, |app, window, cx| {
-            app.open_git_graph(window, cx);
-            app.agents.active_id().expect("initial shell agent")
-        });
-
-        app.update(cx, |app, cx| {
-            app.start_dragging_tab(work_surface::TabRef::Graph, cx);
-        });
-        assert_eq!(
-            app.read_with(cx, |app, _| app.dragging_tab.clone()),
-            Some(work_surface::TabRef::Graph),
-            "starting a drag on the graph tab must record exactly that tab"
-        );
-
-        app.update(cx, |app, cx| {
-            app.drop_dragged_tab(
-                work_surface::TabRef::Graph,
-                work_surface::TabRef::Agent(initial_id),
-                cx,
-            );
-        });
-        assert_eq!(
-            app.read_with(cx, |app, _| app.dragging_tab.clone()),
-            None,
-            "a handled drop must clear the now-stale dragging-tab state, same as any other kind"
-        );
-        // GitHub issue #93's own extension of the settle-fade (GitHub issue #16 §5): dropping
-        // the graph tab must record it into `Self::dropped_tab_settle` exactly like any other
-        // kind - `Self::drop_dragged_tab` is already kind-agnostic here, so this is really
-        // proving `render_graph_tab` reads the same real field, not a separate code path.
-        assert_eq!(
-            app.read_with(cx, |app, _| app.dropped_tab_settle.clone().map(|(t, _)| t)),
-            Some(work_surface::TabRef::Graph),
-            "a real drop of the graph tab must record it for the settle-in fade too"
+            "both non-agent tabs must now sit between the two agent tabs - the real cross-group \
+             interleaving these revisions exist to unlock"
         );
     }
 
@@ -3979,8 +3880,8 @@ mod tab_scoping_tests {
     /// must clear that state once handled, so a later drop on a different tab can't inherit it.
     #[gpui::test]
     fn drop_dragged_tab_honors_the_recorded_insertion_side_then_clears_it(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         let (initial_id, second_id) = app.update_in(cx, |app, window, cx| {
             let initial_id = app.agents.active_id().expect("initial shell agent");
@@ -4027,16 +3928,24 @@ mod tab_scoping_tests {
         );
     }
 
-    /// `Self::start_dragging_tab` (the real `on_drag` constructor callback's body, GitHub issue
-    /// #16's "the original slot renders dimmed" ask) must record exactly the tab that started
-    /// the drag, so `Self::render_file_tab`/`Self::render_agent_tab`'s own `is_dragging` check
-    /// dims the right slot and no other.
+    /// The drag's own bookkeeping, over its whole life: `Self::start_dragging_tab` (the real
+    /// `on_drag` constructor callback's body, GitHub issue #16's "the original slot renders
+    /// dimmed" ask) must record exactly the tab that started it, so the per-tab `is_dragging`
+    /// check dims the right slot and no other; and a real drop must clear that record again, so
+    /// a dropped tab's slot never stays dimmed once the drag is over.
+    ///
+    /// Driven with the graph tab (GitHub issue #93), the kind that reaches this through its own
+    /// separate renderer - the underlying state is kind-agnostic, so what is at risk is the
+    /// wiring, not the fields.
     #[gpui::test]
-    fn start_dragging_tab_records_exactly_the_tab_that_started_the_drag(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        let initial_id = app.read_with(cx, |app, _| app.agents.active_id().expect("shell agent"));
+    fn a_drag_records_its_own_tab_on_start_and_clears_it_on_drop(cx: &mut TestAppContext) {
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
+        let initial_id = app.update_in(cx, |app, window, cx| {
+            app.open_git_graph(window, cx);
+            app.agents.active_id().expect("initial shell agent")
+        });
         assert_eq!(
             app.read_with(cx, |app, _| app.dragging_tab.clone()),
             None,
@@ -4044,52 +3953,30 @@ mod tab_scoping_tests {
         );
 
         app.update(cx, |app, cx| {
-            app.start_dragging_tab(work_surface::TabRef::Agent(initial_id), cx);
+            app.start_dragging_tab(work_surface::TabRef::Graph, cx);
         });
-
         assert_eq!(
             app.read_with(cx, |app, _| app.dragging_tab.clone()),
-            Some(work_surface::TabRef::Agent(initial_id)),
+            Some(work_surface::TabRef::Graph),
             "starting a drag must record exactly the tab that started it"
         );
-    }
 
-    /// A real drop must clear `Self::dragging_tab` alongside `Self::tab_drag_insertion` - a
-    /// dropped tab's slot must never stay dimmed once the drag it was dimmed for is over.
-    #[gpui::test]
-    fn dropping_a_tab_clears_dragging_tab(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-
-        let (initial_id, second_id) = app.update_in(cx, |app, window, cx| {
-            let initial_id = app.agents.active_id().expect("initial shell agent");
-            let second_id = app.agents.spawn(
-                ProcessKind::Shell,
-                repo.path().to_path_buf(),
-                12.0,
-                None,
-                None,
-                window,
-                cx,
-            );
-            (initial_id, second_id)
-        });
-
-        app.update(cx, |app, cx| {
-            app.start_dragging_tab(work_surface::TabRef::Agent(initial_id), cx);
-        });
         app.update(cx, |app, cx| {
             app.drop_dragged_tab(
+                work_surface::TabRef::Graph,
                 work_surface::TabRef::Agent(initial_id),
-                work_surface::TabRef::Agent(second_id),
                 cx,
             );
         });
-
         assert_eq!(
             app.read_with(cx, |app, _| app.dragging_tab.clone()),
             None,
             "a handled drop must clear the now-stale dragging-tab state"
+        );
+        assert_eq!(
+            app.read_with(cx, |app, _| app.dropped_tab_settle.clone().map(|(t, _)| t)),
+            Some(work_surface::TabRef::Graph),
+            "and must record the dropped tab for the settle-in fade (GitHub issue #16 §5)"
         );
     }
 
@@ -4101,8 +3988,8 @@ mod tab_scoping_tests {
     fn cancel_any_tab_drag_clears_both_fields_and_reports_whether_anything_changed(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         let initial_id = app.read_with(cx, |app, _| app.agents.active_id().expect("shell agent"));
 
         assert!(
@@ -4129,10 +4016,11 @@ mod tab_scoping_tests {
 
     /// `tab_settle_animation_id` (the pure logic behind the settle-in fade, GitHub issue #16's
     /// "dropping animates the tab settling into its slot") must return `Some` only for the tab
-    /// that was actually dropped, and `None` for every other tab, including one dropped in a
-    /// previous, no-longer-current drop.
+    /// that was actually dropped, and must hand two separate drops of the very same tab two
+    /// different ids - reusing one would resume GPUI's own already-finished animation state for
+    /// that id instead of starting a fresh fade (`tab_settle_animation_id`'s own docs on why).
     #[test]
-    fn tab_settle_animation_id_matches_only_the_settled_tab() {
+    fn tab_settle_animation_id_matches_only_the_settled_tab_and_is_fresh_per_drop() {
         let dropped = work_surface::TabRef::File(PathBuf::from("a.txt"));
         let other = work_surface::TabRef::File(PathBuf::from("b.txt"));
         let settle = Some((dropped.clone(), 7));
@@ -4143,18 +4031,11 @@ mod tab_scoping_tests {
         );
         assert_eq!(tab_settle_animation_id(&settle, &other), None);
         assert_eq!(tab_settle_animation_id(&None, &dropped), None);
-    }
-
-    /// Two separate drops of the very same tab must get two different animation ids - reusing
-    /// one would resume GPUI's own already-finished animation state for that id instead of
-    /// starting a fresh fade (`tab_settle_animation_id`'s own docs on why).
-    #[test]
-    fn tab_settle_animation_id_is_fresh_across_two_drops_of_the_same_tab() {
-        let tab = work_surface::TabRef::File(PathBuf::from("a.txt"));
-        let first_drop = tab_settle_animation_id(&Some((tab.clone(), 1)), &tab);
-        let second_drop = tab_settle_animation_id(&Some((tab.clone(), 2)), &tab);
-
-        assert_ne!(first_drop, second_drop);
+        assert_ne!(
+            tab_settle_animation_id(&Some((dropped.clone(), 1)), &dropped),
+            tab_settle_animation_id(&Some((dropped.clone(), 2)), &dropped),
+            "two drops of the same tab must never reuse one animation id"
+        );
     }
 
     /// A real drop (`Self::drop_dragged_tab`) must record `Self::dropped_tab_settle` for exactly
@@ -4162,8 +4043,8 @@ mod tab_scoping_tests {
     /// with a fresh id rather than leaving the first tab's own id behind.
     #[gpui::test]
     fn drop_dragged_tab_records_a_fresh_settle_id_for_the_dropped_tab(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         let (initial_id, second_id) = app.update_in(cx, |app, window, cx| {
             let initial_id = app.agents.active_id().expect("initial shell agent");
@@ -4220,8 +4101,8 @@ mod tab_scoping_tests {
     fn drop_dragged_tab_records_real_slide_offsets_for_every_shifted_neighbour(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         let (first_id, second_id, third_id) = app.update_in(cx, |app, window, cx| {
             let first_id = app.agents.active_id().expect("initial shell agent");
@@ -4307,8 +4188,8 @@ mod tab_scoping_tests {
     /// reorder itself; this is that same guarantee for the slide it now also kicks off).
     #[gpui::test]
     fn drop_dragged_tab_records_no_slide_state_for_a_no_op_drop(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         let initial_id = app.read_with(cx, |app, _| {
             app.agents.active_id().expect("initial shell agent")
         });
@@ -4403,8 +4284,8 @@ mod tab_scoping_tests {
     fn a_tabs_label_is_its_panes_live_title_and_the_strip_repaints_when_that_title_changes(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         let shell_id = app.read_with(cx, |app, _| {
             app.agents
                 .active_id()
@@ -4461,9 +4342,9 @@ mod tab_scoping_tests {
     fn two_tabs_with_the_same_live_title_render_the_same_label_with_nothing_added(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt_a = tempfile::tempdir().expect("tempdir a");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt_a = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![worktree_item(wt_a.path().to_path_buf(), "wt-a")];
@@ -4526,9 +4407,9 @@ mod tab_scoping_tests {
     fn a_pane_that_has_reported_no_title_shows_its_real_program_name_not_an_empty_tab(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt_a = tempfile::tempdir().expect("tempdir a");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt_a = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![worktree_item(wt_a.path().to_path_buf(), "wt-a")];
@@ -4583,60 +4464,6 @@ mod tab_scoping_tests {
         );
     }
 
-    /// Uniformity across both tab kinds (`work_surface::TabChipKind::Cli` and `::Term`): an
-    /// agent CLI's tab is titled by the same live mechanism a plain shell's is. An agent's own
-    /// title is the *more* informative of the two - it's what `crate::rail::title_signal`
-    /// already reads to tell whether that agent is working - so there is no per-kind naming
-    /// authority that preferring it would regress.
-    #[gpui::test]
-    fn an_agent_clis_tab_takes_its_live_title_exactly_like_a_shells_does(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt_a = tempfile::tempdir().expect("tempdir a");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-
-        app.update(cx, |app, _cx| {
-            app.worktrees = vec![worktree_item(wt_a.path().to_path_buf(), "wt-a")];
-        });
-        let agent_id = app.update_in(cx, |app, window, cx| {
-            app.select_worktree(0, window, cx);
-            app.agents.spawn(
-                ProcessKind::claude(),
-                wt_a.path().to_path_buf(),
-                12.0,
-                None,
-                None,
-                window,
-                cx,
-            )
-        });
-        cx.run_until_parked();
-        assert_eq!(
-            app.read_with(cx, |app, _| work_surface::tab_chip_kind(
-                app.agents
-                    .iter()
-                    .find(|agent| agent.id == agent_id)
-                    .expect("agent")
-                    .kind
-            )),
-            work_surface::TabChipKind::Cli,
-            "sanity check: this is the CLI chip kind, the other half of the uniformity claim"
-        );
-        assert_eq!(
-            tab_label(&app, cx, agent_id),
-            "claude",
-            "before it says anything, an agent tab shows its real binary name"
-        );
-
-        set_live_title(&app, cx, agent_id, "\u{25d0} Claude Code");
-        cx.run_until_parked();
-
-        assert_eq!(
-            tab_label(&app, cx, agent_id),
-            "\u{25d0} Claude Code",
-            "an agent tab must follow its live title just as a shell tab does"
-        );
-    }
-
     /// Revision R12 §3's exact `+` menu item list: "*New terminal* · *New agent*
     /// (`runs in <branch>`) · *Git graph* · *Open file…* · *Next changed file*." Proven against
     /// the real painted popover (`Self::render_dropdown_menu_row`'s own `debug_selector`, one per
@@ -4648,8 +4475,8 @@ mod tab_scoping_tests {
     fn the_plus_menus_five_rows_match_revision_r12_3_in_order_with_no_new_file_row(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, cx| {
             app.plus_menu_open = true;
@@ -4699,8 +4526,8 @@ mod tab_scoping_tests {
     /// graph tab, and close the menu behind it the same way every other row's click does.
     #[gpui::test]
     fn a_real_click_on_the_plus_menus_git_graph_row_opens_the_graph_tab(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, cx| {
             app.plus_menu_open = true;
@@ -4741,9 +4568,9 @@ mod tab_scoping_tests {
     fn the_new_agent_rows_secondary_text_uses_the_real_selected_worktrees_branch(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt_a = tempfile::tempdir().expect("tempdir a");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt_a = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![worktree_item(
@@ -4785,9 +4612,9 @@ mod tab_scoping_tests {
     /// the worktree - so this is now the only thing bareness could have touched here.
     #[gpui::test]
     fn a_bare_worktrees_tab_strip_still_shows_every_open_file_tab(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt_a = tempfile::tempdir().expect("tempdir a");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let wt_a = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![worktree_item(wt_a.path().to_path_buf(), "wt-a")];
@@ -4872,8 +4699,8 @@ mod tab_scoping_tests {
     /// having "merged" into one.
     #[gpui::test]
     fn window_focus_follows_a_same_worktree_terminal_switch(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         let first_id = app.read_with(cx, |app, _| {
             app.agents.active_id().expect("the initial shell agent")
@@ -4935,10 +4762,10 @@ mod tab_scoping_tests {
     /// stopped being a carved-out exception to anything.
     #[gpui::test]
     fn opening_a_file_in_an_already_bare_worktree_still_gets_a_real_tab(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt_a = tempfile::tempdir().expect("tempdir a");
+        let repo = crate::test_support::temp_root();
+        let wt_a = crate::test_support::temp_root();
         std::fs::write(wt_a.path().join("README.md"), "hello\n").expect("write README.md");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
         app.update(cx, |app, _cx| {
             app.worktrees = vec![worktree_item(wt_a.path().to_path_buf(), "wt-a")];
@@ -4980,90 +4807,6 @@ mod tab_scoping_tests {
         );
     }
 
-    /// GitHub issue #116 (real dragging-while-bare tab-order corruption, fixed against an earlier
-    /// revision where bareness truncated `combined_tab_order` to a single visible file tab) plus
-    /// #120 (that truncation is gone entirely - see `a_bare_worktrees_tab_strip_still_shows_every_open_file_tab`).
-    /// With no truncation left, dragging while bare is now just an ordinary drag - this keeps
-    /// direct coverage that it still persists every open file's position correctly.
-    #[gpui::test]
-    fn dragging_a_tab_while_bare_persists_every_open_files_position(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let wt_a = tempfile::tempdir().expect("tempdir a");
-        std::fs::write(wt_a.path().join("a.txt"), "a\n").expect("write a.txt");
-        std::fs::write(wt_a.path().join("b.txt"), "b\n").expect("write b.txt");
-        std::fs::write(wt_a.path().join("c.txt"), "c\n").expect("write c.txt");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-
-        app.update(cx, |app, _cx| {
-            app.worktrees = vec![worktree_item(wt_a.path().to_path_buf(), "wt-a")];
-        });
-        app.update_in(cx, |app, window, cx| {
-            app.select_worktree(0, window, cx);
-            app.agents.spawn(
-                ProcessKind::Shell,
-                wt_a.path().to_path_buf(),
-                12.0,
-                None,
-                None,
-                window,
-                cx,
-            );
-            app.open_file_view(wt_a.path().join("a.txt"), window, cx);
-            app.open_file_view(wt_a.path().join("b.txt"), window, cx);
-            app.open_file_view(wt_a.path().join("c.txt"), window, cx);
-        });
-        assert!(
-            app.read_with(cx, |app, _| app.current_worktree_is_bare()),
-            "premise: only the default Shell tab exists"
-        );
-        let bare_order = app.read_with(cx, |app, _| app.combined_tab_order());
-        assert_eq!(
-            bare_order
-                .iter()
-                .filter(|t| matches!(t, work_surface::TabRef::File(_)))
-                .count(),
-            3,
-            "premise: every open file tab renders even while bare (GitHub issue #120)"
-        );
-
-        app.update(cx, |app, cx| {
-            app.reorder_tab(
-                work_surface::TabRef::File(PathBuf::from("c.txt")),
-                work_surface::TabRef::File(PathBuf::from("a.txt")),
-                false,
-                cx,
-            );
-        });
-        cx.run_until_parked();
-
-        let order_after_drag = app.read_with(cx, |app, _| app.combined_tab_order());
-        for name in ["a.txt", "b.txt", "c.txt"] {
-            assert!(
-                order_after_drag.iter().any(
-                    |tab_ref| matches!(tab_ref, work_surface::TabRef::File(path) if path == &PathBuf::from(name))
-                ),
-                "{name} must still be in the tab order after the drag"
-            );
-        }
-        assert!(
-            order_after_drag
-                .iter()
-                .position(|t| t == &work_surface::TabRef::File(PathBuf::from("c.txt")))
-                < order_after_drag
-                    .iter()
-                    .position(|t| t == &work_surface::TabRef::File(PathBuf::from("a.txt"))),
-            "the real drag must have really moved c.txt in front of a.txt"
-        );
-
-        let cwd = wt_a.path().to_path_buf();
-        let persisted = app.read_with(cx, |app, _| app.tab_order_state.file_order(&cwd));
-        assert_eq!(
-            persisted.len(),
-            3,
-            "the on-disk persisted order must keep all three files"
-        );
-    }
-
     /// GitHub issue #382: [`AdeApp::active_agent_pane_id`]'s own cascade - the fix for GitHub
     /// issue #227 - only ever zeroed out for the review/run/graph tabs, because those three are
     /// plain `bool` flags. The File/Diff surface is a fourth centre-pane occupant with the
@@ -5080,9 +4823,9 @@ mod tab_scoping_tests {
     /// `active_agent_pane_id`'s cascade.
     #[gpui::test]
     fn switching_from_an_agent_to_a_file_tab_leaves_exactly_one_selected(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         std::fs::write(repo.path().join("mod.rs"), "fn main() {}\n").expect("write");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         // A real second agent (the startup shell is `Agents`' first entry) so this exercises a
@@ -5161,135 +4904,6 @@ mod tab_scoping_tests {
     }
 }
 
-/// GitHub issue #20's `TerminalClear` action - real coverage that dispatching it reaches
-/// whichever agent is genuinely active right now, and only that one, mirroring
-/// `crate::terminal::pane::clear_pty_signal_tests`' own "observe the pty's real echo, not a
-/// direct call" discipline for proving `clear()`'s pty-signal half actually fired.
-#[cfg(test)]
-mod terminal_clear_action_tests {
-    use super::*;
-    use crate::root::focus::palette_focus_tests;
-    use gpui::TestAppContext;
-
-    /// The real pty's OS reader thread and the real child shell it feeds run entirely outside
-    /// GPUI's deterministic scheduler - `cx.background_executor.advance_clock` only fast-forwards
-    /// a *simulated* clock, which grants that real thread and that real process zero actual
-    /// wall-clock scheduling time. A retry loop that only ever advances the virtual clock (the
-    /// pre-fix shape here) can race arbitrarily far ahead of them: standalone, with an otherwise
-    /// idle CPU, the real echo lands within real microseconds so the race is never noticed, but
-    /// under real full-suite parallel load (dozens of other tests' own real subprocesses - other
-    /// ptys, `rust-analyzer`, `pyright`, `typescript-language-server` - contending for the same
-    /// cores) the OS can genuinely take real milliseconds to schedule the reader thread, and a
-    /// loop that burns through its whole retry budget in real microseconds finds every single
-    /// check empty and fails despite the real echo being on its way. This is exactly the same
-    /// class of bug `lsp::client::lsp_diagnostics_wiring_tests`' own `wait_for_real_diagnostics`/
-    /// `wait_until` exist to avoid one layer up (a real notification arriving on a real OS thread
-    /// outside GPUI's scheduler) - the fix is the same discipline: keep re-checking over *real*
-    /// wall-clock time (a real `std::thread::sleep` between checks), bounded by a real deadline,
-    /// not a fixed count of virtual-clock advances with no real-time floor at all.
-    fn wait_for_real_pty_output(
-        cx: &mut gpui::VisualTestContext,
-        deadline: std::time::Instant,
-        mut has_arrived: impl FnMut(&mut gpui::VisualTestContext) -> bool,
-    ) -> bool {
-        loop {
-            cx.background_executor
-                .advance_clock(std::time::Duration::from_millis(8));
-            cx.run_until_parked();
-            if has_arrived(cx) {
-                return true;
-            }
-            if std::time::Instant::now() >= deadline {
-                return false;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(5));
-        }
-    }
-
-    #[gpui::test]
-    fn dispatching_terminal_clear_signals_only_the_active_agents_pty(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-
-        let (first_id, second_id) = app.update_in(cx, |app, window, cx| {
-            let first = app.agents.spawn(
-                ProcessKind::Shell,
-                repo.path().to_path_buf(),
-                12.0,
-                None,
-                None,
-                window,
-                cx,
-            );
-            let second = app.agents.spawn(
-                ProcessKind::Shell,
-                repo.path().to_path_buf(),
-                12.0,
-                None,
-                None,
-                window,
-                cx,
-            );
-            (first, second)
-        });
-        cx.run_until_parked();
-        assert_eq!(
-            app.read_with(cx, |app, _| app.agents.active_id()),
-            Some(second_id),
-            "sanity check: spawning a second agent must make it the active one"
-        );
-
-        cx.dispatch_action(TerminalClear);
-
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(45);
-        let saw_real_output_on_second = wait_for_real_pty_output(cx, deadline, |cx| {
-            let second_lines = app.read_with(cx, |app, cx| {
-                app.agents
-                    .iter()
-                    .find(|agent| agent.id == second_id)
-                    .expect("second agent")
-                    .pane
-                    .read(cx)
-                    .visible_text_lines()
-            });
-            // `TerminalPane::clear` wipes its own local grid *first*, synchronously, before it
-            // ever writes the real Ctrl-L byte to the pty - so any real, non-blank content that
-            // reappears here can only be this real round trip's own echo. That echo can
-            // honestly take either shape: a raw `^L` (ECHOCTL, if the shell's own readline
-            // hasn't taken over the tty yet - the common case for a just-spawned shell) or a
-            // redrawn prompt (readline's own real `clear-screen` binding, once it has) - see
-            // `title_bar::render::agent_state_chip_live_tests`'s own docs for the identical real
-            // ambiguity, live-observed there first. Searching for the literal `^L` text alone
-            // made this test racy against exactly which one a real shell happens to pick under
-            // real full-suite load, where the extra real time before Ctrl-L is dispatched can
-            // let a freshly spawned shell's readline win a race it would usually lose on an
-            // otherwise-idle machine.
-            second_lines.iter().any(|line| !line.trim().is_empty())
-        });
-        assert!(
-            saw_real_output_on_second,
-            "expected the active (second) agent's real pty to echo something back after \
-             TerminalClear's real Ctrl-L byte reached it"
-        );
-
-        let first_lines = app.read_with(cx, |app, cx| {
-            app.agents
-                .iter()
-                .find(|agent| agent.id == first_id)
-                .expect("first agent")
-                .pane
-                .read(cx)
-                .visible_text_lines()
-        });
-        assert!(
-            !first_lines.iter().any(|line| line.contains("^L")),
-            "the inactive (first) agent must never receive the clear signal - only the active \
-             agent, matching handle_close_focused_tab_action's own 'act on whichever tab is \
-             genuinely showing right now' target"
-        );
-    }
-}
-
 /// GitHub issue #16's own "the resulting layout... persists per session/worktree and restores on
 /// relaunch" - real end-to-end coverage that a drag-reordered tab strip survives a genuine
 /// second `AdeApp` instance, not just a worktree switch within the same one.
@@ -5318,8 +4932,8 @@ mod tab_order_persistence_tests {
 
     #[gpui::test]
     fn a_drag_reordered_tab_strip_survives_a_real_restart(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let config_dir = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
+        let config_dir = crate::test_support::temp_root();
         let settings_path = config_dir.path().join("settings.toml");
         std::fs::write(repo.path().join("a.txt"), "a\n").expect("write a.txt");
         std::fs::write(repo.path().join("b.txt"), "b\n").expect("write b.txt");
@@ -5399,42 +5013,36 @@ mod tab_order_persistence_tests {
     }
 }
 
-/// GitHub issue #158's `TerminalCopy`/`TerminalPaste` actions - real coverage that dispatching
-/// each one reaches whichever agent is genuinely active right now, and that copy really lands on
-/// the real OS clipboard (checked the same way `crate::sidebar::tree_ops`' own
-/// `copy_relative_path_writes_the_worktree_relative_path` checks "Copy Path", since this app has
-/// exactly one clipboard mechanism and both go through it).
-///
-/// These fail against the pre-fix tree twice over: the actions didn't exist, and neither did any
-/// selection for copy to read.
+/// The terminal actions the work surface owns - GitHub issue #20's `TerminalClear` and issue
+/// #158's `TerminalCopy`/`TerminalPaste`. Each one must reach whichever agent is genuinely active
+/// right now, and only that one, proven through the pty's own real echo (or the real system
+/// clipboard) rather than by asserting a method was called - `crate::terminal::pane`'s own
+/// `clear_pty_signal_tests` discipline, one layer up.
 #[cfg(test)]
-mod terminal_clipboard_action_tests {
+mod terminal_action_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
     use gpui::{Focusable, TestAppContext};
 
-    /// See `terminal_clear_action_tests::wait_for_real_pty_output`'s own docs for why this real
-    /// wall-clock-bounded retry (not a fixed count of virtual-clock advances) is genuinely
-    /// required here too: the real pty reader thread and the real child shell it feeds are
-    /// outside GPUI's deterministic scheduler, so only real elapsed time - not simulated time -
-    /// gives them a real chance to run under full-suite parallel load.
-    fn wait_for_real_pty_output(
+    /// How long a real pty round trip is given before a test calls it a failure. Generous: it has
+    /// to survive a full-suite run where dozens of other tests' own child processes compete for
+    /// the same cores.
+    const PTY_ROUND_TRIP: std::time::Duration = std::time::Duration::from_secs(30);
+
+    /// Drives GPUI's own clock and the real wall clock together, one poll at a time, until
+    /// `arrived` holds or [`PTY_ROUND_TRIP`] elapses. Both are needed: the pane's poll loop only
+    /// advances on the simulated executor clock, while the pty reader is an ordinary OS thread
+    /// that only makes progress in real time. `test_support::wait_until` is the workspace's one
+    /// sanctioned wall-clock wait (`docs/testing.md`).
+    fn pump_until(
         cx: &mut gpui::VisualTestContext,
-        deadline: std::time::Instant,
-        mut has_arrived: impl FnMut(&mut gpui::VisualTestContext) -> bool,
+        mut arrived: impl FnMut(&mut gpui::VisualTestContext) -> bool,
     ) -> bool {
-        loop {
+        test_support::wait_until(PTY_ROUND_TRIP, || {
             cx.background_executor
                 .advance_clock(std::time::Duration::from_millis(8));
             cx.run_until_parked();
-            if has_arrived(cx) {
-                return true;
-            }
-            if std::time::Instant::now() >= deadline {
-                return false;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(5));
-        }
+            arrived(cx)
+        })
     }
 
     /// Places `text` at a fixed, addressed grid position in the active agent's pane, well below
@@ -5452,26 +5060,84 @@ mod terminal_clipboard_action_tests {
     }
 
     #[gpui::test]
-    fn dispatching_terminal_copy_puts_the_real_selection_on_the_real_clipboard(
-        cx: &mut TestAppContext,
-    ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        cx.run_until_parked();
+    fn dispatching_terminal_clear_signals_only_the_active_agents_pty(cx: &mut TestAppContext) {
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
 
-        cx.update(|_window, cx| {
-            cx.write_to_clipboard(gpui::ClipboardItem::new_string("stale".into()))
+        let (first_id, second_id) = app.update_in(cx, |app, window, cx| {
+            let first = app.agents.spawn(
+                ProcessKind::Shell,
+                repo.path().to_path_buf(),
+                12.0,
+                None,
+                None,
+                window,
+                cx,
+            );
+            let second = app.agents.spawn(
+                ProcessKind::Shell,
+                repo.path().to_path_buf(),
+                12.0,
+                None,
+                None,
+                window,
+                cx,
+            );
+            (first, second)
         });
-        seed_active_pane(&app, cx, "ade-selected-text");
-
-        cx.dispatch_action(TerminalCopy);
-
-        let text = cx.update(|_window, cx| cx.read_from_clipboard().and_then(|item| item.text()));
+        cx.run_until_parked();
         assert_eq!(
-            text.as_deref(),
-            Some("ade-selected-text"),
-            "TerminalCopy must reach the active agent's pane and write its real selection to \
-             the real system clipboard"
+            app.read_with(cx, |app, _| app.agents.active_id()),
+            Some(second_id),
+            "sanity check: spawning a second agent must make it the active one"
+        );
+
+        cx.dispatch_action(TerminalClear);
+
+        let saw_real_output_on_second = pump_until(cx, |cx| {
+            let second_lines = app.read_with(cx, |app, cx| {
+                app.agents
+                    .iter()
+                    .find(|agent| agent.id == second_id)
+                    .expect("second agent")
+                    .pane
+                    .read(cx)
+                    .visible_text_lines()
+            });
+            // `TerminalPane::clear` wipes its own local grid *first*, synchronously, before it
+            // ever writes the real Ctrl-L byte to the pty - so any real, non-blank content that
+            // reappears here can only be this real round trip's own echo. That echo can
+            // honestly take either shape: a raw `^L` (ECHOCTL, if the shell's own readline
+            // hasn't taken over the tty yet - the common case for a just-spawned shell) or a
+            // redrawn prompt (readline's own real `clear-screen` binding, once it has) - see
+            // `title_bar::render::agent_state_chip_live_tests`'s own docs for the identical real
+            // ambiguity, live-observed there first. Searching for the literal `^L` text alone
+            // made this test racy against exactly which one a real shell happens to pick under
+            // real full-suite load, where the extra real time before Ctrl-L is dispatched can
+            // let a freshly spawned shell's readline win a race it would usually lose on an
+            // otherwise-idle machine.
+            second_lines.iter().any(|line| !line.trim().is_empty())
+        });
+        assert!(
+            saw_real_output_on_second,
+            "expected the active (second) agent's real pty to echo something back after \
+             TerminalClear's real Ctrl-L byte reached it"
+        );
+
+        let first_lines = app.read_with(cx, |app, cx| {
+            app.agents
+                .iter()
+                .find(|agent| agent.id == first_id)
+                .expect("first agent")
+                .pane
+                .read(cx)
+                .visible_text_lines()
+        });
+        assert!(
+            !first_lines.iter().any(|line| line.contains("^L")),
+            "the inactive (first) agent must never receive the clear signal - only the active \
+             agent, matching handle_close_focused_tab_action's own 'act on whichever tab is \
+             genuinely showing right now' target"
         );
     }
 
@@ -5479,8 +5145,8 @@ mod terminal_clipboard_action_tests {
     /// contract `terminal_clear_action_tests` pins for `TerminalClear`.
     #[gpui::test]
     fn dispatching_terminal_copy_uses_only_the_active_agents_selection(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         // The window's own initial agent gets a selection first, then a second agent (which
@@ -5520,8 +5186,8 @@ mod terminal_clipboard_action_tests {
     fn the_real_copy_keystroke_over_a_focused_terminal_copies_instead_of_typing(
         cx: &mut TestAppContext,
     ) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         cx.update(|_window, cx| {
@@ -5556,8 +5222,8 @@ mod terminal_clipboard_action_tests {
     /// The paste counterpart of the keystroke test above, proven by the real pty echo.
     #[gpui::test]
     fn the_real_paste_keystroke_over_a_focused_terminal_reaches_the_pty(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         cx.update(|_window, cx| {
@@ -5578,8 +5244,7 @@ mod terminal_clipboard_action_tests {
             "ctrl-shift-v"
         });
 
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(45);
-        let saw_pasted_text = wait_for_real_pty_output(cx, deadline, |cx| {
+        let saw_pasted_text = pump_until(cx, |cx| {
             let lines = app.read_with(cx, |app, cx| {
                 app.agents
                     .active()
@@ -5597,38 +5262,6 @@ mod terminal_clipboard_action_tests {
             "the real paste keystroke over a focused terminal must reach TerminalPaste"
         );
     }
-
-    /// The paste half, proven by the pty's own echo rather than by asserting `write_input` was
-    /// called - mirroring `terminal_clear_action_tests`' discipline for `TerminalClear`.
-    #[gpui::test]
-    fn dispatching_terminal_paste_reaches_the_active_agents_real_pty(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
-        cx.run_until_parked();
-
-        cx.update(|_window, cx| {
-            cx.write_to_clipboard(gpui::ClipboardItem::new_string("ade-pasted-marker".into()))
-        });
-        cx.dispatch_action(TerminalPaste);
-
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(45);
-        let saw_pasted_text = wait_for_real_pty_output(cx, deadline, |cx| {
-            let lines = app.read_with(cx, |app, cx| {
-                app.agents
-                    .active()
-                    .expect("an active agent")
-                    .pane
-                    .read(cx)
-                    .visible_text_lines()
-            });
-            lines.iter().any(|line| line.contains("ade-pasted-marker"))
-        });
-        assert!(
-            saw_pasted_text,
-            "expected the active agent's real pty to echo back the clipboard text \
-             TerminalPaste's handler writes"
-        );
-    }
 }
 
 /// The reported "clicking an agent from another worktree/repo, the tab bar does not appear" -
@@ -5643,42 +5276,17 @@ mod terminal_clipboard_action_tests {
 #[cfg(test)]
 mod select_agent_cross_repo_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
     use crate::work_surface::agents::ProcessKind;
     use gpui::TestAppContext;
-
-    fn git(dir: &std::path::Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(
-            output.status.success(),
-            "git {args:?} failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn init_repo() -> tempfile::TempDir {
-        let dir = tempfile::tempdir().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(dir.path().join("README.md"), "hello\n").expect("write");
-        git(dir.path(), &["add", "README.md"]);
-        git(dir.path(), &["commit", "-m", "initial"]);
-        dir
-    }
 
     #[gpui::test]
     fn selecting_an_agent_in_a_non_focused_repo_switches_to_it_and_shows_its_tab(
         cx: &mut TestAppContext,
     ) {
-        let repo_a = init_repo();
-        let repo_b = init_repo();
+        let repo_a = crate::test_support::temp_repo();
+        let repo_b = crate::test_support::temp_repo();
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo_a.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo_a.path().to_path_buf());
         cx.run_until_parked();
 
         app.update(cx, |app, cx| {
@@ -5753,28 +5361,7 @@ mod select_agent_cross_repo_tests {
 mod agent_pane_readout_tests {
     use super::*;
     use crate::rail::worktrees::WorktreeItem;
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
-
-    fn git(dir: &std::path::Path, args: &[&str]) {
-        let status = std::process::Command::new("git")
-            .args(args)
-            .current_dir(dir)
-            .status()
-            .expect("run git");
-        assert!(status.success(), "git {args:?} failed in {}", dir.display());
-    }
-
-    fn init_repo() -> tempfile::TempDir {
-        let repo = tempfile::tempdir().expect("tempdir");
-        git(repo.path(), &["init", "-b", "main"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(repo.path().join("base.txt"), "base\n").expect("write");
-        git(repo.path(), &["add", "base.txt"]);
-        git(repo.path(), &["commit", "-m", "initial"]);
-        repo
-    }
 
     /// Spawns one real shell agent in `cwd` (optionally under a `shell_override` that exits by
     /// itself) and selects it, so the centre pane really is that agent's pty surface.
@@ -5800,26 +5387,24 @@ mod agent_pane_readout_tests {
         id
     }
 
-    /// Waits for a real child process to genuinely exit - the same real-clock-plus-advance loop
-    /// `crate::sidebar::render`'s own `/bin/false` test uses, not an assumption that it has.
+    /// Waits for a real child process to genuinely exit. Both clocks advance together, one poll
+    /// at a time: the pane only notices an exit on a simulated-clock poll tick, while the child
+    /// itself only exits in real time. `test_support::wait_until` is the workspace's one
+    /// sanctioned wall-clock wait (`docs/testing.md`).
     fn wait_for_exit(app: &gpui::Entity<AdeApp>, cx: &mut gpui::VisualTestContext, id: AgentId) {
-        for _ in 0..200 {
+        let exited = test_support::wait_until(std::time::Duration::from_secs(30), || {
             app.update(cx, |_app, cx| cx.notify());
             cx.run_until_parked();
-            let exited = app.read_with(cx, |app, cx| {
+            cx.executor()
+                .advance_clock(std::time::Duration::from_millis(50));
+            app.read_with(cx, |app, cx| {
                 app.agents
                     .iter()
                     .find(|agent| agent.id == id)
                     .is_some_and(|agent| !agent.pane.read(cx).is_running())
-            });
-            if exited {
-                return;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(20));
-            cx.executor()
-                .advance_clock(std::time::Duration::from_millis(50));
-        }
-        panic!("premise: the spawned child must really have exited");
+            })
+        });
+        assert!(exited, "premise: the spawned child must really have exited");
     }
 
     /// A real, non-bare worktree row for `path`. Seeded explicitly because a test app whose
@@ -5854,8 +5439,8 @@ mod agent_pane_readout_tests {
     /// re-added `Archive` button leaves the pill 83px short and fails this assertion.
     #[gpui::test]
     fn the_context_bar_ends_at_the_status_pill_with_no_merge_or_archive(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         app.update_in(cx, |app, window, cx| {
             app.worktrees = vec![worktree_row(repo.path().to_path_buf(), "main")];
@@ -5911,8 +5496,8 @@ mod agent_pane_readout_tests {
     /// plain shell before that was fixed - which is exactly the duplication the user reported.
     #[gpui::test]
     fn a_running_agents_strip_still_paints_and_carries_its_own_cost(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         let id = spawn_and_select(&app, cx, repo.path().to_path_buf(), None);
         app.update(cx, |app, cx| {
@@ -5967,8 +5552,8 @@ mod agent_pane_readout_tests {
     /// tab paints the info footer and **not** the readout strip.
     #[gpui::test]
     fn a_shell_tab_paints_the_info_footer_and_not_the_agent_readout_strip(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         let id = spawn_and_select(&app, cx, repo.path().to_path_buf(), None);
 
@@ -6009,8 +5594,8 @@ mod agent_pane_readout_tests {
     fn an_agent_tab_paints_only_the_readout_strip_and_keeps_its_pid_in_the_header(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         let id = spawn_and_select(&app, cx, repo.path().to_path_buf(), None);
         app.update(cx, |app, cx| {
@@ -6064,8 +5649,8 @@ mod agent_pane_readout_tests {
     fn header_content_and_footer_bands_sum_to_the_real_pane_height_on_a_long_transcript(
         cx: &mut TestAppContext,
     ) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         let id = spawn_and_select(&app, cx, repo.path().to_path_buf(), None);
         app.update(cx, |app, cx| {
@@ -6205,8 +5790,8 @@ mod agent_pane_readout_tests {
     /// true: a shell tab in a worktree that *does* have agents wore the whole identity row.
     #[gpui::test]
     fn a_shell_tab_beside_a_real_agent_gets_no_identity_bar(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         app.update_in(cx, |app, window, cx| {
             app.worktrees = vec![worktree_row(repo.path().to_path_buf(), "main")];
@@ -6249,8 +5834,8 @@ mod agent_pane_readout_tests {
     /// fabricated `0% cpu` - nothing at all, which is what the `Option` return states.
     #[gpui::test]
     fn the_cost_readout_is_blank_for_an_agent_that_is_not_running(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         app.read_with(cx, |app, _| {
@@ -6273,11 +5858,11 @@ mod agent_pane_readout_tests {
     /// those two, and that `Open terminal` (which used to sit between them) does not paint.
     #[gpui::test]
     fn a_failed_run_keeps_retry_and_a_two_click_discard_and_nothing_else(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let worktree_container = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_repo();
+        let worktree_container = crate::test_support::temp_root();
         let worktree_path = worktree_container.path().join("feature-wt");
         drop(worktree_container);
-        git(
+        test_support::git(
             repo.path(),
             &[
                 "worktree",
@@ -6288,7 +5873,7 @@ mod agent_pane_readout_tests {
             ],
         );
 
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         // `/bin/false` is a real child that really exits non-zero, so `Status::Fail` is derived
         // from a genuine `ProcessSignal::Exited { success: false }` rather than being set.
@@ -6340,8 +5925,8 @@ mod agent_pane_readout_tests {
     /// else in this pane (§4e: "the legitimate secondary CTA"), and it really spawns a shell.
     #[gpui::test]
     fn the_no_agent_empty_state_really_starts_a_terminal(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
 
         // Close whatever the app opened on startup, so the centre pane really is the empty state.
@@ -6391,8 +5976,8 @@ mod agent_pane_readout_tests {
     /// primary CTA that gives it one.
     #[gpui::test]
     fn a_bare_worktree_keeps_its_start_an_agent_button(cx: &mut TestAppContext) {
-        let repo = init_repo();
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_repo();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         cx.run_until_parked();
         spawn_and_select(&app, cx, repo.path().to_path_buf(), None);
 
@@ -6434,7 +6019,6 @@ mod agent_pane_readout_tests {
 #[cfg(test)]
 mod tab_strip_overflow_scroll_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
 
     /// Twenty real shell agent tabs (each a genuine `Agent`, no simulated output) reliably
@@ -6450,8 +6034,8 @@ mod tab_strip_overflow_scroll_tests {
     ///   the concrete, user-facing "tabs are not accessible" this issue reports.
     #[gpui::test]
     fn scrolling_the_tab_strip_reaches_a_tab_that_overflowed_it(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.path().to_path_buf());
+        let repo = crate::test_support::temp_root();
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.path().to_path_buf());
         // Deliberately narrow (`VisualTestContext::simulate_resize`'s own docs) rather than the
         // default maximized 1920×1080 `TestDisplay`: twenty real tabs overflow a maximized test
         // window too, but only past several dozen, which would mean this test paying for several
@@ -6571,7 +6155,6 @@ mod tab_strip_overflow_scroll_tests {
 #[cfg(test)]
 mod tab_strip_trailing_margin_tests {
     use super::*;
-    use crate::root::focus::palette_focus_tests;
     use gpui::TestAppContext;
 
     /// Opens `names` as real file tabs in a real window, then selects the app's own initial shell
@@ -6588,7 +6171,7 @@ mod tab_strip_trailing_margin_tests {
         for name in names {
             std::fs::write(repo.join(name), "// x\n").expect("write");
         }
-        let (app, cx) = palette_focus_tests::open_test_app(cx, repo.to_path_buf());
+        let (app, cx) = crate::test_support::open_test_app(cx, repo.to_path_buf());
         cx.simulate_resize(window_size);
         let shell_id = app
             .read_with(cx, |app, _| app.active_agent_pane_id())
@@ -6625,7 +6208,7 @@ mod tab_strip_trailing_margin_tests {
     /// rows genuinely share one pane width and that the discrepancy was the tab strip's alone.
     #[gpui::test]
     fn the_tab_strips_tabs_run_flush_into_the_panes_real_right_edge(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         // The live screenshots' own tabs, plus enough more of the same to genuinely overflow a
         // deliberately narrow window rather than a maximized one (the same 900px
         // `simulate_resize` `tab_strip_overflow_scroll_tests` uses, and for the same reason: real
@@ -6694,7 +6277,7 @@ mod tab_strip_trailing_margin_tests {
     /// is the design, not a gap in need of filling.
     #[gpui::test]
     fn the_plus_button_sits_immediately_after_the_last_tab(cx: &mut TestAppContext) {
-        let repo = tempfile::tempdir().expect("tempdir");
+        let repo = crate::test_support::temp_root();
         let names = ["state.rs", "lib.rs"];
         // Maximized (the default 1920x1080 `TestDisplay`), so two short tabs come nowhere near
         // filling the strip - the precondition under which PR #403's pusher relocated the `+`.

--- a/crates/app/src/work_surface/session.rs
+++ b/crates/app/src/work_surface/session.rs
@@ -357,40 +357,20 @@ mod session_restore_tests {
     use crate::rail::status::Status;
     use crate::settings::store as settings_store;
     use gpui::TestAppContext;
-    use std::process::Command;
-    use tempfile::TempDir;
-
-    fn git(dir: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(args)
-            .output()
-            .expect("failed to spawn git");
-        assert!(output.status.success(), "git {args:?} failed in {dir:?}");
-    }
 
     /// A real repo with a real initial commit, so `git worktree list --porcelain` reports a real
     /// main-worktree row for the app to select - and so `git worktree add` below works at all.
-    /// Returns the *canonicalized* path, because every one of this app's per-worktree lookups is an
-    /// exact comparison against git's own fully-resolved answers (see
-    /// `crate::rail::repo::canonical_repo_path`'s own docs).
-    fn init_repo() -> (TempDir, PathBuf) {
-        let dir = TempDir::new().expect("tempdir");
-        git(dir.path(), &["init", "-b", "main"]);
-        git(dir.path(), &["config", "user.email", "test@example.com"]);
-        git(dir.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(dir.path().join("README.md"), "hello\n").expect("write");
-        git(dir.path(), &["add", "README.md"]);
-        git(dir.path(), &["commit", "-m", "initial"]);
-        let canonical = std::fs::canonicalize(dir.path()).expect("canonicalize");
-        (dir, canonical)
+    fn init_repo() -> (crate::test_support::TempRoot, PathBuf) {
+        let dir = crate::test_support::temp_repo();
+        let root = dir.to_path_buf();
+        (dir, root)
     }
 
     /// A real linked worktree of `repo`, created under `container` (worktrees live outside the
     /// repo - `crate::rail::repo::Repo::path`'s own docs).
     fn add_worktree(repo: &Path, container: &Path, branch: &str) -> PathBuf {
         let path = container.join(branch);
-        git(
+        test_support::git(
             repo,
             &[
                 "worktree",
@@ -483,9 +463,9 @@ mod session_restore_tests {
         cx: &mut TestAppContext,
     ) {
         let (_repo, repo_path) = init_repo();
-        let container = TempDir::new().expect("tempdir");
+        let container = crate::test_support::temp_root();
         let feature = add_worktree(&repo_path, container.path(), "feature");
-        let settings_dir = TempDir::new().expect("tempdir");
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
 
         std::fs::write(repo_path.join("a.txt"), "a\n").expect("write");
@@ -580,9 +560,9 @@ mod session_restore_tests {
         cx: &mut TestAppContext,
     ) {
         let (_repo, repo_path) = init_repo();
-        let container = TempDir::new().expect("tempdir");
+        let container = crate::test_support::temp_root();
         let feature = add_worktree(&repo_path, container.path(), "feature");
-        let settings_dir = TempDir::new().expect("tempdir");
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
 
         {
@@ -648,7 +628,7 @@ mod session_restore_tests {
     #[gpui::test]
     fn a_file_deleted_between_sessions_is_skipped_with_a_real_reason(cx: &mut TestAppContext) {
         let (_repo, repo_path) = init_repo();
-        let settings_dir = TempDir::new().expect("tempdir");
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
         std::fs::write(repo_path.join("kept.txt"), "kept\n").expect("write");
         std::fs::write(repo_path.join("gone.txt"), "gone\n").expect("write");
@@ -698,7 +678,7 @@ mod session_restore_tests {
         cx: &mut TestAppContext,
     ) {
         let (_repo, repo_path) = init_repo();
-        let settings_dir = TempDir::new().expect("tempdir");
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
         let session_id = "5af4c210-34fa-4ab2-9c35-f6ceab76551c";
 
@@ -786,7 +766,7 @@ mod session_restore_tests {
     #[gpui::test]
     fn an_agent_with_no_resumable_session_is_refused_honestly_and_alone(cx: &mut TestAppContext) {
         let (_repo, repo_path) = init_repo();
-        let settings_dir = TempDir::new().expect("tempdir");
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
         std::fs::write(repo_path.join("kept.txt"), "kept\n").expect("write");
 
@@ -860,9 +840,9 @@ mod session_restore_tests {
         cx: &mut TestAppContext,
     ) {
         let (_repo, repo_path) = init_repo();
-        let container = TempDir::new().expect("tempdir");
+        let container = crate::test_support::temp_root();
         let feature = add_worktree(&repo_path, container.path(), "feature");
-        let settings_dir = TempDir::new().expect("tempdir");
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
         std::fs::write(feature.join("only-here.txt"), "hi\n").expect("write");
 
@@ -904,9 +884,9 @@ mod session_restore_tests {
     #[gpui::test]
     fn an_explicitly_named_path_still_wins_over_the_remembered_worktree(cx: &mut TestAppContext) {
         let (_repo, repo_path) = init_repo();
-        let container = TempDir::new().expect("tempdir");
+        let container = crate::test_support::temp_root();
         let feature = add_worktree(&repo_path, container.path(), "feature");
-        let settings_dir = TempDir::new().expect("tempdir");
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
 
         {
@@ -936,7 +916,7 @@ mod session_restore_tests {
     fn both_repos_tab_sessions_survive_a_relaunch(cx: &mut TestAppContext) {
         let (_repo_a, repo_a) = init_repo();
         let (_repo_b, repo_b) = init_repo();
-        let settings_dir = TempDir::new().expect("tempdir");
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
         std::fs::write(repo_a.join("in-a.txt"), "a\n").expect("write");
         std::fs::write(repo_b.join("in-b.txt"), "b\n").expect("write");
@@ -1000,7 +980,7 @@ mod session_restore_tests {
     #[gpui::test]
     fn a_deliberately_closed_tab_stays_closed_across_a_relaunch(cx: &mut TestAppContext) {
         let (_repo, repo_path) = init_repo();
-        let settings_dir = TempDir::new().expect("tempdir");
+        let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
         std::fs::write(repo_path.join("kept.txt"), "kept\n").expect("write");
         std::fs::write(repo_path.join("closed.txt"), "closed\n").expect("write");

--- a/crates/app/src/work_surface/session.rs
+++ b/crates/app/src/work_surface/session.rs
@@ -358,14 +358,6 @@ mod session_restore_tests {
     use crate::settings::store as settings_store;
     use gpui::TestAppContext;
 
-    /// A real repo with a real initial commit, so `git worktree list --porcelain` reports a real
-    /// main-worktree row for the app to select - and so `git worktree add` below works at all.
-    fn init_repo() -> (crate::test_support::TempRoot, PathBuf) {
-        let dir = crate::test_support::temp_repo();
-        let root = dir.to_path_buf();
-        (dir, root)
-    }
-
     /// A real linked worktree of `repo`, created under `container` (worktrees live outside the
     /// repo - `crate::rail::repo::Repo::path`'s own docs).
     fn add_worktree(repo: &Path, container: &Path, branch: &str) -> PathBuf {
@@ -462,7 +454,8 @@ mod session_restore_tests {
     fn a_relaunch_reopens_every_file_and_terminal_tab_in_its_real_drag_order(
         cx: &mut TestAppContext,
     ) {
-        let (_repo, repo_path) = init_repo();
+        let repo = crate::test_support::temp_repo();
+        let repo_path = repo.to_path_buf();
         let container = crate::test_support::temp_root();
         let feature = add_worktree(&repo_path, container.path(), "feature");
         let settings_dir = crate::test_support::temp_root();
@@ -559,7 +552,8 @@ mod session_restore_tests {
     fn an_unvisited_worktrees_session_costs_nothing_until_it_is_really_selected(
         cx: &mut TestAppContext,
     ) {
-        let (_repo, repo_path) = init_repo();
+        let repo = crate::test_support::temp_repo();
+        let repo_path = repo.to_path_buf();
         let container = crate::test_support::temp_root();
         let feature = add_worktree(&repo_path, container.path(), "feature");
         let settings_dir = crate::test_support::temp_root();
@@ -627,7 +621,8 @@ mod session_restore_tests {
     /// reason - never a panic, and never a phantom tab for a path that no longer resolves.
     #[gpui::test]
     fn a_file_deleted_between_sessions_is_skipped_with_a_real_reason(cx: &mut TestAppContext) {
-        let (_repo, repo_path) = init_repo();
+        let repo = crate::test_support::temp_repo();
+        let repo_path = repo.to_path_buf();
         let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
         std::fs::write(repo_path.join("kept.txt"), "kept\n").expect("write");
@@ -677,7 +672,8 @@ mod session_restore_tests {
     fn a_claude_agent_is_restored_by_a_real_resume_carrying_its_own_session_id(
         cx: &mut TestAppContext,
     ) {
-        let (_repo, repo_path) = init_repo();
+        let repo = crate::test_support::temp_repo();
+        let repo_path = repo.to_path_buf();
         let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
         let session_id = "5af4c210-34fa-4ab2-9c35-f6ceab76551c";
@@ -765,7 +761,8 @@ mod session_restore_tests {
     /// fail the whole restore" half.
     #[gpui::test]
     fn an_agent_with_no_resumable_session_is_refused_honestly_and_alone(cx: &mut TestAppContext) {
-        let (_repo, repo_path) = init_repo();
+        let repo = crate::test_support::temp_repo();
+        let repo_path = repo.to_path_buf();
         let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
         std::fs::write(repo_path.join("kept.txt"), "kept\n").expect("write");
@@ -839,7 +836,8 @@ mod session_restore_tests {
     fn relaunching_with_no_cli_argument_lands_back_in_the_last_worktree_with_its_tabs(
         cx: &mut TestAppContext,
     ) {
-        let (_repo, repo_path) = init_repo();
+        let repo = crate::test_support::temp_repo();
+        let repo_path = repo.to_path_buf();
         let container = crate::test_support::temp_root();
         let feature = add_worktree(&repo_path, container.path(), "feature");
         let settings_dir = crate::test_support::temp_root();
@@ -883,7 +881,8 @@ mod session_restore_tests {
     /// overriding the user, not helping them.
     #[gpui::test]
     fn an_explicitly_named_path_still_wins_over_the_remembered_worktree(cx: &mut TestAppContext) {
-        let (_repo, repo_path) = init_repo();
+        let repo = crate::test_support::temp_repo();
+        let repo_path = repo.to_path_buf();
         let container = crate::test_support::temp_root();
         let feature = add_worktree(&repo_path, container.path(), "feature");
         let settings_dir = crate::test_support::temp_root();
@@ -914,8 +913,10 @@ mod session_restore_tests {
     /// moment the user goes to it.
     #[gpui::test]
     fn both_repos_tab_sessions_survive_a_relaunch(cx: &mut TestAppContext) {
-        let (_repo_a, repo_a) = init_repo();
-        let (_repo_b, repo_b) = init_repo();
+        let repo_a = crate::test_support::temp_repo();
+        let repo_a = repo_a.to_path_buf();
+        let repo_b = crate::test_support::temp_repo();
+        let repo_b = repo_b.to_path_buf();
         let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
         std::fs::write(repo_a.join("in-a.txt"), "a\n").expect("write");
@@ -979,7 +980,8 @@ mod session_restore_tests {
     /// tabs would quietly resurrect them forever.
     #[gpui::test]
     fn a_deliberately_closed_tab_stays_closed_across_a_relaunch(cx: &mut TestAppContext) {
-        let (_repo, repo_path) = init_repo();
+        let repo = crate::test_support::temp_repo();
+        let repo_path = repo.to_path_buf();
         let settings_dir = crate::test_support::temp_root();
         let settings_path = settings_dir.path().join("settings.toml");
         std::fs::write(repo_path.join("kept.txt"), "kept\n").expect("write");

--- a/crates/app/src/work_surface/state.rs
+++ b/crates/app/src/work_surface/state.rs
@@ -626,81 +626,53 @@ mod tests {
         assert!(same(colors.bg, theme::lang::RS.1.into()));
     }
 
+    /// Inactive is one neutral for every chip kind - agent, shell and file tab alike - so a
+    /// background tab never advertises its own identity colour.
     #[test]
-    fn an_inactive_file_tab_chip_is_dimmed_to_the_same_neutral_a_agent_tab_chip_uses() {
+    fn an_inactive_chip_is_always_the_same_neutral_whatever_kind_it_is() {
         let rs = LangChip {
             label: "rs",
             fg: theme::lang::RS.0.into(),
             bg: theme::lang::RS.1.into(),
         };
-        let file_colors = file_tab_chip_colors(rs, false);
-        let agent_colors = tab_chip_colors(ProcessKind::Shell, false);
-        assert!(same(file_colors.bg, agent_colors.bg));
-        assert!(same(file_colors.fg, agent_colors.fg));
-    }
-
-    #[test]
-    fn an_inactive_chip_is_always_dimmed_to_the_same_neutral_regardless_of_kind() {
-        let claude = tab_chip_colors(ProcessKind::claude(), false);
         let shell = tab_chip_colors(ProcessKind::Shell, false);
-        assert!(same(claude.bg, shell.bg));
-        assert!(same(claude.fg, shell.fg));
-        assert!(same(claude.bg, theme::border::ZONE.into()));
+        for other in [
+            tab_chip_colors(ProcessKind::claude(), false),
+            file_tab_chip_colors(rs, false),
+        ] {
+            assert!(same(other.bg, shell.bg));
+            assert!(same(other.fg, shell.fg));
+        }
+        assert!(same(shell.bg, theme::border::ZONE.into()));
     }
 
+    /// An active tab's underline matches its own background - that is how it visually merges
+    /// into the surface below it (`design_handoff_jerry_ade/README.md`) - while an inactive one
+    /// is transparent and carries a different underline entirely.
     #[test]
-    fn active_tab_background_and_underline_are_the_same_colour_so_it_merges_into_the_surface() {
+    fn an_active_tab_merges_into_the_surface_and_an_inactive_one_does_not() {
         let active = tab_colors(true);
-        assert!(
-            same(active.bg, active.underline),
-            "an active tab's underline must match its own background - that's how it visually \
-             merges into the surface below it, per design_handoff_jerry_ade/README.md"
-        );
-    }
-
-    #[test]
-    fn inactive_tab_background_is_transparent_not_the_active_colour() {
         let inactive = tab_colors(false);
+        assert!(same(active.bg, active.underline));
         assert!(same(inactive.bg, TRANSPARENT));
-        assert!(!same(inactive.underline, tab_colors(true).underline));
+        assert!(!same(inactive.underline, active.underline));
     }
 
+    /// Every state a pty footer can honestly report, in one table: never started, exited with
+    /// its real code, and the three attached states the status drives.
     #[test]
-    fn a_process_that_never_started_reports_not_started_not_a_false_exit() {
-        assert_eq!(pty_state_label(false, Status::Idle, None), "not started");
-    }
-
-    #[test]
-    fn an_exited_process_always_reports_its_real_exit_code() {
-        assert_eq!(
-            pty_state_label(false, Status::Fail, Some(101)),
-            "exited 101"
-        );
-        assert_eq!(pty_state_label(false, Status::Review, Some(0)), "exited 0");
-    }
-
-    #[test]
-    fn a_running_agent_past_the_ask_threshold_reports_waiting_on_stdin() {
-        assert_eq!(
-            pty_state_label(true, Status::Ask, None),
-            "attached \u{b7} waiting on stdin"
-        );
-    }
-
-    #[test]
-    fn a_running_and_recently_active_agent_reports_streaming() {
-        assert_eq!(
-            pty_state_label(true, Status::Run, None),
-            "attached \u{b7} streaming"
-        );
-    }
-
-    #[test]
-    fn a_running_idle_shell_reports_idle_not_streaming_or_exited() {
-        assert_eq!(
-            pty_state_label(true, Status::Idle, None),
-            "attached \u{b7} idle"
-        );
+    fn the_pty_state_label_names_each_real_state_it_can_be_in() {
+        let cases: &[(bool, Status, Option<u32>, &str)] = &[
+            (false, Status::Idle, None, "not started"),
+            (false, Status::Fail, Some(101), "exited 101"),
+            (false, Status::Review, Some(0), "exited 0"),
+            (true, Status::Ask, None, "attached \u{b7} waiting on stdin"),
+            (true, Status::Run, None, "attached \u{b7} streaming"),
+            (true, Status::Idle, None, "attached \u{b7} idle"),
+        ];
+        for (running, status, code, expected) in cases {
+            assert_eq!(pty_state_label(*running, *status, *code), *expected);
+        }
     }
 
     /// GitHub issue #295 / §4t: every action that survives has real backing logic. The
@@ -721,24 +693,19 @@ mod tests {
     }
 
     /// §4r, verbatim: "a finished transcript is a record; its actions live where their object
-    /// lives". `Keep all`, `Review`, `Open in editor` and `Discard worktree` all left.
+    /// lives" - `Review` keeps none of `Keep all`, `Review`, `Open in editor`, `Discard
+    /// worktree`. §4e: `Interrupt` on an agent that is *waiting for you* has nothing to
+    /// interrupt, and `Open terminal` opens a *different* terminal, which does not answer the
+    /// question the agent is asking. §4t: `⌃C` in the focused pty is the interrupt, so the
+    /// button duplicating it is deleted from `Run` too.
     #[test]
-    fn a_finished_agent_offers_no_footer_actions_at_all() {
-        assert!(footer_actions(Status::Review).is_empty());
-    }
-
-    /// §4e: "`Interrupt` offered on an agent that is *waiting for you* - there is nothing to
-    /// interrupt", and `Open terminal` "opens a *different* terminal, which does not answer the
-    /// question the agent is asking".
-    #[test]
-    fn an_asking_agent_offers_no_footer_actions_at_all() {
-        assert!(footer_actions(Status::Ask).is_empty());
-    }
-
-    /// §4t: `⌃C` in the focused pty is the interrupt, so the button duplicating it is deleted.
-    #[test]
-    fn a_running_agent_offers_no_footer_actions_at_all() {
-        assert!(footer_actions(Status::Run).is_empty());
+    fn a_finished_asking_or_running_agent_offers_no_footer_actions_at_all() {
+        for status in [Status::Review, Status::Ask, Status::Run] {
+            assert!(
+                footer_actions(status).is_empty(),
+                "{status:?} must offer no footer action at all"
+            );
+        }
     }
 
     /// The one status that keeps two verbs: the run really can be retried, and the two-click
@@ -801,55 +768,46 @@ mod tests {
         assert_eq!(footer_actions(Status::Idle)[0].keycap, Some("mod+enter"));
     }
 
-    /// A live title is the label, verbatim - no branch, no ordinal, nothing appended.
+    /// A live title is the label, verbatim - no branch, no ordinal, nothing appended. The only
+    /// fallback is the program's own name, for a process that has said nothing yet or that
+    /// cleared its title back to empty ("nothing to show", not a blank tab). Two panes really
+    /// showing the same thing render the same label: the duplicate is the truth, and
+    /// synthesising a `#1`/`#2` difference between them would be inventing one.
     #[test]
-    fn a_live_title_is_the_whole_tab_label_with_nothing_appended() {
-        assert_eq!(
-            live_tab_label(Some("\u{2733} Claude Code"), "claude"),
-            "\u{2733} Claude Code"
-        );
-        assert_eq!(live_tab_label(Some("~/src/jerry"), "zsh"), "~/src/jerry");
-    }
-
-    /// The only fallback: a process that has said nothing yet still gets a real name.
-    #[test]
-    fn a_pane_whose_process_has_set_no_title_falls_back_to_its_program_name() {
-        assert_eq!(live_tab_label(None, "zsh"), "zsh");
-    }
-
-    /// A title cleared (or set empty) by the process is "nothing to show", not a blank tab.
-    #[test]
-    fn an_empty_or_whitespace_title_falls_back_rather_than_rendering_a_blank_tab() {
-        assert_eq!(live_tab_label(Some(""), "bash"), "bash");
-        assert_eq!(live_tab_label(Some("   "), "bash"), "bash");
-    }
-
-    /// Two panes really showing the same thing render the same label - the duplicate is the
-    /// truth, and synthesising a `#1`/`#2` difference between them would be inventing one.
-    #[test]
-    fn two_panes_reporting_the_same_title_get_the_same_label() {
+    fn a_tab_label_is_the_live_title_verbatim_or_the_program_name() {
+        let cases: &[(Option<&str>, &str, &str)] = &[
+            (
+                Some("\u{2733} Claude Code"),
+                "claude",
+                "\u{2733} Claude Code",
+            ),
+            (Some("~/src/jerry"), "zsh", "~/src/jerry"),
+            (None, "zsh", "zsh"),
+            (Some(""), "bash", "bash"),
+            (Some("   "), "bash", "bash"),
+        ];
+        for (title, program, expected) in cases {
+            assert_eq!(live_tab_label(*title, program), *expected);
+        }
         assert_eq!(
             live_tab_label(Some("nvim"), "zsh"),
             live_tab_label(Some("nvim"), "bash"),
         );
     }
 
-    /// Revision R12 §3's exact spec wording for the `+` menu's "New agent" row.
+    /// Revision R12 §3's exact spec wording for the `+` menu's "New agent" row - the real
+    /// branch substituted in, and an honest `(detached)` when there is none.
     #[test]
     fn the_new_agent_menu_row_shows_the_real_branch_never_a_model_name() {
         assert_eq!(
             new_agent_menu_secondary_text(Some("feature/real-branch")),
-            "runs in feature/real-branch"
+            "runs in feature/real-branch",
         );
         assert_ne!(
             new_agent_menu_secondary_text(Some("feature/real-branch")),
             "Claude",
             "must never show a model/agent-kind label in place of the branch"
         );
-    }
-
-    #[test]
-    fn the_new_agent_menu_row_falls_back_to_detached_with_no_recorded_branch() {
         assert_eq!(new_agent_menu_secondary_text(None), "runs in (detached)");
     }
 
@@ -957,56 +915,38 @@ mod tests {
         );
     }
 
-    /// GitHub issue #93: a freshly opened graph tab, not yet in the stored order, must be
-    /// appended at the end - the same "brand new tab lands last" rule every other kind already
-    /// gets, not silently dropped or given a hardcoded fixed position.
+    /// The three payload-free singleton tabs - the graph (GitHub issue #93), the review tab
+    /// (#225) and the run transcript (#227) - are ordinary members of the same order every other
+    /// kind is in: appended last when freshly opened rather than pinned to a hardcoded position,
+    /// kept wherever a real drag put them, and dropped when closed rather than left dangling for
+    /// `crate::root::AdeApp::render_tab_strip` to render a tab that no longer exists.
     #[test]
-    fn reconcile_appends_a_freshly_opened_graph_tab() {
-        let order = reconcile_tab_order(&[], &[1], &[], true, None, false);
-        assert_eq!(order, vec![TabRef::Agent(1), TabRef::Graph]);
-    }
+    fn reconcile_treats_every_singleton_tab_kind_like_any_other() {
+        let kinds: &[(TabRef, bool, Option<AgentId>, bool)] = &[
+            (TabRef::Graph, true, None, false),
+            (TabRef::Review(1), false, Some(1), false),
+            (TabRef::Run, false, None, true),
+        ];
+        for (tab, graph_open, review_open, run_open) in kinds {
+            assert_eq!(
+                reconcile_tab_order(&[], &[1], &[], *graph_open, *review_open, *run_open),
+                vec![TabRef::Agent(1), tab.clone()],
+                "a freshly opened {tab:?} lands last, like every other new tab"
+            );
 
-    /// The real point of GitHub issue #93: once a drag has recorded the graph tab somewhere
-    /// specific in the stored order, reconciliation must honor that real position - not always
-    /// re-append it at the end - as long as it's still open.
-    #[test]
-    fn reconcile_preserves_a_stored_graph_tab_position() {
-        let stored = vec![TabRef::Graph, TabRef::Agent(1)];
-        let order = reconcile_tab_order(&stored, &[1], &[], true, None, false);
-        assert_eq!(order, stored);
-    }
+            let stored = vec![tab.clone(), TabRef::Agent(1)];
+            assert_eq!(
+                reconcile_tab_order(&stored, &[1], &[], *graph_open, *review_open, *run_open),
+                stored,
+                "and a dragged position for {tab:?} is honoured rather than re-appended"
+            );
 
-    /// A closed graph tab must be dropped from the order, exactly like a closed agent or file
-    /// tab - not left as a dangling entry `crate::root::AdeApp::render_tab_strip` would try to
-    /// render for a tab that no longer exists.
-    #[test]
-    fn reconcile_drops_a_closed_graph_tab() {
-        let stored = vec![TabRef::Agent(1), TabRef::Graph];
-        let order = reconcile_tab_order(&stored, &[1], &[], false, None, false);
-        assert_eq!(order, vec![TabRef::Agent(1)]);
-    }
-
-    /// GitHub issue #225: a freshly opened review tab is appended like every other kind.
-    #[test]
-    fn reconcile_appends_a_freshly_opened_review_tab() {
-        let order = reconcile_tab_order(&[], &[1], &[], false, Some(1), false);
-        assert_eq!(order, vec![TabRef::Agent(1), TabRef::Review(1)]);
-    }
-
-    #[test]
-    fn reconcile_preserves_a_stored_review_tab_position() {
-        let stored = vec![TabRef::Review(1), TabRef::Agent(1)];
-        assert_eq!(
-            reconcile_tab_order(&stored, &[1], &[], false, Some(1), false),
-            stored
-        );
-    }
-
-    #[test]
-    fn reconcile_drops_a_closed_review_tab() {
-        let stored = vec![TabRef::Agent(1), TabRef::Review(1)];
-        let order = reconcile_tab_order(&stored, &[1], &[], false, None, false);
-        assert_eq!(order, vec![TabRef::Agent(1)]);
+            assert_eq!(
+                reconcile_tab_order(&stored, &[1], &[], false, None, false),
+                vec![TabRef::Agent(1)],
+                "a closed {tab:?} is dropped, not left dangling in the strip"
+            );
+        }
     }
 
     /// A review tab whose agent has closed must be dropped even while `review_open` still names
@@ -1178,10 +1118,11 @@ mod tests {
         );
     }
 
-    /// Dropping a tab immediately before its own already-adjacent slot is a real no-op
-    /// (`move_tab_order`'s own docs) - nothing actually changed position, so nothing may slide.
+    /// Every real no-op produces zero slide offsets: dropping a tab immediately before its own
+    /// already-adjacent slot, dropping it onto itself, and `move_tab_order`'s unknown-entry and
+    /// unknown-target cases (its own docs) - a reorder that changed nothing must animate nothing.
     #[test]
-    fn tab_slide_offsets_is_empty_when_the_drop_lands_on_the_tabs_own_already_adjacent_slot() {
+    fn tab_slide_offsets_is_empty_for_every_real_no_op() {
         let order = vec![
             TabRef::Agent(1),
             TabRef::Agent(2),
@@ -1190,31 +1131,23 @@ mod tests {
         ];
         let width = px(25.0);
 
-        let slides = tab_slide_offsets(&order, &TabRef::Agent(1), &TabRef::Agent(2), false, width);
-
-        assert!(slides.is_empty());
-    }
-
-    /// `move_tab_order`'s own no-op rules (unknown dragged/target entry, or dropping a tab onto
-    /// its own slot) must produce zero slide offsets too - a no-op reorder must animate nothing,
-    /// mirroring `drag_reorder_is_a_no_op_for_an_unknown_or_identical_id`'s own proof for the
-    /// underlying reorder.
-    #[test]
-    fn tab_slide_offsets_is_empty_for_every_move_tab_order_no_op() {
-        let order = vec![TabRef::Agent(1), TabRef::Agent(2)];
-        let width = px(40.0);
-
-        assert!(
-            tab_slide_offsets(&order, &TabRef::Agent(1), &TabRef::Agent(1), false, width)
-                .is_empty()
-        );
-        assert!(
-            tab_slide_offsets(&order, &TabRef::Agent(99), &TabRef::Agent(1), false, width)
-                .is_empty()
-        );
-        assert!(
-            tab_slide_offsets(&order, &TabRef::Agent(1), &TabRef::Agent(99), false, width)
-                .is_empty()
-        );
+        for (dragged, target, after, why) in [
+            (1, 2, false, "the tab's own already-adjacent slot"),
+            (1, 1, false, "a tab dropped onto itself"),
+            (99, 1, false, "an unknown dragged entry"),
+            (1, 99, false, "an unknown target"),
+        ] {
+            assert!(
+                tab_slide_offsets(
+                    &order,
+                    &TabRef::Agent(dragged),
+                    &TabRef::Agent(target),
+                    after,
+                    width
+                )
+                .is_empty(),
+                "{why} must slide nothing"
+            );
+        }
     }
 }

--- a/crates/app/src/work_surface/tab_order_state.rs
+++ b/crates/app/src/work_surface/tab_order_state.rs
@@ -518,7 +518,7 @@ mod tests {
 
     #[test]
     fn saving_and_reloading_round_trips_through_a_real_file() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         let path = dir.path().join("tab-order.toml");
         let root = Path::new("/repo/worktree-a");
 
@@ -536,7 +536,7 @@ mod tests {
 
     #[test]
     fn saving_merges_with_another_instances_entries_instead_of_erasing_them() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         let path = dir.path().join("tab-order.toml");
         let a = Path::new("/repo/worktree-a");
         let b = Path::new("/repo/worktree-b");
@@ -562,14 +562,14 @@ mod tests {
 
     #[test]
     fn a_missing_file_loads_as_empty_state_rather_than_failing() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         let state = TabOrderState::load_at(&dir.path().join("does-not-exist.toml"));
         assert_eq!(state, TabOrderState::default());
     }
 
     #[test]
     fn a_corrupted_file_loads_as_empty_state_rather_than_failing() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         let path = dir.path().join("tab-order.toml");
         std::fs::write(&path, "this is not valid toml {{{").expect("write");
         assert_eq!(TabOrderState::load_at(&path), TabOrderState::default());
@@ -577,7 +577,7 @@ mod tests {
 
     #[test]
     fn a_traversal_entry_in_a_hand_edited_file_is_ignored() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         let path = dir.path().join("tab-order.toml");
         std::fs::write(
             &path,
@@ -595,7 +595,7 @@ mod tests {
 
     #[test]
     fn saving_leaves_no_temp_file_behind_and_the_result_parses() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         let path = dir.path().join("nested").join("tab-order.toml");
         let root = Path::new("/repo/worktree-a");
         let mut state = TabOrderState::default();
@@ -622,7 +622,7 @@ mod tests {
     /// payload, and the real interleaved *order* intact.
     #[test]
     fn a_mixed_session_round_trips_through_a_real_file_with_its_order_intact() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         let path = dir.path().join("tab-order.toml");
         let root = Path::new("/repo/worktree-a");
         let session = vec![
@@ -701,7 +701,7 @@ mod tests {
     /// order, and must still be restored rather than silently ignored.
     #[test]
     fn a_file_written_before_sessions_existed_still_restores_its_file_tabs() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         let path = dir.path().join("tab-order.toml");
         std::fs::write(
             &path,
@@ -724,7 +724,7 @@ mod tests {
     /// the real tabs recorded around it.
     #[test]
     fn an_unrecognised_record_is_skipped_without_losing_the_real_tabs_around_it() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         let path = dir.path().join("tab-order.toml");
         std::fs::write(
             &path,
@@ -754,7 +754,7 @@ mod tests {
     /// `..` path must never decode into a file outside the worktree it is filed under.
     #[test]
     fn a_traversal_session_entry_in_a_hand_edited_file_is_ignored() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = crate::test_support::temp_root();
         let path = dir.path().join("tab-order.toml");
         std::fs::write(
             &path,

--- a/crates/app/src/work_surface/tab_order_state.rs
+++ b/crates/app/src/work_surface/tab_order_state.rs
@@ -479,6 +479,12 @@ mod tests {
             state.worktrees.is_empty(),
             "closing every file tab must not leave an empty entry behind forever"
         );
+
+        // A session whose every entry is unrecordable (outside the root) encodes to nothing, and
+        // must be forgotten the same way an explicitly empty one is.
+        state.set_session_tabs(root, &file_session(&[root.join("a.rs")]));
+        state.set_session_tabs(root, &file_session(&[PathBuf::from("/etc/passwd")]));
+        assert!(state.worktrees.is_empty());
     }
 
     #[test]
@@ -560,37 +566,19 @@ mod tests {
         assert_eq!(on_disk.file_order(b), vec![b.join("b.rs")]);
     }
 
+    /// Neither a file that is not there nor one that is not valid TOML may fail the load - a
+    /// hand-edited or half-written `tab-order.toml` degrades to the empty state.
     #[test]
-    fn a_missing_file_loads_as_empty_state_rather_than_failing() {
+    fn a_missing_or_corrupted_file_loads_as_empty_state_rather_than_failing() {
         let dir = crate::test_support::temp_root();
-        let state = TabOrderState::load_at(&dir.path().join("does-not-exist.toml"));
-        assert_eq!(state, TabOrderState::default());
-    }
+        assert_eq!(
+            TabOrderState::load_at(&dir.path().join("does-not-exist.toml")),
+            TabOrderState::default()
+        );
 
-    #[test]
-    fn a_corrupted_file_loads_as_empty_state_rather_than_failing() {
-        let dir = crate::test_support::temp_root();
         let path = dir.path().join("tab-order.toml");
         std::fs::write(&path, "this is not valid toml {{{").expect("write");
         assert_eq!(TabOrderState::load_at(&path), TabOrderState::default());
-    }
-
-    #[test]
-    fn a_traversal_entry_in_a_hand_edited_file_is_ignored() {
-        let dir = crate::test_support::temp_root();
-        let path = dir.path().join("tab-order.toml");
-        std::fs::write(
-            &path,
-            "[worktrees.\"/repo/worktree-a\"]\nfiles = [\"../worktree-b/secret.rs\", \"src/main.rs\"]\n",
-        )
-        .expect("write");
-
-        let state = TabOrderState::load_at(&path);
-        assert_eq!(
-            state.file_order(Path::new("/repo/worktree-a")),
-            vec![PathBuf::from("/repo/worktree-a/src/main.rs")],
-            "the `..` entry must be silently dropped, and the good one kept"
-        );
     }
 
     #[test]
@@ -750,8 +738,9 @@ mod tests {
         );
     }
 
-    /// The same traversal guard `files` has always had, applied to a hand-edited `tabs` entry: a
-    /// `..` path must never decode into a file outside the worktree it is filed under.
+    /// The traversal guard, on both record shapes: a `..` path in a hand-edited file - in the
+    /// legacy `files` list or in a `tabs` entry - must never decode into a file outside the
+    /// worktree it is filed under, and must be dropped without taking the good entries with it.
     #[test]
     fn a_traversal_session_entry_in_a_hand_edited_file_is_ignored() {
         let dir = crate::test_support::temp_root();
@@ -775,17 +764,16 @@ mod tests {
                 "/repo/worktree-a/src/main.rs"
             ))],
         );
-    }
 
-    /// A worktree whose whole session is a single unrecordable file (outside the root) must be
-    /// forgotten entirely rather than left with an empty entry - the same contract an explicitly
-    /// empty session already has.
-    #[test]
-    fn a_session_that_encodes_to_nothing_forgets_the_worktree() {
-        let root = Path::new("/repo/worktree-a");
-        let mut state = TabOrderState::default();
-        state.set_session_tabs(root, &file_session(&[root.join("a.rs")]));
-        state.set_session_tabs(root, &file_session(&[PathBuf::from("/etc/passwd")]));
-        assert!(state.worktrees.is_empty());
+        std::fs::write(
+            &path,
+            "[worktrees.\"/repo/worktree-a\"]\nfiles = [\"../worktree-b/secret.rs\", \"src/main.rs\"]\n",
+        )
+        .expect("write");
+        assert_eq!(
+            TabOrderState::load_at(&path).file_order(Path::new("/repo/worktree-a")),
+            vec![PathBuf::from("/repo/worktree-a/src/main.rs")],
+            "the legacy `files` list drops its `..` entry and keeps the good one too"
+        );
     }
 }


### PR DESCRIPTION
Part of #425 (epic #427) — sub-PR **D5**: `crates/app/src/{rail,work_surface,root,title_bar}`.

## What

Three things, in this order:

1. **Unbroke the slice.** 66 of its 564 tests failed deterministically — not 12, see below.
2. **Tiered, purged and re-fixtured it** against `docs/testing.md`: 564 → 439 tests (−22.2%).
3. **Cut `root/mod.rs`'s module header** to the comment rule, since this change already touches it.

### Before / after

| | before | after |
|---|---|---|
| tests in the slice | 564 | **439** (−125, −22.2%) |
| failing | **66** | 0 |
| `cargo nextest run` wall clock | 36.170s | **33.749s** |
| test lines in the slice | 21,839 (48.5% of the files) | **20,184** (46.7%) |
| `thread::sleep` in the slice | 6 | **0** |
| copy-pasted `fn git` / `fn init_repo` | 16 pairs | **0** |

Real output, both ends:

```
# at 43fb3d4, before this branch
     Summary [  36.170s] 564 tests run: 498 passed, 66 failed, 2439 skipped

# at b2137cd, this branch
     Summary [  33.749s] 439 tests run: 439 passed, 2439 skipped
```

Gate:

```
$ cargo fmt --all -- --check          # clean
$ cargo clippy --workspace --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.55s
$ .claude/hooks/check-conventions.sh
check-conventions: OK (glob imports: 302/303, render adapter calls: 200/221)
```

## The 66 pre-existing failures — all one bug, and it is a fixture bug

The hand-off listed **12** failures for this slice, measured in a full `-p app --lib` run. A
slice-scoped run at the same commit shows **66**, every one of them deterministic and reproducible
in isolation:

```
$ cargo nextest run -p app --lib -E 'test(=root::repo_list_tests::a_fresh_window_starts_with_exactly_one_focused_repo)'
    thread '...' panicked at crates/app/src/root/mod.rs:4101:13:
    assertion `left == right` failed
      left: "/private/var/folders/h6/.../T/.tmpzDbwt8"
     right: "/var/folders/h6/.../T/.tmpzDbwt8"
```

That is the macOS canonicalization bug the wave-2 briefing describes, and it accounts for **66 of
66**. `AdeApp` canonicalizes every repo root it is handed (`rail::repo::canonical_repo_path`) and
then keys repos, worktrees, agents and open files by exact-path equality or `strip_prefix` against
it. `std::env::temp_dir()` on macOS sits behind a `/var -> /private/var` symlink, so a fixture that
gives the app a bare `tempfile::TempDir::path()` and then builds its expected values from that same
uncanonicalized path is comparing two different strings for one directory.

Per test, and per the three names the hand-off called out:

- `select_agent_cross_repo_tests::selecting_an_agent_in_a_non_focused_repo_switches_to_it_and_shows_its_tab`
  — canonicalization. `focused_repo_path()` returned `/private/var/…`, the test expected `repo_b.path()`.
- `title_menu_tests::select_relative_agent_cycles_through_real_agents_and_wraps_around`
  — canonicalization. The agents were spawned into an uncanonicalized cwd, so
  `current_worktree_agent_sessions()` found none of them.
- `title_menu_tests::file_menu_open_folder_row_focuses_a_real_chosen_folder_in_this_window`
  — canonicalization, same shape as the first.
- **The tab drag/reorder ones were _not_ something else** — I checked them individually rather than
  assuming. `tab_scoping_tests::drag_reordering_two_agent_tabs_changes_their_order` and its five
  siblings all spawn agents into `repo.path()` while the app opened the canonicalized root, so
  `current_worktree_agents()` returned only the app's own startup shell and the very first
  `assert_eq!(before, vec![initial_id, id2, id3])` failed. Same bug, one layer along.
- The remaining 54 (`root::repo_list_tests`, `rail::render::{repo_checkout,worktree_tab_attribution}_tests`,
  `root::focus::palette_result_focus_tests`, `rail::strip_render::problems_view_tests`,
  `root::state::load_worktrees_integration_tests`, `rail::menu_render::rail_menu_tests`,
  `root::new_file`, …) — all the same, all fixed by the same change.

**No test was deleted or re-tiered to make a failure go away, and no product code changed.**
This is a fixture bug; production never reaches these paths uncanonicalized.

The fix is `crate::test_support::{TempRoot, temp_root, temp_repo}` — a temporary directory whose
`path()` is already the root the app will resolve it to, so the fixture and the app agree by
construction. It replaces every bare `tempfile::tempdir()` / `TempDir::new()` in the slice.

## Deletions, by criterion (`docs/testing.md` §"Deletion criteria")

179 tests removed, 54 written in their place. Every removal is one of:

### Criterion 1 — sweep redundancy (166 removed)

| module | collapse | before → after |
|---|---|---|
| `root::scrollbar_geometry` | thumb length / thumb position / click-to-jump, one test per input | 12 → 3 |
| `root::layout` | rail & panel clamp, one test per bound | 7 → 2 |
| `rail::title_signal` | one test per glyph family, one per word-boundary case | 13 → 4 |
| `rail::worktrees` | one test per `build_worktree_items` field, per recovery case, per opened-path shape | 21 → 7 |
| `rail::status` | one test per exit state, per threshold, per side-channel × process kind | 25 → 13 |
| `rail::state` | seven `worktree_note_*` cases; five plural-conjugation labels; `disk_usage_bytes` pair; `urgency_counts` pair | 43 → 30 |
| `work_surface::state` | `pty_state_label` ×5, `footer_actions`-empty ×3, `live_tab_label` ×4, `reconcile_*` per tab kind ×7, chip-colour pair, tab-colour pair, slide no-op pair | 49 → 31 |
| `rail::repo` | `batch_repos_for_refresh` ×4, `last_focused_existing_path` ×5, `repo_new_*` ×3, missing/corrupt pair, `save_merged_at` pair | 22 → 11 |
| `title_bar::menu` | one test per `File Edit View Agent Help` label click | 18 → 13 |
| `title_bar::render` | chip conjugation ×3, chip-silence ×2, degenerate one-agent/zero-agent cases | 17 → 12 |
| `root::focus` | three `*_action_reaches_the_real_handler_with_a_file_view_open`; the two `*_closes_an_already_open_plus_menu`; the two `opening_settings_populates_real_{agent,lsp}_rows` | 52 → 45 |
| `root::state` | four `reset_per_worktree_ui_state_*`, one per field | 18 → 15 |
| `work_surface::render` | graph-tab drag interleave vs. file-tab drag interleave; graph-tab drag-record vs. agent-tab drag-record; agent-CLI live title vs. shell live title; the two `tab_settle_animation_id` cases | 54 → 46 |
| `work_surface::tab_order_state` | traversal guard on `files` vs. on `tabs`; missing vs. corrupt file; empty-session vs. encodes-to-nothing | 19 → 16 |
| `rail::render` | `review_file_count` conjugation pair; paste-over-selection vs. backspace-over-selection | 60 → 57 |

### Criterion 3 — vacuous (2 removed)

- `rail::worktrees::tests::unlocked_state_is_preserved` — a `bool` field round-tripping through its
  own default; passes with the feature removed. Folded into the lock/bare passthrough test.
- `rail::repo::tests::repo_new_starts_with_worktrees_unloaded` — same shape. Folded into
  `repo_new_names_itself_from_its_path_and_starts_with_nothing_loaded`.

### Criterion 5 — duplicate coverage across layers (11 removed)

- `root::focus::palette_focus_tests::toggle_palette_works_on_a_fresh_window_with_nothing_clicked_yet`
  and `settings_focus_tests::toggle_settings_works_on_a_fresh_window_with_nothing_clicked_yet` —
  each has a keystroke-driven sibling (`secondary_keystroke_opens_the_palette_through_the_real_key_bindings`,
  `secondary_comma_keystroke_opens_settings_through_the_real_key_bindings`) that drives the strictly
  longer path from the same fresh window. Kept the keystroke ones.
- `settings_focus_tests::settings_opens_to_general_by_default_on_a_fresh_window` — the default-page
  assertion moved into `settings_page_selection_persists_across_a_close_and_reopen`, which already
  opens Settings on a fresh window first.
- `title_menu_tests::agent_menu_discard_row_arms_then_executes_a_real_discard` — calls
  `request_discard_worktree` directly; `agent_menu_discard_row_stays_open_while_armed_and_closes_once_confirmed`
  drives the identical arm/execute sequence through two real clicks on the rendered row **and**
  asserts the menu open/close. Strictly stronger; kept that one.
- `work_surface::render`'s `dispatching_terminal_copy_puts_the_real_selection_on_the_real_clipboard`
  and `dispatching_terminal_paste_reaches_the_active_agents_real_pty` — both are `dispatch_action`
  twins of the keystroke tests kept beside them, and both were 45-second real-pty waits.
- `work_surface::render::tab_scoping_tests::dragging_a_tab_while_bare_persists_every_open_files_position`
  — since #120 removed the bare-worktree truncation, this is an ordinary drag plus persistence, both
  already covered by `a_drag_reordered_tab_strip_survives_a_real_restart` and
  `tab_order_state`'s own round-trip tests.
- `rail::state::tests::is_prunable_helper_looks_up_by_path` — the same helper, exercised through its
  real caller by the two `prunable_worktree_paths_*` tests below it.
- `rail::render::rail_row_tests::resume_past_agent_is_a_no_op_for_an_unknown_key` — folded into
  `resume_past_agent_without_a_session_id_reopens_a_fresh_agent_instead`, which already holds the
  app it needs to assert nothing spawned.
- `work_surface::render::tab_scoping_tests::dropping_a_tab_clears_dragging_tab` and
  `start_dragging_tab_records_exactly_the_tab_that_started_the_drag` — merged into one drag-lifecycle
  test that records on start and clears on drop.

**Nothing was deleted for being external-dependent.** This slice needs no binary the repo does not
vendor: every real process it starts is a shell or `git`, so nothing was re-tiered to `external`.

## Procedure steps 3–5

- **`thread::sleep` → 0.** Six sites: two duplicate `wait_for_real_pty_output` helpers (now one
  `pump_until` on `test_support::wait_until`, in a merged `terminal_action_tests`), `wait_for_exit`,
  `title_bar::render`'s 45s refresh loop, and `rail::worktree_watch`'s `wait_until_dirty`. All now
  advance GPUI's simulated clock and the real wall clock together, one poll at a time, through
  `test_support::wait_until`.
- **Setup through `crates/test-support`.** All 16 copy-pasted `fn git` + `fn init_repo` pairs are
  gone; the slice now uses `test_support::{git, add_worktree, write_file, seed_repo}` and
  `crate::test_support::{temp_root, temp_repo, open_test_app}`. Every
  `palette_focus_tests::open_test_app` call site in the slice is migrated to
  `crate::test_support::open_test_app`; the re-export stays for the other slices.
- **`ChildGuard`.** Not applicable here — no test in this slice spawns a `std::process::Child`
  itself. Every real process comes from `AdeApp::agents.spawn`, torn down by the test window's own
  drop. One test per full run is still reported `LEAK` by nextest (a different one each run, always
  a passing `open_test_app` test); that is the startup shell's exit racing process teardown, it
  predates this branch, and nextest counts it as passing.

## `crates/test-support`

Not edited — the shared-crate rule holds. The one helper I needed and it does not have is
`temp_root()`/`temp_repo()`; following D2's precedent (`code_surface::fixtures::temp_repo`) I put it
in `crates/app/src/test_support.rs` rather than blocking. **It is `gpui`-free and would be a better
fit in `crates/test-support`** — worth promoting in a follow-up one-file PR, since D1 and D2 both
needed the same thing.

## `root/mod.rs`'s comments

`CLAUDE.md` names this file as more prose than code (53%), and this change touches it, so the rule
applies. Cut: the module header, 77 lines → 12 (the rule is ≤10 for `//!`), and the two worst method
docs — `open_repo_in_current_window` (53 → 15) and `checkout_repo_from_rail` (39 → 11), both of which
were mostly issue archaeology and alternatives-considered.

**Deliberately not done:** the remaining ~2,300 doc lines across 400 blocks in that file. That is a
several-hundred-line rewrite of production prose with no relationship to the test purge, and folding
it in here would make this PR unreviewable. The file is still at 53.3%; it wants its own PR.

## Testing

- [x] `/check` (conventions + fmt + clippy `-D warnings`) passes locally — output pasted above
- [ ] `verify` capture — n/a, no rendering behaviour changed (test code and doc comments only)
- [x] Slice run green: `439 tests run: 439 passed`, output pasted above

## Architecture notes

None — no crate boundary, Command/Query shape, or production behaviour changed. The only non-test
edits are doc comments in `root/mod.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
