### PR TITLE
test(app): close the three orphan failures and the Windows/sleep gaps (#427)

### DIFF
--- a/crates/app/src/hooks/server.rs
+++ b/crates/app/src/hooks/server.rs
@@ -1390,9 +1390,14 @@ mod tests {
         let listener = HookListener::start().expect("listener");
         let port = listener.port();
 
-        // Every slot occupied by a client that drips for ~25s and never completes a request.
+        // Every slot occupied by a client that drips for ~25s and never completes a request. Each
+        // reports when the server let go of it - a failed write is the drip-feeder's own view of
+        // the handler giving up, and counting them is what turns the wait below into an observed
+        // event rather than a guessed duration.
+        let cut_off = Arc::new(AtomicUsize::new(0));
         let mut drips = Vec::new();
         for _ in 0..MAX_IN_FLIGHT {
+            let cut_off = Arc::clone(&cut_off);
             drips.push(std::thread::spawn(move || {
                 let Ok(mut stream) = TcpStream::connect(("127.0.0.1", port)) else {
                     return;
@@ -1404,13 +1409,26 @@ mod tests {
                     let _ = stream.flush();
                     std::thread::sleep(Duration::from_millis(500));
                 }
+                cut_off.fetch_add(1, Ordering::SeqCst);
             }));
         }
 
-        // A fixed wait, longer than the handler deadline but well inside the drippers' lifetime,
-        // so the only way real traffic gets served here is if the handlers really did give up.
-        // Absolute rather than derived from `REQUEST_DEADLINE` - see the sibling test.
-        std::thread::sleep(Duration::from_secs(9));
+        // Deliberately *not* polled with a probe request: a probe competes with the drip-feeders
+        // for the same `MAX_IN_FLIGHT` slots, and one that wins a slot at startup leaves the
+        // server permanently one short of saturation - the test then measures its own polling
+        // instead of the server. Wait on the drip-feeders' own signal instead, which perturbs
+        // nothing. The bound is absolute rather than derived from `REQUEST_DEADLINE`, and well
+        // inside the drippers' own ~25s lifetime, so reaching it at all means the handlers really
+        // did give up rather than the clients running out of patience - see the sibling test.
+        assert!(
+            test_support::wait_until(Duration::from_secs(15), || cut_off.load(Ordering::SeqCst)
+                == MAX_IN_FLIGHT),
+            "every handler must give up on its drip-feeder on its own, but only {} of {} did",
+            cut_off.load(Ordering::SeqCst),
+            MAX_IN_FLIGHT
+        );
+
+        // And the slots they held are genuinely free again, not merely accounted free.
         let good = post(
             port,
             listener.token(),
@@ -1419,7 +1437,8 @@ mod tests {
         );
         assert!(
             good.starts_with("HTTP/1.1 204"),
-            "a real hook must still be served while slow clients are connected, got {good:?}"
+            "a real hook must be served again once the deadline cuts the slow clients off, got \
+             {good:?}"
         );
         assert_eq!(listener.signal_for(99).fact, Some(HookFact::TurnEnded));
 

--- a/crates/app/src/keymap.rs
+++ b/crates/app/src/keymap.rs
@@ -311,13 +311,11 @@ mod tests {
 
     #[test]
     fn resolve_keystroke_renders_the_secondary_modifier_as_the_cross_platform_mod_glyph() {
-        // What `gpui::Keystroke::parse("secondary-n")` produces on a non-macOS build -
-        // `modifiers.control == true`, `modifiers.platform == false`.
+        // `Modifiers::secondary_key()`, not a hand-built `control: true`: `secondary()` reads
+        // `platform` on macOS and `control` elsewhere, so only the constructor gpui pairs with it
+        // produces a keystroke that really is secondary on the build actually running this test.
         let keystroke = gpui::Keystroke {
-            modifiers: gpui::Modifiers {
-                control: true,
-                ..Default::default()
-            },
+            modifiers: gpui::Modifiers::secondary_key(),
             key: "n".to_string(),
             key_char: None,
         };
@@ -348,12 +346,26 @@ mod tests {
         );
     }
 
-    // `resolve_keystroke`'s `else if modifiers.control` branch (a literal `ctrl` held *without*
-    // `secondary`) is only reachable on a real macOS build: on this Linux dev/test sandbox,
-    // `Modifiers::secondary()` *is* `modifiers.control`, so any keystroke with `control: true`
-    // already takes the `secondary` branch first. Not tested here for the same reason
-    // `WindowControlsStyle`'s own docs give for its `cfg!(target_os = "macos")`-gated behavior:
-    // real, compile-time-correct code this sandbox cannot compile-and-run the other branch of.
+    /// `resolve_keystroke`'s `else if modifiers.control` branch - a literal `ctrl` held *without*
+    /// `secondary`, as `crate::default_key_bindings`'s `"ctrl-shift-t"` really is - is only
+    /// reachable where `secondary()` reads `platform` rather than `control`, i.e. macOS.
+    /// Elsewhere `control: true` takes the `secondary` branch first and this asserts nothing.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn a_literal_control_without_secondary_falls_back_to_the_physical_ctrl_glyph() {
+        let keystroke = gpui::Keystroke {
+            modifiers: gpui::Modifiers {
+                control: true,
+                ..Default::default()
+            },
+            key: "t".to_string(),
+            key_char: None,
+        };
+        assert_eq!(
+            resolve_keystroke(&keystroke, true),
+            vec!["\u{2303}".to_string(), "T".to_string()]
+        );
+    }
 
     #[test]
     fn labels_are_the_real_command_palette_display_strings() {

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -1166,6 +1166,9 @@ mod open_ade_window_tests {
     #[gpui::test]
     fn reopen_shape_restores_the_remembered_repo(cx: &mut gpui::TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
+        // `AdeApp` canonicalizes the root it is opened with, so a bare `TempDir::path()` would be
+        // compared against its own `/private/var` resolution below and never match on macOS.
+        let repo_path = std::fs::canonicalize(repo.path()).expect("canonical tempdir");
         let settings_dir = tempfile::tempdir().expect("tempdir");
         let settings_path = settings_dir.path().join("settings.toml");
 
@@ -1177,7 +1180,7 @@ mod open_ade_window_tests {
         // window-less `update`, which `VisualTestContext` doesn't have the same shape of.
         let (_first, _first_window_cx) = cx.add_window_view(|window, cx| {
             AdeApp::new_with_settings(
-                Some(repo.path().to_path_buf()),
+                Some(repo_path.clone()),
                 true,
                 settings_store::Settings::default(),
                 Some(settings_path.clone()),
@@ -1205,7 +1208,7 @@ mod open_ade_window_tests {
         app.read_with(cx, |app, _| {
             assert_eq!(
                 app.focused_repo_path(),
-                repo.path(),
+                repo_path,
                 "a Dock reopen must restore the same repo a fresh relaunch would, not a bare \
                  empty window"
             );

--- a/crates/app/src/palette/render.rs
+++ b/crates/app/src/palette/render.rs
@@ -1554,8 +1554,11 @@ mod palette_language_server_step_tests {
     #[gpui::test]
     fn picking_a_row_restarts_exactly_that_server_and_closes_the_palette(cx: &mut TestAppContext) {
         let repo = tempfile::tempdir().expect("tempdir");
-        let root = repo.path().to_path_buf();
         let (app, _server, cx) = app_with_two_servers(cx, repo.path());
+        // The key `app_with_two_servers` really inserted under - `AdeApp` canonicalizes the root it
+        // is opened with, which on macOS resolves the `/var -> /private/var` symlink `TempDir`
+        // hands out, so `repo.path()` would key an entry that does not exist.
+        let root = app.read_with(cx, |app, _| app.file_tree_root.clone());
 
         cx.dispatch_action(TogglePalette);
         cx.run_until_parked();

--- a/crates/app/src/sidebar/render.rs
+++ b/crates/app/src/sidebar/render.rs
@@ -8057,6 +8057,8 @@ mod changes_sections_tests {
         assert!(cx.debug_bounds("changes-section-runs-2-open").is_some());
     }
 
+    /// `#[cfg(unix)]`: the ended run below is a real `/bin/false` child, which needs a `/bin`.
+    #[cfg(unix)]
     #[gpui::test]
     fn a_live_run_and_an_ended_run_render_side_by_side(cx: &mut TestAppContext) {
         // The mock's sad path (`STAGE-A-SELFCHECK.md`): "a live run and a frozen run render side

--- a/crates/app/src/work_surface/render.rs
+++ b/crates/app/src/work_surface/render.rs
@@ -5856,6 +5856,8 @@ mod agent_pane_readout_tests {
     /// Driven through the genuinely painted button (`debug_bounds` + `simulate_click`), not
     /// through `request_discard_worktree` directly - the point is that this strip still offers
     /// those two, and that `Open terminal` (which used to sit between them) does not paint.
+    /// `#[cfg(unix)]`: the failed run below is a real `/bin/false` child, which needs a `/bin`.
+    #[cfg(unix)]
     #[gpui::test]
     fn a_failed_run_keeps_retry_and_a_two_click_discard_and_nothing_else(cx: &mut TestAppContext) {
         let repo = crate::test_support::temp_repo();

--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -24,7 +24,7 @@ pub use repo::{
     add_worktree, seed_bare_remote, seed_commits, seed_empty_repo, seed_empty_repo_at, seed_repo,
     seed_repo_at, seed_three_commits,
 };
-pub use wait::{stays_false, wait_until};
+pub use wait::{stays_false, wait_until, wait_until_every};
 
 /// Re-exported so a consumer can name the type [`seed_repo`] returns without repeating the
 /// `tempfile` dependency in its own manifest.

--- a/crates/test-support/src/repo.rs
+++ b/crates/test-support/src/repo.rs
@@ -29,6 +29,10 @@ pub fn seed_empty_repo_at(dir: &Path) {
     // A machine with commit signing configured globally would otherwise block every fixture
     // commit on a passphrase prompt that never arrives in a test runner.
     git(dir, &["config", "commit.gpgsign", "false"]);
+    // Git for Windows ships `core.autocrlf=true`, which would materialize CRLF in every fixture
+    // checkout and put `\r` into content, diff-hunk and blame assertions the fixture wrote with
+    // `\n`. Pinned here so a fixture behaves identically on all three platforms (#440, finding 2).
+    git(dir, &["config", "core.autocrlf", "false"]);
 }
 
 /// A git repository on branch `main` with one commit (`file.txt`) and a clean working tree.

--- a/crates/test-support/src/wait.rs
+++ b/crates/test-support/src/wait.rs
@@ -24,7 +24,31 @@ const POLL_INTERVAL: Duration = Duration::from_millis(10);
 ///     "the watcher must observe a real file write within the tier's budget"
 /// );
 /// ```
-pub fn wait_until(deadline: Duration, mut condition: impl FnMut() -> bool) -> bool {
+pub fn wait_until(deadline: Duration, condition: impl FnMut() -> bool) -> bool {
+    wait_until_every(POLL_INTERVAL, deadline, condition)
+}
+
+/// [`wait_until`] with an explicit poll interval, for a condition whose *check* perturbs the very
+/// thing it measures — a probe that takes a connection slot in the server it is asking about, a
+/// check that contends for the lock the subject needs. At [`POLL_INTERVAL`] such a probe measures
+/// its own polling rate rather than the subject; pick an interval coarse enough that it doesn't.
+///
+/// Prefer plain [`wait_until`] everywhere else: a coarse interval buys nothing when the check is
+/// free, and costs up to `interval` of dead time on a condition that has already been satisfied.
+///
+/// ```no_run
+/// # use std::time::Duration;
+/// # let served = || true;
+/// assert!(
+///     test_support::wait_until_every(Duration::from_millis(250), Duration::from_secs(20), served),
+///     "the server must recover once it gives up on the clients holding every slot"
+/// );
+/// ```
+pub fn wait_until_every(
+    interval: Duration,
+    deadline: Duration,
+    mut condition: impl FnMut() -> bool,
+) -> bool {
     let expiry = Instant::now() + deadline;
     loop {
         if condition() {
@@ -34,7 +58,7 @@ pub fn wait_until(deadline: Duration, mut condition: impl FnMut() -> bool) -> bo
         if remaining.is_zero() {
             return false;
         }
-        thread::sleep(POLL_INTERVAL.min(remaining));
+        thread::sleep(interval.min(remaining));
     }
 }
 
@@ -48,7 +72,7 @@ pub fn stays_false(window: Duration, condition: impl FnMut() -> bool) -> bool {
 
 #[cfg(test)]
 mod bounded_wait_tests {
-    use crate::{stays_false, wait_until};
+    use crate::{stays_false, wait_until, wait_until_every};
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::{Duration, Instant};
 
@@ -96,6 +120,46 @@ mod bounded_wait_tests {
         assert!(
             started.elapsed() < Duration::from_millis(10),
             "an already-satisfied condition must cost no wall-clock time at all"
+        );
+    }
+
+    #[test]
+    fn wait_until_every_polls_at_the_interval_it_was_given_rather_than_the_default() {
+        let polls = AtomicUsize::new(0);
+        let started = Instant::now();
+
+        let satisfied =
+            wait_until_every(Duration::from_millis(100), Duration::from_secs(30), || {
+                polls.fetch_add(1, Ordering::SeqCst) >= 3
+            });
+
+        assert!(
+            satisfied,
+            "the condition became true well inside the deadline"
+        );
+        // Four checks at 100ms is at least 300ms of sleeping; at `wait_until`'s own 10ms it would
+        // be ~30ms, which is what this distinguishes.
+        assert!(
+            started.elapsed() >= Duration::from_millis(300),
+            "a coarse interval must really be waited out between checks - it took {:?}",
+            started.elapsed()
+        );
+    }
+
+    #[test]
+    fn wait_until_every_never_sleeps_past_the_deadline() {
+        let started = Instant::now();
+
+        assert!(!wait_until_every(
+            Duration::from_secs(30),
+            Duration::from_millis(50),
+            || false
+        ));
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "the interval must be clamped to what is left of the deadline, not slept in full - it \
+             took {:?}",
+            started.elapsed()
         );
     }
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -56,8 +56,10 @@ body:
 
 - **No `thread::sleep` in test code.** Use `cx.run_until_parked()` or
   `test_support::wait_until(deadline, cond)`. There are **303** existing wall-clock waits, including
-  a `from_secs(9)` and ten `from_millis(500)`; they are the purge issue's problem, but the rule
-  starts here.
+  ten `from_millis(500)`; they are the purge issue's problem, but the rule starts here. The
+  `from_secs(9)` this list used to name is gone: `hooks::server`'s
+  `many_slow_clients_at_once_cannot_starve_a_real_hook` now waits on the drip-feeders' own
+  cut-off signal instead of guessing a duration.
 - Any test that spawns a process owns its teardown, via an RAII guard from `test-support`.
 - Any test that opens a file watcher shuts it down. A leaked watcher thread fails the tier's budget.
 - Every `#[ignore]` carries a reason string naming exactly what is missing.
@@ -102,19 +104,27 @@ Argv, never an interpolated shell string — the same rule production code follo
 | `seed_bare_remote() -> TempDir` | a bare repo on `main`, as a push/fetch target |
 | `add_worktree(repo, "feature", &path)` | a real second working copy on a new branch |
 
-Every seeded repo configures `user.email`, `user.name` and `commit.gpgsign=false`, so a fixture
-behaves the same on a machine with commit signing configured globally.
+Every seeded repo configures `user.email`, `user.name`, `commit.gpgsign=false` and
+`core.autocrlf=false`, so a fixture behaves the same on a machine with commit signing configured
+globally, and on Windows — where git otherwise ships `core.autocrlf=true` and would put `\r` into
+every content, diff and blame assertion.
 
 ### Waiting and teardown
 
 | Helper | Does |
 |---|---|
 | `wait_until(deadline: Duration, cond) -> bool` | polls until `cond` holds or the deadline passes; the caller writes the assertion message |
+| `wait_until_every(interval, deadline, cond) -> bool` | as `wait_until`, with an explicit poll interval — for a check that perturbs what it measures |
 | `stays_false(window: Duration, cond) -> bool` | the inverse — proves something stays quiet for a bounded window |
 | `ChildGuard` | kill-on-drop wrapper for a spawned `Child`; derefs to `Child`, plus `spawn`, `is_running`, `kill_and_wait`, `into_inner` |
 
 `wait_until` is the *only* sanctioned wall-clock wait in the workspace. Anything a GPUI executor
 drives waits with `cx.run_until_parked()` instead.
+
+Reach for `wait_until_every` only when the check itself is not free — a probe that takes a
+connection slot in the server it is asking about, a check that contends for the lock the subject
+needs. At `wait_until`'s 10 ms such a check measures its own polling rate. Prefer, where it exists,
+a signal the subject already emits: perturbing nothing beats polling coarsely.
 
 ### GPUI fixtures (`crates/app/src/test_support.rs`)
 


### PR DESCRIPTION
Part of #427 · closes #440's findings 1 and 2.

## What

Four fixes that fell between the seven slices of #425, in modules no slice owned.

### 1. The three orphan failures

**`keymap::tests::resolve_keystroke_renders_the_secondary_modifier_as_the_cross_platform_mod_glyph` — fixed.**
Not a canonicalization failure; a genuinely wrong test premise. It hand-built
`Modifiers { control: true, .. }` and asserted `resolve_keystroke(&k, true)` renders `U+2318` (⌘).
Production (`keymap.rs:189`) branches on `modifiers.secondary()`, which is `platform` on macOS and
`control` elsewhere (`gpui` `keystroke.rs:483`), so on a macOS build that input is **not** secondary,
correctly falls through to the `else if modifiers.control` arm, and renders `U+2303` (⌃). Production
is right; the test could only ever pass on Linux CI:

```
thread 'keymap::tests::resolve_keystroke_renders_the_secondary_modifier_as_the_cross_platform_mod_glyph'
panicked at crates/app/src/keymap.rs:328:9:
assertion `left == right` failed
  left: ["⌃", "N"]
 right: ["⌘", "N"]
```

Built with `gpui::Modifiers::secondary_key()` (`keystroke.rs:518`) instead, the constructor gpui pairs
with `secondary()`, so the input really is secondary on whichever platform runs it — the same class
D2 hit in `code_surface`. Its stale comment is rewritten.

The old test also *accidentally* covered the literal-`control` arm on Linux. That arm is now covered
deliberately by a new `#[cfg(target_os = "macos")]` test, replacing the prose note that claimed the
arm was untestable — true on Linux, not here.

**`open_ade_window_tests::reopen_shape_restores_the_remembered_repo` — fixed.** The known
`/var` → `/private/var` fixture bug, as expected, confirmed rather than assumed:

```
panicked at crates/app/src/lib.rs:1206:13:
assertion `left == right` failed: a Dock reopen must restore the same repo a fresh relaunch would
  left: "/private/var/folders/h6/qvjj10rd7xlbx0x6m9l0752m0000gn/T/.tmpUOtGpF"
 right: "/var/folders/h6/qvjj10rd7xlbx0x6m9l0752m0000gn/T/.tmpUOtGpF"
```

Fixed with the *canonicalize-at-the-fixture* half of the pattern (`code_surface::fixtures::temp_repo`'s):
`AdeApp` is handed an already-canonical root, so both launches and the assertion agree.

**`palette::render::palette_language_server_step_tests::picking_a_row_restarts_exactly_that_server_and_closes_the_palette` — fixed.**
Same root cause, worse consequence. `app_with_two_servers` inserts under `app.file_tree_root`
(canonical), the test rebuilt its key from `repo.path()` (not), so `get` returned `None`:

```
panicked at crates/app/src/palette/render.rs:1580:13:
the server the user did not pick is left exactly as it was
```

The *first* assertion in that test — `!lsp_clients.contains_key(&(root, "rust-analyzer"))`, the one
that is supposed to prove the pick freed the right key — was passing trivially against a key that
never existed. Fixed with the *read-it-off-the-app* half of the pattern, `app.file_tree_root`, which
is exactly what its own sibling three tests down (`a_single_running_server_is_restarted_…`) already
does. Both assertions are now real.

No deletions, no re-tiering: all three assert real behaviour and all three now pass.

### 2. `core.autocrlf` in `crates/test-support` (#440, finding 2)

`seed_empty_repo_at` now pins `core.autocrlf=false` alongside the `user.email` / `user.name` /
`commit.gpgsign=false` it already sets. Git for Windows ships `autocrlf=true`, so without this every
fixture checkout materialises CRLF and every content/diff/blame assertion sees `\r`. Hard
prerequisite for #426's Windows job.

### 3. The missing `cfg` gate (#440, finding 1)

`sidebar/render.rs`'s `a_live_run_and_an_ended_run_render_side_by_side` passes `Some("/bin/false")`
into a real spawn with no gate — certain failure on a machine with no `/bin`. Gated `#[cfg(unix)]`,
following `hooks/settings_file.rs`'s existing pattern.

**Scope note:** the audit listed six sites. Four in `hooks/settings_file.rs` are already gated, but
`work_surface/render.rs:6295` was **not** — `grep 'cfg(unix)' crates/app/src/work_surface/render.rs`
returns nothing on `chore/test-suite-health`. It is the identical one-line finding and leaving it
would leave a certain Windows failure behind, so it is gated here too. That is one line beyond the
brief; say the word and I'll split it out.

### 4. `wait_until_every` + the `from_secs(9)` sleep

`wait_until_every(interval, deadline, cond)` is added next to `wait_until`, which now delegates to it
at its own 10 ms — so it is the implementation, not an unused helper. Two unit tests cover it.

**The migration did not go the way the brief expected, and the honest result is better.** Polling
`hooks::server`'s `many_slow_clients_at_once_cannot_starve_a_real_hook` with a probe request does not
work at *any* interval, and I can now say why rather than only that it was flaky. I instrumented both
sides. The drip-feeders behave exactly as designed — all 16 connect, all hold a handler until
`REQUEST_DEADLINE`:

```
DRIP connected            (×16)
DRIP write failed after 5.535528792s
DRIP done after 5.535544708s
...
DRIP write failed after 5.546837583s
```

But in the runs that fail, the probe is **served** throughout that window:

```
PROBE t=776.375µs     -> "HTTP/1.1 204 No Cont"
PROBE t=252.131375ms  -> "HTTP/1.1 204 No Cont"
PROBE t=507.240375ms  -> "HTTP/1.1 204 No Cont"
...
```

The probe competes with the drip-feeders for the same `MAX_IN_FLIGHT` slots. A probe that wins one at
startup means only 15 drippers get slots, `in_flight` never reaches 16 again, and the server is
permanently one short of saturation — so a saturation-polling test can never observe the state it
exists to assert. That is the same effect D7 measured as "94 refused / 55 served" at 50 ms and
"never observed saturation" at 10 ms; the interval is not the variable. A coarser interval does not
fix it. 0/6 with a 250 ms probe poll:

```
FAIL [  15.016s] app hooks::server::tests::many_slow_clients_at_once_cannot_starve_a_real_hook
FAIL [  15.016s] ... (×6)
```

So the test does not poll the server at all. It waits on a signal the drip-feeders already emit — a
failed write *is* the handler giving up — counted into an `AtomicUsize` and awaited with plain
`wait_until`. That perturbs nothing, and it asserts strictly more than the sleep did: all 16 were
really cut off, *then* a real hook is served. 6/6 stable, and 5.57s instead of 9s:

```
PASS [   5.576s] (1/1) app hooks::server::tests::many_slow_clients_at_once_cannot_starve_a_real_hook
PASS [   5.569s] (1/1) app hooks::server::tests::many_slow_clients_at_once_cannot_starve_a_real_hook
PASS [   5.566s] (1/1) app hooks::server::tests::many_slow_clients_at_once_cannot_starve_a_real_hook
PASS [   5.561s] (1/1) app hooks::server::tests::many_slow_clients_at_once_cannot_starve_a_real_hook
PASS [   5.572s] (1/1) app hooks::server::tests::many_slow_clients_at_once_cannot_starve_a_real_hook
PASS [   5.567s] (1/1) app hooks::server::tests::many_slow_clients_at_once_cannot_starve_a_real_hook
```

`docs/testing.md` no longer names a `from_secs(9)`, documents `wait_until_every`, and says plainly
that a signal the subject already emits beats polling coarsely.

## Why

This is the gate #426 is blocked on: `cargo nextest run -p app --lib` had to reach zero failures
before the Windows and Linux jobs can run the full suite for the first time.

## Testing

- [x] `/check` (conventions + fmt + clippy `-D warnings`) passes locally
- [ ] `verify` capture — not applicable, no rendered output changes (the two `render.rs` edits are a
      `#[cfg(unix)]` attribute on a test and nothing else)
- [x] New/changed behavior has a real test, run manually and confirmed passing

```
$ CLAUDE_PROJECT_DIR=$PWD .claude/hooks/check-conventions.sh
check-conventions: OK (glob imports: 300/301, render adapter calls: 196/221)

$ cargo fmt --all -- --check
(clean)

$ cargo clippy --workspace --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 13.93s
```

**The full run, the point of this PR:**

```
$ cargo nextest run -p app --lib --no-fail-fast
     Summary [ 115.390s] 2748 tests run: 2748 passed, 14 skipped

$ grep -cE "^\s+(FAIL|TIMEOUT|SIGSEGV|ABORT)" applib.txt
0
```

Captured to a file and counted with `grep -c`, not read off a truncated tail.

Core crates and the shared fixture crate, both of which the `core.autocrlf` change touches:

```
$ cargo nextest run -p wt-core -p pty-core -p lsp-core
     Summary [   8.336s] 354 tests run: 354 passed, 16 skipped

$ cargo nextest run -p test-support
     Summary [   0.553s] 23 tests run: 23 passed, 0 skipped
```

No leaked children after the full run (`pgrep -f 'target/debug/deps/app-'` → 0).

## Architecture notes

`crates/test-support` gained two things and stays `gpui`-free
([`decisions.md` §1](docs/architecture/decisions.md)) — its entire dependency graph, dev-edges
included, is `tempfile`:

```
$ cargo tree -p test-support --edges all
test-support v0.1.1 (crates/test-support)
└── tempfile feature "default"
    ├── tempfile v3.27.0
    │   ├── getrandom v0.4.3
    │   ├── fastrand feature "default"
    │   ├── once_cell feature "std"
    │   └── rustix feature "default"
    └── tempfile feature "getrandom"

$ cargo tree -p test-support --edges all -i gpui
error: package ID specification `gpui` did not match any packages
```

## Not in scope

The `temp_repo` / `TempRoot` convergence across `code_surface/fixtures.rs`, `lsp/fixtures.rs`,
`search/fixtures.rs` and `app/src/test_support.rs` is real and worth doing, and is deliberately left
for a follow-up so this stays reviewable.
